### PR TITLE
feat(harvest): implement Phase 5 signal delivery and query registry

### DIFF
--- a/autumn-harvest/autumn-harvest/src/context.rs
+++ b/autumn-harvest/autumn-harvest/src/context.rs
@@ -16,6 +16,7 @@ use tokio::sync::oneshot;
 
 use crate::error::{HarvestError, HarvestResult};
 use crate::event::WorkflowEvent;
+use crate::query::QueryRegistry;
 use crate::replay::{HistoryMatch, HistoryMatcher};
 use crate::types::{ActivityExecId, ExecutionId, TimerId};
 
@@ -54,6 +55,11 @@ pub enum WorkflowCommand {
     },
     /// Record an opaque marker (used by version gates, side-effect-free notes).
     RecordMarker { name: String, details: Value },
+    /// Suspend until a named signal is delivered.
+    WaitForSignal {
+        signal_name: String,
+        result_tx: oneshot::Sender<Value>,
+    },
     /// The workflow function returned `Ok(output)`.
     Complete { output: Value },
     /// The workflow function returned `Err(error)`.
@@ -98,6 +104,10 @@ impl std::fmt::Debug for WorkflowCommand {
                 .field("name", name)
                 .field("details", details)
                 .finish(),
+            Self::WaitForSignal { signal_name, .. } => f
+                .debug_struct("WaitForSignal")
+                .field("signal_name", signal_name)
+                .finish_non_exhaustive(),
             Self::Complete { output } => {
                 f.debug_struct("Complete").field("output", output).finish()
             }
@@ -134,6 +144,8 @@ pub struct WorkflowContext {
     activity_seq: Mutex<u32>,
     /// Shared typed state map (same `AppState` extras as the web server).
     state: Arc<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
+    /// In-memory query handlers (not persisted to history).
+    query_registry: Mutex<QueryRegistry>,
 }
 
 impl WorkflowContext {
@@ -177,6 +189,7 @@ impl WorkflowContext {
             start_time,
             activity_seq: Mutex::new(0),
             state,
+            query_registry: Mutex::new(QueryRegistry::new()),
         }
     }
 
@@ -194,6 +207,7 @@ impl WorkflowContext {
             start_time,
             activity_seq: Mutex::new(0),
             state: Arc::new(HashMap::new()),
+            query_registry: Mutex::new(QueryRegistry::new()),
         }
     }
 
@@ -441,6 +455,54 @@ impl WorkflowContext {
         }
     }
 
+    /// Wait for the next delivered signal with the given name.
+    pub async fn wait_for_signal(&self, signal_name: &str) -> HarvestResult<Value> {
+        let history_match = self
+            .matcher
+            .lock()
+            .expect("matcher lock poisoned")
+            .match_signal(signal_name);
+
+        match history_match {
+            HistoryMatch::Matched { output } => Ok(output),
+            HistoryMatch::Diverged { expected, actual } => Err(HarvestError::NonDeterministic(
+                format!("signal mismatch: expected {expected}, got {actual}"),
+            )),
+            HistoryMatch::Failed { .. } => Err(HarvestError::NonDeterministic(
+                "signal history contains unexpected failure".into(),
+            )),
+            HistoryMatch::NoMatch => {
+                let (tx, rx) = oneshot::channel();
+                self.push_command(WorkflowCommand::WaitForSignal {
+                    signal_name: signal_name.to_string(),
+                    result_tx: tx,
+                });
+                rx.await.map_err(|_| {
+                    HarvestError::Cancelled(format!(
+                        "signal '{signal_name}' cancelled: result channel dropped"
+                    ))
+                })
+            }
+        }
+    }
+
+    pub fn register_query<F>(&self, name: &str, handler: F)
+    where
+        F: Fn() -> Value + Send + Sync + 'static,
+    {
+        self.query_registry
+            .lock()
+            .expect("query_registry lock poisoned")
+            .register(name, Arc::new(handler));
+    }
+
+    pub fn execute_query(&self, name: &str) -> HarvestResult<Value> {
+        self.query_registry
+            .lock()
+            .expect("query_registry lock poisoned")
+            .execute(name)
+    }
+
     // ── Command drain ─────────────────────────────────────────────────
 
     /// Drain all accumulated commands. Called by the worker after the
@@ -578,6 +640,7 @@ impl ActivityContext {
 mod tests {
     use super::*;
     use crate::types::ActivityExecId;
+    use chrono::Utc;
 
     #[test]
     fn activity_context_state_returns_none_when_not_registered() {
@@ -1245,5 +1308,37 @@ mod tests {
         assert_eq!(child, serde_json::json!({"id":"A","ok":true}));
         assert_eq!(activity, serde_json::json!({"sent":true}));
         assert!(ctx.drain_commands().is_empty());
+    }
+
+    #[tokio::test]
+    async fn wait_for_signal_replays_recorded_signal() {
+        let exec_id = ExecutionId::new();
+        let history = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::SignalReceived {
+                signal_name: "approved".to_string(),
+                payload: serde_json::json!({"ok": true}),
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(exec_id, history);
+
+        let payload = ctx
+            .wait_for_signal("approved")
+            .await
+            .expect("signal should replay");
+        assert_eq!(payload, serde_json::json!({"ok": true}));
+    }
+
+    #[test]
+    fn query_registry_does_not_emit_commands() {
+        let ctx = WorkflowContext::new_test();
+        ctx.register_query("status", || serde_json::json!({"state": "running"}));
+
+        let value = ctx.execute_query("status").expect("query should execute");
+        assert_eq!(value, serde_json::json!({"state": "running"}));
+        assert!(ctx.drain_commands().is_empty(), "queries must not emit events");
     }
 }

--- a/autumn-harvest/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/autumn-harvest/src/lib.rs
@@ -11,6 +11,7 @@ pub mod info;
 pub mod policy;
 pub mod pool;
 pub mod prelude;
+pub mod query;
 pub mod replay;
 pub mod types;
 
@@ -28,6 +29,8 @@ pub mod queue;
 #[allow(clippy::wildcard_imports)]
 pub mod schema;
 #[cfg(feature = "db")]
+pub mod signal;
+#[cfg(feature = "db")]
 pub mod store;
 #[cfg(feature = "db")]
 pub mod timeout;
@@ -44,6 +47,7 @@ pub use executor::{WorkflowOutcome, run_workflow};
 pub use info::{ActivityHandlerFn, ActivityInfo, DagInfo, WorkflowHandlerFn, WorkflowInfo};
 pub use policy::{RetryPolicy, Schedule, TaskStatus, TriggerRule};
 pub use pool::{HarvestPoolConfig, compute_pool_sizes};
+pub use query::QueryRegistry;
 pub use replay::{HistoryMatch, HistoryMatcher};
 pub use types::{ActivityExecId, ExecutionId, TimerId, WorkerId, WorkflowId};
 

--- a/autumn-harvest/autumn-harvest/src/prelude.rs
+++ b/autumn-harvest/autumn-harvest/src/prelude.rs
@@ -11,6 +11,7 @@ pub use crate::error::{HarvestError, HarvestResult, TimeoutType};
 pub use crate::event::WorkflowEvent;
 pub use crate::info::{ActivityInfo, DagInfo, WorkflowInfo};
 pub use crate::policy::{RetryPolicy, Schedule, TriggerRule};
+pub use crate::query::QueryRegistry;
 pub use crate::types::{ActivityExecId, ExecutionId, TimerId, WorkerId, WorkflowId};
 
 // Re-export macros from autumn-harvest-macros.

--- a/autumn-harvest/autumn-harvest/src/query.rs
+++ b/autumn-harvest/autumn-harvest/src/query.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use crate::error::{HarvestError, HarvestResult};
+
+pub type QueryHandler = Arc<dyn Fn() -> Value + Send + Sync>;
+
+#[derive(Default)]
+pub struct QueryRegistry {
+    handlers: HashMap<String, QueryHandler>,
+}
+
+impl QueryRegistry {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(&mut self, name: &str, handler: QueryHandler) {
+        self.handlers.insert(name.to_string(), handler);
+    }
+
+    pub fn execute(&self, name: &str) -> HarvestResult<Value> {
+        self.handlers
+            .get(name)
+            .map(|handler| handler())
+            .ok_or_else(|| HarvestError::NotFound(format!("query handler '{name}'")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn executes_registered_query() {
+        let mut reg = QueryRegistry::new();
+        reg.register("status", Arc::new(|| serde_json::json!({"ok": true})));
+
+        let result = reg.execute("status").expect("query must be found");
+        assert_eq!(result, serde_json::json!({"ok": true}));
+    }
+}

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -284,32 +284,33 @@ impl HistoryMatcher {
     ///
     /// Expects `SignalReceived { signal_name }` at the current cursor.
     pub fn match_signal(&mut self, signal_name: &str) -> HistoryMatch {
-        self.advance_to_next_unconsumed_event();
-        if !self.is_replaying() {
-            return HistoryMatch::NoMatch;
-        }
-
-        match &self.events[self.cursor] {
-            WorkflowEvent::SignalReceived {
-                signal_name: recorded_name,
-                payload,
-            } if recorded_name == signal_name => {
-                let output = payload.clone();
-                self.cursor += 1;
-                self.advance_to_next_unconsumed_event();
-                HistoryMatch::Matched { output }
+        loop {
+            self.advance_to_next_unconsumed_event();
+            if !self.is_replaying() {
+                return HistoryMatch::NoMatch;
             }
-            WorkflowEvent::SignalReceived {
-                signal_name: recorded_name,
-                ..
-            } => HistoryMatch::Diverged {
-                expected: format!("SignalReceived({signal_name})"),
-                actual: format!("SignalReceived({recorded_name})"),
-            },
-            other => HistoryMatch::Diverged {
-                expected: format!("SignalReceived({signal_name})"),
-                actual: other.type_name().to_string(),
-            },
+
+            match &self.events[self.cursor] {
+                WorkflowEvent::SignalReceived {
+                    signal_name: recorded_name,
+                    payload,
+                } if recorded_name == signal_name => {
+                    let output = payload.clone();
+                    self.cursor += 1;
+                    self.advance_to_next_unconsumed_event();
+                    return HistoryMatch::Matched { output };
+                }
+                WorkflowEvent::SignalReceived { .. } => {
+                    // Different signal names are validly interleaved; skip and keep waiting.
+                    self.cursor += 1;
+                }
+                other => {
+                    return HistoryMatch::Diverged {
+                        expected: format!("SignalReceived({signal_name})"),
+                        actual: other.type_name().to_string(),
+                    };
+                }
+            }
         }
     }
 
@@ -1149,5 +1150,28 @@ mod tests {
                 output: serde_json::json!({"ok": true}),
             }
         );
+    }
+
+    #[test]
+    fn matcher_skips_unrelated_signals_while_waiting() {
+        let events = vec![
+            WorkflowEvent::SignalReceived {
+                signal_name: "cancel".into(),
+                payload: serde_json::json!({"reason": "manual"}),
+            },
+            WorkflowEvent::SignalReceived {
+                signal_name: "approved".into(),
+                payload: serde_json::json!({"ok": true}),
+            },
+        ];
+        let mut matcher = HistoryMatcher::new(events);
+        let result = matcher.match_signal("approved");
+        assert_eq!(
+            result,
+            HistoryMatch::Matched {
+                output: serde_json::json!({"ok": true}),
+            }
+        );
+        assert_eq!(matcher.position(), 2);
     }
 }

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -40,6 +40,7 @@ pub struct HistoryMatcher {
     events: Vec<WorkflowEvent>,
     cursor: usize,
     consumed_child_terminal_events: HashSet<usize>,
+    consumed_signal_events: HashSet<usize>,
 }
 
 impl HistoryMatcher {
@@ -50,6 +51,7 @@ impl HistoryMatcher {
             events,
             cursor: 0,
             consumed_child_terminal_events: HashSet::new(),
+            consumed_signal_events: HashSet::new(),
         }
     }
 
@@ -57,7 +59,9 @@ impl HistoryMatcher {
     #[must_use]
     pub fn is_replaying(&self) -> bool {
         let mut cursor = self.cursor;
-        while self.consumed_child_terminal_events.contains(&cursor) {
+        while self.consumed_child_terminal_events.contains(&cursor)
+            || self.consumed_signal_events.contains(&cursor)
+        {
             cursor += 1;
         }
         cursor < self.events.len()
@@ -81,7 +85,8 @@ impl HistoryMatcher {
     }
 
     fn advance_to_next_unconsumed_event(&mut self) {
-        while self.consumed_child_terminal_events.contains(&self.cursor)
+        while (self.consumed_child_terminal_events.contains(&self.cursor)
+            || self.consumed_signal_events.contains(&self.cursor))
             && self.cursor < self.events.len()
         {
             self.cursor += 1;
@@ -284,25 +289,39 @@ impl HistoryMatcher {
     ///
     /// Expects `SignalReceived { signal_name }` at the current cursor.
     pub fn match_signal(&mut self, signal_name: &str) -> HistoryMatch {
-        loop {
-            self.advance_to_next_unconsumed_event();
-            if !self.is_replaying() {
-                return HistoryMatch::NoMatch;
+        self.advance_to_next_unconsumed_event();
+        if !self.is_replaying() {
+            return HistoryMatch::NoMatch;
+        }
+
+        let mut scan_cursor = self.cursor;
+        while scan_cursor < self.events.len() {
+            if self.consumed_child_terminal_events.contains(&scan_cursor)
+                || self.consumed_signal_events.contains(&scan_cursor)
+            {
+                scan_cursor += 1;
+                continue;
             }
 
-            match &self.events[self.cursor] {
+            match &self.events[scan_cursor] {
                 WorkflowEvent::SignalReceived {
                     signal_name: recorded_name,
                     payload,
                 } if recorded_name == signal_name => {
                     let output = payload.clone();
-                    self.cursor += 1;
-                    self.advance_to_next_unconsumed_event();
+
+                    if scan_cursor == self.cursor {
+                        self.cursor += 1;
+                        self.advance_to_next_unconsumed_event();
+                    } else {
+                        self.consumed_signal_events.insert(scan_cursor);
+                    }
+
                     return HistoryMatch::Matched { output };
                 }
                 WorkflowEvent::SignalReceived { .. } => {
-                    // Different signal names are validly interleaved; skip and keep waiting.
-                    self.cursor += 1;
+                    // Different signal names remain available for future waits.
+                    scan_cursor += 1;
                 }
                 other => {
                     return HistoryMatch::Diverged {
@@ -312,6 +331,8 @@ impl HistoryMatcher {
                 }
             }
         }
+
+        HistoryMatch::NoMatch
     }
 
     /// Match a child workflow command against history.
@@ -1172,6 +1193,41 @@ mod tests {
                 output: serde_json::json!({"ok": true}),
             }
         );
-        assert_eq!(matcher.position(), 2);
+        assert_eq!(
+            matcher.position(),
+            0,
+            "cursor should remain on unrelated signal so later waits can consume it"
+        );
+    }
+
+    #[test]
+    fn matcher_preserves_unrelated_signal_for_later_wait() {
+        let events = vec![
+            WorkflowEvent::SignalReceived {
+                signal_name: "cancel".into(),
+                payload: serde_json::json!({"reason": "manual"}),
+            },
+            WorkflowEvent::SignalReceived {
+                signal_name: "approved".into(),
+                payload: serde_json::json!({"ok": true}),
+            },
+        ];
+        let mut matcher = HistoryMatcher::new(events);
+
+        let approved = matcher.match_signal("approved");
+        assert_eq!(
+            approved,
+            HistoryMatch::Matched {
+                output: serde_json::json!({"ok": true}),
+            }
+        );
+
+        let cancel = matcher.match_signal("cancel");
+        assert_eq!(
+            cancel,
+            HistoryMatch::Matched {
+                output: serde_json::json!({"reason": "manual"}),
+            }
+        );
     }
 }

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -10,7 +10,7 @@
 //! it directly, avoiding duplicate side effects.
 
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 
 use crate::event::WorkflowEvent;
 
@@ -41,6 +41,7 @@ pub struct HistoryMatcher {
     cursor: usize,
     consumed_child_terminal_events: HashSet<usize>,
     consumed_signal_events: HashSet<usize>,
+    pending_signals: VecDeque<(String, Value)>,
 }
 
 impl HistoryMatcher {
@@ -52,6 +53,7 @@ impl HistoryMatcher {
             cursor: 0,
             consumed_child_terminal_events: HashSet::new(),
             consumed_signal_events: HashSet::new(),
+            pending_signals: VecDeque::new(),
         }
     }
 
@@ -289,6 +291,18 @@ impl HistoryMatcher {
     ///
     /// Expects `SignalReceived { signal_name }` at the current cursor.
     pub fn match_signal(&mut self, signal_name: &str) -> HistoryMatch {
+        if let Some(index) = self
+            .pending_signals
+            .iter()
+            .position(|(name, _)| name == signal_name)
+        {
+            let (_name, payload) = self
+                .pending_signals
+                .remove(index)
+                .expect("index from position must be valid");
+            return HistoryMatch::Matched { output: payload };
+        }
+
         self.advance_to_next_unconsumed_event();
         if !self.is_replaying() {
             return HistoryMatch::NoMatch;
@@ -309,18 +323,19 @@ impl HistoryMatcher {
                     payload,
                 } if recorded_name == signal_name => {
                     let output = payload.clone();
-
-                    if scan_cursor == self.cursor {
-                        self.cursor += 1;
-                        self.advance_to_next_unconsumed_event();
-                    } else {
-                        self.consumed_signal_events.insert(scan_cursor);
-                    }
+                    self.consumed_signal_events.insert(scan_cursor);
+                    self.cursor = scan_cursor.saturating_add(1);
+                    self.advance_to_next_unconsumed_event();
 
                     return HistoryMatch::Matched { output };
                 }
-                WorkflowEvent::SignalReceived { .. } => {
-                    // Different signal names remain available for future waits.
+                WorkflowEvent::SignalReceived {
+                    signal_name: recorded_name,
+                    payload,
+                } => {
+                    self.consumed_signal_events.insert(scan_cursor);
+                    self.pending_signals
+                        .push_back((recorded_name.clone(), payload.clone()));
                     scan_cursor += 1;
                 }
                 other => {
@@ -1195,8 +1210,8 @@ mod tests {
         );
         assert_eq!(
             matcher.position(),
-            0,
-            "cursor should remain on unrelated signal so later waits can consume it"
+            2,
+            "cursor should advance beyond matched signal to avoid stale divergences"
         );
     }
 
@@ -1227,6 +1242,38 @@ mod tests {
             cancel,
             HistoryMatch::Matched {
                 output: serde_json::json!({"reason": "manual"}),
+            }
+        );
+    }
+
+    #[test]
+    fn matcher_allows_non_signal_command_after_out_of_order_signal_match() {
+        let timer_id = TimerId::new("cooldown");
+        let events = vec![
+            WorkflowEvent::SignalReceived {
+                signal_name: "cancel".into(),
+                payload: serde_json::json!({"reason": "manual"}),
+            },
+            WorkflowEvent::SignalReceived {
+                signal_name: "approved".into(),
+                payload: serde_json::json!({"ok": true}),
+            },
+            WorkflowEvent::TimerStarted {
+                timer_id: timer_id.clone(),
+                duration_secs: 5,
+            },
+            WorkflowEvent::TimerFired { timer_id },
+        ];
+        let mut matcher = HistoryMatcher::new(events);
+
+        let approved = matcher.match_signal("approved");
+        assert!(matches!(approved, HistoryMatch::Matched { .. }));
+
+        let timer = matcher.match_timer("cooldown");
+        assert_eq!(
+            timer,
+            HistoryMatch::Matched {
+                output: Value::Null
             }
         );
     }

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -280,6 +280,39 @@ impl HistoryMatcher {
         HistoryMatch::NoMatch
     }
 
+    /// Match a signal wait command against history.
+    ///
+    /// Expects `SignalReceived { signal_name }` at the current cursor.
+    pub fn match_signal(&mut self, signal_name: &str) -> HistoryMatch {
+        self.advance_to_next_unconsumed_event();
+        if !self.is_replaying() {
+            return HistoryMatch::NoMatch;
+        }
+
+        match &self.events[self.cursor] {
+            WorkflowEvent::SignalReceived {
+                signal_name: recorded_name,
+                payload,
+            } if recorded_name == signal_name => {
+                let output = payload.clone();
+                self.cursor += 1;
+                self.advance_to_next_unconsumed_event();
+                HistoryMatch::Matched { output }
+            }
+            WorkflowEvent::SignalReceived {
+                signal_name: recorded_name,
+                ..
+            } => HistoryMatch::Diverged {
+                expected: format!("SignalReceived({signal_name})"),
+                actual: format!("SignalReceived({recorded_name})"),
+            },
+            other => HistoryMatch::Diverged {
+                expected: format!("SignalReceived({signal_name})"),
+                actual: other.type_name().to_string(),
+            },
+        }
+    }
+
     /// Match a child workflow command against history.
     ///
     /// Expects `ChildWorkflowStarted { workflow_name }` at cursor, then scans for
@@ -1100,5 +1133,21 @@ mod tests {
         assert_eq!(r2, HistoryMatch::Matched { output: output2 });
 
         assert!(!matcher.is_replaying());
+    }
+
+    #[test]
+    fn matcher_replays_signal_payload() {
+        let events = vec![WorkflowEvent::SignalReceived {
+            signal_name: "approved".into(),
+            payload: serde_json::json!({"ok": true}),
+        }];
+        let mut matcher = HistoryMatcher::new(events);
+        let result = matcher.match_signal("approved");
+        assert_eq!(
+            result,
+            HistoryMatch::Matched {
+                output: serde_json::json!({"ok": true}),
+            }
+        );
     }
 }

--- a/autumn-harvest/autumn-harvest/src/signal.rs
+++ b/autumn-harvest/autumn-harvest/src/signal.rs
@@ -1,0 +1,73 @@
+#[cfg(feature = "db")]
+use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
+#[cfg(feature = "db")]
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+
+use crate::error::HarvestResult;
+#[cfg(feature = "db")]
+use crate::models::{HarvestSignal, NewHarvestSignal};
+use crate::types::ExecutionId;
+
+/// Queue a workflow signal for durable delivery.
+#[cfg(feature = "db")]
+pub async fn send_signal(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    signal_name: &str,
+    payload: serde_json::Value,
+) -> HarvestResult<()> {
+    use crate::schema::harvest_signals;
+
+    let row = NewHarvestSignal {
+        workflow_exec_id: exec_id.as_uuid(),
+        signal_name,
+        payload,
+    };
+
+    diesel::insert_into(harvest_signals::table)
+        .values(&row)
+        .execute(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+    Ok(())
+}
+
+/// Load all unconsumed queued signals for an execution, ordered by receive time.
+#[cfg(feature = "db")]
+pub async fn load_pending_signals(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+) -> HarvestResult<Vec<HarvestSignal>> {
+    use crate::schema::harvest_signals::dsl;
+
+    dsl::harvest_signals
+        .filter(dsl::workflow_exec_id.eq(exec_id.as_uuid()))
+        .filter(dsl::consumed.eq(false))
+        .order((dsl::received_at.asc(), dsl::id.asc()))
+        .select(HarvestSignal::as_select())
+        .load(conn)
+        .await
+        .map_err(crate::error::database_error)
+}
+
+/// Mark the provided signal IDs consumed.
+#[cfg(feature = "db")]
+pub async fn mark_signals_consumed(
+    conn: &mut AsyncPgConnection,
+    signal_ids: &[uuid::Uuid],
+) -> HarvestResult<()> {
+    use crate::schema::harvest_signals::dsl;
+
+    if signal_ids.is_empty() {
+        return Ok(());
+    }
+
+    diesel::update(dsl::harvest_signals.filter(dsl::id.eq_any(signal_ids)))
+        .set(dsl::consumed.eq(true))
+        .execute(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+    Ok(())
+}

--- a/autumn-harvest/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/autumn-harvest/src/worker.rs
@@ -28,6 +28,7 @@ use crate::executor::{WorkflowOutcome, run_workflow};
 use crate::info::{ActivityInfo, WorkflowInfo};
 use crate::models::{TaskQueueItem, WorkflowExecution};
 use crate::queue::{self, TaskType};
+use crate::signal;
 use crate::schema::harvest_workflow_executions;
 use crate::store;
 use crate::types::ExecutionId;
@@ -163,6 +164,7 @@ fn workflow_command_name(command: &WorkflowCommand) -> &'static str {
         WorkflowCommand::StartTimer { .. } => "StartTimer",
         WorkflowCommand::StartChildWorkflow { .. } => "StartChildWorkflow",
         WorkflowCommand::RecordMarker { .. } => "RecordMarker",
+        WorkflowCommand::WaitForSignal { .. } => "WaitForSignal",
         WorkflowCommand::Complete { .. } => "Complete",
         WorkflowCommand::Fail { .. } => "Fail",
     }
@@ -379,6 +381,22 @@ async fn process_workflow_task(
         }
     };
 
+    let pending_signals = signal::load_pending_signals(conn, exec_id).await?;
+    if !pending_signals.is_empty() {
+        let signal_events = pending_signals
+            .iter()
+            .map(|s| WorkflowEvent::SignalReceived {
+                signal_name: s.signal_name.clone(),
+                payload: s.payload.clone(),
+            })
+            .collect::<Vec<_>>();
+        let signal_ids = pending_signals.iter().map(|s| s.id).collect::<Vec<_>>();
+        store::append_events(conn, exec_id, &signal_events, history.next_event_id).await?;
+        signal::mark_signals_consumed(conn, &signal_ids).await?;
+    }
+
+    let history = store::load_history(conn, exec_id).await?;
+
     let workflow = match registry.workflows.get(&execution.workflow_name) {
         Some(workflow) => workflow,
         None => {
@@ -410,8 +428,16 @@ async fn process_workflow_task(
             persist_workflow_failure(conn, task.id, exec_id, next_event_id, worker_id, &error).await
         }
         WorkflowOutcome::Suspended { commands } => {
-            let error = suspended_workflow_error(&commands);
-            persist_workflow_failure(conn, task.id, exec_id, next_event_id, worker_id, &error).await
+            if commands
+                .iter()
+                .all(|cmd| matches!(cmd, WorkflowCommand::WaitForSignal { .. }))
+            {
+                queue::requeue_for_retry(conn, task.id, chrono::Duration::seconds(1)).await
+            } else {
+                let error = suspended_workflow_error(&commands);
+                persist_workflow_failure(conn, task.id, exec_id, next_event_id, worker_id, &error)
+                    .await
+            }
         }
     }
 }

--- a/autumn-harvest/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/autumn-harvest/src/worker.rs
@@ -388,8 +388,12 @@ async fn process_workflow_task(
         }
     };
 
-    let pending_signals = signal::load_pending_signals(conn, exec_id).await?;
-    if !pending_signals.is_empty() {
+    let signal_ingest_result: HarvestResult<()> = async {
+        let pending_signals = signal::load_pending_signals(conn, exec_id).await?;
+        if pending_signals.is_empty() {
+            return Ok(());
+        }
+
         let signal_events = pending_signals
             .iter()
             .map(|s| WorkflowEvent::SignalReceived {
@@ -407,6 +411,13 @@ async fn process_workflow_task(
             .scope_boxed()
         })
         .await?;
+        Ok(())
+    }
+    .await;
+
+    if let Err(error) = signal_ingest_result {
+        fail_task_and_execution(conn, task, worker_id, &error.to_string()).await?;
+        return Err(error);
     }
 
     let history = store::load_history(conn, exec_id).await?;

--- a/autumn-harvest/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/autumn-harvest/src/worker.rs
@@ -193,6 +193,24 @@ fn all_commands_wait_for_signal(commands: &[WorkflowCommand]) -> bool {
             .all(|cmd| matches!(cmd, WorkflowCommand::WaitForSignal { .. }))
 }
 
+fn should_requeue_signal_wait(commands: &[WorkflowCommand]) -> bool {
+    if commands.is_empty() {
+        return false;
+    }
+
+    let has_wait = commands
+        .iter()
+        .any(|cmd| matches!(cmd, WorkflowCommand::WaitForSignal { .. }));
+    let only_wait_or_marker = commands.iter().all(|cmd| {
+        matches!(
+            cmd,
+            WorkflowCommand::WaitForSignal { .. } | WorkflowCommand::RecordMarker { .. }
+        )
+    });
+
+    has_wait && only_wait_or_marker
+}
+
 async fn load_workflow_execution(
     conn: &mut AsyncPgConnection,
     exec_id: ExecutionId,
@@ -459,7 +477,7 @@ async fn process_workflow_task(
             persist_workflow_failure(conn, task.id, exec_id, next_event_id, worker_id, &error).await
         }
         WorkflowOutcome::Suspended { commands } => {
-            if all_commands_wait_for_signal(&commands) {
+            if should_requeue_signal_wait(&commands) {
                 queue::requeue_for_retry(conn, task.id, chrono::Duration::seconds(1)).await
             } else {
                 let error = suspended_workflow_error(&commands);
@@ -840,5 +858,29 @@ mod tests {
             },
         ];
         assert!(!all_commands_wait_for_signal(&mixed));
+    }
+
+    #[test]
+    fn should_requeue_signal_wait_allows_marker_plus_wait() {
+        let commands = vec![
+            WorkflowCommand::RecordMarker {
+                name: "version:gate".to_string(),
+                details: serde_json::json!(2),
+            },
+            WorkflowCommand::WaitForSignal {
+                signal_name: "approved".to_string(),
+                result_tx: oneshot::channel::<serde_json::Value>().0,
+            },
+        ];
+        assert!(should_requeue_signal_wait(&commands));
+    }
+
+    #[test]
+    fn should_requeue_signal_wait_rejects_marker_only() {
+        let commands = vec![WorkflowCommand::RecordMarker {
+            name: "version:gate".to_string(),
+            details: serde_json::json!(2),
+        }];
+        assert!(!should_requeue_signal_wait(&commands));
     }
 }

--- a/autumn-harvest/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/autumn-harvest/src/worker.rs
@@ -420,7 +420,13 @@ async fn process_workflow_task(
         return Err(error);
     }
 
-    let history = store::load_history(conn, exec_id).await?;
+    let history = match store::load_history(conn, exec_id).await {
+        Ok(history) => history,
+        Err(error) => {
+            fail_task_and_execution(conn, task, worker_id, &error.to_string()).await?;
+            return Err(error);
+        }
+    };
 
     let workflow = match registry.workflows.get(&execution.workflow_name) {
         Some(workflow) => workflow,

--- a/autumn-harvest/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/autumn-harvest/src/worker.rs
@@ -186,6 +186,13 @@ fn suspended_workflow_error(commands: &[WorkflowCommand]) -> String {
     )
 }
 
+fn all_commands_wait_for_signal(commands: &[WorkflowCommand]) -> bool {
+    !commands.is_empty()
+        && commands
+            .iter()
+            .all(|cmd| matches!(cmd, WorkflowCommand::WaitForSignal { .. }))
+}
+
 async fn load_workflow_execution(
     conn: &mut AsyncPgConnection,
     exec_id: ExecutionId,
@@ -391,8 +398,15 @@ async fn process_workflow_task(
             })
             .collect::<Vec<_>>();
         let signal_ids = pending_signals.iter().map(|s| s.id).collect::<Vec<_>>();
-        store::append_events(conn, exec_id, &signal_events, history.next_event_id).await?;
-        signal::mark_signals_consumed(conn, &signal_ids).await?;
+        conn.transaction::<(), HarvestError, _>(|conn| {
+            async move {
+                store::append_events(conn, exec_id, &signal_events, history.next_event_id).await?;
+                signal::mark_signals_consumed(conn, &signal_ids).await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await?;
     }
 
     let history = store::load_history(conn, exec_id).await?;
@@ -428,10 +442,7 @@ async fn process_workflow_task(
             persist_workflow_failure(conn, task.id, exec_id, next_event_id, worker_id, &error).await
         }
         WorkflowOutcome::Suspended { commands } => {
-            if commands
-                .iter()
-                .all(|cmd| matches!(cmd, WorkflowCommand::WaitForSignal { .. }))
-            {
+            if all_commands_wait_for_signal(&commands) {
                 queue::requeue_for_retry(conn, task.id, chrono::Duration::seconds(1)).await
             } else {
                 let error = suspended_workflow_error(&commands);
@@ -664,6 +675,7 @@ impl Worker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::sync::oneshot;
 
     fn default_runtime_config() -> WorkerRuntimeConfig {
         WorkerRuntimeConfig {
@@ -780,5 +792,36 @@ mod tests {
             ClaimedTaskKind::Activity
         );
         assert!(ClaimedTaskKind::from_db("WORKFLOW").is_err());
+    }
+
+    #[test]
+    fn all_commands_wait_for_signal_requires_non_empty() {
+        let commands: Vec<WorkflowCommand> = vec![];
+        assert!(!all_commands_wait_for_signal(&commands));
+    }
+
+    #[test]
+    fn all_commands_wait_for_signal_only_accepts_wait_commands() {
+        let (signal_tx, _signal_rx) = oneshot::channel::<serde_json::Value>();
+        let (timer_tx, _timer_rx) = oneshot::channel::<()>();
+
+        let only_wait = vec![WorkflowCommand::WaitForSignal {
+            signal_name: "approved".to_string(),
+            result_tx: signal_tx,
+        }];
+        assert!(all_commands_wait_for_signal(&only_wait));
+
+        let mixed = vec![
+            WorkflowCommand::WaitForSignal {
+                signal_name: "approved".to_string(),
+                result_tx: oneshot::channel::<serde_json::Value>().0,
+            },
+            WorkflowCommand::StartTimer {
+                timer_id: crate::types::TimerId::new("t1"),
+                duration_secs: 1,
+                result_tx: timer_tx,
+            },
+        ];
+        assert!(!all_commands_wait_for_signal(&mixed));
     }
 }


### PR DESCRIPTION
### Motivation
- Implement Phase 5 of Autumn Harvest by adding durable signal delivery and an in-memory query registry so workflows can wait for external signals and expose read-only query handlers without mutating history.

### Description
- Add durable signal helpers in `signal.rs` (`send_signal`, `load_pending_signals`, `mark_signals_consumed`) to queue, load, and consume workflow signals in the DB (DB-gated behind the `db` feature). 
- Add `QueryRegistry` in `query.rs` and wire it into `WorkflowContext` as an in-memory registry with `register_query` and `execute_query` for non-persistent queries. 
- Extend `WorkflowCommand` with `WaitForSignal` and implement `WorkflowContext::wait_for_signal` to replay recorded signals or emit `WaitForSignal` during live execution. 
- Extend the replay engine with `HistoryMatcher::match_signal` and corresponding unit test to support signal replay. 
- Update worker dispatch in `worker.rs` to ingest pending queued signals into the execution history before running the workflow, mark them consumed, and requeue tasks that suspended only on signal waits instead of failing. 
- Export new APIs via `lib.rs` and `prelude.rs`, and add unit tests for query and signal behavior in `context.rs` and `replay.rs`.

### Testing
- Ran `cargo fmt` successfully to apply formatting. 
- Ran package tests for `autumn-harvest` without DB defaults (`cd autumn-harvest && cargo test -p autumn-harvest --no-default-features`), and the package test suite passed (unit and module tests including replay, dag, macros, and query/signal-related tests all passed). 
- All added unit tests (signal/query replay and registry behavior) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cda66e2bd4832a9fb2983c92de9017)