### PR TITLE
Improve error page override behavior and documentation

### DIFF
--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -259,20 +259,14 @@ fn accepts_html<B>(req: &axum::http::Request<B>) -> bool {
         }
 
         match mime {
-            "text/html" => {
-                if html.is_none_or(|(existing_q, _)| q > existing_q) {
-                    html = Some((q, index));
-                }
+            "text/html" if html.is_none_or(|(existing_q, _)| q > existing_q) => {
+                html = Some((q, index));
             }
-            "application/json" => {
-                if json.is_none_or(|(existing_q, _)| q > existing_q) {
-                    json = Some((q, index));
-                }
+            "application/json" if json.is_none_or(|(existing_q, _)| q > existing_q) => {
+                json = Some((q, index));
             }
-            "*/*" => {
-                if wildcard.is_none_or(|(existing_q, _)| q > existing_q) {
-                    wildcard = Some((q, index));
-                }
+            "*/*" if wildcard.is_none_or(|(existing_q, _)| q > existing_q) => {
+                wildcard = Some((q, index));
             }
             _ => {}
         }
@@ -286,10 +280,8 @@ fn accepts_html<B>(req: &axum::http::Request<B>) -> bool {
                 hq > jq
             }
         }
-        (Some(_), None, _) => true,
-        (None, Some(_), _) => false,
-        (None, None, Some(_)) => true,
-        (None, None, None) => false,
+        (Some(_), None, _) | (None, None, Some(_)) => true,
+        (None, Some(_), _) | (None, None, None) => false,
     }
 }
 

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -231,17 +231,65 @@ fn accepts_html<B>(req: &axum::http::Request<B>) -> bool {
         return false;
     }
 
-    // Simple heuristic: if text/html appears before application/json,
-    // or if text/html is present and application/json is not, prefer HTML.
-    let html_pos = accept.find("text/html");
-    let json_pos = accept.find("application/json");
+    let mut html: Option<(f32, usize)> = None;
+    let mut json: Option<(f32, usize)> = None;
+    let mut wildcard: Option<(f32, usize)> = None;
 
-    match (html_pos, json_pos) {
-        (Some(_), None) => true,
-        (Some(h), Some(j)) => h < j,
-        (None, Some(_)) => false,
-        // `*/*` without specific types -- default to HTML for browsers
-        (None, None) => accept.contains("*/*"),
+    for (index, raw_part) in accept.split(',').enumerate() {
+        let part = raw_part.trim();
+        if part.is_empty() {
+            continue;
+        }
+
+        let mut mime = "";
+        let mut q = 1.0_f32;
+
+        for (i, segment) in part.split(';').enumerate() {
+            let segment = segment.trim();
+            if i == 0 {
+                mime = segment;
+                continue;
+            }
+
+            if let Some(value) = segment.strip_prefix("q=") {
+                if let Ok(parsed) = value.trim().parse::<f32>() {
+                    q = parsed.clamp(0.0, 1.0);
+                }
+            }
+        }
+
+        match mime {
+            "text/html" => {
+                if html.is_none_or(|(existing_q, _)| q > existing_q) {
+                    html = Some((q, index));
+                }
+            }
+            "application/json" => {
+                if json.is_none_or(|(existing_q, _)| q > existing_q) {
+                    json = Some((q, index));
+                }
+            }
+            "*/*" => {
+                if wildcard.is_none_or(|(existing_q, _)| q > existing_q) {
+                    wildcard = Some((q, index));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    match (html, json, wildcard) {
+        (Some((hq, hidx)), Some((jq, jidx)), _) => {
+            if (hq - jq).abs() < f32::EPSILON {
+                hidx < jidx
+            } else {
+                hq > jq
+            }
+        }
+        (Some(_), None, _) => true,
+        (None, Some(_), _) => false,
+        (None, None, Some(_)) => true,
+        (None, None, None) => false,
     }
 }
 
@@ -305,6 +353,24 @@ mod tests {
     fn prefers_html_when_html_first() {
         let req = Request::builder()
             .header("accept", "text/html, application/json")
+            .body(Body::empty())
+            .unwrap();
+        assert!(accepts_html(&req));
+    }
+
+    #[test]
+    fn prefers_json_when_json_has_higher_q() {
+        let req = Request::builder()
+            .header("accept", "text/html;q=0.4, application/json;q=0.9")
+            .body(Body::empty())
+            .unwrap();
+        assert!(!accepts_html(&req));
+    }
+
+    #[test]
+    fn prefers_html_when_html_has_higher_q() {
+        let req = Request::builder()
+            .header("accept", "application/json;q=0.3, text/html;q=0.8")
             .body(Body::empty())
             .unwrap();
         assert!(accepts_html(&req));

--- a/docs/guide/custom-subsystems.md
+++ b/docs/guide/custom-subsystems.md
@@ -193,14 +193,41 @@ that doesn't fit the built-in memory/Redis split.
 ## `ErrorPageRenderer` — replace the built-in HTML error pages
 
 ```rust,no_run
-# use autumn_web::error_pages::ErrorPageRenderer;
+# use autumn_web::error_pages::{ErrorContext, ErrorPageRenderer};
+# use maud::{html, Markup};
 # struct MyRenderer;
-# impl ErrorPageRenderer for MyRenderer {}
+#
+# impl ErrorPageRenderer for MyRenderer {
+#     fn render_404(&self, ctx: &ErrorContext) -> Markup {
+#         html! { h1 { "Custom 404 for " (ctx.path) } }
+#     }
+#
+#     fn render_500(&self, ctx: &ErrorContext) -> Markup {
+#         html! {
+#             h1 { "Something went wrong." }
+#             @if let Some(id) = &ctx.request_id {
+#                 p { "Request ID: " (id) }
+#             }
+#         }
+#     }
+#
+#     fn render_422(&self, ctx: &ErrorContext) -> Markup {
+#         html! {
+#             h1 { "Validation failed" }
+#             p { (ctx.message) }
+#         }
+#     }
+#
+#     fn render_error(&self, ctx: &ErrorContext) -> Markup {
+#         html! { h1 { (ctx.status.as_u16()) " " (ctx.message) } }
+#     }
+# }
 # use autumn_web::prelude::*;
 #[autumn_web::main]
 async fn main() {
     autumn_web::app()
         .error_pages(MyRenderer)
+        .routes(routes![/* ... */])
         .run()
         .await;
 }
@@ -210,6 +237,11 @@ async fn main() {
 shape the others were modelled on. See its
 [trait docs](../../autumn/src/error_pages/renderer.rs) for the full method
 surface.
+
+`ErrorContext` gives you the status code, request path, request ID, and
+validation details (for `422`). Autumn only uses this renderer for requests
+that prefer HTML (`Accept: text/html`). JSON handlers continue to receive the
+standard structured JSON error shape.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Ensure HTML error pages are only returned when browsers truly prefer HTML rather than using a brittle substring order heuristic. 
- Make it straightforward for app authors to replace framework error pages by expanding the `ErrorPageRenderer` example and documenting the available `ErrorContext` fields.

### Description
- Replace the simple substring heuristic in `accepts_html` with full Accept header parsing that respects media-type `q=` quality factors and selection order in `autumn/src/middleware/error_page_filter.rs`.
- Add unit tests that cover quality-factor negotiation (`prefers_json_when_json_has_higher_q` and `prefers_html_when_html_has_higher_q`) and keep existing integration tests for the error-page filter pipeline. 
- Expand the `ErrorPageRenderer` example and notes in `docs/guide/custom-subsystems.md` to show per-status (`404`, `500`, `422`) overrides and explain `ErrorContext` and JSON vs HTML behavior.

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully. 
- Ran unit and integration tests targeting the error-page middleware with `cargo test -p autumn-web error_page_filter::tests::` and the broader package tests, and all exercised tests passed (`18 passed` for the `error_page_filter` suite and earlier `29 passed` for related `error_pages` tests).
- Confirmed the modified code compiles as part of the `autumn-web` package during test runs (no test failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e635eae740832ab74481d2dd4cd9e7)