### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -288,6 +288,25 @@ impl AutumnError {
 
     /// Create a `422 Unprocessable Entity` error with field-level
     /// validation details.
+    ///
+    /// Use this when a request fails multiple field-specific validation rules
+    /// (e.g., in a form submission). It attaches the `details` parameter, a mapping
+    /// of field names to their respective error messages, so the client can display
+    /// errors next to the relevant inputs.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use autumn_web::error::AutumnError;
+    /// use http::StatusCode;
+    /// use std::collections::HashMap;
+    ///
+    /// let mut errors = HashMap::new();
+    /// errors.insert("username".to_string(), vec!["Username is taken".to_string()]);
+    ///
+    /// let err = AutumnError::validation(errors);
+    /// assert_eq!(err.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    /// ```
     #[must_use]
     pub fn validation(details: std::collections::HashMap<String, Vec<String>>) -> Self {
         Self {


### PR DESCRIPTION
📖 Chapter: `autumn/src/error.rs`
🔦 Insight: Added missing `///` documentation to `AutumnError::validation` explaining its usage, along with an executable `## Examples` doc-test.
🧪 Example: Added an executable doctest to demonstrate usage for `validation`.

---
*PR created automatically by Jules for task [12797382726402599407](https://jules.google.com/task/12797382726402599407) started by @madmax983*