### PR TITLE
🗺️ Atlas: [architectural change] Hide internal modules

### DIFF
--- a/autumn-harvest/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/autumn-harvest/src/lib.rs
@@ -16,25 +16,35 @@ pub mod replay;
 pub mod types;
 
 #[cfg(feature = "db")]
+#[doc(hidden)]
 pub mod dlq;
 #[cfg(feature = "db")]
+#[doc(hidden)]
 pub mod heartbeat;
 #[cfg(feature = "db")]
+#[doc(hidden)]
 pub mod models;
 #[cfg(feature = "db")]
+#[doc(hidden)]
 pub mod notify;
 #[cfg(feature = "db")]
+#[doc(hidden)]
 pub mod queue;
 #[cfg(feature = "db")]
 #[allow(clippy::wildcard_imports)]
+#[doc(hidden)]
 pub mod schema;
 #[cfg(feature = "db")]
+#[doc(hidden)]
 pub mod signal;
 #[cfg(feature = "db")]
+#[doc(hidden)]
 pub mod store;
 #[cfg(feature = "db")]
+#[doc(hidden)]
 pub mod timeout;
 #[cfg(feature = "db")]
+#[doc(hidden)]
 pub mod worker;
 
 pub use builder::{HarvestBuilder, WorkerConfig};


### PR DESCRIPTION
🗺️ Atlas: [architectural change]

🕸️ Tangle: The internal mechanical modules of `autumn-harvest` (`dlq`, `heartbeat`, `models`, `notify`, `queue`, `schema`, `signal`, `store`, `timeout`, and `worker`) were exposed publicly without hiding them from docs or the public API, which violates the Facade pattern and leaks implementation details to consumers.

📐 Blueprint: Add `#[doc(hidden)]` to these internal modules in `autumn-harvest/src/lib.rs` to effectively hide them from the public API documentation while still allowing `pub use` exports of the necessary elements and test access. 

🧱 Stability: Enforces high cohesion and low coupling by clearly defining the public API boundaries and preventing consumers from accidentally using internal structures. The change maintains compilation and API stability internally and externally.

🔬 Verification: Ran `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test` in `autumn-harvest` workspace and verified that the code compiles cleanly and there are no regressions.

---
*PR created automatically by Jules for task [10894482381478610956](https://jules.google.com/task/10894482381478610956) started by @madmax983*