### PR TITLE
⚡ Bolt: Optimize channel lookup to avoid String allocation

### DIFF
--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -194,12 +194,19 @@ impl Channels {
     #[must_use]
     pub fn sender(&self, name: &str) -> Sender {
         let mut registry = self.inner.registry.lock().expect("channels lock poisoned");
-        let tx = registry
-            .entry(name.to_owned())
-            .or_insert_with(|| Arc::new(broadcast::channel(self.inner.capacity).0));
-        let sender = Sender {
-            inner: Arc::clone(tx),
+
+        // ⚡ Bolt Optimization: Use get() first to avoid allocating a String key
+        // on every lookup for channels that already exist.
+        #[allow(clippy::option_if_let_else)]
+        let tx = if let Some(tx) = registry.get(name) {
+            Arc::clone(tx)
+        } else {
+            let tx = Arc::new(broadcast::channel(self.inner.capacity).0);
+            registry.insert(name.to_owned(), Arc::clone(&tx));
+            tx
         };
+
+        let sender = Sender { inner: tx };
         drop(registry);
         sender
     }
@@ -226,9 +233,18 @@ impl Channels {
     #[must_use]
     pub fn subscribe(&self, name: &str) -> Subscriber {
         let mut registry = self.inner.registry.lock().expect("channels lock poisoned");
-        let tx = registry
-            .entry(name.to_owned())
-            .or_insert_with(|| Arc::new(broadcast::channel(self.inner.capacity).0));
+
+        // ⚡ Bolt Optimization: Use get() first to avoid allocating a String key
+        // on every lookup for channels that already exist.
+        #[allow(clippy::option_if_let_else)]
+        let tx = if let Some(tx) = registry.get(name) {
+            Arc::clone(tx)
+        } else {
+            let tx = Arc::new(broadcast::channel(self.inner.capacity).0);
+            registry.insert(name.to_owned(), Arc::clone(&tx));
+            tx
+        };
+
         let subscriber = Subscriber {
             inner: tx.subscribe(),
         };


### PR DESCRIPTION
* 💡 What: Refactored `Channels::sender` and `Channels::subscribe` to use a `.get()` lookup before falling back to allocation and insertion.
* 🎯 Why: The original `entry(name.to_owned())` unconditionally allocated a heap `String` on the hot path for every channel fetch, even if the channel already existed in the registry.
* 📊 Impact: Eliminates an unnecessary `String` heap allocation per channel fetch for existing channels, reducing GC pressure and shortening the duration the `Mutex` is locked during high-throughput message routing.
* 🔬 Measurement: Run `cargo test -p autumn-web --features ws` and ensure channels behavior remains identical while utilizing zero allocations on the read path.

---
*PR created automatically by Jules for task [5946178135355521576](https://jules.google.com/task/5946178135355521576) started by @madmax983*