### PR TITLE
🔒 Warden: [security fix] Fix timing attack in verify_password

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -121,8 +121,18 @@ pub async fn verify_password(password: &str, hash: &str) -> crate::AutumnResult<
     let password = password.to_string();
     let hash = hash.to_string();
     tokio::task::spawn_blocking(move || {
-        bcrypt::verify(password, &hash)
-            .map_err(|e| crate::AutumnError::from(std::io::Error::other(e.to_string())))
+        match bcrypt::verify(&password, &hash) {
+            Ok(valid) => Ok(valid),
+            Err(e) => {
+                // Compute a dummy hash to prevent timing attacks.
+                // If the provided hash is invalid, `bcrypt::verify` returns almost instantly.
+                // By doing a dummy hash, we ensure the function takes the same amount of time.
+                let _ = bcrypt::hash(&password, DEFAULT_BCRYPT_COST);
+                Err(crate::AutumnError::from(std::io::Error::other(
+                    e.to_string(),
+                )))
+            }
+        }
     })
     .await
     .map_err(|e| crate::AutumnError::from(std::io::Error::other(e.to_string())))?

--- a/autumn/tests/security/auth_timing.rs
+++ b/autumn/tests/security/auth_timing.rs
@@ -1,0 +1,35 @@
+use std::time::Instant;
+
+use autumn_web::auth::verify_password;
+
+#[tokio::test]
+async fn eris_auth_timing_poc() {
+    // Generate a valid bcrypt hash
+    let valid_hash = autumn_web::auth::hash_password("correct_horse_battery_staple")
+        .await
+        .unwrap();
+
+    // Verify time for a valid hash
+    let start_valid = Instant::now();
+    let res_valid = verify_password("wrong_password", &valid_hash).await;
+    let _duration_valid = start_valid.elapsed();
+    assert!(res_valid.is_ok());
+    assert!(!res_valid.unwrap());
+
+    // Verify time for an invalid hash format
+    let invalid_hash = "not_a_bcrypt_hash_at_all";
+    let start_invalid = Instant::now();
+    let res_invalid = verify_password("any_password", invalid_hash).await;
+    let duration_invalid = start_invalid.elapsed();
+    assert!(res_invalid.is_err());
+
+    // Both should take a non-trivial amount of time because of bcrypt hashing.
+    // E.g. at least 50ms depending on CPU speed for cost=12. We check that
+    // duration_invalid is at least somewhat close to duration_valid.
+    // If the vulnerability exists, duration_invalid would be micro-seconds (< 1ms).
+    // Let's assert it takes at least 10ms.
+    assert!(
+        duration_invalid.as_millis() > 10,
+        "Timing attack vulnerability: verification of invalid hash was too fast ({duration_invalid:?})"
+    );
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth_dos;
+pub mod auth_timing;
 pub mod csrf_empty_bypass;
 pub mod csrf_form_bypass;
 pub mod csrf_timing;


### PR DESCRIPTION
🦠 Threat: Password timing attack / User enumeration. When an invalid hash format is supplied (e.g. for non-existent users if a dummy hash isn't stored), `bcrypt::verify` returns instantly. This leaks the fact that a user doesn't exist compared to a valid hash which takes longer to verify.
🛡️ Defense: Implemented a constant-time dummy hash fallback in `verify_password`. When `bcrypt::verify` fails, it computes a dummy hash using `DEFAULT_BCRYPT_COST` so the function takes roughly the same time.
💥 Severity: Medium - Could allow attackers to enumerate user accounts.
🧪 Verification: Added the `eris_auth_timing_poc` test in `autumn/tests/security/auth_timing.rs` which verifies that checking an invalid hash takes > 10ms.

---
*PR created automatically by Jules for task [258228589719327473](https://jules.google.com/task/258228589719327473) started by @madmax983*