### PR TITLE
🗺️ Atlas: [architectural change] Break circular dependency between state and actuators

### DIFF
--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -16,7 +16,26 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
 
-use crate::state::AppState;
+/// Trait to abstract the state requirements for actuator handlers.
+pub trait ProvideActuatorState {
+    fn metrics(&self) -> &crate::middleware::MetricsCollector;
+    fn log_levels(&self) -> &LogLevels;
+    fn task_registry(&self) -> &TaskRegistry;
+    fn config_props(&self) -> &ConfigProperties;
+    fn profile(&self) -> &str;
+    fn uptime_display(&self) -> String;
+
+    #[cfg(feature = "ws")]
+    fn channels(&self) -> &crate::channels::Channels;
+
+    #[cfg(feature = "ws")]
+    fn shutdown_token(&self) -> tokio_util::sync::CancellationToken;
+
+    #[cfg(feature = "db")]
+    fn pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>;
+}
 
 // ── Shared types for AppState ──────────────────────────────────
 
@@ -563,13 +582,15 @@ struct DatabaseCheck {
 
 /// `GET <actuator-prefix>/health`
 #[allow(unused_variables, clippy::useless_let_if_seq)]
-pub async fn health(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn health<S: ProvideActuatorState + Send + Sync + 'static>(
+    State(state): State<S>,
+) -> impl IntoResponse {
     let db_check;
     let overall_healthy;
 
     #[cfg(feature = "db")]
     {
-        if let Some(pool) = state.pool.as_ref() {
+        if let Some(pool) = state.pool() {
             let status = pool.status();
             let available = status.available as u64;
             let size = status.max_size as u64;
@@ -642,7 +663,9 @@ struct RuntimeInfo {
 }
 
 /// `GET <actuator-prefix>/info`
-pub(crate) async fn info(State(state): State<AppState>) -> Json<ActuatorInfo> {
+pub(crate) async fn info<S: ProvideActuatorState + Send + Sync + 'static>(
+    State(state): State<S>,
+) -> Json<ActuatorInfo> {
     Json(ActuatorInfo {
         app: AppInfo {
             name: std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| "unknown".into()),
@@ -684,9 +707,11 @@ fn should_redact(key: &str) -> bool {
 }
 
 /// `GET /actuator/env` — only available when actuator sensitive mode is enabled.
-pub(crate) async fn env_endpoint(State(state): State<AppState>) -> Json<ActuatorEnv> {
+pub(crate) async fn env_endpoint<S: ProvideActuatorState + Send + Sync + 'static>(
+    State(state): State<S>,
+) -> Json<ActuatorEnv> {
     let properties = state
-        .config_props
+        .config_props()
         .snapshot()
         .into_iter()
         .map(|(key, prop)| (key, prop.value))
@@ -702,13 +727,15 @@ pub(crate) async fn env_endpoint(State(state): State<AppState>) -> Json<Actuator
 
 /// `GET <actuator-prefix>/metrics` -- request metrics, latency, status codes, DB pool stats.
 #[allow(unused_variables, unused_mut)]
-pub(crate) async fn metrics_endpoint(State(state): State<AppState>) -> Json<serde_json::Value> {
-    let snapshot = state.metrics.snapshot();
+pub(crate) async fn metrics_endpoint<S: ProvideActuatorState + Send + Sync + 'static>(
+    State(state): State<S>,
+) -> Json<serde_json::Value> {
+    let snapshot = state.metrics().snapshot();
     let mut result = serde_json::to_value(&snapshot).unwrap_or_default();
 
     // Include DB pool stats if available
     #[cfg(feature = "db")]
-    if let Some(pool) = state.pool.as_ref() {
+    if let Some(pool) = state.pool() {
         let status = pool.status();
         let db_stats = serde_json::json!({
             "pool_size": status.max_size,
@@ -726,10 +753,12 @@ pub(crate) async fn metrics_endpoint(State(state): State<AppState>) -> Json<serd
 // ── Prometheus ─────────────────────────────────────────────────
 
 /// `GET <actuator-prefix>/prometheus` -- export metrics in Prometheus format.
-pub(crate) async fn prometheus_endpoint(State(state): State<AppState>) -> impl IntoResponse {
+pub(crate) async fn prometheus_endpoint<S: ProvideActuatorState + Send + Sync + 'static>(
+    State(state): State<S>,
+) -> impl IntoResponse {
     use std::fmt::Write;
 
-    let snapshot = state.metrics.snapshot();
+    let snapshot = state.metrics().snapshot();
     let mut out = String::with_capacity(1024);
 
     // requests_total
@@ -802,8 +831,10 @@ pub(crate) async fn prometheus_endpoint(State(state): State<AppState>) -> impl I
 // ── Config Properties (sensitive) ──────────────────────────────
 
 /// `GET <actuator-prefix>/configprops` -- all config properties with source tracking.
-pub(crate) async fn configprops_endpoint(State(state): State<AppState>) -> Json<serde_json::Value> {
-    let props = state.config_props.snapshot();
+pub(crate) async fn configprops_endpoint<S: ProvideActuatorState + Send + Sync + 'static>(
+    State(state): State<S>,
+) -> Json<serde_json::Value> {
+    let props = state.config_props().snapshot();
 
     Json(serde_json::json!({
         "active_profile": state.profile(),
@@ -825,11 +856,13 @@ pub(crate) struct LoggersResponse {
 }
 
 /// `GET <actuator-prefix>/loggers` -- view current log levels.
-pub(crate) async fn loggers_get(State(state): State<AppState>) -> Json<LoggersResponse> {
+pub(crate) async fn loggers_get<S: ProvideActuatorState + Send + Sync + 'static>(
+    State(state): State<S>,
+) -> Json<LoggersResponse> {
     Json(LoggersResponse {
-        current_level: state.log_levels.current_level(),
+        current_level: state.log_levels().current_level(),
         available_levels: AVAILABLE_LEVELS.to_vec(),
-        loggers: state.log_levels.logger_overrides(),
+        loggers: state.log_levels().logger_overrides(),
     })
 }
 
@@ -840,8 +873,8 @@ pub(crate) struct SetLoggerRequest {
 }
 
 /// `PUT <actuator-prefix>/loggers/{name}` -- change a logger's level at runtime.
-pub(crate) async fn loggers_put(
-    State(state): State<AppState>,
+pub(crate) async fn loggers_put<S: ProvideActuatorState + Send + Sync + 'static>(
+    State(state): State<S>,
     Path(name): Path<String>,
     Json(body): Json<SetLoggerRequest>,
 ) -> impl IntoResponse {
@@ -862,7 +895,7 @@ pub(crate) async fn loggers_put(
         );
     }
 
-    let previous = state.log_levels.set_logger_level(&name, &level);
+    let previous = state.log_levels().set_logger_level(&name, &level);
 
     (
         StatusCode::OK,
@@ -877,8 +910,10 @@ pub(crate) async fn loggers_put(
 // ── Tasks (sensitive) ──────────────────────────────────────────
 
 /// `GET <actuator-prefix>/tasks` -- scheduled task status.
-pub(crate) async fn tasks_endpoint(State(state): State<AppState>) -> Json<serde_json::Value> {
-    let tasks = state.task_registry.snapshot();
+pub(crate) async fn tasks_endpoint<S: ProvideActuatorState + Send + Sync + 'static>(
+    State(state): State<S>,
+) -> Json<serde_json::Value> {
+    let tasks = state.task_registry().snapshot();
 
     Json(serde_json::json!({
         "scheduled_tasks": tasks,
@@ -889,8 +924,8 @@ pub(crate) async fn tasks_endpoint(State(state): State<AppState>) -> Json<serde_
 
 /// `GET <actuator-prefix>/tasks/stream` -- stream scheduled task events.
 #[cfg(feature = "ws")]
-pub(crate) async fn tasks_stream_endpoint(
-    State(state): State<AppState>,
+pub(crate) async fn tasks_stream_endpoint<S: ProvideActuatorState + Send + Sync + 'static>(
+    State(state): State<S>,
     ws: axum::extract::ws::WebSocketUpgrade,
 ) -> impl IntoResponse {
     ws.on_upgrade(move |mut socket| async move {
@@ -982,60 +1017,67 @@ pub(crate) fn actuator_endpoint_paths(prefix: &str, sensitive: bool) -> Vec<Stri
 ///
 /// In dev mode (or when `actuator.sensitive = true`), all endpoints are
 /// exposed. In prod mode, only health, info, and metrics are available.
-pub fn actuator_router(sensitive: bool) -> axum::Router<AppState> {
+pub fn actuator_router<S: ProvideActuatorState + Send + Sync + Clone + 'static>(
+    sensitive: bool,
+) -> axum::Router<S> {
     actuator_router_with_prefix("/actuator", sensitive)
 }
 
 /// Build the actuator router at a configured prefix.
 ///
 /// This is the prefix-aware variant used by the framework router.
-pub(crate) fn actuator_router_with_prefix(prefix: &str, sensitive: bool) -> axum::Router<AppState> {
+pub(crate) fn actuator_router_with_prefix<
+    S: ProvideActuatorState + Send + Sync + Clone + 'static,
+>(
+    prefix: &str,
+    sensitive: bool,
+) -> axum::Router<S> {
     let mut router = axum::Router::new()
         .route(
             &actuator_route_path(prefix, "/health"),
-            axum::routing::get(health),
+            axum::routing::get(health::<S>),
         )
         .route(
             &actuator_route_path(prefix, "/info"),
-            axum::routing::get(info),
+            axum::routing::get(info::<S>),
         )
         .route(
             &actuator_route_path(prefix, "/metrics"),
-            axum::routing::get(metrics_endpoint),
+            axum::routing::get(metrics_endpoint::<S>),
         );
 
     if sensitive {
         router = router
             .route(
                 &actuator_route_path(prefix, "/env"),
-                axum::routing::get(env_endpoint),
+                axum::routing::get(env_endpoint::<S>),
             )
             .route(
                 &actuator_route_path(prefix, "/configprops"),
-                axum::routing::get(configprops_endpoint),
+                axum::routing::get(configprops_endpoint::<S>),
             )
             .route(
                 &actuator_route_path(prefix, "/loggers"),
-                axum::routing::get(loggers_get),
+                axum::routing::get(loggers_get::<S>),
             )
             .route(
                 &actuator_route_path(prefix, "/loggers/{name}"),
-                axum::routing::put(loggers_put),
+                axum::routing::put(loggers_put::<S>),
             )
             .route(
                 &actuator_route_path(prefix, "/tasks"),
-                axum::routing::get(tasks_endpoint),
+                axum::routing::get(tasks_endpoint::<S>),
             )
             .route(
                 &actuator_route_path(prefix, "/prometheus"),
-                axum::routing::get(prometheus_endpoint),
+                axum::routing::get(prometheus_endpoint::<S>),
             );
 
         #[cfg(feature = "ws")]
         {
             router = router.route(
                 &actuator_route_path(prefix, "/tasks/stream"),
-                axum::routing::get(tasks_stream_endpoint),
+                axum::routing::get(tasks_stream_endpoint::<S>),
             );
         }
     }
@@ -1047,6 +1089,7 @@ pub(crate) fn actuator_router_with_prefix(prefix: &str, sensitive: bool) -> axum
 mod tests {
     use super::*;
     use crate::config::AutumnConfig;
+    use crate::state::AppState;
     use axum::body::Body;
     use axum::http::Request;
     use tower::ServiceExt;
@@ -1228,8 +1271,8 @@ mod tests {
     #[tokio::test]
     async fn actuator_metrics_returns_http_stats() {
         let state = test_state();
-        state.metrics.record("GET", "/test", 200, 10);
-        state.metrics.record("POST", "/test", 500, 50);
+        state.metrics().record("GET", "/test", 200, 10);
+        state.metrics().record("POST", "/test", 500, 50);
 
         let app = actuator_router(true).with_state(state);
         let resp = app
@@ -1382,7 +1425,7 @@ mod tests {
         assert_eq!(json["status"], "ok");
         assert_eq!(json["message"], "Logger 'autumn_web' set to 'debug'");
 
-        let overrides = state.log_levels.logger_overrides();
+        let overrides = state.log_levels().logger_overrides();
         assert_eq!(
             overrides.get("autumn_web").map(String::as_str),
             Some("debug")
@@ -1450,8 +1493,8 @@ mod tests {
     #[tokio::test]
     async fn actuator_prometheus_returns_metrics() {
         let state = test_state();
-        state.metrics.record("GET", "/test", 200, 10);
-        state.metrics.record("POST", "/test", 500, 50);
+        state.metrics().record("GET", "/test", 200, 10);
+        state.metrics().record("POST", "/test", 500, 50);
 
         let app = actuator_router(true).with_state(state);
         let resp = app
@@ -1511,9 +1554,9 @@ mod tests {
     #[tokio::test]
     async fn actuator_tasks_returns_registered_tasks() {
         let state = test_state();
-        state.task_registry.register("cleanup", "every 5m");
-        state.task_registry.record_start("cleanup");
-        state.task_registry.record_success("cleanup", 150);
+        state.task_registry().register("cleanup", "every 5m");
+        state.task_registry().record_start("cleanup");
+        state.task_registry().record_success("cleanup", 150);
 
         let app = actuator_router(true).with_state(state);
         let resp = app

--- a/autumn/src/probe.rs
+++ b/autumn/src/probe.rs
@@ -14,9 +14,24 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::Serialize;
 
-use crate::state::AppState;
+/// Trait to abstract the state requirements for probe handlers.
+pub trait ProvideProbeState {
+    fn probes(&self) -> &ProbeState;
+    fn health_detailed(&self) -> bool;
+    fn profile(&self) -> &str;
+    fn uptime_display(&self) -> String;
 
-/// Shared probe lifecycle state stored in [`AppState`].
+    #[cfg(feature = "db")]
+    fn pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>;
+
+    fn mark_startup_complete(&self) {
+        self.probes().mark_startup_complete();
+    }
+}
+
+/// Shared probe lifecycle state stored in `AppState`.
 #[derive(Clone, Debug, Default)]
 pub struct ProbeState {
     startup_complete: Arc<AtomicBool>,
@@ -115,10 +130,10 @@ pub(crate) struct PoolStatus {
     waiting: u64,
 }
 
-fn dependency_readiness(state: &AppState) -> (bool, Option<PoolStatus>) {
+fn dependency_readiness<S: ProvideProbeState>(state: &S) -> (bool, Option<PoolStatus>) {
     #[cfg(feature = "db")]
     {
-        if let Some(pool) = state.pool.as_ref() {
+        if let Some(pool) = state.pool() {
             let status = pool.status();
             let available = status.available as u64;
             let size = status.max_size as u64;
@@ -138,7 +153,10 @@ fn dependency_readiness(state: &AppState) -> (bool, Option<PoolStatus>) {
     (true, None)
 }
 
-fn probe_response(state: &AppState, kind: ProbeKind) -> (StatusCode, Json<ProbeResponse>) {
+fn probe_response<S: ProvideProbeState>(
+    state: &S,
+    kind: ProbeKind,
+) -> (StatusCode, Json<ProbeResponse>) {
     let startup_complete = state.probes().is_startup_complete();
     let shutting_down = state.probes().is_shutting_down();
     let (dependencies_ready, pool_status) = dependency_readiness(state);
@@ -153,7 +171,7 @@ fn probe_response(state: &AppState, kind: ProbeKind) -> (StatusCode, Json<ProbeR
         ProbeKind::Ready => (StatusCode::SERVICE_UNAVAILABLE, "degraded"),
     };
 
-    let detailed = state.health_detailed;
+    let detailed = state.health_detailed();
     let body = ProbeResponse {
         status,
         version: if detailed {
@@ -178,21 +196,29 @@ fn probe_response(state: &AppState, kind: ProbeKind) -> (StatusCode, Json<ProbeR
 }
 
 /// `GET /live`
-pub async fn live_handler(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn live_handler<S: ProvideProbeState + Send + Sync + 'static>(
+    State(state): State<S>,
+) -> impl IntoResponse {
     probe_response(&state, ProbeKind::Live)
 }
 
 /// `GET /ready`
-pub async fn ready_handler(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn ready_handler<S: ProvideProbeState + Send + Sync + 'static>(
+    State(state): State<S>,
+) -> impl IntoResponse {
     probe_response(&state, ProbeKind::Ready)
 }
 
 /// `GET /startup`
-pub async fn startup_handler(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn startup_handler<S: ProvideProbeState + Send + Sync + 'static>(
+    State(state): State<S>,
+) -> impl IntoResponse {
     probe_response(&state, ProbeKind::Startup)
 }
 
 /// Compatibility alias for the legacy `/health` endpoint.
-pub(crate) fn readiness_response(state: &AppState) -> (StatusCode, Json<ProbeResponse>) {
+pub(crate) fn readiness_response<S: ProvideProbeState>(
+    state: &S,
+) -> (StatusCode, Json<ProbeResponse>) {
     probe_response(state, ProbeKind::Ready)
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -199,19 +199,19 @@ pub(crate) fn try_build_router_inner(
     if mounted_probe_paths.insert(config.health.live_path.as_str()) {
         router = router.route(
             &config.health.live_path,
-            axum::routing::get(crate::probe::live_handler),
+            axum::routing::get(crate::probe::live_handler::<AppState>),
         );
     }
     if mounted_probe_paths.insert(config.health.ready_path.as_str()) {
         router = router.route(
             &config.health.ready_path,
-            axum::routing::get(crate::probe::ready_handler),
+            axum::routing::get(crate::probe::ready_handler::<AppState>),
         );
     }
     if mounted_probe_paths.insert(config.health.startup_path.as_str()) {
         router = router.route(
             &config.health.startup_path,
-            axum::routing::get(crate::probe::startup_handler),
+            axum::routing::get(crate::probe::startup_handler::<AppState>),
         );
     }
     if mounted_probe_paths.insert(config.health.path.as_str()) {

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -345,6 +345,76 @@ impl DbState for AppState {
     }
 }
 
+impl crate::probe::ProvideProbeState for AppState {
+    fn probes(&self) -> &crate::probe::ProbeState {
+        &self.probes
+    }
+
+    fn health_detailed(&self) -> bool {
+        self.health_detailed
+    }
+
+    fn profile(&self) -> &str {
+        self.profile()
+    }
+
+    fn uptime_display(&self) -> String {
+        self.uptime_display()
+    }
+
+    #[cfg(feature = "db")]
+    fn pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
+        self.pool.as_ref()
+    }
+}
+
+impl crate::actuator::ProvideActuatorState for AppState {
+    fn metrics(&self) -> &crate::middleware::MetricsCollector {
+        &self.metrics
+    }
+
+    fn log_levels(&self) -> &crate::actuator::LogLevels {
+        &self.log_levels
+    }
+
+    fn task_registry(&self) -> &crate::actuator::TaskRegistry {
+        &self.task_registry
+    }
+
+    fn config_props(&self) -> &crate::actuator::ConfigProperties {
+        &self.config_props
+    }
+
+    fn profile(&self) -> &str {
+        self.profile()
+    }
+
+    fn uptime_display(&self) -> String {
+        self.uptime_display()
+    }
+
+    #[cfg(feature = "ws")]
+    fn channels(&self) -> &crate::channels::Channels {
+        &self.channels
+    }
+
+    #[cfg(feature = "ws")]
+    fn shutdown_token(&self) -> tokio_util::sync::CancellationToken {
+        self.shutdown_token()
+    }
+
+    #[cfg(feature = "db")]
+    fn pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
+        self.pool.as_ref()
+    }
+}
+
 impl std::fmt::Debug for AppState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut s = f.debug_struct("AppState");


### PR DESCRIPTION
🗺️ Atlas: [architectural change] Break circular dependency between state and actuators

**🕸️ Tangle:** Circular dependency between `state.rs` and its internal functional components (`probe.rs` and `actuator.rs`). `state.rs` needed them to construct the overall state graph, while those modules implicitly reached back into `state.rs` to extract `AppState` for their Axum HTTP handlers.
**📐 Blueprint:** Extracted pure interface traits `ProvideProbeState` and `ProvideActuatorState` to completely decouple the HTTP handler layer from the central concrete representation. `AppState` implements these traits in its home module (`state.rs`).
**🧱 Stability:** Reduced coupling and eliminated the circular use knot.
**🔬 Verification:** All tests successfully run, project cleanly compiles, and `cargo clippy` has no regressions.

---
*PR created automatically by Jules for task [16103657204617204566](https://jules.google.com/task/16103657204617204566) started by @madmax983*