### PR TITLE
Echo: DX Audit Complaint & Fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["autumn", "autumn-macros", "autumn-cli", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/wiki", "examples/reddit-clone"]
+members = ["autumn", "autumn-macros", "autumn-cli", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/wiki", "examples/reddit-clone", "dx-test"]
 resolver = "3"
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["autumn", "autumn-macros", "autumn-cli", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/wiki", "examples/reddit-clone", "dx-test"]
+members = ["autumn", "autumn-macros", "autumn-cli", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/wiki", "examples/reddit-clone"]
 resolver = "3"
 
 [workspace.package]

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -12,7 +12,7 @@
 //! |----------|-------|
 //! | Route macros | [`get`], [`post`], [`put`], [`delete`], [`routes`], [`main`] |
 //! | HTML rendering | [`Markup`], [`PreEscaped`], [`html!`](maud::html) |
-//! | Extractors | [`Db`], [`Json`], [`Form`], [`Path`] |
+//! | Extractors | [`Db`], [`Json`], [`Form`], [`Path`], [`Query`] |
 //! | Error handling | [`AutumnError`], [`AutumnResult`] |
 //! | State | [`AppState`] |
 //!
@@ -46,6 +46,8 @@ pub use crate::extract::Form;
 pub use crate::extract::Json;
 /// Path extractor.
 pub use crate::extract::Path;
+/// Query extractor.
+pub use crate::extract::Query;
 /// Flash message extractor.
 #[cfg(feature = "flash")]
 pub use crate::flash::{Flash, FlashLevel, FlashMessage};

--- a/docs/dx-audit-echo.md
+++ b/docs/dx-audit-echo.md
@@ -1,0 +1,32 @@
+# Echo: DX Audit Complaint & Fix
+
+## 1. Experience
+I followed the "README Run" by literally copy-pasting the "Quickstart" example code into a fresh `main.rs` file.
+
+After setting up a basic app, I wanted to try and read the query string from the path since that's a very common thing. I intuitively tried:
+
+```rust
+use autumn_web::prelude::*;
+
+#[get("/hello")]
+async fn hello_query(query: Query<std::collections::HashMap<String, String>>) -> String {
+    format!("Query: {:?}", *query)
+}
+```
+
+## 2. Stumble
+The example code failed to compile!
+
+```
+error[E0425]: cannot find type `Query` in this scope
+ --> src/main.rs:4:29
+  |
+4 | async fn hello_query(query: Query<std::collections::HashMap<String, String>>) -> String {
+  |                             ^^^^^ not found in this scope
+```
+
+## 3. Report
+The `Query` extractor is a core web concept. The documentation promises that frequently used Axum extractors should be re-exported in `autumn_web::prelude::*` to provide a seamless, low-boilerplate developer experience. However, not having `Query` in the prelude forces me to read the source code and guess its import path or import it manually, breaking the low-boilerplate DX promise. "Simple" is better than "Powerful", and having to hunt for imports is not simple.
+
+## 4. Verify
+Export `Query` from `autumn_web::extract` and re-export it in `autumn_web::prelude`. I checked the source code, and indeed `Path`, `Form`, and `Json` are present but `Query` is missing.


### PR DESCRIPTION
This PR resolves a Developer Experience issue identified by the Echo persona where the `Query` extractor was omitted from `autumn_web::prelude::*`. This broke the low-boilerplate DX promise and forced developers to guess import paths for common Axum functionality.

- Documented the Echo DX audit experience and issue in `docs/dx-audit-echo.md`.
- Added the `Query` extractor to `autumn/src/prelude.rs` and the module docs.

---
*PR created automatically by Jules for task [17432934115224754116](https://jules.google.com/task/17432934115224754116) started by @madmax983*