### PR TITLE
🤖 Sentinel: [CSRF edge cases test gap closure]

### DIFF
--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -480,6 +480,125 @@ mod tests {
         let headers = http::HeaderMap::new();
         assert_eq!(extract_cookie_token(&headers, "autumn-csrf"), None);
     }
+
+    #[tokio::test]
+    async fn post_with_empty_cookie_but_valid_header() {
+        let token = Uuid::new_v4().to_string();
+        let app = Router::new()
+            .route("/submit", post(|| async { "created" }))
+            .layer(CsrfLayer::from_config(&default_csrf_config()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/submit")
+                    .header("Cookie", "autumn-csrf=")
+                    .header("X-CSRF-Token", &token)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn post_with_valid_cookie_but_empty_header() {
+        let token = Uuid::new_v4().to_string();
+        let app = Router::new()
+            .route("/submit", post(|| async { "created" }))
+            .layer(CsrfLayer::from_config(&default_csrf_config()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/submit")
+                    .header("Cookie", format!("autumn-csrf={token}"))
+                    .header("X-CSRF-Token", "")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn post_with_empty_cookie_but_valid_form_field() {
+        let token = Uuid::new_v4().to_string();
+        let app = Router::new()
+            .route("/submit", post(|| async { "created" }))
+            .layer(CsrfLayer::from_config(&default_csrf_config()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/submit")
+                    .header("Cookie", "autumn-csrf=")
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(Body::from(format!("_csrf={token}")))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn post_with_valid_cookie_but_empty_form_field() {
+        let token = Uuid::new_v4().to_string();
+        let app = Router::new()
+            .route("/submit", post(|| async { "created" }))
+            .layer(CsrfLayer::from_config(&default_csrf_config()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/submit")
+                    .header("Cookie", format!("autumn-csrf={token}"))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(Body::from("_csrf="))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn post_with_large_body_fails_csrf() {
+        let token = Uuid::new_v4().to_string();
+        let app = Router::new()
+            .route("/submit", post(|| async { "created" }))
+            .layer(CsrfLayer::from_config(&default_csrf_config()));
+
+        // Create a body just slightly over 2MB. The CSRF extractor limits to 2MB.
+        let large_padding = "a".repeat(2 * 1024 * 1024 + 10);
+        let body_content = format!("_csrf={token}&pad={large_padding}");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/submit")
+                    .header("Cookie", format!("autumn-csrf={token}"))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(Body::from(body_content))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
* **🧬 Mutants Found:** Found multiple surviving mutants in `autumn/src/security/csrf.rs`, particularly around logic boolean operators (`&&`), missing cookie/header boundary conditions, and payload size bounds (`2 * 1024 * 1024`).
* **🎯 Tests Added/Strengthened:** Added 5 targeted tests: `post_with_empty_cookie_but_valid_header`, `post_with_valid_cookie_but_empty_header`, `post_with_empty_cookie_but_valid_form_field`, `post_with_valid_cookie_but_empty_form_field`, and `post_with_large_body_fails_csrf`. These explicitly cover edge cases regarding partial empty tokens and maximum allowed CSRF extraction sizes.
* **⚠️ Suspected Bugs:** None. The framework was behaving securely, but the tests were not asserting these boundary conditions tightly enough.
* **📊 Kill Rate:** Improved coverage in `csrf.rs` by correctly trapping operator mutations inside validation conditionals and payload limits.
* **🔗 Havoc Interaction:** None.

---
*PR created automatically by Jules for task [6972804127117268414](https://jules.google.com/task/6972804127117268414) started by @madmax983*