### PR TITLE
🧹 [Remove unused_variables allow attribute in health actuator]

### DIFF
--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -655,7 +655,6 @@ struct DatabaseCheck {
 }
 
 /// `GET <actuator-prefix>/health`
-#[allow(unused_variables)]
 pub async fn health<S: ProvideActuatorState + Send + Sync + 'static>(
     State(state): State<S>,
 ) -> impl IntoResponse {


### PR DESCRIPTION
🎯 **What:** Removed unnecessary `#[allow(unused_variables)]` attribute in the health actuator endpoint.
💡 **Why:** The attribute is no longer needed since all variables (including `state` for non-db builds) are actively used. Cleaning this up improves maintainability by removing stale directives.
✅ **Verification:** Formatted the code, checked all features with clippy, and verified that all tests passed successfully, ensuring no regressions.
✨ **Result:** A cleaner codebase with accurate compiler warnings enabled for the `health` function.

---
*PR created automatically by Jules for task [18187898320708328699](https://jules.google.com/task/18187898320708328699) started by @madmax983*