### PR TITLE
🎻 Bard: Fix broken intra-doc links and redundant targets

### DIFF
--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -30,7 +30,7 @@ use proc_macro::TokenStream;
 /// Annotate an async function as a GET route handler.
 ///
 /// Generates a companion `__autumn_route_info_{name}()` function that
-/// returns an [`autumn_web::route::Route`] pairing the path with an Axum
+/// returns a `Route` pairing the path with an Axum
 /// handler. In debug builds, `#[axum::debug_handler]` is automatically
 /// applied for improved error messages. This has zero cost in release
 /// builds.
@@ -53,7 +53,7 @@ pub fn get(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Annotate an async function as a POST route handler.
 ///
 /// Generates a companion `__autumn_route_info_{name}()` function that
-/// returns an [`autumn_web::route::Route`] pairing the path with an Axum
+/// returns a `Route` pairing the path with an Axum
 /// handler. In debug builds, `#[axum::debug_handler]` is automatically
 /// applied for improved error messages. This has zero cost in release
 /// builds.
@@ -76,7 +76,7 @@ pub fn post(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Annotate an async function as a PUT route handler.
 ///
 /// Generates a companion `__autumn_route_info_{name}()` function that
-/// returns an [`autumn_web::route::Route`] pairing the path with an Axum
+/// returns a `Route` pairing the path with an Axum
 /// handler. In debug builds, `#[axum::debug_handler]` is automatically
 /// applied for improved error messages. This has zero cost in release
 /// builds.
@@ -99,7 +99,7 @@ pub fn put(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Annotate an async function as a DELETE route handler.
 ///
 /// Generates a companion `__autumn_route_info_{name}()` function that
-/// returns an [`autumn_web::route::Route`] pairing the path with an Axum
+/// returns a `Route` pairing the path with an Axum
 /// handler. In debug builds, `#[axum::debug_handler]` is automatically
 /// applied for improved error messages. This has zero cost in release
 /// builds.

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -43,8 +43,8 @@
 //! ## The `Auth<T>` extractor
 //!
 //! [`Auth<T>`] extracts the authenticated user from request extensions.
-//! It is typically populated by a custom middleware or by calling
-//! [`Auth::set`] in a login handler. Returns `401 Unauthorized` if no
+//! It is typically populated by a custom middleware which might call
+//! `request.extensions_mut().insert(user)` in a handler. Returns `401 Unauthorized` if no
 //! user is present.
 //!
 //! ## Route protection with `RequireAuth`
@@ -223,7 +223,7 @@ impl std::fmt::Display for AuthRejection {
 
 // ── RequireAuth middleware ───────────────────────────────────────
 
-/// Tower [`Layer`] that rejects unauthenticated requests with `401`.
+/// Tower [`tower::Layer`] that rejects unauthenticated requests with `401`.
 ///
 /// Checks for a specific key in the session to determine if the request
 /// is authenticated. If the key is missing, the request is rejected before
@@ -266,7 +266,7 @@ impl<S> tower::Layer<S> for RequireAuth {
     }
 }
 
-/// Tower [`Service`] produced by [`RequireAuth`].
+/// Tower [`tower::Service`] produced by [`RequireAuth`].
 #[derive(Clone)]
 pub struct RequireAuthService<S> {
     inner: S,

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -247,7 +247,7 @@ pub use autumn_macros::model;
 
 /// Derive a repository with CRUD operations and derived queries.
 ///
-/// See [`repository`](autumn_macros::repository) for details.
+/// See [`repository`] for details.
 #[cfg(feature = "db")]
 pub use autumn_macros::repository;
 

--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -15,7 +15,7 @@
 //!
 //! # Configuration
 //!
-//! See [`CsrfConfig`](super::config::CsrfConfig) for available settings.
+//! See [`CsrfConfig`] for available settings.
 //!
 //! # Examples
 //!

--- a/autumn/src/security/headers.rs
+++ b/autumn/src/security/headers.rs
@@ -1,7 +1,7 @@
 //! Security response headers middleware.
 //!
 //! Applies OWASP-recommended security headers to every HTTP response.
-//! The headers are configured via [`HeadersConfig`](super::config::HeadersConfig)
+//! The headers are configured via [`HeadersConfig`]
 //! in `autumn.toml` under `[security.headers]`.
 //!
 //! # Headers applied


### PR DESCRIPTION
📖 Chapter: `autumn` and `autumn-macros` core modules (auth, security, lib)
🔦 Insight: Cleaned up 10 broken intra-doc warnings generated by `cargo doc`. Improved references by directly pointing to `tower::Layer` and `tower::Service` where needed, and removed repetitive explicit link targets. Corrected `Auth::set` to the proper Axum extraction procedure `request.extensions_mut().insert(user)`. Fixed an unreachable reference to `Route` in the macros crate.
🧪 Example: "Added clean links ensuring zero warnings in `cargo doc --no-deps`."
🖼️ Preview: (Verified locally via `cargo doc --no-deps`)

---
*PR created automatically by Jules for task [16229236859335898258](https://jules.google.com/task/16229236859335898258) started by @madmax983*