### PR TITLE
🎻 Bard: [documentation update] Fix broken intra-doc link in `ws` module

### DIFF
--- a/autumn/src/ws.rs
+++ b/autumn/src/ws.rs
@@ -1,6 +1,6 @@
 //! WebSocket support for Autumn applications.
 //!
-//! This module provides ergonomic WebSocket handling through the [`#[ws]`](crate::ws)
+//! This module provides ergonomic WebSocket handling through the [`#[ws]`](macro@crate::ws)
 //! macro and re-exports of Axum's WebSocket types.
 //!
 //! # Two-function pattern


### PR DESCRIPTION
📖 Chapter: The `ws` module
🔦 Insight: Clarified the `#[ws]` macro reference by prefixing it with `macro@` to resolve a rustdoc ambiguity warning between the module `ws` and the macro `ws`.
🧪 Example: N/A - pure doc link fix.
🖼️ Preview: Resolved warning during `cargo doc` execution.

---
*PR created automatically by Jules for task [13542739053252450496](https://jules.google.com/task/13542739053252450496) started by @madmax983*