### PR TITLE
Enable htmx-compatible Content-Security-Policy by default

### DIFF
--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -72,7 +72,7 @@ pub struct SecurityConfig {
 /// | `strict_transport_security` | `false` |
 /// | `hsts_max_age_secs` | `31_536_000` (1 year) |
 /// | `hsts_include_subdomains` | `true` |
-/// | `content_security_policy` | `""` (disabled) |
+/// | `content_security_policy` | htmx-compatible policy (see [`default_content_security_policy`]) |
 /// | `referrer_policy` | `"strict-origin-when-cross-origin"` |
 /// | `permissions_policy` | `""` (disabled) |
 ///
@@ -125,11 +125,15 @@ pub struct HeadersConfig {
     #[serde(default = "default_true")]
     pub hsts_include_subdomains: bool,
 
-    /// `Content-Security-Policy` header value. Default: `""` (not sent).
+    /// `Content-Security-Policy` header value.
     ///
-    /// When non-empty, the CSP header restricts which resources the browser
-    /// is allowed to load. Example: `"default-src 'self'; script-src 'self'"`.
-    #[serde(default)]
+    /// Default is an htmx-compatible policy that restricts resources to the
+    /// same origin while permitting inline styles (common for htmx-driven
+    /// UIs) and data-URI images. Set to `""` to disable the header entirely
+    /// or override with a custom policy via `autumn.toml`.
+    ///
+    /// See [`default_content_security_policy`] for the exact default value.
+    #[serde(default = "default_content_security_policy")]
     pub content_security_policy: String,
 
     /// `Referrer-Policy` header value. Default: `"strict-origin-when-cross-origin"`.
@@ -153,7 +157,7 @@ impl Default for HeadersConfig {
             strict_transport_security: false,
             hsts_max_age_secs: default_hsts_max_age(),
             hsts_include_subdomains: true,
-            content_security_policy: String::new(),
+            content_security_policy: default_content_security_policy(),
             referrer_policy: default_referrer_policy(),
             permissions_policy: String::new(),
         }
@@ -244,6 +248,36 @@ fn default_referrer_policy() -> String {
     "strict-origin-when-cross-origin".to_owned()
 }
 
+/// Default Content-Security-Policy used when no override is provided.
+///
+/// Designed to be strict enough to pass common security scanners while
+/// still allowing htmx to function normally:
+///
+/// - `default-src 'self'` restricts all fetches to the same origin, covering
+///   htmx's AJAX/SSE/WebSocket requests out of the box.
+/// - `img-src 'self' data:` permits same-origin images and inline
+///   `data:` images (common in htmx demos and dynamic content).
+/// - `style-src 'self' 'unsafe-inline'` permits inline `style=""`
+///   attributes, which are frequently used in htmx-rendered partials.
+/// - `script-src 'self'` permits same-origin scripts only (htmx's
+///   `hx-*` attributes are not affected by CSP because they are not
+///   inline event handlers).
+/// - `frame-ancestors 'none'` provides clickjacking protection even if
+///   `X-Frame-Options` is absent.
+/// - `base-uri 'self'` prevents `<base>` tag injection attacks.
+/// - `form-action 'self'` restricts form submissions to the same origin.
+#[must_use]
+pub fn default_content_security_policy() -> String {
+    "default-src 'self'; \
+     img-src 'self' data:; \
+     style-src 'self' 'unsafe-inline'; \
+     script-src 'self'; \
+     frame-ancestors 'none'; \
+     base-uri 'self'; \
+     form-action 'self'"
+        .to_owned()
+}
+
 fn default_csrf_header() -> String {
     "X-CSRF-Token".to_owned()
 }
@@ -277,11 +311,48 @@ mod tests {
         assert!(config.headers.xss_protection);
         assert!(!config.headers.strict_transport_security);
         assert_eq!(config.headers.hsts_max_age_secs, 31_536_000);
-        assert!(config.headers.content_security_policy.is_empty());
+        // Default CSP is htmx-compatible (see S-049): same-origin default
+        // with inline styles permitted so htmx-rendered partials work.
+        let csp = &config.headers.content_security_policy;
+        assert!(csp.contains("default-src 'self'"));
+        assert!(csp.contains("style-src 'self' 'unsafe-inline'"));
+        assert!(csp.contains("frame-ancestors 'none'"));
         assert_eq!(
             config.headers.referrer_policy,
             "strict-origin-when-cross-origin"
         );
+    }
+
+    #[test]
+    fn default_csp_allows_htmx() {
+        // htmx relies on same-origin fetches (AJAX/SSE) and frequently
+        // renders partials with inline style attributes. The default CSP
+        // must permit both without requiring developer configuration.
+        let csp = default_content_security_policy();
+        assert!(
+            csp.contains("default-src 'self'"),
+            "default-src 'self' must cover htmx fetch/SSE/WebSocket requests"
+        );
+        assert!(
+            csp.contains("style-src 'self' 'unsafe-inline'"),
+            "inline styles must be permitted for htmx-rendered partials"
+        );
+        // unsafe-eval must NOT be present: htmx 2+ does not need it and
+        // enabling it would weaken the default posture.
+        assert!(
+            !csp.contains("unsafe-eval"),
+            "default CSP must not include 'unsafe-eval'"
+        );
+    }
+
+    #[test]
+    fn empty_csp_disables_header() {
+        // Developers can disable the CSP entirely via autumn.toml.
+        let toml_str = r#"
+            content_security_policy = ""
+        "#;
+        let config: HeadersConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.content_security_policy.is_empty());
     }
 
     #[test]

--- a/autumn/src/security/headers.rs
+++ b/autumn/src/security/headers.rs
@@ -12,7 +12,7 @@
 //! | `X-Content-Type-Options` | `x_content_type_options` is `true` | `nosniff` |
 //! | `X-XSS-Protection` | `xss_protection` is `true` | `1; mode=block` |
 //! | `Strict-Transport-Security` | `strict_transport_security` is `true` | `max-age=31536000; includeSubDomains` |
-//! | `Content-Security-Policy` | `content_security_policy` is non-empty | not sent |
+//! | `Content-Security-Policy` | `content_security_policy` is non-empty | htmx-compatible same-origin policy |
 //! | `Referrer-Policy` | `referrer_policy` is non-empty | `strict-origin-when-cross-origin` |
 //! | `Permissions-Policy` | `permissions_policy` is non-empty | not sent |
 //!
@@ -234,14 +234,40 @@ mod tests {
             response.headers().get("referrer-policy").unwrap(),
             "strict-origin-when-cross-origin"
         );
-        // HSTS not present by default
+        // HSTS not present by default (auto-enabled in prod via profile defaults)
         assert!(
             response
                 .headers()
                 .get("strict-transport-security")
                 .is_none()
         );
-        // CSP not present by default
+        // Default CSP is htmx-compatible (S-049): same-origin with inline
+        // styles permitted for htmx-rendered partials.
+        let csp = response
+            .headers()
+            .get("content-security-policy")
+            .expect("default CSP should be sent")
+            .to_str()
+            .unwrap();
+        assert!(csp.contains("default-src 'self'"));
+        assert!(csp.contains("style-src 'self' 'unsafe-inline'"));
+    }
+
+    #[tokio::test]
+    async fn csp_header_disabled_when_empty() {
+        let config = HeadersConfig {
+            content_security_policy: String::new(),
+            ..Default::default()
+        };
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(SecurityHeadersLayer::from_config(&config));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
         assert!(response.headers().get("content-security-policy").is_none());
     }
 

--- a/autumn/src/security/mod.rs
+++ b/autumn/src/security/mod.rs
@@ -36,7 +36,7 @@
 //! xss_protection = true                # X-XSS-Protection: 1; mode=block
 //! strict_transport_security = true     # HSTS (auto-enabled in prod)
 //! hsts_max_age_secs = 31536000         # 1 year
-//! content_security_policy = ""         # set to enable CSP
+//! content_security_policy = "default-src 'self'; ..."  # htmx-compatible default; "" to disable
 //! referrer_policy = "strict-origin-when-cross-origin"
 //! permissions_policy = ""              # set to enable Permissions-Policy
 //!


### PR DESCRIPTION
## Summary
This PR changes the default Content-Security-Policy (CSP) from disabled (empty string) to an htmx-compatible policy that maintains security while allowing htmx-driven UIs to function without additional configuration.

## Key Changes

- **New default CSP**: Implemented `default_content_security_policy()` function that provides a strict same-origin policy with exceptions for inline styles and data-URI images, specifically designed to work with htmx
  - `default-src 'self'` covers htmx's AJAX/SSE/WebSocket requests
  - `style-src 'self' 'unsafe-inline'` permits inline styles common in htmx-rendered partials
  - `img-src 'self' data:` allows same-origin and data-URI images
  - `script-src 'self'` restricts scripts to same-origin only
  - Additional directives (`frame-ancestors 'none'`, `base-uri 'self'`, `form-action 'self'`) provide defense-in-depth

- **Configuration changes**:
  - Changed `HeadersConfig::content_security_policy` default from empty string to `default_content_security_policy()`
  - Updated `Default` impl for `HeadersConfig` to use the new default function
  - Developers can still disable CSP entirely by setting `content_security_policy = ""` in `autumn.toml`

- **Documentation updates**:
  - Updated module-level docs in `config.rs`, `headers.rs`, and `mod.rs` to reflect the new default behavior
  - Added comprehensive doc comments explaining the CSP design rationale and htmx compatibility
  - Clarified that the header is now sent by default with the htmx-compatible policy

- **Test coverage**:
  - Updated existing default config test to verify CSP contains expected directives
  - Added `default_csp_allows_htmx()` test validating htmx compatibility (same-origin fetches, inline styles, no unsafe-eval)
  - Added `empty_csp_disables_header()` test confirming developers can disable CSP via config
  - Updated `security_headers_layer_applies_defaults()` test to verify CSP header is now sent by default
  - Added `csp_header_disabled_when_empty()` test confirming header is omitted when explicitly disabled

## Implementation Details

The default policy balances security with developer experience by:
- Passing common security scanners without requiring custom configuration
- Supporting htmx's core functionality (AJAX, SSE, WebSocket) out of the box
- Allowing inline styles which are frequently used in htmx-rendered partials
- Maintaining a strict posture by avoiding `unsafe-eval` and restricting scripts to same-origin
- Providing clickjacking protection via `frame-ancestors 'none'`

https://claude.ai/code/session_012frWFW1JmxEDLCsbWFCyiA