### PR TITLE
Echo: DX Audit Complaint & Fix

### DIFF
--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -169,6 +169,25 @@ impl AutumnError {
         self
     }
 
+    /// Create a `500 Internal Server Error`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use autumn_web::error::AutumnError;
+    /// use http::StatusCode;
+    ///
+    /// let err = AutumnError::internal_server_error(std::io::Error::other("boom"));
+    /// assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    /// ```
+    pub fn internal_server_error(err: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self {
+            inner: Box::new(err),
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            details: None,
+        }
+    }
+
     /// Create a `404 Not Found` error.
     ///
     /// # Examples
@@ -298,6 +317,21 @@ impl AutumnError {
     }
 
     // ── String-message convenience constructors ────────────────
+
+    /// Create a `500 Internal Server Error` from a plain string message.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use autumn_web::error::AutumnError;
+    /// use http::StatusCode;
+    ///
+    /// let err = AutumnError::internal_server_error_msg("Database explosion");
+    /// assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    /// ```
+    pub fn internal_server_error_msg(msg: impl Into<String>) -> Self {
+        Self::internal_server_error(StringError(msg.into()))
+    }
 
     /// Create a `404 Not Found` error from a plain string message.
     ///
@@ -473,6 +507,12 @@ mod tests {
     }
 
     #[test]
+    fn internal_server_error_is_500() {
+        let err = AutumnError::internal_server_error(TestError("boom".into()));
+        assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
     fn test_not_found_error() {
         let err = AutumnError::not_found(std::io::Error::other("no such user"));
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
@@ -520,6 +560,13 @@ mod tests {
     fn service_unavailable_is_503() {
         let err = AutumnError::service_unavailable(TestError("pool exhausted".into()));
         assert_eq!(err.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn internal_server_error_msg_is_500() {
+        let err = AutumnError::internal_server_error_msg("db failure");
+        assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(err.to_string(), "db failure");
     }
 
     #[test]

--- a/docs/reports/dx-audit-error.md
+++ b/docs/reports/dx-audit-error.md
@@ -1,0 +1,44 @@
+# Echo: DX Audit Complaint & Fix
+
+## Experience (Walkthrough)
+
+I was trying to write an endpoint that could return a 500 error manually if some condition failed.
+I looked at the documentation for `AutumnError` and saw methods like `not_found`, `bad_request`, `unprocessable`, etc.
+Naturally, I assumed there would be an `internal_server_error` or `internal` method to match.
+
+So I wrote:
+```rust
+#[get("/error")]
+async fn error_test() -> Result<&'static str, AutumnError> {
+    Err(AutumnError::internal_server_error("Something went wrong"))
+}
+```
+
+## Stumble (Friction Points)
+
+The code failed to compile!
+
+```
+error[E0599]: no function or associated item named `internal_server_error` found for struct `autumn_web::AutumnError` in the current scope
+```
+
+I checked the rustdocs for `AutumnError`. There is literally no constructor for a 500 internal server error.
+To create one, I have to do this incredibly verbose dance:
+
+```rust
+#[get("/error")]
+async fn error_test() -> Result<&'static str, AutumnError> {
+    let err: AutumnError = std::io::Error::other("boom").into();
+    Err(err)
+}
+```
+Or I have to use another constructor and override the status:
+```rust
+Err(AutumnError::bad_request_msg("boom").with_status(StatusCode::INTERNAL_SERVER_ERROR))
+```
+
+This is terrible DX. If you provide `bad_request_msg`, you should provide `internal_server_error_msg`. I shouldn't have to jump through hoops to construct the most common error code in web development.
+
+## Fix
+
+Add `internal_server_error` and `internal_server_error_msg` to `AutumnError` to match the other HTTP status code constructors.


### PR DESCRIPTION
Echo DX Audit workflow to discover and fix the missing `internal_server_error` and `internal_server_error_msg` constructors in `AutumnError`.

---
*PR created automatically by Jules for task [17255418316827354657](https://jules.google.com/task/17255418316827354657) started by @madmax983*