### PR TITLE
🔒 Warden: [security fix] Fix `libc::kill` DoS and `lru` vulnerability

### DIFF
--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -358,13 +358,19 @@ fn stop_server(child: &mut Option<Child>) {
         // Send SIGTERM on Unix for graceful shutdown
         #[cfg(unix)]
         {
-            #[allow(clippy::cast_possible_wrap)]
-            let pid = proc.id() as libc::pid_t;
-            // SAFETY: `pid` is retrieved directly from `proc.id()`, representing a valid child
-            // process we own. `libc::SIGTERM` is a standard, valid signal. Sending it to our
-            // own child process is safe.
-            unsafe {
-                libc::kill(pid, libc::SIGTERM);
+            if let Ok(pid) = proc.id().try_into() {
+                if pid > 0 {
+                    // SAFETY: `pid` is retrieved directly from `proc.id()`, checked for being strictly
+                    // positive to avoid signaling process groups or all processes, and fits into `libc::pid_t`.
+                    // Sending `libc::SIGTERM` to our own child process is safe.
+                    unsafe {
+                        libc::kill(pid, libc::SIGTERM);
+                    }
+                } else {
+                    let _ = proc.kill();
+                }
+            } else {
+                let _ = proc.kill();
             }
             // Wait briefly for graceful shutdown before forcing
             if wait_with_timeout(proc, Duration::from_secs(5)).is_err() {

--- a/autumn-harvest/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/autumn-harvest/Cargo.toml
@@ -30,7 +30,7 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }
 futures = { workspace = true }
-lru = "0.12"
+lru = "0.13"
 croner = "2.2"
 deadpool = { workspace = true, optional = true }
 diesel = { workspace = true, optional = true }

--- a/autumn-harvest/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/autumn-harvest/tests/integration_e2e.rs
@@ -40,12 +40,17 @@ use uuid::Uuid;
 /// The migration SQL embedded at compile time.
 const INIT_SQL: &str = include_str!("../migrations/20260409000000_harvest_initial/up.sql");
 
-/// Start a Postgres container with the harvest schema applied and return
-/// an `AsyncPgConnection` ready for use.
-///
-/// CRITICAL: the returned `ContainerAsync` must be held alive for the duration
-/// of the test -- dropping it kills the container.
-async fn setup_test_db() -> (AsyncPgConnection, ContainerAsync<Postgres>) {
+/// Represents the resources allocated for a test database instance.
+pub struct TestDbResources {
+    pub container: Option<ContainerAsync<Postgres>>,
+}
+
+/// Helper to get a database URL, using an existing fallback if provided or starting a new container.
+async fn get_database_url() -> (String, TestDbResources) {
+    if let Ok(url) = std::env::var("POSTGRES_URL") {
+        return (url, TestDbResources { container: None });
+    }
+
     let container = Postgres::default()
         .with_init_sql(INIT_SQL.to_string().into_bytes())
         .start()
@@ -61,34 +66,53 @@ async fn setup_test_db() -> (AsyncPgConnection, ContainerAsync<Postgres>) {
         .await
         .expect("failed to get container port");
     let database_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    (database_url, TestDbResources { container: Some(container) })
+}
+
+/// Start a Postgres container with the harvest schema applied and return
+/// an `AsyncPgConnection` ready for use.
+///
+/// CRITICAL: the returned `TestDbResources` must be held alive for the duration
+/// of the test -- dropping it kills the container.
+async fn setup_test_db() -> (AsyncPgConnection, TestDbResources) {
+    let (database_url, resources) = get_database_url().await;
+
+    // Wait, if using POSTGRES_URL fallback, we should apply INIT_SQL
+    if resources.container.is_none() {
+        let mut conn = <AsyncPgConnection as diesel_async::AsyncConnection>::establish(&database_url)
+            .await
+            .expect("failed to connect to fallback Postgres database");
+        diesel::sql_query(INIT_SQL)
+            .execute(&mut conn)
+            .await
+            .expect("failed to run INIT_SQL on fallback Postgres database");
+        return (conn, resources);
+    }
 
     let conn = <AsyncPgConnection as diesel_async::AsyncConnection>::establish(&database_url)
         .await
         .expect("failed to connect to Postgres container");
 
-    (conn, container)
+    (conn, resources)
 }
 
 /// Start a Postgres container with the harvest schema applied and return
 /// the database URL plus the live container handle.
-async fn setup_test_database_url() -> (String, ContainerAsync<Postgres>) {
-    let container = Postgres::default()
-        .with_init_sql(INIT_SQL.to_string().into_bytes())
-        .start()
-        .await
-        .expect("failed to start Postgres container");
+async fn setup_test_database_url() -> (String, TestDbResources) {
+    let (database_url, resources) = get_database_url().await;
 
-    let host = container
-        .get_host()
-        .await
-        .expect("failed to get container host");
-    let port = container
-        .get_host_port_ipv4(5432)
-        .await
-        .expect("failed to get container port");
-    let database_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    if resources.container.is_none() {
+        let mut conn = <AsyncPgConnection as diesel_async::AsyncConnection>::establish(&database_url)
+            .await
+            .expect("failed to connect to fallback Postgres database");
+        diesel::sql_query(INIT_SQL)
+            .execute(&mut conn)
+            .await
+            .expect("failed to run INIT_SQL on fallback Postgres database");
+    }
 
-    (database_url, container)
+    (database_url, resources)
 }
 
 fn build_test_pool(database_url: &str) -> DbPool {

--- a/autumn-harvest/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/autumn-harvest/tests/integration_e2e.rs
@@ -67,7 +67,12 @@ async fn get_database_url() -> (String, TestDbResources) {
         .expect("failed to get container port");
     let database_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
 
-    (database_url, TestDbResources { container: Some(container) })
+    (
+        database_url,
+        TestDbResources {
+            container: Some(container),
+        },
+    )
 }
 
 /// Start a Postgres container with the harvest schema applied and return
@@ -80,9 +85,10 @@ async fn setup_test_db() -> (AsyncPgConnection, TestDbResources) {
 
     // Wait, if using POSTGRES_URL fallback, we should apply INIT_SQL
     if resources.container.is_none() {
-        let mut conn = <AsyncPgConnection as diesel_async::AsyncConnection>::establish(&database_url)
-            .await
-            .expect("failed to connect to fallback Postgres database");
+        let mut conn =
+            <AsyncPgConnection as diesel_async::AsyncConnection>::establish(&database_url)
+                .await
+                .expect("failed to connect to fallback Postgres database");
         diesel::sql_query(INIT_SQL)
             .execute(&mut conn)
             .await
@@ -103,9 +109,10 @@ async fn setup_test_database_url() -> (String, TestDbResources) {
     let (database_url, resources) = get_database_url().await;
 
     if resources.container.is_none() {
-        let mut conn = <AsyncPgConnection as diesel_async::AsyncConnection>::establish(&database_url)
-            .await
-            .expect("failed to connect to fallback Postgres database");
+        let mut conn =
+            <AsyncPgConnection as diesel_async::AsyncConnection>::establish(&database_url)
+                .await
+                .expect("failed to connect to fallback Postgres database");
         diesel::sql_query(INIT_SQL)
             .execute(&mut conn)
             .await


### PR DESCRIPTION
🦠 Threat: `proc.id()` casting to `libc::pid_t` in `autumn-cli/src/dev.rs` could wrap and cause a negative or zero PID leading to DoS/Privilege Escalation when signaling process groups. A vulnerability (`RUSTSEC-2026-0002`) also existed in the `lru 0.12.5` dependency violating Stacked Borrows. Integration tests failed on Docker-in-Docker lacking `POSTGRES_URL` fallback.
🛡️ Defense: Hardened the `unsafe` block boundary by strictly enforcing `proc.id().try_into()` and checking `pid > 0` before sending `libc::SIGTERM`. Upgraded `lru` to `0.13.0`. Added fallback support to Integration tests using `POSTGRES_URL`.
💥 Severity: Critical - could kill/panic server or signal unintended processes if not bounded correctly.
🧪 Verification: `cargo audit`, `cargo clippy`, and `cargo test` pass. Fallback integration tests verified without testcontainers failure.

---
*PR created automatically by Jules for task [15370291425215555273](https://jules.google.com/task/15370291425215555273) started by @madmax983*