### PR TITLE
🧹 Code Health: remove outdated clippy ignores on try_build_router_inner

### DIFF
--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -165,8 +165,6 @@ pub fn try_build_router_merged(
     ))
 }
 
-#[allow(clippy::cognitive_complexity)]
-#[allow(clippy::too_many_lines)]
 pub fn try_build_router_inner(
     route_list: Vec<Route>,
     config: &AutumnConfig,


### PR DESCRIPTION
🎯 **What:** Removed `#[allow(clippy::cognitive_complexity)]` and `#[allow(clippy::too_many_lines)]` attributes from `try_build_router_inner` in `autumn/src/router.rs`.

💡 **Why:** The code health issue originally cited "Overly Complex Router Assembly" and suggested extracting grouping and layer assembly. However, `try_build_router_inner` had *already* been refactored in a previous commit—arguments were grouped into a `RouterContext` struct, and the function's length and complexity were significantly reduced. Because the complexity was already flattened, the `#[allow]` attributes were masking clean code and could be safely removed without violating any `clippy` checks. Attempting to further refactor `apply_middleware` by extracting internal layers (like CORS and CSRF) was found to cause severe `cannot infer type` errors in downstream Axum integration tests due to the complexities of `Router` type inference when chained methods are split. Thus, the safe code health improvement was to remove the outdated ignore pragmas.

✅ **Verification:** Ran `cargo clippy -p autumn-web --all-targets --all-features -- -D warnings` and `cargo test -p autumn-web`. Both passed cleanly, proving that the function is no longer complex enough to trigger the lints and that behavior remains unchanged.

✨ **Result:** A cleaner codebase that properly respects `clippy` complexity checks for router assembly, removing outdated suppression pragmas.

---
*PR created automatically by Jules for task [16774969767627548331](https://jules.google.com/task/16774969767627548331) started by @madmax983*