### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -503,10 +503,7 @@ mod tests {
     fn extract_cookie_ignores_malformed_cookies() {
         let mut headers = http::HeaderMap::new();
         // Missing '='
-        headers.insert(
-            http::header::COOKIE,
-            "autumn-csrf abc123".parse().unwrap(),
-        );
+        headers.insert(http::header::COOKIE, "autumn-csrf abc123".parse().unwrap());
         assert_eq!(extract_cookie_token(&headers, "autumn-csrf"), None);
 
         // Multiple spaces
@@ -514,7 +511,10 @@ mod tests {
             http::header::COOKIE,
             "   autumn-csrf  =  abc123  ; other=xyz".parse().unwrap(),
         );
-        assert_eq!(extract_cookie_token(&headers, "autumn-csrf"), Some("abc123".to_owned()));
+        assert_eq!(
+            extract_cookie_token(&headers, "autumn-csrf"),
+            Some("abc123".to_owned())
+        );
     }
 
     #[test]

--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -499,6 +499,34 @@ mod tests {
         assert_eq!(extract_cookie_token(&headers, "autumn-csrf"), None);
     }
 
+    #[test]
+    fn extract_cookie_ignores_malformed_cookies() {
+        let mut headers = http::HeaderMap::new();
+        // Missing '='
+        headers.insert(
+            http::header::COOKIE,
+            "autumn-csrf abc123".parse().unwrap(),
+        );
+        assert_eq!(extract_cookie_token(&headers, "autumn-csrf"), None);
+
+        // Multiple spaces
+        headers.insert(
+            http::header::COOKIE,
+            "   autumn-csrf  =  abc123  ; other=xyz".parse().unwrap(),
+        );
+        assert_eq!(extract_cookie_token(&headers, "autumn-csrf"), Some("abc123".to_owned()));
+    }
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(super::constant_time_eq("abc", "abc"));
+        assert!(!super::constant_time_eq("abc", "ab"));
+        assert!(!super::constant_time_eq("abc", "abd"));
+        assert!(super::constant_time_eq("", ""));
+        assert!(!super::constant_time_eq("a", "b"));
+        assert!(!super::constant_time_eq("a", "A"));
+    }
+
     #[tokio::test]
     async fn post_with_empty_cookie_but_valid_header() {
         let token = Uuid::new_v4().to_string();


### PR DESCRIPTION
🎯 Target: `autumn/src/security/csrf.rs` (`constant_time_eq` and `extract_cookie_token`)
💣 Risk: Edge cases where cookie parsing incorrectly extracts tokens from malformed headers (like missing `=` or extra spaces), or where `constant_time_eq` evaluates true on incorrectly formatted tokens.
🧪 Strategy: Added unit tests `extract_cookie_ignores_malformed_cookies` and `test_constant_time_eq` checking explicitly for different string permutations and lengths as well as missing operators or extra spacing in headers.
🔬 Verification: Run `cargo test -p autumn-web --lib security::csrf` to verify this specific module's tests.

---
*PR created automatically by Jules for task [8195713439462476323](https://jules.google.com/task/8195713439462476323) started by @madmax983*