### PR TITLE
🛡️ Sentry: [test coverage improvement] Fix unwrap risks in config and test telemetry fallback

### DIFF
--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -345,8 +345,9 @@ fn deep_merge_with_depth(base: &mut toml::Value, overlay: toml::Value, depth: us
             overlay_val.is_table() && base_table.get(&key).is_some_and(toml::Value::is_table);
 
         if is_recursive_merge {
-            let base_val = base_table.get_mut(&key).unwrap();
-            deep_merge_with_depth(base_val, overlay_val, depth + 1);
+            if let Some(base_val) = base_table.get_mut(&key) {
+                deep_merge_with_depth(base_val, overlay_val, depth + 1);
+            }
         } else {
             base_table.insert(key, overlay_val);
         }

--- a/autumn/src/telemetry.rs
+++ b/autumn/src/telemetry.rs
@@ -532,4 +532,14 @@ mod tests {
         // Sanity: the disabled guard must be droppable without panic.
         drop(guard);
     }
+    #[test]
+    fn build_filter_falls_back_to_info_on_invalid_level() {
+        let log = LogConfig {
+            level: "this_is_not_a_valid_directive_it_lacks_an_equal_sign_and_is_not_a_level,foo=bar=baz=invalid".to_owned(),
+            ..Default::default()
+        };
+
+        let filter = build_filter(&log);
+        assert_eq!(filter.to_string(), "info");
+    }
 }


### PR DESCRIPTION
🎯 Target: 
- `autumn/src/config.rs`: `deep_merge_with_depth`
- `autumn/src/telemetry.rs`: `build_filter`

💣 Risk: 
- `config.rs`: Potential panic via `.unwrap()` when deeply merging configuration TOML tables if the type expectation unexpectedly failed (e.g. from an exotic recursive TOML structure where the structure check might desynchronize slightly, though unlikely). Replaced with a safe `if let Some` extraction.
- `telemetry.rs`: The fallback logic in `build_filter` for an invalid `log.level` string was entirely untested, leaving a coverage gap in the tracing subscriber setup logic.

🧪 Strategy: 
- Replaced the `.unwrap()` in `config.rs` with `if let Some(base_val) = base_table.get_mut(&key)` to fail safely or skip merging on mismatch without exploding.
- Added `build_filter_falls_back_to_info_on_invalid_level` test to `telemetry.rs` which explicitly asserts that a malformed log level directive string securely falls back to the default `"info"` level without crashing the telemetry boot sequence.

🔬 Verification: 
Run `cargo test -p autumn-web --all-features` to ensure all functionality is preserved and new tests pass.

---
*PR created automatically by Jules for task [7097103380234745536](https://jules.google.com/task/7097103380234745536) started by @madmax983*