### PR TITLE
🌟 Nova: Actuator HTMX Dashboard

### DIFF
--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1178,7 +1178,20 @@ pub(crate) fn actuator_router_with_prefix<
         }
     }
 
+    // Nova: Add HTMX UI endpoints
     router
+        .route(
+            &actuator_route_path(prefix, "/ui"),
+            axum::routing::get(ui_dashboard),
+        )
+        .route(
+            &actuator_route_path(prefix, "/ui/metrics"),
+            axum::routing::get(ui_metrics::<S>),
+        )
+        .route(
+            &actuator_route_path(prefix, "/ui/tasks"),
+            axum::routing::get(ui_tasks::<S>),
+        )
 }
 
 #[cfg(test)]
@@ -1844,6 +1857,81 @@ mod tests {
         ConfigProperties::track_property(&mut props, "log.level", "info", "info", "dev");
         assert_eq!(props["log.level"].source, "default");
     }
+
+    #[tokio::test]
+    async fn actuator_ui_dashboard_returns_html_or_unimplemented() {
+        let app = actuator_router(true).with_state(test_state());
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/ui")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        if cfg!(feature = "maud") {
+            assert_eq!(res.status(), StatusCode::OK);
+            assert_eq!(
+                res.headers().get("content-type").unwrap(),
+                "text/html; charset=utf-8"
+            );
+        } else {
+            assert_eq!(res.status(), StatusCode::NOT_IMPLEMENTED);
+        }
+    }
+
+    #[tokio::test]
+    async fn actuator_ui_metrics_returns_html_or_unimplemented() {
+        let app = actuator_router(true).with_state(test_state());
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/ui/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        if cfg!(feature = "maud") {
+            assert_eq!(res.status(), StatusCode::OK);
+            assert_eq!(
+                res.headers().get("content-type").unwrap(),
+                "text/html; charset=utf-8"
+            );
+        } else {
+            assert_eq!(res.status(), StatusCode::NOT_IMPLEMENTED);
+        }
+    }
+
+    #[tokio::test]
+    async fn actuator_ui_tasks_returns_html_or_unimplemented() {
+        let app = actuator_router(true).with_state(test_state());
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/ui/tasks")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        if cfg!(feature = "maud") {
+            assert_eq!(res.status(), StatusCode::OK);
+            assert_eq!(
+                res.headers().get("content-type").unwrap(),
+                "text/html; charset=utf-8"
+            );
+        } else {
+            assert_eq!(res.status(), StatusCode::NOT_IMPLEMENTED);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1862,4 +1950,145 @@ mod havoc_proptest {
             assert!(levels.logger_overrides().len() <= 1000, "Memory leak: unbounded loggers inserted");
         }
     }
+}
+
+// ── Nova: Actuator HTMX Dashboard UI ──────────────────────────
+
+#[cfg(feature = "maud")]
+async fn ui_dashboard() -> impl IntoResponse {
+    let html = maud::html! {
+        (maud::DOCTYPE)
+        html lang="en" {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                title { "Autumn Actuator Dashboard" }
+                script src="/static/js/htmx.min.js" {}
+                style {
+                    "body { font-family: system-ui, sans-serif; background: #f9fafb; color: #111827; margin: 0; padding: 2rem; }"
+                    "h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 1.5rem; }"
+                    ".grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem; }"
+                    ".card { background: white; padding: 1.5rem; border-radius: 0.5rem; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }"
+                    ".card h2 { font-size: 1.125rem; font-weight: 500; margin-top: 0; margin-bottom: 1rem; border-bottom: 1px solid #e5e7eb; padding-bottom: 0.5rem; }"
+                    ".stat { display: flex; justify-content: space-between; margin-bottom: 0.5rem; }"
+                    ".stat-label { color: #6b7280; }"
+                    ".stat-value { font-weight: 500; }"
+                    ".task-item { border: 1px solid #e5e7eb; padding: 0.75rem; border-radius: 0.375rem; margin-bottom: 0.75rem; }"
+                    ".task-name { font-weight: 600; display: block; margin-bottom: 0.25rem; }"
+                    ".task-meta { font-size: 0.875rem; color: #6b7280; }"
+                    ".badge { display: inline-block; padding: 0.125rem 0.375rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; }"
+                    ".badge-green { background: #dcfce7; color: #166534; }"
+                    ".badge-gray { background: #f3f4f6; color: #374151; }"
+                    ".badge-red { background: #fee2e2; color: #991b1b; }"
+                }
+            }
+            body {
+                h1 { "🍂 Autumn Actuator Dashboard" }
+                div class="grid" {
+                    div class="card" hx-get="ui/metrics" hx-trigger="load, every 2s" {
+                        "Loading metrics..."
+                    }
+                    div class="card" hx-get="ui/tasks" hx-trigger="load, every 2s" {
+                        "Loading tasks..."
+                    }
+                }
+            }
+        }
+    };
+    (
+        [(axum::http::header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        html.into_string(),
+    )
+}
+
+#[cfg(not(feature = "maud"))]
+async fn ui_dashboard() -> impl IntoResponse {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        "Maud feature is required for the UI dashboard",
+    )
+}
+
+#[cfg(feature = "maud")]
+async fn ui_metrics<S: ProvideActuatorState>(State(state): State<S>) -> impl IntoResponse {
+    let metrics = state.metrics().snapshot();
+    let uptime = state.uptime_display();
+
+    let html = maud::html! {
+        h2 { "System Metrics" }
+        div class="stat" {
+            span class="stat-label" { "Uptime" }
+            span class="stat-value" { (uptime) }
+        }
+        div class="stat" {
+            span class="stat-label" { "Total Requests" }
+            span class="stat-value" { (metrics.http.requests_total) }
+        }
+        div class="stat" {
+            span class="stat-label" { "Active Requests" }
+            span class="stat-value" { (metrics.http.requests_active) }
+        }
+        div class="stat" {
+            span class="stat-label" { "P95 Latency" }
+            span class="stat-value" { (metrics.http.latency_ms.p95) " ms" }
+        }
+        div class="stat" {
+            span class="stat-label" { "P99 Latency" }
+            span class="stat-value" { (metrics.http.latency_ms.p99) " ms" }
+        }
+    };
+    (
+        [(axum::http::header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        html.into_string(),
+    )
+}
+
+#[cfg(not(feature = "maud"))]
+async fn ui_metrics<S: ProvideActuatorState>() -> impl IntoResponse {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        "Maud feature is required for the UI dashboard",
+    )
+}
+
+#[cfg(feature = "maud")]
+async fn ui_tasks<S: ProvideActuatorState>(State(state): State<S>) -> impl IntoResponse {
+    let tasks = state.task_registry().snapshot();
+
+    let html = maud::html! {
+        h2 { "Background Tasks" }
+        @if tasks.is_empty() {
+            p class="stat-label" { "No tasks registered." }
+        } @else {
+            @for (name, task) in tasks.iter() {
+                div class="task-item" {
+                    span class="task-name" { (name) }
+                    div class="task-meta" {
+                        @if task.status == "running" {
+                            span class="badge badge-green" { "Running" }
+                        } @else {
+                            span class="badge badge-gray" { "Idle" }
+                        }
+                        " "
+                        "Runs: " (task.total_runs)
+                        @if task.total_failures > 0 {
+                            " " span class="badge badge-red" { "Failures: " (task.total_failures) }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    (
+        [(axum::http::header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        html.into_string(),
+    )
+}
+
+#[cfg(not(feature = "maud"))]
+async fn ui_tasks<S: ProvideActuatorState>() -> impl IntoResponse {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        "Maud feature is required for the UI dashboard",
+    )
 }

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1083,21 +1083,21 @@ pub(crate) fn actuator_endpoint_paths(prefix: &str, sensitive: bool) -> Vec<Stri
         actuator_route_path(prefix, "/health"),
         actuator_route_path(prefix, "/info"),
         actuator_route_path(prefix, "/metrics"),
+        actuator_route_path(prefix, "/ui"),
+        actuator_route_path(prefix, "/ui/metrics"),
     ];
 
     if sensitive {
-        paths.extend([
-            actuator_route_path(prefix, "/env"),
-            actuator_route_path(prefix, "/configprops"),
-            actuator_route_path(prefix, "/loggers"),
-            actuator_route_path(prefix, "/tasks"),
-            actuator_route_path(prefix, "/prometheus"),
-        ]);
-
+        paths.push(actuator_route_path(prefix, "/env"));
+        paths.push(actuator_route_path(prefix, "/configprops"));
+        paths.push(actuator_route_path(prefix, "/loggers"));
+        paths.push(actuator_route_path(prefix, "/tasks"));
+        paths.push(actuator_route_path(prefix, "/ui/tasks"));
+        paths.push(actuator_route_path(prefix, "/prometheus"));
         #[cfg(feature = "ws")]
         {
-            paths.push(actuator_route_path(prefix, "/tasks/stream"));
             paths.push(actuator_route_path(prefix, "/channels"));
+            paths.push(actuator_route_path(prefix, "/tasks/stream"));
         }
     }
 

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1144,6 +1144,10 @@ pub(crate) fn actuator_router_with_prefix<
                 axum::routing::get(env_endpoint::<S>),
             )
             .route(
+                &actuator_route_path(prefix, "/prometheus"),
+                axum::routing::get(prometheus_endpoint::<S>),
+            )
+            .route(
                 &actuator_route_path(prefix, "/configprops"),
                 axum::routing::get(configprops_endpoint::<S>),
             )
@@ -1160,25 +1164,25 @@ pub(crate) fn actuator_router_with_prefix<
                 axum::routing::get(tasks_endpoint::<S>),
             )
             .route(
-                &actuator_route_path(prefix, "/prometheus"),
-                axum::routing::get(prometheus_endpoint::<S>),
+                &actuator_route_path(prefix, "/ui/tasks"),
+                axum::routing::get(ui_tasks::<S>),
             );
 
         #[cfg(feature = "ws")]
         {
             router = router
                 .route(
-                    &actuator_route_path(prefix, "/tasks/stream"),
-                    axum::routing::get(tasks_stream_endpoint::<S>),
-                )
-                .route(
                     &actuator_route_path(prefix, "/channels"),
                     axum::routing::get(channels_endpoint::<S>),
+                )
+                .route(
+                    &actuator_route_path(prefix, "/tasks/stream"),
+                    axum::routing::get(tasks_stream_endpoint::<S>),
                 );
         }
     }
 
-    // Nova: Add HTMX UI endpoints
+    // Nova: Add HTMX UI endpoints available unconditionally like metrics
     router
         .route(
             &actuator_route_path(prefix, "/ui"),
@@ -1187,10 +1191,6 @@ pub(crate) fn actuator_router_with_prefix<
         .route(
             &actuator_route_path(prefix, "/ui/metrics"),
             axum::routing::get(ui_metrics::<S>),
-        )
-        .route(
-            &actuator_route_path(prefix, "/ui/tasks"),
-            axum::routing::get(ui_tasks::<S>),
         )
 }
 
@@ -1954,7 +1954,7 @@ mod havoc_proptest {
 
 // ── Nova: Actuator HTMX Dashboard UI ──────────────────────────
 
-#[cfg(feature = "maud")]
+#[cfg(all(feature = "maud", feature = "htmx"))]
 async fn ui_dashboard() -> impl IntoResponse {
     let html = maud::html! {
         (maud::DOCTYPE)
@@ -2001,7 +2001,7 @@ async fn ui_dashboard() -> impl IntoResponse {
     )
 }
 
-#[cfg(not(feature = "maud"))]
+#[cfg(not(all(feature = "maud", feature = "htmx")))]
 async fn ui_dashboard() -> impl IntoResponse {
     (
         StatusCode::NOT_IMPLEMENTED,
@@ -2009,7 +2009,7 @@ async fn ui_dashboard() -> impl IntoResponse {
     )
 }
 
-#[cfg(feature = "maud")]
+#[cfg(all(feature = "maud", feature = "htmx"))]
 async fn ui_metrics<S: ProvideActuatorState>(State(state): State<S>) -> impl IntoResponse {
     let metrics = state.metrics().snapshot();
     let uptime = state.uptime_display();
@@ -2043,7 +2043,7 @@ async fn ui_metrics<S: ProvideActuatorState>(State(state): State<S>) -> impl Int
     )
 }
 
-#[cfg(not(feature = "maud"))]
+#[cfg(not(all(feature = "maud", feature = "htmx")))]
 async fn ui_metrics<S: ProvideActuatorState>() -> impl IntoResponse {
     (
         StatusCode::NOT_IMPLEMENTED,
@@ -2051,7 +2051,7 @@ async fn ui_metrics<S: ProvideActuatorState>() -> impl IntoResponse {
     )
 }
 
-#[cfg(feature = "maud")]
+#[cfg(all(feature = "maud", feature = "htmx"))]
 async fn ui_tasks<S: ProvideActuatorState>(State(state): State<S>) -> impl IntoResponse {
     let tasks = state.task_registry().snapshot();
 
@@ -2085,7 +2085,7 @@ async fn ui_tasks<S: ProvideActuatorState>(State(state): State<S>) -> impl IntoR
     )
 }
 
-#[cfg(not(feature = "maud"))]
+#[cfg(not(all(feature = "maud", feature = "htmx")))]
 async fn ui_tasks<S: ProvideActuatorState>() -> impl IntoResponse {
     (
         StatusCode::NOT_IMPLEMENTED,


### PR DESCRIPTION
🌟 Nova: Actuator HTMX Dashboard

💡 **The Spark:** We already have robust `/actuator` endpoints serving JSON metrics, tasks, and system state, but developers either have to use external tools (like the TUI `monitor` CLI) or manually parse JSON to visualize it. What if we expose a built-in, zero-configuration HTMX dashboard directly from the application?

🚀 **The Feature:** Implemented `ui_dashboard`, `ui_metrics`, and `ui_tasks` under `/actuator/ui/`. These endpoints return Maud-rendered HTML fragments and use HTMX polling to automatically refresh live metrics and background task states directly in the browser. 

🔮 **The Potential:** Zero-setup admin dashboard for Autumn apps. Developers can simply navigate to `<app-url>/actuator/ui` and instantly monitor their app's health, latency percentiles, and background job statuses without setting up Prometheus/Grafana or opening the terminal.

⚠️ **Risk:** Low. Isolated in `autumn/src/actuator.rs` inside conditional `#[cfg(feature = "maud")]` blocks, mapping new `/ui*` endpoints that strictly query read-only system state (metrics snapshot and task registry snapshot).

---
*PR created automatically by Jules for task [12456958051049608564](https://jules.google.com/task/12456958051049608564) started by @madmax983*