### PR TITLE
👺 Havoc: Fix panic in Channels::new(0)

### DIFF
--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -166,7 +166,7 @@ impl Channels {
     pub fn new(capacity: usize) -> Self {
         Self {
             inner: Arc::new(ChannelsInner {
-                capacity,
+                capacity: capacity.max(1),
                 registry: Mutex::new(HashMap::new()),
             }),
         }

--- a/autumn/tests/havoc_channels.proptest-regressions
+++ b/autumn/tests/havoc_channels.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc ee44b75093454a9bdf83c263251d74aaf8a4df6ddea8459232303def0566f0c8 # shrinks to capacity = 0

--- a/autumn/tests/havoc_channels.rs
+++ b/autumn/tests/havoc_channels.rs
@@ -1,0 +1,10 @@
+use autumn_web::channels::Channels;
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn channels_capacity_bounds(capacity in 0usize..2) {
+        let channels = Channels::new(capacity);
+        let _tx = channels.sender("test");
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** Calling `Channels::new(0)` directly triggers a panic inside `tokio::sync::broadcast` when attempting to lazily create a sender.

📉 **The Stack Trace:**
```
thread 'channels_capacity_bounds' panicked at autumn/src/channels.rs:204:31:
broadcast channel capacity cannot be zero
```

🧪 **Reproduction:** Run `cargo test -p autumn-web --test havoc_channels --features ws` on the `proptest` included in this PR. Passing `0` to `Channels::new` causes a crash on first subscribe/sender access.

😈 **Comment:** You assumed the capacity would always be a strictly positive integer without enforcing it. You were wrong.


---
*PR created automatically by Jules for task [11853618364891520481](https://jules.google.com/task/11853618364891520481) started by @madmax983*