### PR TITLE
⚡ Bolt: [optimize levenshtein distance allocation]

### DIFF
--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -386,20 +386,20 @@ fn warn_profile_typo(profile: &str) {
 /// Levenshtein edit distance between two strings.
 ///
 /// ⚡ Bolt Optimization:
-/// Avoids allocating two `Vec<char>` buffers by iterating directly over `Chars`.
-/// While this re-evaluates UTF-8 boundaries in the inner loop, avoiding the heap
-/// allocations is typically faster for the short strings compared here (e.g., config profile typos).
+/// Reduces memory allocations by using a single `Vec` instead of two and
+/// iterating directly over `Chars` to avoid `Vec<char>` allocations.
 fn levenshtein(a: &str, b: &str) -> usize {
     let n = b.chars().count();
-    let mut prev = (0..=n).collect::<Vec<_>>();
-    let mut curr = vec![0; n + 1];
+    let mut prev: Vec<usize> = (0..=n).collect();
     for (i, a_ch) in a.chars().enumerate() {
-        curr[0] = i + 1;
+        let mut prev_diag = prev[0];
+        prev[0] = i + 1;
         for (j, b_ch) in b.chars().enumerate() {
+            let old_prev = prev[j + 1];
             let cost = usize::from(a_ch != b_ch);
-            curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+            prev[j + 1] = (prev[j + 1] + 1).min(prev[j] + 1).min(prev_diag + cost);
+            prev_diag = old_prev;
         }
-        std::mem::swap(&mut prev, &mut curr);
     }
     prev[n]
 }


### PR DESCRIPTION
💡 What: Replaced the two-vector approach in `levenshtein` with a single-vector optimization.
🎯 Why: The original `levenshtein` function allocated two `Vec<usize>` arrays (`prev` and `curr`). Memory allocations are a significant source of overhead, and we can compute the Levenshtein distance using only a single vector and a scalar variable to track the diagonal element (`prev_diag`), reducing the heap allocations by 50%.
📊 Impact: Eliminates one `Vec<usize>` allocation per call to `levenshtein()`. This directly speeds up the `suggest_profile` typo-correction code.
🔬 Measurement: Verified correctness using existing `cargo test -p autumn-web --lib config`. Since this is used primarily in CLI typo checking, formal benchmarking was skipped, but the theoretical reduction in `malloc` operations is mathematically proven.

---
*PR created automatically by Jules for task [9597452996589179016](https://jules.google.com/task/9597452996589179016) started by @madmax983*