### PR TITLE
🧪 Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/middleware/dev.rs
+++ b/autumn/src/middleware/dev.rs
@@ -396,6 +396,30 @@ mod tests {
     }
 
     #[test]
+    fn inject_snippet_edge_cases() {
+        // Multiple </body> tags: Should insert before the *last* </body> tag.
+        let multi_body = inject_snippet(b"<html><body>text</body> <!-- </body> --> </html>");
+        let multi_body_str = std::str::from_utf8(&multi_body).expect("utf-8");
+        assert!(multi_body_str.ends_with("</script></body> --> </html>"));
+
+        // <html tag with attributes.
+        let html_attr = inject_snippet(b"<html lang=\"en\"><main>ok</main>");
+        let html_attr_str = std::str::from_utf8(&html_attr).expect("utf-8");
+        assert!(html_attr_str.ends_with("</script>"));
+
+        // Only </html> tag.
+        let html_close = inject_snippet(b"<div>content</div></html>");
+        let html_close_str = std::str::from_utf8(&html_close).expect("utf-8");
+        assert!(html_close_str.ends_with("</script>"));
+
+        // Invalid UTF-8 sequence, but containing </body>.
+        let invalid_utf8 = b"<html><body>\xFF\xFE</body></html>".to_vec();
+        let invalid_result = inject_snippet(&invalid_utf8);
+        // String::from_utf8_lossy Replaces invalid bytes with U+FFFD.
+        assert!(String::from_utf8_lossy(&invalid_result).contains("</script></body></html>"));
+    }
+
+    #[test]
     fn is_static_path_matches_root_and_nested_assets() {
         assert!(is_static_path("/static"));
         assert!(is_static_path("/static/css/autumn.css"));


### PR DESCRIPTION
🎯 **Target:** `autumn/src/middleware/dev.rs` live reload snippet injection logic.
💣 **Risk:** The `inject_snippet` function uses string manipulation on bytes converted to lossy UTF-8 with unhandled test edge cases. Incorrect string replacement could corrupt HTML formatting or silently fail during development proxy injections in the presence of malformed HTML elements or invalid UTF-8 sequences.
🧪 **Strategy:** Added the `inject_snippet_edge_cases` test covering scenarios involving multiple target tags (`</body>`), `<html` tags containing properties, standard `</html>` fallback tags, and gracefully handling inputs containing invalid UTF-8 bytes.
🔬 **Verification:** Verified that tests accurately catch errors by temporarily removing fallback injection checks in the original function. Ensured all local module and standard `clippy`/`fmt`/`test` executions successfully pass.

---
*PR created automatically by Jules for task [903244264236841509](https://jules.google.com/task/903244264236841509) started by @madmax983*