### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -698,7 +698,7 @@ impl AppBuilder {
     // `AwsSecretsConfigPlugin` that calls `app.with_config_loader(...)`).
     // See `docs/guides/extensibility.md`.
 
-    /// Install a custom [`ConfigLoader`](crate::config::ConfigLoader),
+    /// Install a custom [`ConfigLoader`],
     /// replacing the default TOML + env loader.
     ///
     /// Useful when your config lives somewhere other than `autumn.toml` —
@@ -720,7 +720,7 @@ impl AppBuilder {
         self
     }
 
-    /// Install a custom [`DatabasePoolProvider`](crate::db::DatabasePoolProvider),
+    /// Install a custom [`DatabasePoolProvider`],
     /// replacing the default `deadpool + diesel-async` pool factory.
     ///
     /// Useful for adding metrics/circuit-breaker wrappers, switching to a

--- a/autumn/tests/app_builder.rs
+++ b/autumn/tests/app_builder.rs
@@ -1,3 +1,6 @@
+//!
+//! Integration tests for the `AppBuilder`.
+//!
 use autumn_web::{get, routes};
 
 #[get("/test")]

--- a/autumn/tests/chaos_channels.rs
+++ b/autumn/tests/chaos_channels.rs
@@ -1,3 +1,6 @@
+//!
+//! Chaos tests for channels.
+//!
 #![cfg(feature = "ws")]
 
 use autumn_web::channels::Channels;

--- a/autumn/tests/chaos_channels_proptest.rs
+++ b/autumn/tests/chaos_channels_proptest.rs
@@ -1,3 +1,6 @@
+//!
+//! Chaos tests using proptest for channels.
+//!
 #![cfg(feature = "ws")]
 
 use autumn_web::channels::Channels;

--- a/autumn/tests/chaos_metrics_leak.rs
+++ b/autumn/tests/chaos_metrics_leak.rs
@@ -1,3 +1,6 @@
+//!
+//! Chaos tests for metrics leak.
+//!
 use autumn_web::middleware::{MetricsCollector, MetricsLayer};
 use axum::body::Body;
 use axum::http::Request;

--- a/autumn/tests/compile_fail.rs
+++ b/autumn/tests/compile_fail.rs
@@ -1,3 +1,6 @@
+//!
+//! Tests for compile failures using trybuild.
+//!
 #[test]
 fn compile_fail_tests() {
     let t = trybuild::TestCases::new();

--- a/autumn/tests/config_runtime_drift.rs
+++ b/autumn/tests/config_runtime_drift.rs
@@ -1,3 +1,6 @@
+//!
+//! Integration tests for config runtime drift.
+//!
 use autumn_web::config::AutumnConfig;
 use autumn_web::test::TestApp;
 

--- a/autumn/tests/extractors.rs
+++ b/autumn/tests/extractors.rs
@@ -1,3 +1,6 @@
+//!
+//! Integration tests for extractors.
+//!
 use autumn_web::extract::{Form, Json};
 use axum::Router;
 use axum::body::Body;

--- a/autumn/tests/maud_render.rs
+++ b/autumn/tests/maud_render.rs
@@ -1,3 +1,6 @@
+//!
+//! Integration tests for maud rendering.
+//!
 #![cfg(feature = "maud")]
 
 use autumn_web::{Markup, html};

--- a/autumn/tests/middleware_pipeline.rs
+++ b/autumn/tests/middleware_pipeline.rs
@@ -1,3 +1,6 @@
+//!
+//! Integration tests for middleware pipeline.
+//!
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/autumn/tests/raw_router_escape_hatch.rs
+++ b/autumn/tests/raw_router_escape_hatch.rs
@@ -1,3 +1,6 @@
+//!
+//! Integration tests for the raw router escape hatch.
+//!
 use autumn_web::test::TestApp;
 use autumn_web::{AppState, get, routes};
 

--- a/autumn/tests/route_macro.rs
+++ b/autumn/tests/route_macro.rs
@@ -1,3 +1,6 @@
+//!
+//! Integration tests for the single route macro.
+//!
 use autumn_web::extract::Path;
 use autumn_web::{delete, get, post, put};
 

--- a/autumn/tests/routes_macro.rs
+++ b/autumn/tests/routes_macro.rs
@@ -1,3 +1,6 @@
+//!
+//! Integration tests for the route macros.
+//!
 use autumn_web::{get, routes};
 
 #[get("/one")]

--- a/autumn/tests/security_tests.rs
+++ b/autumn/tests/security_tests.rs
@@ -1,1 +1,4 @@
+//!
+//! Security tests for the framework.
+//!
 mod security;


### PR DESCRIPTION
📖 Chapter: API intra-doc links
🔦 Insight: Removed redundant explicit link targets in `AppBuilder` rustdocs that triggered `rustdoc::redundant_explicit_links` warnings.
🧪 Example: Cleaned up `[`ConfigLoader`](crate::config::ConfigLoader)` to `[`ConfigLoader`]`.

---
*PR created automatically by Jules for task [17679774328354450928](https://jules.google.com/task/17679774328354450928) started by @madmax983*