### PR TITLE
⚡ Bolt: Replace Vec with VecDeque for sliding history windows

### DIFF
--- a/autumn-cli/src/monitor.rs
+++ b/autumn-cli/src/monitor.rs
@@ -156,7 +156,6 @@ struct DashboardState {
     metrics: MetricsResponse,
     tasks: TasksResponse,
 
-
     /// OPTIMIZATION: Uses VecDeque instead of Vec to avoid O(N) shifts on pop_front().
     throughput_history: VecDeque<u64>,
     /// Rolling p50 latency samples.

--- a/autumn-cli/src/monitor.rs
+++ b/autumn-cli/src/monitor.rs
@@ -4,7 +4,7 @@
 //! real-time metrics, health status, and task information in a rich
 //! terminal UI.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io;
 use std::time::{Duration, Instant};
 
@@ -155,12 +155,14 @@ struct DashboardState {
     health: HealthResponse,
     metrics: MetricsResponse,
     tasks: TasksResponse,
-    /// Rolling throughput samples (requests in last interval).
-    throughput_history: Vec<u64>,
+
+
+    /// OPTIMIZATION: Uses VecDeque instead of Vec to avoid O(N) shifts on pop_front().
+    throughput_history: VecDeque<u64>,
     /// Rolling p50 latency samples.
-    latency_p50_history: Vec<u64>,
+    latency_p50_history: VecDeque<u64>,
     /// Rolling p99 latency samples.
-    latency_p99_history: Vec<u64>,
+    latency_p99_history: VecDeque<u64>,
     /// Previous total requests for computing delta.
     prev_requests_total: u64,
     /// Whether the app is reachable.
@@ -184,9 +186,9 @@ impl DashboardState {
             health: HealthResponse::default(),
             metrics: MetricsResponse::default(),
             tasks: TasksResponse::default(),
-            throughput_history: Vec::with_capacity(SPARKLINE_DEPTH),
-            latency_p50_history: Vec::with_capacity(SPARKLINE_DEPTH),
-            latency_p99_history: Vec::with_capacity(SPARKLINE_DEPTH),
+            throughput_history: VecDeque::with_capacity(SPARKLINE_DEPTH),
+            latency_p50_history: VecDeque::with_capacity(SPARKLINE_DEPTH),
+            latency_p99_history: VecDeque::with_capacity(SPARKLINE_DEPTH),
             prev_requests_total: 0,
             connected: false,
             last_error: None,
@@ -246,22 +248,26 @@ impl DashboardState {
                     .requests_total
                     .saturating_sub(self.prev_requests_total);
                 if self.prev_requests_total > 0 || !self.throughput_history.is_empty() {
-                    self.throughput_history.push(delta);
+                    self.throughput_history.push_back(delta);
                     if self.throughput_history.len() > SPARKLINE_DEPTH {
-                        self.throughput_history.remove(0);
+                        self.throughput_history.pop_front();
                     }
                 }
                 self.prev_requests_total = m.http.requests_total;
 
                 // Track latency history
-                self.latency_p50_history.push(m.http.latency_ms.p50);
+                self.latency_p50_history.push_back(m.http.latency_ms.p50);
                 if self.latency_p50_history.len() > SPARKLINE_DEPTH {
-                    self.latency_p50_history.remove(0);
+                    self.latency_p50_history.pop_front();
                 }
-                self.latency_p99_history.push(m.http.latency_ms.p99);
+                self.latency_p99_history.push_back(m.http.latency_ms.p99);
                 if self.latency_p99_history.len() > SPARKLINE_DEPTH {
-                    self.latency_p99_history.remove(0);
+                    self.latency_p99_history.pop_front();
                 }
+
+                self.throughput_history.make_contiguous();
+                self.latency_p50_history.make_contiguous();
+                self.latency_p99_history.make_contiguous();
 
                 self.metrics = m;
             }
@@ -517,7 +523,7 @@ fn draw_stats_cards(frame: &mut ratatui::Frame, area: Rect, state: &DashboardSta
     frame.render_widget(total, chunks[0]);
 
     // Card 2: Throughput (req/s)
-    let rps = state.throughput_history.last().copied().unwrap_or(0);
+    let rps = state.throughput_history.back().copied().unwrap_or(0);
     let rps_block = make_card_block("Throughput");
     let rps_widget = Paragraph::new(Text::from(vec![
         Line::raw(""),
@@ -615,7 +621,7 @@ fn draw_sparklines(frame: &mut ratatui::Frame, area: Rect, state: &DashboardStat
 
     let throughput_sparkline = Sparkline::default()
         .block(throughput_block)
-        .data(&state.throughput_history)
+        .data(state.throughput_history.as_slices().0)
         .style(Style::default().fg(Color::Green));
     frame.render_widget(throughput_sparkline, chunks[0]);
 
@@ -632,7 +638,7 @@ fn draw_sparklines(frame: &mut ratatui::Frame, area: Rect, state: &DashboardStat
 
     let latency_sparkline = Sparkline::default()
         .block(latency_block)
-        .data(&state.latency_p99_history)
+        .data(state.latency_p99_history.as_slices().0)
         .style(Style::default().fg(Color::Rgb(255, 150, 50)));
     frame.render_widget(latency_sparkline, chunks[1]);
 }
@@ -1114,9 +1120,9 @@ mod tests {
                 idle_connections: 7,
             }),
         };
-        state.throughput_history = vec![10, 20, 30, 25, 15, 42];
-        state.latency_p50_history = vec![3, 4, 5, 3, 4];
-        state.latency_p99_history = vec![50, 80, 100, 90, 70];
+        state.throughput_history = VecDeque::from(vec![10, 20, 30, 25, 15, 42]);
+        state.latency_p50_history = VecDeque::from(vec![3, 4, 5, 3, 4]);
+        state.latency_p99_history = VecDeque::from(vec![50, 80, 100, 90, 70]);
         state
     }
 
@@ -1481,7 +1487,7 @@ mod tests {
     #[test]
     fn render_zero_throughput() {
         let mut state = test_state();
-        state.throughput_history = vec![0, 0, 0];
+        state.throughput_history = VecDeque::from(vec![0, 0, 0]);
         render_frame(&state, 120, 40);
     }
 


### PR DESCRIPTION
💡 What: Switched `Vec` to `VecDeque` for rolling history metrics in `autumn-cli/src/monitor.rs`.
🎯 Why: The previous implementation used `.remove(0)` on a `Vec` when pushing new metrics into full windows. This is an O(N) operation that shifts all remaining elements in the array backwards on every poll iteration. A `VecDeque` provides O(1) `pop_front()` behavior for this exact ring buffer / sliding window use case.
📊 Impact: Eliminates O(N) memory shifts per sparkline array per poll interval, achieving constant time O(1) removals.
🔬 Measurement: Verified correctness by running `cargo check`, `cargo fmt`, `cargo clippy`, and `cargo test --workspace` which all pass. Performance impact can be analytically proven as `Vec::remove(0)` is O(N) and `VecDeque::pop_front` is O(1).

---
*PR created automatically by Jules for task [7079338813623532394](https://jules.google.com/task/7079338813623532394) started by @madmax983*