### PR TITLE
Remove after_* and after_commit hook lifecycle methods

### DIFF
--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -268,7 +268,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     // When `hooks_type` is present, the struct gains a `hooks` field,
     // the extractor initialises it with `Default::default()`, and the
     // save / update / delete methods are wrapped in a transactional
-    // hook lifecycle (before_* → persist → after_* → commit → after_commit).
+    // hook lifecycle (before_* → persist).
     //
     // When absent, the generated code is identical to the pre-hooks version
     // (zero-cost path).
@@ -297,36 +297,20 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         let save_body = quote! {
             use ::autumn_web::reexports::diesel::prelude::*;
             use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-            use ::autumn_web::reexports::diesel_async::AsyncConnection;
-            use ::autumn_web::reexports::diesel_async::scoped_futures::ScopedFutureExt;
             use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
 
             let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
             let mut input = new.clone();
             let mut ctx = MutationContext::new(MutationOp::Create);
 
-            // before_create can validate/reject/rewrite before the transaction
+            // before_create can validate/reject/rewrite
             self.hooks.before_create(&mut ctx, &mut input).await?;
 
-            // Transaction: persist + after_create
-            let hooks = &self.hooks;
-            let ctx_ref = &ctx;
-            let record = conn.transaction::<#model_name, ::autumn_web::AutumnError, _>(|conn| {
-                async move {
-                    let record = ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                        .values(&input)
-                        .get_result::<#model_name>(conn)
-                        .await
-                        .map_err(::autumn_web::AutumnError::from)?;
-                    hooks.after_create(ctx_ref, &record, conn).await?;
-                    Ok(record)
-                }.scope_boxed()
-            }).await?;
-
-            // after_commit: best-effort, errors logged but don't roll back
-            if let Err(e) = self.hooks.after_commit(&ctx, MutationOp::Create).await {
-                ::autumn_web::reexports::tracing::warn!("after_commit hook error: {e}");
-            }
+            let record = ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                .values(&input)
+                .get_result::<#model_name>(&mut conn)
+                .await
+                .map_err(::autumn_web::AutumnError::from)?;
 
             Ok(record)
         };
@@ -336,8 +320,6 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         let update_body = quote! {
             use ::autumn_web::reexports::diesel::prelude::*;
             use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-            use ::autumn_web::reexports::diesel_async::AsyncConnection;
-            use ::autumn_web::reexports::diesel_async::scoped_futures::ScopedFutureExt;
             use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks, UpdateDraft};
 
             let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
@@ -362,23 +344,11 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
             // Persist the proposed state
             let proposed = draft.into_after();
-            let hooks = &self.hooks;
-            let ctx_ref = &ctx;
-            let record = conn.transaction::<#model_name, ::autumn_web::AutumnError, _>(|conn| {
-                async move {
-                    let record = ::autumn_web::reexports::diesel::update(#table_ident::table.find(id))
-                        .set(&proposed)
-                        .get_result::<#model_name>(conn)
-                        .await
-                        .map_err(::autumn_web::AutumnError::from)?;
-                    hooks.after_update(ctx_ref, &record, conn).await?;
-                    Ok(record)
-                }.scope_boxed()
-            }).await?;
-
-            if let Err(e) = self.hooks.after_commit(&ctx, MutationOp::Update).await {
-                ::autumn_web::reexports::tracing::warn!("after_commit hook error: {e}");
-            }
+            let record = ::autumn_web::reexports::diesel::update(#table_ident::table.find(id))
+                .set(&proposed)
+                .get_result::<#model_name>(&mut conn)
+                .await
+                .map_err(::autumn_web::AutumnError::from)?;
 
             Ok(record)
         };
@@ -387,8 +357,6 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         let delete_body = quote! {
             use ::autumn_web::reexports::diesel::prelude::*;
             use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-            use ::autumn_web::reexports::diesel_async::AsyncConnection;
-            use ::autumn_web::reexports::diesel_async::scoped_futures::ScopedFutureExt;
             use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
 
             let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
@@ -407,23 +375,10 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
             self.hooks.before_delete(&mut ctx, &record).await?;
 
-            // Transaction: delete + after_delete
-            let hooks = &self.hooks;
-            let ctx_ref = &ctx;
-            conn.transaction::<(), ::autumn_web::AutumnError, _>(|conn| {
-                async move {
-                    ::autumn_web::reexports::diesel::delete(#table_ident::table.find(id))
-                        .execute(conn)
-                        .await
-                        .map_err(::autumn_web::AutumnError::from)?;
-                    hooks.after_delete(ctx_ref, id, conn).await?;
-                    Ok(())
-                }.scope_boxed()
-            }).await?;
-
-            if let Err(e) = self.hooks.after_commit(&ctx, MutationOp::Delete).await {
-                ::autumn_web::reexports::tracing::warn!("after_commit hook error: {e}");
-            }
+            ::autumn_web::reexports::diesel::delete(#table_ident::table.find(id))
+                .execute(&mut conn)
+                .await
+                .map_err(::autumn_web::AutumnError::from)?;
 
             Ok(())
         };

--- a/autumn/src/hooks.rs
+++ b/autumn/src/hooks.rs
@@ -179,7 +179,6 @@ pub trait MutationHooks: Send + Sync + 'static {
     ) -> impl Future<Output = AutumnResult<()>> + Send {
         async { Ok(()) }
     }
-
 }
 
 // ── Default no-op hooks ──────────────────────────────────────────────

--- a/autumn/src/hooks.rs
+++ b/autumn/src/hooks.rs
@@ -32,24 +32,14 @@
 //!
 //! Every mutating CRUD operation follows the same lifecycle:
 //!
-//! 1. **`before_*`** -- called outside the transaction with a mutable
+//! 1. **`before_*`** -- called before the mutation with a mutable
 //!    reference to the [`MutationContext`] and the input/model. The hook
 //!    may validate, enrich, or reject (by returning `Err`).
-//! 2. **persist** -- the actual `INSERT`, `UPDATE`, or `DELETE` runs
-//!    inside a database transaction.
-//! 3. **`after_*`** -- called inside the same transaction with the
-//!    persisted record. Returning `Err` rolls back the transaction.
-//! 4. **commit** -- the transaction is committed.
-//! 5. **`after_commit`** -- called after a successful commit. Errors
-//!    are logged as warnings but do **not** roll back (the data is
-//!    already persisted). Use this for side-effects like sending
-//!    notifications or publishing events.
+//! 2. **persist** -- the actual `INSERT`, `UPDATE`, or `DELETE` runs.
 //!
 //! # Error semantics
 //!
 //! - `before_*` errors prevent the mutation entirely.
-//! - `after_*` errors (inside the transaction) cause a rollback.
-//! - `after_commit` errors are best-effort: logged, never propagated.
 //!
 //! # Helper types
 //!
@@ -160,16 +150,6 @@ pub trait MutationHooks: Send + Sync + 'static {
         async { Ok(()) }
     }
 
-    /// Called after a new record has been inserted (inside the transaction).
-    fn after_create(
-        &self,
-        _ctx: &MutationContext,
-        _record: &Self::Model,
-        _conn: &mut diesel_async::AsyncPgConnection,
-    ) -> impl Future<Output = AutumnResult<()>> + Send {
-        async { Ok(()) }
-    }
-
     /// Called before an existing record is updated.
     ///
     /// The `draft` holds the merged before/after state. Use per-field
@@ -191,16 +171,6 @@ pub trait MutationHooks: Send + Sync + 'static {
         async { Ok(()) }
     }
 
-    /// Called after an existing record has been updated (inside the transaction).
-    fn after_update(
-        &self,
-        _ctx: &MutationContext,
-        _record: &Self::Model,
-        _conn: &mut diesel_async::AsyncPgConnection,
-    ) -> impl Future<Output = AutumnResult<()>> + Send {
-        async { Ok(()) }
-    }
-
     /// Called before an existing record is deleted.
     fn before_delete(
         &self,
@@ -210,24 +180,6 @@ pub trait MutationHooks: Send + Sync + 'static {
         async { Ok(()) }
     }
 
-    /// Called after a record has been deleted (inside the transaction).
-    fn after_delete(
-        &self,
-        _ctx: &MutationContext,
-        _id: i64,
-        _conn: &mut diesel_async::AsyncPgConnection,
-    ) -> impl Future<Output = AutumnResult<()>> + Send {
-        async { Ok(()) }
-    }
-
-    /// Called after the transaction has been committed for any operation.
-    fn after_commit(
-        &self,
-        _ctx: &MutationContext,
-        _op: MutationOp,
-    ) -> impl Future<Output = AutumnResult<()>> + Send {
-        async { Ok(()) }
-    }
 }
 
 // ── Default no-op hooks ──────────────────────────────────────────────
@@ -717,11 +669,8 @@ mod tests {
         let mut draft = UpdateDraft::new(());
 
         assert!(hooks.before_create(&mut ctx, &mut new_model).await.is_ok());
-        // after_create, after_update, after_delete require &mut AsyncPgConnection
-        // and are covered by compile-pass and db_hooks_lifecycle tests.
         assert!(hooks.before_update(&mut ctx, &mut draft).await.is_ok());
         assert!(hooks.before_delete(&mut ctx, &model).await.is_ok());
-        assert!(hooks.after_commit(&ctx, MutationOp::Create).await.is_ok());
     }
 
     // ── Patch serde tests ──────────────────────────────────────────

--- a/autumn/tests/db_hooks_lifecycle.rs
+++ b/autumn/tests/db_hooks_lifecycle.rs
@@ -1,7 +1,7 @@
 //! Database-level integration tests for mutation hook lifecycle.
 //!
 //! These tests spin up a real Postgres instance via testcontainers and validate
-//! that before/after hooks integrate correctly with actual database operations.
+//! that before hooks integrate correctly with actual database operations.
 //!
 //! **Requires Docker** to be running.
 
@@ -10,7 +10,7 @@ use autumn_web::hooks::{MutationContext, MutationHooks, MutationOp, UpdateDraft}
 use diesel::prelude::*;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::pooled_connection::deadpool::Pool;
-use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
 
@@ -88,43 +88,6 @@ impl MutationHooks for RejectEmptyTitleHooks {
             ));
         }
         Ok(())
-    }
-}
-
-/// Always fails in `after_create` to test transaction rollback.
-#[derive(Clone, Default)]
-struct FailAfterCreateHooks;
-
-impl MutationHooks for FailAfterCreateHooks {
-    type Model = Article;
-    type NewModel = NewArticle;
-    type UpdateModel = ();
-
-    async fn after_create(
-        &self,
-        _ctx: &MutationContext,
-        _record: &Article,
-        _conn: &mut AsyncPgConnection,
-    ) -> AutumnResult<()> {
-        Err(autumn_web::AutumnError::bad_request_msg(
-            "after_create intentionally failed",
-        ))
-    }
-}
-
-/// Always fails in `after_commit` to test that committed data persists.
-#[derive(Clone, Default)]
-struct FailAfterCommitHooks;
-
-impl MutationHooks for FailAfterCommitHooks {
-    type Model = Article;
-    type NewModel = NewArticle;
-    type UpdateModel = ();
-
-    async fn after_commit(&self, _ctx: &MutationContext, _op: MutationOp) -> AutumnResult<()> {
-        Err(autumn_web::AutumnError::bad_request_msg(
-            "after_commit intentionally failed",
-        ))
     }
 }
 
@@ -248,102 +211,6 @@ async fn before_create_rejection_prevents_insert() {
         .await
         .unwrap();
     assert_eq!(count, 0);
-}
-
-#[tokio::test]
-#[ignore = "requires Docker (testcontainers)"]
-async fn after_create_rejection_rolls_back() {
-    use diesel_async::scoped_futures::ScopedFutureExt;
-
-    let (pool, _container) = setup_pool().await;
-    let mut conn = pool.get().await.unwrap();
-
-    let hooks = FailAfterCreateHooks;
-    let ctx = MutationContext::new(MutationOp::Create);
-
-    // Wrap insert + after_create in a transaction.
-    let result: Result<Article, diesel::result::Error> = conn
-        .transaction::<Article, diesel::result::Error, _>(|conn| {
-            let hooks = hooks.clone();
-            let ctx = ctx.clone();
-            async move {
-                let record: Article = diesel::insert_into(test_articles::table)
-                    .values(&NewArticle {
-                        title: "Transactional".into(),
-                        slug: "transactional".into(),
-                        status: "draft".into(),
-                    })
-                    .get_result(conn)
-                    .await?;
-
-                // after_create returns Err -> we map to diesel error to trigger rollback.
-                if let Err(_e) = hooks.after_create(&ctx, &record, conn).await {
-                    return Err(diesel::result::Error::RollbackTransaction);
-                }
-
-                Ok(record)
-            }
-            .scope_boxed()
-        })
-        .await;
-
-    assert!(result.is_err());
-
-    // Verify rollback: no rows in DB.
-    let mut conn = pool.get().await.unwrap();
-    let count: i64 = test_articles::table
-        .count()
-        .get_result(&mut conn)
-        .await
-        .unwrap();
-    assert_eq!(count, 0);
-}
-
-#[tokio::test]
-#[ignore = "requires Docker (testcontainers)"]
-async fn after_commit_failure_does_not_rollback() {
-    use diesel_async::scoped_futures::ScopedFutureExt;
-
-    let (pool, _container) = setup_pool().await;
-    let mut conn = pool.get().await.unwrap();
-
-    let hooks = FailAfterCommitHooks;
-    let ctx = MutationContext::new(MutationOp::Create);
-
-    // Insert inside a transaction and commit.
-    let record: Article = conn
-        .transaction::<Article, diesel::result::Error, _>(|conn| {
-            async move {
-                let record: Article = diesel::insert_into(test_articles::table)
-                    .values(&NewArticle {
-                        title: "Committed".into(),
-                        slug: "committed".into(),
-                        status: "published".into(),
-                    })
-                    .get_result(conn)
-                    .await?;
-                Ok(record)
-            }
-            .scope_boxed()
-        })
-        .await
-        .unwrap();
-
-    // Transaction committed. Now call after_commit which returns Err.
-    let after_result = hooks.after_commit(&ctx, MutationOp::Create).await;
-    assert!(after_result.is_err(), "after_commit should return Err");
-
-    // Verify the row still exists despite after_commit failure.
-    let mut conn = pool.get().await.unwrap();
-    let persisted: Article = test_articles::table
-        .find(record.id)
-        .first(&mut conn)
-        .await
-        .unwrap();
-
-    assert_eq!(persisted.title, "Committed");
-    assert_eq!(persisted.slug, "committed");
-    assert_eq!(persisted.status, "published");
 }
 
 #[tokio::test]

--- a/autumn/tests/hooks_lifecycle.rs
+++ b/autumn/tests/hooks_lifecycle.rs
@@ -66,9 +66,6 @@ async fn no_hooks_methods_are_all_ok() {
     let mut draft = UpdateDraft::new(String::new());
 
     assert!(hooks.before_create(&mut ctx, &mut new).await.is_ok());
-    // after_create, after_update, after_delete require &mut AsyncPgConnection
-    // and are covered by compile-pass and db_hooks_lifecycle tests.
     assert!(hooks.before_update(&mut ctx, &mut draft).await.is_ok());
     assert!(hooks.before_delete(&mut ctx, &model).await.is_ok());
-    assert!(hooks.after_commit(&ctx, MutationOp::Create).await.is_ok());
 }

--- a/examples/wiki/README.md
+++ b/examples/wiki/README.md
@@ -36,7 +36,6 @@ Open <http://localhost:3000>.
 
 - `before_create` slugifies the title and fills in a default `"draft"` status
 - `before_update` re-slugifies when the title changes
-- `after_create` and `after_update` append a revision row in the same transaction
 
 That means the UI routes and the generated REST API both get the same lifecycle
 behavior automatically.

--- a/examples/wiki/src/hooks.rs
+++ b/examples/wiki/src/hooks.rs
@@ -1,10 +1,7 @@
 use autumn_web::AutumnResult;
 use autumn_web::hooks::{MutationContext, MutationHooks, UpdateDraft};
-use diesel_async::AsyncPgConnection;
-use diesel_async::RunQueryDsl;
 
-use crate::models::{NewPage, NewRevision, Page, UpdatePage};
-use crate::schema::revisions;
+use crate::models::{NewPage, Page, UpdatePage};
 use crate::slugify::slugify;
 
 #[derive(Clone, Default)]
@@ -31,31 +28,6 @@ impl MutationHooks for PageHooks {
         Ok(())
     }
 
-    async fn after_create(
-        &self,
-        ctx: &MutationContext,
-        record: &Page,
-        conn: &mut AsyncPgConnection,
-    ) -> AutumnResult<()> {
-        // Transactional revision audit — runs inside the same tx as the INSERT
-        let rev = NewRevision {
-            page_id: record.id,
-            op: "create".into(),
-            title: record.title.clone(),
-            body: record.body.clone(),
-            status: record.status.clone(),
-            changed_by: ctx.actor.clone(),
-            summary: Some("Page created".into()),
-        };
-
-        diesel::insert_into(revisions::table)
-            .values(&rev)
-            .execute(conn)
-            .await?;
-
-        Ok(())
-    }
-
     async fn before_update(
         &self,
         _ctx: &mut MutationContext,
@@ -65,30 +37,6 @@ impl MutationHooks for PageHooks {
         if draft.after.title != draft.before.title {
             draft.after.slug = slugify(&draft.after.title);
         }
-
-        Ok(())
-    }
-
-    async fn after_update(
-        &self,
-        ctx: &MutationContext,
-        record: &Page,
-        conn: &mut AsyncPgConnection,
-    ) -> AutumnResult<()> {
-        let rev = NewRevision {
-            page_id: record.id,
-            op: "update".into(),
-            title: record.title.clone(),
-            body: record.body.clone(),
-            status: record.status.clone(),
-            changed_by: ctx.actor.clone(),
-            summary: Some("Page updated".into()),
-        };
-
-        diesel::insert_into(revisions::table)
-            .values(&rev)
-            .execute(conn)
-            .await?;
 
         Ok(())
     }


### PR DESCRIPTION
This PR simplifies the mutation hook lifecycle by removing all post-persistence hook methods (`after_create`, `after_update`, `after_delete`, and `after_commit`), leaving only the `before_*` validation hooks.

## Summary

The hook system previously supported a complex lifecycle with transactional `after_*` hooks and post-commit `after_commit` hooks. This change removes that complexity, keeping only the `before_*` hooks which run before any database mutation and can validate/reject/enrich the input.

## Key Changes

- **Removed hook trait methods**: `after_create`, `after_update`, `after_delete`, and `after_commit` from the `MutationHooks` trait
- **Simplified repository macro**: Removed transaction wrapping and scoped futures usage from generated `save`, `update`, and `delete` methods
- **Removed test coverage**: Deleted `after_create_rejection_rolls_back` and `after_commit_failure_does_not_rollback` integration tests that validated the removed lifecycle
- **Removed example implementations**: Deleted revision audit logic from the wiki example that relied on `after_create` and `after_update` hooks
- **Updated documentation**: Simplified hook lifecycle documentation to reflect the new before-only model

## Implementation Details

- The `before_*` hooks remain unchanged and continue to run before mutations, allowing validation and input transformation
- Database operations no longer use `AsyncConnection::transaction()` or `ScopedFutureExt`
- Removed unused imports (`AsyncConnection`, `scoped_futures::ScopedFutureExt`) from generated code
- The mutation context and operation tracking remain for potential future use by `before_*` hooks

https://claude.ai/code/session_01HkhHoRahWcLXMy6u8qeCs8