### PR TITLE
🌟 Nova: Export Diagnostic Snapshot

### DIFF
--- a/autumn-cli/src/export.rs
+++ b/autumn-cli/src/export.rs
@@ -18,6 +18,7 @@ pub fn run_inner(url: &str, output: &str) -> Result<(), String> {
 
     let client = Client::builder()
         .timeout(Duration::from_secs(5))
+        .no_proxy()
         .build()
         .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
 
@@ -25,6 +26,22 @@ pub fn run_inner(url: &str, output: &str) -> Result<(), String> {
     let metrics = fetch_endpoint(&client, base_url, "/actuator/metrics");
     let tasks = fetch_endpoint(&client, base_url, "/actuator/tasks");
     let loggers = fetch_endpoint(&client, base_url, "/actuator/loggers");
+
+    // If any endpoint returns an error, fail the export
+    for (name, val) in [
+        ("health", &health),
+        ("metrics", &metrics),
+        ("tasks", &tasks),
+        ("loggers", &loggers),
+    ] {
+        if let Some(err) = val.get("error") {
+            return Err(format!(
+                "Failed to fetch {} from {base_url}: {}",
+                name,
+                err.as_str().unwrap_or("Unknown error")
+            ));
+        }
+    }
 
     // Use std::time for a simple timestamp as chrono is not available
     let timestamp = std::time::SystemTime::now()

--- a/autumn-cli/src/export.rs
+++ b/autumn-cli/src/export.rs
@@ -1,0 +1,160 @@
+use std::fs::File;
+use std::io::Write;
+use std::time::Duration;
+
+use reqwest::blocking::Client;
+use serde_json::{Value, json};
+
+pub fn run(url: &str, output: &str) {
+    let base_url = url.trim_end_matches('/');
+    println!("Exporting diagnostics from {base_url}");
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to create HTTP client: {e}");
+            std::process::exit(1);
+        });
+
+    let health = fetch_endpoint(&client, base_url, "/actuator/health");
+    let metrics = fetch_endpoint(&client, base_url, "/actuator/metrics");
+    let tasks = fetch_endpoint(&client, base_url, "/actuator/tasks");
+    let loggers = fetch_endpoint(&client, base_url, "/actuator/loggers");
+
+    // Use std::time for a simple timestamp as chrono is not available
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let snapshot = json!({
+        "timestamp": timestamp,
+        "url": base_url,
+        "health": health,
+        "metrics": metrics,
+        "tasks": tasks,
+        "loggers": loggers,
+    });
+
+    match File::create(output) {
+        Ok(mut file) => {
+            let json_str = serde_json::to_string_pretty(&snapshot).unwrap();
+            if let Err(e) = file.write_all(json_str.as_bytes()) {
+                eprintln!("Failed to write to file '{output}': {e}");
+                std::process::exit(1);
+            }
+            println!("Successfully exported diagnostics to {output}");
+        }
+        Err(e) => {
+            eprintln!("Failed to create file '{output}': {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn fetch_endpoint(client: &Client, base_url: &str, path: &str) -> Value {
+    let full_url = format!("{base_url}{path}");
+    match client.get(&full_url).send() {
+        Ok(response) => {
+            if response.status().is_success() || response.status().as_u16() == 503 {
+                response
+                    .json::<Value>()
+                    .unwrap_or_else(|e| json!({ "error": format!("Failed to parse JSON: {}", e) }))
+            } else {
+                json!({ "error": format!("HTTP {}", response.status()) })
+            }
+        }
+        Err(e) => {
+            json!({ "error": format!("Request failed: {}", e) })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    #[test]
+    fn test_fetch_endpoint_success() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let url = format!("http://127.0.0.1:{port}");
+
+        thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut reader = BufReader::new(&mut stream);
+                let mut req_line = String::new();
+                reader.read_line(&mut req_line).unwrap();
+
+                loop {
+                    let mut header_line = String::new();
+                    reader.read_line(&mut header_line).unwrap();
+                    if header_line == "\r\n" {
+                        break;
+                    }
+                }
+
+                let body = r#"{"status": "ok"}"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream.write_all(response.as_bytes()).unwrap();
+            }
+        });
+
+        let client = Client::new();
+        let val = fetch_endpoint(&client, &url, "/test");
+        assert_eq!(val["status"], "ok");
+    }
+
+    #[test]
+    fn test_fetch_endpoint_failure() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener); // Close so connection fails
+
+        let client = Client::builder()
+            .timeout(Duration::from_millis(100))
+            .build()
+            .unwrap();
+        let val = fetch_endpoint(&client, &format!("http://127.0.0.1:{port}"), "/test");
+        assert!(val.get("error").is_some());
+    }
+
+    #[test]
+    fn test_fetch_endpoint_404() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let url = format!("http://127.0.0.1:{port}");
+
+        thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut reader = BufReader::new(&mut stream);
+                let mut req_line = String::new();
+                reader.read_line(&mut req_line).unwrap();
+
+                loop {
+                    let mut header_line = String::new();
+                    reader.read_line(&mut header_line).unwrap();
+                    if header_line == "\r\n" {
+                        break;
+                    }
+                }
+
+                let response =
+                    "HTTP/1.1 404 NOT FOUND\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
+                stream.write_all(response.as_bytes()).unwrap();
+            }
+        });
+
+        let client = Client::new();
+        let val = fetch_endpoint(&client, &url, "/test");
+        assert!(val["error"].as_str().unwrap().contains("HTTP 404"));
+    }
+}

--- a/autumn-cli/src/export.rs
+++ b/autumn-cli/src/export.rs
@@ -6,16 +6,20 @@ use reqwest::blocking::Client;
 use serde_json::{Value, json};
 
 pub fn run(url: &str, output: &str) {
+    if let Err(e) = run_inner(url, output) {
+        eprintln!("{e}");
+        std::process::exit(1);
+    }
+}
+
+pub fn run_inner(url: &str, output: &str) -> Result<(), String> {
     let base_url = url.trim_end_matches('/');
     println!("Exporting diagnostics from {base_url}");
 
     let client = Client::builder()
         .timeout(Duration::from_secs(5))
         .build()
-        .unwrap_or_else(|e| {
-            eprintln!("Failed to create HTTP client: {e}");
-            std::process::exit(1);
-        });
+        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
 
     let health = fetch_endpoint(&client, base_url, "/actuator/health");
     let metrics = fetch_endpoint(&client, base_url, "/actuator/metrics");
@@ -41,15 +45,12 @@ pub fn run(url: &str, output: &str) {
         Ok(mut file) => {
             let json_str = serde_json::to_string_pretty(&snapshot).unwrap();
             if let Err(e) = file.write_all(json_str.as_bytes()) {
-                eprintln!("Failed to write to file '{output}': {e}");
-                std::process::exit(1);
+                return Err(format!("Failed to write to file '{output}': {e}"));
             }
             println!("Successfully exported diagnostics to {output}");
+            Ok(())
         }
-        Err(e) => {
-            eprintln!("Failed to create file '{output}': {e}");
-            std::process::exit(1);
-        }
+        Err(e) => Err(format!("Failed to create file '{output}': {e}")),
     }
 }
 
@@ -156,5 +157,141 @@ mod tests {
         let client = Client::new();
         let val = fetch_endpoint(&client, &url, "/test");
         assert!(val["error"].as_str().unwrap().contains("HTTP 404"));
+    }
+
+    #[test]
+    fn test_run_inner_success() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let url = format!("http://127.0.0.1:{port}");
+
+        thread::spawn(move || {
+            // Need to handle 4 requests: health, metrics, tasks, loggers
+            for _ in 0..4 {
+                if let Ok((mut stream, _)) = listener.accept() {
+                    let mut reader = BufReader::new(&mut stream);
+                    let mut req_line = String::new();
+                    if reader.read_line(&mut req_line).is_err() || req_line.is_empty() {
+                        continue;
+                    }
+
+                    loop {
+                        let mut header_line = String::new();
+                        if reader.read_line(&mut header_line).is_err()
+                            || header_line == "\r\n"
+                            || header_line.trim().is_empty()
+                        {
+                            break;
+                        }
+                    }
+
+                    let body = r#"{"status": "ok"}"#;
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                }
+            }
+        });
+
+        let output_file = tempfile::NamedTempFile::new().unwrap();
+        let output_path = output_file.path().to_str().unwrap();
+
+        let result = run_inner(&url, output_path);
+        assert!(result.is_ok());
+
+        let contents = std::fs::read_to_string(output_path).unwrap();
+        let json: Value = serde_json::from_str(&contents).unwrap();
+
+        assert_eq!(json["url"], url);
+        assert_eq!(json["health"]["status"], "ok");
+        assert_eq!(json["metrics"]["status"], "ok");
+        assert_eq!(json["tasks"]["status"], "ok");
+        assert_eq!(json["loggers"]["status"], "ok");
+    }
+
+    #[test]
+    fn test_fetch_endpoint_invalid_json() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let url = format!("http://127.0.0.1:{port}");
+
+        thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut reader = BufReader::new(&mut stream);
+                let mut req_line = String::new();
+                reader.read_line(&mut req_line).unwrap();
+
+                loop {
+                    let mut header_line = String::new();
+                    reader.read_line(&mut header_line).unwrap();
+                    if header_line == "\r\n" {
+                        break;
+                    }
+                }
+
+                let body = r#"{"status": "ok", "#; // Invalid JSON
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream.write_all(response.as_bytes()).unwrap();
+            }
+        });
+
+        let client = Client::new();
+        let val = fetch_endpoint(&client, &url, "/test");
+        assert!(
+            val["error"]
+                .as_str()
+                .unwrap()
+                .contains("Failed to parse JSON")
+        );
+    }
+
+    #[test]
+    fn test_run_inner_file_creation_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let url = format!("http://127.0.0.1:{port}");
+
+        thread::spawn(move || {
+            // Need to handle 4 requests: health, metrics, tasks, loggers
+            for _ in 0..4 {
+                if let Ok((mut stream, _)) = listener.accept() {
+                    let mut reader = BufReader::new(&mut stream);
+                    let mut req_line = String::new();
+                    if reader.read_line(&mut req_line).is_err() || req_line.is_empty() {
+                        continue;
+                    }
+
+                    loop {
+                        let mut header_line = String::new();
+                        if reader.read_line(&mut header_line).is_err()
+                            || header_line == "\r\n"
+                            || header_line.trim().is_empty()
+                        {
+                            break;
+                        }
+                    }
+
+                    let body = r#"{"status": "ok"}"#;
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                }
+            }
+        });
+
+        // Use an invalid path that cannot be created
+        let result = run_inner(&url, "/invalid/path/that/does/not/exist/diag.json");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to create file"));
     }
 }

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 
 mod build;
 mod dev;
+mod export;
 mod migrate;
 mod monitor;
 mod new;
@@ -61,6 +62,15 @@ enum Commands {
         #[arg(short, long, default_value = "1")]
         interval: u64,
     },
+    /// Export an offline diagnostic snapshot of the application
+    Export {
+        /// URL of the running Autumn application
+        #[arg(short, long, default_value = "http://localhost:3000")]
+        url: String,
+        /// Output file for diagnostics
+        #[arg(short, long, default_value = "autumn-diag.json")]
+        output: String,
+    },
 }
 
 /// Subcommands for `autumn migrate`.
@@ -86,6 +96,7 @@ fn main() {
             migrate::run(action);
         }
         Commands::Monitor { url, interval } => monitor::run(&url, interval),
+        Commands::Export { url, output } => export::run(&url, &output),
         Commands::New { name } => new::run(&name),
         Commands::Setup { force } => setup::run(force),
     }
@@ -275,6 +286,38 @@ mod tests {
                 assert_eq!(interval, 5);
             }
             _ => panic!("expected Monitor command"),
+        }
+    }
+
+    #[test]
+    fn parse_export_defaults() {
+        let cli = Cli::try_parse_from(["autumn", "export"]).unwrap();
+        match cli.command {
+            Commands::Export { url, output } => {
+                assert_eq!(url, "http://localhost:3000");
+                assert_eq!(output, "autumn-diag.json");
+            }
+            _ => panic!("expected Export command"),
+        }
+    }
+
+    #[test]
+    fn parse_export_custom() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "export",
+            "-u",
+            "http://prod:8080",
+            "-o",
+            "snapshot.json",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Export { url, output } => {
+                assert_eq!(url, "http://prod:8080");
+                assert_eq!(output, "snapshot.json");
+            }
+            _ => panic!("expected Export command"),
         }
     }
 


### PR DESCRIPTION
💡 **The Spark:** "I noticed we have comprehensive diagnostic endpoints in the actuator (`/health`, `/metrics`, etc.) and a live TUI (`monitor`), but no way to extract that data easily for offline analysis, bug reports, or external monitoring systems."

🚀 **The Feature:** "Implemented the `autumn export` CLI command. It queries a running application's actuator endpoints and outputs a single JSON snapshot file containing the health, metrics, scheduled tasks, and loggers state."

🔮 **The Potential:** "Could be used for automated health checks in CI/CD, creating attachable diagnostic reports for GitHub issues, or piping into external alerting tools (e.g. `jq` scripts)."

⚠️ **Risk:** "Low. Isolated in `autumn-cli/src/export.rs`. Additive-only change that doesn't modify existing framework logic."

---
*PR created automatically by Jules for task [6756263783616646130](https://jules.google.com/task/6756263783616646130) started by @madmax983*