### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/error_pages/defaults.rs
+++ b/autumn/src/error_pages/defaults.rs
@@ -308,4 +308,14 @@ mod tests {
         assert!(s.contains("<html"));
         assert!(s.contains("</html>"));
     }
+
+    #[test]
+    fn test_canonical_reason_fallback() {
+        let pages = DefaultErrorPages;
+        let ctx = make_ctx(StatusCode::from_u16(599).unwrap());
+        let html = pages.render_error(&ctx);
+        let s = html.into_string();
+        assert!(s.contains("599"));
+        assert!(s.contains("Error"));
+    }
 }


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 Target: `autumn/src/error_pages/defaults.rs` 
💣 Risk: Uncovered fallback logic when formatting canonical reasons for unknown HTTP status codes (`.unwrap_or("Error")`).
🧪 Strategy: Added `test_canonical_reason_fallback` unit test to `autumn/src/error_pages/defaults.rs`. This explicitly constructs a 599 status code (which has no known canonical reason) to ensure the `.unwrap_or("Error")` arm is exercised and returns "Error" correctly inside the HTML error template.
🔭 Verification: `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test -p autumn-web --lib test_canonical_reason_fallback` run and pass. Coverage on this branch is now closed.

---
*PR created automatically by Jules for task [4244420017045388009](https://jules.google.com/task/4244420017045388009) started by @madmax983*