### PR TITLE
👹 Havoc: Refactor channels tests to embrace chaos

### DIFF
--- a/autumn/tests/chaos_channels_proptest.rs
+++ b/autumn/tests/chaos_channels_proptest.rs
@@ -2,6 +2,7 @@
 
 use autumn_web::channels::Channels;
 use proptest::prelude::*;
+use std::sync::Arc;
 
 proptest! {
     #[test]
@@ -10,23 +11,50 @@ proptest! {
 
         // This should never panic on any capacity (see explicit zero test)
         let tx = channels.sender("test_channel");
-        let _rx = channels.subscribe("test_channel");
-        prop_assert!(tx.send("test").is_ok());
+
+        // Edge case: Sending with no subscribers should cleanly error, not panic
+        let res = tx.send("test");
+        prop_assert!(res.is_err());
     }
 }
 
 #[tokio::test]
-async fn test_channels_zero_capacity_regression() -> Result<(), Box<dyn std::error::Error>> {
-    let channels = Channels::new(0);
+async fn test_channels_zero_capacity_regression() {
+    let channels = Arc::new(Channels::new(0));
+    let mut tasks = vec![];
 
-    // This should never panic even if capacity is 0 (which was the bug)
-    let tx = channels.sender("test_channel");
-    let mut rx = channels.subscribe("test_channel");
+    // 10 concurrent writers overfilling the 1-capacity buffer
+    for i in 0..10 {
+        let channels = Arc::clone(&channels);
+        tasks.push(tokio::spawn(async move {
+            let tx = channels.sender("chaos_channel");
+            for j in 0..100 {
+                let _ = tx.send(format!("msg_{i}_{j}"));
+                tokio::task::yield_now().await;
+            }
+        }));
+    }
 
-    // We shouldn't use expect/unwrap in tests
-    tx.send("test_message")?;
-    let msg = rx.recv().await?;
-    assert_eq!(msg.as_str(), "test_message");
+    // 10 concurrent readers experiencing lagged errors
+    for _ in 0..10 {
+        let channels = Arc::clone(&channels);
+        tasks.push(tokio::spawn(async move {
+            let mut rx = channels.subscribe("chaos_channel");
+            let mut lagged = 0;
 
-    Ok(())
+            for _ in 0..100 {
+                if let Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) = rx.recv().await {
+                    lagged += 1;
+                }
+            }
+
+            // Buffer size is 1, writers send 1000 messages total.
+            // Readers will definitely fall behind and experience Lagged errors.
+            assert!(lagged > 0);
+        }));
+    }
+
+    for task in tasks {
+        task.await.expect("Task panicked");
+    }
 }

--- a/autumn/tests/chaos_channels_proptest.rs
+++ b/autumn/tests/chaos_channels_proptest.rs
@@ -15,6 +15,11 @@ proptest! {
         // Edge case: Sending with no subscribers should cleanly error, not panic
         let res = tx.send("test");
         prop_assert!(res.is_err());
+
+        // Exercise capacity: Adding a subscriber should make the send successful
+        // and actually rely on the generated capacity.
+        let _rx = channels.subscribe("test_channel");
+        prop_assert!(tx.send("test_with_subscriber").is_ok());
     }
 }
 

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,7 @@
+1. **Understand the Goal**: The user wants to "Fix chaos channels panic test" at `autumn/tests/chaos_channels_proptest.rs:11`. The issue is that the current test is a "happy path" test, which violates the Havoc persona rules ("never write happy path tests", "focus on concurrency/chaos/edge-cases").
+2. **Rewrite the Proptest**: Change `test_channels_capacity_fuzzing` to test the edge case of sending a message when there are NO subscribers, expecting it to gracefully return an `Err` instead of panicking.
+3. **Rewrite the Zero Capacity Test**: Change `test_channels_zero_capacity_regression` into a concurrency chaos test. It will spawn multiple tasks that rapidly subscribe and overfill the buffer of a `Channels::new(0)` instance, ensuring that `Lagged` errors are produced without any panics.
+4. **Verify the Tests**: Use `run_in_bash_session` to run `cargo test -p autumn-web --test chaos_channels_proptest --all-features` and ensure the chaotic tests pass successfully.
+5. **Write PR Description**: Create `pr_description.md` strictly following the Havoc persona format.
+6. **Pre-commit Checks**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+7. **Submit PR**: Use the `submit` tool with the Havoc persona title and description.

--- a/plan.md
+++ b/plan.md
@@ -1,7 +1,6 @@
-1. **Understand the Goal**: The user wants to "Fix chaos channels panic test" at `autumn/tests/chaos_channels_proptest.rs:11`. The issue is that the current test is a "happy path" test, which violates the Havoc persona rules ("never write happy path tests", "focus on concurrency/chaos/edge-cases").
-2. **Rewrite the Proptest**: Change `test_channels_capacity_fuzzing` to test the edge case of sending a message when there are NO subscribers, expecting it to gracefully return an `Err` instead of panicking.
-3. **Rewrite the Zero Capacity Test**: Change `test_channels_zero_capacity_regression` into a concurrency chaos test. It will spawn multiple tasks that rapidly subscribe and overfill the buffer of a `Channels::new(0)` instance, ensuring that `Lagged` errors are produced without any panics.
-4. **Verify the Tests**: Use `run_in_bash_session` to run `cargo test -p autumn-web --test chaos_channels_proptest --all-features` and ensure the chaotic tests pass successfully.
-5. **Write PR Description**: Create `pr_description.md` strictly following the Havoc persona format.
-6. **Pre-commit Checks**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
-7. **Submit PR**: Use the `submit` tool with the Havoc persona title and description.
+1. **Address the PR Comment**: The reviewer pointed out that `test_channels_capacity_fuzzing` no longer actually tests capacity because it removes the subscriber and only asserts an error. This makes the `capacity` fuzzer parameter pointless.
+2. **Rewrite `test_channels_capacity_fuzzing`**: Keep the `is_err` check for the zero-subscriber edge case, but *also* add a subscriber and test a successful send (which actually exercises the capacity buffer) so the proptest is no longer vacuous.
+3. **Verify the Tests**: Run `cargo test -p autumn-web --test chaos_channels_proptest --all-features` to ensure tests still pass.
+4. **Pre-commit Checks**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+5. **Submit PR Update**: Use the `submit` tool with the same branch name `havoc-chaos-channels` to push the code changes.
+6. **Reply to PR Comment**: Use the `reply_to_pr_comments` tool to acknowledge the fix.

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,0 @@
-1. **Address the PR Comment**: The reviewer pointed out that `test_channels_capacity_fuzzing` no longer actually tests capacity because it removes the subscriber and only asserts an error. This makes the `capacity` fuzzer parameter pointless.
-2. **Rewrite `test_channels_capacity_fuzzing`**: Keep the `is_err` check for the zero-subscriber edge case, but *also* add a subscriber and test a successful send (which actually exercises the capacity buffer) so the proptest is no longer vacuous.
-3. **Verify the Tests**: Run `cargo test -p autumn-web --test chaos_channels_proptest --all-features` to ensure tests still pass.
-4. **Pre-commit Checks**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
-5. **Submit PR Update**: Use the `submit` tool with the same branch name `havoc-chaos-channels` to push the code changes.
-6. **Reply to PR Comment**: Use the `reply_to_pr_comments` tool to acknowledge the fix.


### PR DESCRIPTION
🌪️ **The Trigger:**
The `test_channels_zero_capacity_regression` and `test_channels_capacity_fuzzing` tests for the `Channels` module were testing the happy path (checking for no panics) instead of embracing edge-cases and chaos scenarios.

📉 **The Stack Trace:**
N/A - This was a test health/design issue, not a runtime crash. The existing tests failed to adequately stress the `Channels` implementation, particularly regarding concurrency and bounded capacity behavior under extreme load.

🧪 **Reproduction:**
By replacing the simple assertion loops with a high-concurrency setup (10 tasks sending 100 messages each, 10 tasks reading) on a 0-capacity channel, we actively create and verify the expected `Lagged` errors. We also explicitly test the edge-case of sending messages to a channel with no subscribers expecting an error rather than just avoiding a panic.

😈 **Comment:**
This ensures our channels hold up under heavy contention and properly bubble up errors when consumers inevitably fall behind or when messages are fired into the void. Chaos guarantees stability!

---
*PR created automatically by Jules for task [16665335570032543125](https://jules.google.com/task/16665335570032543125) started by @madmax983*