### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -183,7 +183,7 @@ impl Channels {
     /// # Panics
     ///
     /// Panics if the internal mutex is poisoned (indicates a prior panic
-    /// while holding the lock).
+    /// while holding the lock — a bug).
     ///
     /// # Examples
     ///
@@ -223,7 +223,8 @@ impl Channels {
     ///
     /// # Panics
     ///
-    /// Panics if the internal mutex is poisoned.
+    /// Panics if the internal mutex is poisoned (indicates a prior panic
+    /// while holding the lock — a bug).
     ///
     /// # Examples
     ///
@@ -261,7 +262,8 @@ impl Channels {
     ///
     /// # Panics
     ///
-    /// Panics if the internal mutex is poisoned.
+    /// Panics if the internal mutex is poisoned (indicates a prior panic
+    /// while holding the lock — a bug).
     #[must_use]
     pub fn channel_count(&self) -> usize {
         let registry = self.inner.registry.lock().expect("channels lock poisoned");
@@ -275,7 +277,8 @@ impl Channels {
     ///
     /// # Panics
     ///
-    /// Panics if the internal mutex is poisoned.
+    /// Panics if the internal mutex is poisoned (indicates a prior panic
+    /// while holding the lock — a bug).
     pub fn gc(&self) {
         let mut registry = self.inner.registry.lock().expect("channels lock poisoned");
         registry.retain(|_, tx| tx.receiver_count() > 0 || Arc::strong_count(tx) > 1);
@@ -287,7 +290,8 @@ impl Channels {
     ///
     /// # Panics
     ///
-    /// Panics if the internal mutex is poisoned.
+    /// Panics if the internal mutex is poisoned (indicates a prior panic
+    /// while holding the lock — a bug).
     #[must_use]
     pub fn snapshot(&self) -> HashMap<String, usize> {
         let registry = self.inner.registry.lock().expect("channels lock poisoned");


### PR DESCRIPTION
🎸 Bard: [documentation update]

📖 Chapter
Documentation for the channels module

🔦 Insight
The documentation for panics across various functions in the channels module (`subscribe`, `sender`, `channel_count`, `gc`, `snapshot`) lacked the essential detail that such a panic indicates a prior panic while holding the lock (a bug).

🧪 Example
```rust
use autumn_web::channels::Channels;

let channels = Channels::new(32);
let tx = channels.sender("notifications");
tx.send("new message").ok();
```

---
*PR created automatically by Jules for task [6184279281253628389](https://jules.google.com/task/6184279281253628389) started by @madmax983*