### PR TITLE
👺 Havoc: Fix integer overflow in parse_duration

### DIFF
--- a/autumn/proptest-regressions/task.txt
+++ b/autumn/proptest-regressions/task.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 685d17ced02b208b877b6ee067105edaa0cd3288c5e066109985392801ca53ba # shrinks to s = "300000000000000d"

--- a/autumn/src/task.rs
+++ b/autumn/src/task.rs
@@ -57,13 +57,14 @@ pub fn parse_duration(s: &str) -> Option<Duration> {
         } else if ch.is_ascii_alphabetic() {
             let num: u64 = current_num.parse().ok()?;
             current_num.clear();
-            match ch {
-                's' => total_secs += num,
-                'm' => total_secs += num * 60,
-                'h' => total_secs += num * 3600,
-                'd' => total_secs += num * 86400,
+            let secs = match ch {
+                's' => num,
+                'm' => num.checked_mul(60)?,
+                'h' => num.checked_mul(3600)?,
+                'd' => num.checked_mul(86400)?,
                 _ => return None,
-            }
+            };
+            total_secs = total_secs.checked_add(secs)?;
         } else if ch == ' ' {
             // Skip spaces between components
         } else {
@@ -85,6 +86,16 @@ pub fn parse_duration(s: &str) -> Option<Duration> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn parse_duration_does_not_panic(s in "[0-9]{1,30}[smhd]") {
+            // It might fail to parse and return None (due to overflow),
+            // but it should never panic.
+            let _ = parse_duration(&s);
+        }
+    }
 
     #[test]
     fn parse_seconds() {


### PR DESCRIPTION
🧨 **The Trigger:**
Passing an exceptionally large digit sequence (e.g., `"300000000000000d"`) to `parse_duration` causes it to silently multiply out of bounds and panic because it blindly loops and multiplies unchecked.

📉 **The Stack Trace:**
```
thread 'task::tests::parse_duration_does_not_panic' panicked at autumn/src/task.rs:64:38:
attempt to multiply with overflow
```

🧪 **Reproduction:**
Run the proptest included in this PR `cargo test -p autumn-web --lib task::tests::parse_duration_does_not_panic`.

😈 **Comment:**
"You assumed users would only schedule tasks for the next 100 years. You were wrong. Replaced `+` and `*` with `checked_add` and `checked_mul` so it gracefully returns `None` instead of blowing up your thread."

---
*PR created automatically by Jules for task [8138686452754518194](https://jules.google.com/task/8138686452754518194) started by @madmax983*