### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -577,4 +577,22 @@ mod tests {
         assert_eq!(error.status(), StatusCode::NOT_FOUND);
         assert_eq!(error.to_string(), "No route matches /some/unknown/path");
     }
+
+    #[tokio::test]
+    async fn fallback_404_handler_ignores_query_params() {
+        let uri = axum::http::Uri::from_static("/search?q=rust&sort=desc");
+        let error = fallback_404_handler(uri).await;
+
+        assert_eq!(error.status(), StatusCode::NOT_FOUND);
+        assert_eq!(error.to_string(), "No route matches /search");
+    }
+
+    #[tokio::test]
+    async fn fallback_404_handler_with_root_path() {
+        let uri = axum::http::Uri::from_static("/");
+        let error = fallback_404_handler(uri).await;
+
+        assert_eq!(error.status(), StatusCode::NOT_FOUND);
+        assert_eq!(error.to_string(), "No route matches /");
+    }
 }


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 Target
- `fallback_404_handler` in `autumn/src/middleware/error_page_filter.rs`
- Add coverage for the exception filter layer fallback 404 handler, specifically targeting edge cases with the root path and query parameters to ensure `uri.path()` logic functions safely.

💣 Risk
- Unhandled missing edge cases (e.g. ignoring query parameters on the 404 URL or the root path rendering) could result in improperly constructed error URLs for exceptions, resulting in leaking URL queries into error pages or mismatching URLs entirely.

🧪 Strategy
- Appended two deterministic tokio asynchronous tests `fallback_404_handler_ignores_query_params` and `fallback_404_handler_with_root_path`.
- The tests verify that `fallback_404_handler` uses `uri.path()` instead of the full URI and cleanly converts the un-matched Axum `Uri` struct into an `AutumnError` returning a correct NOT_FOUND status code.

🔭 Verification
- The local tests run clean and pass: `cargo test -p autumn-web --all-features -- error_page_filter`.

---
*PR created automatically by Jules for task [9219001399293081837](https://jules.google.com/task/9219001399293081837) started by @madmax983*