### PR TITLE
Add CORS configuration support with environment variable overrides

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "2"
 maud = { version = "0.27", features = ["axum"] }
 toml = "0.8"
 tower = "0.5"
-tower-http = { version = "0.6", features = ["fs", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 tokio-cron-scheduler = "0.13"

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1028,7 +1028,10 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            response.headers().get("access-control-allow-origin").unwrap(),
+            response
+                .headers()
+                .get("access-control-allow-origin")
+                .unwrap(),
             "*"
         );
     }
@@ -1078,7 +1081,12 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        assert!(response.headers().get("access-control-allow-origin").is_none());
+        assert!(
+            response
+                .headers()
+                .get("access-control-allow-origin")
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -1101,7 +1109,11 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        assert!(response.headers().contains_key("access-control-allow-methods"));
+        assert!(
+            response
+                .headers()
+                .contains_key("access-control-allow-methods")
+        );
     }
 
     #[tokio::test]

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -457,6 +457,17 @@ pub fn build_router(
     let static_dir = project_dir("static");
     router = router.nest_service("/static", tower_http::services::ServeDir::new(&static_dir));
 
+    // CORS middleware (only applied when allowed_origins is non-empty)
+    if !config.cors.allowed_origins.is_empty() {
+        let cors = build_cors_layer(&config.cors);
+        tracing::info!(
+            origins = ?config.cors.allowed_origins,
+            credentials = config.cors.allow_credentials,
+            "CORS enabled"
+        );
+        router = router.layer(cors);
+    }
+
     router.layer(RequestIdLayer).with_state(state)
 }
 
@@ -511,6 +522,43 @@ pub fn build_router_with_static(
     // which then serves static files (e.g. /about/ → dist/about/index.html).
     let serve_dir = tower_http::services::ServeDir::new(dist);
     app_router.fallback_service(serve_dir)
+}
+
+/// Build a `tower_http::cors::CorsLayer` from the framework's [`CorsConfig`].
+///
+/// Called only when `config.cors.allowed_origins` is non-empty.
+fn build_cors_layer(cors: &crate::config::CorsConfig) -> tower_http::cors::CorsLayer {
+    use http::header::HeaderName;
+    use tower_http::cors::{AllowOrigin, CorsLayer};
+
+    let layer = if cors.allowed_origins.iter().any(|o| o == "*") {
+        CorsLayer::new().allow_origin(AllowOrigin::any())
+    } else {
+        let origins: Vec<http::HeaderValue> = cors
+            .allowed_origins
+            .iter()
+            .filter_map(|o| o.parse().ok())
+            .collect();
+        CorsLayer::new().allow_origin(origins)
+    };
+
+    let methods: Vec<http::Method> = cors
+        .allowed_methods
+        .iter()
+        .filter_map(|m| m.parse().ok())
+        .collect();
+
+    let headers: Vec<HeaderName> = cors
+        .allowed_headers
+        .iter()
+        .filter_map(|h| h.parse().ok())
+        .collect();
+
+    layer
+        .allow_methods(methods)
+        .allow_headers(headers)
+        .allow_credentials(cors.allow_credentials)
+        .max_age(std::time::Duration::from_secs(cors.max_age_secs))
 }
 
 #[cfg(feature = "htmx")]
@@ -947,6 +995,113 @@ mod tests {
         unsafe { std::env::remove_var("AUTUMN_MANIFEST_DIR") };
         let dir = super::project_dir("dist");
         assert_eq!(dir, std::path::PathBuf::from("dist"));
+    }
+
+    /// Helper to build a test router with custom config.
+    fn test_router_with_config(routes: Vec<Route>, config: &AutumnConfig) -> axum::Router {
+        let state = AppState {
+            #[cfg(feature = "db")]
+            pool: None,
+            profile: None,
+            started_at: std::time::Instant::now(),
+            health_detailed: true,
+        };
+        build_router(routes, config, state)
+    }
+
+    #[tokio::test]
+    async fn cors_wildcard_allows_any_origin() {
+        let mut config = AutumnConfig::default();
+        config.cors.allowed_origins = vec!["*".to_owned()];
+        let router = test_router_with_config(vec![test_get_route("/test", "test")], &config);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/test")
+                    .header("Origin", "https://example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get("access-control-allow-origin").unwrap(),
+            "*"
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_specific_origin_reflected() {
+        let mut config = AutumnConfig::default();
+        config.cors.allowed_origins = vec!["https://example.com".to_owned()];
+        let router = test_router_with_config(vec![test_get_route("/test", "test")], &config);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/test")
+                    .header("Origin", "https://example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("access-control-allow-origin")
+                .unwrap(),
+            "https://example.com"
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_disabled_when_no_origins() {
+        let config = AutumnConfig::default();
+        assert!(config.cors.allowed_origins.is_empty());
+        let router = test_router_with_config(vec![test_get_route("/test", "test")], &config);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/test")
+                    .header("Origin", "https://example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().get("access-control-allow-origin").is_none());
+    }
+
+    #[tokio::test]
+    async fn cors_preflight_returns_204() {
+        let mut config = AutumnConfig::default();
+        config.cors.allowed_origins = vec!["https://example.com".to_owned()];
+        let router = test_router_with_config(vec![test_get_route("/test", "test")], &config);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("OPTIONS")
+                    .uri("/test")
+                    .header("Origin", "https://example.com")
+                    .header("Access-Control-Request-Method", "GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().contains_key("access-control-allow-methods"));
     }
 
     #[tokio::test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -45,6 +45,11 @@
 //! | `AUTUMN_LOG__FORMAT` | `log.format` | `Auto` / `Pretty` / `Json` |
 //! | `AUTUMN_HEALTH__PATH` | `health.path` | `String` |
 //! | `AUTUMN_HEALTH__DETAILED` | `health.detailed` | `bool` |
+//! | `AUTUMN_CORS__ALLOWED_ORIGINS` | `cors.allowed_origins` | comma-separated `String` |
+//! | `AUTUMN_CORS__ALLOWED_METHODS` | `cors.allowed_methods` | comma-separated `String` |
+//! | `AUTUMN_CORS__ALLOWED_HEADERS` | `cors.allowed_headers` | comma-separated `String` |
+//! | `AUTUMN_CORS__ALLOW_CREDENTIALS` | `cors.allow_credentials` | `bool` |
+//! | `AUTUMN_CORS__MAX_AGE_SECS` | `cors.max_age_secs` | `u64` |
 //! | `AUTUMN_PROFILE` | active profile | `String` |
 
 use std::path::{Path, PathBuf};
@@ -134,6 +139,13 @@ fn profile_defaults_as_toml(profile: &str) -> toml::Value {
             let mut actuator = toml::map::Map::new();
             actuator.insert("sensitive".into(), toml::Value::Boolean(true));
             table.insert("actuator".into(), toml::Value::Table(actuator));
+
+            let mut cors = toml::map::Map::new();
+            cors.insert(
+                "allowed_origins".into(),
+                toml::Value::Array(vec![toml::Value::String("*".to_owned())]),
+            );
+            table.insert("cors".into(), toml::Value::Table(cors));
         }
         "prod" => {
             let mut log = toml::map::Map::new();
@@ -303,6 +315,10 @@ pub struct AutumnConfig {
     /// Actuator endpoint settings.
     #[serde(default)]
     pub actuator: ActuatorConfig,
+
+    /// CORS (Cross-Origin Resource Sharing) settings.
+    #[serde(default)]
+    pub cors: CorsConfig,
 }
 
 impl AutumnConfig {
@@ -452,6 +468,28 @@ impl AutumnConfig {
                 ),
             }
         }
+
+        // ── CORS ────────────────────────────────────────────────
+        if let Ok(val) = std::env::var("AUTUMN_CORS__ALLOWED_ORIGINS") {
+            self.cors.allowed_origins = val.split(',').map(|s| s.trim().to_owned()).collect();
+        }
+        if let Ok(val) = std::env::var("AUTUMN_CORS__ALLOWED_METHODS") {
+            self.cors.allowed_methods = val.split(',').map(|s| s.trim().to_owned()).collect();
+        }
+        if let Ok(val) = std::env::var("AUTUMN_CORS__ALLOWED_HEADERS") {
+            self.cors.allowed_headers = val.split(',').map(|s| s.trim().to_owned()).collect();
+        }
+        if let Ok(val) = std::env::var("AUTUMN_CORS__ALLOW_CREDENTIALS") {
+            match val.as_str() {
+                "true" | "1" => self.cors.allow_credentials = true,
+                "false" | "0" => self.cors.allow_credentials = false,
+                _ => eprintln!(
+                    "Warning: AUTUMN_CORS__ALLOW_CREDENTIALS={val:?} is not valid \
+                     (expected true/false), ignoring"
+                ),
+            }
+        }
+        parse_env("AUTUMN_CORS__MAX_AGE_SECS", &mut self.cors.max_age_secs);
     }
 
     /// Returns the active profile name, if any.
@@ -680,6 +718,103 @@ impl Default for ActuatorConfig {
 
 fn default_actuator_prefix() -> String {
     "/actuator".to_owned()
+}
+
+/// CORS (Cross-Origin Resource Sharing) configuration.
+///
+/// Controls which origins, methods, and headers are allowed for
+/// cross-origin requests. Disabled by default -- enable by setting
+/// `allowed_origins` in `autumn.toml` or via environment variables.
+///
+/// # Defaults
+///
+/// | Field | Default |
+/// |-------|---------|
+/// | `allowed_origins` | `[]` (CORS disabled) |
+/// | `allowed_methods` | `["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]` |
+/// | `allowed_headers` | `["Content-Type", "Authorization"]` |
+/// | `allow_credentials` | `false` |
+/// | `max_age_secs` | `86400` (24 hours) |
+///
+/// # Profile smart defaults
+///
+/// The `dev` profile enables permissive CORS (`allowed_origins = ["*"]`)
+/// so local front-end development works out of the box.
+///
+/// # Examples
+///
+/// ```toml
+/// [cors]
+/// allowed_origins = ["https://example.com", "https://app.example.com"]
+/// allow_credentials = true
+/// ```
+///
+/// ```rust
+/// use autumn_web::config::CorsConfig;
+///
+/// let cors = CorsConfig::default();
+/// assert!(cors.allowed_origins.is_empty());
+/// assert!(!cors.allow_credentials);
+/// ```
+#[derive(Debug, Deserialize)]
+pub struct CorsConfig {
+    /// Origins allowed to make cross-origin requests.
+    ///
+    /// Use `["*"]` to allow any origin (not recommended for production
+    /// with credentials). When empty, CORS middleware is not applied.
+    #[serde(default)]
+    pub allowed_origins: Vec<String>,
+
+    /// HTTP methods allowed for cross-origin requests.
+    /// Default: `["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]`.
+    #[serde(default = "default_cors_methods")]
+    pub allowed_methods: Vec<String>,
+
+    /// Headers allowed in cross-origin requests.
+    /// Default: `["Content-Type", "Authorization"]`.
+    #[serde(default = "default_cors_headers")]
+    pub allowed_headers: Vec<String>,
+
+    /// Whether to include `Access-Control-Allow-Credentials: true`.
+    /// Default: `false`.
+    #[serde(default)]
+    pub allow_credentials: bool,
+
+    /// How long (in seconds) browsers may cache preflight responses.
+    /// Default: `86400` (24 hours).
+    #[serde(default = "default_cors_max_age")]
+    pub max_age_secs: u64,
+}
+
+impl Default for CorsConfig {
+    fn default() -> Self {
+        Self {
+            allowed_origins: Vec::new(),
+            allowed_methods: default_cors_methods(),
+            allowed_headers: default_cors_headers(),
+            allow_credentials: false,
+            max_age_secs: default_cors_max_age(),
+        }
+    }
+}
+
+fn default_cors_methods() -> Vec<String> {
+    vec![
+        "GET".to_owned(),
+        "POST".to_owned(),
+        "PUT".to_owned(),
+        "DELETE".to_owned(),
+        "PATCH".to_owned(),
+        "OPTIONS".to_owned(),
+    ]
+}
+
+fn default_cors_headers() -> Vec<String> {
+    vec!["Content-Type".to_owned(), "Authorization".to_owned()]
+}
+
+const fn default_cors_max_age() -> u64 {
+    86400
 }
 
 /// Parse an environment variable into a typed target, logging a warning on failure.
@@ -1203,6 +1338,7 @@ path = "/healthz"
         assert_eq!(config.server.host, "127.0.0.1");
         assert_eq!(config.server.shutdown_timeout_secs, 1);
         assert!(config.health.detailed);
+        assert_eq!(config.cors.allowed_origins, vec!["*"]);
     }
 
     #[test]
@@ -1446,6 +1582,36 @@ path = "/healthz"
     }
 
     #[test]
+    fn env_override_cors_allowed_origins() {
+        let _guard = EnvGuard::set(
+            "AUTUMN_CORS__ALLOWED_ORIGINS",
+            "https://a.com, https://b.com",
+        );
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides();
+        assert_eq!(
+            config.cors.allowed_origins,
+            vec!["https://a.com", "https://b.com"]
+        );
+    }
+
+    #[test]
+    fn env_override_cors_allow_credentials() {
+        let _guard = EnvGuard::set("AUTUMN_CORS__ALLOW_CREDENTIALS", "true");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides();
+        assert!(config.cors.allow_credentials);
+    }
+
+    #[test]
+    fn env_override_cors_max_age() {
+        let _guard = EnvGuard::set("AUTUMN_CORS__MAX_AGE_SECS", "3600");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides();
+        assert_eq!(config.cors.max_age_secs, 3600);
+    }
+
+    #[test]
     fn load_uses_profile_layering() {
         // Test AutumnConfig::load() with a dev profile via env var.
         // This kills the "replace load → Ok(Default::default())" mutant.
@@ -1553,6 +1719,23 @@ path = "/healthz"
         config.health.detailed = true;
         config.apply_env_overrides();
         assert!(!config.health.detailed);
+    }
+
+    #[test]
+    fn cors_defaults() {
+        let cors = CorsConfig::default();
+        assert!(cors.allowed_origins.is_empty());
+        assert_eq!(cors.allowed_methods.len(), 6);
+        assert!(cors.allowed_methods.contains(&"GET".to_owned()));
+        assert!(cors.allowed_headers.contains(&"Content-Type".to_owned()));
+        assert!(!cors.allow_credentials);
+        assert_eq!(cors.max_age_secs, 86400);
+    }
+
+    #[test]
+    fn cors_in_full_config_defaults() {
+        let config = AutumnConfig::default();
+        assert!(config.cors.allowed_origins.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This PR adds comprehensive Cross-Origin Resource Sharing (CORS) configuration support to the Autumn framework, allowing developers to control which origins, methods, and headers are allowed for cross-origin requests.

## Key Changes

- **New `CorsConfig` struct** in `config.rs` with fields for:
  - `allowed_origins`: List of allowed origins (empty by default, disables CORS)
  - `allowed_methods`: HTTP methods allowed (defaults to GET, POST, PUT, DELETE, PATCH, OPTIONS)
  - `allowed_headers`: Headers allowed in requests (defaults to Content-Type, Authorization)
  - `allow_credentials`: Whether to include credentials header (defaults to false)
  - `max_age_secs`: Preflight cache duration (defaults to 86400 seconds / 24 hours)

- **Environment variable support** for all CORS settings:
  - `AUTUMN_CORS__ALLOWED_ORIGINS` (comma-separated)
  - `AUTUMN_CORS__ALLOWED_METHODS` (comma-separated)
  - `AUTUMN_CORS__ALLOWED_HEADERS` (comma-separated)
  - `AUTUMN_CORS__ALLOW_CREDENTIALS` (boolean)
  - `AUTUMN_CORS__MAX_AGE_SECS` (u64)

- **Profile-aware defaults**: The `dev` profile enables permissive CORS (`allowed_origins = ["*"]`) for convenient local development

- **CORS middleware integration** in `app.rs`:
  - `build_cors_layer()` function creates a `tower_http::cors::CorsLayer` from config
  - Middleware is only applied when `allowed_origins` is non-empty
  - Supports both wildcard (`*`) and specific origin configurations
  - Logs CORS enablement with origin and credential details

- **Comprehensive test coverage**:
  - Config parsing and environment variable overrides
  - Wildcard origin handling
  - Specific origin reflection
  - CORS disabled state
  - Preflight request handling (OPTIONS)

- **Updated dependencies**: Added `cors` feature to `tower-http` in Cargo.toml

## Implementation Details

- CORS is disabled by default (empty `allowed_origins` list) for security
- The middleware intelligently handles both wildcard and specific origins
- Invalid HTTP methods/headers are silently filtered during layer construction
- Environment variables support comma-separated values with automatic trimming
- Full documentation with examples in the `CorsConfig` struct

https://claude.ai/code/session_01Q3oumipsYoWkcM3svBb4MF