### PR TITLE
Fix clippy warnings and align autumn-harvest docs with current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ async fn main() {
 | [`examples/blog`](examples/blog) | Blog engine with admin UI, validation, and hybrid rendering via `#[static_get]` |
 | [`examples/bookmarks`](examples/bookmarks) | Repository macro, generated CRUD API, profiles, scheduled tasks, and actuator endpoints |
 | [`examples/wiki`](examples/wiki) | Mutation hooks, revision history, generated REST API, and slug lifecycle management |
-| [`examples/reddit-clone`](examples/reddit-clone) | Full-featured Reddit clone using Autumn's server-first stack: auth, sessions, CSRF, `#[secured]`, `#[model]`, `#[repository]`, hooks, `#[scheduled]`, `#[static_get]`, `#[ws]` channels, autumn-harvest workflows, htmx voting, and profiles |
+| [`examples/reddit-clone`](examples/reddit-clone) | Full-featured Reddit clone using Autumn's server-first stack: auth, sessions, CSRF, `#[secured]`, `#[model]`, `#[repository]`, hooks, `#[scheduled]`, `#[static_get]`, `#[ws]` channels, htmx voting, and profiles (workflow integration notes are currently documentation-only stubs) |
 
 ## Documentation
 
@@ -120,4 +120,3 @@ Autumn can still run without a database if you omit the `[database]` section.
 ## License
 
 MIT OR Apache-2.0
-

--- a/autumn-harvest/CLAUDE.md
+++ b/autumn-harvest/CLAUDE.md
@@ -231,7 +231,7 @@ The `testing` feature in `autumn-harvest/Cargo.toml` gates `WorkflowContext::new
 2. The function must take `ctx: &WorkflowContext` or `ctx: &ActivityContext` as its first argument.
 3. Return type must be `Result<T, E>` where both `T` and `E` implement `serde::Serialize` / `serde::Deserialize` and `E: ToString`.
 4. Add the function name to `workflows![...]` or `activities![...]` in the builder call.
-5. If the activity uses shared state (DB pool, HTTP client), register it on the builder with `.state(value)` (Phase 2) and access via `ctx.state::<T>()`.
+5. If the activity uses shared state (DB pool, HTTP client), inject state through your own runtime wiring for now and access via `ctx.state::<T>()`; fluent `.state(value)` support is planned, not yet implemented.
 
 ---
 
@@ -309,4 +309,4 @@ Worker pool and web pool are independently sized but share a total connection ce
 - **DAG scheduler**: `DagBuilder`, topological sort, `#[dag]` macro
 - **Trigger rules**: timetable, signals/queries, saga pattern
 - **Management HTTP API**: start/cancel/query workflow executions
-- **`HarvestExt` trait**: embeds the worker into Autumn's `AppBuilder` lifecycle (start/stop with the server)
+- **`HarvestExt` trait**: planned integration to embed worker lifecycle into Autumn's `AppBuilder` (start/stop with the server)

--- a/autumn-harvest/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/autumn-harvest/src/builder.rs
@@ -7,7 +7,8 @@ use crate::info::{ActivityInfo, DagInfo, WorkflowInfo};
 /// Fluent builder for configuring the autumn-harvest engine.
 ///
 /// In a full Autumn app, this is consumed by the `HarvestExt` trait on
-/// `AppBuilder`. In tests or standalone use, call `.build()` directly.
+/// `AppBuilder`. In tests or standalone use today, use this type as a
+/// registration container and pass values to worker/runtime construction APIs.
 #[derive(Default, Debug)]
 pub struct HarvestBuilder {
     workflows: Vec<WorkflowInfo>,

--- a/autumn-harvest/autumn-harvest/src/context.rs
+++ b/autumn-harvest/autumn-harvest/src/context.rs
@@ -245,7 +245,10 @@ impl WorkflowContext {
     /// Returns `None` if the state type was not registered with the builder.
     #[must_use]
     pub fn state<T: Any + Send + Sync>(&self) -> Option<&T> {
-        self.state.get(&TypeId::of::<T>())?.downcast_ref::<T>()
+        self.state
+            .get(&TypeId::of::<T>())?
+            .as_ref()
+            .downcast_ref::<T>()
     }
 
     // ── Version gate ──────────────────────────────────────────────────
@@ -410,6 +413,16 @@ impl WorkflowContext {
     ///
     /// During replay, returns the recorded child output or failure.
     /// During live execution, emits a `StartChildWorkflow` command and suspends.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HarvestError::NonDeterministic`], [`HarvestError::ActivityFailed`],
+    /// or [`HarvestError::Cancelled`] when replay, child execution, or
+    /// cancellation fail.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the matcher or commands mutex is poisoned.
     pub async fn spawn_child_workflow_raw(
         &self,
         workflow_name: &str,
@@ -456,6 +469,15 @@ impl WorkflowContext {
     }
 
     /// Wait for the next delivered signal with the given name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HarvestError::NonDeterministic`] if replay history diverges or
+    /// [`HarvestError::Cancelled`] if the signal wait channel is dropped.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the matcher or commands mutex is poisoned.
     pub async fn wait_for_signal(&self, signal_name: &str) -> HarvestResult<Value> {
         let history_match = self
             .matcher
@@ -486,6 +508,11 @@ impl WorkflowContext {
         }
     }
 
+    /// Register a query handler callable by name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the query registry mutex is poisoned.
     pub fn register_query<F>(&self, name: &str, handler: F)
     where
         F: Fn() -> Value + Send + Sync + 'static,
@@ -496,6 +523,15 @@ impl WorkflowContext {
             .register(name, Arc::new(handler));
     }
 
+    /// Execute a registered query by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HarvestError::NotFound`] when no handler exists with `name`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the query registry mutex is poisoned.
     pub fn execute_query(&self, name: &str) -> HarvestResult<Value> {
         self.query_registry
             .lock()
@@ -577,7 +613,10 @@ impl ActivityContext {
     /// Access typed shared state.
     #[must_use]
     pub fn state<T: Any + Send + Sync>(&self) -> Option<&T> {
-        self.state.get(&TypeId::of::<T>())?.downcast_ref::<T>()
+        self.state
+            .get(&TypeId::of::<T>())?
+            .as_ref()
+            .downcast_ref::<T>()
     }
 
     /// Send a heartbeat to signal the activity is still running.
@@ -1339,6 +1378,9 @@ mod tests {
 
         let value = ctx.execute_query("status").expect("query should execute");
         assert_eq!(value, serde_json::json!({"state": "running"}));
-        assert!(ctx.drain_commands().is_empty(), "queries must not emit events");
+        assert!(
+            ctx.drain_commands().is_empty(),
+            "queries must not emit events"
+        );
     }
 }

--- a/autumn-harvest/autumn-harvest/src/dag.rs
+++ b/autumn-harvest/autumn-harvest/src/dag.rs
@@ -97,6 +97,12 @@ impl DagTaskRef {
     }
 
     #[must_use]
+    /// Attach `upstream` as a dependency of this task.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self` and `upstream` were created by different
+    /// [`DagBuilder`] instances.
     pub fn upstream(self, upstream: &Self) -> Self {
         assert!(
             Rc::ptr_eq(&self.tasks, &upstream.tasks),

--- a/autumn-harvest/autumn-harvest/src/info.rs
+++ b/autumn-harvest/autumn-harvest/src/info.rs
@@ -86,10 +86,9 @@ impl DagInfo {
     ///
     /// Returns [`DagBuildError`] if the builder creates an invalid graph.
     pub fn build_definition(&self) -> Result<DagDefinition, DagBuildError> {
-        let mut dag = match self.default_queue {
-            Some(queue) => DagBuilder::with_default_queue(queue),
-            None => DagBuilder::new(),
-        };
+        let mut dag = self.default_queue.map_or_else(DagBuilder::new, |queue| {
+            DagBuilder::with_default_queue(queue)
+        });
         (self.builder)(&mut dag);
         dag.build()
     }

--- a/autumn-harvest/autumn-harvest/src/query.rs
+++ b/autumn-harvest/autumn-harvest/src/query.rs
@@ -22,6 +22,11 @@ impl QueryRegistry {
         self.handlers.insert(name.to_string(), handler);
     }
 
+    /// Execute a registered query handler.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HarvestError::NotFound`] when `name` is not registered.
     pub fn execute(&self, name: &str) -> HarvestResult<Value> {
         self.handlers
             .get(name)

--- a/autumn-harvest/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/autumn-harvest/src/replay.rs
@@ -290,6 +290,10 @@ impl HistoryMatcher {
     /// Match a signal wait command against history.
     ///
     /// Expects `SignalReceived { signal_name }` at the current cursor.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if internal queue bookkeeping is corrupted unexpectedly.
     pub fn match_signal(&mut self, signal_name: &str) -> HistoryMatch {
         if let Some(index) = self
             .pending_signals

--- a/autumn-harvest/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/autumn-harvest/src/worker.rs
@@ -28,8 +28,8 @@ use crate::executor::{WorkflowOutcome, run_workflow};
 use crate::info::{ActivityInfo, WorkflowInfo};
 use crate::models::{TaskQueueItem, WorkflowExecution};
 use crate::queue::{self, TaskType};
-use crate::signal;
 use crate::schema::harvest_workflow_executions;
+use crate::signal;
 use crate::store;
 use crate::types::ExecutionId;
 


### PR DESCRIPTION
### Motivation
- Clean up `autumn-harvest` so quality gates (Clippy/docs) pass for the no-DB build and to avoid misleading documentation about unimplemented features. 
- Address lints and missing docs that block `-D warnings` in CI without changing runtime behavior (Phase 2/3 runtime features remain unimplemented). 

### Description
- Fix `Any` downcast usage in `WorkflowContext::state` and `ActivityContext::state` by converting the stored `Box<dyn Any + Send + Sync>` to `&dyn Any` before `downcast_ref`. 
- Add missing `# Errors` and `# Panics` documentation on public workflow/context APIs flagged by Clippy (`spawn_child_workflow_raw`, `wait_for_signal`, query registration/execution, etc.).
- Replace a `match` with `map_or_else` in `DagInfo::build_definition` to satisfy Clippy's `option_if_let_else` suggestion. 
- Add small public-doc clarifications and README/CLAUDE notes to avoid overstating features (`.state(...)` fluent API, `HarvestExt`, and example workflow integrations). 

### Testing
- Ran `cargo fmt --check` in `autumn-harvest`; formatting check passed. 
- Ran `cargo clippy -p autumn-harvest --no-default-features -- -D warnings`; Clippy returned clean for the package. 
- Ran `cargo test -p autumn-harvest --no-default-features`; unit and module tests completed successfully (the package tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceaa439fa8832a9082bb14af5f0653)