### PR TITLE
feat: Sprint 4 — error handling, macro diagnostics, request ID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 toml = "0.8"
+tower = "0.5"
 
 # Proc macro
 syn = { version = "2", features = ["full"] }

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -29,10 +29,24 @@ pub fn route_macro(
         return syn::Error::new(path.span(), "Route path must not be empty").to_compile_error();
     }
 
-    // Parse the annotated item — must be a function
-    let input_fn: ItemFn = match syn::parse2(item) {
+    // Validate path starts with '/'
+    if !path.value().starts_with('/') {
+        let suggested = format!("/{}", path.value());
+        return syn::Error::new(
+            path.span(),
+            format!("Route path must start with '/'. Did you mean \"{suggested}\"?"),
+        )
+        .to_compile_error();
+    }
+
+    // Parse the annotated item — must be a function.
+    // Clone before parsing so we can use the original tokens for error spans.
+    let input_fn: ItemFn = match syn::parse2(item.clone()) {
         Ok(f) => f,
-        Err(err) => return err.to_compile_error(),
+        Err(_) => {
+            return syn::Error::new_spanned(item, "route macros can only be applied to functions")
+                .to_compile_error();
+        }
     };
 
     // Validate: must be async
@@ -54,7 +68,7 @@ pub fn route_macro(
     // Note: we intentionally do NOT apply #[axum::debug_handler] here.
     // That macro generates code with `::axum::` paths, which don't resolve
     // when the user only depends on `autumn` (axum is a transitive dep).
-    // Better error diagnostics will come via custom compile_error! in S-007.
+    // Custom compile_error! diagnostics (S-007) provide error guidance instead.
 
     quote! {
         #input_fn

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -10,13 +10,16 @@ repository.workspace = true
 autumn-macros = { path = "../autumn-macros" }
 axum.workspace = true
 http.workspace = true
-tokio.workspace = true
+pin-project-lite = "0.2"
 serde.workspace = true
+serde_json = "1"
 thiserror.workspace = true
+tokio.workspace = true
 toml.workspace = true
+tower.workspace = true
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-serde_json = "1"
 tempfile = "3"
 tokio.workspace = true
 trybuild = "1"

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -20,6 +20,7 @@
 
 use crate::AppState;
 use crate::config::AutumnConfig;
+use crate::middleware::RequestIdLayer;
 use crate::route::Route;
 
 /// Create a new application builder.
@@ -89,7 +90,7 @@ impl AppBuilder {
             println!("  {} {} ({})", route.method, route.path, route.name);
             router = router.route(route.path, route.handler);
         }
-        let router = router.with_state(AppState);
+        let router = router.layer(RequestIdLayer).with_state(AppState);
 
         // 5. Bind and serve with graceful shutdown
         let addr = format!("{}:{}", config.server.host, config.server.port);

--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -1,0 +1,204 @@
+//! Framework error type and result alias.
+//!
+//! [`AutumnError`] wraps any `Error + Send + Sync` with an HTTP status code.
+//! The blanket [`From`] impl maps all errors to 500 Internal Server Error,
+//! so the `?` operator works in handlers with zero ceremony.
+//!
+//! For non-500 cases, use the status refinement methods:
+//! [`not_found()`](AutumnError::not_found),
+//! [`bad_request()`](AutumnError::bad_request),
+//! [`unprocessable()`](AutumnError::unprocessable), or
+//! [`with_status()`](AutumnError::with_status).
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+/// Framework error type wrapping any error with an HTTP status code.
+///
+/// # Usage
+///
+/// The `?` operator converts any `Error` into an `AutumnError` with status 500:
+/// ```ignore
+/// async fn handler() -> AutumnResult<&'static str> {
+///     might_fail()?; // becomes 500 on error
+///     Ok("ok")
+/// }
+/// ```
+///
+/// For expected errors, use status refinement:
+/// ```ignore
+/// async fn get_user(id: Path<i32>) -> AutumnResult<Json<User>> {
+///     let user = find_user(id.0)
+///         .map_err(AutumnError::not_found)?; // 404
+///     Ok(Json(user))
+/// }
+/// ```
+///
+/// # Why no `Error` impl
+///
+/// `AutumnError` intentionally does **not** implement [`std::error::Error`].
+/// Doing so would conflict with the blanket `From<E: Error>` impl (the
+/// reflexive `From<T> for T` would overlap). This type is a *response* type,
+/// not a propagatable error.
+pub struct AutumnError {
+    inner: Box<dyn std::error::Error + Send + Sync>,
+    status: StatusCode,
+}
+
+/// Convenience alias — the standard return type for Autumn handlers.
+pub type AutumnResult<T> = Result<T, AutumnError>;
+
+impl<E> From<E> for AutumnError
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn from(err: E) -> Self {
+        Self {
+            inner: Box::new(err),
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+impl AutumnError {
+    /// Override the HTTP status code.
+    #[must_use]
+    pub const fn with_status(mut self, status: StatusCode) -> Self {
+        self.status = status;
+        self
+    }
+
+    /// Create a 404 Not Found error.
+    pub fn not_found(err: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self {
+            inner: Box::new(err),
+            status: StatusCode::NOT_FOUND,
+        }
+    }
+
+    /// Create a 400 Bad Request error.
+    pub fn bad_request(err: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self {
+            inner: Box::new(err),
+            status: StatusCode::BAD_REQUEST,
+        }
+    }
+
+    /// Create a 422 Unprocessable Entity error.
+    pub fn unprocessable(err: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self {
+            inner: Box::new(err),
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+        }
+    }
+
+    /// Returns the HTTP status code.
+    #[must_use]
+    pub const fn status(&self) -> StatusCode {
+        self.status
+    }
+}
+
+impl std::fmt::Display for AutumnError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl std::fmt::Debug for AutumnError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AutumnError")
+            .field("status", &self.status)
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl IntoResponse for AutumnError {
+    fn into_response(self) -> Response {
+        let status = self.status;
+        let body = serde_json::json!({
+            "error": {
+                "status": status.as_u16(),
+                "message": self.inner.to_string(),
+            }
+        });
+
+        (status, axum::Json(body)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    #[derive(Debug)]
+    struct TestError(String);
+
+    impl std::fmt::Display for TestError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    impl std::error::Error for TestError {}
+
+    #[test]
+    fn blanket_from_defaults_to_500() {
+        let err: AutumnError = TestError("boom".into()).into();
+        assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn not_found_is_404() {
+        let err = AutumnError::not_found(TestError("missing".into()));
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn bad_request_is_400() {
+        let err = AutumnError::bad_request(TestError("invalid input".into()));
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn unprocessable_is_422() {
+        let err = AutumnError::unprocessable(TestError("bad entity".into()));
+        assert_eq!(err.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[test]
+    fn with_status_overrides() {
+        let err: AutumnError = TestError("forbidden".into()).into();
+        let err = err.with_status(StatusCode::FORBIDDEN);
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn display_uses_inner_message() {
+        let err: AutumnError = TestError("something broke".into()).into();
+        assert_eq!(err.to_string(), "something broke");
+    }
+
+    #[test]
+    fn into_response_has_correct_status() {
+        let err = AutumnError::not_found(TestError("not found".into()));
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn into_response_has_json_body() {
+        let err = AutumnError::not_found(TestError("not found".into()));
+        let response = err.into_response();
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["error"]["status"], 404);
+        assert_eq!(json["error"]["message"], "not found");
+    }
+}

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -8,10 +8,13 @@
 
 pub mod app;
 pub mod config;
+pub mod error;
 pub mod extract;
+pub mod middleware;
 pub mod route;
 
 pub use app::app;
+pub use error::{AutumnError, AutumnResult};
 
 // Re-export proc macros so users can write `use autumn::get;` or `#[autumn::main]`
 pub use autumn_macros::{delete, get, main, post, put, routes};

--- a/autumn/src/middleware/mod.rs
+++ b/autumn/src/middleware/mod.rs
@@ -1,0 +1,5 @@
+//! Built-in middleware for Autumn applications.
+
+pub mod request_id;
+
+pub use request_id::{RequestId, RequestIdLayer};

--- a/autumn/src/middleware/request_id.rs
+++ b/autumn/src/middleware/request_id.rs
@@ -1,0 +1,202 @@
+//! Request ID middleware — assigns a unique UUID to every request.
+//!
+//! Each request gets a [`RequestId`] that is:
+//! - Inserted into request extensions (accessible to handlers)
+//! - Added as an `X-Request-Id` response header
+
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use axum::http::{HeaderValue, Request, Response};
+use pin_project_lite::pin_project;
+use tower::{Layer, Service};
+use uuid::Uuid;
+
+/// A unique identifier assigned to each incoming HTTP request.
+///
+/// Wraps a [`Uuid`] v4 and is inserted into request extensions so handlers
+/// can access it via `Extension<RequestId>`.  It is also added to the
+/// response as an `X-Request-Id` header for correlation in logs and
+/// downstream services.
+#[derive(Clone, Debug)]
+pub struct RequestId(Uuid);
+
+impl RequestId {
+    /// Returns the underlying UUID value.
+    #[must_use]
+    pub const fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Tower [`Layer`] that wraps a service with [`RequestIdService`].
+///
+/// Add this layer to an Axum router to automatically assign a UUID
+/// to every request:
+///
+/// ```ignore
+/// use autumn::middleware::RequestIdLayer;
+///
+/// let app = axum::Router::new()
+///     .route("/", get(handler))
+///     .layer(RequestIdLayer);
+/// ```
+#[derive(Clone, Debug)]
+pub struct RequestIdLayer;
+
+impl<S> Layer<S> for RequestIdLayer {
+    type Service = RequestIdService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RequestIdService { inner }
+    }
+}
+
+/// Tower [`Service`] produced by [`RequestIdLayer`].
+///
+/// Generates a [`RequestId`] for each request, inserts it into request
+/// extensions, and adds it as an `X-Request-Id` response header.
+#[derive(Clone, Debug)]
+pub struct RequestIdService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for RequestIdService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = RequestIdFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        let id = RequestId(Uuid::new_v4());
+        req.extensions_mut().insert(id.clone());
+
+        RequestIdFuture {
+            inner: self.inner.call(req),
+            request_id: Some(id),
+        }
+    }
+}
+
+pin_project! {
+    /// Future that adds the `X-Request-Id` header to the response.
+    pub struct RequestIdFuture<F> {
+        #[pin]
+        inner: F,
+        request_id: Option<RequestId>,
+    }
+}
+
+impl<F, ResBody, E> Future for RequestIdFuture<F>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+{
+    type Output = Result<Response<ResBody>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.inner.poll(cx) {
+            Poll::Ready(Ok(mut response)) => {
+                if let Some(id) = this.request_id.take()
+                    && let Ok(value) = HeaderValue::from_str(&id.to_string())
+                {
+                    response.headers_mut().insert("x-request-id", value);
+                }
+                Poll::Ready(Ok(response))
+            }
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::extract::Extension;
+    use axum::routing::get;
+    use tower::ServiceExt; // for oneshot
+
+    #[tokio::test]
+    async fn response_has_request_id_header() {
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(RequestIdLayer);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert!(response.headers().contains_key("x-request-id"));
+        // Verify it's a valid UUID
+        let id_str = response.headers()["x-request-id"].to_str().unwrap();
+        assert!(Uuid::parse_str(id_str).is_ok());
+    }
+
+    #[tokio::test]
+    async fn each_request_gets_unique_id() {
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(RequestIdLayer);
+
+        let r1 = app
+            .clone()
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let r2 = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let id1 = r1.headers()["x-request-id"].to_str().unwrap();
+        let id2 = r2.headers()["x-request-id"].to_str().unwrap();
+        assert_ne!(id1, id2);
+    }
+
+    #[tokio::test]
+    async fn request_id_available_in_extensions() {
+        async fn handler(Extension(id): Extension<RequestId>) -> String {
+            id.to_string()
+        }
+
+        let app = Router::new().route("/", get(handler)).layer(RequestIdLayer);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        // The response body should contain a valid UUID
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(Uuid::parse_str(&body_str).is_ok());
+    }
+
+    #[test]
+    fn request_id_display() {
+        let id = RequestId(Uuid::nil());
+        assert_eq!(id.to_string(), "00000000-0000-0000-0000-000000000000");
+    }
+}

--- a/autumn/tests/compile-fail/missing_leading_slash.rs
+++ b/autumn/tests/compile-fail/missing_leading_slash.rs
@@ -1,0 +1,8 @@
+use autumn::get;
+
+#[get("hello")]
+async fn hello() -> &'static str {
+    "Hello!"
+}
+
+fn main() {}

--- a/autumn/tests/compile-fail/missing_leading_slash.stderr
+++ b/autumn/tests/compile-fail/missing_leading_slash.stderr
@@ -1,0 +1,5 @@
+error: Route path must start with '/'. Did you mean "/hello"?
+ --> tests/compile-fail/missing_leading_slash.rs:3:7
+  |
+3 | #[get("hello")]
+  |       ^^^^^^^

--- a/autumn/tests/compile-fail/non_function.stderr
+++ b/autumn/tests/compile-fail/non_function.stderr
@@ -1,5 +1,5 @@
-error: expected `fn`
+error: route macros can only be applied to functions
  --> tests/compile-fail/non_function.rs:4:1
   |
 4 | struct Hello;
-  | ^^^^^^
+  | ^^^^^^^^^^^^^

--- a/autumn/tests/compile-pass/valid_handlers.rs
+++ b/autumn/tests/compile-pass/valid_handlers.rs
@@ -1,0 +1,27 @@
+use autumn::extract::Path;
+use autumn::{delete, get, post, put};
+
+#[get("/hello")]
+async fn hello() -> &'static str {
+    "hello"
+}
+
+#[post("/items")]
+async fn create() -> &'static str {
+    "created"
+}
+
+#[put("/items/{id}")]
+async fn update(_id: Path<i32>) -> &'static str {
+    "updated"
+}
+
+#[delete("/items/{id}")]
+async fn remove(_id: Path<i32>) -> &'static str {
+    "removed"
+}
+
+#[get("/no-return")]
+async fn no_return() {}
+
+fn main() {}

--- a/docs/sprint-status.yaml
+++ b/docs/sprint-status.yaml
@@ -1,7 +1,7 @@
 version: "6.0.0"
 project_name: "autumn"
 project_level: 4
-current_sprint: 3
+current_sprint: 4
 sprint_plan_path: "docs/sprint-plan-autumn-2026-03-20.md"
 last_updated: "2026-03-21"
 
@@ -102,10 +102,39 @@ sprints:
         story_doc: "docs/stories/S-010.md"
         completion_date: "2026-03-21"
 
+  - sprint_number: 4
+    start_date: "2026-05-05"
+    end_date: "2026-05-16"
+    capacity_points: 12
+    committed_points: 13
+    completed_points: 13
+    status: "completed"
+    goal: "Error handling and request infrastructure — ? works in handlers, every request gets an ID"
+    stories:
+      - story_id: "S-007"
+        title: "Proc macro compile_error! diagnostics"
+        points: 5
+        status: "completed"
+        story_doc: "docs/stories/S-007.md"
+        completion_date: "2026-03-21"
+      - story_id: "S-012"
+        title: "AutumnError type + blanket From<E: Error>"
+        points: 5
+        status: "completed"
+        story_doc: "docs/stories/S-012.md"
+        completion_date: "2026-03-21"
+      - story_id: "S-011"
+        title: "Request ID middleware"
+        points: 3
+        status: "completed"
+        story_doc: "docs/stories/S-011.md"
+        completion_date: "2026-03-21"
+
 velocity:
   sprint_1: 12
   sprint_2: 13
   sprint_3: 13
+  sprint_4: 13
   rolling_average: 13
 
 team:

--- a/docs/stories/S-007.md
+++ b/docs/stories/S-007.md
@@ -1,0 +1,261 @@
+# S-007: Proc macro compile_error! diagnostics
+
+**Epic:** EPIC-002 (Route System)
+**Priority:** Must Have
+**Story Points:** 5
+**Status:** Not Started
+**Assigned To:** markm
+**Created:** 2026-03-21
+**Sprint:** 4
+
+---
+
+## User Story
+
+As a **framework user**
+I want to **see clear, actionable error messages when I misuse route macros**
+So that **I can fix mistakes quickly without deciphering cryptic trait bound errors**
+
+---
+
+## Description
+
+### Background
+
+With `debug_handler` removed (it emits `::axum::` paths that don't resolve when the user only depends on `autumn`), this story becomes the **primary mechanism for good error messages**. The goal is to catch common mistakes at macro expansion time and produce `compile_error!` messages that point directly at the user's code, using `syn::Error::new_spanned()`.
+
+The existing `route_macro()` in `autumn-macros/src/route.rs` already validates:
+- Empty path strings → `"Route path must not be empty"`
+- Non-async functions → `"Autumn route handlers must be async functions"`
+
+This story extends validation to catch more mistakes before they turn into incomprehensible trait bound errors from Axum.
+
+### Scope
+
+**In scope:**
+- Missing return type produces a clear warning or error
+- Non-function items (e.g., `#[get("/")]` on a struct) produce `"route macros can only be applied to functions"` instead of a generic parse error
+- Path must start with `/` — `#[get("hello")]` → `"Route path must start with '/'. Did you mean \"/hello\"?"`
+- Non-`pub` handler produces a warning-level diagnostic (or doc comment noting it may not be collected by `routes![]`)
+- All diagnostics use `syn::Error::new_spanned()` to point at the offending code span
+- Compile-fail tests via `trybuild` for each new diagnostic
+
+**Out of scope:**
+- Duplicate path detection across handlers (requires global state, not feasible in proc macros)
+- Type-checking handler parameters or return types (Axum handles this)
+- Async trait bound validation (too complex for v0.1)
+
+### Why This Matters
+
+Without `debug_handler`, a handler missing `impl IntoResponse` for its return type produces errors like:
+```
+the trait bound `MyType: IntoResponse` is not satisfied
+```
+...with 50 lines of trait bound suggestions. We can't fix that (it's a rustc/Axum thing), but we **can** catch the mistakes that happen *before* that point — wrong item types, bad paths, missing `async`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `#[get("/path")]` on a non-function item (struct, enum, impl block) produces: `"route macros can only be applied to functions"`
+- [ ] `#[get("no-leading-slash")]` produces: `"Route path must start with '/'. Did you mean \"/no-leading-slash\"?"`
+- [ ] `#[get("/path")] fn sync_handler()` continues to produce: `"Autumn route handlers must be async functions"`
+- [ ] `#[get("/path")] async fn handler()` (no return type) compiles with a note via doc comment that `()` is the implicit return
+- [ ] All error messages use `new_spanned()` to point at the relevant code span
+- [ ] `trybuild` compile-fail tests exist for each error case
+- [ ] `trybuild` compile-pass tests verify valid handlers still work
+- [ ] Existing tests continue to pass (no regressions)
+
+---
+
+## Technical Notes
+
+### Implementation in `route_macro()`
+
+All changes go in `autumn-macros/src/route.rs`, extending the existing `route_macro()` function:
+
+```rust
+pub fn route_macro(
+    http_method: &str,
+    axum_fn: &str,
+    attr: TokenStream,
+    item: TokenStream,
+) -> TokenStream {
+    // ── Existing: parse path ──
+    let path: LitStr = match syn::parse2(attr) {
+        Ok(path) => path,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    // ── Existing: empty path check ──
+    if path.value().is_empty() {
+        return syn::Error::new(path.span(), "Route path must not be empty")
+            .to_compile_error();
+    }
+
+    // ── NEW: path must start with '/' ──
+    if !path.value().starts_with('/') {
+        let suggestion = format!("/{}", path.value());
+        return syn::Error::new(
+            path.span(),
+            format!(
+                "Route path must start with '/'. Did you mean \"{}\"?",
+                suggestion
+            ),
+        )
+        .to_compile_error();
+    }
+
+    // ── Existing: parse as function (IMPROVED error message) ──
+    let input_fn: ItemFn = match syn::parse2(item.clone()) {
+        Ok(f) => f,
+        Err(_) => {
+            // Try to give a better error for non-function items
+            return syn::Error::new_spanned(
+                item,
+                "route macros can only be applied to functions",
+            )
+            .to_compile_error();
+        }
+    };
+
+    // ── Existing: async check ──
+    if input_fn.sig.asyncness.is_none() {
+        return syn::Error::new_spanned(
+            input_fn.sig.fn_token,
+            "Autumn route handlers must be async functions",
+        )
+        .to_compile_error();
+    }
+
+    // ... rest of code generation unchanged
+}
+```
+
+### trybuild Test Structure
+
+Add `trybuild` as a dev-dependency to `autumn-macros`:
+
+```toml
+[dev-dependencies]
+trybuild = "2"
+```
+
+Test directory structure:
+```
+autumn-macros/
+├── tests/
+│   ├── compile_tests.rs          # trybuild test runner
+│   └── compile-fail/
+│       ├── non_function.rs       # #[get("/")] on a struct
+│       ├── non_function.stderr   # expected error
+│       ├── missing_slash.rs      # #[get("hello")]
+│       ├── missing_slash.stderr
+│       ├── sync_handler.rs       # fn not async fn
+│       ├── sync_handler.stderr
+│       └── empty_path.rs         # #[get("")]
+│       └── empty_path.stderr
+│   └── compile-pass/
+│       ├── basic_handler.rs      # valid #[get("/hello")]
+│       └── path_params.rs        # valid #[get("/users/{id}")]
+```
+
+Test runner:
+```rust
+// autumn-macros/tests/compile_tests.rs
+#[test]
+fn compile_fail_tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail/*.rs");
+    t.pass("tests/compile-pass/*.rs");
+}
+```
+
+### Diagnostics Quality
+
+Use `new_spanned()` everywhere so errors point at user code:
+
+```
+error: Autumn route handlers must be async functions
+ --> src/main.rs:3:1
+  |
+3 | fn hello() -> &'static str {
+  | ^^
+```
+
+Not:
+```
+error: Autumn route handlers must be async functions
+  --> autumn-macros/src/route.rs:42:9
+```
+
+### Dependencies on `trybuild`
+
+`trybuild` tests need the full `autumn` crate available to resolve `::autumn::` paths. The compile-fail test files should `use autumn::get;` (or whichever macro). This means the tests may need to live in the `autumn` crate's test directory rather than `autumn-macros`, or `autumn-macros` needs `autumn` as a dev-dependency.
+
+**Recommended approach:** Place `trybuild` tests in `autumn/tests/` since the macros re-export through `autumn` and the generated code references `::autumn::` paths. This matches how users actually use the macros.
+
+```
+autumn/
+├── tests/
+│   ├── compile_tests.rs
+│   └── compile-fail/
+│   └── compile-pass/
+```
+
+---
+
+## Dependencies
+
+**Prerequisite Stories:** S-002 (done — provides `route_macro()` to extend)
+
+**Blocks:** None directly (this is polish, not a dependency for other stories)
+
+---
+
+## Definition of Done
+
+- [ ] Path-must-start-with-slash validation added
+- [ ] Non-function item produces clear error message
+- [ ] All diagnostics use `new_spanned()` for correct spans
+- [ ] `trybuild` compile-fail tests for each error case
+- [ ] `trybuild` compile-pass tests for valid handlers
+- [ ] Existing tests pass (no regressions)
+- [ ] `cargo fmt --check` clean
+- [ ] `cargo clippy` zero warnings
+- [ ] Doc comments updated on `route_macro()` listing all validations
+
+---
+
+## Story Points Breakdown
+
+- **Path validation (leading slash):** 0.5 pts
+- **Non-function item error:** 0.5 pts
+- **Improve existing error spans:** 0.5 pts
+- **trybuild setup and compile-fail tests:** 2 pts
+- **trybuild compile-pass tests:** 1 pt
+- **Edge cases and regression testing:** 0.5 pts
+- **Total:** 5 pts
+
+**Rationale:** The validation logic itself is simple (`syn::Error::new_spanned()`), but `trybuild` test setup and getting the crate dependency graph right for compile-fail tests is the bulk of the work. Each test file needs careful `.stderr` snapshots.
+
+---
+
+## Additional Notes
+
+- This story replaces `debug_handler` as the primary DX improvement mechanism. See the comment in `route.rs` line 54-57: *"Better error diagnostics will come via custom compile_error! in S-007."*
+- `trybuild` tests are snapshot-based — the `.stderr` files must match compiler output exactly. Run `TRYBUILD=overwrite cargo test` to regenerate snapshots when the compiler version changes.
+- Future work: S-012 (AutumnError) may warrant additional diagnostics for handler return types, but that's post-Sprint 4.
+
+---
+
+## Progress Tracking
+
+**Status History:**
+- 2026-03-21: Created by Scrum Master
+
+**Actual Effort:** TBD
+
+---
+
+**This story was created using BMAD Method v6 - Phase 4 (Implementation Planning)**

--- a/docs/stories/S-011.md
+++ b/docs/stories/S-011.md
@@ -1,0 +1,337 @@
+# S-011: Request ID middleware
+
+**Epic:** EPIC-003 (Application Bootstrap)
+**Priority:** Must Have
+**Story Points:** 3
+**Status:** Not Started
+**Assigned To:** markm
+**Created:** 2026-03-21
+**Sprint:** 4
+
+---
+
+## User Story
+
+As a **framework user**
+I want to **have every request automatically tagged with a unique ID**
+So that **I can trace requests through logs, pass IDs to downstream services, and debug production issues**
+
+---
+
+## Description
+
+### Background
+
+Request IDs are table-stakes infrastructure for any production web framework. Every request gets a UUID, which is:
+1. Added as an `X-Request-Id` response header (so clients/load balancers can correlate)
+2. Inserted into request extensions (so handlers and other middleware can access it)
+
+This is Autumn's first custom middleware and establishes the pattern for future middleware (structured logging, auth, etc.). It's implemented as a Tower `Layer` + `Service`, wired into `AppBuilder::run()`.
+
+### Scope
+
+**In scope:**
+- `RequestId` newtype wrapping `uuid::Uuid`
+- `RequestIdLayer` implementing Tower `Layer`
+- `RequestIdService<S>` implementing Tower `Service`
+- Generate UUID v4 per request
+- Add `X-Request-Id` response header
+- Insert `RequestId` into request extensions (accessible via `req.extensions().get::<RequestId>()`)
+- Wire into `AppBuilder::run()` as a default layer
+- Add `uuid` crate dependency
+- Unit tests for the middleware
+
+**Out of scope:**
+- Accepting incoming `X-Request-Id` headers (forwarding from load balancers — v1.0)
+- `tracing` span integration (S-028)
+- Configurable header name
+- Handler extractor for `RequestId` (could be added later, but `Extension<RequestId>` works via Axum)
+
+---
+
+## Acceptance Criteria
+
+- [ ] Every HTTP response includes an `X-Request-Id` header with a UUID v4 value
+- [ ] Each request gets a unique ID (no collisions in basic testing)
+- [ ] The `RequestId` is available in request extensions for downstream middleware/handlers
+- [ ] `RequestIdLayer` is applied by default in `AppBuilder::run()`
+- [ ] A handler can access the request ID via `Extension<RequestId>` (Axum's built-in extractor)
+- [ ] `uuid` crate is added as a dependency to `autumn`
+- [ ] Unit tests verify: header presence, unique IDs per request, extension availability
+- [ ] `RequestId` implements `Clone`, `Debug`, `Display`
+
+---
+
+## Technical Notes
+
+### Module Structure
+
+```
+autumn/src/
+├── middleware/
+│   ├── mod.rs              ← pub mod request_id;
+│   └── request_id.rs       ← NEW
+├── app.rs                  ← modified (add layer)
+├── lib.rs                  ← add pub mod middleware;
+```
+
+### `autumn/src/middleware/request_id.rs`
+
+```rust
+use axum::http::{Request, Response, HeaderValue};
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+use uuid::Uuid;
+
+/// A unique identifier assigned to each HTTP request.
+#[derive(Clone, Debug)]
+pub struct RequestId(Uuid);
+
+impl RequestId {
+    /// Returns the UUID value.
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+}
+
+impl std::fmt::Display for RequestId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Tower Layer that assigns a unique ID to each request.
+#[derive(Clone)]
+pub struct RequestIdLayer;
+
+impl<S> Layer<S> for RequestIdLayer {
+    type Service = RequestIdService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RequestIdService { inner }
+    }
+}
+
+/// Tower Service that generates a UUID and attaches it to
+/// the request extensions and response headers.
+#[derive(Clone)]
+pub struct RequestIdService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for RequestIdService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = /* ... */;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        let id = RequestId(Uuid::new_v4());
+
+        // Insert into request extensions (accessible to handlers)
+        req.extensions_mut().insert(id.clone());
+
+        // Call inner service, then add response header
+        // (implementation will use pin_project or a custom future
+        //  to add the X-Request-Id header to the response)
+    }
+}
+```
+
+### Future Implementation
+
+The `Service::call` method needs to wrap the inner future to add the response header. Two approaches:
+
+1. **`pin_project_lite`** — define a custom future that wraps `S::Future` and adds the header on completion
+2. **`tower_http::set_header`** — use existing Tower middleware for the response header, and a simpler custom service just for extension insertion
+
+**Recommended:** Option 1 (custom future) keeps it self-contained and educational. The pattern is standard Tower middleware:
+
+```rust
+use pin_project_lite::pin_project;
+
+pin_project! {
+    pub struct RequestIdFuture<F> {
+        #[pin]
+        inner: F,
+        request_id: Option<RequestId>,
+    }
+}
+
+impl<F, ResBody, E> Future for RequestIdFuture<F>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+{
+    type Output = Result<Response<ResBody>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.inner.poll(cx) {
+            Poll::Ready(Ok(mut response)) => {
+                if let Some(id) = this.request_id.take() {
+                    response.headers_mut().insert(
+                        "x-request-id",
+                        HeaderValue::from_str(&id.to_string())
+                            .unwrap_or_else(|_| HeaderValue::from_static("invalid")),
+                    );
+                }
+                Poll::Ready(Ok(response))
+            }
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+```
+
+### Wiring into AppBuilder
+
+In `autumn/src/app.rs`, add the layer before serving:
+
+```rust
+// In AppBuilder::run():
+let router = router
+    .layer(RequestIdLayer)
+    .with_state(AppState);
+```
+
+Layer ordering: `RequestIdLayer` should be one of the outermost layers so the ID is available to all inner middleware.
+
+### Dependencies
+
+Add to `autumn/Cargo.toml`:
+```toml
+[dependencies]
+uuid = { version = "1", features = ["v4"] }
+pin-project-lite = "0.2"
+```
+
+### Testing Strategy
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{routing::get, Router};
+    use axum::http::StatusCode;
+    use tower::ServiceExt; // for oneshot
+
+    #[tokio::test]
+    async fn response_has_request_id_header() {
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(RequestIdLayer);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert!(response.headers().contains_key("x-request-id"));
+    }
+
+    #[tokio::test]
+    async fn each_request_gets_unique_id() {
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(RequestIdLayer);
+
+        let r1 = app.clone()
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await.unwrap();
+        let r2 = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await.unwrap();
+
+        let id1 = r1.headers().get("x-request-id").unwrap();
+        let id2 = r2.headers().get("x-request-id").unwrap();
+        assert_ne!(id1, id2);
+    }
+
+    #[tokio::test]
+    async fn request_id_in_extensions() {
+        async fn handler(Extension(id): Extension<RequestId>) -> String {
+            id.to_string()
+        }
+
+        let app = Router::new()
+            .route("/", get(handler))
+            .layer(RequestIdLayer);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        // Body contains the UUID string
+    }
+}
+```
+
+---
+
+## Dependencies
+
+**Prerequisite Stories:** S-009 (done — provides `AppBuilder::run()` to wire the layer into)
+
+**Blocks:** None directly
+
+**Related:** S-028 (structured logging) will use `RequestId` in `tracing` spans
+
+---
+
+## Definition of Done
+
+- [ ] `RequestId` newtype in `autumn/src/middleware/request_id.rs`
+- [ ] `RequestIdLayer` + `RequestIdService` implementing Tower Layer/Service
+- [ ] UUID v4 generated per request
+- [ ] `X-Request-Id` response header on every response
+- [ ] `RequestId` inserted into request extensions
+- [ ] Wired into `AppBuilder::run()` as a default layer
+- [ ] `RequestId` re-exported from `autumn::middleware::request_id` (and optionally crate root)
+- [ ] Tests: header presence, unique IDs, extension accessibility
+- [ ] `cargo fmt --check` clean
+- [ ] `cargo clippy` zero warnings
+- [ ] Doc comments on all public items
+- [ ] No `unwrap()` in library code (use `expect()` with context)
+
+---
+
+## Story Points Breakdown
+
+- **RequestId type + Display/Debug:** 0.5 pts
+- **Tower Layer + Service impl:** 1 pt
+- **Custom future (pin_project_lite):** 0.5 pts
+- **Wire into AppBuilder:** 0.25 pts
+- **Tests:** 0.75 pts
+- **Total:** 3 pts
+
+**Rationale:** Tower middleware is a well-documented pattern, and the logic is simple (generate UUID, add header, insert extension). The custom future for response header modification is the only tricky part. Tests can use `oneshot` for easy in-process testing.
+
+---
+
+## Additional Notes
+
+- This is Autumn's first middleware and establishes the `middleware/` module structure. Future middleware (auth, CORS, logging) will follow the same pattern.
+- `pin-project-lite` is preferred over `pin-project` for the lighter dependency footprint. It's already widely used in the async ecosystem.
+- The `X-Request-Id` header name follows the de facto standard used by Heroku, Rails, and most cloud providers.
+- Future enhancement: accept incoming `X-Request-Id` from load balancers/proxies instead of always generating a new one. This is common in production but not needed for v0.1.
+
+---
+
+## Progress Tracking
+
+**Status History:**
+- 2026-03-21: Created by Scrum Master
+
+**Actual Effort:** TBD
+
+---
+
+**This story was created using BMAD Method v6 - Phase 4 (Implementation Planning)**

--- a/docs/stories/S-012.md
+++ b/docs/stories/S-012.md
@@ -1,0 +1,350 @@
+# S-012: AutumnError type + blanket From<E: Error>
+
+**Epic:** EPIC-005 (Error Handling)
+**Priority:** Must Have
+**Story Points:** 5
+**Status:** Not Started
+**Assigned To:** markm
+**Created:** 2026-03-21
+**Sprint:** 4
+
+---
+
+## User Story
+
+As a **framework user**
+I want to **use `?` in my handlers to propagate any error, with sensible defaults**
+So that **I don't have to write custom error enums or manual `map_err()` for every fallible operation**
+
+---
+
+## Description
+
+### Background
+
+Error handling is the second riskiest design piece in Autumn (after proc macros). The key architectural decision (TD-003) is: blanket `From<E: Error>` that always maps to 500, with explicit methods for non-500 status codes. This works on stable Rust without specialization.
+
+This story creates the foundation — `AutumnError`, `AutumnResult<T>`, the blanket `From`, and `IntoResponse`. Status code refinement methods (`not_found()`, `bad_request()`, etc.) are included here rather than split into a separate story, since they're simple constructors that complete the type's API.
+
+### The Design
+
+```rust
+// The ? operator "just works" — any Error becomes a 500
+async fn list(db: Db) -> AutumnResult<Json<Vec<User>>> {
+    let users = users::table.load(&mut *db).await?; // 500 on failure
+    Ok(Json(users))
+}
+
+// Explicit status for expected errors
+async fn get(id: Path<i32>, db: Db) -> AutumnResult<Json<User>> {
+    let user = users::table.find(id.0).first(&mut *db).await
+        .map_err(AutumnError::not_found)?; // 404 on missing
+    Ok(Json(user))
+}
+```
+
+### Scope
+
+**In scope:**
+- `AutumnError` struct with `inner: Box<dyn Error + Send + Sync>` and `status: StatusCode`
+- `AutumnResult<T> = Result<T, AutumnError>`
+- Blanket `impl<E: Error + Send + Sync + 'static> From<E> for AutumnError` (always 500)
+- `IntoResponse` impl: JSON error body `{"error": {"status": N, "message": "..."}}`
+- Status refinement methods: `with_status()`, `not_found()`, `bad_request()`, `unprocessable()`
+- `Display` and `Debug` impls
+- Re-export from `autumn` crate root
+- Unit tests for all conversions and response rendering
+- New file: `autumn/src/error.rs`
+
+**Out of scope:**
+- HTML error pages (v1.0 feature, FR-045)
+- Structured logging of errors with `tracing` (S-028)
+- Integration with `Db` extractor rejection (S-017)
+- Custom error enums / `thiserror` integration guide (docs)
+
+### v0.1 Simplification
+
+All errors render as JSON. This is acceptable because:
+- JSON errors are universally parseable (browsers, API clients, htmx)
+- HTML error pages require template infrastructure not yet built
+- v0.1 is pre-production — JSON errors are fine for development
+
+---
+
+## Acceptance Criteria
+
+- [ ] `AutumnError` struct exists in `autumn/src/error.rs`
+- [ ] `AutumnResult<T>` type alias exists and is re-exported from crate root
+- [ ] `?` on any `E: Error + Send + Sync + 'static` produces an `AutumnError` with status 500
+- [ ] `AutumnError::not_found(err)` produces status 404
+- [ ] `AutumnError::bad_request(err)` produces status 400
+- [ ] `AutumnError::unprocessable(err)` produces status 422
+- [ ] `AutumnError::with_status(status)` overrides the status code
+- [ ] `IntoResponse` impl returns JSON: `{"error": {"status": 500, "message": "..."}}`
+- [ ] Error message in response uses `Display` of inner error (not `Debug`)
+- [ ] `AutumnError` implements `Display` and `Debug`
+- [ ] Unit tests cover: blanket From, each status method, IntoResponse JSON body, status code in response
+- [ ] `AutumnError` and `AutumnResult` are re-exported from `autumn` crate root
+
+---
+
+## Technical Notes
+
+### `autumn/src/error.rs`
+
+```rust
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+/// Framework error type. Wraps any `Error` with an HTTP status code.
+///
+/// # Usage
+/// ```
+/// use autumn::{AutumnResult, AutumnError};
+///
+/// async fn handler() -> AutumnResult<&'static str> {
+///     // ? on any Error → 500
+///     let data = might_fail()?;
+///     Ok("ok")
+/// }
+/// ```
+pub struct AutumnError {
+    inner: Box<dyn std::error::Error + Send + Sync>,
+    status: StatusCode,
+}
+
+/// Convenience alias. Every Autumn handler returns this.
+pub type AutumnResult<T> = Result<T, AutumnError>;
+
+// ── Blanket conversion: ? works on any Error ─────────────────
+
+impl<E> From<E> for AutumnError
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn from(err: E) -> Self {
+        AutumnError {
+            inner: Box::new(err),
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+// ── Status code refinement ───────────────────────────────────
+
+impl AutumnError {
+    /// Override the HTTP status code for this error.
+    pub fn with_status(mut self, status: StatusCode) -> Self {
+        self.status = status;
+        self
+    }
+
+    /// Create a 404 Not Found error.
+    pub fn not_found(err: impl std::error::Error + Send + Sync + 'static) -> Self {
+        AutumnError {
+            inner: Box::new(err),
+            status: StatusCode::NOT_FOUND,
+        }
+    }
+
+    /// Create a 400 Bad Request error.
+    pub fn bad_request(err: impl std::error::Error + Send + Sync + 'static) -> Self {
+        AutumnError {
+            inner: Box::new(err),
+            status: StatusCode::BAD_REQUEST,
+        }
+    }
+
+    /// Create a 422 Unprocessable Entity error.
+    pub fn unprocessable(err: impl std::error::Error + Send + Sync + 'static) -> Self {
+        AutumnError {
+            inner: Box::new(err),
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+        }
+    }
+
+    /// Returns the HTTP status code.
+    pub fn status(&self) -> StatusCode {
+        self.status
+    }
+}
+
+// ── Display + Debug ──────────────────────────────────────────
+
+impl std::fmt::Display for AutumnError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl std::fmt::Debug for AutumnError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AutumnError")
+            .field("status", &self.status)
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+// ── HTTP response rendering ──────────────────────────────────
+
+impl IntoResponse for AutumnError {
+    fn into_response(self) -> Response {
+        let status = self.status;
+        let body = serde_json::json!({
+            "error": {
+                "status": status.as_u16(),
+                "message": self.inner.to_string(),
+            }
+        });
+
+        (status, axum::Json(body)).into_response()
+    }
+}
+```
+
+### Blanket From Gotcha
+
+The blanket `From<E: Error>` means `AutumnError` **cannot** implement `std::error::Error` itself — that would create a conflicting impl (`From<AutumnError> for AutumnError` via the blanket vs the reflexive `From<T> for T`). This is a known trade-off (documented in TD-003).
+
+`AutumnError` implements `Display` and `Debug` but NOT `Error`. This is fine — it's a response type, not an error type that gets propagated further.
+
+### Dependencies
+
+The `IntoResponse` impl needs `serde_json` for the JSON body. Check if it's already a dependency via `axum`'s re-exports, or add it:
+
+```toml
+[dependencies]
+serde_json = "1"
+```
+
+Axum's `Json` extractor already depends on `serde_json`, but we need it directly for `serde_json::json!()`.
+
+### Module Wiring
+
+In `autumn/src/lib.rs`:
+```rust
+pub mod error;
+pub use error::{AutumnError, AutumnResult};
+```
+
+### Testing Strategy
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    // Use a concrete error type for testing
+    #[derive(Debug)]
+    struct TestError(String);
+    impl std::fmt::Display for TestError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+    impl std::error::Error for TestError {}
+
+    #[test]
+    fn blanket_from_defaults_to_500() {
+        let err: AutumnError = TestError("boom".into()).into();
+        assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn not_found_is_404() {
+        let err = AutumnError::not_found(TestError("missing".into()));
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn with_status_overrides() {
+        let err: AutumnError = TestError("nope".into()).into();
+        let err = err.with_status(StatusCode::FORBIDDEN);
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn display_uses_inner_message() {
+        let err: AutumnError = TestError("something broke".into()).into();
+        assert_eq!(err.to_string(), "something broke");
+    }
+
+    #[test]
+    fn into_response_is_json_with_correct_status() {
+        let err = AutumnError::not_found(TestError("user 42".into()));
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        // Body contains JSON with status and message
+    }
+}
+```
+
+---
+
+## Dependencies
+
+**Prerequisite Stories:** S-001 (done — crate structure exists)
+
+**Blocks:**
+- S-013: Status code refinement methods (included in this story)
+- S-014: IntoResponse impl for AutumnError (included in this story)
+- S-015: AutumnResult<T> type alias (included in this story)
+- S-016: Database pool (uses AutumnError for rejection)
+- S-017: Db extractor (returns AutumnError on pool failure)
+
+**Note:** S-013, S-014, and S-015 from the sprint plan are effectively subsumed by this story. They were split for estimation granularity, but the implementation is cohesive — splitting `AutumnError` across 4 PRs would create churn. Sprint 5 can re-scope if needed.
+
+---
+
+## Definition of Done
+
+- [ ] `AutumnError` struct in `autumn/src/error.rs`
+- [ ] `AutumnResult<T>` type alias
+- [ ] Blanket `From<E: Error>` impl
+- [ ] `not_found()`, `bad_request()`, `unprocessable()`, `with_status()` methods
+- [ ] `IntoResponse` impl with JSON body
+- [ ] `Display` and `Debug` impls
+- [ ] Re-exported from `autumn` crate root
+- [ ] Unit tests for all conversions and response rendering
+- [ ] `cargo fmt --check` clean
+- [ ] `cargo clippy` zero warnings
+- [ ] Doc comments on all public items
+- [ ] No `unwrap()` in library code
+
+---
+
+## Story Points Breakdown
+
+- **AutumnError struct + AutumnResult alias:** 0.5 pts
+- **Blanket From impl + testing the gotcha:** 1 pt
+- **Status refinement methods:** 0.5 pts
+- **IntoResponse impl (JSON body):** 1 pt
+- **Display + Debug impls:** 0.5 pts
+- **Unit tests (conversions, response body, status codes):** 1.5 pts
+- **Total:** 5 pts
+
+**Rationale:** The type design is straightforward (already specified in the architecture doc), but the blanket `From` gotcha (can't impl `Error` for `AutumnError`) needs careful testing to confirm it works on stable Rust. The `IntoResponse` impl needs JSON serialization and response body verification in tests.
+
+---
+
+## Additional Notes
+
+- The blanket `From` approach is documented as TD-003 in the architecture doc. It's the second riskiest design decision after the proc macro strategy.
+- Advanced users can still use `thiserror` enums — they implement `Error`, so the blanket `From` picks them up automatically.
+- The JSON error format `{"error": {"status": N, "message": "..."}}` is a v0.1 convention. It may evolve (add `code`, `details` fields) but the structure should remain stable.
+- `tracing::error!()` logging of errors is deferred to S-028 (structured logging). For now, errors are only rendered in the response.
+
+---
+
+## Progress Tracking
+
+**Status History:**
+- 2026-03-21: Created by Scrum Master
+
+**Actual Effort:** TBD
+
+---
+
+**This story was created using BMAD Method v6 - Phase 4 (Implementation Planning)**


### PR DESCRIPTION
## Summary

- **S-007** (5 pts): Proc macro `compile_error!` diagnostics — leading-slash validation, improved non-function error messages, trybuild compile-fail/pass tests
- **S-012** (5 pts): `AutumnError` + blanket `From<E: Error>` — error type with JSON `IntoResponse`, status refinement methods (`not_found`, `bad_request`, `unprocessable`, `with_status`), `AutumnResult<T>` alias
- **S-011** (3 pts): Request ID middleware — Tower `Layer`/`Service` generating UUID v4 per request, `X-Request-Id` response header, request extensions, wired into `AppBuilder::run()`

Sprint 4 total: 13/12 pts committed, 13 completed. Rolling velocity: 13 pts/sprint.

## Test plan

- [x] `cargo test --workspace` — 54 tests passing
- [x] `cargo clippy --workspace` — zero warnings
- [x] `cargo fmt --all --check` — clean
- [x] trybuild compile-fail tests verify diagnostic messages
- [x] trybuild compile-pass tests verify valid handlers still work
- [x] `AutumnError` unit tests cover all conversions, status codes, and JSON response body
- [x] Request ID middleware tests verify header presence, uniqueness, and extension availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)