### PR TITLE
🔭 Vantage: Spec for Error Page Overrides

### DIFF
--- a/docs/stories/S-050-error-page-overrides.md
+++ b/docs/stories/S-050-error-page-overrides.md
@@ -1,0 +1,56 @@
+# 🔭 Vantage: Spec for Error Page Overrides
+
+**Epic:** EPIC-011 (v1.0 Security & Stability)
+**Priority:** Should Have
+**Story Points:** 5
+**Status:** Not Started
+**Assigned To:** markm
+**Created:** 2026-03-31
+**Sprint:** Backlog
+
+---
+
+## User Story
+
+👤 **User Story:** As a Frontend Developer, I want sensible, default-styled error pages (like 404 and 500) and a straightforward mechanism to override them with my own custom templates, so that users experience a cohesive brand identity even when things go wrong.
+
+---
+
+## The "So What?" Ask
+
+What business problem does this solve?
+When users hit a 404 or a 500 error, seeing an unstyled, raw text error or a generic browser default breaks trust and feels unprofessional. Providing a default styled error page out of the box makes the application feel production-ready immediately. Allowing developers to easily override these pages ensures that businesses can maintain their brand identity across the entire user experience without needing to build custom routing solutions just to catch and display errors.
+
+---
+
+## Gap Analysis
+
+Look at the market:
+- **Spring Boot:** Provides a `/error` endpoint and a Whitelabel Error Page, which can be easily overridden by placing an `error.html` template in standard directories.
+- **Rails:** Provides default error pages in the `public/` folder (`404.html`, `500.html`) which can be edited directly.
+- **Our Gap:** Currently, Autumn relies on generic error handling or raw text responses when requests fail. We need a framework-native way to render styled HTML error pages by default and a clean extension point for developers to supply custom views.
+
+---
+
+## Acceptance Criteria
+
+✅ **Acceptance Criteria:**
+- Must provide a default, styled 404 Not Found page that includes the requested path to help users understand what went wrong.
+- Must provide a default, styled 500 Internal Server Error page that includes the Request ID (but safely hides sensitive error details) for easy debugging.
+- Must expose a documented extension mechanism that developers can use to supply custom views for different HTTP status codes.
+- Must ensure that JSON API requests never receive HTML error pages, but instead receive structured JSON errors so that integrations do not break.
+- Must be configurable globally when bootstrapping the application.
+
+---
+
+## Metric Definition
+
+Success = An unconfigured Autumn app returns a visually styled HTML page for 404/500 errors, and a developer can replace this default with a custom view in under 10 lines of configuration.
+
+---
+
+## Out of Scope
+
+🚫 **Out of Scope:**
+- Creating a generic template loading system from the file system at runtime.
+- Complex internationalization (i18n) of the default error pages (Phase 2).


### PR DESCRIPTION
This PR defines the product requirements for the "Error Page Overrides" feature, prioritizing the UX and "Jobs to be Done" of rendering styled errors for broken requests without dictating engineering decisions like traits or macros.

It is part of Epic EPIC-011 and satisfies FR-045. No code changes are introduced, adhering to the PM constraints.

---
*PR created automatically by Jules for task [17589302343803308240](https://jules.google.com/task/17589302343803308240) started by @madmax983*