### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -94,6 +94,7 @@ pub mod prelude;
 pub mod route;
 pub mod security;
 pub mod session;
+/// Static site generation support.
 pub mod static_gen;
 pub mod task;
 pub mod validation;
@@ -608,6 +609,7 @@ pub mod reexports {
     pub use validator;
 }
 
+/// Shared application state passed to route handlers.
 pub mod state;
 #[allow(
     clippy::missing_panics_doc,

--- a/autumn/src/middleware/metrics.rs
+++ b/autumn/src/middleware/metrics.rs
@@ -202,41 +202,62 @@ impl Default for MetricsCollector {
 /// Serializable metrics snapshot returned by `/actuator/metrics`.
 #[derive(Serialize)]
 pub struct MetricsSnapshot {
+    /// HTTP-specific metrics including latency and status codes.
     pub http: HttpMetrics,
 }
 
+/// A snapshot of HTTP metrics across the entire application.
 #[derive(Serialize)]
 pub struct HttpMetrics {
+    /// Total number of requests processed.
     pub requests_total: u64,
+    /// Number of currently active (in-flight) requests.
     pub requests_active: u64,
+    /// Global latency percentiles (in milliseconds).
     pub latency_ms: LatencySnapshot,
+    /// Metrics broken down by route ("METHOD /path").
     pub by_route: HashMap<String, RouteSnapshot>,
+    /// Global distribution of HTTP status codes.
     pub by_status: StatusSnapshot,
 }
 
+/// Percentiles for latency measurements.
 #[derive(Serialize, Default)]
 pub struct LatencySnapshot {
+    /// 50th percentile (median) latency in milliseconds.
     pub p50: u64,
+    /// 95th percentile latency in milliseconds.
     pub p95: u64,
+    /// 99th percentile latency in milliseconds.
     pub p99: u64,
 }
 
+/// Metrics for a specific route.
 #[derive(Serialize)]
 pub struct RouteSnapshot {
+    /// Total number of requests to this route.
     pub count: u64,
+    /// 50th percentile (median) latency for this route in milliseconds.
     pub p50_ms: u64,
+    /// 95th percentile latency for this route in milliseconds.
     pub p95_ms: u64,
+    /// 99th percentile latency for this route in milliseconds.
     pub p99_ms: u64,
 }
 
+/// Global distribution of HTTP status codes.
 #[derive(Serialize)]
 pub struct StatusSnapshot {
+    /// Number of 2xx success responses.
     #[serde(rename = "2xx")]
     pub s2xx: u64,
+    /// Number of 3xx redirection responses.
     #[serde(rename = "3xx")]
     pub s3xx: u64,
+    /// Number of 4xx client error responses.
     #[serde(rename = "4xx")]
     pub s4xx: u64,
+    /// Number of 5xx server error responses.
     #[serde(rename = "5xx")]
     pub s5xx: u64,
 }

--- a/autumn/src/task.rs
+++ b/autumn/src/task.rs
@@ -32,7 +32,9 @@ pub enum Schedule {
     FixedDelay(Duration),
     /// Run on a cron schedule (6-field: sec min hour day month weekday).
     Cron {
+        /// The 6-field cron expression (e.g., `"0 * * * * *"` for every minute).
         expression: String,
+        /// The timezone for the cron expression (e.g., `"America/New_York"`).
         timezone: Option<String>,
     },
 }

--- a/autumn/src/validation.rs
+++ b/autumn/src/validation.rs
@@ -138,7 +138,9 @@ where
 /// Helper trait for extracting the validatable inner type from extractors
 /// like `Json<T>`, `Form<T>`, `Query<T>`.
 pub trait AsValidatable {
+    /// The inner type to validate.
     type Inner;
+    /// Returns a reference to the inner type to validate.
     fn as_validatable(&self) -> &Self::Inner;
 }
 


### PR DESCRIPTION
📖 Chapter: `autumn-web` core modules and metrics
🔦 Insight: Added missing `///` comments to several undocumented public items: the `static_gen` and `state` modules, struct fields in `middleware::metrics`, the `task::Schedule` enum, and the `validation::AsValidatable` trait.
🧪 Example: Resolved `missing_docs` lint errors during `cargo doc` compilation.

---
*PR created automatically by Jules for task [2440664863712513509](https://jules.google.com/task/2440664863712513509) started by @madmax983*