### PR TITLE
wasm: fix cookie access, add prelude and wasm tests, and make target-specific dev-deps

### DIFF
--- a/autumn-wasm/Cargo.toml
+++ b/autumn-wasm/Cargo.toml
@@ -14,10 +14,13 @@ serde_json.workspace = true
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 serde-wasm-bindgen = "0.6"
-web-sys = { version = "0.3", features = ["Document", "Window", "Element", "HtmlElement", "Node", "NodeList", "EventTarget", "Request", "RequestInit", "RequestCredentials", "RequestMode", "Response", "Headers"] }
+web-sys = { version = "0.3", features = ["Document", "Window", "Element", "HtmlElement", "HtmlDocument", "Node", "NodeList", "EventTarget", "Request", "RequestInit", "RequestCredentials", "RequestMode", "Response", "Headers"] }
 
-[dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [lints]
 workspace = true

--- a/autumn-wasm/src/action.rs
+++ b/autumn-wasm/src/action.rs
@@ -30,7 +30,7 @@ where
     use wasm_bindgen_futures::JsFuture;
 
     let payload = serde_json::to_string(input).map_err(|error| error.to_string())?;
-    let mut opts = web_sys::RequestInit::new();
+    let opts = web_sys::RequestInit::new();
     opts.set_method("POST");
     opts.set_mode(web_sys::RequestMode::SameOrigin);
     opts.set_credentials(web_sys::RequestCredentials::SameOrigin);
@@ -73,6 +73,8 @@ where
 
 #[cfg(target_arch = "wasm32")]
 fn apply_csrf_headers(window: &web_sys::Window, request: &web_sys::Request) {
+    use wasm_bindgen::JsCast;
+
     let mut header_name = "x-csrf-token".to_owned();
     let mut token = None;
 
@@ -102,8 +104,10 @@ fn apply_csrf_headers(window: &web_sys::Window, request: &web_sys::Request) {
                 .and_then(|meta| meta.get_attribute("content"))
                 .unwrap_or_else(|| "autumn-csrf".to_owned());
 
-            if let Ok(cookie_header) = document.cookie() {
-                token = parse_cookie_value(&cookie_header, &cookie_name);
+            if let Ok(html_document) = document.dyn_into::<web_sys::HtmlDocument>() {
+                if let Ok(cookie_header) = html_document.cookie() {
+                    token = parse_cookie_value(&cookie_header, &cookie_name);
+                }
             }
         }
     }
@@ -160,6 +164,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn post_json_returns_error_on_non_wasm_target() {
         let result = super::post_json::<serde_json::Value, serde_json::Value>(

--- a/autumn-wasm/src/island.rs
+++ b/autumn-wasm/src/island.rs
@@ -20,7 +20,7 @@ impl IslandRegistration {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use std::sync::Mutex;

--- a/autumn-wasm/src/lib.rs
+++ b/autumn-wasm/src/lib.rs
@@ -2,6 +2,7 @@ pub mod action;
 mod boot;
 pub mod compose;
 mod island;
+pub mod prelude;
 pub mod signal;
 
 pub use boot::boot;
@@ -14,10 +15,6 @@ pub type Element = web_sys::Element;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub type Element = ();
-
-pub mod prelude {
-    pub use crate::{Composition, IslandRegistration, Signal, Subscription, action, boot};
-}
 
 #[cfg(test)]
 mod tests {

--- a/autumn-wasm/src/prelude.rs
+++ b/autumn-wasm/src/prelude.rs
@@ -1,0 +1,3 @@
+//! Common imports for island client code.
+
+pub use crate::{Composition, IslandRegistration, Signal, Subscription, action, boot};

--- a/autumn-wasm/tests/wasm_smoke.rs
+++ b/autumn-wasm/tests/wasm_smoke.rs
@@ -1,0 +1,12 @@
+#![cfg(target_arch = "wasm32")]
+
+use autumn_wasm::{IslandRegistration, boot};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+fn noop_mount(_: autumn_wasm::Element, _: String) {}
+
+#[wasm_bindgen_test]
+fn boot_accepts_registry_on_wasm_target() {
+    let registry = [IslandRegistration::new("counter", "counter-root", noop_mount)];
+    boot(&registry);
+}

--- a/autumn-wasm/tests/wasm_smoke.rs
+++ b/autumn-wasm/tests/wasm_smoke.rs
@@ -7,6 +7,10 @@ fn noop_mount(_: autumn_wasm::Element, _: String) {}
 
 #[wasm_bindgen_test]
 fn boot_accepts_registry_on_wasm_target() {
-    let registry = [IslandRegistration::new("counter", "counter-root", noop_mount)];
+    let registry = [IslandRegistration::new(
+        "counter",
+        "counter-root",
+        noop_mount,
+    )];
     boot(&registry);
 }

--- a/run_all_tests.ps1
+++ b/run_all_tests.ps1
@@ -1,5 +1,4 @@
-#!/usr/bin/env bash
-set -euo pipefail
+$ErrorActionPreference = "Stop"
 
 rustup target add wasm32-unknown-unknown
 cargo test -p autumn-web


### PR DESCRIPTION
### Motivation

- Ensure browser cookie access works in wasm by using `HtmlDocument` and improve CSRF header extraction for web targets.
- Provide a reusable `prelude` module for island client code and centralize common exports.
- Make dev-dependencies target-specific and add a wasm smoke test and test helper scripts to exercise wasm builds.

### Description

- Updated `Cargo.toml` to add the `HtmlDocument` feature to `web-sys` and split dev-dependencies into `target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies` (keeps `tokio`) and `target.'cfg(target_arch = "wasm32")'.dev-dependencies` (adds `wasm-bindgen-test`).
- In `action.rs` removed a needless mutable request init, imported `JsCast` locally, and changed cookie access to `HtmlDocument` via `dyn_into` so `document.cookie()` is called on an `HtmlDocument`; also gated the non-wasm `post_json` test with `cfg(not(target_arch = "wasm32"))`.
- Restricted `island` tests to non-wasm targets with `cfg(all(test, not(target_arch = "wasm32")))` so they won't run in wasm environments.
- Extracted the inline `prelude` into a new `src/prelude.rs` file and re-exported it via `pub mod prelude;` in `lib.rs`.
- Added a wasm smoke test `tests/wasm_smoke.rs` using `wasm_bindgen_test` to validate `boot` usage on wasm targets.
- Added `run_all_tests.sh` and `run_all_tests.ps1` helper scripts to add the `wasm32-unknown-unknown` target and run/compile tests for wasm and non-wasm packages.

### Testing

- Ran non-wasm unit tests with `cargo test -p autumn-web` which completed successfully.
- Ran non-wasm package tests with `cargo test -p autumn-wasm` which completed successfully on the host target.
- Compiled wasm-target tests with `cargo test -p autumn-wasm --target wasm32-unknown-unknown --no-run` to verify wasm test buildability, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd64c3f770832a85b7c891fa312878)