### PR TITLE
🗺️ Atlas: [architectural change] encapsulate AppState fields

### DIFF
--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -657,8 +657,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 _parts: &mut ::autumn_web::reexports::http::request::Parts,
                 state: &::autumn_web::AppState,
             ) -> Result<Self, Self::Rejection> {
-                let pool = state.pool
-                    .as_ref()
+                let pool = state.pool()
                     .ok_or_else(|| ::autumn_web::AutumnError::service_unavailable_msg("No database pool configured"))?
                     .clone();
                 #extractor_init

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -291,4 +291,20 @@ mod tests {
             "uptime should contain 's': {display}"
         );
     }
+
+    #[test]
+    fn app_state_accessors() {
+        let state = AppState::for_test();
+
+        // Exercise the new getters to ensure they compile and return the expected types
+        let _metrics = state.metrics();
+        let _log_levels = state.log_levels();
+        let _task_registry = state.task_registry();
+        let _config_props = state.config_props();
+
+        #[cfg(feature = "db")]
+        {
+            let _pool = state.pool();
+        }
+    }
 }

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -81,7 +81,10 @@ impl AppState {
     /// Returns the database connection pool.
     #[cfg(feature = "db")]
     #[must_use]
-    pub const fn pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>> {
+    pub const fn pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
         self.pool.as_ref()
     }
 

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -23,73 +23,110 @@ use tokio_util::sync::CancellationToken;
 /// use autumn_web::AppState;
 ///
 /// // State without a database (e.g., for testing)
-/// let state = AppState {
-///     pool: None,
-///     profile: Some("dev".into()),
-///     started_at: std::time::Instant::now(),
-///     health_detailed: true,
-///     metrics: autumn_web::middleware::MetricsCollector::new(),
-///     log_levels: autumn_web::actuator::LogLevels::new("info"),
-///     task_registry: autumn_web::actuator::TaskRegistry::new(),
-///     config_props: Default::default(),
-///     #[cfg(feature = "ws")]
-///     channels: autumn_web::channels::Channels::new(32),
-///     #[cfg(feature = "ws")]
-///     shutdown: tokio_util::sync::CancellationToken::new(),
-/// };
+/// let state = AppState::for_test().with_profile("dev");
 /// ```
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct AppState {
     /// Shared application state passed to all route handlers.
     /// Database connection pool, or `None` when no `database.url` is configured.
     #[cfg(feature = "db")]
-    pub pool:
+    pub(crate) pool:
         Option<diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>,
 
     /// Shared application state passed to all route handlers.
     /// Active profile name (e.g., "dev", "prod", "staging").
-    pub profile: Option<String>,
+    pub(crate) profile: Option<String>,
 
     /// Shared application state passed to all route handlers.
     /// When the application started. Used for uptime calculation.
-    pub started_at: std::time::Instant,
+    pub(crate) started_at: std::time::Instant,
 
     /// Shared application state passed to all route handlers.
     /// Whether the health endpoint should include detailed info.
-    pub health_detailed: bool,
+    pub(crate) health_detailed: bool,
 
     /// Shared application state passed to all route handlers.
     /// In-memory metrics collector for the `/actuator/metrics` endpoint.
-    pub metrics: middleware::MetricsCollector,
+    pub(crate) metrics: middleware::MetricsCollector,
 
     /// Shared application state passed to all route handlers.
     /// Runtime log level state for the `/actuator/loggers` endpoint.
-    pub log_levels: actuator::LogLevels,
+    pub(crate) log_levels: actuator::LogLevels,
 
     /// Shared application state passed to all route handlers.
     /// Scheduled task registry for the `/actuator/tasks` endpoint.
-    pub task_registry: actuator::TaskRegistry,
+    pub(crate) task_registry: actuator::TaskRegistry,
 
     /// Shared application state passed to all route handlers.
     /// Resolved config properties with source tracking for `/actuator/configprops`.
-    pub config_props: actuator::ConfigProperties,
+    pub(crate) config_props: actuator::ConfigProperties,
 
     /// Named broadcast channel registry for real-time messaging.
     ///
     /// Available when the `ws` feature is enabled. Use
     /// [`channels()`](Self::channels) for convenient access.
     #[cfg(feature = "ws")]
-    pub channels: Channels,
+    pub(crate) channels: Channels,
 
     /// Cancellation token signalled during graceful shutdown.
     ///
     /// WebSocket handlers receive a child token so they can clean up
     /// when the server is stopping.
     #[cfg(feature = "ws")]
-    pub shutdown: CancellationToken,
+    pub(crate) shutdown: CancellationToken,
 }
 
 impl AppState {
+    /// Returns the database connection pool.
+    #[cfg(feature = "db")]
+    #[must_use]
+    pub const fn pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>> {
+        self.pool.as_ref()
+    }
+
+    /// Returns the metrics collector.
+    #[must_use]
+    pub const fn metrics(&self) -> &middleware::MetricsCollector {
+        &self.metrics
+    }
+
+    /// Returns the log levels configuration.
+    #[must_use]
+    pub const fn log_levels(&self) -> &actuator::LogLevels {
+        &self.log_levels
+    }
+
+    /// Returns the task registry.
+    #[must_use]
+    pub const fn task_registry(&self) -> &actuator::TaskRegistry {
+        &self.task_registry
+    }
+
+    /// Returns the config properties.
+    #[must_use]
+    pub const fn config_props(&self) -> &actuator::ConfigProperties {
+        &self.config_props
+    }
+
+    /// Sets the database pool.
+    #[cfg(feature = "db")]
+    #[must_use]
+    pub fn with_pool(
+        mut self,
+        pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+    ) -> Self {
+        self.pool = Some(pool);
+        self
+    }
+
+    /// Sets the active profile.
+    #[must_use]
+    pub fn with_profile(mut self, profile: impl Into<String>) -> Self {
+        self.profile = Some(profile.into());
+        self
+    }
+
     /// Shared application state passed to all route handlers.
     /// Returns the active profile name, or `"default"` if none is set.
     #[must_use]
@@ -141,9 +178,9 @@ impl AppState {
 
     /// Create an `AppState` suitable for testing, with sensible defaults
     /// for all fields. Database pool is `None`.
-    #[cfg(test)]
     #[allow(dead_code)]
-    pub(crate) fn for_test() -> Self {
+    #[must_use]
+    pub fn for_test() -> Self {
         Self {
             #[cfg(feature = "db")]
             pool: None,
@@ -193,21 +230,7 @@ mod tests {
 
     #[test]
     fn app_state_debug_without_pool() {
-        let state = AppState {
-            #[cfg(feature = "db")]
-            pool: None,
-            profile: Some("dev".into()),
-            started_at: std::time::Instant::now(),
-            health_detailed: true,
-            metrics: middleware::MetricsCollector::new(),
-            log_levels: actuator::LogLevels::new("info"),
-            task_registry: actuator::TaskRegistry::new(),
-            config_props: actuator::ConfigProperties::default(),
-            #[cfg(feature = "ws")]
-            channels: Channels::new(32),
-            #[cfg(feature = "ws")]
-            shutdown: CancellationToken::new(),
-        };
+        let state = AppState::for_test().with_profile("dev");
         let debug = format!("{state:?}");
         assert!(debug.contains("AppState"));
         assert!(debug.contains("dev"));
@@ -222,20 +245,7 @@ mod tests {
             ..Default::default()
         };
         let pool = db::create_pool(&config).unwrap().unwrap();
-        let state = AppState {
-            pool: Some(pool),
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: true,
-            metrics: middleware::MetricsCollector::new(),
-            log_levels: actuator::LogLevels::new("info"),
-            task_registry: actuator::TaskRegistry::new(),
-            config_props: actuator::ConfigProperties::default(),
-            #[cfg(feature = "ws")]
-            channels: Channels::new(32),
-            #[cfg(feature = "ws")]
-            shutdown: CancellationToken::new(),
-        };
+        let state = AppState::for_test().with_pool(pool);
         let debug = format!("{state:?}");
         assert!(debug.contains("Pool(max=5)"));
     }
@@ -246,81 +256,25 @@ mod tests {
 
     #[test]
     fn app_state_is_clone() {
-        let state = AppState {
-            #[cfg(feature = "db")]
-            pool: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: true,
-            metrics: middleware::MetricsCollector::new(),
-            log_levels: actuator::LogLevels::new("info"),
-            task_registry: actuator::TaskRegistry::new(),
-            config_props: actuator::ConfigProperties::default(),
-            #[cfg(feature = "ws")]
-            channels: Channels::new(32),
-            #[cfg(feature = "ws")]
-            shutdown: CancellationToken::new(),
-        };
+        let state = AppState::for_test();
         let _cloned = require_clone(&state);
     }
 
     #[test]
     fn app_state_profile_accessor() {
-        let state = AppState {
-            #[cfg(feature = "db")]
-            pool: None,
-            profile: Some("staging".into()),
-            started_at: std::time::Instant::now(),
-            health_detailed: true,
-            metrics: middleware::MetricsCollector::new(),
-            log_levels: actuator::LogLevels::new("info"),
-            task_registry: actuator::TaskRegistry::new(),
-            config_props: actuator::ConfigProperties::default(),
-            #[cfg(feature = "ws")]
-            channels: Channels::new(32),
-            #[cfg(feature = "ws")]
-            shutdown: CancellationToken::new(),
-        };
+        let state = AppState::for_test().with_profile("staging");
         assert_eq!(state.profile(), "staging");
     }
 
     #[test]
     fn app_state_profile_default() {
-        let state = AppState {
-            #[cfg(feature = "db")]
-            pool: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: true,
-            metrics: middleware::MetricsCollector::new(),
-            log_levels: actuator::LogLevels::new("info"),
-            task_registry: actuator::TaskRegistry::new(),
-            config_props: actuator::ConfigProperties::default(),
-            #[cfg(feature = "ws")]
-            channels: Channels::new(32),
-            #[cfg(feature = "ws")]
-            shutdown: CancellationToken::new(),
-        };
+        let state = AppState::for_test();
         assert_eq!(state.profile(), "default");
     }
 
     #[test]
     fn app_state_uptime_display() {
-        let state = AppState {
-            #[cfg(feature = "db")]
-            pool: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: true,
-            metrics: middleware::MetricsCollector::new(),
-            log_levels: actuator::LogLevels::new("info"),
-            task_registry: actuator::TaskRegistry::new(),
-            config_props: actuator::ConfigProperties::default(),
-            #[cfg(feature = "ws")]
-            channels: Channels::new(32),
-            #[cfg(feature = "ws")]
-            shutdown: CancellationToken::new(),
-        };
+        let state = AppState::for_test();
         let display = state.uptime_display();
         assert!(
             display.contains('s'),

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -179,6 +179,13 @@ impl AppState {
         self.shutdown.child_token()
     }
 
+    /// Helper for integration tests to simulate a server shutdown.
+    #[cfg(feature = "ws")]
+    #[doc(hidden)]
+    pub fn trigger_shutdown_for_test(&self) {
+        self.shutdown.cancel();
+    }
+
     /// Create an `AppState` suitable for testing, with sensible defaults
     /// for all fields. Database pool is `None`.
     #[allow(dead_code)]

--- a/autumn/tests/middleware_pipeline.rs
+++ b/autumn/tests/middleware_pipeline.rs
@@ -14,21 +14,7 @@ use axum::response::Response;
 use tower::ServiceExt;
 
 fn test_state() -> AppState {
-    AppState {
-        #[cfg(feature = "db")]
-        pool: None,
-        profile: None,
-        started_at: std::time::Instant::now(),
-        health_detailed: false,
-        metrics: autumn_web::middleware::MetricsCollector::new(),
-        log_levels: autumn_web::actuator::LogLevels::new("info"),
-        task_registry: autumn_web::actuator::TaskRegistry::new(),
-        config_props: autumn_web::actuator::ConfigProperties::default(),
-        #[cfg(feature = "ws")]
-        channels: autumn_web::channels::Channels::new(32),
-        #[cfg(feature = "ws")]
-        shutdown: tokio_util::sync::CancellationToken::new(),
-    }
+    AppState::for_test()
 }
 
 // ── Exception Filter tests ─────────────────────────────────────────

--- a/autumn/tests/raw_router_escape_hatch.rs
+++ b/autumn/tests/raw_router_escape_hatch.rs
@@ -9,21 +9,7 @@ use axum::http::{Request, StatusCode};
 use tower::ServiceExt;
 
 fn test_state() -> AppState {
-    AppState {
-        #[cfg(feature = "db")]
-        pool: None,
-        profile: Some("test".into()),
-        started_at: std::time::Instant::now(),
-        health_detailed: false,
-        metrics: autumn_web::middleware::MetricsCollector::new(),
-        log_levels: autumn_web::actuator::LogLevels::new("info"),
-        task_registry: autumn_web::actuator::TaskRegistry::new(),
-        config_props: autumn_web::actuator::ConfigProperties::default(),
-        #[cfg(feature = "ws")]
-        channels: autumn_web::channels::Channels::new(32),
-        #[cfg(feature = "ws")]
-        shutdown: tokio_util::sync::CancellationToken::new(),
-    }
+    AppState::for_test().with_profile("test")
 }
 
 // ── Merge tests ───────────────────────────────────────────────────

--- a/autumn/tests/security/session_fixation.rs
+++ b/autumn/tests/security/session_fixation.rs
@@ -18,21 +18,7 @@ async fn test_session_fixation() {
     let store = MemoryStore::new();
     let config = SessionConfig::default();
 
-    let state = autumn_web::state::AppState {
-        #[cfg(feature = "db")]
-        pool: None,
-        profile: None,
-        started_at: std::time::Instant::now(),
-        health_detailed: false,
-        metrics: autumn_web::middleware::MetricsCollector::new(),
-        log_levels: autumn_web::actuator::LogLevels::new("info"),
-        task_registry: autumn_web::actuator::TaskRegistry::new(),
-        config_props: autumn_web::actuator::ConfigProperties::default(),
-        #[cfg(feature = "ws")]
-        channels: autumn_web::channels::Channels::new(32),
-        #[cfg(feature = "ws")]
-        shutdown: tokio_util::sync::CancellationToken::new(),
-    };
+    let state = autumn_web::state::AppState::for_test();
 
     let app = Router::new()
         .route("/login", get(login_handler))
@@ -107,21 +93,7 @@ async fn test_rotate_id() {
     let store = MemoryStore::new();
     let config = SessionConfig::default();
 
-    let state = autumn_web::state::AppState {
-        #[cfg(feature = "db")]
-        pool: None,
-        profile: None,
-        started_at: std::time::Instant::now(),
-        health_detailed: false,
-        metrics: autumn_web::middleware::MetricsCollector::new(),
-        log_levels: autumn_web::actuator::LogLevels::new("info"),
-        task_registry: autumn_web::actuator::TaskRegistry::new(),
-        config_props: autumn_web::actuator::ConfigProperties::default(),
-        #[cfg(feature = "ws")]
-        channels: autumn_web::channels::Channels::new(32),
-        #[cfg(feature = "ws")]
-        shutdown: tokio_util::sync::CancellationToken::new(),
-    };
+    let state = autumn_web::state::AppState::for_test();
 
     let app = Router::new()
         .route("/rotate", get(rotate_handler))

--- a/autumn/tests/static_build_mode.rs
+++ b/autumn/tests/static_build_mode.rs
@@ -25,21 +25,7 @@ const fn about_meta() -> StaticRouteMeta {
 }
 
 fn test_state() -> autumn_web::AppState {
-    autumn_web::AppState {
-        #[cfg(feature = "db")]
-        pool: None,
-        profile: None,
-        started_at: std::time::Instant::now(),
-        health_detailed: false,
-        metrics: autumn_web::middleware::MetricsCollector::new(),
-        log_levels: autumn_web::actuator::LogLevels::new("info"),
-        task_registry: autumn_web::actuator::TaskRegistry::new(),
-        config_props: autumn_web::actuator::ConfigProperties::default(),
-        #[cfg(feature = "ws")]
-        channels: autumn_web::channels::Channels::new(32),
-        #[cfg(feature = "ws")]
-        shutdown: tokio_util::sync::CancellationToken::new(),
-    }
+    autumn_web::AppState::for_test()
 }
 
 #[tokio::test]

--- a/autumn/tests/static_gen_serving.rs
+++ b/autumn/tests/static_gen_serving.rs
@@ -11,21 +11,7 @@ use tower::ServiceExt;
 
 /// Helper: build an `AppState` suitable for testing (no database, no profile).
 fn test_state() -> autumn_web::AppState {
-    autumn_web::AppState {
-        #[cfg(feature = "db")]
-        pool: None,
-        profile: None,
-        started_at: std::time::Instant::now(),
-        health_detailed: true,
-        metrics: autumn_web::middleware::MetricsCollector::new(),
-        log_levels: autumn_web::actuator::LogLevels::new("info"),
-        task_registry: autumn_web::actuator::TaskRegistry::new(),
-        config_props: autumn_web::actuator::ConfigProperties::default(),
-        #[cfg(feature = "ws")]
-        channels: autumn_web::channels::Channels::new(32),
-        #[cfg(feature = "ws")]
-        shutdown: tokio_util::sync::CancellationToken::new(),
-    }
+    autumn_web::AppState::for_test()
 }
 
 /// Helper: create a `Route` for a GET handler that returns the given body.

--- a/autumn/tests/websocket.rs
+++ b/autumn/tests/websocket.rs
@@ -9,7 +9,6 @@
 
 #![cfg(feature = "ws")]
 
-use autumn_web::channels::Channels;
 use autumn_web::config::AutumnConfig;
 use autumn_web::prelude::*;
 use autumn_web::ws::{CancellationToken, Message, WebSocket, WsHandler};
@@ -18,19 +17,7 @@ use http::Request;
 use tower::ServiceExt;
 
 fn test_state() -> AppState {
-    AppState {
-        #[cfg(feature = "db")]
-        pool: None,
-        profile: Some("test".into()),
-        started_at: std::time::Instant::now(),
-        health_detailed: false,
-        metrics: autumn_web::middleware::MetricsCollector::new(),
-        log_levels: autumn_web::actuator::LogLevels::new("info"),
-        task_registry: autumn_web::actuator::TaskRegistry::new(),
-        config_props: autumn_web::actuator::ConfigProperties::default(),
-        channels: Channels::new(32),
-        shutdown: CancellationToken::new(),
-    }
+    AppState::for_test().with_profile("test")
 }
 
 // ── Test handlers ────────────────────────────────────────────────
@@ -179,6 +166,10 @@ async fn shutdown_token_propagates() {
     let child = state.shutdown_token();
 
     assert!(!child.is_cancelled());
-    state.shutdown.cancel();
-    assert!(child.is_cancelled());
+    // Since shutdown is internal, we can't easily cancel it directly in tests,
+    // but the actual framework cancellation logic is part of app.rs run().
+    // Since AppState test setup creates a new token, the test itself ensures
+    // child token derivation works.
+    // For coverage, we'd simulate what the server does:
+    // state.shutdown.cancel() is internal, so we only test derivation here.
 }

--- a/autumn/tests/websocket.rs
+++ b/autumn/tests/websocket.rs
@@ -166,10 +166,6 @@ async fn shutdown_token_propagates() {
     let child = state.shutdown_token();
 
     assert!(!child.is_cancelled());
-    // Since shutdown is internal, we can't easily cancel it directly in tests,
-    // but the actual framework cancellation logic is part of app.rs run().
-    // Since AppState test setup creates a new token, the test itself ensures
-    // child token derivation works.
-    // For coverage, we'd simulate what the server does:
-    // state.shutdown.cancel() is internal, so we only test derivation here.
+    state.trigger_shutdown_for_test();
+    assert!(child.is_cancelled());
 }

--- a/examples/bookmarks/src/tasks.rs
+++ b/examples/bookmarks/src/tasks.rs
@@ -17,8 +17,7 @@ use crate::schema::bookmarks;
 #[scheduled(every = "1h", name = "link-checker")]
 pub async fn check_links(state: AppState) -> AutumnResult<()> {
     let pool = state
-        .pool
-        .as_ref()
+        .pool()
         .ok_or_else(|| AutumnError::service_unavailable_msg("No database pool"))?;
 
     let mut conn = pool.get().await.map_err(AutumnError::from)?;

--- a/examples/reddit-clone/src/tasks.rs
+++ b/examples/reddit-clone/src/tasks.rs
@@ -20,8 +20,7 @@ use crate::schema::posts;
 #[scheduled(every = "15m", name = "hot-rank-calculator")]
 pub async fn recalculate_hot_ranks(state: AppState) -> AutumnResult<()> {
     let pool = state
-        .pool
-        .as_ref()
+        .pool()
         .ok_or_else(|| AutumnError::service_unavailable_msg("No database pool"))?;
 
     let mut conn = pool.get().await.map_err(AutumnError::from)?;


### PR DESCRIPTION
🕸️ Tangle: `AppState` exposed its fields globally via `pub`, making it a classic "God Struct" whose internals could be mutated or coupled to by downstream libraries or handlers.
📐 Blueprint: Added `#[non_exhaustive]` to `AppState`, made all fields `pub(crate)`, exposed safe getter methods (e.g., `pool()`, `metrics()`), and provided builder methods (e.g. `with_profile`) alongside a `for_test()` generator to safely construct and modify test state.
🧱 Stability: Improves strict encapsulation, ensuring internal invariants are protected and decoupling users from future field additions to `AppState`.
🔬 Verification: Ran `cargo clippy`, `cargo test`, and verified the integration tests and dependent examples (like `bookmarks`, `reddit-clone`) were properly updated to use the new API surface.

---
*PR created automatically by Jules for task [6312072313110888304](https://jules.google.com/task/6312072313110888304) started by @madmax983*