### PR TITLE
🔒 Warden: [security fix] Prevent integer overflow in parse_duration

### DIFF
--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -89,5 +89,9 @@ proptest = "1.4"
 tokio-tungstenite = "0.29.0"
 loom = "0.7.2"
 
+[[test]]
+name = "integer_overflow"
+path = "tests/security/integer_overflow.rs"
+
 [lints]
 workspace = true

--- a/autumn/src/task.rs
+++ b/autumn/src/task.rs
@@ -57,13 +57,14 @@ pub fn parse_duration(s: &str) -> Option<Duration> {
         } else if ch.is_ascii_alphabetic() {
             let num: u64 = current_num.parse().ok()?;
             current_num.clear();
-            match ch {
-                's' => total_secs += num,
-                'm' => total_secs += num * 60,
-                'h' => total_secs += num * 3600,
-                'd' => total_secs += num * 86400,
+            let add_secs = match ch {
+                's' => num,
+                'm' => num.checked_mul(60)?,
+                'h' => num.checked_mul(3600)?,
+                'd' => num.checked_mul(86400)?,
                 _ => return None,
-            }
+            };
+            total_secs = total_secs.checked_add(add_secs)?;
         } else if ch == ' ' {
             // Skip spaces between components
         } else {

--- a/autumn/tests/security/integer_overflow.rs
+++ b/autumn/tests/security/integer_overflow.rs
@@ -4,23 +4,23 @@ use autumn_web::task::parse_duration;
 fn test_parse_duration_integer_overflow() {
     // Attempting to parse a duration that overflows u64 calculation
     let max_u64 = u64::MAX;
-    let malicious_input = format!("{}d", max_u64);
+    let malicious_input = format!("{max_u64}d");
 
     // This should gracefully return None rather than panicking due to integer overflow
     let result = parse_duration(&malicious_input);
     assert_eq!(result, None);
 
-    let malicious_input2 = format!("{}h", max_u64);
+    let malicious_input2 = format!("{max_u64}h");
     let result2 = parse_duration(&malicious_input2);
     assert_eq!(result2, None);
 
-    let malicious_input3 = format!("{}m", max_u64);
+    let malicious_input3 = format!("{max_u64}m");
     let result3 = parse_duration(&malicious_input3);
     assert_eq!(result3, None);
 
     // Also test overflow on addition
     let half_max = u64::MAX / 2 + 10;
-    let malicious_input4 = format!("{}s {}s", half_max, half_max);
+    let malicious_input4 = format!("{half_max}s {half_max}s");
     let result4 = parse_duration(&malicious_input4);
     assert_eq!(result4, None);
 }

--- a/autumn/tests/security/integer_overflow.rs
+++ b/autumn/tests/security/integer_overflow.rs
@@ -1,0 +1,26 @@
+use autumn_web::task::parse_duration;
+
+#[test]
+fn test_parse_duration_integer_overflow() {
+    // Attempting to parse a duration that overflows u64 calculation
+    let max_u64 = u64::MAX;
+    let malicious_input = format!("{}d", max_u64);
+
+    // This should gracefully return None rather than panicking due to integer overflow
+    let result = parse_duration(&malicious_input);
+    assert_eq!(result, None);
+
+    let malicious_input2 = format!("{}h", max_u64);
+    let result2 = parse_duration(&malicious_input2);
+    assert_eq!(result2, None);
+
+    let malicious_input3 = format!("{}m", max_u64);
+    let result3 = parse_duration(&malicious_input3);
+    assert_eq!(result3, None);
+
+    // Also test overflow on addition
+    let half_max = u64::MAX / 2 + 10;
+    let malicious_input4 = format!("{}s {}s", half_max, half_max);
+    let result4 = parse_duration(&malicious_input4);
+    assert_eq!(result4, None);
+}


### PR DESCRIPTION
🦠 Threat: Integer overflow in duration parsing. If a user provides an excessively large number of days or hours, it would overflow a `u64`, causing a panic and leading to a potential Denial of Service (DoS).
🛡️ Defense: Replaced the risky operators (`+=` and `*`) with safe math methods `checked_add` and `checked_mul`. It now propagates `None` securely if an overflow occurs.
💥 Severity: High - could crash or panic the server when handling user input.
🧪 Verification: Added `integer_overflow` integration test to verify the fix correctly returns `None` instead of panicking.

---
*PR created automatically by Jules for task [12124085846172857383](https://jules.google.com/task/12124085846172857383) started by @madmax983*