### PR TITLE
🛡️ Sentry: [test coverage improvement] Flash module test enhancements

### DIFF
--- a/autumn/src/flash.rs
+++ b/autumn/src/flash.rs
@@ -191,4 +191,59 @@ mod tests {
         assert_eq!(FlashLevel::Warning.as_str(), "warning");
         assert_eq!(FlashLevel::Error.as_str(), "error");
     }
+
+    #[tokio::test]
+    async fn should_not_remove_key_when_consuming_empty_flash() {
+        let session = Session::new_for_test("test_id".to_string(), HashMap::new());
+        // Insert a dummy key to verify the session remains untouched and "dirty" flag logic
+        session.insert("dummy", "val").await;
+
+        let flash = Flash::new(session.clone());
+        let messages = flash.consume().await;
+
+        // No messages were present
+        assert_eq!(messages.len(), 0);
+
+        // "dummy" key is still there
+        assert_eq!(session.get("dummy").await.unwrap(), "val");
+        // Flash key shouldn't be added or touched
+        assert!(!session.contains_key(FLASH_SESSION_KEY).await);
+    }
+
+    #[tokio::test]
+    async fn should_handle_invalid_json_gracefully() {
+        let session = Session::new_for_test("test_id".to_string(), HashMap::new());
+        // Insert broken JSON manually
+        session
+            .insert(FLASH_SESSION_KEY, "{ invalid_json: true")
+            .await;
+
+        let flash = Flash::new(session);
+        let messages = flash.peek().await;
+
+        // It should gracefully fall back to an empty vector rather than panicking
+        assert_eq!(messages.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn should_support_all_convenience_methods() {
+        let session = Session::new_for_test("test_id".to_string(), HashMap::new());
+        let flash = Flash::new(session);
+
+        flash.success("Success msg").await;
+        flash.info("Info msg").await;
+        flash.warning("Warning msg").await;
+        flash.error("Error msg").await;
+
+        let messages = flash.peek().await;
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0].level, FlashLevel::Success);
+        assert_eq!(messages[0].message, "Success msg");
+        assert_eq!(messages[1].level, FlashLevel::Info);
+        assert_eq!(messages[1].message, "Info msg");
+        assert_eq!(messages[2].level, FlashLevel::Warning);
+        assert_eq!(messages[2].message, "Warning msg");
+        assert_eq!(messages[3].level, FlashLevel::Error);
+        assert_eq!(messages[3].message, "Error msg");
+    }
 }


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement] Flash module test enhancements

Added comprehensive unit tests to `autumn/src/flash.rs` to address coverage gaps in the flash message queue implementation.

🎯 Target:
- `autumn::flash::Flash` extractor methods (`success`, `info`, `warning`, `error`, `peek`, and `consume`).

💣 Risk:
- The convenience methods (`info`, `warning`) were completely untested.
- The behavior of `peek()` when encountering invalid JSON in the underlying session data was undefined in tests (risk of unwrap panics).
- The behavior of `consume()` when no flash messages are present was untested, potentially causing unnecessary state mutations or logic bugs.

🧪 Strategy:
- Added `should_support_all_convenience_methods` to ensure all severity levels are properly serialized and pushed.
- Added `should_handle_invalid_json_gracefully` by manually injecting broken JSON directly into the session to guarantee `peek()` falls back to an empty vector instead of panicking.
- Added `should_not_remove_key_when_consuming_empty_flash` to explicitly verify that `consume()` short-circuits and avoids touching the session when the flash queue is already empty.

🔬 Verification:
`cargo test -p autumn-web --lib flash`

---
*PR created automatically by Jules for task [13108935311502010308](https://jules.google.com/task/13108935311502010308) started by @madmax983*