### PR TITLE
👺 Havoc: Fix broadcast channel panic on 0 capacity

### DIFF
--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -166,7 +166,10 @@ impl Channels {
     pub fn new(capacity: usize) -> Self {
         Self {
             inner: Arc::new(ChannelsInner {
-                capacity,
+                // tokio::sync::broadcast::channel panics if capacity is 0 or > usize::MAX >> 1
+                // We clamp it safely, but also must avoid memory exhaustion attacks where an
+                // attacker sends a giant number. So we clamp to a reasonable max, like 1,000,000.
+                capacity: capacity.clamp(1, 1_000_000),
                 registry: Mutex::new(HashMap::new()),
             }),
         }
@@ -333,6 +336,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::redundant_clone)]
     fn channels_is_clone() {
         let channels = Channels::new(16);
         let _cloned = channels.clone();
@@ -351,5 +355,20 @@ mod tests {
         // Both channels have 0 receivers, but gc only checks receiver_count
         // "alive" has no receivers either, so both get cleaned
         assert_eq!(channels.channel_count(), 0);
+    }
+}
+
+#[cfg(test)]
+mod havoc_proptest {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10))]
+        #[test]
+        fn havoc_channels_capacity_panic(capacity in proptest::num::usize::ANY) {
+            let channels = Channels::new(capacity);
+            let _tx = channels.sender("havoc");
+        }
     }
 }

--- a/autumn/tests/websocket.rs
+++ b/autumn/tests/websocket.rs
@@ -35,6 +35,7 @@ fn test_state() -> AppState {
 
 // ── Test handlers ────────────────────────────────────────────────
 
+#[allow(clippy::unused_async)]
 #[ws("/echo")]
 async fn echo() -> impl WsHandler {
     |mut socket: WebSocket| async move {
@@ -46,14 +47,16 @@ async fn echo() -> impl WsHandler {
     }
 }
 
+#[allow(clippy::unused_async)]
 #[ws("/with-state")]
 async fn with_state(state: AppState) -> impl WsHandler {
-    let _channels = state.channels().clone();
+    let _channels = state.channels();
     |mut socket: WebSocket| async move {
         socket.send(Message::Text("hello".into())).await.ok();
     }
 }
 
+#[allow(clippy::unused_async)]
 #[ws("/with-shutdown")]
 async fn with_shutdown() -> impl WsHandler {
     autumn_web::ws::WithShutdown(
@@ -68,7 +71,7 @@ async fn with_shutdown() -> impl WsHandler {
                             _ => break,
                         }
                     }
-                    _ = shutdown.cancelled() => {
+                    () = shutdown.cancelled() => {
                         socket.send(Message::Close(None)).await.ok();
                         break;
                     }


### PR DESCRIPTION
🧨 **The Trigger**: Initializing `Channels` with a capacity of `0` (or greater than `usize::MAX >> 1`), causing `tokio::sync::broadcast::channel` to panic during `sender()` or `subscribe()` creation.
📉 **The Stack Trace**:
```
thread 'havoc_proptest::havoc_channels_capacity_panic' panicked at 'capacity cannot be zero'
```
🧪 **Reproduction**: Run `cargo test -p autumn-web --features ws havoc_channels_capacity_panic` on an unpatched build.
😈 **Comment**: You assumed users would always provide a sensible buffer size. You were wrong.

---
*PR created automatically by Jules for task [16762825821923076231](https://jules.google.com/task/16762825821923076231) started by @madmax983*