### PR TITLE
⚡ Bolt: [performance improvement] Optimize MetricsCollector key allocation

### DIFF
--- a/autumn/src/middleware/metrics.rs
+++ b/autumn/src/middleware/metrics.rs
@@ -120,7 +120,11 @@ impl MetricsCollector {
         }
 
         // Per-route
-        let key = format!("{method} {route}");
+        let mut key = String::with_capacity(method.len() + 1 + route.len());
+        key.push_str(method);
+        key.push(' ');
+        key.push_str(route);
+
         if let Ok(mut routes) = self.inner.by_route.write() {
             let entry = routes.entry(key).or_default();
             entry.count += 1;


### PR DESCRIPTION
💡 **What**: Replaced `format!("{method} {route}")` with `String::with_capacity(method.len() + 1 + route.len())` followed by exact `push_str` and `push` operations in `MetricsCollector::record`.

🎯 **Why**: The `MetricsCollector::record` method is on the framework's hot path, running once per completed HTTP request. `format!` incurs significant formatting machinery overhead and doesn't explicitly guarantee perfectly sized initial allocations. Explicitly allocating exactly the required string capacity before appending ensures a single, minimal heap allocation.

📊 **Impact**: Reduces CPU overhead on every HTTP request by eliminating the runtime formatting machinery and minimizes memory allocations by explicitly calculating and reserving the precise capacity required.

🔬 **Measurement**: Verified via existing unit tests in `middleware::metrics`. No regressions in HTTP behavior or metrics collection outputs.

---
*PR created automatically by Jules for task [14995899795163985876](https://jules.google.com/task/14995899795163985876) started by @madmax983*