### PR TITLE
feat(app): add AppBuilder::layer for custom Tower middleware (S-049)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Autumn framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Custom Tower middleware** — new `AppBuilder::layer()` accepts any
+  `tower::Layer`, allowing one-line integration of `TimeoutLayer`, rate
+  limiters, and other third-party Tower middleware. User layers execute
+  inside `RequestIdLayer` on ingress so they observe the generated request
+  ID. See `docs/guide/middleware.md`. (S-049)
+
 ## [0.2.0] - 2026-04-19
 
 ### Added

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -87,7 +87,7 @@ http.workspace = true
 serde_json = "1"
 tempfile = "3"
 tokio.workspace = true
-tower.workspace = true
+tower = { workspace = true, features = ["timeout", "util"] }
 trybuild = "1"
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -72,6 +72,7 @@ pub fn app() -> AppBuilder {
         scoped_groups: Vec::new(),
         merge_routers: Vec::new(),
         nest_routers: Vec::new(),
+        custom_layers: Vec::new(),
         startup_hooks: Vec::new(),
         shutdown_hooks: Vec::new(),
         extensions: HashMap::new(),
@@ -160,6 +161,9 @@ pub struct AppBuilder {
     scoped_groups: Vec<ScopedGroup>,
     merge_routers: Vec<axum::Router<AppState>>,
     nest_routers: Vec<(String, axum::Router<AppState>)>,
+    /// Custom Tower layers registered via [`AppBuilder::layer`], applied
+    /// inside `RequestIdLayer` on ingress so they observe the request ID.
+    custom_layers: Vec<CustomLayerApplier>,
     startup_hooks: Vec<StartupHook>,
     shutdown_hooks: Vec<ShutdownHook>,
     extensions: HashMap<TypeId, Box<dyn Any + Send>>,
@@ -197,6 +201,14 @@ pub(crate) struct ScopedGroup {
     pub(crate) apply_layer:
         Box<dyn FnOnce(axum::Router<AppState>) -> axum::Router<AppState> + Send>,
 }
+
+/// A deferred router mutator that applies a user-registered
+/// [`tower::Layer`] to the app-wide router.
+///
+/// Stored on [`AppBuilder`] by [`AppBuilder::layer`] and drained inside
+/// `apply_middleware` where the final layer stack is assembled.
+pub(crate) type CustomLayerApplier =
+    Box<dyn FnOnce(axum::Router<AppState>) -> axum::Router<AppState> + Send>;
 
 impl AppBuilder {
     /// Register a collection of routes with the application.
@@ -368,6 +380,78 @@ impl AppBuilder {
             routes,
             apply_layer: Box::new(move |router| router.layer(layer)),
         });
+        self
+    }
+
+    /// Apply a custom [`tower::Layer`] to the entire application.
+    ///
+    /// This is the escape hatch for integrating any middleware from the
+    /// Tower / Tower-HTTP ecosystem (timeouts, rate limiting, bespoke
+    /// tracing, request signing, etc.) without forking the framework.
+    ///
+    /// # Ordering
+    ///
+    /// User layers are applied **inside** Autumn's request-ID layer on the
+    /// ingress path, which means your middleware always sees the generated
+    /// `RequestId` in the request extensions. The full stack (outermost to
+    /// innermost on ingress) is:
+    ///
+    /// `Metrics -> ExceptionFilter -> ErrorPageContext -> Session ->`
+    /// `SecurityHeaders -> RequestId -> [user layers, registration order]`
+    /// `-> CSRF -> CORS -> route handler`
+    ///
+    /// When `.layer()` is called multiple times, the **first** call becomes
+    /// the outermost user layer on ingress (matching `tower::ServiceBuilder`
+    /// semantics).
+    ///
+    /// See [the middleware guide](https://github.com/madmax983/autumn/blob/trunk/docs/guide/middleware.md)
+    /// for ready-made recipes.
+    ///
+    /// # Examples
+    ///
+    /// Adding a Tower timeout layer in one line (Tower's `TimeoutLayer`
+    /// returns `BoxError`, so it must be paired with `HandleErrorLayer` to
+    /// satisfy axum's `Infallible` error requirement):
+    ///
+    /// ```rust,no_run
+    /// use std::time::Duration;
+    /// use autumn_web::prelude::*;
+    /// use axum::{error_handling::HandleErrorLayer, http::StatusCode};
+    /// use tower::{ServiceBuilder, timeout::TimeoutLayer};
+    ///
+    /// # #[get("/")] async fn index() -> &'static str { "" }
+    /// # #[autumn_web::main]
+    /// # async fn main() {
+    /// autumn_web::app()
+    ///     .routes(routes![index])
+    ///     .layer(
+    ///         ServiceBuilder::new()
+    ///             .layer(HandleErrorLayer::new(|_| async {
+    ///                 StatusCode::REQUEST_TIMEOUT
+    ///             }))
+    ///             .layer(TimeoutLayer::new(Duration::from_secs(5))),
+    ///     )
+    ///     .run()
+    ///     .await;
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn layer<L>(mut self, layer: L) -> Self
+    where
+        L: tower::Layer<axum::routing::Route> + Clone + Send + Sync + 'static,
+        L::Service: tower::Service<
+                axum::http::Request<axum::body::Body>,
+                Response = axum::http::Response<axum::body::Body>,
+                Error = std::convert::Infallible,
+            > + Clone
+            + Send
+            + Sync
+            + 'static,
+        <L::Service as tower::Service<axum::http::Request<axum::body::Body>>>::Future:
+            Send + 'static,
+    {
+        self.custom_layers
+            .push(Box::new(move |router| router.layer(layer)));
         self
     }
 
@@ -735,6 +819,7 @@ impl AppBuilder {
             scoped_groups,
             merge_routers,
             nest_routers,
+            custom_layers,
             startup_hooks,
             shutdown_hooks,
             extensions: _,
@@ -822,6 +907,7 @@ impl AppBuilder {
                 scoped_groups,
                 merge_routers,
                 nest_routers,
+                custom_layers,
                 error_page_renderer,
                 session_store,
             },
@@ -923,6 +1009,7 @@ impl AppBuilder {
             scoped_groups: _,
             merge_routers: _,
             nest_routers: _,
+            custom_layers: _,
             startup_hooks: _,
             shutdown_hooks: _,
             extensions: _,
@@ -985,6 +1072,7 @@ impl AppBuilder {
                 scoped_groups: Vec::new(),
                 merge_routers: Vec::new(),
                 nest_routers: Vec::new(),
+                custom_layers: Vec::new(),
                 error_page_renderer: None,
                 session_store,
             },

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -210,6 +210,67 @@ pub(crate) struct ScopedGroup {
 pub(crate) type CustomLayerApplier =
     Box<dyn FnOnce(axum::Router<AppState>) -> axum::Router<AppState> + Send>;
 
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Marker trait for types that can be registered with
+/// [`AppBuilder::layer`] as an app-wide Tower middleware.
+///
+/// Any [`tower::Layer`] whose produced service is a compatible axum
+/// service (i.e. `Service<Request, Response = Response, Error = Infallible>`,
+/// plus the usual `Clone + Send + Sync + 'static` bounds and a `Send`
+/// future) implements this trait automatically via a blanket impl.
+///
+/// The trait is **sealed**: it exists only to surface a clean
+/// `IntoAppLayer is not implemented for YourType` error message when a
+/// candidate layer fails to meet axum's service bounds, instead of a
+/// 40-line associated-type wall. You cannot implement it manually, and
+/// you should not need to — just bring your own `tower::Layer`.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not a usable Autumn app-wide Tower layer",
+    label = "this type does not implement `tower::Layer<axum::routing::Route>` with the required service bounds",
+    note = "`AppBuilder::layer(..)` requires:\n    L: tower::Layer<axum::routing::Route> + Clone + Send + Sync + 'static,\n    L::Service: Service<axum::extract::Request, Response = axum::response::Response, Error = Infallible> + Clone + Send + Sync + 'static,\n    <L::Service as Service<axum::extract::Request>>::Future: Send + 'static\nSee docs/guide/middleware.md for common patterns and how to wrap raw-error layers (e.g. TimeoutLayer) with HandleErrorLayer."
+)]
+pub trait IntoAppLayer: sealed::Sealed + Send + Sync + 'static {
+    /// Apply this layer to the given router. Not intended for direct use.
+    #[doc(hidden)]
+    fn apply_to(self, router: axum::Router<AppState>) -> axum::Router<AppState>;
+}
+
+impl<L> sealed::Sealed for L
+where
+    L: tower::Layer<axum::routing::Route> + Clone + Send + Sync + 'static,
+    L::Service: tower::Service<
+            axum::extract::Request,
+            Response = axum::response::Response,
+            Error = std::convert::Infallible,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
+    <L::Service as tower::Service<axum::extract::Request>>::Future: Send + 'static,
+{
+}
+
+impl<L> IntoAppLayer for L
+where
+    L: tower::Layer<axum::routing::Route> + Clone + Send + Sync + 'static,
+    L::Service: tower::Service<
+            axum::extract::Request,
+            Response = axum::response::Response,
+            Error = std::convert::Infallible,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
+    <L::Service as tower::Service<axum::extract::Request>>::Future: Send + 'static,
+{
+    fn apply_to(self, router: axum::Router<AppState>) -> axum::Router<AppState> {
+        router.layer(self)
+    }
+}
+
 impl AppBuilder {
     /// Register a collection of routes with the application.
     ///
@@ -389,6 +450,13 @@ impl AppBuilder {
     /// Tower / Tower-HTTP ecosystem (timeouts, rate limiting, bespoke
     /// tracing, request signing, etc.) without forking the framework.
     ///
+    /// The generic bound is [`IntoAppLayer`], a sealed trait with a blanket
+    /// impl for every `tower::Layer` that meets axum's service requirements
+    /// — in practice this means any standard Tower layer whose service
+    /// produces `Infallible` errors. If your layer produces real errors
+    /// (like `TimeoutLayer`'s `BoxError`), wrap it with
+    /// [`axum::error_handling::HandleErrorLayer`] before passing it here.
+    ///
     /// # Ordering
     ///
     /// User layers are applied **inside** Autumn's request-ID layer on the
@@ -448,19 +516,7 @@ impl AppBuilder {
     /// # }
     /// ```
     #[must_use]
-    pub fn layer<L>(mut self, layer: L) -> Self
-    where
-        L: tower::Layer<axum::routing::Route> + Clone + Send + Sync + 'static,
-        L::Service: tower::Service<
-                axum::extract::Request,
-                Response = axum::response::Response,
-                Error = std::convert::Infallible,
-            > + Clone
-            + Send
-            + Sync
-            + 'static,
-        <L::Service as tower::Service<axum::extract::Request>>::Future: Send + 'static,
-    {
+    pub fn layer<L: IntoAppLayer>(mut self, layer: L) -> Self {
         // TODO(0.x): consider retaining a TypeId alongside the closure so
         // plugins can introspect which layers are already registered
         // (e.g. warn when auth is installed after rate-limiting). Requires
@@ -468,7 +524,7 @@ impl AppBuilder {
         // metadata. Deliberately deferred — pure closures keep the public
         // surface minimal until a concrete introspection use case appears.
         self.custom_layers
-            .push(Box::new(move |router| router.layer(layer)));
+            .push(Box::new(move |router| layer.apply_to(router)));
         self
     }
 

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -402,7 +402,19 @@ impl AppBuilder {
     ///
     /// When `.layer()` is called multiple times, the **first** call becomes
     /// the outermost user layer on ingress (matching `tower::ServiceBuilder`
-    /// semantics).
+    /// semantics): the layer from the first `.layer(...)` call sees the
+    /// request first on the way in and the response last on the way out.
+    ///
+    /// # Scope
+    ///
+    /// This layer applies **globally** to every route in the app, including
+    /// routes added later by plugins, routes mounted via `.merge` / `.nest`,
+    /// and the built-in `404` fallback. Use [`AppBuilder::scoped`] when you
+    /// need middleware scoped to a group of routes.
+    ///
+    /// Shared state (pools, metrics registries, rate-limit stores, etc.)
+    /// should be wrapped in `Arc` so the layer can satisfy the
+    /// `Clone + Send + Sync + 'static` bounds without moving the state.
     ///
     /// See [the middleware guide](https://github.com/madmax983/autumn/blob/trunk/docs/guide/middleware.md)
     /// for ready-made recipes.
@@ -419,7 +431,7 @@ impl AppBuilder {
     /// use axum::{error_handling::HandleErrorLayer, http::StatusCode};
     /// use tower::{ServiceBuilder, timeout::TimeoutLayer};
     ///
-    /// # #[get("/")] async fn index() -> &'static str { "" }
+    /// # #[get("/")] async fn index() -> &'static str { "ok" }
     /// # #[autumn_web::main]
     /// # async fn main() {
     /// autumn_web::app()
@@ -440,16 +452,21 @@ impl AppBuilder {
     where
         L: tower::Layer<axum::routing::Route> + Clone + Send + Sync + 'static,
         L::Service: tower::Service<
-                axum::http::Request<axum::body::Body>,
-                Response = axum::http::Response<axum::body::Body>,
+                axum::extract::Request,
+                Response = axum::response::Response,
                 Error = std::convert::Infallible,
             > + Clone
             + Send
             + Sync
             + 'static,
-        <L::Service as tower::Service<axum::http::Request<axum::body::Body>>>::Future:
-            Send + 'static,
+        <L::Service as tower::Service<axum::extract::Request>>::Future: Send + 'static,
     {
+        // TODO(0.x): consider retaining a TypeId alongside the closure so
+        // plugins can introspect which layers are already registered
+        // (e.g. warn when auth is installed after rate-limiting). Requires
+        // replacing CustomLayerApplier with a small trait that carries type
+        // metadata. Deliberately deferred — pure closures keep the public
+        // surface minimal until a concrete introspection use case appears.
         self.custom_layers
             .push(Box::new(move |router| router.layer(layer)));
         self
@@ -1009,7 +1026,7 @@ impl AppBuilder {
             scoped_groups: _,
             merge_routers: _,
             nest_routers: _,
-            custom_layers: _,
+            custom_layers,
             startup_hooks: _,
             shutdown_hooks: _,
             extensions: _,
@@ -1063,6 +1080,8 @@ impl AppBuilder {
         // is honored during static generation — apps that swap in a custom
         // store specifically to avoid Redis/external backends at build time
         // would otherwise silently fall back to the config-driven backend.
+        // Custom Tower layers registered via .layer(...) are likewise
+        // applied so static output matches the production response pipeline.
         let router = crate::router::try_build_router_inner(
             all_routes,
             &config,
@@ -1072,7 +1091,7 @@ impl AppBuilder {
                 scoped_groups: Vec::new(),
                 merge_routers: Vec::new(),
                 nest_routers: Vec::new(),
-                custom_layers: Vec::new(),
+                custom_layers,
                 error_page_renderer: None,
                 session_store,
             },

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -73,6 +73,11 @@ pub struct RouterContext {
     pub scoped_groups: Vec<ScopedGroup>,
     pub merge_routers: Vec<axum::Router<AppState>>,
     pub nest_routers: Vec<(String, axum::Router<AppState>)>,
+    /// Custom Tower layers registered via
+    /// [`AppBuilder::layer`](crate::app::AppBuilder::layer). Applied inside
+    /// [`RequestIdLayer`](crate::middleware::RequestIdLayer) on the ingress
+    /// path so user middleware observes the generated request ID.
+    pub custom_layers: Vec<crate::app::CustomLayerApplier>,
     pub error_page_renderer: Option<SharedRenderer>,
     /// Custom session store installed via
     /// [`AppBuilder::with_session_store`](crate::app::AppBuilder::with_session_store).
@@ -103,6 +108,7 @@ pub fn try_build_router(
             scoped_groups: Vec::new(),
             merge_routers: Vec::new(),
             nest_routers: Vec::new(),
+            custom_layers: Vec::new(),
             error_page_renderer: None,
             session_store: None,
         },
@@ -161,6 +167,7 @@ pub fn try_build_router_merged(
             scoped_groups: Vec::new(),
             merge_routers,
             nest_routers,
+            custom_layers: Vec::new(),
             error_page_renderer: None,
             session_store: None,
         },
@@ -203,6 +210,7 @@ pub fn try_build_router_inner(
         config,
         &state,
         ctx.exception_filters,
+        ctx.custom_layers,
         ctx.error_page_renderer,
         ctx.session_store,
     )?;
@@ -428,6 +436,7 @@ fn apply_middleware(
     config: &AutumnConfig,
     state: &AppState,
     exception_filters: Vec<Arc<dyn ExceptionFilter>>,
+    custom_layers: Vec<crate::app::CustomLayerApplier>,
     error_page_renderer: Option<SharedRenderer>,
     session_store: Option<Arc<dyn crate::session::BoxedSessionStore>>,
 ) -> Result<axum::Router<AppState>, RouterBuildError> {
@@ -441,6 +450,19 @@ fn apply_middleware(
 
     // 404 fallback handler for unmatched routes
     router = router.fallback(crate::middleware::error_page_filter::fallback_404_handler);
+
+    // User-registered Tower layers (AppBuilder::layer). Applied BEFORE
+    // RequestIdLayer wraps the router, so user middleware sits INNER to
+    // RequestId on ingress and can read the generated request ID from the
+    // request extensions. Iterate in reverse so the first registered layer
+    // ends up outermost among user layers — matching tower::ServiceBuilder.
+    let custom_layer_count = custom_layers.len();
+    for applier in custom_layers.into_iter().rev() {
+        router = applier(router);
+    }
+    if custom_layer_count > 0 {
+        tracing::debug!(count = custom_layer_count, "Custom Tower layers applied");
+    }
 
     // Apply framework middleware. Exception filters wrap outermost so they
     // see all error responses regardless of scoping or interceptors.
@@ -476,7 +498,10 @@ fn apply_middleware(
 
     // Error page context layer must be inner to the exception filter so
     // WantsHtml is set on the response before the filter inspects it.
-    // Layer order: Metrics -> ExceptionFilter -> ErrorPageContext -> router
+    // Full ingress layer order (outermost -> innermost):
+    //   Metrics -> ExceptionFilter -> ErrorPageContext -> Session ->
+    //   SecurityHeaders -> RequestId -> [user layers] -> CSRF -> CORS ->
+    //   handler
     let router = router
         .layer(crate::middleware::error_page_filter::ErrorPageContextLayer)
         .layer(ExceptionFilterLayer::new(all_filters))
@@ -541,6 +566,7 @@ pub fn try_build_router_with_static(
             scoped_groups: Vec::new(),
             merge_routers: Vec::new(),
             nest_routers: Vec::new(),
+            custom_layers: Vec::new(),
             error_page_renderer: None,
             session_store: None,
         },

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -155,21 +155,9 @@ impl TestApp {
     /// Mirrors [`crate::app::AppBuilder::layer`] so tests can exercise the
     /// exact middleware wiring that `AppBuilder::run()` produces.
     #[must_use]
-    pub fn layer<L>(mut self, layer: L) -> Self
-    where
-        L: tower::Layer<axum::routing::Route> + Clone + Send + Sync + 'static,
-        L::Service: tower::Service<
-                axum::extract::Request,
-                Response = axum::response::Response,
-                Error = std::convert::Infallible,
-            > + Clone
-            + Send
-            + Sync
-            + 'static,
-        <L::Service as tower::Service<axum::extract::Request>>::Future: Send + 'static,
-    {
+    pub fn layer<L: crate::app::IntoAppLayer>(mut self, layer: L) -> Self {
         self.custom_layers
-            .push(Box::new(move |router| router.layer(layer)));
+            .push(Box::new(move |router| layer.apply_to(router)));
         self
     }
 

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -105,6 +105,7 @@ pub struct TestApp {
     routes: Vec<Route>,
     merge_routers: Vec<axum::Router<crate::state::AppState>>,
     nest_routers: Vec<(String, axum::Router<crate::state::AppState>)>,
+    custom_layers: Vec<crate::app::CustomLayerApplier>,
     config: AutumnConfig,
     #[cfg(feature = "db")]
     pool: Option<Pool<AsyncPgConnection>>,
@@ -123,6 +124,7 @@ impl TestApp {
             routes: Vec::new(),
             merge_routers: Vec::new(),
             nest_routers: Vec::new(),
+            custom_layers: Vec::new(),
             config,
             #[cfg(feature = "db")]
             pool: None,
@@ -145,6 +147,30 @@ impl TestApp {
     #[must_use]
     pub fn nest(mut self, path: &str, router: axum::Router<crate::state::AppState>) -> Self {
         self.nest_routers.push((path.to_owned(), router));
+        self
+    }
+
+    /// Apply a custom [`tower::Layer`] to the entire test application.
+    ///
+    /// Mirrors [`crate::app::AppBuilder::layer`] so tests can exercise the
+    /// exact middleware wiring that `AppBuilder::run()` produces.
+    #[must_use]
+    pub fn layer<L>(mut self, layer: L) -> Self
+    where
+        L: tower::Layer<axum::routing::Route> + Clone + Send + Sync + 'static,
+        L::Service: tower::Service<
+                axum::http::Request<axum::body::Body>,
+                Response = axum::http::Response<axum::body::Body>,
+                Error = std::convert::Infallible,
+            > + Clone
+            + Send
+            + Sync
+            + 'static,
+        <L::Service as tower::Service<axum::http::Request<axum::body::Body>>>::Future:
+            Send + 'static,
+    {
+        self.custom_layers
+            .push(Box::new(move |router| router.layer(layer)));
         self
     }
 
@@ -213,12 +239,19 @@ impl TestApp {
             shutdown: tokio_util::sync::CancellationToken::new(),
         };
 
-        let router = crate::router::try_build_router_merged(
+        let router = crate::router::try_build_router_inner(
             self.routes,
             &self.config,
             state,
-            self.merge_routers,
-            self.nest_routers,
+            crate::router::RouterContext {
+                exception_filters: Vec::new(),
+                scoped_groups: Vec::new(),
+                merge_routers: self.merge_routers,
+                nest_routers: self.nest_routers,
+                custom_layers: self.custom_layers,
+                error_page_renderer: None,
+                session_store: None,
+            },
         )
         .unwrap();
         TestClient { router }

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -159,15 +159,14 @@ impl TestApp {
     where
         L: tower::Layer<axum::routing::Route> + Clone + Send + Sync + 'static,
         L::Service: tower::Service<
-                axum::http::Request<axum::body::Body>,
-                Response = axum::http::Response<axum::body::Body>,
+                axum::extract::Request,
+                Response = axum::response::Response,
                 Error = std::convert::Infallible,
             > + Clone
             + Send
             + Sync
             + 'static,
-        <L::Service as tower::Service<axum::http::Request<axum::body::Body>>>::Future:
-            Send + 'static,
+        <L::Service as tower::Service<axum::extract::Request>>::Future: Send + 'static,
     {
         self.custom_layers
             .push(Box::new(move |router| router.layer(layer)));

--- a/autumn/tests/custom_layer.rs
+++ b/autumn/tests/custom_layer.rs
@@ -1,0 +1,221 @@
+//! Integration tests for `AppBuilder::layer` (Story S-049).
+//!
+//! Verifies that user-registered Tower middleware integrates with Autumn's
+//! built-in stack, sees the generated request ID, and correctly propagates
+//! `Service::poll_ready` backpressure.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use autumn_web::middleware::RequestId;
+use autumn_web::test::TestApp;
+use autumn_web::{get, routes};
+use axum::body::Body;
+use axum::error_handling::HandleErrorLayer;
+use axum::http::{Request, Response, StatusCode};
+use tokio::sync::Notify;
+use tower::{Service, ServiceBuilder, timeout::TimeoutLayer};
+
+// ── Test 1: TimeoutLayer triggers end-to-end ─────────────────────────────
+
+#[get("/slow")]
+async fn slow_handler() -> &'static str {
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    "done"
+}
+
+#[tokio::test]
+async fn timeout_layer_one_liner_triggers() {
+    let client = TestApp::new()
+        .routes(routes![slow_handler])
+        .layer(
+            ServiceBuilder::new()
+                .layer(HandleErrorLayer::new(|_| async {
+                    StatusCode::REQUEST_TIMEOUT
+                }))
+                .layer(TimeoutLayer::new(Duration::from_millis(50))),
+        )
+        .build();
+
+    client.get("/slow").send().await.assert_status(408);
+}
+
+// ── Test 2: poll_ready backpressure propagates ───────────────────────────
+
+#[derive(Clone)]
+struct PendingLayer {
+    gate: Arc<Notify>,
+    ready: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl<S> tower::Layer<S> for PendingLayer {
+    type Service = PendingService<S>;
+    fn layer(&self, inner: S) -> Self::Service {
+        PendingService {
+            inner,
+            gate: self.gate.clone(),
+            ready: self.ready.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct PendingService<S> {
+    inner: S,
+    gate: Arc<Notify>,
+    ready: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl<S> Service<Request<Body>> for PendingService<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>, Error = std::convert::Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response<Body>;
+    type Error = std::convert::Infallible;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Response<Body>, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if self.ready.load(std::sync::atomic::Ordering::SeqCst) {
+            self.inner.poll_ready(cx)
+        } else {
+            let gate = self.gate.clone();
+            let waker = cx.waker().clone();
+            tokio::spawn(async move {
+                gate.notified().await;
+                waker.wake();
+            });
+            Poll::Pending
+        }
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        let mut inner = self.inner.clone();
+        Box::pin(async move { inner.call(req).await })
+    }
+}
+
+#[get("/ping")]
+async fn ping_handler() -> &'static str {
+    "pong"
+}
+
+#[tokio::test]
+async fn poll_ready_propagates_backpressure() {
+    let gate = Arc::new(Notify::new());
+    let ready = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    let client = TestApp::new()
+        .routes(routes![ping_handler])
+        .layer(PendingLayer {
+            gate: gate.clone(),
+            ready: ready.clone(),
+        })
+        .build();
+
+    // Fire a request while the layer is pending. The router must respect
+    // `poll_ready` and NOT call the service — assert the request does not
+    // complete within a short budget.
+    let req_future = client.get("/ping").send();
+    let stuck = tokio::time::timeout(Duration::from_millis(100), req_future).await;
+    assert!(
+        stuck.is_err(),
+        "request should be pending while gate is shut"
+    );
+
+    // Open the gate; poll_ready must observe the transition and dispatch.
+    ready.store(true, std::sync::atomic::Ordering::SeqCst);
+    gate.notify_waiters();
+
+    let resp = tokio::time::timeout(Duration::from_secs(1), client.get("/ping").send())
+        .await
+        .expect("request must complete once the layer is ready");
+    resp.assert_status(200);
+}
+
+// ── Test 3: custom layer observes the generated request ID ───────────────
+
+#[derive(Clone)]
+struct CaptureIdLayer {
+    captured: Arc<Mutex<Option<String>>>,
+}
+
+impl<S> tower::Layer<S> for CaptureIdLayer {
+    type Service = CaptureIdService<S>;
+    fn layer(&self, inner: S) -> Self::Service {
+        CaptureIdService {
+            inner,
+            captured: self.captured.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct CaptureIdService<S> {
+    inner: S,
+    captured: Arc<Mutex<Option<String>>>,
+}
+
+impl<S> Service<Request<Body>> for CaptureIdService<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>, Error = std::convert::Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response<Body>;
+    type Error = std::convert::Infallible;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Response<Body>, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        if let Some(id) = req.extensions().get::<RequestId>() {
+            *self.captured.lock().unwrap() = Some(id.to_string());
+        }
+        let mut inner = self.inner.clone();
+        Box::pin(async move { inner.call(req).await })
+    }
+}
+
+#[tokio::test]
+async fn custom_layer_sees_request_id() {
+    let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+    let client = TestApp::new()
+        .routes(routes![ping_handler])
+        .layer(CaptureIdLayer {
+            captured: captured.clone(),
+        })
+        .build();
+
+    let resp = client.get("/ping").send().await;
+    resp.assert_status(200);
+
+    let response_id = resp
+        .header("x-request-id")
+        .expect("RequestIdLayer should set X-Request-Id")
+        .to_owned();
+    let observed = captured
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("custom layer should have captured the request ID");
+
+    assert_eq!(
+        observed, response_id,
+        "custom layer must observe the same request ID that RequestIdLayer wrote to the response"
+    );
+}

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -1,0 +1,169 @@
+# Middleware in Autumn
+
+Autumn ships a curated stack of built-in middleware — request IDs, security
+headers, CSRF, CORS, sessions, metrics, exception filters. That covers the
+boring-but-critical concerns most applications share. When you need something
+off the beaten path (a timeout, a rate limiter, a custom tracing span, a
+legacy header injector), reach for [`AppBuilder::layer`] and drop in any
+standard [`tower::Layer`].
+
+This guide explains where user layers sit in the stack, how to register them,
+and the common recipes.
+
+---
+
+## Quick start
+
+Apply a Tower timeout layer to every route in the app:
+
+```rust,no_run
+use std::time::Duration;
+use autumn_web::prelude::*;
+use axum::{error_handling::HandleErrorLayer, http::StatusCode};
+use tower::{ServiceBuilder, timeout::TimeoutLayer};
+
+#[get("/slow")]
+async fn slow() -> &'static str {
+    tokio::time::sleep(Duration::from_secs(10)).await;
+    "done"
+}
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .routes(routes![slow])
+        .layer(
+            ServiceBuilder::new()
+                .layer(HandleErrorLayer::new(|_| async {
+                    StatusCode::REQUEST_TIMEOUT
+                }))
+                .layer(TimeoutLayer::new(Duration::from_secs(5))),
+        )
+        .run()
+        .await;
+}
+```
+
+Tower's `TimeoutLayer` surfaces its own `BoxError` on timeout, while axum
+requires every layer to produce `Infallible`. `HandleErrorLayer` bridges the
+two — it converts any error from the inner layer into an HTTP response.
+
+---
+
+## Middleware ordering
+
+On a request's **ingress** path (outermost → innermost), layers run in this
+order:
+
+```
+  Metrics
+    └─ ExceptionFilter
+         └─ ErrorPageContext
+              └─ Session
+                   └─ SecurityHeaders
+                        └─ RequestId
+                             └─ [your .layer() calls, first = outermost]
+                                  └─ CSRF
+                                       └─ CORS
+                                            └─ route handler
+```
+
+The ordering guarantee that matters most: **user layers run inside
+`RequestIdLayer` on ingress**, so every `.layer()` you register can read the
+generated `RequestId` from the request extensions. Exception filters,
+metrics, and error-page rendering all sit *outside* your layers, which means
+errors you produce (and errors you let bubble up from handlers) are still
+caught by Autumn's error pipeline.
+
+Multiple `.layer()` calls stack in registration order, mirroring
+[`tower::ServiceBuilder`]: the first `.layer(A)` call becomes the outermost
+user layer, so `A` sees the request first and the response last.
+
+---
+
+## Reading the request ID from a custom layer
+
+```rust,ignore
+use autumn_web::middleware::RequestId;
+use axum::http::Request;
+
+fn log_with_id<B>(req: &Request<B>) {
+    if let Some(id) = req.extensions().get::<RequestId>() {
+        tracing::info!(request_id = %id, "custom layer fired");
+    }
+}
+```
+
+Because user layers sit inside `RequestIdLayer`, the extension is always
+present in `call(..)` — there's no race condition to worry about.
+
+---
+
+## Limitations (for now)
+
+- **No per-route layers.** `.layer()` wraps the whole app. If you need a
+  middleware scoped to a group of routes, use
+  [`AppBuilder::scoped`] — it accepts the same `tower::Layer` bounds and
+  applies the layer only to the routes in that group. Per-route layering
+  (equivalent to axum's `route_layer`) is tracked as a follow-up.
+- **`Service::Error = Infallible`.** Any layer you register must produce
+  `Infallible` on its service's `Error` associated type. For layers that
+  surface real errors (timeouts, rate limits, circuit breakers), wrap them
+  with [`axum::error_handling::HandleErrorLayer`] as shown above.
+
+---
+
+## Recipes
+
+### Rate limiting with `tower-governor`
+
+```rust,ignore
+use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
+
+let governor_conf = GovernorConfigBuilder::default()
+    .per_second(10)
+    .burst_size(20)
+    .finish()
+    .unwrap();
+
+autumn_web::app()
+    .routes(routes![index])
+    .layer(GovernorLayer::new(governor_conf))
+    .run()
+    .await;
+```
+
+### Extra tracing span per request
+
+```rust,ignore
+use tower_http::trace::TraceLayer;
+
+autumn_web::app()
+    .routes(routes![index])
+    .layer(TraceLayer::new_for_http())
+    .run()
+    .await;
+```
+
+### Custom header injection (legacy system integration)
+
+Write a small `Layer`/`Service` pair (see the pattern in
+`autumn/tests/custom_layer.rs`) that rewrites or inserts request/response
+headers, then register it with `.layer(MyLayer)`. Because the layer sits
+inside `RequestIdLayer`, you can stamp the request ID onto any outgoing
+header for downstream services.
+
+---
+
+## See also
+
+- [`AppBuilder::layer`] — method reference and trait bounds.
+- [`AppBuilder::scoped`] — the group-scoped variant.
+- [Extensibility guide](./extensibility.md) — picks the right tier for your
+  extension point.
+
+[`AppBuilder::layer`]: https://docs.rs/autumn-web/latest/autumn_web/app/struct.AppBuilder.html#method.layer
+[`AppBuilder::scoped`]: https://docs.rs/autumn-web/latest/autumn_web/app/struct.AppBuilder.html#method.scoped
+[`tower::Layer`]: https://docs.rs/tower/latest/tower/trait.Layer.html
+[`tower::ServiceBuilder`]: https://docs.rs/tower/latest/tower/struct.ServiceBuilder.html
+[`axum::error_handling::HandleErrorLayer`]: https://docs.rs/axum/latest/axum/error_handling/struct.HandleErrorLayer.html

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -81,6 +81,27 @@ user layer, so `A` sees the request first and the response last.
 
 ---
 
+## Wrap shared state in `Arc`
+
+Because `AppBuilder::layer()` requires the layer to be `Clone + Send + Sync +
+'static`, any state your middleware needs to share across requests — HTTP
+client pools, metrics registries, rate-limit stores, caches — should live
+behind an [`Arc`]. Clone the layer; the `Arc` cheaply bumps a refcount.
+
+```rust,ignore
+use std::sync::Arc;
+
+#[derive(Clone)]
+struct MetricsLayer {
+    registry: Arc<prometheus::Registry>, // shared, cheaply clonable
+}
+```
+
+Trying to store the raw `prometheus::Registry` directly would force every
+request-handling clone to deep-copy the registry (if it were `Clone` at all)
+and would fail the `Sync` bound outright for types like `RefCell`. `Arc`
+sidesteps both issues.
+
 ## Reading the request ID from a custom layer
 
 ```rust,ignore

--- a/docs/stories/S-049-custom-middleware.md
+++ b/docs/stories/S-049-custom-middleware.md
@@ -3,7 +3,8 @@
 **Epic:** EPIC-011 (v1.0 Security & Stability)
 **Priority:** Should Have
 **Story Points:** 5
-**Status:** Not Started
+**Status:** Completed
+**Completion Date:** 2026-04-20
 **Assigned To:** markm
 **Created:** 2026-03-31
 **Sprint:** Backlog


### PR DESCRIPTION
## Summary

Implements [S-049: Custom Middleware](docs/stories/S-049-custom-middleware.md) — a first-class `AppBuilder::layer()` that accepts any standard `tower::Layer` and wires it into Autumn's middleware stack.

- **`.layer()` on `AppBuilder`** accepts any `tower::Layer<axum::routing::Route>` (same bounds as `.scoped()`).
- Custom layers execute **inside `RequestIdLayer`** on ingress — so user middleware always sees the generated `RequestId` in request extensions.
- Multiple `.layer()` calls stack in registration order: first added = outermost (matches `tower::ServiceBuilder`).
- Mirrored on `TestApp` so integration tests exercise the full pipeline end-to-end.

## Middleware ordering

Outermost → innermost on ingress:

```
Metrics → ExceptionFilter → ErrorPageContext → Session → SecurityHeaders
  → RequestId → [user layers] → CSRF → CORS → handler
```

## Changes

- `autumn/src/app.rs` — new `CustomLayerApplier` type alias, `custom_layers` field, `.layer()` builder method with rustdoc + TimeoutLayer example.
- `autumn/src/router.rs` — thread `custom_layers` through `RouterContext` / `apply_middleware`; apply user layers before `RequestIdLayer` wraps the router.
- `autumn/src/test.rs` — mirror `.layer()` on `TestApp`; switch `build()` to `try_build_router_inner` so the full middleware stack runs in tests.
- `autumn/tests/custom_layer.rs` (new) — three integration tests covering all acceptance criteria.
- `docs/guide/middleware.md` (new) — user-facing guide with ordering diagram, recipes (timeout, rate limit, tracing), and limitations.
- `docs/stories/S-049-custom-middleware.md` — marked `Completed` with completion date.
- `CHANGELOG.md` — `[Unreleased] / Added` entry.
- `autumn/Cargo.toml` — enable `tower` `timeout` + `util` features in `[dev-dependencies]`.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p autumn-web --all-targets -- -D warnings` — clean
- [x] `cargo test -p autumn-web` — 526 lib tests + all integration tests pass (the sole failure, `security::auth_dos::eris_auth_dos_poc`, is a pre-existing timing flake that fails identically on clean `trunk-dev`)
- [x] `cargo doc -p autumn-web --no-deps` — builds; only pre-existing doc-link warnings
- [x] New `tests/custom_layer.rs` — all 3 tests pass:
  - `timeout_layer_one_liner_triggers` — `TimeoutLayer` returns 408
  - `poll_ready_propagates_backpressure` — request stalls while `poll_ready` returns `Pending`, resumes on notify
  - `custom_layer_sees_request_id` — user layer observes the same `RequestId` that `RequestIdLayer` writes to `X-Request-Id`

## Out of scope (per story)

- Route-specific layers (use `.scoped()` for group-level middleware).
- Convenience helpers like `.timeout(Duration)` (can be revisited).

https://claude.ai/code/session_01GXSfxU6SP1JDfXF4MCEGVn