### PR TITLE
⚒️ Forge: Remove dead_code allow in TaskStatus

### DIFF
--- a/autumn-cli/src/monitor.rs
+++ b/autumn-cli/src/monitor.rs
@@ -140,13 +140,10 @@ struct TaskStatus {
     #[serde(default)]
     status: String,
     #[serde(default)]
-    #[allow(dead_code)]
     last_run: Option<String>,
     #[serde(default)]
-    #[allow(dead_code)]
     last_duration_ms: Option<u64>,
     #[serde(default)]
-    #[allow(dead_code)]
     last_result: Option<String>,
     #[serde(default)]
     last_error: Option<String>,
@@ -878,6 +875,33 @@ fn draw_tasks_panel(frame: &mut ratatui::Frame, area: Rect, state: &DashboardSta
             } else {
                 Span::raw("")
             },
+            task.last_run.as_ref().map_or_else(
+                || Span::raw(""),
+                |run| {
+                    Span::styled(
+                        format!("  last run: {}", truncate(run, 20)),
+                        Style::default().fg(ratatui::style::Color::DarkGray),
+                    )
+                },
+            ),
+            task.last_duration_ms.map_or_else(
+                || Span::raw(""),
+                |dur| {
+                    Span::styled(
+                        format!("  {dur}ms"),
+                        Style::default().fg(ratatui::style::Color::DarkGray),
+                    )
+                },
+            ),
+            task.last_result.as_ref().map_or_else(
+                || Span::raw(""),
+                |res| {
+                    Span::styled(
+                        format!("  res: {}", truncate(res, 20)),
+                        Style::default().fg(ratatui::style::Color::DarkGray),
+                    )
+                },
+            ),
         ]));
 
         if let Some(err) = &task.last_error {


### PR DESCRIPTION
🚰 Smell
The `last_run`, `last_duration_ms`, and `last_result` fields in `TaskStatus` were marked with `#[allow(dead_code)]` and never used.

✨ Solution
Removed the `#[allow(dead_code)]` attributes and updated `draw_tasks_panel` to display these fields. Used `map_or_else` instead of `if let` for Clippy compliance.

🧹 Benefit
Exposes previously hidden task status information in the dashboard, improving visibility.

🛡️ Verification
- `cargo clippy --all-targets --all-features -- -D warnings` passed
- `cargo fmt --all` passed
- `cargo test -p autumn-cli` passed

---
*PR created automatically by Jules for task [6535421100180176869](https://jules.google.com/task/6535421100180176869) started by @madmax983*