### PR TITLE
🔒 Warden: Fix unsound unsafe env var mutation in tests

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1399,57 +1399,10 @@ async fn shutdown_signal() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::env_guard::EnvGuard;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use std::sync::{Mutex, OnceLock};
     use tower::ServiceExt;
-
-    struct EnvGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        previous: Vec<(&'static str, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
-            static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-            let lock = ENV_LOCK
-                .get_or_init(|| Mutex::new(()))
-                .lock()
-                .expect("env mutex poisoned");
-            let mut previous = Vec::with_capacity(entries.len());
-            for (key, value) in entries {
-                previous.push((*key, std::env::var(key).ok()));
-                match value {
-                    Some(value) => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::set_var(key, value) };
-                    }
-                    None => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::remove_var(key) };
-                    }
-                }
-            }
-            Self {
-                _lock: lock,
-                previous,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (key, previous) in self.previous.iter().rev() {
-                if let Some(previous) = previous {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::set_var(key, previous) };
-                } else {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::remove_var(key) };
-                }
-            }
-        }
-    }
 
     /// Helper to build a test router with default config and no database.
     fn test_router(routes: Vec<Route>) -> axum::Router {

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -103,6 +103,9 @@ pub mod validation;
 #[cfg(feature = "ws")]
 pub mod ws;
 
+#[cfg(test)]
+pub(crate) mod test_utils;
+
 /// Create a new [`app::AppBuilder`] for configuring and launching an Autumn server.
 ///
 /// This is the primary entry point for every Autumn application.

--- a/autumn/src/middleware/dev.rs
+++ b/autumn/src/middleware/dev.rs
@@ -197,57 +197,10 @@ fn live_reload_script() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::env_guard::EnvGuard;
     use axum::body::to_bytes;
     use axum::http::header::ACCEPT;
-    use std::sync::{Mutex, OnceLock};
     use tower::ServiceExt;
-
-    struct EnvGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        previous: Vec<(&'static str, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
-            static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-            let lock = ENV_LOCK
-                .get_or_init(|| Mutex::new(()))
-                .lock()
-                .expect("env mutex poisoned");
-            let mut previous = Vec::with_capacity(entries.len());
-            for (key, value) in entries {
-                previous.push((*key, std::env::var(key).ok()));
-                match value {
-                    Some(value) => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::set_var(key, value) };
-                    }
-                    None => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::remove_var(key) };
-                    }
-                }
-            }
-            Self {
-                _lock: lock,
-                previous,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (key, previous) in self.previous.iter().rev() {
-                if let Some(previous) = previous {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::set_var(key, previous) };
-                } else {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::remove_var(key) };
-                }
-            }
-        }
-    }
 
     #[test]
     fn is_enabled_requires_both_env_vars() {

--- a/autumn/src/test_utils.rs
+++ b/autumn/src/test_utils.rs
@@ -1,0 +1,51 @@
+#[cfg(test)]
+pub mod env_guard {
+    use std::sync::{Mutex, OnceLock};
+
+    pub struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        previous: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        pub fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
+            static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+            let lock = ENV_LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .expect("env mutex poisoned");
+            let mut previous = Vec::with_capacity(entries.len());
+            for (key, value) in entries {
+                previous.push((*key, std::env::var(key).ok()));
+                match value {
+                    Some(value) => {
+                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                        unsafe { std::env::set_var(key, value) };
+                    }
+                    None => {
+                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                        unsafe { std::env::remove_var(key) };
+                    }
+                }
+            }
+            Self {
+                _lock: lock,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, previous) in self.previous.iter().rev() {
+                if let Some(previous) = previous {
+                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                    unsafe { std::env::set_var(key, previous) };
+                } else {
+                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                    unsafe { std::env::remove_var(key) };
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
🦠 Threat: Tests were concurrently calling `unsafe { std::env::set_var }` by using localized instances of `EnvGuard` and `OnceLock<Mutex<()>>`. Because the mutexes were module-local, they failed to serialize access to the process-wide environment, causing data races and potential Undefined Behavior (UB) when threads concurrently read/wrote to `std::env`.

🛡️ Defense: Refactored the codebase to consolidate `EnvGuard` into a centralized `test_utils` module. Now all tests in the `autumn` crate import and use a single, shared `ENV_LOCK`, effectively containing the `unsafe` code and serializing process-global environment modifications correctly.

💥 Severity: High (in testing context) - Multithreaded UB and test flakiness due to memory safety violations.

🧪 Verification: Ran `cargo clippy`, `cargo fmt`, and `cargo test --all-targets`. All checks passed successfully with no UB triggered by data races during the environment modification tests.

---
*PR created automatically by Jules for task [8442310248470920097](https://jules.google.com/task/8442310248470920097) started by @madmax983*