### PR TITLE
🔒 Warden/Eris: Fix integer overflow vulnerability in `parse_duration`

### DIFF
--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -91,3 +91,7 @@ loom = "0.7.2"
 
 [lints]
 workspace = true
+
+[[test]]
+name = "task_overflow"
+path = "tests/security/task_overflow.rs"

--- a/autumn/src/task.rs
+++ b/autumn/src/task.rs
@@ -57,13 +57,14 @@ pub fn parse_duration(s: &str) -> Option<Duration> {
         } else if ch.is_ascii_alphabetic() {
             let num: u64 = current_num.parse().ok()?;
             current_num.clear();
-            match ch {
-                's' => total_secs += num,
-                'm' => total_secs += num * 60,
-                'h' => total_secs += num * 3600,
-                'd' => total_secs += num * 86400,
+            let add_secs = match ch {
+                's' => num,
+                'm' => num.checked_mul(60)?,
+                'h' => num.checked_mul(3600)?,
+                'd' => num.checked_mul(86400)?,
                 _ => return None,
-            }
+            };
+            total_secs = total_secs.checked_add(add_secs)?;
         } else if ch == ' ' {
             // Skip spaces between components
         } else {
@@ -146,5 +147,10 @@ mod tests {
     #[test]
     fn compound_trailing_number() {
         assert!(parse_duration("1h 30").is_none());
+    }
+
+    #[test]
+    fn integer_overflow() {
+        assert!(parse_duration("9999999999999999999d").is_none());
     }
 }

--- a/autumn/tests/security/task_overflow.rs
+++ b/autumn/tests/security/task_overflow.rs
@@ -1,0 +1,11 @@
+use autumn_web::task::parse_duration;
+
+#[test]
+fn test_parse_duration_integer_overflow() {
+    // A string that would previously cause an integer overflow panic
+    // when calculating total_secs (9999999999999999999 * 86400)
+    let s = "9999999999999999999d";
+
+    // It should safely return None now, instead of panicking.
+    assert!(parse_duration(s).is_none());
+}


### PR DESCRIPTION
Fix integer overflow DoS vulnerability in `parse_duration`

**Context:** During an offensive security review (Eris persona), it was discovered that `autumn::task::parse_duration` was susceptible to integer overflow when parsing very large duration strings (e.g. `9999999999999999999d`). This could be exploited to crash the application via a DoS attack if user-supplied inputs reach this function.

**Changes:**
- Updated `parse_duration` in `autumn/src/task.rs` to use safe arithmetic (`checked_add`, `checked_mul`). It now returns `None` upon overflow instead of panicking.
- Created `autumn/tests/security/task_overflow.rs` as a permanent regression test to ensure malicious/garbage duration inputs are safely handled.
- Added the `task_overflow` test target to `autumn/Cargo.toml`.

---
*PR created automatically by Jules for task [1699959026548375342](https://jules.google.com/task/1699959026548375342) started by @madmax983*