### PR TITLE
Implement static-first serving with manifest-based interception

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1284,10 +1284,7 @@ fn build_router_with_static_inner(
                         if let Ok(contents) = std::fs::read(&file_path) {
                             return http::Response::builder()
                                 .status(http::StatusCode::OK)
-                                .header(
-                                    http::header::CONTENT_TYPE,
-                                    "text/html; charset=utf-8",
-                                )
+                                .header(http::header::CONTENT_TYPE, "text/html; charset=utf-8")
                                 .body(axum::body::Body::from(contents))
                                 .unwrap();
                         }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1164,9 +1164,13 @@ fn build_router_inner(
 /// Build the router with optional static-file-first serving.
 ///
 /// If `dist_dir` is `Some` and contains a valid `manifest.json`, the
-/// returned router uses `ServeDir` to serve pre-built HTML files first
-/// and falls back to the dynamic Axum router for any path not found on
-/// disk.  This is the "static-first, SSR-fallback" pattern.
+/// returned router intercepts GET requests whose path appears in the
+/// manifest and serves pre-built HTML directly — before the dynamic
+/// router runs.  This matches Next.js SSG/ISR semantics where static
+/// pages always win over dynamic handlers.
+///
+/// Requests not in the manifest (including all non-GET methods) fall
+/// through to the dynamic router unchanged.
 ///
 /// When `dist_dir` is `None` or the manifest is missing, the returned
 /// router is identical to [`build_router`].
@@ -1249,39 +1253,50 @@ fn build_router_with_static_inner(
         );
     }
 
-    // Store the layer in an Arc so the ISR check middleware can use it.
+    // Store the layer in an Arc so the static-first middleware can use it.
     let layer = Arc::new(layer);
 
-    // Mount static files as a fallback on the app router rather than
-    // wrapping the app behind ServeDir. The previous approach
-    // (ServeDir.fallback(app)) caused 405 errors for POST/PUT/DELETE
-    // because ServeDir only handles GET/HEAD — non-GET requests never
-    // reached the app router's fallback.
+    // Static-first serving: intercept GET requests whose path appears in
+    // the manifest and serve pre-built HTML directly, BEFORE the dynamic
+    // router runs.  This matches Next.js SSG/ISR semantics where static
+    // pages always win over dynamic handlers.
     //
-    // With this approach: explicit routes (GET, POST, etc.) always win.
-    // Only requests that match NO dynamic route fall through to ServeDir,
-    // which then serves static files (e.g. /about/ → dist/about/index.html).
+    // Requests not in the manifest (including all non-GET methods) fall
+    // through to the dynamic router unchanged.
     //
-    // ISR staleness checking: before ServeDir handles the request, we
-    // trigger resolve() on the StaticFileLayer to check for stale pages
-    // and spawn background regeneration tasks if needed.
-    let isr_layer = layer;
-    let serve_dir = tower_http::services::ServeDir::new(dist);
-    app_router
-        .layer(axum::middleware::from_fn(
-            move |req: axum::extract::Request, next: axum::middleware::Next| {
-                let isr_layer = isr_layer.clone();
-                async move {
-                    // Trigger ISR check for GET requests (resolves the path
-                    // and spawns background regeneration if stale)
-                    if req.method() == http::Method::GET {
-                        let _ = isr_layer.resolve(req.uri().path());
+    // ISR staleness checking happens inside `resolve()`: stale pages are
+    // still served immediately while background regeneration runs
+    // (stale-while-revalidate).
+    let static_layer = layer;
+    app_router.layer(axum::middleware::from_fn(
+        move |req: axum::extract::Request, next: axum::middleware::Next| {
+            let static_layer = static_layer.clone();
+            async move {
+                if req.method() == http::Method::GET {
+                    let path = req.uri().path();
+                    // Normalize trailing slash: /about/ → /about (but keep / as /)
+                    let normalized = if path.len() > 1 && path.ends_with('/') {
+                        &path[..path.len() - 1]
+                    } else {
+                        path
+                    };
+                    if let Some(file_path) = static_layer.resolve(normalized) {
+                        if let Ok(contents) = std::fs::read(&file_path) {
+                            return http::Response::builder()
+                                .status(http::StatusCode::OK)
+                                .header(
+                                    http::header::CONTENT_TYPE,
+                                    "text/html; charset=utf-8",
+                                )
+                                .body(axum::body::Body::from(contents))
+                                .unwrap();
+                        }
                     }
-                    next.run(req).await
                 }
-            },
-        ))
-        .fallback_service(serve_dir)
+                next.run(req).await
+            }
+        },
+    ))
 }
 
 /// Build a `tower_http::cors::CorsLayer` from the framework's [`crate::config::CorsConfig`].
@@ -1852,8 +1867,8 @@ mod tests {
             Some(dist.as_path()),
         );
 
-        // GET /docs/ should serve the static file via ServeDir fallback
-        // (no dynamic route competes for this path).
+        // GET /docs/ should serve the pre-built HTML via static-first
+        // middleware (manifest lookup with trailing-slash normalization).
         let response = router
             .oneshot(
                 Request::builder()

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1164,12 +1164,12 @@ fn build_router_inner(
 /// Build the router with optional static-file-first serving.
 ///
 /// If `dist_dir` is `Some` and contains a valid `manifest.json`, the
-/// returned router intercepts GET requests whose path appears in the
-/// manifest and serves pre-built HTML directly — before the dynamic
+/// returned router intercepts GET/HEAD requests whose path appears in
+/// the manifest and serves pre-built HTML directly — before the dynamic
 /// router runs.  This matches Next.js SSG/ISR semantics where static
 /// pages always win over dynamic handlers.
 ///
-/// Requests not in the manifest (including all non-GET methods) fall
+/// Requests not in the manifest (including non-GET/HEAD methods) fall
 /// through to the dynamic router unchanged.
 ///
 /// When `dist_dir` is `None` or the manifest is missing, the returned
@@ -1256,12 +1256,12 @@ fn build_router_with_static_inner(
     // Store the layer in an Arc so the static-first middleware can use it.
     let layer = Arc::new(layer);
 
-    // Static-first serving: intercept GET requests whose path appears in
-    // the manifest and serve pre-built HTML directly, BEFORE the dynamic
+    // Static-first serving: intercept GET/HEAD requests whose path appears
+    // in the manifest and serve pre-built HTML directly, BEFORE the dynamic
     // router runs.  This matches Next.js SSG/ISR semantics where static
     // pages always win over dynamic handlers.
     //
-    // Requests not in the manifest (including all non-GET methods) fall
+    // Requests not in the manifest (including non-GET/HEAD methods) fall
     // through to the dynamic router unchanged.
     //
     // ISR staleness checking happens inside `resolve()`: stale pages are
@@ -1272,7 +1272,9 @@ fn build_router_with_static_inner(
         move |req: axum::extract::Request, next: axum::middleware::Next| {
             let static_layer = static_layer.clone();
             async move {
-                if req.method() == http::Method::GET {
+                let is_get = req.method() == http::Method::GET;
+                let is_head = req.method() == http::Method::HEAD;
+                if is_get || is_head {
                     let path = req.uri().path();
                     // Normalize trailing slash: /about/ → /about (but keep / as /)
                     let normalized = if path.len() > 1 && path.ends_with('/') {
@@ -1281,11 +1283,16 @@ fn build_router_with_static_inner(
                         path
                     };
                     if let Some(file_path) = static_layer.resolve(normalized) {
-                        if let Ok(contents) = std::fs::read(&file_path) {
+                        if let Ok(contents) = tokio::fs::read(&file_path).await {
+                            let body = if is_head {
+                                axum::body::Body::empty()
+                            } else {
+                                axum::body::Body::from(contents)
+                            };
                             return http::Response::builder()
                                 .status(http::StatusCode::OK)
                                 .header(http::header::CONTENT_TYPE, "text/html; charset=utf-8")
-                                .body(axum::body::Body::from(contents))
+                                .body(body)
                                 .unwrap();
                         }
                     }

--- a/autumn/tests/static_gen_serving.rs
+++ b/autumn/tests/static_gen_serving.rs
@@ -1,8 +1,9 @@
 //! Integration tests for static-file-first serving through the full router.
 //!
-//! Exercises `build_router_with_static` end-to-end: static files shadow
-//! dynamic routes when a `dist/` directory with a valid manifest is present,
-//! and dynamic routes still work when no static build exists.
+//! Exercises `build_router_with_static` end-to-end: pre-built static files
+//! take priority over dynamic routes when a `dist/` directory with a valid
+//! manifest is present (Next.js SSG/ISR semantics).  Dynamic routes still
+//! work for paths not in the manifest or when no static build exists.
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -42,11 +43,11 @@ fn dynamic_get_route(
     }
 }
 
-/// Dynamic routes take priority over static files. When both exist,
-/// the dynamic handler runs (SSR). Static files in dist/ are served
-/// only for paths with NO matching dynamic route.
+/// Static files take priority over dynamic routes (Next.js SSG/ISR
+/// semantics).  When both exist, the pre-built HTML is served directly.
+/// The dynamic handler only runs for paths NOT in the manifest.
 #[tokio::test]
-async fn dynamic_routes_take_priority_over_static_files() {
+async fn static_files_take_priority_over_dynamic_routes() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let dist = tmp.path().join("dist");
     std::fs::create_dir_all(dist.join("about")).expect("mkdir about");
@@ -82,7 +83,8 @@ async fn dynamic_routes_take_priority_over_static_files() {
         Some(dist.as_path()),
     );
 
-    // Dynamic handler wins — GET /about returns the SSR response, not the static file.
+    // Static file wins — GET /about returns the pre-built HTML, not the
+    // dynamic handler.  This matches Next.js SSG semantics.
     let resp = router
         .oneshot(
             Request::builder()
@@ -99,8 +101,8 @@ async fn dynamic_routes_take_priority_over_static_files() {
         .unwrap();
     let text = std::str::from_utf8(&body).expect("valid utf-8");
     assert!(
-        text.contains("Dynamic About"),
-        "Dynamic handler should take priority, got: {text}"
+        text.contains("Static About"),
+        "Static file should take priority, got: {text}"
     );
 }
 

--- a/autumn/tests/static_gen_serving.rs
+++ b/autumn/tests/static_gen_serving.rs
@@ -200,8 +200,60 @@ async fn unknown_routes_fall_through_to_dynamic() {
     );
 }
 
-/// POST requests must pass through `ServeDir` to the dynamic router,
-/// even when a dist/ directory is active.
+/// HEAD requests for manifest-backed static routes return 200 with an
+/// empty body (standard HTTP HEAD semantics).
+#[tokio::test]
+async fn head_requests_served_for_static_routes() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dist = tmp.path().join("dist");
+    std::fs::create_dir_all(dist.join("about")).expect("mkdir about");
+    std::fs::write(dist.join("about/index.html"), "<h1>Static About</h1>").expect("write html");
+
+    let manifest = autumn_web::static_gen::StaticManifest {
+        generated_at: "2026-03-27T00:00:00Z".to_owned(),
+        autumn_version: "0.1.0".to_owned(),
+        routes: HashMap::from([(
+            "/about".to_owned(),
+            autumn_web::static_gen::ManifestEntry {
+                file: "about/index.html".to_owned(),
+                revalidate: None,
+            },
+        )]),
+    };
+    std::fs::write(
+        dist.join("manifest.json"),
+        serde_json::to_string(&manifest).expect("serialize manifest"),
+    )
+    .expect("write manifest");
+
+    let config = autumn_web::config::AutumnConfig::default();
+    let router = autumn_web::app::build_router_with_static(
+        vec![],
+        &config,
+        test_state(),
+        Some(dist.as_path()),
+    );
+
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .method("HEAD")
+                .uri("/about")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert!(body.is_empty(), "HEAD response body should be empty");
+}
+
+/// POST requests pass through to the dynamic router, even when a
+/// dist/ directory is active.
 #[tokio::test]
 async fn post_requests_pass_through_static_layer() {
     let tmp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary
This PR changes the static file serving strategy from a fallback-based approach (using `ServeDir.fallback()`) to a static-first middleware that intercepts GET requests and serves pre-built HTML directly when paths exist in the manifest. This matches Next.js SSG/ISR semantics where static pages always take priority over dynamic handlers.

## Key Changes

- **Static-first middleware**: Replaced `ServeDir` fallback with a custom middleware that checks the manifest before the dynamic router runs. GET requests with paths in the manifest are served immediately with pre-built HTML.

- **Manifest-based path resolution**: The middleware now calls `static_layer.resolve(normalized_path)` to check if a path exists in the manifest, returning the file directly if found.

- **Trailing slash normalization**: Added logic to normalize paths (e.g., `/about/` → `/about`) before manifest lookup, ensuring consistent path matching.

- **Improved semantics**: Non-GET requests and paths not in the manifest fall through to the dynamic router unchanged, providing clearer behavior than the previous approach.

- **ISR staleness checking**: Maintained the existing ISR functionality where `resolve()` triggers background regeneration for stale pages while serving them immediately (stale-while-revalidate).

- **Documentation updates**: Updated comments and docstrings to clarify the new static-first behavior and its alignment with Next.js semantics.

- **Test updates**: Renamed and updated test to reflect that static files now take priority over dynamic routes, with assertions updated accordingly.

## Implementation Details

The middleware intercepts all requests and:
1. For GET requests, normalizes the path and checks if it exists in the manifest via `resolve()`
2. If found, reads the file and returns it as HTML directly
3. Otherwise, passes the request to the dynamic router
4. Non-GET requests always pass through to the dynamic router

This approach avoids the 405 errors that occurred with the previous `ServeDir.fallback()` pattern, where non-GET requests would be rejected by `ServeDir` before reaching the app router.

https://claude.ai/code/session_01BWgvZs5xPLPUy7LCWGhSPH