### PR TITLE
🔒 Warden: [security fix] Prevent username enumeration timing attacks

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -121,8 +121,17 @@ pub async fn verify_password(password: &str, hash: &str) -> crate::AutumnResult<
     let password = password.to_string();
     let hash = hash.to_string();
     tokio::task::spawn_blocking(move || {
-        bcrypt::verify(password, &hash)
-            .map_err(|e| crate::AutumnError::from(std::io::Error::other(e.to_string())))
+        match bcrypt::verify(&password, &hash) {
+            Ok(valid) => Ok(valid),
+            Err(e) => {
+                // If the hash format is invalid, bcrypt::verify fails immediately.
+                // We perform a dummy hash to prevent timing attacks.
+                let _ = bcrypt::hash(&password, DEFAULT_BCRYPT_COST);
+                Err(crate::AutumnError::from(std::io::Error::other(
+                    e.to_string(),
+                )))
+            }
+        }
     })
     .await
     .map_err(|e| crate::AutumnError::from(std::io::Error::other(e.to_string())))?

--- a/autumn/tests/security/auth_timing.rs
+++ b/autumn/tests/security/auth_timing.rs
@@ -1,0 +1,28 @@
+use autumn_web::auth::{hash_password, verify_password};
+use std::time::Instant;
+
+#[tokio::test]
+async fn test_verify_password_timing() {
+    let password = "test_password";
+    let valid_hash = hash_password(password).await.unwrap();
+
+    // Time verification with a valid hash
+    let start_valid = Instant::now();
+    let _ = verify_password(password, &valid_hash).await;
+    let valid_duration = start_valid.elapsed();
+
+    // Time verification with an invalid hash format (e.g., dummy hash)
+    let start_invalid = Instant::now();
+    let _ = verify_password(password, "invalid_hash_format").await;
+    let invalid_duration = start_invalid.elapsed();
+
+    // The invalid duration should be roughly similar to the valid duration.
+    // If it's less than 10% of the valid duration, it's definitely a fast-fail.
+    println!("Valid hash duration: {valid_duration:?}");
+    println!("Invalid hash duration: {invalid_duration:?}");
+
+    assert!(
+        invalid_duration > valid_duration / 2,
+        "VULNERABILITY: verify_password failed instantly on invalid hash format! Valid: {valid_duration:?}, Invalid: {invalid_duration:?}",
+    );
+}

--- a/autumn/tests/security/auth_timing.rs
+++ b/autumn/tests/security/auth_timing.rs
@@ -1,28 +1,40 @@
-use autumn_web::auth::{hash_password, verify_password};
 use std::time::Instant;
+
+use autumn_web::auth::{hash_password, verify_password};
 
 #[tokio::test]
 async fn test_verify_password_timing() {
     let password = "test_password";
     let valid_hash = hash_password(password).await.unwrap();
 
-    // Time verification with a valid hash
-    let start_valid = Instant::now();
-    let _ = verify_password(password, &valid_hash).await;
-    let valid_duration = start_valid.elapsed();
+    let mut valid_durations = vec![];
+    for _ in 0..3 {
+        let start = Instant::now();
+        let _ = verify_password(password, &valid_hash).await;
+        valid_durations.push(start.elapsed());
+    }
 
-    // Time verification with an invalid hash format (e.g., dummy hash)
-    let start_invalid = Instant::now();
-    let _ = verify_password(password, "invalid_hash_format").await;
-    let invalid_duration = start_invalid.elapsed();
+    let mut invalid_durations = vec![];
+    for _ in 0..3 {
+        let start = Instant::now();
+        let _ = verify_password(password, "invalid_hash_format").await;
+        invalid_durations.push(start.elapsed());
+    }
+
+    // Use the minimum duration of the samples to filter out scheduling noise from the CI environment.
+    let min_valid = valid_durations.iter().min().unwrap();
+    let min_invalid = invalid_durations.iter().min().unwrap();
+
+    println!("Valid hash durations: {valid_durations:?}");
+    println!("Invalid hash durations: {invalid_durations:?}");
+    println!("Min valid: {min_valid:?}, Min invalid: {min_invalid:?}");
 
     // The invalid duration should be roughly similar to the valid duration.
-    // If it's less than 10% of the valid duration, it's definitely a fast-fail.
-    println!("Valid hash duration: {valid_duration:?}");
-    println!("Invalid hash duration: {invalid_duration:?}");
-
+    // If it's less than 20% of the valid duration, it's definitely a fast-fail.
+    // We use a forgiving ratio (1/5) because bcrypt operations can vary significantly,
+    // and we just want to prove it's not returning instantly (< 1ms vs ~1s).
     assert!(
-        invalid_duration > valid_duration / 2,
-        "VULNERABILITY: verify_password failed instantly on invalid hash format! Valid: {valid_duration:?}, Invalid: {invalid_duration:?}",
+        *min_invalid > *min_valid / 5,
+        "VULNERABILITY: verify_password failed too quickly on invalid hash format! Valid min: {min_valid:?}, Invalid min: {min_invalid:?}",
     );
 }

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth_dos;
+pub mod auth_timing;
 pub mod csrf_empty_bypass;
 pub mod csrf_form_bypass;
 pub mod csrf_timing;


### PR DESCRIPTION
🦠 Threat: An attacker can enumerate valid users on the platform because checking an invalid user's credentials against a dummy hash fails instantly, unlike the compute-intensive bcrypt verification that happens for valid users.
🛡️ Defense: Implemented a fallback mechanism where if `bcrypt::verify` fails due to format issues (i.e. invalid dummy hash), a dummy hash using `bcrypt::hash` is executed with the default cost to balance the execution time and negate the timing attack surface.
💥 Severity: Medium - Information Disclosure (Username enumeration via timing attacks).
🧪 Verification: Security proof-of-concept test added to `tests/security/auth_timing.rs` successfully verifies that execution timings for invalid hashes are within acceptable bounds of valid verification procedures.

---
*PR created automatically by Jules for task [2056243864411581802](https://jules.google.com/task/2056243864411581802) started by @madmax983*