### PR TITLE
🍎 Eris: Fix CSRF token verification timing vulnerability

### DIFF
--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -173,6 +173,21 @@ pub struct CsrfService<S> {
     settings: Arc<CsrfSettings>,
 }
 
+/// Constant-time string comparison to prevent timing attacks when verifying CSRF tokens.
+#[inline(never)]
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut result = 0;
+    for (x, y) in a.bytes().zip(b.bytes()) {
+        // Prevent compiler from optimizing out the bitwise operations
+        result |= x ^ y;
+    }
+    // ensure result is evaluated using std::hint::black_box to defeat compiler optimizations
+    std::hint::black_box(result) == 0
+}
+
 /// Extract the CSRF cookie value from the Cookie header.
 fn extract_cookie_token(req_headers: &http::HeaderMap, cookie_name: &str) -> Option<String> {
     req_headers
@@ -246,7 +261,7 @@ where
                     .map(str::to_owned);
 
                 if let (Some(c), Some(h)) = (&cookie_token, &header_token) {
-                    if !c.is_empty() && !h.is_empty() && c == h {
+                    if !c.is_empty() && !h.is_empty() && constant_time_eq(c, h) {
                         token_found = true;
                     }
                 }
@@ -273,7 +288,10 @@ where
                                         // Simple URL decoding by replacing + with space and % encoded chars
                                         // Note: CSRF tokens are UUIDs, so they shouldn't contain special chars anyway
                                         if let Some(c) = &cookie_token {
-                                            if !c.is_empty() && !value.is_empty() && c == value {
+                                            if !c.is_empty()
+                                                && !value.is_empty()
+                                                && constant_time_eq(c, value)
+                                            {
                                                 token_found = true;
                                             }
                                         }

--- a/autumn/tests/security/csrf_timing.rs
+++ b/autumn/tests/security/csrf_timing.rs
@@ -1,0 +1,54 @@
+use autumn_web::security::CsrfLayer;
+use autumn_web::security::config::CsrfConfig;
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+    routing::post,
+};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn test_csrf_timing_attack() {
+    let config = CsrfConfig {
+        enabled: true,
+        ..Default::default()
+    };
+
+    let app = Router::new()
+        .route("/submit", post(|| async { "created" }))
+        .layer(CsrfLayer::from_config(&config));
+
+    // The real token to match
+    let token = "12345678-1234-1234-1234-123456789012".to_string();
+
+    // In a timing attack, comparing "2..." vs "1..." takes different time
+    // But testing execution time reliably in CI is flaky.
+    // Instead, we verify that the constant-time trait or verify is used.
+    // As a PoC, we will simulate the behavior but testing actual timing is difficult.
+
+    // We'll write the test to ensure that the code compiles with the fix,
+    // and that valid tokens still work and invalid tokens fail.
+
+    let valid_req = Request::builder()
+        .method("POST")
+        .uri("/submit")
+        .header("Cookie", format!("autumn-csrf={token}"))
+        .header("X-CSRF-Token", &token)
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(valid_req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let invalid_req = Request::builder()
+        .method("POST")
+        .uri("/submit")
+        .header("Cookie", format!("autumn-csrf={token}"))
+        .header("X-CSRF-Token", "12345678-1234-1234-1234-123456789013")
+        .body(Body::empty())
+        .unwrap();
+
+    let response2 = app.oneshot(invalid_req).await.unwrap();
+    assert_eq!(response2.status(), StatusCode::FORBIDDEN);
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -1,3 +1,4 @@
 pub mod csrf_empty_bypass;
 pub mod csrf_form_bypass;
+pub mod csrf_timing;
 pub mod session_fixation;


### PR DESCRIPTION
**Findings Report: CSRF Token Timing Attack**

**Reconnaissance & Hypothesis:**
During an audit of Layer 5 (Authentication & Session Management) focusing on CSRF protection in `autumn/src/security/csrf.rs`, it was observed that the CSRF token from the user's cookie was being compared against the provided token (via `X-CSRF-Token` header or `_csrf` form field) using standard string equality (`==`). Standard equality operators exit early upon the first mismatched character.
*Hypothesis:* This early-exit comparison exposes a timing side-channel. An attacker who can repeatedly trigger the validation and measure the response time could incrementally brute-force the CSRF token character by character.

**Exploit Development:**
While a full exploitation PoC over the network involves significant jitter and is flaky in CI, the theoretical vulnerability is definitively present due to the use of `==` on sensitive token material. A regression test (`test_csrf_timing_attack`) was drafted to ensure CSRF protection still functions properly when the fix is applied.

**Severity Assessment:**
*CVSS 3.1:* Low to Medium (Exploitation over a network requires an extremely high volume of requests with low jitter, making it difficult but theoretically possible).

**Remediation & Verification:**
The comparison logic in `autumn/src/security/csrf.rs` was replaced with a custom `constant_time_eq` function. This function uses a bitwise XOR fold over the characters and applies `std::hint::black_box` to prevent compiler optimizations from reintroducing early exits.
The fix was verified by ensuring that the `test_csrf_timing_attack` and all other security tests still pass.

---

**[ERIS-NOTE] Path Traversal and SQL Injection AST Boundaries**
During the audit of Layer 6 (Proc Macro Attack Surface), attempts to perform path traversal using `#[get("/../../../etc/passwd")]` and SQL injection via `#[model(table = "users; DROP TABLE...")]` were found to be non-exploitable. The route macro maps paths to Axum routing patterns rather than the filesystem, and the model macro enforces that table names are valid Rust identifiers at the AST level.

---
*PR created automatically by Jules for task [15437898326666595649](https://jules.google.com/task/15437898326666595649) started by @madmax983*