### PR TITLE
🔒 Warden: Fix potential data exposure in mask_database_url fallback

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1235,8 +1235,12 @@ fn mask_database_url(url: &str, pool_size: usize) -> String {
             let _ = parsed_url.set_password(Some("****"));
             return format!("{parsed_url} (pool_size={pool_size})");
         }
+        return format!("{url} (pool_size={pool_size})");
     }
-    format!("{url} (pool_size={pool_size})")
+
+    // If the URL is malformed and fails to parse, safely redact the entire string
+    // to prevent any potential password leakage from partial/failed parsing.
+    format!("**** (pool_size={pool_size})")
 }
 
 /// Build the configuration summary string.
@@ -2315,6 +2319,16 @@ mod tests {
         assert!(!masked.contains("****"));
         assert!(masked.contains("postgres://localhost/mydb"));
         assert!(masked.contains("pool_size=5"));
+    }
+
+    #[test]
+    fn mask_database_url_invalid_url_fallback() {
+        // Malformed URL that fails `url::Url::parse` but contains a password
+        let invalid = "postgres://user:my_secret_password@local host:5432/mydb";
+        let masked = mask_database_url(invalid, 10);
+        assert!(masked.contains("****"));
+        assert!(!masked.contains("my_secret_password"));
+        assert!(masked.contains("**** (pool_size=10)"));
     }
 
     #[test]

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,17 +1,13 @@
-🤖 Sentinel: [fix chaos channels panic test]
+🔒 Warden: [Fix potential data exposure in mask_database_url fallback]
 
-🦠 **Mutants Found:**
-The `test_channels_zero_capacity_regression` previously did not send or receive any messages. This allowed bugs where channel operations could panic or fail under a 0-capacity setup to easily go undetected since only channel creation was exercised.
+🦠 **Threat:**
+The `mask_database_url` function parses database URLs using the `url` crate to securely redact passwords before logging. However, if an attacker or misconfiguration provides a malformed URL (e.g., one containing spaces or invalid characters) that still contains a password, `url::Url::parse` will fail. The previous implementation fell back to logging the unparsed, raw URL string, exposing the password in plaintext logs.
 
-🎯 **Tests Added/Strengthened:**
-* Updated `test_channels_zero_capacity_regression` to fully test sending and receiving messages.
-* Updated `test_channels_capacity_fuzzing` to assert that message sending successfully works and does not panic on any fuzzed capacity.
+🛡️ **Defense:**
+Updated the fallback logic in `mask_database_url`. If `url::Url::parse` fails, the function now safely redacts the entire URL string (`"****"`). This ensures a "fail-closed" mechanism, preventing any sensitive information from leaking into the logs when the parser encounters malformed input. Valid URLs without passwords remain unaffected and are logged naturally.
 
-⚠️ **Suspected Bugs:**
-Operations on 0-capacity (or other unexpected capacities) could panic at runtime because the tests were only validating channel initialization and not the actual send/receive operations.
+💥 **Severity:**
+High. Exposure of database credentials in logs can lead to unauthorized database access, data breaches, and system compromise.
 
-📊 **Kill Rate:**
-High. The tests now verify the entire flow of `Channels` logic on edge capacities rather than just initialization.
-
-🔗 **Havoc Interaction:**
-These changes were needed to secure regression tests against edge cases exposed during concurrency/chaos evaluations.
+🧪 **Verification:**
+Added the unit test `mask_database_url_invalid_url_fallback` in `autumn/src/app.rs` to verify that malformed URLs containing a password are fully redacted and do not expose the password. Verified that `cargo test`, `cargo clippy`, and `cargo fmt` pass successfully.


### PR DESCRIPTION
🔒 Warden: [Fix potential data exposure in mask_database_url fallback]

🦠 **Threat:**
The `mask_database_url` function parses database URLs using the `url` crate to securely redact passwords before logging. However, if an attacker or misconfiguration provides a malformed URL (e.g., one containing spaces or invalid characters) that still contains a password, `url::Url::parse` will fail. The previous implementation fell back to logging the unparsed, raw URL string, exposing the password in plaintext logs.

🛡️ **Defense:**
Updated the fallback logic in `mask_database_url`. If `url::Url::parse` fails, the function now safely redacts the entire URL string (`"****"`). This ensures a "fail-closed" mechanism, preventing any sensitive information from leaking into the logs when the parser encounters malformed input. Valid URLs without passwords remain unaffected and are logged naturally.

💥 **Severity:**
High. Exposure of database credentials in logs can lead to unauthorized database access, data breaches, and system compromise.

🧪 **Verification:**
Added the unit test `mask_database_url_invalid_url_fallback` in `autumn/src/app.rs` to verify that malformed URLs containing a password are fully redacted and do not expose the password. Verified that `cargo test`, `cargo clippy`, and `cargo fmt` pass successfully.

---
*PR created automatically by Jules for task [2737016822847162923](https://jules.google.com/task/2737016822847162923) started by @madmax983*