### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -17,20 +17,46 @@ use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
 
 /// Trait to abstract the state requirements for actuator handlers.
+///
+/// Implement this trait on your application's state type to provide
+/// the necessary dependencies for actuator endpoints (e.g. `/actuator/metrics`).
+/// This avoids tight coupling between the actuator middleware and the specific `AppState`.
 pub trait ProvideActuatorState {
+    /// Returns a reference to the [`crate::middleware::MetricsCollector`]
+    /// tracking current HTTP traffic metrics.
     fn metrics(&self) -> &crate::middleware::MetricsCollector;
+
+    /// Returns a reference to the dynamic [`LogLevels`] configuration
+    /// allowing runtime adjustment of `tracing` filters.
     fn log_levels(&self) -> &LogLevels;
+
+    /// Returns a reference to the [`TaskRegistry`] holding status and metadata
+    /// for async scheduled background tasks.
     fn task_registry(&self) -> &TaskRegistry;
+
+    /// Returns a reference to the [`ConfigProperties`] snapshot, providing
+    /// active configuration state for the environment endpoint.
     fn config_props(&self) -> &ConfigProperties;
+
+    /// Returns the currently active execution profile (e.g. "dev", "prod")
+    /// which modifies what sensitive endpoints are exposed.
     fn profile(&self) -> &str;
+
+    /// Returns a human-readable string displaying how long the application
+    /// has been running (e.g., "2d 4h 13m").
     fn uptime_display(&self) -> String;
 
+    /// Returns a reference to the system [`crate::channels::Channels`] which
+    /// broadcasts operational events to WebSocket streams.
     #[cfg(feature = "ws")]
     fn channels(&self) -> &crate::channels::Channels;
 
+    /// Returns the main cancellation token that triggers a graceful framework shutdown.
     #[cfg(feature = "ws")]
     fn shutdown_token(&self) -> tokio_util::sync::CancellationToken;
 
+    /// Returns an optional reference to the database connection pool,
+    /// used to expose database connection metrics in the `/actuator/metrics` endpoint.
     #[cfg(feature = "db")]
     fn pool(
         &self,

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -90,10 +90,25 @@ pub fn __set_macro_context(manifest_dir: String, is_debug: bool) {
     let _ = MACRO_IS_DEBUG.set(is_debug);
 }
 
+/// Trait for environment variable reading to allow testing overrides.
+///
+/// This abstracts the OS environment (`std::env::var`) so that
+/// configuration loading logic can be unit-tested deterministically
+/// by supplying a mock environment.
 pub trait Env {
     /// Read an environment variable.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// use autumn_web::config::{Env, OsEnv};
+    /// let env = OsEnv;
+    /// let val = env.var("NON_EXISTENT_VAR");
+    /// assert!(val.is_err());
+    /// ```
+    ///
     /// # Errors
+    ///
     /// Returns [`std::env::VarError`] if the variable is not present or is not valid Unicode.
     fn var(&self, key: &str) -> Result<String, std::env::VarError>;
 }

--- a/autumn/src/probe.rs
+++ b/autumn/src/probe.rs
@@ -15,17 +15,57 @@ use axum::response::IntoResponse;
 use serde::Serialize;
 
 /// Trait to abstract the state requirements for probe handlers.
+///
+/// Implement this trait on your application's state type to provide
+/// the necessary dependencies for health/liveness probes.
+/// This prevents tight coupling between probe handlers and the specific `AppState`.
 pub trait ProvideProbeState {
+    /// Returns a reference to the shared [`ProbeState`] that tracks
+    /// lifecycle phases (startup, ready, draining).
     fn probes(&self) -> &ProbeState;
+
+    /// Returns whether detailed health information (e.g., uptime, pool stats)
+    /// should be included in the response.
     fn health_detailed(&self) -> bool;
+
+    /// Returns the currently active execution profile (e.g. "dev", "prod").
     fn profile(&self) -> &str;
+
+    /// Returns a human-readable string displaying how long the application
+    /// has been running (e.g., "2d 4h 13m").
     fn uptime_display(&self) -> String;
 
+    /// Returns an optional reference to the database connection pool,
+    /// used to evaluate database connectivity during a readiness check.
     #[cfg(feature = "db")]
     fn pool(
         &self,
     ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>;
 
+    /// Helper method to mark the application startup as complete.
+    ///
+    /// Delegates to [`ProbeState::mark_startup_complete`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use autumn_web::probe::{ProvideProbeState, ProbeState};
+    ///
+    /// struct MyState { probes: ProbeState }
+    /// impl ProvideProbeState for MyState {
+    ///     fn probes(&self) -> &ProbeState { &self.probes }
+    ///     fn health_detailed(&self) -> bool { false }
+    ///     fn profile(&self) -> &str { "dev" }
+    ///     fn uptime_display(&self) -> String { String::new() }
+    ///     #[cfg(feature = "db")]
+    ///     fn pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>> { None }
+    /// }
+    ///
+    /// let state = MyState { probes: ProbeState::pending_startup() };
+    /// assert!(!state.probes().is_startup_complete());
+    /// state.mark_startup_complete();
+    /// assert!(state.probes().is_startup_complete());
+    /// ```
     fn mark_startup_complete(&self) {
         self.probes().mark_startup_complete();
     }

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -129,26 +129,35 @@ impl TestApp {
         }
     }
 
-    /// Register routes with the test application.
+    /// Merge a router into the internal application state.
     ///
-    /// Can be called multiple times -- routes are combined additively.
+    /// This is useful when testing modular route definitions without building
+    /// the full application.
     #[must_use]
     pub fn merge(mut self, router: axum::Router<crate::state::AppState>) -> Self {
         self.merge_routers.push(router);
         self
     }
 
+    /// Nest a router under a specific path prefix for testing.
+    ///
+    /// This is useful for testing sub-applications or API versions.
     #[must_use]
     pub fn nest(mut self, path: &str, router: axum::Router<crate::state::AppState>) -> Self {
         self.nest_routers.push((path.to_owned(), router));
         self
     }
 
+    /// Construct a [`TestClient`] directly from an `axum::Router`.
+    ///
+    /// Useful for bypassing `TestApp` builder if you just want to write requests
+    /// against a standard axum Router.
     #[must_use]
     pub const fn from_router(router: axum::Router) -> TestClient {
         TestClient { router }
     }
 
+    /// Register a collection of routes to be built into the `TestApp`.
     #[must_use]
     pub fn routes(mut self, routes: Vec<Route>) -> Self {
         self.routes.extend(routes);
@@ -258,11 +267,13 @@ pub struct TestClient {
 }
 
 impl TestClient {
-    /// Start building a GET request.
+    /// Unwrap the underlying [`axum::Router`] out of the [`TestClient`].
     pub fn into_router(self) -> axum::Router {
         self.router
     }
 
+    /// Start building a GET request.
+    #[must_use]
     pub fn get(&self, uri: &str) -> RequestBuilder {
         RequestBuilder::new(self.router.clone(), Method::GET, uri)
     }


### PR DESCRIPTION
📖 Chapter: Added docs to missing items in `actuator.rs`, `test.rs`, `config.rs`, and `probe.rs`.
🔦 Insight: Removed clippy `missing_docs` warnings from the codebase and `must_use` double warning. Added helpful explanation to internal traits like `ProvideActuatorState` and `ProvideProbeState`.
🧪 Example: Added an example block to `Env::var` and `ProvideProbeState::mark_startup_complete`.
🖼️ Preview: All `missing_docs` are removed and formatting passes tests properly.

---
*PR created automatically by Jules for task [7956471837338211676](https://jules.google.com/task/7956471837338211676) started by @madmax983*