### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -34,7 +34,7 @@ pub fn build_router(
 ///
 /// Like [`build_router`], but also merges and nests additional raw
 /// Axum routers. This is primarily useful for integration testing;
-/// in production, use [`AppBuilder::merge`] and [`AppBuilder::nest`].
+/// in production, use [`AppBuilder::merge`](crate::app::AppBuilder::merge) and [`AppBuilder::nest`](crate::app::AppBuilder::nest).
 pub fn build_router_merged(
     route_list: Vec<Route>,
     config: &AutumnConfig,


### PR DESCRIPTION
📖 Chapter: The `router` module
🔦 Insight: Fixed broken intra-doc links for `AppBuilder::merge` and `AppBuilder::nest` in `autumn/src/router.rs`. These links were causing `cargo doc` warnings and failing one of the Bard persona rules (never commit documentation with broken links). Replaced the missing items in scope with absolute `crate::app::AppBuilder::...` paths.
🧪 Example: N/A - pure documentation link fix.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [3497472988483138076](https://jules.google.com/task/3497472988483138076) started by @madmax983*