### PR TITLE
⚡ Bolt: Optimize signal and timer event ingestion loops

### DIFF
--- a/autumn-harvest/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/autumn-harvest/src/worker.rs
@@ -816,17 +816,16 @@ async fn ingest_pending_signals(
         return Ok(());
     }
 
-    let signal_events = pending_signals
-        .iter()
-        .map(|signal| WorkflowEvent::SignalReceived {
-            signal_name: signal.signal_name.clone(),
-            payload: signal.payload.clone(),
-        })
-        .collect::<Vec<_>>();
-    let signal_ids = pending_signals
-        .iter()
-        .map(|signal| signal.id)
-        .collect::<Vec<_>>();
+    let mut signal_events = Vec::with_capacity(pending_signals.len());
+    let mut signal_ids = Vec::with_capacity(pending_signals.len());
+
+    for signal in pending_signals {
+        signal_ids.push(signal.id);
+        signal_events.push(WorkflowEvent::SignalReceived {
+            signal_name: signal.signal_name,
+            payload: signal.payload,
+        });
+    }
 
     conn.transaction::<(), HarvestError, _>(|conn| {
         async move {
@@ -864,13 +863,15 @@ async fn ingest_fired_timers(
         return Ok(());
     }
 
-    let timer_events = due_timers
-        .iter()
-        .map(|timer| WorkflowEvent::TimerFired {
-            timer_id: TimerId::new(timer.timer_id.clone()),
-        })
-        .collect::<Vec<_>>();
-    let timer_row_ids = due_timers.iter().map(|timer| timer.id).collect::<Vec<_>>();
+    let mut timer_events = Vec::with_capacity(due_timers.len());
+    let mut timer_row_ids = Vec::with_capacity(due_timers.len());
+
+    for timer in due_timers {
+        timer_row_ids.push(timer.id);
+        timer_events.push(WorkflowEvent::TimerFired {
+            timer_id: TimerId::new(timer.timer_id),
+        });
+    }
 
     conn.transaction::<(), HarvestError, _>(|conn| {
         async move {


### PR DESCRIPTION
💡 What: Switched from chained `.iter().map().collect::<Vec<_>>()` iterator chains that cloned strings to consuming `for` loops and `Vec::with_capacity()`.
🎯 Why: In `ingest_pending_signals` and `ingest_fired_timers`, iterating twice and cloning data (like `signal_name` and `payload`) caused unnecessary heap allocations on a potentially hot event processing path.
📊 Impact: Eliminates 2 heap allocations (`String`/`Vec<u8>`) per pending signal, 1 clone per fired timer, and iterates over the data once instead of twice.
🔬 Measurement: Verified with `cargo clippy`, `cargo fmt`, and `cargo test`.

---
*PR created automatically by Jules for task [4761338493785528884](https://jules.google.com/task/4761338493785528884) started by @madmax983*