### PR TITLE
⚡ Bolt: Use RwLock for AppState extensions to reduce contention

### DIFF
--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1196,9 +1196,9 @@ mod tests {
 
     fn test_state_with_config(config: &AutumnConfig) -> AppState {
         AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: config.profile.clone().or_else(|| Some("dev".into())),

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1223,7 +1223,7 @@ fn build_state(
     >,
 ) -> AppState {
     AppState {
-        extensions: std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        extensions: std::sync::Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
         #[cfg(feature = "db")]
         pool,
         profile: config.profile.clone(),
@@ -1429,9 +1429,9 @@ mod tests {
     pub fn test_router(routes: Vec<Route>) -> axum::Router {
         let config = AutumnConfig::default();
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -1593,9 +1593,9 @@ mod tests {
         let mut config = AutumnConfig::default();
         config.health.path = "/healthz".to_owned();
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -1679,9 +1679,9 @@ mod tests {
         }];
         let config = AutumnConfig::default();
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -1731,9 +1731,9 @@ mod tests {
         ];
         let config = AutumnConfig::default();
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -1895,9 +1895,9 @@ mod tests {
         // No dynamic route for /docs — only a static file.
         let config = AutumnConfig::default();
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -2120,9 +2120,9 @@ mod tests {
     /// Helper to build a test router with custom config.
     pub fn test_router_with_config(routes: Vec<Route>, config: &AutumnConfig) -> axum::Router {
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -2259,9 +2259,9 @@ mod tests {
 
         let config = AutumnConfig::default();
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -2296,9 +2296,9 @@ mod tests {
         // When dist_dir is None, return the app router directly.
         let config = AutumnConfig::default();
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -2540,9 +2540,9 @@ mod tests {
     #[tokio::test]
     async fn start_task_scheduler_broadcasts_events() {
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -2600,9 +2600,9 @@ mod tests {
     #[tokio::test]
     async fn start_task_scheduler_broadcasts_failure_events() {
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -470,9 +470,9 @@ mod tests {
         }
 
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -522,9 +522,9 @@ mod tests {
         }
 
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -582,9 +582,9 @@ mod tests {
         use crate::state::AppState;
 
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -698,9 +698,9 @@ mod tests {
         }
 
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -764,9 +764,9 @@ mod tests {
             .unwrap();
 
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -835,9 +835,9 @@ mod tests {
             .unwrap();
 
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -902,9 +902,9 @@ mod tests {
             .unwrap();
 
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -962,9 +962,9 @@ mod tests {
         store.save("valid-session", session_data).await.unwrap();
 
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -230,9 +230,9 @@ mod tests {
         }
 
         let app = Router::new().route("/", get(handler)).with_state(AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             pool: None,
             profile: None,
             started_at: std::time::Instant::now(),

--- a/autumn/src/health.rs
+++ b/autumn/src/health.rs
@@ -55,9 +55,9 @@ mod tests {
 
     fn test_state() -> AppState {
         AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: Some("dev".into()),
@@ -134,7 +134,7 @@ mod tests {
         let app = axum::Router::new()
             .route("/health", axum::routing::get(handler))
             .with_state(AppState {
-                extensions: std::sync::Arc::new(std::sync::Mutex::new(
+                extensions: std::sync::Arc::new(std::sync::RwLock::new(
                     std::collections::HashMap::new(),
                 )),
                 pool: Some(pool),

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -97,9 +97,9 @@ mod tests {
     fn prelude_types_are_accessible() {
         #[cfg(feature = "db")]
         let _state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
@@ -116,9 +116,9 @@ mod tests {
         };
         #[cfg(not(feature = "db"))]
         let _state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -791,9 +791,9 @@ mod tests {
 
     fn test_state() -> AppState {
         AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: Some("test".to_owned()),

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -940,9 +940,9 @@ mod tests {
         }
 
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -983,7 +983,7 @@ mod tests {
 
     fn test_state() -> crate::state::AppState {
         crate::state::AppState {
-            extensions: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            extensions: Arc::new(std::sync::RwLock::new(HashMap::new())),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -11,7 +11,7 @@
 
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::actuator;
 #[cfg(feature = "ws")]
@@ -48,7 +48,7 @@ use tokio_util::sync::CancellationToken;
 pub struct AppState {
     /// Runtime-managed typed extensions installed by integrations after the app
     /// state has been constructed.
-    pub(crate) extensions: Arc<Mutex<HashMap<TypeId, Arc<dyn Any + Send + Sync>>>>,
+    pub(crate) extensions: Arc<std::sync::RwLock<HashMap<TypeId, Arc<dyn Any + Send + Sync>>>>,
 
     /// Database connection pool, or `None` when no `database.url` is configured.
     #[cfg(feature = "db")]
@@ -108,7 +108,7 @@ impl AppState {
         T: Any + Send + Sync + 'static,
     {
         self.extensions
-            .lock()
+            .write()
             .expect("app state extension lock poisoned")
             .insert(TypeId::of::<T>(), Arc::new(value));
     }
@@ -127,7 +127,7 @@ impl AppState {
         T: Any + Send + Sync + 'static,
     {
         self.extensions
-            .lock()
+            .read()
             .expect("app state extension lock poisoned")
             .get(&TypeId::of::<T>())
             .cloned()
@@ -308,7 +308,7 @@ impl AppState {
     #[must_use]
     pub fn detached() -> Self {
         Self {
-            extensions: Arc::new(Mutex::new(HashMap::new())),
+            extensions: Arc::new(std::sync::RwLock::new(HashMap::new())),
             #[cfg(feature = "db")]
             pool: None,
             profile: None,
@@ -430,7 +430,7 @@ impl std::fmt::Debug for AppState {
             "extensions",
             &self
                 .extensions
-                .lock()
+                .read()
                 .map_or(0, |extensions| extensions.len()),
         );
         s.field("profile", &self.profile)

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -194,9 +194,9 @@ impl TestApp {
     #[must_use]
     pub fn build(self) -> TestClient {
         let state = AppState {
-            extensions: std::sync::Arc::new(
-                std::sync::Mutex::new(std::collections::HashMap::new()),
-            ),
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             #[cfg(feature = "db")]
             pool: self.pool,
             profile: self.config.profile.clone(),


### PR DESCRIPTION
⚡ Bolt: [performance improvement]

💡 **What:** Changed `AppState::extensions` from `Arc<Mutex<HashMap<TypeId, Arc<dyn Any + Send + Sync>>>>` to `Arc<RwLock<HashMap<...>>>`.

🎯 **Why:** The extensions map is read frequently on hot paths (every time a handler extracts an extension), but it is generally only written to during application setup. A `Mutex` unnecessarily serializes all concurrent reads, leading to lock contention under load. By using an `RwLock`, multiple request handlers can read extensions concurrently without blocking each other, enabling better scalability.

📊 **Impact:** Reduces lock contention on hot paths when multiple concurrent requests read from shared state extensions. Readers no longer block each other.

🔬 **Measurement:** Verify by running `cargo test -p autumn-web --lib state` and `cargo bench` under high concurrency.

---
*PR created automatically by Jules for task [5718017486294387587](https://jules.google.com/task/5718017486294387587) started by @madmax983*