### PR TITLE
feat: add harvest topology escape hatches

### DIFF
--- a/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/madmax983/autumn-harvest"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 thiserror = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/autumn-harvest/autumn-harvest/migrations/20260409000000_harvest_initial/up.sql
+++ b/autumn-harvest/autumn-harvest/migrations/20260409000000_harvest_initial/up.sql
@@ -26,7 +26,7 @@ CREATE TABLE harvest_workflow_executions (
     memo                JSONB,
     search_attrs        JSONB,
     created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    UNIQUE (workflow_id, run_id)
+    UNIQUE (workflow_name, workflow_id)
 );
 
 CREATE INDEX idx_harvest_we_shard  ON harvest_workflow_executions (shard_id);

--- a/autumn-harvest/autumn-harvest/migrations/20260410010000_harvest_workflow_start_uniqueness/down.sql
+++ b/autumn-harvest/autumn-harvest/migrations/20260410010000_harvest_workflow_start_uniqueness/down.sql
@@ -1,0 +1,24 @@
+-- Revert to the legacy workflow execution uniqueness key.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'harvest_workflow_executions'::regclass
+          AND conname = 'harvest_workflow_executions_workflow_name_workflow_id_key'
+    ) THEN
+        ALTER TABLE harvest_workflow_executions
+            DROP CONSTRAINT harvest_workflow_executions_workflow_name_workflow_id_key;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'harvest_workflow_executions'::regclass
+          AND conname = 'harvest_workflow_executions_workflow_id_run_id_key'
+    ) THEN
+        ALTER TABLE harvest_workflow_executions
+            ADD CONSTRAINT harvest_workflow_executions_workflow_id_run_id_key
+            UNIQUE (workflow_id, run_id);
+    END IF;
+END $$;

--- a/autumn-harvest/autumn-harvest/migrations/20260410010000_harvest_workflow_start_uniqueness/up.sql
+++ b/autumn-harvest/autumn-harvest/migrations/20260410010000_harvest_workflow_start_uniqueness/up.sql
@@ -1,0 +1,29 @@
+-- Add the uniqueness key required by idempotent workflow starts.
+--
+-- Existing databases may have applied the initial Harvest migration when the
+-- only workflow execution uniqueness key was `(workflow_id, run_id)`. The
+-- runtime now uses `ON CONFLICT (workflow_name, workflow_id)`, so upgrade those
+-- databases while no-oping cleanly on fresh installs that already have it.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'harvest_workflow_executions'::regclass
+          AND conname = 'harvest_workflow_executions_workflow_id_run_id_key'
+    ) THEN
+        ALTER TABLE harvest_workflow_executions
+            DROP CONSTRAINT harvest_workflow_executions_workflow_id_run_id_key;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'harvest_workflow_executions'::regclass
+          AND conname = 'harvest_workflow_executions_workflow_name_workflow_id_key'
+    ) THEN
+        ALTER TABLE harvest_workflow_executions
+            ADD CONSTRAINT harvest_workflow_executions_workflow_name_workflow_id_key
+            UNIQUE (workflow_name, workflow_id);
+    END IF;
+END $$;

--- a/autumn-harvest/autumn-harvest/src/execution.rs
+++ b/autumn-harvest/autumn-harvest/src/execution.rs
@@ -1,0 +1,151 @@
+//! Workflow execution persistence helpers.
+//!
+//! The public start helper in this module gives callers idempotent workflow
+//! start semantics scoped to `(workflow_name, workflow_id)`.
+
+use chrono::Utc;
+use diesel::ExpressionMethods;
+use diesel::OptionalExtension;
+use diesel::QueryDsl;
+use diesel::SelectableHelper;
+use diesel_async::AsyncConnection;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use scoped_futures::ScopedFutureExt;
+use uuid::Uuid;
+
+use crate::error::{HarvestError, HarvestResult, database_error};
+use crate::event::WorkflowEvent;
+use crate::models::{NewWorkflowExecution, WorkflowExecution};
+use crate::queue::{self, EnqueueParams, TaskType};
+use crate::schema::harvest_workflow_executions;
+use crate::store;
+use crate::types::ExecutionId;
+
+/// Parameters for starting a workflow execution.
+#[derive(Debug, Clone)]
+pub struct StartWorkflowParams<'a> {
+    pub workflow_name: &'a str,
+    pub workflow_id: &'a str,
+    pub shard_id: i32,
+    pub input: serde_json::Value,
+    pub parent_id: Option<Uuid>,
+    pub queue_name: &'a str,
+    pub execution_timeout: Option<chrono::Duration>,
+    pub memo: Option<serde_json::Value>,
+    pub search_attrs: Option<serde_json::Value>,
+}
+
+/// Result of an idempotent workflow start attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StartedWorkflowExecution {
+    pub exec_id: ExecutionId,
+    pub workflow_name: String,
+    pub workflow_id: String,
+    pub state: String,
+    pub created: bool,
+}
+
+impl StartedWorkflowExecution {
+    fn from_row(execution: WorkflowExecution, created: bool) -> Self {
+        Self {
+            exec_id: ExecutionId::from_uuid(execution.id),
+            workflow_name: execution.workflow_name,
+            workflow_id: execution.workflow_id,
+            state: execution.state,
+            created,
+        }
+    }
+}
+
+/// Start a workflow execution or load the existing one if the same
+/// `(workflow_name, workflow_id)` has already been published.
+///
+/// New starts insert the execution row, append `WorkflowStarted`, and enqueue
+/// the initial workflow task in one transaction. Duplicate starts return the
+/// previously-created execution without appending extra events or queue work.
+///
+/// # Errors
+///
+/// Returns [`HarvestError::Database`] for insert/query failures and propagates
+/// queue/event-store failures from the new-start transaction.
+pub async fn start_or_load_workflow_execution(
+    conn: &mut AsyncPgConnection,
+    request: StartWorkflowParams<'_>,
+) -> HarvestResult<StartedWorkflowExecution> {
+    let exec_id = ExecutionId::new();
+    let row = NewWorkflowExecution {
+        id: exec_id.as_uuid(),
+        workflow_name: request.workflow_name,
+        workflow_id: request.workflow_id,
+        run_id: Uuid::new_v4(),
+        shard_id: request.shard_id,
+        input: request.input.clone(),
+        parent_id: request.parent_id,
+        queue_name: request.queue_name,
+        execution_timeout: request.execution_timeout,
+        memo: request.memo.clone(),
+        search_attrs: request.search_attrs.clone(),
+    };
+    let mut enqueue = EnqueueParams::new(
+        request.queue_name.to_owned(),
+        TaskType::Workflow,
+        request.input.clone(),
+    );
+    enqueue.workflow_exec_id = Some(exec_id.as_uuid());
+
+    conn.transaction::<StartedWorkflowExecution, HarvestError, _>(|conn| {
+        let row = row;
+        let enqueue = enqueue.clone();
+        let request = request.clone();
+        async move {
+            let inserted = diesel::insert_into(harvest_workflow_executions::table)
+                .values(&row)
+                .on_conflict((
+                    harvest_workflow_executions::workflow_name,
+                    harvest_workflow_executions::workflow_id,
+                ))
+                .do_nothing()
+                .returning(WorkflowExecution::as_returning())
+                .get_result(conn)
+                .await
+                .optional()
+                .map_err(database_error)?;
+
+            if let Some(execution) = inserted {
+                let started_event = WorkflowEvent::WorkflowStarted {
+                    input: request.input.clone(),
+                    timestamp: Utc::now(),
+                };
+                store::append_events(conn, exec_id, &[started_event], 0).await?;
+                queue::enqueue(conn, &enqueue).await?;
+                return Ok(StartedWorkflowExecution::from_row(execution, true));
+            }
+
+            let execution =
+                load_workflow_execution_by_key(conn, request.workflow_name, request.workflow_id)
+                    .await?;
+            Ok(StartedWorkflowExecution::from_row(execution, false))
+        }
+        .scope_boxed()
+    })
+    .await
+}
+
+async fn load_workflow_execution_by_key(
+    conn: &mut AsyncPgConnection,
+    workflow_name: &str,
+    workflow_id: &str,
+) -> HarvestResult<WorkflowExecution> {
+    harvest_workflow_executions::table
+        .filter(harvest_workflow_executions::workflow_name.eq(workflow_name))
+        .filter(harvest_workflow_executions::workflow_id.eq(workflow_id))
+        .select(WorkflowExecution::as_select())
+        .first(conn)
+        .await
+        .optional()
+        .map_err(database_error)?
+        .ok_or_else(|| {
+            HarvestError::NotFound(format!("workflow execution {workflow_name}/{workflow_id}"))
+        })
+}

--- a/autumn-harvest/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/autumn-harvest/src/lib.rs
@@ -6,6 +6,9 @@ pub mod context;
 pub mod dag;
 pub mod error;
 pub mod event;
+#[cfg(feature = "db")]
+#[doc(hidden)]
+pub mod execution;
 pub mod executor;
 pub mod info;
 pub mod policy;
@@ -55,6 +58,10 @@ pub use context::{ActivityContext, WorkflowCommand, WorkflowContext};
 pub use dag::{DagBuildError, DagBuilder, DagDefinition, DagTask, DagTaskRef};
 pub use error::{HarvestError, HarvestResult, TimeoutType};
 pub use event::WorkflowEvent;
+#[cfg(feature = "db")]
+pub use execution::{
+    StartWorkflowParams, StartedWorkflowExecution, start_or_load_workflow_execution,
+};
 pub use executor::{WorkflowOutcome, run_workflow};
 pub use info::{ActivityHandlerFn, ActivityInfo, DagInfo, WorkflowHandlerFn, WorkflowInfo};
 pub use policy::{RetryPolicy, Schedule, TaskStatus, TriggerRule};

--- a/autumn-harvest/autumn-harvest/src/notify.rs
+++ b/autumn-harvest/autumn-harvest/src/notify.rs
@@ -44,10 +44,21 @@ fn quote_pg_identifier(identifier: &str) -> String {
 // ---------------------------------------------------------------------------
 
 /// Payload sent via Postgres NOTIFY when a task is enqueued.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct NotifyPayload {
     /// The UUID of the newly enqueued task.
     pub task_id: Uuid,
+}
+
+/// Outcome of waiting on a queue listener.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueueWaitOutcome {
+    /// A notification payload arrived before the timeout elapsed.
+    Notification(NotifyPayload),
+    /// No payload arrived before `poll_interval` elapsed.
+    TimedOut,
+    /// The listener channel closed because the underlying connection died.
+    ChannelClosed,
 }
 
 // ---------------------------------------------------------------------------
@@ -183,20 +194,29 @@ impl QueueListener {
         &mut self,
         poll_interval: Duration,
     ) -> HarvestResult<Option<NotifyPayload>> {
+        match self.wait_for_notification_outcome(poll_interval).await? {
+            QueueWaitOutcome::Notification(payload) => Ok(Some(payload)),
+            QueueWaitOutcome::TimedOut | QueueWaitOutcome::ChannelClosed => Ok(None),
+        }
+    }
+
+    /// Wait for a notification and distinguish timeout from listener shutdown.
+    ///
+    /// This is useful for callers that need to reconnect after the underlying
+    /// LISTEN connection dies instead of treating every wake miss as a normal
+    /// timeout.
+    pub async fn wait_for_notification_outcome(
+        &mut self,
+        poll_interval: Duration,
+    ) -> HarvestResult<QueueWaitOutcome> {
         match tokio::time::timeout(poll_interval, self.rx.recv()).await {
             Ok(Some(notification)) => {
                 let payload: NotifyPayload = serde_json::from_str(notification.payload())
                     .map_err(|e| HarvestError::Database(format!("bad notify payload: {e}")))?;
-                Ok(Some(payload))
+                Ok(QueueWaitOutcome::Notification(payload))
             }
-            Ok(None) => {
-                // Channel closed -- connection died.
-                Ok(None)
-            }
-            Err(_elapsed) => {
-                // Timeout -- no notification received, fall back to poll.
-                Ok(None)
-            }
+            Ok(None) => Ok(QueueWaitOutcome::ChannelClosed),
+            Err(_elapsed) => Ok(QueueWaitOutcome::TimedOut),
         }
     }
 

--- a/autumn-harvest/autumn-harvest/src/types.rs
+++ b/autumn-harvest/autumn-harvest/src/types.rs
@@ -12,8 +12,10 @@ use uuid::Uuid;
 /// User-provided idempotency key for a workflow execution.
 ///
 /// This is the business-level identifier chosen by the caller (e.g.
-/// `"user-123"` or `"order-456"`). It is NOT the run ID — multiple
-/// runs of the same workflow may share a `WorkflowId` in a retry scenario.
+/// `"user-123"` or `"order-456"`). It is NOT the run ID. Reusing the same
+/// `WorkflowId` for the same workflow name should resolve to the same logical
+/// workflow start; explicit reruns should use a fresh key until Harvest grows a
+/// dedicated restart API.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct WorkflowId(String);
 
@@ -45,6 +47,11 @@ impl ExecutionId {
     #[must_use]
     pub fn new() -> Self {
         Self(Uuid::new_v4())
+    }
+
+    #[must_use]
+    pub const fn from_uuid(id: Uuid) -> Self {
+        Self(id)
     }
 
     #[must_use]

--- a/autumn-harvest/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/autumn-harvest/tests/integration_e2e.rs
@@ -18,8 +18,8 @@ use autumn_harvest::store;
 use autumn_harvest::types::{ActivityExecId, ExecutionId};
 use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
 use autumn_harvest::{
-    ActivityContext, HarvestBuilder, HarvestError, TimeoutType, WorkerConfig, WorkflowContext,
-    queue, timeout,
+    ActivityContext, HarvestBuilder, HarvestError, StartWorkflowParams, TimeoutType, WorkerConfig,
+    WorkflowContext, queue, start_or_load_workflow_execution, timeout,
 };
 
 use chrono::Utc;
@@ -27,8 +27,10 @@ use diesel::prelude::*;
 use diesel_async::AsyncConnection;
 use diesel_async::AsyncPgConnection;
 use diesel_async::RunQueryDsl;
+use diesel_async::SimpleAsyncConnection;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use scoped_futures::ScopedFutureExt;
+use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
@@ -74,6 +76,25 @@ async fn setup_test_db() -> (AsyncPgConnection, ContainerAsync<Postgres>) {
 async fn setup_test_database_url() -> (String, ContainerAsync<Postgres>) {
     let container = Postgres::default()
         .with_init_sql(INIT_SQL.to_string().into_bytes())
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let database_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    (database_url, container)
+}
+
+async fn setup_blank_test_database_url() -> (String, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
         .start()
         .await
         .expect("failed to start Postgres container");
@@ -204,6 +225,74 @@ async fn insert_workflow_execution(conn: &mut AsyncPgConnection) -> ExecutionId 
         .expect("failed to insert workflow execution");
 
     exec_id
+}
+
+#[tokio::test]
+async fn legacy_workflow_uniqueness_schema_can_be_upgraded_for_idempotent_starts() {
+    let (database_url, _container) = setup_blank_test_database_url().await;
+    let mut conn = <AsyncPgConnection as diesel_async::AsyncConnection>::establish(&database_url)
+        .await
+        .expect("failed to connect to Postgres container");
+    let legacy_init_sql = INIT_SQL.replacen(
+        "UNIQUE (workflow_name, workflow_id)",
+        "UNIQUE (workflow_id, run_id)",
+        1,
+    );
+    conn.batch_execute(&legacy_init_sql)
+        .await
+        .expect("failed to apply legacy harvest schema");
+
+    let request = StartWorkflowParams {
+        workflow_name: "upgrade_test",
+        workflow_id: "workflow-42",
+        shard_id: 0,
+        input: serde_json::json!({ "workflow_id": 42 }),
+        parent_id: None,
+        queue_name: "default",
+        execution_timeout: None,
+        memo: None,
+        search_attrs: None,
+    };
+
+    let legacy_error = start_or_load_workflow_execution(&mut conn, request.clone())
+        .await
+        .expect_err("legacy schema should reject the new ON CONFLICT target");
+    assert!(
+        matches!(legacy_error, HarvestError::Database(_)),
+        "legacy schema should fail with a database error, got {legacy_error:?}",
+    );
+
+    let upgrade_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("migrations/20260410010000_harvest_workflow_start_uniqueness/up.sql");
+    let upgrade_sql = std::fs::read_to_string(&upgrade_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read harvest upgrade migration at {}: {error}",
+            upgrade_path.display()
+        )
+    });
+    conn.batch_execute(&upgrade_sql)
+        .await
+        .expect("failed to apply harvest upgrade migration");
+
+    let first = start_or_load_workflow_execution(&mut conn, request.clone())
+        .await
+        .expect("upgrade migration should restore workflow start");
+    let second = start_or_load_workflow_execution(&mut conn, request)
+        .await
+        .expect("upgrade migration should restore idempotent workflow start");
+
+    assert!(
+        first.created,
+        "first start should create a workflow execution"
+    );
+    assert!(
+        !second.created,
+        "second start should reuse the existing workflow execution",
+    );
+    assert_eq!(
+        first.exec_id, second.exec_id,
+        "idempotent starts should point at the same execution after the upgrade migration",
+    );
 }
 
 async fn enqueue_started_workflow_task(

--- a/autumn-harvest/autumn-web-harvest/Cargo.toml
+++ b/autumn-harvest/autumn-web-harvest/Cargo.toml
@@ -11,8 +11,10 @@ repository.workspace = true
 autumn-harvest = { path = "../autumn-harvest" }
 autumn-web = { path = "../../autumn" }
 tokio = { workspace = true }
+tokio-util = { version = "0.7", features = ["rt"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+toml = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }

--- a/autumn-harvest/autumn-web-harvest/migrations/20260409010000_harvest_workflow_outbox/down.sql
+++ b/autumn-harvest/autumn-web-harvest/migrations/20260409010000_harvest_workflow_outbox/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS harvest_workflow_outbox;

--- a/autumn-harvest/autumn-web-harvest/migrations/20260409010000_harvest_workflow_outbox/up.sql
+++ b/autumn-harvest/autumn-web-harvest/migrations/20260409010000_harvest_workflow_outbox/up.sql
@@ -1,0 +1,26 @@
+CREATE TABLE harvest_workflow_outbox (
+    id BIGSERIAL PRIMARY KEY,
+    workflow_name TEXT NOT NULL,
+    workflow_id TEXT NOT NULL,
+    queue_name TEXT NOT NULL,
+    input JSONB NOT NULL,
+    memo JSONB,
+    search_attrs JSONB,
+    delivery_attempts BIGINT NOT NULL DEFAULT 0,
+    last_error TEXT,
+    delivered_execution_id TEXT,
+    delivered_at TIMESTAMP,
+    next_attempt_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    claimed_at TIMESTAMP,
+    claimed_by TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (workflow_name, workflow_id)
+);
+
+CREATE INDEX idx_harvest_workflow_outbox_due
+    ON harvest_workflow_outbox (next_attempt_at, id)
+    WHERE delivered_at IS NULL;
+
+CREATE INDEX idx_harvest_workflow_outbox_claimed
+    ON harvest_workflow_outbox (claimed_at)
+    WHERE delivered_at IS NULL AND claimed_at IS NOT NULL;

--- a/autumn-harvest/autumn-web-harvest/src/api.rs
+++ b/autumn-harvest/autumn-web-harvest/src/api.rs
@@ -9,25 +9,20 @@ use autumn_web::reexports::axum;
 use axum::Extension;
 use axum::Json;
 use axum::Router;
-use axum::extract::{Path, Query, State};
+use axum::extract::{Path, Query};
 use axum::routing::{get, patch, post};
 use diesel::ExpressionMethods;
 use diesel::OptionalExtension;
 use diesel::QueryDsl;
 use diesel::SelectableHelper;
-use diesel_async::AsyncConnection;
 use diesel_async::AsyncPgConnection;
 use diesel_async::RunQueryDsl;
-use scoped_futures::ScopedFutureExt;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use uuid::Uuid;
 
 use autumn_harvest::context::WorkflowContext;
 use autumn_harvest::error::{HarvestError, HarvestResult, database_error};
-use autumn_harvest::event::WorkflowEvent;
-use autumn_harvest::models::{DagRun, HarvestSchedule, NewWorkflowExecution, WorkflowExecution};
-use autumn_harvest::queue::{self, EnqueueParams, TaskType};
+use autumn_harvest::models::{DagRun, HarvestSchedule, WorkflowExecution};
 use autumn_harvest::scheduler::{
     DagCatalog, RegisteredDag, SchedulerMonitor, SchedulerSnapshot, trigger_dag,
 };
@@ -36,23 +31,27 @@ use autumn_harvest::signal;
 use autumn_harvest::store;
 use autumn_harvest::types::ExecutionId;
 use autumn_harvest::worker::HandlerRegistry;
+use autumn_harvest::{StartWorkflowParams, start_or_load_workflow_execution};
+
+use crate::state::HarvestDbPool;
 
 #[derive(Clone)]
 pub struct HarvestApiRuntime {
     registry: Arc<HandlerRegistry>,
     dags: Arc<DagCatalog>,
-    worker_id: String,
+    worker_id: Option<String>,
     queues: Vec<String>,
     scheduler: SchedulerMonitor,
 }
 
 impl HarvestApiRuntime {
-    /// Build an API runtime snapshot from the live worker and scheduler state.
+    /// Build an API runtime snapshot from the available Harvest registrations
+    /// and any locally owned worker/scheduler state.
     #[must_use]
     pub const fn new(
         registry: Arc<HandlerRegistry>,
         dags: Arc<DagCatalog>,
-        worker_id: String,
+        worker_id: Option<String>,
         queues: Vec<String>,
         scheduler: SchedulerMonitor,
     ) -> Self {
@@ -69,6 +68,7 @@ impl HarvestApiRuntime {
 #[derive(Clone, Default)]
 pub struct HarvestApiState {
     runtime: Arc<Mutex<Option<HarvestApiRuntime>>>,
+    storage_pool: Arc<Mutex<Option<HarvestDbPool>>>,
 }
 
 impl HarvestApiState {
@@ -89,6 +89,18 @@ impl HarvestApiState {
             .expect("harvest api state lock poisoned") = Some(runtime);
     }
 
+    /// Install the Harvest storage pool used by management routes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal API-state mutex is poisoned.
+    pub fn install_storage_pool(&self, pool: HarvestDbPool) {
+        *self
+            .storage_pool
+            .lock()
+            .expect("harvest api state lock poisoned") = Some(pool);
+    }
+
     /// Clear the currently running Harvest runtime snapshot.
     ///
     /// # Panics
@@ -99,6 +111,10 @@ impl HarvestApiState {
             .runtime
             .lock()
             .expect("harvest api state lock poisoned") = None;
+        *self
+            .storage_pool
+            .lock()
+            .expect("harvest api state lock poisoned") = None;
     }
 
     fn runtime(&self) -> HarvestResult<HarvestApiRuntime> {
@@ -107,6 +123,16 @@ impl HarvestApiState {
             .expect("harvest api state lock poisoned")
             .clone()
             .ok_or_else(|| HarvestError::Config("harvest runtime is not started".to_string()))
+    }
+
+    fn storage_pool(&self) -> HarvestResult<HarvestDbPool> {
+        self.storage_pool
+            .lock()
+            .expect("harvest api state lock poisoned")
+            .clone()
+            .ok_or_else(|| {
+                HarvestError::Config("harvest storage pool is not configured".to_string())
+            })
     }
 }
 
@@ -193,10 +219,10 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
 }
 
 async fn list_workflows(
-    State(state): State<AppState>,
+    Extension(api_state): Extension<HarvestApiState>,
     Query(query): Query<WorkflowListQuery>,
 ) -> Result<Json<Vec<WorkflowExecution>>, AutumnError> {
-    let mut conn = db_conn(&state).await?;
+    let mut conn = db_conn(&api_state).await?;
     let limit = query.limit.unwrap_or(50).clamp(1, 200);
     let workflows = harvest_workflow_executions::table
         .order(harvest_workflow_executions::created_at.desc())
@@ -210,11 +236,11 @@ async fn list_workflows(
 }
 
 async fn get_workflow(
-    State(state): State<AppState>,
+    Extension(api_state): Extension<HarvestApiState>,
     Path(id): Path<String>,
 ) -> Result<Json<WorkflowDetailsResponse>, AutumnError> {
     let exec_id = parse_execution_id(&id)?;
-    let mut conn = db_conn(&state).await?;
+    let mut conn = db_conn(&api_state).await?;
     let execution = load_execution(&mut conn, exec_id)
         .await
         .map_err(map_error)?;
@@ -235,7 +261,6 @@ async fn get_workflow(
 }
 
 async fn start_workflow(
-    State(state): State<AppState>,
     Extension(api_state): Extension<HarvestApiState>,
     Path(workflow_name): Path<String>,
     Json(request): Json<StartWorkflowRequest>,
@@ -247,73 +272,57 @@ async fn start_workflow(
         )));
     }
 
-    let mut conn = db_conn(&state).await?;
-    let exec_id = ExecutionId::new();
-    let workflow_id = request.workflow_id.unwrap_or_else(|| exec_id.to_string());
+    let mut conn = db_conn(&api_state).await?;
+    let workflow_id = request
+        .workflow_id
+        .unwrap_or_else(|| ExecutionId::new().to_string());
     let queue_name = request
         .queue
         .or_else(|| runtime.queues.as_slice().first().cloned())
         .unwrap_or_else(|| "default".to_string());
     let input = request.input.unwrap_or(Value::Null);
 
-    let row = NewWorkflowExecution {
-        id: exec_id.as_uuid(),
-        workflow_name: &workflow_name,
-        workflow_id: &workflow_id,
-        run_id: Uuid::new_v4(),
-        shard_id: 0,
-        input: input.clone(),
-        parent_id: None,
-        queue_name: &queue_name,
-        execution_timeout: request
-            .execution_timeout_secs
-            .map(chrono::Duration::seconds),
-        memo: request.memo.clone(),
-        search_attrs: request.search_attrs.clone(),
-    };
-    let started_event = WorkflowEvent::WorkflowStarted {
-        input: input.clone(),
-        timestamp: chrono::Utc::now(),
-    };
-    let mut params = EnqueueParams::new(queue_name.clone(), TaskType::Workflow, input);
-    params.workflow_exec_id = Some(exec_id.as_uuid());
-
-    conn.transaction::<(), HarvestError, _>(|conn| {
-        let row = row;
-        let params = params.clone();
-        async move {
-            diesel::insert_into(harvest_workflow_executions::table)
-                .values(&row)
-                .execute(conn)
-                .await
-                .map_err(database_error)?;
-            store::append_events(conn, exec_id, &[started_event], 0).await?;
-            queue::enqueue(conn, &params).await?;
-            Ok(())
-        }
-        .scope_boxed()
-    })
+    let start = start_or_load_workflow_execution(
+        &mut conn,
+        StartWorkflowParams {
+            workflow_name: &workflow_name,
+            workflow_id: &workflow_id,
+            shard_id: 0,
+            input,
+            parent_id: None,
+            queue_name: &queue_name,
+            execution_timeout: request
+                .execution_timeout_secs
+                .map(chrono::Duration::seconds),
+            memo: request.memo.clone(),
+            search_attrs: request.search_attrs.clone(),
+        },
+    )
     .await
     .map_err(map_error)?;
 
     Ok((
-        axum::http::StatusCode::CREATED,
+        if start.created {
+            axum::http::StatusCode::CREATED
+        } else {
+            axum::http::StatusCode::OK
+        },
         Json(StartWorkflowResponse {
-            execution_id: exec_id.to_string(),
-            workflow_name,
-            workflow_id,
-            state: "RUNNING".to_string(),
+            execution_id: start.exec_id.to_string(),
+            workflow_name: start.workflow_name,
+            workflow_id: start.workflow_id,
+            state: start.state,
         }),
     ))
 }
 
 async fn signal_workflow(
-    State(state): State<AppState>,
+    Extension(api_state): Extension<HarvestApiState>,
     Path((id, signal_name)): Path<(String, String)>,
     Json(payload): Json<Value>,
 ) -> Result<(axum::http::StatusCode, Json<BasicAck>), AutumnError> {
     let exec_id = parse_execution_id(&id)?;
-    let mut conn = db_conn(&state).await?;
+    let mut conn = db_conn(&api_state).await?;
     load_execution(&mut conn, exec_id)
         .await
         .map_err(map_error)?;
@@ -328,13 +337,12 @@ async fn signal_workflow(
 }
 
 async fn query_workflow(
-    State(state): State<AppState>,
     Extension(api_state): Extension<HarvestApiState>,
     Path((id, query_name)): Path<(String, String)>,
 ) -> Result<Json<Value>, AutumnError> {
     let runtime = api_state.runtime().map_err(map_error)?;
     let exec_id = parse_execution_id(&id)?;
-    let mut conn = db_conn(&state).await?;
+    let mut conn = db_conn(&api_state).await?;
     let execution = load_execution(&mut conn, exec_id)
         .await
         .map_err(map_error)?;
@@ -367,11 +375,10 @@ async fn query_workflow(
 }
 
 async fn list_dags(
-    State(state): State<AppState>,
     Extension(api_state): Extension<HarvestApiState>,
 ) -> Result<Json<Vec<DagSummary>>, AutumnError> {
     let runtime = api_state.runtime().map_err(map_error)?;
-    let mut conn = db_conn(&state).await?;
+    let mut conn = db_conn(&api_state).await?;
     let schedules = harvest_schedules::table
         .order(harvest_schedules::dag_name.asc())
         .select(HarvestSchedule::as_select())
@@ -400,10 +407,10 @@ async fn list_dags(
 }
 
 async fn list_dag_runs(
-    State(state): State<AppState>,
+    Extension(api_state): Extension<HarvestApiState>,
     Path(dag_name): Path<String>,
 ) -> Result<Json<Vec<DagRun>>, AutumnError> {
-    let mut conn = db_conn(&state).await?;
+    let mut conn = db_conn(&api_state).await?;
     let runs = harvest_dag_runs::table
         .filter(harvest_dag_runs::dag_name.eq(&dag_name))
         .order(harvest_dag_runs::created_at.desc())
@@ -416,17 +423,14 @@ async fn list_dag_runs(
 }
 
 async fn trigger_dag_run(
-    State(state): State<AppState>,
     Extension(api_state): Extension<HarvestApiState>,
     Path(dag_name): Path<String>,
     Json(request): Json<DagTriggerRequest>,
 ) -> Result<(axum::http::StatusCode, Json<DagRun>), AutumnError> {
     let runtime = api_state.runtime().map_err(map_error)?;
-    let pool = state
-        .pool()
-        .ok_or_else(|| AutumnError::service_unavailable_msg("database is not configured"))?;
+    let pool = api_state.storage_pool().map_err(map_error)?;
     let run = trigger_dag(
-        pool.clone(),
+        pool.clone_inner(),
         Arc::clone(&runtime.registry),
         Arc::clone(&runtime.dags),
         &dag_name,
@@ -439,13 +443,13 @@ async fn trigger_dag_run(
 }
 
 async fn patch_dag(
-    State(state): State<AppState>,
+    Extension(api_state): Extension<HarvestApiState>,
     Path(dag_name): Path<String>,
     Json(request): Json<DagPauseRequest>,
 ) -> Result<Json<HarvestSchedule>, AutumnError> {
     use autumn_harvest::schema::harvest_schedules::dsl;
 
-    let mut conn = db_conn(&state).await?;
+    let mut conn = db_conn(&api_state).await?;
     let updated = diesel::update(dsl::harvest_schedules.filter(dsl::dag_name.eq(&dag_name)))
         .set((
             dsl::is_paused.eq(request.paused),
@@ -482,7 +486,9 @@ async fn health(
 
     Ok(Json(HarvestHealth {
         runtime_ready: runtime.is_some(),
-        worker_id: runtime.as_ref().map(|runtime| runtime.worker_id.clone()),
+        worker_id: runtime
+            .as_ref()
+            .and_then(|runtime| runtime.worker_id.clone()),
         queues: runtime
             .as_ref()
             .map_or_else(Vec::new, |runtime| runtime.queues.clone()),
@@ -506,7 +512,7 @@ async fn load_execution(
 }
 
 async fn db_conn(
-    state: &AppState,
+    api_state: &HarvestApiState,
 ) -> Result<
     deadpool::managed::Object<
         diesel_async::pooled_connection::AsyncDieselConnectionManager<
@@ -515,9 +521,7 @@ async fn db_conn(
     >,
     AutumnError,
 > {
-    let pool = state
-        .pool()
-        .ok_or_else(|| AutumnError::service_unavailable_msg("database is not configured"))?;
+    let pool = api_state.storage_pool().map_err(map_error)?;
     let conn = pool
         .get()
         .await

--- a/autumn-harvest/autumn-web-harvest/src/config.rs
+++ b/autumn-harvest/autumn-web-harvest/src/config.rs
@@ -1,0 +1,516 @@
+use std::path::{Path, PathBuf};
+
+use autumn_web::config::{ConfigError, DatabaseConfig, Env, OsEnv};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum HarvestMode {
+    #[default]
+    Embedded,
+    Split,
+    External,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct HarvestDatabaseConfig {
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HarvestOutboxConfig {
+    pub enabled: bool,
+    pub batch_size: i64,
+    pub poll_interval_ms: u64,
+    pub claim_ttl_ms: u64,
+    pub base_retry_delay_ms: u64,
+    pub max_retry_delay_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HarvestRuntimeConfig {
+    pub mode: HarvestMode,
+    pub worker_enabled: bool,
+    pub scheduler_enabled: bool,
+    pub database: HarvestDatabaseConfig,
+    pub outbox: HarvestOutboxConfig,
+}
+
+impl HarvestRuntimeConfig {
+    pub fn load() -> Result<Self, ConfigError> {
+        Self::load_with_env(&OsEnv)
+    }
+
+    pub fn load_with_env(env: &dyn Env) -> Result<Self, ConfigError> {
+        let profile = resolve_profile(env);
+        let mut config = Self::default();
+
+        if let Some(root) = load_partial_root(&find_config_file_named("autumn.toml", env))? {
+            config.apply_partial(root.harvest);
+        }
+
+        if let Some(profile) = profile {
+            let path = find_config_file_named(&format!("autumn-{profile}.toml"), env);
+            if let Some(root) = load_partial_root(&path)? {
+                config.apply_partial(root.harvest);
+            }
+        }
+
+        config.apply_env_overrides(env)?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn apply_partial(&mut self, partial: PartialHarvestRuntimeConfig) {
+        if let Some(mode) = partial.mode {
+            self.mode = mode;
+        }
+        if let Some(worker_enabled) = partial.worker_enabled {
+            self.worker_enabled = worker_enabled;
+        }
+        if let Some(scheduler_enabled) = partial.scheduler_enabled {
+            self.scheduler_enabled = scheduler_enabled;
+        }
+        if let Some(url) = partial.database.url {
+            self.database.url = Some(url);
+        }
+        if let Some(enabled) = partial.outbox.enabled {
+            self.outbox.enabled = enabled;
+        }
+        if let Some(batch_size) = partial.outbox.batch_size {
+            self.outbox.batch_size = batch_size;
+        }
+        if let Some(poll_interval_ms) = partial.outbox.poll_interval_ms {
+            self.outbox.poll_interval_ms = poll_interval_ms;
+        }
+        if let Some(claim_ttl_ms) = partial.outbox.claim_ttl_ms {
+            self.outbox.claim_ttl_ms = claim_ttl_ms;
+        }
+        if let Some(base_retry_delay_ms) = partial.outbox.base_retry_delay_ms {
+            self.outbox.base_retry_delay_ms = base_retry_delay_ms;
+        }
+        if let Some(max_retry_delay_ms) = partial.outbox.max_retry_delay_ms {
+            self.outbox.max_retry_delay_ms = max_retry_delay_ms;
+        }
+    }
+
+    fn apply_env_overrides(&mut self, env: &dyn Env) -> Result<(), ConfigError> {
+        if let Ok(mode) = env.var("AUTUMN_HARVEST__MODE") {
+            self.mode = parse_mode(&mode)?;
+        }
+
+        if let Ok(worker_enabled) = env.var("AUTUMN_HARVEST__WORKER_ENABLED") {
+            self.worker_enabled = parse_bool("AUTUMN_HARVEST__WORKER_ENABLED", &worker_enabled)?;
+        }
+
+        if let Ok(scheduler_enabled) = env.var("AUTUMN_HARVEST__SCHEDULER_ENABLED") {
+            self.scheduler_enabled =
+                parse_bool("AUTUMN_HARVEST__SCHEDULER_ENABLED", &scheduler_enabled)?;
+        }
+
+        if let Ok(url) = env.var("AUTUMN_HARVEST_DATABASE__URL") {
+            self.database.url = (!url.is_empty()).then_some(url);
+        }
+
+        if let Ok(enabled) = env.var("AUTUMN_HARVEST_OUTBOX__ENABLED") {
+            self.outbox.enabled = parse_bool("AUTUMN_HARVEST_OUTBOX__ENABLED", &enabled)?;
+        }
+        if let Ok(batch_size) = env.var("AUTUMN_HARVEST_OUTBOX__BATCH_SIZE") {
+            self.outbox.batch_size = parse_i64("AUTUMN_HARVEST_OUTBOX__BATCH_SIZE", &batch_size)?;
+        }
+        if let Ok(poll_interval_ms) = env.var("AUTUMN_HARVEST_OUTBOX__POLL_INTERVAL_MS") {
+            self.outbox.poll_interval_ms =
+                parse_u64("AUTUMN_HARVEST_OUTBOX__POLL_INTERVAL_MS", &poll_interval_ms)?;
+        }
+        if let Ok(claim_ttl_ms) = env.var("AUTUMN_HARVEST_OUTBOX__CLAIM_TTL_MS") {
+            self.outbox.claim_ttl_ms =
+                parse_u64("AUTUMN_HARVEST_OUTBOX__CLAIM_TTL_MS", &claim_ttl_ms)?;
+        }
+        if let Ok(base_retry_delay_ms) = env.var("AUTUMN_HARVEST_OUTBOX__BASE_RETRY_DELAY_MS") {
+            self.outbox.base_retry_delay_ms = parse_u64(
+                "AUTUMN_HARVEST_OUTBOX__BASE_RETRY_DELAY_MS",
+                &base_retry_delay_ms,
+            )?;
+        }
+        if let Ok(max_retry_delay_ms) = env.var("AUTUMN_HARVEST_OUTBOX__MAX_RETRY_DELAY_MS") {
+            self.outbox.max_retry_delay_ms = parse_u64(
+                "AUTUMN_HARVEST_OUTBOX__MAX_RETRY_DELAY_MS",
+                &max_retry_delay_ms,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn validate(&self) -> Result<(), ConfigError> {
+        let database_config = DatabaseConfig {
+            url: self.database.url.clone(),
+            ..DatabaseConfig::default()
+        };
+        database_config.validate()?;
+
+        if matches!(self.mode, HarvestMode::Split | HarvestMode::External)
+            && self.database.url.is_none()
+        {
+            return Err(ConfigError::Validation(format!(
+                "harvest.database.url is required when harvest.mode is {:?}",
+                self.mode
+            )));
+        }
+
+        if self.outbox.batch_size < 1 {
+            return Err(ConfigError::Validation(
+                "harvest.outbox.batch_size must be at least 1".to_owned(),
+            ));
+        }
+        if self.outbox.poll_interval_ms < 1 {
+            return Err(ConfigError::Validation(
+                "harvest.outbox.poll_interval_ms must be at least 1".to_owned(),
+            ));
+        }
+        if self.outbox.claim_ttl_ms < 1 {
+            return Err(ConfigError::Validation(
+                "harvest.outbox.claim_ttl_ms must be at least 1".to_owned(),
+            ));
+        }
+        if self.outbox.base_retry_delay_ms < 1 {
+            return Err(ConfigError::Validation(
+                "harvest.outbox.base_retry_delay_ms must be at least 1".to_owned(),
+            ));
+        }
+        if self.outbox.max_retry_delay_ms < self.outbox.base_retry_delay_ms {
+            return Err(ConfigError::Validation(
+                "harvest.outbox.max_retry_delay_ms must be greater than or equal to harvest.outbox.base_retry_delay_ms".to_owned(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for HarvestRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            mode: HarvestMode::Embedded,
+            worker_enabled: true,
+            scheduler_enabled: true,
+            database: HarvestDatabaseConfig::default(),
+            outbox: HarvestOutboxConfig::default(),
+        }
+    }
+}
+
+impl Default for HarvestOutboxConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            batch_size: 32,
+            poll_interval_ms: 1_000,
+            claim_ttl_ms: 30_000,
+            base_retry_delay_ms: 1_000,
+            max_retry_delay_ms: 60_000,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PartialRoot {
+    #[serde(default)]
+    harvest: PartialHarvestRuntimeConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PartialHarvestRuntimeConfig {
+    mode: Option<HarvestMode>,
+    worker_enabled: Option<bool>,
+    scheduler_enabled: Option<bool>,
+    #[serde(default)]
+    database: PartialHarvestDatabaseConfig,
+    #[serde(default)]
+    outbox: PartialHarvestOutboxConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PartialHarvestDatabaseConfig {
+    url: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PartialHarvestOutboxConfig {
+    enabled: Option<bool>,
+    batch_size: Option<i64>,
+    poll_interval_ms: Option<u64>,
+    claim_ttl_ms: Option<u64>,
+    base_retry_delay_ms: Option<u64>,
+    max_retry_delay_ms: Option<u64>,
+}
+
+fn find_config_file_named(filename: &str, env: &dyn Env) -> PathBuf {
+    if let Ok(manifest_dir) = env.var("AUTUMN_MANIFEST_DIR") {
+        let candidate = PathBuf::from(manifest_dir).join(filename);
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    PathBuf::from(filename)
+}
+
+fn load_partial_root(path: &Path) -> Result<Option<PartialRoot>, ConfigError> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => Ok(Some(toml::from_str(&contents)?)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(ConfigError::Io(error)),
+    }
+}
+
+fn resolve_profile(env: &dyn Env) -> Option<String> {
+    if let Ok(profile) = env.var("AUTUMN_PROFILE") {
+        if !profile.is_empty() {
+            return Some(profile);
+        }
+    }
+
+    let args: Vec<String> = std::env::args().collect();
+    for (i, arg) in args.iter().enumerate() {
+        if arg == "--profile" {
+            if let Some(profile) = args.get(i + 1) {
+                return Some(profile.clone());
+            }
+        }
+        if let Some(profile) = arg.strip_prefix("--profile=") {
+            return Some(profile.to_owned());
+        }
+    }
+
+    match env.var("AUTUMN_IS_DEBUG").ok().as_deref() {
+        Some("1") => Some("dev".to_owned()),
+        Some("0") => Some("prod".to_owned()),
+        _ => None,
+    }
+}
+
+fn parse_mode(value: &str) -> Result<HarvestMode, ConfigError> {
+    match value {
+        "embedded" => Ok(HarvestMode::Embedded),
+        "split" => Ok(HarvestMode::Split),
+        "external" => Ok(HarvestMode::External),
+        _ => Err(ConfigError::Validation(format!(
+            "invalid harvest mode {value:?}; expected one of: embedded, split, external"
+        ))),
+    }
+}
+
+fn parse_bool(key: &str, value: &str) -> Result<bool, ConfigError> {
+    match value {
+        "true" | "1" => Ok(true),
+        "false" | "0" => Ok(false),
+        _ => Err(ConfigError::Validation(format!(
+            "invalid boolean for {key}: {value:?}"
+        ))),
+    }
+}
+
+fn parse_i64(key: &str, value: &str) -> Result<i64, ConfigError> {
+    value
+        .parse::<i64>()
+        .map_err(|_| ConfigError::Validation(format!("invalid integer for {key}: {value:?}")))
+}
+
+fn parse_u64(key: &str, value: &str) -> Result<u64, ConfigError> {
+    value
+        .parse::<u64>()
+        .map_err(|_| ConfigError::Validation(format!("invalid integer for {key}: {value:?}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    use autumn_web::config::MockEnv;
+
+    #[test]
+    fn harvest_config_defaults_to_embedded_mode() {
+        let env = MockEnv::new();
+        let config = HarvestRuntimeConfig::load_with_env(&env).expect("harvest config should load");
+
+        assert_eq!(config.mode, HarvestMode::Embedded);
+        assert!(config.worker_enabled);
+        assert!(config.scheduler_enabled);
+        assert_eq!(config.database.url, None);
+    }
+
+    #[test]
+    fn harvest_config_split_mode_requires_database_url() {
+        let dir = unique_temp_dir("harvest-config-split");
+        write_file(
+            &dir.join("autumn.toml"),
+            r#"
+[harvest]
+mode = "split"
+"#,
+        );
+        let env = MockEnv::new()
+            .with("AUTUMN_MANIFEST_DIR", dir.to_string_lossy().as_ref())
+            .with("AUTUMN_PROFILE", "dev");
+
+        let error = HarvestRuntimeConfig::load_with_env(&env)
+            .expect_err("split mode must fail without harvest database url");
+
+        assert!(
+            error.to_string().contains("harvest.database.url"),
+            "expected missing harvest.database.url validation error, got {error}"
+        );
+    }
+
+    #[test]
+    fn harvest_config_external_mode_requires_database_url() {
+        let dir = unique_temp_dir("harvest-config-external");
+        write_file(
+            &dir.join("autumn.toml"),
+            r#"
+[harvest]
+mode = "external"
+"#,
+        );
+        let env = MockEnv::new()
+            .with("AUTUMN_MANIFEST_DIR", dir.to_string_lossy().as_ref())
+            .with("AUTUMN_PROFILE", "prod");
+
+        let error = HarvestRuntimeConfig::load_with_env(&env)
+            .expect_err("external mode must fail without harvest database url");
+
+        assert!(
+            error.to_string().contains("harvest.database.url"),
+            "expected missing harvest.database.url validation error, got {error}"
+        );
+    }
+
+    #[test]
+    fn harvest_config_allows_external_mode_with_runtime_toggles_disabled() {
+        let dir = unique_temp_dir("harvest-config-toggles");
+        write_file(
+            &dir.join("autumn.toml"),
+            r#"
+[harvest]
+mode = "external"
+worker_enabled = false
+scheduler_enabled = false
+
+[harvest.database]
+url = "postgres://harvest:harvest@localhost:5432/harvest"
+"#,
+        );
+        let env = MockEnv::new()
+            .with("AUTUMN_MANIFEST_DIR", dir.to_string_lossy().as_ref())
+            .with("AUTUMN_PROFILE", "prod");
+
+        let config =
+            HarvestRuntimeConfig::load_with_env(&env).expect("external config should load");
+
+        assert_eq!(config.mode, HarvestMode::External);
+        assert!(!config.worker_enabled);
+        assert!(!config.scheduler_enabled);
+        assert_eq!(
+            config.database.url.as_deref(),
+            Some("postgres://harvest:harvest@localhost:5432/harvest")
+        );
+    }
+
+    #[test]
+    fn harvest_config_env_overrides_toml() {
+        let dir = unique_temp_dir("harvest-config-env");
+        write_file(
+            &dir.join("autumn.toml"),
+            r#"
+[harvest]
+mode = "embedded"
+"#,
+        );
+        let env = MockEnv::new()
+            .with("AUTUMN_MANIFEST_DIR", dir.to_string_lossy().as_ref())
+            .with("AUTUMN_PROFILE", "dev")
+            .with("AUTUMN_HARVEST__MODE", "external")
+            .with("AUTUMN_HARVEST__WORKER_ENABLED", "false")
+            .with("AUTUMN_HARVEST__SCHEDULER_ENABLED", "false")
+            .with(
+                "AUTUMN_HARVEST_DATABASE__URL",
+                "postgres://harvest:harvest@localhost:5432/env_override",
+            );
+
+        let config =
+            HarvestRuntimeConfig::load_with_env(&env).expect("env override config should load");
+
+        assert_eq!(config.mode, HarvestMode::External);
+        assert!(!config.worker_enabled);
+        assert!(!config.scheduler_enabled);
+        assert_eq!(
+            config.database.url.as_deref(),
+            Some("postgres://harvest:harvest@localhost:5432/env_override")
+        );
+    }
+
+    #[test]
+    fn harvest_config_outbox_defaults_are_sane() {
+        let env = MockEnv::new();
+        let config = HarvestRuntimeConfig::load_with_env(&env).expect("harvest config should load");
+
+        assert!(config.outbox.enabled);
+        assert_eq!(config.outbox.batch_size, 32);
+        assert_eq!(config.outbox.poll_interval_ms, 1_000);
+        assert_eq!(config.outbox.claim_ttl_ms, 30_000);
+        assert_eq!(config.outbox.base_retry_delay_ms, 1_000);
+        assert_eq!(config.outbox.max_retry_delay_ms, 60_000);
+    }
+
+    #[test]
+    fn harvest_config_outbox_env_overrides_are_applied() {
+        let env = MockEnv::new()
+            .with("AUTUMN_HARVEST_OUTBOX__ENABLED", "false")
+            .with("AUTUMN_HARVEST_OUTBOX__BATCH_SIZE", "64")
+            .with("AUTUMN_HARVEST_OUTBOX__POLL_INTERVAL_MS", "250")
+            .with("AUTUMN_HARVEST_OUTBOX__CLAIM_TTL_MS", "120000")
+            .with("AUTUMN_HARVEST_OUTBOX__BASE_RETRY_DELAY_MS", "500")
+            .with("AUTUMN_HARVEST_OUTBOX__MAX_RETRY_DELAY_MS", "900000");
+
+        let config =
+            HarvestRuntimeConfig::load_with_env(&env).expect("env overrides should parse cleanly");
+
+        assert!(!config.outbox.enabled);
+        assert_eq!(config.outbox.batch_size, 64);
+        assert_eq!(config.outbox.poll_interval_ms, 250);
+        assert_eq!(config.outbox.claim_ttl_ms, 120_000);
+        assert_eq!(config.outbox.base_retry_delay_ms, 500);
+        assert_eq!(config.outbox.max_retry_delay_ms, 900_000);
+    }
+
+    #[test]
+    fn harvest_config_outbox_rejects_invalid_values() {
+        let env = MockEnv::new()
+            .with("AUTUMN_HARVEST_OUTBOX__BATCH_SIZE", "0")
+            .with("AUTUMN_HARVEST_OUTBOX__POLL_INTERVAL_MS", "0");
+
+        let error = HarvestRuntimeConfig::load_with_env(&env)
+            .expect_err("invalid outbox settings must fail validation");
+
+        assert!(
+            error.to_string().contains("outbox"),
+            "expected outbox validation error, got {error}"
+        );
+    }
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "autumn-web-harvest-{label}-{}",
+            uuid::Uuid::new_v4()
+        ));
+        fs::create_dir_all(&dir).expect("temp dir should be created");
+        dir
+    }
+
+    fn write_file(path: &Path, contents: &str) {
+        fs::write(path, contents)
+            .unwrap_or_else(|error| panic!("failed to write {}: {error}", path.display()));
+    }
+}

--- a/autumn-harvest/autumn-web-harvest/src/config.rs
+++ b/autumn-harvest/autumn-web-harvest/src/config.rs
@@ -37,10 +37,22 @@ pub struct HarvestRuntimeConfig {
 }
 
 impl HarvestRuntimeConfig {
+    /// Load Harvest runtime configuration from Autumn config files and process environment.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] when config files cannot be read or parsed, environment overrides
+    /// are invalid, or the resulting topology configuration is not valid.
     pub fn load() -> Result<Self, ConfigError> {
         Self::load_with_env(&OsEnv)
     }
 
+    /// Load Harvest runtime configuration using an explicit environment provider.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] when config files cannot be read or parsed, environment overrides
+    /// are invalid, or the resulting topology configuration is not valid.
     pub fn load_with_env(env: &dyn Env) -> Result<Self, ConfigError> {
         let profile = resolve_profile(env);
         let mut config = Self::default();

--- a/autumn-harvest/autumn-web-harvest/src/ext.rs
+++ b/autumn-harvest/autumn-web-harvest/src/ext.rs
@@ -209,7 +209,6 @@ fn start_harvest_runtime(
         .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
     let harvest_config = HarvestRuntimeConfig::load()
         .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
-    ensure_supported_topology(&harvest_config)?;
     ensure_runtime_migrations(state.profile(), &app_config, &harvest_config)?;
 
     let runtime_state = state.clone();
@@ -232,9 +231,9 @@ fn start_harvest_runtime(
     let built = registration.builder.build();
     state.insert_extension(harvest_config.outbox.clone());
     let mut runner_resources =
-        HarvestRunnerResources::new(harvest_pool.clone()).with_app_state(runtime_state.clone());
-    if let Some(app_pool) = app_pool.clone() {
-        runner_resources = runner_resources.with_app_pool(app_pool);
+        HarvestRunnerResources::new(harvest_pool).with_app_state(runtime_state.clone());
+    if let Some(app_pool) = app_pool.as_ref() {
+        runner_resources = runner_resources.with_app_pool(app_pool.clone());
     }
     let runner = HarvestRunner::start(built, &harvest_config, runner_resources)?;
     let harvest_db_pool = runner.storage_pool();
@@ -257,12 +256,6 @@ fn start_harvest_runtime(
         guard.runtime = Some(HarvestRuntime { runner, outbox });
     }
     Ok(())
-}
-
-fn ensure_supported_topology(config: &HarvestRuntimeConfig) -> autumn_web::AutumnResult<()> {
-    match config.mode {
-        HarvestMode::Embedded | HarvestMode::Split | HarvestMode::External => Ok(()),
-    }
 }
 
 fn resolve_harvest_pool(
@@ -497,23 +490,15 @@ mod tests {
     }
 
     #[test]
-    fn harvest_ext_embedded_mode_is_supported() {
+    fn harvest_ext_embedded_mode_reuses_app_pool() {
+        let app_pool = test_pool("postgres://app:app@localhost:5432/app", 3);
+        let state = AppState::for_test().with_pool(app_pool);
         let config = HarvestRuntimeConfig::default();
 
-        assert!(ensure_supported_topology(&config).is_ok());
-    }
+        let harvest_pool =
+            resolve_harvest_pool(&state, &config).expect("embedded mode should reuse app pool");
 
-    #[test]
-    fn harvest_ext_split_mode_is_supported() {
-        let config = HarvestRuntimeConfig {
-            mode: HarvestMode::Split,
-            database: HarvestDatabaseConfig {
-                url: Some("postgres://harvest:harvest@localhost:5432/harvest".to_owned()),
-            },
-            ..HarvestRuntimeConfig::default()
-        };
-
-        ensure_supported_topology(&config).expect("split mode should now be supported");
+        assert_eq!(harvest_pool.status().max_size, 3);
     }
 
     #[test]
@@ -539,11 +524,8 @@ mod tests {
     fn injected_runtime_state_contains_explicit_app_and_harvest_pool_roles() {
         let app_pool = test_pool("postgres://app:app@localhost:5432/app", 3);
         let harvest_pool = test_pool("postgres://harvest:harvest@localhost:5432/harvest", 7);
-        let injected = injected_runtime_state(
-            Some(AppState::for_test().with_pool(app_pool.clone())),
-            Some(app_pool.clone()),
-            harvest_pool.clone(),
-        );
+        let app_state = AppState::for_test().with_pool(app_pool.clone());
+        let injected = injected_runtime_state(Some(app_state), Some(app_pool), harvest_pool);
 
         let app_db = injected
             .get(&TypeId::of::<AppDbPool>())
@@ -564,7 +546,9 @@ mod tests {
     }
 
     #[test]
-    fn harvest_ext_external_mode_is_supported_when_runtime_is_externalized() {
+    fn harvest_ext_external_mode_builds_dedicated_harvest_pool() {
+        let app_pool = test_pool("postgres://app:app@localhost:5432/app", 3);
+        let state = AppState::for_test().with_pool(app_pool);
         let config = HarvestRuntimeConfig {
             mode: HarvestMode::External,
             worker_enabled: false,
@@ -575,25 +559,9 @@ mod tests {
             outbox: crate::config::HarvestOutboxConfig::default(),
         };
 
-        ensure_supported_topology(&config)
-            .expect("external mode should allow a web app without local worker ownership");
-    }
+        let harvest_pool = resolve_harvest_pool(&state, &config)
+            .expect("external mode should resolve a dedicated harvest pool");
 
-    #[test]
-    fn harvest_ext_allows_worker_and_scheduler_toggles_to_be_managed_independently() {
-        let worker_only = HarvestRuntimeConfig {
-            worker_enabled: true,
-            scheduler_enabled: false,
-            ..HarvestRuntimeConfig::default()
-        };
-        let scheduler_only = HarvestRuntimeConfig {
-            worker_enabled: false,
-            scheduler_enabled: true,
-            ..HarvestRuntimeConfig::default()
-        };
-
-        ensure_supported_topology(&worker_only).expect("worker-only ownership should be supported");
-        ensure_supported_topology(&scheduler_only)
-            .expect("scheduler-only ownership should be supported");
+        assert_eq!(harvest_pool.status().max_size, 10);
     }
 }

--- a/autumn-harvest/autumn-web-harvest/src/ext.rs
+++ b/autumn-harvest/autumn-web-harvest/src/ext.rs
@@ -1,28 +1,37 @@
 //! Autumn `AppBuilder` integration for Harvest worker lifecycle.
 
-use std::any::{Any, TypeId};
-use std::collections::HashMap;
+use std::any::Any;
 use std::sync::{Arc, Mutex};
 
 use autumn_web::AppState;
 use autumn_web::app::AppBuilder;
+use autumn_web::config::AutumnConfig;
+use autumn_web::config::DatabaseConfig;
+use autumn_web::db;
 use autumn_web::error::AutumnError;
 use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
-use crate::api::{HarvestApiRuntime, HarvestApiState, harvest_api_router};
+use crate::api::{HarvestApiState, harvest_api_router};
+use crate::config::{HarvestMode, HarvestRuntimeConfig};
+use crate::outbox::spawn_workflow_start_outbox_relay;
+use crate::runner::{HarvestRunner, HarvestRunnerResources};
 use autumn_harvest::builder::{HarvestBuilder, WorkerConfig};
-use autumn_harvest::context::SharedStateMap;
 use autumn_harvest::info::{ActivityInfo, DagInfo, WorkflowInfo};
-use autumn_harvest::scheduler::{SchedulerMonitor, SchedulerRuntime, compile_dag_catalog};
-use autumn_harvest::worker::{DbPool, Worker, WorkerRuntimeConfig};
+use autumn_harvest::worker::DbPool;
 
 const HARVEST_MIGRATIONS: EmbeddedMigrations = embed_migrations!("../autumn-harvest/migrations");
+const OUTBOX_MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
+
+struct OutboxRuntime {
+    shutdown: CancellationToken,
+    handle: JoinHandle<()>,
+}
 
 struct HarvestRuntime {
-    worker: Arc<Worker>,
-    worker_handle: JoinHandle<()>,
-    scheduler: Option<SchedulerRuntime>,
+    runner: HarvestRunner,
+    outbox: Option<OutboxRuntime>,
 }
 
 #[derive(Default)]
@@ -171,7 +180,6 @@ where
     let shutdown_api_state = api_state;
 
     let builder = builder
-        .migrations(HARVEST_MIGRATIONS)
         .on_startup(move |state| {
             let shared = Arc::clone(&startup_shared);
             let api_state = startup_api_state.clone();
@@ -197,10 +205,16 @@ fn start_harvest_runtime(
     shared: &Arc<Mutex<HarvestIntegrationShared>>,
     api_state: &HarvestApiState,
 ) -> autumn_web::AutumnResult<()> {
+    let app_config = AutumnConfig::load()
+        .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+    let harvest_config = HarvestRuntimeConfig::load()
+        .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+    ensure_supported_topology(&harvest_config)?;
+    ensure_runtime_migrations(state.profile(), &app_config, &harvest_config)?;
+
     let runtime_state = state.clone();
-    let pool = state.pool().ok_or_else(|| {
-        AutumnError::service_unavailable_msg("autumn-harvest requires a configured database")
-    })?;
+    let app_pool = state.pool().cloned();
+    let harvest_pool = resolve_harvest_pool(state, &harvest_config)?;
 
     let (registration, runtime_already_started) = {
         let mut guard = shared.lock().expect("harvest lock poisoned");
@@ -216,55 +230,63 @@ fn start_harvest_runtime(
     }
 
     let built = registration.builder.build();
-    let (registry, dags, worker_config) = built.into_worker_parts_with_extra_state(
-        injected_runtime_state(runtime_state, Some(pool.clone())),
-    );
-    let dag_catalog = Arc::new(
-        compile_dag_catalog(dags)
-            .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?,
-    );
-    let runtime_config = WorkerRuntimeConfig::from(worker_config);
-    let worker_id = runtime_config.worker_id.clone();
-    let queues = runtime_config.queues.clone();
-    let registry = Arc::new(registry);
-    let worker = Arc::new(
-        Worker::new(runtime_config, Arc::clone(&registry))
-            .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?,
-    );
-    let worker_pool = pool.clone();
-    let worker_handle = {
-        let worker = Arc::clone(&worker);
-        tokio::spawn(async move {
-            worker.run(&worker_pool).await;
-        })
-    };
-    let scheduler = (!dag_catalog.is_empty()).then(|| {
-        SchedulerRuntime::spawn(
-            pool.clone(),
-            Arc::clone(&registry),
-            Arc::clone(&dag_catalog),
-        )
+    state.insert_extension(harvest_config.outbox.clone());
+    let mut runner_resources =
+        HarvestRunnerResources::new(harvest_pool.clone()).with_app_state(runtime_state.clone());
+    if let Some(app_pool) = app_pool.clone() {
+        runner_resources = runner_resources.with_app_pool(app_pool);
+    }
+    let runner = HarvestRunner::start(built, &harvest_config, runner_resources)?;
+    let harvest_db_pool = runner.storage_pool();
+    state.insert_extension(harvest_db_pool.clone());
+    api_state.install_storage_pool(harvest_db_pool);
+    let outbox = app_pool.as_ref().and_then(|_| {
+        if harvest_config.outbox.enabled {
+            let shutdown = CancellationToken::new();
+            let handle =
+                spawn_workflow_start_outbox_relay(runtime_state.clone(), shutdown.child_token());
+            Some(OutboxRuntime { shutdown, handle })
+        } else {
+            None
+        }
     });
-    let scheduler_monitor = scheduler
-        .as_ref()
-        .map_or_else(SchedulerMonitor::offline, SchedulerRuntime::monitor);
-    api_state.install(HarvestApiRuntime::new(
-        registry,
-        dag_catalog,
-        worker_id,
-        queues,
-        scheduler_monitor,
-    ));
+    api_state.install(runner.api_runtime());
 
     {
         let mut guard = shared.lock().expect("harvest lock poisoned");
-        guard.runtime = Some(HarvestRuntime {
-            worker,
-            worker_handle,
-            scheduler,
-        });
+        guard.runtime = Some(HarvestRuntime { runner, outbox });
     }
     Ok(())
+}
+
+fn ensure_supported_topology(config: &HarvestRuntimeConfig) -> autumn_web::AutumnResult<()> {
+    match config.mode {
+        HarvestMode::Embedded | HarvestMode::Split | HarvestMode::External => Ok(()),
+    }
+}
+
+fn resolve_harvest_pool(
+    state: &AppState,
+    config: &HarvestRuntimeConfig,
+) -> autumn_web::AutumnResult<DbPool> {
+    match config.mode {
+        HarvestMode::Embedded => state.pool().cloned().ok_or_else(|| {
+            AutumnError::service_unavailable_msg("autumn-harvest requires a configured database")
+        }),
+        HarvestMode::Split | HarvestMode::External => {
+            let database = DatabaseConfig {
+                url: config.database.url.clone(),
+                ..DatabaseConfig::default()
+            };
+            db::create_pool(&database)
+                .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?
+                .ok_or_else(|| {
+                    AutumnError::service_unavailable_msg(
+                        "harvest.database.url must resolve to a dedicated database pool",
+                    )
+                })
+        }
+    }
 }
 
 async fn stop_harvest_runtime(
@@ -278,33 +300,107 @@ async fn stop_harvest_runtime(
         return;
     };
 
-    runtime.worker.shutdown();
-    if let Some(scheduler) = runtime.scheduler {
-        scheduler.shutdown();
-        if let Err(error) = scheduler.join().await {
-            tracing::warn!(error = %error, "harvest scheduler task failed during shutdown");
+    if let Some(outbox) = runtime.outbox {
+        outbox.shutdown.cancel();
+        if let Err(error) = outbox.handle.await {
+            if !error.is_cancelled() {
+                tracing::warn!(error = %error, "harvest outbox relay failed during shutdown");
+            }
         }
     }
-    if let Err(error) = runtime.worker_handle.await {
-        tracing::warn!(error = %error, "harvest worker task failed during shutdown");
-    }
+    runtime.runner.stop().await;
     api_state.clear();
 }
 
-fn injected_runtime_state(pool_state: AppState, pool: Option<DbPool>) -> SharedStateMap {
-    let mut state: HashMap<TypeId, Box<dyn Any + Send + Sync>> = HashMap::new();
-    state.insert(TypeId::of::<AppState>(), Box::new(pool_state));
-    if let Some(pool) = pool {
-        state.insert(TypeId::of::<DbPool>(), Box::new(pool));
+fn ensure_runtime_migrations(
+    profile: &str,
+    app_config: &AutumnConfig,
+    harvest_config: &HarvestRuntimeConfig,
+) -> autumn_web::AutumnResult<()> {
+    if let Some(app_database_url) = app_config.database.url.as_deref() {
+        apply_migrations_for_profile(
+            profile,
+            app_database_url,
+            OUTBOX_MIGRATIONS,
+            "Harvest workflow outbox",
+        )?;
     }
-    state
+
+    let harvest_database_url = match harvest_config.mode {
+        HarvestMode::Embedded => app_config.database.url.as_deref().ok_or_else(|| {
+            AutumnError::service_unavailable_msg(
+                "autumn-harvest requires database.url when harvest.mode is embedded",
+            )
+        })?,
+        HarvestMode::Split | HarvestMode::External => {
+            harvest_config.database.url.as_deref().ok_or_else(|| {
+                AutumnError::service_unavailable_msg(
+                    "harvest.database.url is required for dedicated Harvest storage",
+                )
+            })?
+        }
+    };
+
+    apply_migrations_for_profile(
+        profile,
+        harvest_database_url,
+        HARVEST_MIGRATIONS,
+        "Harvest storage",
+    )
+}
+
+fn apply_migrations_for_profile(
+    profile: &str,
+    database_url: &str,
+    migrations: EmbeddedMigrations,
+    label: &str,
+) -> autumn_web::AutumnResult<()> {
+    if profile == "dev" {
+        let result = autumn_web::migrate::run_pending(database_url, migrations)
+            .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+        if result.applied.is_empty() {
+            tracing::info!(target = label, "No pending migrations");
+        } else {
+            for migration in result.applied {
+                tracing::info!(target = label, migration = %migration, "Applied migration");
+            }
+        }
+        return Ok(());
+    }
+
+    match autumn_web::migrate::pending_migrations(database_url, migrations) {
+        Ok(pending) if pending.is_empty() => {
+            tracing::info!(target = label, "Database migrations are up to date");
+        }
+        Ok(pending) => {
+            tracing::warn!(
+                target = label,
+                count = pending.len(),
+                "Pending migrations detected. Run `autumn migrate` to apply them."
+            );
+            for migration in pending {
+                tracing::warn!(target = label, migration = %migration, "Pending migration");
+            }
+        }
+        Err(error) => {
+            tracing::warn!(target = label, error = %error, "Could not check migration status");
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::any::TypeId;
+
+    use crate::config::{HarvestDatabaseConfig, HarvestMode, HarvestRuntimeConfig};
+    use crate::runner::injected_runtime_state;
+    use crate::{AppDbPool, HarvestDbPool};
     use autumn_harvest::dag::DagBuilder;
     use autumn_harvest::policy::Schedule;
+    use autumn_web::config::DatabaseConfig;
     fn fake_workflow_info() -> WorkflowInfo {
         WorkflowInfo {
             name: "echo",
@@ -344,6 +440,16 @@ mod tests {
         AppState::for_test()
     }
 
+    fn test_pool(database_url: &str, pool_size: usize) -> DbPool {
+        autumn_web::db::create_pool(&DatabaseConfig {
+            url: Some(database_url.to_owned()),
+            pool_size,
+            ..DatabaseConfig::default()
+        })
+        .expect("test pool config should build")
+        .expect("test pool should exist")
+    }
+
     #[test]
     fn harvest_ext_accumulates_registration_on_app_builder() {
         let builder = autumn_web::app()
@@ -380,12 +486,114 @@ mod tests {
     #[test]
     fn injected_runtime_state_contains_app_state() {
         let state = test_app_state();
-        let injected = injected_runtime_state(state.clone(), None);
+        let harvest_pool = test_pool("postgres://harvest:harvest@localhost:5432/harvest", 4);
+        let injected = injected_runtime_state(Some(state.clone()), None, harvest_pool);
         let stored = injected
             .get(&TypeId::of::<AppState>())
             .and_then(|value| value.downcast_ref::<AppState>())
             .expect("app state should be injected");
 
         assert_eq!(stored.profile(), state.profile());
+    }
+
+    #[test]
+    fn harvest_ext_embedded_mode_is_supported() {
+        let config = HarvestRuntimeConfig::default();
+
+        assert!(ensure_supported_topology(&config).is_ok());
+    }
+
+    #[test]
+    fn harvest_ext_split_mode_is_supported() {
+        let config = HarvestRuntimeConfig {
+            mode: HarvestMode::Split,
+            database: HarvestDatabaseConfig {
+                url: Some("postgres://harvest:harvest@localhost:5432/harvest".to_owned()),
+            },
+            ..HarvestRuntimeConfig::default()
+        };
+
+        ensure_supported_topology(&config).expect("split mode should now be supported");
+    }
+
+    #[test]
+    fn harvest_ext_split_mode_builds_dedicated_harvest_pool() {
+        let app_pool = test_pool("postgres://app:app@localhost:5432/app", 3);
+        let state = AppState::for_test().with_pool(app_pool.clone());
+        let config = HarvestRuntimeConfig {
+            mode: HarvestMode::Split,
+            database: HarvestDatabaseConfig {
+                url: Some("postgres://harvest:harvest@localhost:5432/harvest".to_owned()),
+            },
+            ..HarvestRuntimeConfig::default()
+        };
+
+        let harvest_pool = resolve_harvest_pool(&state, &config)
+            .expect("split mode should resolve a dedicated harvest pool");
+
+        assert_eq!(app_pool.status().max_size, 3);
+        assert_eq!(harvest_pool.status().max_size, 10);
+    }
+
+    #[test]
+    fn injected_runtime_state_contains_explicit_app_and_harvest_pool_roles() {
+        let app_pool = test_pool("postgres://app:app@localhost:5432/app", 3);
+        let harvest_pool = test_pool("postgres://harvest:harvest@localhost:5432/harvest", 7);
+        let injected = injected_runtime_state(
+            Some(AppState::for_test().with_pool(app_pool.clone())),
+            Some(app_pool.clone()),
+            harvest_pool.clone(),
+        );
+
+        let app_db = injected
+            .get(&TypeId::of::<AppDbPool>())
+            .and_then(|value| value.downcast_ref::<AppDbPool>())
+            .expect("app db pool should be injected");
+        let harvest_db = injected
+            .get(&TypeId::of::<HarvestDbPool>())
+            .and_then(|value| value.downcast_ref::<HarvestDbPool>())
+            .expect("harvest db pool should be injected");
+        let legacy_harvest_db = injected
+            .get(&TypeId::of::<DbPool>())
+            .and_then(|value| value.downcast_ref::<DbPool>())
+            .expect("legacy harvest db pool should still be injected");
+
+        assert_eq!(app_db.status().max_size, 3);
+        assert_eq!(harvest_db.status().max_size, 7);
+        assert_eq!(legacy_harvest_db.status().max_size, 7);
+    }
+
+    #[test]
+    fn harvest_ext_external_mode_is_supported_when_runtime_is_externalized() {
+        let config = HarvestRuntimeConfig {
+            mode: HarvestMode::External,
+            worker_enabled: false,
+            scheduler_enabled: false,
+            database: HarvestDatabaseConfig {
+                url: Some("postgres://harvest:harvest@localhost:5432/harvest".to_owned()),
+            },
+            outbox: crate::config::HarvestOutboxConfig::default(),
+        };
+
+        ensure_supported_topology(&config)
+            .expect("external mode should allow a web app without local worker ownership");
+    }
+
+    #[test]
+    fn harvest_ext_allows_worker_and_scheduler_toggles_to_be_managed_independently() {
+        let worker_only = HarvestRuntimeConfig {
+            worker_enabled: true,
+            scheduler_enabled: false,
+            ..HarvestRuntimeConfig::default()
+        };
+        let scheduler_only = HarvestRuntimeConfig {
+            worker_enabled: false,
+            scheduler_enabled: true,
+            ..HarvestRuntimeConfig::default()
+        };
+
+        ensure_supported_topology(&worker_only).expect("worker-only ownership should be supported");
+        ensure_supported_topology(&scheduler_only)
+            .expect("scheduler-only ownership should be supported");
     }
 }

--- a/autumn-harvest/autumn-web-harvest/src/lib.rs
+++ b/autumn-harvest/autumn-web-harvest/src/lib.rs
@@ -1,8 +1,19 @@
 //! Autumn adapter crate for autumn-harvest.
 
 pub mod api;
+pub mod config;
 pub mod ext;
+pub mod outbox;
 pub mod prelude;
+pub mod runner;
+pub mod state;
 
 pub use api::{HarvestApiRuntime, HarvestApiState, harvest_api_router};
+pub use config::{HarvestDatabaseConfig, HarvestMode, HarvestOutboxConfig, HarvestRuntimeConfig};
 pub use ext::HarvestExt;
+pub use outbox::{
+    WorkflowStartRequest, drain_workflow_start_outbox_once, enqueue_workflow_start_outbox,
+    flush_workflow_start_outbox,
+};
+pub use runner::{HarvestRunner, HarvestRunnerResources};
+pub use state::{AppDbPool, HarvestDbPool};

--- a/autumn-harvest/autumn-web-harvest/src/outbox.rs
+++ b/autumn-harvest/autumn-web-harvest/src/outbox.rs
@@ -2,9 +2,7 @@ use std::time::Duration;
 
 use autumn_web::AppState;
 use autumn_web::error::AutumnError;
-use chrono::{NaiveDateTime, Utc};
-use diesel::ExpressionMethods;
-use diesel::QueryDsl;
+use chrono::NaiveDateTime;
 use diesel_async::AsyncPgConnection;
 use diesel_async::RunQueryDsl;
 use serde::{Deserialize, Serialize};
@@ -41,7 +39,7 @@ diesel::table! {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkflowStartRequest {
     pub workflow_name: String,
     pub workflow_id: String,
@@ -83,6 +81,12 @@ struct NewHarvestWorkflowOutboxRow<'a> {
     search_attrs: Option<Value>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct OutboxDrainStats {
+    claimed: usize,
+    delivered: usize,
+}
+
 impl HarvestWorkflowOutboxRow {
     fn request(&self) -> WorkflowStartRequest {
         WorkflowStartRequest {
@@ -96,6 +100,13 @@ impl HarvestWorkflowOutboxRow {
     }
 }
 
+/// Persist a workflow-start request in the application database outbox.
+///
+/// Duplicate `(workflow_name, workflow_id)` requests are ignored so callers can retry safely.
+///
+/// # Errors
+///
+/// Returns a Diesel error if the outbox insert cannot be executed.
 pub async fn enqueue_workflow_start_outbox(
     conn: &mut AsyncPgConnection,
     request: &WorkflowStartRequest,
@@ -120,13 +131,30 @@ pub async fn enqueue_workflow_start_outbox(
     Ok(())
 }
 
+/// Claim one batch of due outbox rows and attempt delivery to Harvest storage.
+///
+/// The returned count is the number of rows successfully delivered, not the number claimed.
+///
+/// # Errors
+///
+/// Returns an [`AutumnError`] when the app database pool is unavailable or row claiming/updating
+/// fails.
 pub async fn drain_workflow_start_outbox_once(
     state: &AppState,
     limit: i64,
 ) -> Result<usize, AutumnError> {
+    drain_workflow_start_outbox_batch(state, limit)
+        .await
+        .map(|stats| stats.delivered)
+}
+
+async fn drain_workflow_start_outbox_batch(
+    state: &AppState,
+    limit: i64,
+) -> Result<OutboxDrainStats, AutumnError> {
     let config = outbox_config(state);
     if !config.enabled {
-        return Ok(0);
+        return Ok(OutboxDrainStats::default());
     }
 
     let Some(app_pool) = state.pool().cloned() else {
@@ -144,6 +172,7 @@ pub async fn drain_workflow_start_outbox_once(
         .await
         .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
 
+    let claimed = rows.len();
     let mut delivered = 0usize;
     for row in rows {
         match dispatch_workflow_start_request(state, &row.request()).await {
@@ -163,9 +192,16 @@ pub async fn drain_workflow_start_outbox_once(
         }
     }
 
-    Ok(delivered)
+    Ok(OutboxDrainStats { claimed, delivered })
 }
 
+/// Drain all currently due workflow-start outbox rows.
+///
+/// The returned count is the number of rows successfully delivered.
+///
+/// # Errors
+///
+/// Returns an [`AutumnError`] when claiming or marking any outbox row fails.
 pub async fn flush_workflow_start_outbox(state: &AppState) -> Result<usize, AutumnError> {
     let config = outbox_config(state);
     if !config.enabled {
@@ -173,11 +209,12 @@ pub async fn flush_workflow_start_outbox(state: &AppState) -> Result<usize, Autu
     }
 
     let batch_limit = config.batch_size.max(1);
+    let batch_limit_usize = usize::try_from(batch_limit).unwrap_or(usize::MAX);
     let mut total = 0usize;
     loop {
-        let delivered = drain_workflow_start_outbox_once(state, batch_limit).await?;
-        total += delivered;
-        if delivered < batch_limit as usize {
+        let drain = drain_workflow_start_outbox_batch(state, batch_limit).await?;
+        total += drain.delivered;
+        if drain.claimed < batch_limit_usize {
             break;
         }
     }
@@ -202,7 +239,7 @@ pub(crate) fn spawn_workflow_start_outbox_relay(
 
         loop {
             tokio::select! {
-                _ = shutdown.cancelled() => {
+                () = shutdown.cancelled() => {
                     debug!("Harvest workflow outbox relay shutting down");
                     break;
                 }
@@ -266,7 +303,7 @@ async fn claim_due_outbox_rows(
     config: &HarvestOutboxConfig,
 ) -> Result<Vec<HarvestWorkflowOutboxRow>, diesel::result::Error> {
     diesel::sql_query(
-        r#"
+        r"
         WITH due AS (
             SELECT id
             FROM harvest_workflow_outbox
@@ -286,9 +323,9 @@ async fn claim_due_outbox_rows(
         FROM due
         WHERE outbox.id = due.id
         RETURNING outbox.*
-        "#,
+        ",
     )
-    .bind::<diesel::sql_types::BigInt, _>(config.claim_ttl_ms as i64)
+    .bind::<diesel::sql_types::BigInt, _>(i64::try_from(config.claim_ttl_ms).unwrap_or(i64::MAX))
     .bind::<diesel::sql_types::BigInt, _>(limit)
     .bind::<diesel::sql_types::Text, _>(claimant)
     .load::<HarvestWorkflowOutboxRow>(conn)
@@ -301,20 +338,22 @@ async fn mark_outbox_row_delivered(
     claimant: &str,
     exec_id: ExecutionId,
 ) -> Result<(), diesel::result::Error> {
-    diesel::update(
-        harvest_workflow_outbox::table
-            .find(row_id)
-            .filter(harvest_workflow_outbox::claimed_by.eq(Some(claimant.to_owned()))),
+    diesel::sql_query(
+        r"
+        UPDATE harvest_workflow_outbox
+        SET delivery_attempts = delivery_attempts + 1,
+            last_error = NULL,
+            delivered_execution_id = $3,
+            delivered_at = NOW(),
+            claimed_at = NULL,
+            claimed_by = NULL
+        WHERE id = $1
+          AND claimed_by = $2
+        ",
     )
-    .set((
-        harvest_workflow_outbox::delivery_attempts
-            .eq(harvest_workflow_outbox::delivery_attempts + 1_i64),
-        harvest_workflow_outbox::last_error.eq::<Option<String>>(None),
-        harvest_workflow_outbox::delivered_execution_id.eq(Some(exec_id.to_string())),
-        harvest_workflow_outbox::delivered_at.eq(Some(Utc::now().naive_utc())),
-        harvest_workflow_outbox::claimed_at.eq::<Option<NaiveDateTime>>(None),
-        harvest_workflow_outbox::claimed_by.eq::<Option<String>>(None),
-    ))
+    .bind::<diesel::sql_types::BigInt, _>(row_id)
+    .bind::<diesel::sql_types::Text, _>(claimant)
+    .bind::<diesel::sql_types::Text, _>(exec_id.to_string())
     .execute(conn)
     .await
     .map(|_| ())
@@ -327,29 +366,31 @@ async fn mark_outbox_row_failed(
     config: &HarvestOutboxConfig,
     error: &str,
 ) -> Result<(), diesel::result::Error> {
-    let next_attempt_at =
-        Utc::now().naive_utc() + chrono::Duration::milliseconds(retry_delay_ms(config, row) as i64);
+    let retry_delay_ms = i64::try_from(retry_delay_ms(config, row)).unwrap_or(i64::MAX);
 
-    diesel::update(
-        harvest_workflow_outbox::table
-            .find(row.id)
-            .filter(harvest_workflow_outbox::claimed_by.eq(Some(claimant.to_owned()))),
+    diesel::sql_query(
+        r"
+        UPDATE harvest_workflow_outbox
+        SET delivery_attempts = delivery_attempts + 1,
+            last_error = $3,
+            next_attempt_at = NOW() + ($4 * INTERVAL '1 millisecond'),
+            claimed_at = NULL,
+            claimed_by = NULL
+        WHERE id = $1
+          AND claimed_by = $2
+        ",
     )
-    .set((
-        harvest_workflow_outbox::delivery_attempts
-            .eq(harvest_workflow_outbox::delivery_attempts + 1_i64),
-        harvest_workflow_outbox::last_error.eq(Some(error.to_owned())),
-        harvest_workflow_outbox::next_attempt_at.eq(next_attempt_at),
-        harvest_workflow_outbox::claimed_at.eq::<Option<NaiveDateTime>>(None),
-        harvest_workflow_outbox::claimed_by.eq::<Option<String>>(None),
-    ))
+    .bind::<diesel::sql_types::BigInt, _>(row.id)
+    .bind::<diesel::sql_types::Text, _>(claimant)
+    .bind::<diesel::sql_types::Text, _>(error)
+    .bind::<diesel::sql_types::BigInt, _>(retry_delay_ms)
     .execute(conn)
     .await
     .map(|_| ())
 }
 
 fn retry_delay_ms(config: &HarvestOutboxConfig, row: &HarvestWorkflowOutboxRow) -> u64 {
-    let attempt = row.delivery_attempts.max(0) as u32;
+    let attempt = u32::try_from(row.delivery_attempts.max(0)).unwrap_or(u32::MAX);
     let multiplier = 1_u64 << attempt.min(16);
     config
         .base_retry_delay_ms
@@ -360,6 +401,7 @@ fn retry_delay_ms(config: &HarvestOutboxConfig, row: &HarvestWorkflowOutboxRow) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
 
     #[test]
     fn retry_delay_caps_growth() {

--- a/autumn-harvest/autumn-web-harvest/src/outbox.rs
+++ b/autumn-harvest/autumn-web-harvest/src/outbox.rs
@@ -1,0 +1,391 @@
+use std::time::Duration;
+
+use autumn_web::AppState;
+use autumn_web::error::AutumnError;
+use chrono::{NaiveDateTime, Utc};
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+use autumn_harvest::error::{HarvestError, HarvestResult, database_error};
+use autumn_harvest::types::ExecutionId;
+use autumn_harvest::{StartWorkflowParams, start_or_load_workflow_execution};
+
+use crate::config::HarvestOutboxConfig;
+use crate::state::HarvestDbPool;
+
+diesel::table! {
+    harvest_workflow_outbox (id) {
+        id -> BigInt,
+        workflow_name -> Text,
+        workflow_id -> Text,
+        queue_name -> Text,
+        input -> Jsonb,
+        memo -> Nullable<Jsonb>,
+        search_attrs -> Nullable<Jsonb>,
+        delivery_attempts -> BigInt,
+        last_error -> Nullable<Text>,
+        delivered_execution_id -> Nullable<Text>,
+        delivered_at -> Nullable<Timestamp>,
+        next_attempt_at -> Timestamp,
+        claimed_at -> Nullable<Timestamp>,
+        claimed_by -> Nullable<Text>,
+        created_at -> Timestamp,
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowStartRequest {
+    pub workflow_name: String,
+    pub workflow_id: String,
+    pub queue_name: String,
+    pub input: Value,
+    pub memo: Option<Value>,
+    pub search_attrs: Option<Value>,
+}
+
+#[allow(dead_code)] // Row mirrors full table state across claim/update/retry paths and tests.
+#[derive(Debug, Clone, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[diesel(table_name = harvest_workflow_outbox)]
+struct HarvestWorkflowOutboxRow {
+    id: i64,
+    workflow_name: String,
+    workflow_id: String,
+    queue_name: String,
+    input: Value,
+    memo: Option<Value>,
+    search_attrs: Option<Value>,
+    delivery_attempts: i64,
+    last_error: Option<String>,
+    delivered_execution_id: Option<String>,
+    delivered_at: Option<NaiveDateTime>,
+    next_attempt_at: NaiveDateTime,
+    claimed_at: Option<NaiveDateTime>,
+    claimed_by: Option<String>,
+    created_at: NaiveDateTime,
+}
+
+#[derive(diesel::Insertable)]
+#[diesel(table_name = harvest_workflow_outbox)]
+struct NewHarvestWorkflowOutboxRow<'a> {
+    workflow_name: &'a str,
+    workflow_id: &'a str,
+    queue_name: &'a str,
+    input: Value,
+    memo: Option<Value>,
+    search_attrs: Option<Value>,
+}
+
+impl HarvestWorkflowOutboxRow {
+    fn request(&self) -> WorkflowStartRequest {
+        WorkflowStartRequest {
+            workflow_name: self.workflow_name.clone(),
+            workflow_id: self.workflow_id.clone(),
+            queue_name: self.queue_name.clone(),
+            input: self.input.clone(),
+            memo: self.memo.clone(),
+            search_attrs: self.search_attrs.clone(),
+        }
+    }
+}
+
+pub async fn enqueue_workflow_start_outbox(
+    conn: &mut AsyncPgConnection,
+    request: &WorkflowStartRequest,
+) -> Result<(), diesel::result::Error> {
+    diesel::insert_into(harvest_workflow_outbox::table)
+        .values(NewHarvestWorkflowOutboxRow {
+            workflow_name: &request.workflow_name,
+            workflow_id: &request.workflow_id,
+            queue_name: &request.queue_name,
+            input: request.input.clone(),
+            memo: request.memo.clone(),
+            search_attrs: request.search_attrs.clone(),
+        })
+        .on_conflict((
+            harvest_workflow_outbox::workflow_name,
+            harvest_workflow_outbox::workflow_id,
+        ))
+        .do_nothing()
+        .execute(conn)
+        .await?;
+
+    Ok(())
+}
+
+pub async fn drain_workflow_start_outbox_once(
+    state: &AppState,
+    limit: i64,
+) -> Result<usize, AutumnError> {
+    let config = outbox_config(state);
+    if !config.enabled {
+        return Ok(0);
+    }
+
+    let Some(app_pool) = state.pool().cloned() else {
+        return Err(AutumnError::service_unavailable_msg(
+            "Database not configured for Harvest outbox",
+        ));
+    };
+
+    let claimant = format!("harvest-outbox-{}", Uuid::new_v4().simple());
+    let mut app_conn = app_pool
+        .get()
+        .await
+        .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+    let rows = claim_due_outbox_rows(&mut app_conn, limit.max(1), &claimant, &config)
+        .await
+        .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+
+    let mut delivered = 0usize;
+    for row in rows {
+        match dispatch_workflow_start_request(state, &row.request()).await {
+            Ok(exec_id) => {
+                mark_outbox_row_delivered(&mut app_conn, row.id, &claimant, exec_id)
+                    .await
+                    .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+                delivered += 1;
+            }
+            Err(error) => {
+                mark_outbox_row_failed(&mut app_conn, &row, &claimant, &config, &error.to_string())
+                    .await
+                    .map_err(|db_error| {
+                        AutumnError::service_unavailable_msg(db_error.to_string())
+                    })?;
+            }
+        }
+    }
+
+    Ok(delivered)
+}
+
+pub async fn flush_workflow_start_outbox(state: &AppState) -> Result<usize, AutumnError> {
+    let config = outbox_config(state);
+    if !config.enabled {
+        return Ok(0);
+    }
+
+    let batch_limit = config.batch_size.max(1);
+    let mut total = 0usize;
+    loop {
+        let delivered = drain_workflow_start_outbox_once(state, batch_limit).await?;
+        total += delivered;
+        if delivered < batch_limit as usize {
+            break;
+        }
+    }
+
+    Ok(total)
+}
+
+pub(crate) fn spawn_workflow_start_outbox_relay(
+    state: AppState,
+    shutdown: CancellationToken,
+) -> JoinHandle<()> {
+    let config = outbox_config(&state);
+
+    tokio::spawn(async move {
+        if !config.enabled {
+            debug!("Harvest workflow outbox relay is disabled");
+            return;
+        }
+
+        let mut interval = tokio::time::interval(Duration::from_millis(config.poll_interval_ms));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                _ = shutdown.cancelled() => {
+                    debug!("Harvest workflow outbox relay shutting down");
+                    break;
+                }
+                _ = interval.tick() => {
+                    match flush_workflow_start_outbox(&state).await {
+                        Ok(0) => {}
+                        Ok(delivered) => {
+                            debug!(delivered, "Harvest workflow outbox relay drained pending rows");
+                        }
+                        Err(error) => {
+                            warn!(error = %error, "Harvest workflow outbox relay drain failed");
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+pub(crate) async fn dispatch_workflow_start_request(
+    state: &AppState,
+    request: &WorkflowStartRequest,
+) -> HarvestResult<ExecutionId> {
+    let harvest_pool = state.extension::<HarvestDbPool>().ok_or_else(|| {
+        HarvestError::Config(
+            "Harvest workflow publication is missing HarvestDbPool on AppState".into(),
+        )
+    })?;
+    let mut conn = harvest_pool.get().await.map_err(database_error)?;
+
+    let start = start_or_load_workflow_execution(
+        &mut conn,
+        StartWorkflowParams {
+            workflow_name: &request.workflow_name,
+            workflow_id: &request.workflow_id,
+            shard_id: 0,
+            input: request.input.clone(),
+            parent_id: None,
+            queue_name: &request.queue_name,
+            execution_timeout: None,
+            memo: request.memo.clone(),
+            search_attrs: request.search_attrs.clone(),
+        },
+    )
+    .await?;
+
+    Ok(start.exec_id)
+}
+
+fn outbox_config(state: &AppState) -> HarvestOutboxConfig {
+    state
+        .extension::<HarvestOutboxConfig>()
+        .map(|config| config.as_ref().clone())
+        .unwrap_or_default()
+}
+
+async fn claim_due_outbox_rows(
+    conn: &mut AsyncPgConnection,
+    limit: i64,
+    claimant: &str,
+    config: &HarvestOutboxConfig,
+) -> Result<Vec<HarvestWorkflowOutboxRow>, diesel::result::Error> {
+    diesel::sql_query(
+        r#"
+        WITH due AS (
+            SELECT id
+            FROM harvest_workflow_outbox
+            WHERE delivered_at IS NULL
+              AND next_attempt_at <= NOW()
+              AND (
+                  claimed_at IS NULL
+                  OR claimed_at < NOW() - ($1 * INTERVAL '1 millisecond')
+              )
+            ORDER BY id
+            FOR UPDATE SKIP LOCKED
+            LIMIT $2
+        )
+        UPDATE harvest_workflow_outbox AS outbox
+        SET claimed_at = NOW(),
+            claimed_by = $3
+        FROM due
+        WHERE outbox.id = due.id
+        RETURNING outbox.*
+        "#,
+    )
+    .bind::<diesel::sql_types::BigInt, _>(config.claim_ttl_ms as i64)
+    .bind::<diesel::sql_types::BigInt, _>(limit)
+    .bind::<diesel::sql_types::Text, _>(claimant)
+    .load::<HarvestWorkflowOutboxRow>(conn)
+    .await
+}
+
+async fn mark_outbox_row_delivered(
+    conn: &mut AsyncPgConnection,
+    row_id: i64,
+    claimant: &str,
+    exec_id: ExecutionId,
+) -> Result<(), diesel::result::Error> {
+    diesel::update(
+        harvest_workflow_outbox::table
+            .find(row_id)
+            .filter(harvest_workflow_outbox::claimed_by.eq(Some(claimant.to_owned()))),
+    )
+    .set((
+        harvest_workflow_outbox::delivery_attempts
+            .eq(harvest_workflow_outbox::delivery_attempts + 1_i64),
+        harvest_workflow_outbox::last_error.eq::<Option<String>>(None),
+        harvest_workflow_outbox::delivered_execution_id.eq(Some(exec_id.to_string())),
+        harvest_workflow_outbox::delivered_at.eq(Some(Utc::now().naive_utc())),
+        harvest_workflow_outbox::claimed_at.eq::<Option<NaiveDateTime>>(None),
+        harvest_workflow_outbox::claimed_by.eq::<Option<String>>(None),
+    ))
+    .execute(conn)
+    .await
+    .map(|_| ())
+}
+
+async fn mark_outbox_row_failed(
+    conn: &mut AsyncPgConnection,
+    row: &HarvestWorkflowOutboxRow,
+    claimant: &str,
+    config: &HarvestOutboxConfig,
+    error: &str,
+) -> Result<(), diesel::result::Error> {
+    let next_attempt_at =
+        Utc::now().naive_utc() + chrono::Duration::milliseconds(retry_delay_ms(config, row) as i64);
+
+    diesel::update(
+        harvest_workflow_outbox::table
+            .find(row.id)
+            .filter(harvest_workflow_outbox::claimed_by.eq(Some(claimant.to_owned()))),
+    )
+    .set((
+        harvest_workflow_outbox::delivery_attempts
+            .eq(harvest_workflow_outbox::delivery_attempts + 1_i64),
+        harvest_workflow_outbox::last_error.eq(Some(error.to_owned())),
+        harvest_workflow_outbox::next_attempt_at.eq(next_attempt_at),
+        harvest_workflow_outbox::claimed_at.eq::<Option<NaiveDateTime>>(None),
+        harvest_workflow_outbox::claimed_by.eq::<Option<String>>(None),
+    ))
+    .execute(conn)
+    .await
+    .map(|_| ())
+}
+
+fn retry_delay_ms(config: &HarvestOutboxConfig, row: &HarvestWorkflowOutboxRow) -> u64 {
+    let attempt = row.delivery_attempts.max(0) as u32;
+    let multiplier = 1_u64 << attempt.min(16);
+    config
+        .base_retry_delay_ms
+        .saturating_mul(multiplier)
+        .min(config.max_retry_delay_ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_delay_caps_growth() {
+        let config = HarvestOutboxConfig {
+            base_retry_delay_ms: 1_000,
+            max_retry_delay_ms: 10_000,
+            ..HarvestOutboxConfig::default()
+        };
+        let row = HarvestWorkflowOutboxRow {
+            id: 1,
+            workflow_name: "user_onboarding".to_owned(),
+            workflow_id: "user-onboarding:1".to_owned(),
+            queue_name: "default".to_owned(),
+            input: Value::Null,
+            memo: None,
+            search_attrs: None,
+            delivery_attempts: 8,
+            last_error: None,
+            delivered_execution_id: None,
+            delivered_at: None,
+            next_attempt_at: Utc::now().naive_utc(),
+            claimed_at: None,
+            claimed_by: None,
+            created_at: Utc::now().naive_utc(),
+        };
+
+        assert_eq!(retry_delay_ms(&config, &row), 10_000);
+    }
+}

--- a/autumn-harvest/autumn-web-harvest/src/prelude.rs
+++ b/autumn-harvest/autumn-web-harvest/src/prelude.rs
@@ -5,5 +5,14 @@
 //! ```
 
 pub use crate::api::{HarvestApiRuntime, HarvestApiState, harvest_api_router};
+pub use crate::config::{
+    HarvestDatabaseConfig, HarvestMode, HarvestOutboxConfig, HarvestRuntimeConfig,
+};
 pub use crate::ext::HarvestExt;
+pub use crate::outbox::{
+    WorkflowStartRequest, drain_workflow_start_outbox_once, enqueue_workflow_start_outbox,
+    flush_workflow_start_outbox,
+};
+pub use crate::runner::{HarvestRunner, HarvestRunnerResources};
+pub use crate::state::{AppDbPool, HarvestDbPool};
 pub use autumn_harvest::prelude::*;

--- a/autumn-harvest/autumn-web-harvest/src/runner.rs
+++ b/autumn-harvest/autumn-web-harvest/src/runner.rs
@@ -1,0 +1,238 @@
+//! Reusable Harvest runtime ownership for standalone or embedded processes.
+
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use autumn_harvest::BuiltHarvest;
+use autumn_harvest::context::SharedStateMap;
+use autumn_harvest::scheduler::{
+    DagCatalog, SchedulerMonitor, SchedulerRuntime, compile_dag_catalog,
+};
+use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
+use autumn_web::AppState;
+use autumn_web::error::AutumnError;
+use tokio::task::JoinHandle;
+
+use crate::api::HarvestApiRuntime;
+use crate::config::HarvestRuntimeConfig;
+use crate::state::{AppDbPool, HarvestDbPool};
+
+/// Resource bundle used to start a Harvest runtime outside `HarvestExt`.
+///
+/// The Harvest storage pool is required. Application state and an application
+/// database pool are optional, but should be provided when activities or
+/// workflows need access to app-owned state or business tables.
+#[derive(Clone)]
+pub struct HarvestRunnerResources {
+    app_state: Option<AppState>,
+    app_pool: Option<DbPool>,
+    harvest_pool: DbPool,
+}
+
+impl HarvestRunnerResources {
+    /// Create a new resource bundle with the required Harvest storage pool.
+    #[must_use]
+    pub fn new(harvest_pool: DbPool) -> Self {
+        Self {
+            app_state: None,
+            app_pool: None,
+            harvest_pool,
+        }
+    }
+
+    /// Inject application state for workflows or activities that expect it.
+    #[must_use]
+    pub fn with_app_state(mut self, app_state: AppState) -> Self {
+        self.app_state = Some(app_state);
+        self
+    }
+
+    /// Inject the application/business database role for workflow code that
+    /// touches app tables directly.
+    #[must_use]
+    pub fn with_app_pool(mut self, app_pool: DbPool) -> Self {
+        self.app_pool = Some(app_pool);
+        self
+    }
+}
+
+struct PreparedHarvestRuntime {
+    registry: Arc<HandlerRegistry>,
+    dag_catalog: Arc<DagCatalog>,
+    worker_runtime_config: WorkerRuntimeConfig,
+    storage_pool: HarvestDbPool,
+}
+
+impl PreparedHarvestRuntime {
+    fn build(
+        built: BuiltHarvest,
+        resources: HarvestRunnerResources,
+    ) -> autumn_web::AutumnResult<Self> {
+        let (registry, dags, worker_config) =
+            built.into_worker_parts_with_extra_state(injected_runtime_state(
+                resources.app_state,
+                resources.app_pool,
+                resources.harvest_pool.clone(),
+            ));
+        let dag_catalog = Arc::new(
+            compile_dag_catalog(dags)
+                .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?,
+        );
+
+        Ok(Self {
+            registry: Arc::new(registry),
+            dag_catalog,
+            worker_runtime_config: WorkerRuntimeConfig::from(worker_config),
+            storage_pool: HarvestDbPool::from(resources.harvest_pool),
+        })
+    }
+}
+
+/// Running Harvest runtime ownership for a process.
+///
+/// This owns any locally started worker and scheduler tasks while also
+/// exposing the management API snapshot and Harvest storage pool needed by a
+/// web app or control plane process.
+pub struct HarvestRunner {
+    api_runtime: HarvestApiRuntime,
+    storage_pool: HarvestDbPool,
+    worker: Option<Arc<Worker>>,
+    worker_handle: Option<JoinHandle<()>>,
+    scheduler: Option<SchedulerRuntime>,
+}
+
+impl HarvestRunner {
+    /// Start a Harvest runtime from a previously built registration set.
+    ///
+    /// Local worker and scheduler ownership are driven by `config`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the workflow/activity registrations are invalid or
+    /// the worker configuration cannot be materialized.
+    pub fn start(
+        built: BuiltHarvest,
+        config: &HarvestRuntimeConfig,
+        resources: HarvestRunnerResources,
+    ) -> autumn_web::AutumnResult<Self> {
+        let prepared = PreparedHarvestRuntime::build(built, resources)?;
+        let registry = Arc::clone(&prepared.registry);
+        let dag_catalog = Arc::clone(&prepared.dag_catalog);
+        let queues = prepared.worker_runtime_config.queues.clone();
+        let harvest_pool = prepared.storage_pool.clone_inner();
+
+        if !config.worker_enabled && !config.scheduler_enabled {
+            tracing::info!(
+                mode = ?config.mode,
+                "harvest runtime started without local worker or scheduler ownership"
+            );
+        }
+
+        let worker = if config.worker_enabled {
+            Some(Arc::new(
+                Worker::new(
+                    prepared.worker_runtime_config.clone(),
+                    Arc::clone(&registry),
+                )
+                .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?,
+            ))
+        } else {
+            None
+        };
+        let worker_id = worker
+            .as_ref()
+            .map(|_| prepared.worker_runtime_config.worker_id.clone());
+        let worker_handle = worker.as_ref().map(|worker| {
+            let worker = Arc::clone(worker);
+            let pool = harvest_pool.clone();
+            tokio::spawn(async move {
+                worker.run(&pool).await;
+            })
+        });
+        let scheduler = if config.scheduler_enabled && !dag_catalog.is_empty() {
+            Some(SchedulerRuntime::spawn(
+                harvest_pool.clone(),
+                Arc::clone(&registry),
+                Arc::clone(&dag_catalog),
+            ))
+        } else {
+            None
+        };
+        let scheduler_monitor = scheduler
+            .as_ref()
+            .map_or_else(SchedulerMonitor::offline, SchedulerRuntime::monitor);
+        let api_runtime =
+            HarvestApiRuntime::new(registry, dag_catalog, worker_id, queues, scheduler_monitor);
+
+        Ok(Self {
+            api_runtime,
+            storage_pool: prepared.storage_pool,
+            worker,
+            worker_handle,
+            scheduler,
+        })
+    }
+
+    /// Clone the API runtime snapshot for management/query routes.
+    #[must_use]
+    pub fn api_runtime(&self) -> HarvestApiRuntime {
+        self.api_runtime.clone()
+    }
+
+    /// Clone the Harvest storage pool used by management routes.
+    #[must_use]
+    pub fn storage_pool(&self) -> HarvestDbPool {
+        self.storage_pool.clone()
+    }
+
+    /// Stop any locally owned worker and scheduler tasks.
+    pub async fn stop(self) {
+        let Self {
+            api_runtime: _,
+            storage_pool: _,
+            worker,
+            worker_handle,
+            scheduler,
+        } = self;
+
+        if let Some(worker) = worker {
+            worker.shutdown();
+        }
+        if let Some(scheduler) = scheduler {
+            scheduler.shutdown();
+            if let Err(error) = scheduler.join().await {
+                tracing::warn!(error = %error, "harvest scheduler task failed during shutdown");
+            }
+        }
+        if let Some(worker_handle) = worker_handle {
+            if let Err(error) = worker_handle.await {
+                tracing::warn!(error = %error, "harvest worker task failed during shutdown");
+            }
+        }
+    }
+}
+
+pub(crate) fn injected_runtime_state(
+    pool_state: Option<AppState>,
+    app_pool: Option<DbPool>,
+    harvest_pool: DbPool,
+) -> SharedStateMap {
+    let mut state: HashMap<TypeId, Box<dyn Any + Send + Sync>> = HashMap::new();
+    if let Some(pool_state) = pool_state {
+        state.insert(TypeId::of::<AppState>(), Box::new(pool_state));
+    }
+    if let Some(app_pool) = app_pool {
+        state.insert(
+            TypeId::of::<AppDbPool>(),
+            Box::new(AppDbPool::from(app_pool)),
+        );
+    }
+    let harvest_pool = HarvestDbPool::from(harvest_pool);
+    state.insert(
+        TypeId::of::<HarvestDbPool>(),
+        Box::new(harvest_pool.clone()),
+    );
+    state.insert(TypeId::of::<DbPool>(), Box::new(harvest_pool.clone_inner()));
+    state
+}

--- a/autumn-harvest/autumn-web-harvest/src/runner.rs
+++ b/autumn-harvest/autumn-web-harvest/src/runner.rs
@@ -33,7 +33,7 @@ pub struct HarvestRunnerResources {
 impl HarvestRunnerResources {
     /// Create a new resource bundle with the required Harvest storage pool.
     #[must_use]
-    pub fn new(harvest_pool: DbPool) -> Self {
+    pub const fn new(harvest_pool: DbPool) -> Self {
         Self {
             app_state: None,
             app_pool: None,
@@ -152,7 +152,7 @@ impl HarvestRunner {
         });
         let scheduler = if config.scheduler_enabled && !dag_catalog.is_empty() {
             Some(SchedulerRuntime::spawn(
-                harvest_pool.clone(),
+                harvest_pool,
                 Arc::clone(&registry),
                 Arc::clone(&dag_catalog),
             ))

--- a/autumn-harvest/autumn-web-harvest/src/state.rs
+++ b/autumn-harvest/autumn-web-harvest/src/state.rs
@@ -1,0 +1,74 @@
+use std::ops::Deref;
+
+use autumn_harvest::worker::DbPool;
+
+/// Application/business database role exposed to Harvest activities.
+///
+/// In embedded mode this may point to the same underlying Postgres pool as
+/// Harvest system storage. In split mode it intentionally stays bound to the
+/// app database so activities can touch business tables explicitly.
+#[derive(Clone)]
+pub struct AppDbPool(DbPool);
+
+impl AppDbPool {
+    #[must_use]
+    pub fn clone_inner(&self) -> DbPool {
+        self.0.clone()
+    }
+}
+
+impl From<DbPool> for AppDbPool {
+    fn from(pool: DbPool) -> Self {
+        Self(pool)
+    }
+}
+
+impl Deref for AppDbPool {
+    type Target = DbPool;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for AppDbPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppDbPool")
+            .field("max_size", &self.0.status().max_size)
+            .finish()
+    }
+}
+
+/// Harvest system-storage database role used for queue, history, and scheduler
+/// tables.
+#[derive(Clone)]
+pub struct HarvestDbPool(DbPool);
+
+impl HarvestDbPool {
+    #[must_use]
+    pub fn clone_inner(&self) -> DbPool {
+        self.0.clone()
+    }
+}
+
+impl From<DbPool> for HarvestDbPool {
+    fn from(pool: DbPool) -> Self {
+        Self(pool)
+    }
+}
+
+impl Deref for HarvestDbPool {
+    type Target = DbPool;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for HarvestDbPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HarvestDbPool")
+            .field("max_size", &self.0.status().max_size)
+            .finish()
+    }
+}

--- a/autumn-harvest/autumn-web-harvest/tests/api_scheduler_integration.rs
+++ b/autumn-harvest/autumn-web-harvest/tests/api_scheduler_integration.rs
@@ -11,12 +11,18 @@ use autumn_harvest::policy::Schedule;
 use autumn_harvest::scheduler::{
     DagCatalog, SchedulerMonitor, compile_dag_catalog, register_schedules, tick_once,
 };
-use autumn_harvest::schema::{harvest_dag_runs, harvest_schedules, harvest_workflow_executions};
+use autumn_harvest::schema::{
+    harvest_dag_runs, harvest_schedules, harvest_task_queue, harvest_workflow_executions,
+};
 use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
 use autumn_harvest::{ActivityContext, WorkflowContext};
 use autumn_web::AppState;
 use autumn_web::reexports::axum;
+use autumn_web_harvest::HarvestDbPool;
 use autumn_web_harvest::api::{HarvestApiRuntime, HarvestApiState, harvest_api_router};
+use autumn_web_harvest::{
+    HarvestMode, HarvestRunner, HarvestRunnerResources, HarvestRuntimeConfig,
+};
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use diesel::ExpressionMethods;
@@ -67,6 +73,10 @@ fn build_test_pool(database_url: &str) -> DbPool {
 
 fn test_app_state(pool: DbPool) -> AppState {
     AppState::for_test().with_pool(pool).with_profile("test")
+}
+
+fn test_app_state_without_database() -> AppState {
+    AppState::for_test().with_profile("test")
 }
 
 fn build_test_worker(registry: Arc<HandlerRegistry>) -> Arc<Worker> {
@@ -219,6 +229,39 @@ async fn load_execution_from_url(database_url: &str, exec_id: &str) -> WorkflowE
         .first(&mut conn)
         .await
         .expect("failed to reload workflow execution")
+}
+
+async fn load_workflow_rows_from_url(
+    database_url: &str,
+    workflow_name: &str,
+    workflow_id: &str,
+) -> Vec<WorkflowExecution> {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect fresh Postgres client for workflow lookup");
+    harvest_workflow_executions::table
+        .filter(harvest_workflow_executions::workflow_name.eq(workflow_name))
+        .filter(harvest_workflow_executions::workflow_id.eq(workflow_id))
+        .order(harvest_workflow_executions::created_at.asc())
+        .select(WorkflowExecution::as_select())
+        .load(&mut conn)
+        .await
+        .expect("failed to load workflow rows by workflow key")
+}
+
+async fn count_workflow_tasks_from_url(database_url: &str, exec_id: &str) -> i64 {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect fresh Postgres client for task lookup");
+    let exec_id = exec_id
+        .parse::<autumn_harvest::ExecutionId>()
+        .expect("invalid execution id");
+    harvest_task_queue::table
+        .filter(harvest_task_queue::workflow_exec_id.eq(Some(exec_id.as_uuid())))
+        .count()
+        .get_result(&mut conn)
+        .await
+        .expect("failed to count workflow tasks")
 }
 
 async fn load_schedule_from_url(database_url: &str, dag_name: &str) -> HarvestSchedule {
@@ -403,15 +446,16 @@ fn manual_interval_pipeline_info() -> DagInfo {
 }
 
 #[tokio::test]
-async fn harvest_api_starts_queries_and_signals_workflows() {
+async fn harvest_api_uses_installed_storage_pool_when_app_state_has_no_database() {
     let (database_url, _container) = setup_test_database_url().await;
     let pool = build_test_pool(&database_url);
     let registry = approval_registry();
     let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool.clone()));
     api_state.install(HarvestApiRuntime::new(
         Arc::clone(&registry),
         Arc::new(HashMap::new()),
-        "test-worker".to_string(),
+        Some("test-worker".to_string()),
         vec!["default".to_string()],
         SchedulerMonitor::offline(),
     ));
@@ -419,7 +463,7 @@ async fn harvest_api_starts_queries_and_signals_workflows() {
     let worker = build_test_worker(Arc::clone(&registry));
     let worker_task = spawn_test_worker(Arc::clone(&worker), pool.clone());
 
-    let app = harvest_api_router(api_state.clone()).with_state(test_app_state(pool.clone()));
+    let app = harvest_api_router(api_state.clone()).with_state(test_app_state_without_database());
 
     let (start_status, start_json) = post_json(
         &app,
@@ -486,15 +530,154 @@ async fn harvest_api_starts_queries_and_signals_workflows() {
 }
 
 #[tokio::test]
+async fn harvest_api_duplicate_start_reuses_existing_execution() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let pool = build_test_pool(&database_url);
+    let registry = approval_registry();
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool.clone()));
+    api_state.install(HarvestApiRuntime::new(
+        Arc::clone(&registry),
+        Arc::new(HashMap::new()),
+        Some("test-worker".to_string()),
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+    ));
+    let app = harvest_api_router(api_state).with_state(test_app_state(pool));
+
+    let payload = json!({
+        "workflow_id": "approval-duplicate",
+        "input": { "request_id": "dup-1" },
+    });
+
+    let (first_status, first_json) =
+        post_json(&app, "/workflows/approval_workflow/start", payload.clone()).await;
+    assert_eq!(first_status, StatusCode::CREATED);
+    let first_exec_id = first_json["execution_id"]
+        .as_str()
+        .expect("first execution_id must be a string")
+        .to_owned();
+
+    let (second_status, second_json) =
+        post_json(&app, "/workflows/approval_workflow/start", payload).await;
+    assert_eq!(
+        second_status,
+        StatusCode::OK,
+        "duplicate start should reuse the existing execution"
+    );
+    assert_eq!(
+        second_json["execution_id"].as_str(),
+        Some(first_exec_id.as_str()),
+        "duplicate start should return the original execution id"
+    );
+
+    let executions =
+        load_workflow_rows_from_url(&database_url, "approval_workflow", "approval-duplicate").await;
+    assert_eq!(
+        executions.len(),
+        1,
+        "duplicate start should not create a second workflow row"
+    );
+    let tasks = count_workflow_tasks_from_url(&database_url, &first_exec_id).await;
+    assert_eq!(
+        tasks, 1,
+        "duplicate start should not enqueue duplicate workflow tasks"
+    );
+}
+
+#[tokio::test]
+async fn external_runner_processes_workflows_started_via_management_api() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let pool = build_test_pool(&database_url);
+    let api_state = HarvestApiState::new();
+
+    let web_runtime = HarvestRunner::start(
+        autumn_harvest::HarvestBuilder::new()
+            .workflows(vec![WorkflowInfo {
+                name: "approval_workflow",
+                module: "tests",
+                handler: approval_workflow,
+            }])
+            .build(),
+        &HarvestRuntimeConfig {
+            mode: HarvestMode::External,
+            worker_enabled: false,
+            scheduler_enabled: false,
+            database: autumn_web_harvest::HarvestDatabaseConfig {
+                url: Some(database_url.clone()),
+            },
+            outbox: autumn_web_harvest::HarvestOutboxConfig::default(),
+        },
+        HarvestRunnerResources::new(pool.clone()),
+    )
+    .expect("external web runtime should start without local ownership");
+
+    let runner = HarvestRunner::start(
+        autumn_harvest::HarvestBuilder::new()
+            .workflows(vec![WorkflowInfo {
+                name: "approval_workflow",
+                module: "tests",
+                handler: approval_workflow,
+            }])
+            .build(),
+        &HarvestRuntimeConfig {
+            mode: HarvestMode::External,
+            worker_enabled: true,
+            scheduler_enabled: false,
+            database: autumn_web_harvest::HarvestDatabaseConfig {
+                url: Some(database_url.clone()),
+            },
+            outbox: autumn_web_harvest::HarvestOutboxConfig::default(),
+        },
+        HarvestRunnerResources::new(pool.clone()),
+    )
+    .expect("external runner should start");
+
+    api_state.install_storage_pool(web_runtime.storage_pool());
+    api_state.install(web_runtime.api_runtime());
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    let (start_status, start_json) = post_json(
+        &app,
+        "/workflows/approval_workflow/start",
+        json!({
+            "workflow_id": "approval-external-runner",
+            "input": { "request_id": "external-runner" },
+        }),
+    )
+    .await;
+    assert_eq!(start_status, StatusCode::CREATED);
+    let exec_id = start_json["execution_id"]
+        .as_str()
+        .expect("execution_id must be present")
+        .to_string();
+
+    let (signal_status, _signal_json) = post_json(
+        &app,
+        format!("/workflows/{exec_id}/signal/approved"),
+        json!({ "approved": true }),
+    )
+    .await;
+    assert_eq!(signal_status, StatusCode::ACCEPTED);
+
+    let execution = wait_for_workflow_state(&database_url, &exec_id, "COMPLETED").await;
+    assert_eq!(execution.workflow_name, "approval_workflow");
+
+    runner.stop().await;
+    web_runtime.stop().await;
+}
+
+#[tokio::test]
 async fn harvest_api_signal_does_not_wake_timer_waits_early() {
     let (database_url, _container) = setup_test_database_url().await;
     let pool = build_test_pool(&database_url);
     let registry = approval_and_timer_signal_registry();
     let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool.clone()));
     api_state.install(HarvestApiRuntime::new(
         Arc::clone(&registry),
         Arc::new(HashMap::new()),
-        "test-worker".to_string(),
+        Some("test-worker".to_string()),
         vec!["default".to_string()],
         SchedulerMonitor::offline(),
     ));
@@ -604,10 +787,11 @@ async fn harvest_api_lists_and_triggers_manual_dags() {
     .await;
 
     let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool.clone()));
     api_state.install(HarvestApiRuntime::new(
         Arc::clone(&registry),
         Arc::clone(&dag_catalog),
-        "scheduler-only".to_string(),
+        Some("scheduler-only".to_string()),
         vec!["default".to_string()],
         SchedulerMonitor::offline(),
     ));

--- a/autumn-harvest/autumn-web-harvest/tests/api_scheduler_integration.rs
+++ b/autumn-harvest/autumn-web-harvest/tests/api_scheduler_integration.rs
@@ -14,9 +14,9 @@ use autumn_harvest::scheduler::{
 use autumn_harvest::schema::{harvest_dag_runs, harvest_schedules, harvest_workflow_executions};
 use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
 use autumn_harvest::{ActivityContext, WorkflowContext};
+use autumn_web_harvest::api::{HarvestApiRuntime, HarvestApiState, harvest_api_router};
 use autumn_web::AppState;
 use autumn_web::reexports::axum;
-use autumn_web_harvest::api::{HarvestApiRuntime, HarvestApiState, harvest_api_router};
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use diesel::ExpressionMethods;

--- a/autumn-harvest/autumn-web-harvest/tests/api_scheduler_integration.rs
+++ b/autumn-harvest/autumn-web-harvest/tests/api_scheduler_integration.rs
@@ -14,9 +14,9 @@ use autumn_harvest::scheduler::{
 use autumn_harvest::schema::{harvest_dag_runs, harvest_schedules, harvest_workflow_executions};
 use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
 use autumn_harvest::{ActivityContext, WorkflowContext};
-use autumn_web_harvest::api::{HarvestApiRuntime, HarvestApiState, harvest_api_router};
 use autumn_web::AppState;
 use autumn_web::reexports::axum;
+use autumn_web_harvest::api::{HarvestApiRuntime, HarvestApiState, harvest_api_router};
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use diesel::ExpressionMethods;

--- a/autumn-harvest/autumn-web-harvest/tests/outbox_integration.rs
+++ b/autumn-harvest/autumn-web-harvest/tests/outbox_integration.rs
@@ -1,9 +1,10 @@
 use autumn_web::AppState;
 use autumn_web::config::DatabaseConfig;
 use autumn_web_harvest::{
-    HarvestDbPool, WorkflowStartRequest, drain_workflow_start_outbox_once,
-    enqueue_workflow_start_outbox,
+    HarvestDbPool, HarvestOutboxConfig, WorkflowStartRequest, drain_workflow_start_outbox_once,
+    enqueue_workflow_start_outbox, flush_workflow_start_outbox,
 };
+use diesel::QueryableByName;
 use diesel_async::AsyncConnection;
 use diesel_async::AsyncPgConnection;
 use diesel_async::RunQueryDsl;
@@ -18,9 +19,22 @@ const OUTBOX_INIT_SQL: &str =
 const HARVEST_INIT_SQL: &str =
     include_str!("../../autumn-harvest/migrations/20260409000000_harvest_initial/up.sql");
 
+#[derive(Debug, QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    count: i64,
+}
+
+#[derive(Debug, QueryableByName)]
+struct DelayRow {
+    #[diesel(sql_type = diesel::sql_types::Double)]
+    seconds: f64,
+}
+
 #[tokio::test]
 async fn framework_outbox_delivers_to_split_harvest_store() {
-    let (state, mut app_conn, _harvest_url, _container) = setup_split_test_databases(true).await;
+    let (state, mut app_conn, _app_url, _harvest_url, _container) =
+        setup_split_test_databases(true).await;
 
     let request = WorkflowStartRequest {
         workflow_name: "user_onboarding".to_string(),
@@ -52,7 +66,8 @@ async fn framework_outbox_delivers_to_split_harvest_store() {
 
 #[tokio::test]
 async fn framework_outbox_retries_failed_delivery() {
-    let (state, mut app_conn, _harvest_url, _container) = setup_split_test_databases(false).await;
+    let (state, mut app_conn, _app_url, _harvest_url, _container) =
+        setup_split_test_databases(false).await;
 
     let request = WorkflowStartRequest {
         workflow_name: "post_publication".to_string(),
@@ -82,11 +97,119 @@ async fn framework_outbox_retries_failed_delivery() {
     assert_eq!(delivered, 0, "failed delivery should not report success");
 }
 
+#[tokio::test]
+async fn framework_outbox_flush_keeps_draining_full_failed_batches() {
+    let (state, mut app_conn, _app_url, _harvest_url, _container) =
+        setup_split_test_databases(false).await;
+    state.insert_extension(HarvestOutboxConfig {
+        batch_size: 2,
+        ..HarvestOutboxConfig::default()
+    });
+
+    for workflow_id in [
+        "post-publication:1",
+        "post-publication:2",
+        "post-publication:3",
+    ] {
+        enqueue_workflow_start_outbox(
+            &mut app_conn,
+            &WorkflowStartRequest {
+                workflow_name: "post_publication".to_string(),
+                workflow_id: workflow_id.to_string(),
+                queue_name: "default".to_string(),
+                input: serde_json::json!({ "workflow_id": workflow_id }),
+                memo: None,
+                search_attrs: None,
+            },
+        )
+        .await
+        .expect("outbox row should persist before drain");
+    }
+
+    let delivered = flush_workflow_start_outbox(&state)
+        .await
+        .expect("flush should keep draining full failed batches");
+    assert_eq!(delivered, 0, "failed rows should not count as delivered");
+
+    let attempts: CountRow = diesel::sql_query(
+        "SELECT COUNT(*) AS count FROM harvest_workflow_outbox WHERE delivery_attempts = 1",
+    )
+    .get_result(&mut app_conn)
+    .await
+    .expect("should count processed outbox rows");
+    assert_eq!(
+        attempts.count, 3,
+        "flush should process every due row even when the first full batch only fails",
+    );
+}
+
+#[tokio::test]
+async fn framework_outbox_retry_delay_tracks_database_clock() {
+    let (_state, mut app_conn, app_url, harvest_url, _container) =
+        setup_split_test_databases(false).await;
+    app_conn
+        .batch_execute("SET TIME ZONE 'America/Chicago'")
+        .await
+        .expect("app session should accept a non-UTC timezone");
+
+    let state = build_test_state(&app_url, &harvest_url, 1);
+    state.insert_extension(HarvestOutboxConfig {
+        base_retry_delay_ms: 1_000,
+        max_retry_delay_ms: 1_000,
+        ..HarvestOutboxConfig::default()
+    });
+    let mut pooled = state
+        .pool()
+        .expect("state should expose the app pool")
+        .get()
+        .await
+        .expect("failed to borrow pooled app connection");
+    pooled
+        .batch_execute("SET TIME ZONE 'America/Chicago'")
+        .await
+        .expect("pooled app session should accept a non-UTC timezone");
+    drop(pooled);
+
+    enqueue_workflow_start_outbox(
+        &mut app_conn,
+        &WorkflowStartRequest {
+            workflow_name: "post_publication".to_string(),
+            workflow_id: "post-publication:timezone".to_string(),
+            queue_name: "default".to_string(),
+            input: serde_json::json!({ "post_id": 42 }),
+            memo: None,
+            search_attrs: None,
+        },
+    )
+    .await
+    .expect("outbox row should persist before failure");
+
+    let delivered = drain_workflow_start_outbox_once(&state, 1)
+        .await
+        .expect("drain should record the failed delivery");
+    assert_eq!(delivered, 0, "failed delivery should not report success");
+
+    let delay: DelayRow = diesel::sql_query(
+        "SELECT EXTRACT(EPOCH FROM (next_attempt_at - created_at)) AS seconds \
+         FROM harvest_workflow_outbox \
+         WHERE workflow_id = 'post-publication:timezone'",
+    )
+    .get_result(&mut app_conn)
+    .await
+    .expect("should compute the retry delay from persisted timestamps");
+    assert!(
+        (0.5..5.0).contains(&delay.seconds),
+        "retry delay should stay close to one second regardless of session timezone, got {}s",
+        delay.seconds,
+    );
+}
+
 async fn setup_split_test_databases(
     apply_harvest_migrations: bool,
 ) -> (
     AppState,
     AsyncPgConnection,
+    String,
     String,
     ContainerAsync<Postgres>,
 ) {
@@ -140,20 +263,24 @@ async fn setup_split_test_databases(
             .expect("failed to apply harvest migrations");
     }
 
-    let app_pool = build_pool(&app_url);
-    let harvest_pool = build_pool(&harvest_url);
-    let state = AppState::for_test().with_pool(app_pool);
-    state.insert_extension(HarvestDbPool::from(harvest_pool));
+    let state = build_test_state(&app_url, &harvest_url, 4);
 
-    (state, app_conn, harvest_url, container)
+    (state, app_conn, app_url, harvest_url, container)
+}
+
+fn build_test_state(app_url: &str, harvest_url: &str, pool_size: usize) -> AppState {
+    let state = AppState::for_test().with_pool(build_pool(app_url, pool_size));
+    state.insert_extension(HarvestDbPool::from(build_pool(harvest_url, pool_size)));
+    state
 }
 
 fn build_pool(
     database_url: &str,
+    pool_size: usize,
 ) -> diesel_async::pooled_connection::deadpool::Pool<AsyncPgConnection> {
     autumn_web::db::create_pool(&DatabaseConfig {
         url: Some(database_url.to_owned()),
-        pool_size: 4,
+        pool_size,
         ..DatabaseConfig::default()
     })
     .expect("failed to build pool config")

--- a/autumn-harvest/autumn-web-harvest/tests/outbox_integration.rs
+++ b/autumn-harvest/autumn-web-harvest/tests/outbox_integration.rs
@@ -1,0 +1,161 @@
+use autumn_web::AppState;
+use autumn_web::config::DatabaseConfig;
+use autumn_web_harvest::{
+    HarvestDbPool, WorkflowStartRequest, drain_workflow_start_outbox_once,
+    enqueue_workflow_start_outbox,
+};
+use diesel_async::AsyncConnection;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use diesel_async::SimpleAsyncConnection;
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use uuid::Uuid;
+
+const OUTBOX_INIT_SQL: &str =
+    include_str!("../migrations/20260409010000_harvest_workflow_outbox/up.sql");
+const HARVEST_INIT_SQL: &str =
+    include_str!("../../autumn-harvest/migrations/20260409000000_harvest_initial/up.sql");
+
+#[tokio::test]
+async fn framework_outbox_delivers_to_split_harvest_store() {
+    let (state, mut app_conn, _harvest_url, _container) = setup_split_test_databases(true).await;
+
+    let request = WorkflowStartRequest {
+        workflow_name: "user_onboarding".to_string(),
+        workflow_id: "user-onboarding:42".to_string(),
+        queue_name: "default".to_string(),
+        input: serde_json::json!({
+            "user_id": 42,
+            "username": "ferris",
+        }),
+        memo: Some(serde_json::json!({
+            "kind": "user_onboarding",
+            "user_id": 42,
+        })),
+        search_attrs: Some(serde_json::json!({
+            "user_id": 42,
+            "username": "ferris",
+        })),
+    };
+
+    enqueue_workflow_start_outbox(&mut app_conn, &request)
+        .await
+        .expect("outbox row should persist in the app database");
+
+    let delivered = drain_workflow_start_outbox_once(&state, 32)
+        .await
+        .expect("outbox drain should succeed");
+    assert_eq!(delivered, 1, "one row should be delivered");
+}
+
+#[tokio::test]
+async fn framework_outbox_retries_failed_delivery() {
+    let (state, mut app_conn, _harvest_url, _container) = setup_split_test_databases(false).await;
+
+    let request = WorkflowStartRequest {
+        workflow_name: "post_publication".to_string(),
+        workflow_id: "post-publication:99".to_string(),
+        queue_name: "default".to_string(),
+        input: serde_json::json!({
+            "post_id": 99,
+            "title": "Ferris arrives",
+        }),
+        memo: Some(serde_json::json!({
+            "kind": "post_publication",
+            "post_id": 99,
+        })),
+        search_attrs: Some(serde_json::json!({
+            "post_id": 99,
+            "post_slug": "ferris-arrives",
+        })),
+    };
+
+    enqueue_workflow_start_outbox(&mut app_conn, &request)
+        .await
+        .expect("outbox row should persist even when delivery later fails");
+
+    let delivered = drain_workflow_start_outbox_once(&state, 32)
+        .await
+        .expect("outbox drain should record failure without crashing");
+    assert_eq!(delivered, 0, "failed delivery should not report success");
+}
+
+async fn setup_split_test_databases(
+    apply_harvest_migrations: bool,
+) -> (
+    AppState,
+    AsyncPgConnection,
+    String,
+    ContainerAsync<Postgres>,
+) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let admin_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let app_db_name = format!("framework_outbox_app_{}", Uuid::new_v4().simple());
+    let harvest_db_name = format!("framework_outbox_harvest_{}", Uuid::new_v4().simple());
+
+    let mut admin_conn = <AsyncPgConnection as AsyncConnection>::establish(&admin_url)
+        .await
+        .expect("failed to connect to admin database");
+    diesel::sql_query(format!("CREATE DATABASE {app_db_name}"))
+        .execute(&mut admin_conn)
+        .await
+        .expect("failed to create app database");
+    diesel::sql_query(format!("CREATE DATABASE {harvest_db_name}"))
+        .execute(&mut admin_conn)
+        .await
+        .expect("failed to create harvest database");
+
+    let app_url = format!("postgres://postgres:postgres@{host}:{port}/{app_db_name}");
+    let harvest_url = format!("postgres://postgres:postgres@{host}:{port}/{harvest_db_name}");
+
+    let mut app_conn = <AsyncPgConnection as AsyncConnection>::establish(&app_url)
+        .await
+        .expect("failed to connect to app database");
+    app_conn
+        .batch_execute(OUTBOX_INIT_SQL)
+        .await
+        .expect("failed to apply app outbox migration");
+
+    if apply_harvest_migrations {
+        let mut harvest_conn = <AsyncPgConnection as AsyncConnection>::establish(&harvest_url)
+            .await
+            .expect("failed to connect to harvest database");
+        harvest_conn
+            .batch_execute(HARVEST_INIT_SQL)
+            .await
+            .expect("failed to apply harvest migrations");
+    }
+
+    let app_pool = build_pool(&app_url);
+    let harvest_pool = build_pool(&harvest_url);
+    let state = AppState::for_test().with_pool(app_pool);
+    state.insert_extension(HarvestDbPool::from(harvest_pool));
+
+    (state, app_conn, harvest_url, container)
+}
+
+fn build_pool(
+    database_url: &str,
+) -> diesel_async::pooled_connection::deadpool::Pool<AsyncPgConnection> {
+    autumn_web::db::create_pool(&DatabaseConfig {
+        url: Some(database_url.to_owned()),
+        pool_size: 4,
+        ..DatabaseConfig::default()
+    })
+    .expect("failed to build pool config")
+    .expect("database url should create a pool")
+}

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1057,6 +1057,9 @@ mod tests {
 
     fn test_state_with_config(config: &AutumnConfig) -> AppState {
         AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: config.profile.clone().or_else(|| Some("dev".into())),

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -620,6 +620,9 @@ impl AppBuilder {
 
         // 6. Build the router (with optional static-file layer)
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool,
             profile: config.profile.clone(),
@@ -792,6 +795,9 @@ impl AppBuilder {
         };
 
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool,
             profile: config.profile.clone(),
@@ -1169,6 +1175,9 @@ mod tests {
     pub fn test_router(routes: Vec<Route>) -> axum::Router {
         let config = AutumnConfig::default();
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -1330,6 +1339,9 @@ mod tests {
         let mut config = AutumnConfig::default();
         config.health.path = "/healthz".to_owned();
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -1413,6 +1425,9 @@ mod tests {
         }];
         let config = AutumnConfig::default();
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -1462,6 +1477,9 @@ mod tests {
         ];
         let config = AutumnConfig::default();
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -1623,6 +1641,9 @@ mod tests {
         // No dynamic route for /docs — only a static file.
         let config = AutumnConfig::default();
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -1828,6 +1849,9 @@ mod tests {
     /// Helper to build a test router with custom config.
     pub fn test_router_with_config(routes: Vec<Route>, config: &AutumnConfig) -> axum::Router {
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -1964,6 +1988,9 @@ mod tests {
 
         let config = AutumnConfig::default();
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -1998,6 +2025,9 @@ mod tests {
         // When dist_dir is None, return the app router directly.
         let config = AutumnConfig::default();
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -2212,6 +2242,9 @@ mod tests {
     #[tokio::test]
     async fn start_task_scheduler_broadcasts_events() {
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -2265,6 +2298,9 @@ mod tests {
     #[tokio::test]
     async fn start_task_scheduler_broadcasts_failure_events() {
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -446,6 +446,9 @@ mod tests {
         }
 
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -495,6 +498,9 @@ mod tests {
         }
 
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -552,6 +558,9 @@ mod tests {
         use crate::state::AppState;
 
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -663,6 +672,9 @@ mod tests {
         }
 
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -726,6 +738,9 @@ mod tests {
             .unwrap();
 
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -794,6 +809,9 @@ mod tests {
             .unwrap();
 
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -858,6 +876,9 @@ mod tests {
             .unwrap();
 
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -915,6 +936,9 @@ mod tests {
         store.save("valid-session", session_data).await.unwrap();
 
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -230,6 +230,9 @@ mod tests {
         }
 
         let app = Router::new().route("/", get(handler)).with_state(AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             pool: None,
             profile: None,
             started_at: std::time::Instant::now(),

--- a/autumn/src/health.rs
+++ b/autumn/src/health.rs
@@ -55,6 +55,9 @@ mod tests {
 
     fn test_state() -> AppState {
         AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: Some("dev".into()),
@@ -143,6 +146,9 @@ mod tests {
         let app = axum::Router::new()
             .route("/health", axum::routing::get(handler))
             .with_state(AppState {
+                extensions: std::sync::Arc::new(std::sync::Mutex::new(
+                    std::collections::HashMap::new(),
+                )),
                 pool: Some(pool),
                 profile: Some("prod".into()),
                 started_at: std::time::Instant::now(),

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -92,6 +92,9 @@ mod tests {
     fn prelude_types_are_accessible() {
         #[cfg(feature = "db")]
         let _state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
@@ -108,6 +111,9 @@ mod tests {
         };
         #[cfg(not(feature = "db"))]
         let _state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -687,6 +687,9 @@ mod tests {
 
     fn test_state() -> AppState {
         AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: Some("test".to_owned()),

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -1060,24 +1060,7 @@ mod tests {
 
     #[tokio::test]
     async fn session_layer_returns_503_when_store_load_fails() {
-        use crate::state::AppState;
-
-        let state = AppState {
-            #[cfg(feature = "db")]
-            pool: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: false,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-        };
+        let state = test_state();
 
         let app = Router::new()
             .route("/", get(|| async { "ok" }))
@@ -1107,24 +1090,7 @@ mod tests {
 
     #[tokio::test]
     async fn session_layer_returns_503_when_store_save_fails() {
-        use crate::state::AppState;
-
-        let state = AppState {
-            #[cfg(feature = "db")]
-            pool: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: false,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-        };
+        let state = test_state();
 
         let app = Router::new()
             .route(

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -893,6 +893,9 @@ mod tests {
         }
 
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -933,6 +936,7 @@ mod tests {
 
     fn test_state() -> crate::state::AppState {
         crate::state::AppState {
+            extensions: Arc::new(std::sync::Mutex::new(HashMap::new())),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -9,6 +9,10 @@
 //! from the state. However, custom extractors can access the state via
 //! `axum::extract::State<AppState>`.
 
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
 use crate::actuator;
 #[cfg(feature = "ws")]
 use crate::channels::Channels;
@@ -42,6 +46,10 @@ use tokio_util::sync::CancellationToken;
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct AppState {
+    /// Runtime-managed typed extensions installed by integrations after the app
+    /// state has been constructed.
+    pub(crate) extensions: Arc<Mutex<HashMap<TypeId, Arc<dyn Any + Send + Sync>>>>,
+
     /// Database connection pool, or `None` when no `database.url` is configured.
     #[cfg(feature = "db")]
     pub(crate) pool:
@@ -87,6 +95,45 @@ pub struct AppState {
 }
 
 impl AppState {
+    /// Install or replace a typed runtime extension.
+    ///
+    /// Integrations use this to publish typed runtime resources, such as
+    /// background-worker handles or dedicated storage pools, after startup.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal extension map mutex is poisoned.
+    pub fn insert_extension<T>(&self, value: T)
+    where
+        T: Any + Send + Sync + 'static,
+    {
+        self.extensions
+            .lock()
+            .expect("app state extension lock poisoned")
+            .insert(TypeId::of::<T>(), Arc::new(value));
+    }
+
+    /// Borrow a typed runtime extension if it has been installed.
+    ///
+    /// The returned [`Arc`] is cloned out of the internal registry so callers
+    /// do not hold the state mutex while using the value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal extension map mutex is poisoned.
+    #[must_use]
+    pub fn extension<T>(&self) -> Option<Arc<T>>
+    where
+        T: Any + Send + Sync + 'static,
+    {
+        self.extensions
+            .lock()
+            .expect("app state extension lock poisoned")
+            .get(&TypeId::of::<T>())
+            .cloned()
+            .and_then(|value| Arc::downcast::<T>(value).ok())
+    }
+
     /// Returns the database connection pool.
     #[cfg(feature = "db")]
     #[must_use]
@@ -145,6 +192,16 @@ impl AppState {
         pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
     ) -> Self {
         self.pool = Some(pool);
+        self
+    }
+
+    /// Install a typed runtime extension while building test or ad-hoc state.
+    #[must_use]
+    pub fn with_extension<T>(self, value: T) -> Self
+    where
+        T: Any + Send + Sync + 'static,
+    {
+        self.insert_extension(value);
         self
     }
 
@@ -243,12 +300,15 @@ impl AppState {
         self.set_draining_for_test(true);
     }
 
-    /// Create an `AppState` suitable for testing, with sensible defaults
-    /// for all fields. Database pool is `None`.
-    #[allow(dead_code)]
+    /// Create a minimal detached `AppState` without an HTTP server.
+    ///
+    /// This is useful for background runtimes or helper processes that still
+    /// need framework-managed resources such as typed extensions, metrics, or
+    /// WebSocket channel registries.
     #[must_use]
-    pub fn for_test() -> Self {
+    pub fn detached() -> Self {
         Self {
+            extensions: Arc::new(Mutex::new(HashMap::new())),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -264,6 +324,14 @@ impl AppState {
             #[cfg(feature = "ws")]
             shutdown: CancellationToken::new(),
         }
+    }
+
+    /// Create an `AppState` suitable for testing, with sensible defaults
+    /// for all fields. Database pool is `None`.
+    #[allow(dead_code)]
+    #[must_use]
+    pub fn for_test() -> Self {
+        Self::detached()
     }
 }
 
@@ -287,6 +355,14 @@ impl std::fmt::Debug for AppState {
                 .pool
                 .as_ref()
                 .map(|p| format!("Pool(max={})", p.status().max_size)),
+        );
+        s.field(
+            "extensions",
+            &self
+                .extensions
+                .lock()
+                .map(|extensions| extensions.len())
+                .unwrap_or(0),
         );
         s.field("profile", &self.profile)
             .field("started_at", &self.started_at)
@@ -327,6 +403,13 @@ mod tests {
         let state = AppState::for_test().with_pool(pool);
         let debug = format!("{state:?}");
         assert!(debug.contains("Pool(max=5)"));
+    }
+
+    #[test]
+    fn detached_state_starts_without_profile() {
+        let state = AppState::detached();
+
+        assert_eq!(state.profile(), "default");
     }
 
     fn require_clone<T: Clone>(t: &T) -> T {
@@ -375,5 +458,18 @@ mod tests {
         {
             let _pool = state.pool();
         }
+        let _missing = state.extension::<String>();
+    }
+
+    #[test]
+    fn app_state_runtime_extensions_round_trip() {
+        let state = AppState::for_test();
+        state.insert_extension(String::from("haunted"));
+
+        let stored = state
+            .extension::<String>()
+            .expect("runtime extension should be installed");
+
+        assert_eq!(stored.as_str(), "haunted");
     }
 }

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -164,6 +164,9 @@ impl TestApp {
     #[must_use]
     pub fn build(self) -> TestClient {
         let state = AppState {
+            extensions: std::sync::Arc::new(
+                std::sync::Mutex::new(std::collections::HashMap::new()),
+            ),
             #[cfg(feature = "db")]
             pool: self.pool,
             profile: self.config.profile.clone(),

--- a/docs/adr/TD-008-harvest-topology-progression.md
+++ b/docs/adr/TD-008-harvest-topology-progression.md
@@ -1,0 +1,171 @@
+# TD-008: Harvest Topology Progression From Embedded To External
+
+- Status: Proposed
+- Date: 2026-04-09
+
+## Context
+
+Today `autumn-web-harvest` embeds Harvest directly into an Autumn web app:
+
+- Harvest startup migrates the Harvest storage role explicitly instead of
+  piggybacking on the app migration list.
+- Harvest startup resolves a Harvest-specific database pool.
+- Activities in examples such as `reddit-clone` read and write business tables through that same pool.
+- Durable app-to-Harvest publication is handled by a framework-owned outbox in
+  the app database.
+
+This is the right default for small apps. It gives the "just turn on workflows"
+story with one database URL, one process, one migration path, and essentially no
+operational ceremony.
+
+It is also too coupled for the long game. Once an app grows large enough to want
+Harvest isolation, the current shape forces application data access, Harvest
+system storage, worker startup, and migration ownership to move together. That
+turns the escape hatch into a refactor instead of a deployment decision.
+
+Autumn should follow the same product philosophy as `bookmarks` and
+`bookmarks-distributed`: start with the happy path, then make the grown-up path
+an explicit, boring upgrade rather than a betrayal of the original API.
+
+## Decision
+
+Autumn Harvest will support one programming model across three deployment modes:
+
+1. `embedded`
+   Harvest uses the app database by default and runs worker/scheduler in the web
+   process.
+2. `split`
+   Harvest uses a separate logical database on the same Postgres instance, while
+   the worker and scheduler may still run in the web process.
+3. `external`
+   Harvest uses a separate Postgres cluster, while runtime ownership is decided
+   by `worker_enabled` and `scheduler_enabled`. The web app can keep Harvest's
+   API and outbox while a separate process owns the worker and scheduler.
+
+The key architectural rule is:
+
+`Harvest system storage and application business storage are distinct roles even when they point at the same DSN.`
+
+That means:
+
+- Harvest runtime persistence must resolve through a Harvest-specific database
+  configuration and pool.
+- Application handlers and activities that need business data must resolve that
+  through an app-specific pool or application state seam.
+- In `embedded` mode, both roles may use the same Postgres database.
+- In `split` and `external` modes, they diverge by configuration instead of by
+  API or macro surface.
+
+## Configuration Direction
+
+The intended configuration model is:
+
+```toml
+[database]
+url = "postgres://app:app@localhost:5432/my_app"
+
+[harvest]
+mode = "embedded" # or "split" or "external"
+worker_enabled = true
+scheduler_enabled = true
+
+[harvest.database]
+url = "postgres://harvest:harvest@localhost:5432/my_app_harvest"
+```
+
+Rules:
+
+- `embedded`: `harvest.database.url` is optional; if omitted, Harvest reuses the
+  app database URL.
+- `split`: `harvest.database.url` is required and should point at a separate
+  logical database on the same Postgres instance.
+- `external`: `harvest.database.url` is required and should point at a separate
+  Postgres cluster; in-process workers are optional rather than assumed.
+
+Example external web app config:
+
+```toml
+[database]
+url = "postgres://app:app@localhost:5432/reddit_app"
+
+[harvest]
+mode = "external"
+worker_enabled = false
+scheduler_enabled = false
+
+[harvest.database]
+url = "postgres://harvest:harvest@harvest-cluster:5432/reddit_harvest"
+```
+
+Example dedicated Harvest runner bootstrap:
+
+```rust
+use autumn_harvest::HarvestBuilder;
+use autumn_web::config::DatabaseConfig;
+use autumn_web_harvest::{HarvestRunner, HarvestRunnerResources, HarvestRuntimeConfig};
+
+let config = HarvestRuntimeConfig::load()?;
+let harvest_pool = autumn_web::db::create_pool(&DatabaseConfig {
+    url: config.database.url.clone(),
+    ..DatabaseConfig::default()
+})?
+.expect("harvest runner requires a database");
+
+let runner = HarvestRunner::start(
+    HarvestBuilder::new()
+        .workflows(workflows)
+        .activities(activities)
+        .dags(dags)
+        .build(),
+    &config,
+    HarvestRunnerResources::new(harvest_pool),
+)?;
+```
+
+## Trade-offs
+
+### Gains
+
+- Keeps the small-app experience frictionless.
+- Makes growth a configuration and operations change instead of a programming
+  model rewrite.
+- Allows separate retention, backup, connection-pool sizing, and tuning for
+  Harvest state.
+- Preserves a clear product story: same framework surface, different topology.
+
+### Losses
+
+- Adds explicit Harvest configuration and a second database role to the mental
+  model.
+- Requires more careful state injection for activities that touch application
+  tables.
+- Removes any illusion that app writes and Harvest persistence remain one
+  atomic transaction after leaving `embedded` mode.
+
+## Consequences
+
+- `autumn-web-harvest` must stop assuming `AppState.pool()` is the Harvest
+  system store.
+- The adapter should inject distinct state for Harvest storage and application
+  storage, even if both use the same DSN in `embedded` mode.
+- Migrations must target the Harvest database role explicitly once
+  `harvest.database.url` is configured.
+- The app database should own the durable outbox table, with framework-managed
+  leasing and retry semantics for publication into Harvest storage.
+- The reusable runtime-ownership seam should stay below `HarvestExt`, so the
+  web app and a dedicated runner process reuse the same bootstrap path instead
+  of maintaining two registration models.
+- The app-to-Harvest boundary must become idempotent. For `split` and
+  `external`, when application writes and workflow starts/signals must stay
+  durable together, the supported pattern should be outbox plus replay-safe
+  delivery rather than fake cross-database atomicity.
+- Examples should tell the growth story explicitly:
+  `reddit-clone` remains the embedded happy path; a future distributed sibling
+  should demonstrate the larger topology.
+
+## Non-Goals
+
+- Exactly-once delivery across separate application and Harvest databases
+- Multi-region active/active Harvest clusters
+- Non-Postgres Harvest storage backends
+- Immediate rewrite of all existing examples to distributed topology

--- a/docs/plans/2026-04-09-harvest-enterprise-outbox.md
+++ b/docs/plans/2026-04-09-harvest-enterprise-outbox.md
@@ -1,0 +1,224 @@
+# Harvest Enterprise Outbox Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the reddit-clone-only Harvest workflow outbox with a framework-owned, lease-based, retry-aware outbox that works across embedded and split Harvest deployments.
+
+**Architecture:** `autumn-web-harvest` owns the outbox schema, runtime config, relay loop, and dispatch helpers. The app database stores durable workflow-start intents; the Harvest database remains the sink for workflow executions. `HarvestExt` becomes responsible for starting and stopping the outbox relay and for applying Harvest storage migrations to the correct database in embedded vs split mode.
+
+**Tech Stack:** Rust 2024, Diesel async/Postgres, tokio, Autumn `AppBuilder` startup hooks, `autumn-harvest` idempotent workflow start helper, Docker-backed integration tests via `testcontainers`.
+
+---
+
+### Task 1: Add the framework outbox model and configuration surface
+
+**Files:**
+- Create: `autumn-harvest/autumn-web-harvest/src/outbox.rs`
+- Modify: `autumn-harvest/autumn-web-harvest/src/config.rs`
+- Modify: `autumn-harvest/autumn-web-harvest/src/lib.rs`
+- Modify: `autumn-harvest/autumn-web-harvest/src/prelude.rs`
+
+**Step 1: Write the failing config tests**
+
+Add unit tests in `autumn-harvest/autumn-web-harvest/src/config.rs` asserting:
+- outbox defaults are enabled with sane batch/poll/lease/retry values
+- env overrides such as `AUTUMN_HARVEST_OUTBOX__BATCH_SIZE` and `AUTUMN_HARVEST_OUTBOX__POLL_INTERVAL_MS` are honored
+- invalid outbox values fail validation
+
+**Step 2: Run the config tests to verify they fail**
+
+Run: `cargo test -p autumn-web-harvest harvest_config_`
+
+Expected: FAIL because the new outbox config fields do not exist yet.
+
+**Step 3: Add minimal config and public API**
+
+Implement:
+- `HarvestOutboxConfig` on `HarvestRuntimeConfig`
+- parse + validate support for:
+  - `enabled`
+  - `batch_size`
+  - `poll_interval_ms`
+  - `claim_ttl_ms`
+  - `base_retry_delay_ms`
+  - `max_retry_delay_ms`
+- public re-exports from `lib.rs` and `prelude.rs`
+- `WorkflowStartRequest` and outbox row/query types in `src/outbox.rs`
+
+**Step 4: Re-run the config tests**
+
+Run: `cargo test -p autumn-web-harvest harvest_config_`
+
+Expected: PASS
+
+### Task 2: Add RED tests for durable lease-based outbox delivery
+
+**Files:**
+- Create: `autumn-harvest/autumn-web-harvest/tests/outbox_integration.rs`
+- Create: `autumn-harvest/autumn-web-harvest/migrations/20260409010000_harvest_workflow_outbox/up.sql`
+- Create: `autumn-harvest/autumn-web-harvest/migrations/20260409010000_harvest_workflow_outbox/down.sql`
+
+**Step 1: Write failing integration tests**
+
+Cover these behaviors:
+- a due outbox row in the app database is delivered into the Harvest database and marked delivered
+- failed delivery records `last_error`, clears the claim, increments attempts, and schedules a retry in the future
+- concurrent claim attempts from two drainers do not claim the same row twice
+
+Use one Postgres container with two logical databases:
+- app DB gets the framework outbox migration
+- harvest DB gets Harvest core migrations
+
+**Step 2: Run the integration tests to verify they fail**
+
+Run: `cargo test -p autumn-web-harvest --test outbox_integration`
+
+Expected: FAIL because the outbox module, migration, and relay logic are not implemented.
+
+### Task 3: Implement the framework outbox runtime
+
+**Files:**
+- Modify: `autumn-harvest/autumn-web-harvest/src/outbox.rs`
+- Modify: `autumn-harvest/autumn-web-harvest/src/ext.rs`
+- Modify: `autumn-harvest/autumn-web-harvest/src/state.rs`
+
+**Step 1: Implement durable enqueue + claim + completion paths**
+
+In `src/outbox.rs`, add:
+- `enqueue_workflow_start_outbox(conn, request)`
+- `flush_workflow_start_outbox(state)`
+- `drain_workflow_start_outbox_once(state, limit)`
+- internal SQL-backed claim helper using `FOR UPDATE SKIP LOCKED`
+- per-row success/failure completion helpers
+- exponential-ish retry scheduling capped by config
+
+The outbox table should include at least:
+- request payload columns: `workflow_name`, `workflow_id`, `queue_name`, `input`, `memo`, `search_attrs`
+- delivery metadata: `delivery_attempts`, `last_error`, `delivered_execution_id`, `delivered_at`
+- lease/retry metadata: `next_attempt_at`, `claimed_at`, `claimed_by`
+
+**Step 2: Wire runtime ownership into `HarvestExt`**
+
+Extend `HarvestRuntime` so startup:
+- installs `HarvestDbPool` as before
+- starts an outbox relay when an app DB is available and outbox is enabled
+- stores the relay handle for coordinated shutdown
+
+Shutdown must:
+- cancel the relay
+- await the task before returning
+
+**Step 3: Re-run the outbox integration tests**
+
+Run: `cargo test -p autumn-web-harvest --test outbox_integration`
+
+Expected: PASS
+
+### Task 4: Fix Harvest migration ownership for split mode
+
+**Files:**
+- Modify: `autumn-harvest/autumn-web-harvest/src/ext.rs`
+- Modify: `autumn-harvest/autumn-web-harvest/tests/api_scheduler_integration.rs`
+
+**Step 1: Add failing split-mode migration test**
+
+Add a test proving:
+- app DB receives the framework outbox migration
+- split Harvest DB receives Harvest core tables
+- app DB does not need Harvest system tables in split mode
+
+**Step 2: Run that test to verify it fails**
+
+Run: `cargo test -p autumn-web-harvest split_mode_`
+
+Expected: FAIL because current migration ownership is still bound to the app builder.
+
+**Step 3: Move Harvest storage migration responsibility under `HarvestExt` startup**
+
+Implement startup migration helpers so:
+- outbox migration targets the app DB
+- Harvest core migrations target the resolved Harvest DB
+- embedded mode migrates both roles against the same logical DB
+- split mode migrates app outbox and Harvest storage separately
+
+Preserve existing dev/prod semantics:
+- dev applies pending migrations automatically
+- non-dev logs pending state instead of mutating
+
+**Step 4: Re-run split-mode migration tests**
+
+Run: `cargo test -p autumn-web-harvest split_mode_`
+
+Expected: PASS
+
+### Task 5: Migrate reddit-clone onto the framework outbox
+
+**Files:**
+- Delete: `examples/reddit-clone/src/outbox.rs`
+- Modify: `examples/reddit-clone/src/workflows.rs`
+- Modify: `examples/reddit-clone/src/routes/auth.rs`
+- Modify: `examples/reddit-clone/src/routes/posts.rs`
+- Modify: `examples/reddit-clone/src/main.rs`
+- Modify: `examples/reddit-clone/src/models.rs`
+- Modify: `examples/reddit-clone/src/schema.rs`
+- Modify: `examples/reddit-clone/migrations/00000000000000_create_reddit/up.sql`
+- Modify: `examples/reddit-clone/migrations/00000000000000_create_reddit/down.sql`
+
+**Step 1: Write failing reddit-clone tests**
+
+Add or update tests so the example proves:
+- registration writes a framework outbox row transactionally
+- post submission writes a framework outbox row transactionally
+- the example no longer owns a bespoke outbox schema/module
+
+**Step 2: Run the example tests to verify they fail**
+
+Run: `cargo test -p reddit-clone workflows`
+
+Expected: FAIL because the example still references its local outbox module and schema.
+
+**Step 3: Replace local outbox code with framework calls**
+
+Use `autumn_web_harvest` helpers from route transactions and remove:
+- local relay startup/shutdown code
+- local outbox schema/models
+- duplicated dispatch request type
+
+Keep reddit-clone responsible only for building the workflow-start payloads.
+
+**Step 4: Re-run reddit-clone tests**
+
+Run: `cargo test -p reddit-clone workflows`
+
+Expected: PASS
+
+### Task 6: Verify the whole slice and document the new story
+
+**Files:**
+- Modify: `examples/reddit-clone/README.md`
+- Modify: `docs/adr/TD-008-harvest-topology-progression.md`
+- Modify: `docs/plans/2026-04-09-harvest-topology-roadmap.md`
+
+**Step 1: Update docs**
+
+Document:
+- embedded vs split outbox behavior
+- that app writes + outbox row are atomic in the app DB
+- that delivery into Harvest is at-least-once and relies on idempotent workflow start
+- that split mode now owns its own Harvest migrations
+
+**Step 2: Run final verification**
+
+Run:
+- `cargo fmt --all`
+- `cargo test -p autumn-web-harvest --lib`
+- `cargo test -p autumn-web-harvest --test api_scheduler_integration`
+- `cargo test -p autumn-web-harvest --test outbox_integration`
+- `cargo test -p reddit-clone workflows`
+- `cargo test -p reddit-clone --no-run -j 1`
+
+Expected: PASS
+
+**Step 3: Review dirty-tree scope**
+
+Confirm the diff removes the example-local outbox implementation instead of leaving duplicate systems behind.

--- a/docs/plans/2026-04-09-harvest-external-runner-mode.md
+++ b/docs/plans/2026-04-09-harvest-external-runner-mode.md
@@ -1,0 +1,80 @@
+# Harvest External Runner Mode Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `harvest.mode = "external"` a real deployment option where the web app can keep Harvest APIs and outbox delivery without owning the worker/scheduler, while a separate process can run the Harvest runtime against the same Harvest store.
+
+**Architecture:** Split Harvest startup into two layers: runtime preparation and runtime ownership. `HarvestExt` should prepare registrations, storage pools, migrations, API state, and optional local runtime ownership based on `worker_enabled` / `scheduler_enabled`. A new reusable standalone runner surface should consume `HarvestBuilder::build()` plus explicit pool/config inputs so the external process reuses the same runtime bootstrap instead of inventing a second registration model.
+
+**Tech Stack:** Rust 2024, `autumn-web`, `autumn-web-harvest`, `autumn-harvest`, Tokio, Axum, Diesel Async, deadpool, Postgres testcontainers.
+
+---
+
+### Task 1: Replace The External Placeholder With Red Tests
+
+**Files:**
+- Modify: `autumn-harvest/autumn-web-harvest/src/ext.rs`
+- Modify: `autumn-harvest/autumn-web-harvest/tests/api_scheduler_integration.rs`
+
+**Step 1: Write the failing test**
+
+Add coverage for:
+- external mode no longer being rejected when local worker/scheduler ownership is disabled
+- web-side runtime preparation installing an API runtime with offline scheduler state and no worker id when local ownership is disabled
+- standalone runner bootstrap being able to own worker/scheduler against the Harvest store and drive a started workflow to completion
+
+**Step 2: Run test to verify it fails**
+
+Run:
+- `cargo test -p autumn-web-harvest external_mode`
+- `cargo test -p autumn-web-harvest --test api_scheduler_integration external_runner`
+
+Expected: failure because `ext.rs` still rejects external mode and no standalone runner surface exists.
+
+### Task 2: Refactor Runtime Ownership And Add The Standalone Runner
+
+**Files:**
+- Modify: `autumn-harvest/autumn-web-harvest/src/ext.rs`
+- Modify: `autumn-harvest/autumn-web-harvest/src/api.rs`
+- Create: `autumn-harvest/autumn-web-harvest/src/runner.rs`
+- Modify: `autumn-harvest/autumn-web-harvest/src/lib.rs`
+- Modify: `autumn-harvest/autumn-web-harvest/src/prelude.rs`
+
+**Step 1: Write minimal implementation**
+
+- Introduce a reusable runtime-preparation path that turns `BuiltHarvest` plus injected state into:
+  - `HandlerRegistry`
+  - compiled DAG catalog
+  - worker runtime config
+  - API runtime snapshot
+- Make API runtime model optional local ownership honestly, especially `worker_id`
+- Let `HarvestExt` conditionally start worker and scheduler according to config instead of hard-rejecting the toggles
+- Add a standalone runner type/function that starts local ownership against an explicit Harvest pool and can be cleanly shut down
+
+**Step 2: Run tests to verify they pass**
+
+Run the new targeted tests plus the adapter unit tests.
+
+### Task 3: Document The External Deployment Story And Verify It End-To-End
+
+**Files:**
+- Modify: `docs/adr/TD-008-harvest-topology-progression.md`
+- Modify: `docs/plans/2026-04-09-harvest-topology-roadmap.md`
+- Modify: `examples/reddit-clone/README.md`
+
+**Step 1: Update docs**
+
+- Show the exact `external` config with `worker_enabled = false` and `scheduler_enabled = false` in the web app
+- Show the separate runner bootstrap using the new standalone API
+- Clarify that external mode means separate Harvest storage, while runtime ownership is decided by the toggles
+
+**Step 2: Run verification**
+
+Run:
+- `cargo fmt --all`
+- `cargo test -p autumn-web-harvest --lib`
+- `cargo test -p autumn-web-harvest --test api_scheduler_integration`
+- `cargo test -p autumn-web-harvest --test outbox_integration`
+- `cargo test -p reddit-clone --no-run -j 1`
+
+Expected: all pass, with the container-backed tests proving the web app and dedicated runner can share the Harvest store without in-process worker ownership.

--- a/docs/plans/2026-04-09-harvest-idempotent-start.md
+++ b/docs/plans/2026-04-09-harvest-idempotent-start.md
@@ -1,0 +1,111 @@
+# Harvest Idempotent Start Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make duplicate workflow starts with the same business key converge on one Harvest execution instead of creating duplicate rows and queue work.
+
+**Architecture:** Treat `workflow_id` as the caller-provided idempotency key within a `workflow_name`. Enforce that contract in Postgres with a unique constraint, then funnel both the Harvest HTTP API and app-side publication helpers through one shared start-or-load helper that returns an existing execution when a duplicate start races or retries.
+
+**Tech Stack:** Rust, Diesel Async, Postgres, testcontainers, Axum
+
+---
+
+### Task 1: Capture Duplicate-Start Behavior With Failing Tests
+
+**Files:**
+- Modify: `autumn-harvest/autumn-web-harvest/tests/api_scheduler_integration.rs`
+- Modify: `examples/reddit-clone/src/workflows.rs`
+
+**Step 1: Write the failing API test**
+
+Add an integration test that starts the same workflow twice with the same `workflow_id`, then asserts:
+- the second call does not create a second execution
+- both responses carry the same `execution_id`
+- only one workflow row exists for `(workflow_name, workflow_id)`
+- only one queued workflow task exists for that execution
+
+**Step 2: Run the API test to verify it fails**
+
+Run: `cargo test -p autumn-web-harvest --test api_scheduler_integration harvest_api_duplicate_start_reuses_existing_execution`
+
+Expected: FAIL because the current start path blindly inserts a new execution every time.
+
+**Step 3: Write the failing reddit-clone helper test**
+
+Add a focused test around the app-side publication helper so repeated publication with the same derived `workflow_id` resolves to one execution instead of duplicating queue work.
+
+**Step 4: Run the helper test to verify it fails**
+
+Run: `cargo test -p reddit-clone workflows`
+
+Expected: FAIL on the duplicate publication case.
+
+### Task 2: Add Shared Harvest Start-Or-Load Helper
+
+**Files:**
+- Create: `autumn-harvest/autumn-harvest/src/execution.rs`
+- Modify: `autumn-harvest/autumn-harvest/src/lib.rs`
+- Modify: `autumn-harvest/autumn-harvest/src/prelude.rs` if the helper should be re-exported
+
+**Step 1: Write the helper surface**
+
+Add a shared DB helper that:
+- accepts workflow identity, queue, input, memo, search attrs, and timeout
+- attempts to insert the workflow execution, start event, and queue task transactionally
+- on uniqueness conflict, loads the existing execution by `(workflow_name, workflow_id)` and returns it
+
+**Step 2: Keep the helper narrow**
+
+Do not implement outbox logic here. This slice is only “duplicate start is safe,” not “cross-store delivery is magically atomic.”
+
+### Task 3: Enforce Idempotency In The Schema
+
+**Files:**
+- Modify: `autumn-harvest/autumn-harvest/migrations/20260409000000_harvest_initial/up.sql`
+- Modify: `autumn-harvest/autumn-harvest/src/types.rs`
+
+**Step 1: Add the real uniqueness boundary**
+
+Change the workflow execution schema so `(workflow_name, workflow_id)` is unique.
+
+**Step 2: Update the type docs**
+
+Make `WorkflowId` documentation match reality: it is the caller’s idempotency key for a logical workflow start. Fresh reruns should use a fresh key until Harvest grows an explicit restart/rerun API.
+
+### Task 4: Route All Start Paths Through The Shared Helper
+
+**Files:**
+- Modify: `autumn-harvest/autumn-web-harvest/src/api.rs`
+- Modify: `examples/reddit-clone/src/workflows.rs`
+
+**Step 1: Update the Harvest API**
+
+Use the new helper in `start_workflow`. Return:
+- `201 Created` when a new execution is created
+- `200 OK` when a duplicate start reuses an existing execution
+
+**Step 2: Update reddit-clone publication**
+
+Replace the local blind insert helper with the shared Harvest helper so split-mode app publication gets the same idempotent behavior as the HTTP API.
+
+### Task 5: Verify And Document
+
+**Files:**
+- Modify: `docs/plans/2026-04-09-harvest-topology-roadmap.md` only if the implementation meaningfully changes the wording
+
+**Step 1: Run focused verification**
+
+Run:
+- `cargo fmt --all`
+- `cargo test -p autumn-harvest --lib`
+- `cargo test -p autumn-web-harvest --test api_scheduler_integration`
+- `cargo test -p reddit-clone workflows`
+
+**Step 2: Run broader compile verification**
+
+Run:
+- `cargo test -p reddit-clone --no-run -j 1`
+
+**Step 3: Record any remaining caveat honestly**
+
+The remaining caveat should now be “duplicate starts are safe, but split-store publication is still not atomic without outbox semantics.”

--- a/docs/plans/2026-04-09-harvest-topology-roadmap.md
+++ b/docs/plans/2026-04-09-harvest-topology-roadmap.md
@@ -1,0 +1,283 @@
+# Autumn Harvest Topology Roadmap
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let Autumn Harvest grow from "same logical DB, embedded mode" to
+"separate logical DB on the same Postgres instance" to "separate Postgres
+cluster" without changing the workflow/activity programming model.
+
+**Architecture:** Preserve the current macro and builder surface, but separate
+Harvest's system-storage role from the application's business-storage role. In
+`embedded` mode both roles may resolve to the same DSN; in `split` and
+`external` modes they diverge by configuration. Runtime ownership should also
+progress: embedded defaults to in-process worker/scheduler, while external mode
+must support dedicated Harvest runner processes.
+
+**Tech Stack:** Rust 2024, Autumn `AppBuilder`, autumn-harvest core,
+autumn-web-harvest adapter, Diesel, diesel-async, deadpool, Postgres.
+
+**Depends on:** The existing core/adapter split, current embedded integration,
+and the existing `reddit-clone` and `bookmarks-distributed` examples.
+
+---
+
+## Design Decisions Baked Into This Plan
+
+### DD-1: Two Database Roles, Even In Embedded Mode
+
+Treat application storage and Harvest storage as distinct roles from day one.
+`embedded` mode is "same DSN, different role," not "one pool for everything."
+
+### DD-2: Three Named Topology Modes
+
+Expose the progression directly:
+
+- `embedded`: same logical DB, in-process worker/scheduler
+- `split`: separate logical DB on same Postgres instance
+- `external`: separate Postgres cluster, with dedicated runtime support
+
+The names matter because they give users a roadmap instead of a bag of flags.
+
+### DD-3: Split/External Require Honest Delivery Semantics
+
+Once Harvest no longer shares the same database as app writes, the framework
+must stop pretending those operations are atomically coupled. The supported seam
+becomes idempotent workflow start/signal plus outbox-driven publication when
+durable coupling is required.
+
+Current status:
+
+- workflow start is idempotent on `(workflow_name, workflow_id)`
+- `autumn-web-harvest` owns a durable workflow-start outbox with lease/retry semantics
+- `reddit-clone` now uses the framework outbox instead of an app-local relay
+
+### DD-4: Example Strategy Mirrors `bookmarks` vs `bookmarks-distributed`
+
+Keep `examples/reddit-clone` as the happy-path embedded story. Add a future
+distributed sibling only after the topology seams are real, so the docs show
+"how you grow up" rather than "how to suffer early."
+
+---
+
+## Task 1: Add Explicit Harvest Topology Configuration
+
+**Files:**
+- Modify: `autumn-harvest/autumn-web-harvest/src/ext.rs`
+- Create: `autumn-harvest/autumn-web-harvest/src/config.rs`
+- Modify: `autumn/` configuration integration as needed
+- Modify: docs and example config files
+
+**Step 1: Write the failing test**
+
+Add unit tests for config resolution covering:
+
+- `embedded` defaults Harvest DB URL to the app DB URL
+- `split` requires `harvest.database.url`
+- `external` requires `harvest.database.url`
+- `external` can disable in-process worker/scheduler by configuration
+
+**Step 2: Run test to verify it fails**
+
+Run targeted adapter/config tests.
+
+**Step 3: Write minimal implementation**
+
+Introduce a typed Harvest config surface, for example:
+
+```toml
+[harvest]
+mode = "embedded"
+worker_enabled = true
+scheduler_enabled = true
+
+[harvest.database]
+url = "postgres://..."
+```
+
+Resolve config so that embedded mode remains zero-friction.
+
+**Step 4: Run test to verify it passes**
+
+All new topology-resolution tests should pass.
+
+## Task 2: Separate Harvest Storage From App Storage In Runtime State
+
+**Files:**
+- Modify: `autumn-harvest/autumn-web-harvest/src/ext.rs`
+- Modify: `autumn-harvest/autumn-harvest/src/worker.rs` only if required for pool typing
+- Modify: example activities that currently depend on the shared `DbPool`
+
+**Step 1: Write the failing test**
+
+Use adapter unit tests plus a small integration test proving that:
+
+- Harvest runtime can boot with a Harvest DB pool resolved independently
+- activities can still access application storage through an explicit app-state seam
+
+**Step 2: Run test to verify it fails**
+
+The current implementation should fail because startup assumes `AppState.pool()`
+is the Harvest store.
+
+**Step 3: Write minimal implementation**
+
+- Define distinct injected state roles such as `HarvestDbPool` and `AppDbPool`
+  (or equivalent typed wrappers).
+- Keep the Harvest core worker bound to Harvest system storage.
+- Update `reddit-clone` activities to request the application DB role
+  explicitly instead of reusing Harvest's pool by accident.
+
+**Step 4: Run test to verify it passes**
+
+Embedded mode still works, but the seam is now explicit.
+
+## Task 3: Split Migration Ownership And Tooling
+
+**Files:**
+- Modify: `autumn-harvest/autumn-web-harvest/src/ext.rs`
+- Create or modify CLI/migrator entry points
+- Modify: example READMEs and deployment docs
+
+**Step 1: Write the failing test**
+
+Add coverage proving that Harvest migrations target the Harvest DB role instead
+of whichever app DB happened to be configured first.
+
+**Step 2: Run test to verify it fails**
+
+Current behavior should show that Harvest migration ownership is still tied to
+the app database startup path.
+
+**Step 3: Write minimal implementation**
+
+Provide an explicit migration story:
+
+- embedded: app startup may still auto-apply Harvest migrations in dev
+- split/external: explicit Harvest migrator path should exist
+
+The preferred long-term UX is either a dedicated Harvest migrator binary or a
+CLI flow such as `autumn harvest migrate`.
+
+**Step 4: Run test to verify it passes**
+
+Migration targeting should be deterministic in all three modes.
+
+## Task 4: Make App-To-Harvest Delivery Idempotent
+
+**Files:**
+- Modify: workflow start/signal helpers in app examples
+- Create: outbox helper abstractions if needed
+- Modify: Harvest API/client surface as needed
+
+**Step 1: Write the failing test**
+
+Add tests that model retries and duplicate publication:
+
+- starting the same workflow twice with the same idempotency key is safe
+- delivering the same signal twice is safe or deterministically rejected
+
+**Step 2: Run test to verify it fails**
+
+The current embedded-only assumptions should expose gaps once the DB roles are
+split.
+
+**Step 3: Write minimal implementation**
+
+- Standardize idempotency keys for workflow start/signal calls
+- Add an outbox-backed publication path for cases where app writes and Harvest
+  dispatch must survive process or network failure between stores
+
+**Step 4: Run test to verify it passes**
+
+The framework now has an honest story once users leave embedded mode.
+
+## Task 5: Add External Runner Mode
+
+Current status:
+
+- `autumn-web-harvest` now supports `external` mode without forcing local
+  worker/scheduler ownership.
+- Runtime ownership is decided by `worker_enabled` and `scheduler_enabled`.
+- The reusable standalone entry point is `HarvestRunner`.
+
+**Files:**
+- Modify: `autumn-harvest/autumn-web-harvest/src/ext.rs`
+- Create: dedicated Harvest runner binary or reusable startup entry point
+- Modify: runtime docs and deployment examples
+
+**Step 1: Write the failing test**
+
+Prove that a web app can mount Harvest APIs and register workflows without
+starting an in-process worker/scheduler when running in `external` mode.
+
+**Step 2: Run test to verify it fails**
+
+Current startup should still assume in-process ownership.
+
+**Step 3: Write minimal implementation**
+
+- Allow worker and scheduler startup to be independently disabled
+- Provide a dedicated runtime entry point for the external Harvest process
+- Keep management/query APIs usable from the web side
+
+**Step 4: Run test to verify it passes**
+
+External mode should be a real deployment option, not just a config placeholder.
+
+## Task 6: Tell The Growth Story In Docs And Examples
+
+**Files:**
+- Modify: `README.md`
+- Modify: Harvest docs
+- Keep: `examples/reddit-clone` as embedded default
+- Create later: `examples/reddit-clone-distributed` or equivalent
+
+**Step 1: Write the failing test**
+
+Use docs/example review as the contract:
+
+- embedded example remains dead simple
+- split/external path is documented without hand-wavy caveats
+- the growth story mirrors `bookmarks` to `bookmarks-distributed`
+
+**Step 2: Run test to verify it fails**
+
+Current docs do not yet offer a coherent topology progression story.
+
+**Step 3: Write minimal implementation**
+
+- Document the three modes with exact config and migration steps
+- Explain when to stay embedded and when to split
+- Add a distributed example only after the runtime seam is stable enough to
+  demonstrate without framework-internal caveats
+
+**Step 4: Run test to verify it passes**
+
+A user should be able to understand:
+
+1. how to start in embedded mode
+2. when to move to split mode
+3. how to graduate to external mode without rewriting workflows
+
+---
+
+## Verification
+
+Before calling this roadmap implemented, verify all of the following:
+
+- Embedded example (`reddit-clone`) still boots and runs with the zero-config story
+- Split mode can point Harvest at a different logical database on the same
+  Postgres instance
+- External mode can run with the web app and Harvest runtime in separate
+  processes
+- Workflow start/signal semantics are idempotent across retries
+- Harvest migrations can be applied deterministically for every topology
+- Documentation shows the growth path explicitly, not as an afterthought
+
+## Suggested Rollout Order
+
+1. Config surface and storage-role separation
+2. Migration ownership and tooling
+3. Idempotent delivery/outbox seam
+4. External runner mode
+5. Distributed example and polished documentation

--- a/docs/plans/2026-04-09-harvest-topology-task1-config.md
+++ b/docs/plans/2026-04-09-harvest-topology-task1-config.md
@@ -1,0 +1,163 @@
+# Harvest Topology Config Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an explicit Harvest topology configuration surface that supports `embedded`, `split`, and `external` modes without breaking the current zero-config embedded experience.
+
+**Architecture:** Keep the first slice narrowly scoped to configuration resolution in `autumn-web-harvest`. The adapter will load Harvest-specific topology settings from the same `autumn.toml` / `autumn-{profile}.toml` / `AUTUMN_*` layering model as Autumn itself, but without yet rewriting the full runtime ownership boundary. This lets us prove the topology modes, validation, and fallback behavior before we separate pools and startup ownership.
+
+**Tech Stack:** Rust 2024, `autumn-web-harvest`, `autumn` config conventions, `serde`, `toml`, unit tests in adapter crate.
+
+---
+
+### Task 1: Introduce Typed Harvest Topology Config
+
+**Files:**
+- Create: `autumn-harvest/autumn-web-harvest/src/config.rs`
+- Modify: `autumn-harvest/autumn-web-harvest/src/lib.rs`
+- Modify: `autumn-harvest/autumn-web-harvest/src/prelude.rs`
+
+**Step 1: Write the failing test**
+
+Add unit tests in `config.rs` covering:
+
+- `embedded` mode defaults to `HarvestMode::Embedded`
+- `embedded` with no `harvest.database.url` resolves to "reuse app database URL"
+- `split` without `harvest.database.url` fails validation
+- `external` without `harvest.database.url` fails validation
+- `external` allows `worker_enabled = false` and `scheduler_enabled = false`
+- env overrides like `AUTUMN_HARVEST__MODE=external` and `AUTUMN_HARVEST_DATABASE__URL=...` win over TOML
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p autumn-web-harvest harvest_config --lib`
+Expected: FAIL because `config.rs` and the new types do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create:
+
+- `HarvestMode` enum with `Embedded`, `Split`, `External`
+- `HarvestRuntimeConfig` struct with:
+  - `mode: HarvestMode`
+  - `worker_enabled: bool`
+  - `scheduler_enabled: bool`
+  - `database: HarvestDatabaseConfig`
+- `HarvestDatabaseConfig` with `url: Option<String>`
+
+Implement:
+
+- TOML loading from `autumn.toml` and `autumn-{profile}.toml`
+- env overrides:
+  - `AUTUMN_HARVEST__MODE`
+  - `AUTUMN_HARVEST__WORKER_ENABLED`
+  - `AUTUMN_HARVEST__SCHEDULER_ENABLED`
+  - `AUTUMN_HARVEST_DATABASE__URL`
+- validation rules:
+  - embedded: DB URL optional
+  - split/external: DB URL required
+
+Keep this self-contained inside the adapter crate for now.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p autumn-web-harvest harvest_config --lib`
+Expected: PASS.
+
+### Task 2: Thread Harvest Config Into Adapter Startup
+
+**Files:**
+- Modify: `autumn-harvest/autumn-web-harvest/src/ext.rs`
+- Test: `autumn-harvest/autumn-web-harvest/src/ext.rs`
+
+**Step 1: Write the failing test**
+
+Add adapter tests proving:
+
+- startup resolves a Harvest config successfully in embedded mode without requiring new user config
+- `split`/`external` config validation errors surface as startup errors instead of silent fallback
+
+Do not test separate pools yet. Only test config resolution and validation plumbing.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p autumn-web-harvest harvest_ext --lib`
+Expected: FAIL because `ext.rs` does not know about the new Harvest config surface.
+
+**Step 3: Write minimal implementation**
+
+In `ext.rs`:
+
+- load `HarvestRuntimeConfig` during startup
+- keep current embedded behavior as the fallback runtime shape
+- for now, reject `split` and `external` with explicit `AutumnError::service_unavailable_msg(...)` if the mode is configured but runtime support is not yet implemented
+
+This preserves forward progress without pretending the topology is already fully supported.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p autumn-web-harvest harvest_ext --lib`
+Expected: PASS.
+
+### Task 3: Document The Config Surface Without Overpromising
+
+**Files:**
+- Modify: `docs/adr/TD-008-harvest-topology-progression.md`
+- Modify: `docs/plans/2026-04-09-harvest-topology-roadmap.md`
+- Modify: `autumn-harvest/CLAUDE.md`
+
+**Step 1: Write the failing test**
+
+Use doc review as the contract:
+
+- docs must say Task 1 introduces topology config and validation
+- docs must not claim split/external runtime support exists yet
+
+**Step 2: Run review to verify current docs are stale**
+
+Read the new docs and check whether they need a note about incremental support status.
+
+**Step 3: Write minimal implementation**
+
+Update docs to say:
+
+- config surface lands first
+- embedded remains the default supported mode
+- split/external config is groundwork until later roadmap tasks land
+
+**Step 4: Run review to verify it is accurate**
+
+Re-read the edited docs and ensure they match the actual implementation status.
+
+### Task 4: Verify The First Slice
+
+**Files:**
+- Modify as needed based on fallout
+
+**Step 1: Run verification**
+
+Run:
+
+- `cargo fmt --all`
+- `cargo test -p autumn-web-harvest harvest_config --lib`
+- `cargo test -p autumn-web-harvest harvest_ext --lib`
+- `cargo test -p reddit-clone --no-run`
+
+**Step 2: Fix fallout**
+
+Patch any adapter import/export drift or startup-validation behavior until the
+checks above pass.
+
+**Step 3: Commit**
+
+```bash
+git add docs/adr/TD-008-harvest-topology-progression.md \
+        docs/plans/2026-04-09-harvest-topology-roadmap.md \
+        docs/plans/2026-04-09-harvest-topology-task1-config.md \
+        autumn-harvest/autumn-web-harvest/src/config.rs \
+        autumn-harvest/autumn-web-harvest/src/ext.rs \
+        autumn-harvest/autumn-web-harvest/src/lib.rs \
+        autumn-harvest/autumn-web-harvest/src/prelude.rs \
+        autumn-harvest/CLAUDE.md
+git commit -m "feat: add Harvest topology config surface"
+```

--- a/docs/plans/2026-04-09-reddit-clone-harvest-outbox.md
+++ b/docs/plans/2026-04-09-reddit-clone-harvest-outbox.md
@@ -1,0 +1,142 @@
+# Reddit Clone Harvest Outbox Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make reddit-clone’s app-to-Harvest publication durable when the app database and Harvest database are separate stores.
+
+**Architecture:** Persist workflow-start requests into an app-db outbox inside the same transaction as the user/post write, then drain that outbox into Harvest using Harvest’s idempotent start helper. Keep the relay intentionally simple: immediate best-effort drain after commits plus a startup background poller that retries any pending rows until they are marked delivered.
+
+**Tech Stack:** Rust, Diesel Async, Postgres, tokio, testcontainers, autumn-web startup hooks, autumn-harvest idempotent start helper
+
+---
+
+### Task 1: Add Red Tests For Durable Publication
+
+**Files:**
+- Modify: `examples/reddit-clone/src/workflows.rs`
+- Create or Modify: `examples/reddit-clone/src/outbox.rs`
+
+**Step 1: Write the failing split-store outbox delivery test**
+
+Create a Docker-backed test that:
+- creates one Postgres instance with separate logical databases for app data and Harvest data
+- applies reddit-clone migrations to the app DB
+- applies Harvest migrations to the Harvest DB
+- inserts a pending outbox row into the app DB
+- runs one drain pass
+- asserts the outbox row is marked delivered in app DB
+- asserts exactly one Harvest workflow execution exists in the Harvest DB
+
+**Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p reddit-clone durable_outbox_delivery_to_split_harvest_store`
+
+Expected: FAIL because no outbox table or relay exists yet.
+
+**Step 3: Write the failing retry test**
+
+Add a test where the Harvest DB is unavailable during the first drain and verify the outbox row remains pending with an error recorded.
+
+**Step 4: Run the test to verify it fails**
+
+Run: `cargo test -p reddit-clone outbox_retries_failed_delivery`
+
+Expected: FAIL because failures are not yet persisted on outbox rows.
+
+### Task 2: Add App-DB Outbox Schema And Models
+
+**Files:**
+- Modify: `examples/reddit-clone/migrations/00000000000000_create_reddit/up.sql`
+- Modify: `examples/reddit-clone/src/schema.rs`
+- Modify: `examples/reddit-clone/src/models.rs`
+
+**Step 1: Add the outbox table**
+
+Add a `harvest_workflow_outbox` table with:
+- `id BIGSERIAL PRIMARY KEY`
+- `workflow_name TEXT`
+- `workflow_id TEXT`
+- `queue_name TEXT`
+- `input JSONB`
+- `memo JSONB NULL`
+- `search_attrs JSONB NULL`
+- `delivery_attempts BIGINT DEFAULT 0`
+- `last_error TEXT NULL`
+- `delivered_execution_id TEXT NULL`
+- `delivered_at TIMESTAMP NULL`
+- `created_at TIMESTAMP DEFAULT NOW()`
+
+Add an index over pending rows, for example `(delivered_at, id)`.
+
+**Step 2: Add Diesel schema/models**
+
+Add read/write structs so route code and relay code can enqueue and update outbox rows cleanly.
+
+### Task 3: Add Outbox Helpers And Relay
+
+**Files:**
+- Create: `examples/reddit-clone/src/outbox.rs`
+- Modify: `examples/reddit-clone/src/main.rs`
+- Modify: `examples/reddit-clone/src/workflows.rs`
+
+**Step 1: Define a serializable workflow dispatch request**
+
+Represent the exact Harvest start payload needed by onboarding/post-publication.
+
+**Step 2: Add enqueue helpers**
+
+Add helpers that write outbox rows via the app DB.
+
+**Step 3: Add drain helpers**
+
+Drain pending rows by:
+- reading a batch from the app DB
+- calling Harvest’s `start_or_load_workflow_execution`
+- marking successful rows delivered
+- incrementing attempts and recording `last_error` on failure
+
+Keep the drain logic safe under duplicate invocation; Harvest idempotency should carry the heavy load.
+
+**Step 4: Add a background relay**
+
+Use `on_startup`/`on_shutdown` in reddit-clone to run a periodic drain loop with a cancellation token.
+
+### Task 4: Route App Writes Through The Outbox
+
+**Files:**
+- Modify: `examples/reddit-clone/src/routes/auth.rs`
+- Modify: `examples/reddit-clone/src/routes/posts.rs`
+
+**Step 1: Register path**
+
+Wrap the user insert plus onboarding outbox insert in one app-DB transaction.
+
+**Step 2: Post submission path**
+
+Wrap the post insert, author vote insert, and post-publication outbox insert in one app-DB transaction.
+
+**Step 3: Keep latency sane**
+
+After commit, run one best-effort drain pass so normal dev mode still feels immediate.
+
+### Task 5: Verify And Document Remaining Gaps
+
+**Files:**
+- Modify: `examples/reddit-clone/src/main.rs` comments if needed
+- Modify: `docs/plans/2026-04-09-harvest-topology-roadmap.md` only if wording materially changes
+
+**Step 1: Run verification**
+
+Run:
+- `cargo fmt --all`
+- `cargo fmt --all` in `autumn-harvest`
+- `cargo test -p reddit-clone workflows`
+- `cargo test -p reddit-clone --no-run -j 1`
+
+Run Docker-backed coverage:
+- `cargo test -p reddit-clone durable_outbox_delivery_to_split_harvest_store`
+- `cargo test -p reddit-clone outbox_retries_failed_delivery`
+
+**Step 2: State the remaining caveat honestly**
+
+This slice should make publication durable and retryable, but not instantly synchronous across two stores in every failure mode. Signal dedupe and generalized framework-level outbox support remain future work.

--- a/docs/plans/2026-04-09-reddit-clone-harvest-runner.md
+++ b/docs/plans/2026-04-09-reddit-clone-harvest-runner.md
@@ -1,0 +1,74 @@
+# Reddit Clone Harvest Runner Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a first-party Harvest runner binary to `reddit-clone` so the example has a real external-runtime escape hatch instead of only a library-level API.
+
+**Architecture:** Split `reddit-clone` into a small reusable library seam that owns route/task/workflow registration, keep `src/main.rs` as the embedded happy-path web entry point, and add a second binary that loads Autumn + Harvest config, resolves app and Harvest pools, and starts `HarvestRunner` with the same workflow/activity registration set.
+
+**Tech Stack:** Rust 2024, `autumn-web`, `autumn-web-harvest`, Tokio, Diesel Async, Postgres.
+
+---
+
+### Task 1: Write The Red Tests
+
+**Files:**
+- Create: `examples/reddit-clone/src/harvest_runtime.rs`
+- Create: `examples/reddit-clone/src/bin/harvest-runner.rs`
+
+**Step 1: Write failing tests**
+
+Add tests for:
+- a shared Harvest builder helper reusing the registered workflows and activities
+- runner config helpers resolving the app DB and Harvest DB URLs correctly
+- runner startup rejecting configs with neither worker nor scheduler ownership enabled
+
+**Step 2: Run tests to verify they fail**
+
+Run targeted reddit-clone tests for the new helpers.
+
+### Task 2: Add The Reusable Library Seam And Runner Binary
+
+**Files:**
+- Create: `examples/reddit-clone/src/lib.rs`
+- Modify: `examples/reddit-clone/src/main.rs`
+- Create: `examples/reddit-clone/src/harvest_runtime.rs`
+- Create: `examples/reddit-clone/src/bin/harvest-runner.rs`
+- Modify: `examples/reddit-clone/Cargo.toml`
+
+**Step 1: Write minimal implementation**
+
+- Move module ownership to `lib.rs`
+- Expose a shared Harvest builder/config helper
+- Keep the web main binary thin
+- Add a runner binary that:
+  - loads config
+  - builds app + Harvest pools
+  - constructs a detached `AppState`
+  - starts `HarvestRunner`
+  - waits for Ctrl+C and shuts down cleanly
+
+**Step 2: Run tests to verify they pass**
+
+Run the targeted helper tests and compile both binaries.
+
+### Task 3: Document The Example Escape Hatch
+
+**Files:**
+- Modify: `examples/reddit-clone/README.md`
+- Create: `examples/reddit-clone/autumn-external-web.toml`
+- Create: `examples/reddit-clone/autumn-external-runner.toml`
+
+**Step 1: Update docs/config**
+
+- Add explicit example profiles for web-side external mode and runner-side ownership
+- Document exact commands for running both processes
+- Call out any current process-local caveats honestly
+
+**Step 2: Verify**
+
+Run:
+- `cargo fmt --all`
+- `cargo test -p reddit-clone --lib`
+- `cargo test -p reddit-clone --bin reddit-clone --no-run -j 1`
+- `cargo test -p reddit-clone --bin reddit-clone-harvest-runner --no-run -j 1`

--- a/docs/plans/2026-04-10-reddit-live-event-bus.md
+++ b/docs/plans/2026-04-10-reddit-live-event-bus.md
@@ -1,0 +1,141 @@
+# Reddit Live Event Bus Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a real pluggable live-event bus for `reddit-clone` so distributed web/runner processes can use a broker-backed fan-out path while keeping the app database event log as replay truth.
+
+**Architecture:** Keep `live_feed_events` as the durable source of truth. Introduce a bus abstraction with two backends: `postgres_notify` for the happy path and `redis_pubsub` for distributed deployments. Writers persist the event row first, then publish a best-effort bus hint carrying the durable event id; web nodes consume the bus and replay rows from the durable log so missed notifications do not lose data.
+
+**Tech Stack:** Rust 2024, Autumn `AppState` runtime extensions, Diesel async Postgres, Redis async pub/sub, testcontainers (Postgres + Redis), Tokio tasks.
+
+---
+
+### Task 1: Add bus config coverage first
+
+**Files:**
+- Modify: `examples/reddit-clone/src/lib.rs`
+- Modify: `examples/reddit-clone/autumn-split-web.toml`
+- Modify: `examples/reddit-clone/autumn-split-runner.toml`
+
+**Step 1: Write the failing tests**
+
+- Add config tests for:
+  - default config uses `postgres_notify`
+  - split profiles opt into `redis_pubsub`
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p reddit-clone live_feed_bus --lib`
+Expected: FAIL because no live-feed bus config type/loader exists yet.
+
+**Step 3: Implement minimal config surface**
+
+- Add a loader for `[distributed.live_feed_bus]`
+- Default to `postgres_notify` when the section is absent
+- Parse `redis_pubsub` profile config cleanly
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p reddit-clone live_feed_bus --lib`
+
+### Task 2: Prove broker-backed relay behavior with a failing integration test
+
+**Files:**
+- Modify: `examples/reddit-clone/src/live_events.rs`
+- Modify: `examples/reddit-clone/Cargo.toml`
+- Modify: `Cargo.toml`
+
+**Step 1: Write the failing test**
+
+- Add a Docker-backed test that:
+  - starts Postgres and Redis
+  - starts a web relay configured for `redis_pubsub`
+  - persists an event from a separate runner state
+  - publishes the event id through the bus
+  - asserts the web `feed` channel receives the event before a long poll fallback could fire
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p reddit-clone live_events::tests::redis_bus_rebroadcasts_runner_events_into_web_channels -- --nocapture`
+Expected: FAIL because the Redis bus backend does not exist.
+
+**Step 3: Add dependencies**
+
+- Enable the Redis module in `testcontainers-modules`
+- Add the `redis` crate with async Tokio features in `examples/reddit-clone/Cargo.toml`
+
+**Step 4: Run test again**
+
+Run the same command and confirm it still fails for the missing implementation, not for missing crates.
+
+### Task 3: Implement the live-event bus runtime
+
+**Files:**
+- Create: `examples/reddit-clone/src/live_bus.rs`
+- Modify: `examples/reddit-clone/src/lib.rs`
+- Modify: `examples/reddit-clone/src/live_events.rs`
+- Modify: `examples/reddit-clone/src/main.rs`
+- Modify: `examples/reddit-clone/src/bin/harvest-runner.rs`
+- Modify: `examples/reddit-clone/src/routes/comments.rs`
+- Modify: `examples/reddit-clone/src/workflows.rs`
+
+**Step 1: Add the bus types**
+
+- Implement:
+  - `LiveFeedBusKind`
+  - `LiveFeedBusConfig`
+  - `LiveFeedBusPublisher`
+  - `LiveFeedBusListener`
+- Support:
+  - Postgres `LISTEN/NOTIFY`
+  - Redis pub/sub
+
+**Step 2: Install a publisher into runtime state**
+
+- On app startup, load the bus config and install `LiveFeedBusPublisher` into `AppState`
+- In the standalone runner, install the same publisher into the detached `AppState` before Harvest starts
+
+**Step 3: Split persistence from publication**
+
+- Change live-event persistence to return the durable event id
+- Move bus publication out of the DB transaction
+- Keep publication best-effort and log failures instead of aborting the user-facing write
+
+**Step 4: Update the relay**
+
+- Replace the hard-coded Postgres listener with the pluggable bus listener
+- Keep durable replay by `event_id > cursor`
+- Preserve polling fallback when the bus is unavailable
+
+**Step 5: Run focused tests**
+
+Run:
+- `cargo test -p reddit-clone live_events::tests::relay_notify_path_beats_long_poll_interval -- --nocapture`
+- `cargo test -p reddit-clone live_events::tests::redis_bus_rebroadcasts_runner_events_into_web_channels -- --nocapture`
+
+### Task 4: Document and verify the escape hatch
+
+**Files:**
+- Modify: `examples/reddit-clone/README.md`
+- Modify: `examples/reddit-clone/docker-compose.yml`
+
+**Step 1: Update local distributed example docs**
+
+- Add Redis service to `docker-compose.yml`
+- Document that:
+  - embedded/default mode uses Postgres notify
+  - split/distributed mode can switch to Redis pub/sub
+  - the app DB event log remains the replay source of truth
+
+**Step 2: Run verification**
+
+Run:
+- `cargo fmt --all`
+- `cargo test -p reddit-clone --lib`
+- `cargo test -p reddit-clone --bin reddit-clone-harvest-runner -- --nocapture`
+- `cargo test -p reddit-clone --no-run -j 1`
+
+**Step 3: Review the affected area for half-done seams**
+
+Run: `rg -n "TODO|FIXME|Stub:" examples/reddit-clone/src examples/reddit-clone/README.md`
+Expected: no new stubs in the live-event bus path.

--- a/docs/plans/2026-04-10-reddit-live-feed-observability.md
+++ b/docs/plans/2026-04-10-reddit-live-feed-observability.md
@@ -1,0 +1,143 @@
+# Reddit Live Feed Observability Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add production-shaped reconnect behavior and observability for the reddit-clone live-feed relay without changing the public live-event delivery model.
+
+**Architecture:** Keep the durable `live_feed_events` table as the source of truth, but give the relay an explicit runtime health object that records wake-source, reconnect, publish, and replay state. The relay should reconnect listeners with bounded backoff after failures instead of silently degrading forever, and that state should be available in-process for tests and operator inspection.
+
+**Tech Stack:** Rust 2024, Tokio, Diesel Async, Redis pub/sub, Postgres `LISTEN/NOTIFY`, Autumn `AppState` typed extensions, serde_json.
+
+---
+
+### Task 1: Define Relay Health Surface
+
+**Files:**
+- Modify: `examples/reddit-clone/src/live_events.rs`
+- Test: `examples/reddit-clone/src/live_events.rs`
+
+**Step 1: Write the failing test**
+
+Add a test that installs the relay runtime state and asserts the health snapshot reports:
+- current listener mode
+- wake counts by source
+- reconnect attempt count
+- last replay cursor / last replayed event timestamp
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p reddit-clone live_events::tests::relay_health_snapshot_reports_runtime_state -- --exact --nocapture`
+
+Expected: FAIL because no runtime health snapshot exists yet.
+
+**Step 3: Write minimal implementation**
+
+Add a `LiveFeedRelayHealth` extension with atomic counters + lock-protected snapshot fields and helper methods used by the relay and publisher.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p reddit-clone live_events::tests::relay_health_snapshot_reports_runtime_state -- --exact --nocapture`
+
+Expected: PASS
+
+### Task 2: Reconnect Dead Listeners
+
+**Files:**
+- Modify: `examples/reddit-clone/src/live_events.rs`
+- Test: `examples/reddit-clone/src/live_events.rs`
+
+**Step 1: Write the failing test**
+
+Add a test that starts the relay with no initial listener, injects a reconnect hook that succeeds later, and verifies the relay records reconnect attempts then resumes wake-driven rebroadcast without relying on the long poll interval.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p reddit-clone live_events::tests::relay_reconnects_after_listener_drop -- --exact --nocapture`
+
+Expected: FAIL because the current relay never heals once the listener is gone.
+
+**Step 3: Write minimal implementation**
+
+Teach the relay loop to:
+- track listener health
+- attempt reconnects when listener is missing or broken
+- use bounded retry interval
+- record reconnect success/failure into relay health
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p reddit-clone live_events::tests::relay_reconnects_after_listener_drop -- --exact --nocapture`
+
+Expected: PASS
+
+### Task 3: Record Publish/Wakeup/Replay Metrics
+
+**Files:**
+- Modify: `examples/reddit-clone/src/live_events.rs`
+- Test: `examples/reddit-clone/src/live_events.rs`
+
+**Step 1: Write the failing test**
+
+Add focused assertions around:
+- Redis publish success/failure counts
+- wake counts for Redis / Postgres / poll fallback
+- replayed event count and replay lag
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p reddit-clone live_events::tests::relay_health_tracks_publish_and_wake_sources -- --exact --nocapture`
+
+Expected: FAIL because those counters do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Update publisher + relay paths to record counts and timestamps in the shared health object without introducing blocking locks across awaits.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p reddit-clone live_events::tests::relay_health_tracks_publish_and_wake_sources -- --exact --nocapture`
+
+Expected: PASS
+
+### Task 4: Update Operator Docs
+
+**Files:**
+- Modify: `examples/reddit-clone/README.md`
+
+**Step 1: Document the new surface**
+
+Add a short operator section covering:
+- what the relay health snapshot measures
+- what reconnect behavior looks like
+- which wake source is primary vs backup in each topology
+- what sustained poll fallback means
+
+**Step 2: Verify docs read cleanly**
+
+Run: `rg -n "live feed relay|poll fallback|Redis|Postgres" examples/reddit-clone/README.md`
+
+Expected: updated wording present and internally consistent.
+
+### Task 5: Final Verification
+
+**Files:**
+- Modify: `examples/reddit-clone/src/live_events.rs`
+- Modify: `examples/reddit-clone/README.md`
+
+**Step 1: Run focused tests**
+
+Run: `cargo test -p reddit-clone live_events::tests::relay_health_snapshot_reports_runtime_state live_events::tests::relay_reconnects_after_listener_drop live_events::tests::relay_health_tracks_publish_and_wake_sources -- --nocapture`
+
+Expected: PASS
+
+**Step 2: Run broader coverage**
+
+Run: `cargo test -p reddit-clone --lib`
+
+Expected: PASS
+
+**Step 3: Scan for stubs**
+
+Run: `rg -n "TODO|FIXME|Stub:" examples/reddit-clone/src/live_events.rs examples/reddit-clone/README.md`
+
+Expected: no matches

--- a/examples/reddit-clone/Cargo.toml
+++ b/examples/reddit-clone/Cargo.toml
@@ -4,19 +4,33 @@ edition.workspace = true
 version.workspace = true
 publish = false
 
+[[bin]]
+name = "reddit-clone-harvest-runner"
+path = "src/bin/harvest-runner.rs"
+
 [dependencies]
 autumn-harvest = { path = "../../autumn-harvest/autumn-harvest" }
 autumn-web-harvest = { path = "../../autumn-harvest/autumn-web-harvest" }
 autumn-web = { path = "../../autumn", features = ["ws"] }
 chrono = { version = "0.4", features = ["serde"] }
-diesel = { version = "2", features = ["postgres", "chrono"] }
+diesel = { version = "2", features = ["postgres", "chrono", "serde_json"] }
 diesel-async = { version = "0.8", features = ["postgres"] }
 pq-sys = { version = "0.7", features = ["bundled_without_openssl"] }
+redis = { version = "1.2", features = ["aio", "tokio-comp"] }
 diesel_migrations = "2"
+futures = { workspace = true }
 maud = { version = "0.27", features = ["axum"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 validator = { version = "0.20", features = ["derive"] }
+scoped-futures = "0.1"
+thiserror = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+testcontainers = { workspace = true }
+testcontainers-modules = { workspace = true }

--- a/examples/reddit-clone/README.md
+++ b/examples/reddit-clone/README.md
@@ -22,7 +22,7 @@ showcasing the framework's major features in a single cohesive application.
 | CSRF protection (`CsrfToken` + htmx header injection) | `routes/layout.rs`, all forms |
 | Field validation (`#[validate(length(min, max))]`) | `models.rs` |
 | Scheduled background tasks (`#[scheduled(every = "15m")]`) | `tasks.rs` |
-| **WebSockets** (`#[ws]`, `Channels` pub/sub, `CancellationToken`) | `routes/live.rs` |
+| **WebSockets** (`#[ws]`, `Channels`, durable app-db relay, pluggable live-event bus, `CancellationToken`, relay health JSON) | `routes/live.rs`, `live_events.rs`, `live_bus.rs` |
 | **Durable Workflows** (real autumn-harvest onboarding + post-publication flows + management API) | `workflows.rs`, `/api/harvest/*` |
 | Actuator endpoints (`/health`, `/actuator/*`) | Auto-mounted |
 | Maud HTML templates | All route files |
@@ -33,12 +33,15 @@ showcasing the framework's major features in a single cohesive application.
 ## Running
 
 ```bash
-# Start PostgreSQL
+# Start PostgreSQL + Redis
+# Fresh volumes are recommended if you want the split example too, because the
+# container init script creates the separate `reddit_harvest` database once.
 docker compose up -d
 
 # Run the app in dev mode
-# The first boot applies both the reddit-clone schema and the embedded
-# autumn-harvest workflow tables.
+# The first boot applies the reddit-clone schema, the framework-owned Harvest
+# workflow outbox on the app database, and the Harvest storage tables on the
+# configured Harvest database role.
 cargo run -p reddit-clone
 
 # Optional: watch mode from the workspace root
@@ -47,10 +50,83 @@ cargo run -p reddit-clone
 # Visit http://localhost:3000
 ```
 
-If Harvest logs errors like `relation "harvest_task_queue" does not exist`, you
-are pointing the app at a database that never received the embedded Harvest
-migrations. Start the example once in dev mode against that database before
-using a release/profile-specific run.
+If Harvest logs errors like `relation "harvest_task_queue" does not exist`, the
+configured Harvest storage database never received its migrations. Start the
+example once in dev mode against that database before using a release or
+profile-specific run.
+
+If app writes succeed but workflow publication stays pending, inspect the
+framework-owned `harvest_workflow_outbox` table in the app database. Delivery
+from that table into Harvest storage is intentionally at-least-once and depends
+on idempotent workflow start.
+
+The live-feed relay also exposes an operator-facing JSON snapshot:
+
+```bash
+curl http://localhost:3000/api/live/relay/health
+```
+
+## External Runner Escape Hatch
+
+`reddit-clone` stays the embedded happy path, but the Harvest topology seam is
+real now. If the app grows large enough to want a dedicated Harvest cluster and
+separate runtime ownership, the web process can keep the API and outbox while a
+different process owns worker/scheduler execution.
+
+For a local two-process demo, use the checked-in split profiles:
+
+```bash
+# Reset Postgres so the init script creates both `reddit` and `reddit_harvest`
+docker compose down -v
+docker compose up -d
+
+# Web process: app DB + Harvest API/outbox, but no local worker/scheduler
+AUTUMN_PROFILE=split-web cargo run -p reddit-clone
+
+# Separate process: owns Harvest worker/scheduler against the harvest DB
+AUTUMN_PROFILE=split-runner cargo run -p reddit-clone --bin reddit-clone-harvest-runner
+```
+
+Those profiles live in:
+
+- `autumn-split-web.toml`
+- `autumn-split-runner.toml`
+
+The runner binary reuses the same workflow/activity registration as the web app;
+it just changes runtime ownership. For a true external deployment, keep the
+same binary and commands, but point `harvest.database.url` at a separate
+cluster instead of the local `reddit_harvest` logical database.
+
+The live WebSocket feed keeps the app database as durable truth via
+`live_feed_events`, but the wakeup path is now pluggable:
+
+- Default/embedded mode uses Postgres `LISTEN/NOTIFY`
+- Split profiles use Redis pub/sub for cross-process wakeups
+- Split mode also keeps Postgres `NOTIFY` as a safety-net, so missed Redis
+  publishes still wake web nodes immediately from the durable event log
+- Polling is now the last fallback only when neither wake path is available
+
+That means the database still owns replay correctness while Redis takes over
+the “please wake up now” job once you outgrow letting Postgres moonlight as a
+bus.
+
+## Live Feed Operations
+
+`/api/live/relay/health` reports the current relay state for the local process.
+The important fields are:
+
+- `listener_state`: which wake path is currently active (`postgres`, `redis`, `redis+postgres`, or `polling`)
+- `reconnect_attempts` / `reconnect_successes` / `reconnect_failures`: whether the process is healing broken listeners or just taking notes about them
+- `wake_redis`, `wake_postgres`, `wake_poll`: which path is actually waking the relay
+- `replayed_events`, `last_seen_id`, `last_replayed_at`: whether durable rows are still flowing through replay
+- `last_error`: the last relay or publish error seen by this process
+
+Operator heuristics:
+
+- Sustained growth in `wake_poll` means the process is living on fallback instead of a real bus.
+- Growing `reconnect_failures` with a flat `reconnect_successes` means the configured wake path is still broken.
+- A stale `last_replayed_at` while app writes continue means live updates are stuck before rebroadcast.
+- In split mode, `listener_state = "redis+postgres"` is healthy: Redis is primary and Postgres is the backup wake path.
 
 ## WebSocket Live Feed
 
@@ -87,7 +163,9 @@ src/
   schema.rs         # Diesel table definitions
   repositories.rs   # #[repository] with derived queries and API generation
   hooks.rs          # MutationHooks for post lifecycle (auto-slug)
-  tasks.rs          # #[scheduled] hot-rank recalculator
+  live_bus.rs       # Live-feed bus config and backend selection
+  live_events.rs    # Durable app-db live-feed relay with Postgres/Redis wakeups
+  tasks.rs          # Scheduled hot-rank + live-feed retention jobs
   workflows.rs      # real autumn-harvest onboarding + post-publication workflows and activities
   slugify.rs        # URL slug generation utility
   routes/
@@ -98,6 +176,6 @@ src/
     posts.rs        # Front page, submit, view, edit, delete
     comments.rs     # Comment creation and lazy loading
     votes.rs        # htmx-powered upvote/downvote with toggle + ON CONFLICT
-    live.rs         # #[ws] WebSocket feeds with Channels pub/sub
+    live.rs         # #[ws] WebSocket feeds consuming process-local Channels
     about.rs        # #[static_get] pre-rendered about page
 ```

--- a/examples/reddit-clone/autumn-split-runner.toml
+++ b/examples/reddit-clone/autumn-split-runner.toml
@@ -1,0 +1,14 @@
+[database]
+url = "postgres://autumn:autumn@localhost:5432/reddit"
+
+[harvest]
+mode = "split"
+worker_enabled = true
+scheduler_enabled = true
+
+[harvest.database]
+url = "postgres://autumn:autumn@localhost:5432/reddit_harvest"
+
+[distributed.live_feed_bus]
+kind = "redis_pubsub"
+redis_url = "redis://127.0.0.1:6379/"

--- a/examples/reddit-clone/autumn-split-web.toml
+++ b/examples/reddit-clone/autumn-split-web.toml
@@ -1,0 +1,14 @@
+[database]
+url = "postgres://autumn:autumn@localhost:5432/reddit"
+
+[harvest]
+mode = "split"
+worker_enabled = false
+scheduler_enabled = false
+
+[harvest.database]
+url = "postgres://autumn:autumn@localhost:5432/reddit_harvest"
+
+[distributed.live_feed_bus]
+kind = "redis_pubsub"
+redis_url = "redis://127.0.0.1:6379/"

--- a/examples/reddit-clone/docker-compose.yml
+++ b/examples/reddit-clone/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+      - ./docker/init:/docker-entrypoint-initdb.d
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
 
 volumes:
   pgdata:

--- a/examples/reddit-clone/docker/init/01-create-harvest-db.sql
+++ b/examples/reddit-clone/docker/init/01-create-harvest-db.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE reddit_harvest;

--- a/examples/reddit-clone/migrations/00000000000000_create_reddit/down.sql
+++ b/examples/reddit-clone/migrations/00000000000000_create_reddit/down.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS live_feed_events;
 DROP TABLE IF EXISTS votes;
 DROP TABLE IF EXISTS comments;
 DROP TABLE IF EXISTS posts;

--- a/examples/reddit-clone/migrations/00000000000000_create_reddit/up.sql
+++ b/examples/reddit-clone/migrations/00000000000000_create_reddit/up.sql
@@ -80,3 +80,13 @@ CREATE TABLE votes (
 CREATE INDEX idx_votes_user_id ON votes (user_id);
 CREATE INDEX idx_votes_post_id ON votes (post_id);
 CREATE INDEX idx_votes_comment_id ON votes (comment_id);
+
+-- Durable live-feed events for cross-process WebSocket fan-out
+CREATE TABLE live_feed_events (
+    id BIGSERIAL PRIMARY KEY,
+    subreddit_slug TEXT NOT NULL,
+    event JSONB NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_live_feed_events_created_at ON live_feed_events (created_at);

--- a/examples/reddit-clone/src/bin/harvest-runner.rs
+++ b/examples/reddit-clone/src/bin/harvest-runner.rs
@@ -1,0 +1,186 @@
+use autumn_web::AppState;
+use autumn_web::config::{AutumnConfig, DatabaseConfig};
+use autumn_web::db;
+use autumn_web_harvest::{
+    HarvestMode, HarvestRunner, HarvestRunnerResources, HarvestRuntimeConfig,
+};
+use reddit_clone::harvest_runtime::harvest_builder;
+use reddit_clone::live_events;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+enum RunnerConfigError {
+    #[error(
+        "reddit-clone harvest runner requires database.url because its activities touch app tables"
+    )]
+    MissingAppDatabaseUrl,
+    #[error(
+        "reddit-clone harvest runner requires at least one of harvest.worker_enabled or harvest.scheduler_enabled to be true"
+    )]
+    NoLocalOwnership,
+    #[error("reddit-clone harvest runner requires harvest.database.url when harvest.mode is {0:?}")]
+    MissingHarvestDatabaseUrl(HarvestMode),
+}
+
+#[derive(Debug, Error)]
+enum RunnerMainError {
+    #[error(transparent)]
+    Config(#[from] autumn_web::config::ConfigError),
+    #[error(transparent)]
+    RunnerConfig(#[from] RunnerConfigError),
+    #[error("failed to create database pool: {0}")]
+    Pool(String),
+    #[error("failed to start harvest runner: {0}")]
+    Startup(String),
+    #[error("failed waiting for ctrl-c: {0}")]
+    Signal(#[from] std::io::Error),
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(error) = run().await {
+        eprintln!("reddit-clone harvest runner failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), RunnerMainError> {
+    let app_config = AutumnConfig::load()?;
+    let harvest_config = HarvestRuntimeConfig::load()?;
+    validate_runner_ownership(&harvest_config)?;
+
+    let app_database_url = resolve_app_database_url(&app_config)?;
+    let harvest_database_url = resolve_harvest_database_url(&app_config, &harvest_config)?;
+    let app_pool = build_pool(app_database_url, app_config.database.pool_size)?;
+    let harvest_pool = build_pool(harvest_database_url, app_config.database.pool_size)?;
+    let profile = app_config.profile.as_deref().unwrap_or("default");
+    let app_state = detached_runner_state(profile).with_pool(app_pool.clone());
+    live_events::install_live_event_bus(&app_state)
+        .await
+        .map_err(|error| RunnerMainError::Startup(error.to_string()))?;
+    let runner = HarvestRunner::start(
+        harvest_builder().build(),
+        &harvest_config,
+        HarvestRunnerResources::new(harvest_pool)
+            .with_app_pool(app_pool)
+            .with_app_state(app_state),
+    )
+    .map_err(|error| RunnerMainError::Startup(error.to_string()))?;
+
+    eprintln!(
+        "reddit-clone Harvest runner started (profile={profile}, mode={:?}, worker_enabled={}, scheduler_enabled={})",
+        harvest_config.mode, harvest_config.worker_enabled, harvest_config.scheduler_enabled
+    );
+
+    tokio::signal::ctrl_c().await?;
+    eprintln!("shutting down reddit-clone Harvest runner");
+    runner.stop().await;
+    Ok(())
+}
+
+fn build_pool(
+    database_url: &str,
+    pool_size: usize,
+) -> Result<autumn_harvest::worker::DbPool, RunnerMainError> {
+    db::create_pool(&DatabaseConfig {
+        url: Some(database_url.to_owned()),
+        pool_size,
+        ..DatabaseConfig::default()
+    })
+    .map_err(|error| RunnerMainError::Pool(error.to_string()))?
+    .ok_or_else(|| RunnerMainError::Pool("database URL did not produce a pool".to_owned()))
+}
+
+fn resolve_app_database_url(config: &AutumnConfig) -> Result<&str, RunnerConfigError> {
+    config
+        .database
+        .url
+        .as_deref()
+        .ok_or(RunnerConfigError::MissingAppDatabaseUrl)
+}
+
+fn resolve_harvest_database_url<'a>(
+    app_config: &'a AutumnConfig,
+    harvest_config: &'a HarvestRuntimeConfig,
+) -> Result<&'a str, RunnerConfigError> {
+    match harvest_config.mode {
+        HarvestMode::Embedded => resolve_app_database_url(app_config),
+        HarvestMode::Split | HarvestMode::External => harvest_config.database.url.as_deref().ok_or(
+            RunnerConfigError::MissingHarvestDatabaseUrl(harvest_config.mode),
+        ),
+    }
+}
+
+fn validate_runner_ownership(config: &HarvestRuntimeConfig) -> Result<(), RunnerConfigError> {
+    if config.worker_enabled || config.scheduler_enabled {
+        Ok(())
+    } else {
+        Err(RunnerConfigError::NoLocalOwnership)
+    }
+}
+
+fn detached_runner_state(profile: &str) -> AppState {
+    AppState::detached().with_profile(profile)
+}
+
+#[cfg(test)]
+mod tests {
+    use autumn_web::config::AutumnConfig;
+    use autumn_web_harvest::{
+        HarvestDatabaseConfig, HarvestMode, HarvestOutboxConfig, HarvestRuntimeConfig,
+    };
+
+    use super::{
+        detached_runner_state, resolve_app_database_url, resolve_harvest_database_url,
+        validate_runner_ownership,
+    };
+
+    #[test]
+    fn runner_requires_local_worker_or_scheduler_ownership() {
+        let error = validate_runner_ownership(&HarvestRuntimeConfig {
+            mode: HarvestMode::External,
+            worker_enabled: false,
+            scheduler_enabled: false,
+            database: HarvestDatabaseConfig {
+                url: Some("postgres://autumn:autumn@localhost:5432/reddit_harvest".to_owned()),
+            },
+            outbox: HarvestOutboxConfig::default(),
+        })
+        .expect_err("runner without local ownership should be rejected");
+
+        assert!(error.to_string().contains("worker_enabled"));
+    }
+
+    #[test]
+    fn runner_reuses_app_database_for_embedded_harvest_storage() {
+        let app_config = AutumnConfig {
+            database: autumn_web::config::DatabaseConfig {
+                url: Some("postgres://autumn:autumn@localhost:5432/reddit".to_owned()),
+                ..Default::default()
+            },
+            ..AutumnConfig::default()
+        };
+        let harvest_config = HarvestRuntimeConfig::default();
+
+        assert_eq!(
+            resolve_harvest_database_url(&app_config, &harvest_config)
+                .expect("embedded mode should reuse app database"),
+            "postgres://autumn:autumn@localhost:5432/reddit"
+        );
+    }
+
+    #[test]
+    fn detached_runner_state_carries_profile_and_pool() {
+        let state = detached_runner_state("split-runner");
+
+        assert_eq!(state.profile(), "split-runner");
+    }
+
+    #[test]
+    fn runner_requires_app_database_url_for_reddit_clone_activities() {
+        let error = resolve_app_database_url(&AutumnConfig::default())
+            .expect_err("runner needs app db for reddit-clone activities");
+
+        assert!(error.to_string().contains("database.url"));
+    }
+}

--- a/examples/reddit-clone/src/harvest_runtime.rs
+++ b/examples/reddit-clone/src/harvest_runtime.rs
@@ -1,0 +1,68 @@
+use autumn_harvest::HarvestBuilder;
+use autumn_harvest::prelude::WorkerConfig;
+use autumn_web::app::AppBuilder;
+use autumn_web_harvest::HarvestExt;
+
+use crate::workflows;
+
+pub const HARVEST_API_PATH: &str = "/api/harvest";
+
+#[must_use]
+pub fn configured_worker_config() -> WorkerConfig {
+    WorkerConfig {
+        max_concurrent_workflows: 4,
+        max_concurrent_activities: 8,
+        ..WorkerConfig::default()
+    }
+}
+
+#[must_use]
+pub fn harvest_builder() -> HarvestBuilder {
+    HarvestBuilder::new()
+        .workflows(workflows::registered_workflows())
+        .activities(workflows::registered_activities())
+        .worker(configured_worker_config())
+}
+
+#[must_use]
+pub fn configure_embedded_harvest(builder: AppBuilder) -> AppBuilder {
+    let worker_config = configured_worker_config();
+
+    builder
+        .workflows(workflows::registered_workflows())
+        .activities(workflows::registered_activities())
+        .worker(worker_config)
+        .harvest_api(HARVEST_API_PATH)
+}
+
+#[cfg(test)]
+mod tests {
+    use autumn_harvest::HarvestBuilder;
+
+    use super::{HARVEST_API_PATH, configured_worker_config, harvest_builder};
+
+    #[test]
+    fn shared_harvest_builder_reuses_registered_workflows_and_activities() {
+        let builder: HarvestBuilder = harvest_builder();
+        let built = builder.build();
+
+        assert_eq!(built.workflow_count(), 2);
+        assert_eq!(built.activity_count(), 3);
+        assert_eq!(built.worker_config().max_concurrent_workflows, 4);
+        assert_eq!(built.worker_config().max_concurrent_activities, 8);
+    }
+
+    #[test]
+    fn configured_worker_config_matches_embedded_web_defaults() {
+        let config = configured_worker_config();
+
+        assert_eq!(config.max_concurrent_workflows, 4);
+        assert_eq!(config.max_concurrent_activities, 8);
+        assert_eq!(config.queues, vec!["default".to_string()]);
+    }
+
+    #[test]
+    fn harvest_api_path_stays_stable_for_runner_and_web_docs() {
+        assert_eq!(HARVEST_API_PATH, "/api/harvest");
+    }
+}

--- a/examples/reddit-clone/src/lib.rs
+++ b/examples/reddit-clone/src/lib.rs
@@ -1,0 +1,201 @@
+pub mod harvest_runtime;
+pub mod hooks;
+pub mod live_bus;
+pub mod live_events;
+pub mod models;
+pub mod repositories;
+pub mod routes;
+pub mod schema;
+pub mod slugify;
+pub mod tasks;
+pub mod workflows;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::fs;
+    use std::path::Path;
+
+    use autumn_web::config::{AutumnConfig, MockEnv};
+    use autumn_web_harvest::{HarvestMode, HarvestRuntimeConfig};
+
+    use crate::live_bus::{LiveFeedBusConfig, LiveFeedBusKind};
+
+    const MIGRATION_SQL: &str = include_str!("../migrations/00000000000000_create_reddit/up.sql");
+
+    #[test]
+    fn migration_uses_bigserial_ids() {
+        assert!(
+            MIGRATION_SQL.contains("BIGSERIAL PRIMARY KEY"),
+            "All IDs must be 64-bit to match the Int8/i64 application schema",
+        );
+    }
+
+    #[test]
+    fn migration_creates_all_tables() {
+        for table in &[
+            "users",
+            "subreddits",
+            "posts",
+            "comments",
+            "votes",
+            "live_feed_events",
+        ] {
+            assert!(
+                MIGRATION_SQL.contains(&format!("CREATE TABLE {table}")),
+                "Migration must create the '{table}' table",
+            );
+        }
+    }
+
+    #[test]
+    fn app_and_harvest_migration_versions_do_not_collide() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let app_migrations = collect_migration_versions(&manifest_dir.join("migrations"));
+        let harvest_adapter_migrations = collect_migration_versions(
+            &manifest_dir.join("../../autumn-harvest/autumn-web-harvest/migrations"),
+        );
+        let harvest_migrations = collect_migration_versions(
+            &manifest_dir.join("../../autumn-harvest/autumn-harvest/migrations"),
+        );
+
+        let collisions: Vec<_> = app_migrations
+            .intersection(&harvest_adapter_migrations)
+            .cloned()
+            .collect();
+
+        assert!(
+            collisions.is_empty(),
+            "reddit-clone and autumn-web-harvest migrations must not share Diesel version prefixes: {collisions:?}",
+        );
+
+        let collisions: Vec<_> = app_migrations
+            .intersection(&harvest_migrations)
+            .cloned()
+            .collect();
+
+        assert!(
+            collisions.is_empty(),
+            "reddit-clone and Harvest migrations must not share Diesel version prefixes: {collisions:?}",
+        );
+    }
+
+    #[test]
+    fn dev_profile_enables_csrf_for_forms() {
+        let env = MockEnv::new()
+            .with("AUTUMN_PROFILE", "dev")
+            .with("AUTUMN_MANIFEST_DIR", env!("CARGO_MANIFEST_DIR"));
+
+        let config =
+            AutumnConfig::load_with_env(&env).expect("reddit-clone dev config should load");
+
+        assert!(
+            config.security.csrf.enabled,
+            "reddit-clone extracts `CsrfToken`, so its dev profile must enable CSRF",
+        );
+    }
+
+    #[test]
+    fn split_web_profile_disables_local_harvest_runtime_ownership() {
+        let env = MockEnv::new()
+            .with("AUTUMN_PROFILE", "split-web")
+            .with("AUTUMN_MANIFEST_DIR", env!("CARGO_MANIFEST_DIR"));
+
+        let config = HarvestRuntimeConfig::load_with_env(&env)
+            .expect("split-web harvest config should load");
+
+        assert_eq!(config.mode, HarvestMode::Split);
+        assert!(!config.worker_enabled);
+        assert!(!config.scheduler_enabled);
+        assert_eq!(
+            config.database.url.as_deref(),
+            Some("postgres://autumn:autumn@localhost:5432/reddit_harvest")
+        );
+    }
+
+    #[test]
+    fn split_web_profile_declares_redis_live_feed_bus() {
+        let env = MockEnv::new()
+            .with("AUTUMN_PROFILE", "split-web")
+            .with("AUTUMN_MANIFEST_DIR", env!("CARGO_MANIFEST_DIR"));
+        let config = LiveFeedBusConfig::load_with_env(&env)
+            .expect("split-web live-feed bus config should load");
+
+        assert_eq!(
+            config.kind,
+            LiveFeedBusKind::RedisPubSub,
+            "split-web should use an external live-feed bus instead of Postgres notify",
+        );
+        assert_eq!(config.redis_url.as_deref(), Some("redis://127.0.0.1:6379/"),);
+    }
+
+    #[test]
+    fn split_runner_profile_enables_local_harvest_runtime_ownership() {
+        let env = MockEnv::new()
+            .with("AUTUMN_PROFILE", "split-runner")
+            .with("AUTUMN_MANIFEST_DIR", env!("CARGO_MANIFEST_DIR"));
+
+        let config = HarvestRuntimeConfig::load_with_env(&env)
+            .expect("split-runner harvest config should load");
+
+        assert_eq!(config.mode, HarvestMode::Split);
+        assert!(config.worker_enabled);
+        assert!(config.scheduler_enabled);
+        assert_eq!(
+            config.database.url.as_deref(),
+            Some("postgres://autumn:autumn@localhost:5432/reddit_harvest")
+        );
+    }
+
+    #[test]
+    fn split_runner_profile_declares_redis_live_feed_bus() {
+        let env = MockEnv::new()
+            .with("AUTUMN_PROFILE", "split-runner")
+            .with("AUTUMN_MANIFEST_DIR", env!("CARGO_MANIFEST_DIR"));
+        let config = LiveFeedBusConfig::load_with_env(&env)
+            .expect("split-runner live-feed bus config should load");
+
+        assert_eq!(
+            config.kind,
+            LiveFeedBusKind::RedisPubSub,
+            "split-runner should publish live-feed wakeups through Redis",
+        );
+        assert_eq!(config.redis_url.as_deref(), Some("redis://127.0.0.1:6379/"),);
+    }
+
+    #[test]
+    fn default_live_feed_bus_uses_postgres_notify() {
+        let env = MockEnv::new().with("AUTUMN_MANIFEST_DIR", env!("CARGO_MANIFEST_DIR"));
+        let config = LiveFeedBusConfig::load_with_env(&env)
+            .expect("default live-feed bus config should load");
+
+        assert_eq!(config.kind, LiveFeedBusKind::PostgresNotify);
+        assert_eq!(config.redis_url, None);
+        assert_eq!(config.channel, "reddit_live_feed");
+    }
+
+    fn collect_migration_versions(dir: &Path) -> BTreeSet<String> {
+        fs::read_dir(dir)
+            .unwrap_or_else(|error| {
+                panic!("failed to read migrations at {}: {error}", dir.display())
+            })
+            .map(|entry| entry.expect("migration directory entry should be readable"))
+            .filter_map(|entry| {
+                entry
+                    .file_type()
+                    .ok()
+                    .filter(|kind| kind.is_dir())
+                    .map(|_| entry)
+            })
+            .map(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .split('_')
+                    .next()
+                    .expect("migration directory should have a version prefix")
+                    .to_owned()
+            })
+            .collect()
+    }
+}

--- a/examples/reddit-clone/src/lib.rs
+++ b/examples/reddit-clone/src/lib.rs
@@ -22,6 +22,8 @@ mod tests {
     use crate::live_bus::{LiveFeedBusConfig, LiveFeedBusKind};
 
     const MIGRATION_SQL: &str = include_str!("../migrations/00000000000000_create_reddit/up.sql");
+    const MIGRATION_DOWN_SQL: &str =
+        include_str!("../migrations/00000000000000_create_reddit/down.sql");
 
     #[test]
     fn migration_uses_bigserial_ids() {
@@ -46,6 +48,14 @@ mod tests {
                 "Migration must create the '{table}' table",
             );
         }
+    }
+
+    #[test]
+    fn migration_down_drops_live_feed_events() {
+        assert!(
+            MIGRATION_DOWN_SQL.contains("DROP TABLE IF EXISTS live_feed_events"),
+            "Rollback migration must drop the live_feed_events table added by up.sql",
+        );
     }
 
     #[test]

--- a/examples/reddit-clone/src/live_bus.rs
+++ b/examples/reddit-clone/src/live_bus.rs
@@ -82,7 +82,7 @@ impl LiveFeedBusConfig {
         )
         .map_err(|source| LiveFeedBusConfigLoadError::Parse {
             path: base_path,
-            source,
+            source: Box::new(source),
         })?;
 
         Ok(distributed.live_feed_bus)
@@ -101,7 +101,7 @@ pub enum LiveFeedBusConfigLoadError {
     Parse {
         path: PathBuf,
         #[source]
-        source: toml::de::Error,
+        source: Box<toml::de::Error>,
     },
 }
 
@@ -152,7 +152,7 @@ fn load_distributed_section(
                     .parse()
                     .map_err(|source| LiveFeedBusConfigLoadError::Parse {
                         path: path.to_path_buf(),
-                        source,
+                        source: Box::new(source),
                     })?;
             Ok(config.get("distributed").cloned())
         }

--- a/examples/reddit-clone/src/live_bus.rs
+++ b/examples/reddit-clone/src/live_bus.rs
@@ -1,0 +1,185 @@
+//! Live-feed bus configuration for embedded and distributed reddit-clone runs.
+//!
+//! The durable `live_feed_events` table remains the replay source of truth.
+//! This config only selects how processes nudge each other to replay new rows.
+
+use std::path::{Path, PathBuf};
+
+use autumn_web::config::{Env, OsEnv};
+use serde::Deserialize;
+use thiserror::Error;
+
+fn default_channel() -> String {
+    "reddit_live_feed".to_owned()
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LiveFeedBusKind {
+    #[default]
+    PostgresNotify,
+    #[serde(rename = "redis_pubsub")]
+    RedisPubSub,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct LiveFeedBusConfig {
+    #[serde(default)]
+    pub kind: LiveFeedBusKind,
+    #[serde(default)]
+    pub redis_url: Option<String>,
+    #[serde(default = "default_channel")]
+    pub channel: String,
+}
+
+impl Default for LiveFeedBusConfig {
+    fn default() -> Self {
+        Self {
+            kind: LiveFeedBusKind::PostgresNotify,
+            redis_url: None,
+            channel: default_channel(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DistributedConfig {
+    #[serde(default)]
+    live_feed_bus: LiveFeedBusConfig,
+}
+
+impl LiveFeedBusConfig {
+    pub fn load() -> Result<Self, LiveFeedBusConfigLoadError> {
+        Self::load_with_env(&OsEnv)
+    }
+
+    pub fn load_with_env(env: &dyn Env) -> Result<Self, LiveFeedBusConfigLoadError> {
+        let manifest_dir = resolve_manifest_dir(env);
+        let profile = resolve_profile(env);
+
+        Self::load_from_dir(manifest_dir, profile.as_deref())
+    }
+
+    pub fn load_from_dir(
+        manifest_dir: impl AsRef<Path>,
+        profile: Option<&str>,
+    ) -> Result<Self, LiveFeedBusConfigLoadError> {
+        let manifest_dir = manifest_dir.as_ref();
+        let base_path = manifest_dir.join("autumn.toml");
+        let mut distributed =
+            load_distributed_section(&base_path)?.unwrap_or_else(empty_distributed_section);
+
+        if let Some(profile) = profile {
+            let overlay_path = manifest_dir.join(format!("autumn-{profile}.toml"));
+            if let Some(overlay) = load_distributed_section(&overlay_path)? {
+                deep_merge(&mut distributed, overlay);
+            }
+        }
+
+        let distributed: DistributedConfig = toml::from_str(
+            &toml::to_string(&distributed)
+                .expect("distributed live-feed bus config should serialize"),
+        )
+        .map_err(|source| LiveFeedBusConfigLoadError::Parse {
+            path: base_path,
+            source,
+        })?;
+
+        Ok(distributed.live_feed_bus)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum LiveFeedBusConfigLoadError {
+    #[error("failed to read live-feed bus config {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse live-feed bus config {path}: {source}")]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+}
+
+fn resolve_manifest_dir(env: &dyn Env) -> PathBuf {
+    env.var("AUTUMN_MANIFEST_DIR")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+}
+
+fn resolve_profile(env: &dyn Env) -> Option<String> {
+    if let Ok(profile) = env.var("AUTUMN_PROFILE") {
+        if !profile.is_empty() {
+            return Some(profile);
+        }
+    }
+
+    for (index, arg) in std::env::args().enumerate() {
+        if arg == "--profile" {
+            if let Some(profile) = std::env::args().nth(index + 1) {
+                if !profile.is_empty() {
+                    return Some(profile);
+                }
+            }
+        }
+        if let Some(profile) = arg.strip_prefix("--profile=") {
+            if !profile.is_empty() {
+                return Some(profile.to_owned());
+            }
+        }
+    }
+
+    match env.var("AUTUMN_IS_DEBUG").ok().as_deref() {
+        Some("1") => Some("dev".to_owned()),
+        Some("0") => Some("prod".to_owned()),
+        _ => None,
+    }
+}
+
+fn load_distributed_section(
+    path: &Path,
+) -> Result<Option<toml::Value>, LiveFeedBusConfigLoadError> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            let config: toml::Value =
+                contents
+                    .parse()
+                    .map_err(|source| LiveFeedBusConfigLoadError::Parse {
+                        path: path.to_path_buf(),
+                        source,
+                    })?;
+            Ok(config.get("distributed").cloned())
+        }
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(LiveFeedBusConfigLoadError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn deep_merge(base: &mut toml::Value, overlay: toml::Value) {
+    match (base, overlay) {
+        (toml::Value::Table(base), toml::Value::Table(overlay)) => {
+            for (key, value) in overlay {
+                match base.get_mut(&key) {
+                    Some(existing) => deep_merge(existing, value),
+                    None => {
+                        base.insert(key, value);
+                    }
+                }
+            }
+        }
+        (base, overlay) => *base = overlay,
+    }
+}
+
+fn empty_distributed_section() -> toml::Value {
+    toml::Value::Table(toml::map::Map::new())
+}

--- a/examples/reddit-clone/src/live_events.rs
+++ b/examples/reddit-clone/src/live_events.rs
@@ -768,12 +768,14 @@ pub async fn prune_live_feed_events(state: AppState) -> AutumnResult<()> {
         .get()
         .await
         .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
-    let cutoff = Utc::now().naive_utc() - chrono::Duration::days(LIVE_EVENT_RETENTION_DAYS);
 
-    let deleted =
-        diesel::delete(live_feed_events::table.filter(live_feed_events::created_at.lt(cutoff)))
-            .execute(&mut conn)
-            .await?;
+    let deleted = diesel::sql_query(
+        "DELETE FROM live_feed_events \
+         WHERE created_at < NOW() - ($1 * INTERVAL '1 day')",
+    )
+    .bind::<diesel::sql_types::BigInt, _>(LIVE_EVENT_RETENTION_DAYS)
+    .execute(&mut conn)
+    .await?;
 
     if deleted > 0 {
         debug!(deleted, "pruned expired reddit-clone live-feed events");
@@ -1036,6 +1038,8 @@ mod tests {
     use crate::live_bus::{LiveFeedBusConfig, LiveFeedBusKind};
     use autumn_web::config::DatabaseConfig;
     use autumn_web::db;
+    use diesel::QueryableByName;
+    use diesel_async::SimpleAsyncConnection;
     use testcontainers::ContainerAsync;
     use testcontainers_modules::postgres::Postgres;
     use testcontainers_modules::redis::{REDIS_PORT, Redis};
@@ -1043,7 +1047,14 @@ mod tests {
 
     const REDDIT_INIT_SQL: &str = include_str!("../migrations/00000000000000_create_reddit/up.sql");
 
+    #[derive(Debug, QueryableByName)]
+    struct CountRow {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        count: i64,
+    }
+
     #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
     async fn relay_rebroadcasts_runner_events_into_web_channels() {
         let (_container, database_url, web_state, runner_state) = setup_live_event_states().await;
         let mut feed = web_state.channels().subscribe("feed");
@@ -1096,6 +1107,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
     async fn relay_notify_path_beats_long_poll_interval() {
         let (_container, database_url, web_state, runner_state) = setup_live_event_states().await;
         let mut feed = web_state.channels().subscribe("feed");
@@ -1138,6 +1150,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
     async fn redis_bus_rebroadcasts_runner_events_into_web_channels() {
         let (_pg, _redis, database_url, redis_url, web_state, runner_state) =
             setup_live_event_states_with_redis().await;
@@ -1192,6 +1205,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
     async fn redis_bus_still_wakes_on_postgres_backup_when_publish_is_missed() {
         let (_pg, _redis, database_url, redis_url, web_state, runner_state) =
             setup_live_event_states_with_redis().await;
@@ -1245,6 +1259,50 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn prune_live_feed_events_uses_database_clock_for_retention() {
+        let (_container, state) = setup_live_event_prune_state().await;
+        let mut conn = state
+            .pool()
+            .expect("prune state should have a database pool")
+            .get()
+            .await
+            .expect("pool should provide a connection");
+        conn.batch_execute("SET TIME ZONE 'America/Chicago'")
+            .await
+            .expect("test connection should accept a non-UTC timezone");
+        diesel::sql_query(
+            "INSERT INTO live_feed_events (subreddit_slug, event, created_at) VALUES \
+             ('rust', '{\"type\":\"old\"}'::jsonb, NOW() - INTERVAL '7 days' - INTERVAL '1 minute'), \
+             ('rust', '{\"type\":\"keep\"}'::jsonb, NOW() - INTERVAL '7 days' + INTERVAL '1 minute')",
+        )
+        .execute(&mut conn)
+        .await
+        .expect("test should seed retention boundary events");
+        drop(conn);
+
+        prune_live_feed_events(state.clone())
+            .await
+            .expect("prune should succeed");
+
+        let mut conn = state
+            .pool()
+            .expect("prune state should have a database pool")
+            .get()
+            .await
+            .expect("pool should provide a connection");
+        let remaining: CountRow =
+            diesel::sql_query("SELECT COUNT(*) AS count FROM live_feed_events")
+                .get_result(&mut conn)
+                .await
+                .expect("test should count remaining live events");
+        assert_eq!(
+            remaining.count, 1,
+            "prune should use the database clock so the just-inside-retention row survives",
+        );
+    }
+
+    #[tokio::test]
     async fn comment_event_payload_includes_preview_and_path() {
         let event = comment_created_event(
             7,
@@ -1268,6 +1326,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
     async fn relay_health_snapshot_reports_runtime_state() {
         let (_container, database_url, web_state, runner_state) = setup_live_event_states().await;
         let (listener, wake_tx) = test_listener_pair("test-postgres");
@@ -1318,6 +1377,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
     async fn relay_reconnects_after_listener_drop() {
         let (_container, database_url, web_state, runner_state) = setup_live_event_states().await;
         let (stale_listener, stale_wake_tx) = test_listener_pair("stale-listener");
@@ -1393,6 +1453,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
     async fn relay_health_tracks_publish_and_wake_sources() {
         let success_state = AppState::detached().with_profile("relay-metrics-success");
         install_live_event_bus_with_config(&success_state, LiveFeedBusConfig::default())
@@ -1504,6 +1565,33 @@ mod tests {
             .with_pool(runner_pool);
 
         (container, database_url, web_state, runner_state)
+    }
+
+    async fn setup_live_event_prune_state() -> (ContainerAsync<Postgres>, AppState) {
+        let container = Postgres::default()
+            .with_init_sql(REDDIT_INIT_SQL.to_string().into_bytes())
+            .start()
+            .await
+            .expect("failed to start Postgres container");
+
+        let host = container
+            .get_host()
+            .await
+            .expect("failed to get container host");
+        let port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("failed to get container port");
+        let database_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+        let pool = db::create_pool(&DatabaseConfig {
+            url: Some(database_url),
+            pool_size: 1,
+            ..DatabaseConfig::default()
+        })
+        .expect("prune pool config should build")
+        .expect("prune pool should exist");
+
+        (container, AppState::for_test().with_pool(pool))
     }
 
     async fn setup_live_event_states_with_redis() -> (

--- a/examples/reddit-clone/src/live_events.rs
+++ b/examples/reddit-clone/src/live_events.rs
@@ -1,0 +1,1587 @@
+//! Durable live-feed events shared across web and worker processes.
+//!
+//! WebSocket subscribers still consume in-process Autumn channels, but those
+//! channels are now fed from a durable app-database event log so separate web
+//! and worker processes see the same activity stream. The relay can wake on
+//! Postgres `LISTEN/NOTIFY` or Redis pub/sub; Redis deployments also keep a
+//! Postgres wake safety-net so missed broker publishes do not degrade to slow
+//! polling.
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::RwLock;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::time::Duration;
+
+use autumn_harvest::notify::{QueueListener, QueueWaitOutcome, queue_channel};
+use autumn_web::AppState;
+use autumn_web::app::AppBuilder;
+use autumn_web::config::AutumnConfig;
+use autumn_web::error::AutumnError;
+use chrono::{NaiveDateTime, Utc};
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use diesel::SelectableHelper;
+use diesel::dsl::max;
+use diesel::sql_types::Text;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use futures::StreamExt;
+use redis::AsyncCommands;
+use serde_json::{Value, json};
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+use crate::live_bus::{LiveFeedBusConfig, LiveFeedBusKind};
+
+const LIVE_EVENT_RELAY_BATCH_SIZE: i64 = 128;
+const LIVE_EVENT_POLL_INTERVAL_MS: u64 = 250;
+const LIVE_EVENT_RECONNECT_INTERVAL_MS: u64 = 250;
+const LIVE_EVENT_RETENTION_DAYS: i64 = 7;
+const LIVE_EVENT_NOTIFY_QUEUE: &str = "reddit_live_feed";
+
+diesel::table! {
+    live_feed_events (id) {
+        id -> Int8,
+        subreddit_slug -> Text,
+        event -> Jsonb,
+        created_at -> Timestamp,
+    }
+}
+
+#[allow(dead_code)] // Row mirrors table state across relay queries and retention logic.
+#[derive(Debug, Clone, diesel::Queryable, diesel::Selectable)]
+#[diesel(table_name = live_feed_events)]
+struct LiveFeedEventRow {
+    id: i64,
+    subreddit_slug: String,
+    event: Value,
+    created_at: NaiveDateTime,
+}
+
+#[derive(diesel::Insertable)]
+#[diesel(table_name = live_feed_events)]
+struct NewLiveFeedEventRow<'a> {
+    subreddit_slug: &'a str,
+    event: Value,
+}
+
+#[derive(Clone)]
+struct LiveFeedRelayOptions {
+    database_url: Option<String>,
+    bus: LiveFeedBusConfig,
+    poll_interval: Duration,
+    reconnect_interval: Duration,
+    connector: Arc<dyn LiveEventListenerConnector>,
+}
+
+impl LiveFeedRelayOptions {
+    fn from_config(config: &AutumnConfig, bus: LiveFeedBusConfig) -> Self {
+        Self {
+            database_url: config.database.url.clone(),
+            bus,
+            poll_interval: Duration::from_millis(LIVE_EVENT_POLL_INTERVAL_MS),
+            reconnect_interval: Duration::from_millis(LIVE_EVENT_RECONNECT_INTERVAL_MS),
+            connector: Arc::new(DefaultLiveEventListenerConnector),
+        }
+    }
+}
+
+impl std::fmt::Debug for LiveFeedRelayOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LiveFeedRelayOptions")
+            .field(
+                "database_url",
+                &self.database_url.as_deref().map(|_| "<configured>"),
+            )
+            .field("bus", &self.bus)
+            .field("poll_interval", &self.poll_interval)
+            .field("reconnect_interval", &self.reconnect_interval)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct LiveEventBusMessage {
+    event_id: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+enum LiveFeedWakeSource {
+    Redis,
+    Postgres,
+    PollFallback,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LiveFeedWakeOutcome {
+    Wake(LiveFeedWakeSource),
+    TimedOut,
+    ListenerClosed,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct LiveFeedRelayHealthSnapshot {
+    pub bus_kind: String,
+    pub listener_state: String,
+    pub reconnect_attempts: u64,
+    pub reconnect_successes: u64,
+    pub reconnect_failures: u64,
+    pub publish_successes: u64,
+    pub publish_failures: u64,
+    pub wake_redis: u64,
+    pub wake_postgres: u64,
+    pub wake_poll: u64,
+    pub replayed_events: u64,
+    pub last_seen_id: i64,
+    pub last_replayed_at: Option<String>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Clone)]
+struct LiveFeedRelayHealth {
+    inner: Arc<LiveFeedRelayHealthInner>,
+}
+
+struct LiveFeedRelayHealthInner {
+    bus_kind: String,
+    listener_state: RwLock<String>,
+    reconnect_attempts: AtomicU64,
+    reconnect_successes: AtomicU64,
+    reconnect_failures: AtomicU64,
+    publish_successes: AtomicU64,
+    publish_failures: AtomicU64,
+    wake_redis: AtomicU64,
+    wake_postgres: AtomicU64,
+    wake_poll: AtomicU64,
+    replayed_events: AtomicU64,
+    last_seen_id: AtomicI64,
+    last_replayed_at: RwLock<Option<String>>,
+    last_error: RwLock<Option<String>>,
+}
+
+impl LiveFeedRelayHealth {
+    fn new(bus: &LiveFeedBusConfig) -> Self {
+        Self {
+            inner: Arc::new(LiveFeedRelayHealthInner {
+                bus_kind: match bus.kind {
+                    LiveFeedBusKind::PostgresNotify => "postgres_notify".to_owned(),
+                    LiveFeedBusKind::RedisPubSub => "redis_pubsub".to_owned(),
+                },
+                listener_state: RwLock::new("initializing".to_owned()),
+                reconnect_attempts: AtomicU64::new(0),
+                reconnect_successes: AtomicU64::new(0),
+                reconnect_failures: AtomicU64::new(0),
+                publish_successes: AtomicU64::new(0),
+                publish_failures: AtomicU64::new(0),
+                wake_redis: AtomicU64::new(0),
+                wake_postgres: AtomicU64::new(0),
+                wake_poll: AtomicU64::new(0),
+                replayed_events: AtomicU64::new(0),
+                last_seen_id: AtomicI64::new(0),
+                last_replayed_at: RwLock::new(None),
+                last_error: RwLock::new(None),
+            }),
+        }
+    }
+
+    fn snapshot(&self) -> LiveFeedRelayHealthSnapshot {
+        LiveFeedRelayHealthSnapshot {
+            bus_kind: self.inner.bus_kind.clone(),
+            listener_state: self
+                .inner
+                .listener_state
+                .read()
+                .map(|state| state.clone())
+                .unwrap_or_else(|_| "poisoned".to_owned()),
+            reconnect_attempts: AtomicU64::load(&self.inner.reconnect_attempts, Ordering::Relaxed),
+            reconnect_successes: AtomicU64::load(
+                &self.inner.reconnect_successes,
+                Ordering::Relaxed,
+            ),
+            reconnect_failures: AtomicU64::load(&self.inner.reconnect_failures, Ordering::Relaxed),
+            publish_successes: AtomicU64::load(&self.inner.publish_successes, Ordering::Relaxed),
+            publish_failures: AtomicU64::load(&self.inner.publish_failures, Ordering::Relaxed),
+            wake_redis: AtomicU64::load(&self.inner.wake_redis, Ordering::Relaxed),
+            wake_postgres: AtomicU64::load(&self.inner.wake_postgres, Ordering::Relaxed),
+            wake_poll: AtomicU64::load(&self.inner.wake_poll, Ordering::Relaxed),
+            replayed_events: AtomicU64::load(&self.inner.replayed_events, Ordering::Relaxed),
+            last_seen_id: AtomicI64::load(&self.inner.last_seen_id, Ordering::Relaxed),
+            last_replayed_at: self
+                .inner
+                .last_replayed_at
+                .read()
+                .map(|ts| ts.clone())
+                .unwrap_or(None),
+            last_error: self
+                .inner
+                .last_error
+                .read()
+                .map(|error| error.clone())
+                .unwrap_or_else(|_| Some("relay health lock poisoned".to_owned())),
+        }
+    }
+
+    fn set_listener_state(&self, state: impl Into<String>) {
+        if let Ok(mut listener_state) = self.inner.listener_state.write() {
+            *listener_state = state.into();
+        }
+    }
+
+    fn clear_error(&self) {
+        if let Ok(mut last_error) = self.inner.last_error.write() {
+            *last_error = None;
+        }
+    }
+
+    fn set_error(&self, error: impl Into<String>) {
+        if let Ok(mut last_error) = self.inner.last_error.write() {
+            *last_error = Some(error.into());
+        }
+    }
+
+    fn record_publish_success(&self) {
+        self.inner.publish_successes.fetch_add(1, Ordering::Relaxed);
+        self.clear_error();
+    }
+
+    fn record_publish_failure(&self, error: &AutumnError) {
+        self.inner.publish_failures.fetch_add(1, Ordering::Relaxed);
+        self.set_error(error.to_string());
+    }
+
+    fn record_reconnect_attempt(&self) {
+        self.inner
+            .reconnect_attempts
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_reconnect_success(&self, listener_state: &str) {
+        self.inner
+            .reconnect_successes
+            .fetch_add(1, Ordering::Relaxed);
+        self.set_listener_state(listener_state);
+        self.clear_error();
+    }
+
+    fn record_reconnect_failure(&self, error: impl Into<String>) {
+        self.inner
+            .reconnect_failures
+            .fetch_add(1, Ordering::Relaxed);
+        self.set_listener_state("polling");
+        self.set_error(error);
+    }
+
+    fn record_wake(&self, source: LiveFeedWakeSource) {
+        match source {
+            LiveFeedWakeSource::Redis => {
+                self.inner.wake_redis.fetch_add(1, Ordering::Relaxed);
+            }
+            LiveFeedWakeSource::Postgres => {
+                self.inner.wake_postgres.fetch_add(1, Ordering::Relaxed);
+            }
+            LiveFeedWakeSource::PollFallback => {
+                self.inner.wake_poll.fetch_add(1, Ordering::Relaxed);
+            }
+        };
+    }
+
+    fn record_replay(&self, cursor: i64, replayed: usize, last_created_at: Option<NaiveDateTime>) {
+        if replayed > 0 {
+            self.inner
+                .replayed_events
+                .fetch_add(replayed as u64, Ordering::Relaxed);
+            self.inner.last_seen_id.store(cursor, Ordering::Relaxed);
+            if let Some(created_at) = last_created_at {
+                if let Ok(mut last_replayed_at) = self.inner.last_replayed_at.write() {
+                    *last_replayed_at = Some(
+                        chrono::DateTime::<Utc>::from_naive_utc_and_offset(created_at, Utc)
+                            .to_rfc3339(),
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct LiveEventBusPublisher {
+    inner: LiveEventBusPublisherInner,
+    health: Arc<LiveFeedRelayHealth>,
+}
+
+#[derive(Clone)]
+enum LiveEventBusPublisherInner {
+    PostgresNotify,
+    RedisPubSub {
+        channel: String,
+        client: redis::Client,
+    },
+}
+
+struct LiveEventBusListener {
+    label: String,
+    redis: Option<redis::aio::PubSub>,
+    postgres: Option<QueueListener>,
+    #[cfg(test)]
+    test_rx: Option<tokio::sync::mpsc::UnboundedReceiver<LiveFeedWakeSource>>,
+}
+
+impl LiveEventBusListener {
+    fn from_parts(
+        redis: Option<redis::aio::PubSub>,
+        postgres: Option<QueueListener>,
+    ) -> Option<Self> {
+        if redis.is_none() && postgres.is_none() {
+            None
+        } else {
+            let label = match (redis.is_some(), postgres.is_some()) {
+                (true, true) => "redis+postgres",
+                (true, false) => "redis",
+                (false, true) => "postgres",
+                (false, false) => "polling",
+            };
+            Some(Self {
+                label: label.to_owned(),
+                redis,
+                postgres,
+                #[cfg(test)]
+                test_rx: None,
+            })
+        }
+    }
+
+    #[cfg(test)]
+    fn test(
+        label: impl Into<String>,
+        test_rx: tokio::sync::mpsc::UnboundedReceiver<LiveFeedWakeSource>,
+    ) -> Self {
+        Self {
+            label: label.into(),
+            redis: None,
+            postgres: None,
+            test_rx: Some(test_rx),
+        }
+    }
+
+    fn label(&self) -> &str {
+        &self.label
+    }
+}
+
+impl LiveEventBusPublisher {
+    fn from_config(
+        config: &LiveFeedBusConfig,
+        health: Arc<LiveFeedRelayHealth>,
+    ) -> AutumnResult<Self> {
+        let inner = match config.kind {
+            LiveFeedBusKind::PostgresNotify => LiveEventBusPublisherInner::PostgresNotify,
+            LiveFeedBusKind::RedisPubSub => {
+                let redis_url = config.redis_url.as_deref().ok_or_else(|| {
+                    AutumnError::service_unavailable_msg(
+                        "distributed.live_feed_bus.redis_url is required when kind = redis_pubsub",
+                    )
+                })?;
+                let client = redis::Client::open(redis_url)
+                    .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+                LiveEventBusPublisherInner::RedisPubSub {
+                    channel: config.channel.clone(),
+                    client,
+                }
+            }
+        };
+
+        Ok(Self { inner, health })
+    }
+
+    async fn publish(&self, event_id: i64) -> AutumnResult<()> {
+        let result = match &self.inner {
+            LiveEventBusPublisherInner::PostgresNotify => Ok(()),
+            LiveEventBusPublisherInner::RedisPubSub { channel, client } => {
+                let payload = serde_json::to_string(&LiveEventBusMessage { event_id })
+                    .expect("live-event bus payload should serialize");
+                match client.get_multiplexed_async_connection().await {
+                    Ok(mut conn) => match conn.publish(channel.as_str(), payload).await {
+                        Ok::<usize, redis::RedisError>(_published) => Ok(()),
+                        Err(error) => Err(AutumnError::service_unavailable_msg(error.to_string())),
+                    },
+                    Err(error) => Err(AutumnError::service_unavailable_msg(error.to_string())),
+                }
+            }
+        };
+
+        match &result {
+            Ok(()) => self.health.record_publish_success(),
+            Err(error) => self.health.record_publish_failure(error),
+        }
+
+        let _ = event_id;
+        result
+    }
+}
+
+type LiveEventConnectFuture<'a> =
+    Pin<Box<dyn Future<Output = Option<LiveEventBusListener>> + Send + 'a>>;
+
+trait LiveEventListenerConnector: Send + Sync {
+    fn connect<'a>(
+        &'a self,
+        database_url: Option<&'a str>,
+        bus: &'a LiveFeedBusConfig,
+    ) -> LiveEventConnectFuture<'a>;
+}
+
+struct DefaultLiveEventListenerConnector;
+
+impl LiveEventListenerConnector for DefaultLiveEventListenerConnector {
+    fn connect<'a>(
+        &'a self,
+        database_url: Option<&'a str>,
+        bus: &'a LiveFeedBusConfig,
+    ) -> LiveEventConnectFuture<'a> {
+        Box::pin(connect_live_event_listener(database_url, bus))
+    }
+}
+
+#[must_use]
+pub fn live_feed_relay_health_snapshot(state: &AppState) -> Option<LiveFeedRelayHealthSnapshot> {
+    state
+        .extension::<LiveFeedRelayHealth>()
+        .map(|health| health.snapshot())
+}
+
+fn ensure_live_feed_relay_health(
+    state: &AppState,
+    bus: &LiveFeedBusConfig,
+) -> Arc<LiveFeedRelayHealth> {
+    if let Some(health) = state.extension::<LiveFeedRelayHealth>() {
+        health
+    } else {
+        let health = LiveFeedRelayHealth::new(bus);
+        state.insert_extension(health.clone());
+        state
+            .extension::<LiveFeedRelayHealth>()
+            .expect("live-feed relay health should be installed after insertion")
+    }
+}
+
+#[must_use]
+pub fn configure_live_feed(builder: AppBuilder) -> AppBuilder {
+    builder.on_startup(start_live_event_relay)
+}
+
+pub async fn install_live_event_bus(state: &AppState) -> AutumnResult<()> {
+    let config = LiveFeedBusConfig::load()
+        .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+    install_live_event_bus_with_config(state, config).await
+}
+
+async fn install_live_event_bus_with_config(
+    state: &AppState,
+    config: LiveFeedBusConfig,
+) -> AutumnResult<()> {
+    let health = ensure_live_feed_relay_health(state, &config);
+    state.insert_extension(LiveEventBusPublisher::from_config(&config, health)?);
+    Ok(())
+}
+
+pub async fn publish_stored_live_event(state: &AppState, event_id: i64) -> AutumnResult<()> {
+    let publisher = state.extension::<LiveEventBusPublisher>().ok_or_else(|| {
+        AutumnError::service_unavailable_msg("reddit-clone live-event bus is not installed")
+    })?;
+    publisher.publish(event_id).await
+}
+
+pub async fn publish_stored_live_event_best_effort(state: &AppState, event_id: i64) {
+    if let Err(error) = publish_stored_live_event(state, event_id).await {
+        warn!(
+            error = %error,
+            event_id,
+            "failed to publish reddit-clone live event to the configured bus"
+        );
+    }
+}
+
+pub async fn start_live_event_relay(state: AppState) -> AutumnResult<()> {
+    if state.pool().is_none() {
+        return Err(AutumnError::service_unavailable_msg(
+            "reddit-clone live feed relay requires database.url",
+        ));
+    }
+
+    let config = AutumnConfig::load()
+        .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+    let bus = LiveFeedBusConfig::load()
+        .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+    install_live_event_bus_with_config(&state, bus.clone()).await?;
+
+    drop(
+        start_live_event_relay_with_options(state, LiveFeedRelayOptions::from_config(&config, bus))
+            .await?,
+    );
+    Ok(())
+}
+
+async fn start_live_event_relay_with_options(
+    state: AppState,
+    options: LiveFeedRelayOptions,
+) -> AutumnResult<JoinHandle<()>> {
+    let pool = state.pool().cloned().ok_or_else(|| {
+        AutumnError::service_unavailable_msg("reddit-clone live feed relay requires database.url")
+    })?;
+    let initial_cursor = load_current_live_event_cursor(&pool).await?;
+    let health = ensure_live_feed_relay_health(&state, &options.bus);
+    let listener = options
+        .connector
+        .connect(options.database_url.as_deref(), &options.bus)
+        .await;
+    health.set_listener_state(listener.as_ref().map_or_else(
+        || "polling".to_owned(),
+        |listener| listener.label().to_owned(),
+    ));
+    Ok(spawn_live_event_relay_task(
+        state,
+        options,
+        listener,
+        initial_cursor,
+        health,
+    ))
+}
+
+async fn connect_live_event_listener(
+    database_url: Option<&str>,
+    bus: &LiveFeedBusConfig,
+) -> Option<LiveEventBusListener> {
+    match bus.kind {
+        LiveFeedBusKind::PostgresNotify => LiveEventBusListener::from_parts(
+            None,
+            connect_postgres_live_event_listener(database_url, &bus.channel).await,
+        ),
+        LiveFeedBusKind::RedisPubSub => {
+            let redis =
+                connect_redis_live_event_listener(bus.redis_url.as_deref(), &bus.channel).await;
+            let postgres = connect_postgres_live_event_listener(database_url, &bus.channel).await;
+            if postgres.is_some() {
+                debug!(
+                    channel = %queue_channel(&bus.channel),
+                    "reddit-clone live-feed Postgres backup listener connected for Redis bus"
+                );
+            }
+            LiveEventBusListener::from_parts(redis, postgres)
+        }
+    }
+}
+
+async fn connect_postgres_live_event_listener(
+    database_url: Option<&str>,
+    _channel: &str,
+) -> Option<QueueListener> {
+    match database_url {
+        Some(database_url) => {
+            let queue = LIVE_EVENT_NOTIFY_QUEUE.to_owned();
+            match QueueListener::connect(database_url, std::slice::from_ref(&queue)).await {
+                Ok(listener) => {
+                    debug!(
+                        channel = %queue_channel(LIVE_EVENT_NOTIFY_QUEUE),
+                        "reddit-clone live-feed Postgres listener connected"
+                    );
+                    Some(listener)
+                }
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        channel = %queue_channel(LIVE_EVENT_NOTIFY_QUEUE),
+                        "failed to start reddit-clone live-feed Postgres listener; falling back to polling"
+                    );
+                    None
+                }
+            }
+        }
+        None => None,
+    }
+}
+
+async fn connect_redis_live_event_listener(
+    redis_url: Option<&str>,
+    channel: &str,
+) -> Option<redis::aio::PubSub> {
+    let Some(redis_url) = redis_url else {
+        warn!("distributed.live_feed_bus.redis_url is missing; falling back to polling");
+        return None;
+    };
+    match redis::Client::open(redis_url) {
+        Ok(client) => match client.get_async_pubsub().await {
+            Ok(mut pubsub) => match pubsub.subscribe(channel).await {
+                Ok(()) => {
+                    debug!(
+                        channel = %channel,
+                        "reddit-clone live-feed Redis listener connected"
+                    );
+                    Some(pubsub)
+                }
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        channel = %channel,
+                        "failed to subscribe reddit-clone live-feed Redis listener; falling back to polling"
+                    );
+                    None
+                }
+            },
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    "failed to connect reddit-clone live-feed Redis pubsub listener; falling back to polling"
+                );
+                None
+            }
+        },
+        Err(error) => {
+            warn!(
+                error = %error,
+                "failed to construct reddit-clone Redis client; falling back to polling"
+            );
+            None
+        }
+    }
+}
+
+fn spawn_live_event_relay_task(
+    state: AppState,
+    options: LiveFeedRelayOptions,
+    mut listener: Option<LiveEventBusListener>,
+    mut last_seen_id: i64,
+    health: Arc<LiveFeedRelayHealth>,
+) -> JoinHandle<()> {
+    let shutdown = state.shutdown_token();
+    let poll_interval = options.poll_interval;
+    let reconnect_interval = options.reconnect_interval;
+
+    tokio::spawn(async move {
+        let mut next_reconnect_at = tokio::time::Instant::now() + reconnect_interval;
+
+        loop {
+            tokio::select! {
+                _ = shutdown.cancelled() => {
+                    debug!(last_seen_id, "reddit-clone live-feed relay shutting down");
+                    break;
+                }
+                _ = tokio::time::sleep_until(next_reconnect_at), if listener.is_none() => {
+                    health.record_reconnect_attempt();
+                    match options
+                        .connector
+                        .connect(options.database_url.as_deref(), &options.bus)
+                        .await
+                    {
+                        Some(new_listener) => {
+                            health.record_reconnect_success(new_listener.label());
+                            listener = Some(new_listener);
+                        }
+                        None => {
+                            health.record_reconnect_failure(
+                                "failed to reconnect reddit-clone live-feed listener; using poll fallback",
+                            );
+                        }
+                    }
+                    next_reconnect_at = tokio::time::Instant::now() + reconnect_interval;
+                }
+                wake = wait_for_live_event_wakeup(listener.as_mut(), poll_interval) => {
+                    match wake {
+                        Ok(LiveFeedWakeOutcome::Wake(source)) => {
+                            health.record_wake(source);
+                            debug!(?source, "reddit-clone live-feed relay woke on the configured bus");
+                        }
+                        Ok(LiveFeedWakeOutcome::TimedOut) => {
+                            if listener.is_none() {
+                                health.record_wake(LiveFeedWakeSource::PollFallback);
+                            }
+                        }
+                        Ok(LiveFeedWakeOutcome::ListenerClosed) => {
+                            warn!("reddit-clone live-feed relay listener closed; attempting reconnect");
+                            health.record_reconnect_failure(
+                                "live-feed listener closed; retrying configured wake path",
+                            );
+                            listener = None;
+                            next_reconnect_at = tokio::time::Instant::now();
+                        }
+                        Err(error) => {
+                            warn!(
+                                error = %error,
+                                "reddit-clone live-feed relay listener failed; falling back to polling"
+                            );
+                            health.record_reconnect_failure(error.to_string());
+                            listener = None;
+                            next_reconnect_at = tokio::time::Instant::now();
+                        }
+                    }
+                    match rebroadcast_pending_live_events(&state, last_seen_id).await {
+                        Ok(progress) => {
+                            if progress.cursor > last_seen_id {
+                                debug!(
+                                    previous_cursor = last_seen_id,
+                                    cursor = progress.cursor,
+                                    "reddit-clone live-feed relay broadcast pending events"
+                                );
+                                last_seen_id = progress.cursor;
+                            }
+                            health.record_replay(progress.cursor, progress.replayed, progress.last_created_at);
+                        }
+                        Err(error) => {
+                            warn!(
+                                error = %error,
+                                last_seen_id,
+                                "reddit-clone live-feed relay failed to rebroadcast events"
+                            );
+                            health.set_error(error.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+pub async fn store_activity_event(
+    conn: &mut AsyncPgConnection,
+    subreddit_slug: &str,
+    event: &Value,
+) -> Result<i64, diesel::result::Error> {
+    let event_id: i64 = diesel::insert_into(live_feed_events::table)
+        .values(NewLiveFeedEventRow {
+            subreddit_slug,
+            event: event.clone(),
+        })
+        .returning(live_feed_events::id)
+        .get_result(conn)
+        .await?;
+    notify_live_event_stored(conn, event_id).await?;
+
+    Ok(event_id)
+}
+
+pub async fn prune_live_feed_events(state: AppState) -> AutumnResult<()> {
+    let pool = state.pool().cloned().ok_or_else(|| {
+        AutumnError::service_unavailable_msg("reddit-clone live-feed pruning requires database.url")
+    })?;
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+    let cutoff = Utc::now().naive_utc() - chrono::Duration::days(LIVE_EVENT_RETENTION_DAYS);
+
+    let deleted =
+        diesel::delete(live_feed_events::table.filter(live_feed_events::created_at.lt(cutoff)))
+            .execute(&mut conn)
+            .await?;
+
+    if deleted > 0 {
+        debug!(deleted, "pruned expired reddit-clone live-feed events");
+    }
+
+    Ok(())
+}
+
+#[must_use]
+pub fn post_created_event(
+    post_id: i64,
+    title: &str,
+    post_slug: &str,
+    subreddit_slug: &str,
+    author_username: &str,
+) -> Value {
+    json!({
+        "type": "post_created",
+        "post_id": post_id,
+        "title": title,
+        "post_slug": post_slug,
+        "subreddit_slug": subreddit_slug,
+        "author_username": author_username,
+        "path": format!("/r/{subreddit_slug}/posts/{post_slug}"),
+    })
+}
+
+#[must_use]
+pub fn comment_created_event(
+    comment_id: i64,
+    post_id: i64,
+    post_slug: &str,
+    subreddit_slug: &str,
+    author_username: &str,
+    body: &str,
+) -> Value {
+    json!({
+        "type": "comment_created",
+        "comment_id": comment_id,
+        "post_id": post_id,
+        "post_slug": post_slug,
+        "subreddit_slug": subreddit_slug,
+        "author_username": author_username,
+        "body_preview": comment_body_preview(body),
+        "path": format!("/r/{subreddit_slug}/posts/{post_slug}#comment-{comment_id}"),
+    })
+}
+
+type AutumnResult<T> = Result<T, AutumnError>;
+
+async fn load_current_live_event_cursor(
+    pool: &diesel_async::pooled_connection::deadpool::Pool<AsyncPgConnection>,
+) -> AutumnResult<i64> {
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+
+    Ok(live_feed_events::table
+        .select(max(live_feed_events::id))
+        .get_result::<Option<i64>>(&mut conn)
+        .await?
+        .unwrap_or(0))
+}
+
+async fn notify_live_event_stored(
+    conn: &mut AsyncPgConnection,
+    event_id: i64,
+) -> Result<(), diesel::result::Error> {
+    let channel = queue_channel(LIVE_EVENT_NOTIFY_QUEUE);
+    let payload = serde_json::to_string(&autumn_harvest::notify::NotifyPayload {
+        task_id: Uuid::nil(),
+    })
+    .expect("live-feed notify payload should serialize");
+
+    diesel::sql_query("SELECT pg_notify($1, $2)")
+        .bind::<Text, _>(channel)
+        .bind::<Text, _>(payload)
+        .execute(conn)
+        .await?;
+
+    let _ = event_id;
+    Ok(())
+}
+
+struct RebroadcastProgress {
+    cursor: i64,
+    replayed: usize,
+    last_created_at: Option<NaiveDateTime>,
+}
+
+async fn rebroadcast_pending_live_events(
+    state: &AppState,
+    after_id: i64,
+) -> AutumnResult<RebroadcastProgress> {
+    let pool = state.pool().cloned().ok_or_else(|| {
+        AutumnError::service_unavailable_msg("reddit-clone live-feed relay requires database.url")
+    })?;
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+    let mut cursor = after_id;
+    let mut replayed = 0usize;
+    let mut last_created_at = None;
+
+    loop {
+        let rows: Vec<LiveFeedEventRow> = live_feed_events::table
+            .filter(live_feed_events::id.gt(cursor))
+            .order(live_feed_events::id.asc())
+            .limit(LIVE_EVENT_RELAY_BATCH_SIZE)
+            .select(LiveFeedEventRow::as_select())
+            .load(&mut conn)
+            .await?;
+
+        if rows.is_empty() {
+            return Ok(RebroadcastProgress {
+                cursor,
+                replayed,
+                last_created_at,
+            });
+        }
+
+        for row in &rows {
+            rebroadcast_row(state, row);
+            cursor = row.id;
+            replayed += 1;
+            last_created_at = Some(row.created_at);
+        }
+
+        if rows.len() < LIVE_EVENT_RELAY_BATCH_SIZE as usize {
+            return Ok(RebroadcastProgress {
+                cursor,
+                replayed,
+                last_created_at,
+            });
+        }
+    }
+}
+
+async fn wait_for_live_event_wakeup(
+    listener: Option<&mut LiveEventBusListener>,
+    poll_interval: Duration,
+) -> AutumnResult<LiveFeedWakeOutcome> {
+    match listener {
+        Some(listener) => {
+            #[cfg(test)]
+            if let Some(test_rx) = listener.test_rx.as_mut() {
+                return wait_for_test_wake(test_rx, poll_interval).await;
+            }
+
+            match (listener.redis.as_mut(), listener.postgres.as_mut()) {
+                (Some(redis), Some(postgres)) => {
+                    tokio::select! {
+                        wake = wait_for_redis_message(redis, poll_interval) => wake,
+                        wake = wait_for_postgres_notification(postgres, poll_interval) => wake,
+                    }
+                }
+                (Some(redis), None) => wait_for_redis_message(redis, poll_interval).await,
+                (None, Some(postgres)) => {
+                    wait_for_postgres_notification(postgres, poll_interval).await
+                }
+                (None, None) => {
+                    tokio::time::sleep(poll_interval).await;
+                    Ok(LiveFeedWakeOutcome::TimedOut)
+                }
+            }
+        }
+        None => {
+            tokio::time::sleep(poll_interval).await;
+            Ok(LiveFeedWakeOutcome::TimedOut)
+        }
+    }
+}
+
+async fn wait_for_postgres_notification(
+    listener: &mut QueueListener,
+    poll_interval: Duration,
+) -> AutumnResult<LiveFeedWakeOutcome> {
+    match listener
+        .wait_for_notification_outcome(poll_interval)
+        .await
+        .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?
+    {
+        QueueWaitOutcome::Notification(_) => {
+            Ok(LiveFeedWakeOutcome::Wake(LiveFeedWakeSource::Postgres))
+        }
+        QueueWaitOutcome::TimedOut => Ok(LiveFeedWakeOutcome::TimedOut),
+        QueueWaitOutcome::ChannelClosed => Ok(LiveFeedWakeOutcome::ListenerClosed),
+    }
+}
+
+async fn wait_for_redis_message(
+    listener: &mut redis::aio::PubSub,
+    poll_interval: Duration,
+) -> AutumnResult<LiveFeedWakeOutcome> {
+    let mut stream = listener.on_message();
+    match tokio::time::timeout(poll_interval, stream.next()).await {
+        Ok(Some(message)) => {
+            let payload: String = message
+                .get_payload()
+                .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+            let _message: LiveEventBusMessage = serde_json::from_str(&payload)
+                .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+            Ok(LiveFeedWakeOutcome::Wake(LiveFeedWakeSource::Redis))
+        }
+        Ok(None) => Ok(LiveFeedWakeOutcome::ListenerClosed),
+        Err(_elapsed) => Ok(LiveFeedWakeOutcome::TimedOut),
+    }
+}
+
+#[cfg(test)]
+async fn wait_for_test_wake(
+    listener: &mut tokio::sync::mpsc::UnboundedReceiver<LiveFeedWakeSource>,
+    poll_interval: Duration,
+) -> AutumnResult<LiveFeedWakeOutcome> {
+    match tokio::time::timeout(poll_interval, listener.recv()).await {
+        Ok(Some(source)) => Ok(LiveFeedWakeOutcome::Wake(source)),
+        Ok(None) => Ok(LiveFeedWakeOutcome::ListenerClosed),
+        Err(_elapsed) => Ok(LiveFeedWakeOutcome::TimedOut),
+    }
+}
+
+fn rebroadcast_row(state: &AppState, row: &LiveFeedEventRow) {
+    let payload = row.event.to_string();
+    let channels = state.channels();
+
+    channels.sender("feed").send(payload.as_str()).ok();
+    channels
+        .sender(&format!("r/{}", row.subreddit_slug))
+        .send(payload)
+        .ok();
+}
+
+fn comment_body_preview(body: &str) -> String {
+    const MAX_PREVIEW_LEN: usize = 120;
+
+    let collapsed = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.len() <= MAX_PREVIEW_LEN {
+        return collapsed;
+    }
+
+    let mut preview = collapsed
+        .chars()
+        .take(MAX_PREVIEW_LEN.saturating_sub(3))
+        .collect::<String>();
+    preview.push_str("...");
+    preview
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    use crate::live_bus::{LiveFeedBusConfig, LiveFeedBusKind};
+    use autumn_web::config::DatabaseConfig;
+    use autumn_web::db;
+    use testcontainers::ContainerAsync;
+    use testcontainers_modules::postgres::Postgres;
+    use testcontainers_modules::redis::{REDIS_PORT, Redis};
+    use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+    const REDDIT_INIT_SQL: &str = include_str!("../migrations/00000000000000_create_reddit/up.sql");
+
+    #[tokio::test]
+    async fn relay_rebroadcasts_runner_events_into_web_channels() {
+        let (_container, database_url, web_state, runner_state) = setup_live_event_states().await;
+        let mut feed = web_state.channels().subscribe("feed");
+        let mut subreddit = web_state.channels().subscribe("r/rust");
+        let relay = start_live_event_relay_with_options(
+            web_state.clone(),
+            LiveFeedRelayOptions {
+                database_url: Some(database_url),
+                bus: LiveFeedBusConfig::default(),
+                poll_interval: Duration::from_millis(LIVE_EVENT_POLL_INTERVAL_MS),
+                reconnect_interval: Duration::from_millis(LIVE_EVENT_RECONNECT_INTERVAL_MS),
+                connector: Arc::new(DefaultLiveEventListenerConnector),
+            },
+        )
+        .await
+        .expect("relay should start");
+
+        let mut conn = runner_state
+            .pool()
+            .expect("runner state should have a database pool")
+            .get()
+            .await
+            .expect("runner pool should provide a connection");
+        let event = post_created_event(42, "Ferris ships", "ferris-ships", "rust", "ferris");
+        store_activity_event(&mut conn, "rust", &event)
+            .await
+            .expect("runner should persist the live event");
+
+        let feed_msg = tokio::time::timeout(Duration::from_secs(3), feed.recv())
+            .await
+            .expect("feed relay timed out")
+            .expect("feed channel closed unexpectedly");
+        let subreddit_msg = tokio::time::timeout(Duration::from_secs(3), subreddit.recv())
+            .await
+            .expect("subreddit relay timed out")
+            .expect("subreddit channel closed unexpectedly");
+
+        let feed_json: Value =
+            serde_json::from_str(feed_msg.as_str()).expect("feed message should be valid JSON");
+        let subreddit_json: Value = serde_json::from_str(subreddit_msg.as_str())
+            .expect("subreddit message should be valid JSON");
+
+        assert_eq!(feed_json["type"], "post_created");
+        assert_eq!(feed_json["post_id"], 42);
+        assert_eq!(feed_json["subreddit_slug"], "rust");
+        assert_eq!(subreddit_json, feed_json);
+
+        web_state.trigger_shutdown_for_test();
+        relay.await.expect("relay task should shut down cleanly");
+    }
+
+    #[tokio::test]
+    async fn relay_notify_path_beats_long_poll_interval() {
+        let (_container, database_url, web_state, runner_state) = setup_live_event_states().await;
+        let mut feed = web_state.channels().subscribe("feed");
+        let relay = start_live_event_relay_with_options(
+            web_state.clone(),
+            LiveFeedRelayOptions {
+                database_url: Some(database_url),
+                bus: LiveFeedBusConfig::default(),
+                poll_interval: Duration::from_secs(30),
+                reconnect_interval: Duration::from_millis(LIVE_EVENT_RECONNECT_INTERVAL_MS),
+                connector: Arc::new(DefaultLiveEventListenerConnector),
+            },
+        )
+        .await
+        .expect("relay should start");
+
+        let mut conn = runner_state
+            .pool()
+            .expect("runner state should have a database pool")
+            .get()
+            .await
+            .expect("runner pool should provide a connection");
+        let event = post_created_event(99, "Wake up", "wake-up", "rust", "ferris");
+        store_activity_event(&mut conn, "rust", &event)
+            .await
+            .expect("runner should persist the live event");
+
+        let feed_msg = tokio::time::timeout(Duration::from_secs(1), feed.recv())
+            .await
+            .expect("feed relay should wake long before poll fallback")
+            .expect("feed channel closed unexpectedly");
+        let feed_json: Value =
+            serde_json::from_str(feed_msg.as_str()).expect("feed message should be valid JSON");
+
+        assert_eq!(feed_json["post_id"], 99);
+        assert_eq!(feed_json["subreddit_slug"], "rust");
+
+        web_state.trigger_shutdown_for_test();
+        relay.await.expect("relay task should shut down cleanly");
+    }
+
+    #[tokio::test]
+    async fn redis_bus_rebroadcasts_runner_events_into_web_channels() {
+        let (_pg, _redis, database_url, redis_url, web_state, runner_state) =
+            setup_live_event_states_with_redis().await;
+        let bus = LiveFeedBusConfig {
+            kind: LiveFeedBusKind::RedisPubSub,
+            redis_url: Some(redis_url),
+            channel: "reddit_live_feed".to_owned(),
+        };
+        install_live_event_bus_with_config(&runner_state, bus.clone())
+            .await
+            .expect("runner should install the live-event bus");
+        let mut feed = web_state.channels().subscribe("feed");
+        let relay = start_live_event_relay_with_options(
+            web_state.clone(),
+            LiveFeedRelayOptions {
+                database_url: Some(database_url),
+                bus,
+                poll_interval: Duration::from_secs(30),
+                reconnect_interval: Duration::from_millis(LIVE_EVENT_RECONNECT_INTERVAL_MS),
+                connector: Arc::new(DefaultLiveEventListenerConnector),
+            },
+        )
+        .await
+        .expect("relay should start");
+
+        let mut conn = runner_state
+            .pool()
+            .expect("runner state should have a database pool")
+            .get()
+            .await
+            .expect("runner pool should provide a connection");
+        let event = post_created_event(123, "Redis wakes the feed", "redis-feed", "rust", "ferris");
+        let event_id = store_activity_event(&mut conn, "rust", &event)
+            .await
+            .expect("runner should persist the live event");
+        publish_stored_live_event(&runner_state, event_id)
+            .await
+            .expect("runner should publish the durable event id");
+
+        let feed_msg = tokio::time::timeout(Duration::from_secs(1), feed.recv())
+            .await
+            .expect("redis bus should wake the relay before the poll fallback")
+            .expect("feed channel closed unexpectedly");
+        let feed_json: Value =
+            serde_json::from_str(feed_msg.as_str()).expect("feed message should be valid JSON");
+
+        assert_eq!(feed_json["post_id"], 123);
+        assert_eq!(feed_json["subreddit_slug"], "rust");
+
+        web_state.trigger_shutdown_for_test();
+        relay.await.expect("relay task should shut down cleanly");
+    }
+
+    #[tokio::test]
+    async fn redis_bus_still_wakes_on_postgres_backup_when_publish_is_missed() {
+        let (_pg, _redis, database_url, redis_url, web_state, runner_state) =
+            setup_live_event_states_with_redis().await;
+        let mut feed = web_state.channels().subscribe("feed");
+        let relay = start_live_event_relay_with_options(
+            web_state.clone(),
+            LiveFeedRelayOptions {
+                database_url: Some(database_url),
+                bus: LiveFeedBusConfig {
+                    kind: LiveFeedBusKind::RedisPubSub,
+                    redis_url: Some(redis_url),
+                    channel: "reddit_live_feed".to_owned(),
+                },
+                poll_interval: Duration::from_secs(30),
+                reconnect_interval: Duration::from_millis(LIVE_EVENT_RECONNECT_INTERVAL_MS),
+                connector: Arc::new(DefaultLiveEventListenerConnector),
+            },
+        )
+        .await
+        .expect("relay should start");
+
+        let mut conn = runner_state
+            .pool()
+            .expect("runner state should have a database pool")
+            .get()
+            .await
+            .expect("runner pool should provide a connection");
+        let event = post_created_event(
+            124,
+            "Postgres backup wake",
+            "postgres-backup-wake",
+            "rust",
+            "ferris",
+        );
+        store_activity_event(&mut conn, "rust", &event)
+            .await
+            .expect("runner should persist the live event");
+
+        let feed_msg = tokio::time::timeout(Duration::from_secs(1), feed.recv())
+            .await
+            .expect("postgres backup wake should beat the poll fallback even without Redis publish")
+            .expect("feed channel closed unexpectedly");
+        let feed_json: Value =
+            serde_json::from_str(feed_msg.as_str()).expect("feed message should be valid JSON");
+
+        assert_eq!(feed_json["post_id"], 124);
+        assert_eq!(feed_json["subreddit_slug"], "rust");
+
+        web_state.trigger_shutdown_for_test();
+        relay.await.expect("relay task should shut down cleanly");
+    }
+
+    #[tokio::test]
+    async fn comment_event_payload_includes_preview_and_path() {
+        let event = comment_created_event(
+            7,
+            42,
+            "ferris-ships",
+            "rust",
+            "ferris",
+            "Borrow checker approved this message.",
+        );
+
+        assert_eq!(event["type"], "comment_created");
+        assert_eq!(event["comment_id"], 7);
+        assert_eq!(event["post_id"], 42);
+        assert_eq!(event["subreddit_slug"], "rust");
+        assert_eq!(event["author_username"], "ferris");
+        assert_eq!(event["path"], json!("/r/rust/posts/ferris-ships#comment-7"));
+        assert_eq!(
+            event["body_preview"],
+            json!("Borrow checker approved this message.")
+        );
+    }
+
+    #[tokio::test]
+    async fn relay_health_snapshot_reports_runtime_state() {
+        let (_container, database_url, web_state, runner_state) = setup_live_event_states().await;
+        let (listener, wake_tx) = test_listener_pair("test-postgres");
+        let mut feed = web_state.channels().subscribe("feed");
+        let relay = start_live_event_relay_with_options(
+            web_state.clone(),
+            LiveFeedRelayOptions {
+                database_url: Some(database_url),
+                bus: LiveFeedBusConfig::default(),
+                poll_interval: Duration::from_secs(30),
+                reconnect_interval: Duration::from_millis(25),
+                connector: Arc::new(TestListenerConnector::from_sequence(vec![Some(listener)])),
+            },
+        )
+        .await
+        .expect("relay should start");
+
+        let mut conn = runner_state
+            .pool()
+            .expect("runner state should have a database pool")
+            .get()
+            .await
+            .expect("runner pool should provide a connection");
+        let event = post_created_event(211, "health snapshot", "health-snapshot", "rust", "ferris");
+        let event_id = store_activity_event(&mut conn, "rust", &event)
+            .await
+            .expect("runner should persist the live event");
+        wake_tx
+            .send(LiveFeedWakeSource::Postgres)
+            .expect("test listener should accept a wake signal");
+
+        let _ = tokio::time::timeout(Duration::from_secs(1), feed.recv())
+            .await
+            .expect("relay should rebroadcast after the synthetic wake")
+            .expect("feed channel closed unexpectedly");
+
+        let snapshot =
+            live_feed_relay_health_snapshot(&web_state).expect("relay health should be installed");
+        assert_eq!(snapshot.bus_kind, "postgres_notify");
+        assert_eq!(snapshot.listener_state, "test-postgres");
+        assert_eq!(snapshot.wake_postgres, 1);
+        assert_eq!(snapshot.replayed_events, 1);
+        assert_eq!(snapshot.last_seen_id, event_id);
+        assert!(snapshot.last_replayed_at.is_some());
+
+        web_state.trigger_shutdown_for_test();
+        relay.await.expect("relay task should shut down cleanly");
+    }
+
+    #[tokio::test]
+    async fn relay_reconnects_after_listener_drop() {
+        let (_container, database_url, web_state, runner_state) = setup_live_event_states().await;
+        let (stale_listener, stale_wake_tx) = test_listener_pair("stale-listener");
+        drop(stale_wake_tx);
+        let (healthy_listener, healthy_wake_tx) = test_listener_pair("reconnected-listener");
+        let connector = Arc::new(TestListenerConnector::from_sequence(vec![
+            Some(stale_listener),
+            Some(healthy_listener),
+        ]));
+        let mut feed = web_state.channels().subscribe("feed");
+        let relay = start_live_event_relay_with_options(
+            web_state.clone(),
+            LiveFeedRelayOptions {
+                database_url: Some(database_url),
+                bus: LiveFeedBusConfig::default(),
+                poll_interval: Duration::from_secs(30),
+                reconnect_interval: Duration::from_millis(25),
+                connector: connector.clone(),
+            },
+        )
+        .await
+        .expect("relay should start");
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let snapshot = live_feed_relay_health_snapshot(&web_state)
+                    .expect("relay health should be installed");
+                if snapshot.reconnect_attempts >= 1
+                    && snapshot.reconnect_successes >= 1
+                    && snapshot.listener_state == "reconnected-listener"
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("relay should reconnect well before the poll fallback");
+
+        let mut conn = runner_state
+            .pool()
+            .expect("runner state should have a database pool")
+            .get()
+            .await
+            .expect("runner pool should provide a connection");
+        let event = post_created_event(212, "reconnect wake", "reconnect-wake", "rust", "ferris");
+        store_activity_event(&mut conn, "rust", &event)
+            .await
+            .expect("runner should persist the live event");
+        healthy_wake_tx
+            .send(LiveFeedWakeSource::Redis)
+            .expect("reconnected listener should accept wake signals");
+
+        let feed_msg = tokio::time::timeout(Duration::from_secs(1), feed.recv())
+            .await
+            .expect("relay should rebroadcast once the listener reconnects")
+            .expect("feed channel closed unexpectedly");
+        let feed_json: Value =
+            serde_json::from_str(feed_msg.as_str()).expect("feed message should be valid JSON");
+
+        assert_eq!(feed_json["post_id"], 212);
+
+        let snapshot =
+            live_feed_relay_health_snapshot(&web_state).expect("relay health should be installed");
+        assert!(snapshot.reconnect_attempts >= 1);
+        assert!(snapshot.reconnect_successes >= 1);
+        assert_eq!(snapshot.listener_state, "reconnected-listener");
+        assert_eq!(snapshot.wake_redis, 1);
+        assert_eq!(connector.attempts(), 2);
+
+        web_state.trigger_shutdown_for_test();
+        relay.await.expect("relay task should shut down cleanly");
+    }
+
+    #[tokio::test]
+    async fn relay_health_tracks_publish_and_wake_sources() {
+        let success_state = AppState::detached().with_profile("relay-metrics-success");
+        install_live_event_bus_with_config(&success_state, LiveFeedBusConfig::default())
+            .await
+            .expect("publisher should install with default config");
+        publish_stored_live_event(&success_state, 7)
+            .await
+            .expect("default publisher should record a successful publish");
+
+        let success_snapshot = live_feed_relay_health_snapshot(&success_state)
+            .expect("publisher install should create relay health");
+        assert_eq!(success_snapshot.publish_successes, 1);
+        assert_eq!(success_snapshot.publish_failures, 0);
+
+        let failure_state = AppState::detached().with_profile("relay-metrics-failure");
+        install_live_event_bus_with_config(
+            &failure_state,
+            LiveFeedBusConfig {
+                kind: LiveFeedBusKind::RedisPubSub,
+                redis_url: Some("redis://127.0.0.1:1/".to_owned()),
+                channel: "reddit_live_feed".to_owned(),
+            },
+        )
+        .await
+        .expect("redis publisher config should install even before the socket exists");
+        publish_stored_live_event(&failure_state, 8)
+            .await
+            .expect_err("publish should fail against an unreachable Redis socket");
+
+        let failure_snapshot = live_feed_relay_health_snapshot(&failure_state)
+            .expect("publisher install should create relay health");
+        assert_eq!(failure_snapshot.publish_successes, 0);
+        assert_eq!(failure_snapshot.publish_failures, 1);
+        assert!(failure_snapshot.last_error.is_some());
+
+        let (_container, database_url, web_state, _runner_state) = setup_live_event_states().await;
+        let relay = start_live_event_relay_with_options(
+            web_state.clone(),
+            LiveFeedRelayOptions {
+                database_url: Some(database_url),
+                bus: LiveFeedBusConfig::default(),
+                poll_interval: Duration::from_millis(25),
+                reconnect_interval: Duration::from_millis(25),
+                connector: Arc::new(TestListenerConnector::from_sequence(vec![None])),
+            },
+        )
+        .await
+        .expect("relay should start even when it has to fall back to polling");
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let snapshot = live_feed_relay_health_snapshot(&web_state)
+                    .expect("relay health should be installed");
+                if snapshot.wake_poll > 0 && snapshot.reconnect_attempts >= 1 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("relay should record poll wakeups and reconnect attempts");
+
+        let poll_snapshot =
+            live_feed_relay_health_snapshot(&web_state).expect("relay health should be installed");
+        assert!(poll_snapshot.wake_poll > 0);
+        assert!(poll_snapshot.reconnect_attempts >= 1);
+
+        web_state.trigger_shutdown_for_test();
+        relay.await.expect("relay task should shut down cleanly");
+    }
+
+    async fn setup_live_event_states() -> (ContainerAsync<Postgres>, String, AppState, AppState) {
+        let container = Postgres::default()
+            .with_init_sql(REDDIT_INIT_SQL.to_string().into_bytes())
+            .start()
+            .await
+            .expect("failed to start Postgres container");
+
+        let host = container
+            .get_host()
+            .await
+            .expect("failed to get container host");
+        let port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("failed to get container port");
+        let database_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+        let web_pool = db::create_pool(&DatabaseConfig {
+            url: Some(database_url.clone()),
+            pool_size: 4,
+            ..DatabaseConfig::default()
+        })
+        .expect("web pool config should build")
+        .expect("web pool should exist");
+        let runner_pool = db::create_pool(&DatabaseConfig {
+            url: Some(database_url.clone()),
+            pool_size: 4,
+            ..DatabaseConfig::default()
+        })
+        .expect("runner pool config should build")
+        .expect("runner pool should exist");
+
+        let web_state = AppState::detached()
+            .with_profile("split-web")
+            .with_pool(web_pool);
+        let runner_state = AppState::detached()
+            .with_profile("split-runner")
+            .with_pool(runner_pool);
+
+        (container, database_url, web_state, runner_state)
+    }
+
+    async fn setup_live_event_states_with_redis() -> (
+        ContainerAsync<Postgres>,
+        ContainerAsync<Redis>,
+        String,
+        String,
+        AppState,
+        AppState,
+    ) {
+        let (postgres, database_url, web_state, runner_state) = setup_live_event_states().await;
+        let redis = Redis::default()
+            .start()
+            .await
+            .expect("failed to start Redis container");
+        let redis_host = redis.get_host().await.expect("failed to get Redis host");
+        let redis_port = redis
+            .get_host_port_ipv4(REDIS_PORT)
+            .await
+            .expect("failed to get Redis port");
+        let redis_url = format!("redis://{redis_host}:{redis_port}/");
+
+        (
+            postgres,
+            redis,
+            database_url,
+            redis_url,
+            web_state,
+            runner_state,
+        )
+    }
+
+    #[derive(Clone)]
+    struct TestListenerConnector {
+        attempts: Arc<AtomicUsize>,
+        listeners: Arc<Mutex<VecDeque<Option<LiveEventBusListener>>>>,
+    }
+
+    impl TestListenerConnector {
+        fn from_sequence(listeners: Vec<Option<LiveEventBusListener>>) -> Self {
+            Self {
+                attempts: Arc::new(AtomicUsize::new(0)),
+                listeners: Arc::new(Mutex::new(listeners.into())),
+            }
+        }
+
+        fn attempts(&self) -> usize {
+            AtomicUsize::load(self.attempts.as_ref(), Ordering::Relaxed)
+        }
+    }
+
+    impl LiveEventListenerConnector for TestListenerConnector {
+        fn connect(
+            &self,
+            _database_url: Option<&str>,
+            _bus: &LiveFeedBusConfig,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Option<LiveEventBusListener>> + Send + '_>,
+        > {
+            self.attempts.fetch_add(1, Ordering::Relaxed);
+            let listeners = self.listeners.clone();
+            Box::pin(async move {
+                listeners
+                    .lock()
+                    .expect("test connector queue poisoned")
+                    .pop_front()
+                    .flatten()
+            })
+        }
+    }
+
+    fn test_listener_pair(
+        label: &'static str,
+    ) -> (
+        LiveEventBusListener,
+        tokio::sync::mpsc::UnboundedSender<LiveFeedWakeSource>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        (LiveEventBusListener::test(label, rx), tx)
+    }
+}

--- a/examples/reddit-clone/src/main.rs
+++ b/examples/reddit-clone/src/main.rs
@@ -11,176 +11,69 @@
 //   CSRF protection     -> CsrfToken extractor in forms
 //   Validation          -> #[validate(length(min, max))] on model fields
 //   Scheduled tasks     -> #[scheduled(every = "15m")] hot-rank recalculator
-//   WebSockets          -> #[ws] live feed with Channels pub/sub
+//   WebSockets          -> #[ws] live feed with Channels + durable app-db relay + pluggable bus
 //   Durable Workflows   -> autumn-harvest onboarding + post-publication workflows + management API
 //   Profiles            -> autumn.toml + autumn-dev.toml dev overrides
 //   Actuator            -> /health, /actuator/health, /actuator/info, /actuator/tasks
 //   HTML stack          -> Maud templates, htmx interactivity, Tailwind CSS
 //
-// Run with:   cargo run -p reddit-clone   (first dev boot applies reddit + Harvest migrations)
+// Run with:   cargo run -p reddit-clone   (first dev boot applies reddit + Harvest migrations;
+//                                          startup also drains pending Harvest outbox rows and
+//                                          starts the durable live-feed relay)
 // Front page: http://localhost:3000
 // WebSocket:  ws://localhost:3000/ws/feed
 // API test:   curl http://localhost:3000/api/posts
 //             curl http://localhost:3000/api/subreddits
 
-mod hooks;
-mod models;
-mod repositories;
-mod routes;
-mod schema;
-mod slugify;
-mod tasks;
-mod workflows;
-
-use autumn_harvest::prelude::WorkerConfig;
 use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
 use autumn_web::prelude::*;
-use autumn_web_harvest::prelude::HarvestExt;
+use reddit_clone::{harvest_runtime, live_events, repositories, routes, tasks};
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
 #[autumn_web::main]
 async fn main() {
-    autumn_web::app()
-        .migrations(MIGRATIONS)
-        .routes(routes![
-            // ── Front page ─────────────────────────────
-            routes::posts::front_page,
-            // ── Static page (pre-rendered) ─────────────
-            routes::about::about,
-            // ── Auth ───────────────────────────────────
-            routes::auth::register_form,
-            routes::auth::register,
-            routes::auth::login_form,
-            routes::auth::login,
-            routes::auth::logout,
-            routes::auth::profile,
-            // ── Subreddits ─────────────────────────────
-            routes::subreddits::list,
-            routes::subreddits::create_form,
-            routes::subreddits::create,
-            routes::subreddits::show,
-            // ── Posts ──────────────────────────────────
-            routes::posts::submit_form,
-            routes::posts::submit_to_sub_form,
-            routes::posts::submit,
-            routes::posts::show,
-            routes::posts::edit_form,
-            routes::posts::update,
-            routes::posts::delete_post,
-            // ── Comments ───────────────────────────────
-            routes::comments::create,
-            routes::comments::list_comments,
-            // ── Votes (htmx) ──────────────────────────
-            routes::votes::upvote,
-            routes::votes::downvote,
-            // ── WebSocket live feeds ───────────────────
-            routes::live::live_feed,
-            routes::live::subreddit_feed,
-            // ── Generated REST API (read-only) ────────
-            repositories::subreddit_api_list,
-            repositories::subreddit_api_get,
-            repositories::post_api_list,
-            repositories::post_api_get,
-        ])
-        .static_routes(static_routes![routes::about::about])
-        .tasks(tasks![tasks::recalculate_hot_ranks])
-        .workflows(workflows::registered_workflows())
-        .activities(workflows::registered_activities())
-        .worker(WorkerConfig {
-            max_concurrent_workflows: 4,
-            max_concurrent_activities: 8,
-            ..WorkerConfig::default()
-        })
-        .harvest_api("/api/harvest")
-        .run()
-        .await;
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::BTreeSet;
-    use std::fs;
-    use std::path::Path;
-
-    use autumn_web::config::{AutumnConfig, MockEnv};
-
-    const MIGRATION_SQL: &str = include_str!("../migrations/00000000000000_create_reddit/up.sql");
-
-    #[test]
-    fn migration_uses_bigserial_ids() {
-        assert!(
-            MIGRATION_SQL.contains("BIGSERIAL PRIMARY KEY"),
-            "All IDs must be 64-bit to match the Int8/i64 application schema",
-        );
-    }
-
-    #[test]
-    fn migration_creates_all_tables() {
-        for table in &["users", "subreddits", "posts", "comments", "votes"] {
-            assert!(
-                MIGRATION_SQL.contains(&format!("CREATE TABLE {table}")),
-                "Migration must create the '{table}' table",
-            );
-        }
-    }
-
-    #[test]
-    fn app_and_harvest_migration_versions_do_not_collide() {
-        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let app_migrations = collect_migration_versions(&manifest_dir.join("migrations"));
-        let harvest_migrations = collect_migration_versions(
-            &manifest_dir.join("../../autumn-harvest/autumn-harvest/migrations"),
-        );
-
-        let collisions: Vec<_> = app_migrations
-            .intersection(&harvest_migrations)
-            .cloned()
-            .collect();
-
-        assert!(
-            collisions.is_empty(),
-            "reddit-clone and Harvest migrations must not share Diesel version prefixes: {collisions:?}",
-        );
-    }
-
-    #[test]
-    fn dev_profile_enables_csrf_for_forms() {
-        let env = MockEnv::new()
-            .with("AUTUMN_PROFILE", "dev")
-            .with("AUTUMN_MANIFEST_DIR", env!("CARGO_MANIFEST_DIR"));
-
-        let config =
-            AutumnConfig::load_with_env(&env).expect("reddit-clone dev config should load");
-
-        assert!(
-            config.security.csrf.enabled,
-            "reddit-clone extracts `CsrfToken`, so its dev profile must enable CSRF",
-        );
-    }
-
-    fn collect_migration_versions(dir: &Path) -> BTreeSet<String> {
-        fs::read_dir(dir)
-            .unwrap_or_else(|error| {
-                panic!("failed to read migrations at {}: {error}", dir.display())
-            })
-            .map(|entry| entry.expect("migration directory entry should be readable"))
-            .filter_map(|entry| {
-                entry
-                    .file_type()
-                    .ok()
-                    .filter(|kind| kind.is_dir())
-                    .map(|_| entry)
-            })
-            .map(|entry| {
-                entry
-                    .file_name()
-                    .to_string_lossy()
-                    .split('_')
-                    .next()
-                    .expect("migration directory should have a version prefix")
-                    .to_owned()
-            })
-            .collect()
-    }
+    live_events::configure_live_feed(harvest_runtime::configure_embedded_harvest(
+        autumn_web::app()
+            .migrations(MIGRATIONS)
+            .routes(routes![
+                routes::posts::front_page,
+                routes::about::about,
+                routes::auth::register_form,
+                routes::auth::register,
+                routes::auth::login_form,
+                routes::auth::login,
+                routes::auth::logout,
+                routes::auth::profile,
+                routes::subreddits::list,
+                routes::subreddits::create_form,
+                routes::subreddits::create,
+                routes::subreddits::show,
+                routes::posts::submit_form,
+                routes::posts::submit_to_sub_form,
+                routes::posts::submit,
+                routes::posts::show,
+                routes::posts::edit_form,
+                routes::posts::update,
+                routes::posts::delete_post,
+                routes::comments::create,
+                routes::comments::list_comments,
+                routes::votes::upvote,
+                routes::votes::downvote,
+                routes::live::live_feed_health,
+                routes::live::live_feed,
+                routes::live::subreddit_feed,
+                repositories::subreddit_api_list,
+                repositories::subreddit_api_get,
+                repositories::post_api_list,
+                repositories::post_api_get,
+            ])
+            .static_routes(static_routes![routes::about::about])
+            .tasks(tasks![
+                tasks::recalculate_hot_ranks,
+                tasks::prune_live_feed_events
+            ]),
+    ))
+    .run()
+    .await;
 }

--- a/examples/reddit-clone/src/main.rs
+++ b/examples/reddit-clone/src/main.rs
@@ -33,7 +33,6 @@ mod tasks;
 mod workflows;
 
 use autumn_harvest::prelude::WorkerConfig;
-use autumn_web_harvest::prelude::HarvestExt;
 use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
 use autumn_web::prelude::*;
 use autumn_web_harvest::prelude::HarvestExt;

--- a/examples/reddit-clone/src/main.rs
+++ b/examples/reddit-clone/src/main.rs
@@ -33,6 +33,7 @@ mod tasks;
 mod workflows;
 
 use autumn_harvest::prelude::WorkerConfig;
+use autumn_web_harvest::prelude::HarvestExt;
 use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
 use autumn_web::prelude::*;
 use autumn_web_harvest::prelude::HarvestExt;

--- a/examples/reddit-clone/src/models.rs
+++ b/examples/reddit-clone/src/models.rs
@@ -1,7 +1,6 @@
 use crate::schema::{comments, posts, subreddits, users, votes};
 
-// ── User ───────────────────────────────────────────────────────
-// Manual model — password_hash should never be auto-exposed via API.
+// Manual model -- password_hash should never be auto-exposed via API.
 
 #[derive(Debug, Clone, diesel::Queryable, diesel::Selectable, serde::Serialize)]
 #[diesel(table_name = users)]
@@ -15,14 +14,12 @@ pub struct User {
     pub created_at: chrono::NaiveDateTime,
 }
 
-#[derive(Debug, diesel::Insertable, serde::Deserialize)]
+#[derive(Debug, Clone, diesel::Insertable, serde::Deserialize)]
 #[diesel(table_name = users)]
 pub struct NewUser {
     pub username: String,
     pub password_hash: String,
 }
-
-// ── Subreddit ──────────────────────────────────────────────────
 
 #[autumn_web::model]
 pub struct Subreddit {
@@ -40,8 +37,6 @@ pub struct Subreddit {
     #[default]
     pub created_at: chrono::NaiveDateTime,
 }
-
-// ── Post ───────────────────────────────────────────────────────
 
 #[autumn_web::model]
 pub struct Post {
@@ -69,8 +64,6 @@ pub struct Post {
     pub updated_at: chrono::NaiveDateTime,
 }
 
-// ── Comment ────────────────────────────────────────────────────
-
 #[autumn_web::model]
 pub struct Comment {
     #[id]
@@ -88,8 +81,7 @@ pub struct Comment {
     pub created_at: chrono::NaiveDateTime,
 }
 
-// ── Vote ───────────────────────────────────────────────────────
-// Manual model — complex constraints.
+// Manual model -- complex constraints.
 
 #[allow(dead_code)] // Used by generated API routes; not directly referenced in app code
 #[derive(Debug, Clone, diesel::Queryable, diesel::Selectable, serde::Serialize)]

--- a/examples/reddit-clone/src/routes/auth.rs
+++ b/examples/reddit-clone/src/routes/auth.rs
@@ -6,8 +6,12 @@
 use autumn_web::auth::{hash_password, verify_password};
 use autumn_web::extract::Path;
 use autumn_web::prelude::*;
+use autumn_web::reexports::axum::extract::State;
+use autumn_web_harvest::{enqueue_workflow_start_outbox, flush_workflow_start_outbox};
 use diesel::prelude::*;
+use diesel_async::AsyncConnection;
 use diesel_async::RunQueryDsl;
+use scoped_futures::ScopedFutureExt;
 use tracing::warn;
 
 use crate::models::{NewUser, User};
@@ -71,6 +75,7 @@ pub struct RegisterForm {
 
 #[post("/register")]
 pub async fn register(
+    State(state): State<AppState>,
     mut db: Db,
     session: Session,
     form: Form<RegisterForm>,
@@ -114,19 +119,34 @@ pub async fn register(
         password_hash: hashed,
     };
 
-    let user: User = diesel::insert_into(users::table)
-        .values(&new_user)
-        .returning(User::as_returning())
-        .get_result(&mut *db)
-        .await
-        .map_err(|_| AutumnError::unprocessable_msg("Username already taken"))?;
+    let user = (&mut *db)
+        .transaction::<User, AutumnError, _>(|conn| {
+            let new_user = new_user.clone();
+            async move {
+                let user: User = diesel::insert_into(users::table)
+                    .values(&new_user)
+                    .returning(User::as_returning())
+                    .get_result(conn)
+                    .await
+                    .map_err(|_| AutumnError::unprocessable_msg("Username already taken"))?;
 
-    if let Err(error) = crate::workflows::start_user_onboarding(&mut db, &user).await {
+                let request = crate::workflows::user_onboarding_dispatch(&user);
+                enqueue_workflow_start_outbox(conn, &request)
+                    .await
+                    .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+
+                Ok(user)
+            }
+            .scope_boxed()
+        })
+        .await?;
+
+    if let Err(error) = flush_workflow_start_outbox(&state).await {
         warn!(
             user_id = user.id,
             username = %user.username,
             error = %error,
-            "failed to enqueue onboarding workflow"
+            "failed to flush onboarding workflow outbox"
         );
     }
 

--- a/examples/reddit-clone/src/routes/auth.rs
+++ b/examples/reddit-clone/src/routes/auth.rs
@@ -119,7 +119,7 @@ pub async fn register(
         password_hash: hashed,
     };
 
-    let user = (&mut *db)
+    let user = (*db)
         .transaction::<User, AutumnError, _>(|conn| {
             let new_user = new_user.clone();
             async move {

--- a/examples/reddit-clone/src/routes/comments.rs
+++ b/examples/reddit-clone/src/routes/comments.rs
@@ -55,7 +55,7 @@ pub async fn create(
     let post_slug_for_event = post_slug.clone();
     let body_for_insert = body.clone();
     let author_username_for_event = author_username.clone();
-    let event_id = (&mut *db)
+    let event_id = (*db)
         .transaction::<i64, AutumnError, _>(|conn| {
             let sub_slug = sub_slug_for_event.clone();
             let post_slug = post_slug_for_event.clone();

--- a/examples/reddit-clone/src/routes/comments.rs
+++ b/examples/reddit-clone/src/routes/comments.rs
@@ -6,9 +6,15 @@
 
 use autumn_web::extract::Path;
 use autumn_web::prelude::*;
+use autumn_web::reexports::axum::extract::State;
 use diesel::prelude::*;
+use diesel_async::AsyncConnection;
 use diesel_async::RunQueryDsl;
+use scoped_futures::ScopedFutureExt;
 
+use crate::live_events::{
+    comment_created_event, publish_stored_live_event_best_effort, store_activity_event,
+};
 use crate::models::Comment;
 use crate::schema::{comments, posts, subreddits, users};
 
@@ -24,6 +30,7 @@ pub struct CommentForm {
 #[post("/r/{sub_slug}/posts/{post_slug}/comments")]
 pub async fn create(
     Path((sub_slug, post_slug)): Path<(String, String)>,
+    State(state): State<AppState>,
     session: Session,
     mut db: Db,
     form: Form<CommentForm>,
@@ -34,38 +41,68 @@ pub async fn create(
         .ok_or_else(|| AutumnError::unauthorized_msg("Login required"))?
         .parse()
         .map_err(|_| AutumnError::bad_request_msg("Invalid session"))?;
+    let author_username = session
+        .get("username")
+        .await
+        .unwrap_or_else(|| format!("user-{user_id}"));
 
     let body = form.0.body.trim().to_string();
     if body.is_empty() {
         return Err(AutumnError::unprocessable_msg("Comment cannot be empty"));
     }
 
-    // Find the post
-    let post_id: i64 = posts::table
-        .inner_join(subreddits::table.on(posts::subreddit_id.eq(subreddits::id)))
-        .filter(subreddits::slug.eq(&sub_slug))
-        .filter(posts::slug.eq(&post_slug))
-        .select(posts::id)
-        .first(&mut *db)
-        .await
-        .map_err(|_| AutumnError::not_found_msg("Post not found"))?;
+    let sub_slug_for_event = sub_slug.clone();
+    let post_slug_for_event = post_slug.clone();
+    let body_for_insert = body.clone();
+    let author_username_for_event = author_username.clone();
+    let event_id = (&mut *db)
+        .transaction::<i64, AutumnError, _>(|conn| {
+            let sub_slug = sub_slug_for_event.clone();
+            let post_slug = post_slug_for_event.clone();
+            let body = body_for_insert.clone();
+            let author_username = author_username_for_event.clone();
+            async move {
+                let post_id: i64 = posts::table
+                    .inner_join(subreddits::table.on(posts::subreddit_id.eq(subreddits::id)))
+                    .filter(subreddits::slug.eq(&sub_slug))
+                    .filter(posts::slug.eq(&post_slug))
+                    .select(posts::id)
+                    .first(conn)
+                    .await
+                    .map_err(|_| AutumnError::not_found_msg("Post not found"))?;
 
-    // Insert comment
-    diesel::insert_into(comments::table)
-        .values((
-            comments::body.eq(&body),
-            comments::author_id.eq(user_id),
-            comments::post_id.eq(post_id),
-            comments::score.eq(1_i64),
-        ))
-        .execute(&mut *db)
-        .await?;
+                let comment_id: i64 = diesel::insert_into(comments::table)
+                    .values((
+                        comments::body.eq(&body),
+                        comments::author_id.eq(user_id),
+                        comments::post_id.eq(post_id),
+                        comments::score.eq(1_i64),
+                    ))
+                    .returning(comments::id)
+                    .get_result(conn)
+                    .await?;
 
-    // Update comment count on post
-    diesel::update(posts::table.find(post_id))
-        .set(posts::comment_count.eq(posts::comment_count + 1))
-        .execute(&mut *db)
+                diesel::update(posts::table.find(post_id))
+                    .set(posts::comment_count.eq(posts::comment_count + 1))
+                    .execute(conn)
+                    .await?;
+
+                let event = comment_created_event(
+                    comment_id,
+                    post_id,
+                    &post_slug,
+                    &sub_slug,
+                    &author_username,
+                    &body,
+                );
+                let event_id = store_activity_event(conn, &sub_slug, &event).await?;
+
+                Ok(event_id)
+            }
+            .scope_boxed()
+        })
         .await?;
+    publish_stored_live_event_best_effort(&state, event_id).await;
 
     Ok(redirect_to(&format!("/r/{sub_slug}/posts/{post_slug}")))
 }

--- a/examples/reddit-clone/src/routes/live.rs
+++ b/examples/reddit-clone/src/routes/live.rs
@@ -1,10 +1,11 @@
 //! WebSocket live feed — real-time notifications for post and comment activity.
 //!
 //! Demonstrates: `#[ws]` macro, `Channels` pub/sub, `CancellationToken`
-//! for graceful shutdown, and the two-function pattern (pre-upgrade
-//! extractor access + post-upgrade socket handling).
+//! for graceful shutdown, and the durable app-db relay that keeps separate
+//! web and worker processes on the same live-feed stream.
 
 use autumn_web::prelude::*;
+use autumn_web::reexports::axum::extract::State;
 use autumn_web::ws::{Message, WebSocket, WithShutdown, WsHandler};
 use tokio_util::sync::CancellationToken;
 
@@ -46,6 +47,24 @@ pub async fn live_feed(state: AppState) -> impl WsHandler {
     )
 }
 
+/// JSON health snapshot for the durable live-feed relay.
+///
+/// Operators can poll this endpoint to see which wake path the process is
+/// currently using, whether reconnect attempts are happening, and whether the
+/// relay has recently replayed durable events.
+#[get("/api/live/relay/health")]
+pub async fn live_feed_health(
+    State(state): State<AppState>,
+) -> AutumnResult<Json<crate::live_events::LiveFeedRelayHealthSnapshot>> {
+    crate::live_events::live_feed_relay_health_snapshot(&state)
+        .map(Json)
+        .ok_or_else(|| {
+            AutumnError::service_unavailable_msg(
+                "reddit-clone live-feed relay health is not installed",
+            )
+        })
+}
+
 /// WebSocket endpoint for a specific subreddit's activity.
 ///
 /// Clients connect to `/ws/r/{slug}` and receive JSON notifications
@@ -82,19 +101,4 @@ pub async fn subreddit_feed(
             }
         },
     )
-}
-
-/// Publish a feed event to the global and subreddit-specific channels.
-///
-/// Called from post/comment creation routes to broadcast activity.
-#[allow(dead_code)] // Available for routes that want to broadcast events
-pub fn publish_activity(state: &AppState, subreddit_slug: &str, event: &str) {
-    let channels = state.channels();
-    // Broadcast to global feed
-    channels.sender("feed").send(event).ok();
-    // Broadcast to subreddit-specific feed
-    channels
-        .sender(&format!("r/{subreddit_slug}"))
-        .send(event)
-        .ok();
 }

--- a/examples/reddit-clone/src/routes/posts.rs
+++ b/examples/reddit-clone/src/routes/posts.rs
@@ -336,7 +336,7 @@ pub async fn submit(
     let title_for_insert = title.clone();
     let slug_for_insert = slug.clone();
     let author_username_for_outbox = author_username.clone();
-    let post_id = (&mut *db)
+    let post_id = (*db)
         .transaction::<i64, AutumnError, _>(|conn| {
             let title = title_for_insert.clone();
             let slug = slug_for_insert.clone();

--- a/examples/reddit-clone/src/routes/posts.rs
+++ b/examples/reddit-clone/src/routes/posts.rs
@@ -6,8 +6,12 @@
 
 use autumn_web::extract::Path;
 use autumn_web::prelude::*;
+use autumn_web::reexports::axum::extract::State;
+use autumn_web_harvest::{enqueue_workflow_start_outbox, flush_workflow_start_outbox};
 use diesel::prelude::*;
+use diesel_async::AsyncConnection;
 use diesel_async::RunQueryDsl;
+use scoped_futures::ScopedFutureExt;
 use tracing::warn;
 
 use crate::models::{Post, Subreddit, User};
@@ -277,6 +281,7 @@ pub struct SubmitPostForm {
 #[secured]
 #[post("/submit")]
 pub async fn submit(
+    State(state): State<AppState>,
     session: Session,
     mut db: Db,
     form: Form<SubmitPostForm>,
@@ -324,39 +329,63 @@ pub async fn submit(
 
     // Insert the post, then create an explicit author upvote so
     // score always matches the sum of actual vote rows.
-    let post_id: i64 = diesel::insert_into(posts::table)
-        .values((
-            posts::title.eq(&title),
-            posts::slug.eq(&slug),
-            posts::body.eq(form.0.body.trim()),
-            posts::url.eq(&url),
-            posts::author_id.eq(user_id),
-            posts::subreddit_id.eq(form.0.subreddit_id),
-            posts::score.eq(1_i64),
-        ))
-        .returning(posts::id)
-        .get_result(&mut *db)
+    let body = form.0.body.trim().to_string();
+    let subreddit_id = form.0.subreddit_id;
+    let subreddit_slug = sub.slug.clone();
+    let url_for_insert = url.clone();
+    let title_for_insert = title.clone();
+    let slug_for_insert = slug.clone();
+    let author_username_for_outbox = author_username.clone();
+    let post_id = (&mut *db)
+        .transaction::<i64, AutumnError, _>(|conn| {
+            let title = title_for_insert.clone();
+            let slug = slug_for_insert.clone();
+            let body = body.clone();
+            let url = url_for_insert.clone();
+            let subreddit_slug = subreddit_slug.clone();
+            let author_username = author_username_for_outbox.clone();
+            async move {
+                let post_id: i64 = diesel::insert_into(posts::table)
+                    .values((
+                        posts::title.eq(&title),
+                        posts::slug.eq(&slug),
+                        posts::body.eq(&body),
+                        posts::url.eq(&url),
+                        posts::author_id.eq(user_id),
+                        posts::subreddit_id.eq(subreddit_id),
+                        posts::score.eq(1_i64),
+                    ))
+                    .returning(posts::id)
+                    .get_result(conn)
+                    .await?;
+
+                diesel::insert_into(crate::schema::votes::table)
+                    .values((
+                        crate::schema::votes::user_id.eq(user_id),
+                        crate::schema::votes::post_id.eq(post_id),
+                        crate::schema::votes::value.eq(1_i16),
+                    ))
+                    .execute(conn)
+                    .await?;
+
+                let request = crate::workflows::post_publication_dispatch(
+                    post_id,
+                    &title,
+                    &slug,
+                    &subreddit_slug,
+                    &author_username,
+                );
+                enqueue_workflow_start_outbox(conn, &request)
+                    .await
+                    .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+
+                Ok(post_id)
+            }
+            .scope_boxed()
+        })
         .await?;
 
-    diesel::insert_into(crate::schema::votes::table)
-        .values((
-            crate::schema::votes::user_id.eq(user_id),
-            crate::schema::votes::post_id.eq(post_id),
-            crate::schema::votes::value.eq(1_i16),
-        ))
-        .execute(&mut *db)
-        .await?;
-
-    if let Err(error) = crate::workflows::start_post_publication(
-        &mut db,
-        post_id,
-        &title,
-        &slug,
-        &sub.slug,
-        &author_username,
-    )
-    .await
-    {
+    if let Err(error) = flush_workflow_start_outbox(&state).await {
         warn!(
             post_id,
             title = %title,
@@ -364,7 +393,7 @@ pub async fn submit(
             subreddit_slug = %sub.slug,
             author_username = %author_username,
             error = %error,
-            "failed to enqueue post publication workflow"
+            "failed to flush post publication workflow outbox"
         );
     }
 

--- a/examples/reddit-clone/src/schema.rs
+++ b/examples/reddit-clone/src/schema.rs
@@ -61,10 +61,26 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    live_feed_events (id) {
+        id -> Int8,
+        subreddit_slug -> Text,
+        event -> Jsonb,
+        created_at -> Timestamp,
+    }
+}
+
 diesel::joinable!(posts -> users (author_id));
 diesel::joinable!(posts -> subreddits (subreddit_id));
 diesel::joinable!(comments -> users (author_id));
 diesel::joinable!(comments -> posts (post_id));
 diesel::joinable!(subreddits -> users (creator_id));
 
-diesel::allow_tables_to_appear_in_same_query!(users, subreddits, posts, comments, votes,);
+diesel::allow_tables_to_appear_in_same_query!(
+    users,
+    subreddits,
+    posts,
+    comments,
+    votes,
+    live_feed_events,
+);

--- a/examples/reddit-clone/src/tasks.rs
+++ b/examples/reddit-clone/src/tasks.rs
@@ -68,3 +68,10 @@ pub async fn recalculate_hot_ranks(state: AppState) -> AutumnResult<()> {
     tracing::info!("hot-rank: recalculated {updated} posts");
     Ok(())
 }
+
+/// Prune durable live-feed rows after a short retention window so the
+/// cross-process broadcast log does not grow without bound.
+#[scheduled(every = "1h", name = "live-feed-retention")]
+pub async fn prune_live_feed_events(state: AppState) -> AutumnResult<()> {
+    crate::live_events::prune_live_feed_events(state).await
+}

--- a/examples/reddit-clone/src/workflows.rs
+++ b/examples/reddit-clone/src/workflows.rs
@@ -347,6 +347,7 @@ mod tests {
     );
 
     #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
     async fn duplicate_publication_reuses_existing_execution() {
         let (mut conn, _container) = setup_test_db().await;
         let workflow_id = onboarding_workflow_id(42);

--- a/examples/reddit-clone/src/workflows.rs
+++ b/examples/reddit-clone/src/workflows.rs
@@ -8,19 +8,23 @@
 use std::time::Duration;
 
 use autumn_harvest::error::database_error;
-use autumn_harvest::models::NewWorkflowExecution;
 use autumn_harvest::prelude::*;
-use autumn_harvest::queue::{EnqueueParams, TaskType};
-use autumn_harvest::worker::DbPool;
 use autumn_web::AppState;
+use autumn_web_harvest::{AppDbPool, WorkflowStartRequest};
 use diesel::ExpressionMethods;
 use diesel::QueryDsl;
-use diesel_async::AsyncPgConnection;
 use diesel_async::RunQueryDsl;
 use serde_json::{Value, json};
 
+#[cfg(test)]
+use autumn_harvest::{StartWorkflowParams, start_or_load_workflow_execution};
+#[cfg(test)]
+use diesel_async::AsyncPgConnection;
+
+use crate::live_events::{
+    post_created_event, publish_stored_live_event_best_effort, store_activity_event,
+};
 use crate::models::User;
-use crate::routes::live::publish_activity;
 use crate::schema::posts;
 use crate::schema::users;
 use crate::tasks::calculate_hot_rank;
@@ -102,8 +106,8 @@ async fn award_starter_karma(ctx: &ActivityContext, input: Value) -> HarvestResu
         .get("starter_karma")
         .and_then(Value::as_i64)
         .unwrap_or(STARTER_KARMA);
-    let pool = ctx.state::<DbPool>().ok_or_else(|| {
-        HarvestError::Config("reddit-clone Harvest activity is missing DbPool".into())
+    let pool = ctx.state::<AppDbPool>().ok_or_else(|| {
+        HarvestError::Config("reddit-clone Harvest activity is missing AppDbPool".into())
     })?;
     let mut conn = pool.get().await.map_err(database_error)?;
 
@@ -125,8 +129,8 @@ async fn award_starter_karma(ctx: &ActivityContext, input: Value) -> HarvestResu
 )]
 async fn refresh_post_hot_rank(ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
     let post_id = parse_i64_field(&input, "post_id", "post hot-rank input")?;
-    let pool = ctx.state::<DbPool>().ok_or_else(|| {
-        HarvestError::Config("reddit-clone Harvest activity is missing DbPool".into())
+    let pool = ctx.state::<AppDbPool>().ok_or_else(|| {
+        HarvestError::Config("reddit-clone Harvest activity is missing AppDbPool".into())
     })?;
     let mut conn = pool.get().await.map_err(database_error)?;
     let (score, created_at): (i64, chrono::NaiveDateTime) = posts::table
@@ -154,25 +158,33 @@ async fn refresh_post_hot_rank(ctx: &ActivityContext, input: Value) -> HarvestRe
     retry = RetryPolicy::fixed(3, Duration::from_secs(1))
 )]
 async fn broadcast_post_created(ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
-    let state = ctx.state::<AppState>().ok_or_else(|| {
-        HarvestError::Config("reddit-clone Harvest activity is missing AppState".into())
+    let pool = ctx.state::<AppDbPool>().ok_or_else(|| {
+        HarvestError::Config("reddit-clone Harvest activity is missing AppDbPool".into())
     })?;
+    let mut conn = pool.get().await.map_err(database_error)?;
     let post_id = parse_i64_field(&input, "post_id", "post broadcast input")?;
     let title = parse_string_field(&input, "title", "post broadcast input")?;
     let post_slug = parse_string_field(&input, "post_slug", "post broadcast input")?;
     let subreddit_slug = parse_string_field(&input, "subreddit_slug", "post broadcast input")?;
     let author_username = parse_string_field(&input, "author_username", "post broadcast input")?;
-    let event = json!({
-        "type": "post_created",
-        "post_id": post_id,
-        "title": title,
-        "post_slug": post_slug,
-        "subreddit_slug": subreddit_slug,
-        "author_username": author_username,
-        "path": format!("/r/{subreddit_slug}/posts/{post_slug}"),
-    });
-
-    publish_activity(state, &subreddit_slug, &event.to_string());
+    let event = post_created_event(
+        post_id,
+        &title,
+        &post_slug,
+        &subreddit_slug,
+        &author_username,
+    );
+    let event_id = store_activity_event(&mut conn, &subreddit_slug, &event)
+        .await
+        .map_err(database_error)?;
+    if let Some(state) = ctx.state::<AppState>() {
+        publish_stored_live_event_best_effort(state, event_id).await;
+    } else {
+        tracing::warn!(
+            event_id,
+            "reddit-clone Harvest activity is missing AppState for live-event bus publication"
+        );
+    }
 
     Ok(json!({
         "post_id": post_id,
@@ -192,64 +204,25 @@ pub fn registered_activities() -> Vec<ActivityInfo> {
     ]
 }
 
-pub async fn start_user_onboarding(
-    conn: &mut AsyncPgConnection,
-    user: &User,
-) -> HarvestResult<ExecutionId> {
-    let workflow_id = onboarding_workflow_id(user.id);
-    let input = onboarding_input(user);
-
-    start_workflow_execution(
-        conn,
-        ONBOARDING_WORKFLOW_NAME,
-        &workflow_id,
-        ONBOARDING_QUEUE,
-        input,
-        json!({
-            "kind": "user_onboarding",
-            "user_id": user.id,
-        }),
-        json!({
-            "user_id": user.id,
-            "username": user.username,
-        }),
-    )
-    .await
-}
-
-pub async fn start_post_publication(
-    conn: &mut AsyncPgConnection,
-    post_id: i64,
-    title: &str,
-    post_slug: &str,
-    subreddit_slug: &str,
-    author_username: &str,
-) -> HarvestResult<ExecutionId> {
-    let workflow_id = post_publication_workflow_id(post_id);
-    let input = post_publication_input(post_id, title, post_slug, subreddit_slug, author_username);
-
-    start_workflow_execution(
-        conn,
-        POST_PUBLICATION_WORKFLOW_NAME,
-        &workflow_id,
-        POST_PUBLICATION_QUEUE,
-        input,
-        json!({
-            "kind": "post_publication",
-            "post_id": post_id,
-        }),
-        json!({
-            "post_id": post_id,
-            "post_slug": post_slug,
-            "subreddit_slug": subreddit_slug,
-            "author_username": author_username,
-        }),
-    )
-    .await
-}
-
 fn onboarding_workflow_id(user_id: i64) -> String {
     format!("user-onboarding:{user_id}")
+}
+
+pub(crate) fn user_onboarding_dispatch(user: &User) -> WorkflowStartRequest {
+    WorkflowStartRequest {
+        workflow_name: ONBOARDING_WORKFLOW_NAME.to_string(),
+        workflow_id: onboarding_workflow_id(user.id),
+        queue_name: ONBOARDING_QUEUE.to_string(),
+        input: onboarding_input(user),
+        memo: Some(json!({
+            "kind": "user_onboarding",
+            "user_id": user.id,
+        })),
+        search_attrs: Some(json!({
+            "user_id": user.id,
+            "username": user.username,
+        })),
+    }
 }
 
 fn onboarding_input(user: &User) -> Value {
@@ -261,6 +234,31 @@ fn onboarding_input(user: &User) -> Value {
 
 fn post_publication_workflow_id(post_id: i64) -> String {
     format!("post-publication:{post_id}")
+}
+
+pub(crate) fn post_publication_dispatch(
+    post_id: i64,
+    title: &str,
+    post_slug: &str,
+    subreddit_slug: &str,
+    author_username: &str,
+) -> WorkflowStartRequest {
+    WorkflowStartRequest {
+        workflow_name: POST_PUBLICATION_WORKFLOW_NAME.to_string(),
+        workflow_id: post_publication_workflow_id(post_id),
+        queue_name: POST_PUBLICATION_QUEUE.to_string(),
+        input: post_publication_input(post_id, title, post_slug, subreddit_slug, author_username),
+        memo: Some(json!({
+            "kind": "post_publication",
+            "post_id": post_id,
+        })),
+        search_attrs: Some(json!({
+            "post_id": post_id,
+            "post_slug": post_slug,
+            "subreddit_slug": subreddit_slug,
+            "author_username": author_username,
+        })),
+    }
 }
 
 fn post_publication_input(
@@ -279,45 +277,33 @@ fn post_publication_input(
     })
 }
 
+#[cfg(test)]
 async fn start_workflow_execution(
     conn: &mut AsyncPgConnection,
-    workflow_name: &'static str,
+    workflow_name: &str,
     workflow_id: &str,
-    queue_name: &'static str,
+    queue_name: &str,
     input: Value,
-    memo: Value,
-    search_attrs: Value,
+    memo: Option<Value>,
+    search_attrs: Option<Value>,
 ) -> HarvestResult<ExecutionId> {
-    let exec_id = ExecutionId::new();
-    let row = NewWorkflowExecution {
-        id: exec_id.as_uuid(),
-        workflow_name,
-        workflow_id,
-        run_id: ExecutionId::new().as_uuid(),
-        shard_id: 0,
-        input: input.clone(),
-        parent_id: None,
-        queue_name,
-        execution_timeout: None,
-        memo: Some(memo),
-        search_attrs: Some(search_attrs),
-    };
-    let started_event = WorkflowEvent::WorkflowStarted {
-        input: input.clone(),
-        timestamp: chrono::Utc::now(),
-    };
-    let mut params = EnqueueParams::new(queue_name, TaskType::Workflow, input);
-    params.workflow_exec_id = Some(exec_id.as_uuid());
+    let start = start_or_load_workflow_execution(
+        conn,
+        StartWorkflowParams {
+            workflow_name,
+            workflow_id,
+            shard_id: 0,
+            input,
+            parent_id: None,
+            queue_name,
+            execution_timeout: None,
+            memo,
+            search_attrs,
+        },
+    )
+    .await?;
 
-    diesel::insert_into(autumn_harvest::schema::harvest_workflow_executions::table)
-        .values(&row)
-        .execute(conn)
-        .await
-        .map_err(database_error)?;
-    autumn_harvest::store::append_events(conn, exec_id, &[started_event], 0).await?;
-    autumn_harvest::queue::enqueue(conn, &params).await?;
-
-    Ok(exec_id)
+    Ok(start.exec_id)
 }
 
 fn parse_user_id(input: &Value) -> HarvestResult<i64> {
@@ -346,6 +332,83 @@ fn parse_string_field(input: &Value, field: &str, context: &str) -> HarvestResul
 #[cfg(test)]
 mod tests {
     use super::*;
+    use diesel::ExpressionMethods;
+    use diesel::QueryDsl;
+    use diesel::SelectableHelper;
+    use diesel_async::AsyncConnection;
+    use diesel_async::AsyncPgConnection;
+    use diesel_async::RunQueryDsl;
+    use testcontainers::ContainerAsync;
+    use testcontainers_modules::postgres::Postgres;
+    use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+    const HARVEST_INIT_SQL: &str = include_str!(
+        "../../../autumn-harvest/autumn-harvest/migrations/20260409000000_harvest_initial/up.sql"
+    );
+
+    #[tokio::test]
+    async fn duplicate_publication_reuses_existing_execution() {
+        let (mut conn, _container) = setup_test_db().await;
+        let workflow_id = onboarding_workflow_id(42);
+        let input = json!({
+            "user_id": 42,
+            "username": "ferris",
+        });
+
+        let first_exec_id = start_workflow_execution(
+            &mut conn,
+            ONBOARDING_WORKFLOW_NAME,
+            &workflow_id,
+            ONBOARDING_QUEUE,
+            input.clone(),
+            Some(json!({
+                "kind": "user_onboarding",
+                "user_id": 42,
+            })),
+            Some(json!({
+                "user_id": 42,
+                "username": "ferris",
+            })),
+        )
+        .await
+        .expect("first publication should succeed");
+
+        let second_exec_id = start_workflow_execution(
+            &mut conn,
+            ONBOARDING_WORKFLOW_NAME,
+            &workflow_id,
+            ONBOARDING_QUEUE,
+            input,
+            Some(json!({
+                "kind": "user_onboarding",
+                "user_id": 42,
+            })),
+            Some(json!({
+                "user_id": 42,
+                "username": "ferris",
+            })),
+        )
+        .await
+        .expect("duplicate publication should resolve safely");
+
+        assert_eq!(
+            second_exec_id, first_exec_id,
+            "duplicate publication should return the original execution id"
+        );
+
+        let executions =
+            load_workflow_rows(&mut conn, ONBOARDING_WORKFLOW_NAME, &workflow_id).await;
+        assert_eq!(
+            executions.len(),
+            1,
+            "duplicate publication should not create a second workflow row"
+        );
+        let queued_tasks = count_workflow_tasks(&mut conn, first_exec_id).await;
+        assert_eq!(
+            queued_tasks, 1,
+            "duplicate publication should not enqueue duplicate tasks"
+        );
+    }
 
     #[test]
     fn onboarding_metadata_uses_expected_names() {
@@ -415,5 +478,61 @@ mod tests {
                 "author_username": "ferris",
             })
         );
+    }
+
+    async fn setup_test_db() -> (AsyncPgConnection, ContainerAsync<Postgres>) {
+        let container = Postgres::default()
+            .with_init_sql(HARVEST_INIT_SQL.to_string().into_bytes())
+            .start()
+            .await
+            .expect("failed to start Postgres container");
+
+        let host = container
+            .get_host()
+            .await
+            .expect("failed to get container host");
+        let port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("failed to get container port");
+        let database_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+        let conn = <AsyncPgConnection as AsyncConnection>::establish(&database_url)
+            .await
+            .expect("failed to connect to Postgres container");
+
+        (conn, container)
+    }
+
+    async fn load_workflow_rows(
+        conn: &mut AsyncPgConnection,
+        workflow_name: &str,
+        workflow_id: &str,
+    ) -> Vec<autumn_harvest::models::WorkflowExecution> {
+        autumn_harvest::schema::harvest_workflow_executions::table
+            .filter(
+                autumn_harvest::schema::harvest_workflow_executions::workflow_name
+                    .eq(workflow_name),
+            )
+            .filter(
+                autumn_harvest::schema::harvest_workflow_executions::workflow_id.eq(workflow_id),
+            )
+            .order(autumn_harvest::schema::harvest_workflow_executions::created_at.asc())
+            .select(autumn_harvest::models::WorkflowExecution::as_select())
+            .load(conn)
+            .await
+            .expect("failed to load workflow rows")
+    }
+
+    async fn count_workflow_tasks(conn: &mut AsyncPgConnection, exec_id: ExecutionId) -> i64 {
+        autumn_harvest::schema::harvest_task_queue::table
+            .filter(
+                autumn_harvest::schema::harvest_task_queue::workflow_exec_id
+                    .eq(Some(exec_id.as_uuid())),
+            )
+            .count()
+            .get_result(conn)
+            .await
+            .expect("failed to count workflow task rows")
     }
 }


### PR DESCRIPTION
## Summary
- add Harvest topology progression docs and runtime seams for embedded, split, and external runner modes
- add framework-owned Harvest outbox + idempotent workflow start support, then wire reddit-clone to the shared topology path
- add the reddit-clone distributed story with a standalone Harvest runner, Redis-backed live-feed bus, reconnecting relay health, and operator docs

## Verification
- cargo fmt --all
- cargo test -p autumn-harvest --lib (from autumn-harvest/)
- cargo test -p reddit-clone --lib
- cargo test -p reddit-clone --no-run -j 1

## Notes
- left unrelated local changes in examples/reddit-clone/static/css/autumn.css and .codex-worktrees/ out of the commit