### PR TITLE
Preserve non-UTF8 env values in dev reload env handling

### DIFF
--- a/autumn/src/middleware/dev.rs
+++ b/autumn/src/middleware/dev.rs
@@ -224,6 +224,21 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn is_enabled_accepts_non_utf8_state_env() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStringExt;
+
+        let non_utf8 = std::ffi::OsString::from_vec(vec![0x66, 0x80, 0x6f]);
+        let _env = EnvGuard::set_many_os(&[
+            (DEV_RELOAD_ENV, Some(OsStr::new("1"))),
+            (DEV_RELOAD_STATE_ENV, Some(non_utf8.as_os_str())),
+        ]);
+
+        assert!(is_enabled());
+    }
+
     #[tokio::test]
     async fn live_reload_state_handler_defaults_when_state_missing() {
         let _env = EnvGuard::set_many(&[(DEV_RELOAD_ENV, Some("1")), (DEV_RELOAD_STATE_ENV, None)]);

--- a/autumn/src/test_utils.rs
+++ b/autumn/src/test_utils.rs
@@ -1,15 +1,25 @@
 #[cfg(test)]
 use std::sync::{Mutex, OnceLock};
+#[cfg(test)]
+use std::{ffi::OsStr, ffi::OsString};
 
 #[cfg(test)]
 pub struct EnvGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
-    previous: Vec<(&'static str, Option<String>)>,
+    previous: Vec<(&'static str, Option<OsString>)>,
 }
 
 #[cfg(test)]
 impl EnvGuard {
     pub fn set_many(entries: &[(&'static str, Option<&str>)]) -> Self {
+        let entries: Vec<(&'static str, Option<&OsStr>)> = entries
+            .iter()
+            .map(|(key, value)| (*key, value.map(OsStr::new)))
+            .collect();
+        Self::set_many_os(&entries)
+    }
+
+    pub fn set_many_os(entries: &[(&'static str, Option<&OsStr>)]) -> Self {
         static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         let lock = ENV_LOCK
             .get_or_init(|| Mutex::new(()))
@@ -17,7 +27,7 @@ impl EnvGuard {
             .expect("env mutex poisoned");
         let mut previous = Vec::with_capacity(entries.len());
         for (key, value) in entries {
-            previous.push((*key, std::env::var(key).ok()));
+            previous.push((*key, std::env::var_os(key)));
             match value {
                 Some(value) => {
                     // SAFETY: test-only helper serializes environment mutation with a process-wide mutex.


### PR DESCRIPTION
### Motivation
- Tests that mutate environment variables need to preserve non-UTF8 values so they don't mask runtime behavior when `AUTUMN_DEV_RELOAD_STATE` contains non-Unicode bytes and live reload checks use `var_os`.

### Description
- Changed `EnvGuard::previous` to store `Option<OsString>` and snapshot environment with `std::env::var_os` so prior non-UTF8 values are preserved at restore time in `autumn/src/test_utils.rs`.
- Added `EnvGuard::set_many_os(entries: &[(&'static str, Option<&OsStr>)])` and made the existing `set_many` delegate to it by converting `&str` values to `&OsStr` to keep the previous API.
- Updated `EnvGuard` to set/remove env entries using `std::env::set_var`/`remove_var` while storing/restoring using `OsString` to avoid lossy `String` conversions.
- Added a Unix-only regression test `is_enabled_accepts_non_utf8_state_env` in `autumn/src/middleware/dev.rs` that uses `EnvGuard::set_many_os` to verify `is_enabled()` remains true when `AUTUMN_DEV_RELOAD_STATE` contains non-UTF8 bytes.

### Testing
- Ran `cargo test -p autumn-web is_enabled_` and the two targeted tests in `middleware::dev::tests` passed (`is_enabled_requires_both_env_vars` and `is_enabled_accepts_non_utf8_state_env`).
- The change compiles and the added tests passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91bf9263c832a8ec46f2745307d39)