### PR TITLE
Add Phase 2 WASM typed server action support

### DIFF
--- a/autumn-macros/src/actions_macro.rs
+++ b/autumn-macros/src/actions_macro.rs
@@ -1,0 +1,19 @@
+use proc_macro2::TokenStream;
+
+pub fn actions_macro(input: TokenStream) -> TokenStream {
+    crate::collect::collect_companions(input, "__autumn_action_meta_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+
+    #[test]
+    fn collects_action_metadata_companions() {
+        let out = actions_macro(quote!(rename_todo, complete_todo)).to_string();
+
+        assert!(out.contains("__autumn_action_meta_rename_todo"));
+        assert!(out.contains("__autumn_action_meta_complete_todo"));
+    }
+}

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -11,6 +11,7 @@
 //! Users should not depend on this crate directly — use `autumn-web` instead,
 //! which re-exports everything.
 
+mod actions_macro;
 mod cached;
 mod collect;
 mod island;
@@ -23,6 +24,7 @@ mod route;
 mod routes_macro;
 mod scheduled;
 mod secured;
+mod server_action;
 mod service;
 mod static_route;
 mod static_routes_macro;
@@ -155,6 +157,16 @@ pub fn island(_attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn islands(input: TokenStream) -> TokenStream {
     islands_macro::islands_macro(input.into()).into()
+}
+
+#[proc_macro_attribute]
+pub fn server(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    server_action::server_macro(item.into()).into()
+}
+
+#[proc_macro]
+pub fn actions(input: TokenStream) -> TokenStream {
+    actions_macro::actions_macro(input.into()).into()
 }
 
 /// Set up the async runtime for an Autumn application.

--- a/autumn-macros/src/server_action.rs
+++ b/autumn-macros/src/server_action.rs
@@ -1,0 +1,197 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{FnArg, ItemFn, ReturnType, Type};
+
+pub fn server_macro(item: TokenStream) -> TokenStream {
+    let input: ItemFn = match syn::parse2(item) {
+        Ok(input) => input,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    if input.sig.asyncness.is_none() {
+        return syn::Error::new_spanned(input.sig.fn_token, "#[server] requires async fn")
+            .to_compile_error();
+    }
+
+    if input.sig.inputs.len() != 1 {
+        return syn::Error::new_spanned(
+            &input.sig.ident,
+            "#[server] requires exactly one input argument",
+        )
+        .to_compile_error();
+    }
+
+    let input_arg = match input.sig.inputs.first().expect("validated len") {
+        FnArg::Typed(typed) => typed,
+        FnArg::Receiver(recv) => {
+            return syn::Error::new_spanned(recv, "#[server] does not support methods")
+                .to_compile_error();
+        }
+    };
+
+    let input_type = (*input_arg.ty).clone();
+    let output_type = match extract_output_type(&input.sig.output) {
+        Ok(output) => output,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    let attrs = &input.attrs;
+    let vis = &input.vis;
+    let sig = &input.sig;
+    let block = &input.block;
+    let name = &input.sig.ident;
+
+    let route_path = format!("/_autumn/actions/{name}");
+    let action_handler = format_ident!("__autumn_action_handler_{name}");
+    let action_route = format_ident!("__autumn_action_route_{name}");
+    let action_meta = format_ident!("__autumn_action_meta_{name}");
+
+    quote! {
+        #[cfg(not(target_arch = "wasm32"))]
+        #(#attrs)*
+        #vis #sig #block
+
+        #[cfg(target_arch = "wasm32")]
+        #vis async fn #name(input: #input_type) -> ::autumn_web::AutumnResult<#output_type> {
+            ::autumn_web::wasm::post_json::<#input_type, #output_type>(#route_path, &input)
+                .await
+                .map_err(|error| {
+                    ::autumn_web::AutumnError::internal_msg(
+                        format!("server action `{}` failed: {error}", stringify!(#name)),
+                    )
+                })
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        #[doc(hidden)]
+        pub async fn #action_handler(
+            ::autumn_web::extract::Json(input): ::autumn_web::extract::Json<#input_type>,
+        ) -> ::autumn_web::AutumnResult<::autumn_web::extract::Json<#output_type>> {
+            #name(input).await.map(::autumn_web::extract::Json)
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        #[doc(hidden)]
+        pub fn #action_route() -> ::autumn_web::route::Route {
+            ::autumn_web::route::Route {
+                method: ::autumn_web::reexports::http::Method::POST,
+                path: #route_path,
+                handler: ::autumn_web::reexports::axum::routing::post(#action_handler),
+                name: stringify!(#name),
+            }
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        #[doc(hidden)]
+        pub fn #action_meta() -> ::autumn_web::wasm::ActionMeta {
+            ::autumn_web::wasm::ActionMeta {
+                name: stringify!(#name),
+                path: #route_path,
+                route: #action_route,
+            }
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        #[doc(hidden)]
+        pub fn #action_meta() -> ::autumn_web::wasm::ActionMeta {
+            ::autumn_web::wasm::ActionMeta {
+                name: stringify!(#name),
+                path: #route_path,
+                route: ::autumn_web::wasm::noop_action_route,
+            }
+        }
+    }
+}
+
+fn extract_output_type(return_type: &ReturnType) -> syn::Result<Type> {
+    let ReturnType::Type(_, ty) = return_type else {
+        return Err(syn::Error::new_spanned(
+            return_type,
+            "#[server] requires an explicit return type AutumnResult<T>",
+        ));
+    };
+
+    let Type::Path(type_path) = &**ty else {
+        return Err(syn::Error::new_spanned(
+            ty,
+            "#[server] return type must be AutumnResult<T>",
+        ));
+    };
+
+    let Some(segment) = type_path.path.segments.last() else {
+        return Err(syn::Error::new_spanned(
+            ty,
+            "#[server] return type must be AutumnResult<T>",
+        ));
+    };
+
+    if segment.ident != "AutumnResult" {
+        return Err(syn::Error::new_spanned(
+            ty,
+            "#[server] return type must be AutumnResult<T>",
+        ));
+    }
+
+    let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return Err(syn::Error::new_spanned(
+            ty,
+            "#[server] return type must be AutumnResult<T>",
+        ));
+    };
+
+    let Some(syn::GenericArgument::Type(output)) = args.args.first() else {
+        return Err(syn::Error::new_spanned(
+            ty,
+            "#[server] return type must be AutumnResult<T>",
+        ));
+    };
+
+    Ok(output.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+
+    #[test]
+    fn rejects_non_async_functions() {
+        let out = server_macro(quote! {
+            fn rename(input: RenameTodo) -> AutumnResult<TodoView> { todo!() }
+        });
+
+        assert!(out.to_string().contains("requires async fn"));
+    }
+
+    #[test]
+    fn rejects_functions_without_single_input() {
+        let out = server_macro(quote! {
+            async fn rename(a: RenameTodo, b: RenameTodo) -> AutumnResult<TodoView> { todo!() }
+        });
+
+        assert!(out.to_string().contains("exactly one input argument"));
+    }
+
+    #[test]
+    fn rejects_non_autumn_result_return_type() {
+        let out = server_macro(quote! {
+            async fn rename(input: RenameTodo) -> TodoView { todo!() }
+        });
+
+        assert!(out.to_string().contains("AutumnResult<T>"));
+    }
+
+    #[test]
+    fn expands_server_action_helpers() {
+        let out = server_macro(quote! {
+            async fn rename_todo(input: RenameTodo) -> AutumnResult<TodoView> {
+                todo!()
+            }
+        })
+        .to_string();
+
+        assert!(out.contains("__autumn_action_meta_rename_todo"));
+        assert!(out.contains("__autumn_action_route_rename_todo"));
+        assert!(out.contains("/_autumn/actions/rename_todo"));
+    }
+}

--- a/autumn-wasm/Cargo.toml
+++ b/autumn-wasm/Cargo.toml
@@ -12,7 +12,12 @@ serde_json.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
-web-sys = { version = "0.3", features = ["Document", "Window", "Element", "HtmlElement", "Node", "NodeList", "EventTarget"] }
+wasm-bindgen-futures = "0.4"
+serde-wasm-bindgen = "0.6"
+web-sys = { version = "0.3", features = ["Document", "Window", "Element", "HtmlElement", "Node", "NodeList", "EventTarget", "Request", "RequestInit", "RequestCredentials", "RequestMode", "Response", "Headers"] }
+
+[dev-dependencies]
+tokio.workspace = true
 
 [lints]
 workspace = true

--- a/autumn-wasm/src/action.rs
+++ b/autumn-wasm/src/action.rs
@@ -1,0 +1,81 @@
+use serde::{Serialize, de::DeserializeOwned};
+
+#[cfg(target_arch = "wasm32")]
+pub async fn post_json<I, O>(path: &str, input: &I) -> Result<O, String>
+where
+    I: Serialize,
+    O: DeserializeOwned,
+{
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_futures::JsFuture;
+
+    let payload = serde_json::to_string(input).map_err(|error| error.to_string())?;
+    let mut opts = web_sys::RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(web_sys::RequestMode::SameOrigin);
+    opts.set_credentials(web_sys::RequestCredentials::SameOrigin);
+    opts.set_body(&wasm_bindgen::JsValue::from_str(&payload));
+
+    let request = web_sys::Request::new_with_str_and_init(path, &opts)
+        .map_err(|error| format!("request build failed: {error:?}"))?;
+    request
+        .headers()
+        .set("Content-Type", "application/json")
+        .map_err(|error| format!("header set failed: {error:?}"))?;
+
+    if let Some(window) = web_sys::window() {
+        if let Some(document) = window.document() {
+            if let Ok(Some(meta)) = document.query_selector("meta[name='csrf-token']") {
+                if let Some(token) = meta.get_attribute("content") {
+                    let _ = request.headers().set("x-csrf-token", &token);
+                }
+            }
+        }
+
+        let response = JsFuture::from(window.fetch_with_request(&request))
+            .await
+            .map_err(|error| format!("network failed: {error:?}"))?;
+        let response: web_sys::Response = response
+            .dyn_into()
+            .map_err(|_| "response cast failed".to_owned())?;
+
+        if !response.ok() {
+            return Err(format!("request failed with status {}", response.status()));
+        }
+
+        let json = JsFuture::from(
+            response
+                .json()
+                .map_err(|error| format!("json body read failed: {error:?}"))?,
+        )
+        .await
+        .map_err(|error| format!("json promise failed: {error:?}"))?;
+
+        serde_wasm_bindgen::from_value(json).map_err(|error| error.to_string())
+    } else {
+        Err("window unavailable".to_owned())
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn post_json<I, O>(_path: &str, _input: &I) -> Result<O, String>
+where
+    I: Serialize,
+    O: DeserializeOwned,
+{
+    Err("server action client is only available on wasm32".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn post_json_returns_error_on_non_wasm_target() {
+        let result = super::post_json::<serde_json::Value, serde_json::Value>(
+            "/_autumn/actions/demo",
+            &serde_json::json!({"ok": true}),
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
+}

--- a/autumn-wasm/src/lib.rs
+++ b/autumn-wasm/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod action;
 mod boot;
 mod island;
 
@@ -11,7 +12,7 @@ pub type Element = web_sys::Element;
 pub type Element = ();
 
 pub mod prelude {
-    pub use crate::{IslandRegistration, boot};
+    pub use crate::{IslandRegistration, action, boot};
 }
 
 #[cfg(test)]

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -19,6 +19,7 @@ test-support = ["dep:testcontainers", "dep:testcontainers-modules"]
 
 [dependencies]
 autumn-macros = { version = "0.1.0", path = "../autumn-macros" }
+autumn-wasm = { version = "0.1.0", path = "../autumn-wasm" }
 axum.workspace = true
 bytes = "1"
 http-body-util = "0.1"

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -460,6 +460,24 @@ impl AppBuilder {
             return;
         }
 
+        let Self {
+            routes,
+            tasks,
+            static_metas: _,
+            islands: _,
+            actions,
+            exception_filters,
+            scoped_groups,
+            merge_routers,
+            nest_routers,
+            error_page_renderer,
+            #[cfg(feature = "db")]
+            migrations,
+        } = self;
+
+        let mut all_routes = routes;
+        all_routes.extend(actions.iter().map(|action| (action.route)()));
+
         // 1. Load configuration (profile-aware)
         let config = AutumnConfig::load().unwrap_or_else(|e| {
             eprintln!("Failed to load configuration: {e}");
@@ -471,7 +489,7 @@ impl AppBuilder {
 
         // 3. Validate routes
         assert!(
-            !self.routes.is_empty(),
+            !all_routes.is_empty(),
             "No routes registered. Did you forget to call .routes()?"
         );
 
@@ -486,7 +504,7 @@ impl AppBuilder {
         // 4b. Startup transparency log (AUTUMN_SHOW_CONFIG=1 or log level <= DEBUG)
         let show_config = std::env::var("AUTUMN_SHOW_CONFIG").as_deref() == Ok("1");
         if show_config {
-            log_startup_transparency(&self.routes, &self.tasks, &self.scoped_groups, &config);
+            log_startup_transparency(&all_routes, &tasks, &scoped_groups, &config);
         }
 
         // 5. Create database pool (if configured)
@@ -511,7 +529,7 @@ impl AppBuilder {
 
         // 5b. Run migrations if registered
         #[cfg(feature = "db")]
-        if let (Some(migrations), Some(url)) = (self.migrations, &config.database.url) {
+        if let (Some(migrations), Some(url)) = (migrations, &config.database.url) {
             migrate::auto_migrate(url, config.profile.as_deref(), migrations);
         }
 
@@ -539,20 +557,20 @@ impl AppBuilder {
             None
         };
         let router = build_router_with_static_inner(
-            self.routes,
+            all_routes,
             &config,
             state.clone(),
             dist_ref,
-            self.exception_filters,
-            self.scoped_groups,
-            self.merge_routers,
-            self.nest_routers,
-            self.error_page_renderer,
+            exception_filters,
+            scoped_groups,
+            merge_routers,
+            nest_routers,
+            error_page_renderer,
         );
 
         // 7. Start scheduled tasks (if any)
-        if !self.tasks.is_empty() {
-            start_task_scheduler(self.tasks, &state);
+        if !tasks.is_empty() {
+            start_task_scheduler(tasks, &state);
         }
 
         // 8. Bind and serve with graceful shutdown
@@ -609,6 +627,24 @@ impl AppBuilder {
     /// Builds the Axum router, renders each static route through it, and
     /// writes HTML + manifest to the `dist/` directory.
     async fn run_build_mode(self) {
+        let Self {
+            routes,
+            tasks: _,
+            static_metas,
+            islands: _,
+            actions,
+            exception_filters: _,
+            scoped_groups: _,
+            merge_routers: _,
+            nest_routers: _,
+            error_page_renderer: _,
+            #[cfg(feature = "db")]
+                migrations: _,
+        } = self;
+
+        let mut all_routes = routes;
+        all_routes.extend(actions.iter().map(|action| (action.route)()));
+
         // Load config (same as normal startup)
         let config = AutumnConfig::load().unwrap_or_else(|e| {
             eprintln!("Failed to load configuration: {e}");
@@ -616,7 +652,7 @@ impl AppBuilder {
         });
         crate::logging::init(&config.log);
 
-        if self.static_metas.is_empty() {
+        if static_metas.is_empty() {
             eprintln!("No static routes registered. Nothing to build.");
             eprintln!("Hint: use .static_routes(static_routes![...]) on your AppBuilder.");
             std::process::exit(1);
@@ -649,14 +685,14 @@ impl AppBuilder {
         };
 
         // Build the full router (same as production)
-        let router = build_router(self.routes, &config, state);
+        let router = build_router(all_routes, &config, state);
 
         let env = crate::config::OsEnv;
         let dist_dir = project_dir("dist", &env);
 
-        eprintln!("Building {} static route(s)...", self.static_metas.len());
+        eprintln!("Building {} static route(s)...", static_metas.len());
 
-        match crate::static_gen::render_static_routes(router, &self.static_metas, &dist_dir).await {
+        match crate::static_gen::render_static_routes(router, &static_metas, &dist_dir).await {
             Ok(()) => {
                 eprintln!(
                     "\n  \u{2713} Static build complete \u{2192} {}",
@@ -1431,6 +1467,15 @@ mod tests {
 
     #[test]
     fn app_builder_tracks_wasm_metadata() {
+        fn action_route() -> Route {
+            Route {
+                method: http::Method::POST,
+                path: "/actions/increment",
+                handler: axum::routing::post(|| async { "ok" }),
+                name: "increment",
+            }
+        }
+
         let app = app()
             .islands(vec![crate::wasm::IslandMeta {
                 name: "counter",
@@ -1440,6 +1485,7 @@ mod tests {
             .actions(vec![crate::wasm::ActionMeta {
                 name: "increment",
                 path: "/actions/increment",
+                route: action_route,
             }]);
 
         assert_eq!(app.islands.len(), 1);

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -155,6 +155,7 @@ pub use validation::ValidateExt;
 
 // ── Proc-macro re-exports ──────────────────────────────────────────
 
+pub use autumn_macros::actions;
 /// Annotate an async function as a `DELETE` route handler.
 ///
 /// Generates a companion function that returns a [`route::Route`]
@@ -217,6 +218,7 @@ pub use autumn_macros::islands;
 /// }
 /// ```
 pub use autumn_macros::main;
+pub use autumn_macros::server;
 
 /// Derive Diesel and Serde traits for a database model struct.
 ///

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -27,8 +27,8 @@
 pub use autumn_macros::ws;
 /// HTTP method route macros, main macro, and route collection.
 pub use autumn_macros::{
-    cached, delete, get, island, islands, main, post, put, routes, scheduled, secured, service,
-    static_get, static_routes, tasks,
+    actions, cached, delete, get, island, islands, main, post, put, routes, scheduled, secured,
+    server, service, static_get, static_routes, tasks,
 };
 
 // ── Rendering ────────────────────────────────────────────────────

--- a/autumn/src/wasm/mod.rs
+++ b/autumn/src/wasm/mod.rs
@@ -9,6 +9,26 @@ pub use types::{ActionMeta, IslandMeta};
 
 const DEFAULT_MANIFEST_PATH: &str = "target/autumn/wasm/manifest.json";
 
+#[doc(hidden)]
+pub fn noop_action_route() -> crate::route::Route {
+    crate::route::Route {
+        method: http::Method::POST,
+        path: "/_autumn/actions/__noop",
+        handler: axum::routing::post(|| async {
+            crate::AutumnError::not_found_msg("server action route is unavailable on wasm32")
+        }),
+        name: "__autumn_noop_action_route",
+    }
+}
+
+pub async fn post_json<I, O>(path: &str, input: &I) -> Result<O, String>
+where
+    I: serde::Serialize,
+    O: serde::de::DeserializeOwned,
+{
+    autumn_wasm::action::post_json(path, input).await
+}
+
 /// Load the optional WASM asset manifest from disk.
 ///
 /// # Errors

--- a/autumn/src/wasm/types.rs
+++ b/autumn/src/wasm/types.rs
@@ -9,10 +9,11 @@ pub struct IslandMeta {
 }
 
 /// Metadata for a generated server action endpoint.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy)]
 pub struct ActionMeta {
     pub name: &'static str,
     pub path: &'static str,
+    pub route: fn() -> crate::route::Route,
 }
 
 #[cfg(test)]
@@ -35,17 +36,24 @@ mod tests {
     }
 
     #[test]
-    fn action_meta_deserializes_from_json() {
-        let meta: ActionMeta =
-            serde_json::from_str(r#"{"name":"increment","path":"/actions/increment"}"#)
-                .expect("deserialize action meta");
-
-        assert_eq!(
-            meta,
-            ActionMeta {
+    fn action_meta_keeps_route_companion() {
+        fn fake_route() -> crate::route::Route {
+            crate::route::Route {
+                method: http::Method::POST,
+                path: "/_autumn/actions/increment",
+                handler: axum::routing::post(|| async { "ok" }),
                 name: "increment",
-                path: "/actions/increment",
             }
-        );
+        }
+
+        let meta = ActionMeta {
+            name: "increment",
+            path: "/_autumn/actions/increment",
+            route: fake_route,
+        };
+
+        let route = (meta.route)();
+        assert_eq!(route.path, "/_autumn/actions/increment");
+        assert_eq!(route.name, "increment");
     }
 }

--- a/autumn/tests/app_builder.rs
+++ b/autumn/tests/app_builder.rs
@@ -1,4 +1,4 @@
-use autumn_web::{get, routes};
+use autumn_web::{AutumnResult, actions, get, routes, server};
 
 #[get("/test")]
 async fn test_handler() -> &'static str {
@@ -8,6 +8,21 @@ async fn test_handler() -> &'static str {
 #[get("/other")]
 async fn other_handler() -> &'static str {
     "other"
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct RenameInput {
+    id: i64,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct RenameOutput {
+    id: i64,
+}
+
+#[server]
+async fn rename_todo(input: RenameInput) -> AutumnResult<RenameOutput> {
+    Ok(RenameOutput { id: input.id })
 }
 
 #[test]
@@ -23,6 +38,14 @@ fn app_builder_multiple_route_calls() {
     let builder = autumn_web::app()
         .routes(routes![test_handler])
         .routes(routes![other_handler]);
+    let _ = builder;
+}
+
+#[test]
+fn app_builder_accepts_actions() {
+    let builder = autumn_web::app()
+        .routes(routes![test_handler])
+        .actions(actions![rename_todo]);
     let _ = builder;
 }
 

--- a/autumn/tests/compile-fail/server_action_non_async.rs
+++ b/autumn/tests/compile-fail/server_action_non_async.rs
@@ -1,0 +1,14 @@
+use autumn_web::prelude::*;
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct Input;
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct Output;
+
+#[server]
+fn bad_action(_input: Input) -> AutumnResult<Output> {
+    todo!()
+}
+
+fn main() {}

--- a/autumn/tests/compile-fail/server_action_non_async.stderr
+++ b/autumn/tests/compile-fail/server_action_non_async.stderr
@@ -1,0 +1,5 @@
+error: #[server] requires async fn
+  --> tests/compile-fail/server_action_non_async.rs:10:1
+   |
+10 | fn bad_action(_input: Input) -> AutumnResult<Output> {
+   | ^^

--- a/autumn/tests/compile-pass/server_action_basic.rs
+++ b/autumn/tests/compile-pass/server_action_basic.rs
@@ -1,0 +1,22 @@
+use autumn_web::prelude::*;
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct RenameTodo {
+    id: i64,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct TodoView {
+    id: i64,
+}
+
+#[server]
+async fn rename_todo(input: RenameTodo) -> AutumnResult<TodoView> {
+    Ok(TodoView { id: input.id })
+}
+
+fn main() {
+    let actions = actions![rename_todo];
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].path, "/_autumn/actions/rename_todo");
+}

--- a/autumn/tests/compile_fail.rs
+++ b/autumn/tests/compile_fail.rs
@@ -25,6 +25,7 @@ fn compile_fail_tests() {
 
     // Cached macro failures
     t.compile_fail("tests/compile-fail/cached_self_receiver.rs");
+    t.compile_fail("tests/compile-fail/server_action_non_async.rs");
 }
 
 #[test]
@@ -70,4 +71,5 @@ fn compile_pass_tests() {
     // Cached macro
     t.pass("tests/compile-pass/cached_basic.rs");
     t.pass("tests/compile-pass/cached_result.rs");
+    t.pass("tests/compile-pass/server_action_basic.rs");
 }


### PR DESCRIPTION
### Motivation

- Provide a first-class Phase 2 implementation for typed server actions so browser Rust can call server Rust without handwritten fetch glue.  
- Keep Autumn server-first while enabling a WASM client lane that shares DTOs and generates the boring HTTP glue.  
- Surface action metadata and route companions so the server can register generated endpoints and `autumn build`/`autumn dev` can include them in router/static builds.

### Description

- Add `#[server]` attribute macro that expands to a server implementation (non-wasm), a WASM-target async stub that calls a generated client helper, and hidden metadata/route companions (`__autumn_action_*`).  
- Add `actions![]` collection macro that mirrors `routes![]` and collects generated action metadata companions.  
- Introduce a small WASM client transport `autumn-wasm::action::post_json` (same-origin POST JSON with optional CSRF meta-token forwarding) and expose it via `autumn_web::wasm::post_json` with a `noop_action_route` fallback on wasm targets.  
- Extend `ActionMeta` to carry a route companion pointer and wire `AppBuilder` to include action routes in router construction and static builds, plus re-export the new macros from `autumn-web` and `prelude`.

### Testing

- Formatted code with `cargo fmt` (succeeded).  
- Ran unit and integration test slices: `cargo test -p autumn-web app_builder`, `cargo test -p autumn-web compile_pass_tests -- --nocapture`, and `cargo test -p autumn-web compile_fail_tests -- --nocapture`, all of which passed.  
- Ran `cargo test -p autumn-wasm` to validate the WASM-side client helper and wasm crate tests (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caf4535c50832a960baa21c9d6e514)