### PR TITLE
🗺️ Atlas: [fix clippy warnings]

### DIFF
--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -333,6 +333,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::redundant_clone)]
     fn channels_is_clone() {
         let channels = Channels::new(16);
         let _cloned = channels.clone();

--- a/autumn/tests/websocket.rs
+++ b/autumn/tests/websocket.rs
@@ -36,6 +36,7 @@ fn test_state() -> AppState {
 // ── Test handlers ────────────────────────────────────────────────
 
 #[ws("/echo")]
+#[allow(clippy::unused_async)]
 async fn echo() -> impl WsHandler {
     |mut socket: WebSocket| async move {
         while let Some(Ok(msg)) = socket.recv().await {
@@ -47,6 +48,7 @@ async fn echo() -> impl WsHandler {
 }
 
 #[ws("/with-state")]
+#[allow(clippy::unused_async)]
 async fn with_state(state: AppState) -> impl WsHandler {
     let _channels = state.channels().clone();
     |mut socket: WebSocket| async move {
@@ -55,6 +57,7 @@ async fn with_state(state: AppState) -> impl WsHandler {
 }
 
 #[ws("/with-shutdown")]
+#[allow(clippy::unused_async)]
 async fn with_shutdown() -> impl WsHandler {
     autumn_web::ws::WithShutdown(
         |mut socket: WebSocket, shutdown: CancellationToken| async move {
@@ -68,7 +71,7 @@ async fn with_shutdown() -> impl WsHandler {
                             _ => break,
                         }
                     }
-                    _ = shutdown.cancelled() => {
+                    () = shutdown.cancelled() => {
                         socket.send(Message::Close(None)).await.ok();
                         break;
                     }


### PR DESCRIPTION
🕸️ Tangle: The codebase had several Clippy warnings, including redundant clone in tests and unused async/ignored unit patterns in WebSocket logic tests.

📐 Blueprint:
- Fixed `redundant_clone` by maintaining the clone call inside `channels_is_clone` test while adding `#[allow(clippy::redundant_clone)]` to preserve structural testing of the `Channels` type while suppressing the warning.
- Added `#[allow(clippy::unused_async)]` to test handlers in `autumn/tests/websocket.rs` since they must conform to `impl WsHandler` via `async fn` signature but don't strictly use `.await` at the top block level.
- Used explicit `()` pattern in `tokio::select!` instead of `_` to fix `ignored_unit_patterns` warnings.

🧱 Stability: Enforced cleaner builds by addressing all static analysis warnings without breaking logic.
🔬 Verification: Ran `cargo clippy` and `cargo test` which now report no warnings and all tests pass.

---
*PR created automatically by Jules for task [10441391760807525259](https://jules.google.com/task/10441391760807525259) started by @madmax983*