### PR TITLE
🤖 Sentinel: [Test gap closed in db::create_pool]

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -321,6 +321,23 @@ mod tests {
 
     // ── Pool creation tests ──────────────────────────────────────
 
+    #[tokio::test]
+    async fn default_pool_provider_respects_url_config() {
+        let config = DatabaseConfig {
+            url: Some("postgres://localhost/test".into()),
+            ..Default::default()
+        };
+        let provider = DieselDeadpoolPoolProvider::new();
+        let pool = provider
+            .create_pool(&config)
+            .await
+            .expect("default provider should succeed");
+        assert!(
+            pool.is_some(),
+            "default provider should return Some when url is provided"
+        );
+    }
+
     #[test]
     fn create_pool_with_no_url_returns_none() {
         let config = DatabaseConfig::default();


### PR DESCRIPTION
🤖 Sentinel: [Test gap closed in db::create_pool]

🧬 **Mutants Found:**
1 surviving mutant in `db.rs` associated with the `DieselDeadpoolPoolProvider::create_pool` implementation. The mutant replaced the method's return value with `Ok(None)`, effectively bypassing the pool creation even when a valid configuration with a `database.url` was provided.

🎯 **Tests Added/Strengthened:**
Added the `default_pool_provider_respects_url_config` test inside the `db.rs` test module. This test verifies the missing behavioral boundary by ensuring that `DieselDeadpoolPoolProvider` delegates to `create_pool` properly and yields a `Some` containing a connection pool when provided a `DatabaseConfig` with a valid `url`. 

⚠️ **Suspected Bugs:**
None - the implementation is correct, but there was a gap in testing the provider abstraction itself.

📊 **Kill Rate:**
`db.rs` mutant kill rate improved; 1 missed mutant killed resulting in 100% kill rate of viable mutants.

🔗 **Havoc Interaction:**
None - not overlapping with Havoc boundaries.

---
*PR created automatically by Jules for task [214252197594132085](https://jules.google.com/task/214252197594132085) started by @madmax983*