### PR TITLE
⚡ Bolt: [Batch update dead links in background task]

### DIFF
--- a/examples/bookmarks/src/tasks.rs
+++ b/examples/bookmarks/src/tasks.rs
@@ -42,7 +42,7 @@ pub async fn check_links(state: AppState) -> AutumnResult<()> {
         .build()
         .map_err(|e| AutumnError::from(std::io::Error::other(e.to_string())))?;
 
-    let mut dead_count = 0u32;
+    let mut dead_ids = Vec::new();
     for (id, url) in &alive {
         let reachable = client
             .head(url)
@@ -52,12 +52,17 @@ pub async fn check_links(state: AppState) -> AutumnResult<()> {
 
         if !reachable {
             tracing::warn!("link-checker: dead link id={id} url={url}");
-            diesel::update(bookmarks::table.find(id))
-                .set(bookmarks::alive.eq(false))
-                .execute(&mut conn)
-                .await?;
-            dead_count += 1;
+            dead_ids.push(*id);
         }
+    }
+
+    let dead_count = dead_ids.len();
+
+    if !dead_ids.is_empty() {
+        diesel::update(bookmarks::table.filter(bookmarks::id.eq_any(&dead_ids)))
+            .set(bookmarks::alive.eq(false))
+            .execute(&mut conn)
+            .await?;
     }
 
     tracing::info!(


### PR DESCRIPTION
💡 **What:** Refactored the `check_links` background task in `examples/bookmarks` to use a single batch update (`eq_any` or `IN` clause) for all identified dead links, rather than updating them one by one.

🎯 **Why:** To eliminate an N+1 query issue. By issuing an `UPDATE ... WHERE id IN (...)` statement, the task avoids excessive network round trips and multiple query parsing overheads on the database server.

📊 **Measured Improvement:** Instead of `N` individual `diesel::update` requests for `N` unreachable URLs, the operation now takes exactly `1` request. It is well understood in PostgreSQL / database environments that batched updates eliminate network latency roundtrips and execute strictly in O(1) query time relative to O(N) queries for a list of URLs. I attempted a local test benchmark runner but test app setup constraints locally suggested isolating this to logical reasoning.

---
*PR created automatically by Jules for task [7413503610290487223](https://jules.google.com/task/7413503610290487223) started by @madmax983*