### PR TITLE
feat(app): complete raw Axum route mounting docs and middleware coverage

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -538,8 +538,9 @@ impl AppBuilder {
     /// config, etc.) and Autumn's global middleware (request IDs,
     /// security headers, session management) applies to its routes.
     ///
-    /// Merged routes are added **after** Autumn's annotated routes, so
-    /// if both define the same path, the annotated route takes precedence.
+    /// Merged routes are added **after** Autumn's annotated routes.
+    /// If both define the same method+path pair, Axum treats that as an
+    /// overlap and router construction will fail.
     ///
     /// Can be called multiple times -- routers are accumulated.
     ///

--- a/autumn/tests/raw_router_escape_hatch.rs
+++ b/autumn/tests/raw_router_escape_hatch.rs
@@ -131,6 +131,17 @@ async fn raw_routes_can_extract_app_state() {
 }
 
 #[tokio::test]
+async fn merged_routes_get_request_id_header() {
+    let raw = axum::Router::<AppState>::new().route("/raw", axum::routing::get(|| async { "raw" }));
+    let app = TestApp::new().merge(raw).build();
+    app.get("/raw")
+        .send()
+        .await
+        .assert_status(200)
+        .assert_header_contains("x-request-id", "-");
+}
+
+#[tokio::test]
 async fn nested_routes_can_extract_app_state() {
     let raw = axum::Router::<AppState>::new().route(
         "/state",

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -836,6 +836,42 @@ without a database pool. Handlers that use `Db` will return 503 Service
 Unavailable. This is useful for static sites, APIs that do not need a
 database, or during early development.
 
+### Escape hatch: mounting raw Axum routers
+
+When route macros are enough, prefer them -- you keep Autumn's discovery
+conventions and the codebase stays more uniform.
+
+When you need Axum-native composition (for example, mounting a third-party
+router like GraphQL), use `.merge()` or `.nest()`:
+
+```rust,no_run
+use autumn_web::prelude::*;
+use autumn_web::AppState;
+
+#[get("/")]
+async fn index() -> &'static str { "ok" }
+
+#[autumn_web::main]
+async fn main() {
+    let graphql = axum::Router::<AppState>::new()
+        .route("/graphql", axum::routing::get(|| async { "graphql endpoint" }));
+
+    autumn_web::app()
+        .routes(routes![index]) // Autumn-managed routes
+        .merge(graphql) // Raw Axum routes on the same app
+        .run()
+        .await;
+}
+```
+
+Use `.merge()` for direct mounting and `.nest("/prefix", router)` when you want
+all routes under a prefix (for example `/api/v2`).
+
+Merged/nested routers share the same `AppState` and still pass through Autumn's
+global middleware (including `X-Request-Id` response headers). Avoid defining
+the same method+path in both managed and raw routers -- Axum treats overlaps as
+an error during router construction.
+
 ---
 
 ## What's Next?


### PR DESCRIPTION
### Motivation

- Provide a supported escape hatch to mount raw `axum::Router` instances into Autumn apps and document when to use it versus macro-driven routes. 
- Ensure merged/nested routers clearly share `AppState` and receive Autumn's global middleware (notably `X-Request-Id`) and that documentation aligns with actual router behavior on overlaps.

### Description

- Added an integration test `merged_routes_get_request_id_header` in `autumn/tests/raw_router_escape_hatch.rs` that verifies merged raw Axum routes receive Autumn's `X-Request-Id` response header. 
- Clarified `AppBuilder::merge` docs in `autumn/src/app.rs` to state that overlapping method+path pairs cause an Axum router construction error instead of silently letting annotated routes take precedence. 
- Expanded the Getting Started guide (`docs/guide/getting-started.md`) with a new “Escape hatch: mounting raw Axum routers” section showing usage examples for `.merge()` and `.nest()` and documenting shared state, middleware propagation, and overlap caveats. 

### Testing

- Ran the integration test suite for the change with `cargo test -p autumn-web --test raw_router_escape_hatch`, which completed successfully (`10 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6365faa48832a8713d1082dec166f)