### PR TITLE
🤖 Sentinel: Fix chaos channels panic test

### DIFF
--- a/autumn/tests/chaos_channels_proptest.rs
+++ b/autumn/tests/chaos_channels_proptest.rs
@@ -9,16 +9,24 @@ proptest! {
         let channels = Channels::new(capacity);
 
         // This should never panic on any capacity (see explicit zero test)
-        let _tx = channels.sender("test_channel");
+        let tx = channels.sender("test_channel");
         let _rx = channels.subscribe("test_channel");
+        prop_assert!(tx.send("test").is_ok());
     }
 }
 
-#[test]
-fn test_channels_zero_capacity_regression() {
+#[tokio::test]
+async fn test_channels_zero_capacity_regression() -> Result<(), Box<dyn std::error::Error>> {
     let channels = Channels::new(0);
 
     // This should never panic even if capacity is 0 (which was the bug)
-    let _tx = channels.sender("test_channel");
-    let _rx = channels.subscribe("test_channel");
+    let tx = channels.sender("test_channel");
+    let mut rx = channels.subscribe("test_channel");
+
+    // We shouldn't use expect/unwrap in tests
+    tx.send("test_message")?;
+    let msg = rx.recv().await?;
+    assert_eq!(msg.as_str(), "test_message");
+
+    Ok(())
 }

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,17 @@
+🤖 Sentinel: [fix chaos channels panic test]
+
+🦠 **Mutants Found:**
+The `test_channels_zero_capacity_regression` previously did not send or receive any messages. This allowed bugs where channel operations could panic or fail under a 0-capacity setup to easily go undetected since only channel creation was exercised.
+
+🎯 **Tests Added/Strengthened:**
+* Updated `test_channels_zero_capacity_regression` to fully test sending and receiving messages.
+* Updated `test_channels_capacity_fuzzing` to assert that message sending successfully works and does not panic on any fuzzed capacity.
+
+⚠️ **Suspected Bugs:**
+Operations on 0-capacity (or other unexpected capacities) could panic at runtime because the tests were only validating channel initialization and not the actual send/receive operations.
+
+📊 **Kill Rate:**
+High. The tests now verify the entire flow of `Channels` logic on edge capacities rather than just initialization.
+
+🔗 **Havoc Interaction:**
+These changes were needed to secure regression tests against edge cases exposed during concurrency/chaos evaluations.


### PR DESCRIPTION
🤖 Sentinel: [fix chaos channels panic test]

🦠 **Mutants Found:**
The `test_channels_zero_capacity_regression` previously did not send or receive any messages. This allowed bugs where channel operations could panic or fail under a 0-capacity setup to easily go undetected since only channel creation was exercised.

🎯 **Tests Added/Strengthened:**
* Updated `test_channels_zero_capacity_regression` to fully test sending and receiving messages.
* Updated `test_channels_capacity_fuzzing` to assert that message sending successfully works and does not panic on any fuzzed capacity.

⚠️ **Suspected Bugs:**
Operations on 0-capacity (or other unexpected capacities) could panic at runtime because the tests were only validating channel initialization and not the actual send/receive operations.

📊 **Kill Rate:**
High. The tests now verify the entire flow of `Channels` logic on edge capacities rather than just initialization.

🔗 **Havoc Interaction:**
These changes were needed to secure regression tests against edge cases exposed during concurrency/chaos evaluations.

---
*PR created automatically by Jules for task [10425139510727484758](https://jules.google.com/task/10425139510727484758) started by @madmax983*