### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -41,8 +41,8 @@
 //! - [`config`] -- Layered configuration: defaults, `autumn.toml`, env overrides.
 //! - [`db`] -- Database connection pool and the [`Db`] request extractor.
 //! - [`error`] -- Framework error type ([`AutumnError`]) and result alias.
-//! - [`extract`] -- Re-exported Axum extractors ([`Form`](axum::extract::Form),
-//!   [`Json`], [`Path`], [`Query`](axum::extract::Query)).
+//! - [`extract`] -- Re-exported Axum extractors ([`Form`],
+//!   [`Json`], [`Path`], [`Query`]).
 //! - [`health`] -- Compatibility alias for readiness plus legacy health helpers.
 //! - [`logging`] -- Structured logging via `tracing-subscriber`.
 //! - [`middleware`] -- Built-in middleware (request IDs).
@@ -84,7 +84,14 @@ pub mod hooks;
 #[cfg(feature = "db")]
 pub mod migrate;
 pub mod probe;
+
+/// Router construction and integration with Axum.
+///
+/// This module is responsible for taking the application's configuration,
+/// defined routes, middleware, and state, and building the final `axum::Router`
+/// that will handle incoming HTTP requests.
 pub mod router;
+
 #[cfg(test)]
 pub(crate) mod test_utils;
 #[cfg(feature = "db")]
@@ -167,7 +174,7 @@ pub use validation::ValidateExt;
 
 /// Annotate an async function as a `DELETE` route handler.
 ///
-/// Generates a companion function that returns a [`route::Route`]
+/// Generates a companion function that returns a [`crate::route::Route`]
 /// pairing the path with an Axum handler. In debug builds
 /// `#[axum::debug_handler]` is applied automatically for better error
 /// messages (zero cost in release).
@@ -186,7 +193,7 @@ pub use autumn_macros::delete;
 
 /// Annotate an async function as a `GET` route handler.
 ///
-/// Generates a companion function that returns a [`route::Route`]
+/// Generates a companion function that returns a [`crate::route::Route`]
 /// pairing the path with an Axum handler. In debug builds
 /// `#[axum::debug_handler]` is applied automatically for better error
 /// messages (zero cost in release).
@@ -295,7 +302,7 @@ pub use autumn_macros::service;
 
 /// Annotate an async function as a `POST` route handler.
 ///
-/// Generates a companion function that returns a [`route::Route`]
+/// Generates a companion function that returns a [`crate::route::Route`]
 /// pairing the path with an Axum handler. In debug builds
 /// `#[axum::debug_handler]` is applied automatically for better error
 /// messages (zero cost in release).
@@ -314,7 +321,7 @@ pub use autumn_macros::post;
 
 /// Annotate an async function as a `PUT` route handler.
 ///
-/// Generates a companion function that returns a [`route::Route`]
+/// Generates a companion function that returns a [`crate::route::Route`]
 /// pairing the path with an Axum handler. In debug builds
 /// `#[axum::debug_handler]` is applied automatically for better error
 /// messages (zero cost in release).

--- a/autumn/src/route.rs
+++ b/autumn/src/route.rs
@@ -1,7 +1,7 @@
 //! Route descriptor types used by macro-generated code.
 //!
 //! Each route macro ([`get`](crate::get), [`post`](crate::post), etc.)
-//! generates a companion function that returns a [`Route`]. The
+//! generates a companion function that returns a [`crate::route::Route`]. The
 //! [`routes!`](crate::routes) macro collects these into a `Vec<Route>`
 //! for the [`AppBuilder`](crate::app::AppBuilder).
 //!

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -14,14 +14,23 @@ use axum::response::IntoResponse;
 use http::StatusCode;
 use thiserror::Error;
 
+/// Errors that can occur during the router build process.
+///
+/// These errors are typically fatal and represent configuration or routing
+/// definition issues that must be fixed before the application can start.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum RouterBuildError {
+    /// The session backend configuration is invalid (e.g. Redis without a URL).
     #[error("invalid session backend configuration: {0}")]
     InvalidSessionBackend(#[from] crate::session::SessionBackendConfigError),
+    /// A user-defined route conflicts with a framework-provided route.
     #[error("framework route overlap at {path}: {existing} conflicts with {incoming}")]
     FrameworkRouteOverlap {
+        /// The HTTP path where the overlap occurred.
         path: String,
+        /// The name of the existing framework route.
         existing: &'static str,
+        /// The name of the incoming user route.
         incoming: &'static str,
     },
 }

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -228,6 +228,7 @@ pub trait SessionStore: Send + Sync + 'static {
     fn destroy(&self, id: &str) -> impl Future<Output = Result<(), SessionStoreError>> + Send;
 }
 
+/// An error that occurred during a session store operation.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 #[error("{message}")]
 pub struct SessionStoreError {
@@ -235,6 +236,7 @@ pub struct SessionStoreError {
 }
 
 impl SessionStoreError {
+    /// Create a new session store error from an underlying backend error.
     #[must_use]
     pub fn backend(operation: &'static str, error: impl std::fmt::Display) -> Self {
         Self {
@@ -332,11 +334,14 @@ pub struct SessionConfig {
     pub redis: SessionRedisConfig,
 }
 
+/// Supported session storage backends.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SessionBackend {
+    /// In-memory storage. Resets on application restart.
     #[default]
     Memory,
+    /// Redis-backed storage. Suitable for production and multi-instance deployments.
     Redis,
 }
 
@@ -350,11 +355,14 @@ impl SessionBackend {
     }
 }
 
+/// Configuration specific to the Redis session backend.
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct SessionRedisConfig {
+    /// The Redis connection URL (e.g. `redis://127.0.0.1:6379`).
     #[serde(default)]
     pub url: Option<String>,
 
+    /// Prefix used for session keys in Redis. Defaults to `autumn:sessions`.
     #[serde(default = "default_redis_key_prefix")]
     pub key_prefix: String,
 }
@@ -372,18 +380,33 @@ fn default_redis_key_prefix() -> String {
     "autumn:sessions".to_owned()
 }
 
+/// Represents the resolved plan for which session backend to initialize.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionBackendPlan {
-    Memory { warn_in_production: bool },
-    Redis { url: String, key_prefix: String },
+    /// Use the in-memory store.
+    Memory {
+        /// Whether to log a warning because memory sessions are used in production.
+        warn_in_production: bool,
+    },
+    /// Use the Redis store.
+    Redis {
+        /// The validated Redis connection URL.
+        url: String,
+        /// The prefix to use for session keys.
+        key_prefix: String,
+    },
 }
 
+/// Errors that can occur when resolving the session backend configuration.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum SessionBackendConfigError {
+    /// Redis was selected, but no URL was provided.
     #[error("session.backend=redis requires session.redis.url")]
     MissingRedisUrl,
+    /// The provided Redis URL could not be parsed.
     #[error("session.redis.url is not a valid Redis URL: {0}")]
     InvalidRedisUrl(String),
+    /// Redis was selected, but the `redis` crate feature is not enabled.
     #[error("session.backend=redis requires the `redis` feature")]
     RedisFeatureDisabled,
 }

--- a/autumn/src/telemetry.rs
+++ b/autumn/src/telemetry.rs
@@ -80,7 +80,12 @@ pub enum TelemetryInitError {
     EmptyServiceName,
     /// OTLP endpoint was not a valid absolute URI.
     #[error("invalid OTLP endpoint {endpoint:?}: {reason}")]
-    InvalidEndpoint { endpoint: String, reason: String },
+    InvalidEndpoint {
+        /// The endpoint that was provided.
+        endpoint: String,
+        /// The reason the endpoint is considered invalid.
+        reason: String,
+    },
     /// The exporter feature is not compiled in.
     #[error("telemetry-otlp cargo feature is not enabled")]
     FeatureDisabled,


### PR DESCRIPTION
📖 Chapter: Router, Session, and Telemetry
🔦 Insight: Documented all previously missing fields and variants in public enums and structs such as `RouterBuildError`, `SessionBackend`, and `InvalidEndpoint`. Additionally, fixed duplicate module documentation for `route` and removed redundant explicit intra-doc links in the top-level lib documentation.
🧪 Example: Successfully passed all `cargo doc` compilation checks with strict `-D missing-docs -D warnings` flags. No executable tests added this time, focusing on core types explanation.

---
*PR created automatically by Jules for task [14506651177998813854](https://jules.google.com/task/14506651177998813854) started by @madmax983*