### PR TITLE
⚒️ Forge: [flatten config merge]

### DIFF
--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -262,21 +262,26 @@ fn deep_merge_with_depth(base: &mut toml::Value, overlay: toml::Value, depth: us
         return;
     }
 
-    if base.is_table() && overlay.is_table() {
-        if let toml::Value::Table(overlay_table) = overlay {
-            let base_table = base.as_table_mut().expect("checked is_table above");
-            for (key, overlay_val) in overlay_table {
-                if overlay_val.is_table() {
-                    if let Some(base_val) = base_table.get_mut(&key) {
-                        if base_val.is_table() {
-                            deep_merge_with_depth(base_val, overlay_val, depth + 1);
-                            continue;
-                        }
-                    }
+    if !base.is_table() {
+        return;
+    }
+
+    let toml::Value::Table(overlay_table) = overlay else {
+        return;
+    };
+
+    let base_table = base.as_table_mut().expect("checked is_table above");
+
+    for (key, overlay_val) in overlay_table {
+        if overlay_val.is_table() {
+            if let Some(base_val) = base_table.get_mut(&key) {
+                if base_val.is_table() {
+                    deep_merge_with_depth(base_val, overlay_val, depth + 1);
+                    continue;
                 }
-                base_table.insert(key, overlay_val);
             }
         }
+        base_table.insert(key, overlay_val);
     }
 }
 


### PR DESCRIPTION
🚮 **Smell:** Deeply nested `if` and `if let` blocks ("Pyramid of Doom") inside `deep_merge_with_depth` in `autumn/src/config.rs` made the function difficult to read.
✨ **Solution:** Used Guard Clauses (`if !base.is_table() { return; }` and `let toml::Value::Table(...) = ... else { return; }`) to return early and flatten the nesting structure.
🧼 **Benefit:** Dramatically improves clarity and reduces cognitive load by bringing the core `for` loop logic two indentation levels to the left.
🛡️ **Verification:** Tests passed. No logic changed. All 94 unit tests in `autumn/src/config.rs` pass, including specifically the tests for `deep_merge_with_depth` (`deep_merge_tables`, `deep_merge_stops_at_max_depth`, `deep_merge_handles_deep_nesting`, etc). Verified using `cargo clippy`, `cargo fmt`, and `cargo test`.

---
*PR created automatically by Jules for task [1137898396886449171](https://jules.google.com/task/1137898396886449171) started by @madmax983*