### PR TITLE
feat: Sprints 5+6 — database layer, model macro, extractors, Maud

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ repository = "https://github.com/markm/autumn"
 [workspace.dependencies]
 # Runtime
 axum = { version = "0.8", features = ["macros"] }
+diesel = { version = "2", features = ["sqlite"] }
+diesel-async = { version = "0.8", features = ["deadpool", "postgres"] }
 http = "1"
+libsqlite3-sys = { version = "0.36", features = ["bundled"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ libsqlite3-sys = { version = "0.36", features = ["bundled"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
+maud = { version = "0.27", features = ["axum"] }
 toml = "0.8"
 tower = "0.5"
 

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -6,12 +6,13 @@
 //! - Route annotation macros (`#[get]`, `#[post]`, etc.)
 //! - The `routes![]` collection macro
 //! - The `#[autumn::main]` entry point macro (S-008)
-//! - The `#[derive(Model)]` convenience macro (S-018)
+//! - The `#[model]` attribute macro (S-018)
 //!
 //! Users should not depend on this crate directly — use `autumn` instead,
 //! which re-exports everything.
 
 mod main_macro;
+mod model;
 mod route;
 mod routes_macro;
 
@@ -152,4 +153,42 @@ pub fn routes(input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     main_macro::main_macro(item.into()).into()
+}
+
+/// Attribute macro for Autumn database models.
+///
+/// Applies Diesel (`Queryable`, `Selectable`, `Insertable`) and Serde
+/// (`Serialize`, `Deserialize`) derives, plus a `#[diesel(table_name)]`
+/// attribute. The table name can be specified explicitly or inferred
+/// from the struct name by converting `PascalCase` to `snake_case`
+/// and appending `s`.
+///
+/// # Examples
+///
+/// Explicit table name:
+///
+/// ```ignore
+/// use autumn::model;
+///
+/// #[model(table = "users")]
+/// pub struct User {
+///     pub id: i32,
+///     pub name: String,
+/// }
+/// ```
+///
+/// Inferred table name (`BlogPost` -> `blog_posts`):
+///
+/// ```ignore
+/// use autumn::model;
+///
+/// #[model]
+/// pub struct BlogPost {
+///     pub id: i32,
+///     pub title: String,
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn model(attr: TokenStream, item: TokenStream) -> TokenStream {
+    model::model_macro(attr.into(), item.into()).into()
 }

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -1,0 +1,125 @@
+//! `#[model]` attribute macro implementation.
+//!
+//! Emits Diesel + Serde derives and a `#[diesel(table_name)]` attribute
+//! on the annotated struct.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::parse::Parser as _;
+use syn::{DeriveInput, LitStr};
+
+/// Process `#[model]` or `#[model(table = "...")]` attribute arguments.
+///
+/// Returns `Some(table_name)` if a `table = "..."` key was given, or
+/// `None` to fall back to inference from the struct name.
+fn parse_attr_args(attr: TokenStream) -> syn::Result<Option<String>> {
+    if attr.is_empty() {
+        return Ok(None);
+    }
+
+    let mut table = None;
+    syn::meta::parser(|meta| {
+        if meta.path.is_ident("table") {
+            let value: LitStr = meta.value()?.parse()?;
+            table = Some(value.value());
+            Ok(())
+        } else {
+            Err(meta.error("unsupported model attribute"))
+        }
+    })
+    .parse2(attr)?;
+
+    Ok(table)
+}
+
+pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input: DeriveInput = match syn::parse2(item) {
+        Ok(input) => input,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    // Must be a struct
+    let fields = match &input.data {
+        syn::Data::Struct(data) => &data.fields,
+        _ => {
+            return syn::Error::new_spanned(
+                &input.ident,
+                "#[model] can only be applied to structs",
+            )
+            .to_compile_error();
+        }
+    };
+
+    // Extract table name from attribute args, or infer from struct name
+    let table_name = match parse_attr_args(attr) {
+        Ok(explicit) => explicit.unwrap_or_else(|| infer_table_name(&input.ident)),
+        Err(err) => return err.to_compile_error(),
+    };
+
+    let table_ident = syn::Ident::new(&table_name, input.ident.span());
+
+    let name = &input.ident;
+    let vis = &input.vis;
+    let generics = &input.generics;
+    let attrs = &input.attrs;
+
+    quote! {
+        #[derive(Debug, Clone, ::diesel::Queryable, ::diesel::Selectable, ::diesel::Insertable)]
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[diesel(table_name = #table_ident)]
+        #(#attrs)*
+        #vis struct #name #generics #fields
+    }
+}
+
+fn infer_table_name(ident: &syn::Ident) -> String {
+    let name = ident.to_string();
+    let snake = pascal_to_snake(&name);
+    format!("{snake}s")
+}
+
+fn pascal_to_snake(s: &str) -> String {
+    let mut result = String::new();
+    for (i, ch) in s.chars().enumerate() {
+        if ch.is_uppercase() && i > 0 {
+            result.push('_');
+        }
+        result.push(ch.to_ascii_lowercase());
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pascal_to_snake_simple() {
+        assert_eq!(pascal_to_snake("User"), "user");
+    }
+
+    #[test]
+    fn pascal_to_snake_multi_word() {
+        assert_eq!(pascal_to_snake("BlogPost"), "blog_post");
+    }
+
+    #[test]
+    fn pascal_to_snake_three_words() {
+        assert_eq!(
+            pascal_to_snake("UserProfileSettings"),
+            "user_profile_settings"
+        );
+    }
+
+    #[test]
+    fn infer_table_name_simple() {
+        let ident = syn::Ident::new("User", proc_macro2::Span::call_site());
+        assert_eq!(infer_table_name(&ident), "users");
+    }
+
+    #[test]
+    fn infer_table_name_multi_word() {
+        let ident = syn::Ident::new("BlogPost", proc_macro2::Span::call_site());
+        assert_eq!(infer_table_name(&ident), "blog_posts");
+    }
+}

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -9,7 +9,10 @@ repository.workspace = true
 [dependencies]
 autumn-macros = { path = "../autumn-macros" }
 axum.workspace = true
+diesel.workspace = true
+diesel-async.workspace = true
 http.workspace = true
+libsqlite3-sys.workspace = true
 pin-project-lite = "0.2"
 serde.workspace = true
 serde_json = "1"

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -13,6 +13,7 @@ diesel.workspace = true
 diesel-async.workspace = true
 http.workspace = true
 libsqlite3-sys.workspace = true
+maud.workspace = true
 pin-project-lite = "0.2"
 serde.workspace = true
 serde_json = "1"

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -20,6 +20,7 @@
 
 use crate::AppState;
 use crate::config::AutumnConfig;
+use crate::db;
 use crate::middleware::RequestIdLayer;
 use crate::route::Route;
 
@@ -60,9 +61,10 @@ impl AppBuilder {
     /// This method:
     /// 1. Loads configuration from `autumn.toml` (or defaults)
     /// 2. Validates that at least one route is registered
-    /// 3. Builds the Axum router from collected routes
-    /// 4. Binds to the configured address and port
-    /// 5. Serves requests with graceful shutdown on Ctrl+C
+    /// 3. Creates the database pool (if configured)
+    /// 4. Builds the Axum router from collected routes
+    /// 5. Binds to the configured address and port
+    /// 6. Serves requests with graceful shutdown on Ctrl+C
     ///
     /// # Panics
     ///
@@ -84,15 +86,34 @@ impl AppBuilder {
         // 3. Log banner
         println!("Autumn v{}", env!("CARGO_PKG_VERSION"));
 
-        // 4. Build Axum router, logging each route as it mounts
+        // 4. Create database pool (if configured)
+        let pool = match db::create_pool(&config.database) {
+            Ok(pool) => pool,
+            Err(e) => {
+                eprintln!("Failed to create database pool: {e}");
+                std::process::exit(1);
+            }
+        };
+
+        if pool.is_some() {
+            println!(
+                "  Database pool: {} max connections",
+                config.database.pool_size
+            );
+        } else {
+            println!("  Database: not configured");
+        }
+
+        // 5. Build Axum router, logging each route as it mounts
         let mut router = axum::Router::new();
         for route in self.routes {
             println!("  {} {} ({})", route.method, route.path, route.name);
             router = router.route(route.path, route.handler);
         }
-        let router = router.layer(RequestIdLayer).with_state(AppState);
+        let state = AppState { pool };
+        let router = router.layer(RequestIdLayer).with_state(state);
 
-        // 5. Bind and serve with graceful shutdown
+        // 6. Bind and serve with graceful shutdown
         let addr = format!("{}:{}", config.server.host, config.server.port);
         println!("Listening on http://{addr}");
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1,10 +1,10 @@
 //! Framework configuration with sensible defaults.
 //!
-//! Autumn uses a three-layer configuration system (applied in later stories):
+//! Autumn uses a three-layer configuration system:
 //!
 //! 1. **Framework defaults** (this module) — compiled into the binary
 //! 2. **`autumn.toml`** — project-level overrides (S-026)
-//! 3. **`AUTUMN_*` environment variables** — deployment overrides (S-027)
+//! 3. **`AUTUMN_*` environment variables** — deployment overrides (S-019)
 //!
 //! This module defines the typed config structs and their defaults.
 //! An Autumn application runs with zero configuration — every field
@@ -25,6 +25,10 @@ pub enum ConfigError {
     /// The config file contains invalid TOML.
     #[error("invalid autumn.toml: {0}")]
     Parse(#[from] toml::de::Error),
+
+    /// A configuration value is invalid.
+    #[error("configuration error: {0}")]
+    Validation(String),
 }
 
 /// Top-level framework configuration.
@@ -63,15 +67,19 @@ pub struct AutumnConfig {
 impl AutumnConfig {
     /// Load configuration from `autumn.toml` in the current directory.
     ///
-    /// Returns defaults if the file doesn't exist. Returns an error
-    /// if the file exists but contains invalid TOML.
+    /// Applies environment variable overrides and validates the result.
+    /// Returns defaults if the file doesn't exist.
     ///
     /// # Errors
     ///
-    /// Returns [`ConfigError::Io`] if the file cannot be read, or
-    /// [`ConfigError::Parse`] if the file contains invalid TOML.
+    /// Returns [`ConfigError::Io`] if the file cannot be read,
+    /// [`ConfigError::Parse`] if the file contains invalid TOML, or
+    /// [`ConfigError::Validation`] if a value is invalid.
     pub fn load() -> Result<Self, ConfigError> {
-        Self::load_from(Path::new("autumn.toml"))
+        let mut config = Self::load_from(Path::new("autumn.toml"))?;
+        config.apply_env_overrides();
+        config.database.validate()?;
+        Ok(config)
     }
 
     /// Load configuration from a specific path.
@@ -90,6 +98,36 @@ impl AutumnConfig {
         let contents = std::fs::read_to_string(path)?;
         let config: Self = toml::from_str(&contents)?;
         Ok(config)
+    }
+
+    /// Apply environment variable overrides to the loaded config.
+    ///
+    /// Database-specific overrides (full `AUTUMN_*` system in S-027):
+    /// - `AUTUMN_DATABASE__URL` -> `database.url`
+    /// - `AUTUMN_DATABASE__POOL_SIZE` -> `database.pool_size`
+    /// - `AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS` -> `database.connect_timeout_secs`
+    ///
+    /// Double underscore `__` separates nested config sections.
+    pub fn apply_env_overrides(&mut self) {
+        if let Ok(val) = std::env::var("AUTUMN_DATABASE__URL") {
+            self.database.url = Some(val);
+        }
+        if let Ok(val) = std::env::var("AUTUMN_DATABASE__POOL_SIZE") {
+            match val.parse::<usize>() {
+                Ok(size) => self.database.pool_size = size,
+                Err(_) => eprintln!(
+                    "Warning: AUTUMN_DATABASE__POOL_SIZE={val:?} is not a valid number, ignoring"
+                ),
+            }
+        }
+        if let Ok(val) = std::env::var("AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS") {
+            match val.parse::<u64>() {
+                Ok(secs) => self.database.connect_timeout_secs = secs,
+                Err(_) => eprintln!(
+                    "Warning: AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS={val:?} is not a valid number, ignoring"
+                ),
+            }
+        }
     }
 }
 
@@ -113,9 +151,9 @@ pub struct ServerConfig {
 /// Database connection configuration.
 #[derive(Debug, Deserialize)]
 pub struct DatabaseConfig {
-    /// Postgres connection URL. Default: `"postgres://localhost/autumn_dev"`.
-    #[serde(default = "default_db_url")]
-    pub url: String,
+    /// Postgres connection URL. `None` means no database is configured.
+    #[serde(default)]
+    pub url: Option<String>,
 
     /// Maximum number of connections in the pool. Default: `10`.
     #[serde(default = "default_pool_size")]
@@ -124,6 +162,25 @@ pub struct DatabaseConfig {
     /// Seconds to wait when acquiring a connection. Default: `5`.
     #[serde(default = "default_connect_timeout")]
     pub connect_timeout_secs: u64,
+}
+
+impl DatabaseConfig {
+    /// Validate database configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns a validation error if the URL has an invalid scheme.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if let Some(ref url) = self.url
+            && !url.starts_with("postgres://")
+            && !url.starts_with("postgresql://")
+        {
+            return Err(ConfigError::Validation(format!(
+                "Invalid database URL: must start with postgres:// or postgresql://, got {url:?}"
+            )));
+        }
+        Ok(())
+    }
 }
 
 /// Logging configuration.
@@ -179,10 +236,6 @@ const fn default_shutdown_timeout() -> u64 {
     30
 }
 
-fn default_db_url() -> String {
-    "postgres://localhost/autumn_dev".to_owned()
-}
-
 const fn default_pool_size() -> usize {
     10
 }
@@ -214,7 +267,7 @@ impl Default for ServerConfig {
 impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
-            url: default_db_url(),
+            url: None,
             pool_size: default_pool_size(),
             connect_timeout_secs: default_connect_timeout(),
         }
@@ -242,6 +295,34 @@ impl Default for HealthConfig {
 mod tests {
     use super::*;
 
+    /// RAII guard that sets an env var and restores it on drop.
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: Tests run single-threaded (or with unique keys) so
+            // mutating the environment is acceptable.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                // SAFETY: Restoring previous env state in test teardown.
+                Some(val) => unsafe { std::env::set_var(self.key, val) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
     #[test]
     fn server_defaults() {
         let config = ServerConfig::default();
@@ -253,7 +334,7 @@ mod tests {
     #[test]
     fn database_defaults() {
         let config = DatabaseConfig::default();
-        assert_eq!(config.url, "postgres://localhost/autumn_dev");
+        assert!(config.url.is_none());
         assert_eq!(config.pool_size, 10);
         assert_eq!(config.connect_timeout_secs, 5);
     }
@@ -275,7 +356,7 @@ mod tests {
     fn top_level_default_populates_all_sections() {
         let config = AutumnConfig::default();
         assert_eq!(config.server.port, 3000);
-        assert_eq!(config.database.url, "postgres://localhost/autumn_dev");
+        assert!(config.database.url.is_none());
         assert_eq!(config.log.level, "info");
         assert_eq!(config.health.path, "/health");
     }
@@ -286,7 +367,7 @@ mod tests {
         assert_eq!(config.server.port, 3000);
         assert_eq!(config.server.host, "127.0.0.1");
         assert_eq!(config.server.shutdown_timeout_secs, 30);
-        assert_eq!(config.database.url, "postgres://localhost/autumn_dev");
+        assert!(config.database.url.is_none());
         assert_eq!(config.database.pool_size, 10);
         assert_eq!(config.database.connect_timeout_secs, 5);
         assert_eq!(config.log.level, "info");
@@ -298,9 +379,7 @@ mod tests {
     fn deserialize_partial_config_merges_with_defaults() {
         let json = r#"{"server": {"port": 8080}}"#;
         let config: AutumnConfig = serde_json::from_str(json).expect("partial config should parse");
-        // Overridden
         assert_eq!(config.server.port, 8080);
-        // Defaults preserved
         assert_eq!(config.server.host, "127.0.0.1");
         assert_eq!(config.database.pool_size, 10);
         assert_eq!(config.log.level, "info");
@@ -322,7 +401,7 @@ mod tests {
     fn load_missing_file_returns_defaults() {
         let config = AutumnConfig::load_from(Path::new("this_file_does_not_exist.toml")).unwrap();
         assert_eq!(config.server.port, 3000);
-        assert_eq!(config.database.url, "postgres://localhost/autumn_dev");
+        assert!(config.database.url.is_none());
     }
 
     #[test]
@@ -356,7 +435,10 @@ path = "/healthz"
         assert_eq!(config.server.port, 8080);
         assert_eq!(config.server.host, "0.0.0.0");
         assert_eq!(config.server.shutdown_timeout_secs, 60);
-        assert_eq!(config.database.url, "postgres://user:pass@db:5432/myapp");
+        assert_eq!(
+            config.database.url.as_deref(),
+            Some("postgres://user:pass@db:5432/myapp")
+        );
         assert_eq!(config.database.pool_size, 20);
         assert_eq!(config.database.connect_timeout_secs, 10);
         assert_eq!(config.log.level, "debug");
@@ -372,7 +454,6 @@ path = "/healthz"
 
         let config = AutumnConfig::load_from(&path).unwrap();
         assert_eq!(config.server.port, 9090);
-        // Defaults preserved
         assert_eq!(config.server.host, "127.0.0.1");
         assert_eq!(config.database.pool_size, 10);
         assert_eq!(config.log.level, "info");
@@ -398,5 +479,84 @@ path = "/healthz"
 
         let config = AutumnConfig::load_from(&path).unwrap();
         assert_eq!(config.server.port, 3000);
+    }
+
+    // ── Environment variable override tests ──────────────────────
+
+    #[test]
+    fn env_override_database_url() {
+        let _guard = EnvGuard::set("AUTUMN_DATABASE__URL", "postgres://override:5432/test");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides();
+        assert_eq!(
+            config.database.url.as_deref(),
+            Some("postgres://override:5432/test")
+        );
+    }
+
+    #[test]
+    fn env_override_pool_size() {
+        let _guard = EnvGuard::set("AUTUMN_DATABASE__POOL_SIZE", "25");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides();
+        assert_eq!(config.database.pool_size, 25);
+    }
+
+    #[test]
+    fn env_override_connect_timeout() {
+        let _guard = EnvGuard::set("AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS", "15");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides();
+        assert_eq!(config.database.connect_timeout_secs, 15);
+    }
+
+    #[test]
+    fn env_override_invalid_pool_size_ignored() {
+        let _guard = EnvGuard::set("AUTUMN_DATABASE__POOL_SIZE", "not_a_number");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides();
+        assert_eq!(config.database.pool_size, 10);
+    }
+
+    // ── Validation tests ─────────────────────────────────────────
+
+    #[test]
+    fn validate_rejects_invalid_url_scheme() {
+        let config = DatabaseConfig {
+            url: Some("mysql://localhost/test".to_owned()),
+            ..Default::default()
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("must start with postgres://")
+        );
+    }
+
+    #[test]
+    fn validate_accepts_postgres_url() {
+        let config = DatabaseConfig {
+            url: Some("postgres://localhost/test".to_owned()),
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_postgresql_url() {
+        let config = DatabaseConfig {
+            url: Some("postgresql://localhost/test".to_owned()),
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_no_url() {
+        let config = DatabaseConfig::default();
+        assert!(config.validate().is_ok());
     }
 }

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -1,0 +1,73 @@
+//! Database connection pool management.
+//!
+//! Uses `diesel-async` with `deadpool` for async Postgres connections.
+//! The pool is created at startup and stored in [`AppState`](crate::AppState).
+//!
+//! When no `database.url` is configured, [`create_pool`] returns `Ok(None)`
+//! and the application runs without a database — useful for static-site or
+//! API-gateway use cases.
+
+use diesel_async::AsyncPgConnection;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::pooled_connection::deadpool::Pool;
+
+use crate::config::DatabaseConfig;
+
+/// Error type for pool creation failures.
+pub type PoolError = diesel_async::pooled_connection::deadpool::BuildError;
+
+/// Create a connection pool from the database configuration.
+///
+/// Returns `Ok(None)` if no database URL is configured (`database.url` is
+/// absent or `null` in `autumn.toml`).
+///
+/// # Errors
+///
+/// Returns [`PoolError`] if the pool cannot be built (e.g., invalid
+/// max-size configuration).
+pub fn create_pool(config: &DatabaseConfig) -> Result<Option<Pool<AsyncPgConnection>>, PoolError> {
+    let Some(url) = &config.url else {
+        return Ok(None);
+    };
+
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
+    let pool = Pool::builder(manager).max_size(config.pool_size).build()?;
+
+    Ok(Some(pool))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DatabaseConfig;
+
+    #[test]
+    fn create_pool_with_no_url_returns_none() {
+        let config = DatabaseConfig::default();
+        let pool = create_pool(&config).expect("should not fail with no URL");
+        assert!(pool.is_none());
+    }
+
+    #[test]
+    fn create_pool_with_url_returns_some() {
+        let config = DatabaseConfig {
+            url: Some("postgres://localhost/test".into()),
+            ..Default::default()
+        };
+        let pool = create_pool(&config).expect("should build pool from valid config");
+        assert!(pool.is_some());
+    }
+
+    #[test]
+    fn pool_respects_max_size() {
+        let config = DatabaseConfig {
+            url: Some("postgres://localhost/test".into()),
+            pool_size: 5,
+            ..Default::default()
+        };
+        let pool = create_pool(&config)
+            .expect("should build pool")
+            .expect("should be Some");
+        assert_eq!(pool.status().max_size, 5);
+    }
+}

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -1,4 +1,4 @@
-//! Database connection pool management.
+//! Database connection pool and extractor.
 //!
 //! Uses `diesel-async` with `deadpool` for async Postgres connections.
 //! The pool is created at startup and stored in [`AppState`](crate::AppState).
@@ -6,12 +6,26 @@
 //! When no `database.url` is configured, [`create_pool`] returns `Ok(None)`
 //! and the application runs without a database — useful for static-site or
 //! API-gateway use cases.
+//!
+//! The [`Db`] extractor acquires a connection from the pool for each request:
+//!
+//! ```ignore
+//! #[get("/users")]
+//! async fn list(db: Db) -> AutumnResult<Json<Vec<User>>> {
+//!     let users = users::table.load(&mut *db).await?;
+//!     Ok(Json(users))
+//! }
+//! ```
 
+use axum::extract::FromRequestParts;
+use axum::http::StatusCode;
 use diesel_async::AsyncPgConnection;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::pooled_connection::deadpool::Pool;
 
+use crate::AppState;
 use crate::config::DatabaseConfig;
+use crate::error::AutumnError;
 
 /// Error type for pool creation failures.
 pub type PoolError = diesel_async::pooled_connection::deadpool::BuildError;
@@ -36,10 +50,70 @@ pub fn create_pool(config: &DatabaseConfig) -> Result<Option<Pool<AsyncPgConnect
     Ok(Some(pool))
 }
 
+// ── Db extractor ─────────────────────────────────────────────
+
+/// Connection type managed by the deadpool pool.
+type PooledConnection = diesel_async::pooled_connection::deadpool::Object<AsyncPgConnection>;
+
+/// Async database connection extractor.
+///
+/// Declare `db: Db` in your handler signature to get a pooled
+/// connection to Postgres. The connection is returned to the pool
+/// when `Db` is dropped.
+///
+/// ```ignore
+/// #[get("/users")]
+/// async fn list(db: Db) -> AutumnResult<Json<Vec<User>>> {
+///     let users = users::table.load(&mut *db).await?;
+///     Ok(Json(users))
+/// }
+/// ```
+pub struct Db(PooledConnection);
+
+impl std::ops::Deref for Db {
+    type Target = AsyncPgConnection;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Db {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl FromRequestParts<AppState> for Db {
+    type Rejection = AutumnError;
+
+    async fn from_request_parts(
+        _parts: &mut axum::http::request::Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let pool = state.pool.as_ref().ok_or_else(|| {
+            AutumnError::bad_request(std::io::Error::new(
+                std::io::ErrorKind::NotConnected,
+                "Database not configured",
+            ))
+            .with_status(StatusCode::SERVICE_UNAVAILABLE)
+        })?;
+
+        let conn = pool.get().await.map_err(|e| {
+            eprintln!("Failed to acquire database connection: {e}");
+            AutumnError::bad_request(std::io::Error::other(e.to_string()))
+            .with_status(StatusCode::SERVICE_UNAVAILABLE)
+        })?;
+
+        Ok(Self(conn))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::DatabaseConfig;
+
+    // ── Pool creation tests ──────────────────────────────────────
 
     #[test]
     fn create_pool_with_no_url_returns_none() {
@@ -69,5 +143,31 @@ mod tests {
             .expect("should build pool")
             .expect("should be Some");
         assert_eq!(pool.status().max_size, 5);
+    }
+
+    // ── Db extractor tests ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn db_extractor_rejects_when_no_pool() {
+        use axum::Router;
+        use axum::body::Body;
+        use axum::http::Request;
+        use axum::routing::get;
+        use tower::ServiceExt;
+
+        async fn handler(_db: Db) -> &'static str {
+            "ok"
+        }
+
+        let app = Router::new()
+            .route("/", get(handler))
+            .with_state(AppState { pool: None });
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 }

--- a/autumn/src/extract.rs
+++ b/autumn/src/extract.rs
@@ -1,5 +1,9 @@
 //! Re-exports of Axum extractors for use in Autumn handlers.
 //!
 //! These are provided so users don't need `axum` as a direct dependency.
+//!
+//! `Json<T>` serves double duty — it's both an extractor (parses JSON request
+//! bodies) and a response type (serializes to JSON with `application/json`
+//! content type).
 
-pub use axum::extract::{Path, Query};
+pub use axum::extract::{Form, Json, Path, Query};

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod app;
 pub mod config;
+pub mod db;
 pub mod error;
 pub mod extract;
 pub mod middleware;
@@ -17,7 +18,7 @@ pub use app::app;
 pub use error::{AutumnError, AutumnResult};
 
 // Re-export proc macros so users can write `use autumn::get;` or `#[autumn::main]`
-pub use autumn_macros::{delete, get, main, post, put, routes};
+pub use autumn_macros::{delete, get, main, model, post, put, routes};
 
 /// Re-exports of upstream crates used in macro-generated code.
 ///
@@ -27,13 +28,34 @@ pub use autumn_macros::{delete, get, main, post, put, routes};
 /// into reexports directly.
 pub mod reexports {
     pub use axum;
+    pub use diesel;
     pub use http;
     pub use tokio;
 }
 
 /// Shared application state passed to all route handlers.
 ///
-/// Placeholder for v0.1 — the real `AppState` will hold config, database
-/// pool, and other framework-managed resources (S-009).
-#[derive(Clone, Debug)]
-pub struct AppState;
+/// Holds framework-managed resources such as the optional database
+/// connection pool. Axum requires `Clone`, so internal resources
+/// use `Arc` or are already cheaply cloneable (deadpool `Pool` is
+/// `Arc`-wrapped internally).
+#[derive(Clone)]
+pub struct AppState {
+    /// Database connection pool. `None` when no `database.url` is configured.
+    pub pool:
+        Option<diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>,
+}
+
+impl std::fmt::Debug for AppState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppState")
+            .field(
+                "pool",
+                &self
+                    .pool
+                    .as_ref()
+                    .map(|p| format!("Pool(max={})", p.status().max_size)),
+            )
+            .finish()
+    }
+}

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -15,10 +15,17 @@ pub mod middleware;
 pub mod route;
 
 pub use app::app;
+pub use db::Db;
 pub use error::{AutumnError, AutumnResult};
 
 // Re-export proc macros so users can write `use autumn::get;` or `#[autumn::main]`
 pub use autumn_macros::{delete, get, main, model, post, put, routes};
+
+// Re-export Maud types for HTML rendering
+pub use maud::{Markup, PreEscaped, html};
+
+// Re-export Json at root level (commonly used in return types)
+pub use axum::Json;
 
 /// Re-exports of upstream crates used in macro-generated code.
 ///

--- a/autumn/tests/compile-fail/model_on_enum.rs
+++ b/autumn/tests/compile-fail/model_on_enum.rs
@@ -1,0 +1,9 @@
+use autumn::model;
+
+#[model]
+enum Status {
+    Active,
+    Inactive,
+}
+
+fn main() {}

--- a/autumn/tests/compile-fail/model_on_enum.stderr
+++ b/autumn/tests/compile-fail/model_on_enum.stderr
@@ -1,0 +1,5 @@
+error: #[model] can only be applied to structs
+ --> tests/compile-fail/model_on_enum.rs:4:6
+  |
+4 | enum Status {
+  |      ^^^^^^

--- a/autumn/tests/compile-pass/json_form_handlers.rs
+++ b/autumn/tests/compile-pass/json_form_handlers.rs
@@ -1,0 +1,47 @@
+use autumn::extract::{Form, Json};
+use autumn::{get, html, post, AutumnResult, Markup};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize)]
+struct Item {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct NewItem {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct LoginForm {
+    user: String,
+}
+
+#[get("/items")]
+async fn list_items() -> Json<Vec<Item>> {
+    Json(vec![])
+}
+
+#[post("/items")]
+async fn create_item(Json(_body): Json<NewItem>) -> AutumnResult<Json<Item>> {
+    Ok(Json(Item {
+        name: "test".into(),
+    }))
+}
+
+#[post("/login")]
+async fn login(Form(_data): Form<LoginForm>) -> &'static str {
+    "ok"
+}
+
+#[get("/page")]
+async fn page() -> Markup {
+    html! { p { "hello" } }
+}
+
+#[get("/fallible")]
+async fn fallible_page() -> AutumnResult<Markup> {
+    Ok(html! { p { "ok" } })
+}
+
+fn main() {}

--- a/autumn/tests/compile-pass/model_derive.rs
+++ b/autumn/tests/compile-pass/model_derive.rs
@@ -1,0 +1,31 @@
+use autumn::model;
+
+// Diesel schema definition needed for the macro to work
+diesel::table! {
+    users (id) {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+#[model(table = "users")]
+pub struct User {
+    pub id: i32,
+    pub name: String,
+}
+
+// Test inferred table name
+diesel::table! {
+    blog_posts (id) {
+        id -> Integer,
+        title -> Text,
+    }
+}
+
+#[model]
+pub struct BlogPost {
+    pub id: i32,
+    pub title: String,
+}
+
+fn main() {}

--- a/autumn/tests/extractors.rs
+++ b/autumn/tests/extractors.rs
@@ -1,0 +1,115 @@
+use autumn::extract::{Form, Json};
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde::{Deserialize, Serialize};
+use tower::ServiceExt;
+
+// ── Json tests ───────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct JsonInput {
+    value: i32,
+}
+
+#[derive(Serialize)]
+struct JsonOutput {
+    doubled: i32,
+}
+
+#[tokio::test]
+async fn json_extractor_and_response() {
+    async fn handler(Json(input): Json<JsonInput>) -> Json<JsonOutput> {
+        Json(JsonOutput {
+            doubled: input.value * 2,
+        })
+    }
+
+    let app = Router::new().route("/", axum::routing::post(handler));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"value": 21}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(content_type.contains("application/json"));
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(output["doubled"], 42);
+}
+
+#[tokio::test]
+async fn invalid_json_returns_error() {
+    async fn handler(Json(_): Json<serde_json::Value>) -> &'static str {
+        "ok"
+    }
+
+    let app = Router::new().route("/", axum::routing::post(handler));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header("content-type", "application/json")
+                .body(Body::from("not json"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+// ── Form tests ───────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct FormInput {
+    name: String,
+    age: u32,
+}
+
+#[tokio::test]
+async fn form_extraction_works() {
+    async fn handler(Form(data): Form<FormInput>) -> String {
+        format!("{} is {}", data.name, data.age)
+    }
+
+    let app = Router::new().route("/", axum::routing::post(handler));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from("name=Alice&age=30"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"Alice is 30");
+}

--- a/autumn/tests/maud_render.rs
+++ b/autumn/tests/maud_render.rs
@@ -1,0 +1,35 @@
+use autumn::{Markup, html};
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn maud_handler_returns_html() {
+    async fn index() -> Markup {
+        html! { h1 { "hello" } }
+    }
+
+    let app = Router::new().route("/", axum::routing::get(index));
+
+    let response = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(content_type.contains("text/html"));
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let html_str = String::from_utf8(body.to_vec()).unwrap();
+    assert!(html_str.contains("<h1>hello</h1>"));
+}


### PR DESCRIPTION
## Summary

### Sprint 5 (13 pts) — Database foundation
- **S-016** (5 pts): diesel-async connection pool with deadpool. `autumn/src/db.rs` with `create_pool()`, `AppState` holds `Option<Pool<AsyncPgConnection>>`, `DatabaseConfig.url` changed to `Option<String>`
- **S-018** (5 pts): `#[model]` attribute macro — emits Diesel + Serde derives and `#[diesel(table_name)]`. Supports explicit `#[model(table = "users")]` or inferred from struct name
- **S-019** (3 pts): Env var overrides (`AUTUMN_DATABASE__URL`, `AUTUMN_DATABASE__POOL_SIZE`, `AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS`), URL validation, `ConfigError::Validation`

### Sprint 6 (12 pts) — 3-month gut check
- **S-017** (5 pts): `Db` extractor with `FromRequestParts`, `Deref`/`DerefMut` to `AsyncPgConnection`, 503 on missing pool
- **S-020** (3 pts): Maud re-export (`html!`, `Markup`, `PreEscaped`) with axum feature for `IntoResponse`
- **S-023** (2 pts): `Form<T>` extractor re-export
- **S-031** (2 pts): `Json<T>` re-export (extractor + response type)

After this PR, a handler like `async fn list(db: Db) -> AutumnResult<Markup>` compiles and works end-to-end.

## Test plan

- [x] `cargo test --workspace` — 75 tests passing
- [x] `cargo clippy --workspace` — zero warnings
- [x] `cargo fmt --all --check` — clean
- [x] Db extractor rejects with 503 when no pool configured
- [x] Maud handler returns `text/html` content type with correct HTML
- [x] Json round-trip: POST JSON body → JSON response with correct content type
- [x] Form extraction from `application/x-www-form-urlencoded` body
- [x] `#[model]` compile-pass with Diesel schema, compile-fail on enum
- [x] Env var overrides work for database config
- [x] URL validation rejects non-postgres:// schemes

🤖 Generated with [Claude Code](https://claude.com/claude-code)