### PR TITLE
⚡ Bolt: [performance improvement] Pre-allocate HashMap in ConfigProperties

### DIFF
--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -288,7 +288,8 @@ impl ConfigProperties {
         let profile = config.profile.as_deref().unwrap_or("default");
         let defaults = crate::config::AutumnConfig::default();
 
-        let mut props = HashMap::new();
+        // Avoids dynamic reallocation since we know roughly how many config properties are tracked.
+        let mut props = HashMap::with_capacity(32);
         let profile_str = profile.to_string();
 
         Self::track_server_props(&mut props, config, &defaults, &profile_str);


### PR DESCRIPTION
💡 **What:** Replaced `HashMap::new()` with `HashMap::with_capacity(32)` inside `ConfigProperties::from_config`.
🎯 **Why:** The configuration loader sequentially tracks properties across 7 logical groups (server, db, log, telemetry, health, actuator, session), inserting ~20 fixed properties into the `HashMap`. Using `HashMap::new()` forces the map to dynamically reallocate and copy elements multiple times as its capacity grows from the default size.
📊 **Impact:** Avoids several dynamic heap allocations and memory moves during `App` startup or configuration loading, reducing latency and initialization overhead.
🔬 **Measurement:** Verify with `cargo test -p autumn-web --lib actuator`. No behavior has changed.

---
*PR created automatically by Jules for task [2827559545273475760](https://jules.google.com/task/2827559545273475760) started by @madmax983*