### PR TITLE
🔒 Warden: [security fix] Fix integer overflow vulnerability in `parse_duration`

### DIFF
--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -73,6 +73,10 @@ testcontainers = { workspace = true, optional = true }
 testcontainers-modules = { workspace = true, optional = true }
 subtle = "2.6.1"
 
+[[test]]
+name = "integer_overflow"
+path = "tests/security/integer_overflow.rs"
+
 [dev-dependencies]
 diesel = { version = "2", features = ["chrono"] }
 filetime = "0.2"

--- a/autumn/src/task.rs
+++ b/autumn/src/task.rs
@@ -57,13 +57,14 @@ pub fn parse_duration(s: &str) -> Option<Duration> {
         } else if ch.is_ascii_alphabetic() {
             let num: u64 = current_num.parse().ok()?;
             current_num.clear();
-            match ch {
-                's' => total_secs += num,
-                'm' => total_secs += num * 60,
-                'h' => total_secs += num * 3600,
-                'd' => total_secs += num * 86400,
+            let secs = match ch {
+                's' => num,
+                'm' => num.checked_mul(60)?,
+                'h' => num.checked_mul(3600)?,
+                'd' => num.checked_mul(86400)?,
                 _ => return None,
-            }
+            };
+            total_secs = total_secs.checked_add(secs)?;
         } else if ch == ' ' {
             // Skip spaces between components
         } else {

--- a/autumn/tests/security/integer_overflow.rs
+++ b/autumn/tests/security/integer_overflow.rs
@@ -1,0 +1,13 @@
+use autumn_web::task::parse_duration;
+
+#[test]
+fn test_parse_duration_overflow() {
+    // These should not panic but return None
+
+    // Overflow in checked_add
+    // u64::MAX is 18446744073709551615
+    assert_eq!(parse_duration("18446744073709551615s 10s"), None);
+
+    // Overflow in checked_mul
+    assert_eq!(parse_duration("18446744073709551615d"), None);
+}


### PR DESCRIPTION
🦠 Threat: Integer overflow in `parse_duration` when processing user-controlled strings, leading to potential panics and Denial of Service.
🛡️ Defense: Used safe math operations (`checked_mul`, `checked_add`) to handle arithmetic and gracefully return `None` upon overflow.
💥 Severity: Medium - unhandled integer overflow causes panics, potentially crashing the server if task parsing occurs dynamically or via user input during runtime.
🧪 Verification: Added regression tests for integer overflow in `tests/security/integer_overflow.rs`.

---
*PR created automatically by Jules for task [11871131529566424228](https://jules.google.com/task/11871131529566424228) started by @madmax983*