### PR TITLE
🧹 Code Health: Improve TaskStatus usage in monitor

### DIFF
--- a/autumn-cli/src/monitor.rs
+++ b/autumn-cli/src/monitor.rs
@@ -140,13 +140,10 @@ struct TaskStatus {
     #[serde(default)]
     status: String,
     #[serde(default)]
-    #[allow(dead_code)]
     last_run: Option<String>,
     #[serde(default)]
-    #[allow(dead_code)]
     last_duration_ms: Option<u64>,
     #[serde(default)]
-    #[allow(dead_code)]
     last_result: Option<String>,
     #[serde(default)]
     last_error: Option<String>,
@@ -879,6 +876,35 @@ fn draw_tasks_panel(frame: &mut ratatui::Frame, area: Rect, state: &DashboardSta
                 Span::raw("")
             },
         ]));
+
+        if task.last_run.is_some() || task.last_duration_ms.is_some() || task.last_result.is_some()
+        {
+            let mut run_info = vec![Span::raw("  ")];
+            if let Some(last_run) = &task.last_run {
+                run_info.push(Span::styled(
+                    format!("last run: {last_run}"),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+            if let Some(dur) = task.last_duration_ms {
+                run_info.push(Span::styled(
+                    format!(" ({dur}ms)"),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+            if let Some(res) = &task.last_result {
+                run_info.push(Span::raw(" ["));
+                let res_color =
+                    if res.eq_ignore_ascii_case("ok") || res.eq_ignore_ascii_case("success") {
+                        Color::Green
+                    } else {
+                        Color::Yellow
+                    };
+                run_info.push(Span::styled(res, Style::default().fg(res_color)));
+                run_info.push(Span::raw("]"));
+            }
+            lines.push(Line::from(run_info));
+        }
 
         if let Some(err) = &task.last_error {
             lines.push(Line::from(vec![


### PR DESCRIPTION
🎯 **What:** Removed `#[allow(dead_code)]` from `TaskStatus` fields (`last_run`, `last_duration_ms`, `last_result`) and integrated them into the TUI dashboard display. Also added `#[allow(dead_code)]` to the unused `available_levels` field in `LoggersResponse` to fix clippy warnings.
💡 **Why:** The fields in `TaskStatus` were previously unused despite being deserialized. By integrating them into the UI, we not only resolve the dead code warning but also provide more detailed task execution history to the user.
✅ **Verification:** Ran `cargo test -p autumn-cli --bin autumn`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt`. All checks passed successfully.
✨ **Result:** `TaskStatus` is now fully utilized in the TUI, providing better visibility into scheduled tasks, and the codebase compiles cleanly without dead code warnings.

---
*PR created automatically by Jules for task [12878405628861377111](https://jules.google.com/task/12878405628861377111) started by @madmax983*