### PR TITLE
🌟 Nova: Live Traffic Stream (Firehose)

### DIFF
--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -921,6 +921,42 @@ pub(crate) async fn tasks_stream_endpoint(
     })
 }
 
+// ── Traffic Stream (WebSocket) ─────────────────────────────────
+
+/// `GET <actuator-prefix>/traffic/stream` -- stream live traffic metrics events.
+#[cfg(feature = "ws")]
+pub(crate) async fn traffic_stream_endpoint(
+    State(state): State<AppState>,
+    ws: axum::extract::ws::WebSocketUpgrade,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |mut socket| async move {
+        let mut rx = state.channels().subscribe("sys:traffic");
+        let shutdown = state.shutdown_token();
+
+        loop {
+            tokio::select! {
+                res = rx.recv() => {
+                    match res {
+                        Ok(msg) => {
+                            let ws_msg = axum::extract::ws::Message::Text(msg.into_string().into());
+                            if socket.send(ws_msg).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+                () = shutdown.cancelled() => {
+                    let _ = socket.send(axum::extract::ws::Message::Close(None)).await;
+                    break;
+                }
+                else => break,
+            }
+        }
+    })
+}
+
 // ── Router builder ──────────────────────────────────────────────
 
 pub(crate) fn normalize_actuator_prefix(prefix: &str) -> String {
@@ -1033,10 +1069,15 @@ pub(crate) fn actuator_router_with_prefix(prefix: &str, sensitive: bool) -> axum
 
         #[cfg(feature = "ws")]
         {
-            router = router.route(
-                &actuator_route_path(prefix, "/tasks/stream"),
-                axum::routing::get(tasks_stream_endpoint),
-            );
+            router = router
+                .route(
+                    &actuator_route_path(prefix, "/tasks/stream"),
+                    axum::routing::get(tasks_stream_endpoint),
+                )
+                .route(
+                    &actuator_route_path(prefix, "/traffic/stream"),
+                    axum::routing::get(traffic_stream_endpoint),
+                );
         }
     }
 
@@ -1206,6 +1247,22 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri("/actuator/env")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "ws")]
+    async fn actuator_traffic_stream_hidden_in_nonsensitive_mode() {
+        let app = actuator_router(false).with_state(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/traffic/stream")
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/autumn/src/middleware/metrics.rs
+++ b/autumn/src/middleware/metrics.rs
@@ -20,6 +20,9 @@ use pin_project_lite::pin_project;
 use serde::Serialize;
 use tower::{Layer, Service};
 
+#[cfg(feature = "ws")]
+use crate::channels::Channels;
+
 /// Shared metrics collector that aggregates request statistics.
 #[derive(Debug, Clone)]
 pub struct MetricsCollector {
@@ -306,13 +309,27 @@ fn compute_percentiles(latencies: &VecDeque<u64>) -> Percentiles {
 #[derive(Clone)]
 pub struct MetricsLayer {
     collector: MetricsCollector,
+    #[cfg(feature = "ws")]
+    channels: Option<Channels>,
 }
 
 impl MetricsLayer {
     /// Create a new metrics layer backed by the given collector.
     #[must_use]
     pub const fn new(collector: MetricsCollector) -> Self {
-        Self { collector }
+        Self {
+            collector,
+            #[cfg(feature = "ws")]
+            channels: None,
+        }
+    }
+
+    /// Provide a channels registry for live traffic streaming over `WebSockets`.
+    #[cfg(feature = "ws")]
+    #[must_use]
+    pub fn with_channels(mut self, channels: Channels) -> Self {
+        self.channels = Some(channels);
+        self
     }
 }
 
@@ -323,6 +340,8 @@ impl<S> Layer<S> for MetricsLayer {
         MetricsService {
             inner,
             collector: self.collector.clone(),
+            #[cfg(feature = "ws")]
+            channels: self.channels.clone(),
         }
     }
 }
@@ -332,6 +351,8 @@ impl<S> Layer<S> for MetricsLayer {
 pub struct MetricsService<S> {
     inner: S,
     collector: MetricsCollector,
+    #[cfg(feature = "ws")]
+    channels: Option<Channels>,
 }
 
 impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for MetricsService<S>
@@ -361,10 +382,27 @@ where
             method: Some(method),
             route: Some(route),
             start: Instant::now(),
+            #[cfg(feature = "ws")]
+            channels: self.channels.clone(),
         }
     }
 }
 
+#[cfg(feature = "ws")]
+pin_project! {
+    /// Future that records metrics after the inner service completes.
+    pub struct MetricsFuture<F> {
+        #[pin]
+        inner: F,
+        collector: Option<MetricsCollector>,
+        method: Option<String>,
+        route: Option<String>,
+        start: Instant,
+        channels: Option<Channels>,
+    }
+}
+
+#[cfg(not(feature = "ws"))]
 pin_project! {
     /// Future that records metrics after the inner service completes.
     pub struct MetricsFuture<F> {
@@ -395,6 +433,21 @@ where
                     let status = response.status().as_u16();
                     collector.record(&method, &route, status, latency_ms);
                     collector.decrement_active();
+
+                    #[cfg(feature = "ws")]
+                    if let Some(channels) = this.channels.take() {
+                        let tx = channels.sender("sys:traffic");
+                        if tx.receiver_count() > 0 {
+                            let msg = serde_json::json!({
+                                "method": method,
+                                "route": route,
+                                "status": status,
+                                "latency_ms": latency_ms,
+                            })
+                            .to_string();
+                            let _ = tx.send(msg);
+                        }
+                    }
                 }
                 Poll::Ready(Ok(response))
             }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -344,10 +344,14 @@ pub(crate) fn try_build_router_inner(
     // Error page context layer must be inner to the exception filter so
     // WantsHtml is set on the response before the filter inspects it.
     // Layer order: Metrics -> ExceptionFilter -> ErrorPageContext -> router
+    let metrics_layer = crate::middleware::MetricsLayer::new(state.metrics.clone());
+    #[cfg(feature = "ws")]
+    let metrics_layer = metrics_layer.with_channels(state.channels.clone());
+
     let mut router = router
         .layer(crate::middleware::error_page_filter::ErrorPageContextLayer)
         .layer(ExceptionFilterLayer::new(all_filters))
-        .layer(crate::middleware::MetricsLayer::new(state.metrics.clone()));
+        .layer(metrics_layer);
 
     if dev_reload_enabled {
         router = router


### PR DESCRIPTION
🌟 **Nova: Live Traffic Stream (Firehose)**

💡 **The Spark:** We have a robust `MetricsCollector` that records every request, its route, status, and latency. We also have a `Channels` registry for WebSockets/SSE (`state.channels()`) that is already used by `tasks_stream_endpoint`. Combining these two components allows us to create a real-time live traffic stream without complex external dependencies.

🚀 **The Feature:** When `MetricsFuture` finishes processing an HTTP request, if the `ws` feature is enabled and a client is connected, it formats a JSON summary (method, route, status, latency) and broadcasts it to the `sys:traffic` channel. An actuator endpoint `/actuator/traffic/stream` has been created to consume this stream over WebSockets.

🔮 **The Potential:** This lays the foundation for real-time traffic visualization in the CLI's monitor dashboard or browser-based developer tooling. It provides a highly responsive "tail -f" equivalent for HTTP requests over the network.

⚠️ **Risk:** Low. To ensure zero performance overhead when the stream is not in use, the JSON payload creation and channel broadcast are gated by checking `tx.receiver_count() > 0`. A test has been added to ensure the endpoint remains hidden in non-sensitive mode.

---
*PR created automatically by Jules for task [449446580826383415](https://jules.google.com/task/449446580826383415) started by @madmax983*