### PR TITLE
🧪 Sentinel: test coverage for signals

### DIFF
--- a/autumn-harvest/autumn-harvest/tests/signal_tests.rs
+++ b/autumn-harvest/autumn-harvest/tests/signal_tests.rs
@@ -1,0 +1,141 @@
+#![cfg(feature = "db")]
+
+use autumn_harvest::signal::{load_pending_signals, mark_signals_consumed, send_signal};
+use autumn_harvest::types::ExecutionId;
+use diesel_async::RunQueryDsl;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+const INIT_SQL: &str = include_str!("../migrations/20260409000000_harvest_initial/up.sql");
+
+async fn setup_test_db() -> (
+    diesel_async::AsyncPgConnection,
+    testcontainers::ContainerAsync<Postgres>,
+) {
+    let container = Postgres::default()
+        .with_init_sql(INIT_SQL.to_string().into_bytes())
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let database_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let conn = <diesel_async::AsyncPgConnection as diesel_async::AsyncConnection>::establish(
+        &database_url,
+    )
+    .await
+    .expect("failed to connect to Postgres container");
+
+    (conn, container)
+}
+
+#[tokio::test]
+async fn test_send_and_load_signals() {
+    let (mut conn, _container) = setup_test_db().await;
+    let exec_id = ExecutionId::new();
+
+    // Create workflow execution first (FK constraint)
+    use autumn_harvest::models::NewWorkflowExecution;
+    use autumn_harvest::schema::harvest_workflow_executions;
+    let new_exec = NewWorkflowExecution {
+        id: exec_id.as_uuid(),
+        workflow_name: "test_workflow",
+        workflow_id: "test_id",
+        run_id: exec_id.as_uuid(),
+        shard_id: 0,
+        input: serde_json::json!({}),
+        parent_id: None,
+        queue_name: "default",
+        execution_timeout: None,
+        memo: None,
+        search_attrs: None,
+    };
+    diesel::insert_into(harvest_workflow_executions::table)
+        .values(&new_exec)
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    // Load initial - should be empty
+    let signals = load_pending_signals(&mut conn, exec_id).await.unwrap();
+    assert!(signals.is_empty());
+
+    // Send a signal
+    let payload = serde_json::json!({"key": "value"});
+    send_signal(&mut conn, exec_id, "test_signal", payload.clone())
+        .await
+        .unwrap();
+
+    // Load again
+    let signals = load_pending_signals(&mut conn, exec_id).await.unwrap();
+    assert_eq!(signals.len(), 1);
+    assert_eq!(signals[0].signal_name, "test_signal");
+    assert_eq!(signals[0].payload, payload);
+    assert!(!signals[0].consumed);
+}
+
+#[tokio::test]
+async fn test_mark_signals_consumed() {
+    let (mut conn, _container) = setup_test_db().await;
+    let exec_id = ExecutionId::new();
+
+    // Create workflow execution
+    use autumn_harvest::models::NewWorkflowExecution;
+    use autumn_harvest::schema::harvest_workflow_executions;
+    let new_exec = NewWorkflowExecution {
+        id: exec_id.as_uuid(),
+        workflow_name: "test_workflow",
+        workflow_id: "test_id",
+        run_id: exec_id.as_uuid(),
+        shard_id: 0,
+        input: serde_json::json!({}),
+        parent_id: None,
+        queue_name: "default",
+        execution_timeout: None,
+        memo: None,
+        search_attrs: None,
+    };
+    diesel::insert_into(harvest_workflow_executions::table)
+        .values(&new_exec)
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    // Send signals
+    send_signal(&mut conn, exec_id, "sig1", serde_json::json!(1))
+        .await
+        .unwrap();
+    send_signal(&mut conn, exec_id, "sig2", serde_json::json!(2))
+        .await
+        .unwrap();
+
+    let signals = load_pending_signals(&mut conn, exec_id).await.unwrap();
+    assert_eq!(signals.len(), 2);
+
+    // Mark first signal consumed
+    let ids_to_mark = vec![signals[0].id];
+    mark_signals_consumed(&mut conn, &ids_to_mark)
+        .await
+        .unwrap();
+
+    // Load again
+    let pending_signals = load_pending_signals(&mut conn, exec_id).await.unwrap();
+    assert_eq!(pending_signals.len(), 1);
+    assert_eq!(pending_signals[0].id, signals[1].id);
+    assert_eq!(pending_signals[0].signal_name, "sig2");
+
+    let ids_to_mark = vec![];
+    mark_signals_consumed(&mut conn, &ids_to_mark)
+        .await
+        .unwrap(); // Empty list test
+    let pending_signals = load_pending_signals(&mut conn, exec_id).await.unwrap();
+    assert_eq!(pending_signals.len(), 1);
+}

--- a/autumn-harvest/autumn-harvest/tests/signal_tests.rs
+++ b/autumn-harvest/autumn-harvest/tests/signal_tests.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "db")]
 
+use autumn_harvest::models::NewWorkflowExecution;
+use autumn_harvest::schema::harvest_workflow_executions;
 use autumn_harvest::signal::{load_pending_signals, mark_signals_consumed, send_signal};
 use autumn_harvest::types::ExecutionId;
 use diesel_async::RunQueryDsl;
@@ -43,8 +45,6 @@ async fn test_send_and_load_signals() {
     let exec_id = ExecutionId::new();
 
     // Create workflow execution first (FK constraint)
-    use autumn_harvest::models::NewWorkflowExecution;
-    use autumn_harvest::schema::harvest_workflow_executions;
     let new_exec = NewWorkflowExecution {
         id: exec_id.as_uuid(),
         workflow_name: "test_workflow",
@@ -88,8 +88,6 @@ async fn test_mark_signals_consumed() {
     let exec_id = ExecutionId::new();
 
     // Create workflow execution
-    use autumn_harvest::models::NewWorkflowExecution;
-    use autumn_harvest::schema::harvest_workflow_executions;
     let new_exec = NewWorkflowExecution {
         id: exec_id.as_uuid(),
         workflow_name: "test_workflow",

--- a/fix_clippy.sh
+++ b/fix_clippy.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-sed -i '/use autumn_harvest::models::NewWorkflowExecution;/d' autumn-harvest/autumn-harvest/tests/signal_tests.rs
-sed -i '/use autumn_harvest::schema::harvest_workflow_executions;/d' autumn-harvest/autumn-harvest/tests/signal_tests.rs
-sed -i '3i use autumn_harvest::models::NewWorkflowExecution;\nuse autumn_harvest::schema::harvest_workflow_executions;' autumn-harvest/autumn-harvest/tests/signal_tests.rs

--- a/fix_clippy.sh
+++ b/fix_clippy.sh
@@ -1,11 +1,4 @@
-# Oh! Because the module itself is `pub(crate)`, clippy complains if items inside it are `pub(crate)`.
-# We should change `pub(crate)` inside those modules to `pub`.
-sed -i 's/pub(crate) fn/pub fn/g' autumn/src/router.rs
-sed -i 's/pub(crate) struct/pub struct/g' autumn/src/router.rs
-sed -i 's/pub(crate) async fn/pub async fn/g' autumn/src/router.rs
-
-sed -i 's/pub(crate) fn/pub fn/g' autumn/src/logging.rs
-sed -i 's/pub(crate) struct/pub struct/g' autumn/src/logging.rs
-sed -i 's/pub(crate) async fn/pub async fn/g' autumn/src/logging.rs
-
-sed -i 's/FeatureDisabled,/#[allow(dead_code)]\n    FeatureDisabled,/g' autumn/src/telemetry.rs
+#!/bin/bash
+sed -i '/use autumn_harvest::models::NewWorkflowExecution;/d' autumn-harvest/autumn-harvest/tests/signal_tests.rs
+sed -i '/use autumn_harvest::schema::harvest_workflow_executions;/d' autumn-harvest/autumn-harvest/tests/signal_tests.rs
+sed -i '3i use autumn_harvest::models::NewWorkflowExecution;\nuse autumn_harvest::schema::harvest_workflow_executions;' autumn-harvest/autumn-harvest/tests/signal_tests.rs

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,8 +1,0 @@
-🧪 Sentinel: test coverage for signals
-
-🎯 **What:** The `autumn-harvest` module `signal.rs` completely lacked any tests for `send_signal`, `load_pending_signals`, and `mark_signals_consumed`. A test file `signal_tests.rs` has been created.
-📊 **Coverage:** E2E DB integration test added using `testcontainers`. Covers:
-1. Signal queuing (`send_signal`) via foreign-keyed execution ID constraints.
-2. Signal fetching (`load_pending_signals`) and state assertions.
-3. Consumed marking (`mark_signals_consumed`) testing visibility scope.
-✨ **Result:** Test coverage for `signal.rs` endpoints. All test logic was modeled via the `integration_e2e.rs` template ensuring full end-to-end integration matching production paths.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,8 @@
+🧪 Sentinel: test coverage for signals
+
+🎯 **What:** The `autumn-harvest` module `signal.rs` completely lacked any tests for `send_signal`, `load_pending_signals`, and `mark_signals_consumed`. A test file `signal_tests.rs` has been created.
+📊 **Coverage:** E2E DB integration test added using `testcontainers`. Covers:
+1. Signal queuing (`send_signal`) via foreign-keyed execution ID constraints.
+2. Signal fetching (`load_pending_signals`) and state assertions.
+3. Consumed marking (`mark_signals_consumed`) testing visibility scope.
+✨ **Result:** Test coverage for `signal.rs` endpoints. All test logic was modeled via the `integration_e2e.rs` template ensuring full end-to-end integration matching production paths.


### PR DESCRIPTION
🎯 **What:** The `autumn-harvest` module `signal.rs` completely lacked any tests for `send_signal`, `load_pending_signals`, and `mark_signals_consumed`. A test file `signal_tests.rs` has been created.
📊 **Coverage:** E2E DB integration test added using `testcontainers`. Covers:
1. Signal queuing (`send_signal`) via foreign-keyed execution ID constraints.
2. Signal fetching (`load_pending_signals`) and state assertions.
3. Consumed marking (`mark_signals_consumed`) testing visibility scope.
✨ **Result:** Test coverage for `signal.rs` endpoints. All test logic was modeled via the `integration_e2e.rs` template ensuring full end-to-end integration matching production paths.

---
*PR created automatically by Jules for task [15141817745404882103](https://jules.google.com/task/15141817745404882103) started by @madmax983*