### PR TITLE
👺 Havoc: Fix integer overflow panic in task::parse_duration

### DIFF
--- a/autumn/src/task.rs
+++ b/autumn/src/task.rs
@@ -58,10 +58,10 @@ pub fn parse_duration(s: &str) -> Option<Duration> {
             let num: u64 = current_num.parse().ok()?;
             current_num.clear();
             match ch {
-                's' => total_secs += num,
-                'm' => total_secs += num * 60,
-                'h' => total_secs += num * 3600,
-                'd' => total_secs += num * 86400,
+                's' => total_secs = total_secs.checked_add(num)?,
+                'm' => total_secs = total_secs.checked_add(num.checked_mul(60)?)?,
+                'h' => total_secs = total_secs.checked_add(num.checked_mul(3600)?)?,
+                'd' => total_secs = total_secs.checked_add(num.checked_mul(86400)?)?,
                 _ => return None,
             }
         } else if ch == ' ' {
@@ -146,5 +146,18 @@ mod tests {
     #[test]
     fn compound_trailing_number() {
         assert!(parse_duration("1h 30").is_none());
+    }
+}
+
+#[cfg(test)]
+mod havoc_proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn parse_duration_fuzz_panic(s in "[0-9]{15,30}[smhd]") {
+            let _ = parse_duration(&s);
+        }
     }
 }


### PR DESCRIPTION
🧨 **The Trigger:** Duration input string with extremely large numbers (e.g. `"9999999999999999999d"`) causes an integer overflow when multiplying by unit scaling factors (e.g., `86400`) or adding to the running total.
📉 **The Stack Trace:**
```
thread 'task::havoc_proptests::parse_duration_fuzz_panic' (31255) panicked at autumn/src/task.rs:64:38:
attempt to multiply with overflow
```
🧪 **Reproduction:** Run `cargo test -p autumn-web --lib task::havoc_proptests` using `proptest` on `parse_duration` generating long string sequences.
😈 **Comment:** You assumed the user wouldn't want to wait 214000000000000 days. You were wrong.

---
*PR created automatically by Jules for task [3410729257917812384](https://jules.google.com/task/3410729257917812384) started by @madmax983*