### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -305,15 +305,18 @@ fn warn_profile_typo(profile: &str) {
 }
 
 /// Levenshtein edit distance between two strings.
+///
+/// ⚡ Bolt Optimization:
+/// Avoids allocating two `Vec<char>` buffers by iterating directly over `Chars`.
+/// While this re-evaluates UTF-8 boundaries in the inner loop, avoiding the heap
+/// allocations is typically faster for the short strings compared here (e.g., config profile typos).
 fn levenshtein(a: &str, b: &str) -> usize {
-    let a: Vec<char> = a.chars().collect();
-    let b: Vec<char> = b.chars().collect();
-    let n = b.len();
+    let n = b.chars().count();
     let mut prev = (0..=n).collect::<Vec<_>>();
     let mut curr = vec![0; n + 1];
-    for (i, a_ch) in a.iter().enumerate() {
+    for (i, a_ch) in a.chars().enumerate() {
         curr[0] = i + 1;
-        for (j, b_ch) in b.iter().enumerate() {
+        for (j, b_ch) in b.chars().enumerate() {
             let cost = usize::from(a_ch != b_ch);
             curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
         }


### PR DESCRIPTION
💡 What: Removed intermediate `.collect::<Vec<char>>()` calls for strings `a` and `b` in the `levenshtein` distance function inside `autumn/src/config.rs`.
🎯 Why: Iterating over `String::chars()` and collecting them into a `Vec<char>` requires allocating heap memory solely for the purpose of iteration, which can be done directly over the `Chars` iterator.
📊 Impact: Saves two heap allocations per invocation. This is especially advantageous for the typically small profile strings being compared for typo warnings.
🔬 Measurement: Verified with `cargo test -p autumn-web --lib config` and standard rust tooling (`fmt`, `clippy`).

---
*PR created automatically by Jules for task [4268112580158914075](https://jules.google.com/task/4268112580158914075) started by @madmax983*