### PR TITLE
🔒 Warden: [security fix] Bump lru to 0.16 to fix RUSTSEC-2026-0002

### DIFF
--- a/autumn-harvest/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/autumn-harvest/Cargo.toml
@@ -30,7 +30,7 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }
 futures = { workspace = true }
-lru = "0.12"
+lru = "0.16"
 croner = "2.2"
 deadpool = { workspace = true, optional = true }
 diesel = { workspace = true, optional = true }


### PR DESCRIPTION
🦠 Threat: The `lru` crate version `0.12.5` used in `autumn-harvest` was subject to RUSTSEC-2026-0002 (`IterMut` violates Stacked Borrows by invalidating internal pointers).
🛡️ Defense: Updated the `lru` dependency to version `0.16.3` (or effectively `0.16` series) in `autumn-harvest/Cargo.toml` and ran `cargo update -p lru` to resolve the vulnerability.
💥 Severity: Moderate to High — unsound `unsafe` blocks could lead to undefined behavior or panics depending on the compiler's aliasing model optimizations.
🧪 Verification: Ran `cargo audit --deny warnings` which now cleanly passes with 0 vulnerabilities and 0 denied warnings. Ran `cargo test`, `cargo check`, and `cargo clippy` successfully. Integration tests in `autumn-harvest` failed due to unrelated local Docker overlay mount issues in the containerized environment.

_Note: Assumed the objective was to clear the cargo audit scan log based on the prompt._

---
*PR created automatically by Jules for task [9795699596954556798](https://jules.google.com/task/9795699596954556798) started by @madmax983*