### PR TITLE
🔒 Warden: [security fix] Fix CSRF Cookie Tossing Bypass

### DIFF
--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -190,20 +190,28 @@ fn constant_time_eq(a: &str, b: &str) -> bool {
 
 /// Extract the CSRF cookie value from the Cookie header.
 fn extract_cookie_token(req_headers: &http::HeaderMap, cookie_name: &str) -> Option<String> {
-    req_headers
-        .get_all(http::header::COOKIE)
-        .iter()
-        .filter_map(|v| v.to_str().ok())
-        .flat_map(|cookie_str| cookie_str.split(';'))
-        .map(str::trim)
-        .find_map(|pair| {
-            let (name, value) = pair.split_once('=')?;
-            if name.trim() == cookie_name {
-                Some(value.trim().to_owned())
-            } else {
-                None
+    let mut found_token = None;
+
+    for cookie_header in &req_headers.get_all(http::header::COOKIE) {
+        if let Ok(cookie_str) = cookie_header.to_str() {
+            for pair in cookie_str.split(';') {
+                let pair = pair.trim();
+                if let Some((name, value)) = pair.split_once('=') {
+                    if name.trim() == cookie_name {
+                        if found_token.is_some() {
+                            // Multiple cookies with the same name found.
+                            // This indicates a potential Cookie Tossing attack!
+                            // Reject by returning None.
+                            return None;
+                        }
+                        found_token = Some(value.trim().to_owned());
+                    }
+                }
             }
-        })
+        }
+    }
+
+    found_token
 }
 
 impl<S, ResBody> Service<Request<axum::body::Body>> for CsrfService<S>

--- a/autumn/tests/security/csrf_cookie_tossing.rs
+++ b/autumn/tests/security/csrf_cookie_tossing.rs
@@ -1,0 +1,53 @@
+use autumn_web::security::CsrfLayer;
+use autumn_web::security::config::CsrfConfig;
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+    routing::post,
+};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn eris_csrf_cookie_tossing_bypass() {
+    let config = CsrfConfig {
+        enabled: true,
+        ..Default::default()
+    };
+
+    let app = Router::new()
+        .route("/submit", post(|| async { "created" }))
+        .layer(CsrfLayer::from_config(&config));
+
+    // The legitimate token set by the server
+    let legit_token = "valid_server_token".to_string();
+
+    // The malicious token injected by the attacker via Cookie Tossing
+    let malicious_token = "malicious_attacker_token".to_string();
+
+    // Attacker sends a request containing their forged X-CSRF-Token header
+    // and a Cookie header that contains BOTH the malicious cookie (tossed)
+    // AND the legitimate cookie. If the malicious cookie comes first,
+    // the extract_cookie_token might pick it and match it against the header.
+    let malicious_req = Request::builder()
+        .method("POST")
+        .uri("/submit")
+        .header(
+            "Cookie",
+            format!("autumn-csrf={malicious_token}; autumn-csrf={legit_token}"),
+        )
+        .header("X-CSRF-Token", &malicious_token)
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(malicious_req).await.unwrap();
+
+    // The test MUST return FORBIDDEN to be secure. If it returns OK, it's vulnerable.
+    // If this test fails (response is OK), it means the application is vulnerable
+    // to Cookie Tossing and needs to reject requests with multiple CSRF cookies.
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "VULNERABILITY: CSRF bypass via Cookie Tossing! Multiple cookies allowed the malicious token to match."
+    );
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth_dos;
 pub mod auth_timing_test;
+pub mod csrf_cookie_tossing;
 pub mod csrf_empty_bypass;
 pub mod csrf_form_bypass;
 pub mod csrf_timing;


### PR DESCRIPTION
🦠 **Threat**: The Autumn framework's `CsrfLayer` was vulnerable to a CSRF bypass via "Cookie Tossing". Because the `extract_cookie_token` function used `find_map` to process the `Cookie` header, it returned the *first* `autumn-csrf` cookie it found. An attacker controlling a sibling subdomain could inject a forged `autumn-csrf` cookie (without the `__Host-` prefix) into the victim's request. If the forged cookie appeared before the legitimate one, the server would validate the attacker's chosen token (provided in the forged header or form field) against the forged cookie, entirely bypassing the CSRF protection.

🛡️ **Defense**: Modified `extract_cookie_token` to explicitly iterate over all provided cookies and return `None` (causing CSRF validation to fail) if *multiple* cookies matching the `autumn-csrf` name are detected. A legitimate user session will only ever present one such cookie.

💥 **Severity**: High. Allowed cross-site request forgery attacks on state-changing endpoints for any application hosted on a subdomain, completely bypassing the Double Submit Cookie pattern.

🧪 **Verification**: Added a new integration test `eris_csrf_cookie_tossing_bypass` in `autumn/tests/security/csrf_cookie_tossing.rs`. The test simulates a request with a legitimate and an injected cookie alongside a malicious header token. Confirmed the test initially failed (returned 200 OK) and now correctly passes by returning 403 FORBIDDEN. Also verified all other security tests continue to pass.

---
*PR created automatically by Jules for task [17648068418594049010](https://jules.google.com/task/17648068418594049010) started by @madmax983*