### PR TITLE
🗺️ Atlas: [architectural change] Extract router building logic from app.rs to router.rs

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1567,10 +1567,7 @@ mod tests {
     }
 
     /// Helper to build a test router with custom config.
-    pub fn test_router_with_config(
-        routes: Vec<Route>,
-        config: &AutumnConfig,
-    ) -> axum::Router {
+    pub fn test_router_with_config(routes: Vec<Route>, config: &AutumnConfig) -> axum::Router {
         let state = AppState {
             #[cfg(feature = "db")]
             pool: None,

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -29,10 +29,8 @@ use std::sync::Arc;
 use crate::config::AutumnConfig;
 #[cfg(feature = "db")]
 use crate::db;
-use crate::error_pages::{self, ErrorPageRenderer, SharedRenderer};
-use crate::middleware::RequestIdLayer;
-use crate::middleware::dev;
-use crate::middleware::exception_filter::{ExceptionFilter, ExceptionFilterLayer};
+use crate::error_pages::{ErrorPageRenderer, SharedRenderer};
+use crate::middleware::exception_filter::ExceptionFilter;
 #[cfg(feature = "db")]
 use crate::migrate;
 use crate::route::Route;
@@ -123,11 +121,12 @@ pub struct AppBuilder {
 ///
 /// Created by [`AppBuilder::scoped`]. The routes are mounted under the
 /// prefix with the middleware applied only to this group.
-struct ScopedGroup {
-    prefix: String,
-    routes: Vec<Route>,
+pub(crate) struct ScopedGroup {
+    pub(crate) prefix: String,
+    pub(crate) routes: Vec<Route>,
     /// Closure that applies the layer to a sub-router.
-    apply_layer: Box<dyn FnOnce(axum::Router<AppState>) -> axum::Router<AppState> + Send>,
+    pub(crate) apply_layer:
+        Box<dyn FnOnce(axum::Router<AppState>) -> axum::Router<AppState> + Send>,
 }
 
 impl AppBuilder {
@@ -536,7 +535,7 @@ impl AppBuilder {
         } else {
             None
         };
-        let router = build_router_with_static_inner(
+        let router = crate::router::build_router_with_static_inner(
             all_routes,
             &config,
             state.clone(),
@@ -662,7 +661,7 @@ impl AppBuilder {
         };
 
         // Build the full router (same as production)
-        let router = build_router(all_routes, &config, state);
+        let router = crate::router::build_router(all_routes, &config, state);
 
         let env = crate::config::OsEnv;
         let dist_dir = project_dir("dist", &env);
@@ -924,446 +923,13 @@ fn format_config_summary(config: &AutumnConfig) -> String {
     )
 }
 
-/// Build the fully-configured Axum router from routes, config, and state.
-///
-/// Extracted from `AppBuilder::run` so the router construction logic is
 /// Resolve a project-relative subdirectory (e.g. `"dist"` or `"static"`)
 /// against `AUTUMN_MANIFEST_DIR` if set, otherwise use it as-is.
-fn project_dir(subdir: &str, env: &dyn crate::config::Env) -> std::path::PathBuf {
+pub(crate) fn project_dir(subdir: &str, env: &dyn crate::config::Env) -> std::path::PathBuf {
     env.var("AUTUMN_MANIFEST_DIR").map_or_else(
         |_| std::path::PathBuf::from(subdir),
         |d| std::path::PathBuf::from(d).join(subdir),
     )
-}
-
-/// testable without binding a real TCP listener.
-pub fn build_router(
-    route_list: Vec<Route>,
-    config: &AutumnConfig,
-    state: AppState,
-) -> axum::Router {
-    build_router_inner(
-        route_list,
-        config,
-        state,
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        None,
-    )
-}
-
-/// Build a router that includes user-supplied raw Axum routers.
-///
-/// Like [`build_router`], but also merges and nests additional raw
-/// Axum routers. This is primarily useful for integration testing;
-/// in production, use [`AppBuilder::merge`] and [`AppBuilder::nest`].
-pub fn build_router_merged(
-    route_list: Vec<Route>,
-    config: &AutumnConfig,
-    state: AppState,
-    merge_routers: Vec<axum::Router<AppState>>,
-    nest_routers: Vec<(String, axum::Router<AppState>)>,
-) -> axum::Router {
-    build_router_inner(
-        route_list,
-        config,
-        state,
-        Vec::new(),
-        Vec::new(),
-        merge_routers,
-        nest_routers,
-        None,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-#[allow(clippy::cognitive_complexity)]
-fn build_router_inner(
-    route_list: Vec<Route>,
-    config: &AutumnConfig,
-    state: AppState,
-    exception_filters: Vec<Arc<dyn ExceptionFilter>>,
-    scoped_groups: Vec<ScopedGroup>,
-    merge_routers: Vec<axum::Router<AppState>>,
-    nest_routers: Vec<(String, axum::Router<AppState>)>,
-    error_page_renderer: Option<SharedRenderer>,
-) -> axum::Router {
-    // Group routes by path so multiple methods on the same path
-    // (e.g. GET /admin + POST /admin) are merged into a single
-    // MethodRouter. Axum 0.7+ panics if .route() is called twice
-    // with the same path — merging avoids this.
-    let mut grouped: indexmap::IndexMap<&str, axum::routing::MethodRouter<AppState>> =
-        indexmap::IndexMap::new();
-    for route in &route_list {
-        tracing::debug!(
-            method = %route.method,
-            path = route.path,
-            name = route.name,
-            "Mounted route"
-        );
-    }
-    for route in route_list {
-        grouped
-            .entry(route.path)
-            .and_modify(|existing| {
-                *existing = existing.clone().merge(route.handler.clone());
-            })
-            .or_insert(route.handler);
-    }
-
-    let mut router = axum::Router::new();
-    for (path, method_router) in grouped {
-        router = router.route(path, method_router);
-    }
-
-    let dev_reload_enabled = dev::is_enabled();
-
-    // Framework-provided routes
-    #[cfg(feature = "htmx")]
-    {
-        router = router.route("/static/js/htmx.min.js", axum::routing::get(htmx_handler));
-        tracing::debug!(
-            method = "GET",
-            path = "/static/js/htmx.min.js",
-            name = format!("htmx {}", crate::htmx::HTMX_VERSION),
-            "Mounted route"
-        );
-    }
-
-    if dev_reload_enabled {
-        router = router.route(
-            dev::LIVE_RELOAD_PATH,
-            axum::routing::get(dev::live_reload_state_handler),
-        );
-        tracing::debug!(
-            path = dev::LIVE_RELOAD_PATH,
-            "Mounted dev live reload endpoint"
-        );
-    }
-
-    // Health check endpoint (auto-mounted)
-    router = router.route(
-        &config.health.path,
-        axum::routing::get(crate::health::handler),
-    );
-    tracing::debug!(path = %config.health.path, "Mounted health check");
-
-    // Actuator endpoints
-    let actuator_sensitive = config.actuator.sensitive;
-    router = router.merge(crate::actuator::actuator_router(actuator_sensitive));
-    tracing::debug!(
-        sensitive = actuator_sensitive,
-        "Mounted actuator endpoints at /actuator/*"
-    );
-
-    // Static file serving from project's static/ directory.
-    let env = crate::config::OsEnv;
-    let static_dir = project_dir("static", &env);
-    router = router.nest_service("/static", tower_http::services::ServeDir::new(&static_dir));
-
-    // Mount scoped route groups (each with its own middleware layer).
-    for group in scoped_groups {
-        let mut sub_router = axum::Router::new();
-        for route in group.routes {
-            tracing::debug!(
-                method = %route.method,
-                path = route.path,
-                name = route.name,
-                scope = %group.prefix,
-                "Mounted scoped route"
-            );
-            sub_router = sub_router.route(route.path, route.handler);
-        }
-        sub_router = (group.apply_layer)(sub_router);
-        router = router.nest(&group.prefix, sub_router);
-    }
-
-    // Merge user-supplied raw Axum routers (escape hatch).
-    // Merged after annotated routes so annotated routes take precedence.
-    for raw_router in merge_routers {
-        tracing::debug!("Merged raw Axum router");
-        router = router.merge(raw_router);
-    }
-
-    // Nest user-supplied raw Axum routers under path prefixes.
-    for (prefix, raw_router) in nest_routers {
-        tracing::debug!(prefix = %prefix, "Nested raw Axum router");
-        router = router.nest(&prefix, raw_router);
-    }
-
-    // CORS middleware (only applied when allowed_origins is non-empty)
-    if !config.cors.allowed_origins.is_empty() {
-        let cors = build_cors_layer(&config.cors);
-        tracing::info!(
-            origins = ?config.cors.allowed_origins,
-            credentials = config.cors.allow_credentials,
-            "CORS enabled"
-        );
-        router = router.layer(cors);
-    }
-
-    // CSRF middleware (only applied when enabled)
-    if config.security.csrf.enabled {
-        let csrf_layer = crate::security::CsrfLayer::from_config(&config.security.csrf);
-        tracing::info!("CSRF protection enabled");
-        router = router.layer(csrf_layer);
-    }
-
-    // Session management layer (always enabled with default in-memory store)
-    let session_layer = crate::session::SessionLayer::new(
-        crate::session::MemoryStore::new(),
-        config.session.clone(),
-    );
-    tracing::debug!("Session management enabled (in-memory store)");
-
-    // Security headers layer (always applied)
-    let security_headers =
-        crate::security::SecurityHeadersLayer::from_config(&config.security.headers);
-    tracing::debug!("Security headers enabled");
-
-    // 404 fallback handler for unmatched routes
-    router = router.fallback(crate::middleware::error_page_filter::fallback_404_handler);
-
-    // Apply framework middleware. Exception filters wrap outermost so they
-    // see all error responses regardless of scoping or interceptors.
-    let router = router
-        .layer(RequestIdLayer)
-        .layer(security_headers)
-        .layer(session_layer);
-
-    // Error page filter: renders HTML error pages for browser requests.
-    // Always registered (uses default renderer if no custom one is provided).
-    let is_dev = config
-        .profile
-        .as_deref()
-        .map_or(cfg!(debug_assertions), |p| p == "dev");
-    let renderer = error_page_renderer.unwrap_or_else(error_pages::default_renderer);
-    let error_page_filter =
-        crate::middleware::error_page_filter::ErrorPageFilter { renderer, is_dev };
-
-    // Combine the error page filter with user exception filters.
-    // The error page filter runs first (innermost), then user filters.
-    let mut all_filters: Vec<Arc<dyn ExceptionFilter>> = vec![Arc::new(error_page_filter)];
-    all_filters.extend(exception_filters);
-
-    let count = all_filters.len();
-    tracing::debug!(
-        count,
-        "Registered exception filters (including error page filter)"
-    );
-
-    // Error page context layer must be inner to the exception filter so
-    // WantsHtml is set on the response before the filter inspects it.
-    // Layer order: Metrics -> ExceptionFilter -> ErrorPageContext -> router
-    let mut router = router
-        .layer(crate::middleware::error_page_filter::ErrorPageContextLayer)
-        .layer(ExceptionFilterLayer::new(all_filters))
-        .layer(crate::middleware::MetricsLayer::new(state.metrics.clone()));
-
-    if dev_reload_enabled {
-        router = router
-            .layer(axum::middleware::from_fn(dev::disable_static_cache))
-            .layer(axum::middleware::from_fn(dev::inject_live_reload));
-    }
-
-    router.with_state(state)
-}
-
-/// Build the router with optional static-file-first serving.
-///
-/// If `dist_dir` is `Some` and contains a valid `manifest.json`, the
-/// returned router intercepts GET/HEAD requests whose path appears in
-/// the manifest and serves pre-built HTML directly — before the dynamic
-/// router runs.  This matches Next.js SSG/ISR semantics where static
-/// pages always win over dynamic handlers.
-///
-/// Requests not in the manifest (including non-GET/HEAD methods) fall
-/// through to the dynamic router unchanged.
-///
-/// When `dist_dir` is `None` or the manifest is missing, the returned
-/// router is identical to [`build_router`].
-///
-/// This function is public primarily for integration testing.
-pub fn build_router_with_static(
-    route_list: Vec<Route>,
-    config: &AutumnConfig,
-    state: AppState,
-    dist_dir: Option<&std::path::Path>,
-) -> axum::Router {
-    build_router_with_static_inner(
-        route_list,
-        config,
-        state,
-        dist_dir,
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        None,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn build_router_with_static_inner(
-    route_list: Vec<Route>,
-    config: &AutumnConfig,
-    state: AppState,
-    dist_dir: Option<&std::path::Path>,
-    exception_filters: Vec<Arc<dyn ExceptionFilter>>,
-    scoped_groups: Vec<ScopedGroup>,
-    merge_routers: Vec<axum::Router<AppState>>,
-    nest_routers: Vec<(String, axum::Router<AppState>)>,
-    error_page_renderer: Option<SharedRenderer>,
-) -> axum::Router {
-    let app_router = build_router_inner(
-        route_list,
-        config,
-        state,
-        exception_filters,
-        scoped_groups,
-        merge_routers,
-        nest_routers,
-        error_page_renderer,
-    );
-
-    let Some(dist) = dist_dir else {
-        return app_router;
-    };
-
-    let Some(layer) = crate::static_gen::StaticFileLayer::new(dist) else {
-        tracing::debug!(
-            dist = %dist.display(),
-            "No valid manifest.json in dist dir; skipping static file layer"
-        );
-        return app_router;
-    };
-
-    // Enable ISR regeneration by attaching the app router to the static layer.
-    // Routes with `revalidate` set will spawn background re-render tasks
-    // when their files become stale.
-    let has_isr = layer
-        .manifest()
-        .routes
-        .values()
-        .any(|e| e.revalidate.is_some());
-    let layer = if has_isr {
-        layer.with_router(app_router.clone())
-    } else {
-        layer
-    };
-
-    for (route, entry) in &layer.manifest().routes {
-        tracing::debug!(
-            route = %route,
-            file = %entry.file,
-            revalidate = ?entry.revalidate,
-            "Static route"
-        );
-    }
-
-    // Store the layer in an Arc so the static-first middleware can use it.
-    let layer = Arc::new(layer);
-
-    // Static-first serving: intercept GET/HEAD requests whose path appears
-    // in the manifest and serve pre-built HTML directly, BEFORE the dynamic
-    // router runs.  This matches Next.js SSG/ISR semantics where static
-    // pages always win over dynamic handlers.
-    //
-    // Requests not in the manifest (including non-GET/HEAD methods) fall
-    // through to the dynamic router unchanged.
-    //
-    // ISR staleness checking happens inside `resolve()`: stale pages are
-    // still served immediately while background regeneration runs
-    // (stale-while-revalidate).
-    let static_layer = layer;
-    app_router.layer(axum::middleware::from_fn(
-        move |req: axum::extract::Request, next: axum::middleware::Next| {
-            let static_layer = static_layer.clone();
-            async move {
-                let is_get = req.method() == http::Method::GET;
-                let is_head = req.method() == http::Method::HEAD;
-                if is_get || is_head {
-                    let path = req.uri().path();
-                    // Normalize trailing slash: /about/ → /about (but keep / as /)
-                    let normalized = if path.len() > 1 && path.ends_with('/') {
-                        &path[..path.len() - 1]
-                    } else {
-                        path
-                    };
-                    if let Some(file_path) = static_layer.resolve(normalized) {
-                        if let Ok(contents) = tokio::fs::read(&file_path).await {
-                            let body = if is_head {
-                                axum::body::Body::empty()
-                            } else {
-                                axum::body::Body::from(contents)
-                            };
-                            return http::Response::builder()
-                                .status(http::StatusCode::OK)
-                                .header(http::header::CONTENT_TYPE, "text/html; charset=utf-8")
-                                .body(body)
-                                .unwrap();
-                        }
-                    }
-                }
-                next.run(req).await
-            }
-        },
-    ))
-}
-
-/// Build a `tower_http::cors::CorsLayer` from the framework's [`crate::config::CorsConfig`].
-///
-/// Called only when `config.cors.allowed_origins` is non-empty.
-fn build_cors_layer(cors: &crate::config::CorsConfig) -> tower_http::cors::CorsLayer {
-    use http::header::HeaderName;
-    use tower_http::cors::{AllowOrigin, CorsLayer};
-
-    let layer = if cors.allowed_origins.iter().any(|o| o == "*") {
-        CorsLayer::new().allow_origin(AllowOrigin::any())
-    } else {
-        let origins: Vec<http::HeaderValue> = cors
-            .allowed_origins
-            .iter()
-            .filter_map(|o| o.parse().ok())
-            .collect();
-        CorsLayer::new().allow_origin(origins)
-    };
-
-    let methods: Vec<http::Method> = cors
-        .allowed_methods
-        .iter()
-        .filter_map(|m| m.parse().ok())
-        .collect();
-
-    let headers: Vec<HeaderName> = cors
-        .allowed_headers
-        .iter()
-        .filter_map(|h| h.parse().ok())
-        .collect();
-
-    layer
-        .allow_methods(methods)
-        .allow_headers(headers)
-        .allow_credentials(cors.allow_credentials)
-        .max_age(std::time::Duration::from_secs(cors.max_age_secs))
-}
-
-#[cfg(feature = "htmx")]
-async fn htmx_handler() -> axum::response::Response {
-    use axum::response::IntoResponse;
-    (
-        [
-            (http::header::CONTENT_TYPE, "application/javascript"),
-            (
-                http::header::CACHE_CONTROL,
-                "public, max-age=31536000, immutable",
-            ),
-        ],
-        crate::htmx::HTMX_JS,
-    )
-        .into_response()
 }
 
 /// Wait for a shutdown signal (Ctrl+C or SIGTERM on Unix).
@@ -1404,13 +970,13 @@ mod tests {
     use std::sync::{Mutex, OnceLock};
     use tower::ServiceExt;
 
-    struct EnvGuard {
+    pub struct EnvGuard {
         _lock: std::sync::MutexGuard<'static, ()>,
         previous: Vec<(&'static str, Option<String>)>,
     }
 
     impl EnvGuard {
-        fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
+        pub fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
             static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
             let lock = ENV_LOCK
                 .get_or_init(|| Mutex::new(()))
@@ -1452,7 +1018,7 @@ mod tests {
     }
 
     /// Helper to build a test router with default config and no database.
-    fn test_router(routes: Vec<Route>) -> axum::Router {
+    pub fn test_router(routes: Vec<Route>) -> axum::Router {
         let config = AutumnConfig::default();
         let state = AppState {
             #[cfg(feature = "db")]
@@ -1469,11 +1035,11 @@ mod tests {
             #[cfg(feature = "ws")]
             shutdown: tokio_util::sync::CancellationToken::new(),
         };
-        build_router(routes, &config, state)
+        crate::router::build_router(routes, &config, state)
     }
 
     /// Helper to create a simple GET route for testing.
-    fn test_get_route(path: &'static str, name: &'static str) -> Route {
+    pub fn test_get_route(path: &'static str, name: &'static str) -> Route {
         Route {
             method: http::Method::GET,
             path,
@@ -1558,7 +1124,8 @@ mod tests {
             #[cfg(feature = "ws")]
             shutdown: tokio_util::sync::CancellationToken::new(),
         };
-        let router = build_router(vec![test_get_route("/dummy", "dummy")], &config, state);
+        let router =
+            crate::router::build_router(vec![test_get_route("/dummy", "dummy")], &config, state);
 
         let response = router
             .oneshot(
@@ -1639,7 +1206,7 @@ mod tests {
             #[cfg(feature = "ws")]
             shutdown: tokio_util::sync::CancellationToken::new(),
         };
-        let router = build_router(post_routes, &config, state);
+        let router = crate::router::build_router(post_routes, &config, state);
 
         let response = router
             .oneshot(
@@ -1687,7 +1254,7 @@ mod tests {
             #[cfg(feature = "ws")]
             shutdown: tokio_util::sync::CancellationToken::new(),
         };
-        let router = build_router(route_list, &config, state);
+        let router = crate::router::build_router(route_list, &config, state);
 
         // GET /admin should return "list"
         let resp = router
@@ -1727,8 +1294,10 @@ mod tests {
     #[cfg(feature = "htmx")]
     #[tokio::test]
     async fn htmx_handler_returns_javascript_with_correct_headers() {
-        let app =
-            axum::Router::new().route("/static/js/htmx.min.js", axum::routing::get(htmx_handler));
+        let app = axum::Router::new().route(
+            "/static/js/htmx.min.js",
+            axum::routing::get(crate::router::htmx_handler),
+        );
 
         let response = app
             .oneshot(
@@ -1845,7 +1414,7 @@ mod tests {
             #[cfg(feature = "ws")]
             shutdown: tokio_util::sync::CancellationToken::new(),
         };
-        let router = build_router_with_static(
+        let router = crate::router::build_router_with_static(
             vec![test_get_route("/other", "other_page")],
             &config,
             state,
@@ -1998,7 +1567,10 @@ mod tests {
     }
 
     /// Helper to build a test router with custom config.
-    fn test_router_with_config(routes: Vec<Route>, config: &AutumnConfig) -> axum::Router {
+    pub fn test_router_with_config(
+        routes: Vec<Route>,
+        config: &AutumnConfig,
+    ) -> axum::Router {
         let state = AppState {
             #[cfg(feature = "db")]
             pool: None,
@@ -2014,7 +1586,7 @@ mod tests {
             #[cfg(feature = "ws")]
             shutdown: tokio_util::sync::CancellationToken::new(),
         };
-        build_router(routes, config, state)
+        crate::router::build_router(routes, config, state)
     }
 
     #[tokio::test]
@@ -2149,7 +1721,7 @@ mod tests {
             #[cfg(feature = "ws")]
             shutdown: tokio_util::sync::CancellationToken::new(),
         };
-        let router = build_router_with_static(
+        let router = crate::router::build_router_with_static(
             vec![test_get_route("/test", "test")],
             &config,
             state,
@@ -2182,8 +1754,12 @@ mod tests {
             #[cfg(feature = "ws")]
             shutdown: tokio_util::sync::CancellationToken::new(),
         };
-        let router =
-            build_router_with_static(vec![test_get_route("/test", "test")], &config, state, None);
+        let router = crate::router::build_router_with_static(
+            vec![test_get_route("/test", "test")],
+            &config,
+            state,
+            None,
+        );
 
         let response = router
             .oneshot(Request::builder().uri("/test").body(Body::empty()).unwrap())

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -82,6 +82,7 @@ pub mod health;
 pub mod hooks;
 #[cfg(feature = "db")]
 pub mod migrate;
+pub mod router;
 #[cfg(feature = "db")]
 pub use hooks::{
     DraftField, FieldDiff, MutationContext, MutationHooks, MutationOp, NoHooks, Patch, UpdateDraft,

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1,0 +1,443 @@
+use std::sync::Arc;
+
+use crate::app::ScopedGroup;
+use crate::config::AutumnConfig;
+use crate::error_pages::{self, SharedRenderer};
+use crate::middleware::RequestIdLayer;
+use crate::middleware::dev;
+use crate::middleware::exception_filter::{ExceptionFilter, ExceptionFilterLayer};
+use crate::route::Route;
+use crate::state::AppState;
+
+/// Build the fully-configured Axum router from routes, config, and state.
+///
+/// Extracted from `AppBuilder::run` so the router construction logic is
+/// testable without binding a real TCP listener.
+pub fn build_router(
+    route_list: Vec<Route>,
+    config: &AutumnConfig,
+    state: AppState,
+) -> axum::Router {
+    build_router_inner(
+        route_list,
+        config,
+        state,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        None,
+    )
+}
+
+/// Build a router that includes user-supplied raw Axum routers.
+///
+/// Like [`build_router`], but also merges and nests additional raw
+/// Axum routers. This is primarily useful for integration testing;
+/// in production, use [`AppBuilder::merge`] and [`AppBuilder::nest`].
+pub fn build_router_merged(
+    route_list: Vec<Route>,
+    config: &AutumnConfig,
+    state: AppState,
+    merge_routers: Vec<axum::Router<AppState>>,
+    nest_routers: Vec<(String, axum::Router<AppState>)>,
+) -> axum::Router {
+    build_router_inner(
+        route_list,
+        config,
+        state,
+        Vec::new(),
+        Vec::new(),
+        merge_routers,
+        nest_routers,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::cognitive_complexity)]
+pub(crate) fn build_router_inner(
+    route_list: Vec<Route>,
+    config: &AutumnConfig,
+    state: AppState,
+    exception_filters: Vec<Arc<dyn ExceptionFilter>>,
+    scoped_groups: Vec<ScopedGroup>,
+    merge_routers: Vec<axum::Router<AppState>>,
+    nest_routers: Vec<(String, axum::Router<AppState>)>,
+    error_page_renderer: Option<SharedRenderer>,
+) -> axum::Router {
+    // Group routes by path so multiple methods on the same path
+    // (e.g. GET /admin + POST /admin) are merged into a single
+    // MethodRouter. Axum 0.7+ panics if .route() is called twice
+    // with the same path — merging avoids this.
+    let mut grouped: indexmap::IndexMap<&str, axum::routing::MethodRouter<AppState>> =
+        indexmap::IndexMap::new();
+    for route in &route_list {
+        tracing::debug!(
+            method = %route.method,
+            path = route.path,
+            name = route.name,
+            "Mounted route"
+        );
+    }
+    for route in route_list {
+        grouped
+            .entry(route.path)
+            .and_modify(|existing| {
+                *existing = existing.clone().merge(route.handler.clone());
+            })
+            .or_insert(route.handler);
+    }
+
+    let mut router = axum::Router::new();
+    for (path, method_router) in grouped {
+        router = router.route(path, method_router);
+    }
+
+    let dev_reload_enabled = dev::is_enabled();
+
+    // Framework-provided routes
+    #[cfg(feature = "htmx")]
+    {
+        router = router.route("/static/js/htmx.min.js", axum::routing::get(htmx_handler));
+        tracing::debug!(
+            method = "GET",
+            path = "/static/js/htmx.min.js",
+            name = format!("htmx {}", crate::htmx::HTMX_VERSION),
+            "Mounted route"
+        );
+    }
+
+    if dev_reload_enabled {
+        router = router.route(
+            dev::LIVE_RELOAD_PATH,
+            axum::routing::get(dev::live_reload_state_handler),
+        );
+        tracing::debug!(
+            path = dev::LIVE_RELOAD_PATH,
+            "Mounted dev live reload endpoint"
+        );
+    }
+
+    // Health check endpoint (auto-mounted)
+    router = router.route(
+        &config.health.path,
+        axum::routing::get(crate::health::handler),
+    );
+    tracing::debug!(path = %config.health.path, "Mounted health check");
+
+    // Actuator endpoints
+    let actuator_sensitive = config.actuator.sensitive;
+    router = router.merge(crate::actuator::actuator_router(actuator_sensitive));
+    tracing::debug!(
+        sensitive = actuator_sensitive,
+        "Mounted actuator endpoints at /actuator/*"
+    );
+
+    // Static file serving from project's static/ directory.
+    let env = crate::config::OsEnv;
+    let static_dir = crate::app::project_dir("static", &env);
+    router = router.nest_service("/static", tower_http::services::ServeDir::new(&static_dir));
+
+    // Mount scoped route groups (each with its own middleware layer).
+    for group in scoped_groups {
+        let mut sub_router = axum::Router::new();
+        for route in group.routes {
+            tracing::debug!(
+                method = %route.method,
+                path = route.path,
+                name = route.name,
+                scope = %group.prefix,
+                "Mounted scoped route"
+            );
+            sub_router = sub_router.route(route.path, route.handler);
+        }
+        sub_router = (group.apply_layer)(sub_router);
+        router = router.nest(&group.prefix, sub_router);
+    }
+
+    // Merge user-supplied raw Axum routers (escape hatch).
+    // Merged after annotated routes so annotated routes take precedence.
+    for raw_router in merge_routers {
+        tracing::debug!("Merged raw Axum router");
+        router = router.merge(raw_router);
+    }
+
+    // Nest user-supplied raw Axum routers under path prefixes.
+    for (prefix, raw_router) in nest_routers {
+        tracing::debug!(prefix = %prefix, "Nested raw Axum router");
+        router = router.nest(&prefix, raw_router);
+    }
+
+    // CORS middleware (only applied when allowed_origins is non-empty)
+    if !config.cors.allowed_origins.is_empty() {
+        let cors = build_cors_layer(&config.cors);
+        tracing::info!(
+            origins = ?config.cors.allowed_origins,
+            credentials = config.cors.allow_credentials,
+            "CORS enabled"
+        );
+        router = router.layer(cors);
+    }
+
+    // CSRF middleware (only applied when enabled)
+    if config.security.csrf.enabled {
+        let csrf_layer = crate::security::CsrfLayer::from_config(&config.security.csrf);
+        tracing::info!("CSRF protection enabled");
+        router = router.layer(csrf_layer);
+    }
+
+    // Session management layer (always enabled with default in-memory store)
+    let session_layer = crate::session::SessionLayer::new(
+        crate::session::MemoryStore::new(),
+        config.session.clone(),
+    );
+    tracing::debug!("Session management enabled (in-memory store)");
+
+    // Security headers layer (always applied)
+    let security_headers =
+        crate::security::SecurityHeadersLayer::from_config(&config.security.headers);
+    tracing::debug!("Security headers enabled");
+
+    // 404 fallback handler for unmatched routes
+    router = router.fallback(crate::middleware::error_page_filter::fallback_404_handler);
+
+    // Apply framework middleware. Exception filters wrap outermost so they
+    // see all error responses regardless of scoping or interceptors.
+    let router = router
+        .layer(RequestIdLayer)
+        .layer(security_headers)
+        .layer(session_layer);
+
+    // Error page filter: renders HTML error pages for browser requests.
+    // Always registered (uses default renderer if no custom one is provided).
+    let is_dev = config
+        .profile
+        .as_deref()
+        .map_or(cfg!(debug_assertions), |p| p == "dev");
+    let renderer = error_page_renderer.unwrap_or_else(error_pages::default_renderer);
+    let error_page_filter =
+        crate::middleware::error_page_filter::ErrorPageFilter { renderer, is_dev };
+
+    // Combine the error page filter with user exception filters.
+    // The error page filter runs first (innermost), then user filters.
+    let mut all_filters: Vec<Arc<dyn ExceptionFilter>> = vec![Arc::new(error_page_filter)];
+    all_filters.extend(exception_filters);
+
+    let count = all_filters.len();
+    tracing::debug!(
+        count,
+        "Registered exception filters (including error page filter)"
+    );
+
+    // Error page context layer must be inner to the exception filter so
+    // WantsHtml is set on the response before the filter inspects it.
+    // Layer order: Metrics -> ExceptionFilter -> ErrorPageContext -> router
+    let mut router = router
+        .layer(crate::middleware::error_page_filter::ErrorPageContextLayer)
+        .layer(ExceptionFilterLayer::new(all_filters))
+        .layer(crate::middleware::MetricsLayer::new(state.metrics.clone()));
+
+    if dev_reload_enabled {
+        router = router
+            .layer(axum::middleware::from_fn(dev::disable_static_cache))
+            .layer(axum::middleware::from_fn(dev::inject_live_reload));
+    }
+
+    router.with_state(state)
+}
+
+/// Build the router with optional static-file-first serving.
+///
+/// If `dist_dir` is `Some` and contains a valid `manifest.json`, the
+/// returned router intercepts GET/HEAD requests whose path appears in
+/// the manifest and serves pre-built HTML directly — before the dynamic
+/// router runs.  This matches Next.js SSG/ISR semantics where static
+/// pages always win over dynamic handlers.
+///
+/// Requests not in the manifest (including non-GET/HEAD methods) fall
+/// through to the dynamic router unchanged.
+///
+/// When `dist_dir` is `None` or the manifest is missing, the returned
+/// router is identical to [`build_router`].
+///
+/// This function is public primarily for integration testing.
+pub fn build_router_with_static(
+    route_list: Vec<Route>,
+    config: &AutumnConfig,
+    state: AppState,
+    dist_dir: Option<&std::path::Path>,
+) -> axum::Router {
+    build_router_with_static_inner(
+        route_list,
+        config,
+        state,
+        dist_dir,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_router_with_static_inner(
+    route_list: Vec<Route>,
+    config: &AutumnConfig,
+    state: AppState,
+    dist_dir: Option<&std::path::Path>,
+    exception_filters: Vec<Arc<dyn ExceptionFilter>>,
+    scoped_groups: Vec<ScopedGroup>,
+    merge_routers: Vec<axum::Router<AppState>>,
+    nest_routers: Vec<(String, axum::Router<AppState>)>,
+    error_page_renderer: Option<SharedRenderer>,
+) -> axum::Router {
+    let app_router = build_router_inner(
+        route_list,
+        config,
+        state,
+        exception_filters,
+        scoped_groups,
+        merge_routers,
+        nest_routers,
+        error_page_renderer,
+    );
+
+    let Some(dist) = dist_dir else {
+        return app_router;
+    };
+
+    let Some(layer) = crate::static_gen::StaticFileLayer::new(dist) else {
+        tracing::debug!(
+            dist = %dist.display(),
+            "No valid manifest.json in dist dir; skipping static file layer"
+        );
+        return app_router;
+    };
+
+    // Enable ISR regeneration by attaching the app router to the static layer.
+    // Routes with `revalidate` set will spawn background re-render tasks
+    // when their files become stale.
+    let has_isr = layer
+        .manifest()
+        .routes
+        .values()
+        .any(|e| e.revalidate.is_some());
+    let layer = if has_isr {
+        layer.with_router(app_router.clone())
+    } else {
+        layer
+    };
+
+    for (route, entry) in &layer.manifest().routes {
+        tracing::debug!(
+            route = %route,
+            file = %entry.file,
+            revalidate = ?entry.revalidate,
+            "Static route"
+        );
+    }
+
+    // Store the layer in an Arc so the static-first middleware can use it.
+    let layer = Arc::new(layer);
+
+    // Static-first serving: intercept GET/HEAD requests whose path appears
+    // in the manifest and serve pre-built HTML directly, BEFORE the dynamic
+    // router runs.  This matches Next.js SSG/ISR semantics where static
+    // pages always win over dynamic handlers.
+    //
+    // Requests not in the manifest (including non-GET/HEAD methods) fall
+    // through to the dynamic router unchanged.
+    //
+    // ISR staleness checking happens inside `resolve()`: stale pages are
+    // still served immediately while background regeneration runs
+    // (stale-while-revalidate).
+    let static_layer = layer;
+    app_router.layer(axum::middleware::from_fn(
+        move |req: axum::extract::Request, next: axum::middleware::Next| {
+            let static_layer = static_layer.clone();
+            async move {
+                let is_get = req.method() == http::Method::GET;
+                let is_head = req.method() == http::Method::HEAD;
+                if is_get || is_head {
+                    let path = req.uri().path();
+                    // Normalize trailing slash: /about/ → /about (but keep / as /)
+                    let normalized = if path.len() > 1 && path.ends_with('/') {
+                        &path[..path.len() - 1]
+                    } else {
+                        path
+                    };
+                    if let Some(file_path) = static_layer.resolve(normalized) {
+                        if let Ok(contents) = tokio::fs::read(&file_path).await {
+                            let body = if is_head {
+                                axum::body::Body::empty()
+                            } else {
+                                axum::body::Body::from(contents)
+                            };
+                            return http::Response::builder()
+                                .status(http::StatusCode::OK)
+                                .header(http::header::CONTENT_TYPE, "text/html; charset=utf-8")
+                                .body(body)
+                                .unwrap();
+                        }
+                    }
+                }
+                next.run(req).await
+            }
+        },
+    ))
+}
+
+/// Build a `tower_http::cors::CorsLayer` from the framework's [`crate::config::CorsConfig`].
+///
+/// Called only when `config.cors.allowed_origins` is non-empty.
+pub(crate) fn build_cors_layer(cors: &crate::config::CorsConfig) -> tower_http::cors::CorsLayer {
+    use http::header::HeaderName;
+    use tower_http::cors::{AllowOrigin, CorsLayer};
+
+    let layer = if cors.allowed_origins.iter().any(|o| o == "*") {
+        CorsLayer::new().allow_origin(AllowOrigin::any())
+    } else {
+        let origins: Vec<http::HeaderValue> = cors
+            .allowed_origins
+            .iter()
+            .filter_map(|o| o.parse().ok())
+            .collect();
+        CorsLayer::new().allow_origin(origins)
+    };
+
+    let methods: Vec<http::Method> = cors
+        .allowed_methods
+        .iter()
+        .filter_map(|m| m.parse().ok())
+        .collect();
+
+    let headers: Vec<HeaderName> = cors
+        .allowed_headers
+        .iter()
+        .filter_map(|h| h.parse().ok())
+        .collect();
+
+    layer
+        .allow_methods(methods)
+        .allow_headers(headers)
+        .allow_credentials(cors.allow_credentials)
+        .max_age(std::time::Duration::from_secs(cors.max_age_secs))
+}
+
+#[cfg(feature = "htmx")]
+pub(crate) async fn htmx_handler() -> axum::response::Response {
+    use axum::response::IntoResponse;
+    (
+        [
+            (http::header::CONTENT_TYPE, "application/javascript"),
+            (
+                http::header::CACHE_CONTROL,
+                "public, max-age=31536000, immutable",
+            ),
+        ],
+        crate::htmx::HTMX_JS,
+    )
+        .into_response()
+}

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -65,9 +65,9 @@ use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
 use tower::ServiceExt;
 
-use crate::app::build_router;
 use crate::config::AutumnConfig;
 use crate::route::Route;
+use crate::router::build_router;
 use crate::state::AppState;
 
 #[cfg(feature = "db")]

--- a/autumn/tests/middleware_pipeline.rs
+++ b/autumn/tests/middleware_pipeline.rs
@@ -46,7 +46,7 @@ async fn exception_filter_on_error_response() {
     let config = AutumnConfig::default();
 
     let router =
-        autumn_web::app::build_router(routes![ok_handler, fail_handler], &config, test_state());
+        autumn_web::router::build_router(routes![ok_handler, fail_handler], &config, test_state());
     // Manually layer the exception filter (build_router doesn't take filters)
     let router = router.layer(ExceptionFilterLayer::new(vec![Arc::new(
         MarkCalledFilter {

--- a/autumn/tests/raw_router_escape_hatch.rs
+++ b/autumn/tests/raw_router_escape_hatch.rs
@@ -20,8 +20,13 @@ async fn merged_route_is_accessible() {
         .route("/raw", axum::routing::get(|| async { "from raw router" }));
 
     let config = AutumnConfig::default();
-    let router =
-        autumn_web::app::build_router_merged(routes![], &config, test_state(), vec![raw], vec![]);
+    let router = autumn_web::router::build_router_merged(
+        routes![],
+        &config,
+        test_state(),
+        vec![raw],
+        vec![],
+    );
 
     let resp = router
         .oneshot(Request::builder().uri("/raw").body(Body::empty()).unwrap())
@@ -44,8 +49,13 @@ async fn merged_route_receives_app_state() {
     );
 
     let config = AutumnConfig::default();
-    let router =
-        autumn_web::app::build_router_merged(routes![], &config, test_state(), vec![raw], vec![]);
+    let router = autumn_web::router::build_router_merged(
+        routes![],
+        &config,
+        test_state(),
+        vec![raw],
+        vec![],
+    );
 
     let resp = router
         .oneshot(
@@ -69,8 +79,13 @@ async fn autumn_middleware_applies_to_merged_routes() {
         axum::Router::<AppState>::new().route("/raw-mid", axum::routing::get(|| async { "ok" }));
 
     let config = AutumnConfig::default();
-    let router =
-        autumn_web::app::build_router_merged(routes![], &config, test_state(), vec![raw], vec![]);
+    let router = autumn_web::router::build_router_merged(
+        routes![],
+        &config,
+        test_state(),
+        vec![raw],
+        vec![],
+    );
 
     let resp = router
         .oneshot(
@@ -104,7 +119,7 @@ async fn multiple_merged_routers_accumulate() {
         axum::Router::<AppState>::new().route("/raw2", axum::routing::get(|| async { "second" }));
 
     let config = AutumnConfig::default();
-    let router = autumn_web::app::build_router_merged(
+    let router = autumn_web::router::build_router_merged(
         routes![],
         &config,
         test_state(),
@@ -142,7 +157,7 @@ async fn nested_route_works_under_prefix() {
         .route("/users", axum::routing::get(|| async { "v2 users" }));
 
     let config = AutumnConfig::default();
-    let router = autumn_web::app::build_router_merged(
+    let router = autumn_web::router::build_router_merged(
         routes![],
         &config,
         test_state(),
@@ -189,7 +204,7 @@ async fn nested_route_receives_app_state() {
     );
 
     let config = AutumnConfig::default();
-    let router = autumn_web::app::build_router_merged(
+    let router = autumn_web::router::build_router_merged(
         routes![],
         &config,
         test_state(),
@@ -219,7 +234,7 @@ async fn nested_route_gets_autumn_middleware() {
         axum::Router::<AppState>::new().route("/check", axum::routing::get(|| async { "ok" }));
 
     let config = AutumnConfig::default();
-    let router = autumn_web::app::build_router_merged(
+    let router = autumn_web::router::build_router_merged(
         routes![],
         &config,
         test_state(),
@@ -257,7 +272,7 @@ async fn annotated_and_merged_routes_coexist() {
         .route("/raw-only", axum::routing::get(|| async { "from raw" }));
 
     let config = AutumnConfig::default();
-    let router = autumn_web::app::build_router_merged(
+    let router = autumn_web::router::build_router_merged(
         routes![annotated_handler],
         &config,
         test_state(),
@@ -306,7 +321,7 @@ async fn merged_route_adds_different_method_to_same_path() {
         .route("/annotated", axum::routing::post(|| async { "posted" }));
 
     let config = AutumnConfig::default();
-    let router = autumn_web::app::build_router_merged(
+    let router = autumn_web::router::build_router_merged(
         routes![annotated_handler],
         &config,
         test_state(),

--- a/autumn/tests/static_build_mode.rs
+++ b/autumn/tests/static_build_mode.rs
@@ -1,9 +1,9 @@
 //! Integration test: verify `render_static_routes` works with a real
 //! Autumn router (not just a mock fallback handler).
 
-use autumn_web::app::build_router;
 use autumn_web::config::AutumnConfig;
 use autumn_web::route::Route;
+use autumn_web::router::build_router;
 use autumn_web::static_gen::{StaticRouteMeta, render_static_routes};
 
 fn about_route() -> Route {

--- a/autumn/tests/static_gen_serving.rs
+++ b/autumn/tests/static_gen_serving.rs
@@ -58,7 +58,7 @@ async fn static_files_take_priority_over_dynamic_routes() {
 
     // Dynamic handler registered at the same path as the static file.
     let config = autumn_web::config::AutumnConfig::default();
-    let router = autumn_web::app::build_router_with_static(
+    let router = autumn_web::router::build_router_with_static(
         vec![dynamic_get_route(
             "/about",
             "about_dynamic",
@@ -96,7 +96,7 @@ async fn static_files_take_priority_over_dynamic_routes() {
 #[tokio::test]
 async fn dynamic_routes_still_work_without_dist() {
     let config = autumn_web::config::AutumnConfig::default();
-    let router = autumn_web::app::build_router_with_static(
+    let router = autumn_web::router::build_router_with_static(
         vec![dynamic_get_route(
             "/about",
             "about_dynamic",
@@ -157,7 +157,7 @@ async fn unknown_routes_fall_through_to_dynamic() {
 
     // 2. Build router with a dynamic /admin route (not in the manifest).
     let config = autumn_web::config::AutumnConfig::default();
-    let router = autumn_web::app::build_router_with_static(
+    let router = autumn_web::router::build_router_with_static(
         vec![dynamic_get_route("/admin", "admin", "Admin Panel")],
         &config,
         test_state(),
@@ -213,7 +213,7 @@ async fn head_requests_served_for_static_routes() {
     .expect("write manifest");
 
     let config = autumn_web::config::AutumnConfig::default();
-    let router = autumn_web::app::build_router_with_static(
+    let router = autumn_web::router::build_router_with_static(
         vec![],
         &config,
         test_state(),
@@ -266,7 +266,7 @@ async fn post_requests_pass_through_static_layer() {
 
     // Register both GET and POST on /admin
     let config = autumn_web::config::AutumnConfig::default();
-    let router = autumn_web::app::build_router_with_static(
+    let router = autumn_web::router::build_router_with_static(
         vec![
             dynamic_get_route("/admin", "admin_list", "Admin Panel"),
             autumn_web::route::Route {

--- a/autumn/tests/websocket.rs
+++ b/autumn/tests/websocket.rs
@@ -114,7 +114,7 @@ async fn non_upgrade_get_returns_error() {
     let config = AutumnConfig::default();
     let state = test_state();
 
-    let router = autumn_web::app::build_router(routes![echo], &config, state);
+    let router = autumn_web::router::build_router(routes![echo], &config, state);
 
     // A plain GET (without upgrade headers) should NOT get 200
     let req = Request::builder().uri("/echo").body(Body::empty()).unwrap();
@@ -129,7 +129,7 @@ async fn upgrade_request_without_real_tcp_returns_426() {
     let config = AutumnConfig::default();
     let state = test_state();
 
-    let router = autumn_web::app::build_router(routes![echo], &config, state);
+    let router = autumn_web::router::build_router(routes![echo], &config, state);
 
     // With tower::oneshot there's no real TCP connection, so the upgrade
     // cannot complete. Axum correctly returns 426 Upgrade Required.
@@ -154,7 +154,7 @@ async fn upgrade_request_without_real_tcp_returns_426() {
 async fn real_websocket_echo_works() {
     let config = AutumnConfig::default();
     let state = test_state();
-    let app = autumn_web::app::build_router(routes![echo], &config, state);
+    let app = autumn_web::router::build_router(routes![echo], &config, state);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -192,7 +192,7 @@ async fn real_websocket_echo_works() {
 async fn real_websocket_with_shutdown_works() {
     let config = AutumnConfig::default();
     let state = test_state();
-    let app = autumn_web::app::build_router(routes![with_shutdown], &config, state.clone());
+    let app = autumn_web::router::build_router(routes![with_shutdown], &config, state.clone());
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();


### PR DESCRIPTION
🗺️ Atlas: [architectural change] Extract router building logic from app.rs to router.rs

🕸️ Tangle: The `autumn/src/app.rs` file was significantly bloated (~2500 lines) because it was mixing the builder pattern for application configuration with the low-level complexities of constructing the Axum router and applying all framework middlewares, CORS, error pages, and static file serving logic.
📐 Blueprint: Extracted `build_router`, `build_router_merged`, `build_router_with_static`, and associated inner functions to a new `autumn/src/router.rs` module. Adjusted visibilities (`pub(crate)`) and updated call sites in `app.rs` and the test suite to use `crate::router::...`.
🧱 Stability: This reduces the coupling inside `app.rs`, keeping it focused solely on the user-facing builder API and startup flow.
🔬 Verification: `cargo clippy --all-targets --all-features` and `cargo test -p autumn-web` execute successfully with zero warnings.

---
*PR created automatically by Jules for task [2221617953959894711](https://jules.google.com/task/2221617953959894711) started by @madmax983*