### PR TITLE
feat: trait-based subsystem replacement (S-053) — config / DB / telemetry / session

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["autumn", "autumn-macros", "autumn-cli", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/wiki", "examples/reddit-clone"]
+members = ["autumn", "autumn-macros", "autumn-cli", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/wiki", "examples/reddit-clone", "examples/custom_config_loader"]
 resolver = "3"
 
 # Unify autumn-web across the workspace and any transitive consumers (e.g.

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -30,7 +30,9 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use crate::config::AutumnConfig;
+use crate::config::{AutumnConfig, ConfigLoader};
+#[cfg(feature = "db")]
+use crate::db::DatabasePoolProvider;
 use crate::error_pages::{ErrorPageRenderer, SharedRenderer};
 use crate::middleware::exception_filter::ExceptionFilter;
 #[cfg(feature = "db")]
@@ -77,6 +79,11 @@ pub fn app() -> AppBuilder {
         error_page_renderer: None,
         #[cfg(feature = "db")]
         migrations: Vec::new(),
+        config_loader_factory: None,
+        #[cfg(feature = "db")]
+        pool_provider_factory: None,
+        telemetry_provider: None,
+        session_store: None,
     }
 }
 
@@ -84,6 +91,38 @@ type StartupHookFuture = Pin<Box<dyn Future<Output = crate::AutumnResult<()>> + 
 type StartupHook = Box<dyn Fn(AppState) -> StartupHookFuture + Send + Sync>;
 type ShutdownHookFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 type ShutdownHook = Box<dyn Fn() -> ShutdownHookFuture + Send + Sync>;
+
+// ── Tier-1 subsystem factories ────────────────────────────────
+//
+// `ConfigLoader` and `DatabasePoolProvider` use RPIT (`-> impl Future + Send`)
+// in their trait methods, so `Box<dyn Trait>` is not dyn-compatible. We store
+// boxed factory closures that capture the concrete impl at the call site and
+// erase its future type via `Pin<Box<dyn Future>>`. `TelemetryProvider`'s
+// `init` is sync, so it's stored as a normal `Box<dyn>`.
+type ConfigLoaderFactory = Box<
+    dyn FnOnce() -> Pin<
+            Box<dyn Future<Output = Result<AutumnConfig, crate::config::ConfigError>> + Send>,
+        > + Send,
+>;
+#[cfg(feature = "db")]
+type PoolProviderFactory = Box<
+    dyn FnOnce(
+            crate::config::DatabaseConfig,
+        ) -> Pin<
+            Box<
+                dyn Future<
+                        Output = Result<
+                            Option<
+                                diesel_async::pooled_connection::deadpool::Pool<
+                                    diesel_async::AsyncPgConnection,
+                                >,
+                            >,
+                            crate::db::PoolError,
+                        >,
+                    > + Send,
+            >,
+        > + Send,
+>;
 
 /// Builder for configuring and launching an Autumn application.
 ///
@@ -131,6 +170,20 @@ pub struct AppBuilder {
     /// Embedded Diesel migrations, registered via `.migrations()`.
     #[cfg(feature = "db")]
     migrations: Vec<migrate::EmbeddedMigrations>,
+    /// Custom config loader (tier-1 subsystem replacement). When `None`, the
+    /// default [`TomlEnvConfigLoader`](crate::config::TomlEnvConfigLoader) runs.
+    config_loader_factory: Option<ConfigLoaderFactory>,
+    /// Custom DB pool provider (tier-1 subsystem replacement). When `None`,
+    /// the default [`DieselDeadpoolPoolProvider`](crate::db::DieselDeadpoolPoolProvider) runs.
+    #[cfg(feature = "db")]
+    pool_provider_factory: Option<PoolProviderFactory>,
+    /// Custom telemetry provider (tier-1 subsystem replacement). When `None`,
+    /// the default [`TracingOtlpTelemetryProvider`](crate::telemetry::TracingOtlpTelemetryProvider) runs.
+    telemetry_provider: Option<Box<dyn crate::telemetry::TelemetryProvider>>,
+    /// Custom session store (tier-1 subsystem replacement). When `Some`,
+    /// `apply_session_layer` skips the config-driven `memory`/`redis` selection
+    /// and uses this store directly.
+    session_store: Option<Arc<dyn crate::session::BoxedSessionStore>>,
 }
 
 /// A group of routes sharing a common path prefix and middleware layer.
@@ -476,6 +529,102 @@ impl AppBuilder {
         self.extensions.get(&TypeId::of::<T>())?.downcast_ref::<T>()
     }
 
+    // ── Tier-1 subsystem replacement hooks ─────────────────────
+    //
+    // Each `with_*` method swaps a framework-default subsystem for a
+    // user-provided trait impl. The defaults preserve current behaviour, so
+    // applications that don't customize see no change. Plugins typically chain
+    // these in their `build()` body to ship a subsystem (e.g. an
+    // `AwsSecretsConfigPlugin` that calls `app.with_config_loader(...)`).
+    // See `docs/guides/extensibility.md`.
+
+    /// Install a custom [`ConfigLoader`](crate::config::ConfigLoader),
+    /// replacing the default TOML + env loader.
+    ///
+    /// Useful when your config lives somewhere other than `autumn.toml` —
+    /// AWS Secrets Manager, Vault, a JSON file, an HTTP fetch, etc. Emits a
+    /// `tracing::warn!` if a loader was already installed.
+    #[must_use]
+    pub fn with_config_loader<L>(mut self, loader: L) -> Self
+    where
+        L: crate::config::ConfigLoader,
+    {
+        if self.config_loader_factory.is_some() {
+            tracing::warn!(
+                "config loader replaced; the previously-installed loader was overwritten"
+            );
+        }
+        self.config_loader_factory = Some(Box::new(move || {
+            Box::pin(async move { loader.load().await })
+        }));
+        self
+    }
+
+    /// Install a custom [`DatabasePoolProvider`](crate::db::DatabasePoolProvider),
+    /// replacing the default `deadpool + diesel-async` pool factory.
+    ///
+    /// Useful for adding metrics/circuit-breaker wrappers, switching to a
+    /// per-shard pool, or driving a non-default backend at the same
+    /// `Pool<AsyncPgConnection>` interface. Emits a `tracing::warn!` if a
+    /// provider was already installed.
+    #[cfg(feature = "db")]
+    #[must_use]
+    pub fn with_pool_provider<P>(mut self, provider: P) -> Self
+    where
+        P: crate::db::DatabasePoolProvider,
+    {
+        if self.pool_provider_factory.is_some() {
+            tracing::warn!(
+                "database pool provider replaced; the previously-installed provider was overwritten"
+            );
+        }
+        self.pool_provider_factory =
+            Some(Box::new(move |config: crate::config::DatabaseConfig| {
+                Box::pin(async move { provider.create_pool(&config).await })
+            }));
+        self
+    }
+
+    /// Install a custom [`TelemetryProvider`](crate::telemetry::TelemetryProvider),
+    /// replacing the default `tracing-subscriber + OTLP` initializer.
+    ///
+    /// Useful for shipping a Datadog tracer, Honeycomb beeline, Sentry
+    /// integration, or any other observability backend. Emits a
+    /// `tracing::warn!` if a provider was already installed.
+    #[must_use]
+    pub fn with_telemetry_provider<T>(mut self, provider: T) -> Self
+    where
+        T: crate::telemetry::TelemetryProvider,
+    {
+        if self.telemetry_provider.is_some() {
+            tracing::warn!(
+                "telemetry provider replaced; the previously-installed provider was overwritten"
+            );
+        }
+        self.telemetry_provider = Some(Box::new(provider));
+        self
+    }
+
+    /// Install a custom [`SessionStore`](crate::session::SessionStore),
+    /// bypassing the config-driven `memory`/`redis` backend selection.
+    ///
+    /// Useful for backing sessions with a database, encrypted cookie store,
+    /// or enterprise SSO bridge. Emits a `tracing::warn!` if a store was
+    /// already installed.
+    #[must_use]
+    pub fn with_session_store<S>(mut self, store: S) -> Self
+    where
+        S: crate::session::SessionStore,
+    {
+        if self.session_store.is_some() {
+            tracing::warn!(
+                "session store replaced; the previously-installed store was overwritten"
+            );
+        }
+        self.session_store = Some(Arc::new(store));
+        self
+    }
+
     /// Apply a [`Plugin`](crate::plugin::Plugin) to the builder.
     ///
     /// The plugin's [`build`](crate::plugin::Plugin::build) runs exactly once
@@ -593,12 +742,18 @@ impl AppBuilder {
             error_page_renderer,
             #[cfg(feature = "db")]
             migrations,
+            config_loader_factory,
+            #[cfg(feature = "db")]
+            pool_provider_factory,
+            telemetry_provider,
+            session_store,
         } = self;
 
         let all_routes = routes;
 
         // 1 & 2. Load configuration and initialize logging/telemetry
-        let (config, _telemetry_guard) = load_config_and_telemetry();
+        let (config, _telemetry_guard) =
+            load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
 
         // 3. Validate routes
         assert!(
@@ -622,10 +777,12 @@ impl AppBuilder {
 
         // 5. Create database pool and run migrations (if configured)
         #[cfg(feature = "db")]
-        let pool = setup_database(&config, migrations).unwrap_or_else(|e| {
-            tracing::error!("{e}");
-            std::process::exit(1);
-        });
+        let pool = setup_database(&config, migrations, pool_provider_factory)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::error!("{e}");
+                std::process::exit(1);
+            });
 
         #[cfg(feature = "db")]
         if pool.is_some() {
@@ -661,6 +818,7 @@ impl AppBuilder {
                 merge_routers,
                 nest_routers,
                 error_page_renderer,
+                session_store,
             },
         )
         .unwrap_or_else(|error| {
@@ -767,12 +925,18 @@ impl AppBuilder {
             error_page_renderer: _,
             #[cfg(feature = "db")]
                 migrations: _,
+            config_loader_factory,
+            #[cfg(feature = "db")]
+            pool_provider_factory,
+            telemetry_provider,
+            session_store: _,
         } = self;
 
         let all_routes = routes;
 
         // Load config (same as normal startup)
-        let (config, _telemetry_guard) = load_config_and_telemetry();
+        let (config, _telemetry_guard) =
+            load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
 
         if static_metas.is_empty() {
             eprintln!("No static routes registered. Nothing to build.");
@@ -782,10 +946,12 @@ impl AppBuilder {
 
         // Build state (with DB if configured)
         #[cfg(feature = "db")]
-        let pool = setup_database(&config, vec![]).unwrap_or_else(|e| {
-            eprintln!("{e}");
-            std::process::exit(1);
-        });
+        let pool = setup_database(&config, vec![], pool_provider_factory)
+            .await
+            .unwrap_or_else(|e| {
+                eprintln!("{e}");
+                std::process::exit(1);
+            });
 
         let mut state = build_state(
             &config,
@@ -1175,37 +1341,53 @@ fn log_startup_transparency(
     tracing::info!("Configuration:{}", format_config_summary(config));
 }
 
-fn load_config_and_telemetry() -> (AutumnConfig, crate::telemetry::TelemetryGuard) {
-    // 1. Load configuration (profile-aware)
-    let config = AutumnConfig::load().unwrap_or_else(|e| {
+async fn load_config_and_telemetry(
+    config_loader: Option<ConfigLoaderFactory>,
+    telemetry_provider: Option<Box<dyn crate::telemetry::TelemetryProvider>>,
+) -> (AutumnConfig, crate::telemetry::TelemetryGuard) {
+    // 1. Load configuration via the installed loader, falling back to the
+    //    five-layer TOML + env default.
+    let config = match config_loader {
+        Some(factory) => factory().await,
+        None => crate::config::TomlEnvConfigLoader::new().load().await,
+    }
+    .unwrap_or_else(|e| {
         eprintln!("Failed to load configuration: {e}");
         std::process::exit(1);
     });
 
-    // 2. Initialize logging/telemetry immediately after config.
-    let telemetry_guard = crate::logging::init_with_telemetry(
-        &config.log,
-        &config.telemetry,
-        config.profile.as_deref(),
-    )
-    .unwrap_or_else(|error| {
-        eprintln!("Failed to initialize telemetry: {error}");
-        std::process::exit(1);
-    });
+    // 2. Initialize logging/telemetry via the installed provider, falling
+    //    back to the default `tracing-subscriber + OTLP` initializer.
+    let provider: Box<dyn crate::telemetry::TelemetryProvider> = telemetry_provider
+        .unwrap_or_else(|| Box::new(crate::telemetry::TracingOtlpTelemetryProvider::new()));
+    let telemetry_guard = provider
+        .init(&config.log, &config.telemetry, config.profile.as_deref())
+        .unwrap_or_else(|error| {
+            eprintln!("Failed to initialize telemetry: {error}");
+            std::process::exit(1);
+        });
 
     (config, telemetry_guard)
 }
 
 #[cfg(feature = "db")]
-fn setup_database(
+async fn setup_database(
     config: &AutumnConfig,
     migrations: Vec<crate::migrate::EmbeddedMigrations>,
+    pool_provider: Option<PoolProviderFactory>,
 ) -> Result<
     Option<diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>,
     String,
 > {
-    let pool = crate::db::create_pool(&config.database)
-        .map_err(|e| format!("Failed to create database pool: {e}"))?;
+    let pool = match pool_provider {
+        Some(factory) => factory(config.database.clone()).await,
+        None => {
+            crate::db::DieselDeadpoolPoolProvider::new()
+                .create_pool(&config.database)
+                .await
+        }
+    }
+    .map_err(|e| format!("Failed to create database pool: {e}"))?;
 
     if let Some(url) = &config.database.url {
         for mig in migrations {

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -775,6 +775,11 @@ impl AppBuilder {
             log_startup_transparency(&all_routes, &tasks, &scoped_groups, &config);
         }
 
+        // 4c. Fail-fast on invalid session config — but only when no custom
+        // SessionStore was installed via with_session_store(...). Done before
+        // setup_database so a doomed boot doesn't run migrations first.
+        fail_fast_on_invalid_session_config(&config, session_store.is_some());
+
         // 5. Create database pool and run migrations (if configured)
         #[cfg(feature = "db")]
         let pool = setup_database(&config, migrations, pool_provider_factory)
@@ -943,6 +948,11 @@ impl AppBuilder {
             eprintln!("Hint: use .static_routes(static_routes![...]) on your AppBuilder.");
             std::process::exit(1);
         }
+
+        // Fail-fast on invalid session config — only when no custom store
+        // was installed. Symmetrical to the same check in run() so static
+        // builds don't run migrations against a doomed boot either.
+        fail_fast_on_invalid_session_config(&config, session_store.is_some());
 
         // Build state (with DB if configured)
         #[cfg(feature = "db")]
@@ -1355,6 +1365,28 @@ fn log_startup_transparency(
     tracing::info!("Active middleware: {}", format_middleware_list(config));
 
     tracing::info!("Configuration:{}", format_config_summary(config));
+}
+
+/// Fail the boot fast (before any DB side effects) when the default
+/// session backend is misconfigured.
+///
+/// `AutumnConfig::validate()` is intentionally session-agnostic so that a
+/// custom [`SessionStore`](crate::session::SessionStore) installed via
+/// [`AppBuilder::with_session_store`] can override an otherwise-invalid
+/// `session.backend = "redis"`-without-`redis.url` config. But when no
+/// custom store is installed, the config-driven path will fail later in
+/// `apply_session_layer` — and by then, `setup_database` has already run
+/// migrations, leaving DB side effects from a doomed boot. This helper
+/// runs the same `backend_plan` check `apply_session_layer` does, but
+/// before any side effects, and only when the override path is inactive.
+fn fail_fast_on_invalid_session_config(config: &AutumnConfig, has_custom_session_store: bool) {
+    if has_custom_session_store {
+        return;
+    }
+    if let Err(error) = config.session.backend_plan(config.profile.as_deref()) {
+        eprintln!("Invalid session backend config: {error}");
+        std::process::exit(1);
+    }
 }
 
 async fn load_config_and_telemetry(

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -929,7 +929,7 @@ impl AppBuilder {
             #[cfg(feature = "db")]
             pool_provider_factory,
             telemetry_provider,
-            session_store: _,
+            session_store,
         } = self;
 
         let all_routes = routes;
@@ -961,12 +961,28 @@ impl AppBuilder {
         // run_build_mode used ProbeState::default(), which does not start as pending
         state.probes = crate::probe::ProbeState::default();
 
-        // Build the full router (same as production)
-        let router =
-            crate::router::try_build_router(all_routes, &config, state).unwrap_or_else(|error| {
-                eprintln!("Failed to build router: {error}");
-                std::process::exit(1);
-            });
+        // Build the full router (same as production). Use the inner builder
+        // so the custom session store installed via with_session_store(...)
+        // is honored during static generation — apps that swap in a custom
+        // store specifically to avoid Redis/external backends at build time
+        // would otherwise silently fall back to the config-driven backend.
+        let router = crate::router::try_build_router_inner(
+            all_routes,
+            &config,
+            state,
+            crate::router::RouterContext {
+                exception_filters: Vec::new(),
+                scoped_groups: Vec::new(),
+                merge_routers: Vec::new(),
+                nest_routers: Vec::new(),
+                error_page_renderer: None,
+                session_store,
+            },
+        )
+        .unwrap_or_else(|error| {
+            eprintln!("Failed to build router: {error}");
+            std::process::exit(1);
+        });
 
         let env = crate::config::OsEnv;
         let dist_dir = project_dir("dist", &env);
@@ -1389,9 +1405,15 @@ async fn setup_database(
     }
     .map_err(|e| format!("Failed to create database pool: {e}"))?;
 
-    if let Some(url) = &config.database.url {
-        for mig in migrations {
-            crate::migrate::auto_migrate(url, config.profile.as_deref(), mig);
+    // Skip migrations when the provider opted out of a database (returned
+    // `Ok(None)`) — even if `database.url` is configured. Custom providers
+    // signal "this app runs without a DB" by returning None; running
+    // migrations against the URL anyway would defeat the opt-out.
+    if pool.is_some() {
+        if let Some(url) = &config.database.url {
+            for mig in migrations {
+                crate::migrate::auto_migrate(url, config.profile.as_deref(), mig);
+            }
         }
     }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -604,17 +604,15 @@ impl AutumnConfig {
     /// syntactically well-formed TOML but semantically invalid.
     pub fn validate(&self) -> Result<(), ConfigError> {
         self.database.validate()?;
-        match self.session.backend_plan(self.profile.as_deref()) {
-            Ok(crate::session::SessionBackendPlan::Memory {
-                warn_in_production: true,
-            }) => eprintln!(
-                "Warning: prod profile is using in-memory sessions. Configure \
-                 `session.backend = \"redis\"` or set \
-                 `session.allow_memory_in_production = true` to acknowledge the risk."
-            ),
-            Ok(_) => {}
-            Err(error) => return Err(ConfigError::Validation(error.to_string())),
-        }
+        // Session backend validation deliberately lives in
+        // `crate::session::apply_session_layer`, not here. That function
+        // short-circuits when a custom `SessionStore` was installed via
+        // `AppBuilder::with_session_store(...)`, so the (then-irrelevant)
+        // `session.backend = "redis"` config without a redis URL doesn't
+        // need to fail the boot. Validating the same thing here would
+        // defeat the override and exit the app before the custom store
+        // ever gets a chance to apply. The "prod profile + memory backend"
+        // warning lives in `apply_session_layer` for the same reason.
         Ok(())
     }
 
@@ -1548,6 +1546,25 @@ mod tests {
         assert_eq!(resolved.profile.as_deref(), Some("integration-test"));
     }
 
+    #[test]
+    fn validate_does_not_error_on_redis_backend_without_url() {
+        // Regression: previously `validate()` called
+        // `session.backend_plan(profile)` which returned an error for
+        // `backend = "redis"` without `redis.url`, exiting the boot before
+        // a `with_session_store(...)` override could apply. Session
+        // backend validation now lives in `apply_session_layer`, which
+        // short-circuits when a custom store is installed. `validate()`
+        // is config-shape-only and must accept this combination.
+        let mut config = AutumnConfig::default();
+        config.session.backend = crate::session::SessionBackend::Redis;
+        config.session.redis.url = None;
+
+        config.validate().expect(
+            "validate() must accept redis-backend-without-url so custom \
+             session store overrides aren't blocked at boot",
+        );
+    }
+
     #[tokio::test]
     async fn default_toml_env_loader_succeeds_without_files() {
         // No autumn.toml in the test runner's pwd; loader should fall back to
@@ -1692,18 +1709,23 @@ mod tests {
     }
 
     #[test]
-    fn autumn_config_validate_session_err() {
+    fn autumn_config_validate_no_longer_errors_on_invalid_session_backend() {
+        // Session backend validation moved to `apply_session_layer` so a
+        // custom store installed via `AppBuilder::with_session_store(...)`
+        // can override an otherwise-invalid backend config without the boot
+        // exiting first. `validate()` is config-shape-only now; runtime
+        // session selection (and the backend error) lives in
+        // `apply_session_layer`, which short-circuits when a custom store
+        // is installed. `crate::session::tests::session_backend_plan_*`
+        // still cover the underlying error cases directly on
+        // `SessionConfig::backend_plan`.
         let mut config = AutumnConfig::default();
         config.session.backend = crate::session::SessionBackend::Redis;
         config.session.redis.url = None;
 
-        let result = config.validate();
-        assert!(result.is_err());
-        if let Err(ConfigError::Validation(msg)) = result {
-            assert!(msg.contains("session.backend=redis requires session.redis.url"));
-        } else {
-            panic!("Expected ConfigError::Validation");
-        }
+        config
+            .validate()
+            .expect("validate() must accept invalid session backend so custom store can override");
     }
 
     #[test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -456,7 +456,7 @@ pub enum ConfigError {
 /// assert_eq!(config.log.level, "info");
 /// assert_eq!(config.health.path, "/health");
 /// ```
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct AutumnConfig {
     /// Active profile name (e.g., "dev", "prod", "staging").
     /// Resolved at load time, not deserialized from TOML.
@@ -932,7 +932,7 @@ impl AutumnConfig {
 /// assert_eq!(server.port, 3000);
 /// assert_eq!(server.host, "127.0.0.1");
 /// ```
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ServerConfig {
     /// Port to listen on. Default: `3000`.
     #[serde(default = "default_port")]
@@ -979,7 +979,7 @@ pub struct ServerConfig {
 /// assert!(db.url.is_none());
 /// assert_eq!(db.pool_size, 10);
 /// ```
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct DatabaseConfig {
     /// Postgres connection URL. `None` means no database is configured.
     ///
@@ -1030,7 +1030,7 @@ impl DatabaseConfig {
 /// assert_eq!(log.level, "info");
 /// assert_eq!(log.format, LogFormat::Auto);
 /// ```
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct LogConfig {
     /// Tracing filter directive. Default: `"info"`.
     ///
@@ -1062,7 +1062,7 @@ pub struct LogConfig {
 ///
 /// assert_eq!(LogFormat::default(), LogFormat::Auto);
 /// ```
-#[derive(Debug, Deserialize, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
 pub enum LogFormat {
     /// Pretty in dev, JSON in production (based on `AUTUMN_ENV`).
     #[default]
@@ -1077,7 +1077,7 @@ pub enum LogFormat {
 ///
 /// Controls whether Autumn enables OTLP trace export and how the process
 /// identifies itself in resource metadata.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct TelemetryConfig {
     /// Enable framework-managed telemetry. Default: `false`.
     #[serde(default)]
@@ -1156,7 +1156,7 @@ impl TelemetryProtocol {
 /// assert_eq!(health.startup_path, "/startup");
 /// assert!(!health.detailed);
 /// ```
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct HealthConfig {
     /// Compatibility alias path for readiness. Default: `"/health"`.
     ///
@@ -1188,7 +1188,7 @@ pub struct HealthConfig {
 /// Controls which operational endpoints are exposed. The `sensitive` flag
 /// determines whether sensitive endpoints (env, configprops, loggers,
 /// tasks) are available. Defaults to `true` for `dev`, `false` for `prod`.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ActuatorConfig {
     /// URL prefix for actuator endpoints. Default: `"/actuator"`.
     #[serde(default = "default_actuator_prefix")]
@@ -1249,7 +1249,7 @@ fn default_actuator_prefix() -> String {
 /// assert!(cors.allowed_origins.is_empty());
 /// assert!(!cors.allow_credentials);
 /// ```
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct CorsConfig {
     /// Origins allowed to make cross-origin requests.
     ///
@@ -1454,10 +1454,109 @@ impl Default for HealthConfig {
     }
 }
 
+// ----------------------------------------------------------------------------
+// ConfigLoader — tier-1 boot-time replaceable config loading
+// ----------------------------------------------------------------------------
+
+/// Pluggable boot-time configuration loader.
+///
+/// Replace the default TOML + env loader with a custom strategy (e.g. AWS
+/// Secrets Manager, Consul, a JSON file, an HTTP fetch) by implementing this
+/// trait and installing it on the [`AppBuilder`](crate::app::AppBuilder) via
+/// [`with_config_loader`](crate::app::AppBuilder::with_config_loader).
+///
+/// The trait's return type uses `impl Future + Send` so implementations can
+/// freely use `async fn` in their bodies while the framework can still spawn
+/// the load on any executor.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use autumn_web::config::{AutumnConfig, ConfigError, ConfigLoader};
+///
+/// pub struct JsonFileConfigLoader { path: std::path::PathBuf }
+///
+/// impl ConfigLoader for JsonFileConfigLoader {
+///     async fn load(&self) -> Result<AutumnConfig, ConfigError> {
+///         let bytes = std::fs::read(&self.path).map_err(ConfigError::Io)?;
+///         serde_json::from_slice(&bytes)
+///             .map_err(|e| ConfigError::Validation(e.to_string()))
+///     }
+/// }
+/// ```
+pub trait ConfigLoader: Send + Sync + 'static {
+    /// Load and return a fully-resolved [`AutumnConfig`].
+    ///
+    /// Implementations are responsible for any layering, profile resolution,
+    /// and validation they care to apply. The default implementation
+    /// ([`TomlEnvConfigLoader`]) preserves Autumn's five-layer load
+    /// (framework defaults → profile defaults → `autumn.toml` →
+    /// `autumn-{profile}.toml` → `AUTUMN_*` env vars).
+    fn load(&self) -> impl std::future::Future<Output = Result<AutumnConfig, ConfigError>> + Send;
+}
+
+/// Default [`ConfigLoader`] — Autumn's five-layer TOML + env load strategy.
+///
+/// Delegates to [`AutumnConfig::load_with_env`] using [`OsEnv`] for environment
+/// variable reads. This is the loader used when no override is installed via
+/// [`with_config_loader`](crate::app::AppBuilder::with_config_loader).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TomlEnvConfigLoader;
+
+impl TomlEnvConfigLoader {
+    /// Construct a new default loader.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl ConfigLoader for TomlEnvConfigLoader {
+    async fn load(&self) -> Result<AutumnConfig, ConfigError> {
+        AutumnConfig::load_with_env(&OsEnv)
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
     use super::*;
+
+    /// Mock loader for tests — returns a hand-built config without touching disk.
+    struct MockConfigLoader {
+        config: AutumnConfig,
+    }
+
+    impl ConfigLoader for MockConfigLoader {
+        async fn load(&self) -> Result<AutumnConfig, ConfigError> {
+            Ok(self.config.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn config_loader_trait_returns_supplied_config() {
+        let mut custom = AutumnConfig::default();
+        custom.server.port = 9999;
+        custom.profile = Some("integration-test".to_owned());
+
+        let loader = MockConfigLoader {
+            config: custom.clone(),
+        };
+        let resolved = loader.load().await.expect("mock loader should succeed");
+
+        assert_eq!(resolved.server.port, 9999);
+        assert_eq!(resolved.profile.as_deref(), Some("integration-test"));
+    }
+
+    #[tokio::test]
+    async fn default_toml_env_loader_succeeds_without_files() {
+        // No autumn.toml in the test runner's pwd; loader should fall back to
+        // framework defaults rather than failing.
+        let loader = TomlEnvConfigLoader::new();
+        let resolved = loader.load().await.expect("default loader should succeed");
+        // Default port is 3000 per ServerConfig::default — sanity check.
+        assert_eq!(resolved.server.port, 3000);
+    }
 
     #[test]
     fn database_config_validate_none() {

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -143,11 +143,131 @@ where
     }
 }
 
+// ----------------------------------------------------------------------------
+// DatabasePoolProvider — tier-1 boot-time replaceable pool factory
+// ----------------------------------------------------------------------------
+
+/// Pluggable boot-time database pool factory.
+///
+/// Replace the default `deadpool + diesel-async` factory with a custom
+/// strategy (custom metrics wrapper, circuit breaker, separate pools per
+/// shard, etc.) by implementing this trait and installing it on the
+/// [`AppBuilder`](crate::app::AppBuilder) via
+/// [`with_pool_provider`](crate::app::AppBuilder::with_pool_provider).
+///
+/// The trait abstracts the *factory*, not the pool *type* — the return type is
+/// fixed at `Pool<AsyncPgConnection>` for now. Swapping to a different backend
+/// (e.g. `MySQL`, `SQLite`) would require generic `Pool<C>` propagation through
+/// `Db` / `DbState` / `AppState` and is intentionally out of scope.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use autumn_web::config::DatabaseConfig;
+/// use autumn_web::db::{DatabasePoolProvider, PoolError};
+/// use diesel_async::AsyncPgConnection;
+/// use diesel_async::pooled_connection::deadpool::Pool;
+///
+/// pub struct MetricsPoolProvider;
+///
+/// impl DatabasePoolProvider for MetricsPoolProvider {
+///     async fn create_pool(
+///         &self,
+///         config: &DatabaseConfig,
+///     ) -> Result<Option<Pool<AsyncPgConnection>>, PoolError> {
+///         // Wrap the default pool with custom metrics, then return it.
+///         autumn_web::db::create_pool(config)
+///     }
+/// }
+/// ```
+pub trait DatabasePoolProvider: Send + Sync + 'static {
+    /// Create a connection pool from the resolved [`DatabaseConfig`].
+    ///
+    /// Returning `Ok(None)` signals that the application should run without a
+    /// database — useful for static-site / API-gateway use cases or for
+    /// disabling the DB in test contexts.
+    fn create_pool(
+        &self,
+        config: &DatabaseConfig,
+    ) -> impl std::future::Future<Output = Result<Option<Pool<AsyncPgConnection>>, PoolError>> + Send;
+}
+
+/// Default [`DatabasePoolProvider`] — the `deadpool + diesel-async` factory.
+///
+/// Delegates to the free function [`create_pool`]. This is the provider used
+/// when no override is installed via
+/// [`with_pool_provider`](crate::app::AppBuilder::with_pool_provider).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DieselDeadpoolPoolProvider;
+
+impl DieselDeadpoolPoolProvider {
+    /// Construct a new default provider.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl DatabasePoolProvider for DieselDeadpoolPoolProvider {
+    async fn create_pool(
+        &self,
+        config: &DatabaseConfig,
+    ) -> Result<Option<Pool<AsyncPgConnection>>, PoolError> {
+        create_pool(config)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::DatabaseConfig;
     use std::time::Duration;
+
+    // ── Pool provider trait tests ────────────────────────────────
+
+    /// No-op provider for tests — always returns `Ok(None)` regardless of the
+    /// supplied config. Verifies the trait actually overrides the default
+    /// (which would otherwise build a pool from the URL).
+    struct NoOpPoolProvider;
+
+    impl DatabasePoolProvider for NoOpPoolProvider {
+        async fn create_pool(
+            &self,
+            _config: &DatabaseConfig,
+        ) -> Result<Option<Pool<AsyncPgConnection>>, PoolError> {
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn pool_provider_trait_returns_supplied_pool() {
+        // Even with a configured URL, the no-op provider returns None — proving
+        // the trait can replace the default factory's behaviour.
+        let config = DatabaseConfig {
+            url: Some("postgres://localhost/ignored".to_owned()),
+            ..Default::default()
+        };
+        let provider = NoOpPoolProvider;
+        let pool = provider
+            .create_pool(&config)
+            .await
+            .expect("no-op provider should succeed");
+        assert!(
+            pool.is_none(),
+            "no-op provider must override default behaviour"
+        );
+    }
+
+    #[tokio::test]
+    async fn default_pool_provider_matches_free_function() {
+        let config = DatabaseConfig::default();
+        let via_provider = DieselDeadpoolPoolProvider::new()
+            .create_pool(&config)
+            .await
+            .expect("default provider should succeed");
+        let via_function = create_pool(&config).expect("free fn should succeed");
+        assert_eq!(via_provider.is_none(), via_function.is_none());
+    }
 
     // ── Pool creation tests ──────────────────────────────────────
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -115,7 +115,7 @@ pub mod sse;
 pub mod static_gen;
 
 pub mod task;
-pub(crate) mod telemetry;
+pub mod telemetry;
 pub mod validation;
 #[cfg(feature = "ws")]
 pub mod ws;

--- a/autumn/src/plugin.rs
+++ b/autumn/src/plugin.rs
@@ -85,6 +85,14 @@ pub trait Plugin: Sized + Send + 'static {
     /// [`AppBuilder::on_startup`], [`AppBuilder::on_shutdown`],
     /// [`AppBuilder::nest`], [`AppBuilder::with_extension`] and (with the
     /// `db` feature) [`AppBuilder::migrations`].
+    ///
+    /// Plugins can also install **tier-1 subsystem replacements** here —
+    /// [`AppBuilder::with_config_loader`], [`AppBuilder::with_pool_provider`]
+    /// (with the `db` feature), [`AppBuilder::with_telemetry_provider`], and
+    /// [`AppBuilder::with_session_store`] — which is the canonical way to
+    /// distribute a custom subsystem (e.g. `AwsSecretsConfigPlugin`) for
+    /// downstream consumers as a one-line install. See
+    /// `docs/guide/extensibility.md` for the full extensibility model.
     #[must_use]
     fn build(self, app: AppBuilder) -> AppBuilder;
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -74,6 +74,11 @@ pub struct RouterContext {
     pub merge_routers: Vec<axum::Router<AppState>>,
     pub nest_routers: Vec<(String, axum::Router<AppState>)>,
     pub error_page_renderer: Option<SharedRenderer>,
+    /// Custom session store installed via
+    /// [`AppBuilder::with_session_store`](crate::app::AppBuilder::with_session_store).
+    /// When `Some`, [`apply_session_layer`](crate::session::apply_session_layer)
+    /// uses it directly and skips the config-driven backend selection.
+    pub session_store: Option<Arc<dyn crate::session::BoxedSessionStore>>,
 }
 
 /// Checked variant of [`build_router`] that returns configuration errors
@@ -99,6 +104,7 @@ pub fn try_build_router(
             merge_routers: Vec::new(),
             nest_routers: Vec::new(),
             error_page_renderer: None,
+            session_store: None,
         },
     )?;
     Ok(apply_startup_barrier(
@@ -156,6 +162,7 @@ pub fn try_build_router_merged(
             merge_routers,
             nest_routers,
             error_page_renderer: None,
+            session_store: None,
         },
     )?;
     Ok(apply_startup_barrier(
@@ -197,6 +204,7 @@ pub fn try_build_router_inner(
         &state,
         ctx.exception_filters,
         ctx.error_page_renderer,
+        ctx.session_store,
     )?;
 
     if dev_reload_enabled {
@@ -421,6 +429,7 @@ fn apply_middleware(
     state: &AppState,
     exception_filters: Vec<Arc<dyn ExceptionFilter>>,
     error_page_renderer: Option<SharedRenderer>,
+    session_store: Option<Arc<dyn crate::session::BoxedSessionStore>>,
 ) -> Result<axum::Router<AppState>, RouterBuildError> {
     router = apply_cors_middleware(router, config);
     router = apply_csrf_middleware(router, config);
@@ -436,8 +445,12 @@ fn apply_middleware(
     // Apply framework middleware. Exception filters wrap outermost so they
     // see all error responses regardless of scoping or interceptors.
     let router = router.layer(RequestIdLayer).layer(security_headers);
-    let router =
-        crate::session::apply_session_layer(router, &config.session, config.profile.as_deref())?;
+    let router = crate::session::apply_session_layer(
+        router,
+        &config.session,
+        config.profile.as_deref(),
+        session_store,
+    )?;
     tracing::debug!(backend = ?config.session.backend, "Session management enabled");
 
     // Error page filter: renders HTML error pages for browser requests.
@@ -529,6 +542,7 @@ pub fn try_build_router_with_static(
             merge_routers: Vec::new(),
             nest_routers: Vec::new(),
             error_page_renderer: None,
+            session_store: None,
         },
     )
 }

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -46,7 +46,7 @@ use serde::Deserialize;
 /// assert!(config.headers.x_content_type_options);
 /// assert!(!config.csrf.enabled);
 /// ```
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct SecurityConfig {
     /// HTTP security headers applied to all responses.
     #[serde(default)]
@@ -84,7 +84,7 @@ pub struct SecurityConfig {
 /// content_security_policy = "default-src 'self'; script-src 'self'"
 /// strict_transport_security = true
 /// ```
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct HeadersConfig {
     /// `X-Frame-Options` header value. Default: `"DENY"`.
@@ -188,7 +188,7 @@ impl Default for HeadersConfig {
 /// token_header = "X-XSRF-Token"
 /// cookie_name = "XSRF-TOKEN"
 /// ```
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct CsrfConfig {
     /// Enable CSRF protection. Default: `false`.
     ///

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -280,6 +280,64 @@ impl SessionStore for MemoryStore {
     }
 }
 
+// ── Erasure bridge for runtime-installed custom stores ─────────
+//
+// `SessionStore` uses RPIT (`-> impl Future + Send`) and is therefore not
+// dyn-compatible. To let `AppBuilder::with_session_store(impl SessionStore)`
+// erase the concrete type into something `AppBuilder` can store and
+// `apply_session_layer` can wrap into a `SessionLayer`, we keep a
+// pub(crate) dyn-compatible `BoxedSessionStore` shadow trait with a blanket
+// impl over any `SessionStore`, plus an `ArcSessionStore` newtype that
+// satisfies `SessionStore` by delegating through the trait object. Users
+// only see `SessionStore`; the bridge stays an implementation detail.
+
+pub(crate) type BoxedLoadFuture<'a> = Pin<
+    Box<
+        dyn Future<Output = Result<Option<HashMap<String, String>>, SessionStoreError>> + Send + 'a,
+    >,
+>;
+pub(crate) type BoxedUnitFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<(), SessionStoreError>> + Send + 'a>>;
+
+pub(crate) trait BoxedSessionStore: Send + Sync + 'static {
+    fn boxed_load<'a>(&'a self, id: &'a str) -> BoxedLoadFuture<'a>;
+
+    fn boxed_save<'a>(&'a self, id: &'a str, data: HashMap<String, String>) -> BoxedUnitFuture<'a>;
+
+    fn boxed_destroy<'a>(&'a self, id: &'a str) -> BoxedUnitFuture<'a>;
+}
+
+impl<S: SessionStore> BoxedSessionStore for S {
+    fn boxed_load<'a>(&'a self, id: &'a str) -> BoxedLoadFuture<'a> {
+        Box::pin(SessionStore::load(self, id))
+    }
+
+    fn boxed_save<'a>(&'a self, id: &'a str, data: HashMap<String, String>) -> BoxedUnitFuture<'a> {
+        Box::pin(SessionStore::save(self, id, data))
+    }
+
+    fn boxed_destroy<'a>(&'a self, id: &'a str) -> BoxedUnitFuture<'a> {
+        Box::pin(SessionStore::destroy(self, id))
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ArcSessionStore(pub(crate) Arc<dyn BoxedSessionStore>);
+
+impl SessionStore for ArcSessionStore {
+    async fn load(&self, id: &str) -> Result<Option<HashMap<String, String>>, SessionStoreError> {
+        self.0.boxed_load(id).await
+    }
+
+    async fn save(&self, id: &str, data: HashMap<String, String>) -> Result<(), SessionStoreError> {
+        self.0.boxed_save(id, data).await
+    }
+
+    async fn destroy(&self, id: &str) -> Result<(), SessionStoreError> {
+        self.0.boxed_destroy(id).await
+    }
+}
+
 // ── Session configuration ───────────────────────────────────────
 
 /// Configuration for session management.
@@ -682,7 +740,15 @@ pub(crate) fn apply_session_layer(
     router: axum::Router<crate::state::AppState>,
     config: &SessionConfig,
     profile: Option<&str>,
+    custom_store: Option<Arc<dyn BoxedSessionStore>>,
 ) -> Result<axum::Router<crate::state::AppState>, SessionBackendConfigError> {
+    if let Some(store) = custom_store {
+        tracing::debug!(
+            "Custom session store installed via with_session_store(); skipping config-driven backend selection"
+        );
+        return Ok(router.layer(SessionLayer::new(ArcSessionStore(store), config.clone())));
+    }
+
     match config.backend_plan(profile)? {
         SessionBackendPlan::Memory { warn_in_production } => {
             if warn_in_production {
@@ -717,6 +783,72 @@ mod tests {
     use axum::routing::get;
     use http::Request as HttpRequest;
     use tower::ServiceExt;
+
+    /// Sentinel store for verifying that the type-erased `BoxedSessionStore`
+    /// bridge actually delegates back to the user's `SessionStore` impl
+    /// instead of silently picking up the default memory store.
+    #[derive(Clone, Default)]
+    struct SentinelStore {
+        load_calls: Arc<RwLock<u32>>,
+    }
+
+    impl SessionStore for SentinelStore {
+        async fn load(
+            &self,
+            _id: &str,
+        ) -> Result<Option<HashMap<String, String>>, SessionStoreError> {
+            *self.load_calls.write().await += 1;
+            // Return a recognisable session payload so the test can prove the
+            // wrapper actually went through this impl.
+            let mut data = HashMap::new();
+            data.insert("from".to_owned(), "sentinel".to_owned());
+            Ok(Some(data))
+        }
+
+        async fn save(
+            &self,
+            _id: &str,
+            _data: HashMap<String, String>,
+        ) -> Result<(), SessionStoreError> {
+            Ok(())
+        }
+
+        async fn destroy(&self, _id: &str) -> Result<(), SessionStoreError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn arc_session_store_wrapper_delegates_to_inner_session_store() {
+        let inner = SentinelStore::default();
+        let load_counter = inner.load_calls.clone();
+        let arc: Arc<dyn BoxedSessionStore> = Arc::new(inner);
+        let wrapper = ArcSessionStore(arc);
+
+        let result = wrapper
+            .load("session-id")
+            .await
+            .expect("wrapped store should succeed");
+
+        assert_eq!(*load_counter.read().await, 1);
+        assert_eq!(
+            result
+                .as_ref()
+                .and_then(|m| m.get("from"))
+                .map(String::as_str),
+            Some("sentinel"),
+            "wrapper must return data from the wrapped impl, not a default"
+        );
+    }
+
+    #[tokio::test]
+    async fn boxed_session_store_blanket_impl_works_for_any_session_store() {
+        // Any SessionStore type erases via the BoxedSessionStore blanket impl.
+        let store = SentinelStore::default();
+        let boxed: Arc<dyn BoxedSessionStore> = Arc::new(store);
+        let result = boxed.boxed_load("session-id").await.unwrap();
+        assert!(result.is_some());
+    }
 
     #[derive(Clone)]
     struct FailingStore {

--- a/autumn/src/telemetry.rs
+++ b/autumn/src/telemetry.rs
@@ -410,3 +410,120 @@ fn build_resource_attributes(resource: &TelemetryResource) -> [KeyValue; 3] {
         KeyValue::new("deployment.environment", resource.environment.clone()),
     ]
 }
+
+// ----------------------------------------------------------------------------
+// TelemetryProvider — tier-1 boot-time replaceable telemetry init
+// ----------------------------------------------------------------------------
+
+/// Pluggable boot-time telemetry initializer.
+///
+/// Replace the default `tracing-subscriber + OTLP` initializer with a custom
+/// strategy (Datadog tracer, Honeycomb beeline, Sentry breadcrumbs, custom
+/// log aggregator) by implementing this trait and installing it on the
+/// [`AppBuilder`](crate::app::AppBuilder) via
+/// [`with_telemetry_provider`](crate::app::AppBuilder::with_telemetry_provider).
+///
+/// Initialization is synchronous — the trait mirrors the shape of the
+/// underlying [`init`] free function. Custom providers that need async setup
+/// can spin up a runtime internally or, more commonly, do their async work
+/// from within the returned [`TelemetryGuard`]'s lifecycle hooks.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use autumn_web::config::{LogConfig, TelemetryConfig};
+/// use autumn_web::telemetry::{TelemetryGuard, TelemetryInitError, TelemetryProvider};
+///
+/// pub struct DatadogTelemetryProvider;
+///
+/// impl TelemetryProvider for DatadogTelemetryProvider {
+///     fn init(
+///         &self,
+///         _log: &LogConfig,
+///         _telemetry: &TelemetryConfig,
+///         _profile: Option<&str>,
+///     ) -> Result<TelemetryGuard, TelemetryInitError> {
+///         // configure datadog-tracing here, then return a guard whose Drop
+///         // cleanly flushes the exporter.
+///         Ok(TelemetryGuard::disabled())
+///     }
+/// }
+/// ```
+pub trait TelemetryProvider: Send + Sync + 'static {
+    /// Initialize tracing/log subscribers and any exporters.
+    ///
+    /// Returns a [`TelemetryGuard`] whose `Drop` impl is responsible for
+    /// flushing exporters and tearing down any background tasks.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TelemetryInitError`] if subscriber registration or exporter
+    /// setup fails. Propagates to bootstrap and aborts the app.
+    fn init(
+        &self,
+        log: &LogConfig,
+        telemetry: &TelemetryConfig,
+        profile: Option<&str>,
+    ) -> Result<TelemetryGuard, TelemetryInitError>;
+}
+
+/// Default [`TelemetryProvider`] — `tracing-subscriber` with optional OTLP export.
+///
+/// Delegates to the free function [`init`]. This is the provider used when no
+/// override is installed via
+/// [`with_telemetry_provider`](crate::app::AppBuilder::with_telemetry_provider).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TracingOtlpTelemetryProvider;
+
+impl TracingOtlpTelemetryProvider {
+    /// Construct a new default telemetry provider.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl TelemetryProvider for TracingOtlpTelemetryProvider {
+    fn init(
+        &self,
+        log: &LogConfig,
+        telemetry: &TelemetryConfig,
+        profile: Option<&str>,
+    ) -> Result<TelemetryGuard, TelemetryInitError> {
+        init(log, telemetry, profile)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// No-op provider for tests — returns a disabled guard without touching the
+    /// global tracing subscriber. Verifies the trait actually overrides the
+    /// default `tracing-subscriber + OTLP` initializer.
+    struct NoOpTelemetryProvider;
+
+    impl TelemetryProvider for NoOpTelemetryProvider {
+        fn init(
+            &self,
+            _log: &LogConfig,
+            _telemetry: &TelemetryConfig,
+            _profile: Option<&str>,
+        ) -> Result<TelemetryGuard, TelemetryInitError> {
+            Ok(TelemetryGuard::disabled())
+        }
+    }
+
+    #[test]
+    fn telemetry_provider_trait_returns_supplied_guard() {
+        let provider = NoOpTelemetryProvider;
+        let log = LogConfig::default();
+        let telemetry = TelemetryConfig::default();
+        // Should succeed and not touch the global subscriber.
+        let guard = provider
+            .init(&log, &telemetry, Some("test"))
+            .expect("no-op provider should succeed");
+        // Sanity: the disabled guard must be droppable without panic.
+        drop(guard);
+    }
+}

--- a/autumn/src/telemetry.rs
+++ b/autumn/src/telemetry.rs
@@ -111,7 +111,13 @@ pub struct TelemetryGuard {
 }
 
 impl TelemetryGuard {
-    const fn disabled() -> Self {
+    /// Construct a no-op telemetry guard.
+    ///
+    /// Useful for [`TelemetryProvider`] implementations that decide at runtime
+    /// not to register a global tracing subscriber — e.g. a Datadog provider
+    /// reading a feature flag, or any custom impl that wants to opt out of
+    /// telemetry without panicking.
+    pub const fn disabled() -> Self {
         Self {
             #[cfg(feature = "telemetry-otlp")]
             provider: None,

--- a/docs/guide/custom-subsystems.md
+++ b/docs/guide/custom-subsystems.md
@@ -1,0 +1,285 @@
+# Replacing Autumn subsystems with custom impls
+
+This guide is the per-trait how-to for **tier-1** subsystem replacement. For
+the bigger picture — when to reach for tier-1 vs tier-2 (`#[intercept]`)
+vs tier-3 (`Plugin`) — see [`extensibility.md`](extensibility.md).
+
+Each tier-1 subsystem in Autumn follows the same shape:
+
+1. **A trait** in the subsystem's home module.
+2. **A default impl** that wraps the framework's existing behaviour.
+3. **A fluent builder method** on `AppBuilder` (`with_<subsystem>`) that
+   replaces the default with your impl.
+
+Replacement is opt-in. Apps that don't call `with_<subsystem>` see no
+behaviour change.
+
+---
+
+## `ConfigLoader` — replace the TOML + env config layering
+
+```rust,no_run
+use autumn_web::config::{AutumnConfig, ConfigError, ConfigLoader};
+
+pub struct JsonFileConfigLoader { path: std::path::PathBuf }
+
+impl ConfigLoader for JsonFileConfigLoader {
+    async fn load(&self) -> Result<AutumnConfig, ConfigError> {
+        let bytes = std::fs::read(&self.path).map_err(ConfigError::Io)?;
+        serde_json::from_slice(&bytes)
+            .map_err(|e| ConfigError::Validation(e.to_string()))
+    }
+}
+
+# use autumn_web::prelude::*;
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .with_config_loader(JsonFileConfigLoader { path: "config.json".into() })
+        .run()
+        .await;
+}
+```
+
+A complete runnable version of this lives at
+[`examples/custom_config_loader`](../../examples/custom_config_loader). Run it
+with `cargo run -p custom-config-loader-example`.
+
+**When to reach for it:** AWS Secrets Manager, Vault, Consul, an HTTP fetch,
+a JSON/YAML file, encrypted overlays, anything that's not five-layer TOML +
+env vars. The trait's only contract is "produce a fully-resolved
+`AutumnConfig` or a `ConfigError`" — the framework handles the rest of the
+boot sequence the same way it would for the default loader.
+
+---
+
+## `DatabasePoolProvider` — replace the deadpool + diesel-async pool factory
+
+```rust,no_run
+use autumn_web::config::DatabaseConfig;
+use autumn_web::db::{DatabasePoolProvider, PoolError};
+use diesel_async::AsyncPgConnection;
+use diesel_async::pooled_connection::deadpool::Pool;
+
+pub struct MetricsPoolProvider;
+
+impl DatabasePoolProvider for MetricsPoolProvider {
+    async fn create_pool(
+        &self,
+        config: &DatabaseConfig,
+    ) -> Result<Option<Pool<AsyncPgConnection>>, PoolError> {
+        // Wrap the default factory's output with your own metrics, circuit
+        // breaker, custom builder, etc. before returning.
+        autumn_web::db::create_pool(config)
+    }
+}
+
+# use autumn_web::prelude::*;
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .with_pool_provider(MetricsPoolProvider)
+        .run()
+        .await;
+}
+```
+
+**When to reach for it:** custom metrics wrappers, circuit breakers, separate
+pools per shard, sidecar connection lifecycle (warmup queries, custom probe
+endpoints), or alternative builders that still produce
+`Pool<AsyncPgConnection>`.
+
+**What this trait does NOT abstract:** the pool *type*. The return is always
+`Pool<AsyncPgConnection>`. Switching to a non-Postgres backend (MySQL, SQLite)
+would require generic `Pool<C>` propagation through `Db`, `DbState`, and
+`AppState` — a much larger refactor that's intentionally out of scope.
+
+---
+
+## `TelemetryProvider` — replace the tracing + OTLP initializer
+
+```rust,no_run
+use autumn_web::config::{LogConfig, TelemetryConfig};
+use autumn_web::telemetry::{TelemetryGuard, TelemetryInitError, TelemetryProvider};
+
+pub struct DatadogTelemetryProvider;
+
+impl TelemetryProvider for DatadogTelemetryProvider {
+    fn init(
+        &self,
+        _log: &LogConfig,
+        _telemetry: &TelemetryConfig,
+        _profile: Option<&str>,
+    ) -> Result<TelemetryGuard, TelemetryInitError> {
+        // Configure datadog-tracing here. Return a TelemetryGuard whose
+        // Drop impl flushes your exporter.
+        Ok(TelemetryGuard::disabled())
+    }
+}
+
+# use autumn_web::prelude::*;
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .with_telemetry_provider(DatadogTelemetryProvider)
+        .run()
+        .await;
+}
+```
+
+**When to reach for it:** Datadog tracer, Honeycomb beeline, Sentry
+breadcrumb integration, custom JSON aggregator, or anything else that wants
+control of the global tracing subscriber and exporter setup.
+
+**Synchronous on purpose:** `init` mirrors the underlying
+`tracing-subscriber` API. If your provider needs async setup (HTTP
+discovery, registration with a control plane), do that work inside the
+returned `TelemetryGuard`'s lifecycle hooks, or spin up an internal runtime
+inside `init`.
+
+---
+
+## `SessionStore` — replace the memory/redis backend with anything else
+
+```rust,no_run
+use std::collections::HashMap;
+use autumn_web::session::{SessionStore, SessionStoreError};
+
+pub struct EncryptedCookieStore;
+
+impl SessionStore for EncryptedCookieStore {
+    async fn load(
+        &self,
+        _id: &str,
+    ) -> Result<Option<HashMap<String, String>>, SessionStoreError> {
+        // Decrypt cookie payload, deserialize, return.
+        Ok(None)
+    }
+
+    async fn save(
+        &self,
+        _id: &str,
+        _data: HashMap<String, String>,
+    ) -> Result<(), SessionStoreError> {
+        // Serialize, encrypt, set cookie via response handler.
+        Ok(())
+    }
+
+    async fn destroy(&self, _id: &str) -> Result<(), SessionStoreError> {
+        Ok(())
+    }
+}
+
+# use autumn_web::prelude::*;
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .with_session_store(EncryptedCookieStore)
+        .run()
+        .await;
+}
+```
+
+When you install a custom store, `apply_session_layer` skips the
+config-driven `memory` vs `redis` selection entirely — your store handles
+all sessions for the app.
+
+**When to reach for it:** database-backed sessions, encrypted cookie stores,
+enterprise SSO bridges, multi-tenant session isolation, or anything else
+that doesn't fit the built-in memory/Redis split.
+
+---
+
+## `ErrorPageRenderer` — replace the built-in HTML error pages
+
+```rust,no_run
+# use autumn_web::error_pages::ErrorPageRenderer;
+# struct MyRenderer;
+# impl ErrorPageRenderer for MyRenderer {}
+# use autumn_web::prelude::*;
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .error_pages(MyRenderer)
+        .run()
+        .await;
+}
+```
+
+`ErrorPageRenderer` is the original tier-1 install in the framework — the
+shape the others were modelled on. See its
+[trait docs](../../autumn/src/error_pages/renderer.rs) for the full method
+surface.
+
+---
+
+## Distributing a custom subsystem as a crate
+
+If you want to ship one of these tier-1 replacements for someone else to
+install with a single line, wrap it in a `Plugin`:
+
+```rust,no_run
+use autumn_web::app::AppBuilder;
+use autumn_web::plugin::Plugin;
+
+pub struct AwsSecretsConfigPlugin {
+    region: String,
+}
+
+impl AwsSecretsConfigPlugin {
+    pub fn new(region: impl Into<String>) -> Self {
+        Self { region: region.into() }
+    }
+}
+
+impl Plugin for AwsSecretsConfigPlugin {
+    fn build(self, app: AppBuilder) -> AppBuilder {
+        app.with_config_loader(AwsSecretsConfigLoader::new(self.region))
+    }
+}
+# pub struct AwsSecretsConfigLoader;
+# impl AwsSecretsConfigLoader { pub fn new(_: String) -> Self { Self } }
+# impl autumn_web::config::ConfigLoader for AwsSecretsConfigLoader {
+#     async fn load(&self) -> Result<autumn_web::config::AutumnConfig, autumn_web::config::ConfigError> { unimplemented!() }
+# }
+```
+
+End user:
+
+```rust,no_run
+# use autumn_web::prelude::*;
+# struct AwsSecretsConfigPlugin;
+# impl AwsSecretsConfigPlugin { fn new(_: &str) -> Self { Self } }
+# impl autumn_web::plugin::Plugin for AwsSecretsConfigPlugin {
+#     fn build(self, app: autumn_web::app::AppBuilder) -> autumn_web::app::AppBuilder { app }
+# }
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .plugin(AwsSecretsConfigPlugin::new("us-east-1"))
+        .run()
+        .await;
+}
+```
+
+This is the tier-3 distribution pattern. See
+[`extensibility.md`](extensibility.md) for the full picture, and
+[`autumn/src/plugin.rs`](../../autumn/src/plugin.rs) for naming conventions
+on first-party (`autumn-<name>-plugin`) vs third-party
+(`autumn-plugin-<name>`) plugin crates.
+
+---
+
+## What if I need to replace something that doesn't have a `with_*` method?
+
+Three options:
+
+1. **Most likely**: there's a tier-2 (`#[intercept]`) or built-in extension
+   point that already does what you need. Check the relevant module's
+   rustdoc.
+2. **If it's a runtime extension**: use `AppBuilder::with_extension(value)`
+   to install an arbitrary typed value. Your code retrieves it via
+   `state.extension::<T>()` from request handlers or other framework code.
+3. **If it's a real subsystem gap**: file an issue. Adding a new tier-1
+   `with_<subsystem>` method follows a well-trodden pattern (the
+   `S-053` PR added four of them at once).

--- a/docs/guide/extensibility.md
+++ b/docs/guide/extensibility.md
@@ -1,0 +1,196 @@
+# Extensibility in Autumn
+
+Autumn ships with sensible defaults for everything — config loading, the
+database pool, the session store, the telemetry subscriber, error pages, the
+request cache, route handlers, middleware. None of those defaults are written
+in stone. The framework gives you three different mechanisms to swap them out,
+each suited to a different scope of change. Knowing which tier a piece of
+behaviour lives in is the fastest way to find the right hook.
+
+This guide names the three tiers, shows which subsystems live where, and
+points you at the per-tier how-tos.
+
+---
+
+## The three tiers at a glance
+
+| Tier | Mechanism | Scope | Typical use case |
+|------|-----------|-------|------------------|
+| **1** | `AppBuilder::with_<subsystem>(impl Trait)` | Boot-time, one-per-app | Replace a framework subsystem (config loader, DB pool, session store, telemetry, error pages) |
+| **2** | `#[intercept(Layer::new(...))]` | Per-request, stackable | Add cross-cutting middleware (caching, custom auth, request shaping, tracing) |
+| **3** | `Plugin::build(app)` | Distribution wrapper around tier 1 + 2 | Ship a reusable integration as a crate (e.g. `autumn-aws-secrets-plugin`) |
+
+These compose: a tier-3 `Plugin` typically does its work by calling tier-1 or
+tier-2 hooks inside `build()`. There is no fourth tier — if you find yourself
+reaching for one, file an issue.
+
+---
+
+## Tier 1: boot-time subsystem replacement
+
+Tier-1 hooks let you replace a framework subsystem with your own
+trait-implementing struct. Each is a fluent `with_<subsystem>` method on
+`AppBuilder`. They run exactly once during `AppBuilder::run()`, before the
+HTTP server starts.
+
+```rust,no_run
+use autumn_web::prelude::*;
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .with_config_loader(MyJsonConfigLoader::new("config.json"))
+        .with_telemetry_provider(DatadogTelemetryProvider)
+        .with_session_store(MyEncryptedCookieStore)
+        .routes(routes![/* ... */])
+        .run()
+        .await;
+}
+```
+
+### Subsystems available at tier 1
+
+| Subsystem | Trait | Builder method | Default |
+|-----------|-------|----------------|---------|
+| Config loading | [`ConfigLoader`](../../autumn/src/config.rs) | `with_config_loader` | `TomlEnvConfigLoader` (five-layer TOML + env) |
+| Database pool | [`DatabasePoolProvider`](../../autumn/src/db.rs) | `with_pool_provider` | `DieselDeadpoolPoolProvider` (deadpool + diesel-async) |
+| Telemetry | [`TelemetryProvider`](../../autumn/src/telemetry.rs) | `with_telemetry_provider` | `TracingOtlpTelemetryProvider` (`tracing-subscriber` + optional OTLP) |
+| Session store | [`SessionStore`](../../autumn/src/session.rs) | `with_session_store` | `MemoryStore` or `RedisStore` based on `session.backend` config |
+| Error pages | [`ErrorPageRenderer`](../../autumn/src/error_pages/renderer.rs) | `error_pages` | Built-in HTML renderer |
+
+See **[`custom-subsystems.md`](custom-subsystems.md)** for a per-subsystem
+how-to with full code examples.
+
+### When tier 1 is the right answer
+
+- You want **one** subsystem behaving differently for the **whole app**.
+- The replacement happens at **boot time**, not per-request.
+- You want **type-checked** integration with the rest of the framework.
+
+---
+
+## Tier 2: per-request middleware via `#[intercept]`
+
+Tier-2 hooks attach a tower-style `Layer` to a route or group of routes. They
+run once per matching request and can stack arbitrarily.
+
+```rust,no_run
+# use autumn_web::prelude::*;
+# struct CacheResponseLayer;
+# impl CacheResponseLayer { fn new(_: ()) -> Self { Self } }
+# let cache = ();
+
+#[get("/expensive")]
+#[intercept(CacheResponseLayer::new(cache.clone()))]
+async fn expensive() -> &'static str {
+    "computed once, served many"
+}
+```
+
+### When tier 2 is the right answer
+
+- You're augmenting **request handling**, not boot-time behaviour.
+- You want the change to apply to **a subset** of routes (or all of them, but
+  via stacking rather than replacement).
+- Multiple instances should be **layered**, not "last one wins".
+
+### Tier-2 examples
+
+- **Caching** — `#[intercept(CacheResponseLayer::new(my_cache))]` is the
+  intentional path for response caching. The `Cache` trait isn't a tier-1
+  install because there is no single "framework cache" — different routes
+  benefit from different cache configurations.
+- **Custom tracing** — wrap a route with `#[intercept(TracingLayer)]` to
+  emit additional spans without touching the global subscriber.
+- **Auth shape variants** — apply `#[intercept(BearerAuthLayer)]` to API
+  routes while leaving session-cookie routes untouched.
+
+---
+
+## Tier 3: distribution as a `Plugin`
+
+Tier-3 packages tier-1 and tier-2 calls into a reusable struct that anyone can
+install with a single line. This is the right shape for cross-organisation
+distribution — publish a crate with a `Plugin` in it, users `cargo add` it and
+write `.plugin(YourPlugin::new(...))`.
+
+```rust,no_run
+use autumn_web::app::AppBuilder;
+use autumn_web::plugin::Plugin;
+
+pub struct AwsSecretsConfigPlugin {
+    region: String,
+}
+
+impl Plugin for AwsSecretsConfigPlugin {
+    fn build(self, app: AppBuilder) -> AppBuilder {
+        // Tier-1 install inside the plugin's build() — the user just sees
+        // `.plugin(AwsSecretsConfigPlugin::new("us-east-1"))`.
+        app.with_config_loader(AwsSecretsConfigLoader::new(self.region))
+    }
+}
+
+# pub struct AwsSecretsConfigLoader;
+# impl AwsSecretsConfigLoader { fn new(_: String) -> Self { Self } }
+# impl autumn_web::config::ConfigLoader for AwsSecretsConfigLoader {
+#     async fn load(&self) -> Result<autumn_web::config::AutumnConfig, autumn_web::config::ConfigError> { unimplemented!() }
+# }
+```
+
+End user:
+
+```rust,no_run
+# use autumn_web::prelude::*;
+# struct AwsSecretsConfigPlugin;
+# impl AwsSecretsConfigPlugin { fn new(_: &str) -> Self { Self } }
+# impl autumn_web::plugin::Plugin for AwsSecretsConfigPlugin {
+#     fn build(self, app: autumn_web::app::AppBuilder) -> autumn_web::app::AppBuilder { app }
+# }
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .plugin(AwsSecretsConfigPlugin::new("us-east-1"))
+        .run()
+        .await;
+}
+```
+
+### When tier 3 is the right answer
+
+- You're packaging behaviour for **someone else** to consume.
+- The behaviour spans **multiple tier-1 or tier-2 installs** and should
+  travel together as a unit (e.g. an OTel plugin that installs both a
+  `TelemetryProvider` AND a per-request tracing layer).
+- You want **conflict detection** — two plugins claiming the same `name()`
+  trigger a warning, so duplicate `.plugin(...)` calls don't silently shadow
+  each other.
+
+See [`autumn/src/plugin.rs`](../../autumn/src/plugin.rs) for the trait
+definition and naming conventions for first-party vs third-party plugin
+crates.
+
+---
+
+## Choosing between tiers — a quick decision tree
+
+1. **"I want to change framework behaviour for the whole app, once at boot."**
+   → Tier 1.
+2. **"I want to apply a wrapper to specific requests."**
+   → Tier 2.
+3. **"I'm building this for someone else to install with one line."**
+   → Tier 3, wrapping tier-1 or tier-2 calls.
+
+If a subsystem you want to replace doesn't have a tier-1 method yet, file an
+issue — adding one is mechanical and we generally welcome the patch.
+
+---
+
+## Further reading
+
+- [`custom-subsystems.md`](custom-subsystems.md) — per-trait how-to for tier-1
+  hooks, with full runnable code.
+- [`examples/custom_config_loader`](../../examples/custom_config_loader) — a
+  workspace example demonstrating a JSON-file `ConfigLoader` installed via
+  `with_config_loader`.
+- [`autumn/src/plugin.rs`](../../autumn/src/plugin.rs) — `Plugin` trait
+  documentation, including the naming conventions for distributed plugins.

--- a/examples/custom_config_loader/Cargo.toml
+++ b/examples/custom_config_loader/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "custom-config-loader-example"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+autumn-web = { path = "../../autumn" }
+serde_json = "1"

--- a/examples/custom_config_loader/config.json
+++ b/examples/custom_config_loader/config.json
@@ -1,0 +1,10 @@
+{
+  "server": {
+    "host": "127.0.0.1",
+    "port": 4567
+  },
+  "log": {
+    "level": "info",
+    "format": "Pretty"
+  }
+}

--- a/examples/custom_config_loader/src/main.rs
+++ b/examples/custom_config_loader/src/main.rs
@@ -1,0 +1,65 @@
+//! Demonstrates replacing autumn-web's default TOML + env config loader with a
+//! custom JSON-file loader via the [`ConfigLoader`] trait and the
+//! [`AppBuilder::with_config_loader`] hook (S-053 success metric).
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run -p custom-config-loader-example
+//! ```
+//!
+//! The example reads `config.json` (sitting next to this `main.rs`) and boots
+//! a tiny app whose port and profile come from JSON instead of the framework's
+//! default TOML/env layering. Visit `http://127.0.0.1:<port>/` to see the
+//! profile reported by the app.
+//!
+//! The same shape works for any other source — AWS Secrets Manager, Vault,
+//! Consul, an HTTP fetch, etc. — by swapping out the body of `JsonFileConfigLoader::load`.
+
+use std::path::PathBuf;
+
+use autumn_web::config::{AutumnConfig, ConfigError, ConfigLoader};
+use autumn_web::prelude::*;
+
+#[get("/")]
+async fn index() -> &'static str {
+    "Hello from autumn — booted with configuration loaded from config.json via a custom ConfigLoader."
+}
+
+/// Custom [`ConfigLoader`] backed by a single JSON file on disk.
+///
+/// Real-world replacements (AWS Secrets Manager, Vault, etc.) follow the same
+/// shape: capture whatever inputs you need in `Self`, do the I/O inside `load`,
+/// then deserialize into [`AutumnConfig`]. The only contract is "return a
+/// fully-resolved `AutumnConfig` or a `ConfigError`" — the framework handles
+/// the rest of the boot sequence the same way it would for the default loader.
+struct JsonFileConfigLoader {
+    path: PathBuf,
+}
+
+impl JsonFileConfigLoader {
+    fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+impl ConfigLoader for JsonFileConfigLoader {
+    async fn load(&self) -> Result<AutumnConfig, ConfigError> {
+        let bytes = std::fs::read(&self.path).map_err(ConfigError::Io)?;
+        serde_json::from_slice(&bytes)
+            .map_err(|e| ConfigError::Validation(format!("invalid JSON config: {e}")))
+    }
+}
+
+#[autumn_web::main]
+async fn main() {
+    // Resolve the fixture relative to this crate's manifest so `cargo run`
+    // works from any directory in the workspace.
+    let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config.json");
+
+    autumn_web::app()
+        .with_config_loader(JsonFileConfigLoader::new(config_path))
+        .routes(routes![index])
+        .run()
+        .await;
+}


### PR DESCRIPTION
## Summary
Closes [S-053](docs/stories/S-053-trait-based-subsystem-replacement.md). Adds tier-1 boot-time replacement hooks for the four enterprise-relevant framework subsystems plus a documented extensibility model that names the framework's three extension tiers.

A third-party crate can now ship `AwsSecretsConfigPlugin`, `DatadogTelemetryPlugin`, etc. that users install with one line — the framework's defaults stop being a hard ceiling.

## The three extension tiers (documented in `docs/guide/extensibility.md`)

| Tier | Mechanism | Scope | Example |
|------|-----------|-------|---------|
| **1** | `AppBuilder::with_<subsystem>(impl Trait)` | Boot-time, one-per-app | `.with_config_loader(AwsLoader)` |
| **2** | `#[intercept(Layer::new(...))]` | Per-request, stackable | `#[intercept(CacheResponseLayer::new(cache))]` |
| **3** | `Plugin::build(app)` | Distribution wrapper | Plugin whose `build()` chains tier-1 / tier-2 calls |

## Tier-1 hooks added

| Hook | Trait | Default impl |
|------|-------|--------------|
| `with_config_loader` | `ConfigLoader` (new) | `TomlEnvConfigLoader` (five-layer TOML + env) |
| `with_pool_provider` | `DatabasePoolProvider` (new, `#[cfg(feature = "db")]`) | `DieselDeadpoolPoolProvider` |
| `with_telemetry_provider` | `TelemetryProvider` (new) | `TracingOtlpTelemetryProvider` |
| `with_session_store` | `SessionStore` (existed) | `MemoryStore`/`RedisStore` from config |

All four follow the existing `ErrorPageRenderer` precedent — fluent `with_<subsystem>` method, default impl preserves current behaviour, zero boilerplate for apps that don't customize.

## Implementation notes

- New traits use `fn ... -> impl Future + Send` (matching `SessionStore`); no `async-trait` dep.
- `AppBuilder` stores boxed factory closures for the async traits (RPIT futures aren't dyn-compatible directly), plus `Arc<dyn BoxedSessionStore>` for sessions.
- Each `with_*` method emits `tracing::warn!` if it overwrites a previously-installed value.
- Plugins can chain `.with_config_loader(...)` etc. in their `build()` body — picked up at `run()` time because plugin registration happens synchronously before the run loop.

## `SessionStore` erasure bridge
`SessionStore` uses RPIT (`-> impl Future + Send`) and isn't dyn-compatible. Added a `pub(crate)` `BoxedSessionStore` shadow trait with a blanket impl over any `SessionStore`, plus an `ArcSessionStore` newtype that re-implements `SessionStore` by delegating through the trait object. Users only see `SessionStore`; the bridge stays internal.

## Side change: `Clone` derives on config structs
The pool-provider factory captures an owned `DatabaseConfig` (closure outlives the borrow). Added `#[derive(Clone)]` to `AutumnConfig`, `ServerConfig`, `DatabaseConfig`, `LogConfig`, `LogFormat`, `TelemetryConfig`, `HealthConfig`, `ActuatorConfig`, `CorsConfig`, `SecurityConfig`, `HeadersConfig`, `CsrfConfig`. Free deserialization unaffected.

## Docs deliverables
- **`docs/guide/extensibility.md`** — narrative of the three tiers + decision tree.
- **`docs/guide/custom-subsystems.md`** — per-trait how-to with code samples for each tier-1 trait + the tier-3 `Plugin` wrapping pattern.
- **Trait rustdoc** with `no_run` examples on each new trait.
- **`autumn/src/plugin.rs`** module rustdoc extended to mention the new install hooks.

## Example crate
**`examples/custom_config_loader/`** — runnable workspace member implementing `JsonFileConfigLoader` and installing it via `with_config_loader(...)`. This is the spec's success metric, made compile-enforced by being a workspace member.

## Out of scope (explicit)
- Multi-backend pool (MySQL/SQLite). Pool *type* stays `Pool<AsyncPgConnection>`.
- Updating `autumn-harvest-plugin` to adopt the trait API (would require a harvest 0.1.1 release; current 0.1.0 still compiles unchanged).
- Cache as a tier-1 install — intentionally tier-2 via `#[intercept(CacheResponseLayer::new(...))]`. Documented.
- Shutdown-signal-source / migration-runner abstraction — flagged in the design audit as low/niche value, deferred.

## Verification (local, before push)
- `cargo check --workspace --tests` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test -p autumn-web --lib` — 525 passed, 0 failed (new unit tests added in `config`, `db`, `telemetry`, `session` modules)
- `cargo build -p custom-config-loader-example` — compiles

## Test plan
- [ ] CI passes (lint + test matrix + MSRV)
- [ ] Reviewers can verify the spec's success metric: `cargo run -p custom-config-loader-example` boots the app on port 4567 (from `config.json`), proving the JSON loader replaced the default TOML+env loader

🤖 Generated with [Claude Code](https://claude.com/claude-code)
