### PR TITLE
ci: trigger on trunk-dev push and pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [trunk]
+    branches: [trunk, trunk-dev]
   pull_request:
-    branches: [trunk]
+    branches: [trunk, trunk-dev]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
\`trunk-dev\` is now the staging branch — feature PRs target it before promotion to \`trunk\`. CI was only triggering on \`trunk\` events, so PRs to \`trunk-dev\` have been merging without lint/test gates.

## Change
\`\`\`diff
 on:
   push:
-    branches: [trunk]
+    branches: [trunk, trunk-dev]
   pull_request:
-    branches: [trunk]
+    branches: [trunk, trunk-dev]
\`\`\`

\`trunk\` stays on the list for direct-to-trunk commits (rare) and the eventual \`trunk-dev\` → \`trunk\` promotion PR.

## Test plan
- [ ] This PR itself triggers CI against \`trunk-dev\` (the meta-test)
- [ ] Future PRs targeting \`trunk-dev\` run lint + tests + MSRV as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)