### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/security/headers.rs
+++ b/autumn/src/security/headers.rs
@@ -307,6 +307,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn referrer_policy_when_configured() {
+        let config = HeadersConfig {
+            referrer_policy: "strict-origin-when-cross-origin".to_owned(),
+            ..Default::default()
+        };
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(SecurityHeadersLayer::from_config(&config));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.headers().get("referrer-policy").unwrap(),
+            "strict-origin-when-cross-origin"
+        );
+    }
+
+    #[tokio::test]
     async fn permissions_policy_when_configured() {
         let config = HeadersConfig {
             permissions_policy: "camera=(), microphone=()".to_owned(),


### PR DESCRIPTION
🎯 **Target**: `autumn/src/security/headers.rs` (`ComputedHeaders::from_config`)
💣 **Risk**: The branch responsible for injecting the `Referrer-Policy` header into the computed security headers based on the `HeadersConfig` was untested. A regression here would result in applications deploying without the intended referrer policy security controls.
🧪 **Strategy**: Added a standard integration-style `axum` test (`referrer_policy_when_configured`) inside the `tests` module that builds the `SecurityHeadersLayer` with a strict referrer policy, triggers a request, and asserts that the resulting response correctly includes the `"referrer-policy"` header.
🔬 **Verification**: `cargo test -p autumn-web --lib security::headers::tests`

---
*PR created automatically by Jules for task [5874610828233898675](https://jules.google.com/task/5874610828233898675) started by @madmax983*