### PR TITLE
docs: refresh trunk docs and example guides

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/madmax983/autumn"
 # Runtime
 axum = { version = "0.8", features = ["macros"] }
 diesel = { version = "2", features = ["sqlite"] }
-pq-sys = { version = "0.7", features = ["bundled"] }
+pq-sys = { version = "0.7", features = ["bundled_without_openssl"] }
 diesel-async = { version = "0.8", features = ["deadpool", "postgres"] }
 diesel_migrations = "2"
 http = "1"

--- a/README.md
+++ b/README.md
@@ -1,59 +1,60 @@
-# Autumn ðŸ‚
+# Autumn ??
 
 [![CI](https://github.com/madmax983/autumn/actions/workflows/ci.yml/badge.svg)](https://github.com/madmax983/autumn/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/madmax983/autumn/branch/trunk/graph/badge.svg)](https://codecov.io/gh/madmax983/autumn)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE)
 [![Rust: 1.86.0+](https://img.shields.io/badge/rust-1.86.0%2B-orange.svg)](https://www.rust-lang.org)
 
-> Spring Boot-style web framework for Rust. Built on [Axum](https://github.com/tokio-rs/axum).
+> Spring Boot-style web framework for Rust, built on [Axum](https://github.com/tokio-rs/axum).
 
 Autumn assembles proven Rust crates into a convention-over-configuration web
-framework. It gives you route macros, HTML templating, database access, and a
-Tailwind CSS build pipeline out of the box â€” so you can focus on your
-application instead of wiring together middleware. If you've used Spring Boot,
-Rails, or Laravel, the shape will feel familiar.
+stack with proc-macro ergonomics, framework defaults, and escape hatches when
+you need them. If Spring Boot, Rails, or Laravel feels familiar, Autumn aims
+for that same "ship the app, not the plumbing" shape in Rust.
 
-> **Autumn is v0.1 â€” experimental.** APIs will change. Not recommended for production use.
+> **Status:** the latest tagged release is `v0.1.0` (2026-03-26), but `trunk`
+> already contains substantial post-`v0.1.0` work. This README documents the
+> current `trunk` branch, not just the `v0.1.0` tag. The framework is still
+> experimental and not recommended for production use yet.
 
 ## Features
 
-- **Route macros** â€” `#[get("/")]`, `#[post("/")]`, `#[put("/")]`, `#[delete("/")]`
-- **Route collection** â€” `routes![handler1, handler2]` macro
-- **Application bootstrap** â€” `#[autumn_web::main]` + `autumn_web::app().routes(...).run().await`
-- **Configuration** â€” `autumn.toml` with `[server]`, `[database]`, `[log]`, `[health]` sections
-- **Environment overrides** â€” `AUTUMN_SERVER__PORT`, `AUTUMN_DATABASE__URL`, etc.
-- **Database pool** â€” Diesel + diesel-async + deadpool (Postgres)
-- **Db extractor** â€” `db: autumn_web::Db` in handlers for an `AsyncPgConnection`
-- **HTML rendering** â€” Maud (`autumn_web::html!`, `autumn_web::Markup`)
-- **htmx integration** â€” auto-served at `/static/js/htmx.min.js`
-- **Tailwind CSS** â€” build pipeline via `build.rs` + `autumn setup` CLI command
-- **Health check** â€” auto-mounted JSON endpoint at `/health` (configurable)
-- **Structured logging** â€” tracing with Pretty / JSON / Auto formats
-- **Graceful shutdown** â€” Ctrl+C / SIGTERM with configurable drain timeout
-- **Static file serving** â€” auto-served from `static/` directory
-- **Error handling** â€” `AutumnError` with status refinement (`.not_found()`, `.bad_request()`, etc.)
-- **JSON support** â€” `autumn_web::Json<T>` for request parsing and responses
-- **Form support** â€” `autumn_web::extract::Form<T>` for form data
-- **Path extraction** â€” `autumn_web::extract::Path<T>` for URL parameters
+- **Route and app macros** — `#[get]`, `#[post]`, `#[put]`, `#[delete]`, `routes![]`, `#[autumn_web::main]`
+- **Hybrid rendering** — `#[static_get]` + `static_routes![]` with `autumn build` pre-rendering to `dist/`
+- **Application builder** — `.routes()`, `.tasks()`, `.static_routes()`, `.scoped()`, `.merge()`, and `.nest()`
+- **Configuration and profiles** — defaults, `autumn.toml`, `autumn-{profile}.toml`, and `AUTUMN_*` overrides
+- **Database ergonomics** — async Postgres pool, `Db` extractor, `#[model]`, `#[repository]`, hooks, and embedded migrations
+- **HTML stack** — Maud templating, bundled htmx, Tailwind build pipeline, and static asset serving
+- **Operations** — `/health`, `/actuator/*`, structured logging, metrics, and graceful shutdown
+- **Background work** — `#[scheduled]` tasks and runtime task visibility at `/actuator/tasks`
+- **Security primitives** — session cookies, auth extractor, security headers, CSRF, and `#[secured]`
+- **CLI workflow** — `autumn new`, `autumn setup`, `autumn dev`, `autumn build`, and `autumn migrate`
 
 ## Quickstart
 
 ```bash
-# Install the CLI (from source â€” crates.io publication is not yet available)
+# Install the CLI from this workspace
 cargo install --path autumn-cli
 
 # Create a new project
 autumn new my-app
 cd my-app
 
-# Download Tailwind CSS (optional â€” only needed for styled CSS)
+# Optional: download Tailwind CSS for styled builds
 autumn setup
 
-# Run it
-cargo run
+# Development server with file watching
+autumn dev
 
-# Visit http://localhost:3000
+# Or run without watch mode
+# cargo run
 ```
+
+Visit <http://localhost:3000>. Autumn also auto-mounts `/health`,
+`/actuator/health`, `/actuator/info`, and `/static/js/htmx.min.js`.
+
+If you add `#[static_get]` routes, `autumn build` pre-renders them into
+`dist/`.
 
 ## Example
 
@@ -83,32 +84,37 @@ async fn main() {
 
 ## Built On
 
-Autumn stands on the shoulders of these excellent crates:
-
-- [Axum](https://github.com/tokio-rs/axum) â€” async web framework
-- [Diesel](https://diesel.rs/) + [diesel-async](https://github.com/weiznich/diesel_async) â€” ORM and query builder (Postgres)
-- [Maud](https://maud.lambda.xyz/) â€” compile-time HTML templating
-- [htmx](https://htmx.org/) â€” HTML-driven interactivity
-- [Tailwind CSS](https://tailwindcss.com/) â€” utility-first CSS
-- [Tokio](https://tokio.rs/) â€” async runtime
-- [Tracing](https://github.com/tokio-rs/tracing) â€” structured logging
+- [Axum](https://github.com/tokio-rs/axum) — async HTTP routing and middleware
+- [Diesel](https://diesel.rs/) + [diesel-async](https://github.com/weiznich/diesel_async) — database access
+- [Maud](https://maud.lambda.xyz/) — compiled HTML templates
+- [htmx](https://htmx.org/) — HTML-first interactivity
+- [Tailwind CSS](https://tailwindcss.com/) — utility-first styling
+- [Tokio](https://tokio.rs/) — async runtime
+- [Tracing](https://github.com/tokio-rs/tracing) — structured logging
 
 ## Examples
 
 | Example | Description |
 |---------|-------------|
-| [`examples/hello`](examples/hello) | Minimal hello-world app â€” three routes, no database |
-| [`examples/todo-app`](examples/todo-app) | Full reference app with Diesel, Maud, htmx, Tailwind, and a JSON API |
+| [`examples/hello`](examples/hello) | Minimal hello-world app with route macros and no database |
+| [`examples/todo-app`](examples/todo-app) | Classic full-stack CRUD app with Diesel, Maud, htmx, Tailwind, and JSON endpoints |
+| [`examples/blog`](examples/blog) | Blog engine with admin UI, validation, and hybrid rendering via `#[static_get]` |
+| [`examples/bookmarks`](examples/bookmarks) | Repository macro, generated CRUD API, profiles, scheduled tasks, and actuator endpoints |
+| [`examples/wiki`](examples/wiki) | Mutation hooks, revision history, generated REST API, and slug lifecycle management |
 
 ## Documentation
 
-- [Getting Started Guide](docs/guide/) *(coming soon)*
-- [API Reference](https://docs.rs/autumn-web) *(coming soon)*
+- [Getting Started Guide](docs/guide/getting-started.md)
+- [Todo Tutorial](docs/guide/tutorial/index.md)
+- [API Reference](https://docs.rs/autumn-web)
+- [Hybrid Rendering Design Notes](docs/design/hybrid-rendering.md)
 
 ## Requirements
 
-- Rust 1.85.0+ (edition 2024)
-- PostgreSQL *(optional â€” Autumn runs without a database)*
+- Rust 1.86.0+ (edition 2024)
+- PostgreSQL for database-backed apps
+
+Autumn can still run without a database if you omit the `[database]` section.
 
 ## License
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,18 +1,25 @@
 # Getting Started with Autumn
 
 This guide takes you from zero to a running Autumn web app with routes, a
-database, HTML templates, and interactive UI. Budget about 30 minutes.
+database, HTML templates, interactive UI, and the current post-`v0.1.0`
+framework surface on `trunk`. Budget about 30 minutes.
 
 Autumn is a convention-over-configuration web framework for Rust, built on
 [Axum](https://github.com/tokio-rs/axum). It bundles Diesel (database), Maud
-(HTML), Tailwind CSS (styling), and htmx (interactivity) behind a
-Spring Boot-style developer experience.
+(HTML), Tailwind CSS (styling), htmx (interactivity), actuator endpoints,
+profile-aware configuration, and newer CLI workflows behind a Spring Boot-style
+developer experience.
+
+> **Version note:** `v0.1.0` was tagged on 2026-03-26. This guide tracks the
+> current `trunk` branch, which already includes unreleased post-`v0.1.0`
+> features like `autumn dev`, `autumn build`, profiles, actuator, and static
+> generation.
 
 ---
 
 ## Prerequisites
 
-- **Rust 1.85.0+** (edition 2024) -- install via [rustup](https://rustup.rs/)
+- **Rust 1.86.0+** (edition 2024) -- install via [rustup](https://rustup.rs/)
 - **PostgreSQL** -- only needed if you want database features; Autumn runs
   fine without one
 - A terminal and a text editor
@@ -35,12 +42,15 @@ from source (crates.io publication is not yet available):
 cargo install --path autumn-cli
 ```
 
-This gives you the `autumn` binary with two commands:
+This gives you the `autumn` binary with the core workflow commands:
 
 | Command         | What it does                                |
 |-----------------|---------------------------------------------|
 | `autumn new`    | Scaffold a new project                      |
 | `autumn setup`  | Download Tailwind CSS (with checksum verify) |
+| `autumn dev`    | Run the dev server with file watching        |
+| `autumn build`  | Pre-render `#[static_get]` routes into `dist/` |
+| `autumn migrate`| Run migrations or inspect migration status   |
 
 ---
 
@@ -134,13 +144,18 @@ or your own `impl IntoResponse`.
 ## Run It
 
 ```bash
+autumn dev
+```
+
+If you prefer not to use watch mode:
+
+```bash
 cargo run
 ```
 
 You will see log output like:
 
 ```
-  INFO autumn: Autumn v0.1.0
   INFO autumn: Database not configured
   INFO autumn: Listening addr=127.0.0.1:3000
 ```
@@ -151,7 +166,13 @@ Visit [http://localhost:3000](http://localhost:3000) -- you should see
 path parameter route.
 
 A health check is automatically mounted at
-[http://localhost:3000/health](http://localhost:3000/health) and returns JSON:
+[http://localhost:3000/health](http://localhost:3000/health). Actuator
+endpoints are also auto-mounted at
+[http://localhost:3000/actuator/health](http://localhost:3000/actuator/health),
+[http://localhost:3000/actuator/info](http://localhost:3000/actuator/info), and
+[http://localhost:3000/actuator/metrics](http://localhost:3000/actuator/metrics).
+
+The `/health` response looks like:
 
 ```json
 { "status": "ok", "version": "0.1.0" }
@@ -713,11 +734,13 @@ Error responses are JSON:
 
 ## Configuration
 
-Autumn uses a three-layer configuration system:
+Autumn uses a five-layer configuration system:
 
 1. **Framework defaults** -- compiled into the binary, zero-config start
-2. **`autumn.toml`** -- project-level overrides
-3. **`AUTUMN_*` environment variables** -- deployment overrides (highest priority)
+2. **Profile smart defaults** -- built-in `dev` / `prod` behavior
+3. **`autumn.toml`** -- project-level overrides
+4. **`autumn-{profile}.toml`** -- profile-specific overrides
+5. **`AUTUMN_*` environment variables** -- deployment overrides (highest priority)
 
 ### `autumn.toml` reference
 
@@ -738,6 +761,9 @@ format = "Auto"              # Auto | Pretty | Json
 
 [health]
 path = "/health"             # default
+
+[actuator]
+sensitive = false            # prod default; dev smart defaults enable sensitive endpoints
 ```
 
 ### Environment variable overrides
@@ -756,6 +782,17 @@ Every config field can be overridden via environment variables. The pattern is
 | `AUTUMN_LOG__LEVEL`                  | `log.level`            |
 | `AUTUMN_LOG__FORMAT`                 | `log.format`           |
 | `AUTUMN_HEALTH__PATH`               | `health.path`          |
+| `AUTUMN_PROFILE`                     | active profile         |
+
+Profiles resolve in this order:
+
+1. `AUTUMN_PROFILE`
+2. `--profile <name>`
+3. debug/release auto-detection (`dev` for debug, `prod` for release)
+
+That means you can keep shared defaults in `autumn.toml`, put local dev
+settings in `autumn-dev.toml`, and override the final few things in CI or
+deployment with env vars.
 
 ### Log format behavior
 
@@ -777,7 +814,8 @@ database, or during early development.
 ## What's Next?
 
 You now have a working Autumn application with routes, database access,
-HTML rendering, Tailwind styling, and htmx interactivity.
+HTML rendering, Tailwind styling, htmx interactivity, health checks, and
+actuator endpoints.
 
 Here are some things to explore:
 
@@ -800,14 +838,15 @@ Here are some things to explore:
       // ...
   }
   ```
-- **Check the health endpoint** at `/health` -- it reports pool status when a
-  database is configured, showing available connections and queue depth.
+- **Check `/health` and `/actuator/*`** -- `/health` gives a small health
+  response, while actuator adds info, metrics, env/configprops, loggers, and
+  scheduled task visibility depending on the active profile.
 - **Inspect request IDs** -- every response includes an `X-Request-Id` header
   (UUID v4) for log correlation.
-- **Look at the full example** -- the
-  [`examples/todo-app`](https://github.com/your-org/autumn/tree/trunk/examples/todo-app)
-  directory has a complete todo application with Maud templates, htmx, Tailwind
-  styling, and a JSON API alongside the HTML routes.
+- **Look at the example apps** -- [`examples/todo-app`](../../examples/todo-app),
+  [`examples/blog`](../../examples/blog), [`examples/bookmarks`](../../examples/bookmarks),
+  and [`examples/wiki`](../../examples/wiki) each exercise different parts of
+  the current framework.
 
-Autumn is v0.1 -- APIs will evolve. File issues, ask questions, and ship
-something.
+Autumn is still pre-1.0 and evolving quickly. File issues, break glass when you
+need Axum escape hatches, and ship something.

--- a/docs/guide/tutorial/01-project-setup.md
+++ b/docs/guide/tutorial/01-project-setup.md
@@ -9,8 +9,8 @@ compiles, runs, and responds to HTTP requests at `http://localhost:3000`.
 
 Before you start, make sure you have:
 
-- **Rust** (edition 2024) — install from <https://rustup.rs> if you haven't already
-- **The Autumn CLI** — install with `cargo install autumn-cli`
+- **Rust** (edition 2024) � install from <https://rustup.rs> if you haven't already
+- **The Autumn CLI** � install from this workspace with `cargo install --path autumn-cli`
 - A terminal and a text editor
 
 Docker is not needed until Chapter 3 (Database Setup). For now, you only need
@@ -56,18 +56,18 @@ Let's look at what was generated.
 
 ```
 todo-app/
-├── Cargo.toml
-├── autumn.toml
-├── build.rs
-├── src/
-│   └── main.rs
-├── static/
-│   └── css/
-│       └── input.css
-├── tailwind.config.js
-├── migrations/
-│   └── .gitkeep
-└── .gitignore
++-- Cargo.toml
++-- autumn.toml
++-- build.rs
++-- src/
+�   +-- main.rs
++-- static/
+�   +-- css/
+�       +-- input.css
++-- tailwind.config.js
++-- migrations/
+�   +-- .gitkeep
++-- .gitignore
 ```
 
 Each file has a specific role. Let's walk through them.
@@ -119,19 +119,19 @@ async fn main() {
 
 There is a lot happening in a small file. Here is what each piece does:
 
-- **`#[get("/")]`** — a route macro that registers `index` as a GET handler
+- **`#[get("/")]`** � a route macro that registers `index` as a GET handler
   for the root path. Autumn provides `#[get]`, `#[post]`, `#[put]`, and
   `#[delete]` macros.
-- **`#[get("/hello/{name}")]`** — a route with a path parameter. The `{name}`
+- **`#[get("/hello/{name}")]`** � a route with a path parameter. The `{name}`
   segment is extracted into the handler's `Path<String>` argument.
-- **`autumn_web::extract::Path`** — an extractor that pulls typed values from the
+- **`autumn_web::extract::Path`** � an extractor that pulls typed values from the
   URL path. Autumn re-exports Axum's extractors so you don't need `axum` as a
   direct dependency.
-- **`#[autumn_web::main]`** — sets up the Tokio async runtime. This is equivalent
+- **`#[autumn_web::main]`** � sets up the Tokio async runtime. This is equivalent
   to `#[tokio::main]` with Autumn's preferred configuration.
-- **`autumn_web::app()`** — creates an application builder. You register routes
+- **`autumn_web::app()`** � creates an application builder. You register routes
   with `.routes()` and start the server with `.run().await`.
-- **`routes![index, hello, hello_name]`** — a macro that collects route
+- **`routes![index, hello, hello_name]`** � a macro that collects route
   handlers into a `Vec<Route>` for the app builder.
 
 The pattern is always the same: define handlers with route macros, collect
@@ -141,7 +141,7 @@ them with `routes![]`, and pass them to `autumn_web::app().routes(...).run()`.
 
 ```toml
 # Autumn configuration
-# All values shown are defaults — uncomment and change as needed.
+# All values shown are defaults � uncomment and change as needed.
 
 [server]
 host = "127.0.0.1"
@@ -162,12 +162,14 @@ path = "/health"
 # connect_timeout_secs = 5
 ```
 
-Autumn uses a three-layer configuration system:
+Autumn uses a five-layer configuration system:
 
-1. **Framework defaults** — compiled into the binary (port 3000, log level
+1. **Framework defaults** � compiled into the binary (port 3000, log level
    info, etc.)
-2. **`autumn.toml`** — project-level overrides (this file)
-3. **`AUTUMN_*` environment variables** — deployment overrides (e.g.,
+2. **Profile smart defaults** � built-in `dev` / `prod` behavior
+3. **`autumn.toml`** � project-level overrides (this file)
+4. **`autumn-{profile}.toml`** � profile-specific overrides
+5. **`AUTUMN_*` environment variables** � deployment overrides (e.g.,
    `AUTUMN_SERVER__PORT=8080`)
 
 Every value has a sensible default. You can delete `autumn.toml` entirely and
@@ -271,7 +273,7 @@ This downloads the Tailwind CLI to `target/autumn/tailwindcss` (or
 is about 50 MB.
 
 If you prefer to install Tailwind globally or already have it on your PATH,
-you can skip this step — `build.rs` checks both locations.
+you can skip this step � `build.rs` checks both locations.
 
 ## Run the Application
 
@@ -285,12 +287,11 @@ The first build will take a minute or two as Cargo downloads and compiles
 dependencies. Subsequent builds are fast. You will see output like:
 
 ```
-  INFO Autumn v0.1.0
   INFO Database not configured
   INFO Listening addr=127.0.0.1:3000
 ```
 
-The "Database not configured" message is expected — you have not set up
+The "Database not configured" message is expected � you have not set up
 Postgres yet.
 
 Open your browser and visit <http://localhost:3000>. You should see:
@@ -301,10 +302,12 @@ Welcome to Autumn!
 
 Try the other routes:
 
-- <http://localhost:3000/hello> — "Hello, Autumn!"
-- <http://localhost:3000/hello/world> — "Hello, world!"
-- <http://localhost:3000/health> — a JSON health check response (auto-mounted
+- <http://localhost:3000/hello> � "Hello, Autumn!"
+- <http://localhost:3000/hello/world> � "Hello, world!"
+- <http://localhost:3000/health> � a JSON health check response (auto-mounted
   by the framework)
+- <http://localhost:3000/actuator/health> � the actuator health view
+- <http://localhost:3000/actuator/info> � build and runtime information
 
 Press `Ctrl+C` in your terminal to stop the server. You will see:
 
@@ -313,7 +316,7 @@ Press `Ctrl+C` in your terminal to stop the server. You will see:
   INFO Server shut down cleanly
 ```
 
-Autumn handles graceful shutdown automatically — in-flight requests drain
+Autumn handles graceful shutdown automatically � in-flight requests drain
 before the process exits.
 
 ## What Just Happened
@@ -325,8 +328,8 @@ Here is what Autumn did when you called `.run().await`:
 2. **Initialized structured logging** based on the `[log]` section
 3. **Skipped database pool creation** (no `[database]` section configured)
 4. **Built an Axum router** from the routes you registered with `.routes()`
-5. **Mounted framework routes** — the health check endpoint and the bundled
-   htmx JavaScript
+5. **Mounted framework routes** � the health check endpoint, actuator
+   endpoints, and the bundled htmx JavaScript
 6. **Served static files** from the `static/` directory
 7. **Bound to `127.0.0.1:3000`** and started accepting connections
 
@@ -339,31 +342,31 @@ Your project should look like this:
 
 ```
 todo-app/
-├── Cargo.toml
-├── autumn.toml
-├── build.rs
-├── src/
-│   └── main.rs
-├── static/
-│   └── css/
-│       ├── input.css
-│       └── autumn.css   ← generated by build.rs
-├── tailwind.config.js
-├── migrations/
-│   └── .gitkeep
-├── target/
-│   └── autumn/
-│       └── tailwindcss  ← downloaded by `autumn setup`
-└── .gitignore
++-- Cargo.toml
++-- autumn.toml
++-- build.rs
++-- src/
+�   +-- main.rs
++-- static/
+�   +-- css/
+�       +-- input.css
+�       +-- autumn.css   ? generated by build.rs
++-- tailwind.config.js
++-- migrations/
+�   +-- .gitkeep
++-- target/
+�   +-- autumn/
+�       +-- tailwindcss  ? downloaded by `autumn setup`
++-- .gitignore
 ```
 
 `cargo run` starts a server that responds at `http://localhost:3000` with
-three routes (`/`, `/hello`, `/hello/{name}`) plus the framework-provided
-`/health` endpoint.
+three routes (`/`, `/hello`, `/hello/{name}`) plus framework-provided
+`/health` and `/actuator/*` endpoints.
 
 This is your foundation. In the next chapter, you will replace the placeholder
 routes with the beginnings of a todo application.
 
 ---
 
-Next: [Chapter 2 — Routes and Handlers](02-routes.md)
+Next: [Chapter 2 � Routes and Handlers](02-routes.md)

--- a/docs/guide/tutorial/10-configuration.md
+++ b/docs/guide/tutorial/10-configuration.md
@@ -1,45 +1,50 @@
 # Chapter 10: Configuration and Production Defaults
 
-**Goal:** By the end of this chapter, you will understand Autumn's three-layer
-configuration system, know how to override settings with environment
-variables, and have configured structured logging and the health check
-endpoint.
+**Goal:** By the end of this chapter, you will understand Autumn's profile-aware
+configuration system, know how to override settings with environment variables,
+and have a clear mental model for logging, health checks, and actuator
+endpoints in development and production.
 
 ---
 
 ## Sections
 
-### The Three Configuration Layers
+### The Five Configuration Layers
 
-1. Framework defaults (compiled in)
-2. `autumn.toml` (project-level)
-3. `AUTUMN_*` environment variables (deployment-level)
+1. Framework defaults
+2. Profile smart defaults for `dev` / `prod`
+3. `autumn.toml`
+4. `autumn-{profile}.toml`
+5. `AUTUMN_*` environment variables
 
-How the layers merge and why each exists.
+How the layers merge, how the active profile is resolved, and why Autumn keeps
+shared config separate from environment-specific overrides.
 
 ### `autumn.toml` Sections
 
 Walking through every section: `[server]` (host, port, shutdown timeout),
 `[database]` (URL, pool size, connect timeout), `[log]` (level, format),
-`[health]` (path).
+`[health]` (path, detail level), `[actuator]` (sensitive endpoint exposure),
+and the security/session sections that matter once you leave toy apps behind.
 
 ### Environment Variable Overrides
 
 The `AUTUMN_SECTION__FIELD` naming convention (double underscore separates
 sections). Examples: `AUTUMN_SERVER__PORT=8080`,
-`AUTUMN_DATABASE__URL=postgres://...`. Env vars always win over the TOML
-file.
+`AUTUMN_DATABASE__URL=postgres://...`, `AUTUMN_LOG__FORMAT=Json`,
+`AUTUMN_PROFILE=prod`. Env vars always win over TOML layers.
 
 ### Structured Logging
 
-The `LogFormat` enum: `Auto`, `Pretty`, `Json`. Auto picks Pretty in
-development and JSON in production (based on `AUTUMN_ENV`). Configuring log
-levels with tracing filter syntax.
+The `LogFormat` enum: `Auto`, `Pretty`, `Json`. How profile smart defaults and
+runtime environment interact, and when to force JSON for deployment logs.
 
-### The Health Check Endpoint
+### Health and Actuator
 
-Auto-mounted at `/health` by default. Customizing the path. What to check in
-a production health endpoint.
+Auto-mounted `/health` for simple probes plus `/actuator/health`,
+`/actuator/info`, `/actuator/metrics`, and the sensitive endpoints exposed in
+development. Customizing the health path and reasoning about what should stay
+visible in production.
 
 ### Graceful Shutdown
 
@@ -48,12 +53,14 @@ setting. Draining in-flight requests.
 
 ### Checkpoint
 
-Expected project state with production-ready configuration.
+Expected project state with profile-aware config, environment overrides, and a
+clear dev-vs-prod operational story.
 
 ---
 
-*Content coming in Sprint 12.*
+*This chapter still needs the full walkthrough, but the outline above reflects
+the current framework rather than the old pre-profile configuration model.*
 
 ---
 
-Previous: [Chapter 9 â€” Error Handling](09-errors.md) | Next: [Chapter 11 â€” What's Next](11-whats-next.md)
+Previous: [Chapter 9 — Error Handling](09-errors.md) | Next: [Chapter 11 — What's Next](11-whats-next.md)

--- a/docs/guide/tutorial/11-whats-next.md
+++ b/docs/guide/tutorial/11-whats-next.md
@@ -17,22 +17,28 @@ one framework dependency.
 ### Comparing to the Reference Implementation
 
 Your code vs. `examples/todo-app/`. Any polish the example includes that the
-tutorial omitted. Using the example as a continued reference.
+tutorial omitted. Then branch out into the newer example apps:
+
+- `examples/blog/` for hybrid rendering and a richer admin UI
+- `examples/bookmarks/` for repository macros, generated CRUD APIs, and scheduled tasks
+- `examples/wiki/` for mutation hooks and revision history
 
 ### Ideas for Extending the App
 
-- **Authentication** â€” add user accounts with session cookies
-- **Categories** â€” associate todos with categories (a second table, foreign keys)
-- **Search** â€” add a search bar with `ILIKE` queries
-- **Pagination** â€” limit the list with `.limit()` and `.offset()`
-- **Testing** â€” write integration tests with Autumn's test utilities
+- **Authentication** — add user accounts with session cookies
+- **Actuator hardening** — tune which operational endpoints stay visible in prod
+- **Background work** — add a `#[scheduled]` task for cleanup or polling
+- **Categories** — associate todos with categories (a second table, foreign keys)
+- **Search** — add a search bar with `ILIKE` queries
+- **Pagination** — limit the list with `.limit()` and `.offset()`
+- **Testing** — write integration tests with Autumn's test utilities
 
 ### Further Reading
 
-- [API Reference](../../api/) â€” generated Rust docs for every public type
-- [Getting Started Guide](../getting-started.md) â€” quick overview of all features
-- [Example App](../../../examples/todo-app/) â€” the reference implementation
-- [Autumn on crates.io](https://crates.io/crates/autumn) â€” versioned releases
+- [API Reference](https://docs.rs/autumn-web) — generated Rust docs for every public type
+- [Getting Started Guide](../getting-started.md) — quick overview of all features
+- [Example App](../../../examples/todo-app/) — the reference implementation
+- [Autumn on crates.io](https://crates.io/crates/autumn-web) — versioned releases
 
 ### Community
 
@@ -44,4 +50,4 @@ Where to ask questions, report bugs, and contribute.
 
 ---
 
-Previous: [Chapter 10 â€” Configuration and Production Defaults](10-configuration.md) | Back to [Tutorial Index](index.md)
+Previous: [Chapter 10 — Configuration and Production Defaults](10-configuration.md) | Back to [Tutorial Index](index.md)

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -1,43 +1,77 @@
 # Autumn Blog Example
 
-A full-featured blog engine built with the Autumn web framework, showcasing the
-complete stack: **Diesel** (Postgres), **Maud** templates, **Tailwind CSS**
-styling, and **htmx** interactivity.
+A blog engine built with Autumn's full-stack path: Diesel, Maud, Tailwind,
+htmx, embedded migrations, and the new hybrid-rendering pipeline.
 
-## Features
+## What it demonstrates
 
-- **Public blog** — browse published posts with a clean, responsive UI
-- **Admin dashboard** — create, edit, publish, and delete posts
-- **Slug-based URLs** — auto-generated from post titles (`/posts/my-first-post`)
-- **htmx delete** — inline post deletion without full page reloads
-- **JSON API** — `GET /api/posts` and `POST /api/posts` for programmatic access
-- **Draft/published workflow** — toggle visibility with a checkbox
+- Public blog listing and slug-based post pages
+- Admin UI for create, edit, publish, and delete
+- JSON endpoints alongside server-rendered HTML
+- Validation before insert/update
+- `#[static_get]` + `static_routes![]` for build-time rendering
+- Automatic migrations on startup
+- Framework health and actuator endpoints
 
 ## Quick start
 
+From the workspace root:
+
 ```bash
-# 1. Start Postgres
-docker compose up -d
+# 1. Download Tailwind CSS
+cargo run -p autumn-cli -- setup
 
-# 2. Run the app (migrations run automatically on startup)
+# 2. Start Postgres
+docker compose -f examples/blog/docker-compose.yml up -d
+
+# 3. Run the app (migrations are embedded and applied on startup)
 cargo run -p blog
-
-# 3. Open your browser
-open http://localhost:3000
 ```
+
+Open <http://localhost:3000>.
+
+## Try the hybrid-rendering flow
+
+The `/about` page is declared with `#[static_get("/about")]`.
+
+```bash
+# Pre-render static routes into dist/
+cargo run -p autumn-cli -- build -p blog
+```
+
+Dynamic routes like `/` and `/posts/{slug}` still render through the server;
+static routes get written to `dist/` for deployment or CDN serving.
 
 ## Routes
 
-| Method   | Path               | Description                |
-|----------|--------------------|----------------------------|
-| `GET`    | `/`                | Public blog listing        |
-| `GET`    | `/posts/{slug}`    | View a published post      |
-| `GET`    | `/admin`           | Admin post dashboard       |
-| `GET`    | `/admin/new`       | New post form              |
-| `POST`   | `/admin`           | Create a post              |
-| `GET`    | `/admin/{id}/edit` | Edit post form             |
-| `POST`   | `/admin/{id}`      | Update a post              |
-| `DELETE` | `/admin/{id}`      | Delete a post (htmx)      |
-| `GET`    | `/api/posts`       | JSON: list published posts |
-| `POST`   | `/api/posts`       | JSON: create a post        |
-| `GET`    | `/health`          | Health check               |
+### HTML
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/` | Public blog listing |
+| GET | `/about` | Static page rendered via `#[static_get]` |
+| GET | `/posts/{slug}` | View a published post |
+| GET | `/admin` | Admin post dashboard |
+| GET | `/admin/new` | New post form |
+| POST | `/admin` | Create a post |
+| GET | `/admin/{id}/edit` | Edit post form |
+| POST | `/admin/{id}` | Update a post |
+| DELETE | `/admin/{id}` | Delete a post with htmx |
+
+### JSON API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/posts` | List published posts as JSON |
+| POST | `/api/posts` | Create a post as JSON |
+
+### Framework
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Health probe |
+| GET | `/actuator/health` | Detailed health view |
+| GET | `/actuator/info` | Build and runtime metadata |
+| GET | `/actuator/metrics` | Request and pool metrics |
+| GET | `/static/js/htmx.min.js` | Bundled htmx |
+| GET | `/static/css/autumn.css` | Compiled Tailwind output |

--- a/examples/bookmarks/README.md
+++ b/examples/bookmarks/README.md
@@ -1,17 +1,18 @@
 # Autumn Bookmarks Example
 
-A bookmark manager showcasing **Autumn v0.2 features** — profiles, validation,
-the `#[model]` / `#[repository]` macros, scheduled tasks, and actuator endpoints.
+A bookmark manager showcasing the newer Autumn feature set: profile-aware
+configuration, `#[model]`, `#[repository(api = ...)]`, scheduled tasks,
+embedded migrations, and actuator endpoints.
 
-## v0.2 Features Demonstrated
+## What it demonstrates
 
 | Feature | Where | What it does |
 |---------|-------|--------------|
 | **Profiles** | `autumn.toml` + `autumn-dev.toml` | Dev profile auto-detected; DB URL only in dev config |
-| **Validation** | `routes/api.rs` | `Valid<Json<NewBookmark>>` checks URL format + title length |
 | **`#[model]`** | `models.rs` | Generates `Bookmark`, `NewBookmark`, `UpdateBookmark` from one struct |
-| **`#[repository]`** | `repositories.rs` | Generates `PgBookmarkRepository` with CRUD + `find_by_tag` |
+| **`#[repository]`** | `repositories.rs` | Generates `PgBookmarkRepository` with CRUD + `find_by_tag` + REST handlers |
 | **Scheduled tasks** | `tasks.rs` | `#[scheduled(every = "1h")]` link health checker |
+| **Embedded migrations** | `main.rs` | Runs Diesel migrations at startup |
 | **Actuator** | Nav bar links | `/actuator/health`, `/actuator/info` auto-mounted |
 
 ## Prerequisites
@@ -48,11 +49,15 @@ The server starts at <http://localhost:3000>.
 
 ### JSON API
 
-| Method | Path                   | Description                           |
-|--------|------------------------|---------------------------------------|
-| GET    | `/api/bookmarks`       | List all bookmarks (JSON)             |
-| POST   | `/api/bookmarks`       | Create bookmark (validated JSON body) |
-| DELETE | `/api/bookmarks/{id}`  | Delete bookmark                       |
+These routes are generated from `#[autumn_web::repository(Bookmark, api = "/api/bookmarks")]`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/bookmarks` | List all bookmarks |
+| GET | `/api/bookmarks/{id}` | Fetch one bookmark |
+| POST | `/api/bookmarks` | Create a bookmark |
+| PUT | `/api/bookmarks/{id}` | Update a bookmark |
+| DELETE | `/api/bookmarks/{id}` | Delete a bookmark |
 
 ### Framework
 
@@ -60,20 +65,24 @@ The server starts at <http://localhost:3000>.
 |--------|--------------------------|------------------------|
 | GET    | `/actuator/health`       | Health + profile info  |
 | GET    | `/actuator/info`         | Build & runtime info   |
+| GET    | `/actuator/metrics`      | Request and pool stats |
 | GET    | `/health`                | Health check           |
 | GET    | `/static/js/htmx.min.js` | Bundled htmx          |
 | GET    | `/static/css/autumn.css` | Compiled Tailwind CSS  |
 
-## Try the validation
+## Try the generated CRUD API
 
 ```bash
-# Valid request
+# Create
 curl -X POST http://localhost:3000/api/bookmarks \
   -H 'Content-Type: application/json' \
-  -d '{"url":"https://rust-lang.org","title":"Rust","tag":"lang"}'
+  -d '{"url":"https://rust-lang.org","title":"Rust","tag":"lang","alive":true}'
 
-# Invalid URL → 422 with field errors
-curl -X POST http://localhost:3000/api/bookmarks \
+# List
+curl http://localhost:3000/api/bookmarks
+
+# Update
+curl -X PUT http://localhost:3000/api/bookmarks/1 \
   -H 'Content-Type: application/json' \
-  -d '{"url":"not-a-url","title":"","tag":"bad"}'
+  -d '{"title":"Rust Lang","tag":"rust","alive":true}'
 ```

--- a/examples/bookmarks/src/main.rs
+++ b/examples/bookmarks/src/main.rs
@@ -1,9 +1,9 @@
-// Bookmarks — an Autumn v0.2 example showcasing all new features:
+// Bookmarks � an Autumn example showcasing the post-v0.1.0 feature set:
 //
-//   Profiles        → autumn.toml + autumn-dev.toml (dev auto-detected)
-//   Validation      → Valid<Json<NewBookmark>> with #[validate] rules
-//   Scheduled tasks → #[scheduled(every = "1h")] link health checker
-//   Actuator        → /actuator/health, /actuator/info, /actuator/env
+//   Profiles        ? autumn.toml + autumn-dev.toml (dev auto-detected)
+//   CRUD API        ? #[repository(api = "/api/bookmarks")] generates REST handlers
+//   Scheduled tasks ? #[scheduled(every = "1h")] link health checker
+//   Actuator        ? /actuator/health, /actuator/info, /actuator/env
 //
 // Run with:  cargo run -p bookmarks
 // API test:  curl -X POST http://localhost:3000/api/bookmarks \
@@ -23,7 +23,7 @@ const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
 #[autumn_web::main]
 async fn main() {
-    // ── v0.2: .tasks() registers scheduled background tasks ─────
+    // -- v0.2: .tasks() registers scheduled background tasks -----
     autumn_web::app()
         .migrations(MIGRATIONS)
         .routes(routes![

--- a/examples/bookmarks/src/main.rs
+++ b/examples/bookmarks/src/main.rs
@@ -1,9 +1,9 @@
-// Bookmarks — an Autumn example showcasing the post-v0.1.0 feature set:
+// Bookmarks - an Autumn example showcasing the post-v0.1.0 feature set:
 //
-//   Profiles        ? autumn.toml + autumn-dev.toml (dev auto-detected)
-//   CRUD API        ? #[repository(api = "/api/bookmarks")] generates REST handlers
-//   Scheduled tasks ? #[scheduled(every = "1h")] link health checker
-//   Actuator        ? /actuator/health, /actuator/info, /actuator/env
+//   Profiles        -> autumn.toml + autumn-dev.toml (dev auto-detected)
+//   CRUD API        -> #[repository(api = "/api/bookmarks")] generates REST handlers
+//   Scheduled tasks -> #[scheduled(every = "1h")] link health checker
+//   Actuator        -> /actuator/health, /actuator/info, /actuator/env
 //
 // Run with:  cargo run -p bookmarks
 // API test:  curl -X POST http://localhost:3000/api/bookmarks \

--- a/examples/todo-app/README.md
+++ b/examples/todo-app/README.md
@@ -1,12 +1,14 @@
 # Autumn Todo App
 
-A full-stack reference application demonstrating Autumn's key features:
+A full-stack reference application demonstrating the classic Autumn stack:
 
 - **Diesel + diesel-async** for Postgres database access
 - **Maud** templates with **Tailwind CSS** styling
 - **htmx** for interactive toggle and delete without page reloads
 - **JSON API** alongside server-rendered HTML
 - **AutumnError** for consistent error handling (404, 422, 500)
+- **Embedded migrations** so the schema comes up with the app
+- **Framework ops endpoints** via `/health` and `/actuator/*`
 
 ## Prerequisites
 
@@ -55,5 +57,8 @@ The server starts at <http://localhost:3000>.
 | Method | Path                      | Description              |
 |--------|---------------------------|--------------------------|
 | GET    | `/health`                 | Health check             |
+| GET    | `/actuator/health`        | Detailed health view     |
+| GET    | `/actuator/info`          | Build and runtime info   |
+| GET    | `/actuator/metrics`       | Request and pool metrics |
 | GET    | `/static/js/htmx.min.js` | Bundled htmx             |
 | GET    | `/static/css/autumn.css`  | Compiled Tailwind CSS    |

--- a/examples/wiki/README.md
+++ b/examples/wiki/README.md
@@ -1,0 +1,77 @@
+# Autumn Wiki Example
+
+A small wiki showing how Autumn's mutation hooks and generated repositories fit
+together when you need lifecycle logic, revision history, and a JSON API
+without hand-writing the CRUD boilerplate twice.
+
+## What it demonstrates
+
+- `#[model]` for `Page` and `Revision`
+- `#[repository(Page, hooks = PageHooks, api = "/api/v1/pages")]`
+- Mutation hooks for slug generation and revision auditing
+- Maud templates for a server-rendered editing flow
+- Embedded migrations on startup
+- Framework health and actuator endpoints
+
+## Quick start
+
+From the workspace root:
+
+```bash
+# 1. Download Tailwind CSS
+cargo run -p autumn-cli -- setup
+
+# 2. Start Postgres
+docker compose -f examples/wiki/docker-compose.yml up -d
+
+# 3. Run the app
+cargo run -p wiki
+```
+
+Open <http://localhost:3000>.
+
+## Hook behavior
+
+`PageHooks` keeps the interesting invariants in one place:
+
+- `before_create` slugifies the title and fills in a default `"draft"` status
+- `before_update` re-slugifies when the title changes
+- `after_create` and `after_update` append a revision row in the same transaction
+
+That means the UI routes and the generated REST API both get the same lifecycle
+behavior automatically.
+
+## Routes
+
+### HTML
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/` | List all pages |
+| GET | `/new` | New page form |
+| POST | `/pages` | Create a page |
+| GET | `/pages/{slug}` | View a page |
+| GET | `/pages/{slug}/edit` | Edit form |
+| POST | `/pages/{slug}` | Update a page |
+| GET | `/pages/{slug}/history` | Full revision history |
+
+### JSON API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/pages` | List pages |
+| GET | `/api/v1/pages/{id}` | Fetch one page |
+| POST | `/api/v1/pages` | Create a page |
+| PUT | `/api/v1/pages/{id}` | Update a page |
+| DELETE | `/api/v1/pages/{id}` | Delete a page |
+
+### Framework
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Health probe |
+| GET | `/actuator/health` | Detailed health view |
+| GET | `/actuator/info` | Build and runtime metadata |
+| GET | `/actuator/metrics` | Request and pool metrics |
+| GET | `/static/js/htmx.min.js` | Bundled htmx |
+| GET | `/static/css/autumn.css` | Compiled Tailwind output |


### PR DESCRIPTION
## Summary
- refresh the root README and guide/tutorial docs to describe current `trunk` instead of stopping at `v0.1.0`
- update example documentation for blog, bookmarks, and todo-app, and add a new wiki README
- fix stale bookmarks example commentary and align the docs with actuator, profiles, CLI workflows, and hybrid rendering

## Verification
- `git diff --check`
- stale-reference sweep with `rg` against the updated docs/examples
- `cargo tree -i openssl-sys -p bookmarks`
- `cargo check -p bookmarks -j 1` *(fails locally because `pq-sys -> pq-src -> openssl-sys` cannot find an OpenSSL installation on this Windows machine)*