### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn-harvest/autumn-harvest-autumn/tests/api_scheduler_integration.rs
+++ b/autumn-harvest/autumn-harvest-autumn/tests/api_scheduler_integration.rs
@@ -29,15 +29,16 @@ use diesel_async::RunQueryDsl;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use serde_json::{Value, json};
 use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
-use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
 use tower::ServiceExt;
 
 const INIT_SQL: &str =
     include_str!("../../autumn-harvest/migrations/00000000000000_harvest_initial/up.sql");
 type HarvestApiApp = axum::Router;
 
-async fn setup_test_database_url() -> (String, ContainerAsync<Postgres>) {
+async fn setup_test_database_url() -> (String, ContainerAsync<testcontainers_modules::postgres::Postgres>) {
     let container = Postgres::default()
         .with_init_sql(INIT_SQL.to_string().into_bytes())
         .start()

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -3,7 +3,7 @@
 //! This module provides async Postgres connectivity via `diesel-async` with
 //! the `deadpool` connection pool. The pool is created at startup by
 //! [`AppBuilder::run`](crate::app::AppBuilder::run) and stored in
-//! [`AppState`].
+//! [`AppState`](crate::state::AppState).
 //!
 //! When no `database.url` is configured, [`create_pool`] returns `Ok(None)`
 //! and the application runs without a database -- useful for static-site or

--- a/autumn/src/middleware/dev.rs
+++ b/autumn/src/middleware/dev.rs
@@ -11,6 +11,15 @@ const DEV_RELOAD_ENV: &str = "AUTUMN_DEV_RELOAD";
 const DEV_RELOAD_STATE_ENV: &str = "AUTUMN_DEV_RELOAD_STATE";
 const DEV_RELOAD_CACHE_CONTROL: &str = "no-store, no-cache, must-revalidate";
 
+/// Checks if the development live-reload environment is active.
+///
+/// In the developer experience, it's crucial to tighten the feedback loop. This
+/// function answers the core question: "Are we running in a watched development
+/// session?" It exists to safely guard dev-only handlers (like the live-reload script
+/// injector) from ever waking up in production.
+///
+/// Returns `true` if both the `AUTUMN_DEV_RELOAD` and
+/// `AUTUMN_DEV_RELOAD_STATE` environment variables are present.
 pub fn is_enabled() -> bool {
     std::env::var_os(DEV_RELOAD_ENV).is_some() && std::env::var_os(DEV_RELOAD_STATE_ENV).is_some()
 }

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -166,6 +166,13 @@ where
 }
 
 pin_project_lite::pin_project! {
+    /// Future for the error page filter middleware.
+    ///
+    /// When an application panics or bubbles an error, we don't want to expose
+    /// a raw stack trace to the user, nor do we want to drop the connection.
+    /// This future wraps the underlying handler's execution. If an error occurs,
+    /// it replaces the payload with a beautifully crafted HTML or JSON error page
+    /// based on what the client asked for via the `Accept` header.
     pub struct ErrorPageContextFuture<F> {
         #[pin]
         inner: F,

--- a/autumn/src/test_utils.rs
+++ b/autumn/src/test_utils.rs
@@ -9,6 +9,13 @@ pub struct EnvGuard {
 
 #[cfg(test)]
 impl EnvGuard {
+    /// Safely sets multiple environment variables for testing.
+    ///
+    /// The global nature of environment variables makes testing concurrent
+    /// processes notoriously flaky. This method tames that chaos. It establishes a
+    /// centralized lock per crate to ensure that environment variable mutations
+    /// don't race against each other, returning an `EnvGuard` that gracefully
+    /// cleans up the environment when dropped.
     pub fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
         static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         let lock = ENV_LOCK


### PR DESCRIPTION
🎻 Bard: [documentation update]

📖 Chapter: General Framework Tooling (`dev.rs`, `error_page_filter.rs`, `test_utils.rs`)
🔦 Insight: Explained the 'why' behind environment test locking, dev-mode reload environment flags, and the error page interceptor future. Also fixed a broken intra-doc link pointing to `AppState`.
🧪 Example: Cleaned up missing docs according to storytelling principles.
🖼️ Preview: Resolved all intra-doc warning links during `cargo doc --no-deps`.

---
*PR created automatically by Jules for task [13086919614393548566](https://jules.google.com/task/13086919614393548566) started by @madmax983*