### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -413,6 +413,26 @@ mod tests {
         assert!(!result.unwrap());
     }
 
+    #[tokio::test]
+    async fn verify_password_rejects_invalid_hash_format_safely() {
+        // Test short hash
+        let result = verify_password("test", "short").await;
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+
+        // Test hash with correct length but not starting with $
+        let bad_prefix = "a".repeat(60);
+        let result = verify_password("test", &bad_prefix).await;
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+
+        // Test hash with incorrect length but starting with $
+        let bad_length = "$2b$12$short";
+        let result = verify_password("test", bad_length).await;
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
+
     #[test]
     fn auth_config_defaults() {
         let config = AuthConfig::default();

--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -239,6 +239,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn hx_response_ext_ignores_invalid_header_values() {
+        use axum::response::IntoResponse;
+
+        // This value is invalid because it contains a newline character.
+        // It should be gracefully ignored by the append_hx_header function.
+        let invalid_header_value = "invalid\nvalue";
+
+        let response = "hello"
+            .hx_push_url(invalid_header_value)
+            .hx_redirect(invalid_header_value)
+            .hx_refresh() // valid by default
+            .hx_replace_url(invalid_header_value)
+            .hx_reswap(invalid_header_value)
+            .hx_retarget(invalid_header_value)
+            .hx_trigger(invalid_header_value)
+            .hx_trigger_after_settle(invalid_header_value)
+            .hx_trigger_after_swap(invalid_header_value)
+            .into_response();
+
+        let headers = response.headers();
+        assert!(headers.get("hx-push-url").is_none());
+        assert!(headers.get("hx-redirect").is_none());
+        // hx_refresh is always set to "true" internally, so it will be present
+        assert_eq!(headers.get("hx-refresh").unwrap(), "true");
+        assert!(headers.get("hx-replace-url").is_none());
+        assert!(headers.get("hx-reswap").is_none());
+        assert!(headers.get("hx-retarget").is_none());
+        assert!(headers.get("hx-trigger").is_none());
+        assert!(headers.get("hx-trigger-after-settle").is_none());
+        assert!(headers.get("hx-trigger-after-swap").is_none());
+    }
+
+    #[tokio::test]
     async fn hx_request_extractor_handles_missing_headers() -> Result<(), axum::http::Error> {
         let req = Request::builder().body(())?;
         let (mut parts, ()) = req.into_parts();


### PR DESCRIPTION
🎯 Target: `autumn::htmx::HxResponseExt` and `autumn::auth::verify_password`
💣 Risk: Invalid HTTP header values passed to `HxResponseExt` methods could be mishandled. Invalid format hashes could cause unnecessary processing.
🧪 Strategy: Added explicit tests checking that invalid header values containing newlines are gracefully ignored by the `append_hx_header` function as documented, without panicking. Added explicit tests for `verify_password` rejecting poorly formatted strings safely.
🔬 Verification: `cargo test -p autumn-web --lib htmx && cargo test -p autumn-web --lib auth`

---
*PR created automatically by Jules for task [15278564268263390968](https://jules.google.com/task/15278564268263390968) started by @madmax983*