### PR TITLE
🛡️ Sentry: [test coverage improvement] Add test for dev reload state file reading

### DIFF
--- a/autumn/src/middleware/dev.rs
+++ b/autumn/src/middleware/dev.rs
@@ -288,6 +288,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn live_reload_state_handler_reads_file_when_present() {
+        let tmp_file = tempfile::NamedTempFile::new().expect("failed to create temp file");
+        let content = r#"{"version":42,"kind":"css"}"#;
+        std::fs::write(tmp_file.path(), content).expect("failed to write to temp file");
+        let _env = EnvGuard::set_many(&[
+            (DEV_RELOAD_ENV, Some("1")),
+            (DEV_RELOAD_STATE_ENV, tmp_file.path().to_str()),
+        ]);
+
+        let response = live_reload_state_handler().await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(CACHE_CONTROL).unwrap(),
+            DEV_RELOAD_CACHE_CONTROL
+        );
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        assert_eq!(&body[..], content.as_bytes());
+    }
+
+    #[tokio::test]
     async fn disable_static_cache_only_marks_static_paths() {
         let app = axum::Router::new()
             .route("/static/demo.txt", axum::routing::get(|| async { "demo" }))


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 **Target**: `autumn/src/middleware/dev.rs` - `read_reload_state_body()` & `live_reload_state_handler()`
💣 **Risk**: Untested logic reading from the environment variable-specified state file `AUTUMN_DEV_RELOAD_STATE`. If the file logic failed, live reload would quietly fallback and might cause issues during development iteration.
🧪 **Strategy**: Added a test `live_reload_state_handler_reads_file_when_present` that creates a temporary file using `tempfile::NamedTempFile`, writes a known JSON payload, sets the environment variables safely using the test-local `EnvGuard::set_many`, and asserts that the handler correctly parses and returns the file's contents over the fallback default.
🔬 **Verification**: `cargo test -p autumn-web --lib middleware::dev::tests::live_reload_state_handler_reads_file_when_present`

---
*PR created automatically by Jules for task [6009343205753572481](https://jules.google.com/task/6009343205753572481) started by @madmax983*