### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/health.rs
+++ b/autumn/src/health.rs
@@ -290,4 +290,37 @@ mod tests {
 
         assert_eq!(json["version"], env!("CARGO_PKG_VERSION"));
     }
+
+    #[tokio::test]
+    async fn health_detailed_false_omits_details() {
+        let mut state = test_state();
+        state.health_detailed = false;
+
+        let app = axum::Router::new()
+            .route("/health", axum::routing::get(handler))
+            .with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["status"], "ok");
+        assert!(json.get("version").is_none());
+        assert!(json.get("profile").is_none());
+        assert!(json.get("uptime").is_none());
+        assert!(json.get("pool").is_none());
+    }
 }


### PR DESCRIPTION
🎯 **Target:** `autumn_web::health::handler` function logic governing what gets returned in a basic health check payload vs. a detailed payload.
💣 **Risk:** The previous lack of coverage meant that a logic change to the `detailed = false` flow could potentially leak sensitive or irrelevant application environment data in the basic health check JSON without tests catching the regression.
🧪 **Strategy:** Added a new unit test `health_detailed_false_omits_details` that constructs an `AppState` with `health_detailed = false`, initiates a mock request using `oneshot`, and verifies that the `Option` fields are serialized appropriately (omitted).
🔬 **Verification:** Run `cargo test -p autumn-web --lib health::tests::health_detailed_false_omits_details`

---
*PR created automatically by Jules for task [8350513213793861730](https://jules.google.com/task/8350513213793861730) started by @madmax983*