### PR TITLE
⚡ Bolt: bulk insert due dag runs

### DIFF
--- a/autumn-harvest/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/autumn-harvest/src/scheduler.rs
@@ -404,8 +404,15 @@ async fn create_due_runs(conn: &mut AsyncPgConnection, dags: &DagCatalog) -> Har
         let (created, next_run_at) =
             due_run_plan(dag.schedule.as_ref(), logical_date, now, dag.catchup);
 
-        for run_at in &created {
-            let _ = insert_dag_run(conn, &schedule.dag_name, *run_at, None).await?;
+        if !created.is_empty() {
+            let rows = create_new_dag_runs(&schedule.dag_name, &created);
+            diesel::insert_into(harvest_dag_runs::table)
+                .values(&rows)
+                .on_conflict((harvest_dag_runs::dag_name, harvest_dag_runs::logical_date))
+                .do_nothing()
+                .execute(conn)
+                .await
+                .map_err(crate::error::database_error)?;
         }
 
         diesel::update(dsl::harvest_schedules.find(schedule.id))
@@ -611,6 +618,21 @@ fn task_input(conf: &Value, activity_name: &str) -> Value {
     }
 }
 
+fn create_new_dag_runs<'a>(dag_name: &'a str, run_dates: &[DateTime<Utc>]) -> Vec<NewDagRun<'a>> {
+    run_dates
+        .iter()
+        .map(|&logical_date| NewDagRun {
+            id: uuid::Uuid::new_v4(),
+            dag_name,
+            workflow_exec_id: None,
+            logical_date,
+            data_interval_start: logical_date,
+            data_interval_end: logical_date,
+            conf: None,
+        })
+        .collect()
+}
+
 async fn insert_dag_run(
     db: &mut AsyncPgConnection,
     dag_name: &str,
@@ -730,5 +752,19 @@ mod tests {
             ]
         );
         assert_eq!(next_run_at, Some(parse_utc("2026-04-06T12:03:00Z")));
+    }
+    #[test]
+    fn create_new_dag_runs_generates_correct_rows() {
+        let first_due = parse_utc("2026-04-06T12:00:00Z");
+        let second_due = parse_utc("2026-04-06T12:01:00Z");
+        let dates = vec![first_due, second_due];
+
+        let rows = create_new_dag_runs("test_dag", &dates);
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].dag_name, "test_dag");
+        assert_eq!(rows[0].logical_date, first_due);
+        assert_eq!(rows[1].dag_name, "test_dag");
+        assert_eq!(rows[1].logical_date, second_due);
     }
 }

--- a/autumn-harvest/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/autumn-harvest/src/scheduler.rs
@@ -753,6 +753,7 @@ mod tests {
         );
         assert_eq!(next_run_at, Some(parse_utc("2026-04-06T12:03:00Z")));
     }
+
     #[test]
     fn create_new_dag_runs_generates_correct_rows() {
         let first_due = parse_utc("2026-04-06T12:00:00Z");
@@ -764,7 +765,21 @@ mod tests {
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].dag_name, "test_dag");
         assert_eq!(rows[0].logical_date, first_due);
+        assert_eq!(rows[0].data_interval_start, first_due);
+        assert_eq!(rows[0].data_interval_end, first_due);
+        assert_eq!(rows[0].workflow_exec_id, None);
+        assert_eq!(rows[0].conf, None);
         assert_eq!(rows[1].dag_name, "test_dag");
         assert_eq!(rows[1].logical_date, second_due);
+        assert_eq!(rows[1].data_interval_start, second_due);
+        assert_eq!(rows[1].data_interval_end, second_due);
+        assert_eq!(rows[1].workflow_exec_id, None);
+        assert_eq!(rows[1].conf, None);
+    }
+
+    #[test]
+    fn create_new_dag_runs_returns_empty_for_no_dates() {
+        let rows = create_new_dag_runs("test_dag", &[]);
+        assert!(rows.is_empty());
     }
 }


### PR DESCRIPTION
💡 **What:**
Replaced the `insert_dag_run` query loop in the `create_due_runs` scheduling function with a single bulk insert `INSERT ... ON CONFLICT DO NOTHING`. A new pure function `create_new_dag_runs` constructs the row structures before dispatching the query.

🎯 **Why:**
Previously, if a scheduler evaluated multiple skipped/queued executions (e.g., during catch-up operations), it would loop through them and run an `insert_dag_run` function. This would result in an N+1 query problem, producing an `INSERT` statement with its own network round-trip and an extra `SELECT` mapping for each row created. Using a bulk insert is significantly more efficient and solves this N+1 problem.

📊 **Measured Improvement:**
I was unable to show a meaningful baseline performance improvement dynamically as there were no existing benchmark/Criterion configurations inside the sandbox testing environment. Running full PostgreSQL databases reliably internally for benchmarks also poses challenges. However, the theoretical optimization mathematically reduces the database roundtrips for inserting due runs from O(N) back-and-forth network jumps to a single constant time O(1) bulk insert transaction, saving substantial CPU and network I/O cycles.

---
*PR created automatically by Jules for task [12795411473329429196](https://jules.google.com/task/12795411473329429196) started by @madmax983*