### PR TITLE
Enable htmx-compatible Content-Security-Policy by default

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2413,6 +2413,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn build_router_mounts_dev_reload_script_endpoint_when_enabled() {
+        // The injected <script src="/__autumn/live-reload.js"> tag only works
+        // under the default CSP (`script-src 'self'`) if the framework
+        // actually serves the JS at that path. This guards against the
+        // regression where the script endpoint is forgotten.
+        let reload_file = tempfile::NamedTempFile::new().expect("reload state file");
+        std::fs::write(reload_file.path(), r#"{"version":0,"kind":"full"}"#).expect("write");
+        temp_env::async_with_vars(
+            [
+                ("AUTUMN_DEV_RELOAD", Some("1")),
+                (
+                    "AUTUMN_DEV_RELOAD_STATE",
+                    Some(reload_file.path().to_str().expect("utf-8 path")),
+                ),
+            ],
+            async {
+                let router = test_router(vec![test_get_route("/dummy", "dummy")]);
+
+                let response = router
+                    .oneshot(
+                        Request::builder()
+                            .uri("/__autumn/live-reload.js")
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+
+                assert_eq!(response.status(), StatusCode::OK);
+                assert_eq!(
+                    response
+                        .headers()
+                        .get("content-type")
+                        .and_then(|v| v.to_str().ok()),
+                    Some("application/javascript; charset=utf-8")
+                );
+                let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let js = std::str::from_utf8(&body).expect("utf-8");
+                assert!(js.contains("fetch("), "js body: {js}");
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
     async fn build_router_mounts_dev_reload_endpoint_when_enabled() {
         let reload_file = tempfile::NamedTempFile::new().expect("reload state file");
         std::fs::write(reload_file.path(), r#"{"version":7,"kind":"css"}"#).expect("write");

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2185,6 +2185,27 @@ path = "/healthz"
         assert_eq!(config.server.shutdown_timeout_secs, 30);
         assert_eq!(config.telemetry.environment, "production");
         assert!(!config.health.detailed);
+        // AC: HSTS auto-enabled in the production profile.
+        assert!(
+            config.security.headers.strict_transport_security,
+            "prod profile must auto-enable Strict-Transport-Security"
+        );
+        // Defaults should still be secure-by-default in prod.
+        assert_eq!(config.security.headers.x_frame_options, "DENY");
+        assert!(config.security.headers.x_content_type_options);
+        assert!(!config.security.headers.content_security_policy.is_empty());
+    }
+
+    #[test]
+    fn dev_profile_does_not_auto_enable_hsts() {
+        let defaults = profile_defaults_as_toml("dev");
+        let toml_str = toml::to_string(&defaults).unwrap();
+        let config: AutumnConfig = toml::from_str(&toml_str).unwrap();
+
+        assert!(
+            !config.security.headers.strict_transport_security,
+            "dev profile must not force HSTS on (local http development)"
+        );
     }
 
     #[test]

--- a/autumn/src/middleware/dev.rs
+++ b/autumn/src/middleware/dev.rs
@@ -16,6 +16,7 @@ use axum::middleware::Next;
 use axum::response::IntoResponse;
 
 pub const LIVE_RELOAD_PATH: &str = "/__autumn/live-reload";
+pub const LIVE_RELOAD_SCRIPT_PATH: &str = "/__autumn/live-reload.js";
 const DEV_RELOAD_ENV: &str = "AUTUMN_DEV_RELOAD";
 const DEV_RELOAD_STATE_ENV: &str = "AUTUMN_DEV_RELOAD_STATE";
 const DEV_RELOAD_CACHE_CONTROL: &str = "no-store, no-cache, must-revalidate";
@@ -38,6 +39,23 @@ pub async fn live_reload_state_handler() -> impl IntoResponse {
     headers.insert(
         CONTENT_TYPE,
         HeaderValue::from_static("application/json; charset=utf-8"),
+    );
+    apply_no_store(headers);
+    response
+}
+
+/// Serves the live-reload polling client as an external JavaScript file.
+///
+/// The script is served as a same-origin `<script src="...">` rather than
+/// injected inline so that it passes a `script-src 'self'` Content Security
+/// Policy (the framework-default CSP). See [`LIVE_RELOAD_SCRIPT_PATH`].
+pub async fn live_reload_script_handler() -> impl IntoResponse {
+    let mut response = Response::new(Body::from(live_reload_script_body()));
+    *response.status_mut() = StatusCode::OK;
+    let headers = response.headers_mut();
+    headers.insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("application/javascript; charset=utf-8"),
     );
     apply_no_store(headers);
     response
@@ -131,10 +149,19 @@ fn inject_snippet(body: &[u8]) -> Vec<u8> {
     body.to_vec()
 }
 
+/// Returns the `<script src=...>` tag injected into HTML responses.
+///
+/// The actual JavaScript lives at [`LIVE_RELOAD_SCRIPT_PATH`] so the tag
+/// has no inline body and works under a same-origin-only CSP
+/// (`script-src 'self'`). Tests and internal callers may still ask for
+/// the bare tag via this function.
 fn live_reload_script() -> String {
+    format!(r#"<script src="{LIVE_RELOAD_SCRIPT_PATH}"></script>"#)
+}
+
+fn live_reload_script_body() -> String {
     format!(
-        r#"<script>
-(() => {{
+        r#"(() => {{
   const endpoint = "{LIVE_RELOAD_PATH}";
   let version = null;
   let polling = false;
@@ -204,7 +231,7 @@ fn live_reload_script() -> String {
   }}, 700);
   void poll();
 }})();
-</script>"#
+"#
     )
 }
 
@@ -393,7 +420,7 @@ mod tests {
     fn inject_snippet_inserts_before_body_or_appends_to_html_shell() {
         let with_body = inject_snippet(b"<html><body><main>ok</main></body></html>");
         let with_body = std::str::from_utf8(&with_body).expect("utf-8 html");
-        assert!(with_body.contains(LIVE_RELOAD_PATH));
+        assert!(with_body.contains(LIVE_RELOAD_SCRIPT_PATH));
         assert!(with_body.contains("</script></body>"));
 
         let html_shell = inject_snippet(b"<html><main>ok</main></html>");
@@ -402,6 +429,60 @@ mod tests {
 
         let plain = inject_snippet(b"not html");
         assert_eq!(&plain[..], b"not html");
+    }
+
+    #[test]
+    fn injected_snippet_uses_external_src_no_inline_js() {
+        // The default Autumn CSP is `script-src 'self'` (no 'unsafe-inline'),
+        // so the injected snippet must be a plain external-src <script> tag
+        // with no inline JavaScript body — otherwise the browser will refuse
+        // to execute it and live reload silently breaks.
+        let injected = inject_snippet(b"<html><body>ok</body></html>");
+        let html = std::str::from_utf8(&injected).expect("utf-8 html");
+
+        assert!(
+            html.contains(&format!(
+                r#"<script src="{LIVE_RELOAD_SCRIPT_PATH}"></script>"#
+            )),
+            "expected external-src script tag, got: {html}"
+        );
+        // None of the inline script body should leak into the HTML.
+        assert!(
+            !html.contains("setInterval"),
+            "inline JS leaked into HTML: {html}"
+        );
+        assert!(
+            !html.contains("fetch("),
+            "inline JS leaked into HTML: {html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_reload_script_handler_serves_js_with_correct_content_type() {
+        let response = live_reload_script_handler().await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("application/javascript; charset=utf-8")
+        );
+        assert_eq!(
+            response.headers().get(CACHE_CONTROL).unwrap(),
+            DEV_RELOAD_CACHE_CONTROL
+        );
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let js = std::str::from_utf8(&body).expect("utf-8");
+        // Sanity-check: handler returns the real polling client, not the
+        // <script> wrapper tag.
+        assert!(js.contains("fetch("), "expected polling client, got: {js}");
+        assert!(
+            !js.contains("<script"),
+            "JS body must not contain HTML tags"
+        );
     }
 
     #[test]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -276,9 +276,14 @@ fn mount_framework_routes(
             dev::LIVE_RELOAD_PATH,
             axum::routing::get(dev::live_reload_state_handler),
         );
+        router = router.route(
+            dev::LIVE_RELOAD_SCRIPT_PATH,
+            axum::routing::get(dev::live_reload_script_handler),
+        );
         tracing::debug!(
-            path = dev::LIVE_RELOAD_PATH,
-            "Mounted dev live reload endpoint"
+            state_path = dev::LIVE_RELOAD_PATH,
+            script_path = dev::LIVE_RELOAD_SCRIPT_PATH,
+            "Mounted dev live reload endpoints"
         );
     }
 

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -28,6 +28,9 @@
 //! | `AUTUMN_SECURITY__HEADERS__HSTS_MAX_AGE_SECS` | `security.headers.hsts_max_age_secs` | `u64` |
 //! | `AUTUMN_SECURITY__HEADERS__CONTENT_SECURITY_POLICY` | `security.headers.content_security_policy` | `String` |
 //! | `AUTUMN_SECURITY__CSRF__ENABLED` | `security.csrf.enabled` | `bool` |
+//!
+//! Setting any header value to an empty string disables it (the header is
+//! not emitted). This is the escape hatch for opting out of a default.
 
 use serde::Deserialize;
 
@@ -72,7 +75,7 @@ pub struct SecurityConfig {
 /// | `strict_transport_security` | `false` |
 /// | `hsts_max_age_secs` | `31_536_000` (1 year) |
 /// | `hsts_include_subdomains` | `true` |
-/// | `content_security_policy` | `""` (disabled) |
+/// | `content_security_policy` | htmx-compatible policy (see [`default_content_security_policy`]) |
 /// | `referrer_policy` | `"strict-origin-when-cross-origin"` |
 /// | `permissions_policy` | `""` (disabled) |
 ///
@@ -125,11 +128,16 @@ pub struct HeadersConfig {
     #[serde(default = "default_true")]
     pub hsts_include_subdomains: bool,
 
-    /// `Content-Security-Policy` header value. Default: `""` (not sent).
+    /// `Content-Security-Policy` header value.
     ///
-    /// When non-empty, the CSP header restricts which resources the browser
-    /// is allowed to load. Example: `"default-src 'self'; script-src 'self'"`.
-    #[serde(default)]
+    /// Defaults to an htmx-compatible, same-origin policy (see
+    /// [`default_content_security_policy`]). When set to an empty string,
+    /// the header is not emitted (explicit opt-out).
+    ///
+    /// The default allows htmx to function normally because htmx is served
+    /// from the same origin at `/static/js/htmx.min.js` and operates via
+    /// `addEventListener` rather than inline `eval`.
+    #[serde(default = "default_content_security_policy")]
     pub content_security_policy: String,
 
     /// `Referrer-Policy` header value. Default: `"strict-origin-when-cross-origin"`.
@@ -153,7 +161,7 @@ impl Default for HeadersConfig {
             strict_transport_security: false,
             hsts_max_age_secs: default_hsts_max_age(),
             hsts_include_subdomains: true,
-            content_security_policy: String::new(),
+            content_security_policy: default_content_security_policy(),
             referrer_policy: default_referrer_policy(),
             permissions_policy: String::new(),
         }
@@ -244,6 +252,37 @@ fn default_referrer_policy() -> String {
     "strict-origin-when-cross-origin".to_owned()
 }
 
+/// Default `Content-Security-Policy` value.
+///
+/// Designed to be "sensible by default" while allowing htmx to function
+/// normally when served from the same origin (as Autumn does at
+/// `/static/js/htmx.min.js`).
+///
+/// Directives:
+/// - `default-src 'self'` -- everything defaults to same-origin
+/// - `img-src 'self' data:` -- images from self and inline data URIs
+/// - `style-src 'self' 'unsafe-inline'` -- same-origin stylesheets plus
+///   inline `style` attributes (required by many UI libraries and
+///   template engines)
+/// - `script-src 'self'` -- only same-origin scripts; htmx works here
+///   because it is served from `/static/js/htmx.min.js`
+/// - `connect-src 'self'` -- `fetch`/`XHR`/htmx requests go to same origin
+/// - `form-action 'self'` -- forms can only POST to same origin
+/// - `frame-ancestors 'none'` -- matches the default `X-Frame-Options: DENY`
+/// - `base-uri 'self'` -- prevents `<base>` hijacking
+#[must_use]
+pub fn default_content_security_policy() -> String {
+    "default-src 'self'; \
+     img-src 'self' data:; \
+     style-src 'self' 'unsafe-inline'; \
+     script-src 'self'; \
+     connect-src 'self'; \
+     form-action 'self'; \
+     frame-ancestors 'none'; \
+     base-uri 'self'"
+        .to_owned()
+}
+
 fn default_csrf_header() -> String {
     "X-CSRF-Token".to_owned()
 }
@@ -277,11 +316,52 @@ mod tests {
         assert!(config.headers.xss_protection);
         assert!(!config.headers.strict_transport_security);
         assert_eq!(config.headers.hsts_max_age_secs, 31_536_000);
-        assert!(config.headers.content_security_policy.is_empty());
+        // Default CSP is non-empty and htmx-compatible.
+        assert!(!config.headers.content_security_policy.is_empty());
+        assert!(
+            config
+                .headers
+                .content_security_policy
+                .contains("default-src 'self'")
+        );
+        assert!(
+            config
+                .headers
+                .content_security_policy
+                .contains("script-src 'self'")
+        );
         assert_eq!(
             config.headers.referrer_policy,
             "strict-origin-when-cross-origin"
         );
+    }
+
+    #[test]
+    fn default_csp_does_not_allow_unsafe_eval() {
+        // htmx works without unsafe-eval; only `hx-on` opts into it.
+        // Keep the default tight so that the baseline policy passes
+        // Mozilla Observatory and similar automated scanners.
+        let csp = default_content_security_policy();
+        assert!(!csp.contains("'unsafe-eval'"), "csp = {csp}");
+        assert!(!csp.contains("'unsafe-inline' 'unsafe-eval'"), "csp = {csp}");
+    }
+
+    #[test]
+    fn csp_can_be_disabled_via_toml_empty_string() {
+        let toml_str = r#"
+            content_security_policy = ""
+        "#;
+        let config: HeadersConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.content_security_policy.is_empty());
+    }
+
+    #[test]
+    fn csp_can_be_overridden_via_toml() {
+        let toml_str = r#"
+            content_security_policy = "default-src 'none'"
+        "#;
+        let config: HeadersConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.content_security_policy, "default-src 'none'");
     }
 
     #[test]

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -343,7 +343,10 @@ mod tests {
         // Mozilla Observatory and similar automated scanners.
         let csp = default_content_security_policy();
         assert!(!csp.contains("'unsafe-eval'"), "csp = {csp}");
-        assert!(!csp.contains("'unsafe-inline' 'unsafe-eval'"), "csp = {csp}");
+        assert!(
+            !csp.contains("'unsafe-inline' 'unsafe-eval'"),
+            "csp = {csp}"
+        );
     }
 
     #[test]

--- a/autumn/src/security/headers.rs
+++ b/autumn/src/security/headers.rs
@@ -12,7 +12,7 @@
 //! | `X-Content-Type-Options` | `x_content_type_options` is `true` | `nosniff` |
 //! | `X-XSS-Protection` | `xss_protection` is `true` | `1; mode=block` |
 //! | `Strict-Transport-Security` | `strict_transport_security` is `true` | `max-age=31536000; includeSubDomains` |
-//! | `Content-Security-Policy` | `content_security_policy` is non-empty | not sent |
+//! | `Content-Security-Policy` | `content_security_policy` is non-empty | htmx-compatible same-origin policy |
 //! | `Referrer-Policy` | `referrer_policy` is non-empty | `strict-origin-when-cross-origin` |
 //! | `Permissions-Policy` | `permissions_policy` is non-empty | not sent |
 //!
@@ -241,8 +241,56 @@ mod tests {
                 .get("strict-transport-security")
                 .is_none()
         );
-        // CSP not present by default
-        assert!(response.headers().get("content-security-policy").is_none());
+        // CSP present by default with htmx-compatible policy
+        let csp = response
+            .headers()
+            .get("content-security-policy")
+            .expect("default CSP should be emitted");
+        let csp = csp.to_str().unwrap();
+        assert!(csp.contains("default-src 'self'"), "csp = {csp}");
+        assert!(csp.contains("script-src 'self'"), "csp = {csp}");
+        assert!(csp.contains("img-src 'self' data:"), "csp = {csp}");
+        assert!(!csp.contains("'unsafe-eval'"), "csp = {csp}");
+    }
+
+    #[tokio::test]
+    async fn default_csp_allows_htmx_to_function() {
+        // htmx is served from /static/js/htmx.min.js (same origin), operates
+        // via addEventListener (no eval), and issues hx-* requests to the
+        // same origin. The default CSP must allow all of that.
+        let config = HeadersConfig::default();
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(SecurityHeadersLayer::from_config(&config));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let csp = response
+            .headers()
+            .get("content-security-policy")
+            .expect("default CSP missing")
+            .to_str()
+            .unwrap()
+            .to_owned();
+
+        // htmx script loads from same origin
+        assert!(
+            csp.contains("script-src 'self'"),
+            "csp must allow same-origin scripts for htmx: {csp}"
+        );
+        // htmx XHR/fetch requests go to same origin
+        assert!(
+            csp.contains("connect-src 'self'"),
+            "csp must allow same-origin connects for htmx swaps: {csp}"
+        );
+        // No eval required for htmx standard operation
+        assert!(
+            !csp.contains("'unsafe-eval'"),
+            "default csp should not weaken script-src with unsafe-eval: {csp}"
+        );
     }
 
     #[tokio::test]

--- a/autumn/src/security/mod.rs
+++ b/autumn/src/security/mod.rs
@@ -36,7 +36,7 @@
 //! xss_protection = true                # X-XSS-Protection: 1; mode=block
 //! strict_transport_security = true     # HSTS (auto-enabled in prod)
 //! hsts_max_age_secs = 31536000         # 1 year
-//! content_security_policy = ""         # set to enable CSP
+//! content_security_policy = "default-src 'self'; ..."  # htmx-friendly default; "" disables
 //! referrer_policy = "strict-origin-when-cross-origin"
 //! permissions_policy = ""              # set to enable Permissions-Policy
 //!
@@ -72,6 +72,6 @@ pub mod csrf;
 pub mod headers;
 
 // Re-export commonly used types at the module level.
-pub use config::{CsrfConfig, HeadersConfig, SecurityConfig};
+pub use config::{CsrfConfig, HeadersConfig, SecurityConfig, default_content_security_policy};
 pub use csrf::{CsrfLayer, CsrfToken};
 pub use headers::SecurityHeadersLayer;

--- a/autumn/src/security/mod.rs
+++ b/autumn/src/security/mod.rs
@@ -79,7 +79,9 @@ pub mod headers;
 pub mod rate_limit;
 
 // Re-export commonly used types at the module level.
-pub use config::{CsrfConfig, HeadersConfig, RateLimitConfig, SecurityConfig, default_content_security_policy};
+pub use config::{
+    CsrfConfig, HeadersConfig, RateLimitConfig, SecurityConfig, default_content_security_policy,
+};
 pub use csrf::{CsrfLayer, CsrfToken};
 pub use headers::SecurityHeadersLayer;
 pub use rate_limit::RateLimitLayer;


### PR DESCRIPTION
## Summary
Changes the default `Content-Security-Policy` header from disabled (empty string) to an htmx-compatible, same-origin policy. This improves security posture by enabling CSP by default while maintaining compatibility with htmx, which is served from the same origin.

## Key Changes

- **New default CSP policy**: Implements `default_content_security_policy()` function that returns a sensible-by-default policy allowing:
  - Same-origin resources (`default-src 'self'`)
  - Inline styles (`style-src 'self' 'unsafe-inline'`) for UI library compatibility
  - Data URIs for images (`img-src 'self' data:`)
  - Same-origin scripts and XHR/fetch (`script-src 'self'`, `connect-src 'self'`)
  - No `unsafe-eval` to maintain security baseline

- **Configuration updates**:
  - Changed `HeadersConfig::content_security_policy` default from empty string to the new htmx-compatible policy
  - Updated serde default to use `default_content_security_policy` function
  - Empty string now acts as explicit opt-out mechanism (header not emitted)

- **Documentation improvements**:
  - Added module-level documentation explaining the escape hatch (empty string disables headers)
  - Updated field documentation to clarify the new default and opt-out behavior
  - Added detailed comments explaining each CSP directive and htmx compatibility

- **Test coverage**:
  - Updated existing default config test to verify CSP is non-empty and contains expected directives
  - Added test verifying default CSP doesn't include `unsafe-eval`
  - Added tests for TOML configuration: disabling CSP via empty string and overriding with custom policy
  - Added integration test verifying default CSP allows htmx to function (same-origin scripts, XHR/fetch, no eval)
  - Added test verifying dev profile doesn't auto-enable HSTS

- **Module exports**: Re-exported `default_content_security_policy` from `security` module for public use

## Implementation Details

The default policy is designed to pass automated security scanners (Mozilla Observatory) while supporting htmx's standard operation model:
- htmx script loads from `/static/js/htmx.min.js` (same origin) ✓
- htmx uses `addEventListener` for event handling (no eval needed) ✓
- htmx issues XHR/fetch requests to same origin ✓
- Inline `style` attributes are allowed for UI library compatibility ✓

https://claude.ai/code/session_013bsJ4A1xGPAR8maczCbLfW