### PR TITLE
🔒 Warden: [security fix] Fix data race in test harness environment variable mutation

### DIFF
--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -712,54 +712,7 @@ fn find_binary(package: Option<&str>) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    struct EnvGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        previous: Vec<(&'static str, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        fn set_many(entries: &[(&'static str, Option<&std::ffi::OsStr>)]) -> Self {
-            static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-            let lock = ENV_LOCK
-                .get_or_init(|| Mutex::new(()))
-                .lock()
-                .expect("env mutex poisoned");
-            let mut previous = Vec::with_capacity(entries.len());
-            for (key, value) in entries {
-                previous.push((*key, std::env::var(key).ok()));
-                match value {
-                    Some(value) => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::set_var(key, value) };
-                    }
-                    None => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::remove_var(key) };
-                    }
-                }
-            }
-            Self {
-                _lock: lock,
-                previous,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (key, previous) in self.previous.iter().rev() {
-                if let Some(previous) = previous {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::set_var(key, previous) };
-                } else {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::remove_var(key) };
-                }
-            }
-        }
-    }
+    use crate::test_utils::EnvGuard;
 
     // ── is_relevant_change tests ───────────────────────────────────
 

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -7,6 +7,8 @@ mod migrate;
 mod monitor;
 mod new;
 mod setup;
+#[cfg(test)]
+pub(crate) mod test_utils;
 
 /// The Autumn web framework CLI.
 #[derive(Parser)]

--- a/autumn-cli/src/test_utils.rs
+++ b/autumn-cli/src/test_utils.rs
@@ -1,0 +1,52 @@
+#[cfg(test)]
+use std::sync::{Mutex, OnceLock};
+
+#[cfg(test)]
+pub struct EnvGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    previous: Vec<(&'static str, Option<String>)>,
+}
+
+#[cfg(test)]
+impl EnvGuard {
+    pub fn set_many(entries: &[(&'static str, Option<&std::ffi::OsStr>)]) -> Self {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let lock = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env mutex poisoned");
+        let mut previous = Vec::with_capacity(entries.len());
+        for (key, value) in entries {
+            previous.push((*key, std::env::var(key).ok()));
+            match value {
+                Some(value) => {
+                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                    unsafe { std::env::set_var(key, value) };
+                }
+                None => {
+                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                    unsafe { std::env::remove_var(key) };
+                }
+            }
+        }
+        Self {
+            _lock: lock,
+            previous,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, previous) in self.previous.iter().rev() {
+            if let Some(previous) = previous {
+                // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                unsafe { std::env::set_var(key, previous) };
+            } else {
+                // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                unsafe { std::env::remove_var(key) };
+            }
+        }
+    }
+}

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1086,57 +1086,10 @@ async fn shutdown_signal() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::EnvGuard;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use std::sync::{Mutex, OnceLock};
     use tower::ServiceExt;
-
-    pub struct EnvGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        previous: Vec<(&'static str, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        pub fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
-            static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-            let lock = ENV_LOCK
-                .get_or_init(|| Mutex::new(()))
-                .lock()
-                .expect("env mutex poisoned");
-            let mut previous = Vec::with_capacity(entries.len());
-            for (key, value) in entries {
-                previous.push((*key, std::env::var(key).ok()));
-                match value {
-                    Some(value) => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::set_var(key, value) };
-                    }
-                    None => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::remove_var(key) };
-                    }
-                }
-            }
-            Self {
-                _lock: lock,
-                previous,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (key, previous) in self.previous.iter().rev() {
-                if let Some(previous) = previous {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::set_var(key, previous) };
-                } else {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::remove_var(key) };
-                }
-            }
-        }
-    }
 
     /// Helper to build a test router with default config and no database.
     pub fn test_router(routes: Vec<Route>) -> axum::Router {

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -83,6 +83,8 @@ pub mod hooks;
 #[cfg(feature = "db")]
 pub mod migrate;
 pub mod router;
+#[cfg(test)]
+pub(crate) mod test_utils;
 #[cfg(feature = "db")]
 pub use hooks::{
     DraftField, FieldDiff, MutationContext, MutationHooks, MutationOp, NoHooks, Patch, UpdateDraft,

--- a/autumn/src/middleware/dev.rs
+++ b/autumn/src/middleware/dev.rs
@@ -197,57 +197,10 @@ fn live_reload_script() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::EnvGuard;
     use axum::body::to_bytes;
     use axum::http::header::ACCEPT;
-    use std::sync::{Mutex, OnceLock};
     use tower::ServiceExt;
-
-    struct EnvGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        previous: Vec<(&'static str, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
-            static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-            let lock = ENV_LOCK
-                .get_or_init(|| Mutex::new(()))
-                .lock()
-                .expect("env mutex poisoned");
-            let mut previous = Vec::with_capacity(entries.len());
-            for (key, value) in entries {
-                previous.push((*key, std::env::var(key).ok()));
-                match value {
-                    Some(value) => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::set_var(key, value) };
-                    }
-                    None => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::remove_var(key) };
-                    }
-                }
-            }
-            Self {
-                _lock: lock,
-                previous,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (key, previous) in self.previous.iter().rev() {
-                if let Some(previous) = previous {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::set_var(key, previous) };
-                } else {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::remove_var(key) };
-                }
-            }
-        }
-    }
 
     #[test]
     fn is_enabled_requires_both_env_vars() {

--- a/autumn/src/test_utils.rs
+++ b/autumn/src/test_utils.rs
@@ -1,0 +1,52 @@
+#[cfg(test)]
+use std::sync::{Mutex, OnceLock};
+
+#[cfg(test)]
+pub struct EnvGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    previous: Vec<(&'static str, Option<String>)>,
+}
+
+#[cfg(test)]
+impl EnvGuard {
+    pub fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let lock = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env mutex poisoned");
+        let mut previous = Vec::with_capacity(entries.len());
+        for (key, value) in entries {
+            previous.push((*key, std::env::var(key).ok()));
+            match value {
+                Some(value) => {
+                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                    unsafe { std::env::set_var(key, value) };
+                }
+                None => {
+                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                    unsafe { std::env::remove_var(key) };
+                }
+            }
+        }
+        Self {
+            _lock: lock,
+            previous,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, previous) in self.previous.iter().rev() {
+            if let Some(previous) = previous {
+                // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                unsafe { std::env::set_var(key, previous) };
+            } else {
+                // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                unsafe { std::env::remove_var(key) };
+            }
+        }
+    }
+}


### PR DESCRIPTION
🦠 Threat: `unsafe { std::env::set_var }` was being called by three different inline `EnvGuard` instances across the codebase (`autumn/src/app.rs`, `autumn/src/middleware/dev.rs`, `autumn-cli/src/dev.rs`), each using their own local module `OnceLock`. Because Cargo runs test binaries concurrently, this allowed multi-threaded parallel mutation of the process-global environment, leading to Undefined Behavior (data races in libc environment structures) and potential test flakes or segmentation faults.
🛡️ Defense: Centralized the `EnvGuard` struct into a single `test_utils` module per crate. This ensures that the `OnceLock<Mutex<()>>` correctly serializes all environment mutations during `cargo test` runs, preventing any concurrent access.
💥 Severity: Medium - Undefined Behavior in the test harness could lead to flaky CI pipelines and arbitrary memory corruption during test execution.
🧪 Verification: Ran `cargo check`, `cargo test -p autumn-web --tests`, `cargo test -p autumn-cli --tests`, and `cargo clippy --all-targets --all-features`. Verified that tests still pass, no timeouts occur, and the `EnvGuard` cleanly synchronizes.

---
*PR created automatically by Jules for task [16099102809798715722](https://jules.google.com/task/16099102809798715722) started by @madmax983*