### PR TITLE
🔒 Warden: tighten Auth DoS test assertion

### DIFF
--- a/autumn/tests/security/auth_dos.rs
+++ b/autumn/tests/security/auth_dos.rs
@@ -74,7 +74,7 @@ async fn eris_auth_dos_poc() {
     // A true DoS (blocking workers) would make this take 30+ seconds,
     // while the non-blocking implementation allows the ping to respond immediately.
     assert!(
-        ping_duration < Duration::from_secs(5),
+        ping_duration < Duration::from_millis(250),
         "Ping took too long ({ping_duration:?}), indicating a Denial of Service via blocked worker threads!"
     );
 


### PR DESCRIPTION
🎯 What
Updates the `eris_auth_dos_poc` test assertion.

⚠️ Risk
None.

🛡️ Solution
Lowered the threshold from 5s to 250ms to properly prove the Auth DoS fix allows fast non-blocking responses without causing CI flakiness.

---
*PR created automatically by Jules for task [12210446937699184637](https://jules.google.com/task/12210446937699184637) started by @madmax983*