### PR TITLE
🔒 Warden: Audit and document unsafe blocks with safety proofs

### DIFF
--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -173,6 +173,9 @@ fn stop_server(child: &mut Option<Child>) {
         {
             #[allow(clippy::cast_possible_wrap)]
             let pid = proc.id() as libc::pid_t;
+            // SAFETY: `pid` is retrieved directly from `proc.id()`, representing a valid child
+            // process we own. `libc::SIGTERM` is a standard, valid signal. Sending it to our
+            // own child process is safe.
             unsafe {
                 libc::kill(pid, libc::SIGTERM);
             }

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -599,7 +599,7 @@ impl TestDb {
         // Two-phase init: OnceLock for the OnceCell, OnceCell for the async init.
         static CELL: OnceLock<OnceCell<TestDb>> = OnceLock::new();
         let once = CELL.get_or_init(OnceCell::new);
-        once.get_or_init(|| Self::new()).await
+        once.get_or_init(Self::new).await
     }
 
     /// Get the database connection pool.


### PR DESCRIPTION
🦠 Threat: Undocumented `unsafe` code presents an ongoing maintainability risk, making it harder to reason about code safety correctly.
🛡️ Defense: Audited and formally documented existing `unsafe` usage via strict `// SAFETY:` proofs, enabling safer validation for future modifications. Fixed `clippy::redundant_closure` warnings to ensure clean, warning-free compilations.
💥 Severity: Low - preventative hygiene and maintainability enhancement.
🧪 Verification: Ran `cargo clippy`, `cargo test`, `cargo fmt --all`, and `cargo audit` locally to ensure strict compliance.

---
*PR created automatically by Jules for task [16298494127222182935](https://jules.google.com/task/16298494127222182935) started by @madmax983*