### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn-harvest/autumn-harvest/src/dag.rs
+++ b/autumn-harvest/autumn-harvest/src/dag.rs
@@ -408,4 +408,76 @@ mod tests {
         let err = DagBuildError::CycleDetected;
         assert_eq!(err.to_string(), "dag contains a dependency cycle");
     }
+
+    #[test]
+    fn should_deduplicate_identical_upstream_dependencies() {
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+        // Upstream added twice
+        let _b = builder.activity(dummy_activity2).upstream(&a).upstream(&a);
+
+        let dag = builder.build().unwrap();
+        let tasks = dag.tasks();
+
+        // b's upstreams should only contain a once
+        assert_eq!(tasks[1].upstreams, vec![0]);
+    }
+
+    #[test]
+    fn should_process_disjoint_subgraphs() {
+        let mut builder = DagBuilder::new();
+
+        // Subgraph 1
+        let a = builder.activity(dummy_activity);
+        let _b = builder.activity(dummy_activity2).upstream(&a);
+
+        // Subgraph 2
+        let c = builder.activity(dummy_activity3);
+        let _d = builder.activity(dummy_activity).upstream(&c);
+
+        let dag = builder.build().unwrap();
+        let levels = dag.execution_levels();
+
+        // Level 0: [a, c]
+        // Level 1: [b, d]
+        assert_eq!(levels.len(), 2);
+        assert_eq!(levels[0], vec![0, 2]); // a, c
+        assert_eq!(levels[1], vec![1, 3]); // b, d
+    }
+
+    #[test]
+    fn should_override_default_queue() {
+        let mut builder = DagBuilder::with_default_queue("default-queue");
+
+        let _a = builder.activity(dummy_activity);
+        let _b = builder.activity(dummy_activity2).queue("custom-queue");
+
+        let dag = builder.build().unwrap();
+        let tasks = dag.tasks();
+
+        assert_eq!(tasks[0].queue.as_deref(), Some("default-queue"));
+        assert_eq!(tasks[1].queue.as_deref(), Some("custom-queue"));
+    }
+
+    #[test]
+    fn should_detect_self_referential_dependency_cycles() {
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+
+        // Self-reference cycle
+        let a_clone = a.clone();
+        let _ = a.upstream(&a_clone);
+
+        let res = builder.build();
+        assert_eq!(res.unwrap_err(), DagBuildError::CycleDetected);
+    }
+
+    #[test]
+    fn should_return_task_index() {
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+        assert_eq!(a.index(), 0);
+        let b = builder.activity(dummy_activity);
+        assert_eq!(b.index(), 1);
+    }
 }


### PR DESCRIPTION
🎯 **Target:** Increase test coverage for the `DagBuilder` component in `autumn-harvest/src/dag.rs`.

💣 **Risk:** The core engine relies on `DagBuilder` to correctly compile task graphs. Edge cases such as duplicate upstream dependencies, task-specific queue overrides, processing of multiple disjoint subgraphs, and self-referential cycle detection were previously lacking explicit coverage, potentially allowing subtle bugs or regressions during orchestration graph construction.

🧪 **Strategy:** Added targeted unit tests inside `dag.rs` (`should_deduplicate_identical_upstream_dependencies`, `should_process_disjoint_subgraphs`, `should_override_default_queue`, `should_detect_self_referential_dependency_cycles`, and `should_return_task_index`) to assert correct metadata compilation directly from the builder API, covering the exact gaps identified.

🔭 **Verification:** The added tests pass successfully alongside the existing suite (`cd autumn-harvest/autumn-harvest && cargo test dag`), and workspace compilation remains fully intact (`cargo check --workspace --tests`).

---
*PR created automatically by Jules for task [17440404115551319115](https://jules.google.com/task/17440404115551319115) started by @madmax983*