### PR TITLE
🔒 Warden: [Fix potential data exposure in mask_database_url fallback]

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1285,8 +1285,12 @@ fn mask_database_url(url: &str, pool_size: usize) -> String {
             let _ = parsed_url.set_password(Some("****"));
             return format!("{parsed_url} (pool_size={pool_size})");
         }
+        format!("{parsed_url} (pool_size={pool_size})")
+    } else {
+        // Fallback: If URL parsing fails, mask the entire URL string to prevent any
+        // potential data exposure (e.g. if the malformed string still contained a password)
+        format!("**** (pool_size={pool_size})")
     }
-    format!("{url} (pool_size={pool_size})")
 }
 
 /// Build the configuration summary string.
@@ -2402,6 +2406,14 @@ mod tests {
         assert!(!masked3.contains("secret"));
         assert!(masked3.contains("postgres://:****@localhost:5432/mydb"));
     }
+    #[test]
+    fn mask_database_url_invalid_url_fallback() {
+        let masked = mask_database_url("this is completely invalid as a URL with supersecret", 10);
+        assert!(masked.contains("****"));
+        assert!(!masked.contains("supersecret"));
+        assert!(masked.contains("pool_size=10"));
+    }
+
     #[test]
     fn format_config_summary_defaults() {
         let config = AutumnConfig::default();


### PR DESCRIPTION
🦠 **Threat:**
The `mask_database_url` function parses database URLs using the `url` crate to securely redact passwords before logging. However, if an attacker or misconfiguration provides a malformed URL (e.g., one containing spaces or invalid characters) that still contains a password, `url::Url::parse` will fail. The previous implementation fell back to logging the unparsed, raw URL string, exposing the password in plaintext logs.

🛡️ **Defense:**
Updated the fallback logic in `mask_database_url`. If `url::Url::parse` fails, the function now safely redacts the entire URL string (`"****"`). This ensures a "fail-closed" mechanism, preventing any sensitive information from leaking into the logs when the parser encounters malformed input. Valid URLs without passwords remain unaffected and are logged naturally.

💥 **Severity:**
High. Exposure of database credentials in logs can lead to unauthorized database access, data breaches, and system compromise.

🧪 **Verification:**
Added the unit test `mask_database_url_invalid_url_fallback` in `autumn/src/app.rs` to verify that malformed URLs containing a password are fully redacted and do not expose the password. Verified that `cargo test`, `cargo clippy`, and `cargo fmt` pass successfully.

---
*PR created automatically by Jules for task [1886327929540092415](https://jules.google.com/task/1886327929540092415) started by @madmax983*