### PR TITLE
🍎 Eris: [Timing Attack] verify_password

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -126,7 +126,9 @@ pub async fn verify_password(password: &str, hash: &str) -> crate::AutumnResult<
             Err(_) => {
                 // Fallback to prevent timing attacks. Compute a dummy hash.
                 let _ = bcrypt::hash(&password, DEFAULT_BCRYPT_COST);
-                Err(crate::AutumnError::from(std::io::Error::other("invalid hash format")))
+                Err(crate::AutumnError::from(std::io::Error::other(
+                    "invalid hash format",
+                )))
             }
         }
     })

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -121,8 +121,14 @@ pub async fn verify_password(password: &str, hash: &str) -> crate::AutumnResult<
     let password = password.to_string();
     let hash = hash.to_string();
     tokio::task::spawn_blocking(move || {
-        bcrypt::verify(password, &hash)
-            .map_err(|e| crate::AutumnError::from(std::io::Error::other(e.to_string())))
+        match bcrypt::verify(&password, &hash) {
+            Ok(valid) => Ok(valid),
+            Err(_) => {
+                // Fallback to prevent timing attacks. Compute a dummy hash.
+                let _ = bcrypt::hash(&password, DEFAULT_BCRYPT_COST);
+                Err(crate::AutumnError::from(std::io::Error::other("invalid hash format")))
+            }
+        }
     })
     .await
     .map_err(|e| crate::AutumnError::from(std::io::Error::other(e.to_string())))?

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -121,16 +121,16 @@ pub async fn verify_password(password: &str, hash: &str) -> crate::AutumnResult<
     let password = password.to_string();
     let hash = hash.to_string();
     tokio::task::spawn_blocking(move || {
-        match bcrypt::verify(&password, &hash) {
-            Ok(valid) => Ok(valid),
-            Err(_) => {
+        bcrypt::verify(&password, &hash).map_or_else(
+            |_| {
                 // Fallback to prevent timing attacks. Compute a dummy hash.
                 let _ = bcrypt::hash(&password, DEFAULT_BCRYPT_COST);
                 Err(crate::AutumnError::from(std::io::Error::other(
                     "invalid hash format",
                 )))
-            }
-        }
+            },
+            Ok,
+        )
     })
     .await
     .map_err(|e| crate::AutumnError::from(std::io::Error::other(e.to_string())))?

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -3,3 +3,4 @@ pub mod csrf_empty_bypass;
 pub mod csrf_form_bypass;
 pub mod csrf_timing;
 pub mod session_fixation;
+pub mod timing;

--- a/autumn/tests/security/timing.rs
+++ b/autumn/tests/security/timing.rs
@@ -14,14 +14,12 @@ async fn eris_timing_attack() {
     let _ = verify_password(password, "not_a_valid_hash_at_all_which_is_bad").await;
     let time_invalid = start_invalid.elapsed();
 
-    println!("Time with valid hash: {:?}", time_valid);
-    println!("Time with invalid hash: {:?}", time_invalid);
+    println!("Time with valid hash: {time_valid:?}");
+    println!("Time with invalid hash: {time_invalid:?}");
 
     // If time_invalid is less than a small threshold (e.g. 5ms), it returned instantly
     assert!(
         time_invalid > Duration::from_millis(10),
-        "[ERIS-VULN] verify_password returns instantly on invalid hash, exposing a timing attack! Invalid: {:?}, Valid: {:?}",
-        time_invalid,
-        time_valid
+        "[ERIS-VULN] verify_password returns instantly on invalid hash, exposing a timing attack! Invalid: {time_invalid:?}, Valid: {time_valid:?}",
     );
 }

--- a/autumn/tests/security/timing.rs
+++ b/autumn/tests/security/timing.rs
@@ -1,5 +1,5 @@
-use std::time::{Instant, Duration};
 use autumn_web::auth::{hash_password, verify_password};
+use std::time::{Duration, Instant};
 
 #[tokio::test]
 async fn eris_timing_attack() {
@@ -18,6 +18,10 @@ async fn eris_timing_attack() {
     println!("Time with invalid hash: {:?}", time_invalid);
 
     // If time_invalid is less than a small threshold (e.g. 5ms), it returned instantly
-    assert!(time_invalid > Duration::from_millis(10),
-        "[ERIS-VULN] verify_password returns instantly on invalid hash, exposing a timing attack! Invalid: {:?}, Valid: {:?}", time_invalid, time_valid);
+    assert!(
+        time_invalid > Duration::from_millis(10),
+        "[ERIS-VULN] verify_password returns instantly on invalid hash, exposing a timing attack! Invalid: {:?}, Valid: {:?}",
+        time_invalid,
+        time_valid
+    );
 }

--- a/autumn/tests/security/timing.rs
+++ b/autumn/tests/security/timing.rs
@@ -1,0 +1,23 @@
+use std::time::{Instant, Duration};
+use autumn_web::auth::{hash_password, verify_password};
+
+#[tokio::test]
+async fn eris_timing_attack() {
+    let password = "my_secure_password";
+    let valid_hash = hash_password(password).await.unwrap();
+
+    let start_valid = Instant::now();
+    let _ = verify_password(password, &valid_hash).await;
+    let time_valid = start_valid.elapsed();
+
+    let start_invalid = Instant::now();
+    let _ = verify_password(password, "not_a_valid_hash_at_all_which_is_bad").await;
+    let time_invalid = start_invalid.elapsed();
+
+    println!("Time with valid hash: {:?}", time_valid);
+    println!("Time with invalid hash: {:?}", time_invalid);
+
+    // If time_invalid is less than a small threshold (e.g. 5ms), it returned instantly
+    assert!(time_invalid > Duration::from_millis(10),
+        "[ERIS-VULN] verify_password returns instantly on invalid hash, exposing a timing attack! Invalid: {:?}, Valid: {:?}", time_invalid, time_valid);
+}


### PR DESCRIPTION
**The Vulnerability:**
`verify_password` in `auth.rs` directly delegates to `bcrypt::verify`. When `bcrypt::verify` is given an invalid hash string (e.g. malformed or not a bcrypt hash), it immediately returns an error. This creates a clear timing side-channel: valid hashes take significant time (~100s of milliseconds) while invalid hashes return instantly (~microseconds). This allows an attacker to enumerate user existence based on response time differences.

**The Fix:**
When `bcrypt::verify` fails, we introduce a fallback that computes a dummy `bcrypt::hash` using `DEFAULT_BCRYPT_COST`. This ensures the function always performs the expensive bcrypt operation, standardizing the response time regardless of hash validity.

**Verification:**
Added a regression test `eris_timing_attack` in `autumn/tests/security/timing.rs` that verifies `verify_password` does not return instantly (<10ms) on an invalid hash.

---
*PR created automatically by Jules for task [9174187543557568966](https://jules.google.com/task/9174187543557568966) started by @madmax983*