### PR TITLE
⚡ Bolt: Replace std::fs with tokio::fs in error doc example

### DIFF
--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -87,7 +87,7 @@ struct ErrorInner {
 ///
 /// #[get("/")]
 /// async fn handler() -> AutumnResult<&'static str> {
-///     std::fs::read_to_string("missing.txt")?; // becomes 500 on error
+///     tokio::fs::read_to_string("missing.txt").await?; // becomes 500 on error
 ///     Ok("ok")
 /// }
 /// ```

--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -87,7 +87,7 @@ struct ErrorInner {
 ///
 /// #[get("/")]
 /// async fn handler() -> AutumnResult<&'static str> {
-///     tokio::fs::read_to_string("missing.txt").await?; // becomes 500 on error
+///     autumn_web::reexports::tokio::fs::read_to_string("missing.txt").await?; // becomes 500 on error
 ///     Ok("ok")
 /// }
 /// ```


### PR DESCRIPTION
💡 **What:** Replaced the synchronous `std::fs::read_to_string` with the asynchronous `tokio::fs::read_to_string` in the documentation example for `AutumnError`'s `From` blanket impl.

🎯 **Why:** To avoid setting a bad precedent of performing blocking I/O within an async handler, which could lead to thread exhaustion or suboptimal performance if developers copied the example as-is into their codebase. 

📊 **Measured Improvement:** As this is purely a fix within a Rust doc-comment string (a theoretical `missing.txt` is being read), it cannot be functionally benchmarked for performance gains. However, using `tokio::fs` avoids blocking the async executor in actual application contexts, which is a known performance best practice in Rust async web services.

---
*PR created automatically by Jules for task [18405609325336882119](https://jules.google.com/task/18405609325336882119) started by @madmax983*