### PR TITLE
🧪 Add unit tests for `hash_password` and `verify_password`

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -1082,4 +1082,27 @@ mod tests {
         assert_eq!(config.bcrypt_cost, DEFAULT_BCRYPT_COST);
         assert_eq!(config.session_key, "user_id");
     }
+
+    #[tokio::test]
+    async fn test_hash_password() {
+        let password = "my_super_secret_password";
+
+        // Test hashing
+        let hash = super::hash_password(password)
+            .await
+            .expect("Failed to hash password");
+        assert!(hash.starts_with("$2b$"));
+
+        // Test verification with correct password
+        let is_valid = super::verify_password(password, &hash)
+            .await
+            .expect("Failed to verify password");
+        assert!(is_valid, "Password should be verified successfully");
+
+        // Test verification with incorrect password
+        let is_invalid = super::verify_password("wrong_password", &hash)
+            .await
+            .expect("Failed to verify wrong password");
+        assert!(!is_invalid, "Wrong password should not be verified");
+    }
 }

--- a/pr_description_final.md
+++ b/pr_description_final.md
@@ -1,0 +1,11 @@
+🎯 **What:**
+Added unit tests for the `hash_password` and `verify_password` functions in `autumn/src/auth.rs`.
+
+📊 **Coverage:**
+The new `test_hash_password` test explicitly covers the expected behaviors:
+1. It hashes a known string and checks that the output string represents a valid bcrypt hash starting with `$2b$`.
+2. It calls `verify_password` using the known string and confirms that verification succeeds.
+3. It calls `verify_password` using an incorrect string and confirms that verification fails.
+
+✨ **Result:**
+The `hash_password` API is now directly covered by the test suite, allowing us to refactor with confidence if the underlying hashing algorithm changes.


### PR DESCRIPTION
🎯 **What:** 
Added unit tests for the `hash_password` and `verify_password` functions in `autumn/src/auth.rs`.

📊 **Coverage:**
The new `test_hash_password` test explicitly covers the expected behaviors:
1. It hashes a known string and checks that the output string represents a valid bcrypt hash starting with `$2b$`.
2. It calls `verify_password` using the known string and confirms that verification succeeds.
3. It calls `verify_password` using an incorrect string and confirms that verification fails.

✨ **Result:**
The `hash_password` API is now directly covered by the test suite, allowing us to refactor with confidence if the underlying hashing algorithm changes.

---
*PR created automatically by Jules for task [15767934130815984025](https://jules.google.com/task/15767934130815984025) started by @madmax983*