### PR TITLE
⚡ Bolt: Eliminate String heap allocations in ErrorPageContextLayer on hot path

### DIFF
--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -43,12 +43,16 @@ impl ExceptionFilter for ErrorPageFilter {
         let request_id = response
             .extensions()
             .get::<ErrorPageRequestContext>()
-            .and_then(|ctx| ctx.request_id.clone());
+            .and_then(|ctx| {
+                ctx.request_id
+                    .as_ref()
+                    .map(std::string::ToString::to_string)
+            });
 
         let path = response
             .extensions()
             .get::<ErrorPageRequestContext>()
-            .map(|ctx| ctx.path.clone())
+            .map(|ctx| ctx.uri.path().to_string())
             .unwrap_or_default();
 
         let ctx = ErrorContext {
@@ -108,8 +112,8 @@ pub struct WantsHtml(pub bool);
 /// Request context stored in response extensions for the error page filter.
 #[derive(Clone, Debug)]
 pub struct ErrorPageRequestContext {
-    pub path: String,
-    pub request_id: Option<String>,
+    pub uri: axum::http::Uri,
+    pub request_id: Option<crate::middleware::RequestId>,
 }
 
 /// Tower layer that annotates requests with Accept header preference
@@ -150,16 +154,16 @@ where
 
     fn call(&mut self, req: axum::http::Request<ReqBody>) -> Self::Future {
         let wants_html = accepts_html(&req);
-        let path = req.uri().path().to_string();
+        let uri = req.uri().clone();
         let request_id = req
             .extensions()
             .get::<crate::middleware::RequestId>()
-            .map(std::string::ToString::to_string);
+            .cloned();
 
         ErrorPageContextFuture {
             inner: self.inner.call(req),
             wants_html,
-            path,
+            uri,
             request_id,
         }
     }
@@ -170,8 +174,8 @@ pin_project_lite::pin_project! {
         #[pin]
         inner: F,
         wants_html: bool,
-        path: String,
-        request_id: Option<String>,
+        uri: axum::http::Uri,
+        request_id: Option<crate::middleware::RequestId>,
     }
 }
 
@@ -192,7 +196,7 @@ where
                     .extensions_mut()
                     .insert(WantsHtml(*this.wants_html));
                 response.extensions_mut().insert(ErrorPageRequestContext {
-                    path: this.path.clone(),
+                    uri: this.uri.clone(),
                     request_id: this.request_id.clone(),
                 });
                 std::task::Poll::Ready(Ok(response))

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,3 +1,4 @@
-📖 Chapter: The Missing Module Docs & Link Fixes
-🔦 Insight: Removed redundant explicit link targets in `lib.rs` to clean up `cargo doc` warnings. Added missing Module-Level (`//!`) documentation to `router.rs`, `session_redis.rs`, and `test_utils.rs` to provide high-level context and eliminate "Black Box" modules.
-🧪 Example: Cleaned up intra-doc links, for example transforming ``[`Form`](axum::extract::Form)`` to ``[`Form`]``.
+💡 **What:** Modified `ErrorPageContextService` to store the request URI and a cloned `RequestId` in its extension context instead of immediately allocating and storing `String`s. The `to_string()` calls are now deferred to the `ErrorPageFilter` which only executes on the cold path (when an actual error occurs).
+🎯 **Why:** The `ErrorPageContextLayer` wraps the entire application router, meaning its `call` function executes on *every single incoming request*. Previously, it aggressively called `req.uri().path().to_string()` and `request_id.to_string()` on every request just to store them in extensions in case an error occurred. This resulted in two unnecessary heap allocations per request on the hot path.
+📊 **Impact:** Completely eliminates two `String` heap allocations on the hot path for every successful request. The allocations now only occur on the cold path when formatting an error page.
+🔬 **Measurement:** Review the code to verify allocations are removed from `ErrorPageContextService::call`.


### PR DESCRIPTION
💡 **What:** Modified `ErrorPageContextService` to store the request URI and a cloned `RequestId` in its extension context instead of immediately allocating and storing `String`s. The `to_string()` calls are now deferred to the `ErrorPageFilter` which only executes on the cold path (when an actual error occurs).
🎯 **Why:** The `ErrorPageContextLayer` wraps the entire application router, meaning its `call` function executes on *every single incoming request*. Previously, it aggressively called `req.uri().path().to_string()` and `request_id.to_string()` on every request just to store them in extensions in case an error occurred. This resulted in two unnecessary heap allocations per request on the hot path.
📊 **Impact:** Completely eliminates two `String` heap allocations on the hot path for every successful request. The allocations now only occur on the cold path when formatting an error page.
🔬 **Measurement:** Review the code to verify allocations are removed from `ErrorPageContextService::call`.

---
*PR created automatically by Jules for task [12841047779014430140](https://jules.google.com/task/12841047779014430140) started by @madmax983*