### PR TITLE
👺 Havoc: [Fix UB in Concurrent Env Var Mutations]

### DIFF
--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -712,54 +712,7 @@ fn find_binary(package: Option<&str>) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    struct EnvGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        previous: Vec<(&'static str, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        fn set_many(entries: &[(&'static str, Option<&std::ffi::OsStr>)]) -> Self {
-            static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-            let lock = ENV_LOCK
-                .get_or_init(|| Mutex::new(()))
-                .lock()
-                .expect("env mutex poisoned");
-            let mut previous = Vec::with_capacity(entries.len());
-            for (key, value) in entries {
-                previous.push((*key, std::env::var(key).ok()));
-                match value {
-                    Some(value) => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::set_var(key, value) };
-                    }
-                    None => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::remove_var(key) };
-                    }
-                }
-            }
-            Self {
-                _lock: lock,
-                previous,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (key, previous) in self.previous.iter().rev() {
-                if let Some(previous) = previous {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::set_var(key, previous) };
-                } else {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::remove_var(key) };
-                }
-            }
-        }
-    }
+    use crate::test_utils::EnvGuard;
 
     // ── is_relevant_change tests ───────────────────────────────────
 

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+pub mod test_utils;
+
 use clap::{Parser, Subcommand};
 
 mod build;

--- a/autumn-cli/src/test_utils.rs
+++ b/autumn-cli/src/test_utils.rs
@@ -1,0 +1,51 @@
+use std::sync::{Mutex, OnceLock};
+
+pub struct EnvGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    previous: Vec<(&'static str, Option<String>)>,
+}
+
+impl EnvGuard {
+    /// # Panics
+    ///
+    /// Panics if the global mutex is poisoned by another test panicking while holding the lock.
+    pub fn set_many(entries: &[(&'static str, Option<&std::ffi::OsStr>)]) -> Self {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let lock = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env mutex poisoned");
+        let mut previous = Vec::with_capacity(entries.len());
+        for (key, value) in entries {
+            previous.push((*key, std::env::var(key).ok()));
+            match value {
+                Some(value) => {
+                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                    unsafe { std::env::set_var(key, value) };
+                }
+                None => {
+                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                    unsafe { std::env::remove_var(key) };
+                }
+            }
+        }
+        Self {
+            _lock: lock,
+            previous,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, previous) in self.previous.iter().rev() {
+            if let Some(previous) = previous {
+                // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                unsafe { std::env::set_var(key, previous) };
+            } else {
+                // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                unsafe { std::env::remove_var(key) };
+            }
+        }
+    }
+}

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1086,57 +1086,10 @@ async fn shutdown_signal() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::EnvGuard;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use std::sync::{Mutex, OnceLock};
     use tower::ServiceExt;
-
-    pub struct EnvGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        previous: Vec<(&'static str, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        pub fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
-            static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-            let lock = ENV_LOCK
-                .get_or_init(|| Mutex::new(()))
-                .lock()
-                .expect("env mutex poisoned");
-            let mut previous = Vec::with_capacity(entries.len());
-            for (key, value) in entries {
-                previous.push((*key, std::env::var(key).ok()));
-                match value {
-                    Some(value) => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::set_var(key, value) };
-                    }
-                    None => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::remove_var(key) };
-                    }
-                }
-            }
-            Self {
-                _lock: lock,
-                previous,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (key, previous) in self.previous.iter().rev() {
-                if let Some(previous) = previous {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::set_var(key, previous) };
-                } else {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::remove_var(key) };
-                }
-            }
-        }
-    }
 
     /// Helper to build a test router with default config and no database.
     pub fn test_router(routes: Vec<Route>) -> axum::Router {

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -621,6 +621,8 @@ pub mod state;
 )]
 pub mod test;
 pub use state::AppState;
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_utils;
 
 #[cfg(test)]
 mod tests {

--- a/autumn/src/middleware/dev.rs
+++ b/autumn/src/middleware/dev.rs
@@ -197,57 +197,10 @@ fn live_reload_script() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::EnvGuard;
     use axum::body::to_bytes;
     use axum::http::header::ACCEPT;
-    use std::sync::{Mutex, OnceLock};
     use tower::ServiceExt;
-
-    struct EnvGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        previous: Vec<(&'static str, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
-            static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-            let lock = ENV_LOCK
-                .get_or_init(|| Mutex::new(()))
-                .lock()
-                .expect("env mutex poisoned");
-            let mut previous = Vec::with_capacity(entries.len());
-            for (key, value) in entries {
-                previous.push((*key, std::env::var(key).ok()));
-                match value {
-                    Some(value) => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::set_var(key, value) };
-                    }
-                    None => {
-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                        unsafe { std::env::remove_var(key) };
-                    }
-                }
-            }
-            Self {
-                _lock: lock,
-                previous,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (key, previous) in self.previous.iter().rev() {
-                if let Some(previous) = previous {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::set_var(key, previous) };
-                } else {
-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
-                    unsafe { std::env::remove_var(key) };
-                }
-            }
-        }
-    }
 
     #[test]
     fn is_enabled_requires_both_env_vars() {

--- a/autumn/src/test_utils.rs
+++ b/autumn/src/test_utils.rs
@@ -1,0 +1,59 @@
+use std::sync::{Mutex, OnceLock};
+
+/// RAII guard for safely mutating process-wide environment variables in tests.
+///
+/// Because Cargo runs tests concurrently within the same process by default,
+/// mutating environment variables using `std::env::set_var` can cause undefined behavior
+/// or flaky tests. This struct serializes access to environment mutation using a static,
+/// cross-module Mutex lock.
+pub struct EnvGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    previous: Vec<(&'static str, Option<String>)>,
+}
+
+impl EnvGuard {
+    /// Sets many environment variables while acquiring the global lock.
+    ///
+    /// # Panics
+    /// Panics if the internal static mutex is poisoned.
+    pub fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let lock = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env mutex poisoned");
+
+        let mut previous = Vec::with_capacity(entries.len());
+        for (key, value) in entries {
+            previous.push((*key, std::env::var(key).ok()));
+            match value {
+                Some(value) => {
+                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                    unsafe { std::env::set_var(key, value) };
+                }
+                None => {
+                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                    unsafe { std::env::remove_var(key) };
+                }
+            }
+        }
+        Self {
+            _lock: lock,
+            previous,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, previous) in self.previous.iter().rev() {
+            if let Some(previous) = previous {
+                // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                unsafe { std::env::set_var(key, previous) };
+            } else {
+                // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+                unsafe { std::env::remove_var(key) };
+            }
+        }
+    }
+}

--- a/patch_env_guard_autumn_app.patch
+++ b/patch_env_guard_autumn_app.patch
@@ -1,0 +1,106 @@
+--- autumn/src/app.rs
++++ autumn/src/app.rs
+@@ -1091,48 +1091,3 @@
+-    use std::sync::{Mutex, OnceLock};
+     use tower::ServiceExt;
++    use crate::test_utils::EnvGuard;
+
+-    pub struct EnvGuard {
+-        _lock: std::sync::MutexGuard<'static, ()>,
+-        previous: Vec<(&'static str, Option<String>)>,
+-    }
+-
+-    impl EnvGuard {
+-        pub fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
+-            static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+-            let lock = ENV_LOCK
+-                .get_or_init(|| Mutex::new(()))
+-                .lock()
+-                .expect("env mutex poisoned");
+-            let mut previous = Vec::with_capacity(entries.len());
+-            for (key, value) in entries {
+-                previous.push((*key, std::env::var(key).ok()));
+-                match value {
+-                    Some(value) => {
+-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+-                        unsafe { std::env::set_var(key, value) };
+-                    }
+-                    None => {
+-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+-                        unsafe { std::env::remove_var(key) };
+-                    }
+-                }
+-            }
+-            Self {
+-                _lock: lock,
+-                previous,
+-            }
+-        }
+-    }
+-
+-    impl Drop for EnvGuard {
+-        fn drop(&mut self) {
+-            for (key, previous) in self.previous.iter().rev() {
+-                if let Some(previous) = previous {
+-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+-                    unsafe { std::env::set_var(key, previous) };
+-                } else {
+-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+-                    unsafe { std::env::remove_var(key) };
+-                }
+-            }
+-        }
+-    }
+--- autumn/src/middleware/dev.rs
++++ autumn/src/middleware/dev.rs
+@@ -202,48 +202,3 @@
+-    use std::sync::{Mutex, OnceLock};
+     use tower::ServiceExt;
++    use crate::test_utils::EnvGuard;
+
+-    struct EnvGuard {
+-        _lock: std::sync::MutexGuard<'static, ()>,
+-        previous: Vec<(&'static str, Option<String>)>,
+-    }
+-
+-    impl EnvGuard {
+-        fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
+-            static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+-            let lock = ENV_LOCK
+-                .get_or_init(|| Mutex::new(()))
+-                .lock()
+-                .expect("env mutex poisoned");
+-            let mut previous = Vec::with_capacity(entries.len());
+-            for (key, value) in entries {
+-                previous.push((*key, std::env::var(key).ok()));
+-                match value {
+-                    Some(value) => {
+-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+-                        unsafe { std::env::set_var(key, value) };
+-                    }
+-                    None => {
+-                        // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+-                        unsafe { std::env::remove_var(key) };
+-                    }
+-                }
+-            }
+-            Self {
+-                _lock: lock,
+-                previous,
+-            }
+-        }
+-    }
+-
+-    impl Drop for EnvGuard {
+-        fn drop(&mut self) {
+-            for (key, previous) in self.previous.iter().rev() {
+-                if let Some(previous) = previous {
+-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+-                    unsafe { std::env::set_var(key, previous) };
+-                } else {
+-                    // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.
+-                    unsafe { std::env::remove_var(key) };
+-                }
+-            }
+-        }
+-    }


### PR DESCRIPTION
🧨 **The Trigger:** Multiple independent `EnvGuard` Mutexes modifying the global `std::env` state using `unsafe` blocks.
📉 **The Stack Trace:** (None, it triggers undefined behavior in cross-module thread execution).
🧪 **Reproduction:** Run cargo tests with highly concurrent environments spanning both `app.rs` and `middleware/dev.rs`.
😈 **Comment:** You assumed `static ENV_LOCK` in an individual module would protect the global process environment variable state. You were wrong. I centralized it into `test_utils.rs` so all test modules synchronize on the exact same lock.

---
*PR created automatically by Jules for task [15969991101948270491](https://jules.google.com/task/15969991101948270491) started by @madmax983*