### PR TITLE
Implement WASM phase-3 composition primitives (Signal + Composition)

### DIFF
--- a/autumn-wasm/src/compose.rs
+++ b/autumn-wasm/src/compose.rs
@@ -32,7 +32,7 @@ impl Composition {
             .shared
             .borrow()
             .get(&key)
-            .and_then(|boxed| boxed.downcast_ref::<Signal<T>>())
+            .and_then(|boxed| (**boxed).downcast_ref::<Signal<T>>())
         {
             return existing.clone();
         }
@@ -50,7 +50,7 @@ impl Composition {
         self.shared
             .borrow()
             .get(key)
-            .and_then(|boxed| boxed.downcast_ref::<Signal<T>>())
+            .and_then(|boxed| (**boxed).downcast_ref::<Signal<T>>())
             .cloned()
     }
 }

--- a/autumn-wasm/src/compose.rs
+++ b/autumn-wasm/src/compose.rs
@@ -1,0 +1,81 @@
+use crate::signal::Signal;
+use std::any::Any;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// Registry that allows independently mounted islands to share typed signals.
+#[derive(Clone, Default)]
+pub struct Composition {
+    shared: Rc<RefCell<HashMap<String, Box<dyn Any>>>>,
+}
+
+impl Composition {
+    /// Create an empty composition registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Get an existing named signal or initialize it lazily.
+    ///
+    /// This is useful when two islands need to coordinate state without a
+    /// parent/child relationship.
+    #[must_use]
+    pub fn signal<T: Clone + 'static>(
+        &self,
+        key: impl Into<String>,
+        init: impl FnOnce() -> T,
+    ) -> Signal<T> {
+        let key = key.into();
+        if let Some(existing) = self
+            .shared
+            .borrow()
+            .get(&key)
+            .and_then(|boxed| boxed.downcast_ref::<Signal<T>>())
+        {
+            return existing.clone();
+        }
+
+        let signal = Signal::new(init());
+        self.shared
+            .borrow_mut()
+            .insert(key, Box::new(signal.clone()) as Box<dyn Any>);
+        signal
+    }
+
+    /// Try to read a previously-initialized named signal.
+    #[must_use]
+    pub fn get<T: Clone + 'static>(&self, key: &str) -> Option<Signal<T>> {
+        self.shared
+            .borrow()
+            .get(key)
+            .and_then(|boxed| boxed.downcast_ref::<Signal<T>>())
+            .cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Composition;
+
+    #[test]
+    fn named_signal_returns_same_instance_for_same_type() {
+        let composition = Composition::new();
+        let left = composition.signal("count", || 1_i32);
+        let right = composition.signal("count", || 99_i32);
+
+        left.update(|value| *value += 1);
+
+        assert_eq!(left.get(), 2);
+        assert_eq!(right.get(), 2);
+    }
+
+    #[test]
+    fn get_returns_none_when_type_does_not_match() {
+        let composition = Composition::new();
+        let _count = composition.signal("shared", || 1_i32);
+
+        assert!(composition.get::<String>("shared").is_none());
+    }
+}

--- a/autumn-wasm/src/lib.rs
+++ b/autumn-wasm/src/lib.rs
@@ -1,9 +1,13 @@
 pub mod action;
 mod boot;
+pub mod compose;
 mod island;
+pub mod signal;
 
 pub use boot::boot;
+pub use compose::Composition;
 pub use island::IslandRegistration;
+pub use signal::{Signal, Subscription};
 
 #[cfg(target_arch = "wasm32")]
 pub type Element = web_sys::Element;
@@ -12,7 +16,7 @@ pub type Element = web_sys::Element;
 pub type Element = ();
 
 pub mod prelude {
-    pub use crate::{IslandRegistration, action, boot};
+    pub use crate::{Composition, IslandRegistration, Signal, Subscription, action, boot};
 }
 
 #[cfg(test)]

--- a/autumn-wasm/src/signal.rs
+++ b/autumn-wasm/src/signal.rs
@@ -2,6 +2,10 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::{Rc, Weak};
 
+type SubscriberId = usize;
+type SubscriberCallback<T> = Box<dyn Fn(&T)>;
+type Subscribers<T> = HashMap<SubscriberId, SubscriberCallback<T>>;
+
 /// Reactive local state container for browser islands.
 ///
 /// `Signal` is intentionally tiny and framework-agnostic. It allows
@@ -15,7 +19,7 @@ pub struct Signal<T> {
 struct SignalInner<T> {
     value: RefCell<T>,
     next_id: Cell<usize>,
-    subscribers: RefCell<HashMap<usize, Box<dyn Fn(&T)>>>,
+    subscribers: RefCell<Subscribers<T>>,
 }
 
 impl<T> Signal<T> {
@@ -86,7 +90,7 @@ impl<T: Clone> Signal<T> {
 /// Dropping this value unsubscribes from future updates.
 pub struct Subscription<T> {
     inner: Weak<SignalInner<T>>,
-    id: usize,
+    id: SubscriberId,
 }
 
 impl<T> Drop for Subscription<T> {

--- a/autumn-wasm/src/signal.rs
+++ b/autumn-wasm/src/signal.rs
@@ -1,0 +1,136 @@
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::rc::{Rc, Weak};
+
+/// Reactive local state container for browser islands.
+///
+/// `Signal` is intentionally tiny and framework-agnostic. It allows
+/// multiple islands to observe and update shared state without introducing a
+/// rendering runtime.
+#[derive(Clone)]
+pub struct Signal<T> {
+    inner: Rc<SignalInner<T>>,
+}
+
+struct SignalInner<T> {
+    value: RefCell<T>,
+    next_id: Cell<usize>,
+    subscribers: RefCell<HashMap<usize, Box<dyn Fn(&T)>>>,
+}
+
+impl<T> Signal<T> {
+    /// Create a new signal with the initial value.
+    #[must_use]
+    pub fn new(initial: T) -> Self {
+        Self {
+            inner: Rc::new(SignalInner {
+                value: RefCell::new(initial),
+                next_id: Cell::new(0),
+                subscribers: RefCell::new(HashMap::new()),
+            }),
+        }
+    }
+
+    /// Subscribe to value updates.
+    ///
+    /// The callback is called every time the signal value changes.
+    #[must_use]
+    pub fn subscribe(&self, callback: impl Fn(&T) + 'static) -> Subscription<T> {
+        let id = self.inner.next_id.get();
+        self.inner.next_id.set(id.saturating_add(1));
+        self.inner
+            .subscribers
+            .borrow_mut()
+            .insert(id, Box::new(callback));
+
+        Subscription {
+            inner: Rc::downgrade(&self.inner),
+            id,
+        }
+    }
+
+    fn notify_subscribers(&self) {
+        let value = self.inner.value.borrow();
+        let subscribers = self.inner.subscribers.borrow();
+        for callback in subscribers.values() {
+            callback(&value);
+        }
+    }
+}
+
+impl<T: Clone> Signal<T> {
+    /// Read the current value.
+    #[must_use]
+    pub fn get(&self) -> T {
+        self.inner.value.borrow().clone()
+    }
+
+    /// Set a new value and notify subscribers.
+    pub fn set(&self, next: T) {
+        *self.inner.value.borrow_mut() = next;
+        self.notify_subscribers();
+    }
+
+    /// Update the current value in place and notify subscribers.
+    pub fn update(&self, updater: impl FnOnce(&mut T)) {
+        {
+            let mut value = self.inner.value.borrow_mut();
+            updater(&mut value);
+        }
+        self.notify_subscribers();
+    }
+}
+
+/// Guard type that keeps a signal subscription active.
+///
+/// Dropping this value unsubscribes from future updates.
+pub struct Subscription<T> {
+    inner: Weak<SignalInner<T>>,
+    id: usize,
+}
+
+impl<T> Drop for Subscription<T> {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.upgrade() {
+            inner.subscribers.borrow_mut().remove(&self.id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Signal;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    #[test]
+    fn signal_notifies_subscribers_on_set_and_update() {
+        let signal = Signal::new(1_i32);
+        let observed = Rc::new(RefCell::new(Vec::new()));
+        let observed_clone = Rc::clone(&observed);
+
+        let _sub = signal.subscribe(move |value| {
+            observed_clone.borrow_mut().push(*value);
+        });
+
+        signal.set(2);
+        signal.update(|value| *value += 3);
+
+        assert_eq!(signal.get(), 5);
+        assert_eq!(*observed.borrow(), vec![2, 5]);
+    }
+
+    #[test]
+    fn dropping_subscription_stops_notifications() {
+        let signal = Signal::new(10_i32);
+        let observed = Rc::new(RefCell::new(Vec::new()));
+        let observed_clone = Rc::clone(&observed);
+
+        let sub = signal.subscribe(move |value| observed_clone.borrow_mut().push(*value));
+        signal.set(11);
+        drop(sub);
+        signal.set(12);
+
+        assert_eq!(*observed.borrow(), vec![11]);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide phase-3 WASM primitives to enable island composition and lightweight client-side state sharing without adding a full client runtime. 

### Description
- Add `Signal<T>` and `Subscription<T>` in `autumn-wasm/src/signal.rs` with `new`, `get`, `set`, `update`, and `subscribe` APIs and tests for notification and unsubscribe behavior. 
- Add a `Composition` registry in `autumn-wasm/src/compose.rs` that lazily constructs and returns typed named signals and includes tests for identity and type-mismatch handling. 
- Re-export the new primitives from the crate root and `prelude` in `autumn-wasm/src/lib.rs` so client code can `use autumn_wasm::prelude::*` to access `Composition`, `Signal`, and `Subscription`. 
- Include focused unit tests covering signal notifications, subscription cleanup, and composition lookups. 

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo test -p autumn-wasm` which succeeded; unit tests (including `signal` and `compose` tests) all passed (`11 passed, 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc4003a170832a8f7e3ab13ec4b1d2)