### PR TITLE
feat(harvest): add replay-aware child workflow command support

### DIFF
--- a/autumn-harvest/autumn-harvest/src/context.rs
+++ b/autumn-harvest/autumn-harvest/src/context.rs
@@ -1099,4 +1099,31 @@ mod tests {
             serde_json::json!({"ok": true})
         );
     }
+
+    #[tokio::test]
+    async fn context_child_without_terminal_does_not_emit_live_start() {
+        let child_id = ExecutionId::new();
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"sku": "book"}),
+            },
+        ];
+
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        let result = ctx
+            .spawn_child_workflow_raw("process_order", serde_json::json!({"sku":"book"}))
+            .await;
+
+        assert!(matches!(result, Err(HarvestError::NonDeterministic(_))));
+        assert!(
+            ctx.drain_commands().is_empty(),
+            "replay must not emit new child start command"
+        );
+    }
 }

--- a/autumn-harvest/autumn-harvest/src/context.rs
+++ b/autumn-harvest/autumn-harvest/src/context.rs
@@ -1170,4 +1170,49 @@ mod tests {
         assert_eq!(b, serde_json::json!({"id":"B","ok":true}));
         assert!(ctx.drain_commands().is_empty());
     }
+
+    #[tokio::test]
+    async fn context_replays_child_with_interleaved_activity_without_live_commands() {
+        let child_id = ExecutionId::new();
+        let activity_id = ActivityExecId::new();
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"id":"A"}),
+            },
+            WorkflowEvent::ActivityScheduled {
+                activity_id,
+                name: "send_email".into(),
+                input: serde_json::json!({"id":"A"}),
+                queue: "default".into(),
+            },
+            WorkflowEvent::ActivityCompleted {
+                activity_id,
+                output: serde_json::json!({"sent":true}),
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id,
+                output: serde_json::json!({"id":"A","ok":true}),
+            },
+        ];
+
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        let child = ctx
+            .spawn_child_workflow_raw("process_order", serde_json::json!({"id":"A"}))
+            .await
+            .expect("child should replay");
+        let activity = ctx
+            .execute_activity_raw("send_email", serde_json::json!({"id":"A"}), "default")
+            .await
+            .expect("activity should replay");
+
+        assert_eq!(child, serde_json::json!({"id":"A","ok":true}));
+        assert_eq!(activity, serde_json::json!({"sent":true}));
+        assert!(ctx.drain_commands().is_empty());
+    }
 }

--- a/autumn-harvest/autumn-harvest/src/context.rs
+++ b/autumn-harvest/autumn-harvest/src/context.rs
@@ -44,6 +44,14 @@ pub enum WorkflowCommand {
         /// Fires when the timer completes.
         result_tx: oneshot::Sender<()>,
     },
+    /// Start a child workflow execution.
+    StartChildWorkflow {
+        child_id: ExecutionId,
+        workflow_name: String,
+        input: Value,
+        /// The worker sends the terminal child result back through this channel.
+        result_tx: oneshot::Sender<Result<Value, String>>,
+    },
     /// Record an opaque marker (used by version gates, side-effect-free notes).
     RecordMarker { name: String, details: Value },
     /// The workflow function returned `Ok(output)`.
@@ -75,6 +83,15 @@ impl std::fmt::Debug for WorkflowCommand {
                 .debug_struct("StartTimer")
                 .field("timer_id", timer_id)
                 .field("duration_secs", duration_secs)
+                .finish_non_exhaustive(),
+            Self::StartChildWorkflow {
+                child_id,
+                workflow_name,
+                ..
+            } => f
+                .debug_struct("StartChildWorkflow")
+                .field("child_id", child_id)
+                .field("workflow_name", workflow_name)
                 .finish_non_exhaustive(),
             Self::RecordMarker { name, details } => f
                 .debug_struct("RecordMarker")
@@ -371,6 +388,55 @@ impl WorkflowContext {
                         "timer '{timer_id}' cancelled: result channel dropped"
                     ))
                 })
+            }
+        }
+    }
+
+    /// Spawn a child workflow and await its terminal result.
+    ///
+    /// During replay, returns the recorded child output or failure.
+    /// During live execution, emits a `StartChildWorkflow` command and suspends.
+    pub async fn spawn_child_workflow_raw(
+        &self,
+        workflow_name: &str,
+        input: Value,
+    ) -> HarvestResult<Value> {
+        let history_match = self
+            .matcher
+            .lock()
+            .expect("matcher lock poisoned")
+            .match_child_workflow(workflow_name);
+
+        match history_match {
+            HistoryMatch::Matched { output } => Ok(output),
+            HistoryMatch::Failed { error, attempt } => Err(HarvestError::ActivityFailed {
+                name: format!("child-workflow:{workflow_name}"),
+                attempt,
+                source: error.into(),
+            }),
+            HistoryMatch::Diverged { expected, actual } => Err(HarvestError::NonDeterministic(
+                format!("child workflow mismatch: expected {expected}, got {actual}"),
+            )),
+            HistoryMatch::NoMatch => {
+                let (tx, rx) = oneshot::channel();
+                self.push_command(WorkflowCommand::StartChildWorkflow {
+                    child_id: ExecutionId::new(),
+                    workflow_name: workflow_name.to_string(),
+                    input,
+                    result_tx: tx,
+                });
+
+                match rx.await {
+                    Ok(Ok(output)) => Ok(output),
+                    Ok(Err(error)) => Err(HarvestError::ActivityFailed {
+                        name: format!("child-workflow:{workflow_name}"),
+                        attempt: 1,
+                        source: error.into(),
+                    }),
+                    Err(_) => Err(HarvestError::Cancelled(format!(
+                        "child workflow '{workflow_name}' cancelled: result channel dropped"
+                    ))),
+                }
             }
         }
     }
@@ -967,5 +1033,70 @@ mod tests {
             result.unwrap_err(),
             HarvestError::NonDeterministic(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn context_replays_child_workflow_completion() {
+        let child_id = ExecutionId::new();
+        let output = serde_json::json!({"order_id": "A-1001"});
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"sku": "book"}),
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id,
+                output: output.clone(),
+            },
+        ];
+
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        let result = ctx
+            .spawn_child_workflow_raw("process_order", serde_json::json!({"sku": "book"}))
+            .await
+            .expect("child should replay from history");
+
+        assert_eq!(result, output);
+        assert!(ctx.drain_commands().is_empty());
+    }
+
+    #[tokio::test]
+    async fn context_live_child_command_round_trip() {
+        let ctx = Arc::new(WorkflowContext::new_test());
+        let ctx_for_task = Arc::clone(&ctx);
+        let workflow_name = "process_order";
+
+        let join = tokio::spawn(async move {
+            ctx_for_task
+                .spawn_child_workflow_raw(workflow_name, serde_json::json!({"sku":"book"}))
+                .await
+        });
+        tokio::task::yield_now().await;
+
+        let mut commands = ctx.drain_commands();
+        assert_eq!(commands.len(), 1);
+        let WorkflowCommand::StartChildWorkflow {
+            workflow_name: emitted_name,
+            result_tx,
+            ..
+        } = commands.remove(0)
+        else {
+            panic!("expected StartChildWorkflow command");
+        };
+        assert_eq!(emitted_name, workflow_name);
+        result_tx
+            .send(Ok(serde_json::json!({"ok": true})))
+            .expect("receiver should exist");
+
+        let result = join.await.expect("join should succeed");
+        assert_eq!(
+            result.expect("child call should succeed"),
+            serde_json::json!({"ok": true})
+        );
     }
 }

--- a/autumn-harvest/autumn-harvest/src/context.rs
+++ b/autumn-harvest/autumn-harvest/src/context.rs
@@ -405,7 +405,7 @@ impl WorkflowContext {
             .matcher
             .lock()
             .expect("matcher lock poisoned")
-            .match_child_workflow(workflow_name);
+            .match_child_workflow(workflow_name, &input);
 
         match history_match {
             HistoryMatch::Matched { output } => Ok(output),
@@ -1124,6 +1124,37 @@ mod tests {
         assert!(
             ctx.drain_commands().is_empty(),
             "replay must not emit new child start command"
+        );
+    }
+
+    #[tokio::test]
+    async fn context_child_input_mismatch_is_nondeterministic_and_no_live_start() {
+        let child_id = ExecutionId::new();
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"sku": "book"}),
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id,
+                output: serde_json::json!({"order_id":"A-1001"}),
+            },
+        ];
+
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        let result = ctx
+            .spawn_child_workflow_raw("process_order", serde_json::json!({"sku":"magazine"}))
+            .await;
+
+        assert!(matches!(result, Err(HarvestError::NonDeterministic(_))));
+        assert!(
+            ctx.drain_commands().is_empty(),
+            "replay must not emit new child start command on input mismatch"
         );
     }
 

--- a/autumn-harvest/autumn-harvest/src/context.rs
+++ b/autumn-harvest/autumn-harvest/src/context.rs
@@ -1126,4 +1126,48 @@ mod tests {
             "replay must not emit new child start command"
         );
     }
+
+    #[tokio::test]
+    async fn context_replays_interleaved_child_starts_without_live_commands() {
+        let child_a = ExecutionId::new();
+        let child_b = ExecutionId::new();
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id: child_a,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"id":"A"}),
+            },
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id: child_b,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"id":"B"}),
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id: child_a,
+                output: serde_json::json!({"id":"A","ok":true}),
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id: child_b,
+                output: serde_json::json!({"id":"B","ok":true}),
+            },
+        ];
+
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        let a = ctx
+            .spawn_child_workflow_raw("process_order", serde_json::json!({"id":"A"}))
+            .await
+            .expect("A should replay");
+        let b = ctx
+            .spawn_child_workflow_raw("process_order", serde_json::json!({"id":"B"}))
+            .await
+            .expect("B should replay");
+
+        assert_eq!(a, serde_json::json!({"id":"A","ok":true}));
+        assert_eq!(b, serde_json::json!({"id":"B","ok":true}));
+        assert!(ctx.drain_commands().is_empty());
+    }
 }

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -216,8 +216,13 @@ impl HistoryMatcher {
         // Advance past TimerStarted
         self.cursor += 1;
 
-        // Look for TimerFired
-        if self.cursor < self.events.len() {
+        // Scan forward for TimerFired, skipping consumed child terminals.
+        while self.cursor < self.events.len() {
+            if self.consumed_child_terminal_events.contains(&self.cursor) {
+                self.cursor += 1;
+                continue;
+            }
+
             if let WorkflowEvent::TimerFired { timer_id: id } = &self.events[self.cursor] {
                 if id.as_str() == timer_id {
                     self.cursor += 1;
@@ -227,6 +232,8 @@ impl HistoryMatcher {
                     };
                 }
             }
+
+            break;
         }
 
         // Timer was started but never fired — incomplete history
@@ -839,6 +846,44 @@ mod tests {
             activity,
             HistoryMatch::Matched {
                 output: serde_json::json!({"sent": true}),
+            }
+        );
+        assert_eq!(matcher.position(), 4);
+    }
+
+    #[test]
+    fn matcher_timer_scan_skips_consumed_interleaved_child_terminal() {
+        let child_id = crate::types::ExecutionId::new();
+        let timer_id = TimerId::new("cooldown");
+        let events = vec![
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"id":"A"}),
+            },
+            WorkflowEvent::TimerStarted {
+                timer_id: timer_id.clone(),
+                duration_secs: 30,
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id,
+                output: serde_json::json!({"ok": true}),
+            },
+            WorkflowEvent::TimerFired {
+                timer_id: timer_id.clone(),
+            },
+        ];
+
+        let mut matcher = HistoryMatcher::new(events);
+        let child = matcher.match_child_workflow("process_order", &serde_json::json!({"id":"A"}));
+        assert!(matches!(child, HistoryMatch::Matched { .. }));
+        assert_eq!(matcher.position(), 1);
+
+        let timer = matcher.match_timer("cooldown");
+        assert_eq!(
+            timer,
+            HistoryMatch::Matched {
+                output: Value::Null
             }
         );
         assert_eq!(matcher.position(), 4);

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -175,6 +175,11 @@ impl HistoryMatcher {
                 } if *id == activity_id => {
                     self.cursor += 1;
                 }
+                // Child workflows can run concurrently with activities.
+                // Preserve replay by scanning past interleaved child starts.
+                WorkflowEvent::ChildWorkflowStarted { .. } => {
+                    self.cursor += 1;
+                }
                 // Any other event type is unexpected mid-activity
                 _ => break,
             }
@@ -849,6 +854,39 @@ mod tests {
             }
         );
         assert_eq!(matcher.position(), 4);
+    }
+
+    #[test]
+    fn matcher_activity_scan_skips_interleaved_child_start() {
+        let child_id = crate::types::ExecutionId::new();
+        let activity_id = ActivityExecId::new();
+        let events = vec![
+            WorkflowEvent::ActivityScheduled {
+                activity_id,
+                name: "send_email".into(),
+                input: serde_json::json!({"id":"A"}),
+                queue: "default".into(),
+            },
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"id":"A"}),
+            },
+            WorkflowEvent::ActivityCompleted {
+                activity_id,
+                output: serde_json::json!({"sent": true}),
+            },
+        ];
+
+        let mut matcher = HistoryMatcher::new(events);
+        let activity = matcher.match_activity("send_email");
+        assert_eq!(
+            activity,
+            HistoryMatch::Matched {
+                output: serde_json::json!({"sent": true}),
+            }
+        );
+        assert_eq!(matcher.position(), 3);
     }
 
     #[test]

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -204,6 +204,68 @@ impl HistoryMatcher {
         HistoryMatch::NoMatch
     }
 
+    /// Match a child workflow command against history.
+    ///
+    /// Expects `ChildWorkflowStarted { workflow_name }` at cursor, then scans for
+    /// a terminal `ChildWorkflowCompleted` or `ChildWorkflowFailed` with the same
+    /// `child_id`.
+    pub fn match_child_workflow(&mut self, workflow_name: &str) -> HistoryMatch {
+        if !self.is_replaying() {
+            return HistoryMatch::NoMatch;
+        }
+
+        let started_event = &self.events[self.cursor];
+        let (child_id, recorded_name) = match started_event {
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id,
+                workflow_name,
+                ..
+            } => (*child_id, workflow_name.as_str()),
+            other => {
+                return HistoryMatch::Diverged {
+                    expected: format!("ChildWorkflowStarted({workflow_name})"),
+                    actual: other.type_name().to_string(),
+                };
+            }
+        };
+
+        if recorded_name != workflow_name {
+            return HistoryMatch::Diverged {
+                expected: format!("ChildWorkflowStarted({workflow_name})"),
+                actual: format!("ChildWorkflowStarted({recorded_name})"),
+            };
+        }
+
+        self.cursor += 1;
+
+        while self.cursor < self.events.len() {
+            match &self.events[self.cursor] {
+                WorkflowEvent::ChildWorkflowCompleted {
+                    child_id: id,
+                    output,
+                } if *id == child_id => {
+                    self.cursor += 1;
+                    return HistoryMatch::Matched {
+                        output: output.clone(),
+                    };
+                }
+                WorkflowEvent::ChildWorkflowFailed {
+                    child_id: id,
+                    error,
+                } if *id == child_id => {
+                    self.cursor += 1;
+                    return HistoryMatch::Failed {
+                        error: error.clone(),
+                        attempt: 1,
+                    };
+                }
+                _ => break,
+            }
+        }
+
+        HistoryMatch::NoMatch
+    }
+
     /// Match a version gate against history.
     ///
     /// Looks for a `MarkerRecorded { name: "version:{change_id}" }` at
@@ -485,6 +547,54 @@ mod tests {
         let mut matcher = HistoryMatcher::new(vec![]);
         let version = matcher.match_version("billing_v2", 1, 3);
         assert_eq!(version, 3);
+    }
+
+    #[test]
+    fn matcher_replays_child_workflow_completion() {
+        let child_id = crate::types::ExecutionId::new();
+        let output = serde_json::json!({"result": "ok"});
+        let events = vec![
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"id": 42}),
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id,
+                output: output.clone(),
+            },
+        ];
+
+        let mut matcher = HistoryMatcher::new(events);
+        let result = matcher.match_child_workflow("process_order");
+        assert_eq!(result, HistoryMatch::Matched { output });
+        assert_eq!(matcher.position(), 2);
+    }
+
+    #[test]
+    fn matcher_replays_child_workflow_failure() {
+        let child_id = crate::types::ExecutionId::new();
+        let events = vec![
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id,
+                workflow_name: "process_order".into(),
+                input: Value::Null,
+            },
+            WorkflowEvent::ChildWorkflowFailed {
+                child_id,
+                error: "child failed".into(),
+            },
+        ];
+
+        let mut matcher = HistoryMatcher::new(events);
+        let result = matcher.match_child_workflow("process_order");
+        assert_eq!(
+            result,
+            HistoryMatch::Failed {
+                error: "child failed".into(),
+                attempt: 1,
+            }
+        );
     }
 
     #[test]

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -245,7 +245,13 @@ impl HistoryMatcher {
                     child_id: id,
                     output,
                 } if *id == child_id => {
-                    self.cursor = scan_cursor + 1;
+                    let next_child_start = self.events[(start_cursor + 1)..scan_cursor]
+                        .iter()
+                        .position(|event| {
+                            matches!(event, WorkflowEvent::ChildWorkflowStarted { .. })
+                        })
+                        .map(|offset| start_cursor + 1 + offset);
+                    self.cursor = next_child_start.unwrap_or(scan_cursor + 1);
                     return HistoryMatch::Matched {
                         output: output.clone(),
                     };
@@ -254,7 +260,13 @@ impl HistoryMatcher {
                     child_id: id,
                     error,
                 } if *id == child_id => {
-                    self.cursor = scan_cursor + 1;
+                    let next_child_start = self.events[(start_cursor + 1)..scan_cursor]
+                        .iter()
+                        .position(|event| {
+                            matches!(event, WorkflowEvent::ChildWorkflowStarted { .. })
+                        })
+                        .map(|offset| start_cursor + 1 + offset);
+                    self.cursor = next_child_start.unwrap_or(scan_cursor + 1);
                     return HistoryMatch::Failed {
                         error: error.clone(),
                         attempt: 1,
@@ -651,6 +663,52 @@ mod tests {
             }
         );
         assert_eq!(matcher.position(), 3);
+    }
+
+    #[test]
+    fn matcher_child_workflow_keeps_interleaved_starts_replayable() {
+        let child_a = crate::types::ExecutionId::new();
+        let child_b = crate::types::ExecutionId::new();
+        let events = vec![
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id: child_a,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"id": "A"}),
+            },
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id: child_b,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"id": "B"}),
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id: child_a,
+                output: serde_json::json!({"id": "A", "ok": true}),
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id: child_b,
+                output: serde_json::json!({"id": "B", "ok": true}),
+            },
+        ];
+
+        let mut matcher = HistoryMatcher::new(events);
+        let a = matcher.match_child_workflow("process_order");
+        assert_eq!(
+            a,
+            HistoryMatch::Matched {
+                output: serde_json::json!({"id": "A", "ok": true}),
+            }
+        );
+        // Cursor should stay at Started(B), not advance past it.
+        assert_eq!(matcher.position(), 1);
+
+        let b = matcher.match_child_workflow("process_order");
+        assert_eq!(
+            b,
+            HistoryMatch::Matched {
+                output: serde_json::json!({"id": "B", "ok": true}),
+            }
+        );
+        assert_eq!(matcher.position(), 4);
     }
 
     #[test]

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -921,7 +921,8 @@ mod tests {
                 output: serde_json::json!({"sent": true}),
             }
         );
-        assert_eq!(matcher.position(), 3);
+        // Cursor stays at interleaved child start so child replay remains deterministic.
+        assert_eq!(matcher.position(), 1);
     }
 
     #[test]

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -214,6 +214,7 @@ impl HistoryMatcher {
             return HistoryMatch::NoMatch;
         }
 
+        let start_cursor = self.cursor;
         let started_event = &self.events[self.cursor];
         let (child_id, recorded_name) = match started_event {
             WorkflowEvent::ChildWorkflowStarted {
@@ -236,15 +237,15 @@ impl HistoryMatcher {
             };
         }
 
-        self.cursor += 1;
+        let scan_cursor = self.cursor + 1;
 
-        while self.cursor < self.events.len() {
-            match &self.events[self.cursor] {
+        while scan_cursor < self.events.len() {
+            match &self.events[scan_cursor] {
                 WorkflowEvent::ChildWorkflowCompleted {
                     child_id: id,
                     output,
                 } if *id == child_id => {
-                    self.cursor += 1;
+                    self.cursor = scan_cursor + 1;
                     return HistoryMatch::Matched {
                         output: output.clone(),
                     };
@@ -253,17 +254,27 @@ impl HistoryMatcher {
                     child_id: id,
                     error,
                 } if *id == child_id => {
-                    self.cursor += 1;
+                    self.cursor = scan_cursor + 1;
                     return HistoryMatch::Failed {
                         error: error.clone(),
                         attempt: 1,
                     };
                 }
-                _ => break,
+                _ => {
+                    self.cursor = start_cursor;
+                    return HistoryMatch::Diverged {
+                        expected: format!("ChildWorkflowTerminal({workflow_name})"),
+                        actual: self.events[scan_cursor].type_name().to_string(),
+                    };
+                }
             }
         }
 
-        HistoryMatch::NoMatch
+        self.cursor = start_cursor;
+        HistoryMatch::Diverged {
+            expected: format!("ChildWorkflowTerminal({workflow_name})"),
+            actual: "EndOfHistory".to_string(),
+        }
     }
 
     /// Match a version gate against history.
@@ -594,6 +605,25 @@ mod tests {
                 error: "child failed".into(),
                 attempt: 1,
             }
+        );
+    }
+
+    #[test]
+    fn matcher_child_workflow_without_terminal_diverges_and_preserves_cursor() {
+        let child_id = crate::types::ExecutionId::new();
+        let events = vec![WorkflowEvent::ChildWorkflowStarted {
+            child_id,
+            workflow_name: "process_order".into(),
+            input: Value::Null,
+        }];
+
+        let mut matcher = HistoryMatcher::new(events);
+        let result = matcher.match_child_workflow("process_order");
+        assert!(matches!(result, HistoryMatch::Diverged { .. }));
+        assert_eq!(
+            matcher.position(),
+            0,
+            "cursor must not consume started event"
         );
     }
 

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -129,24 +129,32 @@ impl HistoryMatcher {
 
         // Advance past the Scheduled event
         self.cursor += 1;
+        let mut scan_cursor = self.cursor;
+        let mut first_interleaved_child_start = None;
 
         // Scan forward for Completed or Failed with matching activity_id,
         // skipping Started, Heartbeat, and other intermediate events.
-        while self.cursor < self.events.len() {
-            if self.consumed_child_terminal_events.contains(&self.cursor) {
-                self.cursor += 1;
+        while scan_cursor < self.events.len() {
+            if self.consumed_child_terminal_events.contains(&scan_cursor) {
+                scan_cursor += 1;
                 continue;
             }
 
-            match &self.events[self.cursor] {
+            match &self.events[scan_cursor] {
                 WorkflowEvent::ActivityCompleted {
                     activity_id: id,
                     output,
                 } if *id == activity_id => {
-                    let result = HistoryMatch::Matched {
-                        output: output.clone(),
-                    };
-                    self.cursor += 1;
+                    let output = output.clone();
+                    if let Some(child_start_cursor) = first_interleaved_child_start {
+                        self.consumed_child_terminal_events.insert(scan_cursor);
+                        self.cursor = child_start_cursor;
+                        self.advance_to_next_unconsumed_event();
+                        return HistoryMatch::Matched { output };
+                    }
+
+                    let result = HistoryMatch::Matched { output };
+                    self.cursor = scan_cursor + 1;
                     self.advance_to_next_unconsumed_event();
                     return result;
                 }
@@ -155,11 +163,17 @@ impl HistoryMatcher {
                     error,
                     attempt,
                 } if *id == activity_id => {
-                    let result = HistoryMatch::Failed {
-                        error: error.clone(),
-                        attempt: *attempt,
-                    };
-                    self.cursor += 1;
+                    let error = error.clone();
+                    let attempt = *attempt;
+                    if let Some(child_start_cursor) = first_interleaved_child_start {
+                        self.consumed_child_terminal_events.insert(scan_cursor);
+                        self.cursor = child_start_cursor;
+                        self.advance_to_next_unconsumed_event();
+                        return HistoryMatch::Failed { error, attempt };
+                    }
+
+                    let result = HistoryMatch::Failed { error, attempt };
+                    self.cursor = scan_cursor + 1;
                     self.advance_to_next_unconsumed_event();
                     return result;
                 }
@@ -168,17 +182,18 @@ impl HistoryMatcher {
                 WorkflowEvent::ActivityHeartbeat {
                     activity_id: id, ..
                 } if *id == activity_id => {
-                    self.cursor += 1;
+                    scan_cursor += 1;
                 }
                 WorkflowEvent::ActivityStarted {
                     activity_id: id, ..
                 } if *id == activity_id => {
-                    self.cursor += 1;
+                    scan_cursor += 1;
                 }
                 // Child workflows can run concurrently with activities.
                 // Preserve replay by scanning past interleaved child starts.
                 WorkflowEvent::ChildWorkflowStarted { .. } => {
-                    self.cursor += 1;
+                    first_interleaved_child_start.get_or_insert(scan_cursor);
+                    scan_cursor += 1;
                 }
                 // Any other event type is unexpected mid-activity
                 _ => break,
@@ -220,22 +235,42 @@ impl HistoryMatcher {
 
         // Advance past TimerStarted
         self.cursor += 1;
+        let mut scan_cursor = self.cursor;
+        let mut first_interleaved_child_start = None;
 
         // Scan forward for TimerFired, skipping consumed child terminals.
-        while self.cursor < self.events.len() {
-            if self.consumed_child_terminal_events.contains(&self.cursor) {
-                self.cursor += 1;
+        while scan_cursor < self.events.len() {
+            if self.consumed_child_terminal_events.contains(&scan_cursor) {
+                scan_cursor += 1;
                 continue;
             }
 
-            if let WorkflowEvent::TimerFired { timer_id: id } = &self.events[self.cursor] {
+            if let WorkflowEvent::TimerFired { timer_id: id } = &self.events[scan_cursor] {
                 if id.as_str() == timer_id {
-                    self.cursor += 1;
+                    if let Some(child_start_cursor) = first_interleaved_child_start {
+                        self.consumed_child_terminal_events.insert(scan_cursor);
+                        self.cursor = child_start_cursor;
+                        self.advance_to_next_unconsumed_event();
+                        return HistoryMatch::Matched {
+                            output: Value::Null,
+                        };
+                    }
+
+                    self.cursor = scan_cursor + 1;
                     self.advance_to_next_unconsumed_event();
                     return HistoryMatch::Matched {
                         output: Value::Null,
                     };
                 }
+            }
+
+            if matches!(
+                self.events[scan_cursor],
+                WorkflowEvent::ChildWorkflowStarted { .. }
+            ) {
+                first_interleaved_child_start.get_or_insert(scan_cursor);
+                scan_cursor += 1;
+                continue;
             }
 
             break;
@@ -890,6 +925,43 @@ mod tests {
     }
 
     #[test]
+    fn matcher_activity_replay_preserves_interleaved_child_start_for_later_child_match() {
+        let child_id = crate::types::ExecutionId::new();
+        let activity_id = ActivityExecId::new();
+        let events = vec![
+            WorkflowEvent::ActivityScheduled {
+                activity_id,
+                name: "send_email".into(),
+                input: serde_json::json!({"id":"A"}),
+                queue: "default".into(),
+            },
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"id":"A"}),
+            },
+            WorkflowEvent::ActivityCompleted {
+                activity_id,
+                output: serde_json::json!({"sent": true}),
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id,
+                output: serde_json::json!({"id":"A","ok": true}),
+            },
+        ];
+
+        let mut matcher = HistoryMatcher::new(events);
+        let activity = matcher.match_activity("send_email");
+        assert!(matches!(activity, HistoryMatch::Matched { .. }));
+        // Cursor should stay on ChildWorkflowStarted for later child replay.
+        assert_eq!(matcher.position(), 1);
+
+        let child = matcher.match_child_workflow("process_order", &serde_json::json!({"id":"A"}));
+        assert!(matches!(child, HistoryMatch::Matched { .. }));
+        assert_eq!(matcher.position(), 4);
+    }
+
+    #[test]
     fn matcher_timer_scan_skips_consumed_interleaved_child_terminal() {
         let child_id = crate::types::ExecutionId::new();
         let timer_id = TimerId::new("cooldown");
@@ -924,6 +996,40 @@ mod tests {
                 output: Value::Null
             }
         );
+        assert_eq!(matcher.position(), 4);
+    }
+
+    #[test]
+    fn matcher_timer_replay_preserves_interleaved_child_start_for_later_child_match() {
+        let child_id = crate::types::ExecutionId::new();
+        let timer_id = TimerId::new("cooldown");
+        let events = vec![
+            WorkflowEvent::TimerStarted {
+                timer_id: timer_id.clone(),
+                duration_secs: 30,
+            },
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"id":"A"}),
+            },
+            WorkflowEvent::TimerFired {
+                timer_id: timer_id.clone(),
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id,
+                output: serde_json::json!({"id":"A","ok": true}),
+            },
+        ];
+
+        let mut matcher = HistoryMatcher::new(events);
+        let timer = matcher.match_timer("cooldown");
+        assert!(matches!(timer, HistoryMatch::Matched { .. }));
+        // Cursor should stay on ChildWorkflowStarted for later child replay.
+        assert_eq!(matcher.position(), 1);
+
+        let child = matcher.match_child_workflow("process_order", &serde_json::json!({"id":"A"}));
+        assert!(matches!(child, HistoryMatch::Matched { .. }));
         assert_eq!(matcher.position(), 4);
     }
 

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -133,6 +133,11 @@ impl HistoryMatcher {
         // Scan forward for Completed or Failed with matching activity_id,
         // skipping Started, Heartbeat, and other intermediate events.
         while self.cursor < self.events.len() {
+            if self.consumed_child_terminal_events.contains(&self.cursor) {
+                self.cursor += 1;
+                continue;
+            }
+
             match &self.events[self.cursor] {
                 WorkflowEvent::ActivityCompleted {
                     activity_id: id,
@@ -767,6 +772,47 @@ mod tests {
             }
         );
         // The consumed child terminal event is skipped automatically.
+        assert_eq!(matcher.position(), 4);
+    }
+
+    #[test]
+    fn matcher_activity_scan_skips_consumed_interleaved_child_terminal() {
+        let child_id = crate::types::ExecutionId::new();
+        let activity_id = ActivityExecId::new();
+        let events = vec![
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"id": "A"}),
+            },
+            WorkflowEvent::ActivityScheduled {
+                activity_id,
+                name: "send_email".into(),
+                input: serde_json::json!({"id":"A"}),
+                queue: "default".into(),
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id,
+                output: serde_json::json!({"id": "A", "ok": true}),
+            },
+            WorkflowEvent::ActivityCompleted {
+                activity_id,
+                output: serde_json::json!({"sent": true}),
+            },
+        ];
+
+        let mut matcher = HistoryMatcher::new(events);
+        let child = matcher.match_child_workflow("process_order");
+        assert!(matches!(child, HistoryMatch::Matched { .. }));
+        assert_eq!(matcher.position(), 1);
+
+        let activity = matcher.match_activity("send_email");
+        assert_eq!(
+            activity,
+            HistoryMatch::Matched {
+                output: serde_json::json!({"sent": true}),
+            }
+        );
         assert_eq!(matcher.position(), 4);
     }
 

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -238,7 +238,7 @@ impl HistoryMatcher {
     /// Expects `ChildWorkflowStarted { workflow_name }` at cursor, then scans for
     /// a terminal `ChildWorkflowCompleted` or `ChildWorkflowFailed` with the same
     /// `child_id`.
-    pub fn match_child_workflow(&mut self, workflow_name: &str) -> HistoryMatch {
+    pub fn match_child_workflow(&mut self, workflow_name: &str, input: &Value) -> HistoryMatch {
         self.advance_to_next_unconsumed_event();
         if !self.is_replaying() {
             return HistoryMatch::NoMatch;
@@ -246,12 +246,12 @@ impl HistoryMatcher {
 
         let start_cursor = self.cursor;
         let started_event = &self.events[self.cursor];
-        let (child_id, recorded_name) = match started_event {
+        let (child_id, recorded_name, recorded_input) = match started_event {
             WorkflowEvent::ChildWorkflowStarted {
                 child_id,
                 workflow_name,
-                ..
-            } => (*child_id, workflow_name.as_str()),
+                input,
+            } => (*child_id, workflow_name.as_str(), input),
             other => {
                 return HistoryMatch::Diverged {
                     expected: format!("ChildWorkflowStarted({workflow_name})"),
@@ -264,6 +264,12 @@ impl HistoryMatcher {
             return HistoryMatch::Diverged {
                 expected: format!("ChildWorkflowStarted({workflow_name})"),
                 actual: format!("ChildWorkflowStarted({recorded_name})"),
+            };
+        }
+        if recorded_input != input {
+            return HistoryMatch::Diverged {
+                expected: format!("ChildWorkflowInput({input})"),
+                actual: format!("ChildWorkflowInput({recorded_input})"),
             };
         }
 
@@ -604,7 +610,7 @@ mod tests {
         ];
 
         let mut matcher = HistoryMatcher::new(events);
-        let result = matcher.match_child_workflow("process_order");
+        let result = matcher.match_child_workflow("process_order", &serde_json::json!({"id": 42}));
         assert_eq!(result, HistoryMatch::Matched { output });
         assert_eq!(matcher.position(), 2);
     }
@@ -625,7 +631,7 @@ mod tests {
         ];
 
         let mut matcher = HistoryMatcher::new(events);
-        let result = matcher.match_child_workflow("process_order");
+        let result = matcher.match_child_workflow("process_order", &Value::Null);
         assert_eq!(
             result,
             HistoryMatch::Failed {
@@ -645,7 +651,7 @@ mod tests {
         }];
 
         let mut matcher = HistoryMatcher::new(events);
-        let result = matcher.match_child_workflow("process_order");
+        let result = matcher.match_child_workflow("process_order", &Value::Null);
         assert!(matches!(result, HistoryMatch::Diverged { .. }));
         assert_eq!(
             matcher.position(),
@@ -676,7 +682,7 @@ mod tests {
         ];
 
         let mut matcher = HistoryMatcher::new(events);
-        let result = matcher.match_child_workflow("process_order");
+        let result = matcher.match_child_workflow("process_order", &serde_json::json!({"id": 1}));
         assert_eq!(
             result,
             HistoryMatch::Matched {
@@ -684,6 +690,28 @@ mod tests {
             }
         );
         assert_eq!(matcher.position(), 1);
+    }
+
+    #[test]
+    fn matcher_child_workflow_input_mismatch_diverges() {
+        let child_id = crate::types::ExecutionId::new();
+        let events = vec![
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"sku":"book"}),
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id,
+                output: serde_json::json!({"ok": true}),
+            },
+        ];
+
+        let mut matcher = HistoryMatcher::new(events);
+        let result =
+            matcher.match_child_workflow("process_order", &serde_json::json!({"sku":"magazine"}));
+        assert!(matches!(result, HistoryMatch::Diverged { .. }));
+        assert_eq!(matcher.position(), 0);
     }
 
     #[test]
@@ -712,7 +740,7 @@ mod tests {
         ];
 
         let mut matcher = HistoryMatcher::new(events);
-        let a = matcher.match_child_workflow("process_order");
+        let a = matcher.match_child_workflow("process_order", &serde_json::json!({"id":"A"}));
         assert_eq!(
             a,
             HistoryMatch::Matched {
@@ -722,7 +750,7 @@ mod tests {
         // Cursor should stay at Started(B), not advance past it.
         assert_eq!(matcher.position(), 1);
 
-        let b = matcher.match_child_workflow("process_order");
+        let b = matcher.match_child_workflow("process_order", &serde_json::json!({"id":"B"}));
         assert_eq!(
             b,
             HistoryMatch::Matched {
@@ -759,7 +787,7 @@ mod tests {
         ];
 
         let mut matcher = HistoryMatcher::new(events);
-        let child = matcher.match_child_workflow("process_order");
+        let child = matcher.match_child_workflow("process_order", &serde_json::json!({"id":"A"}));
         assert!(matches!(child, HistoryMatch::Matched { .. }));
         // Cursor should remain at the interleaved activity schedule.
         assert_eq!(matcher.position(), 1);
@@ -802,7 +830,7 @@ mod tests {
         ];
 
         let mut matcher = HistoryMatcher::new(events);
-        let child = matcher.match_child_workflow("process_order");
+        let child = matcher.match_child_workflow("process_order", &serde_json::json!({"id":"A"}));
         assert!(matches!(child, HistoryMatch::Matched { .. }));
         assert_eq!(matcher.position(), 1);
 

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -10,6 +10,7 @@
 //! it directly, avoiding duplicate side effects.
 
 use serde_json::Value;
+use std::collections::HashSet;
 
 use crate::event::WorkflowEvent;
 
@@ -38,19 +39,28 @@ pub enum HistoryMatch {
 pub struct HistoryMatcher {
     events: Vec<WorkflowEvent>,
     cursor: usize,
+    consumed_child_terminal_events: HashSet<usize>,
 }
 
 impl HistoryMatcher {
     /// Create a new matcher from a list of recorded events.
     #[must_use]
-    pub const fn new(events: Vec<WorkflowEvent>) -> Self {
-        Self { events, cursor: 0 }
+    pub fn new(events: Vec<WorkflowEvent>) -> Self {
+        Self {
+            events,
+            cursor: 0,
+            consumed_child_terminal_events: HashSet::new(),
+        }
     }
 
     /// Returns `true` if the cursor is still within the recorded history.
     #[must_use]
     pub fn is_replaying(&self) -> bool {
-        self.cursor < self.events.len()
+        let mut cursor = self.cursor;
+        while self.consumed_child_terminal_events.contains(&cursor) {
+            cursor += 1;
+        }
+        cursor < self.events.len()
     }
 
     /// Current cursor position in the event list.
@@ -65,6 +75,15 @@ impl HistoryMatcher {
     /// don't correspond to a workflow command.
     pub fn advance(&mut self) {
         if self.cursor < self.events.len() {
+            self.cursor += 1;
+            self.advance_to_next_unconsumed_event();
+        }
+    }
+
+    fn advance_to_next_unconsumed_event(&mut self) {
+        while self.consumed_child_terminal_events.contains(&self.cursor)
+            && self.cursor < self.events.len()
+        {
             self.cursor += 1;
         }
     }
@@ -81,6 +100,7 @@ impl HistoryMatcher {
     /// - [`HistoryMatch::NoMatch`] if past end of history
     /// - [`HistoryMatch::Diverged`] if the event at cursor is not the expected activity
     pub fn match_activity(&mut self, activity_name: &str) -> HistoryMatch {
+        self.advance_to_next_unconsumed_event();
         if !self.is_replaying() {
             return HistoryMatch::NoMatch;
         }
@@ -122,6 +142,7 @@ impl HistoryMatcher {
                         output: output.clone(),
                     };
                     self.cursor += 1;
+                    self.advance_to_next_unconsumed_event();
                     return result;
                 }
                 WorkflowEvent::ActivityFailed {
@@ -134,6 +155,7 @@ impl HistoryMatcher {
                         attempt: *attempt,
                     };
                     self.cursor += 1;
+                    self.advance_to_next_unconsumed_event();
                     return result;
                 }
                 // Skip heartbeats, started events, and other intermediate events
@@ -163,6 +185,7 @@ impl HistoryMatcher {
     /// Expects `TimerStarted { timer_id }` at cursor, then scans for
     /// `TimerFired` with the same `timer_id`.
     pub fn match_timer(&mut self, timer_id: &str) -> HistoryMatch {
+        self.advance_to_next_unconsumed_event();
         if !self.is_replaying() {
             return HistoryMatch::NoMatch;
         }
@@ -193,6 +216,7 @@ impl HistoryMatcher {
             if let WorkflowEvent::TimerFired { timer_id: id } = &self.events[self.cursor] {
                 if id.as_str() == timer_id {
                     self.cursor += 1;
+                    self.advance_to_next_unconsumed_event();
                     return HistoryMatch::Matched {
                         output: Value::Null,
                     };
@@ -210,6 +234,7 @@ impl HistoryMatcher {
     /// a terminal `ChildWorkflowCompleted` or `ChildWorkflowFailed` with the same
     /// `child_id`.
     pub fn match_child_workflow(&mut self, workflow_name: &str) -> HistoryMatch {
+        self.advance_to_next_unconsumed_event();
         if !self.is_replaying() {
             return HistoryMatch::NoMatch;
         }
@@ -245,32 +270,21 @@ impl HistoryMatcher {
                     child_id: id,
                     output,
                 } if *id == child_id => {
-                    let next_child_start = self.events[(start_cursor + 1)..scan_cursor]
-                        .iter()
-                        .position(|event| {
-                            matches!(event, WorkflowEvent::ChildWorkflowStarted { .. })
-                        })
-                        .map(|offset| start_cursor + 1 + offset);
-                    self.cursor = next_child_start.unwrap_or(scan_cursor + 1);
-                    return HistoryMatch::Matched {
-                        output: output.clone(),
-                    };
+                    let output = output.clone();
+                    self.consumed_child_terminal_events.insert(scan_cursor);
+                    self.cursor = start_cursor + 1;
+                    self.advance_to_next_unconsumed_event();
+                    return HistoryMatch::Matched { output };
                 }
                 WorkflowEvent::ChildWorkflowFailed {
                     child_id: id,
                     error,
                 } if *id == child_id => {
-                    let next_child_start = self.events[(start_cursor + 1)..scan_cursor]
-                        .iter()
-                        .position(|event| {
-                            matches!(event, WorkflowEvent::ChildWorkflowStarted { .. })
-                        })
-                        .map(|offset| start_cursor + 1 + offset);
-                    self.cursor = next_child_start.unwrap_or(scan_cursor + 1);
-                    return HistoryMatch::Failed {
-                        error: error.clone(),
-                        attempt: 1,
-                    };
+                    let error = error.clone();
+                    self.consumed_child_terminal_events.insert(scan_cursor);
+                    self.cursor = start_cursor + 1;
+                    self.advance_to_next_unconsumed_event();
+                    return HistoryMatch::Failed { error, attempt: 1 };
                 }
                 _ => scan_cursor += 1,
             }
@@ -294,6 +308,7 @@ impl HistoryMatcher {
     /// - `max_version` if past end of history (new code path)
     #[must_use]
     pub fn match_version(&mut self, change_id: &str, min_version: u32, max_version: u32) -> u32 {
+        self.advance_to_next_unconsumed_event();
         let marker_name = format!("version:{change_id}");
 
         if !self.is_replaying() {
@@ -307,6 +322,7 @@ impl HistoryMatcher {
                     .and_then(|v| u32::try_from(v).ok())
                     .unwrap_or(min_version);
                 self.cursor += 1;
+                self.advance_to_next_unconsumed_event();
                 version
             }
             // No marker at current position — old workflow that didn't have
@@ -662,7 +678,7 @@ mod tests {
                 output: serde_json::json!({"ok": true}),
             }
         );
-        assert_eq!(matcher.position(), 3);
+        assert_eq!(matcher.position(), 1);
     }
 
     #[test]
@@ -708,6 +724,49 @@ mod tests {
                 output: serde_json::json!({"id": "B", "ok": true}),
             }
         );
+        assert_eq!(matcher.position(), 4);
+    }
+
+    #[test]
+    fn matcher_child_workflow_keeps_interleaved_activity_replayable() {
+        let child_a = crate::types::ExecutionId::new();
+        let activity_id = ActivityExecId::new();
+        let events = vec![
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id: child_a,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"id": "A"}),
+            },
+            WorkflowEvent::ActivityScheduled {
+                activity_id,
+                name: "send_email".into(),
+                input: serde_json::json!({"id":"A"}),
+                queue: "default".into(),
+            },
+            WorkflowEvent::ActivityCompleted {
+                activity_id,
+                output: serde_json::json!({"sent": true}),
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id: child_a,
+                output: serde_json::json!({"id": "A", "ok": true}),
+            },
+        ];
+
+        let mut matcher = HistoryMatcher::new(events);
+        let child = matcher.match_child_workflow("process_order");
+        assert!(matches!(child, HistoryMatch::Matched { .. }));
+        // Cursor should remain at the interleaved activity schedule.
+        assert_eq!(matcher.position(), 1);
+
+        let activity = matcher.match_activity("send_email");
+        assert_eq!(
+            activity,
+            HistoryMatch::Matched {
+                output: serde_json::json!({"sent": true}),
+            }
+        );
+        // The consumed child terminal event is skipped automatically.
         assert_eq!(matcher.position(), 4);
     }
 

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -237,7 +237,7 @@ impl HistoryMatcher {
             };
         }
 
-        let scan_cursor = self.cursor + 1;
+        let mut scan_cursor = self.cursor + 1;
 
         while scan_cursor < self.events.len() {
             match &self.events[scan_cursor] {
@@ -260,13 +260,7 @@ impl HistoryMatcher {
                         attempt: 1,
                     };
                 }
-                _ => {
-                    self.cursor = start_cursor;
-                    return HistoryMatch::Diverged {
-                        expected: format!("ChildWorkflowTerminal({workflow_name})"),
-                        actual: self.events[scan_cursor].type_name().to_string(),
-                    };
-                }
+                _ => scan_cursor += 1,
             }
         }
 
@@ -625,6 +619,38 @@ mod tests {
             0,
             "cursor must not consume started event"
         );
+    }
+
+    #[test]
+    fn matcher_child_workflow_scans_past_interleaved_events() {
+        let child_a = crate::types::ExecutionId::new();
+        let child_b = crate::types::ExecutionId::new();
+        let events = vec![
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id: child_a,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"id": 1}),
+            },
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id: child_b,
+                workflow_name: "process_order".into(),
+                input: serde_json::json!({"id": 2}),
+            },
+            WorkflowEvent::ChildWorkflowCompleted {
+                child_id: child_a,
+                output: serde_json::json!({"ok": true}),
+            },
+        ];
+
+        let mut matcher = HistoryMatcher::new(events);
+        let result = matcher.match_child_workflow("process_order");
+        assert_eq!(
+            result,
+            HistoryMatch::Matched {
+                output: serde_json::json!({"ok": true}),
+            }
+        );
+        assert_eq!(matcher.position(), 3);
     }
 
     #[test]

--- a/autumn-harvest/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/autumn-harvest/src/worker.rs
@@ -161,6 +161,7 @@ fn workflow_command_name(command: &WorkflowCommand) -> &'static str {
     match command {
         WorkflowCommand::ScheduleActivity { .. } => "ScheduleActivity",
         WorkflowCommand::StartTimer { .. } => "StartTimer",
+        WorkflowCommand::StartChildWorkflow { .. } => "StartChildWorkflow",
         WorkflowCommand::RecordMarker { .. } => "RecordMarker",
         WorkflowCommand::Complete { .. } => "Complete",
         WorkflowCommand::Fail { .. } => "Fail",


### PR DESCRIPTION
### Motivation
- Provide Phase 4 groundwork for child workflow support so workflows can spawn and await child runs deterministically under replay and suspend in live execution.

### Description
- Added a new command variant `WorkflowCommand::StartChildWorkflow` to represent child-workflow starts emitted by a workflow during live execution.
- Implemented `WorkflowContext::spawn_child_workflow_raw(...)` that matches replayed child-workflow events or emits a `StartChildWorkflow` command and suspends in live mode.
- Extended the replay engine with `HistoryMatcher::match_child_workflow(...)` to detect `ChildWorkflowStarted` and terminal `ChildWorkflowCompleted`/`ChildWorkflowFailed` events and return appropriate `HistoryMatch` results.
- Updated worker command-name formatting to include the new child workflow variant for diagnostics and added unit tests exercising both replay and live command round-trip flows.

### Testing
- Ran formatting with `cd autumn-harvest && cargo fmt` which completed successfully.
- Ran targeted unit tests: `cargo test -p autumn-harvest --no-default-features context_replays_child_workflow_completion` which passed.
- Ran grouped child-workflow tests: `cargo test -p autumn-harvest --no-default-features child_workflow` which passed all relevant matcher tests.
- Ran live-path test: `cargo test -p autumn-harvest --no-default-features context_live_child_command_round_trip` which passed and validated the command round-trip.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc401c72b0832ab82ae46a7dbfc736)