### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1005,12 +1005,15 @@ fn build_router_inner(
         );
     }
     for route in route_list {
-        grouped
-            .entry(route.path)
-            .and_modify(|existing| {
-                *existing = existing.clone().merge(route.handler.clone());
-            })
-            .or_insert(route.handler);
+        match grouped.entry(route.path) {
+            indexmap::map::Entry::Occupied(mut entry) => {
+                let taken = std::mem::take(entry.get_mut());
+                *entry.get_mut() = taken.merge(route.handler);
+            }
+            indexmap::map::Entry::Vacant(entry) => {
+                entry.insert(route.handler);
+            }
+        }
     }
 
     let mut router = axum::Router::new();

--- a/autumn/src/static_gen/build.rs
+++ b/autumn/src/static_gen/build.rs
@@ -187,10 +187,10 @@ pub async fn render_static_routes(
 
     // Render concurrently
     let results: Vec<Result<(String, ManifestEntry), BuildError>> =
-        futures::stream::iter(jobs.iter().map(|job| {
+        futures::stream::iter(jobs.into_iter().map(|job| {
             let router = router.clone();
             let staging = staging.clone();
-            let url = job.url.clone();
+            let url = job.url;
             let revalidate = job.revalidate;
             async move {
                 eprintln!("  Rendering {url} ...");


### PR DESCRIPTION
💡 What: Eliminated unnecessary memory allocations (`.clone()`) during route merging in `App::run()` and URL string cloning in the static generator worker pool.
🎯 Why: Passing `.clone()` inside loops scales poorly. By leveraging `std::mem::take` for Axum's `MethodRouter` (which implements `Default`) and taking ownership of vectors via `into_iter()`, we can achieve the same behavior using idiomatic ownership transfers.
📊 Impact: Eliminates N clones of the `MethodRouter` on application startup (where N is the number of routes), and completely removes URL string allocations per rendered page during `autumn build`.
🔬 Measurement: Verify zero behavioral changes via `cargo test` and zero lint warnings via `cargo clippy`.

---
*PR created automatically by Jules for task [16257400355712980645](https://jules.google.com/task/16257400355712980645) started by @madmax983*