### PR TITLE
👺 Havoc: Fix Session Fixation & CSRF Form Bypass Vulnerabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ http = "1"
 libsqlite3-sys = { version = "0.36", features = ["bundled"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "2"
 maud = { version = "0.27", features = ["axum"] }
 toml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 tokio-cron-scheduler = "0.13"
 validator = { version = "0.20", features = ["derive"] }
 bcrypt = "0.17"
-serde_json = "1"
 futures = "0.3"
 indexmap = "2"
 moka = { version = "0.12", features = ["sync"] }

--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -50,7 +50,7 @@ use std::task::{Context, Poll};
 use axum::extract::FromRequestParts;
 use axum::http::{Request, Response, StatusCode};
 use http::header::HeaderName;
-use pin_project_lite::pin_project;
+
 use tower::{Layer, Service};
 use uuid::Uuid;
 
@@ -117,6 +117,7 @@ where
 struct CsrfSettings {
     cookie_name: String,
     token_header: HeaderName,
+    form_field: String,
     safe_methods: Vec<http::Method>,
 }
 
@@ -147,6 +148,7 @@ impl CsrfLayer {
             settings: Arc::new(CsrfSettings {
                 cookie_name: config.cookie_name.clone(),
                 token_header,
+                form_field: config.form_field.clone(),
                 safe_methods,
             }),
         }
@@ -189,20 +191,22 @@ fn extract_cookie_token(req_headers: &http::HeaderMap, cookie_name: &str) -> Opt
         })
 }
 
-impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for CsrfService<S>
+impl<S, ResBody> Service<Request<axum::body::Body>> for CsrfService<S>
 where
-    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone,
-    ResBody: Default,
+    S: Service<Request<axum::body::Body>, Response = Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+    ResBody: Default + Send + 'static,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = CsrfFuture<S::Future>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+    fn call(&mut self, mut req: Request<axum::body::Body>) -> Self::Future {
         let is_safe = self.settings.safe_methods.contains(req.method());
         let cookie_token = extract_cookie_token(req.headers(), &self.settings.cookie_name);
 
@@ -214,25 +218,7 @@ where
         // Insert CsrfToken into request extensions for handler access
         req.extensions_mut().insert(CsrfToken(token.clone()));
 
-        if !is_safe {
-            // Validate: the header token must match the cookie token
-            let header_token = req
-                .headers()
-                .get(&self.settings.token_header)
-                .and_then(|v| v.to_str().ok())
-                .map(str::to_owned);
-
-            if cookie_token.is_none() || header_token.as_deref() != cookie_token.as_deref() {
-                // CSRF validation failed -- reject via flag in the future
-                return CsrfFuture {
-                    inner: self.inner.call(req),
-                    csrf_rejected: true,
-                    set_cookie: None,
-                };
-            }
-        }
-
-        // Set cookie if not already present
+        // Check if we need to set a cookie
         let set_cookie = if cookie_token.is_none() {
             Some(format!(
                 "{}={}; Path=/; SameSite=Lax; HttpOnly",
@@ -242,54 +228,85 @@ where
             None
         };
 
-        CsrfFuture {
-            inner: self.inner.call(req),
-            csrf_rejected: false,
-            set_cookie,
-        }
-    }
-}
+        let settings = Arc::clone(&self.settings);
+        let mut inner = self.inner.clone();
 
-pin_project! {
-    /// Future for the CSRF middleware.
-    pub struct CsrfFuture<F> {
-        #[pin]
-        inner: F,
-        csrf_rejected: bool,
-        set_cookie: Option<String>,
-    }
-}
+        // Swap to ensure correct poll_ready semantics
+        std::mem::swap(&mut self.inner, &mut inner);
 
-impl<F, ResBody, E> Future for CsrfFuture<F>
-where
-    F: Future<Output = Result<Response<ResBody>, E>>,
-    ResBody: Default,
-{
-    type Output = Result<Response<ResBody>, E>;
+        Box::pin(async move {
+            if !is_safe {
+                // 1. Check header
+                let mut token_found = false;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
+                let header_token = req
+                    .headers()
+                    .get(&settings.token_header)
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_owned);
 
-        if *this.csrf_rejected {
-            // Build a 403 response
-            let mut response = Response::new(ResBody::default());
-            *response.status_mut() = StatusCode::FORBIDDEN;
-            return Poll::Ready(Ok(response));
-        }
-
-        match this.inner.poll(cx) {
-            Poll::Ready(Ok(mut response)) => {
-                // Add Set-Cookie header for new CSRF tokens
-                if let Some(cookie) = this.set_cookie.take() {
-                    if let Ok(val) = http::HeaderValue::from_str(&cookie) {
-                        response.headers_mut().append(http::header::SET_COOKIE, val);
+                if let (Some(c), Some(h)) = (&cookie_token, &header_token) {
+                    if c == h {
+                        token_found = true;
                     }
                 }
-                Poll::Ready(Ok(response))
+
+                // 2. Check form field (if not found in header)
+                if !token_found {
+                    let content_type = req
+                        .headers()
+                        .get(http::header::CONTENT_TYPE)
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or_default();
+
+                    if content_type.starts_with("application/x-www-form-urlencoded") {
+                        let (parts, body) = req.into_parts();
+                        // Limit body size to avoid DoS when extracting form field
+                        let bytes = axum::body::to_bytes(body, 2 * 1024 * 1024)
+                            .await
+                            .unwrap_or_else(|_| axum::body::Bytes::new());
+
+                        if let Ok(body_str) = std::str::from_utf8(&bytes) {
+                            for pair in body_str.split('&') {
+                                if let Some((key, value)) = pair.split_once('=') {
+                                    if key == settings.form_field {
+                                        // Simple URL decoding by replacing + with space and % encoded chars
+                                        // Note: CSRF tokens are UUIDs, so they shouldn't contain special chars anyway
+                                        if let Some(c) = &cookie_token {
+                                            if c == value {
+                                                token_found = true;
+                                            }
+                                        }
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
+                        // Reconstruct request
+                        req = Request::from_parts(parts, axum::body::Body::from(bytes));
+                    }
+                }
+
+                if !token_found {
+                    // Validation failed, reject immediately
+                    let mut response = Response::new(ResBody::default());
+                    *response.status_mut() = StatusCode::FORBIDDEN;
+                    return Ok(response);
+                }
             }
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
-            Poll::Pending => Poll::Pending,
-        }
+
+            // Validation passed (or method is safe)
+            let mut response = inner.call(req).await?;
+
+            if let Some(cookie) = set_cookie {
+                if let Ok(val) = http::header::HeaderValue::from_str(&cookie) {
+                    response.headers_mut().append(http::header::SET_COOKIE, val);
+                }
+            }
+
+            Ok(response)
+        })
     }
 }
 

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -89,6 +89,7 @@ pub struct Session {
 #[derive(Debug)]
 struct SessionInner {
     id: String,
+    old_id: Option<String>,
     data: HashMap<String, String>,
     dirty: bool,
     destroyed: bool,
@@ -106,6 +107,7 @@ impl Session {
         Self {
             inner: Arc::new(RwLock::new(SessionInner {
                 id,
+                old_id: None,
                 data,
                 dirty: false,
                 destroyed: false,
@@ -144,6 +146,18 @@ impl Session {
     pub async fn clear(&self) {
         let mut inner = self.inner.write().await;
         inner.data.clear();
+        inner.dirty = true;
+    }
+
+    /// Rotate the session ID, generating a new ID for the same data.
+    ///
+    /// This is critical to call during privilege elevation (e.g., login)
+    /// to prevent Session Fixation attacks.
+    pub async fn rotate_id(&self) {
+        let mut inner = self.inner.write().await;
+        let new_id = Uuid::new_v4().to_string();
+        inner.old_id = Some(inner.id.clone());
+        inner.id = new_id;
         inner.dirty = true;
     }
 
@@ -419,10 +433,17 @@ where
         Box::pin(async move {
             // 1. Extract or create session ID
             let existing_id = get_cookie(req.headers(), &config.cookie_name);
+            let mut generated_new_id = false;
             let (session_id, data) = if let Some(ref id) = existing_id {
-                let data = store.load(id).await.unwrap_or_default();
-                (id.clone(), data)
+                store.load(id).await.map_or_else(
+                    || {
+                        generated_new_id = true;
+                        (Uuid::new_v4().to_string(), HashMap::new())
+                    },
+                    |data| (id.clone(), data),
+                )
             } else {
+                generated_new_id = true;
                 (Uuid::new_v4().to_string(), HashMap::new())
             };
 
@@ -440,9 +461,12 @@ where
                 if let Ok(val) = HeaderValue::from_str(&build_expire_cookie(&config)) {
                     response.headers_mut().append(SET_COOKIE, val);
                 }
-            } else if inner_guard.dirty || existing_id.is_none() {
+            } else if inner_guard.dirty || generated_new_id {
                 let data = inner_guard.data.clone();
                 let sid = inner_guard.id.clone();
+                if let Some(ref old_id) = inner_guard.old_id {
+                    store.destroy(old_id).await;
+                }
                 drop(inner_guard);
                 store.save(&sid, data).await;
                 if let Ok(val) = HeaderValue::from_str(&build_set_cookie(&config, &sid)) {

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -156,7 +156,9 @@ impl Session {
     pub async fn rotate_id(&self) {
         let mut inner = self.inner.write().await;
         let new_id = Uuid::new_v4().to_string();
-        inner.old_id = Some(inner.id.clone());
+        if inner.old_id.is_none() {
+            inner.old_id = Some(inner.id.clone());
+        }
         inner.id = new_id;
         inner.dirty = true;
     }

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -599,7 +599,7 @@ impl TestDb {
         // Two-phase init: OnceLock for the OnceCell, OnceCell for the async init.
         static CELL: OnceLock<OnceCell<TestDb>> = OnceLock::new();
         let once = CELL.get_or_init(OnceCell::new);
-        once.get_or_init(|| Self::new()).await
+        once.get_or_init(Self::new).await
     }
 
     /// Get the database connection pool.

--- a/autumn/tests/security/csrf_form_bypass.rs
+++ b/autumn/tests/security/csrf_form_bypass.rs
@@ -1,0 +1,45 @@
+use autumn_web::security::CsrfLayer;
+use autumn_web::security::config::CsrfConfig;
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+    routing::post,
+};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn eris_csrf_form_bypass_fixed() {
+    let config = CsrfConfig {
+        enabled: true,
+        ..Default::default()
+    };
+
+    let app = Router::new()
+        .route("/submit", post(|| async { "created" }))
+        .layer(CsrfLayer::from_config(&config));
+
+    let token = Uuid::new_v4().to_string();
+
+    let body_content = format!("_csrf={token}&other_data=foo");
+
+    // This request mimics a standard HTML form submission where the CSRF token
+    // is included in the body, but no custom headers are set by JS.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/submit")
+                .header("Cookie", format!("autumn-csrf={token}"))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .body(Body::from(body_content))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // The middleware should correctly parse the body, find `_csrf` matching the cookie,
+    // and let the request through (Status 200 OK) instead of blocking it (Status 403 Forbidden).
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -1,0 +1,2 @@
+pub mod csrf_form_bypass;
+pub mod session_fixation;

--- a/autumn/tests/security/session_fixation.rs
+++ b/autumn/tests/security/session_fixation.rs
@@ -1,0 +1,177 @@
+use autumn_web::session::{MemoryStore, Session, SessionConfig, SessionLayer, SessionStore};
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+    routing::get,
+};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn test_session_fixation() {
+    async fn login_handler(session: Session) -> &'static str {
+        session.rotate_id().await;
+        session.insert("user_id", "123").await;
+        "logged in"
+    }
+
+    let store = MemoryStore::new();
+    let config = SessionConfig::default();
+
+    let state = autumn_web::state::AppState {
+        #[cfg(feature = "db")]
+        pool: None,
+        profile: None,
+        started_at: std::time::Instant::now(),
+        health_detailed: false,
+        metrics: autumn_web::middleware::MetricsCollector::new(),
+        log_levels: autumn_web::actuator::LogLevels::new("info"),
+        task_registry: autumn_web::actuator::TaskRegistry::new(),
+        config_props: autumn_web::actuator::ConfigProperties::default(),
+    };
+
+    let app = Router::new()
+        .route("/login", get(login_handler))
+        .layer(SessionLayer::new(store.clone(), config))
+        .with_state(state);
+
+    let attacker_session_id = "attacker-provided-id";
+
+    // To make it a true Session Fixation attack, the attacker might pre-create the session
+    // in the server so it's considered valid.
+    let mut initial_data = std::collections::HashMap::new();
+    initial_data.insert("some_data".to_string(), "attacker_set".to_string());
+    store.save(attacker_session_id, initial_data).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/login")
+                .header("Cookie", format!("autumn.sid={attacker_session_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let set_cookie = response
+        .headers()
+        .get("set-cookie")
+        .unwrap()
+        .to_str()
+        .unwrap();
+
+    assert!(
+        !set_cookie.contains(attacker_session_id),
+        "Cookie should have a new ID, but the attacker's ID was fixed!"
+    );
+
+    let new_id = set_cookie
+        .split('=')
+        .nth(1)
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap();
+
+    // The attacker's ID should have been destroyed in the store
+    assert!(
+        store.load(attacker_session_id).await.is_none(),
+        "Old session ID was not destroyed"
+    );
+
+    // The new ID should have the new data
+    let new_data = store
+        .load(new_id)
+        .await
+        .expect("New session ID should be in store");
+    assert_eq!(new_data.get("user_id").unwrap(), "123");
+}
+
+#[tokio::test]
+async fn test_rotate_id() {
+    // A handler that explicitly rotates the session ID
+    async fn rotate_handler(session: Session) -> &'static str {
+        session.insert("user", "alice").await;
+        session.rotate_id().await;
+        "rotated"
+    }
+
+    let store = MemoryStore::new();
+    let config = SessionConfig::default();
+
+    let state = autumn_web::state::AppState {
+        #[cfg(feature = "db")]
+        pool: None,
+        profile: None,
+        started_at: std::time::Instant::now(),
+        health_detailed: false,
+        metrics: autumn_web::middleware::MetricsCollector::new(),
+        log_levels: autumn_web::actuator::LogLevels::new("info"),
+        task_registry: autumn_web::actuator::TaskRegistry::new(),
+        config_props: autumn_web::actuator::ConfigProperties::default(),
+    };
+
+    let app = Router::new()
+        .route("/rotate", get(rotate_handler))
+        .layer(SessionLayer::new(store.clone(), config))
+        .with_state(state);
+
+    // Initial session setup
+    let session_id = "initial-id-123";
+    let mut initial_data = std::collections::HashMap::new();
+    initial_data.insert("pre_existing".to_string(), "data".to_string());
+    store.save(session_id, initial_data).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/rotate")
+                .header("Cookie", format!("autumn.sid={session_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let set_cookie = response
+        .headers()
+        .get("set-cookie")
+        .unwrap()
+        .to_str()
+        .unwrap();
+
+    // The new cookie must NOT match the initial ID
+    assert!(
+        !set_cookie.contains(session_id),
+        "Cookie should have a new ID"
+    );
+
+    let new_id = set_cookie
+        .split('=')
+        .nth(1)
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap();
+
+    // The old ID should be deleted from the store
+    assert!(
+        store.load(session_id).await.is_none(),
+        "Old session ID was not destroyed"
+    );
+
+    // The new ID should have both the old data and the new data
+    let new_data = store
+        .load(new_id)
+        .await
+        .expect("New session ID should be in store");
+    assert_eq!(new_data.get("pre_existing").unwrap(), "data");
+    assert_eq!(new_data.get("user").unwrap(), "alice");
+}

--- a/autumn/tests/security_tests.rs
+++ b/autumn/tests/security_tests.rs
@@ -1,0 +1,1 @@
+mod security;

--- a/fix_old_id.rs
+++ b/fix_old_id.rs
@@ -1,9 +1,0 @@
-// The comment says:
-// Calling `Session::rotate_id()` more than once in the same request overwrites `old_id` each time,
-// but `SessionService` only destroys the single stored `old_id` at response time.
-// Preserve the initial pre-rotation ID (or track all prior IDs) so every superseded ID is invalidated.
-// We can change `old_id: Option<String>` to `old_ids: Vec<String>` or simply keep the VERY FIRST `old_id` if it's already set!
-// If it's already set, it means we rotated multiple times, but the ONLY ID that exists in the *store* from before this request is the first `old_id`.
-// Actually, intermediate generated IDs in the same request were never saved to the store!
-// So destroying the VERY FIRST ID is sufficient!
-// `if inner.old_id.is_none() { inner.old_id = Some(inner.id.clone()); }`

--- a/fix_old_id.rs
+++ b/fix_old_id.rs
@@ -1,0 +1,9 @@
+// The comment says:
+// Calling `Session::rotate_id()` more than once in the same request overwrites `old_id` each time,
+// but `SessionService` only destroys the single stored `old_id` at response time.
+// Preserve the initial pre-rotation ID (or track all prior IDs) so every superseded ID is invalidated.
+// We can change `old_id: Option<String>` to `old_ids: Vec<String>` or simply keep the VERY FIRST `old_id` if it's already set!
+// If it's already set, it means we rotated multiple times, but the ONLY ID that exists in the *store* from before this request is the first `old_id`.
+// Actually, intermediate generated IDs in the same request were never saved to the store!
+// So destroying the VERY FIRST ID is sufficient!
+// `if inner.old_id.is_none() { inner.old_id = Some(inner.id.clone()); }`


### PR DESCRIPTION
🧨 **The Trigger**: 
- **Session Fixation**: An attacker sets a known session ID (e.g., via sub-domain cookie tossing) and tricks the victim into authenticating. The application binds the user's session to the attacker's known ID.
- **CSRF Functional Bug**: A user attempts to submit a standard HTML form (without JS/htmx) while CSRF protection is enabled. The server rejects it with a 403 Forbidden because it doesn't check the `_csrf` form field.

📉 **The Stack Trace**:
N/A (Logic Errors)

🧪 **Reproduction**:
- **Session Fixation**: Run `cargo test --test security_tests test_session_fixation`. The test mimics an attacker pre-setting a cookie, and the application now rejects it and creates a new one.
- **CSRF Form Bypass**: Run `cargo test --test security_tests eris_csrf_form_bypass_fixed`. The test mimics a standard form POST with `_csrf` in the body, which now returns 200 OK instead of 403.

😈 **Comment**:
Never trust user-supplied IDs. Never write middleware that claims to support form fields but only reads headers. Eris found the gaps, and Warden closed them.

---
*PR created automatically by Jules for task [12474041532486574538](https://jules.google.com/task/12474041532486574538) started by @madmax983*