### PR TITLE
🌟 Nova: HxRequest Extractor

### DIFF
--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -12,6 +12,10 @@
 //! <script src="/static/js/htmx.min.js"></script>
 //! ```
 
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use std::convert::Infallible;
+
 /// htmx 2.x minified JavaScript, embedded at compile time.
 ///
 /// This is the raw byte content of the minified htmx library. It is
@@ -25,9 +29,67 @@ pub const HTMX_JS: &[u8] = include_bytes!("../vendor/htmx.min.js");
 /// Re-exported at the crate root as [`HTMX_VERSION`].
 pub const HTMX_VERSION: &str = "2.0.4";
 
+/// Extractor for htmx request headers.
+///
+/// Extracts the standard `hx-*` headers sent by htmx requests, enabling
+/// conditional rendering (e.g. sending back partials instead of full pages).
+///
+/// See <https://htmx.org/reference/#request_headers> for more details.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Default)]
+pub struct HxRequest {
+    /// Indicates that the request is via htmx (`HX-Request`)
+    pub is_htmx: bool,
+    /// The id of the target element if provided (`HX-Target`)
+    pub target: Option<String>,
+    /// The id of the triggered element if provided (`HX-Trigger`)
+    pub trigger: Option<String>,
+    /// The name of the triggered element if provided (`HX-Trigger-Name`)
+    pub trigger_name: Option<String>,
+    /// The current URL of the browser (`HX-Current-URL`)
+    pub current_url: Option<String>,
+    /// `true` if the request is for history restoration after a miss (`HX-History-Restore-Request`)
+    pub history_restore_request: bool,
+    /// The user response to an hx-prompt (`HX-Prompt`)
+    pub prompt: Option<String>,
+    /// `true` if the request is via an element using hx-boost (`HX-Boosted`)
+    pub boosted: bool,
+}
+
+impl<S> FromRequestParts<S> for HxRequest
+where
+    S: Send + Sync,
+{
+    type Rejection = Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let header_str = |name: &'static str| -> Option<String> {
+            parts
+                .headers
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .map(ToString::to_string)
+        };
+        let header_bool =
+            |name: &'static str| -> bool { parts.headers.get(name).is_some_and(|v| v == "true") };
+
+        Ok(Self {
+            is_htmx: header_bool("hx-request"),
+            target: header_str("hx-target"),
+            trigger: header_str("hx-trigger"),
+            trigger_name: header_str("hx-trigger-name"),
+            current_url: header_str("hx-current-url"),
+            history_restore_request: header_bool("hx-history-restore-request"),
+            prompt: header_str("hx-prompt"),
+            boosted: header_bool("hx-boosted"),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::http::Request;
 
     #[test]
     #[allow(clippy::const_is_empty)]
@@ -47,5 +109,39 @@ mod tests {
     #[test]
     fn htmx_version_matches_expected() {
         assert_eq!(HTMX_VERSION, "2.0.4");
+    }
+
+    #[tokio::test]
+    async fn hx_request_extractor_parses_headers() {
+        let req = Request::builder()
+            .header("hx-request", "true")
+            .header("hx-target", "my-div")
+            .header("hx-boosted", "true")
+            .body(())
+            .unwrap();
+        let (mut parts, ()) = req.into_parts();
+
+        let hx = HxRequest::from_request_parts(&mut parts, &())
+            .await
+            .unwrap();
+
+        assert!(hx.is_htmx);
+        assert_eq!(hx.target.as_deref(), Some("my-div"));
+        assert!(hx.boosted);
+        assert_eq!(hx.trigger, None);
+    }
+
+    #[tokio::test]
+    async fn hx_request_extractor_handles_missing_headers() {
+        let req = Request::builder().body(()).unwrap();
+        let (mut parts, ()) = req.into_parts();
+
+        let hx = HxRequest::from_request_parts(&mut parts, &())
+            .await
+            .unwrap();
+
+        assert!(!hx.is_htmx);
+        assert_eq!(hx.target, None);
+        assert!(!hx.boosted);
     }
 }

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -49,6 +49,9 @@ pub use crate::extract::Path;
 /// Flash message extractor.
 #[cfg(feature = "flash")]
 pub use crate::flash::{Flash, FlashLevel, FlashMessage};
+/// htmx request extractor.
+#[cfg(feature = "htmx")]
+pub use crate::htmx::HxRequest;
 
 // ── Error handling ───────────────────────────────────────────────
 /// Framework error and result types.


### PR DESCRIPTION
💡 **The Spark:** "I noticed we serve HTMX but don't have a structured way for Axum handlers to read `hx-*` headers (like `hx-target` or `hx-request`), meaning developers have to manually parse `axum::http::HeaderMap` for conditional rendering."
🚀 **The Feature:** "Implemented an `HxRequest` extractor implementing `FromRequestParts` that parses standard HTMX headers into a typed struct. Re-exported in the prelude."
🔮 **The Potential:** "Allows handlers to trivially return partial HTML or swap targets based on the request state instead of rendering full pages unnecessarily."
⚠️ **Risk:** "Low. Isolated additive code in `src/htmx.rs` and cleanly re-exported in the prelude."

---
*PR created automatically by Jules for task [4723633775996717061](https://jules.google.com/task/4723633775996717061) started by @madmax983*