### PR TITLE
🛡️ Sentry: [test coverage improvement] Clamp DB pool size to 1 to prevent panic

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -55,7 +55,9 @@ pub fn create_pool(config: &DatabaseConfig) -> Result<Option<Pool<AsyncPgConnect
     };
 
     let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
-    let pool = Pool::builder(manager).max_size(config.pool_size).build()?;
+    let pool = Pool::builder(manager)
+        .max_size(config.pool_size.max(1))
+        .build()?;
 
     Ok(Some(pool))
 }
@@ -162,6 +164,23 @@ mod tests {
             .expect("should build pool")
             .expect("should be Some");
         assert_eq!(pool.status().max_size, 5);
+    }
+
+    #[test]
+    fn pool_clamps_size_to_one_if_zero() {
+        let config = DatabaseConfig {
+            url: Some("postgres://localhost/test".into()),
+            pool_size: 0,
+            ..Default::default()
+        };
+        let pool = create_pool(&config)
+            .expect("should build pool")
+            .expect("should be Some");
+        assert_eq!(
+            pool.status().max_size,
+            1,
+            "Pool size should be clamped to 1"
+        );
     }
 
     // ── Db extractor tests ───────────────────────────────────────


### PR DESCRIPTION
🎯 Target: `autumn/src/db.rs::create_pool` function.
💣 Risk: If a user configures `database.pool_size = 0`, the application will panic on startup when building the `deadpool` connection pool.
🧪 Strategy: Added a fallback clamping mechanism (`config.pool_size.max(1)`) to ensure the size is strictly > 0, and added a specific unit test (`pool_clamps_size_to_one_if_zero`) to verify safe initialization.
🔬 Verification: Run `cargo test --manifest-path autumn/Cargo.toml pool_clamps_size_to_one_if_zero`.

---
*PR created automatically by Jules for task [11428396194349117834](https://jules.google.com/task/11428396194349117834) started by @madmax983*