### PR TITLE
👺 Havoc: Fix active requests leak when metrics future is dropped

### DIFF
--- a/autumn/src/middleware/metrics.rs
+++ b/autumn/src/middleware/metrics.rs
@@ -377,6 +377,7 @@ where
 }
 
 pin_project! {
+    #[project = MetricsFutureProj]
     /// Future that records metrics after the inner service completes.
     pub struct MetricsFuture<F> {
         #[pin]
@@ -385,6 +386,14 @@ pin_project! {
         method: axum::http::Method,
         route: Option<MatchedPath>,
         start: Instant,
+    }
+    impl<F> PinnedDrop for MetricsFuture<F> {
+        fn drop(this: Pin<&mut Self>) {
+            let this = this.project();
+            if let Some(collector) = this.collector.take() {
+                collector.decrement_active();
+            }
+        }
     }
 }
 

--- a/autumn/tests/chaos_metrics_leak.rs
+++ b/autumn/tests/chaos_metrics_leak.rs
@@ -1,0 +1,48 @@
+use autumn_web::middleware::{MetricsCollector, MetricsLayer};
+use axum::body::Body;
+use axum::http::Request;
+use std::task::{Context, Poll};
+use tower::{Layer, Service, ServiceExt};
+
+#[derive(Clone)]
+struct PendingService;
+
+impl Service<Request<Body>> for PendingService {
+    type Response = axum::http::Response<Body>;
+    type Error = std::io::Error;
+    type Future = std::future::Pending<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: Request<Body>) -> Self::Future {
+        std::future::pending()
+    }
+}
+
+#[tokio::test]
+async fn metrics_layer_leaks_active_on_drop() {
+    let collector = MetricsCollector::new();
+    let svc = MetricsLayer::new(collector.clone()).layer(PendingService);
+
+    assert_eq!(collector.snapshot().http.requests_active, 0);
+
+    let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+    let mut svc_clone = svc.clone();
+    let fut = svc_clone.ready().await.unwrap().call(req);
+
+    // Now active count is 1
+    assert_eq!(collector.snapshot().http.requests_active, 1);
+
+    // Drop the future (simulate client disconnect or timeout)
+    drop(fut);
+
+    // If it's correct, active count should go back to 0.
+    // If it's 1, we found a bug!
+    assert_eq!(
+        collector.snapshot().http.requests_active,
+        0,
+        "Memory leak found! requests_active did not decrement on drop."
+    );
+}

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,4 +1,7 @@
-🧨 **The Trigger:** A client disconnects or times out before the `MetricsFuture` resolves to completion.
-📉 **The Stack Trace:** N/A (Memory/resource leak instead of a panic). The `requests_active` metric continues to increment indefinitely, leading to permanently skewed active connection tracking.
-🧪 **Reproduction:** Run `cargo test --test chaos_metrics_leak -p autumn-web`. The test simulates a dropped future, revealing the counter stays stuck at 1 instead of decrementing.
+🛡️ Sentry: [test coverage improvement]
+
+🎯 **Target**: Tested `fallback_404_handler` function in `autumn/src/middleware/error_page_filter.rs`.
+💣 **Risk**: This function lacked any tests. If someone unknowingly modifies it, it could break our error handling capabilities and routing failovers.
+🧪 **Strategy**: Added the `fallback_404_handler_creates_correct_error` test that invokes the handler with an unmatched URI and asserts the correct properties in the return value (correct status and message).
+🔬 **Verification**: Ran `cargo test -p autumn-web --lib middleware::error_page_filter` directly testing the modified suite to ensure success.er stays stuck at 1 instead of decrementing.
 😈 **Comment:** You assumed every future runs to completion. You were wrong. Dropped futures left active requests dangling forever.

--- a/pr_description.md
+++ b/pr_description.md
@@ -4,4 +4,3 @@
 💣 **Risk**: This function lacked any tests. If someone unknowingly modifies it, it could break our error handling capabilities and routing failovers.
 🧪 **Strategy**: Added the `fallback_404_handler_creates_correct_error` test that invokes the handler with an unmatched URI and asserts the correct properties in the return value (correct status and message).
 🔬 **Verification**: Ran `cargo test -p autumn-web --lib middleware::error_page_filter` directly testing the modified suite to ensure success.er stays stuck at 1 instead of decrementing.
-😈 **Comment:** You assumed every future runs to completion. You were wrong. Dropped futures left active requests dangling forever.

--- a/pr_description.md
+++ b/pr_description.md
@@ -3,4 +3,4 @@
 🎯 **Target**: Tested `fallback_404_handler` function in `autumn/src/middleware/error_page_filter.rs`.
 💣 **Risk**: This function lacked any tests. If someone unknowingly modifies it, it could break our error handling capabilities and routing failovers.
 🧪 **Strategy**: Added the `fallback_404_handler_creates_correct_error` test that invokes the handler with an unmatched URI and asserts the correct properties in the return value (correct status and message).
-🔬 **Verification**: Ran `cargo test -p autumn-web --lib middleware::error_page_filter` directly testing the modified suite to ensure success.er stays stuck at 1 instead of decrementing.
+🔬 **Verification**: Ran `cargo test -p autumn-web --lib middleware::error_page_filter` directly testing the modified suite to ensure success.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,6 +1,4 @@
-🛡️ Sentry: [test coverage improvement]
-
-🎯 **Target**: Tested `fallback_404_handler` function in `autumn/src/middleware/error_page_filter.rs`.
-💣 **Risk**: This function lacked any tests. If someone unknowingly modifies it, it could break our error handling capabilities and routing failovers.
-🧪 **Strategy**: Added the `fallback_404_handler_creates_correct_error` test that invokes the handler with an unmatched URI and asserts the correct properties in the return value (correct status and message).
-🔬 **Verification**: Ran `cargo test -p autumn-web --lib middleware::error_page_filter` directly testing the modified suite to ensure success.
+🧨 **The Trigger:** A client disconnects or times out before the `MetricsFuture` resolves to completion.
+📉 **The Stack Trace:** N/A (Memory/resource leak instead of a panic). The `requests_active` metric continues to increment indefinitely, leading to permanently skewed active connection tracking.
+🧪 **Reproduction:** Run `cargo test --test chaos_metrics_leak -p autumn-web`. The test simulates a dropped future, revealing the counter stays stuck at 1 instead of decrementing.
+😈 **Comment:** You assumed every future runs to completion. You were wrong. Dropped futures left active requests dangling forever.


### PR DESCRIPTION
🧨 **The Trigger:** A client disconnects or times out before the `MetricsFuture` resolves to completion.
📉 **The Stack Trace:** N/A (Memory/resource leak instead of a panic). The `requests_active` metric continues to increment indefinitely, leading to permanently skewed active connection tracking.
🧪 **Reproduction:** Run `cargo test --test chaos_metrics_leak -p autumn-web`. The test simulates a dropped future, revealing the counter stays stuck at 1 instead of decrementing.
😈 **Comment:** You assumed every future runs to completion. You were wrong. Dropped futures left active requests dangling forever.

---
*PR created automatically by Jules for task [15987486639456934168](https://jules.google.com/task/15987486639456934168) started by @madmax983*