### PR TITLE
⚒️ Forge: Refactor CSRF verification logic and test state

### DIFF
--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -273,68 +273,10 @@ where
         std::mem::swap(&mut self.inner, &mut inner);
 
         Box::pin(async move {
-            if !is_safe {
-                // 1. Check header
-                let mut token_found = false;
-
-                let header_token = req
-                    .headers()
-                    .get(&settings.token_header)
-                    .and_then(|v| v.to_str().ok())
-                    .map(str::to_owned);
-
-                if let (Some(c), Some(h)) = (&cookie_token, &header_token) {
-                    if !c.is_empty() && !h.is_empty() && constant_time_eq(c, h) {
-                        token_found = true;
-                    }
-                }
-
-                // 2. Check form field (if not found in header)
-                if !token_found {
-                    let content_type = req
-                        .headers()
-                        .get(http::header::CONTENT_TYPE)
-                        .and_then(|v| v.to_str().ok())
-                        .unwrap_or_default();
-
-                    if content_type.starts_with("application/x-www-form-urlencoded") {
-                        let (parts, body) = req.into_parts();
-                        // Limit body size to avoid DoS when extracting form field
-                        let bytes = axum::body::to_bytes(body, 2 * 1024 * 1024)
-                            .await
-                            .unwrap_or_else(|_| axum::body::Bytes::new());
-
-                        if let Ok(body_str) = std::str::from_utf8(&bytes) {
-                            for pair in body_str.split('&') {
-                                if let Some((key, value)) = pair.split_once('=') {
-                                    if key == settings.form_field {
-                                        // Simple URL decoding by replacing + with space and % encoded chars
-                                        // Note: CSRF tokens are UUIDs, so they shouldn't contain special chars anyway
-                                        if let Some(c) = &cookie_token {
-                                            if !c.is_empty()
-                                                && !value.is_empty()
-                                                && constant_time_eq(c, value)
-                                            {
-                                                token_found = true;
-                                            }
-                                        }
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-
-                        // Reconstruct request
-                        req = Request::from_parts(parts, axum::body::Body::from(bytes));
-                    }
-                }
-
-                if !token_found {
-                    // Validation failed, reject immediately
-                    let mut response = Response::new(ResBody::default());
-                    *response.status_mut() = StatusCode::FORBIDDEN;
-                    return Ok(response);
-                }
+            if !is_safe && !verify_csrf_token(&mut req, &settings, cookie_token.as_deref()).await {
+                let mut response = Response::new(ResBody::default());
+                *response.status_mut() = StatusCode::FORBIDDEN;
+                return Ok(response);
             }
 
             // Validation passed (or method is safe)
@@ -349,6 +291,69 @@ where
             Ok(response)
         })
     }
+}
+
+async fn verify_csrf_token(
+    req: &mut Request<axum::body::Body>,
+    settings: &CsrfSettings,
+    cookie_token: Option<&str>,
+) -> bool {
+    let mut token_found = false;
+
+    // 1. Check header
+    let header_token = req
+        .headers()
+        .get(&settings.token_header)
+        .and_then(|v| v.to_str().ok());
+
+    if let (Some(c), Some(h)) = (cookie_token, header_token) {
+        if !c.is_empty() && !h.is_empty() && constant_time_eq(c, h) {
+            token_found = true;
+        }
+    }
+
+    if token_found {
+        return true;
+    }
+
+    // 2. Check form field (if not found in header)
+    let content_type = req
+        .headers()
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+
+    if !content_type.starts_with("application/x-www-form-urlencoded") {
+        return false;
+    }
+
+    // Temporarily take ownership of the body
+    let body = std::mem::replace(req.body_mut(), axum::body::Body::empty());
+
+    // Limit body size to avoid DoS when extracting form field
+    let bytes = axum::body::to_bytes(body, 2 * 1024 * 1024)
+        .await
+        .unwrap_or_else(|_| axum::body::Bytes::new());
+
+    if let Ok(body_str) = std::str::from_utf8(&bytes) {
+        for pair in body_str.split('&') {
+            if let Some((key, value)) = pair.split_once('=') {
+                if key == settings.form_field {
+                    if let Some(c) = cookie_token {
+                        if !c.is_empty() && !value.is_empty() && constant_time_eq(c, value) {
+                            token_found = true;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    // Restore request body
+    *req.body_mut() = axum::body::Body::from(bytes);
+
+    token_found
 }
 
 #[cfg(test)]

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -931,21 +931,8 @@ mod tests {
         assert!(cookie_str.contains("autumn.sid="));
     }
 
-    #[tokio::test]
-    async fn session_layer_persists_data_across_requests() {
-        use crate::state::AppState;
-        async fn write_handler(session: Session) -> String {
-            session.insert("user", "alice").await;
-            "saved".to_owned()
-        }
-
-        async fn read_handler(session: Session) -> String {
-            session.get("user").await.unwrap_or_default()
-        }
-
-        let store = MemoryStore::new();
-        let config = SessionConfig::default();
-        let state = AppState {
+    fn test_state() -> crate::state::AppState {
+        crate::state::AppState {
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -960,7 +947,23 @@ mod tests {
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "ws")]
             shutdown: tokio_util::sync::CancellationToken::new(),
-        };
+        }
+    }
+
+    #[tokio::test]
+    async fn session_layer_persists_data_across_requests() {
+        async fn write_handler(session: Session) -> String {
+            session.insert("user", "alice").await;
+            "saved".to_owned()
+        }
+
+        async fn read_handler(session: Session) -> String {
+            session.get("user").await.unwrap_or_default()
+        }
+
+        let store = MemoryStore::new();
+        let config = SessionConfig::default();
+        let state = test_state();
 
         let app = Router::new()
             .route("/write", get(write_handler))
@@ -1010,28 +1013,12 @@ mod tests {
 
     #[tokio::test]
     async fn session_destroy_expires_cookie() {
-        use crate::state::AppState;
         async fn handler(session: Session) -> String {
             session.destroy().await;
             "destroyed".to_owned()
         }
 
-        let state = AppState {
-            #[cfg(feature = "db")]
-            pool: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: false,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-        };
+        let state = test_state();
 
         let store = MemoryStore::new();
         store


### PR DESCRIPTION
⚒️ Forge: Refactor CSRF verification logic and test state

🚮 Smell: The `call` method in `autumn/src/security/csrf.rs` was a deeply nested God Function filled with `if let` blocks and complex body parsing logic (the "Pyramid of Doom"). Also, test boilerplate in `autumn/src/session.rs` was repeatedly declaring a large `AppState`.
✨ Solution: Extracted the token verification logic in `csrf.rs` into a neat, private async helper function `verify_csrf_token()`. Leveraged `std::mem::replace` on `req.body_mut()` instead of `into_parts`/`from_parts` to keep the request intact. Added a `test_state()` function to the session tests.
🧼 Benefit: Greatly reduces cognitive load, keeps the code flat using early returns, and eliminates the unnecessary `req.into_parts()` allocation shuffle. Test code is much cleaner.
🛡️ Verification: Tests passed. No logic changed. All tests run cleanly.

---
*PR created automatically by Jules for task [17324426789789004052](https://jules.google.com/task/17324426789789004052) started by @madmax983*