### PR TITLE
👺 Havoc: [fix panics in duration parsing]

### DIFF
--- a/autumn/proptest-regressions/task.txt
+++ b/autumn/proptest-regressions/task.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 7809ee9e8472897f1fc66b02316686c588a95a50169416c96fe5dceb5cf9b9f7 # shrinks to num = "000220000000000000d"

--- a/autumn/src/task.rs
+++ b/autumn/src/task.rs
@@ -57,13 +57,14 @@ pub fn parse_duration(s: &str) -> Option<Duration> {
         } else if ch.is_ascii_alphabetic() {
             let num: u64 = current_num.parse().ok()?;
             current_num.clear();
-            match ch {
-                's' => total_secs += num,
-                'm' => total_secs += num * 60,
-                'h' => total_secs += num * 3600,
-                'd' => total_secs += num * 86400,
+            let multiplier = match ch {
+                's' => 1,
+                'm' => 60,
+                'h' => 3600,
+                'd' => 86400,
                 _ => return None,
-            }
+            };
+            total_secs = total_secs.checked_add(num.checked_mul(multiplier)?)?;
         } else if ch == ' ' {
             // Skip spaces between components
         } else {
@@ -146,5 +147,14 @@ mod tests {
     #[test]
     fn compound_trailing_number() {
         assert!(parse_duration("1h 30").is_none());
+    }
+
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn doesnt_crash_on_large_numbers(num in "[0-9]{18}[smhd]") {
+            let _ = super::parse_duration(&num);
+        }
     }
 }


### PR DESCRIPTION
🧨 **The Trigger:** Input string with an extremely large duration number (e.g. `000220000000000000d`) caused integer overflow.
📉 **The Stack Trace:** thread 'task::tests::doesnt_crash_on_large_numbers' panicked at autumn/src/task.rs:64:38: attempt to multiply with overflow
🧪 **Reproduction:** Run `cargo test -p autumn-web --lib task::tests::doesnt_crash_on_large_numbers`.
😈 **Comment:** You assumed users wouldn't want tasks to run in a trillion years. You were wrong.

---
*PR created automatically by Jules for task [5109439124316175947](https://jules.google.com/task/5109439124316175947) started by @madmax983*