### PR TITLE
🤖 Sentinel: [wiki hooks before_update tests]

### DIFF
--- a/examples/wiki/src/hooks.rs
+++ b/examples/wiki/src/hooks.rs
@@ -41,3 +41,58 @@ impl MutationHooks for PageHooks {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use autumn_web::hooks::MutationOp;
+    use chrono::Utc;
+
+    #[tokio::test]
+    async fn test_before_update_updates_slug_if_title_changes() {
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let before = Page {
+            id: 1,
+            title: "Old Title".into(),
+            slug: "old-title".into(),
+            body: "Old Content".into(),
+            status: "published".into(),
+            created_at: Utc::now().naive_utc(),
+            updated_at: Utc::now().naive_utc(),
+        };
+
+        let mut after = before.clone();
+        after.title = "New Title".into();
+
+        let mut draft = UpdateDraft { before, after };
+
+        hooks.before_update(&mut ctx, &mut draft).await.unwrap();
+
+        assert_eq!(draft.after.slug, "new-title");
+    }
+
+    #[tokio::test]
+    async fn test_before_update_preserves_slug_if_title_unchanged() {
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let before = Page {
+            id: 1,
+            title: "Old Title".into(),
+            slug: "old-title".into(),
+            body: "Old Content".into(),
+            status: "published".into(),
+            created_at: Utc::now().naive_utc(),
+            updated_at: Utc::now().naive_utc(),
+        };
+
+        let mut after = before.clone();
+        after.body = "New Content".into();
+
+        let mut draft = UpdateDraft { before, after };
+
+        hooks.before_update(&mut ctx, &mut draft).await.unwrap();
+
+        assert_eq!(draft.after.slug, "old-title");
+    }
+}


### PR DESCRIPTION
**🧬 Mutants Found:** 1 surviving mutant in `examples/wiki/src/hooks.rs` corresponding to `replace != with == in <impl MutationHooks for PageHooks>::before_update`. (Others missed are UI-level Default/Unviable replacements and a flaky DB test missing docker containers).
**🎯 Tests Added/Strengthened:** 
- `test_before_update_updates_slug_if_title_changes`
- `test_before_update_preserves_slug_if_title_unchanged`
**⚠️ Suspected Bugs:** None. The production code was correct, but tests were weak/missing for this behavior.
**📊 Kill Rate:** Surviving mutants on `before_update` in `examples/wiki/src/hooks.rs` went from 1 -> 0.
**🔗 Havoc Interaction:** N/A (Standard logic, no fuzzing required).

---
*PR created automatically by Jules for task [17698974086155872715](https://jules.google.com/task/17698974086155872715) started by @madmax983*