### PR TITLE
🔒 Warden: [security fix] Fix SQL injection in Postgres NOTIFY

### DIFF
--- a/autumn-harvest/autumn-harvest/src/context.rs
+++ b/autumn-harvest/autumn-harvest/src/context.rs
@@ -1339,6 +1339,9 @@ mod tests {
 
         let value = ctx.execute_query("status").expect("query should execute");
         assert_eq!(value, serde_json::json!({"state": "running"}));
-        assert!(ctx.drain_commands().is_empty(), "queries must not emit events");
+        assert!(
+            ctx.drain_commands().is_empty(),
+            "queries must not emit events"
+        );
     }
 }

--- a/autumn-harvest/autumn-harvest/src/notify.rs
+++ b/autumn-harvest/autumn-harvest/src/notify.rs
@@ -65,13 +65,11 @@ pub async fn notify_task_enqueued(
     let payload = serde_json::to_string(&NotifyPayload { task_id })
         .map_err(|e| HarvestError::Database(format!("failed to serialize notify payload: {e}")))?;
 
-    // Postgres NOTIFY requires the channel as an identifier (not a parameter),
-    // so we must format it into the SQL string. The channel name is derived from
-    // our own queue_channel() function which only produces [a-z0-9_] characters,
-    // so this is safe from injection.
-    let sql = format!("NOTIFY {channel}, '{payload}'");
-
-    diesel::sql_query(sql)
+    // To prevent SQL injection vulnerabilities from unescaped channel names,
+    // we use `pg_notify` via `SELECT` with parameter binding rather than string interpolation.
+    diesel::sql_query("SELECT pg_notify($1, $2)")
+        .bind::<diesel::sql_types::Text, _>(channel)
+        .bind::<diesel::sql_types::Text, _>(payload)
         .execute(conn)
         .await
         .map_err(crate::error::database_error)?;

--- a/autumn-harvest/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/autumn-harvest/src/worker.rs
@@ -28,8 +28,8 @@ use crate::executor::{WorkflowOutcome, run_workflow};
 use crate::info::{ActivityInfo, WorkflowInfo};
 use crate::models::{TaskQueueItem, WorkflowExecution};
 use crate::queue::{self, TaskType};
-use crate::signal;
 use crate::schema::harvest_workflow_executions;
+use crate::signal;
 use crate::store;
 use crate::types::ExecutionId;
 

--- a/autumn-harvest/autumn-harvest/tests/security/mod.rs
+++ b/autumn-harvest/autumn-harvest/tests/security/mod.rs
@@ -1,0 +1,1 @@
+pub mod notify_sqli;

--- a/autumn-harvest/autumn-harvest/tests/security/notify_sqli.rs
+++ b/autumn-harvest/autumn-harvest/tests/security/notify_sqli.rs
@@ -1,21 +1,27 @@
 use autumn_harvest::notify::notify_task_enqueued;
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use uuid::Uuid;
 
 #[tokio::test]
 async fn test_notify_sql_injection_poc() {
-    use diesel_async::{AsyncPgConnection, RunQueryDsl, AsyncConnection};
-    use std::env;
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
 
-    let db_url = if let Ok(url) = env::var("POSTGRES_URL") {
-        url
-    } else {
-        "postgres://postgres:postgres@localhost:5432/postgres".to_string()
-    };
+    let host = container.get_host().await.expect("failed to get host");
 
-    let mut conn = match AsyncPgConnection::establish(&db_url).await {
-        Ok(c) => c,
-        Err(_) => return,
-    };
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get port");
+
+    let db_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let mut conn = AsyncPgConnection::establish(&db_url).await.unwrap();
 
     diesel::sql_query("CREATE TABLE IF EXISTS dummy_test_table (id INT)")
         .execute(&mut conn)
@@ -32,7 +38,10 @@ async fn test_notify_sql_injection_poc() {
         .await
         .is_ok();
 
-    assert!(table_exists, "[ERIS-REGRESSION] SQL Injection vulnerability regressed: arbitrary DROP TABLE executed via notify_task_enqueued");
+    assert!(
+        table_exists,
+        "[ERIS-REGRESSION] SQL Injection vulnerability regressed: arbitrary DROP TABLE executed via notify_task_enqueued"
+    );
 
     // Clean up
     diesel::sql_query("DROP TABLE IF EXISTS dummy_test_table")

--- a/autumn-harvest/autumn-harvest/tests/security/notify_sqli.rs
+++ b/autumn-harvest/autumn-harvest/tests/security/notify_sqli.rs
@@ -1,6 +1,5 @@
 use autumn_harvest::notify::notify_task_enqueued;
 use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
-use testcontainers::ContainerAsync;
 use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use uuid::Uuid;
@@ -23,7 +22,12 @@ async fn test_notify_sql_injection_poc() {
 
     let mut conn = AsyncPgConnection::establish(&db_url).await.unwrap();
 
-    diesel::sql_query("CREATE TABLE IF EXISTS dummy_test_table (id INT)")
+    // Use a simpler table creation syntax that is definitively supported.
+    let _ = diesel::sql_query("DROP TABLE IF EXISTS dummy_test_table")
+        .execute(&mut conn)
+        .await;
+
+    diesel::sql_query("CREATE TABLE dummy_test_table (id INT)")
         .execute(&mut conn)
         .await
         .unwrap();
@@ -44,8 +48,7 @@ async fn test_notify_sql_injection_poc() {
     );
 
     // Clean up
-    diesel::sql_query("DROP TABLE IF EXISTS dummy_test_table")
+    let _ = diesel::sql_query("DROP TABLE dummy_test_table")
         .execute(&mut conn)
-        .await
-        .unwrap();
+        .await;
 }

--- a/autumn-harvest/autumn-harvest/tests/security/notify_sqli.rs
+++ b/autumn-harvest/autumn-harvest/tests/security/notify_sqli.rs
@@ -1,0 +1,42 @@
+use autumn_harvest::notify::notify_task_enqueued;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn test_notify_sql_injection_poc() {
+    use diesel_async::{AsyncPgConnection, RunQueryDsl, AsyncConnection};
+    use std::env;
+
+    let db_url = if let Ok(url) = env::var("POSTGRES_URL") {
+        url
+    } else {
+        "postgres://postgres:postgres@localhost:5432/postgres".to_string()
+    };
+
+    let mut conn = match AsyncPgConnection::establish(&db_url).await {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    diesel::sql_query("CREATE TABLE IF EXISTS dummy_test_table (id INT)")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let malicious_queue_name = "test; DROP TABLE dummy_test_table; --";
+
+    let task_id = Uuid::new_v4();
+    let _ = notify_task_enqueued(&mut conn, malicious_queue_name, task_id).await;
+
+    let table_exists = diesel::sql_query("SELECT * FROM dummy_test_table")
+        .execute(&mut conn)
+        .await
+        .is_ok();
+
+    assert!(table_exists, "[ERIS-REGRESSION] SQL Injection vulnerability regressed: arbitrary DROP TABLE executed via notify_task_enqueued");
+
+    // Clean up
+    diesel::sql_query("DROP TABLE IF EXISTS dummy_test_table")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+}

--- a/autumn-harvest/autumn-harvest/tests/security_tests.rs
+++ b/autumn-harvest/autumn-harvest/tests/security_tests.rs
@@ -1,0 +1,1 @@
+mod security;


### PR DESCRIPTION
🦠 Threat: SQL Injection in `autumn-harvest` task enqueue notifications. An attacker could potentially inject arbitrary SQL commands by manipulating the `queue_name` which was interpolated directly into a `NOTIFY` statement.
🛡️ Defense: Refactored `notify_task_enqueued` to use `SELECT pg_notify($1, $2)` with native parameter binding rather than string interpolation for the channel and payload.
💥 Severity: High. While exploiting this requires controlling the `queue_name` (which might be bounded by app logic), an attacker could execute arbitrary queries against the Postgres database if successful.
🧪 Verification: Created `autumn-harvest/autumn-harvest/tests/security/notify_sqli.rs` as a standalone PoC and regression test that demonstrates the vulnerability by attempting to drop a table via injection. Validated that the fix successfully prevents execution of the injected `DROP TABLE` command. Tests pass cleanly.

---
*PR created automatically by Jules for task [11172317341960246030](https://jules.google.com/task/11172317341960246030) started by @madmax983*