### PR TITLE
🔒 Warden: [security fix] Resolve RUSTSEC-2025-0111 via testcontainers upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ futures = "0.3"
 indexmap = "2"
 moka = { version = "0.12", features = ["sync"] }
 chrono = { version = "0.4", features = ["serde"] }
-testcontainers = "0.23"
-testcontainers-modules = { version = "0.11", features = ["postgres"] }
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["postgres"] }
 
 # Proc macro
 syn = { version = "2", features = ["full"] }

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -599,7 +599,7 @@ impl TestDb {
         // Two-phase init: OnceLock for the OnceCell, OnceCell for the async init.
         static CELL: OnceLock<OnceCell<TestDb>> = OnceLock::new();
         let once = CELL.get_or_init(OnceCell::new);
-        once.get_or_init(|| Self::new()).await
+        once.get_or_init(Self::new).await
     }
 
     /// Get the database connection pool.


### PR DESCRIPTION
🎯 **What**: 
Fixed the RUSTSEC-2025-0111 vulnerability in the `tokio-tar` dependency. It parses PAX extended headers incorrectly, allowing file smuggling.

⚠️ **Risk**: 
This is a critical security vulnerability that allows arbitrary files to be written or overwritten.

🛡️ **Solution**: 
Upgraded `testcontainers` to version `0.27` and `testcontainers-modules` to `0.15` which resolves the vulnerable transitive dependency on `tokio-tar`. Also addressed a newly introduced clippy redundant closure warning in `autumn/src/test.rs`.

---
*PR created automatically by Jules for task [4833960819988463647](https://jules.google.com/task/4833960819988463647) started by @madmax983*