### PR TITLE
🗺️ Atlas: Hide internal state module

### DIFF
--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -633,7 +633,7 @@ pub mod reexports {
 }
 
 /// Shared application state passed to route handlers.
-pub mod state;
+pub(crate) mod state;
 #[allow(
     clippy::missing_panics_doc,
     clippy::must_use_candidate,

--- a/autumn/tests/security/cookie_tossing.rs
+++ b/autumn/tests/security/cookie_tossing.rs
@@ -18,7 +18,7 @@ async fn eris_session_cookie_tossing() {
             }),
         )
         .layer(SessionLayer::new(store.clone(), config))
-        .with_state(autumn_web::state::AppState::for_test());
+        .with_state(autumn_web::AppState::for_test());
 
     // Attacker pre-creates an evil session
     let mut evil_data = std::collections::HashMap::new();

--- a/autumn/tests/security/ctf.rs
+++ b/autumn/tests/security/ctf.rs
@@ -335,7 +335,7 @@ async fn ctf_09_session_fixation_is_blocked() {
     }
 
     let store = MemoryStore::new();
-    let state = autumn_web::state::AppState::for_test();
+    let state = autumn_web::AppState::for_test();
     let app = Router::new()
         .route("/login", get(login_handler))
         .layer(SessionLayer::new(store.clone(), SessionConfig::default()))
@@ -403,7 +403,7 @@ async fn ctf_10_session_cookie_is_hardened_in_prod_config() {
         same_site: "Strict".to_owned(),
         ..SessionConfig::default()
     };
-    let state = autumn_web::state::AppState::for_test();
+    let state = autumn_web::AppState::for_test();
     let app = Router::new()
         .route("/login", get(login_handler))
         .layer(SessionLayer::new(store, config))
@@ -511,7 +511,7 @@ async fn ctf_12_bouncer_turns_away_anonymous_visitors() {
         }
     }
 
-    let state = autumn_web::state::AppState::for_test();
+    let state = autumn_web::AppState::for_test();
     let app = Router::new()
         .route("/private", get(protected))
         .layer(SessionLayer::new(

--- a/autumn/tests/security/session_fixation.rs
+++ b/autumn/tests/security/session_fixation.rs
@@ -18,7 +18,7 @@ async fn test_session_fixation() {
     let store = MemoryStore::new();
     let config = SessionConfig::default();
 
-    let state = autumn_web::state::AppState::for_test();
+    let state = autumn_web::AppState::for_test();
 
     let app = Router::new()
         .route("/login", get(login_handler))
@@ -94,7 +94,7 @@ async fn test_rotate_id() {
     let store = MemoryStore::new();
     let config = SessionConfig::default();
 
-    let state = autumn_web::state::AppState::for_test();
+    let state = autumn_web::AppState::for_test();
 
     let app = Router::new()
         .route("/rotate", get(rotate_handler))


### PR DESCRIPTION
🕸️ Tangle: `pub mod state` in `autumn/src/lib.rs` exposed the internal structure, while the `AppState` itself was correctly re-exported via `pub use state::AppState`. This allowed users and tests to bypass the facade and use `autumn_web::state::AppState`.
📐 Blueprint: Changed `pub mod state` to `pub(crate) mod state`, forcing all external users to access `AppState` via the intended `autumn_web::AppState` facade. Updated integration tests to comply.
🧱 Stability: Improved encapsulation and enforced strict module boundaries, preventing downstream consumers from coupling to the framework's internal layout.
🔬 Verification: `cargo test -p autumn-web` and `cargo check` pass with no regressions.

---
*PR created automatically by Jules for task [11360096872949910904](https://jules.google.com/task/11360096872949910904) started by @madmax983*