### PR TITLE
⚡ Bolt: Remove unnecessary String allocations in metrics middleware hot path

### DIFF
--- a/autumn/src/middleware/metrics.rs
+++ b/autumn/src/middleware/metrics.rs
@@ -347,19 +347,16 @@ where
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        let method = req.method().to_string();
-        let route = req
-            .extensions()
-            .get::<MatchedPath>()
-            .map_or_else(|| "_unmatched".to_owned(), |p| p.as_str().to_owned());
+        let method = req.method().clone();
+        let route = req.extensions().get::<MatchedPath>().cloned();
 
         self.collector.increment_active();
 
         MetricsFuture {
             inner: self.inner.call(req),
             collector: Some(self.collector.clone()),
-            method: Some(method),
-            route: Some(route),
+            method,
+            route,
             start: Instant::now(),
         }
     }
@@ -371,8 +368,8 @@ pin_project! {
         #[pin]
         inner: F,
         collector: Option<MetricsCollector>,
-        method: Option<String>,
-        route: Option<String>,
+        method: axum::http::Method,
+        route: Option<MatchedPath>,
         start: Instant,
     }
 }
@@ -390,10 +387,13 @@ where
                 if let Some(collector) = this.collector.take() {
                     let latency_ms =
                         u64::try_from(this.start.elapsed().as_millis()).unwrap_or(u64::MAX);
-                    let method = this.method.take().unwrap_or_default();
-                    let route = this.route.take().unwrap_or_default();
+                    let method_str = this.method.as_str();
+                    let route_str = this
+                        .route
+                        .as_ref()
+                        .map_or("_unmatched", axum::extract::MatchedPath::as_str);
                     let status = response.status().as_u16();
-                    collector.record(&method, &route, status, latency_ms);
+                    collector.record(method_str, route_str, status, latency_ms);
                     collector.decrement_active();
                 }
                 Poll::Ready(Ok(response))


### PR DESCRIPTION
💡 What: Replaced eager `String` allocation for `method` and `route` with `axum::http::Method` and `axum::extract::MatchedPath` in `MetricsService::call`. The actual string borrowing (`as_str()`) is deferred until the `MetricsFuture::poll` completion handler.
🎯 Why: The original implementation performed a `.to_string()` on the request method and an `as_str().to_owned()` on the matched path on *every single request* passing through the application. This resulted in two unnecessary heap allocations per request on the hot path, causing unnecessary memory allocations.
📊 Impact: Removes two heap allocations (`String`) per HTTP request inside the metrics middleware. Reduces memory churn and improves overall throughput under heavy load.
🔬 Measurement: Run `cargo bench -p autumn-web` to verify standard middleware overhead drops. Check `cargo bench` results in the standard setup.

---
*PR created automatically by Jules for task [17759960071410068507](https://jules.google.com/task/17759960071410068507) started by @madmax983*