### PR TITLE
feat: implement #[get] route macro with compile-fail tests (S-002)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/markm/autumn"
 
 [workspace.dependencies]
 # Runtime
-axum = "0.8"
+axum = { version = "0.8", features = ["macros"] }
 http = "1"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -4,28 +4,35 @@
 //!
 //! This crate provides:
 //! - Route annotation macros (`#[get]`, `#[post]`, etc.)
-//! - The `routes![]` collection macro
-//! - The `#[autumn::main]` entry point macro
-//! - The `#[derive(Model)]` convenience macro
+//! - The `routes![]` collection macro (S-005)
+//! - The `#[autumn::main]` entry point macro (S-008)
+//! - The `#[derive(Model)]` convenience macro (S-018)
 //!
 //! Users should not depend on this crate directly — use `autumn` instead,
 //! which re-exports everything.
 
+mod route;
+
 use proc_macro::TokenStream;
 
-/// Placeholder attribute macro for GET route handlers.
+/// Annotate an async function as a GET route handler.
 ///
-/// # Example (future)
+/// Generates a companion `__autumn_route_info_{name}()` function that
+/// returns an [`autumn::route::Route`] pairing the path with an Axum
+/// handler. In debug builds, `#[axum::debug_handler]` is auto-applied
+/// for better error messages.
+///
+/// # Example
 ///
 /// ```ignore
+/// use autumn::get;
+///
 /// #[get("/hello")]
 /// async fn hello() -> &'static str {
 ///     "Hello, Autumn!"
 /// }
 /// ```
 #[proc_macro_attribute]
-pub fn get(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    // Placeholder: returns the item unchanged.
-    // Real implementation comes in S-002.
-    item
+pub fn get(attr: TokenStream, item: TokenStream) -> TokenStream {
+    route::route_macro("GET", "get", attr.into(), item.into()).into()
 }

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -1,0 +1,71 @@
+//! Route macro implementation.
+//!
+//! Generates a companion `__autumn_route_info_{name}()` function for each
+//! annotated handler, pairing the HTTP method and path with an Axum
+//! `MethodRouter`.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{ItemFn, LitStr};
+
+/// Core implementation shared by all route macros (`#[get]`, `#[post]`, etc.).
+///
+/// `http_method` is the uppercase method name (e.g., `"GET"`).
+/// `axum_fn` is the lowercase axum routing function name (e.g., `"get"`).
+pub fn route_macro(
+    http_method: &str,
+    axum_fn: &str,
+    attr: TokenStream,
+    item: TokenStream,
+) -> TokenStream {
+    // Parse the path string from the attribute: #[get("/hello")]
+    let path: LitStr = match syn::parse2(attr) {
+        Ok(path) => path,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    // Validate path is not empty
+    if path.value().is_empty() {
+        return syn::Error::new(path.span(), "Route path must not be empty").to_compile_error();
+    }
+
+    // Parse the annotated item — must be a function
+    let input_fn: ItemFn = match syn::parse2(item) {
+        Ok(f) => f,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    // Validate: must be async
+    if input_fn.sig.asyncness.is_none() {
+        return syn::Error::new_spanned(
+            input_fn.sig.fn_token,
+            "Autumn route handlers must be async functions",
+        )
+        .to_compile_error();
+    }
+
+    let fn_name = &input_fn.sig.ident;
+    let route_info_name = format_ident!("__autumn_route_info_{}", fn_name);
+    let vis = &input_fn.vis;
+
+    let method_const = format_ident!("{}", http_method); // e.g., GET
+    let routing_fn = format_ident!("{}", axum_fn); // e.g., get
+
+    quote! {
+        #[cfg_attr(
+            debug_assertions,
+            ::autumn::reexports::axum::debug_handler(state = ::autumn::AppState)
+        )]
+        #input_fn
+
+        #[doc(hidden)]
+        #vis fn #route_info_name() -> ::autumn::route::Route {
+            ::autumn::route::Route {
+                method: ::autumn::reexports::http::Method::#method_const,
+                path: #path,
+                handler: ::autumn::reexports::axum::routing::#routing_fn(#fn_name),
+                name: ::core::stringify!(#fn_name),
+            }
+        }
+    }
+}

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -14,5 +14,8 @@ tokio.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 
+[dev-dependencies]
+trybuild = "1"
+
 [lints]
 workspace = true

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -6,8 +6,10 @@
 //! into a Spring Boot-style developer experience with proc-macro-driven
 //! conventions and escape hatches at every level.
 
-// Re-export the proc macro crate so users only need `autumn` in their Cargo.toml.
-pub use autumn_macros;
+pub mod route;
+
+// Re-export route macros so users can write `use autumn::get;`
+pub use autumn_macros::get;
 
 /// Re-exports of upstream crates used in macro-generated code.
 ///
@@ -19,3 +21,10 @@ pub mod reexports {
     pub use axum;
     pub use http;
 }
+
+/// Shared application state passed to all route handlers.
+///
+/// Placeholder for v0.1 — the real `AppState` will hold config, database
+/// pool, and other framework-managed resources (S-009).
+#[derive(Clone, Debug)]
+pub struct AppState;

--- a/autumn/src/route.rs
+++ b/autumn/src/route.rs
@@ -1,0 +1,29 @@
+//! Route types used by macro-generated code.
+//!
+//! Each `#[get("/path")]` (or `#[post]`, etc.) macro generates a companion
+//! function that returns a [`Route`]. The `routes![]` macro collects these
+//! into a `Vec<Route>` for the app builder.
+
+use axum::routing::MethodRouter;
+use http::Method;
+
+use crate::AppState;
+
+/// A single route binding an HTTP method + path to an Axum handler.
+///
+/// Created by the `__autumn_route_info_{name}()` functions that route
+/// macros generate. Users don't construct this directly — they use
+/// `#[get]`, `#[post]`, etc. and the `routes![]` macro.
+pub struct Route {
+    /// HTTP method (GET, POST, PUT, DELETE, etc.).
+    pub method: Method,
+
+    /// URL path pattern (e.g., `"/users/{id}"`).
+    pub path: &'static str,
+
+    /// Axum method router that handles requests to this route.
+    pub handler: MethodRouter<AppState>,
+
+    /// Function name, for startup logging (e.g., `"get_user"`).
+    pub name: &'static str,
+}

--- a/autumn/tests/compile-fail/empty_path.rs
+++ b/autumn/tests/compile-fail/empty_path.rs
@@ -1,0 +1,8 @@
+use autumn::get;
+
+#[get("")]
+async fn hello() -> &'static str {
+    "Hello!"
+}
+
+fn main() {}

--- a/autumn/tests/compile-fail/empty_path.stderr
+++ b/autumn/tests/compile-fail/empty_path.stderr
@@ -1,0 +1,5 @@
+error: Route path must not be empty
+ --> tests/compile-fail/empty_path.rs:3:7
+  |
+3 | #[get("")]
+  |       ^^

--- a/autumn/tests/compile-fail/non_async.rs
+++ b/autumn/tests/compile-fail/non_async.rs
@@ -1,0 +1,8 @@
+use autumn::get;
+
+#[get("/hello")]
+fn hello() -> &'static str {
+    "Hello!"
+}
+
+fn main() {}

--- a/autumn/tests/compile-fail/non_async.stderr
+++ b/autumn/tests/compile-fail/non_async.stderr
@@ -1,0 +1,5 @@
+error: Autumn route handlers must be async functions
+ --> tests/compile-fail/non_async.rs:4:1
+  |
+4 | fn hello() -> &'static str {
+  | ^^

--- a/autumn/tests/compile-fail/non_function.rs
+++ b/autumn/tests/compile-fail/non_function.rs
@@ -1,0 +1,6 @@
+use autumn::get;
+
+#[get("/hello")]
+struct Hello;
+
+fn main() {}

--- a/autumn/tests/compile-fail/non_function.stderr
+++ b/autumn/tests/compile-fail/non_function.stderr
@@ -1,0 +1,5 @@
+error: expected `fn`
+ --> tests/compile-fail/non_function.rs:4:1
+  |
+4 | struct Hello;
+  | ^^^^^^

--- a/autumn/tests/compile_fail.rs
+++ b/autumn/tests/compile_fail.rs
@@ -1,0 +1,5 @@
+#[test]
+fn compile_fail_tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail/*.rs");
+}

--- a/autumn/tests/route_macro.rs
+++ b/autumn/tests/route_macro.rs
@@ -1,0 +1,48 @@
+use autumn::get;
+
+#[get("/hello")]
+async fn hello() -> &'static str {
+    "Hello, Autumn!"
+}
+
+#[get("/")]
+async fn index() -> &'static str {
+    "root"
+}
+
+#[get("/with/nested/path")]
+async fn nested() -> &'static str {
+    "nested"
+}
+
+#[test]
+fn hello_route_info_has_correct_method() {
+    let route = __autumn_route_info_hello();
+    assert_eq!(route.method, http::Method::GET);
+}
+
+#[test]
+fn hello_route_info_has_correct_path() {
+    let route = __autumn_route_info_hello();
+    assert_eq!(route.path, "/hello");
+}
+
+#[test]
+fn hello_route_info_has_correct_name() {
+    let route = __autumn_route_info_hello();
+    assert_eq!(route.name, "hello");
+}
+
+#[test]
+fn index_route_info_has_correct_fields() {
+    let route = __autumn_route_info_index();
+    assert_eq!(route.method, http::Method::GET);
+    assert_eq!(route.path, "/");
+    assert_eq!(route.name, "index");
+}
+
+#[test]
+fn nested_route_info_has_correct_path() {
+    let route = __autumn_route_info_nested();
+    assert_eq!(route.path, "/with/nested/path");
+}

--- a/docs/sprint-status.yaml
+++ b/docs/sprint-status.yaml
@@ -11,7 +11,7 @@ sprints:
     end_date: "2026-04-04"
     capacity_points: 12
     committed_points: 12
-    completed_points: 2
+    completed_points: 10
     status: "in_progress"
     goal: "Get the first annotated route handler compiling and responding to HTTP requests"
     stories:
@@ -24,8 +24,9 @@ sprints:
       - story_id: "S-002"
         title: "Basic #[get] route macro"
         points: 8
-        status: "defined"
+        status: "completed"
         story_doc: "docs/stories/S-002.md"
+        completion_date: "2026-03-21"
       - story_id: "S-025"
         title: "AutumnConfig struct with serde defaults"
         points: 2


### PR DESCRIPTION
- Add Route type (method, path, handler, name) and AppState stub
- Implement #[get("/path")] proc macro: parses path, validates async, generates __autumn_route_info_{name}() companion function
- Auto-apply #[axum::debug_handler] in debug builds via cfg_attr
- Add compile_error! for non-async fns, empty paths, non-function items
- Enable axum "macros" feature for debug_handler support
- 5 compile-pass tests verifying route info fields
- 3 compile-fail tests via trybuild (non_async, empty_path, non_function)