### PR TITLE
🔒 Warden: [security fix]

### DIFF
--- a/autumn-harvest/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/autumn-harvest/Cargo.toml
@@ -45,3 +45,7 @@ testcontainers-modules = { workspace = true }
 
 [lints]
 workspace = true
+
+[[test]]
+name = "security"
+path = "tests/security/sql_injection.rs"

--- a/autumn-harvest/autumn-harvest/src/notify.rs
+++ b/autumn-harvest/autumn-harvest/src/notify.rs
@@ -65,13 +65,9 @@ pub async fn notify_task_enqueued(
     let payload = serde_json::to_string(&NotifyPayload { task_id })
         .map_err(|e| HarvestError::Database(format!("failed to serialize notify payload: {e}")))?;
 
-    // Postgres NOTIFY requires the channel as an identifier (not a parameter),
-    // so we must format it into the SQL string. The channel name is derived from
-    // our own queue_channel() function which only produces [a-z0-9_] characters,
-    // so this is safe from injection.
-    let sql = format!("NOTIFY {channel}, '{payload}'");
-
-    diesel::sql_query(sql)
+    diesel::sql_query("SELECT pg_notify($1, $2)")
+        .bind::<diesel::sql_types::Text, _>(channel)
+        .bind::<diesel::sql_types::Text, _>(payload)
         .execute(conn)
         .await
         .map_err(crate::error::database_error)?;

--- a/autumn-harvest/autumn-harvest/tests/security/sql_injection.rs
+++ b/autumn-harvest/autumn-harvest/tests/security/sql_injection.rs
@@ -1,0 +1,35 @@
+use autumn_harvest::notify::notify_task_enqueued;
+use diesel_async::{AsyncConnection, AsyncPgConnection};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn test_notify_sql_injection() {
+    let url = std::env::var("POSTGRES_URL")
+        .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/postgres".to_string());
+
+    // Attempt to connect. If it fails (e.g. no local postgres), we skip the test.
+    let mut conn = match AsyncPgConnection::establish(&url).await {
+        Ok(c) => c,
+        Err(_) => {
+            println!("Skipping test_notify_sql_injection: Postgres not available");
+            return;
+        }
+    };
+
+    // Before fix, this would execute pg_sleep(2)
+    let malicious_queue = "test', 'payload'); SELECT pg_sleep(2); --";
+
+    let task_id = Uuid::new_v4();
+    let start = std::time::Instant::now();
+    let result = notify_task_enqueued(&mut conn, malicious_queue, task_id).await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_ok(),
+        "Failed to execute pg_notify with malicious queue name"
+    );
+    assert!(
+        elapsed.as_secs() < 1,
+        "SQL Injection succeeded! The query slept."
+    );
+}


### PR DESCRIPTION
🦠 **Threat:** SQL injection vulnerability in the Postgres NOTIFY command due to string interpolation of queue names.
🛡️ **Defense:** Refactored `notify_task_enqueued` to use `SELECT pg_notify($1, $2)` with parameter binding.
💥 **Severity:** High - An attacker controlling the queue name could execute arbitrary SQL statements (e.g., via `pg_sleep` or table drops).
🧪 **Verification:** Added integration test `tests/security/sql_injection.rs` that validates malicious input is handled safely without execution.

---
*PR created automatically by Jules for task [11114719458791665630](https://jules.google.com/task/11114719458791665630) started by @madmax983*