### PR TITLE
👺 Havoc: Fix Zero and OOM Capacity Panic in Channels

### DIFF
--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -164,6 +164,8 @@ impl Channels {
     /// ```
     #[must_use]
     pub fn new(capacity: usize) -> Self {
+        // Clamp capacity between 1 and 16384 to prevent panics and OOM
+        let capacity = capacity.clamp(1, 16384);
         Self {
             inner: Arc::new(ChannelsInner {
                 capacity,

--- a/autumn/tests/chaos_oom_capacity.rs
+++ b/autumn/tests/chaos_oom_capacity.rs
@@ -1,0 +1,7 @@
+use autumn_web::channels::Channels;
+
+#[test]
+fn test_oom_capacity() {
+    let channels = Channels::new(usize::MAX);
+    let _tx = channels.sender("test");
+}

--- a/autumn/tests/chaos_zero_capacity.rs
+++ b/autumn/tests/chaos_zero_capacity.rs
@@ -1,0 +1,7 @@
+use autumn_web::channels::Channels;
+
+#[test]
+fn test_zero_capacity() {
+    let channels = Channels::new(0);
+    let _tx = channels.sender("test");
+}


### PR DESCRIPTION
🧨 **The Trigger:** Calling `Channels::new(0)` causes an immediate crash upon attempting to create a sender or subscriber, as `broadcast::channel(0)` panics inside tokio. Calling `Channels::new(usize::MAX)` causes an Out-Of-Memory panic during allocation of the massive buffer.

📉 **The Stack Trace:**
```
thread 'test_zero_capacity' panicked at autumn/src/channels.rs:204:31:
broadcast channel capacity cannot be zero
```

🧪 **Reproduction:**
Run `cargo test -p autumn-web --test chaos_zero_capacity` and `cargo test -p autumn-web --test chaos_oom_capacity` before applying this fix. Both will instantly panic. After the fix, they will run and pass as the capacity is clamped safely between 1 and 16384.

😈 **Comment:** You assumed the user would never enter `0` or `usize::MAX` for the capacity because it "doesn't make sense". You were wrong. Never trust the caller to enforce memory constraints. I clamped the value.

---
*PR created automatically by Jules for task [5028147624402294929](https://jules.google.com/task/5028147624402294929) started by @madmax983*