### PR TITLE
⚒️ Forge: Replace unwrap with if-let in ExceptionFilter

### DIFF
--- a/autumn/src/middleware/exception_filter.rs
+++ b/autumn/src/middleware/exception_filter.rs
@@ -188,15 +188,8 @@ where
         let this = self.project();
         match this.inner.poll(cx) {
             Poll::Ready(Ok(response)) => {
-                // Check if this response came from AutumnError
-                let has_error_info = response.extensions().get::<AutumnErrorInfo>().is_some();
-                if has_error_info {
-                    // Clone the info out before consuming the response
-                    let error_info = response
-                        .extensions()
-                        .get::<AutumnErrorInfo>()
-                        .cloned()
-                        .unwrap();
+                // Check if this response came from AutumnError and clone the info out
+                if let Some(error_info) = response.extensions().get::<AutumnErrorInfo>().cloned() {
                     let mut response = response;
                     let filters = this.filters;
                     for filter in filters.iter() {


### PR DESCRIPTION
🚮 Smell: A redundant `response.extensions().get::<AutumnErrorInfo>().is_some()` check followed immediately by a `.unwrap()` in `AutumnErrorInfo` retrieval inside `ExceptionFilterFuture::poll`.
✨ Solution: Extracted the logic into an idiomatic `if let Some(error_info) = response.extensions().get::<AutumnErrorInfo>().cloned()` pattern to eliminate the `unwrap`.
🧼 Benefit: Code is cleaner, safer from future modifications introducing panics, and adheres to standard Rust idioms.
🛡️ Verification: Tests passed (`cargo test -p autumn-web`). No logic changed.

---
*PR created automatically by Jules for task [4140328322711420767](https://jules.google.com/task/4140328322711420767) started by @madmax983*