### PR TITLE
🌟 Nova: HX-Location Response Header Support

### DIFF
--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -95,6 +95,11 @@ where
 ///
 /// See <https://htmx.org/reference/#response_headers> for more details.
 pub trait HxResponseExt: IntoResponse + Sized {
+    /// Allows you to do a client-side redirect that does not do a full page reload (`HX-Location`).
+    fn hx_location(self, url: &str) -> Response {
+        append_hx_header(self, "hx-location", url)
+    }
+
     /// Pushes a new URL into the history stack (`HX-Push-Url`).
     fn hx_push_url(self, url: &str) -> Response {
         append_hx_header(self, "hx-push-url", url)
@@ -209,6 +214,7 @@ mod tests {
     async fn hx_response_ext_adds_headers() {
         use axum::response::IntoResponse;
         let response = "hello"
+            .hx_location("/some-location")
             .hx_push_url("/new-url")
             .hx_redirect("/login")
             .hx_refresh()
@@ -221,6 +227,7 @@ mod tests {
             .into_response();
 
         let headers = response.headers();
+        assert_eq!(headers.get("hx-location").unwrap(), "/some-location");
         assert_eq!(headers.get("hx-push-url").unwrap(), "/new-url");
         assert_eq!(headers.get("hx-redirect").unwrap(), "/login");
         assert_eq!(headers.get("hx-refresh").unwrap(), "true");
@@ -247,6 +254,7 @@ mod tests {
         let invalid_header_value = "invalid\nvalue";
 
         let response = "hello"
+            .hx_location(invalid_header_value)
             .hx_push_url(invalid_header_value)
             .hx_redirect(invalid_header_value)
             .hx_refresh() // valid by default
@@ -259,6 +267,7 @@ mod tests {
             .into_response();
 
         let headers = response.headers();
+        assert!(headers.get("hx-location").is_none());
         assert!(headers.get("hx-push-url").is_none());
         assert!(headers.get("hx-redirect").is_none());
         // hx_refresh is always set to "true" internally, so it will be present


### PR DESCRIPTION
🌟 Nova: HX-Location Response Header Support

💡 **The Spark:**
While reviewing the HTMX response headers provided in the `HxResponseExt` trait, I noticed that we support `HX-Push-Url`, `HX-Redirect`, `HX-Refresh`, etc., but we are missing `HX-Location`. This header is incredibly powerful because it allows the server to trigger a client-side redirect that does not do a full page reload, functioning much like an HTMX-native SPA routing mechanism without refreshing the whole window.

🚀 **The Feature:**
Implemented the `hx_location` function in the `HxResponseExt` trait in `autumn/src/htmx.rs` to support the `HX-Location` header. It follows the exact same pattern as the other headers and correctly handles invalid header values gracefully.

🔭 **The Potential:**
This enables Autumn developers to seamlessly instruct the client to redirect to a different view or page utilizing HTMX without losing application state or causing jarring full-page refreshes. It's a natural fit for the existing HTMX integration and expands the client-side manipulation toolkit.

⚠️ **Risk:**
Low. This is a strictly additive change in `autumn/src/htmx.rs` extending an existing trait. It does not alter or modify existing logic and comes with passing tests.

---
*PR created automatically by Jules for task [7385020049344146506](https://jules.google.com/task/7385020049344146506) started by @madmax983*