### PR TITLE
Refactor: simplify code quality across framework and example

### DIFF
--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -165,12 +165,11 @@ impl AutumnConfig {
     /// Returns [`ConfigError::Io`] if the file cannot be read, or
     /// [`ConfigError::Parse`] if the file contains invalid TOML.
     pub fn load_from(path: &Path) -> Result<Self, ConfigError> {
-        if !path.exists() {
-            return Ok(Self::default());
+        match std::fs::read_to_string(path) {
+            Ok(contents) => Ok(toml::from_str(&contents)?),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(ConfigError::Io(e)),
         }
-        let contents = std::fs::read_to_string(path)?;
-        let config: Self = toml::from_str(&contents)?;
-        Ok(config)
     }
 
     /// Apply environment variable overrides to the loaded config.
@@ -196,46 +195,24 @@ impl AutumnConfig {
     /// - `AUTUMN_HEALTH__PATH` → `health.path` (String)
     pub fn apply_env_overrides(&mut self) {
         // ── Server ──────────────────────────────────────────────
-        if let Ok(val) = std::env::var("AUTUMN_SERVER__PORT") {
-            match val.parse::<u16>() {
-                Ok(port) => self.server.port = port,
-                Err(_) => {
-                    eprintln!("Warning: AUTUMN_SERVER__PORT={val:?} is not a valid port, ignoring");
-                }
-            }
-        }
+        parse_env("AUTUMN_SERVER__PORT", &mut self.server.port);
         if let Ok(val) = std::env::var("AUTUMN_SERVER__HOST") {
             self.server.host = val;
         }
-        if let Ok(val) = std::env::var("AUTUMN_SERVER__SHUTDOWN_TIMEOUT_SECS") {
-            match val.parse::<u64>() {
-                Ok(secs) => self.server.shutdown_timeout_secs = secs,
-                Err(_) => eprintln!(
-                    "Warning: AUTUMN_SERVER__SHUTDOWN_TIMEOUT_SECS={val:?} is not a valid number, ignoring"
-                ),
-            }
-        }
+        parse_env(
+            "AUTUMN_SERVER__SHUTDOWN_TIMEOUT_SECS",
+            &mut self.server.shutdown_timeout_secs,
+        );
 
         // ── Database ────────────────────────────────────────────
         if let Ok(val) = std::env::var("AUTUMN_DATABASE__URL") {
             self.database.url = Some(val);
         }
-        if let Ok(val) = std::env::var("AUTUMN_DATABASE__POOL_SIZE") {
-            match val.parse::<usize>() {
-                Ok(size) => self.database.pool_size = size,
-                Err(_) => eprintln!(
-                    "Warning: AUTUMN_DATABASE__POOL_SIZE={val:?} is not a valid number, ignoring"
-                ),
-            }
-        }
-        if let Ok(val) = std::env::var("AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS") {
-            match val.parse::<u64>() {
-                Ok(secs) => self.database.connect_timeout_secs = secs,
-                Err(_) => eprintln!(
-                    "Warning: AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS={val:?} is not a valid number, ignoring"
-                ),
-            }
-        }
+        parse_env("AUTUMN_DATABASE__POOL_SIZE", &mut self.database.pool_size);
+        parse_env(
+            "AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS",
+            &mut self.database.connect_timeout_secs,
+        );
 
         // ── Log ─────────────────────────────────────────────────
         if let Ok(val) = std::env::var("AUTUMN_LOG__LEVEL") {
@@ -442,6 +419,16 @@ pub struct HealthConfig {
     /// Common alternatives: `"/healthz"`, `"/_health"`, `"/ready"`.
     #[serde(default = "default_health_path")]
     pub path: String,
+}
+
+/// Parse an environment variable into a typed target, logging a warning on failure.
+fn parse_env<T: std::str::FromStr>(key: &str, target: &mut T) {
+    if let Ok(val) = std::env::var(key) {
+        match val.parse::<T>() {
+            Ok(v) => *target = v,
+            Err(_) => eprintln!("Warning: {key}={val:?} is not valid, ignoring"),
+        }
+    }
 }
 
 // ── Default functions ──────────────────────────────────────────────

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -26,7 +26,6 @@
 //! ```
 
 use axum::extract::FromRequestParts;
-use axum::http::StatusCode;
 use diesel_async::AsyncPgConnection;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::pooled_connection::deadpool::Pool;
@@ -114,18 +113,14 @@ impl FromRequestParts<AppState> for Db {
         _parts: &mut axum::http::request::Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        let pool = state.pool.as_ref().ok_or_else(|| {
-            AutumnError::bad_request(std::io::Error::new(
-                std::io::ErrorKind::NotConnected,
-                "Database not configured",
-            ))
-            .with_status(StatusCode::SERVICE_UNAVAILABLE)
-        })?;
+        let pool = state
+            .pool
+            .as_ref()
+            .ok_or_else(|| AutumnError::service_unavailable_msg("Database not configured"))?;
 
         let conn = pool.get().await.map_err(|e| {
-            eprintln!("Failed to acquire database connection: {e}");
-            AutumnError::bad_request(std::io::Error::other(e.to_string()))
-                .with_status(StatusCode::SERVICE_UNAVAILABLE)
+            tracing::error!("Failed to acquire database connection: {e}");
+            AutumnError::service_unavailable_msg(e.to_string())
         })?;
 
         Ok(Self(conn))
@@ -175,7 +170,7 @@ mod tests {
     async fn db_extractor_rejects_when_no_pool() {
         use axum::Router;
         use axum::body::Body;
-        use axum::http::Request;
+        use axum::http::{Request, StatusCode};
         use axum::routing::get;
         use tower::ServiceExt;
 

--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -9,7 +9,15 @@
 //! - [`AutumnError::not_found`] -- 404
 //! - [`AutumnError::bad_request`] -- 400
 //! - [`AutumnError::unprocessable`] -- 422
+//! - [`AutumnError::service_unavailable`] -- 503
 //! - [`AutumnError::with_status`] -- arbitrary status code
+//!
+//! For simple string messages without wrapping an error type:
+//!
+//! - [`AutumnError::not_found_msg`] -- 404 with a message
+//! - [`AutumnError::bad_request_msg`] -- 400 with a message
+//! - [`AutumnError::unprocessable_msg`] -- 422 with a message
+//! - [`AutumnError::service_unavailable_msg`] -- 503 with a message
 //!
 //! # Response format
 //!
@@ -36,6 +44,34 @@
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+/// Simple error type wrapping a string message.
+///
+/// Used by the `_msg` convenience constructors on [`AutumnError`] so callers
+/// don't need to wrap strings in `std::io::Error`.
+#[derive(Debug)]
+struct StringError(String);
+
+impl std::fmt::Display for StringError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for StringError {}
+
+/// Typed JSON body for error responses -- avoids dynamic `serde_json::Value`.
+#[derive(Serialize)]
+struct ErrorBody {
+    error: ErrorInner,
+}
+
+#[derive(Serialize)]
+struct ErrorInner {
+    status: u16,
+    message: String,
+}
 
 /// Framework error type wrapping any error with an HTTP status code.
 ///
@@ -186,6 +222,46 @@ impl AutumnError {
         }
     }
 
+    /// Create a `503 Service Unavailable` error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use autumn_web::error::AutumnError;
+    /// use http::StatusCode;
+    ///
+    /// let err = AutumnError::service_unavailable(std::io::Error::other("pool exhausted"));
+    /// assert_eq!(err.status(), StatusCode::SERVICE_UNAVAILABLE);
+    /// ```
+    pub fn service_unavailable(err: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self {
+            inner: Box::new(err),
+            status: StatusCode::SERVICE_UNAVAILABLE,
+        }
+    }
+
+    // ── String-message convenience constructors ────────────────
+
+    /// Create a `404 Not Found` error from a plain string message.
+    pub fn not_found_msg(msg: impl Into<String>) -> Self {
+        Self::not_found(StringError(msg.into()))
+    }
+
+    /// Create a `400 Bad Request` error from a plain string message.
+    pub fn bad_request_msg(msg: impl Into<String>) -> Self {
+        Self::bad_request(StringError(msg.into()))
+    }
+
+    /// Create a `422 Unprocessable Entity` error from a plain string message.
+    pub fn unprocessable_msg(msg: impl Into<String>) -> Self {
+        Self::unprocessable(StringError(msg.into()))
+    }
+
+    /// Create a `503 Service Unavailable` error from a plain string message.
+    pub fn service_unavailable_msg(msg: impl Into<String>) -> Self {
+        Self::service_unavailable(StringError(msg.into()))
+    }
+
     /// Returns the HTTP status code associated with this error.
     ///
     /// # Examples
@@ -221,12 +297,12 @@ impl std::fmt::Debug for AutumnError {
 impl IntoResponse for AutumnError {
     fn into_response(self) -> Response {
         let status = self.status;
-        let body = serde_json::json!({
-            "error": {
-                "status": status.as_u16(),
-                "message": self.inner.to_string(),
-            }
-        });
+        let body = ErrorBody {
+            error: ErrorInner {
+                status: status.as_u16(),
+                message: self.inner.to_string(),
+            },
+        };
 
         (status, axum::Json(body)).into_response()
     }
@@ -270,6 +346,38 @@ mod tests {
     fn unprocessable_is_422() {
         let err = AutumnError::unprocessable(TestError("bad entity".into()));
         assert_eq!(err.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[test]
+    fn service_unavailable_is_503() {
+        let err = AutumnError::service_unavailable(TestError("pool exhausted".into()));
+        assert_eq!(err.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn not_found_msg_is_404() {
+        let err = AutumnError::not_found_msg("no such user");
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+        assert_eq!(err.to_string(), "no such user");
+    }
+
+    #[test]
+    fn bad_request_msg_is_400() {
+        let err = AutumnError::bad_request_msg("invalid input");
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn unprocessable_msg_is_422() {
+        let err = AutumnError::unprocessable_msg("title required");
+        assert_eq!(err.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[test]
+    fn service_unavailable_msg_is_503() {
+        let err = AutumnError::service_unavailable_msg("db down");
+        assert_eq!(err.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(err.to_string(), "db down");
     }
 
     #[test]

--- a/autumn/src/health.rs
+++ b/autumn/src/health.rs
@@ -30,8 +30,25 @@ use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use serde::Serialize;
 
 use crate::AppState;
+
+/// Typed health response — avoids dynamic `serde_json::Value` allocation.
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    version: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pool: Option<PoolStatus>,
+}
+
+#[derive(Serialize)]
+struct PoolStatus {
+    size: u64,
+    available: u64,
+    waiting: u64,
+}
 
 /// Health check handler.
 ///
@@ -59,15 +76,15 @@ pub async fn handler(State(state): State<AppState>) -> impl IntoResponse {
             // Degraded when all connections are in use AND requests are queuing
             let healthy = available > 0 || waiting == 0;
 
-            let body = serde_json::json!({
-                "status": if healthy { "ok" } else { "degraded" },
-                "version": env!("CARGO_PKG_VERSION"),
-                "pool": {
-                    "size": size,
-                    "available": available,
-                    "waiting": waiting,
-                }
-            });
+            let body = HealthResponse {
+                status: if healthy { "ok" } else { "degraded" },
+                version: env!("CARGO_PKG_VERSION"),
+                pool: Some(PoolStatus {
+                    size,
+                    available,
+                    waiting,
+                }),
+            };
 
             let status_code = if healthy {
                 StatusCode::OK
@@ -79,10 +96,11 @@ pub async fn handler(State(state): State<AppState>) -> impl IntoResponse {
         }
     }
 
-    let body = serde_json::json!({
-        "status": "ok",
-        "version": env!("CARGO_PKG_VERSION"),
-    });
+    let body = HealthResponse {
+        status: "ok",
+        version: env!("CARGO_PKG_VERSION"),
+        pool: None,
+    };
     (StatusCode::OK, Json(body))
 }
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -359,7 +359,7 @@ pub use maud::html;
 ///     Json(Item { id: 1, name: input.name })
 /// }
 /// ```
-pub use axum::Json;
+pub use crate::extract::Json;
 
 /// Re-exports of upstream crates used in macro-generated code.
 ///

--- a/autumn/src/middleware/request_id.rs
+++ b/autumn/src/middleware/request_id.rs
@@ -29,9 +29,13 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use axum::http::{HeaderValue, Request, Response};
+use http::header::HeaderName;
 use pin_project_lite::pin_project;
 use tower::{Layer, Service};
 use uuid::Uuid;
+
+/// Header name for the request ID, added to every response.
+static X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
 
 /// A unique identifier assigned to each incoming HTTP request.
 ///
@@ -146,8 +150,11 @@ where
         match this.inner.poll(cx) {
             Poll::Ready(Ok(mut response)) => {
                 if let Some(id) = this.request_id.take() {
-                    if let Ok(value) = HeaderValue::from_str(&id.to_string()) {
-                        response.headers_mut().insert("x-request-id", value);
+                    // Format UUID directly into a stack buffer to avoid a String allocation.
+                    let mut buf = [0u8; uuid::fmt::Hyphenated::LENGTH];
+                    let s = id.0.as_hyphenated().encode_lower(&mut buf);
+                    if let Ok(value) = HeaderValue::from_bytes(s.as_bytes()) {
+                        response.headers_mut().insert(X_REQUEST_ID.clone(), value);
                     }
                 }
                 Poll::Ready(Ok(response))

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -34,10 +34,10 @@ pub use maud::{Markup, PreEscaped, html};
 /// Database connection extractor.
 #[cfg(feature = "db")]
 pub use crate::db::Db;
-/// JSON request/response type.
-pub use axum::Json;
 /// Form data extractor.
-pub use axum::extract::Form;
+pub use crate::extract::Form;
+/// JSON request/response type.
+pub use crate::extract::Json;
 
 // ── Error handling ───────────────────────────────────────────────
 /// Framework error and result types.

--- a/examples/todo-app/src/models.rs
+++ b/examples/todo-app/src/models.rs
@@ -1,4 +1,6 @@
+use autumn_web::error::{AutumnError, AutumnResult};
 use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde::{Deserialize, Serialize};
 
 use crate::schema::todos;
@@ -14,9 +16,41 @@ pub struct Todo {
     pub created_at: chrono::NaiveDateTime,
 }
 
+impl Todo {
+    /// Load all todos ordered by creation date (newest first).
+    pub async fn all(db: &mut AsyncPgConnection) -> AutumnResult<Vec<Self>> {
+        Ok(todos::table
+            .order(todos::created_at.desc())
+            .select(Self::as_select())
+            .load(db)
+            .await?)
+    }
+
+    /// Find a single todo by ID, returning 404 if not found.
+    pub async fn find(id: i32, db: &mut AsyncPgConnection) -> AutumnResult<Self> {
+        todos::table
+            .find(id)
+            .select(Self::as_select())
+            .first(db)
+            .await
+            .map_err(AutumnError::not_found)
+    }
+}
+
 /// Data needed to insert a new todo.
 #[derive(Insertable, Deserialize)]
 #[diesel(table_name = todos)]
 pub struct NewTodo {
     pub title: String,
+}
+
+impl NewTodo {
+    /// Validate and normalize the title. Returns 422 if the title is empty.
+    pub fn validated(self) -> AutumnResult<Self> {
+        let title = self.title.trim().to_owned();
+        if title.is_empty() {
+            return Err(AutumnError::unprocessable_msg("Title must not be empty"));
+        }
+        Ok(Self { title })
+    }
 }

--- a/examples/todo-app/src/routes/api.rs
+++ b/examples/todo-app/src/routes/api.rs
@@ -3,7 +3,7 @@
 //! These endpoints provide a REST-style API alongside the HTML routes,
 //! demonstrating that Autumn handlers can return either HTML or JSON.
 
-use autumn_web::{AutumnError, AutumnResult, Db, Json, get, post};
+use autumn_web::{AutumnResult, Db, Json, get, post};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
@@ -13,33 +13,19 @@ use crate::schema::todos;
 /// Return all todos as a JSON array.
 #[get("/api/todos")]
 pub async fn list_json(mut db: Db) -> AutumnResult<Json<Vec<Todo>>> {
-    let all_todos = todos::table
-        .order(todos::created_at.desc())
-        .select(Todo::as_select())
-        .load(&mut *db)
-        .await?;
-
+    let all_todos = Todo::all(&mut db).await?;
     Ok(Json(all_todos))
 }
 
 /// Create a new todo from a JSON body, return the created todo as JSON.
 #[post("/api/todos")]
 pub async fn create_json(mut db: Db, body: Json<NewTodo>) -> AutumnResult<Json<Todo>> {
-    let new_todo = body.0;
-
-    if new_todo.title.trim().is_empty() {
-        return Err(AutumnError::unprocessable(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "Title must not be empty",
-        )));
-    }
+    let new_todo = body.0.validated()?;
 
     let created: Todo = diesel::insert_into(todos::table)
-        .values(&NewTodo {
-            title: new_todo.title.trim().to_owned(),
-        })
+        .values(&new_todo)
         .returning(Todo::as_returning())
-        .get_result(&mut *db)
+        .get_result(&mut db)
         .await?;
 
     Ok(Json(created))

--- a/examples/todo-app/src/routes/todos.rs
+++ b/examples/todo-app/src/routes/todos.rs
@@ -11,6 +11,17 @@ use diesel_async::RunQueryDsl;
 use crate::models::{NewTodo, Todo};
 use crate::schema::todos;
 
+/// Render a meta-refresh redirect page targeting the given URL.
+fn redirect_to(url: &str) -> Markup {
+    html! {
+        (autumn_web::PreEscaped("<!DOCTYPE html>"))
+        html {
+            head { meta http-equiv="refresh" content=(format!("0;url={url}")); }
+            body { p { "Redirecting to " a href=(url) { (url) } "..." } }
+        }
+    }
+}
+
 // ── Helpers ──────────────────────────────────────────────────────
 
 /// Base HTML layout wrapping page content.
@@ -101,30 +112,15 @@ fn todo_item(todo: &Todo) -> Markup {
 /// Redirect the root path to `/todos`.
 #[get("/")]
 pub async fn index() -> Markup {
-    // Return a minimal page that redirects via meta refresh.
     // We avoid importing axum::response::Redirect to keep the example
     // focused on Autumn's own API surface.
-    html! {
-        (autumn_web::PreEscaped("<!DOCTYPE html>"))
-        html {
-            head {
-                meta http-equiv="refresh" content="0;url=/todos";
-            }
-            body {
-                p { "Redirecting to " a href="/todos" { "/todos" } "..." }
-            }
-        }
-    }
+    redirect_to("/todos")
 }
 
 /// List all todos.
 #[get("/todos")]
 pub async fn list(mut db: Db) -> AutumnResult<Markup> {
-    let all_todos: Vec<Todo> = todos::table
-        .order(todos::created_at.desc())
-        .select(Todo::as_select())
-        .load(&mut *db)
-        .await?;
+    let all_todos = Todo::all(&mut db).await?;
 
     let done_count = all_todos.iter().filter(|t| t.completed).count();
     let total = all_todos.len();
@@ -190,12 +186,7 @@ pub async fn list(mut db: Db) -> AutumnResult<Markup> {
 /// Show a single todo by ID.
 #[get("/todos/{id}")]
 pub async fn detail(id: Path<i32>, mut db: Db) -> AutumnResult<Markup> {
-    let todo: Todo = todos::table
-        .find(*id)
-        .select(Todo::as_select())
-        .first(&mut *db)
-        .await
-        .map_err(AutumnError::not_found)?;
+    let todo = Todo::find(*id, &mut db).await?;
 
     Ok(layout(
         &format!("Todo: {}", todo.title),
@@ -232,58 +223,26 @@ pub async fn detail(id: Path<i32>, mut db: Db) -> AutumnResult<Markup> {
 /// Create a new todo from a form submission, then redirect to the list.
 #[post("/todos")]
 pub async fn create(mut db: Db, form: Form<NewTodo>) -> AutumnResult<Markup> {
-    let new_todo = form.0;
-
-    if new_todo.title.trim().is_empty() {
-        return Err(AutumnError::unprocessable(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "Title must not be empty",
-        )));
-    }
+    let new_todo = form.0.validated()?;
 
     diesel::insert_into(todos::table)
-        .values(&NewTodo {
-            title: new_todo.title.trim().to_owned(),
-        })
+        .values(&new_todo)
         .execute(&mut *db)
         .await?;
 
-    // Redirect back to the todo list after creation
-    Ok(html! {
-        (autumn_web::PreEscaped("<!DOCTYPE html>"))
-        html {
-            head {
-                meta http-equiv="refresh" content="0;url=/todos";
-            }
-            body {
-                p { "Redirecting to " a href="/todos" { "/todos" } "..." }
-            }
-        }
-    })
+    Ok(redirect_to("/todos"))
 }
 
 /// Toggle the completion status of a todo (htmx endpoint).
 ///
-/// Returns the updated todo item HTML fragment for htmx to swap in.
+/// Uses a single `UPDATE ... SET completed = NOT completed RETURNING *`
+/// query — one round-trip instead of three.
 #[post("/todos/{id}/toggle")]
 pub async fn toggle(id: Path<i32>, mut db: Db) -> AutumnResult<Markup> {
-    let todo: Todo = todos::table
-        .find(*id)
-        .select(Todo::as_select())
-        .first(&mut *db)
-        .await
-        .map_err(AutumnError::not_found)?;
-
-    diesel::update(todos::table.find(*id))
-        .set(todos::completed.eq(!todo.completed))
-        .execute(&mut *db)
-        .await?;
-
-    // Reload the updated todo for rendering
-    let updated: Todo = todos::table
-        .find(*id)
-        .select(Todo::as_select())
-        .first(&mut *db)
+    let updated: Todo = diesel::update(todos::table.find(*id))
+        .set(todos::completed.eq(diesel::dsl::not(todos::completed)))
+        .returning(Todo::as_returning())
+        .get_result(&mut *db)
         .await
         .map_err(AutumnError::not_found)?;
 
@@ -300,9 +259,9 @@ pub async fn delete_todo(id: Path<i32>, mut db: Db) -> AutumnResult<String> {
         .await?;
 
     if deleted == 0 {
-        return Err(AutumnError::not_found(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!("Todo with id {} not found", *id),
+        return Err(AutumnError::not_found_msg(format!(
+            "Todo with id {} not found",
+            *id
         )));
     }
 


### PR DESCRIPTION
## Summary

This refactor improves code quality and reduces boilerplate across the Autumn framework and example app:

### Framework Changes (autumn/src/)

- **error.rs**: Added new convenience constructors (`_msg` variants) for creating errors from plain strings without wrapping in `std::io::Error`. Added `service_unavailable` (503) error type. Replaced dynamic `serde_json::Value` with typed `ErrorBody` struct for better type safety.

- **config.rs**: Extracted repeated env var parsing logic into a generic `parse_env()` helper function, reducing duplication in `apply_env_overrides()`.

- **health.rs**: Introduced typed `HealthResponse` and `PoolStatus` structs to replace dynamic JSON, improving type safety and avoiding allocations.

- **db.rs**: Simplified error handling using new `service_unavailable_msg()` constructor. Replaced `eprintln!` with `tracing::error!`.

- **middleware/request_id.rs**: Optimized UUID header insertion by encoding directly into a stack buffer instead of allocating a String.

- **prelude.rs & lib.rs**: Updated re-exports for consistency.

### Example App Changes (examples/todo-app/)

- **models.rs**: Added helper methods to `Todo` (`all()`, `find()`) and `NewTodo` (`validated()`) to reduce boilerplate in handlers.

- **routes/api.rs**: Simplified handlers by using new model methods and `_msg` error constructors.

- **routes/todos.rs**: Extracted redirect logic into `redirect_to()` helper. Simplified handlers by using model methods. Optimized `toggle()` to use single database query with `RETURNING`.
