### PR TITLE
[codex] Fix framework secure asset defaults

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1695,22 +1695,6 @@ fn format_route_lines(
         crate::actuator::actuator_route_glob(&config.actuator.prefix),
         "GET"
     );
-    let user_declared_favicon = routes.iter().any(|route| {
-        route.path == crate::router::DEFAULT_FAVICON_PATH && route.method == http::Method::GET
-    }) || scoped_groups.iter().any(|group| {
-        group.routes.iter().any(|route| {
-            route.method == http::Method::GET
-                && format!("{}{}", group.prefix, route.path) == crate::router::DEFAULT_FAVICON_PATH
-        })
-    });
-    if !user_declared_favicon {
-        let _ = write!(
-            out,
-            "\n    {} {:<8} -> default favicon",
-            crate::router::DEFAULT_FAVICON_PATH,
-            "GET"
-        );
-    }
     #[cfg(feature = "htmx")]
     {
         out.push_str("\n    /static/js/htmx.min.js GET -> htmx");

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1695,8 +1695,27 @@ fn format_route_lines(
         crate::actuator::actuator_route_glob(&config.actuator.prefix),
         "GET"
     );
+    let user_declared_favicon = routes.iter().any(|route| {
+        route.path == crate::router::DEFAULT_FAVICON_PATH && route.method == http::Method::GET
+    }) || scoped_groups.iter().any(|group| {
+        group.routes.iter().any(|route| {
+            route.method == http::Method::GET
+                && format!("{}{}", group.prefix, route.path) == crate::router::DEFAULT_FAVICON_PATH
+        })
+    });
+    if !user_declared_favicon {
+        let _ = write!(
+            out,
+            "\n    {} {:<8} -> default favicon",
+            crate::router::DEFAULT_FAVICON_PATH,
+            "GET"
+        );
+    }
     #[cfg(feature = "htmx")]
-    out.push_str("\n    /static/js/htmx.min.js GET -> htmx");
+    {
+        out.push_str("\n    /static/js/htmx.min.js GET -> htmx");
+        out.push_str("\n    /static/js/autumn-htmx-csrf.js GET -> htmx csrf");
+    }
     out
 }
 
@@ -2202,14 +2221,14 @@ mod tests {
     #[tokio::test]
     async fn htmx_handler_returns_javascript_with_correct_headers() {
         let app = axum::Router::new().route(
-            "/static/js/htmx.min.js",
+            crate::htmx::HTMX_JS_PATH,
             axum::routing::get(crate::router::htmx_handler),
         );
 
         let response = app
             .oneshot(
                 Request::builder()
-                    .uri("/static/js/htmx.min.js")
+                    .uri(crate::htmx::HTMX_JS_PATH)
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -2257,13 +2276,50 @@ mod tests {
 
     #[cfg(feature = "htmx")]
     #[tokio::test]
+    async fn htmx_csrf_handler_returns_csp_compatible_javascript() {
+        let app = axum::Router::new().route(
+            crate::htmx::HTMX_CSRF_JS_PATH,
+            axum::routing::get(crate::router::htmx_csrf_handler),
+        );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(crate::htmx::HTMX_CSRF_JS_PATH)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok()),
+            Some("application/javascript")
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let js = std::str::from_utf8(&body).expect("csrf helper should be valid utf-8");
+
+        assert!(js.contains("htmx:configRequest"));
+        assert!(js.contains("X-CSRF-Token"));
+        assert!(!js.contains("<script"));
+    }
+
+    #[cfg(feature = "htmx")]
+    #[tokio::test]
     async fn build_router_serves_htmx_js() {
         let router = test_router(vec![test_get_route("/dummy", "dummy")]);
 
         let response = router
             .oneshot(
                 Request::builder()
-                    .uri("/static/js/htmx.min.js")
+                    .uri(crate::htmx::HTMX_JS_PATH)
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -2278,6 +2334,86 @@ mod tests {
             .to_str()
             .unwrap();
         assert!(ct.contains("javascript"));
+    }
+
+    #[cfg(feature = "htmx")]
+    #[tokio::test]
+    async fn build_router_serves_htmx_csrf_js() {
+        let router = test_router(vec![test_get_route("/dummy", "dummy")]);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri(crate::htmx::HTMX_CSRF_JS_PATH)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let csp = response
+            .headers()
+            .get("content-security-policy")
+            .expect("framework JS should still receive security headers")
+            .to_str()
+            .unwrap();
+        assert!(csp.contains("script-src 'self'"), "csp = {csp}");
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let js = std::str::from_utf8(&body).expect("csrf helper should be valid utf-8");
+        assert!(js.contains("htmx:configRequest"));
+        assert!(js.contains("X-CSRF-Token"));
+    }
+
+    #[tokio::test]
+    async fn build_router_serves_default_favicon_without_404() {
+        let router = test_router(vec![test_get_route("/dummy", "dummy")]);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri(crate::router::DEFAULT_FAVICON_PATH)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        assert!(
+            response.headers().contains_key("content-security-policy"),
+            "framework fallback responses should still receive security headers"
+        );
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn build_router_does_not_override_user_favicon_route() {
+        let router = test_router(vec![test_get_route(
+            crate::router::DEFAULT_FAVICON_PATH,
+            "favicon",
+        )]);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri(crate::router::DEFAULT_FAVICON_PATH)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"ok");
     }
 
     #[tokio::test]
@@ -2345,6 +2481,13 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+        let csp = response
+            .headers()
+            .get("content-security-policy")
+            .expect("static-first HTML should still receive security headers")
+            .to_str()
+            .unwrap();
+        assert!(csp.contains("script-src 'self'"), "csp = {csp}");
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();

--- a/autumn/src/error_pages/defaults.rs
+++ b/autumn/src/error_pages/defaults.rs
@@ -103,9 +103,9 @@ impl ErrorPageRenderer for DefaultErrorPages {
                         }
                     }
                     div class="mt-8" {
-                        a href="javascript:history.back()"
+                        a href="/"
                           class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
-                            "Go back"
+                            "Go to homepage"
                         }
                     }
                 }
@@ -307,6 +307,17 @@ mod tests {
         assert!(s.contains("<!DOCTYPE html>"));
         assert!(s.contains("<html"));
         assert!(s.contains("</html>"));
+    }
+
+    #[test]
+    fn default_pages_do_not_use_javascript_urls() {
+        let pages = DefaultErrorPages;
+        let html = pages.render_422(&make_ctx(StatusCode::UNPROCESSABLE_ENTITY));
+        let s = html.into_string();
+        assert!(
+            !s.contains("javascript:"),
+            "default error pages must work under script-src 'self'",
+        );
     }
 
     #[test]

--- a/autumn/src/error_pages/dev_badge.rs
+++ b/autumn/src/error_pages/dev_badge.rs
@@ -28,7 +28,8 @@ pub struct DevBadgeContext {
 
 /// Generate the dev error badge HTML snippet.
 ///
-/// This returns a self-contained HTML fragment with inline CSS and JS.
+/// This returns a self-contained HTML fragment with inline CSS and no
+/// JavaScript, so it works under Autumn's default `script-src 'self'` CSP.
 /// It should be injected just before `</body>` in HTML error responses.
 ///
 /// Uses inline CSS (not Tailwind) so it works even if the CSS build fails.
@@ -44,9 +45,12 @@ pub fn dev_error_badge_html(ctx: &DevBadgeContext) -> Markup {
     html! {
         (PreEscaped(DEV_BADGE_STYLES))
         div #autumn-dev-error-badge {
+            input #autumn-dev-badge-toggle type="checkbox" class="autumn-dev-toggle";
+
             // Collapsed badge (always visible)
-            div #autumn-dev-badge-collapsed
-                onclick="document.getElementById('autumn-dev-badge-expanded').style.display='flex';document.getElementById('autumn-dev-badge-collapsed').style.display='none';"
+            label #autumn-dev-badge-collapsed
+                for="autumn-dev-badge-toggle"
+                tabindex="0"
             {
                 span class="autumn-dev-badge-dot" {}
                 span class="autumn-dev-badge-code" { (status) }
@@ -60,8 +64,10 @@ pub fn dev_error_badge_html(ctx: &DevBadgeContext) -> Markup {
                         span class="autumn-dev-badge-dot" {}
                         (status) " " (reason)
                     }
-                    button class="autumn-dev-overlay-close"
-                        onclick="document.getElementById('autumn-dev-badge-expanded').style.display='none';document.getElementById('autumn-dev-badge-collapsed').style.display='flex';"
+                    label class="autumn-dev-overlay-close"
+                        for="autumn-dev-badge-toggle"
+                        role="button"
+                        aria-label="Close error details"
                     {
                         "\u{00d7}"
                     }
@@ -102,6 +108,17 @@ const DEV_BADGE_STYLES: &str = r#"<style>
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     font-size: 13px;
     line-height: 1.5;
+}
+.autumn-dev-toggle {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+#autumn-dev-badge-toggle:not(:checked) ~ #autumn-dev-badge-expanded {
+    display: none;
+}
+#autumn-dev-badge-toggle:checked ~ #autumn-dev-badge-collapsed {
+    display: none;
 }
 #autumn-dev-badge-collapsed {
     display: flex;
@@ -252,6 +269,15 @@ mod tests {
             s.contains("#autumn-dev-error-badge"),
             "badge uses namespaced CSS selectors"
         );
+    }
+
+    #[test]
+    fn badge_does_not_use_inline_javascript_handlers() {
+        let html = dev_error_badge_html(&test_ctx());
+        let s = html.into_string();
+        assert!(!s.contains("onclick="));
+        assert!(!s.contains("<script"));
+        assert!(s.contains("autumn-dev-badge-toggle"));
     }
 
     #[test]

--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -1,8 +1,10 @@
 //! Embedded htmx JavaScript.
 //!
 //! htmx is embedded directly in the Autumn binary via [`include_bytes!`]
-//! and served at `/static/js/htmx.min.js`. No CDN, no npm, no build
-//! step required.
+//! and served at [`HTMX_JS_PATH`]. A small CSRF helper is also served at
+//! [`HTMX_CSRF_JS_PATH`] so htmx forms can work with Autumn's default
+//! `script-src 'self'` Content Security Policy. No CDN, no npm, no build step
+//! required.
 //!
 //! The framework automatically mounts a route handler that serves this
 //! file with immutable caching headers. Reference it in your HTML
@@ -10,6 +12,7 @@
 //!
 //! ```html
 //! <script src="/static/js/htmx.min.js"></script>
+//! <script src="/static/js/autumn-htmx-csrf.js"></script>
 //! ```
 
 use axum::extract::FromRequestParts;
@@ -24,6 +27,37 @@ use std::convert::Infallible;
 /// served automatically by the framework at `/static/js/htmx.min.js`
 /// with `Cache-Control: public, max-age=31536000, immutable`.
 pub const HTMX_JS: &[u8] = include_bytes!("../vendor/htmx.min.js");
+
+/// Same-origin path where Autumn serves embedded htmx.
+pub const HTMX_JS_PATH: &str = "/static/js/htmx.min.js";
+
+/// Same-origin path where Autumn serves the htmx CSRF helper.
+///
+/// The helper reads a CSRF token from either:
+/// - `<meta name="csrf-token" content="...">`
+/// - `<meta name="autumn-csrf-token" content="...">`
+///
+/// The request header defaults to `X-CSRF-Token`; override it with
+/// `data-header="..."` on the meta tag when using a custom CSRF header name.
+pub const HTMX_CSRF_JS_PATH: &str = "/static/js/autumn-htmx-csrf.js";
+
+/// CSP-compatible htmx CSRF helper JavaScript.
+///
+/// Served as an external same-origin script so applications do not need inline
+/// JavaScript under Autumn's default `script-src 'self'` policy.
+pub const HTMX_CSRF_JS: &str = r#"(function () {
+  document.addEventListener("htmx:configRequest", function (evt) {
+    var meta = document.querySelector('meta[name="csrf-token"], meta[name="autumn-csrf-token"]');
+
+    if (!meta || !evt.detail || !evt.detail.headers) {
+      return;
+    }
+
+    var header = meta.getAttribute("data-header") || "X-CSRF-Token";
+    evt.detail.headers[header] = meta.getAttribute("content") || "";
+  });
+})();
+"#;
 
 /// htmx version string for diagnostics and cache busting.
 ///
@@ -179,6 +213,20 @@ mod tests {
     #[test]
     fn htmx_version_matches_expected() {
         assert_eq!(HTMX_VERSION, "2.0.4");
+    }
+
+    #[test]
+    fn htmx_asset_paths_are_same_origin_static_paths() {
+        assert_eq!(HTMX_JS_PATH, "/static/js/htmx.min.js");
+        assert_eq!(HTMX_CSRF_JS_PATH, "/static/js/autumn-htmx-csrf.js");
+    }
+
+    #[test]
+    fn htmx_csrf_js_configures_request_header_without_inline_wrapper() {
+        assert!(HTMX_CSRF_JS.contains("htmx:configRequest"));
+        assert!(HTMX_CSRF_JS.contains("X-CSRF-Token"));
+        assert!(HTMX_CSRF_JS.contains("csrf-token"));
+        assert!(!HTMX_CSRF_JS.contains("<script"));
     }
 
     #[tokio::test]

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -32,7 +32,7 @@
 //! | HTTP server | [Axum] | Routing, extractors, middleware |
 //! | HTML templates | [Maud] | Type-safe, compiled HTML via `html!` macro |
 //! | Database | [Diesel] | Async Postgres via `diesel-async` + deadpool |
-//! | Client interactivity | htmx | Embedded JS served at `/static/js/htmx.min.js` |
+//! | Client interactivity | htmx | Embedded JS served from same-origin `/static/js/` routes |
 //! | Styling | Tailwind CSS | Downloaded + managed by `autumn-cli` |
 //!
 //! ## Modules
@@ -168,7 +168,7 @@ pub use validation::Validated;
 /// Useful for cache-busting or diagnostic logging. The corresponding
 /// minified JS is served automatically at `/static/js/htmx.min.js`.
 #[cfg(feature = "htmx")]
-pub use htmx::HTMX_VERSION;
+pub use htmx::{HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HTMX_VERSION};
 /// Extension trait adding `.validate()` to all `validator::Validate` types.
 pub use validation::ValidateExt;
 

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -289,8 +289,15 @@ fn accepts_html<B>(req: &axum::http::Request<B>) -> bool {
 ///
 /// This is mounted as the router's fallback so unmatched routes get proper
 /// error pages instead of Axum's default plain-text "Not Found".
-pub async fn fallback_404_handler(uri: axum::http::Uri) -> crate::error::AutumnError {
+pub async fn fallback_404_handler(method: axum::http::Method, uri: axum::http::Uri) -> Response {
+    if matches!(method, axum::http::Method::GET | axum::http::Method::HEAD)
+        && uri.path() == crate::router::DEFAULT_FAVICON_PATH
+    {
+        return axum::http::StatusCode::NO_CONTENT.into_response();
+    }
+
     crate::error::AutumnError::not_found_msg(format!("No route matches {}", uri.path()))
+        .into_response()
 }
 
 #[cfg(test)]
@@ -693,27 +700,62 @@ mod tests {
     #[tokio::test]
     async fn fallback_404_handler_creates_correct_error() {
         let uri = axum::http::Uri::from_static("/some/unknown/path");
-        let error = fallback_404_handler(uri).await;
+        let response = fallback_404_handler(axum::http::Method::GET, uri).await;
 
-        assert_eq!(error.status(), StatusCode::NOT_FOUND);
-        assert_eq!(error.to_string(), "No route matches /some/unknown/path");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(String::from_utf8_lossy(&body).contains("No route matches /some/unknown/path"));
     }
 
     #[tokio::test]
     async fn fallback_404_handler_ignores_query_params() {
         let uri = axum::http::Uri::from_static("/search?q=rust&sort=desc");
-        let error = fallback_404_handler(uri).await;
+        let response = fallback_404_handler(axum::http::Method::GET, uri).await;
 
-        assert_eq!(error.status(), StatusCode::NOT_FOUND);
-        assert_eq!(error.to_string(), "No route matches /search");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(String::from_utf8_lossy(&body).contains("No route matches /search"));
     }
 
     #[tokio::test]
     async fn fallback_404_handler_with_root_path() {
         let uri = axum::http::Uri::from_static("/");
-        let error = fallback_404_handler(uri).await;
+        let response = fallback_404_handler(axum::http::Method::GET, uri).await;
 
-        assert_eq!(error.status(), StatusCode::NOT_FOUND);
-        assert_eq!(error.to_string(), "No route matches /");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(String::from_utf8_lossy(&body).contains("No route matches /"));
+    }
+
+    #[tokio::test]
+    async fn fallback_404_handler_returns_empty_no_content_for_favicon_get() {
+        let response = fallback_404_handler(
+            axum::http::Method::GET,
+            axum::http::Uri::from_static(crate::router::DEFAULT_FAVICON_PATH),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fallback_404_handler_keeps_non_get_favicon_requests_as_not_found() {
+        let response = fallback_404_handler(
+            axum::http::Method::POST,
+            axum::http::Uri::from_static(crate::router::DEFAULT_FAVICON_PATH),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -51,12 +51,12 @@ pub use crate::extract::Query;
 /// Flash message extractor.
 #[cfg(feature = "flash")]
 pub use crate::flash::{Flash, FlashLevel, FlashMessage};
-/// htmx request extractor.
-#[cfg(feature = "htmx")]
-pub use crate::htmx::HxRequest;
 /// Extension trait for adding htmx response headers.
 #[cfg(feature = "htmx")]
 pub use crate::htmx::HxResponseExt;
+/// htmx request extractor.
+#[cfg(feature = "htmx")]
+pub use crate::htmx::{HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HxRequest};
 /// Server-Sent Events (SSE) support.
 pub use crate::sse::{Event, Sse};
 /// State extractor.

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -21,7 +21,7 @@ use axum::response::IntoResponse;
 use http::StatusCode;
 use thiserror::Error;
 
-pub(crate) const DEFAULT_FAVICON_PATH: &str = "/favicon.ico";
+pub const DEFAULT_FAVICON_PATH: &str = "/favicon.ico";
 
 /// Errors that can occur during the router build process.
 ///

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -21,6 +21,8 @@ use axum::response::IntoResponse;
 use http::StatusCode;
 use thiserror::Error;
 
+pub(crate) const DEFAULT_FAVICON_PATH: &str = "/favicon.ico";
+
 /// Errors that can occur during the router build process.
 ///
 /// These errors are typically fatal and represent configuration or routing
@@ -185,11 +187,21 @@ pub fn try_build_router_inner(
     state: AppState,
     ctx: RouterContext,
 ) -> Result<axum::Router, RouterBuildError> {
+    let user_declared_favicon = route_list
+        .iter()
+        .any(|route| route.path == DEFAULT_FAVICON_PATH && route.method == http::Method::GET)
+        || ctx.scoped_groups.iter().any(|group| {
+            group.routes.iter().any(|route| {
+                route.method == http::Method::GET
+                    && format!("{}{}", group.prefix, route.path) == DEFAULT_FAVICON_PATH
+            })
+        });
+    let mount_default_favicon = !user_declared_favicon;
     let mut router = group_and_mount_routes(route_list);
 
     let dev_reload_enabled = dev::is_enabled_with_env(&crate::config::OsEnv);
 
-    router = mount_framework_routes(router, dev_reload_enabled);
+    router = mount_framework_routes(router, dev_reload_enabled, mount_default_favicon);
 
     let (mounted_probe_paths, router_with_probes) = mount_probe_endpoints(router, config);
     router = router_with_probes;
@@ -258,15 +270,39 @@ fn group_and_mount_routes(route_list: Vec<Route>) -> axum::Router<AppState> {
 fn mount_framework_routes(
     mut router: axum::Router<AppState>,
     dev_reload_enabled: bool,
+    mount_default_favicon: bool,
 ) -> axum::Router<AppState> {
+    if mount_default_favicon {
+        router = router.route(
+            DEFAULT_FAVICON_PATH,
+            axum::routing::get(default_favicon_handler),
+        );
+        tracing::debug!(
+            method = "GET",
+            path = DEFAULT_FAVICON_PATH,
+            name = "default favicon",
+            "Mounted route"
+        );
+    }
+
     // Framework-provided routes
     #[cfg(feature = "htmx")]
     {
-        router = router.route("/static/js/htmx.min.js", axum::routing::get(htmx_handler));
+        router = router.route(crate::htmx::HTMX_JS_PATH, axum::routing::get(htmx_handler));
+        router = router.route(
+            crate::htmx::HTMX_CSRF_JS_PATH,
+            axum::routing::get(htmx_csrf_handler),
+        );
         tracing::debug!(
             method = "GET",
-            path = "/static/js/htmx.min.js",
+            path = crate::htmx::HTMX_JS_PATH,
             name = format!("htmx {}", crate::htmx::HTMX_VERSION),
+            "Mounted route"
+        );
+        tracing::debug!(
+            method = "GET",
+            path = crate::htmx::HTMX_CSRF_JS_PATH,
+            name = "htmx csrf helper",
             "Mounted route"
         );
     }
@@ -699,6 +735,9 @@ pub fn try_build_router_with_static_inner(
             }
         },
     ));
+    let router = router.layer(crate::security::SecurityHeadersLayer::from_config(
+        &config.security.headers,
+    ));
 
     Ok(apply_startup_barrier(
         router,
@@ -873,6 +912,26 @@ pub async fn htmx_handler() -> axum::response::Response {
         crate::htmx::HTMX_JS,
     )
         .into_response()
+}
+
+#[cfg(feature = "htmx")]
+pub async fn htmx_csrf_handler() -> axum::response::Response {
+    use axum::response::IntoResponse;
+    (
+        [
+            (http::header::CONTENT_TYPE, "application/javascript"),
+            (
+                http::header::CACHE_CONTROL,
+                "public, max-age=31536000, immutable",
+            ),
+        ],
+        crate::htmx::HTMX_CSRF_JS,
+    )
+        .into_response()
+}
+
+pub async fn default_favicon_handler() -> impl IntoResponse {
+    StatusCode::NO_CONTENT
 }
 
 #[cfg(test)]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -187,21 +187,11 @@ pub fn try_build_router_inner(
     state: AppState,
     ctx: RouterContext,
 ) -> Result<axum::Router, RouterBuildError> {
-    let user_declared_favicon = route_list
-        .iter()
-        .any(|route| route.path == DEFAULT_FAVICON_PATH && route.method == http::Method::GET)
-        || ctx.scoped_groups.iter().any(|group| {
-            group.routes.iter().any(|route| {
-                route.method == http::Method::GET
-                    && format!("{}{}", group.prefix, route.path) == DEFAULT_FAVICON_PATH
-            })
-        });
-    let mount_default_favicon = !user_declared_favicon;
     let mut router = group_and_mount_routes(route_list);
 
     let dev_reload_enabled = dev::is_enabled_with_env(&crate::config::OsEnv);
 
-    router = mount_framework_routes(router, dev_reload_enabled, mount_default_favicon);
+    router = mount_framework_routes(router, dev_reload_enabled);
 
     let (mounted_probe_paths, router_with_probes) = mount_probe_endpoints(router, config);
     router = router_with_probes;
@@ -270,21 +260,7 @@ fn group_and_mount_routes(route_list: Vec<Route>) -> axum::Router<AppState> {
 fn mount_framework_routes(
     mut router: axum::Router<AppState>,
     dev_reload_enabled: bool,
-    mount_default_favicon: bool,
 ) -> axum::Router<AppState> {
-    if mount_default_favicon {
-        router = router.route(
-            DEFAULT_FAVICON_PATH,
-            axum::routing::get(default_favicon_handler),
-        );
-        tracing::debug!(
-            method = "GET",
-            path = DEFAULT_FAVICON_PATH,
-            name = "default favicon",
-            "Mounted route"
-        );
-    }
-
     // Framework-provided routes
     #[cfg(feature = "htmx")]
     {
@@ -928,10 +904,6 @@ pub async fn htmx_csrf_handler() -> axum::response::Response {
         crate::htmx::HTMX_CSRF_JS,
     )
         .into_response()
-}
-
-pub async fn default_favicon_handler() -> impl IntoResponse {
-    StatusCode::NO_CONTENT
 }
 
 #[cfg(test)]

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -148,9 +148,9 @@ pub struct HeadersConfig {
     /// [`default_content_security_policy`]). When set to an empty string,
     /// the header is not emitted (explicit opt-out).
     ///
-    /// The default allows htmx to function normally because htmx is served
-    /// from the same origin at `/static/js/htmx.min.js` and operates via
-    /// `addEventListener` rather than inline `eval`.
+    /// The default allows htmx to function normally because htmx and Autumn's
+    /// htmx CSRF helper are served from the same origin and operate via
+    /// `addEventListener` rather than inline scripts.
     #[serde(default = "default_content_security_policy")]
     pub content_security_policy: String,
 
@@ -350,8 +350,8 @@ fn default_referrer_policy() -> String {
 /// Default `Content-Security-Policy` value.
 ///
 /// Designed to be "sensible by default" while allowing htmx to function
-/// normally when served from the same origin (as Autumn does at
-/// `/static/js/htmx.min.js`).
+/// normally when served from the same origin (as Autumn does for htmx and its
+/// CSRF helper under `/static/js/`).
 ///
 /// Directives:
 /// - `default-src 'self'` -- everything defaults to same-origin
@@ -359,8 +359,8 @@ fn default_referrer_policy() -> String {
 /// - `style-src 'self' 'unsafe-inline'` -- same-origin stylesheets plus
 ///   inline `style` attributes (required by many UI libraries and
 ///   template engines)
-/// - `script-src 'self'` -- only same-origin scripts; htmx works here
-///   because it is served from `/static/js/htmx.min.js`
+/// - `script-src 'self'` -- only same-origin scripts; htmx and Autumn's htmx
+///   CSRF helper work here because they are served from `/static/js/`
 /// - `connect-src 'self'` -- `fetch`/`XHR`/htmx requests go to same origin
 /// - `form-action 'self'` -- forms can only POST to same origin
 /// - `frame-ancestors 'none'` -- matches the default `X-Frame-Options: DENY`

--- a/autumn/src/security/headers.rs
+++ b/autumn/src/security/headers.rs
@@ -255,9 +255,10 @@ mod tests {
 
     #[tokio::test]
     async fn default_csp_allows_htmx_to_function() {
-        // htmx is served from /static/js/htmx.min.js (same origin), operates
-        // via addEventListener (no eval), and issues hx-* requests to the
-        // same origin. The default CSP must allow all of that.
+        // htmx and Autumn's htmx CSRF helper are served from /static/js/
+        // (same origin), operate via addEventListener, and issue hx-* requests
+        // to the same origin. The default CSP must allow all of that without
+        // requiring inline scripts.
         let config = HeadersConfig::default();
         let app = Router::new()
             .route("/", get(|| async { "ok" }))

--- a/autumn/tests/raw_router_escape_hatch.rs
+++ b/autumn/tests/raw_router_escape_hatch.rs
@@ -145,6 +145,20 @@ async fn merged_routes_get_request_id_header() {
 }
 
 #[tokio::test]
+async fn merged_router_favicon_route_wins_without_startup_conflict() {
+    let raw = axum::Router::<AppState>::new().route(
+        "/favicon.ico",
+        axum::routing::get(|| async { "raw favicon" }),
+    );
+    let app = TestApp::new().merge(raw).build();
+    app.get("/favicon.ico")
+        .send()
+        .await
+        .assert_status(200)
+        .assert_body_eq("raw favicon");
+}
+
+#[tokio::test]
 async fn nested_routes_can_extract_app_state() {
     let raw = axum::Router::<AppState>::new().route(
         "/state",

--- a/examples/reddit-clone/src/routes/layout.rs
+++ b/examples/reddit-clone/src/routes/layout.rs
@@ -112,25 +112,6 @@ pub fn layout(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use autumn_web::html;
-
-    use super::layout;
-
-    #[test]
-    fn layout_loads_framework_csrf_script_from_same_origin() {
-        let rendered = layout("Test", None, Some("token"), html! {}).into_string();
-
-        assert!(rendered.contains(r#"<script src="/static/js/htmx.min.js"></script>"#));
-        assert!(rendered.contains(r#"<script src="/static/js/autumn-htmx-csrf.js"></script>"#));
-        assert!(
-            !rendered.contains("htmx:configRequest"),
-            "CSRF htmx listener must not be rendered inline under script-src 'self'",
-        );
-    }
-}
-
 /// Score display with upvote/downvote buttons (htmx-powered).
 pub fn vote_controls(post_id: i64, score: i64) -> Markup {
     html! {
@@ -172,5 +153,24 @@ pub fn time_ago(dt: &chrono::NaiveDateTime) -> String {
         format!("{}m ago", diff.num_minutes())
     } else {
         "just now".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use autumn_web::html;
+
+    use super::layout;
+
+    #[test]
+    fn layout_loads_framework_csrf_script_from_same_origin() {
+        let rendered = layout("Test", None, Some("token"), html! {}).into_string();
+
+        assert!(rendered.contains(r#"<script src="/static/js/htmx.min.js"></script>"#));
+        assert!(rendered.contains(r#"<script src="/static/js/autumn-htmx-csrf.js"></script>"#));
+        assert!(
+            !rendered.contains("htmx:configRequest"),
+            "CSRF htmx listener must not be rendered inline under script-src 'self'",
+        );
     }
 }

--- a/examples/reddit-clone/src/routes/layout.rs
+++ b/examples/reddit-clone/src/routes/layout.rs
@@ -2,7 +2,7 @@
 
 use autumn_web::reexports::axum::response::{IntoResponse, Response};
 use autumn_web::reexports::http;
-use autumn_web::{Markup, PreEscaped, html};
+use autumn_web::{HTMX_CSRF_JS_PATH, HTMX_JS_PATH, Markup, PreEscaped, html};
 
 /// Render a meta-refresh redirect page (for regular form submissions).
 pub fn redirect_to(url: &str) -> Markup {
@@ -53,16 +53,8 @@ pub fn layout(
                     meta name="csrf-token" content=(token);
                 }
                 link rel="stylesheet" href="/static/css/autumn.css";
-                script src="/static/js/htmx.min.js" {}
-                // Configure htmx to send CSRF token from meta tag on every request
-                script {
-                    (PreEscaped(r#"
-                    document.addEventListener('htmx:configRequest', function(evt) {
-                        var meta = document.querySelector('meta[name="csrf-token"]');
-                        if (meta) evt.detail.headers['X-CSRF-Token'] = meta.content;
-                    });
-                    "#))
-                }
+                script src=(HTMX_JS_PATH) {}
+                script src=(HTMX_CSRF_JS_PATH) {}
             }
             body class="bg-gray-100 min-h-screen text-gray-900" {
                 // Navigation bar
@@ -117,6 +109,25 @@ pub fn layout(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use autumn_web::html;
+
+    use super::layout;
+
+    #[test]
+    fn layout_loads_framework_csrf_script_from_same_origin() {
+        let rendered = layout("Test", None, Some("token"), html! {}).into_string();
+
+        assert!(rendered.contains(r#"<script src="/static/js/htmx.min.js"></script>"#));
+        assert!(rendered.contains(r#"<script src="/static/js/autumn-htmx-csrf.js"></script>"#));
+        assert!(
+            !rendered.contains("htmx:configRequest"),
+            "CSRF htmx listener must not be rendered inline under script-src 'self'",
+        );
     }
 }
 


### PR DESCRIPTION
## What changed

This moves the recent browser-facing fixes into Autumn's framework defaults instead of treating them as `reddit-clone` quirks.

- serve an external same-origin htmx CSRF helper from Autumn and export its paths for app layouts
- update `reddit-clone` to consume the framework helper instead of rendering an inline listener
- remove inline JavaScript handlers and `javascript:` URLs from built-in framework pages so they work under the default CSP
- make static-first HTML responses keep security headers
- add a default `GET /favicon.ico` framework route that returns `204 No Content` unless the app defines its own favicon route

## Why it changed

Two separate problems showed up while smoke-testing `reddit-clone`:

1. the example needed htmx CSRF wiring that still worked with Autumn's default `script-src 'self'` CSP
2. the browser console still showed missing-resource noise because starter apps did not get a favicon route by default

Both issues were really framework behavior, not app-specific behavior.

## Impact

Autumn apps now get a safer out-of-the-box path for htmx + CSRF under the default CSP, and a quieter default browser console without forcing every quickstart app to hand-roll a favicon immediately.

## Root cause

- the example layout used inline htmx request-header wiring, which the default CSP blocks
- some built-in framework HTML still relied on inline JS patterns
- static-first responses bypassed security headers
- browsers request `/favicon.ico` automatically, but Autumn had no default response for apps that had not added one yet

## Validation

- `cargo fmt --all`
- `cargo test -p autumn-web htmx`
- `cargo test -p autumn-web error_pages`
- `cargo test -p autumn-web favicon`
- `cargo test -p reddit-clone layout::tests`
- `cargo check --all-targets --all-features`
- `cargo build -p reddit-clone`
- runtime smoke check of `/about`, `/static/css/autumn.css`, `/static/js/htmx.min.js`, `/static/js/autumn-htmx-csrf.js`, and `/favicon.ico`
