### PR TITLE
🗺️ Atlas: Decouple Extractors from AppState and Optimize Routing

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -430,11 +430,11 @@ mod tests {
 
     #[tokio::test]
     async fn auth_extractor_returns_401_when_no_user() {
+        use crate::state::AppState;
         use axum::Router;
         use axum::body::Body;
         use axum::routing::get;
         use tower::ServiceExt;
-        use crate::state::AppState;
 
         #[derive(Clone)]
         struct TestUser {
@@ -478,11 +478,11 @@ mod tests {
 
     #[tokio::test]
     async fn auth_extractor_returns_user_when_present() {
+        use crate::state::AppState;
         use axum::Router;
         use axum::body::Body;
         use axum::routing::get;
         use tower::ServiceExt;
-        use crate::state::AppState;
 
         #[derive(Clone)]
         struct TestUser {

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -63,8 +63,6 @@ use axum::response::{IntoResponse, Response};
 use http::StatusCode;
 use http::request::Parts;
 
-use crate::state::AppState;
-
 // ── Password hashing ────────────────────────────────────────────
 
 /// Default bcrypt cost factor.
@@ -206,15 +204,16 @@ pub async fn __check_secured(
 /// ```
 pub struct Auth<T>(pub T);
 
-impl<T> FromRequestParts<AppState> for Auth<T>
+impl<T, S> FromRequestParts<S> for Auth<T>
 where
     T: Clone + Send + Sync + 'static,
+    S: Send + Sync,
 {
     type Rejection = AuthRejection;
 
     fn from_request_parts(
         parts: &mut Parts,
-        _state: &AppState,
+        _state: &S,
     ) -> impl Future<Output = Result<Self, Self::Rejection>> + Send {
         let user = parts.extensions.get::<T>().cloned();
         async move { user.map_or_else(|| Err(AuthRejection), |user| Ok(Self(user))) }
@@ -435,6 +434,7 @@ mod tests {
         use axum::body::Body;
         use axum::routing::get;
         use tower::ServiceExt;
+        use crate::state::AppState;
 
         #[derive(Clone)]
         struct TestUser {
@@ -482,6 +482,7 @@ mod tests {
         use axum::body::Body;
         use axum::routing::get;
         use tower::ServiceExt;
+        use crate::state::AppState;
 
         #[derive(Clone)]
         struct TestUser {
@@ -546,6 +547,7 @@ mod tests {
         use tower::ServiceExt;
 
         use crate::session::{MemoryStore, SessionConfig, SessionLayer};
+        use crate::state::AppState;
 
         let state = AppState {
             #[cfg(feature = "db")]
@@ -650,6 +652,7 @@ mod tests {
         use tower::ServiceExt;
 
         use crate::session::{MemoryStore, SessionConfig, SessionLayer};
+        use crate::state::AppState;
 
         #[autumn_macros::secured]
         async fn protected_handler() -> crate::AutumnResult<&'static str> {
@@ -702,6 +705,7 @@ mod tests {
         use tower::ServiceExt;
 
         use crate::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
+        use crate::state::AppState;
 
         #[autumn_macros::secured]
         async fn protected_handler() -> crate::AutumnResult<&'static str> {
@@ -764,6 +768,7 @@ mod tests {
         use tower::ServiceExt;
 
         use crate::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
+        use crate::state::AppState;
 
         #[autumn_macros::secured("admin")]
         async fn admin_only() -> crate::AutumnResult<&'static str> {
@@ -825,6 +830,7 @@ mod tests {
         use tower::ServiceExt;
 
         use crate::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
+        use crate::state::AppState;
 
         #[autumn_macros::secured("admin", "editor")]
         async fn content_handler() -> crate::AutumnResult<&'static str> {
@@ -890,6 +896,7 @@ mod tests {
         use tower::ServiceExt;
 
         use crate::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
+        use crate::state::AppState;
 
         let store = MemoryStore::new();
         // Pre-populate a session with user_id

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -196,12 +196,12 @@ mod tests {
 
     #[tokio::test]
     async fn db_extractor_rejects_when_no_pool() {
+        use crate::state::AppState;
         use axum::Router;
         use axum::body::Body;
         use axum::http::{Request, StatusCode};
         use axum::routing::get;
         use tower::ServiceExt;
-        use crate::state::AppState;
 
         async fn handler(_db: Db) -> &'static str {
             "ok"

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -32,7 +32,14 @@ use diesel_async::pooled_connection::deadpool::Pool;
 
 use crate::config::DatabaseConfig;
 use crate::error::AutumnError;
-use crate::state::AppState;
+
+/// Trait to abstract the state requirement for the `Db` extractor.
+/// This breaks the circular dependency between the database extractor
+/// and the central `AppState`.
+pub trait DbState {
+    /// Returns the database connection pool, if configured.
+    fn pool(&self) -> Option<&Pool<AsyncPgConnection>>;
+}
 
 /// Error type for pool creation failures.
 ///
@@ -108,16 +115,18 @@ impl std::ops::DerefMut for Db {
     }
 }
 
-impl FromRequestParts<AppState> for Db {
+impl<S> FromRequestParts<S> for Db
+where
+    S: DbState + Send + Sync,
+{
     type Rejection = AutumnError;
 
     async fn from_request_parts(
         _parts: &mut axum::http::request::Parts,
-        state: &AppState,
+        state: &S,
     ) -> Result<Self, Self::Rejection> {
         let pool = state
-            .pool
-            .as_ref()
+            .pool()
             .ok_or_else(|| AutumnError::service_unavailable_msg("Database not configured"))?;
 
         let conn = pool.get().await.map_err(|e| {
@@ -192,6 +201,7 @@ mod tests {
         use axum::http::{Request, StatusCode};
         use axum::routing::get;
         use tower::ServiceExt;
+        use crate::state::AppState;
 
         async fn handler(_db: Db) -> &'static str {
             "ok"

--- a/autumn/src/flash.rs
+++ b/autumn/src/flash.rs
@@ -147,10 +147,7 @@ where
 {
     type Rejection = <Session as FromRequestParts<S>>::Rejection;
 
-    async fn from_request_parts(
-        parts: &mut Parts,
-        state: &S,
-    ) -> Result<Self, Self::Rejection> {
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let session = Session::from_request_parts(parts, state).await?;
         Ok(Self::new(session))
     }

--- a/autumn/src/flash.rs
+++ b/autumn/src/flash.rs
@@ -141,14 +141,15 @@ impl Flash {
     }
 }
 
-use crate::state::AppState;
-
-impl FromRequestParts<AppState> for Flash {
-    type Rejection = <Session as FromRequestParts<AppState>>::Rejection;
+impl<S> FromRequestParts<S> for Flash
+where
+    S: Send + Sync,
+{
+    type Rejection = <Session as FromRequestParts<S>>::Rejection;
 
     async fn from_request_parts(
         parts: &mut Parts,
-        state: &AppState,
+        state: &S,
     ) -> Result<Self, Self::Rejection> {
         let session = Session::from_request_parts(parts, state).await?;
         Ok(Self::new(session))

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -84,7 +84,7 @@ pub(crate) fn build_router_inner(
         grouped
             .entry(route.path)
             .and_modify(|existing| {
-                *existing = existing.clone().merge(route.handler.clone());
+                *existing = std::mem::take(existing).merge(route.handler.clone());
             })
             .or_insert(route.handler);
     }

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -70,8 +70,6 @@ use tokio::sync::RwLock;
 use tower::{Layer, Service};
 use uuid::Uuid;
 
-use crate::state::AppState;
-
 // ── Session data ────────────────────────────────────────────────
 
 /// A handle to the current request's session data.
@@ -178,12 +176,15 @@ impl Session {
     }
 }
 
-impl FromRequestParts<AppState> for Session {
+impl<S> FromRequestParts<S> for Session
+where
+    S: Send + Sync,
+{
     type Rejection = std::convert::Infallible;
 
     fn from_request_parts(
         parts: &mut Parts,
-        _state: &AppState,
+        _state: &S,
     ) -> impl Future<Output = Result<Self, Self::Rejection>> + Send {
         let session = parts
             .extensions
@@ -609,6 +610,7 @@ mod tests {
 
     #[tokio::test]
     async fn session_layer_sets_cookie_on_new_session() {
+        use crate::state::AppState;
         async fn handler(session: Session) -> String {
             session.insert("visited", "true").await;
             "ok".to_owned()
@@ -654,6 +656,7 @@ mod tests {
 
     #[tokio::test]
     async fn session_layer_persists_data_across_requests() {
+        use crate::state::AppState;
         async fn write_handler(session: Session) -> String {
             session.insert("user", "alice").await;
             "saved".to_owned()
@@ -729,6 +732,7 @@ mod tests {
 
     #[tokio::test]
     async fn session_destroy_expires_cookie() {
+        use crate::state::AppState;
         async fn handler(session: Session) -> String {
             session.destroy().await;
             "destroyed".to_owned()

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -12,6 +12,8 @@
 use crate::actuator;
 #[cfg(feature = "ws")]
 use crate::channels::Channels;
+#[cfg(feature = "db")]
+use crate::db::DbState;
 use crate::middleware;
 #[cfg(feature = "ws")]
 use tokio_util::sync::CancellationToken;
@@ -206,6 +208,13 @@ impl AppState {
             #[cfg(feature = "ws")]
             shutdown: CancellationToken::new(),
         }
+    }
+}
+
+#[cfg(feature = "db")]
+impl DbState for AppState {
+    fn pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>> {
+        self.pool.as_ref()
     }
 }
 

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -213,7 +213,10 @@ impl AppState {
 
 #[cfg(feature = "db")]
 impl DbState for AppState {
-    fn pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>> {
+    fn pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
         self.pool.as_ref()
     }
 }


### PR DESCRIPTION
🕸️ Tangle: The structural problem was a circular dependency between several core extractors (`Db`, `Session`, `Flash`, `Auth`) and the central `AppState` struct. Extractors explicitly required `AppState`, tightly coupling independent modules directly to the monolithic state struct.
📐 Blueprint: The solution abstracted state requirements away from the `AppState` struct directly. Specifically:
- Introduced a `DbState` trait to abstract the database connection pool access and implemented it on `AppState`.
- Modified the `Session`, `Flash`, and `Auth` extractors to be generic over `S: Send + Sync`, rather than requiring `AppState` directly.
- Optimized `MethodRouter` merges in `router.rs` to take ownership via `std::mem::take` rather than cloning.
🧱 Stability: Reduced coupling between core components and the application state. Independent components no longer need to know about `AppState`, providing a cleaner dependency graph. Merging routes is slightly faster and allocations are reduced.
🔬 Verification: Builds successfully (`cargo check -p autumn-web`). All tests pass (`cargo test`). Strict architectural separation enforced.

---
*PR created automatically by Jules for task [3512482295207912783](https://jules.google.com/task/3512482295207912783) started by @madmax983*