### PR TITLE
Profile-aware migration controls with opt-in for production

### DIFF
--- a/autumn-cli/src/templates/autumn.toml.tmpl
+++ b/autumn-cli/src/templates/autumn.toml.tmpl
@@ -30,6 +30,7 @@ path = "/health"
 # url = "postgres://user:pass@localhost:5432/{{crate_name}}"
 # pool_size = 10
 # connect_timeout_secs = 5  # pool wait/create timeout in seconds
+# auto_migrate_in_production = false
 
 # Uncomment to externalize sessions in production:
 # [session]

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1607,7 +1607,12 @@ async fn setup_database(
     if pool.is_some() {
         if let Some(url) = &config.database.url {
             for mig in migrations {
-                crate::migrate::auto_migrate(url, config.profile.as_deref(), mig);
+                crate::migrate::auto_migrate(
+                    url,
+                    config.profile.as_deref(),
+                    config.database.auto_migrate_in_production,
+                    mig,
+                );
             }
         }
     }

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -41,6 +41,7 @@
 //! | `AUTUMN_DATABASE__URL` | `database.url` | `String` |
 //! | `AUTUMN_DATABASE__POOL_SIZE` | `database.pool_size` | `usize` |
 //! | `AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS` | `database.connect_timeout_secs` | `u64` |
+//! | `AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION` | `database.auto_migrate_in_production` | `bool` |
 //! | `AUTUMN_LOG__LEVEL` | `log.level` | tracing filter directive |
 //! | `AUTUMN_LOG__FORMAT` | `log.format` | `Auto` / `Pretty` / `Json` |
 //! | `AUTUMN_TELEMETRY__ENABLED` | `telemetry.enabled` | `bool` |
@@ -631,6 +632,7 @@ impl AutumnConfig {
     /// - `AUTUMN_DATABASE__URL` → `database.url` (String)
     /// - `AUTUMN_DATABASE__POOL_SIZE` → `database.pool_size` (usize)
     /// - `AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS` → `database.connect_timeout_secs` (u64)
+    /// - `AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION` -> `database.auto_migrate_in_production` (bool)
     ///
     /// # Log
     /// - `AUTUMN_LOG__LEVEL` → `log.level` (String, tracing filter directive)
@@ -692,6 +694,11 @@ impl AutumnConfig {
             env,
             "AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS",
             &mut self.database.connect_timeout_secs,
+        );
+        parse_env_bool(
+            env,
+            "AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION",
+            &mut self.database.auto_migrate_in_production,
         );
     }
 
@@ -974,6 +981,7 @@ pub struct ServerConfig {
 /// | `url` | `None` |
 /// | `pool_size` | `10` |
 /// | `connect_timeout_secs` | `5` |
+/// | `auto_migrate_in_production` | `false` |
 ///
 /// # Examples
 ///
@@ -1001,6 +1009,14 @@ pub struct DatabaseConfig {
     /// Default: `5`.
     #[serde(default = "default_connect_timeout")]
     pub connect_timeout_secs: u64,
+
+    /// When true, permits automatic migration application while running with
+    /// `prod`/`production` profile. Default: `false`.
+    ///
+    /// Keep this disabled for multi-replica production fleets and use an
+    /// explicit migration job (`autumn migrate`) instead.
+    #[serde(default)]
+    pub auto_migrate_in_production: bool,
 }
 
 impl DatabaseConfig {
@@ -1425,6 +1441,7 @@ impl Default for DatabaseConfig {
             url: None,
             pool_size: default_pool_size(),
             connect_timeout_secs: default_connect_timeout(),
+            auto_migrate_in_production: false,
         }
     }
 }
@@ -1796,6 +1813,7 @@ mod tests {
         assert!(config.database.url.is_none());
         assert_eq!(config.database.pool_size, 10);
         assert_eq!(config.database.connect_timeout_secs, 5);
+        assert!(!config.database.auto_migrate_in_production);
         assert_eq!(config.log.level, "info");
         assert_eq!(config.log.format, LogFormat::Auto);
         assert_eq!(config.health.path, "/health");
@@ -1846,6 +1864,7 @@ shutdown_timeout_secs = 60
 url = "postgres://user:pass@db:5432/myapp"
 pool_size = 20
 connect_timeout_secs = 10
+auto_migrate_in_production = true
 
 [log]
 level = "debug"
@@ -1867,6 +1886,7 @@ path = "/healthz"
         );
         assert_eq!(config.database.pool_size, 20);
         assert_eq!(config.database.connect_timeout_secs, 10);
+        assert!(config.database.auto_migrate_in_production);
         assert_eq!(config.log.level, "debug");
         assert_eq!(config.log.format, LogFormat::Json);
         assert_eq!(config.health.path, "/healthz");
@@ -1942,6 +1962,14 @@ path = "/healthz"
         let mut config = AutumnConfig::default();
         config.apply_env_overrides_with_env(&env);
         assert_eq!(config.database.pool_size, 10);
+    }
+
+    #[test]
+    fn env_override_database_auto_migrate_in_production() {
+        let env = MockEnv::new().with("AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION", "true");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert!(config.database.auto_migrate_in_production);
     }
 
     // ── Server env override tests ────────────────────────────────

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -108,11 +108,18 @@ pub fn pending_migrations(
         .collect())
 }
 
-/// Run migrations according to the active profile.
+fn should_auto_apply(profile: Option<&str>, allow_auto_migrate_in_production: bool) -> bool {
+    let profile_name = profile.unwrap_or("none");
+    matches!(profile_name, "dev" | "development")
+        || (matches!(profile_name, "prod" | "production") && allow_auto_migrate_in_production)
+}
+
+/// Run migrations according to the active profile and migration policy.
 ///
-/// - **dev**: runs all pending migrations automatically and logs each one.
-/// - **prod** / other: logs a warning if pending migrations exist but does
-///   not apply them.
+/// - **dev/development**: runs all pending migrations automatically and logs each one.
+/// - **prod/production**: logs pending migrations unless
+///   `allow_auto_migrate_in_production` is enabled.
+/// - **other profiles**: logs pending migrations without auto-applying.
 ///
 /// Called internally by [`AppBuilder::run`](crate::app::AppBuilder::run)
 /// when migrations are registered via `.migrations()`.
@@ -120,12 +127,23 @@ pub fn pending_migrations(
 pub(crate) fn auto_migrate(
     database_url: &str,
     profile: Option<&str>,
+    allow_auto_migrate_in_production: bool,
     migrations: EmbeddedMigrations,
 ) {
-    let is_dev = profile == Some("dev");
+    let profile_name = profile.unwrap_or("none");
+    let is_dev = matches!(profile_name, "dev" | "development");
+    let is_prod = matches!(profile_name, "prod" | "production");
+    let should_auto_apply = should_auto_apply(profile, allow_auto_migrate_in_production);
 
-    if is_dev {
-        tracing::info!("Dev mode: running pending database migrations...");
+    if should_auto_apply {
+        if is_dev {
+            tracing::info!("Development profile: running pending database migrations...");
+        } else {
+            tracing::warn!(
+                profile = profile_name,
+                "Production auto-migration is enabled; running pending database migrations"
+            );
+        }
         match run_pending(database_url, migrations) {
             Ok(result) if result.applied.is_empty() => {
                 tracing::info!("No pending migrations");
@@ -151,6 +169,12 @@ pub(crate) fn auto_migrate(
                 tracing::info!("Database migrations are up to date");
             }
             Ok(pending) => {
+                if is_prod {
+                    tracing::warn!(
+                        "Production profile detected: automatic migrations are disabled by default. \
+                         Set database.auto_migrate_in_production=true to opt in."
+                    );
+                }
                 tracing::warn!(
                     count = pending.len(),
                     "Pending migrations detected. Run `autumn migrate` to apply them."
@@ -193,5 +217,16 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("migration failed"));
         assert!(msg.contains("syntax error"));
+    }
+
+    #[test]
+    fn profile_aliases_are_recognized() {
+        assert!(should_auto_apply(Some("dev"), false));
+        assert!(should_auto_apply(Some("development"), false));
+        assert!(!should_auto_apply(Some("prod"), false));
+        assert!(!should_auto_apply(Some("production"), false));
+        assert!(should_auto_apply(Some("prod"), true));
+        assert!(should_auto_apply(Some("production"), true));
+        assert!(!should_auto_apply(Some("staging"), true));
     }
 }


### PR DESCRIPTION
### Motivation
- Developers expect pending Diesel migrations to apply automatically in development while production remains protected from accidental schema changes. 
- The change implements an explicit opt-in so production auto-migrations are only enabled when an operator intentionally allows them. 
- The intent is to provide clear startup logging and a safe default (no auto-migrate in production) while preserving developer convenience in `dev`.

### Description
- Added a new config field `database.auto_migrate_in_production: bool` (default `false`) and environment override `AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION` to control production auto-migrations.
- Extended the migration orchestration: `auto_migrate` now accepts an `allow_auto_migrate_in_production: bool` flag, uses `should_auto_apply` to determine behavior, and recognizes `dev`/`development` and `prod`/`production` aliases.
- App startup now passes `config.database.auto_migrate_in_production` into the migration runner so runtime behavior is controlled by the loaded config.
- Improved logging: development runs are informational, production auto-apply emits a clear opt-in warning, and non-auto modes log pending migration counts with instructions to run `autumn migrate`.
- Updated the `autumn.toml` template comment to document `auto_migrate_in_production` and added unit tests for the new config env override and profile alias logic.

### Testing
- Ran formatting check with `cargo fmt --all --check`, which succeeded.
- Executed targeted unit tests: `CARGO_TARGET_DIR=/tmp/autumn-target cargo test -p autumn-web env_override_database_auto_migrate_in_production`, which passed.
- Executed profile logic test: `CARGO_TARGET_DIR=/tmp/autumn-target cargo test -p autumn-web profile_aliases_are_recognized`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e636206d08832aab4c3981b72a66a7)