### PR TITLE
🎻 Bard: fix intra-doc links and add error constructor examples

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1244,7 +1244,7 @@ fn build_router_with_static_inner(
         .fallback_service(serve_dir)
 }
 
-/// Build a `tower_http::cors::CorsLayer` from the framework's [`CorsConfig`].
+/// Build a `tower_http::cors::CorsLayer` from the framework's [`crate::config::CorsConfig`].
 ///
 /// Called only when `config.cors.allowed_origins` is non-empty.
 fn build_cors_layer(cors: &crate::config::CorsConfig) -> tower_http::cors::CorsLayer {

--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -300,31 +300,92 @@ impl AutumnError {
     // ── String-message convenience constructors ────────────────
 
     /// Create a `404 Not Found` error from a plain string message.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use autumn_web::error::AutumnError;
+    /// use http::StatusCode;
+    ///
+    /// let err = AutumnError::not_found_msg("No such user");
+    /// assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    /// assert_eq!(err.to_string(), "No such user");
+    /// ```
     pub fn not_found_msg(msg: impl Into<String>) -> Self {
         Self::not_found(StringError(msg.into()))
     }
 
     /// Create a `400 Bad Request` error from a plain string message.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use autumn_web::error::AutumnError;
+    /// use http::StatusCode;
+    ///
+    /// let err = AutumnError::bad_request_msg("Invalid input parameter");
+    /// assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    /// ```
     pub fn bad_request_msg(msg: impl Into<String>) -> Self {
         Self::bad_request(StringError(msg.into()))
     }
 
     /// Create a `422 Unprocessable Entity` error from a plain string message.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use autumn_web::error::AutumnError;
+    /// use http::StatusCode;
+    ///
+    /// let err = AutumnError::unprocessable_msg("Title is required");
+    /// assert_eq!(err.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    /// ```
     pub fn unprocessable_msg(msg: impl Into<String>) -> Self {
         Self::unprocessable(StringError(msg.into()))
     }
 
     /// Create a `401 Unauthorized` error from a plain string message.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use autumn_web::error::AutumnError;
+    /// use http::StatusCode;
+    ///
+    /// let err = AutumnError::unauthorized_msg("Please log in to continue");
+    /// assert_eq!(err.status(), StatusCode::UNAUTHORIZED);
+    /// ```
     pub fn unauthorized_msg(msg: impl Into<String>) -> Self {
         Self::unauthorized(StringError(msg.into()))
     }
 
     /// Create a `403 Forbidden` error from a plain string message.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use autumn_web::error::AutumnError;
+    /// use http::StatusCode;
+    ///
+    /// let err = AutumnError::forbidden_msg("You lack admin privileges");
+    /// assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    /// ```
     pub fn forbidden_msg(msg: impl Into<String>) -> Self {
         Self::forbidden(StringError(msg.into()))
     }
 
     /// Create a `503 Service Unavailable` error from a plain string message.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use autumn_web::error::AutumnError;
+    /// use http::StatusCode;
+    ///
+    /// let err = AutumnError::service_unavailable_msg("Database connection pool exhausted");
+    /// assert_eq!(err.status(), StatusCode::SERVICE_UNAVAILABLE);
+    /// ```
     pub fn service_unavailable_msg(msg: impl Into<String>) -> Self {
         Self::service_unavailable(StringError(msg.into()))
     }

--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -22,7 +22,7 @@ pub const HTMX_JS: &[u8] = include_bytes!("../vendor/htmx.min.js");
 /// htmx version string for diagnostics and cache busting.
 ///
 /// Corresponds to the version of the embedded htmx JS file.
-/// Re-exported at the crate root as [`HTMX_VERSION`](crate::HTMX_VERSION).
+/// Re-exported at the crate root as [`HTMX_VERSION`].
 pub const HTMX_VERSION: &str = "2.0.4";
 
 #[cfg(test)]


### PR DESCRIPTION
📖 Chapter: `error`, `app`, and `htmx` modules.
🔦 Insight: Clarified exactly what HTTP status code is produced when using `AutumnError` convenience methods (`not_found_msg`, `bad_request_msg`, `unprocessable_msg`, `unauthorized_msg`, `forbidden_msg`, `service_unavailable_msg`). Fixed broken intra-doc link to `CorsConfig`. Fixed redundant explicit link on `HTMX_VERSION`.
🧪 Example: Added 6 new executable doctests showing proper initialization and status code validation.
🖼️ Preview: No visual output.

---
*PR created automatically by Jules for task [13323654536132524302](https://jules.google.com/task/13323654536132524302) started by @madmax983*