### PR TITLE
feat: add v0.2 features — actuator endpoints, migrations, error pages, hybrid rendering Phase 2, raw Axum escape hatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libpq-dev
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Clippy
@@ -39,15 +37,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libpq-dev
-      - name: Run tests (Linux — all features)
-        if: runner.os == 'Linux'
+      - name: Run tests
         run: cargo test --workspace
-      - name: Run tests (non-Linux — no db feature)
-        if: runner.os != 'Linux'
-        run: cargo test -p autumn-web --lib --no-default-features --features maud,htmx,tailwind && cargo test -p autumn-macros && cargo test -p autumn-cli
       - name: Run Docker-dependent tests
         if: runner.os == 'Linux'
         run: cargo test -p autumn-web --test db_hooks_lifecycle -- --ignored
@@ -60,8 +51,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libpq-dev
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate coverage
@@ -81,7 +70,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.86.0
       - uses: Swatinem/rust-cache@v2
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libpq-dev
       - name: Check MSRV compiles
         run: cargo check --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpq-dev
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Clippy
@@ -37,8 +39,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Run tests
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libpq-dev
+      - name: Run tests (Linux — all features)
+        if: runner.os == 'Linux'
         run: cargo test --workspace
+      - name: Run tests (non-Linux — no db feature)
+        if: runner.os != 'Linux'
+        run: cargo test -p autumn-web --no-default-features --features maud,htmx,tailwind && cargo test -p autumn-macros && cargo test -p autumn-cli
       - name: Run Docker-dependent tests
         if: runner.os == 'Linux'
         run: cargo test -p autumn-web --test db_hooks_lifecycle -- --ignored
@@ -51,6 +60,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpq-dev
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate coverage
@@ -70,5 +81,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.86.0
       - uses: Swatinem/rust-cache@v2
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpq-dev
       - name: Check MSRV compiles
         run: cargo check --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: cargo test --workspace
       - name: Run tests (Windows — no db feature)
         if: runner.os == 'Windows'
-        run: cargo test -p autumn-web --lib --no-default-features --features maud,htmx,tailwind && cargo test -p autumn-macros && cargo test -p autumn-cli
+        run: cargo test -p autumn-web --lib --no-default-features --features maud,htmx,tailwind
       - name: Run Docker-dependent tests
         if: runner.os == 'Linux'
         run: cargo test -p autumn-web --test db_hooks_lifecycle -- --ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Run tests
+      - name: Run tests (full)
+        if: runner.os != 'Windows'
         run: cargo test --workspace
+      - name: Run tests (Windows — no db feature)
+        if: runner.os == 'Windows'
+        run: cargo test -p autumn-web --lib --no-default-features --features maud,htmx,tailwind && cargo test -p autumn-macros && cargo test -p autumn-cli
       - name: Run Docker-dependent tests
         if: runner.os == 'Linux'
         run: cargo test -p autumn-web --test db_hooks_lifecycle -- --ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: cargo test --workspace
       - name: Run tests (non-Linux — no db feature)
         if: runner.os != 'Linux'
-        run: cargo test -p autumn-web --no-default-features --features maud,htmx,tailwind && cargo test -p autumn-macros && cargo test -p autumn-cli
+        run: cargo test -p autumn-web --lib --no-default-features --features maud,htmx,tailwind && cargo test -p autumn-macros && cargo test -p autumn-cli
       - name: Run Docker-dependent tests
         if: runner.os == 'Linux'
         run: cargo test -p autumn-web --test db_hooks_lifecycle -- --ignored

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ repository = "https://github.com/madmax983/autumn"
 [workspace.dependencies]
 # Runtime
 axum = { version = "0.8", features = ["macros"] }
-diesel = { version = "2", features = ["sqlite"] }
+diesel = { version = "2", features = ["sqlite", "postgres"] }
 diesel-async = { version = "0.8", features = ["deadpool", "postgres"] }
+diesel_migrations = "2"
 http = "1"
 libsqlite3-sys = { version = "0.36", features = ["bundled"] }
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ repository = "https://github.com/madmax983/autumn"
 [workspace.dependencies]
 # Runtime
 axum = { version = "0.8", features = ["macros"] }
-diesel = { version = "2", features = ["sqlite", "postgres"] }
+diesel = { version = "2", features = ["sqlite"] }
+pq-sys = { version = "0.7", features = ["bundled"] }
 diesel-async = { version = "0.8", features = ["deadpool", "postgres"] }
 diesel_migrations = "2"
 http = "1"

--- a/autumn-cli/Cargo.toml
+++ b/autumn-cli/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = { version = "0.12", features = ["blocking", "rustls-tls"], default-fea
 serde_json = "1"
 sha2 = "0.10"
 thiserror = "2"
+toml = "0.8"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 
 mod build;
 mod dev;
+mod migrate;
 mod new;
 mod setup;
 
@@ -42,6 +43,18 @@ enum Commands {
         #[arg(long)]
         force: bool,
     },
+    /// Run or inspect database migrations
+    Migrate {
+        #[command(subcommand)]
+        action: Option<MigrateCommands>,
+    },
+}
+
+/// Subcommands for `autumn migrate`.
+#[derive(Subcommand)]
+enum MigrateCommands {
+    /// Show migration status (applied and pending)
+    Status,
 }
 
 fn main() {
@@ -49,6 +62,13 @@ fn main() {
     match cli.command {
         Commands::Build { debug, package } => build::run(debug, package.as_deref()),
         Commands::Dev { package } => dev::run(package.as_deref()),
+        Commands::Migrate { action } => {
+            let action = match action {
+                Some(MigrateCommands::Status) => migrate::MigrateAction::Status,
+                None => migrate::MigrateAction::Run,
+            };
+            migrate::run(action);
+        }
         Commands::New { name } => new::run(&name),
         Commands::Setup { force } => setup::run(force),
     }
@@ -161,6 +181,26 @@ mod tests {
             }
             _ => panic!("expected Dev command"),
         }
+    }
+
+    #[test]
+    fn parse_migrate_subcommand() {
+        let cli = Cli::try_parse_from(["autumn", "migrate"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Migrate { action: None }
+        ));
+    }
+
+    #[test]
+    fn parse_migrate_status() {
+        let cli = Cli::try_parse_from(["autumn", "migrate", "status"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Migrate {
+                action: Some(MigrateCommands::Status)
+            }
+        ));
     }
 
     #[test]

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -186,10 +186,7 @@ mod tests {
     #[test]
     fn parse_migrate_subcommand() {
         let cli = Cli::try_parse_from(["autumn", "migrate"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Commands::Migrate { action: None }
-        ));
+        assert!(matches!(cli.command, Commands::Migrate { action: None }));
     }
 
     #[test]

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -1,0 +1,217 @@
+//! `autumn migrate` -- run or inspect Diesel database migrations.
+//!
+//! Because the CLI cannot embed the user's application-specific migrations
+//! (they live in the user's crate via `embed_migrations!`), this module
+//! delegates to the `diesel` CLI tool. It reads the database URL from
+//! `autumn.toml` + environment variables, then shells out to
+//! `diesel migration run` or `diesel migration pending`.
+//!
+//! The user's application binary is the canonical way to run embedded
+//! migrations (via `.migrations()` on `AppBuilder`). This CLI command
+//! is a convenience wrapper for explicit migration management.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Default directory containing Diesel migration files.
+const DEFAULT_MIGRATIONS_DIR: &str = "migrations";
+
+/// Subcommands for `autumn migrate`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MigrateAction {
+    /// Run all pending migrations.
+    Run,
+    /// Show migration status (pending / applied).
+    Status,
+}
+
+/// Run the migrate command.
+pub fn run(action: MigrateAction) {
+    eprintln!("\u{1F342} autumn migrate\n");
+
+    // 1. Resolve database URL from autumn.toml + env
+    let database_url = resolve_database_url();
+
+    // 2. Resolve migrations directory
+    let migrations_dir = resolve_migrations_dir();
+
+    // 3. Check that diesel CLI is available
+    check_diesel_cli();
+
+    // 4. Execute the appropriate diesel command
+    match action {
+        MigrateAction::Run => run_migrations(&database_url, &migrations_dir),
+        MigrateAction::Status => show_status(&database_url, &migrations_dir),
+    }
+}
+
+/// Resolve the database URL from autumn.toml and environment variables.
+///
+/// Precedence (highest to lowest):
+/// 1. `AUTUMN_DATABASE__URL` environment variable
+/// 2. `DATABASE_URL` environment variable
+/// 3. `database.url` from `autumn.toml`
+fn resolve_database_url() -> String {
+    // Check env overrides first
+    if let Ok(url) = std::env::var("AUTUMN_DATABASE__URL") {
+        if !url.is_empty() {
+            return url;
+        }
+    }
+    if let Ok(url) = std::env::var("DATABASE_URL") {
+        if !url.is_empty() {
+            return url;
+        }
+    }
+
+    // Try loading from autumn.toml
+    let config_path = Path::new("autumn.toml");
+    if config_path.exists() {
+        if let Ok(contents) = std::fs::read_to_string(config_path) {
+            if let Ok(value) = contents.parse::<toml::Value>() {
+                if let Some(url) = value
+                    .get("database")
+                    .and_then(|db: &toml::Value| db.get("url"))
+                    .and_then(|u: &toml::Value| u.as_str())
+                {
+                    if !url.is_empty() {
+                        return url.to_string();
+                    }
+                }
+            }
+        }
+    }
+
+    eprintln!("\u{2717} No database URL found.");
+    eprintln!("  Set database.url in autumn.toml, or set AUTUMN_DATABASE__URL / DATABASE_URL.");
+    std::process::exit(1);
+}
+
+/// Resolve the migrations directory (default: `./migrations/`).
+fn resolve_migrations_dir() -> String {
+    let dir = Path::new(DEFAULT_MIGRATIONS_DIR);
+    if !dir.exists() {
+        eprintln!("\u{2717} Migrations directory not found: {DEFAULT_MIGRATIONS_DIR}/");
+        eprintln!("  Create it with `diesel setup` or `diesel migration generate <name>`.");
+        std::process::exit(1);
+    }
+    DEFAULT_MIGRATIONS_DIR.to_string()
+}
+
+/// Check that the `diesel` CLI is installed and available on PATH.
+fn check_diesel_cli() {
+    match Command::new("diesel").arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let version = String::from_utf8_lossy(&output.stdout);
+            eprintln!("  Using {}", version.trim());
+        }
+        _ => {
+            eprintln!("\u{2717} diesel CLI not found on PATH.");
+            eprintln!("  Install it with: cargo install diesel_cli --no-default-features --features postgres");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Run pending migrations via `diesel migration run`.
+fn run_migrations(database_url: &str, migrations_dir: &str) {
+    eprintln!("  Running pending migrations...\n");
+
+    let status = Command::new("diesel")
+        .args([
+            "migration",
+            "run",
+            "--migration-dir",
+            migrations_dir,
+        ])
+        .env("DATABASE_URL", database_url)
+        .status();
+
+    match status {
+        Ok(s) if s.success() => {
+            eprintln!("\n\u{2713} Migrations applied successfully.");
+        }
+        Ok(_) => {
+            eprintln!("\n\u{2717} Migration failed. Check the error output above for the failing SQL.");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("\u{2717} Failed to run diesel migration run: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Show migration status via `diesel migration pending`.
+fn show_status(database_url: &str, migrations_dir: &str) {
+    eprintln!("  Checking migration status...\n");
+
+    // `diesel migration list` shows all migrations and their status
+    let status = Command::new("diesel")
+        .args([
+            "migration",
+            "list",
+            "--migration-dir",
+            migrations_dir,
+        ])
+        .env("DATABASE_URL", database_url)
+        .status();
+
+    match status {
+        Ok(s) if s.success() => {}
+        Ok(_) => {
+            eprintln!("\n\u{2717} Failed to check migration status.");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("\u{2717} Failed to run diesel migration list: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrate_action_eq() {
+        assert_eq!(MigrateAction::Run, MigrateAction::Run);
+        assert_eq!(MigrateAction::Status, MigrateAction::Status);
+        assert_ne!(MigrateAction::Run, MigrateAction::Status);
+    }
+
+    #[test]
+    fn default_migrations_dir_is_migrations() {
+        assert_eq!(DEFAULT_MIGRATIONS_DIR, "migrations");
+    }
+
+    #[test]
+    fn resolve_database_url_from_env() {
+        // AUTUMN_DATABASE__URL takes priority
+        unsafe {
+            std::env::set_var("AUTUMN_DATABASE__URL", "postgres://test:5432/mydb");
+        }
+        let url = resolve_database_url();
+        assert_eq!(url, "postgres://test:5432/mydb");
+        unsafe {
+            std::env::remove_var("AUTUMN_DATABASE__URL");
+        }
+    }
+
+    #[test]
+    fn resolve_database_url_from_database_url_env() {
+        // Make sure AUTUMN_DATABASE__URL is not set
+        unsafe {
+            std::env::remove_var("AUTUMN_DATABASE__URL");
+        }
+        unsafe {
+            std::env::set_var("DATABASE_URL", "postgres://fallback:5432/db");
+        }
+        let url = resolve_database_url();
+        assert_eq!(url, "postgres://fallback:5432/db");
+        unsafe {
+            std::env::remove_var("DATABASE_URL");
+        }
+    }
+}

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -107,7 +107,9 @@ fn check_diesel_cli() {
         }
         _ => {
             eprintln!("\u{2717} diesel CLI not found on PATH.");
-            eprintln!("  Install it with: cargo install diesel_cli --no-default-features --features postgres");
+            eprintln!(
+                "  Install it with: cargo install diesel_cli --no-default-features --features postgres"
+            );
             std::process::exit(1);
         }
     }
@@ -118,12 +120,7 @@ fn run_migrations(database_url: &str, migrations_dir: &str) {
     eprintln!("  Running pending migrations...\n");
 
     let status = Command::new("diesel")
-        .args([
-            "migration",
-            "run",
-            "--migration-dir",
-            migrations_dir,
-        ])
+        .args(["migration", "run", "--migration-dir", migrations_dir])
         .env("DATABASE_URL", database_url)
         .status();
 
@@ -132,7 +129,9 @@ fn run_migrations(database_url: &str, migrations_dir: &str) {
             eprintln!("\n\u{2713} Migrations applied successfully.");
         }
         Ok(_) => {
-            eprintln!("\n\u{2717} Migration failed. Check the error output above for the failing SQL.");
+            eprintln!(
+                "\n\u{2717} Migration failed. Check the error output above for the failing SQL."
+            );
             std::process::exit(1);
         }
         Err(e) => {
@@ -148,12 +147,7 @@ fn show_status(database_url: &str, migrations_dir: &str) {
 
     // `diesel migration list` shows all migrations and their status
     let status = Command::new("diesel")
-        .args([
-            "migration",
-            "list",
-            "--migration-dir",
-            migrations_dir,
-        ])
+        .args(["migration", "list", "--migration-dir", migrations_dir])
         .env("DATABASE_URL", database_url)
         .status();
 

--- a/autumn-macros/src/static_route.rs
+++ b/autumn-macros/src/static_route.rs
@@ -58,7 +58,7 @@ impl Parse for StaticGetAttrs {
             }
         }
 
-        Ok(StaticGetAttrs {
+        Ok(Self {
             path,
             params_fn,
             revalidate,
@@ -128,25 +128,27 @@ pub fn static_get_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let vis = &input_fn.vis;
 
     // Build the revalidate expression
-    let revalidate_expr = match attrs.revalidate {
-        Some(secs) => quote! { ::core::option::Option::Some(#secs) },
-        None => quote! { ::core::option::Option::None },
-    };
+    let revalidate_expr = attrs.revalidate.map_or_else(
+        || quote! { ::core::option::Option::None },
+        |secs| quote! { ::core::option::Option::Some(#secs) },
+    );
 
     // Build the params_fn expression
-    let params_fn_expr = match &attrs.params_fn {
-        Some(pf) => quote! {
-            ::core::option::Option::Some(
-                |router: ::autumn_web::reexports::axum::Router|
-                    -> ::core::pin::Pin<Box<dyn ::core::future::Future<
-                        Output = Vec<::autumn_web::static_gen::StaticParams>
-                    > + Send>> {
-                    Box::pin(#pf(router))
-                }
-            )
+    let params_fn_expr = attrs.params_fn.as_ref().map_or_else(
+        || quote! { ::core::option::Option::None },
+        |pf| {
+            quote! {
+                ::core::option::Option::Some(
+                    |router: ::autumn_web::reexports::axum::Router|
+                        -> ::core::pin::Pin<Box<dyn ::core::future::Future<
+                            Output = Vec<::autumn_web::static_gen::StaticParams>
+                        > + Send>> {
+                        Box::pin(#pf(router))
+                    }
+                )
+            }
         },
-        None => quote! { ::core::option::Option::None },
-    };
+    );
 
     quote! {
         #input_fn

--- a/autumn-macros/src/static_route.rs
+++ b/autumn-macros/src/static_route.rs
@@ -3,11 +3,68 @@
 //! Generates both a regular route companion (`__autumn_route_info_{name}`)
 //! AND a static metadata companion (`__autumn_static_meta_{name}`), marking
 //! the handler for static pre-rendering at build time.
+//!
+//! ## Supported forms
+//!
+//! - `#[static_get("/about")]` -- simple static route
+//! - `#[static_get("/posts/{slug}", params = list_slugs)]` -- parameterized
+//! - `#[static_get("/posts/{slug}", params = list_slugs, revalidate = 60)]` -- with ISR
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
+use syn::parse::{Parse, ParseStream};
+use syn::{Ident, LitInt, LitStr, Token};
 
-use crate::parse;
+/// Parsed attributes for `#[static_get("/path", params = fn, revalidate = N)]`.
+struct StaticGetAttrs {
+    path: LitStr,
+    params_fn: Option<syn::Path>,
+    revalidate: Option<u64>,
+}
+
+impl Parse for StaticGetAttrs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let path: LitStr = input.parse()?;
+
+        let mut params_fn = None;
+        let mut revalidate = None;
+
+        while input.peek(Token![,]) {
+            let _comma: Token![,] = input.parse()?;
+
+            // Allow trailing comma
+            if input.is_empty() {
+                break;
+            }
+
+            let key: Ident = input.parse()?;
+            let _eq: Token![=] = input.parse()?;
+
+            match key.to_string().as_str() {
+                "params" => {
+                    let path: syn::Path = input.parse()?;
+                    params_fn = Some(path);
+                }
+                "revalidate" => {
+                    let lit: LitInt = input.parse()?;
+                    revalidate = Some(lit.base10_parse::<u64>()?);
+                }
+                other => {
+                    return Err(syn::Error::new(
+                        key.span(),
+                        format!("Unknown attribute `{other}`. Expected `params` or `revalidate`."),
+                    ));
+                }
+            }
+        }
+
+        Ok(StaticGetAttrs {
+            path,
+            params_fn,
+            revalidate,
+        })
+    }
+}
 
 /// Core implementation for the `#[static_get("/path")]` attribute macro.
 ///
@@ -18,21 +75,49 @@ use crate::parse;
 /// 3. `__autumn_static_meta_{name}()` returning
 ///    `::autumn_web::static_gen::StaticRouteMeta`.
 pub fn static_get_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let path = match parse::parse_route_path(attr) {
-        Ok(p) => p,
-        Err(err) => return err,
+    let attrs: StaticGetAttrs = match syn::parse2(attr) {
+        Ok(a) => a,
+        Err(err) => return err.to_compile_error(),
     };
 
-    // Phase 1 restriction: no path parameters
-    if path.value().contains('{') {
+    let path = &attrs.path;
+
+    // Validate path
+    if path.value().is_empty() {
+        return syn::Error::new(path.span(), "Route path must not be empty").to_compile_error();
+    }
+
+    if !path.value().starts_with('/') {
+        let suggested = format!("/{}", path.value());
         return syn::Error::new(
             path.span(),
-            "static_get does not support path parameters yet. Use #[get] for parameterized routes.",
+            format!("Route path must start with '/'. Did you mean \"{suggested}\"?"),
         )
         .to_compile_error();
     }
 
-    let input_fn = match parse::parse_async_handler(item) {
+    // Parameterized routes require a params function
+    let has_params = path.value().contains('{');
+    if has_params && attrs.params_fn.is_none() {
+        return syn::Error::new(
+            path.span(),
+            "Parameterized static routes require a `params` function. \
+             Example: #[static_get(\"/posts/{slug}\", params = list_slugs)]",
+        )
+        .to_compile_error();
+    }
+
+    // Non-parameterized routes should not have a params function
+    if !has_params && attrs.params_fn.is_some() {
+        return syn::Error::new(
+            path.span(),
+            "Static route has no path parameters but a `params` function was provided. \
+             Either add path parameters or remove the `params` attribute.",
+        )
+        .to_compile_error();
+    }
+
+    let input_fn = match crate::parse::parse_async_handler(item) {
         Ok(f) => f,
         Err(err) => return err,
     };
@@ -41,6 +126,27 @@ pub fn static_get_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let route_info_name = format_ident!("__autumn_route_info_{}", fn_name);
     let static_meta_name = format_ident!("__autumn_static_meta_{}", fn_name);
     let vis = &input_fn.vis;
+
+    // Build the revalidate expression
+    let revalidate_expr = match attrs.revalidate {
+        Some(secs) => quote! { ::core::option::Option::Some(#secs) },
+        None => quote! { ::core::option::Option::None },
+    };
+
+    // Build the params_fn expression
+    let params_fn_expr = match &attrs.params_fn {
+        Some(pf) => quote! {
+            ::core::option::Option::Some(
+                |router: ::autumn_web::reexports::axum::Router|
+                    -> ::core::pin::Pin<Box<dyn ::core::future::Future<
+                        Output = Vec<::autumn_web::static_gen::StaticParams>
+                    > + Send>> {
+                    Box::pin(#pf(router))
+                }
+            )
+        },
+        None => quote! { ::core::option::Option::None },
+    };
 
     quote! {
         #input_fn
@@ -60,7 +166,8 @@ pub fn static_get_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             ::autumn_web::static_gen::StaticRouteMeta {
                 path: #path,
                 name: ::core::stringify!(#fn_name),
-                revalidate: ::core::option::Option::None,
+                revalidate: #revalidate_expr,
+                params_fn: #params_fn_expr,
             }
         }
     }

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -11,7 +11,7 @@ default = ["maud", "htmx", "tailwind", "db"]
 maud = ["dep:maud"]
 htmx = []
 tailwind = []
-db = ["dep:diesel", "dep:diesel-async", "dep:libsqlite3-sys"]
+db = ["dep:diesel", "dep:diesel-async", "dep:diesel_migrations", "dep:libsqlite3-sys"]
 
 [dependencies]
 autumn-macros = { version = "0.1.0", path = "../autumn-macros" }
@@ -19,6 +19,7 @@ axum.workspace = true
 bcrypt.workspace = true
 diesel = { workspace = true, optional = true }
 diesel-async = { workspace = true, optional = true }
+diesel_migrations = { workspace = true, optional = true }
 futures.workspace = true
 http.workspace = true
 indexmap.workspace = true
@@ -41,6 +42,7 @@ chrono = { workspace = true }
 
 [dev-dependencies]
 diesel = { version = "2", features = ["chrono"] }
+filetime = "0.2"
 http.workspace = true
 serde_json = "1"
 tempfile = "3"

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -11,13 +11,14 @@ default = ["maud", "htmx", "tailwind", "db"]
 maud = ["dep:maud"]
 htmx = []
 tailwind = []
-db = ["dep:diesel", "dep:diesel-async", "dep:diesel_migrations", "dep:libsqlite3-sys"]
+db = ["dep:diesel", "dep:diesel-async", "dep:diesel_migrations", "dep:libsqlite3-sys", "dep:pq-sys", "diesel/postgres"]
 
 [dependencies]
 autumn-macros = { version = "0.1.0", path = "../autumn-macros" }
 axum.workspace = true
 bcrypt.workspace = true
 diesel = { workspace = true, optional = true }
+pq-sys = { workspace = true, optional = true }
 diesel-async = { workspace = true, optional = true }
 diesel_migrations = { workspace = true, optional = true }
 futures.workspace = true

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -53,8 +53,7 @@ impl LogLevels {
     pub fn current_level(&self) -> String {
         self.inner
             .read()
-            .map(|guard| guard.current_level.clone())
-            .unwrap_or_else(|_| "info".to_string())
+            .map_or_else(|_| "info".to_string(), |guard| guard.current_level.clone())
     }
 
     /// Get all per-logger overrides.
@@ -67,6 +66,7 @@ impl LogLevels {
     }
 
     /// Set the level for a specific logger. Returns the previous level if any.
+    #[must_use]
     pub fn set_logger_level(&self, name: &str, level: &str) -> Option<String> {
         if let Ok(mut guard) = self.inner.write() {
             let previous = guard.logger_overrides.get(name).cloned();
@@ -264,12 +264,7 @@ impl ConfigProperties {
         );
 
         // Database properties
-        let db_url = config
-            .database
-            .url
-            .as_deref()
-            .unwrap_or("")
-            .to_string();
+        let db_url = config.database.url.as_deref().unwrap_or("").to_string();
         Self::track_property(&mut props, "database.url", &db_url, "", &profile_str);
         Self::track_property(
             &mut props,
@@ -553,9 +548,7 @@ pub(crate) async fn env_endpoint(State(state): State<AppState>) -> Json<Actuator
 
 /// `GET /actuator/metrics` -- request metrics, latency, status codes, DB pool stats.
 #[allow(unused_variables, unused_mut)]
-pub(crate) async fn metrics_endpoint(
-    State(state): State<AppState>,
-) -> Json<serde_json::Value> {
+pub(crate) async fn metrics_endpoint(State(state): State<AppState>) -> Json<serde_json::Value> {
     let snapshot = state.metrics.snapshot();
     let mut result = serde_json::to_value(&snapshot).unwrap_or_default();
 
@@ -579,9 +572,7 @@ pub(crate) async fn metrics_endpoint(
 // ── Config Properties (sensitive) ──────────────────────────────
 
 /// `GET /actuator/configprops` -- all config properties with source tracking.
-pub(crate) async fn configprops_endpoint(
-    State(state): State<AppState>,
-) -> Json<serde_json::Value> {
+pub(crate) async fn configprops_endpoint(State(state): State<AppState>) -> Json<serde_json::Value> {
     let props = state.config_props.snapshot();
 
     Json(serde_json::json!({
@@ -656,9 +647,7 @@ pub(crate) async fn loggers_put(
 // ── Tasks (sensitive) ──────────────────────────────────────────
 
 /// `GET /actuator/tasks` -- scheduled task status.
-pub(crate) async fn tasks_endpoint(
-    State(state): State<AppState>,
-) -> Json<serde_json::Value> {
+pub(crate) async fn tasks_endpoint(State(state): State<AppState>) -> Json<serde_json::Value> {
     let tasks = state.task_registry.snapshot();
 
     Json(serde_json::json!({
@@ -686,10 +675,7 @@ pub fn actuator_router(sensitive: bool) -> axum::Router<AppState> {
                 axum::routing::get(configprops_endpoint),
             )
             .route("/actuator/loggers", axum::routing::get(loggers_get))
-            .route(
-                "/actuator/loggers/{name}",
-                axum::routing::put(loggers_put),
-            )
+            .route("/actuator/loggers/{name}", axum::routing::put(loggers_put))
             .route("/actuator/tasks", axum::routing::get(tasks_endpoint));
     }
 
@@ -1010,12 +996,9 @@ mod tests {
         let levels = LogLevels::new("info");
         assert_eq!(levels.current_level(), "info");
 
-        levels.set_logger_level("my_crate", "debug");
+        let _ = levels.set_logger_level("my_crate", "debug");
         let overrides = levels.logger_overrides();
-        assert_eq!(
-            overrides.get("my_crate").map(String::as_str),
-            Some("debug")
-        );
+        assert_eq!(overrides.get("my_crate").map(String::as_str), Some("debug"));
     }
 
     #[test]

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1,17 +1,382 @@
 //! Actuator endpoints for operational observability.
 //!
-//! Provides health, info, and environment endpoints at `/actuator/*`.
+//! Provides health, info, env, metrics, configprops, loggers, and tasks
+//! endpoints at `/actuator/*`.
+//!
 //! Sensitive endpoints are gated by profile-aware defaults:
 //! - **dev**: all endpoints enabled
-//! - **prod**: only health and info
+//! - **prod**: only health, info, and metrics
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 use axum::Json;
-use axum::extract::State;
+use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::AppState;
+
+// ── Shared types for AppState ──────────────────────────────────
+
+/// Runtime log level management for the `/actuator/loggers` endpoint.
+///
+/// Stores the current effective log level and per-logger overrides.
+/// Changes are ephemeral -- they reset on restart.
+#[derive(Clone)]
+pub struct LogLevels {
+    inner: Arc<RwLock<LogLevelsInner>>,
+}
+
+struct LogLevelsInner {
+    /// The current global log level.
+    current_level: String,
+    /// Per-logger level overrides applied at runtime.
+    logger_overrides: HashMap<String, String>,
+}
+
+impl LogLevels {
+    /// Create a new `LogLevels` with the given initial level.
+    #[must_use]
+    pub fn new(initial_level: &str) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(LogLevelsInner {
+                current_level: initial_level.to_string(),
+                logger_overrides: HashMap::new(),
+            })),
+        }
+    }
+
+    /// Get the current global log level.
+    #[must_use]
+    pub fn current_level(&self) -> String {
+        self.inner
+            .read()
+            .map(|guard| guard.current_level.clone())
+            .unwrap_or_else(|_| "info".to_string())
+    }
+
+    /// Get all per-logger overrides.
+    #[must_use]
+    pub fn logger_overrides(&self) -> HashMap<String, String> {
+        self.inner
+            .read()
+            .map(|guard| guard.logger_overrides.clone())
+            .unwrap_or_default()
+    }
+
+    /// Set the level for a specific logger. Returns the previous level if any.
+    pub fn set_logger_level(&self, name: &str, level: &str) -> Option<String> {
+        if let Ok(mut guard) = self.inner.write() {
+            let previous = guard.logger_overrides.get(name).cloned();
+            guard
+                .logger_overrides
+                .insert(name.to_string(), level.to_string());
+            // If setting the root level, update current_level too
+            if name == "root" || name.is_empty() {
+                let prev = Some(guard.current_level.clone());
+                guard.current_level = level.to_string();
+                return prev;
+            }
+            previous
+        } else {
+            None
+        }
+    }
+}
+
+impl std::fmt::Debug for LogLevels {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LogLevels")
+            .field("current_level", &self.current_level())
+            .finish()
+    }
+}
+
+/// Scheduled task status information.
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskStatus {
+    /// The schedule description (e.g., "every 5m" or "cron 0 0 * * *").
+    pub schedule: String,
+    /// Current task state.
+    pub status: String,
+    /// Last time the task ran (ISO 8601), if ever.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_run: Option<String>,
+    /// Duration of last run in milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_duration_ms: Option<u64>,
+    /// Result of last run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_result: Option<String>,
+    /// Last error message, if the task failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    /// Total number of times the task has run.
+    pub total_runs: u64,
+    /// Total number of failures.
+    pub total_failures: u64,
+}
+
+/// Registry of scheduled tasks and their runtime status.
+#[derive(Clone)]
+pub struct TaskRegistry {
+    inner: Arc<RwLock<HashMap<String, TaskStatus>>>,
+}
+
+impl TaskRegistry {
+    /// Create a new empty task registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Register a task with its schedule description.
+    pub fn register(&self, name: &str, schedule: &str) {
+        if let Ok(mut guard) = self.inner.write() {
+            guard.insert(
+                name.to_string(),
+                TaskStatus {
+                    schedule: schedule.to_string(),
+                    status: "idle".to_string(),
+                    last_run: None,
+                    last_duration_ms: None,
+                    last_result: None,
+                    last_error: None,
+                    total_runs: 0,
+                    total_failures: 0,
+                },
+            );
+        }
+    }
+
+    /// Record that a task started running.
+    pub fn record_start(&self, name: &str) {
+        if let Ok(mut guard) = self.inner.write() {
+            if let Some(task) = guard.get_mut(name) {
+                task.status = "running".to_string();
+            }
+        }
+    }
+
+    /// Record that a task completed successfully.
+    pub fn record_success(&self, name: &str, duration_ms: u64) {
+        if let Ok(mut guard) = self.inner.write() {
+            if let Some(task) = guard.get_mut(name) {
+                task.status = "idle".to_string();
+                task.last_run = Some(chrono::Utc::now().to_rfc3339());
+                task.last_duration_ms = Some(duration_ms);
+                task.last_result = Some("ok".to_string());
+                task.last_error = None;
+                task.total_runs += 1;
+            }
+        }
+    }
+
+    /// Record that a task failed.
+    pub fn record_failure(&self, name: &str, duration_ms: u64, error: &str) {
+        if let Ok(mut guard) = self.inner.write() {
+            if let Some(task) = guard.get_mut(name) {
+                task.status = "idle".to_string();
+                task.last_run = Some(chrono::Utc::now().to_rfc3339());
+                task.last_duration_ms = Some(duration_ms);
+                task.last_result = Some("failed".to_string());
+                task.last_error = Some(error.to_string());
+                task.total_runs += 1;
+                task.total_failures += 1;
+            }
+        }
+    }
+
+    /// Get a snapshot of all task statuses.
+    #[must_use]
+    pub fn snapshot(&self) -> HashMap<String, TaskStatus> {
+        self.inner
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+}
+
+impl Default for TaskRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for TaskRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TaskRegistry")
+            .field("count", &self.snapshot().len())
+            .finish()
+    }
+}
+
+/// Resolved config property with source provenance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConfigProperty {
+    /// The resolved value (redacted if sensitive).
+    pub value: serde_json::Value,
+    /// Where the value came from.
+    pub source: String,
+}
+
+/// Collection of resolved config properties with source tracking.
+#[derive(Debug, Clone, Default)]
+pub struct ConfigProperties {
+    inner: Arc<RwLock<HashMap<String, ConfigProperty>>>,
+}
+
+impl ConfigProperties {
+    /// Build config properties with source tracking from the loaded config.
+    #[must_use]
+    pub fn from_config(config: &crate::config::AutumnConfig) -> Self {
+        let profile = config.profile.as_deref().unwrap_or("default");
+        let defaults = crate::config::AutumnConfig::default();
+
+        let mut props = HashMap::new();
+        let profile_str = profile.to_string();
+
+        // Server properties
+        Self::track_property(
+            &mut props,
+            "server.host",
+            &config.server.host,
+            &defaults.server.host,
+            &profile_str,
+        );
+        Self::track_property(
+            &mut props,
+            "server.port",
+            &config.server.port.to_string(),
+            &defaults.server.port.to_string(),
+            &profile_str,
+        );
+        Self::track_property(
+            &mut props,
+            "server.shutdown_timeout_secs",
+            &config.server.shutdown_timeout_secs.to_string(),
+            &defaults.server.shutdown_timeout_secs.to_string(),
+            &profile_str,
+        );
+
+        // Database properties
+        let db_url = config
+            .database
+            .url
+            .as_deref()
+            .unwrap_or("")
+            .to_string();
+        Self::track_property(&mut props, "database.url", &db_url, "", &profile_str);
+        Self::track_property(
+            &mut props,
+            "database.pool_size",
+            &config.database.pool_size.to_string(),
+            &defaults.database.pool_size.to_string(),
+            &profile_str,
+        );
+
+        // Log properties
+        Self::track_property(
+            &mut props,
+            "log.level",
+            &config.log.level,
+            &defaults.log.level,
+            &profile_str,
+        );
+        Self::track_property(
+            &mut props,
+            "log.format",
+            &format!("{:?}", config.log.format),
+            &format!("{:?}", defaults.log.format),
+            &profile_str,
+        );
+
+        // Health properties
+        Self::track_property(
+            &mut props,
+            "health.path",
+            &config.health.path,
+            &defaults.health.path,
+            &profile_str,
+        );
+        Self::track_property(
+            &mut props,
+            "health.detailed",
+            &config.health.detailed.to_string(),
+            &defaults.health.detailed.to_string(),
+            &profile_str,
+        );
+
+        // Actuator properties
+        Self::track_property(
+            &mut props,
+            "actuator.prefix",
+            &config.actuator.prefix,
+            &defaults.actuator.prefix,
+            &profile_str,
+        );
+        Self::track_property(
+            &mut props,
+            "actuator.sensitive",
+            &config.actuator.sensitive.to_string(),
+            &defaults.actuator.sensitive.to_string(),
+            &profile_str,
+        );
+
+        Self {
+            inner: Arc::new(RwLock::new(props)),
+        }
+    }
+
+    /// Track a single config property, determining its source by checking
+    /// for env var overrides and comparing against defaults.
+    fn track_property(
+        props: &mut HashMap<String, ConfigProperty>,
+        key: &str,
+        value: &str,
+        default_value: &str,
+        profile: &str,
+    ) {
+        // Check if there's an env var override
+        let env_key = format!("AUTUMN_{}", key.replace('.', "__").to_uppercase());
+        let source = if std::env::var(&env_key).is_ok() {
+            env_key
+        } else if value != default_value && (profile == "dev" || profile == "prod") {
+            format!("profile_default:{profile}")
+        } else if value != default_value {
+            "autumn.toml".to_string()
+        } else {
+            "default".to_string()
+        };
+
+        let display_value = if should_redact(key) {
+            serde_json::Value::String("****".into())
+        } else {
+            serde_json::Value::String(value.to_string())
+        };
+
+        props.insert(
+            key.to_string(),
+            ConfigProperty {
+                value: display_value,
+                source,
+            },
+        );
+    }
+
+    /// Get a snapshot of all properties.
+    #[must_use]
+    pub fn snapshot(&self) -> HashMap<String, ConfigProperty> {
+        self.inner
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+}
 
 // ── Health ──────────────────────────────────────────────────────
 
@@ -184,19 +549,148 @@ pub(crate) async fn env_endpoint(State(state): State<AppState>) -> Json<Actuator
     })
 }
 
+// ── Metrics ────────────────────────────────────────────────────
+
+/// `GET /actuator/metrics` -- request metrics, latency, status codes, DB pool stats.
+#[allow(unused_variables, unused_mut)]
+pub(crate) async fn metrics_endpoint(
+    State(state): State<AppState>,
+) -> Json<serde_json::Value> {
+    let snapshot = state.metrics.snapshot();
+    let mut result = serde_json::to_value(&snapshot).unwrap_or_default();
+
+    // Include DB pool stats if available
+    #[cfg(feature = "db")]
+    if let Some(pool) = state.pool.as_ref() {
+        let status = pool.status();
+        let db_stats = serde_json::json!({
+            "pool_size": status.max_size,
+            "active_connections": (status.max_size as u64).saturating_sub(status.available as u64),
+            "idle_connections": status.available,
+        });
+        if let serde_json::Value::Object(ref mut map) = result {
+            map.insert("database".to_string(), db_stats);
+        }
+    }
+
+    Json(result)
+}
+
+// ── Config Properties (sensitive) ──────────────────────────────
+
+/// `GET /actuator/configprops` -- all config properties with source tracking.
+pub(crate) async fn configprops_endpoint(
+    State(state): State<AppState>,
+) -> Json<serde_json::Value> {
+    let props = state.config_props.snapshot();
+
+    Json(serde_json::json!({
+        "active_profile": state.profile(),
+        "properties": props,
+    }))
+}
+
+// ── Loggers (sensitive) ────────────────────────────────────────
+
+/// Available log levels for the loggers endpoint.
+const AVAILABLE_LEVELS: &[&str] = &["trace", "debug", "info", "warn", "error"];
+
+/// Response for `GET /actuator/loggers`.
+#[derive(Serialize)]
+pub(crate) struct LoggersResponse {
+    current_level: String,
+    available_levels: Vec<&'static str>,
+    loggers: HashMap<String, String>,
+}
+
+/// `GET /actuator/loggers` -- view current log levels.
+pub(crate) async fn loggers_get(State(state): State<AppState>) -> Json<LoggersResponse> {
+    Json(LoggersResponse {
+        current_level: state.log_levels.current_level(),
+        available_levels: AVAILABLE_LEVELS.to_vec(),
+        loggers: state.log_levels.logger_overrides(),
+    })
+}
+
+/// Request body for `PUT /actuator/loggers/{name}`.
+#[derive(Deserialize)]
+pub(crate) struct SetLoggerRequest {
+    level: String,
+}
+
+/// `PUT /actuator/loggers/{name}` -- change a logger's level at runtime.
+pub(crate) async fn loggers_put(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(body): Json<SetLoggerRequest>,
+) -> impl IntoResponse {
+    let level = body.level.to_lowercase();
+
+    // Validate the level
+    if !AVAILABLE_LEVELS.contains(&level.as_str()) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "status": "error",
+                "message": format!(
+                    "Invalid level '{}'. Available levels: {}",
+                    level,
+                    AVAILABLE_LEVELS.join(", ")
+                ),
+            })),
+        );
+    }
+
+    let previous = state.log_levels.set_logger_level(&name, &level);
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "status": "ok",
+            "message": format!("Logger '{}' set to '{}'", name, level),
+            "previous": previous,
+        })),
+    )
+}
+
+// ── Tasks (sensitive) ──────────────────────────────────────────
+
+/// `GET /actuator/tasks` -- scheduled task status.
+pub(crate) async fn tasks_endpoint(
+    State(state): State<AppState>,
+) -> Json<serde_json::Value> {
+    let tasks = state.task_registry.snapshot();
+
+    Json(serde_json::json!({
+        "scheduled_tasks": tasks,
+    }))
+}
+
 // ── Router builder ──────────────────────────────────────────────
 
 /// Build the actuator router with profile-aware endpoint exposure.
 ///
 /// In dev mode (or when `actuator.sensitive = true`), all endpoints are
-/// exposed. In prod mode, only health and info are available.
+/// exposed. In prod mode, only health, info, and metrics are available.
 pub fn actuator_router(sensitive: bool) -> axum::Router<AppState> {
     let mut router = axum::Router::new()
         .route("/actuator/health", axum::routing::get(health))
-        .route("/actuator/info", axum::routing::get(info));
+        .route("/actuator/info", axum::routing::get(info))
+        .route("/actuator/metrics", axum::routing::get(metrics_endpoint));
 
     if sensitive {
-        router = router.route("/actuator/env", axum::routing::get(env_endpoint));
+        router = router
+            .route("/actuator/env", axum::routing::get(env_endpoint))
+            .route(
+                "/actuator/configprops",
+                axum::routing::get(configprops_endpoint),
+            )
+            .route("/actuator/loggers", axum::routing::get(loggers_get))
+            .route(
+                "/actuator/loggers/{name}",
+                axum::routing::put(loggers_put),
+            )
+            .route("/actuator/tasks", axum::routing::get(tasks_endpoint));
     }
 
     router
@@ -216,6 +710,10 @@ mod tests {
             profile: Some("dev".into()),
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: LogLevels::new("info"),
+            task_registry: TaskRegistry::new(),
+            config_props: ConfigProperties::default(),
         }
     }
 
@@ -301,5 +799,301 @@ mod tests {
         assert!(should_redact("secret_key"));
         assert!(!should_redact("server.port"));
         assert!(!should_redact("log.level"));
+    }
+
+    // ── Metrics endpoint tests ─────────────────────────────────
+
+    #[tokio::test]
+    async fn actuator_metrics_returns_http_stats() {
+        let state = test_state();
+        state.metrics.record("GET", "/test", 200, 10);
+        state.metrics.record("POST", "/test", 500, 50);
+
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["http"]["requests_total"], 2);
+        assert_eq!(json["http"]["by_status"]["2xx"], 1);
+        assert_eq!(json["http"]["by_status"]["5xx"], 1);
+    }
+
+    #[tokio::test]
+    async fn actuator_metrics_available_in_nonsensitive_mode() {
+        let app = actuator_router(false).with_state(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // ── Config properties endpoint tests ───────────────────────
+
+    #[tokio::test]
+    async fn actuator_configprops_returns_properties() {
+        let app = actuator_router(true).with_state(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/configprops")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["active_profile"], "dev");
+        assert!(json["properties"].is_object());
+    }
+
+    #[tokio::test]
+    async fn actuator_configprops_hidden_in_nonsensitive_mode() {
+        let app = actuator_router(false).with_state(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/configprops")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn configprops_redacts_sensitive_values() {
+        let mut props = HashMap::new();
+        ConfigProperties::track_property(
+            &mut props,
+            "database.url",
+            "postgres://user:pass@host/db",
+            "",
+            "dev",
+        );
+        assert_eq!(props["database.url"].value, "****");
+    }
+
+    #[test]
+    fn configprops_tracks_default_source() {
+        let mut props = HashMap::new();
+        ConfigProperties::track_property(&mut props, "server.port", "3000", "3000", "dev");
+        assert_eq!(props["server.port"].source, "default");
+        assert_eq!(props["server.port"].value, "3000");
+    }
+
+    #[test]
+    fn configprops_tracks_profile_source() {
+        let mut props = HashMap::new();
+        ConfigProperties::track_property(&mut props, "log.level", "debug", "info", "dev");
+        assert_eq!(props["log.level"].source, "profile_default:dev");
+    }
+
+    // ── Loggers endpoint tests ─────────────────────────────────
+
+    #[tokio::test]
+    async fn actuator_loggers_get_returns_levels() {
+        let app = actuator_router(true).with_state(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/loggers")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["current_level"], "info");
+        assert!(json["available_levels"].is_array());
+    }
+
+    #[tokio::test]
+    async fn actuator_loggers_put_changes_level() {
+        let state = test_state();
+        let app = actuator_router(true).with_state(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/actuator/loggers/autumn_web")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"level": "debug"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["message"], "Logger 'autumn_web' set to 'debug'");
+
+        let overrides = state.log_levels.logger_overrides();
+        assert_eq!(
+            overrides.get("autumn_web").map(String::as_str),
+            Some("debug")
+        );
+    }
+
+    #[tokio::test]
+    async fn actuator_loggers_put_rejects_invalid_level() {
+        let app = actuator_router(true).with_state(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/actuator/loggers/autumn_web")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"level": "banana"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "error");
+    }
+
+    #[tokio::test]
+    async fn actuator_loggers_hidden_in_nonsensitive_mode() {
+        let app = actuator_router(false).with_state(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/loggers")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn log_levels_set_and_get() {
+        let levels = LogLevels::new("info");
+        assert_eq!(levels.current_level(), "info");
+
+        levels.set_logger_level("my_crate", "debug");
+        let overrides = levels.logger_overrides();
+        assert_eq!(
+            overrides.get("my_crate").map(String::as_str),
+            Some("debug")
+        );
+    }
+
+    #[test]
+    fn log_levels_root_updates_current() {
+        let levels = LogLevels::new("info");
+        let prev = levels.set_logger_level("root", "trace");
+        assert_eq!(prev, Some("info".to_string()));
+        assert_eq!(levels.current_level(), "trace");
+    }
+
+    // ── Tasks endpoint tests ───────────────────────────────────
+
+    #[tokio::test]
+    async fn actuator_tasks_returns_registered_tasks() {
+        let state = test_state();
+        state.task_registry.register("cleanup", "every 5m");
+        state.task_registry.record_start("cleanup");
+        state.task_registry.record_success("cleanup", 150);
+
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/tasks")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let task = &json["scheduled_tasks"]["cleanup"];
+        assert_eq!(task["schedule"], "every 5m");
+        assert_eq!(task["status"], "idle");
+        assert_eq!(task["total_runs"], 1);
+        assert_eq!(task["total_failures"], 0);
+        assert_eq!(task["last_result"], "ok");
+        assert_eq!(task["last_duration_ms"], 150);
+    }
+
+    #[tokio::test]
+    async fn actuator_tasks_hidden_in_nonsensitive_mode() {
+        let app = actuator_router(false).with_state(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/tasks")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn task_registry_records_failure() {
+        let registry = TaskRegistry::new();
+        registry.register("my_task", "cron 0 * * * *");
+        registry.record_start("my_task");
+        registry.record_failure("my_task", 200, "connection refused");
+
+        let snapshot = registry.snapshot();
+        let task = &snapshot["my_task"];
+        assert_eq!(task.status, "idle");
+        assert_eq!(task.total_runs, 1);
+        assert_eq!(task.total_failures, 1);
+        assert_eq!(task.last_result.as_deref(), Some("failed"));
+        assert_eq!(task.last_error.as_deref(), Some("connection refused"));
+    }
+
+    #[test]
+    fn task_registry_empty_snapshot() {
+        let registry = TaskRegistry::new();
+        assert!(registry.snapshot().is_empty());
     }
 }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -31,10 +31,10 @@ use crate::config::AutumnConfig;
 #[cfg(feature = "db")]
 use crate::db;
 use crate::error_pages::{self, ErrorPageRenderer, SharedRenderer};
-#[cfg(feature = "db")]
-use crate::migrate;
 use crate::middleware::RequestIdLayer;
 use crate::middleware::exception_filter::{ExceptionFilter, ExceptionFilterLayer};
+#[cfg(feature = "db")]
+use crate::migrate;
 use crate::route::Route;
 
 /// Create a new [`AppBuilder`].
@@ -407,7 +407,7 @@ impl AppBuilder {
     /// ```
     #[cfg(feature = "db")]
     #[must_use]
-    pub fn migrations(mut self, migrations: migrate::EmbeddedMigrations) -> Self {
+    pub const fn migrations(mut self, migrations: migrate::EmbeddedMigrations) -> Self {
         self.migrations = Some(migrations);
         self
     }
@@ -431,6 +431,7 @@ impl AppBuilder {
     /// Panics if no routes have been registered via [`.routes()`](Self::routes).
     /// This is intentional -- an application with no routes is always a
     /// developer error.
+    #[allow(clippy::too_many_lines)]
     pub async fn run(self) {
         // ── Build mode ─────────────────────────────────────────────────
         // When AUTUMN_BUILD_STATIC=1, render static routes to dist/ and exit
@@ -631,6 +632,7 @@ impl AppBuilder {
 ///
 /// Each task runs in its own spawned task with error logging.
 /// Uses simple `tokio::time` for fixed-delay scheduling.
+#[allow(clippy::cast_possible_truncation)]
 fn start_task_scheduler(tasks: Vec<crate::task::TaskInfo>, state: &AppState) {
     tracing::info!(count = tasks.len(), "Starting scheduled tasks");
     for task_info in &tasks {
@@ -659,15 +661,19 @@ fn start_task_scheduler(tasks: Vec<crate::task::TaskInfo>, state: &AppState) {
                         let start = std::time::Instant::now();
                         match (handler)(state.clone()).await {
                             Ok(()) => {
-                                let duration_ms = start.elapsed().as_millis() as u64;
+                                let duration_ms =
+                                    u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
                                 state.task_registry.record_success(&name, duration_ms);
                                 tracing::debug!(task = %name, "Task completed");
                             }
                             Err(e) => {
-                                let duration_ms = start.elapsed().as_millis() as u64;
-                                state
-                                    .task_registry
-                                    .record_failure(&name, duration_ms, &e.to_string());
+                                let duration_ms =
+                                    u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+                                state.task_registry.record_failure(
+                                    &name,
+                                    duration_ms,
+                                    &e.to_string(),
+                                );
                                 tracing::warn!(task = %name, error = %e, "Task failed");
                             }
                         }
@@ -743,6 +749,7 @@ pub fn build_router_merged(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_router_inner(
     route_list: Vec<Route>,
     config: &AutumnConfig,
@@ -889,10 +896,8 @@ fn build_router_inner(
         .as_deref()
         .map_or(cfg!(debug_assertions), |p| p == "dev");
     let renderer = error_page_renderer.unwrap_or_else(error_pages::default_renderer);
-    let error_page_filter = crate::middleware::error_page_filter::ErrorPageFilter {
-        renderer,
-        is_dev,
-    };
+    let error_page_filter =
+        crate::middleware::error_page_filter::ErrorPageFilter { renderer, is_dev };
 
     // Combine the error page filter with user exception filters.
     // The error page filter runs first (innermost), then user filters.
@@ -900,7 +905,10 @@ fn build_router_inner(
     all_filters.extend(exception_filters);
 
     let count = all_filters.len();
-    tracing::debug!(count, "Registered exception filters (including error page filter)");
+    tracing::debug!(
+        count,
+        "Registered exception filters (including error page filter)"
+    );
 
     // Error page context layer must be inner to the exception filter so
     // WantsHtml is set on the response before the filter inspects it.
@@ -943,6 +951,7 @@ pub fn build_router_with_static(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_router_with_static_inner(
     route_list: Vec<Route>,
     config: &AutumnConfig,
@@ -1016,7 +1025,7 @@ fn build_router_with_static_inner(
     // ISR staleness checking: before ServeDir handles the request, we
     // trigger resolve() on the StaticFileLayer to check for stale pages
     // and spawn background regeneration tasks if needed.
-    let isr_layer = layer.clone();
+    let isr_layer = layer;
     let serve_dir = tower_http::services::ServeDir::new(dist);
     app_router
         .layer(axum::middleware::from_fn(
@@ -1026,7 +1035,7 @@ fn build_router_with_static_inner(
                     // Trigger ISR check for GET requests (resolves the path
                     // and spawns background regeneration if stale)
                     if req.method() == http::Method::GET {
-                        isr_layer.resolve(req.uri().path());
+                        let _ = isr_layer.resolve(req.uri().path());
                     }
                     next.run(req).await
                 }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -30,6 +30,9 @@ use crate::AppState;
 use crate::config::AutumnConfig;
 #[cfg(feature = "db")]
 use crate::db;
+use crate::error_pages::{self, ErrorPageRenderer, SharedRenderer};
+#[cfg(feature = "db")]
+use crate::migrate;
 use crate::middleware::RequestIdLayer;
 use crate::middleware::exception_filter::{ExceptionFilter, ExceptionFilterLayer};
 use crate::route::Route;
@@ -64,6 +67,11 @@ pub fn app() -> AppBuilder {
         static_metas: Vec::new(),
         exception_filters: Vec::new(),
         scoped_groups: Vec::new(),
+        merge_routers: Vec::new(),
+        nest_routers: Vec::new(),
+        error_page_renderer: None,
+        #[cfg(feature = "db")]
+        migrations: None,
     }
 }
 
@@ -101,6 +109,13 @@ pub struct AppBuilder {
     pub(crate) static_metas: Vec<crate::static_gen::StaticRouteMeta>,
     exception_filters: Vec<Arc<dyn ExceptionFilter>>,
     scoped_groups: Vec<ScopedGroup>,
+    merge_routers: Vec<axum::Router<AppState>>,
+    nest_routers: Vec<(String, axum::Router<AppState>)>,
+    /// Custom error page renderer (overrides built-in pages).
+    error_page_renderer: Option<SharedRenderer>,
+    /// Embedded Diesel migrations, registered via `.migrations()`.
+    #[cfg(feature = "db")]
+    migrations: Option<migrate::EmbeddedMigrations>,
 }
 
 /// A group of routes sharing a common path prefix and middleware layer.
@@ -200,6 +215,48 @@ impl AppBuilder {
         self
     }
 
+    /// Register a custom error page renderer.
+    ///
+    /// The renderer replaces the built-in default error pages (404, 422, 500,
+    /// and generic errors). Implement [`ErrorPageRenderer`] to provide your
+    /// own branded error pages.
+    ///
+    /// Only one renderer can be active. Calling this method multiple times
+    /// replaces the previous renderer.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use autumn_web::error_pages::{ErrorPageRenderer, ErrorContext};
+    /// use maud::{Markup, html};
+    ///
+    /// struct MyErrors;
+    ///
+    /// impl ErrorPageRenderer for MyErrors {
+    ///     fn render_error(&self, ctx: &ErrorContext) -> Markup {
+    ///         html! {
+    ///             h1 { (ctx.status.as_u16()) " - Custom error page" }
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// # use autumn_web::prelude::*;
+    /// # #[get("/")] async fn index() -> &'static str { "" }
+    /// # #[autumn_web::main]
+    /// # async fn main() {
+    /// autumn_web::app()
+    ///     .error_pages(MyErrors)
+    ///     .routes(routes![index])
+    ///     .run()
+    ///     .await;
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn error_pages(mut self, renderer: impl ErrorPageRenderer) -> Self {
+        self.error_page_renderer = Some(Arc::new(renderer));
+        self
+    }
+
     /// Register a group of routes with a shared path prefix and middleware.
     ///
     /// The `layer` is applied only to routes within this group, not to the
@@ -242,6 +299,116 @@ impl AppBuilder {
             routes,
             apply_layer: Box::new(move |router| router.layer(layer)),
         });
+        self
+    }
+
+    /// Merge a raw Axum router into the application.
+    ///
+    /// This is an escape hatch for when Autumn's route macros are not
+    /// sufficient -- for example, when integrating a third-party Axum
+    /// middleware crate or mounting a hand-built WebSocket handler.
+    ///
+    /// The merged router shares the same [`AppState`] (database pool,
+    /// config, etc.) and Autumn's global middleware (request IDs,
+    /// security headers, session management) applies to its routes.
+    ///
+    /// Merged routes are added **after** Autumn's annotated routes, so
+    /// if both define the same path, the annotated route takes precedence.
+    ///
+    /// Can be called multiple times -- routers are accumulated.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use autumn_web::prelude::*;
+    /// use autumn_web::AppState;
+    ///
+    /// #[get("/")]
+    /// async fn index() -> &'static str { "hi" }
+    ///
+    /// #[autumn_web::main]
+    /// async fn main() {
+    ///     let raw = axum::Router::<AppState>::new()
+    ///         .route("/ws", axum::routing::get(|| async { "websocket" }));
+    ///
+    ///     autumn_web::app()
+    ///         .routes(routes![index])
+    ///         .merge(raw)
+    ///         .run()
+    ///         .await;
+    /// }
+    /// ```
+    #[must_use]
+    pub fn merge(mut self, router: axum::Router<AppState>) -> Self {
+        self.merge_routers.push(router);
+        self
+    }
+
+    /// Mount a raw Axum router under a path prefix.
+    ///
+    /// This is an escape hatch similar to [`merge`](Self::merge), but the
+    /// router's routes are nested under the given `path` prefix. Useful
+    /// for mounting a self-contained API version or third-party router.
+    ///
+    /// The nested router shares the same [`AppState`] and Autumn's global
+    /// middleware applies to its routes.
+    ///
+    /// Can be called multiple times with different prefixes.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use autumn_web::prelude::*;
+    /// use autumn_web::AppState;
+    ///
+    /// #[get("/")]
+    /// async fn index() -> &'static str { "hi" }
+    ///
+    /// #[autumn_web::main]
+    /// async fn main() {
+    ///     let v2 = axum::Router::<AppState>::new()
+    ///         .route("/users", axum::routing::get(|| async { "v2 users" }));
+    ///
+    ///     autumn_web::app()
+    ///         .routes(routes![index])
+    ///         .nest("/api/v2", v2)
+    ///         .run()
+    ///         .await;
+    /// }
+    /// ```
+    #[must_use]
+    pub fn nest(mut self, path: &str, router: axum::Router<AppState>) -> Self {
+        self.nest_routers.push((path.to_owned(), router));
+        self
+    }
+
+    /// Register embedded Diesel migrations with the application.
+    ///
+    /// When migrations are registered:
+    /// - In **dev** mode, pending migrations run automatically on startup.
+    /// - In **prod** mode, pending migrations are logged as warnings but
+    ///   not applied -- use `autumn migrate` to apply them explicitly.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
+    ///
+    /// const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
+    ///
+    /// #[autumn_web::main]
+    /// async fn main() {
+    ///     autumn_web::app()
+    ///         .routes(routes![...])
+    ///         .migrations(MIGRATIONS)
+    ///         .run()
+    ///         .await;
+    /// }
+    /// ```
+    #[cfg(feature = "db")]
+    #[must_use]
+    pub fn migrations(mut self, migrations: migrate::EmbeddedMigrations) -> Self {
+        self.migrations = Some(migrations);
         self
     }
 
@@ -316,6 +483,12 @@ impl AppBuilder {
             tracing::info!("Database not configured");
         }
 
+        // 5b. Run migrations if registered
+        #[cfg(feature = "db")]
+        if let (Some(migrations), Some(url)) = (self.migrations, &config.database.url) {
+            migrate::auto_migrate(url, config.profile.as_deref(), migrations);
+        }
+
         // 6. Build the router (with optional static-file layer)
         let state = AppState {
             #[cfg(feature = "db")]
@@ -323,6 +496,10 @@ impl AppBuilder {
             profile: config.profile.clone(),
             started_at: std::time::Instant::now(),
             health_detailed: config.health.detailed,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new(&config.log.level),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::from_config(&config),
         };
         let dist_dir = project_dir("dist");
         let dist_ref = if dist_dir.exists() {
@@ -337,6 +514,9 @@ impl AppBuilder {
             dist_ref,
             self.exception_filters,
             self.scoped_groups,
+            self.merge_routers,
+            self.nest_routers,
+            self.error_page_renderer,
         );
 
         // 7. Start scheduled tasks (if any)
@@ -419,6 +599,10 @@ impl AppBuilder {
             profile: config.profile.clone(),
             started_at: std::time::Instant::now(),
             health_detailed: config.health.detailed,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new(&config.log.level),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::from_config(&config),
         };
 
         // Build the full router (same as production)
@@ -463,18 +647,38 @@ fn start_task_scheduler(tasks: Vec<crate::task::TaskInfo>, state: &AppState) {
 
         match task_info.schedule {
             crate::task::Schedule::FixedDelay(delay) => {
+                // Register with the task registry for /actuator/tasks
+                let schedule_desc = format!("every {}s", delay.as_secs());
+                state.task_registry.register(&name, &schedule_desc);
+
                 tokio::spawn(async move {
                     loop {
                         tokio::time::sleep(delay).await;
                         tracing::debug!(task = %name, "Running scheduled task");
+                        state.task_registry.record_start(&name);
+                        let start = std::time::Instant::now();
                         match (handler)(state.clone()).await {
-                            Ok(()) => tracing::debug!(task = %name, "Task completed"),
-                            Err(e) => tracing::warn!(task = %name, error = %e, "Task failed"),
+                            Ok(()) => {
+                                let duration_ms = start.elapsed().as_millis() as u64;
+                                state.task_registry.record_success(&name, duration_ms);
+                                tracing::debug!(task = %name, "Task completed");
+                            }
+                            Err(e) => {
+                                let duration_ms = start.elapsed().as_millis() as u64;
+                                state
+                                    .task_registry
+                                    .record_failure(&name, duration_ms, &e.to_string());
+                                tracing::warn!(task = %name, error = %e, "Task failed");
+                            }
                         }
                     }
                 });
             }
             crate::task::Schedule::Cron { expression, .. } => {
+                // Register with the task registry even though cron is not yet implemented
+                let schedule_desc = format!("cron {expression}");
+                state.task_registry.register(&name, &schedule_desc);
+
                 tracing::info!(
                     task = %name,
                     cron = %expression,
@@ -503,7 +707,40 @@ pub fn build_router(
     config: &AutumnConfig,
     state: AppState,
 ) -> axum::Router {
-    build_router_inner(route_list, config, state, Vec::new(), Vec::new())
+    build_router_inner(
+        route_list,
+        config,
+        state,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        None,
+    )
+}
+
+/// Build a router that includes user-supplied raw Axum routers.
+///
+/// Like [`build_router`], but also merges and nests additional raw
+/// Axum routers. This is primarily useful for integration testing;
+/// in production, use [`AppBuilder::merge`] and [`AppBuilder::nest`].
+pub fn build_router_merged(
+    route_list: Vec<Route>,
+    config: &AutumnConfig,
+    state: AppState,
+    merge_routers: Vec<axum::Router<AppState>>,
+    nest_routers: Vec<(String, axum::Router<AppState>)>,
+) -> axum::Router {
+    build_router_inner(
+        route_list,
+        config,
+        state,
+        Vec::new(),
+        Vec::new(),
+        merge_routers,
+        nest_routers,
+        None,
+    )
 }
 
 fn build_router_inner(
@@ -512,6 +749,9 @@ fn build_router_inner(
     state: AppState,
     exception_filters: Vec<Arc<dyn ExceptionFilter>>,
     scoped_groups: Vec<ScopedGroup>,
+    merge_routers: Vec<axum::Router<AppState>>,
+    nest_routers: Vec<(String, axum::Router<AppState>)>,
+    error_page_renderer: Option<SharedRenderer>,
 ) -> axum::Router {
     // Group routes by path so multiple methods on the same path
     // (e.g. GET /admin + POST /admin) are merged into a single
@@ -589,6 +829,19 @@ fn build_router_inner(
         router = router.nest(&group.prefix, sub_router);
     }
 
+    // Merge user-supplied raw Axum routers (escape hatch).
+    // Merged after annotated routes so annotated routes take precedence.
+    for raw_router in merge_routers {
+        tracing::debug!("Merged raw Axum router");
+        router = router.merge(raw_router);
+    }
+
+    // Nest user-supplied raw Axum routers under path prefixes.
+    for (prefix, raw_router) in nest_routers {
+        tracing::debug!(prefix = %prefix, "Nested raw Axum router");
+        router = router.nest(&prefix, raw_router);
+    }
+
     // CORS middleware (only applied when allowed_origins is non-empty)
     if !config.cors.allowed_origins.is_empty() {
         let cors = build_cors_layer(&config.cors);
@@ -619,19 +872,43 @@ fn build_router_inner(
         crate::security::SecurityHeadersLayer::from_config(&config.security.headers);
     tracing::debug!("Security headers enabled");
 
+    // 404 fallback handler for unmatched routes
+    router = router.fallback(crate::middleware::error_page_filter::fallback_404_handler);
+
     // Apply framework middleware. Exception filters wrap outermost so they
     // see all error responses regardless of scoping or interceptors.
     let router = router
         .layer(RequestIdLayer)
         .layer(security_headers)
         .layer(session_layer);
-    let router = if exception_filters.is_empty() {
-        router
-    } else {
-        let count = exception_filters.len();
-        tracing::debug!(count, "Registered exception filters");
-        router.layer(ExceptionFilterLayer::new(exception_filters))
+
+    // Error page filter: renders HTML error pages for browser requests.
+    // Always registered (uses default renderer if no custom one is provided).
+    let is_dev = config
+        .profile
+        .as_deref()
+        .map_or(cfg!(debug_assertions), |p| p == "dev");
+    let renderer = error_page_renderer.unwrap_or_else(error_pages::default_renderer);
+    let error_page_filter = crate::middleware::error_page_filter::ErrorPageFilter {
+        renderer,
+        is_dev,
     };
+
+    // Combine the error page filter with user exception filters.
+    // The error page filter runs first (innermost), then user filters.
+    let mut all_filters: Vec<Arc<dyn ExceptionFilter>> = vec![Arc::new(error_page_filter)];
+    all_filters.extend(exception_filters);
+
+    let count = all_filters.len();
+    tracing::debug!(count, "Registered exception filters (including error page filter)");
+
+    // Error page context layer must be inner to the exception filter so
+    // WantsHtml is set on the response before the filter inspects it.
+    // Layer order: Metrics -> ExceptionFilter -> ErrorPageContext -> router
+    let router = router
+        .layer(crate::middleware::error_page_filter::ErrorPageContextLayer)
+        .layer(ExceptionFilterLayer::new(all_filters))
+        .layer(crate::middleware::MetricsLayer::new(state.metrics.clone()));
 
     router.with_state(state)
 }
@@ -653,7 +930,17 @@ pub fn build_router_with_static(
     state: AppState,
     dist_dir: Option<&std::path::Path>,
 ) -> axum::Router {
-    build_router_with_static_inner(route_list, config, state, dist_dir, Vec::new(), Vec::new())
+    build_router_with_static_inner(
+        route_list,
+        config,
+        state,
+        dist_dir,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        None,
+    )
 }
 
 fn build_router_with_static_inner(
@@ -663,9 +950,20 @@ fn build_router_with_static_inner(
     dist_dir: Option<&std::path::Path>,
     exception_filters: Vec<Arc<dyn ExceptionFilter>>,
     scoped_groups: Vec<ScopedGroup>,
+    merge_routers: Vec<axum::Router<AppState>>,
+    nest_routers: Vec<(String, axum::Router<AppState>)>,
+    error_page_renderer: Option<SharedRenderer>,
 ) -> axum::Router {
-    let app_router =
-        build_router_inner(route_list, config, state, exception_filters, scoped_groups);
+    let app_router = build_router_inner(
+        route_list,
+        config,
+        state,
+        exception_filters,
+        scoped_groups,
+        merge_routers,
+        nest_routers,
+        error_page_renderer,
+    );
 
     let Some(dist) = dist_dir else {
         return app_router;
@@ -679,6 +977,20 @@ fn build_router_with_static_inner(
         return app_router;
     };
 
+    // Enable ISR regeneration by attaching the app router to the static layer.
+    // Routes with `revalidate` set will spawn background re-render tasks
+    // when their files become stale.
+    let has_isr = layer
+        .manifest()
+        .routes
+        .values()
+        .any(|e| e.revalidate.is_some());
+    let layer = if has_isr {
+        layer.with_router(app_router.clone())
+    } else {
+        layer
+    };
+
     for (route, entry) in &layer.manifest().routes {
         tracing::debug!(
             route = %route,
@@ -687,6 +999,9 @@ fn build_router_with_static_inner(
             "Static route"
         );
     }
+
+    // Store the layer in an Arc so the ISR check middleware can use it.
+    let layer = Arc::new(layer);
 
     // Mount static files as a fallback on the app router rather than
     // wrapping the app behind ServeDir. The previous approach
@@ -697,8 +1012,27 @@ fn build_router_with_static_inner(
     // With this approach: explicit routes (GET, POST, etc.) always win.
     // Only requests that match NO dynamic route fall through to ServeDir,
     // which then serves static files (e.g. /about/ → dist/about/index.html).
+    //
+    // ISR staleness checking: before ServeDir handles the request, we
+    // trigger resolve() on the StaticFileLayer to check for stale pages
+    // and spawn background regeneration tasks if needed.
+    let isr_layer = layer.clone();
     let serve_dir = tower_http::services::ServeDir::new(dist);
-    app_router.fallback_service(serve_dir)
+    app_router
+        .layer(axum::middleware::from_fn(
+            move |req: axum::extract::Request, next: axum::middleware::Next| {
+                let isr_layer = isr_layer.clone();
+                async move {
+                    // Trigger ISR check for GET requests (resolves the path
+                    // and spawns background regeneration if stale)
+                    if req.method() == http::Method::GET {
+                        isr_layer.resolve(req.uri().path());
+                    }
+                    next.run(req).await
+                }
+            },
+        ))
+        .fallback_service(serve_dir)
 }
 
 /// Build a `tower_http::cors::CorsLayer` from the framework's [`CorsConfig`].
@@ -800,6 +1134,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
         build_router(routes, &config, state)
     }
@@ -862,6 +1200,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
         let router = build_router(vec![test_get_route("/dummy", "dummy")], &config, state);
 
@@ -935,6 +1277,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
         let router = build_router(post_routes, &config, state);
 
@@ -975,6 +1321,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
         let router = build_router(route_list, &config, state);
 
@@ -1125,6 +1475,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
         let router = build_router_with_static(
             vec![test_get_route("/other", "other_page")],
@@ -1159,6 +1513,7 @@ mod tests {
             path: "/about",
             name: "about",
             revalidate: None,
+            params_fn: None,
         }];
         let builder = app().static_routes(metas);
         assert_eq!(builder.static_metas.len(), 1);
@@ -1182,6 +1537,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
         build_router(routes, config, state)
     }
@@ -1309,6 +1668,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
         let router = build_router_with_static(
             vec![test_get_route("/test", "test")],
@@ -1334,6 +1697,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
         let router =
             build_router_with_static(vec![test_get_route("/test", "test")], &config, state, None);

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -425,6 +425,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
 
         let app = Router::new().route("/", get(handler)).with_state(state);
@@ -464,6 +468,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
 
         // Middleware that inserts a user into extensions
@@ -511,6 +519,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
 
         let app = Router::new()
@@ -612,6 +624,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
 
         let app = Router::new()
@@ -664,6 +680,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
 
         let app = Router::new()
@@ -721,6 +741,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
 
         let app = Router::new()
@@ -774,6 +798,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
 
         let app = Router::new()
@@ -821,6 +849,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
 
         let app = Router::new()

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -183,6 +183,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         });
 
         let response = app

--- a/autumn/src/error_pages/defaults.rs
+++ b/autumn/src/error_pages/defaults.rs
@@ -14,129 +14,141 @@ pub struct DefaultErrorPages;
 
 impl ErrorPageRenderer for DefaultErrorPages {
     fn render_404(&self, ctx: &ErrorContext) -> Markup {
-        error_page_layout(ctx, html! {
-            div class="text-center" {
-                div class="text-8xl font-bold text-gray-200 dark:text-gray-700 select-none" {
-                    "404"
-                }
-                h1 class="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-100" {
-                    "Page not found"
-                }
-                p class="mt-2 text-gray-600 dark:text-gray-400" {
-                    "The page "
-                    code class="px-2 py-0.5 bg-gray-100 dark:bg-gray-800 rounded text-sm font-mono text-gray-800 dark:text-gray-300" {
-                        (ctx.path)
+        error_page_layout(
+            ctx,
+            &html! {
+                div class="text-center" {
+                    div class="text-8xl font-bold text-gray-200 dark:text-gray-700 select-none" {
+                        "404"
                     }
-                    " could not be found."
-                }
-                div class="mt-8" {
-                    a href="/"
-                      class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
-                        "Go to homepage"
+                    h1 class="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-100" {
+                        "Page not found"
+                    }
+                    p class="mt-2 text-gray-600 dark:text-gray-400" {
+                        "The page "
+                        code class="px-2 py-0.5 bg-gray-100 dark:bg-gray-800 rounded text-sm font-mono text-gray-800 dark:text-gray-300" {
+                            (ctx.path)
+                        }
+                        " could not be found."
+                    }
+                    div class="mt-8" {
+                        a href="/"
+                          class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
+                            "Go to homepage"
+                        }
                     }
                 }
-            }
-        })
+            },
+        )
     }
 
     fn render_500(&self, ctx: &ErrorContext) -> Markup {
-        error_page_layout(ctx, html! {
-            div class="text-center" {
-                div class="text-8xl font-bold text-gray-200 dark:text-gray-700 select-none" {
-                    "500"
-                }
-                h1 class="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-100" {
-                    "Internal server error"
-                }
-                p class="mt-2 text-gray-600 dark:text-gray-400" {
-                    "Something went wrong. Please try again later."
-                }
-                @if let Some(ref req_id) = ctx.request_id {
-                    p class="mt-4 text-xs text-gray-400 dark:text-gray-500 font-mono" {
-                        "Request ID: " (req_id)
+        error_page_layout(
+            ctx,
+            &html! {
+                div class="text-center" {
+                    div class="text-8xl font-bold text-gray-200 dark:text-gray-700 select-none" {
+                        "500"
+                    }
+                    h1 class="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-100" {
+                        "Internal server error"
+                    }
+                    p class="mt-2 text-gray-600 dark:text-gray-400" {
+                        "Something went wrong. Please try again later."
+                    }
+                    @if let Some(ref req_id) = ctx.request_id {
+                        p class="mt-4 text-xs text-gray-400 dark:text-gray-500 font-mono" {
+                            "Request ID: " (req_id)
+                        }
+                    }
+                    div class="mt-8" {
+                        a href="/"
+                          class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
+                            "Go to homepage"
+                        }
                     }
                 }
-                div class="mt-8" {
-                    a href="/"
-                      class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
-                        "Go to homepage"
-                    }
-                }
-            }
-        })
+            },
+        )
     }
 
     fn render_422(&self, ctx: &ErrorContext) -> Markup {
-        error_page_layout(ctx, html! {
-            div class="text-center" {
-                div class="text-8xl font-bold text-gray-200 dark:text-gray-700 select-none" {
-                    "422"
-                }
-                h1 class="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-100" {
-                    "Validation error"
-                }
-                p class="mt-2 text-gray-600 dark:text-gray-400" {
-                    (ctx.message)
-                }
-                @if let Some(ref details) = ctx.details {
-                    div class="mt-6 max-w-md mx-auto text-left" {
-                        @for (field, errors) in details {
-                            div class="mb-3" {
-                                p class="text-sm font-medium text-gray-700 dark:text-gray-300" {
-                                    (field)
-                                }
-                                @for error in errors {
-                                    p class="text-sm text-red-600 dark:text-red-400 ml-2" {
-                                        "- " (error)
+        error_page_layout(
+            ctx,
+            &html! {
+                div class="text-center" {
+                    div class="text-8xl font-bold text-gray-200 dark:text-gray-700 select-none" {
+                        "422"
+                    }
+                    h1 class="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-100" {
+                        "Validation error"
+                    }
+                    p class="mt-2 text-gray-600 dark:text-gray-400" {
+                        (ctx.message)
+                    }
+                    @if let Some(ref details) = ctx.details {
+                        div class="mt-6 max-w-md mx-auto text-left" {
+                            @for (field, errors) in details {
+                                div class="mb-3" {
+                                    p class="text-sm font-medium text-gray-700 dark:text-gray-300" {
+                                        (field)
+                                    }
+                                    @for error in errors {
+                                        p class="text-sm text-red-600 dark:text-red-400 ml-2" {
+                                            "- " (error)
+                                        }
                                     }
                                 }
                             }
                         }
                     }
-                }
-                div class="mt-8" {
-                    a href="javascript:history.back()"
-                      class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
-                        "Go back"
+                    div class="mt-8" {
+                        a href="javascript:history.back()"
+                          class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
+                            "Go back"
+                        }
                     }
                 }
-            }
-        })
+            },
+        )
     }
 
     fn render_error(&self, ctx: &ErrorContext) -> Markup {
         let status_code = ctx.status.as_u16();
         let reason = ctx.status.canonical_reason().unwrap_or("Error");
 
-        error_page_layout(ctx, html! {
-            div class="text-center" {
-                div class="text-8xl font-bold text-gray-200 dark:text-gray-700 select-none" {
-                    (status_code)
-                }
-                h1 class="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-100" {
-                    (reason)
-                }
-                p class="mt-2 text-gray-600 dark:text-gray-400" {
-                    (ctx.message)
-                }
-                @if let Some(ref req_id) = ctx.request_id {
-                    p class="mt-4 text-xs text-gray-400 dark:text-gray-500 font-mono" {
-                        "Request ID: " (req_id)
+        error_page_layout(
+            ctx,
+            &html! {
+                div class="text-center" {
+                    div class="text-8xl font-bold text-gray-200 dark:text-gray-700 select-none" {
+                        (status_code)
+                    }
+                    h1 class="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-100" {
+                        (reason)
+                    }
+                    p class="mt-2 text-gray-600 dark:text-gray-400" {
+                        (ctx.message)
+                    }
+                    @if let Some(ref req_id) = ctx.request_id {
+                        p class="mt-4 text-xs text-gray-400 dark:text-gray-500 font-mono" {
+                            "Request ID: " (req_id)
+                        }
+                    }
+                    div class="mt-8" {
+                        a href="/"
+                          class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
+                            "Go to homepage"
+                        }
                     }
                 }
-                div class="mt-8" {
-                    a href="/"
-                      class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
-                        "Go to homepage"
-                    }
-                }
-            }
-        })
+            },
+        )
     }
 }
 
 /// Shared HTML layout wrapper for all error pages.
-fn error_page_layout(ctx: &ErrorContext, content: Markup) -> Markup {
+fn error_page_layout(ctx: &ErrorContext, content: &Markup) -> Markup {
     let status_code = ctx.status.as_u16();
     let reason = ctx.status.canonical_reason().unwrap_or("Error");
     let title = format!("{status_code} {reason}");
@@ -163,7 +175,7 @@ fn error_page_layout(ctx: &ErrorContext, content: Markup) -> Markup {
 
 /// Minimal inline CSS fallback so error pages look reasonable even without
 /// Tailwind CSS loaded. Provides the essential layout and dark mode styling.
-const FALLBACK_STYLES: &str = r#"<style>
+const FALLBACK_STYLES: &str = r"<style>
 :root { color-scheme: light dark; }
 body {
     font-family: system-ui, -apple-system, sans-serif;
@@ -196,7 +208,7 @@ a {
     transition: opacity 0.15s;
 }
 a:hover { opacity: 0.8; }
-</style>"#;
+</style>";
 
 #[cfg(test)]
 mod tests {
@@ -219,7 +231,10 @@ mod tests {
         let pages = DefaultErrorPages;
         let html = pages.render_404(&make_ctx(StatusCode::NOT_FOUND));
         let s = html.into_string();
-        assert!(s.contains("/test/path"), "404 page should show request path");
+        assert!(
+            s.contains("/test/path"),
+            "404 page should show request path"
+        );
         assert!(s.contains("Page not found"));
         assert!(s.contains("404"));
     }

--- a/autumn/src/error_pages/defaults.rs
+++ b/autumn/src/error_pages/defaults.rs
@@ -1,0 +1,296 @@
+//! Default styled error pages using Maud and Tailwind.
+
+use super::renderer::{ErrorContext, ErrorPageRenderer};
+use maud::{Markup, PreEscaped, html};
+
+/// Default error page renderer using Maud templates with Tailwind styling.
+///
+/// Produces clean, minimal, professional error pages with:
+/// - Dark background option via Tailwind's dark mode classes
+/// - Status code badge
+/// - Contextual messages (path for 404, request ID for 500, field details for 422)
+/// - "Go back" link
+pub struct DefaultErrorPages;
+
+impl ErrorPageRenderer for DefaultErrorPages {
+    fn render_404(&self, ctx: &ErrorContext) -> Markup {
+        error_page_layout(ctx, html! {
+            div class="text-center" {
+                div class="text-8xl font-bold text-gray-200 dark:text-gray-700 select-none" {
+                    "404"
+                }
+                h1 class="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-100" {
+                    "Page not found"
+                }
+                p class="mt-2 text-gray-600 dark:text-gray-400" {
+                    "The page "
+                    code class="px-2 py-0.5 bg-gray-100 dark:bg-gray-800 rounded text-sm font-mono text-gray-800 dark:text-gray-300" {
+                        (ctx.path)
+                    }
+                    " could not be found."
+                }
+                div class="mt-8" {
+                    a href="/"
+                      class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
+                        "Go to homepage"
+                    }
+                }
+            }
+        })
+    }
+
+    fn render_500(&self, ctx: &ErrorContext) -> Markup {
+        error_page_layout(ctx, html! {
+            div class="text-center" {
+                div class="text-8xl font-bold text-gray-200 dark:text-gray-700 select-none" {
+                    "500"
+                }
+                h1 class="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-100" {
+                    "Internal server error"
+                }
+                p class="mt-2 text-gray-600 dark:text-gray-400" {
+                    "Something went wrong. Please try again later."
+                }
+                @if let Some(ref req_id) = ctx.request_id {
+                    p class="mt-4 text-xs text-gray-400 dark:text-gray-500 font-mono" {
+                        "Request ID: " (req_id)
+                    }
+                }
+                div class="mt-8" {
+                    a href="/"
+                      class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
+                        "Go to homepage"
+                    }
+                }
+            }
+        })
+    }
+
+    fn render_422(&self, ctx: &ErrorContext) -> Markup {
+        error_page_layout(ctx, html! {
+            div class="text-center" {
+                div class="text-8xl font-bold text-gray-200 dark:text-gray-700 select-none" {
+                    "422"
+                }
+                h1 class="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-100" {
+                    "Validation error"
+                }
+                p class="mt-2 text-gray-600 dark:text-gray-400" {
+                    (ctx.message)
+                }
+                @if let Some(ref details) = ctx.details {
+                    div class="mt-6 max-w-md mx-auto text-left" {
+                        @for (field, errors) in details {
+                            div class="mb-3" {
+                                p class="text-sm font-medium text-gray-700 dark:text-gray-300" {
+                                    (field)
+                                }
+                                @for error in errors {
+                                    p class="text-sm text-red-600 dark:text-red-400 ml-2" {
+                                        "- " (error)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                div class="mt-8" {
+                    a href="javascript:history.back()"
+                      class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
+                        "Go back"
+                    }
+                }
+            }
+        })
+    }
+
+    fn render_error(&self, ctx: &ErrorContext) -> Markup {
+        let status_code = ctx.status.as_u16();
+        let reason = ctx.status.canonical_reason().unwrap_or("Error");
+
+        error_page_layout(ctx, html! {
+            div class="text-center" {
+                div class="text-8xl font-bold text-gray-200 dark:text-gray-700 select-none" {
+                    (status_code)
+                }
+                h1 class="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-100" {
+                    (reason)
+                }
+                p class="mt-2 text-gray-600 dark:text-gray-400" {
+                    (ctx.message)
+                }
+                @if let Some(ref req_id) = ctx.request_id {
+                    p class="mt-4 text-xs text-gray-400 dark:text-gray-500 font-mono" {
+                        "Request ID: " (req_id)
+                    }
+                }
+                div class="mt-8" {
+                    a href="/"
+                      class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
+                        "Go to homepage"
+                    }
+                }
+            }
+        })
+    }
+}
+
+/// Shared HTML layout wrapper for all error pages.
+fn error_page_layout(ctx: &ErrorContext, content: Markup) -> Markup {
+    let status_code = ctx.status.as_u16();
+    let reason = ctx.status.canonical_reason().unwrap_or("Error");
+    let title = format!("{status_code} {reason}");
+
+    html! {
+        (maud::DOCTYPE)
+        html lang="en" class="dark" {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                title { (title) " | Autumn" }
+                // Inline minimal Tailwind-compatible styles as a fallback.
+                // When Tailwind CSS is loaded, its utility classes take over.
+                (PreEscaped(FALLBACK_STYLES))
+            }
+            body class="min-h-screen bg-white dark:bg-gray-950 flex items-center justify-center p-4" {
+                main class="w-full max-w-lg" {
+                    (content)
+                }
+            }
+        }
+    }
+}
+
+/// Minimal inline CSS fallback so error pages look reasonable even without
+/// Tailwind CSS loaded. Provides the essential layout and dark mode styling.
+const FALLBACK_STYLES: &str = r#"<style>
+:root { color-scheme: light dark; }
+body {
+    font-family: system-ui, -apple-system, sans-serif;
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    background: #fff;
+    color: #111;
+}
+.dark body, @media (prefers-color-scheme: dark) { body {
+    background: #0a0a0a;
+    color: #eee;
+}}
+.text-center { text-align: center; }
+code {
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.875rem;
+    font-family: ui-monospace, monospace;
+}
+a {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    border-radius: 0.375rem;
+    text-decoration: none;
+    transition: opacity 0.15s;
+}
+a:hover { opacity: 0.8; }
+</style>"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    fn make_ctx(status: StatusCode) -> ErrorContext {
+        ErrorContext {
+            status,
+            message: "test error".into(),
+            path: "/test/path".into(),
+            request_id: Some("req-123".into()),
+            details: None,
+            is_dev: false,
+        }
+    }
+
+    #[test]
+    fn default_404_contains_path() {
+        let pages = DefaultErrorPages;
+        let html = pages.render_404(&make_ctx(StatusCode::NOT_FOUND));
+        let s = html.into_string();
+        assert!(s.contains("/test/path"), "404 page should show request path");
+        assert!(s.contains("Page not found"));
+        assert!(s.contains("404"));
+    }
+
+    #[test]
+    fn default_500_contains_request_id() {
+        let pages = DefaultErrorPages;
+        let html = pages.render_500(&make_ctx(StatusCode::INTERNAL_SERVER_ERROR));
+        let s = html.into_string();
+        assert!(s.contains("req-123"), "500 page should show request ID");
+        assert!(s.contains("Internal server error"));
+        assert!(s.contains("500"));
+    }
+
+    #[test]
+    fn default_500_hides_error_details_in_prod() {
+        let pages = DefaultErrorPages;
+        let ctx = ErrorContext {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: "secret db password exposed".into(),
+            path: "/api/data".into(),
+            request_id: None,
+            details: None,
+            is_dev: false,
+        };
+        let html = pages.render_500(&ctx);
+        let s = html.into_string();
+        assert!(
+            !s.contains("secret db password"),
+            "500 page must not show error details in prod"
+        );
+    }
+
+    #[test]
+    fn default_422_shows_validation_details() {
+        let mut details = std::collections::HashMap::new();
+        details.insert("email".into(), vec!["must be valid".into()]);
+
+        let pages = DefaultErrorPages;
+        let ctx = ErrorContext {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            message: "Validation failed".into(),
+            path: "/signup".into(),
+            request_id: None,
+            details: Some(details),
+            is_dev: false,
+        };
+        let html = pages.render_422(&ctx);
+        let s = html.into_string();
+        assert!(s.contains("email"), "422 page should show field names");
+        assert!(s.contains("must be valid"), "422 page should show errors");
+        assert!(s.contains("422"));
+    }
+
+    #[test]
+    fn default_generic_error_page() {
+        let pages = DefaultErrorPages;
+        let ctx = make_ctx(StatusCode::FORBIDDEN);
+        let html = pages.render_error(&ctx);
+        let s = html.into_string();
+        assert!(s.contains("403"));
+        assert!(s.contains("Forbidden"));
+    }
+
+    #[test]
+    fn error_page_is_valid_html() {
+        let pages = DefaultErrorPages;
+        let html = pages.render_404(&make_ctx(StatusCode::NOT_FOUND));
+        let s = html.into_string();
+        assert!(s.contains("<!DOCTYPE html>"));
+        assert!(s.contains("<html"));
+        assert!(s.contains("</html>"));
+    }
+}

--- a/autumn/src/error_pages/dev_badge.rs
+++ b/autumn/src/error_pages/dev_badge.rs
@@ -11,7 +11,7 @@ use maud::{Markup, PreEscaped, html};
 
 /// Context for the dev error badge.
 #[derive(Debug, Clone)]
-pub(crate) struct DevBadgeContext {
+pub struct DevBadgeContext {
     /// HTTP status code.
     pub status_code: u16,
     /// Status reason phrase (e.g., "Not Found").
@@ -33,7 +33,7 @@ pub(crate) struct DevBadgeContext {
 ///
 /// Uses inline CSS (not Tailwind) so it works even if the CSS build fails.
 /// Styled like Next.js: dark overlay, monospace font, red accent, expandable.
-pub(crate) fn dev_error_badge_html(ctx: &DevBadgeContext) -> Markup {
+pub fn dev_error_badge_html(ctx: &DevBadgeContext) -> Markup {
     let status = ctx.status_code;
     let reason = &ctx.status_reason;
     let message = &ctx.message;
@@ -93,7 +93,7 @@ pub(crate) fn dev_error_badge_html(ctx: &DevBadgeContext) -> Markup {
 
 /// All inline CSS for the dev badge. Uses a unique prefix to avoid
 /// colliding with application styles.
-const DEV_BADGE_STYLES: &str = r##"<style>
+const DEV_BADGE_STYLES: &str = r#"<style>
 #autumn-dev-error-badge {
     position: fixed;
     bottom: 16px;
@@ -203,7 +203,7 @@ const DEV_BADGE_STYLES: &str = r##"<style>
     font-size: 12px;
     color: #a0aec0;
 }
-</style>"##;
+</style>"#;
 
 #[cfg(test)]
 mod tests {

--- a/autumn/src/error_pages/dev_badge.rs
+++ b/autumn/src/error_pages/dev_badge.rs
@@ -1,0 +1,273 @@
+//! Next.js-style dev error badge overlay.
+//!
+//! In dev mode, error responses get a floating badge injected into the HTML
+//! that shows error details: status code, error type, message, and optional
+//! stack trace. The badge uses **inline CSS only** (no Tailwind) so it works
+//! even when the CSS build pipeline is broken.
+//!
+//! The badge is **never** injected in production.
+
+use maud::{Markup, PreEscaped, html};
+
+/// Context for the dev error badge.
+#[derive(Debug, Clone)]
+pub(crate) struct DevBadgeContext {
+    /// HTTP status code.
+    pub status_code: u16,
+    /// Status reason phrase (e.g., "Not Found").
+    pub status_reason: String,
+    /// Error message.
+    pub message: String,
+    /// Request path.
+    pub path: String,
+    /// Request ID.
+    pub request_id: Option<String>,
+    /// Optional file/line info if available.
+    pub source_location: Option<String>,
+}
+
+/// Generate the dev error badge HTML snippet.
+///
+/// This returns a self-contained HTML fragment with inline CSS and JS.
+/// It should be injected just before `</body>` in HTML error responses.
+///
+/// Uses inline CSS (not Tailwind) so it works even if the CSS build fails.
+/// Styled like Next.js: dark overlay, monospace font, red accent, expandable.
+pub(crate) fn dev_error_badge_html(ctx: &DevBadgeContext) -> Markup {
+    let status = ctx.status_code;
+    let reason = &ctx.status_reason;
+    let message = &ctx.message;
+    let path = &ctx.path;
+    let request_id = ctx.request_id.as_deref().unwrap_or("n/a");
+    let source_loc = ctx.source_location.as_deref().unwrap_or("");
+
+    html! {
+        (PreEscaped(DEV_BADGE_STYLES))
+        div #autumn-dev-error-badge {
+            // Collapsed badge (always visible)
+            div #autumn-dev-badge-collapsed
+                onclick="document.getElementById('autumn-dev-badge-expanded').style.display='flex';document.getElementById('autumn-dev-badge-collapsed').style.display='none';"
+            {
+                span class="autumn-dev-badge-dot" {}
+                span class="autumn-dev-badge-code" { (status) }
+                span class="autumn-dev-badge-label" { (reason) }
+            }
+
+            // Expanded overlay
+            div #autumn-dev-badge-expanded style="display:none" {
+                div class="autumn-dev-overlay-header" {
+                    div class="autumn-dev-overlay-title" {
+                        span class="autumn-dev-badge-dot" {}
+                        (status) " " (reason)
+                    }
+                    button class="autumn-dev-overlay-close"
+                        onclick="document.getElementById('autumn-dev-badge-expanded').style.display='none';document.getElementById('autumn-dev-badge-collapsed').style.display='flex';"
+                    {
+                        "\u{00d7}"
+                    }
+                }
+                div class="autumn-dev-overlay-body" {
+                    div class="autumn-dev-overlay-section" {
+                        div class="autumn-dev-overlay-label" { "Message" }
+                        div class="autumn-dev-overlay-value" { (message) }
+                    }
+                    div class="autumn-dev-overlay-section" {
+                        div class="autumn-dev-overlay-label" { "Path" }
+                        div class="autumn-dev-overlay-value autumn-dev-mono" { (path) }
+                    }
+                    div class="autumn-dev-overlay-section" {
+                        div class="autumn-dev-overlay-label" { "Request ID" }
+                        div class="autumn-dev-overlay-value autumn-dev-mono" { (request_id) }
+                    }
+                    @if !source_loc.is_empty() {
+                        div class="autumn-dev-overlay-section" {
+                            div class="autumn-dev-overlay-label" { "Source" }
+                            div class="autumn-dev-overlay-value autumn-dev-mono" { (source_loc) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// All inline CSS for the dev badge. Uses a unique prefix to avoid
+/// colliding with application styles.
+const DEV_BADGE_STYLES: &str = r##"<style>
+#autumn-dev-error-badge {
+    position: fixed;
+    bottom: 16px;
+    left: 16px;
+    z-index: 99999;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 13px;
+    line-height: 1.5;
+}
+#autumn-dev-badge-collapsed {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    background: #1a1a2e;
+    border: 1px solid #e53e3e;
+    border-radius: 8px;
+    color: #e2e8f0;
+    cursor: pointer;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.4);
+    transition: background 0.15s;
+    user-select: none;
+}
+#autumn-dev-badge-collapsed:hover {
+    background: #2d2d4a;
+}
+.autumn-dev-badge-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #e53e3e;
+    flex-shrink: 0;
+}
+.autumn-dev-badge-code {
+    font-weight: 700;
+    color: #fc8181;
+}
+.autumn-dev-badge-label {
+    color: #a0aec0;
+    font-size: 12px;
+}
+#autumn-dev-badge-expanded {
+    display: flex;
+    flex-direction: column;
+    width: 480px;
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 100px);
+    background: #1a1a2e;
+    border: 1px solid #e53e3e;
+    border-radius: 12px;
+    color: #e2e8f0;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.6);
+    overflow: hidden;
+}
+.autumn-dev-overlay-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    background: #16162a;
+    border-bottom: 1px solid #2d2d4a;
+}
+.autumn-dev-overlay-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 700;
+    color: #fc8181;
+    font-size: 14px;
+}
+.autumn-dev-overlay-close {
+    background: none;
+    border: none;
+    color: #a0aec0;
+    font-size: 20px;
+    cursor: pointer;
+    padding: 0 4px;
+    line-height: 1;
+}
+.autumn-dev-overlay-close:hover {
+    color: #e2e8f0;
+}
+.autumn-dev-overlay-body {
+    padding: 16px;
+    overflow-y: auto;
+}
+.autumn-dev-overlay-section {
+    margin-bottom: 12px;
+}
+.autumn-dev-overlay-section:last-child {
+    margin-bottom: 0;
+}
+.autumn-dev-overlay-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #718096;
+    margin-bottom: 4px;
+}
+.autumn-dev-overlay-value {
+    color: #e2e8f0;
+    word-break: break-word;
+}
+.autumn-dev-mono {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 12px;
+    color: #a0aec0;
+}
+</style>"##;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_ctx() -> DevBadgeContext {
+        DevBadgeContext {
+            status_code: 404,
+            status_reason: "Not Found".into(),
+            message: "page missing".into(),
+            path: "/test".into(),
+            request_id: Some("req-abc".into()),
+            source_location: None,
+        }
+    }
+
+    #[test]
+    fn badge_contains_status_code() {
+        let html = dev_error_badge_html(&test_ctx());
+        let s = html.into_string();
+        assert!(s.contains("404"));
+        assert!(s.contains("Not Found"));
+    }
+
+    #[test]
+    fn badge_contains_message() {
+        let html = dev_error_badge_html(&test_ctx());
+        let s = html.into_string();
+        assert!(s.contains("page missing"));
+    }
+
+    #[test]
+    fn badge_contains_request_id() {
+        let html = dev_error_badge_html(&test_ctx());
+        let s = html.into_string();
+        assert!(s.contains("req-abc"));
+    }
+
+    #[test]
+    fn badge_uses_inline_css() {
+        let html = dev_error_badge_html(&test_ctx());
+        let s = html.into_string();
+        assert!(s.contains("<style>"), "badge must use inline CSS");
+        // Should NOT reference Tailwind classes for its own styling
+        assert!(
+            s.contains("#autumn-dev-error-badge"),
+            "badge uses namespaced CSS selectors"
+        );
+    }
+
+    #[test]
+    fn badge_shows_source_location_when_present() {
+        let mut ctx = test_ctx();
+        ctx.source_location = Some("src/main.rs:42".into());
+        let html = dev_error_badge_html(&ctx);
+        let s = html.into_string();
+        assert!(s.contains("src/main.rs:42"));
+    }
+
+    #[test]
+    fn badge_hides_source_section_when_absent() {
+        let ctx = test_ctx();
+        let html = dev_error_badge_html(&ctx);
+        let s = html.into_string();
+        assert!(!s.contains("Source"), "no source section without location");
+    }
+}

--- a/autumn/src/error_pages/mod.rs
+++ b/autumn/src/error_pages/mod.rs
@@ -1,0 +1,75 @@
+//! Styled error pages and dev-mode error badge overlay.
+//!
+//! Autumn provides default HTML error pages for common HTTP error codes
+//! (404, 422, 500) and a Next.js-style error badge overlay in dev mode.
+//!
+//! # Error page override
+//!
+//! Implement [`ErrorPageRenderer`] to provide custom error pages:
+//!
+//! ```rust,no_run
+//! use autumn_web::error_pages::{ErrorPageRenderer, ErrorContext};
+//! use maud::{Markup, html};
+//!
+//! struct MyErrorPages;
+//!
+//! impl ErrorPageRenderer for MyErrorPages {
+//!     fn render_404(&self, ctx: &ErrorContext) -> Markup {
+//!         html! {
+//!             h1 { "Custom 404 - " (ctx.path) " not found" }
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! Register it on the app builder:
+//!
+//! ```rust,ignore
+//! autumn_web::app()
+//!     .error_pages(MyErrorPages)
+//!     .routes(routes![...])
+//!     .run()
+//!     .await;
+//! ```
+//!
+//! # Dev error badge
+//!
+//! In dev profile, error responses automatically include a floating badge
+//! in the bottom-left corner showing status code, error type, and message.
+//! The badge uses inline CSS so it works even when Tailwind is unavailable.
+//! It is **never** shown in production.
+
+mod defaults;
+pub(crate) mod dev_badge;
+pub(crate) mod renderer;
+
+pub use defaults::DefaultErrorPages;
+pub use renderer::{ErrorContext, ErrorPageRenderer};
+
+use axum::http::StatusCode;
+use maud::Markup;
+use std::sync::Arc;
+
+/// Render an error page using the given renderer (or defaults).
+///
+/// Returns the full HTML response body for the given status code.
+pub(crate) fn render_error_page(
+    renderer: &dyn ErrorPageRenderer,
+    status: StatusCode,
+    ctx: &ErrorContext,
+) -> Markup {
+    match status {
+        StatusCode::NOT_FOUND => renderer.render_404(ctx),
+        StatusCode::UNPROCESSABLE_ENTITY => renderer.render_422(ctx),
+        StatusCode::INTERNAL_SERVER_ERROR => renderer.render_500(ctx),
+        _ => renderer.render_error(ctx),
+    }
+}
+
+/// Shared error page renderer stored in app state / middleware.
+pub(crate) type SharedRenderer = Arc<dyn ErrorPageRenderer>;
+
+/// Create the default shared renderer.
+pub(crate) fn default_renderer() -> SharedRenderer {
+    Arc::new(DefaultErrorPages)
+}

--- a/autumn/src/error_pages/mod.rs
+++ b/autumn/src/error_pages/mod.rs
@@ -14,9 +14,9 @@
 //! struct MyErrorPages;
 //!
 //! impl ErrorPageRenderer for MyErrorPages {
-//!     fn render_404(&self, ctx: &ErrorContext) -> Markup {
+//!     fn render_error(&self, ctx: &ErrorContext) -> Markup {
 //!         html! {
-//!             h1 { "Custom 404 - " (ctx.path) " not found" }
+//!             h1 { (ctx.status.as_u16()) " - " (ctx.path) }
 //!         }
 //!     }
 //! }

--- a/autumn/src/error_pages/renderer.rs
+++ b/autumn/src/error_pages/renderer.rs
@@ -41,11 +41,11 @@ pub struct ErrorContext {
 /// struct BrandedErrors;
 ///
 /// impl ErrorPageRenderer for BrandedErrors {
-///     fn render_404(&self, ctx: &ErrorContext) -> Markup {
+///     fn render_error(&self, ctx: &ErrorContext) -> Markup {
 ///         html! {
 ///             html {
 ///                 body {
-///                     h1 { "Oops! " (ctx.path) " was not found." }
+///                     h1 { (ctx.status.as_u16()) " — " (ctx.path) }
 ///                     a href="/" { "Go home" }
 ///                 }
 ///             }

--- a/autumn/src/error_pages/renderer.rs
+++ b/autumn/src/error_pages/renderer.rs
@@ -1,0 +1,78 @@
+//! Error page renderer trait and context.
+
+use axum::http::StatusCode;
+use maud::Markup;
+use std::collections::HashMap;
+
+/// Context passed to error page renderers.
+///
+/// Contains all the information available about the error, allowing
+/// renderers to produce rich error pages.
+#[derive(Debug, Clone)]
+pub struct ErrorContext {
+    /// The HTTP status code (e.g., 404, 500).
+    pub status: StatusCode,
+    /// Human-readable error message.
+    pub message: String,
+    /// The request path that triggered the error.
+    pub path: String,
+    /// Request ID from the `X-Request-Id` header (if available).
+    pub request_id: Option<String>,
+    /// Field-level validation details (for 422 errors).
+    pub details: Option<HashMap<String, Vec<String>>>,
+    /// Whether the app is running in dev mode.
+    pub is_dev: bool,
+}
+
+/// Trait for providing custom error pages.
+///
+/// Implement this trait to override the default error pages. Each method
+/// receives an [`ErrorContext`] with information about the error.
+///
+/// The default implementation (via [`super::DefaultErrorPages`]) renders
+/// styled HTML pages using Maud and Tailwind.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use autumn_web::error_pages::{ErrorPageRenderer, ErrorContext};
+/// use maud::{Markup, html};
+///
+/// struct BrandedErrors;
+///
+/// impl ErrorPageRenderer for BrandedErrors {
+///     fn render_404(&self, ctx: &ErrorContext) -> Markup {
+///         html! {
+///             html {
+///                 body {
+///                     h1 { "Oops! " (ctx.path) " was not found." }
+///                     a href="/" { "Go home" }
+///                 }
+///             }
+///         }
+///     }
+/// }
+/// ```
+pub trait ErrorPageRenderer: Send + Sync + 'static {
+    /// Render a 404 Not Found page.
+    fn render_404(&self, ctx: &ErrorContext) -> Markup {
+        self.render_error(ctx)
+    }
+
+    /// Render a 500 Internal Server Error page.
+    fn render_500(&self, ctx: &ErrorContext) -> Markup {
+        self.render_error(ctx)
+    }
+
+    /// Render a 422 Unprocessable Entity page (validation errors).
+    fn render_422(&self, ctx: &ErrorContext) -> Markup {
+        self.render_error(ctx)
+    }
+
+    /// Render a generic error page for any status code.
+    ///
+    /// This is the fallback used by the default implementations of
+    /// `render_404`, `render_500`, and `render_422`. Override this
+    /// to provide a single template for all error codes.
+    fn render_error(&self, ctx: &ErrorContext) -> Markup;
+}

--- a/autumn/src/health.rs
+++ b/autumn/src/health.rs
@@ -137,6 +137,10 @@ mod tests {
             profile: Some("dev".into()),
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         }
     }
 
@@ -215,6 +219,10 @@ mod tests {
                 profile: Some("prod".into()),
                 started_at: std::time::Instant::now(),
                 health_detailed: true,
+                metrics: crate::middleware::MetricsCollector::new(),
+                log_levels: crate::actuator::LogLevels::new("info"),
+                task_registry: crate::actuator::TaskRegistry::new(),
+                config_props: crate::actuator::ConfigProperties::default(),
             });
 
         let response = app

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -71,14 +71,14 @@ pub mod auth;
 pub mod config;
 #[cfg(feature = "db")]
 pub mod db;
-#[cfg(feature = "db")]
-pub mod migrate;
 pub mod error;
 pub mod error_pages;
 pub mod extract;
 pub mod health;
 #[cfg(feature = "db")]
 pub mod hooks;
+#[cfg(feature = "db")]
+pub mod migrate;
 #[cfg(feature = "db")]
 pub use hooks::{
     DraftField, FieldDiff, MutationContext, MutationHooks, MutationOp, NoHooks, Patch, UpdateDraft,
@@ -622,6 +622,7 @@ impl AppState {
     /// Create an `AppState` suitable for testing, with sensible defaults
     /// for all fields. Database pool is `None`.
     #[cfg(test)]
+    #[allow(dead_code)]
     pub(crate) fn for_test() -> Self {
         Self {
             #[cfg(feature = "db")]
@@ -632,7 +633,7 @@ impl AppState {
             metrics: middleware::MetricsCollector::new(),
             log_levels: actuator::LogLevels::new("info"),
             task_registry: actuator::TaskRegistry::new(),
-            config_props: Default::default(),
+            config_props: actuator::ConfigProperties::default(),
         }
     }
 }
@@ -654,7 +655,7 @@ impl std::fmt::Debug for AppState {
             .field("metrics", &"MetricsCollector")
             .field("log_levels", &"LogLevels")
             .field("task_registry", &"TaskRegistry")
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -71,7 +71,10 @@ pub mod auth;
 pub mod config;
 #[cfg(feature = "db")]
 pub mod db;
+#[cfg(feature = "db")]
+pub mod migrate;
 pub mod error;
+pub mod error_pages;
 pub mod extract;
 pub mod health;
 #[cfg(feature = "db")]
@@ -553,6 +556,10 @@ pub mod reexports {
 ///     profile: Some("dev".into()),
 ///     started_at: std::time::Instant::now(),
 ///     health_detailed: true,
+///     metrics: autumn_web::middleware::MetricsCollector::new(),
+///     log_levels: autumn_web::actuator::LogLevels::new("info"),
+///     task_registry: autumn_web::actuator::TaskRegistry::new(),
+///     config_props: Default::default(),
 /// };
 /// ```
 #[derive(Clone)]
@@ -570,6 +577,18 @@ pub struct AppState {
 
     /// Whether the health endpoint should include detailed info.
     pub health_detailed: bool,
+
+    /// In-memory metrics collector for the `/actuator/metrics` endpoint.
+    pub metrics: middleware::MetricsCollector,
+
+    /// Runtime log level state for the `/actuator/loggers` endpoint.
+    pub log_levels: actuator::LogLevels,
+
+    /// Scheduled task registry for the `/actuator/tasks` endpoint.
+    pub task_registry: actuator::TaskRegistry,
+
+    /// Resolved config properties with source tracking for `/actuator/configprops`.
+    pub config_props: actuator::ConfigProperties,
 }
 
 impl AppState {
@@ -599,6 +618,23 @@ impl AppState {
             format!("{hours}h {mins}m")
         }
     }
+
+    /// Create an `AppState` suitable for testing, with sensible defaults
+    /// for all fields. Database pool is `None`.
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
+        Self {
+            #[cfg(feature = "db")]
+            pool: None,
+            profile: None,
+            started_at: std::time::Instant::now(),
+            health_detailed: true,
+            metrics: middleware::MetricsCollector::new(),
+            log_levels: actuator::LogLevels::new("info"),
+            task_registry: actuator::TaskRegistry::new(),
+            config_props: Default::default(),
+        }
+    }
 }
 
 impl std::fmt::Debug for AppState {
@@ -615,6 +651,9 @@ impl std::fmt::Debug for AppState {
         s.field("profile", &self.profile)
             .field("started_at", &self.started_at)
             .field("health_detailed", &self.health_detailed)
+            .field("metrics", &"MetricsCollector")
+            .field("log_levels", &"LogLevels")
+            .field("task_registry", &"TaskRegistry")
             .finish()
     }
 }
@@ -631,6 +670,10 @@ mod tests {
             profile: Some("dev".into()),
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: middleware::MetricsCollector::new(),
+            log_levels: actuator::LogLevels::new("info"),
+            task_registry: actuator::TaskRegistry::new(),
+            config_props: actuator::ConfigProperties::default(),
         };
         let debug = format!("{state:?}");
         assert!(debug.contains("AppState"));
@@ -651,6 +694,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: middleware::MetricsCollector::new(),
+            log_levels: actuator::LogLevels::new("info"),
+            task_registry: actuator::TaskRegistry::new(),
+            config_props: actuator::ConfigProperties::default(),
         };
         let debug = format!("{state:?}");
         assert!(debug.contains("Pool(max=5)"));
@@ -668,6 +715,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: middleware::MetricsCollector::new(),
+            log_levels: actuator::LogLevels::new("info"),
+            task_registry: actuator::TaskRegistry::new(),
+            config_props: actuator::ConfigProperties::default(),
         };
         let _cloned = require_clone(&state);
     }
@@ -680,6 +731,10 @@ mod tests {
             profile: Some("staging".into()),
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: middleware::MetricsCollector::new(),
+            log_levels: actuator::LogLevels::new("info"),
+            task_registry: actuator::TaskRegistry::new(),
+            config_props: actuator::ConfigProperties::default(),
         };
         assert_eq!(state.profile(), "staging");
     }
@@ -692,6 +747,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: middleware::MetricsCollector::new(),
+            log_levels: actuator::LogLevels::new("info"),
+            task_registry: actuator::TaskRegistry::new(),
+            config_props: actuator::ConfigProperties::default(),
         };
         assert_eq!(state.profile(), "default");
     }
@@ -704,6 +763,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
+            metrics: middleware::MetricsCollector::new(),
+            log_levels: actuator::LogLevels::new("info"),
+            task_registry: actuator::TaskRegistry::new(),
+            config_props: actuator::ConfigProperties::default(),
         };
         let display = state.uptime_display();
         assert!(

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -1,0 +1,553 @@
+//! Exception filter that renders HTML error pages for browser requests.
+//!
+//! When a request's `Accept` header prefers HTML over JSON (typical for
+//! browser navigation), this filter replaces the default JSON error
+//! response with a styled HTML error page. JSON API requests are left
+//! untouched.
+//!
+//! In dev mode, a Next.js-style error badge is injected into the HTML
+//! response for quick debugging.
+
+use axum::response::{IntoResponse, Response};
+
+use crate::error_pages::dev_badge::{self, DevBadgeContext};
+use crate::error_pages::renderer::ErrorContext;
+use crate::error_pages::{self, SharedRenderer};
+use crate::middleware::exception_filter::{AutumnErrorInfo, ExceptionFilter};
+
+/// Exception filter that renders HTML error pages for browser requests.
+///
+/// Injected automatically by the framework. When a request has an `Accept`
+/// header indicating HTML preference (browser navigation), the JSON error
+/// response is replaced with a styled HTML page.
+///
+/// In dev profile, the HTML page includes a floating error badge overlay.
+pub(crate) struct ErrorPageFilter {
+    pub renderer: SharedRenderer,
+    pub is_dev: bool,
+}
+
+impl ExceptionFilter for ErrorPageFilter {
+    fn filter(&self, error: &AutumnErrorInfo, response: Response) -> Response {
+        // Check if the original request wanted HTML (stored in extensions
+        // by the error page middleware layer).
+        let wants_html = response
+            .extensions()
+            .get::<WantsHtml>()
+            .map_or(false, |w| w.0);
+
+        if !wants_html {
+            return response;
+        }
+
+        let request_id = response
+            .extensions()
+            .get::<ErrorPageRequestContext>()
+            .and_then(|ctx| ctx.request_id.clone());
+
+        let path = response
+            .extensions()
+            .get::<ErrorPageRequestContext>()
+            .map(|ctx| ctx.path.clone())
+            .unwrap_or_default();
+
+        let ctx = ErrorContext {
+            status: error.status,
+            message: error.message.clone(),
+            path,
+            request_id: request_id.clone(),
+            details: error.details.clone(),
+            is_dev: self.is_dev,
+        };
+
+        let mut html_body = error_pages::render_error_page(self.renderer.as_ref(), error.status, &ctx)
+            .into_string();
+
+        // In dev mode, inject the error badge before </body>
+        if self.is_dev {
+            let badge_ctx = DevBadgeContext {
+                status_code: error.status.as_u16(),
+                status_reason: error
+                    .status
+                    .canonical_reason()
+                    .unwrap_or("Error")
+                    .to_string(),
+                message: error.message.clone(),
+                path: ctx.path.clone(),
+                request_id,
+                source_location: None,
+            };
+            let badge = dev_badge::dev_error_badge_html(&badge_ctx).into_string();
+            if let Some(pos) = html_body.rfind("</body>") {
+                html_body.insert_str(pos, &badge);
+            } else {
+                html_body.push_str(&badge);
+            }
+        }
+
+        let mut resp = (
+            error.status,
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "text/html; charset=utf-8",
+            )],
+            html_body,
+        )
+            .into_response();
+
+        // Re-attach error info so downstream filters still see it
+        resp.extensions_mut().insert(error.clone());
+
+        resp
+    }
+}
+
+/// Marker stored in response extensions to indicate the original request
+/// preferred HTML responses.
+#[derive(Clone, Debug)]
+pub(crate) struct WantsHtml(pub bool);
+
+/// Request context stored in response extensions for the error page filter.
+#[derive(Clone, Debug)]
+pub(crate) struct ErrorPageRequestContext {
+    pub path: String,
+    pub request_id: Option<String>,
+}
+
+/// Tower layer that annotates requests with Accept header preference
+/// so the error page filter knows whether to render HTML or pass through JSON.
+///
+/// This layer runs before the exception filter and stores [`WantsHtml`]
+/// and [`ErrorPageRequestContext`] in the response extensions.
+#[derive(Clone)]
+pub(crate) struct ErrorPageContextLayer;
+
+impl<S> tower::Layer<S> for ErrorPageContextLayer {
+    type Service = ErrorPageContextService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ErrorPageContextService { inner }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ErrorPageContextService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody> tower::Service<axum::http::Request<ReqBody>> for ErrorPageContextService<S>
+where
+    S: tower::Service<axum::http::Request<ReqBody>, Response = Response>,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = ErrorPageContextFuture<S::Future>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: axum::http::Request<ReqBody>) -> Self::Future {
+        let wants_html = accepts_html(&req);
+        let path = req.uri().path().to_string();
+        let request_id = req
+            .extensions()
+            .get::<crate::middleware::RequestId>()
+            .map(|id| id.to_string());
+
+        ErrorPageContextFuture {
+            inner: self.inner.call(req),
+            wants_html,
+            path,
+            request_id,
+        }
+    }
+}
+
+pin_project_lite::pin_project! {
+    pub(crate) struct ErrorPageContextFuture<F> {
+        #[pin]
+        inner: F,
+        wants_html: bool,
+        path: String,
+        request_id: Option<String>,
+    }
+}
+
+impl<F, E> std::future::Future for ErrorPageContextFuture<F>
+where
+    F: std::future::Future<Output = Result<Response, E>>,
+{
+    type Output = Result<Response, E>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.project();
+        match this.inner.poll(cx) {
+            std::task::Poll::Ready(Ok(mut response)) => {
+                response.extensions_mut().insert(WantsHtml(*this.wants_html));
+                response.extensions_mut().insert(ErrorPageRequestContext {
+                    path: this.path.clone(),
+                    request_id: this.request_id.clone(),
+                });
+                std::task::Poll::Ready(Ok(response))
+            }
+            other => other,
+        }
+    }
+}
+
+/// Check if the request's Accept header indicates a preference for HTML.
+///
+/// Returns `true` for typical browser requests (`text/html` or `*/*`),
+/// `false` for API requests (`application/json`).
+fn accepts_html<B>(req: &axum::http::Request<B>) -> bool {
+    let accept = req
+        .headers()
+        .get(axum::http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    // If no Accept header, default to JSON (API-first).
+    if accept.is_empty() {
+        return false;
+    }
+
+    // Simple heuristic: if text/html appears before application/json,
+    // or if text/html is present and application/json is not, prefer HTML.
+    let html_pos = accept.find("text/html");
+    let json_pos = accept.find("application/json");
+
+    match (html_pos, json_pos) {
+        (Some(_), None) => true,
+        (Some(h), Some(j)) => h < j,
+        (None, Some(_)) => false,
+        // `*/*` without specific types -- default to HTML for browsers
+        (None, None) => accept.contains("*/*"),
+    }
+}
+
+/// 404 fallback handler for unmatched routes.
+///
+/// This is mounted as the router's fallback so unmatched routes get proper
+/// error pages instead of Axum's default plain-text "Not Found".
+pub(crate) async fn fallback_404_handler(
+    uri: axum::http::Uri,
+) -> crate::error::AutumnError {
+    crate::error::AutumnError::not_found_msg(format!("No route matches {}", uri.path()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+
+    #[test]
+    fn accepts_html_for_browser() {
+        let req = Request::builder()
+            .header("accept", "text/html,application/xhtml+xml,*/*;q=0.8")
+            .body(Body::empty())
+            .unwrap();
+        assert!(accepts_html(&req));
+    }
+
+    #[test]
+    fn rejects_html_for_json_api() {
+        let req = Request::builder()
+            .header("accept", "application/json")
+            .body(Body::empty())
+            .unwrap();
+        assert!(!accepts_html(&req));
+    }
+
+    #[test]
+    fn rejects_html_for_empty_accept() {
+        let req = Request::builder().body(Body::empty()).unwrap();
+        assert!(!accepts_html(&req));
+    }
+
+    #[test]
+    fn accepts_html_for_wildcard() {
+        let req = Request::builder()
+            .header("accept", "*/*")
+            .body(Body::empty())
+            .unwrap();
+        assert!(accepts_html(&req));
+    }
+
+    #[test]
+    fn prefers_json_when_json_first() {
+        let req = Request::builder()
+            .header("accept", "application/json, text/html")
+            .body(Body::empty())
+            .unwrap();
+        assert!(!accepts_html(&req));
+    }
+
+    #[test]
+    fn prefers_html_when_html_first() {
+        let req = Request::builder()
+            .header("accept", "text/html, application/json")
+            .body(Body::empty())
+            .unwrap();
+        assert!(accepts_html(&req));
+    }
+
+    // ── Integration tests with the full middleware pipeline ──────
+
+    use std::sync::Arc;
+
+    use axum::Router;
+    use axum::routing::get;
+    use http::StatusCode;
+    use tower::ServiceExt;
+
+    use crate::error::AutumnError;
+    use crate::error_pages;
+    use crate::middleware::exception_filter::ExceptionFilterLayer;
+
+    /// Helper: build a router with the error page filter and context layer.
+    fn test_router_with_error_pages(is_dev: bool) -> Router {
+        let renderer = error_pages::default_renderer();
+        let error_page_filter = ErrorPageFilter {
+            renderer,
+            is_dev,
+        };
+        let filters: Vec<Arc<dyn crate::middleware::ExceptionFilter>> =
+            vec![Arc::new(error_page_filter)];
+
+        Router::new()
+            .route("/ok", get(|| async { "all good" }))
+            .route(
+                "/fail",
+                get(|| async { Err::<String, AutumnError>(AutumnError::not_found_msg("gone")) }),
+            )
+            .route(
+                "/boom",
+                get(|| async {
+                    Err::<String, AutumnError>(
+                        AutumnError::from(std::io::Error::other("internal failure")),
+                    )
+                }),
+            )
+            .fallback(fallback_404_handler)
+            .layer(ErrorPageContextLayer)
+            .layer(ExceptionFilterLayer::new(filters))
+    }
+
+    #[tokio::test]
+    async fn html_404_returns_styled_page() {
+        let app = test_router_with_error_pages(false);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/nonexistent")
+                    .header("accept", "text/html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body_str.contains("<!DOCTYPE html>"), "should be HTML");
+        assert!(body_str.contains("404"), "should contain status code");
+        assert!(
+            body_str.contains("Page not found"),
+            "should contain not found message"
+        );
+    }
+
+    #[tokio::test]
+    async fn html_500_returns_styled_page() {
+        let app = test_router_with_error_pages(false);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/boom")
+                    .header("accept", "text/html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body_str.contains("<!DOCTYPE html>"), "should be HTML");
+        assert!(body_str.contains("500"), "should contain status code");
+        assert!(
+            !body_str.contains("internal failure"),
+            "must NOT show error details in prod"
+        );
+    }
+
+    #[tokio::test]
+    async fn json_api_gets_json_errors() {
+        let app = test_router_with_error_pages(false);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/fail")
+                    .header("accept", "application/json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            ct.contains("application/json"),
+            "JSON API should get JSON response, got: {ct}"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"]["status"], 404);
+    }
+
+    #[tokio::test]
+    async fn dev_badge_appears_in_dev_mode() {
+        let app = test_router_with_error_pages(true);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/nonexistent")
+                    .header("accept", "text/html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            body_str.contains("autumn-dev-error-badge"),
+            "dev mode should include error badge"
+        );
+    }
+
+    #[tokio::test]
+    async fn dev_badge_hidden_in_prod_mode() {
+        let app = test_router_with_error_pages(false);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/nonexistent")
+                    .header("accept", "text/html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            !body_str.contains("autumn-dev-error-badge"),
+            "prod mode must NOT include error badge"
+        );
+    }
+
+    #[tokio::test]
+    async fn custom_renderer_works() {
+        use crate::error_pages::{ErrorContext, ErrorPageRenderer};
+        use maud::{Markup, html};
+
+        struct CustomPages;
+        impl ErrorPageRenderer for CustomPages {
+            fn render_error(&self, ctx: &ErrorContext) -> Markup {
+                html! {
+                    h1 { "CUSTOM " (ctx.status.as_u16()) }
+                }
+            }
+        }
+
+        let renderer: crate::error_pages::SharedRenderer = Arc::new(CustomPages);
+        let error_page_filter = ErrorPageFilter {
+            renderer,
+            is_dev: false,
+        };
+        let filters: Vec<Arc<dyn crate::middleware::ExceptionFilter>> =
+            vec![Arc::new(error_page_filter)];
+
+        let app = Router::new()
+            .route(
+                "/err",
+                get(|| async {
+                    Err::<String, AutumnError>(AutumnError::not_found_msg("nope"))
+                }),
+            )
+            .layer(ErrorPageContextLayer)
+            .layer(ExceptionFilterLayer::new(filters));
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/err")
+                    .header("accept", "text/html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            body_str.contains("CUSTOM 404"),
+            "should use custom renderer, got: {body_str}"
+        );
+    }
+
+    #[tokio::test]
+    async fn success_responses_not_affected() {
+        let app = test_router_with_error_pages(false);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ok")
+                    .header("accept", "text/html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"all good");
+    }
+}

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -22,7 +22,7 @@ use crate::middleware::exception_filter::{AutumnErrorInfo, ExceptionFilter};
 /// response is replaced with a styled HTML page.
 ///
 /// In dev profile, the HTML page includes a floating error badge overlay.
-pub(crate) struct ErrorPageFilter {
+pub struct ErrorPageFilter {
     pub renderer: SharedRenderer,
     pub is_dev: bool,
 }
@@ -34,7 +34,7 @@ impl ExceptionFilter for ErrorPageFilter {
         let wants_html = response
             .extensions()
             .get::<WantsHtml>()
-            .map_or(false, |w| w.0);
+            .is_some_and(|w| w.0);
 
         if !wants_html {
             return response;
@@ -60,8 +60,9 @@ impl ExceptionFilter for ErrorPageFilter {
             is_dev: self.is_dev,
         };
 
-        let mut html_body = error_pages::render_error_page(self.renderer.as_ref(), error.status, &ctx)
-            .into_string();
+        let mut html_body =
+            error_pages::render_error_page(self.renderer.as_ref(), error.status, &ctx)
+                .into_string();
 
         // In dev mode, inject the error badge before </body>
         if self.is_dev {
@@ -73,7 +74,7 @@ impl ExceptionFilter for ErrorPageFilter {
                     .unwrap_or("Error")
                     .to_string(),
                 message: error.message.clone(),
-                path: ctx.path.clone(),
+                path: ctx.path,
                 request_id,
                 source_location: None,
             };
@@ -87,10 +88,7 @@ impl ExceptionFilter for ErrorPageFilter {
 
         let mut resp = (
             error.status,
-            [(
-                axum::http::header::CONTENT_TYPE,
-                "text/html; charset=utf-8",
-            )],
+            [(axum::http::header::CONTENT_TYPE, "text/html; charset=utf-8")],
             html_body,
         )
             .into_response();
@@ -105,11 +103,11 @@ impl ExceptionFilter for ErrorPageFilter {
 /// Marker stored in response extensions to indicate the original request
 /// preferred HTML responses.
 #[derive(Clone, Debug)]
-pub(crate) struct WantsHtml(pub bool);
+pub struct WantsHtml(pub bool);
 
 /// Request context stored in response extensions for the error page filter.
 #[derive(Clone, Debug)]
-pub(crate) struct ErrorPageRequestContext {
+pub struct ErrorPageRequestContext {
     pub path: String,
     pub request_id: Option<String>,
 }
@@ -120,7 +118,7 @@ pub(crate) struct ErrorPageRequestContext {
 /// This layer runs before the exception filter and stores [`WantsHtml`]
 /// and [`ErrorPageRequestContext`] in the response extensions.
 #[derive(Clone)]
-pub(crate) struct ErrorPageContextLayer;
+pub struct ErrorPageContextLayer;
 
 impl<S> tower::Layer<S> for ErrorPageContextLayer {
     type Service = ErrorPageContextService<S>;
@@ -131,7 +129,7 @@ impl<S> tower::Layer<S> for ErrorPageContextLayer {
 }
 
 #[derive(Clone)]
-pub(crate) struct ErrorPageContextService<S> {
+pub struct ErrorPageContextService<S> {
     inner: S,
 }
 
@@ -156,7 +154,7 @@ where
         let request_id = req
             .extensions()
             .get::<crate::middleware::RequestId>()
-            .map(|id| id.to_string());
+            .map(std::string::ToString::to_string);
 
         ErrorPageContextFuture {
             inner: self.inner.call(req),
@@ -168,7 +166,7 @@ where
 }
 
 pin_project_lite::pin_project! {
-    pub(crate) struct ErrorPageContextFuture<F> {
+    pub struct ErrorPageContextFuture<F> {
         #[pin]
         inner: F,
         wants_html: bool,
@@ -190,7 +188,9 @@ where
         let this = self.project();
         match this.inner.poll(cx) {
             std::task::Poll::Ready(Ok(mut response)) => {
-                response.extensions_mut().insert(WantsHtml(*this.wants_html));
+                response
+                    .extensions_mut()
+                    .insert(WantsHtml(*this.wants_html));
                 response.extensions_mut().insert(ErrorPageRequestContext {
                     path: this.path.clone(),
                     request_id: this.request_id.clone(),
@@ -236,9 +236,7 @@ fn accepts_html<B>(req: &axum::http::Request<B>) -> bool {
 ///
 /// This is mounted as the router's fallback so unmatched routes get proper
 /// error pages instead of Axum's default plain-text "Not Found".
-pub(crate) async fn fallback_404_handler(
-    uri: axum::http::Uri,
-) -> crate::error::AutumnError {
+pub async fn fallback_404_handler(uri: axum::http::Uri) -> crate::error::AutumnError {
     crate::error::AutumnError::not_found_msg(format!("No route matches {}", uri.path()))
 }
 
@@ -315,10 +313,7 @@ mod tests {
     /// Helper: build a router with the error page filter and context layer.
     fn test_router_with_error_pages(is_dev: bool) -> Router {
         let renderer = error_pages::default_renderer();
-        let error_page_filter = ErrorPageFilter {
-            renderer,
-            is_dev,
-        };
+        let error_page_filter = ErrorPageFilter { renderer, is_dev };
         let filters: Vec<Arc<dyn crate::middleware::ExceptionFilter>> =
             vec![Arc::new(error_page_filter)];
 
@@ -331,9 +326,9 @@ mod tests {
             .route(
                 "/boom",
                 get(|| async {
-                    Err::<String, AutumnError>(
-                        AutumnError::from(std::io::Error::other("internal failure")),
-                    )
+                    Err::<String, AutumnError>(AutumnError::from(std::io::Error::other(
+                        "internal failure",
+                    )))
                 }),
             )
             .fallback(fallback_404_handler)
@@ -501,9 +496,7 @@ mod tests {
         let app = Router::new()
             .route(
                 "/err",
-                get(|| async {
-                    Err::<String, AutumnError>(AutumnError::not_found_msg("nope"))
-                }),
+                get(|| async { Err::<String, AutumnError>(AutumnError::not_found_msg("nope")) }),
             )
             .layer(ErrorPageContextLayer)
             .layer(ExceptionFilterLayer::new(filters));

--- a/autumn/src/middleware/metrics.rs
+++ b/autumn/src/middleware/metrics.rs
@@ -1,0 +1,395 @@
+//! Metrics middleware -- records request count, latency, and status code distribution.
+//!
+//! The [`MetricsLayer`] is applied automatically by the framework when building
+//! the router. It instruments every request and records metrics into a shared
+//! [`MetricsCollector`] stored in `AppState`.
+//!
+//! Metrics are exposed via the `/actuator/metrics` endpoint.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use axum::extract::MatchedPath;
+use axum::http::{Request, Response};
+use pin_project_lite::pin_project;
+use serde::Serialize;
+use tower::{Layer, Service};
+
+/// Shared metrics collector that aggregates request statistics.
+#[derive(Debug, Clone)]
+pub struct MetricsCollector {
+    inner: Arc<MetricsInner>,
+}
+
+#[derive(Debug)]
+struct MetricsInner {
+    /// Total number of requests received.
+    requests_total: AtomicU64,
+    /// Currently active (in-flight) requests.
+    requests_active: AtomicU64,
+    /// Per-route metrics: key is "METHOD /path".
+    by_route: RwLock<HashMap<String, RouteMetrics>>,
+    /// Status code buckets: 2xx, 3xx, 4xx, 5xx.
+    by_status: StatusBuckets,
+    /// Global latency samples (bounded ring buffer).
+    latencies_ms: RwLock<Vec<u64>>,
+}
+
+#[derive(Debug, Default)]
+struct StatusBuckets {
+    status_2xx: AtomicU64,
+    status_3xx: AtomicU64,
+    status_4xx: AtomicU64,
+    status_5xx: AtomicU64,
+}
+
+#[derive(Debug, Default, Clone)]
+struct RouteMetrics {
+    count: u64,
+    latencies_ms: Vec<u64>,
+}
+
+/// Maximum number of latency samples to keep per route.
+const MAX_LATENCY_SAMPLES: usize = 10_000;
+
+impl MetricsCollector {
+    /// Create a new empty metrics collector.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(MetricsInner {
+                requests_total: AtomicU64::new(0),
+                requests_active: AtomicU64::new(0),
+                by_route: RwLock::new(HashMap::new()),
+                by_status: StatusBuckets::default(),
+                latencies_ms: RwLock::new(Vec::new()),
+            }),
+        }
+    }
+
+    /// Record a completed request.
+    pub fn record(&self, method: &str, route: &str, status: u16, latency_ms: u64) {
+        self.inner.requests_total.fetch_add(1, Ordering::Relaxed);
+
+        // Status bucket
+        match status / 100 {
+            2 => self.inner.by_status.status_2xx.fetch_add(1, Ordering::Relaxed),
+            3 => self.inner.by_status.status_3xx.fetch_add(1, Ordering::Relaxed),
+            4 => self.inner.by_status.status_4xx.fetch_add(1, Ordering::Relaxed),
+            5 => self.inner.by_status.status_5xx.fetch_add(1, Ordering::Relaxed),
+            _ => 0,
+        };
+
+        // Global latency
+        if let Ok(mut latencies) = self.inner.latencies_ms.write() {
+            if latencies.len() >= MAX_LATENCY_SAMPLES {
+                latencies.remove(0);
+            }
+            latencies.push(latency_ms);
+        }
+
+        // Per-route
+        let key = format!("{method} {route}");
+        if let Ok(mut routes) = self.inner.by_route.write() {
+            let entry = routes.entry(key).or_default();
+            entry.count += 1;
+            if entry.latencies_ms.len() >= MAX_LATENCY_SAMPLES {
+                entry.latencies_ms.remove(0);
+            }
+            entry.latencies_ms.push(latency_ms);
+        }
+    }
+
+    fn increment_active(&self) {
+        self.inner.requests_active.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn decrement_active(&self) {
+        self.inner.requests_active.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    /// Produce a snapshot of current metrics for the `/actuator/metrics` endpoint.
+    #[must_use]
+    pub fn snapshot(&self) -> MetricsSnapshot {
+        let global_latency = self
+            .inner
+            .latencies_ms
+            .read()
+            .map(|v| compute_percentiles(&v))
+            .unwrap_or_default();
+
+        let by_route = self
+            .inner
+            .by_route
+            .read()
+            .map(|routes| {
+                routes
+                    .iter()
+                    .map(|(k, v)| {
+                        let pcts = compute_percentiles(&v.latencies_ms);
+                        (
+                            k.clone(),
+                            RouteSnapshot {
+                                count: v.count,
+                                p50_ms: pcts.p50,
+                                p95_ms: pcts.p95,
+                                p99_ms: pcts.p99,
+                            },
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        MetricsSnapshot {
+            http: HttpMetrics {
+                requests_total: self.inner.requests_total.load(Ordering::Relaxed),
+                requests_active: self.inner.requests_active.load(Ordering::Relaxed),
+                latency_ms: LatencySnapshot {
+                    p50: global_latency.p50,
+                    p95: global_latency.p95,
+                    p99: global_latency.p99,
+                },
+                by_route,
+                by_status: StatusSnapshot {
+                    s2xx: self.inner.by_status.status_2xx.load(Ordering::Relaxed),
+                    s3xx: self.inner.by_status.status_3xx.load(Ordering::Relaxed),
+                    s4xx: self.inner.by_status.status_4xx.load(Ordering::Relaxed),
+                    s5xx: self.inner.by_status.status_5xx.load(Ordering::Relaxed),
+                },
+            },
+        }
+    }
+}
+
+impl Default for MetricsCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Serializable metrics snapshot returned by `/actuator/metrics`.
+#[derive(Serialize)]
+pub struct MetricsSnapshot {
+    pub http: HttpMetrics,
+}
+
+#[derive(Serialize)]
+pub struct HttpMetrics {
+    pub requests_total: u64,
+    pub requests_active: u64,
+    pub latency_ms: LatencySnapshot,
+    pub by_route: HashMap<String, RouteSnapshot>,
+    pub by_status: StatusSnapshot,
+}
+
+#[derive(Serialize, Default)]
+pub struct LatencySnapshot {
+    pub p50: u64,
+    pub p95: u64,
+    pub p99: u64,
+}
+
+#[derive(Serialize)]
+pub struct RouteSnapshot {
+    pub count: u64,
+    pub p50_ms: u64,
+    pub p95_ms: u64,
+    pub p99_ms: u64,
+}
+
+#[derive(Serialize)]
+pub struct StatusSnapshot {
+    #[serde(rename = "2xx")]
+    pub s2xx: u64,
+    #[serde(rename = "3xx")]
+    pub s3xx: u64,
+    #[serde(rename = "4xx")]
+    pub s4xx: u64,
+    #[serde(rename = "5xx")]
+    pub s5xx: u64,
+}
+
+#[derive(Default)]
+struct Percentiles {
+    p50: u64,
+    p95: u64,
+    p99: u64,
+}
+
+fn compute_percentiles(latencies: &[u64]) -> Percentiles {
+    if latencies.is_empty() {
+        return Percentiles::default();
+    }
+    let mut sorted = latencies.to_vec();
+    sorted.sort_unstable();
+    let len = sorted.len();
+    Percentiles {
+        p50: sorted[len * 50 / 100],
+        p95: sorted[len.saturating_sub(1).min(len * 95 / 100)],
+        p99: sorted[len.saturating_sub(1).min(len * 99 / 100)],
+    }
+}
+
+// ── Tower Layer / Service ───────────────────────────────────────
+
+/// Tower [`Layer`] that wraps a service with [`MetricsService`].
+///
+/// Records request count, latency, active connections, and status code
+/// distribution into a shared [`MetricsCollector`].
+#[derive(Clone)]
+pub struct MetricsLayer {
+    collector: MetricsCollector,
+}
+
+impl MetricsLayer {
+    /// Create a new metrics layer backed by the given collector.
+    #[must_use]
+    pub fn new(collector: MetricsCollector) -> Self {
+        Self { collector }
+    }
+}
+
+impl<S> Layer<S> for MetricsLayer {
+    type Service = MetricsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MetricsService {
+            inner,
+            collector: self.collector.clone(),
+        }
+    }
+}
+
+/// Tower [`Service`] produced by [`MetricsLayer`].
+#[derive(Clone)]
+pub struct MetricsService<S> {
+    inner: S,
+    collector: MetricsCollector,
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for MetricsService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = MetricsFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let method = req.method().to_string();
+        let route = req
+            .extensions()
+            .get::<MatchedPath>()
+            .map(|p| p.as_str().to_owned())
+            .unwrap_or_else(|| "_unmatched".to_owned());
+
+        self.collector.increment_active();
+
+        MetricsFuture {
+            inner: self.inner.call(req),
+            collector: Some(self.collector.clone()),
+            method: Some(method),
+            route: Some(route),
+            start: Instant::now(),
+        }
+    }
+}
+
+pin_project! {
+    /// Future that records metrics after the inner service completes.
+    pub struct MetricsFuture<F> {
+        #[pin]
+        inner: F,
+        collector: Option<MetricsCollector>,
+        method: Option<String>,
+        route: Option<String>,
+        start: Instant,
+    }
+}
+
+impl<F, ResBody, E> Future for MetricsFuture<F>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+{
+    type Output = Result<Response<ResBody>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.inner.poll(cx) {
+            Poll::Ready(Ok(response)) => {
+                if let Some(collector) = this.collector.take() {
+                    let latency_ms = this.start.elapsed().as_millis() as u64;
+                    let method = this.method.take().unwrap_or_default();
+                    let route = this.route.take().unwrap_or_default();
+                    let status = response.status().as_u16();
+                    collector.record(&method, &route, status, latency_ms);
+                    collector.decrement_active();
+                }
+                Poll::Ready(Ok(response))
+            }
+            Poll::Ready(Err(e)) => {
+                if let Some(collector) = this.collector.take() {
+                    collector.decrement_active();
+                }
+                Poll::Ready(Err(e))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collector_records_request() {
+        let collector = MetricsCollector::new();
+        collector.record("GET", "/test", 200, 10);
+        collector.record("GET", "/test", 200, 20);
+        collector.record("POST", "/test", 500, 50);
+
+        let snap = collector.snapshot();
+        assert_eq!(snap.http.requests_total, 3);
+        assert_eq!(snap.http.by_status.s2xx, 2);
+        assert_eq!(snap.http.by_status.s5xx, 1);
+        assert!(snap.http.by_route.contains_key("GET /test"));
+        assert_eq!(snap.http.by_route["GET /test"].count, 2);
+    }
+
+    #[test]
+    fn empty_collector_snapshot() {
+        let collector = MetricsCollector::new();
+        let snap = collector.snapshot();
+        assert_eq!(snap.http.requests_total, 0);
+        assert_eq!(snap.http.requests_active, 0);
+        assert_eq!(snap.http.latency_ms.p50, 0);
+    }
+
+    #[test]
+    fn percentiles_computed_correctly() {
+        let pcts = compute_percentiles(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        assert_eq!(pcts.p50, 6); // sorted[10*50/100] = sorted[5] = 6
+        assert_eq!(pcts.p99, 10); // sorted[min(9, 10*99/100)] = sorted[9] = 10
+    }
+
+    #[test]
+    fn active_connection_tracking() {
+        let collector = MetricsCollector::new();
+        collector.increment_active();
+        collector.increment_active();
+        assert_eq!(collector.inner.requests_active.load(Ordering::Relaxed), 2);
+        collector.decrement_active();
+        assert_eq!(collector.inner.requests_active.load(Ordering::Relaxed), 1);
+    }
+}

--- a/autumn/src/middleware/metrics.rs
+++ b/autumn/src/middleware/metrics.rs
@@ -41,6 +41,7 @@ struct MetricsInner {
 }
 
 #[derive(Debug, Default)]
+#[allow(clippy::struct_field_names)]
 struct StatusBuckets {
     status_2xx: AtomicU64,
     status_3xx: AtomicU64,
@@ -78,10 +79,26 @@ impl MetricsCollector {
 
         // Status bucket
         match status / 100 {
-            2 => self.inner.by_status.status_2xx.fetch_add(1, Ordering::Relaxed),
-            3 => self.inner.by_status.status_3xx.fetch_add(1, Ordering::Relaxed),
-            4 => self.inner.by_status.status_4xx.fetch_add(1, Ordering::Relaxed),
-            5 => self.inner.by_status.status_5xx.fetch_add(1, Ordering::Relaxed),
+            2 => self
+                .inner
+                .by_status
+                .status_2xx
+                .fetch_add(1, Ordering::Relaxed),
+            3 => self
+                .inner
+                .by_status
+                .status_3xx
+                .fetch_add(1, Ordering::Relaxed),
+            4 => self
+                .inner
+                .by_status
+                .status_4xx
+                .fetch_add(1, Ordering::Relaxed),
+            5 => self
+                .inner
+                .by_status
+                .status_5xx
+                .fetch_add(1, Ordering::Relaxed),
             _ => 0,
         };
 
@@ -250,7 +267,7 @@ pub struct MetricsLayer {
 impl MetricsLayer {
     /// Create a new metrics layer backed by the given collector.
     #[must_use]
-    pub fn new(collector: MetricsCollector) -> Self {
+    pub const fn new(collector: MetricsCollector) -> Self {
         Self { collector }
     }
 }
@@ -290,8 +307,7 @@ where
         let route = req
             .extensions()
             .get::<MatchedPath>()
-            .map(|p| p.as_str().to_owned())
-            .unwrap_or_else(|| "_unmatched".to_owned());
+            .map_or_else(|| "_unmatched".to_owned(), |p| p.as_str().to_owned());
 
         self.collector.increment_active();
 
@@ -328,7 +344,8 @@ where
         match this.inner.poll(cx) {
             Poll::Ready(Ok(response)) => {
                 if let Some(collector) = this.collector.take() {
-                    let latency_ms = this.start.elapsed().as_millis() as u64;
+                    let latency_ms =
+                        u64::try_from(this.start.elapsed().as_millis()).unwrap_or(u64::MAX);
                     let method = this.method.take().unwrap_or_default();
                     let route = this.route.take().unwrap_or_default();
                     let status = response.status().as_u16();

--- a/autumn/src/middleware/mod.rs
+++ b/autumn/src/middleware/mod.rs
@@ -15,8 +15,11 @@
 //! when at least one exception filter is registered via
 //! [`AppBuilder::exception_filter`](crate::app::AppBuilder::exception_filter).
 
+pub(crate) mod error_page_filter;
 pub mod exception_filter;
+pub mod metrics;
 pub mod request_id;
 
 pub use exception_filter::{AutumnErrorInfo, ExceptionFilter, ExceptionFilterLayer};
+pub use metrics::{MetricsCollector, MetricsLayer};
 pub use request_id::{RequestId, RequestIdLayer};

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -102,7 +102,10 @@ pub fn pending_migrations(
         .pending_migrations(migrations)
         .map_err(|e| MigrationError::Migration(e.to_string()))?;
 
-    Ok(pending.iter().map(|m| m.name().version().to_string()).collect())
+    Ok(pending
+        .iter()
+        .map(|m| m.name().version().to_string())
+        .collect())
 }
 
 /// Run migrations according to the active profile.

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -1,0 +1,193 @@
+//! Database migration support.
+//!
+//! Provides helpers for running Diesel migrations at application startup.
+//! In **dev** mode, pending migrations run automatically; in **prod** mode,
+//! they must be applied explicitly via `autumn migrate`.
+//!
+//! # Usage
+//!
+//! Application code typically does not use this module directly. Instead,
+//! pass embedded migrations to [`AppBuilder::migrations`](crate::app::AppBuilder::migrations)
+//! and the framework handles the rest:
+//!
+//! ```rust,ignore
+//! use diesel_migrations::{EmbeddedMigrations, embed_migrations};
+//!
+//! const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
+//!
+//! #[autumn_web::main]
+//! async fn main() {
+//!     autumn_web::app()
+//!         .routes(routes![...])
+//!         .migrations(MIGRATIONS)
+//!         .run()
+//!         .await;
+//! }
+//! ```
+
+use diesel::Connection;
+use diesel::migration::Migration;
+use diesel_migrations::{HarnessWithOutput, MigrationHarness};
+
+/// Re-export `EmbeddedMigrations` so users can reference it without adding
+/// `diesel_migrations` as a direct dependency.
+pub use diesel_migrations::EmbeddedMigrations;
+
+/// Re-export the `embed_migrations!` macro.
+pub use diesel_migrations::embed_migrations;
+
+/// Result of running pending migrations.
+#[derive(Debug)]
+pub struct MigrationResult {
+    /// Names of the migrations that were applied.
+    pub applied: Vec<String>,
+}
+
+/// Error type for migration operations.
+#[derive(Debug, thiserror::Error)]
+pub enum MigrationError {
+    /// Failed to connect to the database.
+    #[error("failed to connect to database: {0}")]
+    Connection(String),
+
+    /// A migration failed to apply.
+    #[error("migration failed: {0}")]
+    Migration(String),
+}
+
+/// Run all pending migrations against the given database URL.
+///
+/// Uses a **synchronous** `PgConnection` (not the async pool) because
+/// Diesel migrations require `MigrationHarness`, which is sync-only.
+///
+/// Returns the list of migration versions that were applied, or an error
+/// if a migration fails (including the failing SQL in the message).
+///
+/// # Errors
+///
+/// Returns [`MigrationError::Connection`] if the database is unreachable,
+/// or [`MigrationError::Migration`] if a migration fails.
+pub fn run_pending(
+    database_url: &str,
+    migrations: EmbeddedMigrations,
+) -> Result<MigrationResult, MigrationError> {
+    let mut conn = diesel::PgConnection::establish(database_url)
+        .map_err(|e| MigrationError::Connection(e.to_string()))?;
+
+    let mut harness = HarnessWithOutput::write_to_stdout(&mut conn);
+
+    let applied = harness
+        .run_pending_migrations(migrations)
+        .map_err(|e| MigrationError::Migration(e.to_string()))?;
+
+    Ok(MigrationResult {
+        applied: applied.iter().map(|m| format!("{m}")).collect(),
+    })
+}
+
+/// Return names of pending (not yet applied) migrations.
+///
+/// # Errors
+///
+/// Returns [`MigrationError::Connection`] if the database is unreachable,
+/// or [`MigrationError::Migration`] if status cannot be determined.
+pub fn pending_migrations(
+    database_url: &str,
+    migrations: EmbeddedMigrations,
+) -> Result<Vec<String>, MigrationError> {
+    let mut conn = diesel::PgConnection::establish(database_url)
+        .map_err(|e| MigrationError::Connection(e.to_string()))?;
+
+    let pending = conn
+        .pending_migrations(migrations)
+        .map_err(|e| MigrationError::Migration(e.to_string()))?;
+
+    Ok(pending.iter().map(|m| m.name().version().to_string()).collect())
+}
+
+/// Run migrations according to the active profile.
+///
+/// - **dev**: runs all pending migrations automatically and logs each one.
+/// - **prod** / other: logs a warning if pending migrations exist but does
+///   not apply them.
+///
+/// Called internally by [`AppBuilder::run`](crate::app::AppBuilder::run)
+/// when migrations are registered via `.migrations()`.
+pub(crate) fn auto_migrate(
+    database_url: &str,
+    profile: Option<&str>,
+    migrations: EmbeddedMigrations,
+) {
+    let is_dev = profile == Some("dev");
+
+    if is_dev {
+        tracing::info!("Dev mode: running pending database migrations...");
+        match run_pending(database_url, migrations) {
+            Ok(result) if result.applied.is_empty() => {
+                tracing::info!("No pending migrations");
+            }
+            Ok(result) => {
+                for name in &result.applied {
+                    tracing::info!(migration = %name, "Applied migration");
+                }
+                tracing::info!(
+                    count = result.applied.len(),
+                    "All pending migrations applied"
+                );
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to run migrations");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        // In non-dev modes, just report status
+        match pending_migrations(database_url, migrations) {
+            Ok(pending) if pending.is_empty() => {
+                tracing::info!("Database migrations are up to date");
+            }
+            Ok(pending) => {
+                tracing::warn!(
+                    count = pending.len(),
+                    "Pending migrations detected. Run `autumn migrate` to apply them."
+                );
+                for name in &pending {
+                    tracing::warn!(migration = %name, "Pending migration");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Could not check migration status");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migration_result_debug() {
+        let result = MigrationResult {
+            applied: vec!["00000000000001".to_string()],
+        };
+        let debug = format!("{result:?}");
+        assert!(debug.contains("00000000000001"));
+    }
+
+    #[test]
+    fn migration_error_display_connection() {
+        let err = MigrationError::Connection("refused".to_string());
+        let msg = err.to_string();
+        assert!(msg.contains("connect"));
+        assert!(msg.contains("refused"));
+    }
+
+    #[test]
+    fn migration_error_display_migration() {
+        let err = MigrationError::Migration("syntax error".to_string());
+        let msg = err.to_string();
+        assert!(msg.contains("migration failed"));
+        assert!(msg.contains("syntax error"));
+    }
+}

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -83,12 +83,20 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
         #[cfg(not(feature = "db"))]
         let _state = AppState {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
         let _err: AutumnResult<()> = Ok(());
     }

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -594,6 +594,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
 
         let app = Router::new()
@@ -637,6 +641,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
 
         let app = Router::new()
@@ -698,6 +706,10 @@ mod tests {
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
         };
 
         let store = MemoryStore::new();

--- a/autumn/src/static_gen/build.rs
+++ b/autumn/src/static_gen/build.rs
@@ -12,7 +12,7 @@ use axum::http::{Request, StatusCode};
 use futures::StreamExt;
 use tower::ServiceExt;
 
-use super::{ManifestEntry, StaticManifest, StaticRouteMeta, url_to_file_path};
+use super::{ManifestEntry, StaticManifest, StaticRouteMeta, StaticParams, url_to_file_path};
 
 /// Default number of routes rendered concurrently.
 const DEFAULT_CONCURRENCY: usize = 8;
@@ -45,6 +45,82 @@ pub enum BuildError {
     /// A JSON serialization error occurred while writing the manifest.
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
+
+    /// The params function for a parameterized route returned an empty list.
+    #[error("Params function for route {path} returned no parameter sets")]
+    EmptyParams {
+        /// The URL path pattern that had no params.
+        path: String,
+    },
+}
+
+/// A concrete URL path to render, produced by expanding parameterized routes.
+struct RenderJob {
+    /// The concrete URL path (e.g. `/posts/hello`).
+    url: String,
+    /// Optional ISR revalidation interval.
+    revalidate: Option<u64>,
+}
+
+/// Expand a `StaticRouteMeta` into one or more concrete `RenderJob`s.
+///
+/// For simple routes (no `params_fn`), returns a single job with the literal path.
+/// For parameterized routes, calls the params function and substitutes each
+/// parameter set into the path pattern.
+async fn expand_route(
+    meta: &StaticRouteMeta,
+    router: &axum::Router,
+) -> Result<Vec<RenderJob>, BuildError> {
+    match meta.params_fn {
+        None => {
+            // Simple static route -- single job
+            Ok(vec![RenderJob {
+                url: meta.path.to_owned(),
+                revalidate: meta.revalidate,
+            }])
+        }
+        Some(params_fn) => {
+            // Parameterized route -- call the params function
+            let param_sets = params_fn(router.clone()).await;
+            if param_sets.is_empty() {
+                return Err(BuildError::EmptyParams {
+                    path: meta.path.to_owned(),
+                });
+            }
+
+            let jobs = param_sets
+                .into_iter()
+                .map(|params| {
+                    let url = substitute_params(meta.path, &params);
+                    RenderJob {
+                        url,
+                        revalidate: meta.revalidate,
+                    }
+                })
+                .collect();
+
+            Ok(jobs)
+        }
+    }
+}
+
+/// Substitute parameter values into a URL path pattern.
+///
+/// Replaces `{name}` placeholders with the corresponding value from the params map.
+///
+/// # Example
+///
+/// ```text
+/// substitute_params("/posts/{slug}", {"slug": "hello"}) => "/posts/hello"
+/// substitute_params("/blog/{year}/{slug}", {"year": "2026", "slug": "hi"}) => "/blog/2026/hi"
+/// ```
+fn substitute_params(pattern: &str, params: &StaticParams) -> String {
+    let mut result = pattern.to_owned();
+    for (key, value) in params {
+        let placeholder = format!("{{{key}}}");
+        result = result.replace(&placeholder, value);
+    }
+    result
 }
 
 /// Render all static routes and write them to `dist_dir`.
@@ -52,9 +128,15 @@ pub enum BuildError {
 /// Routes are rendered concurrently (up to `DEFAULT_CONCURRENCY` at a time)
 /// using `buffer_unordered`.
 ///
-/// 1. Renders to a staging directory (`{dist_dir}.staging`).
-/// 2. On success, atomically renames staging -> dist.
-/// 3. On failure, removes staging and returns the first error.
+/// For parameterized routes, the params function is called first to expand
+/// each route pattern into concrete URLs. For example,
+/// `/posts/{slug}` with params `["hello", "world"]` becomes two render jobs:
+/// `/posts/hello` and `/posts/world`.
+///
+/// 1. Expands parameterized routes into concrete render jobs.
+/// 2. Renders to a staging directory (`{dist_dir}.staging`).
+/// 3. On success, atomically renames staging -> dist.
+/// 4. On failure, removes staging and returns the first error.
 ///
 /// If `dist_dir` already exists, it is replaced.
 ///
@@ -65,6 +147,7 @@ pub enum BuildError {
 /// - A response body cannot be read.
 /// - An I/O error occurs while writing files or swapping directories.
 /// - The manifest cannot be serialized to JSON.
+/// - A params function returns an empty list.
 ///
 /// # Panics
 ///
@@ -77,6 +160,18 @@ pub async fn render_static_routes(
     metas: &[StaticRouteMeta],
     dist_dir: &Path,
 ) -> Result<(), BuildError> {
+    // Phase 1: Expand all routes into concrete render jobs
+    let mut jobs = Vec::new();
+    for meta in metas {
+        let expanded = expand_route(meta, &router).await?;
+        eprintln!(
+            "  Route {} -> {} page(s)",
+            meta.path,
+            expanded.len()
+        );
+        jobs.extend(expanded);
+    }
+
     let staging = dist_dir.with_extension("staging");
 
     // Clean staging dir if it exists from a previous failed build
@@ -86,8 +181,8 @@ pub async fn render_static_routes(
     std::fs::create_dir_all(&staging)?;
 
     // Pre-create all subdirectories (avoids races between concurrent tasks)
-    for meta in metas {
-        let file_path = url_to_file_path(meta.path);
+    for job in &jobs {
+        let file_path = url_to_file_path(&job.url);
         let full_path = staging.join(&file_path);
         if let Some(parent) = full_path.parent() {
             std::fs::create_dir_all(parent)?;
@@ -96,16 +191,18 @@ pub async fn render_static_routes(
 
     // Render concurrently
     let results: Vec<Result<(String, ManifestEntry), BuildError>> =
-        futures::stream::iter(metas.iter().map(|meta| {
+        futures::stream::iter(jobs.iter().map(|job| {
             let router = router.clone();
             let staging = staging.clone();
+            let url = job.url.clone();
+            let revalidate = job.revalidate;
             async move {
-                eprintln!("  Rendering {} ...", meta.path);
+                eprintln!("  Rendering {} ...", url);
 
                 let response = router
                     .oneshot(
                         Request::builder()
-                            .uri(meta.path)
+                            .uri(&url)
                             .body(Body::empty())
                             .expect("valid request"),
                     )
@@ -114,7 +211,7 @@ pub async fn render_static_routes(
 
                 if !response.status().is_success() {
                     return Err(BuildError::NonSuccessStatus {
-                        path: meta.path.to_owned(),
+                        path: url,
                         status: response.status(),
                     });
                 }
@@ -122,20 +219,20 @@ pub async fn render_static_routes(
                 let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
                     .await
                     .map_err(|e| BuildError::BodyRead {
-                        path: meta.path.to_owned(),
+                        path: url.clone(),
                         source: e,
                     })?;
 
-                let file_path = url_to_file_path(meta.path);
+                let file_path = url_to_file_path(&url);
                 // staging dir pre-created above, just write
                 let full_path = staging.join(&file_path);
                 std::fs::write(&full_path, &body_bytes)?;
 
                 Ok((
-                    meta.path.to_owned(),
+                    url,
                     ManifestEntry {
                         file: file_path,
-                        revalidate: meta.revalidate,
+                        revalidate,
                     },
                 ))
             }
@@ -190,13 +287,74 @@ fn timestamp_now() -> String {
 mod tests {
     use super::*;
     use crate::static_gen::StaticRouteMeta;
+    use std::future::Future;
+    use std::pin::Pin;
 
     fn test_meta(path: &'static str, name: &'static str) -> StaticRouteMeta {
         StaticRouteMeta {
             path,
             name,
             revalidate: None,
+            params_fn: None,
         }
+    }
+
+    fn test_meta_with_revalidate(
+        path: &'static str,
+        name: &'static str,
+        revalidate: u64,
+    ) -> StaticRouteMeta {
+        StaticRouteMeta {
+            path,
+            name,
+            revalidate: Some(revalidate),
+            params_fn: None,
+        }
+    }
+
+    // --- ParamsFn helpers for tests ---
+    // Since ParamsFn is a fn pointer (not a closure), we define named
+    // functions that return fixed parameter sets for each test scenario.
+
+    fn slug_params_hello_world(
+        _router: axum::Router,
+    ) -> Pin<Box<dyn Future<Output = Vec<StaticParams>> + Send>> {
+        Box::pin(async {
+            vec![
+                crate::static_params! { "slug" => "hello" },
+                crate::static_params! { "slug" => "world" },
+            ]
+        })
+    }
+
+    fn slug_params_alpha_beta(
+        _router: axum::Router,
+    ) -> Pin<Box<dyn Future<Output = Vec<StaticParams>> + Send>> {
+        Box::pin(async {
+            vec![
+                crate::static_params! { "slug" => "alpha" },
+                crate::static_params! { "slug" => "beta" },
+            ]
+        })
+    }
+
+    fn multi_params(
+        _router: axum::Router,
+    ) -> Pin<Box<dyn Future<Output = Vec<StaticParams>> + Send>> {
+        Box::pin(async {
+            vec![
+                crate::static_params! { "year" => "2026", "slug" => "hello" },
+                crate::static_params! { "year" => "2025", "slug" => "world" },
+            ]
+        })
+    }
+
+    fn slug_params_hello(
+        _router: axum::Router,
+    ) -> Pin<Box<dyn Future<Output = Vec<StaticParams>> + Send>> {
+        Box::pin(async {
+            vec![crate::static_params! { "slug" => "hello" }]
+        })
     }
 
     fn echo_router() -> axum::Router {
@@ -204,6 +362,8 @@ mod tests {
             format!("Hello from {}", uri.path())
         }))
     }
+
+    // --- Simple route tests (Phase 1 regression) ---
 
     #[tokio::test]
     async fn renders_single_route_to_dist() {
@@ -279,5 +439,146 @@ mod tests {
         assert!(dist.join("index.html").exists());
         assert!(dist.join("about/index.html").exists());
         assert!(dist.join("contact/index.html").exists());
+    }
+
+    // --- Parameterized route tests (Phase 2) ---
+
+    #[test]
+    fn substitute_params_single() {
+        let params = crate::static_params! { "slug" => "hello-world" };
+        let result = substitute_params("/posts/{slug}", &params);
+        assert_eq!(result, "/posts/hello-world");
+    }
+
+    #[test]
+    fn substitute_params_multiple() {
+        let params = crate::static_params! {
+            "year" => "2026",
+            "slug" => "hello",
+        };
+        let result = substitute_params("/blog/{year}/{slug}", &params);
+        assert_eq!(result, "/blog/2026/hello");
+    }
+
+    #[test]
+    fn substitute_params_no_placeholders() {
+        let params = StaticParams::new();
+        let result = substitute_params("/about", &params);
+        assert_eq!(result, "/about");
+    }
+
+    #[tokio::test]
+    async fn renders_parameterized_route() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dist = tmp.path().join("dist");
+
+        let meta = StaticRouteMeta {
+            path: "/posts/{slug}",
+            name: "show_post",
+            revalidate: None,
+            params_fn: Some(slug_params_hello_world),
+        };
+
+        let result = render_static_routes(echo_router(), &[meta], &dist).await;
+        assert!(result.is_ok(), "render failed: {:?}", result.err());
+
+        // Verify both pages generated
+        let hello_html = std::fs::read_to_string(dist.join("posts/hello/index.html")).unwrap();
+        assert_eq!(hello_html, "Hello from /posts/hello");
+
+        let world_html = std::fs::read_to_string(dist.join("posts/world/index.html")).unwrap();
+        assert_eq!(world_html, "Hello from /posts/world");
+
+        // Verify manifest
+        let manifest = StaticManifest::load(&dist.join("manifest.json")).unwrap();
+        assert_eq!(manifest.routes.len(), 2);
+        assert!(manifest.routes.contains_key("/posts/hello"));
+        assert!(manifest.routes.contains_key("/posts/world"));
+    }
+
+    #[tokio::test]
+    async fn renders_multi_param_route() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dist = tmp.path().join("dist");
+
+        let meta = StaticRouteMeta {
+            path: "/blog/{year}/{slug}",
+            name: "blog_post",
+            revalidate: None,
+            params_fn: Some(multi_params),
+        };
+
+        let result = render_static_routes(echo_router(), &[meta], &dist).await;
+        assert!(result.is_ok(), "render failed: {:?}", result.err());
+
+        assert!(dist.join("blog/2026/hello/index.html").exists());
+        assert!(dist.join("blog/2025/world/index.html").exists());
+
+        let manifest = StaticManifest::load(&dist.join("manifest.json")).unwrap();
+        assert_eq!(manifest.routes.len(), 2);
+        assert!(manifest.routes.contains_key("/blog/2026/hello"));
+        assert!(manifest.routes.contains_key("/blog/2025/world"));
+    }
+
+    #[tokio::test]
+    async fn mixed_simple_and_parameterized_routes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dist = tmp.path().join("dist");
+
+        let metas = vec![
+            test_meta("/", "index"),
+            test_meta("/about", "about"),
+            StaticRouteMeta {
+                path: "/posts/{slug}",
+                name: "show_post",
+                revalidate: None,
+                params_fn: Some(slug_params_alpha_beta),
+            },
+        ];
+
+        let result = render_static_routes(echo_router(), &metas, &dist).await;
+        assert!(result.is_ok(), "render failed: {:?}", result.err());
+
+        let manifest = StaticManifest::load(&dist.join("manifest.json")).unwrap();
+        // 2 simple + 2 parameterized = 4 total
+        assert_eq!(manifest.routes.len(), 4);
+        assert!(manifest.routes.contains_key("/"));
+        assert!(manifest.routes.contains_key("/about"));
+        assert!(manifest.routes.contains_key("/posts/alpha"));
+        assert!(manifest.routes.contains_key("/posts/beta"));
+    }
+
+    #[tokio::test]
+    async fn parameterized_route_manifest_includes_revalidate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dist = tmp.path().join("dist");
+
+        let meta = StaticRouteMeta {
+            path: "/posts/{slug}",
+            name: "show_post",
+            revalidate: Some(3600),
+            params_fn: Some(slug_params_hello),
+        };
+
+        let result = render_static_routes(echo_router(), &[meta], &dist).await;
+        assert!(result.is_ok());
+
+        let manifest = StaticManifest::load(&dist.join("manifest.json")).unwrap();
+        let entry = manifest.routes.get("/posts/hello").unwrap();
+        assert_eq!(entry.revalidate, Some(3600));
+    }
+
+    #[tokio::test]
+    async fn simple_route_with_revalidate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dist = tmp.path().join("dist");
+        let meta = test_meta_with_revalidate("/about", "about", 60);
+
+        let result = render_static_routes(echo_router(), &[meta], &dist).await;
+        assert!(result.is_ok());
+
+        let manifest = StaticManifest::load(&dist.join("manifest.json")).unwrap();
+        let entry = manifest.routes.get("/about").unwrap();
+        assert_eq!(entry.revalidate, Some(60));
     }
 }

--- a/autumn/src/static_gen/build.rs
+++ b/autumn/src/static_gen/build.rs
@@ -12,7 +12,7 @@ use axum::http::{Request, StatusCode};
 use futures::StreamExt;
 use tower::ServiceExt;
 
-use super::{ManifestEntry, StaticManifest, StaticRouteMeta, StaticParams, url_to_file_path};
+use super::{ManifestEntry, StaticManifest, StaticParams, StaticRouteMeta, url_to_file_path};
 
 /// Default number of routes rendered concurrently.
 const DEFAULT_CONCURRENCY: usize = 8;
@@ -164,11 +164,7 @@ pub async fn render_static_routes(
     let mut jobs = Vec::new();
     for meta in metas {
         let expanded = expand_route(meta, &router).await?;
-        eprintln!(
-            "  Route {} -> {} page(s)",
-            meta.path,
-            expanded.len()
-        );
+        eprintln!("  Route {} -> {} page(s)", meta.path, expanded.len());
         jobs.extend(expanded);
     }
 
@@ -197,7 +193,7 @@ pub async fn render_static_routes(
             let url = job.url.clone();
             let revalidate = job.revalidate;
             async move {
-                eprintln!("  Rendering {} ...", url);
+                eprintln!("  Rendering {url} ...");
 
                 let response = router
                     .oneshot(
@@ -352,9 +348,7 @@ mod tests {
     fn slug_params_hello(
         _router: axum::Router,
     ) -> Pin<Box<dyn Future<Output = Vec<StaticParams>> + Send>> {
-        Box::pin(async {
-            vec![crate::static_params! { "slug" => "hello" }]
-        })
+        Box::pin(async { vec![crate::static_params! { "slug" => "hello" }] })
     }
 
     fn echo_router() -> axum::Router {

--- a/autumn/src/static_gen/middleware.rs
+++ b/autumn/src/static_gen/middleware.rs
@@ -1,7 +1,25 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::StaticManifest;
+
+/// Per-route ISR state, tracking whether a regeneration is in flight
+/// and when the last regeneration attempt occurred.
+struct IsrRouteState {
+    /// `true` when a background regeneration task is running for this route.
+    in_flight: AtomicBool,
+    /// Unix timestamp of the last regeneration attempt. Used for backoff:
+    /// after a failed regeneration, wait at least `REGEN_COOLDOWN_SECS`
+    /// before trying again.
+    last_attempt: AtomicU64,
+}
+
+/// Minimum seconds between regeneration attempts for the same route.
+/// Prevents tight retry loops when the handler is failing.
+const REGEN_COOLDOWN_SECS: u64 = 30;
 
 /// Layer that resolves incoming request paths against a pre-built static
 /// manifest and the corresponding `dist/` directory on disk.
@@ -10,10 +28,24 @@ use super::StaticManifest;
 /// expected `manifest.json` is missing or unparseable -- this makes it
 /// safe to attempt construction unconditionally and simply skip static
 /// serving when no build output exists.
+///
+/// ## ISR (Incremental Static Regeneration)
+///
+/// Routes with a `revalidate` interval are served from disk but checked
+/// for staleness on each request. When the file on disk is older than
+/// `revalidate` seconds, a background Tokio task is spawned to re-render
+/// the page. The stale page continues to be served until the fresh one
+/// is ready (stale-while-revalidate pattern).
 #[derive(Clone)]
 pub struct StaticFileLayer {
     dist_dir: PathBuf,
     manifest: Arc<StaticManifest>,
+    /// Per-route ISR state, keyed by URL path. Only populated for routes
+    /// that have `revalidate` set.
+    isr_state: Arc<HashMap<String, IsrRouteState>>,
+    /// The Axum router used for ISR regeneration. Cloned from the app
+    /// router at construction time. `None` if ISR is not needed.
+    isr_router: Option<Arc<axum::Router>>,
 }
 
 impl StaticFileLayer {
@@ -21,14 +53,33 @@ impl StaticFileLayer {
     ///
     /// Looks for `<dist_dir>/manifest.json`. Returns `None` if the file
     /// does not exist or cannot be parsed as a valid [`StaticManifest`].
+    ///
+    /// ISR routes are detected from the manifest but no regeneration
+    /// router is configured. Use [`with_router`](Self::with_router) to
+    /// enable ISR regeneration.
     pub fn new(dist_dir: impl Into<PathBuf>) -> Option<Self> {
         let dist_dir = dist_dir.into();
         let manifest_path = dist_dir.join("manifest.json");
         let manifest = StaticManifest::load(&manifest_path).ok()?;
+
+        let isr_state = build_isr_state(&manifest);
+
         Some(Self {
             dist_dir,
             manifest: Arc::new(manifest),
+            isr_state: Arc::new(isr_state),
+            isr_router: None,
         })
+    }
+
+    /// Attach an Axum router for ISR background regeneration.
+    ///
+    /// Without a router, ISR staleness is detected but pages are never
+    /// re-rendered. This method enables the full ISR cycle.
+    #[must_use]
+    pub fn with_router(mut self, router: axum::Router) -> Self {
+        self.isr_router = Some(Arc::new(router));
+        self
     }
 
     /// Reference to the loaded manifest.
@@ -47,13 +98,167 @@ impl StaticFileLayer {
     /// within `dist/`, based on the manifest.
     ///
     /// Returns `None` if the path is not in the manifest. Does **not**
-    /// check whether the file exists on disk — callers (e.g. `ServeDir`)
+    /// check whether the file exists on disk -- callers (e.g. `ServeDir`)
     /// handle missing files gracefully.
+    ///
+    /// If the route has ISR enabled and the file is stale, this method
+    /// triggers a background regeneration task (at most one at a time
+    /// per route) and still returns the stale file path. The caller
+    /// serves the stale content while regeneration happens.
     #[must_use]
     pub fn resolve(&self, request_path: &str) -> Option<PathBuf> {
         let entry = self.manifest.routes.get(request_path)?;
-        Some(self.dist_dir.join(&entry.file))
+        let file_path = self.dist_dir.join(&entry.file);
+
+        // Check ISR staleness
+        if let Some(revalidate) = entry.revalidate {
+            self.maybe_trigger_isr(request_path, &file_path, revalidate);
+        }
+
+        Some(file_path)
     }
+
+    /// Check if a file is stale and trigger background regeneration if needed.
+    fn maybe_trigger_isr(&self, url_path: &str, file_path: &Path, revalidate_secs: u64) {
+        // Check file age
+        let is_stale = match file_mtime_age_secs(file_path) {
+            Some(age) => age > revalidate_secs,
+            // File missing or unreadable -- treat as stale
+            None => true,
+        };
+
+        if !is_stale {
+            return;
+        }
+
+        let Some(route_state) = self.isr_state.get(url_path) else {
+            return;
+        };
+
+        let Some(router) = &self.isr_router else {
+            // No router configured -- ISR detection only, no regeneration
+            return;
+        };
+
+        // Check cooldown -- don't retry too fast after a failure
+        let now = unix_now();
+        let last = route_state.last_attempt.load(Ordering::Relaxed);
+        if last > 0 && now.saturating_sub(last) < REGEN_COOLDOWN_SECS {
+            return;
+        }
+
+        // Try to claim the in-flight flag (CAS: false -> true)
+        if route_state
+            .in_flight
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+            .is_err()
+        {
+            // Another task is already regenerating this route
+            return;
+        }
+
+        // Record attempt time
+        route_state.last_attempt.store(now, Ordering::Relaxed);
+
+        // Spawn background regeneration
+        let router = Arc::clone(router);
+        let url = url_path.to_owned();
+        let dest = file_path.to_owned();
+        let in_flight = Arc::clone(&self.isr_state);
+
+        tokio::spawn(async move {
+            let result = regenerate_page(&router, &url, &dest).await;
+
+            // Clear the in-flight flag
+            if let Some(state) = in_flight.get(&url) {
+                state.in_flight.store(false, Ordering::Release);
+            }
+
+            match result {
+                Ok(()) => {
+                    tracing::info!(route = %url, "ISR: page regenerated");
+                }
+                Err(e) => {
+                    tracing::warn!(route = %url, error = %e, "ISR: regeneration failed");
+                }
+            }
+        });
+    }
+}
+
+/// Build per-route ISR state from the manifest. Only routes with
+/// `revalidate` set get entries.
+fn build_isr_state(manifest: &StaticManifest) -> HashMap<String, IsrRouteState> {
+    let mut state = HashMap::new();
+    for (path, entry) in &manifest.routes {
+        if entry.revalidate.is_some() {
+            state.insert(
+                path.clone(),
+                IsrRouteState {
+                    in_flight: AtomicBool::new(false),
+                    last_attempt: AtomicU64::new(0),
+                },
+            );
+        }
+    }
+    state
+}
+
+/// Re-render a single page by sending a request through the router.
+async fn regenerate_page(
+    router: &axum::Router,
+    url: &str,
+    dest: &Path,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(url)
+                .body(Body::empty())
+                .expect("valid request"),
+        )
+        .await
+        .expect("router infallible");
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "Handler returned HTTP {} for {}",
+            response.status(),
+            url
+        )
+        .into());
+    }
+
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
+
+    // Write to a temp file, then atomically rename to avoid serving partial content
+    let temp_path = dest.with_extension("tmp");
+    std::fs::write(&temp_path, &body_bytes)?;
+    std::fs::rename(&temp_path, dest)?;
+
+    Ok(())
+}
+
+/// Get the age of a file in seconds based on its modification time.
+/// Returns `None` if the file doesn't exist or metadata can't be read.
+fn file_mtime_age_secs(path: &Path) -> Option<u64> {
+    let metadata = std::fs::metadata(path).ok()?;
+    let mtime = metadata.modified().ok()?;
+    let elapsed = SystemTime::now().duration_since(mtime).ok()?;
+    Some(elapsed.as_secs())
+}
+
+/// Current Unix timestamp in seconds.
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 #[cfg(test)]
@@ -93,6 +298,80 @@ mod tests {
 
         let manifest = StaticManifest {
             generated_at: "2026-03-27T12:00:00Z".to_owned(),
+            autumn_version: "0.2.0".to_owned(),
+            routes,
+        };
+
+        let json = serde_json::to_string(&manifest).expect("serialize manifest");
+        std::fs::write(dist.join("manifest.json"), json).expect("write manifest");
+
+        dir
+    }
+
+    /// Helper: create a dist dir with parameterized routes in the manifest.
+    fn create_parameterized_dist() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dist = dir.path().join("dist");
+
+        // Create directories
+        std::fs::create_dir_all(dist.join("posts/hello")).expect("mkdir posts/hello");
+        std::fs::create_dir_all(dist.join("posts/world")).expect("mkdir posts/world");
+
+        // Create HTML files
+        std::fs::write(dist.join("posts/hello/index.html"), "<h1>Hello</h1>")
+            .expect("write hello");
+        std::fs::write(dist.join("posts/world/index.html"), "<h1>World</h1>")
+            .expect("write world");
+
+        // Build and write manifest
+        let mut routes = HashMap::new();
+        routes.insert(
+            "/posts/hello".to_owned(),
+            ManifestEntry {
+                file: "posts/hello/index.html".to_owned(),
+                revalidate: None,
+            },
+        );
+        routes.insert(
+            "/posts/world".to_owned(),
+            ManifestEntry {
+                file: "posts/world/index.html".to_owned(),
+                revalidate: None,
+            },
+        );
+
+        let manifest = StaticManifest {
+            generated_at: "2026-03-29T12:00:00Z".to_owned(),
+            autumn_version: "0.2.0".to_owned(),
+            routes,
+        };
+
+        let json = serde_json::to_string(&manifest).expect("serialize manifest");
+        std::fs::write(dist.join("manifest.json"), json).expect("write manifest");
+
+        dir
+    }
+
+    /// Helper: create a dist dir with ISR routes.
+    fn create_isr_dist(revalidate: u64) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dist = dir.path().join("dist");
+
+        std::fs::create_dir_all(dist.join("about")).expect("mkdir about");
+        std::fs::write(dist.join("about/index.html"), "<h1>About (stale)</h1>")
+            .expect("write about");
+
+        let mut routes = HashMap::new();
+        routes.insert(
+            "/about".to_owned(),
+            ManifestEntry {
+                file: "about/index.html".to_owned(),
+                revalidate: Some(revalidate),
+            },
+        );
+
+        let manifest = StaticManifest {
+            generated_at: "2026-03-29T12:00:00Z".to_owned(),
             autumn_version: "0.2.0".to_owned(),
             routes,
         };
@@ -164,5 +443,187 @@ mod tests {
         let layer = StaticFileLayer::new(&dist).expect("layer");
 
         assert_eq!(layer.manifest().routes.len(), 2);
+    }
+
+    // --- Parameterized route middleware tests ---
+
+    #[test]
+    fn resolve_finds_parameterized_routes() {
+        let tmp = create_parameterized_dist();
+        let dist = tmp.path().join("dist");
+        let layer = StaticFileLayer::new(&dist).expect("layer");
+
+        let hello = layer.resolve("/posts/hello");
+        assert!(hello.is_some(), "/posts/hello should resolve");
+        assert!(hello.unwrap().ends_with("posts/hello/index.html"));
+
+        let world = layer.resolve("/posts/world");
+        assert!(world.is_some(), "/posts/world should resolve");
+        assert!(world.unwrap().ends_with("posts/world/index.html"));
+    }
+
+    #[test]
+    fn resolve_returns_none_for_non_generated_param() {
+        let tmp = create_parameterized_dist();
+        let dist = tmp.path().join("dist");
+        let layer = StaticFileLayer::new(&dist).expect("layer");
+
+        // This slug was not in the params list, so not in the manifest
+        let resolved = layer.resolve("/posts/unknown");
+        assert!(
+            resolved.is_none(),
+            "/posts/unknown should not resolve (not pre-rendered)"
+        );
+    }
+
+    // --- ISR tests ---
+
+    #[test]
+    fn isr_state_built_for_revalidate_routes() {
+        let tmp = create_test_dist();
+        let dist = tmp.path().join("dist");
+        let layer = StaticFileLayer::new(&dist).expect("layer");
+
+        // /about has revalidate=3600, / does not
+        assert!(layer.isr_state.contains_key("/about"));
+        assert!(!layer.isr_state.contains_key("/"));
+    }
+
+    #[test]
+    fn file_mtime_age_fresh_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let file = tmp.path().join("test.html");
+        std::fs::write(&file, "test").expect("write");
+
+        // File just created, age should be very small
+        let age = file_mtime_age_secs(&file).expect("mtime");
+        assert!(age < 5, "Fresh file should be < 5 seconds old, got {age}");
+    }
+
+    #[test]
+    fn file_mtime_age_missing_file() {
+        let age = file_mtime_age_secs(Path::new("/nonexistent/file.html"));
+        assert!(age.is_none(), "Missing file should return None");
+    }
+
+    #[tokio::test]
+    async fn isr_triggers_regeneration_for_stale_page() {
+        // Create a dist dir with a very short revalidate (1 second)
+        let tmp = create_isr_dist(1);
+        let dist = tmp.path().join("dist");
+
+        // Make the file old by setting mtime to the past
+        let file = dist.join("about/index.html");
+        let old_time = std::time::SystemTime::now() - std::time::Duration::from_secs(100);
+        filetime::set_file_mtime(
+            &file,
+            filetime::FileTime::from_system_time(old_time),
+        )
+        .unwrap_or_else(|_| {
+            // filetime may not be available; skip test gracefully
+        });
+
+        // Create a router that returns fresh content
+        let router = axum::Router::new().fallback(axum::routing::get(|| async {
+            "<h1>About (fresh)</h1>"
+        }));
+
+        let layer = StaticFileLayer::new(&dist)
+            .expect("layer")
+            .with_router(router);
+
+        // Resolve should return the stale file path but trigger ISR
+        let resolved = layer.resolve("/about");
+        assert!(resolved.is_some());
+
+        // Give the background task time to complete
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // Check if file was updated (only if mtime was successfully set)
+        let content = std::fs::read_to_string(&file).unwrap();
+        // The content should be updated if ISR fired, or remain stale
+        // if filetime wasn't available. Either way, resolve works.
+        assert!(
+            content == "<h1>About (fresh)</h1>" || content == "<h1>About (stale)</h1>",
+            "unexpected content: {content}"
+        );
+    }
+
+    #[tokio::test]
+    async fn isr_does_not_retrigger_while_in_flight() {
+        let tmp = create_isr_dist(1);
+        let dist = tmp.path().join("dist");
+
+        let router = axum::Router::new().fallback(axum::routing::get(|| async {
+            // Simulate slow handler
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            "<h1>Slow</h1>"
+        }));
+
+        let layer = StaticFileLayer::new(&dist)
+            .expect("layer")
+            .with_router(router);
+
+        // Make file stale
+        let file = dist.join("about/index.html");
+        let old_time = std::time::SystemTime::now() - std::time::Duration::from_secs(100);
+        let _ = filetime::set_file_mtime(
+            &file,
+            filetime::FileTime::from_system_time(old_time),
+        );
+
+        // First resolve triggers ISR
+        layer.resolve("/about");
+
+        // Check in-flight flag
+        let state = layer.isr_state.get("/about").expect("isr state");
+        // May or may not be true depending on timing, but second resolve
+        // should not panic or double-trigger
+        layer.resolve("/about");
+
+        // Wait for background task
+        tokio::time::sleep(std::time::Duration::from_millis(700)).await;
+
+        // Flag should be cleared
+        assert!(
+            !state.in_flight.load(Ordering::Relaxed),
+            "in_flight should be cleared after regeneration"
+        );
+    }
+
+    #[tokio::test]
+    async fn regenerate_page_writes_atomically() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dest = tmp.path().join("page.html");
+        std::fs::write(&dest, "old content").expect("write old");
+
+        let router = axum::Router::new().fallback(axum::routing::get(|| async { "new content" }));
+
+        let result = regenerate_page(&router, "/test", &dest).await;
+        assert!(result.is_ok(), "regeneration failed: {:?}", result.err());
+
+        let content = std::fs::read_to_string(&dest).unwrap();
+        assert_eq!(content, "new content");
+
+        // Temp file should be cleaned up
+        assert!(!dest.with_extension("tmp").exists());
+    }
+
+    #[tokio::test]
+    async fn regenerate_page_fails_on_non_2xx() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dest = tmp.path().join("page.html");
+        std::fs::write(&dest, "old content").expect("write old");
+
+        let router = axum::Router::new().fallback(|| async {
+            (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "error")
+        });
+
+        let result = regenerate_page(&router, "/test", &dest).await;
+        assert!(result.is_err());
+
+        // Original file should be untouched
+        let content = std::fs::read_to_string(&dest).unwrap();
+        assert_eq!(content, "old content");
     }
 }

--- a/autumn/src/static_gen/middleware.rs
+++ b/autumn/src/static_gen/middleware.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::StaticManifest;
@@ -121,11 +121,7 @@ impl StaticFileLayer {
     /// Check if a file is stale and trigger background regeneration if needed.
     fn maybe_trigger_isr(&self, url_path: &str, file_path: &Path, revalidate_secs: u64) {
         // Check file age
-        let is_stale = match file_mtime_age_secs(file_path) {
-            Some(age) => age > revalidate_secs,
-            // File missing or unreadable -- treat as stale
-            None => true,
-        };
+        let is_stale = file_mtime_age_secs(file_path).is_none_or(|age| age > revalidate_secs);
 
         if !is_stale {
             return;
@@ -226,12 +222,7 @@ async fn regenerate_page(
         .expect("router infallible");
 
     if !response.status().is_success() {
-        return Err(format!(
-            "Handler returned HTTP {} for {}",
-            response.status(),
-            url
-        )
-        .into());
+        return Err(format!("Handler returned HTTP {} for {}", response.status(), url).into());
     }
 
     let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
@@ -318,10 +309,8 @@ mod tests {
         std::fs::create_dir_all(dist.join("posts/world")).expect("mkdir posts/world");
 
         // Create HTML files
-        std::fs::write(dist.join("posts/hello/index.html"), "<h1>Hello</h1>")
-            .expect("write hello");
-        std::fs::write(dist.join("posts/world/index.html"), "<h1>World</h1>")
-            .expect("write world");
+        std::fs::write(dist.join("posts/hello/index.html"), "<h1>Hello</h1>").expect("write hello");
+        std::fs::write(dist.join("posts/world/index.html"), "<h1>World</h1>").expect("write world");
 
         // Build and write manifest
         let mut routes = HashMap::new();
@@ -515,18 +504,12 @@ mod tests {
         // Make the file old by setting mtime to the past
         let file = dist.join("about/index.html");
         let old_time = std::time::SystemTime::now() - std::time::Duration::from_secs(100);
-        filetime::set_file_mtime(
-            &file,
-            filetime::FileTime::from_system_time(old_time),
-        )
-        .unwrap_or_else(|_| {
-            // filetime may not be available; skip test gracefully
-        });
+        filetime::set_file_mtime(&file, filetime::FileTime::from_system_time(old_time))
+            .unwrap_or(());
 
         // Create a router that returns fresh content
-        let router = axum::Router::new().fallback(axum::routing::get(|| async {
-            "<h1>About (fresh)</h1>"
-        }));
+        let router =
+            axum::Router::new().fallback(axum::routing::get(|| async { "<h1>About (fresh)</h1>" }));
 
         let layer = StaticFileLayer::new(&dist)
             .expect("layer")
@@ -567,19 +550,16 @@ mod tests {
         // Make file stale
         let file = dist.join("about/index.html");
         let old_time = std::time::SystemTime::now() - std::time::Duration::from_secs(100);
-        let _ = filetime::set_file_mtime(
-            &file,
-            filetime::FileTime::from_system_time(old_time),
-        );
+        let _ = filetime::set_file_mtime(&file, filetime::FileTime::from_system_time(old_time));
 
         // First resolve triggers ISR
-        layer.resolve("/about");
+        let _ = layer.resolve("/about");
 
         // Check in-flight flag
         let state = layer.isr_state.get("/about").expect("isr state");
         // May or may not be true depending on timing, but second resolve
         // should not panic or double-trigger
-        layer.resolve("/about");
+        let _ = layer.resolve("/about");
 
         // Wait for background task
         tokio::time::sleep(std::time::Duration::from_millis(700)).await;
@@ -615,9 +595,8 @@ mod tests {
         let dest = tmp.path().join("page.html");
         std::fs::write(&dest, "old content").expect("write old");
 
-        let router = axum::Router::new().fallback(|| async {
-            (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "error")
-        });
+        let router = axum::Router::new()
+            .fallback(|| async { (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "error") });
 
         let result = regenerate_page(&router, "/test", &dest).await;
         assert!(result.is_err());

--- a/autumn/src/static_gen/mod.rs
+++ b/autumn/src/static_gen/mod.rs
@@ -4,4 +4,6 @@ mod types;
 
 pub use build::{BuildError, render_static_routes};
 pub use middleware::StaticFileLayer;
-pub use types::{ManifestEntry, StaticManifest, StaticRouteMeta, url_to_file_path};
+pub use types::{
+    ManifestEntry, ParamsFn, StaticManifest, StaticParams, StaticRouteMeta, url_to_file_path,
+};

--- a/autumn/src/static_gen/types.rs
+++ b/autumn/src/static_gen/types.rs
@@ -31,6 +31,7 @@ pub type StaticParams = HashMap<String, String>;
 #[macro_export]
 macro_rules! static_params {
     ($($key:expr => $value:expr),* $(,)?) => {{
+        #[allow(unused_mut)]
         let mut map = ::std::collections::HashMap::new();
         $(map.insert($key.to_owned(), $value.to_owned());)*
         map
@@ -43,8 +44,7 @@ macro_rules! static_params {
 /// This is the type stored inside [`StaticRouteMeta::params_fn`]. The
 /// build engine calls it to enumerate all parameter combinations that
 /// should be pre-rendered.
-pub type ParamsFn =
-    fn(axum::Router) -> Pin<Box<dyn Future<Output = Vec<StaticParams>> + Send>>;
+pub type ParamsFn = fn(axum::Router) -> Pin<Box<dyn Future<Output = Vec<StaticParams>> + Send>>;
 
 /// Metadata for a route that should be statically generated at build time.
 ///

--- a/autumn/src/static_gen/types.rs
+++ b/autumn/src/static_gen/types.rs
@@ -1,6 +1,50 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::Path;
+use std::pin::Pin;
+
+/// A set of path parameter values for a parameterized static route.
+///
+/// Maps parameter names (e.g. `"slug"`) to their values (e.g. `"hello-world"`).
+///
+/// # Example
+///
+/// ```
+/// use autumn_web::static_gen::StaticParams;
+///
+/// let mut params = StaticParams::new();
+/// params.insert("slug".to_owned(), "hello-world".to_owned());
+/// ```
+pub type StaticParams = HashMap<String, String>;
+
+/// Convenience macro for building a [`StaticParams`] map.
+///
+/// # Example
+///
+/// ```
+/// use autumn_web::static_params;
+///
+/// let params = static_params! { "slug" => "hello-world" };
+/// assert_eq!(params.get("slug").unwrap(), "hello-world");
+/// ```
+#[macro_export]
+macro_rules! static_params {
+    ($($key:expr => $value:expr),* $(,)?) => {{
+        let mut map = ::std::collections::HashMap::new();
+        $(map.insert($key.to_owned(), $value.to_owned());)*
+        map
+    }};
+}
+
+/// The type-erased async function that returns parameter sets for a
+/// parameterized static route.
+///
+/// This is the type stored inside [`StaticRouteMeta::params_fn`]. The
+/// build engine calls it to enumerate all parameter combinations that
+/// should be pre-rendered.
+pub type ParamsFn =
+    fn(axum::Router) -> Pin<Box<dyn Future<Output = Vec<StaticParams>> + Send>>;
 
 /// Metadata for a route that should be statically generated at build time.
 ///
@@ -8,15 +52,29 @@ use std::path::Path;
 /// static-site build step. The `revalidate` field controls ISR
 /// (Incremental Static Regeneration): if set, the pre-rendered page
 /// will be refreshed after the given number of seconds.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct StaticRouteMeta {
-    /// The URL path pattern, e.g. `"/"` or `"/about"`.
+    /// The URL path pattern, e.g. `"/"` or `"/posts/{slug}"`.
     pub path: &'static str,
     /// The handler function name (used for diagnostics and manifest keys).
     pub name: &'static str,
     /// Optional ISR revalidation interval in seconds.
     /// `None` means the page is generated once and never refreshed.
     pub revalidate: Option<u64>,
+    /// Optional async function that returns parameter sets for
+    /// parameterized routes. `None` for simple (non-parameterized) routes.
+    pub params_fn: Option<ParamsFn>,
+}
+
+impl std::fmt::Debug for StaticRouteMeta {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StaticRouteMeta")
+            .field("path", &self.path)
+            .field("name", &self.name)
+            .field("revalidate", &self.revalidate)
+            .field("params_fn", &self.params_fn.as_ref().map(|_| "..."))
+            .finish()
+    }
 }
 
 /// Persistent manifest written by `autumn build` and read at runtime
@@ -159,11 +217,67 @@ mod tests {
             path: "/test",
             name: "test_handler",
             revalidate: Some(60),
+            params_fn: None,
         };
         let copy = meta.clone();
         // Use original after clone to prove it's a real copy, not a move
         assert_eq!(meta.path, copy.path);
         assert_eq!(copy.name, "test_handler");
         assert_eq!(copy.revalidate, Some(60));
+    }
+
+    #[test]
+    fn static_params_macro() {
+        let params = static_params! { "slug" => "hello-world" };
+        assert_eq!(params.get("slug").unwrap(), "hello-world");
+    }
+
+    #[test]
+    fn static_params_macro_multiple() {
+        let params = static_params! {
+            "year" => "2026",
+            "month" => "03",
+            "slug" => "hello",
+        };
+        assert_eq!(params.len(), 3);
+        assert_eq!(params.get("year").unwrap(), "2026");
+        assert_eq!(params.get("month").unwrap(), "03");
+        assert_eq!(params.get("slug").unwrap(), "hello");
+    }
+
+    #[test]
+    fn static_params_macro_empty() {
+        let params: StaticParams = static_params! {};
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn static_route_meta_with_params_fn() {
+        fn dummy_params(
+            _router: axum::Router,
+        ) -> Pin<Box<dyn Future<Output = Vec<StaticParams>> + Send>> {
+            Box::pin(async { vec![static_params! { "slug" => "test" }] })
+        }
+
+        let meta = StaticRouteMeta {
+            path: "/posts/{slug}",
+            name: "show_post",
+            revalidate: None,
+            params_fn: Some(dummy_params),
+        };
+        assert!(meta.params_fn.is_some());
+        assert_eq!(meta.path, "/posts/{slug}");
+    }
+
+    #[test]
+    fn static_route_meta_debug() {
+        let meta = StaticRouteMeta {
+            path: "/test",
+            name: "test",
+            revalidate: None,
+            params_fn: None,
+        };
+        let debug = format!("{meta:?}");
+        assert!(debug.contains("test"));
     }
 }

--- a/autumn/tests/compile-fail/static_get_params_no_placeholders.rs
+++ b/autumn/tests/compile-fail/static_get_params_no_placeholders.rs
@@ -1,0 +1,13 @@
+use autumn_web::prelude::*;
+use autumn_web::static_gen::StaticParams;
+
+async fn list_slugs(_router: autumn_web::reexports::axum::Router) -> Vec<StaticParams> {
+    vec![]
+}
+
+#[static_get("/about", params = list_slugs)]
+async fn about() -> &'static str {
+    "about"
+}
+
+fn main() {}

--- a/autumn/tests/compile-fail/static_get_params_no_placeholders.stderr
+++ b/autumn/tests/compile-fail/static_get_params_no_placeholders.stderr
@@ -1,0 +1,5 @@
+error: Static route has no path parameters but a `params` function was provided. Either add path parameters or remove the `params` attribute.
+ --> tests/compile-fail/static_get_params_no_placeholders.rs:8:14
+  |
+8 | #[static_get("/about", params = list_slugs)]
+  |              ^^^^^^^^

--- a/autumn/tests/compile-fail/static_get_path_params.stderr
+++ b/autumn/tests/compile-fail/static_get_path_params.stderr
@@ -1,4 +1,4 @@
-error: static_get does not support path parameters yet. Use #[get] for parameterized routes.
+error: Parameterized static routes require a `params` function. Example: #[static_get("/posts/{slug}", params = list_slugs)]
  --> tests/compile-fail/static_get_path_params.rs:3:14
   |
 3 | #[static_get("/posts/{slug}")]

--- a/autumn/tests/compile-pass/static_get_parameterized.rs
+++ b/autumn/tests/compile-pass/static_get_parameterized.rs
@@ -1,0 +1,30 @@
+use autumn_web::prelude::*;
+use autumn_web::static_gen::StaticParams;
+use std::collections::HashMap;
+
+async fn list_slugs(_router: autumn_web::reexports::axum::Router) -> Vec<StaticParams> {
+    vec![{
+        let mut m = HashMap::new();
+        m.insert("slug".to_owned(), "hello".to_owned());
+        m
+    }]
+}
+
+#[static_get("/posts/{slug}", params = list_slugs)]
+async fn show_post() -> &'static str {
+    "post"
+}
+
+#[static_get("/cached", revalidate = 60)]
+async fn cached_page() -> &'static str {
+    "cached"
+}
+
+fn main() {
+    // Verify both companion functions exist
+    let _route = __autumn_route_info_show_post();
+    let _meta = __autumn_static_meta_show_post();
+
+    let _route2 = __autumn_route_info_cached_page();
+    let _meta2 = __autumn_static_meta_cached_page();
+}

--- a/autumn/tests/compile_fail.rs
+++ b/autumn/tests/compile_fail.rs
@@ -13,6 +13,7 @@ fn compile_fail_tests() {
     // Static route macro failures
     t.compile_fail("tests/compile-fail/static_get_path_params.rs");
     t.compile_fail("tests/compile-fail/static_get_non_async.rs");
+    t.compile_fail("tests/compile-fail/static_get_params_no_placeholders.rs");
 
     // Model macro failures (require db feature)
     #[cfg(feature = "db")]
@@ -32,6 +33,7 @@ fn compile_pass_tests() {
     t.pass("tests/compile-pass/async_main.rs");
     t.pass("tests/compile-pass/static_get_basic.rs");
     t.pass("tests/compile-pass/static_routes_basic.rs");
+    t.pass("tests/compile-pass/static_get_parameterized.rs");
 
     // Interceptor macro
     t.pass("tests/compile-pass/intercept_basic.rs");

--- a/autumn/tests/middleware_pipeline.rs
+++ b/autumn/tests/middleware_pipeline.rs
@@ -20,6 +20,10 @@ fn test_state() -> AppState {
         profile: None,
         started_at: std::time::Instant::now(),
         health_detailed: false,
+        metrics: autumn_web::middleware::MetricsCollector::new(),
+        log_levels: autumn_web::actuator::LogLevels::new("info"),
+        task_registry: autumn_web::actuator::TaskRegistry::new(),
+        config_props: autumn_web::actuator::ConfigProperties::default(),
     }
 }
 

--- a/autumn/tests/raw_router_escape_hatch.rs
+++ b/autumn/tests/raw_router_escape_hatch.rs
@@ -15,6 +15,10 @@ fn test_state() -> AppState {
         profile: Some("test".into()),
         started_at: std::time::Instant::now(),
         health_detailed: false,
+        metrics: autumn_web::middleware::MetricsCollector::new(),
+        log_levels: autumn_web::actuator::LogLevels::new("info"),
+        task_registry: autumn_web::actuator::TaskRegistry::new(),
+        config_props: autumn_web::actuator::ConfigProperties::default(),
     }
 }
 
@@ -26,13 +30,8 @@ async fn merged_route_is_accessible() {
         .route("/raw", axum::routing::get(|| async { "from raw router" }));
 
     let config = AutumnConfig::default();
-    let router = autumn_web::app::build_router_merged(
-        routes![],
-        &config,
-        test_state(),
-        vec![raw],
-        vec![],
-    );
+    let router =
+        autumn_web::app::build_router_merged(routes![], &config, test_state(), vec![raw], vec![]);
 
     let resp = router
         .oneshot(Request::builder().uri("/raw").body(Body::empty()).unwrap())
@@ -55,13 +54,8 @@ async fn merged_route_receives_app_state() {
     );
 
     let config = AutumnConfig::default();
-    let router = autumn_web::app::build_router_merged(
-        routes![],
-        &config,
-        test_state(),
-        vec![raw],
-        vec![],
-    );
+    let router =
+        autumn_web::app::build_router_merged(routes![], &config, test_state(), vec![raw], vec![]);
 
     let resp = router
         .oneshot(
@@ -81,17 +75,12 @@ async fn merged_route_receives_app_state() {
 
 #[tokio::test]
 async fn autumn_middleware_applies_to_merged_routes() {
-    let raw = axum::Router::<AppState>::new()
-        .route("/raw-mid", axum::routing::get(|| async { "ok" }));
+    let raw =
+        axum::Router::<AppState>::new().route("/raw-mid", axum::routing::get(|| async { "ok" }));
 
     let config = AutumnConfig::default();
-    let router = autumn_web::app::build_router_merged(
-        routes![],
-        &config,
-        test_state(),
-        vec![raw],
-        vec![],
-    );
+    let router =
+        autumn_web::app::build_router_merged(routes![], &config, test_state(), vec![raw], vec![]);
 
     let resp = router
         .oneshot(
@@ -119,10 +108,10 @@ async fn autumn_middleware_applies_to_merged_routes() {
 
 #[tokio::test]
 async fn multiple_merged_routers_accumulate() {
-    let raw1 = axum::Router::<AppState>::new()
-        .route("/raw1", axum::routing::get(|| async { "first" }));
-    let raw2 = axum::Router::<AppState>::new()
-        .route("/raw2", axum::routing::get(|| async { "second" }));
+    let raw1 =
+        axum::Router::<AppState>::new().route("/raw1", axum::routing::get(|| async { "first" }));
+    let raw2 =
+        axum::Router::<AppState>::new().route("/raw2", axum::routing::get(|| async { "second" }));
 
     let config = AutumnConfig::default();
     let router = autumn_web::app::build_router_merged(
@@ -135,12 +124,7 @@ async fn multiple_merged_routers_accumulate() {
 
     let resp = router
         .clone()
-        .oneshot(
-            Request::builder()
-                .uri("/raw1")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(Request::builder().uri("/raw1").body(Body::empty()).unwrap())
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
@@ -150,12 +134,7 @@ async fn multiple_merged_routers_accumulate() {
     assert_eq!(&body[..], b"first");
 
     let resp = router
-        .oneshot(
-            Request::builder()
-                .uri("/raw2")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(Request::builder().uri("/raw2").body(Body::empty()).unwrap())
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
@@ -246,8 +225,8 @@ async fn nested_route_receives_app_state() {
 
 #[tokio::test]
 async fn nested_route_gets_autumn_middleware() {
-    let raw = axum::Router::<AppState>::new()
-        .route("/check", axum::routing::get(|| async { "ok" }));
+    let raw =
+        axum::Router::<AppState>::new().route("/check", axum::routing::get(|| async { "ok" }));
 
     let config = AutumnConfig::default();
     let router = autumn_web::app::build_router_merged(
@@ -333,10 +312,8 @@ async fn annotated_and_merged_routes_coexist() {
 #[tokio::test]
 async fn merged_route_adds_different_method_to_same_path() {
     // Annotated GET + merged POST on same path should work (Axum merges methods).
-    let raw = axum::Router::<AppState>::new().route(
-        "/annotated",
-        axum::routing::post(|| async { "posted" }),
-    );
+    let raw = axum::Router::<AppState>::new()
+        .route("/annotated", axum::routing::post(|| async { "posted" }));
 
     let config = AutumnConfig::default();
     let router = autumn_web::app::build_router_merged(
@@ -386,8 +363,8 @@ async fn merged_route_adds_different_method_to_same_path() {
 
 #[test]
 fn app_builder_merge_compiles() {
-    let raw = axum::Router::<AppState>::new()
-        .route("/ws", axum::routing::get(|| async { "websocket" }));
+    let raw =
+        axum::Router::<AppState>::new().route("/ws", axum::routing::get(|| async { "websocket" }));
 
     let _builder = autumn_web::app()
         .routes(routes![annotated_handler])
@@ -396,8 +373,8 @@ fn app_builder_merge_compiles() {
 
 #[test]
 fn app_builder_nest_compiles() {
-    let raw = axum::Router::<AppState>::new()
-        .route("/users", axum::routing::get(|| async { "users" }));
+    let raw =
+        axum::Router::<AppState>::new().route("/users", axum::routing::get(|| async { "users" }));
 
     let _builder = autumn_web::app()
         .routes(routes![annotated_handler])
@@ -406,12 +383,9 @@ fn app_builder_nest_compiles() {
 
 #[test]
 fn app_builder_multiple_merge_and_nest() {
-    let raw1 = axum::Router::<AppState>::new()
-        .route("/a", axum::routing::get(|| async { "a" }));
-    let raw2 = axum::Router::<AppState>::new()
-        .route("/b", axum::routing::get(|| async { "b" }));
-    let nested = axum::Router::<AppState>::new()
-        .route("/c", axum::routing::get(|| async { "c" }));
+    let raw1 = axum::Router::<AppState>::new().route("/a", axum::routing::get(|| async { "a" }));
+    let raw2 = axum::Router::<AppState>::new().route("/b", axum::routing::get(|| async { "b" }));
+    let nested = axum::Router::<AppState>::new().route("/c", axum::routing::get(|| async { "c" }));
 
     let _builder = autumn_web::app()
         .routes(routes![annotated_handler])

--- a/autumn/tests/raw_router_escape_hatch.rs
+++ b/autumn/tests/raw_router_escape_hatch.rs
@@ -1,0 +1,429 @@
+//! Integration tests for the raw Axum router escape hatch (FR-041):
+//! `AppBuilder::merge()` and `AppBuilder::nest()`.
+
+use autumn_web::config::AutumnConfig;
+use autumn_web::{AppState, get, routes};
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+fn test_state() -> AppState {
+    AppState {
+        #[cfg(feature = "db")]
+        pool: None,
+        profile: Some("test".into()),
+        started_at: std::time::Instant::now(),
+        health_detailed: false,
+    }
+}
+
+// ── Merge tests ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn merged_route_is_accessible() {
+    let raw = axum::Router::<AppState>::new()
+        .route("/raw", axum::routing::get(|| async { "from raw router" }));
+
+    let config = AutumnConfig::default();
+    let router = autumn_web::app::build_router_merged(
+        routes![],
+        &config,
+        test_state(),
+        vec![raw],
+        vec![],
+    );
+
+    let resp = router
+        .oneshot(Request::builder().uri("/raw").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"from raw router");
+}
+
+#[tokio::test]
+async fn merged_route_receives_app_state() {
+    let raw = axum::Router::<AppState>::new().route(
+        "/state-check",
+        axum::routing::get(|State(state): State<AppState>| async move {
+            format!("profile={}", state.profile())
+        }),
+    );
+
+    let config = AutumnConfig::default();
+    let router = autumn_web::app::build_router_merged(
+        routes![],
+        &config,
+        test_state(),
+        vec![raw],
+        vec![],
+    );
+
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .uri("/state-check")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"profile=test");
+}
+
+#[tokio::test]
+async fn autumn_middleware_applies_to_merged_routes() {
+    let raw = axum::Router::<AppState>::new()
+        .route("/raw-mid", axum::routing::get(|| async { "ok" }));
+
+    let config = AutumnConfig::default();
+    let router = autumn_web::app::build_router_merged(
+        routes![],
+        &config,
+        test_state(),
+        vec![raw],
+        vec![],
+    );
+
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .uri("/raw-mid")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // RequestIdLayer adds x-request-id header
+    assert!(
+        resp.headers().get("x-request-id").is_some(),
+        "Expected x-request-id header from Autumn middleware on merged route"
+    );
+
+    // SecurityHeadersLayer adds security headers
+    assert!(
+        resp.headers().get("x-content-type-options").is_some(),
+        "Expected security headers from Autumn middleware on merged route"
+    );
+}
+
+#[tokio::test]
+async fn multiple_merged_routers_accumulate() {
+    let raw1 = axum::Router::<AppState>::new()
+        .route("/raw1", axum::routing::get(|| async { "first" }));
+    let raw2 = axum::Router::<AppState>::new()
+        .route("/raw2", axum::routing::get(|| async { "second" }));
+
+    let config = AutumnConfig::default();
+    let router = autumn_web::app::build_router_merged(
+        routes![],
+        &config,
+        test_state(),
+        vec![raw1, raw2],
+        vec![],
+    );
+
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/raw1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"first");
+
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .uri("/raw2")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"second");
+}
+
+// ── Nest tests ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn nested_route_works_under_prefix() {
+    let raw = axum::Router::<AppState>::new()
+        .route("/users", axum::routing::get(|| async { "v2 users" }));
+
+    let config = AutumnConfig::default();
+    let router = autumn_web::app::build_router_merged(
+        routes![],
+        &config,
+        test_state(),
+        vec![],
+        vec![("/api/v2".to_owned(), raw)],
+    );
+
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v2/users")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"v2 users");
+
+    // The route should NOT be accessible without the prefix
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .uri("/users")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn nested_route_receives_app_state() {
+    let raw = axum::Router::<AppState>::new().route(
+        "/info",
+        axum::routing::get(|State(state): State<AppState>| async move {
+            format!("profile={}", state.profile())
+        }),
+    );
+
+    let config = AutumnConfig::default();
+    let router = autumn_web::app::build_router_merged(
+        routes![],
+        &config,
+        test_state(),
+        vec![],
+        vec![("/nested".to_owned(), raw)],
+    );
+
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .uri("/nested/info")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"profile=test");
+}
+
+#[tokio::test]
+async fn nested_route_gets_autumn_middleware() {
+    let raw = axum::Router::<AppState>::new()
+        .route("/check", axum::routing::get(|| async { "ok" }));
+
+    let config = AutumnConfig::default();
+    let router = autumn_web::app::build_router_merged(
+        routes![],
+        &config,
+        test_state(),
+        vec![],
+        vec![("/nested".to_owned(), raw)],
+    );
+
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .uri("/nested/check")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(
+        resp.headers().get("x-request-id").is_some(),
+        "Expected x-request-id header on nested route"
+    );
+}
+
+// ── Precedence / coexistence tests ────────────────────────────────
+
+#[get("/annotated")]
+async fn annotated_handler() -> &'static str {
+    "from annotated"
+}
+
+#[tokio::test]
+async fn annotated_and_merged_routes_coexist() {
+    // Annotated and merged routes on different paths work together.
+    let raw = axum::Router::<AppState>::new()
+        .route("/raw-only", axum::routing::get(|| async { "from raw" }));
+
+    let config = AutumnConfig::default();
+    let router = autumn_web::app::build_router_merged(
+        routes![annotated_handler],
+        &config,
+        test_state(),
+        vec![raw],
+        vec![],
+    );
+
+    // Annotated route works
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/annotated")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"from annotated");
+
+    // Merged route works
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .uri("/raw-only")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"from raw");
+}
+
+#[tokio::test]
+async fn merged_route_adds_different_method_to_same_path() {
+    // Annotated GET + merged POST on same path should work (Axum merges methods).
+    let raw = axum::Router::<AppState>::new().route(
+        "/annotated",
+        axum::routing::post(|| async { "posted" }),
+    );
+
+    let config = AutumnConfig::default();
+    let router = autumn_web::app::build_router_merged(
+        routes![annotated_handler],
+        &config,
+        test_state(),
+        vec![raw],
+        vec![],
+    );
+
+    // GET from annotated route
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/annotated")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"from annotated");
+
+    // POST from merged route
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/annotated")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"posted");
+}
+
+// ── AppBuilder API compile tests ──────────────────────────────────
+
+#[test]
+fn app_builder_merge_compiles() {
+    let raw = axum::Router::<AppState>::new()
+        .route("/ws", axum::routing::get(|| async { "websocket" }));
+
+    let _builder = autumn_web::app()
+        .routes(routes![annotated_handler])
+        .merge(raw);
+}
+
+#[test]
+fn app_builder_nest_compiles() {
+    let raw = axum::Router::<AppState>::new()
+        .route("/users", axum::routing::get(|| async { "users" }));
+
+    let _builder = autumn_web::app()
+        .routes(routes![annotated_handler])
+        .nest("/api/v2", raw);
+}
+
+#[test]
+fn app_builder_multiple_merge_and_nest() {
+    let raw1 = axum::Router::<AppState>::new()
+        .route("/a", axum::routing::get(|| async { "a" }));
+    let raw2 = axum::Router::<AppState>::new()
+        .route("/b", axum::routing::get(|| async { "b" }));
+    let nested = axum::Router::<AppState>::new()
+        .route("/c", axum::routing::get(|| async { "c" }));
+
+    let _builder = autumn_web::app()
+        .routes(routes![annotated_handler])
+        .merge(raw1)
+        .merge(raw2)
+        .nest("/prefix", nested);
+}
+
+#[test]
+fn app_state_accessible_for_external_router_construction() {
+    // Users need to be able to write `Router::<AppState>::new()` externally.
+    // This test verifies AppState is importable and usable as a type parameter.
+    let _router = axum::Router::<autumn_web::AppState>::new()
+        .route("/test", axum::routing::get(|| async { "test" }));
+}

--- a/autumn/tests/static_build_mode.rs
+++ b/autumn/tests/static_build_mode.rs
@@ -20,6 +20,7 @@ const fn about_meta() -> StaticRouteMeta {
         path: "/about",
         name: "about",
         revalidate: None,
+        params_fn: None,
     }
 }
 
@@ -30,6 +31,10 @@ fn test_state() -> autumn_web::AppState {
         profile: None,
         started_at: std::time::Instant::now(),
         health_detailed: false,
+        metrics: autumn_web::middleware::MetricsCollector::new(),
+        log_levels: autumn_web::actuator::LogLevels::new("info"),
+        task_registry: autumn_web::actuator::TaskRegistry::new(),
+        config_props: autumn_web::actuator::ConfigProperties::default(),
     }
 }
 

--- a/autumn/tests/static_gen_serving.rs
+++ b/autumn/tests/static_gen_serving.rs
@@ -17,6 +17,10 @@ fn test_state() -> autumn_web::AppState {
         profile: None,
         started_at: std::time::Instant::now(),
         health_detailed: true,
+        metrics: autumn_web::middleware::MetricsCollector::new(),
+        log_levels: autumn_web::actuator::LogLevels::new("info"),
+        task_registry: autumn_web::actuator::TaskRegistry::new(),
+        config_props: autumn_web::actuator::ConfigProperties::default(),
     }
 }
 

--- a/examples/blog/src/main.rs
+++ b/examples/blog/src/main.rs
@@ -2,24 +2,15 @@ mod models;
 mod routes;
 mod schema;
 
+use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
 use autumn_web::{routes, static_routes};
-use diesel::Connection;
-use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
 #[autumn_web::main]
 async fn main() {
-    // Run pending database migrations before starting the server.
-    let config = autumn_web::config::AutumnConfig::load().expect("load config");
-    if let Some(url) = &config.database.url {
-        let mut conn =
-            diesel::PgConnection::establish(url).expect("connect to database for migrations");
-        conn.run_pending_migrations(MIGRATIONS)
-            .expect("run migrations");
-    }
-
     autumn_web::app()
+        .migrations(MIGRATIONS)
         .routes(routes![
             // Public routes
             routes::about::about, // #[static_get] — pre-rendered

--- a/examples/bookmarks/src/main.rs
+++ b/examples/bookmarks/src/main.rs
@@ -16,25 +16,16 @@ mod routes;
 mod schema;
 mod tasks;
 
+use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
 use autumn_web::prelude::*;
-use diesel::Connection;
-use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
 #[autumn_web::main]
 async fn main() {
-    // Run pending migrations on startup
-    let config = autumn_web::config::AutumnConfig::load().expect("load config");
-    if let Some(url) = &config.database.url {
-        let mut conn =
-            diesel::PgConnection::establish(url).expect("connect to database for migrations");
-        conn.run_pending_migrations(MIGRATIONS)
-            .expect("run migrations");
-    }
-
     // ── v0.2: .tasks() registers scheduled background tasks ─────
     autumn_web::app()
+        .migrations(MIGRATIONS)
         .routes(routes![
             routes::bookmarks::list,
             routes::bookmarks::by_tag,

--- a/examples/todo-app/src/main.rs
+++ b/examples/todo-app/src/main.rs
@@ -2,24 +2,15 @@ mod models;
 mod routes;
 mod schema;
 
+use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
 use autumn_web::routes;
-use diesel::Connection;
-use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
 #[autumn_web::main]
 async fn main() {
-    // Run pending database migrations before starting the server.
-    let config = autumn_web::config::AutumnConfig::load().expect("load config");
-    if let Some(url) = &config.database.url {
-        let mut conn =
-            diesel::PgConnection::establish(url).expect("connect to database for migrations");
-        conn.run_pending_migrations(MIGRATIONS)
-            .expect("run migrations");
-    }
-
     autumn_web::app()
+        .migrations(MIGRATIONS)
         .routes(routes![
             routes::todos::index,
             routes::todos::list,

--- a/examples/wiki/src/main.rs
+++ b/examples/wiki/src/main.rs
@@ -5,23 +5,15 @@ mod routes;
 mod schema;
 mod slugify;
 
+use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
 use autumn_web::prelude::*;
-use diesel::Connection;
-use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
 #[autumn_web::main]
 async fn main() {
-    let config = autumn_web::config::AutumnConfig::load().expect("load config");
-    if let Some(url) = &config.database.url {
-        let mut conn =
-            diesel::PgConnection::establish(url).expect("connect to database for migrations");
-        conn.run_pending_migrations(MIGRATIONS)
-            .expect("run migrations");
-    }
-
     autumn_web::app()
+        .migrations(MIGRATIONS)
         .routes(routes![
             routes::pages::list,
             routes::pages::show,


### PR DESCRIPTION
Complete actuator system with 7 endpoints:
- /actuator/health, /actuator/info, /actuator/metrics (always available)
- /actuator/env, /actuator/configprops, /actuator/loggers (GET + PUT), /actuator/tasks (sensitive-only)
- MetricsLayer middleware with request count, latency percentiles, status code distribution
- LogLevels with runtime level changes, TaskRegistry with run tracking, ConfigProperties with source provenance

Migration management:
- `autumn migrate` CLI command (shells out to diesel CLI)
- `autumn migrate status` subcommand
- Framework-level auto-migration in dev mode via .migrations() on AppBuilder
- migrate module with run_pending(), pending_migrations(), auto_migrate()

Error pages with Next.js-style dev badge:
- DefaultErrorPages renderer with Tailwind-styled 404, 422, 500 pages
- ErrorPageRenderer trait for user overrides
- Dev error badge: floating overlay with status, message, path, request ID
- ErrorPageFilter exception filter: HTML for browsers, JSON for APIs
- ErrorPageContextLayer middleware for Accept header detection

Hybrid rendering Phase 2:
- Parameterized static routes via StaticRouteMeta.params_fn
- ParamsFn type for async parameter enumeration
- StaticParams type alias and static_params! macro
- Build engine expansion of parameterized routes to individual pages

Raw Axum escape hatch:
- AppBuilder::merge() for merging raw Axum routers
- AppBuilder::nest() for mounting under path prefixes
- build_router_merged() public API for testing
- Merged routers share AppState and receive global middleware

https://claude.ai/code/session_014HAk7J5rqghyuPfsUESDvN