### PR TITLE
feat: add AutumnConfig struct with serde defaults (S-025)

### DIFF
--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -15,6 +15,7 @@ serde.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+serde_json = "1"
 trybuild = "1"
 
 [lints]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1,0 +1,270 @@
+//! Framework configuration with sensible defaults.
+//!
+//! Autumn uses a three-layer configuration system (applied in later stories):
+//!
+//! 1. **Framework defaults** (this module) — compiled into the binary
+//! 2. **`autumn.toml`** — project-level overrides (S-026)
+//! 3. **`AUTUMN_*` environment variables** — deployment overrides (S-027)
+//!
+//! This module defines the typed config structs and their defaults.
+//! An Autumn application runs with zero configuration — every field
+//! has a sensible default value.
+
+use serde::Deserialize;
+
+/// Top-level framework configuration.
+///
+/// All sections are optional — missing sections use their defaults.
+///
+/// # Example `autumn.toml`
+///
+/// ```toml
+/// [server]
+/// port = 8080
+///
+/// [database]
+/// url = "postgres://user:pass@db:5432/myapp"
+/// pool_size = 20
+/// ```
+#[derive(Debug, Default, Deserialize)]
+pub struct AutumnConfig {
+    /// HTTP server settings (port, host, shutdown behavior).
+    #[serde(default)]
+    pub server: ServerConfig,
+
+    /// Database connection settings (URL, pool size, timeouts).
+    #[serde(default)]
+    pub database: DatabaseConfig,
+
+    /// Logging configuration (level, format).
+    #[serde(default)]
+    pub log: LogConfig,
+
+    /// Health check endpoint settings.
+    #[serde(default)]
+    pub health: HealthConfig,
+}
+
+/// HTTP server configuration.
+#[derive(Debug, Deserialize)]
+pub struct ServerConfig {
+    /// Port to listen on. Default: `3000`.
+    #[serde(default = "default_port")]
+    pub port: u16,
+
+    /// Host/IP to bind to. Default: `"127.0.0.1"`.
+    #[serde(default = "default_host")]
+    pub host: String,
+
+    /// Seconds to wait for in-flight requests during graceful shutdown.
+    /// Default: `30`.
+    #[serde(default = "default_shutdown_timeout")]
+    pub shutdown_timeout_secs: u64,
+}
+
+/// Database connection configuration.
+#[derive(Debug, Deserialize)]
+pub struct DatabaseConfig {
+    /// Postgres connection URL. Default: `"postgres://localhost/autumn_dev"`.
+    #[serde(default = "default_db_url")]
+    pub url: String,
+
+    /// Maximum number of connections in the pool. Default: `10`.
+    #[serde(default = "default_pool_size")]
+    pub pool_size: usize,
+
+    /// Seconds to wait when acquiring a connection. Default: `5`.
+    #[serde(default = "default_connect_timeout")]
+    pub connect_timeout_secs: u64,
+}
+
+/// Logging configuration.
+#[derive(Debug, Deserialize)]
+pub struct LogConfig {
+    /// Tracing filter directive. Default: `"info"`.
+    ///
+    /// Supports arbitrary tracing filter syntax, e.g.
+    /// `"autumn=debug,tower_http=trace"`.
+    #[serde(default = "default_log_level")]
+    pub level: String,
+
+    /// Log output format. Default: [`LogFormat::Auto`].
+    #[serde(default)]
+    pub format: LogFormat,
+}
+
+/// Log output format.
+///
+/// - `Auto` — pretty-print in dev, JSON when `AUTUMN_ENV=production`
+/// - `Pretty` — always human-readable
+/// - `Json` — always structured JSON
+#[derive(Debug, Deserialize, Default, PartialEq, Eq)]
+pub enum LogFormat {
+    /// Pretty in dev, JSON in production (based on `AUTUMN_ENV`).
+    #[default]
+    Auto,
+    /// Human-readable, colorized output.
+    Pretty,
+    /// Structured JSON output.
+    Json,
+}
+
+/// Health check endpoint configuration.
+#[derive(Debug, Deserialize)]
+pub struct HealthConfig {
+    /// URL path for the health check endpoint. Default: `"/health"`.
+    #[serde(default = "default_health_path")]
+    pub path: String,
+}
+
+// ── Default functions ──────────────────────────────────────────────
+
+const fn default_port() -> u16 {
+    3000
+}
+
+fn default_host() -> String {
+    "127.0.0.1".to_owned()
+}
+
+const fn default_shutdown_timeout() -> u64 {
+    30
+}
+
+fn default_db_url() -> String {
+    "postgres://localhost/autumn_dev".to_owned()
+}
+
+const fn default_pool_size() -> usize {
+    10
+}
+
+const fn default_connect_timeout() -> u64 {
+    5
+}
+
+fn default_log_level() -> String {
+    "info".to_owned()
+}
+
+fn default_health_path() -> String {
+    "/health".to_owned()
+}
+
+// ── Default trait impls ────────────────────────────────────────────
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            port: default_port(),
+            host: default_host(),
+            shutdown_timeout_secs: default_shutdown_timeout(),
+        }
+    }
+}
+
+impl Default for DatabaseConfig {
+    fn default() -> Self {
+        Self {
+            url: default_db_url(),
+            pool_size: default_pool_size(),
+            connect_timeout_secs: default_connect_timeout(),
+        }
+    }
+}
+
+impl Default for LogConfig {
+    fn default() -> Self {
+        Self {
+            level: default_log_level(),
+            format: LogFormat::default(),
+        }
+    }
+}
+
+impl Default for HealthConfig {
+    fn default() -> Self {
+        Self {
+            path: default_health_path(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_defaults() {
+        let config = ServerConfig::default();
+        assert_eq!(config.port, 3000);
+        assert_eq!(config.host, "127.0.0.1");
+        assert_eq!(config.shutdown_timeout_secs, 30);
+    }
+
+    #[test]
+    fn database_defaults() {
+        let config = DatabaseConfig::default();
+        assert_eq!(config.url, "postgres://localhost/autumn_dev");
+        assert_eq!(config.pool_size, 10);
+        assert_eq!(config.connect_timeout_secs, 5);
+    }
+
+    #[test]
+    fn log_defaults() {
+        let config = LogConfig::default();
+        assert_eq!(config.level, "info");
+        assert_eq!(config.format, LogFormat::Auto);
+    }
+
+    #[test]
+    fn health_defaults() {
+        let config = HealthConfig::default();
+        assert_eq!(config.path, "/health");
+    }
+
+    #[test]
+    fn top_level_default_populates_all_sections() {
+        let config = AutumnConfig::default();
+        assert_eq!(config.server.port, 3000);
+        assert_eq!(config.database.url, "postgres://localhost/autumn_dev");
+        assert_eq!(config.log.level, "info");
+        assert_eq!(config.health.path, "/health");
+    }
+
+    #[test]
+    fn deserialize_empty_object_uses_all_defaults() {
+        let config: AutumnConfig = serde_json::from_str("{}").expect("empty object should parse");
+        assert_eq!(config.server.port, 3000);
+        assert_eq!(config.server.host, "127.0.0.1");
+        assert_eq!(config.server.shutdown_timeout_secs, 30);
+        assert_eq!(config.database.url, "postgres://localhost/autumn_dev");
+        assert_eq!(config.database.pool_size, 10);
+        assert_eq!(config.database.connect_timeout_secs, 5);
+        assert_eq!(config.log.level, "info");
+        assert_eq!(config.log.format, LogFormat::Auto);
+        assert_eq!(config.health.path, "/health");
+    }
+
+    #[test]
+    fn deserialize_partial_config_merges_with_defaults() {
+        let json = r#"{"server": {"port": 8080}}"#;
+        let config: AutumnConfig = serde_json::from_str(json).expect("partial config should parse");
+        // Overridden
+        assert_eq!(config.server.port, 8080);
+        // Defaults preserved
+        assert_eq!(config.server.host, "127.0.0.1");
+        assert_eq!(config.database.pool_size, 10);
+        assert_eq!(config.log.level, "info");
+    }
+
+    #[test]
+    fn log_format_variants_deserialize() {
+        let auto: LogFormat = serde_json::from_str(r#""Auto""#).expect("Auto");
+        let pretty: LogFormat = serde_json::from_str(r#""Pretty""#).expect("Pretty");
+        let json: LogFormat = serde_json::from_str(r#""Json""#).expect("Json");
+        assert_eq!(auto, LogFormat::Auto);
+        assert_eq!(pretty, LogFormat::Pretty);
+        assert_eq!(json, LogFormat::Json);
+    }
+}

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -6,6 +6,7 @@
 //! into a Spring Boot-style developer experience with proc-macro-driven
 //! conventions and escape hatches at every level.
 
+pub mod config;
 pub mod route;
 
 // Re-export route macros so users can write `use autumn::get;`

--- a/docs/sprint-status.yaml
+++ b/docs/sprint-status.yaml
@@ -11,8 +11,8 @@ sprints:
     end_date: "2026-04-04"
     capacity_points: 12
     committed_points: 12
-    completed_points: 10
-    status: "in_progress"
+    completed_points: 12
+    status: "completed"
     goal: "Get the first annotated route handler compiling and responding to HTTP requests"
     stories:
       - story_id: "S-001"
@@ -30,8 +30,9 @@ sprints:
       - story_id: "S-025"
         title: "AutumnConfig struct with serde defaults"
         points: 2
-        status: "defined"
+        status: "completed"
         story_doc: "docs/stories/S-025.md"
+        completion_date: "2026-03-21"
 
 velocity:
   rolling_average: null


### PR DESCRIPTION
Define typed configuration structs (ServerConfig, DatabaseConfig, LogConfig, HealthConfig, LogFormat) with sensible defaults for zero-config startup. All fields use named serde default functions.

8 unit tests verify defaults, empty-object deserialization, partial config merging, and LogFormat variant parsing.

Sprint 1 complete: 12/12 points (S-001 + S-002 + S-025).