### PR TITLE
🧹 [Fix unused mut warning in metrics endpoint]

### DIFF
--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1407,6 +1407,41 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
+    #[tokio::test]
+    #[cfg(feature = "db")]
+    async fn actuator_metrics_returns_db_stats_when_pool_present() {
+        use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+        use diesel_async::pooled_connection::deadpool::Pool;
+        use diesel_async::AsyncPgConnection;
+
+        let mut state = test_state();
+
+        let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new("postgres://postgres:postgres@localhost:5432/postgres");
+        let pool = Pool::builder(manager).build().unwrap();
+
+        state.pool = Some(pool);
+
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert!(json.get("database").is_some());
+    }
+
+
     // ── Config properties endpoint tests ───────────────────────
 
     #[tokio::test]

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1410,13 +1410,15 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "db")]
     async fn actuator_metrics_returns_db_stats_when_pool_present() {
+        use diesel_async::AsyncPgConnection;
         use diesel_async::pooled_connection::AsyncDieselConnectionManager;
         use diesel_async::pooled_connection::deadpool::Pool;
-        use diesel_async::AsyncPgConnection;
 
         let mut state = test_state();
 
-        let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new("postgres://postgres:postgres@localhost:5432/postgres");
+        let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(
+            "postgres://postgres:postgres@localhost:5432/postgres",
+        );
         let pool = Pool::builder(manager).build().unwrap();
 
         state.pool = Some(pool);
@@ -1440,7 +1442,6 @@ mod tests {
 
         assert!(json.get("database").is_some());
     }
-
 
     // ── Config properties endpoint tests ───────────────────────
 

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -799,26 +799,29 @@ pub(crate) async fn env_endpoint<S: ProvideActuatorState + Send + Sync + 'static
 // ── Metrics ────────────────────────────────────────────────────
 
 /// `GET <actuator-prefix>/metrics` -- request metrics, latency, status codes, DB pool stats.
-#[allow(unused_variables, unused_mut)]
 pub(crate) async fn metrics_endpoint<S: ProvideActuatorState + Send + Sync + 'static>(
     State(state): State<S>,
 ) -> Json<serde_json::Value> {
     let snapshot = state.metrics().snapshot();
-    let mut result = serde_json::to_value(&snapshot).unwrap_or_default();
+    let result = serde_json::to_value(&snapshot).unwrap_or_default();
 
     // Include DB pool stats if available
     #[cfg(feature = "db")]
-    if let Some(pool) = state.pool() {
-        let status = pool.status();
-        let db_stats = serde_json::json!({
-            "pool_size": status.max_size,
-            "active_connections": (status.max_size as u64).saturating_sub(status.available as u64),
-            "idle_connections": status.available,
-        });
-        if let serde_json::Value::Object(ref mut map) = result {
-            map.insert("database".to_string(), db_stats);
+    let result = {
+        let mut result = result;
+        if let Some(pool) = state.pool() {
+            let status = pool.status();
+            let db_stats = serde_json::json!({
+                "pool_size": status.max_size,
+                "active_connections": (status.max_size as u64).saturating_sub(status.available as u64),
+                "idle_connections": status.available,
+            });
+            if let serde_json::Value::Object(ref mut map) = result {
+                map.insert("database".to_string(), db_stats);
+            }
         }
-    }
+        result
+    };
 
     Json(result)
 }


### PR DESCRIPTION
🧹 [Fix unused mut warning in metrics endpoint]

🎯 **What:** Removed the `#[allow(unused_variables, unused_mut)]` attribute from the `metrics_endpoint` in `autumn/src/actuator.rs` and refined the mutability scope of the `result` variable.

💡 **Why:** By conditionally assigning and mutating the `result` variable within an explicit `#[cfg(feature = "db")]` block, we avoid unnecessary mutability when the database feature is disabled, and accurately represent the requirement of the variable.

✅ **Verification:** Verified by running `cargo check --all-targets --all-features` and `cargo check --all-targets --no-default-features`, confirming compilation with and without the `db` feature, alongside test executions on `actuator` module. Also verified via the `request_code_review` tool.

✨ **Result:** Improved compilation cleanliness with safer variable binding, preventing an unnecessary compiler bypass attribute.

---
*PR created automatically by Jules for task [2825778604099031720](https://jules.google.com/task/2825778604099031720) started by @madmax983*