### PR TITLE
🔒 [security fix description] Session Cookie Tossing fix

### DIFF
--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -496,18 +496,27 @@ fn is_production_profile(profile: Option<&str>) -> bool {
 
 /// Extract a named cookie value from the Cookie header.
 fn get_cookie(headers: &http::HeaderMap, name: &str) -> Option<String> {
-    headers.get_all(COOKIE).iter().find_map(|value| {
-        value.to_str().ok().and_then(|s| {
-            s.split(';').map(str::trim).find_map(|pair| {
-                let (k, v) = pair.split_once('=')?;
-                if k.trim() == name {
-                    Some(v.trim().to_owned())
-                } else {
-                    None
+    let mut found_token = None;
+
+    for cookie_header in headers.get_all(COOKIE) {
+        if let Ok(cookie_str) = cookie_header.to_str() {
+            for pair in cookie_str.split(';') {
+                let pair = pair.trim();
+                if let Some((k, v)) = pair.split_once('=') {
+                    if k.trim() == name {
+                        if found_token.is_some() {
+                            // Multiple cookies with the same name found.
+                            // This indicates a potential Cookie Tossing attack!
+                            // Reject by returning None.
+                            return None;
+                        }
+                        found_token = Some(v.trim().to_owned());
+                    }
                 }
-            })
-        })
-    })
+            }
+        }
+    }
+    found_token
 }
 
 /// Build a Set-Cookie header value.
@@ -835,6 +844,21 @@ mod tests {
         assert_eq!(get_cookie(&headers, "autumn.sid"), Some("abc123".into()));
         assert_eq!(get_cookie(&headers, "other"), Some("xyz".into()));
         assert_eq!(get_cookie(&headers, "missing"), None);
+    }
+
+    #[test]
+    fn get_cookie_rejects_multiple_cookies() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            COOKIE,
+            HeaderValue::from_static("autumn.sid=abc123; autumn.sid=xyz456"),
+        );
+        assert_eq!(get_cookie(&headers, "autumn.sid"), None);
+
+        let mut headers2 = http::HeaderMap::new();
+        headers2.append(COOKIE, HeaderValue::from_static("autumn.sid=abc123"));
+        headers2.append(COOKIE, HeaderValue::from_static("autumn.sid=xyz456"));
+        assert_eq!(get_cookie(&headers2, "autumn.sid"), None);
     }
 
     #[test]

--- a/autumn/tests/security/cookie_tossing.rs
+++ b/autumn/tests/security/cookie_tossing.rs
@@ -1,0 +1,54 @@
+use autumn_web::session::{MemoryStore, Session, SessionConfig, SessionLayer, SessionStore};
+use axum::{Router, body::Body, http::Request, routing::get};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn eris_session_cookie_tossing() {
+    let store = MemoryStore::new();
+    let config = SessionConfig::default();
+
+    let app = Router::new()
+        .route(
+            "/session",
+            get(|session: Session| async move {
+                session
+                    .get("user")
+                    .await
+                    .unwrap_or_else(|| "none".to_string())
+            }),
+        )
+        .layer(SessionLayer::new(store.clone(), config))
+        .with_state(autumn_web::state::AppState::for_test());
+
+    // Attacker pre-creates an evil session
+    let mut evil_data = std::collections::HashMap::new();
+    evil_data.insert("user".to_string(), "attacker".to_string());
+    store.save("evil-id", evil_data).await.unwrap();
+
+    // Victim has a legitimate session
+    let mut legit_data = std::collections::HashMap::new();
+    legit_data.insert("user".to_string(), "victim".to_string());
+    store.save("legit-id", legit_data).await.unwrap();
+
+    // Attacker does Cookie Tossing
+    let req = Request::builder()
+        .method("GET")
+        .uri("/session")
+        .header(
+            "Cookie",
+            "autumn.sid=evil-id; autumn.sid=legit-id".to_string(),
+        )
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(req).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let user = String::from_utf8(body.to_vec()).unwrap();
+
+    // If it returns "attacker", it's vulnerable to Cookie Tossing for Session IDs.
+    // If it returns "none" or some error, it's protected.
+    // I bet it returns "attacker" because `find_map` returns the first!
+    assert_ne!(user, "attacker", "Session Cookie Tossing vulnerability!");
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth_dos;
 pub mod auth_timing_test;
+pub mod cookie_tossing;
 pub mod csrf_cookie_tossing;
 pub mod csrf_empty_bypass;
 pub mod csrf_form_bypass;


### PR DESCRIPTION
## 🔒 Session Cookie Tossing Fix

🎯 **What:** `get_cookie` in `autumn/src/session.rs` returned the first matching session cookie it encountered. This exposed the framework to a Session Cookie Tossing vulnerability, where an attacker who exploits a subdomain XSS could set a malicious `autumn.sid` cookie that shadows the legitimate session cookie.
⚠️ **Risk:** Medium to High (Session Fixation via Cookie Tossing). An attacker could bypass session management or hijack user sessions by overriding their legitimate session cookies.
🛡️ **Solution:** Modified `get_cookie` to scan all matched cookies and strictly return `None` (rejecting the request's session ID lookup entirely) if multiple session cookies are present. Added a rigorous regression test in `tests/security/cookie_tossing.rs` to verify the exploit fails.

---
*PR created automatically by Jules for task [13421650357254627986](https://jules.google.com/task/13421650357254627986) started by @madmax983*