### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/middleware/metrics.rs
+++ b/autumn/src/middleware/metrics.rs
@@ -397,7 +397,24 @@ mod tests {
     fn percentiles_computed_correctly() {
         let pcts = compute_percentiles(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         assert_eq!(pcts.p50, 6); // sorted[10*50/100] = sorted[5] = 6
+        assert_eq!(pcts.p95, 10); // sorted[min(9, 10*95/100)] = sorted[9] = 10
         assert_eq!(pcts.p99, 10); // sorted[min(9, 10*99/100)] = sorted[9] = 10
+    }
+
+    #[test]
+    fn percentiles_empty_slice() {
+        let pcts = compute_percentiles(&[]);
+        assert_eq!(pcts.p50, 0);
+        assert_eq!(pcts.p95, 0);
+        assert_eq!(pcts.p99, 0);
+    }
+
+    #[test]
+    fn percentiles_single_element() {
+        let pcts = compute_percentiles(&[42]);
+        assert_eq!(pcts.p50, 42);
+        assert_eq!(pcts.p95, 42);
+        assert_eq!(pcts.p99, 42);
     }
 
     #[test]

--- a/autumn/src/task.rs
+++ b/autumn/src/task.rs
@@ -123,4 +123,21 @@ mod tests {
     fn empty() {
         assert!(parse_duration("").is_none());
     }
+
+    #[test]
+    fn invalid_char_returns_none() {
+        assert!(parse_duration("5m !").is_none());
+        assert!(parse_duration("-5m").is_none());
+    }
+
+    #[test]
+    fn zero_duration_returns_none() {
+        assert!(parse_duration("0s").is_none());
+        assert!(parse_duration("0h 0m").is_none());
+    }
+
+    #[test]
+    fn multiple_spaces() {
+        assert_eq!(parse_duration("1h   30m"), Some(Duration::from_secs(5400)));
+    }
 }


### PR DESCRIPTION
🎯 Target: `autumn/src/middleware/metrics.rs` (`compute_percentiles`) and `autumn/src/task.rs` (`parse_duration`).
💣 Risk: 
- `compute_percentiles`: Potential panic or off-by-one errors when calculating indices for p50, p95, and p99 on empty or single-element slices. 
- `parse_duration`: Unhandled edge cases when parsing strings with invalid characters, negative signs, multiple spaces, or 0 values, potentially leading to logic errors.
🧪 Strategy: Added explicit unit tests for these boundary conditions (empty slice, single element slice, invalid character, 0 duration, multi-space separator).
🔬 Verification: Run `cargo test -p autumn-web --lib metrics` and `cargo test -p autumn-web --lib task`.

---
*PR created automatically by Jules for task [17614077908122442808](https://jules.google.com/task/17614077908122442808) started by @madmax983*