### PR TITLE
🔒 [security fix] Remove unsafe env mutation from #[autumn_web::main]

### DIFF
--- a/autumn-macros/src/main_macro.rs
+++ b/autumn-macros/src/main_macro.rs
@@ -27,20 +27,14 @@ pub fn main_macro(item: TokenStream) -> TokenStream {
     quote! {
         #(#attrs)*
         fn main() {
-            // Tell the framework where autumn.toml lives (the app's crate root).
-            // SAFETY: called at the top of main, before any threads are spawned.
-            unsafe { ::std::env::set_var("AUTUMN_MANIFEST_DIR", env!("CARGO_MANIFEST_DIR")); }
-
-            // Tell the framework whether the *user's* crate was built in debug mode.
+            // Tell the framework where autumn.toml lives (the app's crate root),
+            // and whether the *user's* crate was built in debug mode.
             // cfg!(debug_assertions) evaluates here — in the user's crate context —
             // so it reflects their build mode, not autumn-web's library build mode.
-            // SAFETY: called at the top of main, before any threads are spawned.
-            unsafe {
-                ::std::env::set_var(
-                    "AUTUMN_IS_DEBUG",
-                    if cfg!(debug_assertions) { "1" } else { "0" },
-                );
-            }
+            ::autumn_web::config::__set_macro_context(
+                env!("CARGO_MANIFEST_DIR").to_string(),
+                cfg!(debug_assertions),
+            );
 
             ::autumn_web::reexports::tokio::runtime::Builder::new_multi_thread()
                 .enable_all()

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -79,6 +79,17 @@ use serde::Deserialize;
 use thiserror::Error;
 
 /// Abstraction for reading environment variables, supporting dependency injection for testing.
+use std::sync::OnceLock;
+
+static MACRO_MANIFEST_DIR: OnceLock<String> = OnceLock::new();
+static MACRO_IS_DEBUG: OnceLock<bool> = OnceLock::new();
+
+#[doc(hidden)]
+pub fn __set_macro_context(manifest_dir: String, is_debug: bool) {
+    let _ = MACRO_MANIFEST_DIR.set(manifest_dir);
+    let _ = MACRO_IS_DEBUG.set(is_debug);
+}
+
 pub trait Env {
     /// Read an environment variable.
     ///
@@ -93,6 +104,19 @@ pub struct OsEnv;
 
 impl Env for OsEnv {
     fn var(&self, key: &str) -> Result<String, std::env::VarError> {
+        if key == "AUTUMN_MANIFEST_DIR" {
+            if let Some(dir) = MACRO_MANIFEST_DIR.get() {
+                return Ok(dir.clone());
+            }
+        } else if key == "AUTUMN_IS_DEBUG" {
+            if let Some(is_debug) = MACRO_IS_DEBUG.get() {
+                return Ok(if *is_debug {
+                    "1".to_string()
+                } else {
+                    "0".to_string()
+                });
+            }
+        }
         std::env::var(key)
     }
 }

--- a/docs/guide/macro-transparency.md
+++ b/docs/guide/macro-transparency.md
@@ -200,8 +200,10 @@ async fn main() {
 
 ```rust
 fn main() {
-    unsafe { std::env::set_var("AUTUMN_MANIFEST_DIR", env!("CARGO_MANIFEST_DIR")); }
-    unsafe { std::env::set_var("AUTUMN_IS_DEBUG", "1"); }  // "0" in release
+    autumn_web::config::__set_macro_context(
+        env!("CARGO_MANIFEST_DIR").to_string(),
+        cfg!(debug_assertions),  // true in debug, false in release
+    );
 
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/examples/bookmarks-distributed/src/config.rs
+++ b/examples/bookmarks-distributed/src/config.rs
@@ -83,12 +83,14 @@ impl Default for DistributedDatabaseConfig {
 
 impl DistributedConfig {
     pub fn load() -> Result<Self, DistributedConfigLoadError> {
+        use autumn_web::config::{Env as _, OsEnv};
+        let env = OsEnv;
         let manifest_dir =
-            resolve_manifest_dir(std::env::var("AUTUMN_MANIFEST_DIR").ok().as_deref());
+            resolve_manifest_dir(env.var("AUTUMN_MANIFEST_DIR").ok().as_deref());
         let profile = resolve_runtime_profile(
-            std::env::var("AUTUMN_PROFILE").ok().as_deref(),
+            env.var("AUTUMN_PROFILE").ok().as_deref(),
             &std::env::args().collect::<Vec<_>>(),
-            std::env::var("AUTUMN_IS_DEBUG").ok().as_deref(),
+            env.var("AUTUMN_IS_DEBUG").ok().as_deref(),
         );
 
         Self::load_from_dir(manifest_dir, profile.as_deref())

--- a/examples/bookmarks-distributed/src/config.rs
+++ b/examples/bookmarks-distributed/src/config.rs
@@ -85,8 +85,7 @@ impl DistributedConfig {
     pub fn load() -> Result<Self, DistributedConfigLoadError> {
         use autumn_web::config::{Env as _, OsEnv};
         let env = OsEnv;
-        let manifest_dir =
-            resolve_manifest_dir(env.var("AUTUMN_MANIFEST_DIR").ok().as_deref());
+        let manifest_dir = resolve_manifest_dir(env.var("AUTUMN_MANIFEST_DIR").ok().as_deref());
         let profile = resolve_runtime_profile(
             env.var("AUTUMN_PROFILE").ok().as_deref(),
             &std::env::args().collect::<Vec<_>>(),


### PR DESCRIPTION
🎯 **What:** The `#[autumn_web::main]` macro previously emitted `unsafe { std::env::set_var(...) }` calls into the user's `main()` function to set `AUTUMN_MANIFEST_DIR` and `AUTUMN_IS_DEBUG`. These have been removed and replaced with safe, global static variables (`OnceLock`) initialized via a hidden function.

⚠️ **Risk:** Modifying the environment in a multithreaded context (like after Tokios' runtime starts, or if other threads are spawned early) causes undefined behavior (UB), crashes, or data races in Rust since environment access is not synchronized. Even though the macro tries to run it early, it is an unsafe anti-pattern.

🛡️ **Solution:** `OnceLock` statics are now used to store the macro context securely at runtime without interacting with the OS environment. The existing configuration loader's `OsEnv` implementation has been updated to seamlessly intercept and serve `"AUTUMN_MANIFEST_DIR"` and `"AUTUMN_IS_DEBUG"` from these secure locks before falling back to `std::env::var()`.

---
*PR created automatically by Jules for task [18342118546875125152](https://jules.google.com/task/18342118546875125152) started by @madmax983*