### PR TITLE
Add stability policy and migration guide framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,5 +74,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.86.0
       - uses: Swatinem/rust-cache@v2
+      - name: Check MSRV alignment
+        run: ./scripts/check-msrv.sh
       - name: Check MSRV compiles
         run: cargo check --workspace

--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ async fn main() {
 - [Todo Tutorial](docs/guide/tutorial/index.md)
 - [API Reference](https://docs.rs/autumn-web)
 - [Pre-rendering Design Notes](docs/design/hybrid-rendering.md)
+- [Stability Policy](STABILITY.md) — SemVer, MSRV, and migration commitments
+
+## Stability
+
+Autumn commits to [Semantic Versioning](https://semver.org) for its public
+API starting at `1.0.0`. See [STABILITY.md](STABILITY.md) for the full
+definition of the stable surface, the MSRV policy, and the migration-guide
+process for future major releases.
+
+Until `1.0.0`, Autumn is in its `0.x` series — see the
+[pre-1.0 notes](STABILITY.md#pre-10-notes) for what that means in practice.
 
 ## Requirements
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -1,0 +1,248 @@
+# Autumn Stability Policy
+
+This document is Autumn's commitment to its users: an explicit contract that
+describes what is stable, what is not, and how we plan to evolve the
+framework without destroying the applications that depend on it.
+
+> **Status:** Autumn is pre-`1.0` (current release series: `0.x`). The
+> guarantees below describe the policy that will become binding at the `1.0`
+> release. The `0.x` releases follow the same policy *in spirit*, but Cargo
+> treats every `0.x.y → 0.(x+1).0` bump as breaking, so we use those
+> intermediate bumps to iterate toward the stable surface without pretending
+> the contract is already final.
+
+- [Versioning (SemVer)](#versioning-semver)
+- [The Public API Surface](#the-public-api-surface)
+- [What counts as a breaking change](#what-counts-as-a-breaking-change)
+- [What does *not* count as a breaking change](#what-does-not-count-as-a-breaking-change)
+- [Minimum Supported Rust Version (MSRV) policy](#minimum-supported-rust-version-msrv-policy)
+- [Dependencies and re-exports](#dependencies-and-re-exports)
+- [Feature flags](#feature-flags)
+- [Deprecation process](#deprecation-process)
+- [Migration guides](#migration-guides)
+- [Pre-1.0 notes](#pre-10-notes)
+
+## Versioning (SemVer)
+
+Starting with `1.0.0`, Autumn follows
+[Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html) applied to
+the public API defined in this document.
+
+Given a version `MAJOR.MINOR.PATCH`:
+
+- **MAJOR** (`1.0.0 → 2.0.0`) — we *may* make breaking changes to the public
+  API. Every major release ships with a
+  [migration guide](docs/migrations/) describing what changed and how to
+  update.
+- **MINOR** (`1.0.0 → 1.1.0`) — backwards-compatible feature additions. New
+  modules, new methods, new configuration keys. Existing code that compiles
+  against `1.0.0` will continue to compile against any `1.x.y`.
+- **PATCH** (`1.0.0 → 1.0.1`) — backwards-compatible bug fixes, performance
+  improvements, and documentation updates. No behavior changes other than
+  fixing clearly incorrect behavior.
+
+The concrete definition of "breaking" matches the Rust API guidelines and the
+[Cargo SemVer compatibility reference](https://doc.rust-lang.org/cargo/reference/semver.html).
+
+## The Public API Surface
+
+**Stable (covered by SemVer):**
+
+- All items reachable from `autumn_web` that are:
+  - not marked `#[doc(hidden)]`,
+  - not inside a module named `__private`, `internal`, or similar, and
+  - not documented as "unstable", "experimental", or "subject to change".
+- The procedural macros re-exported from `autumn-macros` (`#[get]`,
+  `#[post]`, `#[put]`, `#[delete]`, `#[ws]`, `#[static_get]`,
+  `#[autumn_web::main]`, `routes![]`, `static_routes![]`, `tasks![]`,
+  `#[secured]`, `#[model]`, `#[repository]`, `#[service]`, `#[scheduled]`,
+  `#[cached]`). Macro *input syntax* is part of the API contract; the
+  generated code is not.
+- The `AutumnConfig` TOML schema and all `AUTUMN_*` environment variables
+  documented in [`autumn/src/config.rs`](autumn/src/config.rs).
+- The HTTP surface mounted automatically by [`AppBuilder::run`][]:
+  `/health`, `/live`, `/ready`, `/startup`, `/actuator/*`, `/static/**`.
+  Their *paths* are stable. Response *shapes* for non-actuator endpoints
+  are stable; actuator endpoint payloads follow the actuator docs.
+- The CLI commands shipped by `autumn-cli` (`autumn new`, `autumn setup`,
+  `autumn dev`, `autumn build`, `autumn migrate`) and their documented
+  flags.
+
+**Not stable (explicitly excluded from SemVer):**
+
+- Anything marked `#[doc(hidden)]`. These are implementation details that
+  macros or other internals need to reach, but user code must not depend on
+  them.
+- Anything under `autumn_web::reexports`. The crates re-exported there
+  (`axum`, `diesel`, `diesel_async`, `http`, `tokio`, `tokio_util`,
+  `tracing`, `validator`, `chrono`) follow *their own* versioning. See
+  [Dependencies and re-exports](#dependencies-and-re-exports).
+- Exact error messages (`Display` output, log lines, rendered HTML error
+  pages). Only *types* and *status codes* are stable.
+- Exact generated HTML/JSON byte sequences. We guarantee semantic
+  equivalence (e.g. the error body stays a `{ "error": { "status": ..,
+  "message": .. } }` shape), not byte-for-byte identity.
+- Internals of derive expansions. The *input* syntax of `#[model]`,
+  `#[repository]`, etc. is stable; the generated struct/impl names, field
+  ordering, or intermediate helper items are not. Treat the macro output
+  as opaque.
+- Anything marked in its rustdoc as **experimental**, **unstable**, or
+  **preview**. Feature flags whose name starts with `unstable-` are always
+  excluded.
+- Debug output (`Debug` impls). Useful for logs, not parsable.
+- Private modules (`pub(crate)`, `pub(super)`) and the `tests` modules.
+
+When in doubt: if `cargo doc --no-deps` doesn't list it, it is not part of
+the public API.
+
+[`AppBuilder::run`]: https://docs.rs/autumn-web/latest/autumn_web/app/struct.AppBuilder.html
+
+## What counts as a breaking change
+
+The following require a major version bump:
+
+- Removing, renaming, or relocating a public item.
+- Adding a required method to a public trait, or changing an existing
+  signature. (Adding a *provided* method is allowed if it does not make an
+  existing impl ambiguous.)
+- Changing a function/method signature in a way that rejects previously
+  accepted callers (adding a required parameter, tightening a bound,
+  changing the return type).
+- Adding, removing, or renaming a public struct field on a struct that is
+  not `#[non_exhaustive]`.
+- Adding a variant to a public enum that is not `#[non_exhaustive]`.
+- Removing or renaming an enum variant, even on a `#[non_exhaustive]` enum.
+- Removing a feature flag or changing what it enables in a non-additive
+  way.
+- Removing, renaming, or changing the meaning of an `AutumnConfig` key or
+  `AUTUMN_*` environment variable.
+- Changing the HTTP method or path of a built-in endpoint
+  (e.g. moving `/health` to `/healthz` without aliasing).
+- Bumping the MSRV outside the window described in the
+  [MSRV policy](#minimum-supported-rust-version-msrv-policy).
+- Bumping a major version of a re-exported dependency whose types appear in
+  our public API (e.g. `axum::Router` leaking through
+  `AppBuilder::router`). These bumps are called out in the migration guide
+  of the corresponding major release.
+
+## What does *not* count as a breaking change
+
+- Adding a new public item (module, type, function, method, trait impl
+  that does not create coherence conflicts).
+- Adding a new variant to a `#[non_exhaustive]` enum.
+- Adding a new field to a `#[non_exhaustive]` struct, or a struct whose
+  construction is guarded by a constructor (e.g. a builder).
+- Adding a new optional configuration key with a sensible default.
+- Adding a new feature flag (opt-in).
+- Performance improvements that do not change observable behavior.
+- Bug fixes, even if they change the observable behavior of clearly
+  incorrect previous output (e.g. returning a correct status code instead
+  of an incorrect one). The CHANGELOG calls these out under **Fixed**.
+- Internal refactors that leave the public API intact.
+- Tightening `#[doc(hidden)]` items or removing them entirely.
+- Changing log message wording or tracing span names.
+
+## Minimum Supported Rust Version (MSRV) policy
+
+- Autumn declares its MSRV in two places, which must agree:
+  1. `rust-version` in [`Cargo.toml`](Cargo.toml).
+  2. The `rust-*` badge in [`README.md`](README.md) and the Requirements
+     section.
+- CI runs a dedicated `MSRV` job (see
+  [`.github/workflows/ci.yml`](.github/workflows/ci.yml)) that builds the
+  workspace with the declared toolchain. A
+  [`scripts/check-msrv.sh`](scripts/check-msrv.sh) check verifies that all
+  `rust-version` declarations in the workspace match each other and match
+  the MSRV in the CI matrix. If the numbers diverge, CI fails.
+- **MSRV bumps are allowed in a MINOR release** once the new MSRV is at
+  least 6 months old as a stable Rust release. This matches the policy of
+  Tokio, Serde, and most of the Rust ecosystem: we get to use modern
+  language features without each bump counting as a breaking change.
+- MSRV bumps are always called out in the CHANGELOG under an **MSRV**
+  heading for that release.
+- A MAJOR release may set any MSRV; the new MSRV is documented in the
+  migration guide.
+- We never lower the MSRV in a patch release. We *may* raise it in a
+  patch release only to fix a soundness or security issue that cannot be
+  fixed otherwise; such bumps are vanishingly rare and documented
+  explicitly.
+
+## Dependencies and re-exports
+
+Autumn is a framework, not a walled garden. We re-export core building
+blocks (Axum, Diesel, Tokio, …) under `autumn_web::reexports` so that users
+can opt into the full upstream API without adding a second dependency.
+
+This means our stability is coupled to the upstream crates. Our policy:
+
+- A major bump of a *leaf* dependency (something that does not appear in
+  our public API) is a patch or minor release here, not a major bump.
+- A major bump of a dependency whose types *do* appear in our public API
+  (e.g. upgrading `axum` from `0.8` to `0.9`, or `diesel` from `2` to
+  `3`) is a major release of Autumn. The migration guide documents the
+  upstream changes users need to be aware of.
+- We are explicit about which dependency versions a given Autumn release
+  supports. See `[workspace.dependencies]` in
+  [`Cargo.toml`](Cargo.toml).
+- We do not promise that every compatible upstream patch release will be
+  picked up immediately. We do promise to respond to upstream security
+  advisories within a reasonable window (ideally within one patch
+  release).
+
+## Feature flags
+
+Cargo feature flags are part of the public API:
+
+- Removing a feature flag, or changing what it enables, is a breaking
+  change.
+- Adding a new feature flag is *not* a breaking change, provided it is
+  additive.
+- Features named `unstable-*` are explicitly excluded from the stability
+  policy. Use them at your own risk.
+- The `default` feature set is stable: removing a feature from `default`
+  is a breaking change.
+
+## Deprecation process
+
+We prefer a long deprecation ramp over abrupt removal:
+
+1. An item is marked with `#[deprecated]` in a minor release and a
+   replacement is documented.
+2. The deprecation note stays for at least one full minor cycle, ideally
+   longer.
+3. The item is removed in the next *major* release.
+
+Deprecations never change behavior — only signal intent.
+
+## Migration guides
+
+Every major release ships with a migration guide under
+[`docs/migrations/`](docs/migrations/). The guide is written against the
+[migration guide template](docs/migrations/TEMPLATE.md) and covers:
+
+1. The summary and scope of the breaking changes.
+2. MSRV delta, if any.
+3. A section per breaking change with *before* / *after* code snippets.
+4. Compiler-error cheat sheet — "if you see this error, do that".
+5. Dependency major bumps carried with the release.
+6. Link to the CHANGELOG section for the release.
+
+Draft migration guides are opened alongside the first breaking change that
+targets the next major; they are merged and polished across the prerelease
+cycle so that the `x.0.0` release ships with a complete guide on day one.
+
+## Pre-1.0 notes
+
+Until Autumn reaches `1.0.0`:
+
+- Every minor (`0.x.0 → 0.(x+1).0`) release *may* contain breaking
+  changes. Cargo's SemVer rules already treat these as breaking, and we
+  use them to iterate on the public surface before it is frozen.
+- We still keep a CHANGELOG with **Breaking Changes** callouts for every
+  `0.x` bump so users know what to look out for.
+- The guarantees above (MSRV handling, non-exhaustive markers, re-export
+  policy, feature flags) are already honored. The only difference is that
+  the API itself is allowed to move.
+- Reaching `1.0.0` is a decision, not a calendar event: we will declare
+  1.0 when the surface described above has been stable across a couple of
+  `0.x` cycles without user-facing churn.

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -420,6 +420,7 @@ fn levenshtein(a: &str, b: &str) -> usize {
 /// assert!(result.is_ok());
 /// ```
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ConfigError {
     /// The config file exists but could not be read.
     #[error("failed to read autumn.toml: {0}")]
@@ -1111,6 +1112,7 @@ pub struct LogConfig {
 /// assert_eq!(LogFormat::default(), LogFormat::Auto);
 /// ```
 #[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum LogFormat {
     /// Pretty in dev, JSON in production (based on `AUTUMN_ENV`).
     #[default]
@@ -1162,6 +1164,7 @@ pub struct TelemetryConfig {
 
 /// OTLP transport protocol selection.
 #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum TelemetryProtocol {
     /// OTLP over gRPC.
     #[serde(alias = "grpc", alias = "GRPC")]

--- a/autumn/src/flash.rs
+++ b/autumn/src/flash.rs
@@ -40,6 +40,7 @@ const FLASH_SESSION_KEY: &str = "__autumn_flash";
 /// The severity level of a flash message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum FlashLevel {
     /// Success messages (e.g., "Item created").
     Success,

--- a/autumn/src/hooks.rs
+++ b/autumn/src/hooks.rs
@@ -57,6 +57,7 @@ use serde::{Deserialize, Serialize};
 
 /// The kind of mutation being performed on a repository record.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MutationOp {
     /// A new record is being created.
     Create,

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -45,6 +45,7 @@ pub struct MigrationResult {
 
 /// Error type for migration operations.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum MigrationError {
     /// Failed to connect to the database.
     #[error("failed to connect to database: {0}")]

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -395,6 +395,7 @@ pub struct SessionConfig {
 /// Supported session storage backends.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum SessionBackend {
     /// In-memory storage. Resets on application restart.
     #[default]
@@ -457,6 +458,7 @@ pub enum SessionBackendPlan {
 
 /// Errors that can occur when resolving the session backend configuration.
 #[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SessionBackendConfigError {
     /// Redis was selected, but no URL was provided.
     #[error("session.backend=redis requires session.redis.url")]

--- a/autumn/src/static_gen/build.rs
+++ b/autumn/src/static_gen/build.rs
@@ -19,6 +19,7 @@ const DEFAULT_CONCURRENCY: usize = 8;
 
 /// Errors that can occur during static rendering.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum BuildError {
     /// A route handler returned a non-2xx HTTP status.
     #[error("Route {path} returned HTTP {status} (expected 2xx)")]

--- a/autumn/src/task.rs
+++ b/autumn/src/task.rs
@@ -27,6 +27,7 @@ pub struct TaskInfo {
 }
 
 /// How a scheduled task is triggered.
+#[non_exhaustive]
 pub enum Schedule {
     /// Run after a fixed delay from the end of the previous run.
     FixedDelay(Duration),

--- a/autumn/src/telemetry.rs
+++ b/autumn/src/telemetry.rs
@@ -18,6 +18,7 @@ use opentelemetry_sdk::{Resource, propagation::TraceContextPropagator, trace::Sd
 
 /// Concrete log formatting chosen for the running process.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ResolvedLogFormat {
     /// Human-readable developer logs.
     Pretty,
@@ -71,6 +72,7 @@ pub struct TelemetryResource {
 
 /// Errors that can occur while planning or initializing telemetry.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum TelemetryInitError {
     /// Telemetry was enabled without an OTLP endpoint.
     #[error("telemetry is enabled but no OTLP endpoint was configured")]

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,34 @@
+# Migration Guides
+
+Every **major** release of Autumn ships with a migration guide describing
+what changed and how to update application code. Minor and patch releases
+are backwards-compatible per the [Stability Policy](../../STABILITY.md) and
+do not need a dedicated guide — their changes are called out in the
+[CHANGELOG](../../CHANGELOG.md).
+
+## Index
+
+- [`TEMPLATE.md`](TEMPLATE.md) — template for new migration guides. Copy
+  this when drafting the guide for the next major release.
+
+As Autumn ships `1.0.0` and beyond, each release will be indexed here, for
+example:
+
+- `1.x-to-2.0.md` — `autumn-web 1.x → 2.0.0`
+- `2.x-to-3.0.md` — `autumn-web 2.x → 3.0.0`
+
+## Process for a new major release
+
+1. **Open a draft guide early.** The first PR that lands a breaking change
+   targeting the next major copies `TEMPLATE.md` to
+   `docs/migrations/<from>-to-<to>.md` and links it from this index.
+2. **Grow the guide with each breaking change.** Every subsequent
+   breaking-change PR appends a section with *before* / *after* snippets
+   and the compiler error users will see.
+3. **Polish during the prerelease window.** The `x.0.0-rc.*` tags exist so
+   we can dogfood the guide against real user upgrades and fill gaps.
+4. **Ship on day one.** `x.0.0` does not go out unless its migration guide
+   is complete and the index above points to it.
+
+If you are a contributor opening a breaking-change PR, adding the matching
+entry to the in-flight migration guide is part of "done."

--- a/docs/migrations/TEMPLATE.md
+++ b/docs/migrations/TEMPLATE.md
@@ -1,0 +1,142 @@
+# Migrating from Autumn `X.Y` to `(X+1).0`
+
+> **Template.** Copy this file to `docs/migrations/<X.Y>-to-<X+1.0>.md`
+> when drafting the guide for the next major release. Replace every
+> `{placeholder}` with concrete content and delete sections that do not
+> apply. Link the new file from
+> [`docs/migrations/README.md`](README.md).
+
+## At a glance
+
+- **Old version:** `autumn-web {X.Y.Z}`
+- **New version:** `autumn-web {(X+1).0.0}`
+- **Expected upgrade effort:** {S / M / L — one paragraph of context}
+- **MSRV delta:** `{old MSRV}` → `{new MSRV}` ({reason, or "unchanged"})
+- **Carried dependency majors:** {e.g. `axum 0.8 → 0.9`, `diesel 2 → 3`,
+  or "none"}
+
+## Summary
+
+One paragraph describing *why* this release is major. Prefer "we want
+these properties, and they required breaking change `X`" over a list of
+unrelated removals.
+
+Link to the [CHANGELOG entry](../../CHANGELOG.md) for the release for the
+full commit-level picture.
+
+## Before you start
+
+- Pin your existing version (`autumn-web = "={X.Y.Z}"`) and commit.
+- Run `cargo update` *before* the upgrade so the subsequent diff is just
+  the major bump.
+- Make sure your test suite is green on the old version. You will want
+  the safety net.
+
+## Step-by-step
+
+1. **Bump the dependency.**
+   ```toml
+   # Cargo.toml
+   [dependencies]
+   autumn-web = "{(X+1).0}"
+   ```
+
+2. **Run `cargo check`.** Work through the compiler errors section by
+   section using the cheat sheet below.
+
+3. **Apply configuration changes** (see
+   [Configuration changes](#configuration-changes)).
+
+4. **Run the test suite.**
+
+5. **Run the application locally** and exercise each feature at least
+   once. Pay attention to the [Behavior changes](#behavior-changes)
+   section.
+
+## Breaking changes
+
+Repeat the block below for each breaking change. Keep changes grouped by
+area (routing / config / database / …) so readers can skip to what they
+care about.
+
+### {Area}: {Short description}
+
+**Why:** One or two sentences on the motivation.
+
+**Before (`{X.Y}`):**
+
+```rust
+// paste a minimal, compiling example from the old version
+```
+
+**After (`{(X+1).0}`):**
+
+```rust
+// paste the equivalent on the new version
+```
+
+**If you are automating the upgrade:** optional `sed`/`rg` one-liner or
+note about a `cargo fix --edition`-style tool if one applies.
+
+---
+
+## Compiler error cheat sheet
+
+Paste the most common errors a user will hit and the fix. This is the
+single most valuable section of the guide — keep it factual and short.
+
+| Error message (truncated) | Where you see it | Fix |
+|---------------------------|------------------|-----|
+| `error[E0432]: unresolved import \`autumn_web::foo\`` | module reorganized | `use autumn_web::bar;` |
+| `error[E0061]: this function takes 2 arguments but 1 was supplied` | `App::run` added a parameter | see [Breaking changes › {Area}] |
+
+## Configuration changes
+
+- `autumn.toml` keys that were renamed, removed, or have new defaults.
+- New `AUTUMN_*` environment variables.
+- Default profile changes.
+
+If nothing changed, delete this section.
+
+## Behavior changes
+
+Changes that still compile but behave differently at runtime. Examples:
+
+- Error responses adopted a new JSON shape.
+- A default middleware is now ordered differently.
+- A scheduled task now runs on a different worker.
+
+If nothing changed, delete this section.
+
+## Deprecations retained from `{X.Y}`
+
+Items that were deprecated during the `{X.Y}` line and have now been
+removed. Link each to the release where the deprecation notice first
+appeared so users can see how much warning they had.
+
+## Upstream dependency updates
+
+For each major dependency bump carried with this release:
+
+- Link to that project's upstream migration notes.
+- Call out any of their changes that leak through Autumn's public API.
+
+If no majors were carried, delete this section.
+
+## Troubleshooting
+
+Known rough edges, workarounds, and known-good version combinations
+(e.g. "use `diesel 2.2.5+` — earlier `2.2.x` releases have a known
+`pq-sys` linkage issue on macOS").
+
+## Reporting problems
+
+If you hit something not covered here, please open an issue at
+<https://github.com/madmax983/autumn/issues> with:
+
+- The error message or unexpected behavior.
+- The old version you upgraded from.
+- A minimal reproduction if possible.
+
+Migration guides are living documents — we update them based on user
+reports for the first few months after a major release.

--- a/scripts/check-msrv.sh
+++ b/scripts/check-msrv.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Verify that the MSRV is declared consistently across the workspace,
+# the README, and the CI matrix. Exit non-zero if any source disagrees.
+#
+# Sources checked:
+#   - [workspace.package].rust-version in Cargo.toml  (canonical MSRV)
+#   - README.md badge + "Requirements" section
+#   - .github/workflows/ci.yml       (`msrv:` job pin)
+#
+# Called from the `msrv` job in ci.yml. Runs locally with:
+#
+#     ./scripts/check-msrv.sh
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+# Canonical MSRV from the workspace Cargo.toml.
+canonical="$(
+  awk '
+    /^\[workspace\.package\]/ { in_block = 1; next }
+    /^\[/ && in_block       { in_block = 0 }
+    in_block && /^rust-version/ {
+      match($0, /"[^"]+"/)
+      print substr($0, RSTART + 1, RLENGTH - 2)
+      exit
+    }
+  ' Cargo.toml
+)"
+
+[[ -n "$canonical" ]] || die "could not find [workspace.package].rust-version in Cargo.toml"
+echo "canonical rust-version = $canonical"
+
+# Any crate-level Cargo.toml that pins its own rust-version must match
+# (we allow inheritance via `rust-version.workspace = true`).
+while IFS= read -r manifest; do
+  pinned="$(
+    awk '
+      /^\[package\]/         { in_pkg = 1; next }
+      /^\[/ && in_pkg        { in_pkg = 0 }
+      in_pkg && /^rust-version[[:space:]]*=[[:space:]]*"/ {
+        match($0, /"[^"]+"/)
+        print substr($0, RSTART + 1, RLENGTH - 2)
+        exit
+      }
+    ' "$manifest"
+  )"
+  if [[ -n "$pinned" && "$pinned" != "$canonical" ]]; then
+    die "$manifest pins rust-version = \"$pinned\" but workspace MSRV is \"$canonical\""
+  fi
+done < <(find . -type f -name Cargo.toml -not -path "./target/*")
+
+# README badge.
+if ! grep -q "rust-${canonical}" README.md; then
+  die "README.md badge does not reference rust-${canonical}"
+fi
+
+# README "Requirements" section.
+if ! grep -q "Rust ${canonical}" README.md; then
+  die "README.md Requirements does not reference Rust ${canonical}"
+fi
+
+# CI workflow pin.
+ci="$root/.github/workflows/ci.yml"
+if ! grep -Eq "rust-toolchain@${canonical}\b" "$ci"; then
+  die "$ci msrv job does not pin dtolnay/rust-toolchain@${canonical}"
+fi
+if ! grep -Eq "MSRV \(${canonical}\)" "$ci"; then
+  die "$ci msrv job name does not reference MSRV (${canonical})"
+fi
+
+echo "MSRV alignment OK (${canonical})"


### PR DESCRIPTION
## Summary

This PR establishes Autumn's commitment to API stability by introducing a comprehensive Stability Policy document and migration guide framework. It also marks several public enums as `#[non_exhaustive]` to enable future evolution without breaking changes, and adds CI validation for MSRV consistency.

## Key Changes

- **STABILITY.md**: New document defining Autumn's SemVer commitment, public API surface, breaking change criteria, MSRV policy, deprecation process, and pre-1.0 notes. Clarifies that the framework follows SemVer starting at `1.0.0`, with `0.x` releases allowed to iterate on the API surface.

- **Migration guide framework**: 
  - Added `docs/migrations/README.md` describing the process for major releases
  - Added `docs/migrations/TEMPLATE.md` as a reusable template for future migration guides with sections for breaking changes, compiler error cheat sheets, configuration changes, and behavior changes

- **MSRV validation**: Added `scripts/check-msrv.sh` to verify MSRV consistency across `Cargo.toml`, `README.md`, and CI workflow. Integrated into the CI pipeline to catch divergence early.

- **Non-exhaustive enums**: Marked the following public enums as `#[non_exhaustive]` to allow adding variants in minor releases without breaking changes:
  - `ConfigError` (config.rs)
  - `SessionBackend` (session.rs)
  - `ResolvedLogFormat` (telemetry.rs)
  - `FlashLevel` (flash.rs)
  - `MutationOp` (hooks.rs)
  - `MigrationError` (migrate.rs)
  - `BuildError` (static_gen/build.rs)
  - `Schedule` (task.rs)

- **README updates**: Added "Stability" section linking to STABILITY.md and explaining the pre-1.0 status, plus updated documentation index.

## Implementation Details

The stability policy explicitly defines:
- What constitutes the public API (items in `autumn_web` not marked `#[doc(hidden)]`, procedural macros, config schema, HTTP endpoints, CLI commands)
- What is excluded (re-exports, error messages, generated code internals, debug output)
- MSRV bumps allowed in minor releases if the new MSRV is 6+ months old (matching Tokio/Serde ecosystem practice)
- Dependency re-export policy for coupled upstream versions
- Three-step deprecation process with at least one full minor cycle before removal

The `#[non_exhaustive]` markers on enums enable Autumn to add new variants in future minor releases without requiring a major version bump, reducing churn for users while maintaining forward compatibility.

https://claude.ai/code/session_01FHTQLA5XqGmag6snV3z5ga