### PR TITLE
🌟 Nova: [Flash Extractor]

### DIFF
--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [features]
 default = ["maud", "htmx", "tailwind", "db", "cache-moka"]
 ws = []
+flash = []
 cache-moka = ["dep:moka"]
 maud = ["dep:maud"]
 htmx = []

--- a/autumn/src/flash.rs
+++ b/autumn/src/flash.rs
@@ -4,10 +4,10 @@
 //! Allows pushing a message for the next request, and retrieving
 //! it exactly once on the following request.
 
-use axum::extract::FromRequestParts;
 use crate::error::AutumnError;
 use crate::session::Session;
 use crate::state::AppState;
+use axum::extract::FromRequestParts;
 
 /// The key used to store flash messages in the session.
 const FLASH_KEY: &str = "_flash";
@@ -38,8 +38,7 @@ impl Flash {
     }
 }
 
-impl FromRequestParts<AppState> for Flash
-{
+impl FromRequestParts<AppState> for Flash {
     type Rejection = AutumnError;
 
     async fn from_request_parts(
@@ -105,6 +104,9 @@ mod tests {
         flash.push("new message").await;
 
         // Verify it was added to the session
-        assert_eq!(session.get(FLASH_KEY).await, Some("new message".to_string()));
+        assert_eq!(
+            session.get(FLASH_KEY).await,
+            Some("new message".to_string())
+        );
     }
 }

--- a/autumn/src/flash.rs
+++ b/autumn/src/flash.rs
@@ -1,0 +1,110 @@
+//! Flash extractor for temporary session-based messages.
+//!
+//! Provides a `Flash` extractor which is backed by `Session`.
+//! Allows pushing a message for the next request, and retrieving
+//! it exactly once on the following request.
+
+use axum::extract::FromRequestParts;
+use crate::error::AutumnError;
+use crate::session::Session;
+use crate::state::AppState;
+
+/// The key used to store flash messages in the session.
+const FLASH_KEY: &str = "_flash";
+
+/// Temporary session-based message.
+///
+/// Can be used as an extractor in Axum handlers, which removes
+/// the message from the session upon extraction.
+///
+/// Allows pushing new messages to the session to be read on
+/// the next request.
+pub struct Flash {
+    message: Option<String>,
+    session: Session,
+}
+
+impl Flash {
+    /// Retrieve the flash message, if any.
+    /// Note: The message is already removed from the session by the extractor.
+    #[must_use]
+    pub fn message(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+
+    /// Set a new flash message for the next request.
+    pub async fn push(&self, message: impl Into<String>) {
+        self.session.insert(FLASH_KEY, message.into()).await;
+    }
+}
+
+impl FromRequestParts<AppState> for Flash
+{
+    type Rejection = AutumnError;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let session = Session::from_request_parts(parts, state).await?;
+        let message = session.remove(FLASH_KEY).await;
+
+        Ok(Self { message, session })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn flash_extractor_reads_and_removes_message() {
+        // Create a session with a flash message
+        let mut data = HashMap::new();
+        data.insert(FLASH_KEY.into(), "hello world".into());
+        let session = Session::new_for_test("test".into(), data);
+
+        // Put the session in request extensions
+        let mut req = Request::builder().body(()).unwrap();
+        req.extensions_mut().insert(session.clone());
+        let (mut parts, ()) = req.into_parts();
+
+        let state = AppState::for_test();
+
+        // Extract Flash
+        let flash = Flash::from_request_parts(&mut parts, &state).await.unwrap();
+
+        // Verify the message was extracted
+        assert_eq!(flash.message(), Some("hello world"));
+
+        // Verify it was removed from the session
+        assert!(session.get(FLASH_KEY).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn flash_push_sets_message() {
+        // Create an empty session
+        let session = Session::new_for_test("test".into(), HashMap::new());
+
+        // Put the session in request extensions
+        let mut req = Request::builder().body(()).unwrap();
+        req.extensions_mut().insert(session.clone());
+        let (mut parts, ()) = req.into_parts();
+
+        let state = AppState::for_test();
+
+        // Extract Flash
+        let flash = Flash::from_request_parts(&mut parts, &state).await.unwrap();
+
+        // Verify no message initially
+        assert_eq!(flash.message(), None);
+
+        // Push a new message
+        flash.push("new message").await;
+
+        // Verify it was added to the session
+        assert_eq!(session.get(FLASH_KEY).await, Some("new message".to_string()));
+    }
+}

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -77,6 +77,8 @@ pub mod db;
 pub mod error;
 pub mod error_pages;
 pub mod extract;
+#[cfg(feature = "flash")]
+pub mod flash;
 pub mod health;
 #[cfg(feature = "db")]
 pub mod hooks;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -65,6 +65,9 @@ pub use crate::hooks::{
 // ── Session & Auth ──────────────────────────────────────────────
 /// Auth extractor for retrieving the authenticated user.
 pub use crate::auth::Auth;
+#[cfg(feature = "flash")]
+/// Flash extractor for temporary session-based messages.
+pub use crate::flash::Flash;
 /// Session extractor for accessing per-user session data.
 pub use crate::session::Session;
 


### PR DESCRIPTION
💡 **The Spark:** "I noticed we have session management but lack a way to handle temporary messages across redirects (e.g., success or error alerts)."
🚀 **The Feature:** "Implemented the `Flash` extractor backed by the existing `Session` layer. It allows pushing a message for the next request and retrieving it exactly once."
🔮 **The Potential:** "Could be used in all examples (like the `todo-app` or `blog`) to easily surface operation results to the user without managing URL query parameters."
⚠️ **Risk:** "Low. It is completely isolated and hidden behind the `flash` feature flag."

---
*PR created automatically by Jules for task [2798846507914080299](https://jules.google.com/task/2798846507914080299) started by @madmax983*