### PR TITLE
👺 Havoc: Fix Panic/OOM on Channels::new Capacity Boundaries

### DIFF
--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -70,6 +70,7 @@ testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
 proptest = "1.4"
 tokio-tungstenite = "0.29.0"
+loom = "0.7.2"
 
 [lints]
 workspace = true

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -164,9 +164,12 @@ impl Channels {
     /// ```
     #[must_use]
     pub fn new(capacity: usize) -> Self {
+        // tokio::sync::broadcast channel capacity must be > 0 and <= usize::MAX / 2
+        // Furthermore, allocating huge capacities will OOM the process.
+        // Cap it at a reasonable maximum for an application, like 16384, and min 1.
         Self {
             inner: Arc::new(ChannelsInner {
-                capacity,
+                capacity: capacity.max(1).min(16384),
                 registry: Mutex::new(HashMap::new()),
             }),
         }

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -169,7 +169,7 @@ impl Channels {
         // Cap it at a reasonable maximum for an application, like 16384, and min 1.
         Self {
             inner: Arc::new(ChannelsInner {
-                capacity: capacity.max(1).min(16384),
+                capacity: capacity.clamp(1, 16384),
                 registry: Mutex::new(HashMap::new()),
             }),
         }

--- a/autumn/tests/chaos_channels_proptest.rs
+++ b/autumn/tests/chaos_channels_proptest.rs
@@ -1,0 +1,15 @@
+#![cfg(feature = "ws")]
+
+use autumn_web::channels::Channels;
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn test_channels_capacity_fuzzing(capacity in any::<usize>()) {
+        let channels = Channels::new(capacity);
+
+        // This should never panic even if capacity is 0 (which was the bug)
+        let _tx = channels.sender("test_channel");
+        let _rx = channels.subscribe("test_channel");
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** `Channels::new(0)` panics with `broadcast channel capacity cannot be zero`. Passing a massive integer `Channels::new(usize::MAX)` causes a memory allocation failure / OOM.
📉 **The Stack Trace:**
```
thread 'test_channels_capacity_fuzzing' panicked at autumn/src/channels.rs:204:31:
broadcast channel capacity cannot be zero
memory allocation of 6917529027641081856 bytes failed
```
🧪 **Reproduction:** Run `cargo test --manifest-path autumn/Cargo.toml --features ws --test chaos_channels_proptest`
😈 **Comment:** You assumed the capacity parameter would always be a reasonable, positive integer. You were wrong.

---
*PR created automatically by Jules for task [12539566199496531236](https://jules.google.com/task/12539566199496531236) started by @madmax983*