### PR TITLE
Add OpenAPI/Swagger auto-generation from route metadata

### DIFF
--- a/autumn-macros/src/api_doc.rs
+++ b/autumn-macros/src/api_doc.rs
@@ -396,24 +396,38 @@ fn unwrap_single_generic(ty: &syn::Type, wrapper: &str) -> Option<syn::Type> {
 
 /// Emit a `::autumn_web::openapi::SchemaEntry` initializer for a type.
 ///
-/// The generated code dispatches at compile time to a const-fn-like
-/// branching expression that yields either:
-/// * a primitive schema when the type matches a known scalar, or
-/// * a `Ref` referencing the type's [`OpenApiSchema::schema_name()`]
-///   when the type is any other named path, or
-/// * a fallback "object"-typed name when we cannot identify the type.
+/// Handles the following patterns:
+///
+/// * `Vec<T>`         → `SchemaKind::Array(&inner)`  (array of `T`)
+/// * `Option<T>`      → `SchemaKind::Nullable(&inner)` (nullable `T`)
+/// * known primitive  → `SchemaKind::Primitive("string"|"integer"|…)`
+/// * everything else  → `SchemaKind::Ref` with the type's last path
+///   segment as the schema name (back-filled by the spec generator)
 fn schema_entry_for_type(ty: &syn::Type) -> TokenStream {
-    // Lift primitive detection out of the proc macro so the user's path
-    // like `crate::models::User` isn't re-parsed at compile time. We emit
-    // a const-dispatched expression using type-id-less pattern matching
-    // via `match` on a generated helper; the simpler approach here is to
-    // always emit a `Ref` with the type's last-segment name. This keeps
-    // the macro output short while still permitting users to register
-    // their types via `OpenApiSchema`.
+    // Vec<T> → array of <schema of T>.
+    if let Some(inner) = unwrap_single_generic(ty, "Vec") {
+        let inner_tokens = schema_entry_for_type(&inner);
+        return quote! {
+            ::autumn_web::openapi::SchemaEntry {
+                name: "array",
+                kind: ::autumn_web::openapi::SchemaKind::Array(&#inner_tokens),
+            }
+        };
+    }
+    // Option<T> → nullable <schema of T>.
+    if let Some(inner) = unwrap_single_generic(ty, "Option") {
+        let inner_tokens = schema_entry_for_type(&inner);
+        return quote! {
+            ::autumn_web::openapi::SchemaEntry {
+                name: "nullable",
+                kind: ::autumn_web::openapi::SchemaKind::Nullable(&#inner_tokens),
+            }
+        };
+    }
+
     let name = last_segment_name(ty).unwrap_or_else(|| "Schema".to_owned());
     let name_lit = LitStr::new(&name, Span::call_site());
-    let primitive = primitive_json_type(&name);
-    if let Some(json_type) = primitive {
+    if let Some(json_type) = primitive_json_type(&name) {
         let json_lit = LitStr::new(json_type, Span::call_site());
         quote! {
             ::autumn_web::openapi::SchemaEntry {

--- a/autumn-macros/src/api_doc.rs
+++ b/autumn-macros/src/api_doc.rs
@@ -303,13 +303,37 @@ pub fn emit_path_param_slice(params: &[String]) -> TokenStream {
 ///
 /// Returns a `Some(tokens)` producing a `SchemaEntry` initializer for the
 /// first JSON extractor seen, or `None` if the handler has no JSON body.
+///
+/// Recognizes Autumn's validation wrapper as well: a parameter typed
+/// `Valid<Json<T>>` is treated the same as `Json<T>` so handlers using
+/// the documented validator pattern still get a `requestBody` in the
+/// generated spec.
 pub fn infer_request_body(input_fn: &syn::ItemFn) -> Option<TokenStream> {
     for arg in &input_fn.sig.inputs {
         let syn::FnArg::Typed(pat) = arg else {
             continue;
         };
-        if let Some(inner) = unwrap_single_generic(&pat.ty, "Json") {
+        if let Some(inner) = unwrap_json_body(&pat.ty) {
             return Some(schema_entry_for_type(&inner));
+        }
+    }
+    None
+}
+
+/// Peel one layer of `Valid<...>` so that
+/// `Valid<Json<NewPost>>` → `Json<NewPost>` → `NewPost`.
+///
+/// Matches either a bare `Json<T>` or `Valid<Json<T>>` and returns the
+/// inner `T`. Any deeper nesting returns `None` — we intentionally
+/// don't guess at unknown wrappers because mis-identifying them would
+/// produce wrong schemas.
+fn unwrap_json_body(ty: &syn::Type) -> Option<syn::Type> {
+    if let Some(inner) = unwrap_single_generic(ty, "Json") {
+        return Some(inner);
+    }
+    if let Some(inner) = unwrap_single_generic(ty, "Valid") {
+        if let Some(payload) = unwrap_single_generic(&inner, "Json") {
+            return Some(payload);
         }
     }
     None

--- a/autumn-macros/src/api_doc.rs
+++ b/autumn-macros/src/api_doc.rs
@@ -315,15 +315,39 @@ pub fn infer_request_body(input_fn: &syn::ItemFn) -> Option<TokenStream> {
     None
 }
 
-/// Inspect the handler's return type for `Json<T>` (including
-/// `Result<Json<T>, _>` and `AutumnResult<Json<T>>`) to infer the
-/// success response body.
+/// Inspect the handler's return type for `Json<T>` to infer the success
+/// response body. Handles several common Axum return-type patterns:
+///
+/// * `Json<T>` — plain JSON body
+/// * `Result<Json<T>, _>` / `AutumnResult<Json<T>>` — fallible JSON
+/// * `(StatusCode, Json<T>)` — JSON with a custom status code
+/// * `Result<(StatusCode, Json<T>), _>` — the two combined
 pub fn infer_response_body(input_fn: &syn::ItemFn) -> Option<TokenStream> {
     let syn::ReturnType::Type(_, ty) = &input_fn.sig.output else {
         return None;
     };
     let ty = unwrap_result_ok(ty).unwrap_or_else(|| (**ty).clone());
-    unwrap_single_generic(&ty, "Json").map(|inner| schema_entry_for_type(&inner))
+    find_json_in_type(&ty).map(|inner| schema_entry_for_type(&inner))
+}
+
+/// Look for `Json<T>` either directly or inside a tuple element.
+///
+/// Axum handlers often return tuples like `(StatusCode, Json<T>)` or
+/// `([(HeaderName, _); N], Json<T>)` to attach status codes or
+/// headers. We scan each tuple element so the generated schema still
+/// reflects the JSON body.
+fn find_json_in_type(ty: &syn::Type) -> Option<syn::Type> {
+    if let Some(inner) = unwrap_single_generic(ty, "Json") {
+        return Some(inner);
+    }
+    if let syn::Type::Tuple(tup) = ty {
+        for elem in &tup.elems {
+            if let Some(inner) = unwrap_single_generic(elem, "Json") {
+                return Some(inner);
+            }
+        }
+    }
+    None
 }
 
 /// Peel a single layer of `Result<T, _>` / `AutumnResult<T>` so we can

--- a/autumn-macros/src/api_doc.rs
+++ b/autumn-macros/src/api_doc.rs
@@ -1,6 +1,14 @@
 // OpenAPI appears many times in this module's docs as an acronym —
-// silence clippy::doc_markdown for it locally.
-#![allow(clippy::doc_markdown)]
+// silence clippy::doc_markdown for it locally. The other allows turn
+// off pedantic style nits (`KeyValue::Foo` vs `Foo` inside the enum's
+// own impl, `Option::map_or_else` vs `match`/`if let`) that would
+// trade clarity for less-readable chained closure calls.
+#![allow(
+    clippy::doc_markdown,
+    clippy::option_if_let_else,
+    clippy::single_match_else,
+    clippy::use_self
+)]
 
 //! `#[api_doc(...)]` attribute parsing for OpenAPI auto-generation.
 //!

--- a/autumn-macros/src/api_doc.rs
+++ b/autumn-macros/src/api_doc.rs
@@ -1,0 +1,475 @@
+// OpenAPI appears many times in this module's docs as an acronym —
+// silence clippy::doc_markdown for it locally.
+#![allow(clippy::doc_markdown)]
+
+//! `#[api_doc(...)]` attribute parsing for OpenAPI auto-generation.
+//!
+//! `#[api_doc]` is handled two ways:
+//!
+//! * As a **stored attribute** on route handlers (`#[get]`, `#[post]`, …):
+//!   the route macro strips it from the function's attribute list,
+//!   parses it here, and embeds the result in the generated `ApiDoc`
+//!   struct.
+//! * As a **standalone proc-macro** (see [`crate::api_doc`]) so Rust
+//!   accepts the attribute on its own. That entry point is a no-op
+//!   wrapper — the real work happens when a route macro is also
+//!   applied, since routes are the only places metadata is collected.
+//!
+//! Supported forms:
+//!
+//! ```ignore
+//! #[api_doc(summary = "Fetch a user", tag = "users")]
+//! #[api_doc(description = "...", tags = ["users", "admin"], status = 201)]
+//! #[api_doc(hidden)]
+//! ```
+//!
+//! Unknown keys are a compile error, so typos surface at build time.
+
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::{Attribute, Expr, ExprLit, Ident, Lit, LitBool, LitStr, Token};
+
+/// Parsed `#[api_doc(...)]` attribute arguments.
+#[derive(Default)]
+pub struct ApiDocAttr {
+    pub summary: Option<LitStr>,
+    pub description: Option<LitStr>,
+    pub tags: Vec<LitStr>,
+    pub operation_id: Option<LitStr>,
+    pub status: Option<u16>,
+    pub hidden: bool,
+}
+
+enum KeyValue {
+    Summary(LitStr),
+    Description(LitStr),
+    Tag(LitStr),
+    Tags(Vec<LitStr>),
+    OperationId(LitStr),
+    Status(u16),
+    Hidden,
+}
+
+impl Parse for KeyValue {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let key: Ident = input.parse()?;
+        let key_str = key.to_string();
+
+        if key_str == "hidden" {
+            if input.peek(Token![=]) {
+                let _eq: Token![=] = input.parse()?;
+                let value: LitBool = input.parse()?;
+                return Ok(if value.value {
+                    KeyValue::Hidden
+                } else {
+                    // `hidden = false` is equivalent to the default (visible).
+                    // Return a distinguishable marker via Tags(vec![]) so
+                    // ApiDocAttr::merge does nothing — this keeps parsing
+                    // symmetric with other bool forms.
+                    KeyValue::Tags(Vec::new())
+                });
+            }
+            return Ok(KeyValue::Hidden);
+        }
+
+        let _eq: Token![=] = input.parse()?;
+        match key_str.as_str() {
+            "summary" => Ok(KeyValue::Summary(input.parse()?)),
+            "description" => Ok(KeyValue::Description(input.parse()?)),
+            "tag" => Ok(KeyValue::Tag(input.parse()?)),
+            "tags" => {
+                // `tags = ["a", "b"]`
+                let content;
+                syn::bracketed!(content in input);
+                let items =
+                    syn::punctuated::Punctuated::<LitStr, Token![,]>::parse_terminated(&content)?;
+                Ok(KeyValue::Tags(items.into_iter().collect()))
+            }
+            "operation_id" => Ok(KeyValue::OperationId(input.parse()?)),
+            "status" => {
+                let value: Expr = input.parse()?;
+                let n = expect_u16(&value)?;
+                Ok(KeyValue::Status(n))
+            }
+            other => Err(syn::Error::new(
+                key.span(),
+                format!(
+                    "unknown key `{other}` in `#[api_doc(...)]`. \
+                     Supported keys: summary, description, tag, tags, operation_id, status, hidden."
+                ),
+            )),
+        }
+    }
+}
+
+fn expect_u16(expr: &Expr) -> syn::Result<u16> {
+    if let Expr::Lit(ExprLit {
+        lit: Lit::Int(int), ..
+    }) = expr
+    {
+        int.base10_parse::<u16>()
+    } else {
+        Err(syn::Error::new_spanned(
+            expr,
+            "expected an integer HTTP status code (e.g. `status = 201`)",
+        ))
+    }
+}
+
+impl ApiDocAttr {
+    fn merge(&mut self, kv: KeyValue) {
+        match kv {
+            KeyValue::Summary(v) => self.summary = Some(v),
+            KeyValue::Description(v) => self.description = Some(v),
+            KeyValue::Tag(v) => self.tags = vec![v],
+            KeyValue::Tags(v) if !v.is_empty() => self.tags = v,
+            KeyValue::Tags(_) => {}
+            KeyValue::OperationId(v) => self.operation_id = Some(v),
+            KeyValue::Status(n) => self.status = Some(n),
+            KeyValue::Hidden => self.hidden = true,
+        }
+    }
+}
+
+impl Parse for ApiDocAttr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let items = syn::punctuated::Punctuated::<KeyValue, Token![,]>::parse_terminated(input)?;
+        let mut out = ApiDocAttr::default();
+        for kv in items {
+            out.merge(kv);
+        }
+        Ok(out)
+    }
+}
+
+/// Strip `#[api_doc(...)]` attributes from a handler's attribute list
+/// and merge all of them into a single [`ApiDocAttr`].
+///
+/// Repeating the attribute is legal; later values override earlier ones
+/// for scalar fields, and `tags = [..]` replaces the accumulated tags.
+pub fn extract(attrs: &mut Vec<Attribute>) -> Result<ApiDocAttr, TokenStream> {
+    let mut collected = ApiDocAttr::default();
+    let mut error: Option<TokenStream> = None;
+
+    attrs.retain(|attr| {
+        if !attr.path().is_ident("api_doc") {
+            return true;
+        }
+        // `#[api_doc]` with no arguments → mark visible with no overrides.
+        let parsed: syn::Result<ApiDocAttr> = match &attr.meta {
+            syn::Meta::Path(_) => Ok(ApiDocAttr::default()),
+            syn::Meta::List(list) => syn::parse2(list.tokens.clone()),
+            syn::Meta::NameValue(nv) => Err(syn::Error::new_spanned(
+                nv,
+                "expected `#[api_doc(...)]`, not `#[api_doc = ...]`",
+            )),
+        };
+        match parsed {
+            Ok(parsed) => {
+                collected.absorb(parsed);
+            }
+            Err(err) => {
+                if error.is_none() {
+                    error = Some(err.to_compile_error());
+                }
+            }
+        }
+        false
+    });
+
+    if let Some(err) = error {
+        return Err(err);
+    }
+    Ok(collected)
+}
+
+impl ApiDocAttr {
+    fn absorb(&mut self, other: ApiDocAttr) {
+        if other.summary.is_some() {
+            self.summary = other.summary;
+        }
+        if other.description.is_some() {
+            self.description = other.description;
+        }
+        if !other.tags.is_empty() {
+            self.tags = other.tags;
+        }
+        if other.operation_id.is_some() {
+            self.operation_id = other.operation_id;
+        }
+        if other.status.is_some() {
+            self.status = other.status;
+        }
+        if other.hidden {
+            self.hidden = true;
+        }
+    }
+
+    /// Emit field initializers `summary: ..., description: ..., tags: ..., hidden: ...`
+    /// for inclusion in an `ApiDoc { ... }` literal.
+    ///
+    /// `default_operation_id` is used when `operation_id` was not set on
+    /// the attribute — typically the handler function's identifier.
+    pub fn emit_ident_fields(&self, default_operation_id: &Ident) -> TokenStream {
+        let summary = option_str(self.summary.as_ref());
+        let description = option_str(self.description.as_ref());
+        let tags = slice_str(&self.tags);
+        let op_id = if let Some(id) = &self.operation_id {
+            quote! { #id }
+        } else {
+            quote! { ::core::stringify!(#default_operation_id) }
+        };
+        let status = self.status.unwrap_or(200);
+        let hidden = self.hidden;
+        quote! {
+            operation_id: #op_id,
+            summary: #summary,
+            description: #description,
+            tags: #tags,
+            success_status: #status,
+            hidden: #hidden,
+        }
+    }
+}
+
+fn option_str(lit: Option<&LitStr>) -> TokenStream {
+    match lit {
+        Some(v) => quote! { ::core::option::Option::Some(#v) },
+        None => quote! { ::core::option::Option::None },
+    }
+}
+
+fn slice_str(items: &[LitStr]) -> TokenStream {
+    if items.is_empty() {
+        quote! { &[] }
+    } else {
+        let literals: Vec<_> = items.iter().map(|s| quote! { #s }).collect();
+        quote! { &[#(#literals),*] }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Route path + signature inspection helpers
+// ──────────────────────────────────────────────────────────────────
+
+/// Extract `{name}` path parameters from a route template.
+///
+/// Closing braces without an opening brace are ignored. Segments that
+/// contain regex (`{id:[0-9]+}`) take only the name before the colon.
+pub fn extract_path_params(path: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = path.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'{' {
+            if let Some(end_rel) = bytes[i + 1..].iter().position(|b| *b == b'}') {
+                let inner = &path[i + 1..i + 1 + end_rel];
+                let name = inner.split(':').next().unwrap_or(inner).trim();
+                if !name.is_empty() {
+                    out.push(name.to_owned());
+                }
+                i += 1 + end_rel + 1;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Emit a `&'static [&'static str]` literal for a list of owned strings.
+pub fn emit_path_param_slice(params: &[String]) -> TokenStream {
+    if params.is_empty() {
+        quote! { &[] }
+    } else {
+        let literals: Vec<_> = params
+            .iter()
+            .map(|p| LitStr::new(p, Span::call_site()))
+            .collect();
+        quote! { &[#(#literals),*] }
+    }
+}
+
+/// Inspect the handler's parameter list for `Json<T>` request bodies.
+///
+/// Returns a `Some(tokens)` producing a `SchemaEntry` initializer for the
+/// first JSON extractor seen, or `None` if the handler has no JSON body.
+pub fn infer_request_body(input_fn: &syn::ItemFn) -> Option<TokenStream> {
+    for arg in &input_fn.sig.inputs {
+        let syn::FnArg::Typed(pat) = arg else {
+            continue;
+        };
+        if let Some(inner) = unwrap_single_generic(&pat.ty, "Json") {
+            return Some(schema_entry_for_type(&inner));
+        }
+    }
+    None
+}
+
+/// Inspect the handler's return type for `Json<T>` (including
+/// `Result<Json<T>, _>` and `AutumnResult<Json<T>>`) to infer the
+/// success response body.
+pub fn infer_response_body(input_fn: &syn::ItemFn) -> Option<TokenStream> {
+    let syn::ReturnType::Type(_, ty) = &input_fn.sig.output else {
+        return None;
+    };
+    let ty = unwrap_result_ok(ty).unwrap_or_else(|| (**ty).clone());
+    unwrap_single_generic(&ty, "Json").map(|inner| schema_entry_for_type(&inner))
+}
+
+/// Peel a single layer of `Result<T, _>` / `AutumnResult<T>` so we can
+/// inspect the `Ok` variant for a `Json<...>` wrapper.
+fn unwrap_result_ok(ty: &syn::Type) -> Option<syn::Type> {
+    let path = match ty {
+        syn::Type::Path(p) => &p.path,
+        _ => return None,
+    };
+    let last = path.segments.last()?;
+    let name = last.ident.to_string();
+    let syn::PathArguments::AngleBracketed(args) = &last.arguments else {
+        return None;
+    };
+    match name.as_str() {
+        "Result" => args.args.iter().find_map(|arg| match arg {
+            syn::GenericArgument::Type(t) => Some(t.clone()),
+            _ => None,
+        }),
+        "AutumnResult" => args.args.iter().find_map(|arg| match arg {
+            syn::GenericArgument::Type(t) => Some(t.clone()),
+            _ => None,
+        }),
+        _ => None,
+    }
+}
+
+/// If `ty` is `Name<Inner>` (single generic argument), return `Inner`.
+/// The outermost segment of `ty`'s path must match `wrapper`.
+fn unwrap_single_generic(ty: &syn::Type, wrapper: &str) -> Option<syn::Type> {
+    let syn::Type::Path(path) = ty else {
+        return None;
+    };
+    let last = path.path.segments.last()?;
+    if last.ident != wrapper {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &last.arguments else {
+        return None;
+    };
+    args.args.iter().find_map(|arg| match arg {
+        syn::GenericArgument::Type(t) => Some(t.clone()),
+        _ => None,
+    })
+}
+
+/// Emit a `::autumn_web::openapi::SchemaEntry` initializer for a type.
+///
+/// The generated code dispatches at compile time to a const-fn-like
+/// branching expression that yields either:
+/// * a primitive schema when the type matches a known scalar, or
+/// * a `Ref` referencing the type's [`OpenApiSchema::schema_name()`]
+///   when the type is any other named path, or
+/// * a fallback "object"-typed name when we cannot identify the type.
+fn schema_entry_for_type(ty: &syn::Type) -> TokenStream {
+    // Lift primitive detection out of the proc macro so the user's path
+    // like `crate::models::User` isn't re-parsed at compile time. We emit
+    // a const-dispatched expression using type-id-less pattern matching
+    // via `match` on a generated helper; the simpler approach here is to
+    // always emit a `Ref` with the type's last-segment name. This keeps
+    // the macro output short while still permitting users to register
+    // their types via `OpenApiSchema`.
+    let name = last_segment_name(ty).unwrap_or_else(|| "Schema".to_owned());
+    let name_lit = LitStr::new(&name, Span::call_site());
+    let primitive = primitive_json_type(&name);
+    if let Some(json_type) = primitive {
+        let json_lit = LitStr::new(json_type, Span::call_site());
+        quote! {
+            ::autumn_web::openapi::SchemaEntry {
+                name: #name_lit,
+                kind: ::autumn_web::openapi::SchemaKind::Primitive(#json_lit),
+            }
+        }
+    } else {
+        quote! {
+            ::autumn_web::openapi::SchemaEntry {
+                name: #name_lit,
+                kind: ::autumn_web::openapi::SchemaKind::Ref,
+            }
+        }
+    }
+}
+
+/// Map a short Rust primitive name to its JSON-schema `type` keyword.
+fn primitive_json_type(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "String" | "str" => "string",
+        "bool" => "boolean",
+        "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "isize" | "usize" => {
+            "integer"
+        }
+        "f32" | "f64" => "number",
+        _ => return None,
+    })
+}
+
+/// Return the final identifier in a type's path (e.g. `foo::Bar` → `"Bar"`).
+fn last_segment_name(ty: &syn::Type) -> Option<String> {
+    match ty {
+        syn::Type::Path(p) => p.path.segments.last().map(|s| s.ident.to_string()),
+        syn::Type::Reference(r) => last_segment_name(&r.elem),
+        _ => None,
+    }
+}
+
+/// Convenience wrapper: emit an `Option<SchemaEntry>` expression.
+pub fn schema_option(expr: Option<TokenStream>) -> TokenStream {
+    match expr {
+        Some(e) => quote! { ::core::option::Option::Some(#e) },
+        None => quote! { ::core::option::Option::None },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_path_params_handles_single() {
+        assert_eq!(extract_path_params("/users/{id}"), vec!["id".to_owned()]);
+    }
+
+    #[test]
+    fn extract_path_params_handles_multiple() {
+        assert_eq!(
+            extract_path_params("/posts/{year}/{slug}"),
+            vec!["year".to_owned(), "slug".to_owned()]
+        );
+    }
+
+    #[test]
+    fn extract_path_params_handles_regex_prefix() {
+        assert_eq!(
+            extract_path_params("/users/{id:[0-9]+}"),
+            vec!["id".to_owned()]
+        );
+    }
+
+    #[test]
+    fn extract_path_params_returns_empty_for_static() {
+        assert!(extract_path_params("/hello").is_empty());
+        assert!(extract_path_params("/").is_empty());
+    }
+
+    #[test]
+    fn extract_path_params_ignores_unclosed_braces() {
+        assert!(extract_path_params("/oops/{broken").is_empty());
+    }
+
+    #[test]
+    fn primitive_json_type_matches_common() {
+        assert_eq!(primitive_json_type("String"), Some("string"));
+        assert_eq!(primitive_json_type("i64"), Some("integer"));
+        assert_eq!(primitive_json_type("bool"), Some("boolean"));
+        assert_eq!(primitive_json_type("Foo"), None);
+    }
+}

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -400,7 +400,7 @@ pub fn cached(attr: TokenStream, item: TokenStream) -> TokenStream {
     cached::cached_macro(attr.into(), item.into()).into()
 }
 
-/// Enrich a route handler's auto-generated OpenAPI documentation.
+/// Enrich a route handler's auto-generated `OpenAPI` documentation.
 ///
 /// Applied on top of a route macro (`#[get]`, `#[post]`, etc.), this
 /// attribute lets you override or add documentation fields that cannot
@@ -417,8 +417,8 @@ pub fn cached(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// |-----|------|--------|
 /// | `summary` | string | Short one-line description |
 /// | `description` | string | Longer multi-line description |
-/// | `tag` | string | Single OpenAPI tag for grouping |
-/// | `tags` | `[string, ...]` | Multiple OpenAPI tags |
+/// | `tag` | string | Single `OpenAPI` tag for grouping |
+/// | `tags` | `[string, ...]` | Multiple `OpenAPI` tags |
 /// | `operation_id` | string | Override the default operation id |
 /// | `status` | integer | Success HTTP status code (defaults to `200`) |
 /// | `hidden` | flag / bool | Exclude the route from the generated spec |

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -467,6 +467,21 @@ pub fn api_doc(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 const ROUTE_ATTR_NAMES: &[&str] = &["get", "post", "put", "delete", "patch", "static_get", "ws"];
 
+/// Return `true` when an attribute names one of the Autumn route macros.
+///
+/// We match on the **last** path segment so qualified forms like
+/// `#[autumn_web::get("/x")]`, `#[autumn_macros::post("/x")]`, or
+/// even `#[crate::get("/x")]` are recognized alongside the bare
+/// `#[get("/x")]`. Unqualified identifiers are covered by the same
+/// logic because their path has a single segment.
+fn is_route_attribute(attr: &syn::Attribute) -> bool {
+    attr.path()
+        .segments
+        .last()
+        .map(|segment| segment.ident.to_string())
+        .is_some_and(|name| ROUTE_ATTR_NAMES.contains(&name.as_str()))
+}
+
 fn api_doc_standalone(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr_ts: proc_macro2::TokenStream = attr.into();
     let mut input_fn: syn::ItemFn = match syn::parse(item.clone()) {
@@ -476,11 +491,7 @@ fn api_doc_standalone(attr: TokenStream, item: TokenStream) -> TokenStream {
         Err(_) => return item,
     };
 
-    let route_idx = input_fn.attrs.iter().position(|a| {
-        a.path()
-            .get_ident()
-            .is_some_and(|ident| ROUTE_ATTR_NAMES.contains(&ident.to_string().as_str()))
-    });
+    let route_idx = input_fn.attrs.iter().position(is_route_attribute);
 
     let Some(idx) = route_idx else {
         // Standalone `#[api_doc]` with no paired route macro is a no-op;

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -11,6 +11,7 @@
 //! Users should not depend on this crate directly — use `autumn-web` instead,
 //! which re-exports everything.
 
+mod api_doc;
 mod cached;
 mod collect;
 mod main_macro;
@@ -397,6 +398,60 @@ pub fn service(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn cached(attr: TokenStream, item: TokenStream) -> TokenStream {
     cached::cached_macro(attr.into(), item.into()).into()
+}
+
+/// Enrich a route handler's auto-generated OpenAPI documentation.
+///
+/// Applied on top of a route macro (`#[get]`, `#[post]`, etc.), this
+/// attribute lets you override or add documentation fields that cannot
+/// be inferred from the handler signature (summaries, descriptions,
+/// tags, custom success status codes).
+///
+/// The route macro consumes this attribute and folds the metadata into
+/// the route's `ApiDoc`. When no route macro is applied, the attribute
+/// is a no-op.
+///
+/// # Supported keys
+///
+/// | Key | Type | Effect |
+/// |-----|------|--------|
+/// | `summary` | string | Short one-line description |
+/// | `description` | string | Longer multi-line description |
+/// | `tag` | string | Single OpenAPI tag for grouping |
+/// | `tags` | `[string, ...]` | Multiple OpenAPI tags |
+/// | `operation_id` | string | Override the default operation id |
+/// | `status` | integer | Success HTTP status code (defaults to `200`) |
+/// | `hidden` | flag / bool | Exclude the route from the generated spec |
+///
+/// # Examples
+///
+/// ```ignore
+/// use autumn_web::prelude::*;
+///
+/// #[get("/users/{id}")]
+/// #[api_doc(summary = "Fetch a user by id", tag = "users")]
+/// async fn get_user(Path(id): Path<i32>) -> String {
+///     format!("User {id}")
+/// }
+///
+/// #[post("/users")]
+/// #[api_doc(description = "Create a new user", status = 201)]
+/// async fn create_user(Json(req): Json<serde_json::Value>) -> Json<serde_json::Value> {
+///     Json(req)
+/// }
+///
+/// #[get("/internal/metrics")]
+/// #[api_doc(hidden)]
+/// async fn metrics() -> &'static str { "" }
+/// ```
+#[proc_macro_attribute]
+pub fn api_doc(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    // Standalone form: no-op. Route macros parse and consume `#[api_doc]`
+    // directly from their input's attribute list (see api_doc::extract).
+    // When `#[api_doc]` appears without any route macro, it still needs to
+    // be a valid attribute so the item compiles — we simply pass the item
+    // through unchanged.
+    item
 }
 
 /// Annotate an async function as a WebSocket route handler.

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -445,13 +445,60 @@ pub fn cached(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// async fn metrics() -> &'static str { "" }
 /// ```
 #[proc_macro_attribute]
-pub fn api_doc(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    // Standalone form: no-op. Route macros parse and consume `#[api_doc]`
-    // directly from their input's attribute list (see api_doc::extract).
-    // When `#[api_doc]` appears without any route macro, it still needs to
-    // be a valid attribute so the item compiles — we simply pass the item
-    // through unchanged.
-    item
+pub fn api_doc(attr: TokenStream, item: TokenStream) -> TokenStream {
+    // Rust expands attribute macros top-down (outermost first), so if the
+    // user writes
+    //
+    //   #[api_doc(summary = "...")]
+    //   #[get("/x")]
+    //   async fn handler() { ... }
+    //
+    // this macro fires BEFORE `#[get]` and would strip `#[api_doc]` from
+    // the item — the route macro would then never see the overrides.
+    //
+    // To support both orderings, we detect any pending route attribute
+    // (`get`, `post`, etc.) sitting below us and reorder: we remove the
+    // route attribute and emit it as the NEW outermost attribute, and
+    // we re-attach `#[api_doc(...)]` to the function body. Rust then
+    // expands the route macro next, which finds and consumes the
+    // preserved `#[api_doc]` via the usual attribute-list walk.
+    api_doc_standalone(attr, item)
+}
+
+const ROUTE_ATTR_NAMES: &[&str] = &["get", "post", "put", "delete", "patch", "static_get", "ws"];
+
+fn api_doc_standalone(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr_ts: proc_macro2::TokenStream = attr.into();
+    let mut input_fn: syn::ItemFn = match syn::parse(item.clone()) {
+        Ok(f) => f,
+        // Not a function (e.g. applied to a struct) — leave it alone so
+        // the user sees the usual "expected function" error from rustc.
+        Err(_) => return item,
+    };
+
+    let route_idx = input_fn.attrs.iter().position(|a| {
+        a.path()
+            .get_ident()
+            .is_some_and(|ident| ROUTE_ATTR_NAMES.contains(&ident.to_string().as_str()))
+    });
+
+    let Some(idx) = route_idx else {
+        // Standalone `#[api_doc]` with no paired route macro is a no-op;
+        // route metadata is only emitted through route macros.
+        return quote::quote! { #input_fn }.into();
+    };
+
+    let route_attr = input_fn.attrs.remove(idx);
+    let preserved: syn::Attribute = syn::parse_quote! {
+        #[api_doc(#attr_ts)]
+    };
+    input_fn.attrs.insert(0, preserved);
+
+    quote::quote! {
+        #route_attr
+        #input_fn
+    }
+    .into()
 }
 
 /// Annotate an async function as a WebSocket route handler.

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -491,6 +491,17 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         path: #api_path,
                         operation_id: ::core::stringify!(#list_fn),
                         success_status: 200,
+                        response: ::core::option::Option::Some(
+                            ::autumn_web::openapi::SchemaEntry {
+                                name: "array",
+                                kind: ::autumn_web::openapi::SchemaKind::Array(
+                                    &::autumn_web::openapi::SchemaEntry {
+                                        name: ::core::stringify!(#model_name),
+                                        kind: ::autumn_web::openapi::SchemaKind::Ref,
+                                    }
+                                ),
+                            }
+                        ),
                         ..::core::default::Default::default()
                     },
                 }
@@ -518,6 +529,12 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         operation_id: ::core::stringify!(#get_fn),
                         path_params: &["id"],
                         success_status: 200,
+                        response: ::core::option::Option::Some(
+                            ::autumn_web::openapi::SchemaEntry {
+                                name: ::core::stringify!(#model_name),
+                                kind: ::autumn_web::openapi::SchemaKind::Ref,
+                            }
+                        ),
                         ..::core::default::Default::default()
                     },
                 }
@@ -543,6 +560,18 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         path: #api_path,
                         operation_id: ::core::stringify!(#create_fn),
                         success_status: 201,
+                        request_body: ::core::option::Option::Some(
+                            ::autumn_web::openapi::SchemaEntry {
+                                name: ::core::stringify!(#new_name),
+                                kind: ::autumn_web::openapi::SchemaKind::Ref,
+                            }
+                        ),
+                        response: ::core::option::Option::Some(
+                            ::autumn_web::openapi::SchemaEntry {
+                                name: ::core::stringify!(#model_name),
+                                kind: ::autumn_web::openapi::SchemaKind::Ref,
+                            }
+                        ),
                         ..::core::default::Default::default()
                     },
                 }
@@ -570,6 +599,18 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         operation_id: ::core::stringify!(#update_fn),
                         path_params: &["id"],
                         success_status: 200,
+                        request_body: ::core::option::Option::Some(
+                            ::autumn_web::openapi::SchemaEntry {
+                                name: ::core::stringify!(#update_name),
+                                kind: ::autumn_web::openapi::SchemaKind::Ref,
+                            }
+                        ),
+                        response: ::core::option::Option::Some(
+                            ::autumn_web::openapi::SchemaEntry {
+                                name: ::core::stringify!(#model_name),
+                                kind: ::autumn_web::openapi::SchemaKind::Ref,
+                            }
+                        ),
                         ..::core::default::Default::default()
                     },
                 }

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -486,6 +486,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     path: #api_path,
                     handler: ::autumn_web::reexports::axum::routing::get(#list_fn),
                     name: ::core::stringify!(#list_fn),
+                    api_doc: ::autumn_web::openapi::ApiDoc {
+                        method: "GET",
+                        path: #api_path,
+                        operation_id: ::core::stringify!(#list_fn),
+                        success_status: 200,
+                        ..::core::default::Default::default()
+                    },
                 }
             }
 
@@ -505,6 +512,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     path: #id_path,
                     handler: ::autumn_web::reexports::axum::routing::get(#get_fn),
                     name: ::core::stringify!(#get_fn),
+                    api_doc: ::autumn_web::openapi::ApiDoc {
+                        method: "GET",
+                        path: #id_path,
+                        operation_id: ::core::stringify!(#get_fn),
+                        path_params: &["id"],
+                        success_status: 200,
+                        ..::core::default::Default::default()
+                    },
                 }
             }
 
@@ -523,6 +538,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     path: #api_path,
                     handler: ::autumn_web::reexports::axum::routing::post(#create_fn),
                     name: ::core::stringify!(#create_fn),
+                    api_doc: ::autumn_web::openapi::ApiDoc {
+                        method: "POST",
+                        path: #api_path,
+                        operation_id: ::core::stringify!(#create_fn),
+                        success_status: 201,
+                        ..::core::default::Default::default()
+                    },
                 }
             }
 
@@ -542,6 +564,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     path: #id_path,
                     handler: ::autumn_web::reexports::axum::routing::put(#update_fn),
                     name: ::core::stringify!(#update_fn),
+                    api_doc: ::autumn_web::openapi::ApiDoc {
+                        method: "PUT",
+                        path: #id_path,
+                        operation_id: ::core::stringify!(#update_fn),
+                        path_params: &["id"],
+                        success_status: 200,
+                        ..::core::default::Default::default()
+                    },
                 }
             }
 
@@ -560,6 +590,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     path: #id_path,
                     handler: ::autumn_web::reexports::axum::routing::delete(#delete_fn),
                     name: ::core::stringify!(#delete_fn),
+                    api_doc: ::autumn_web::openapi::ApiDoc {
+                        method: "DELETE",
+                        path: #id_path,
+                        operation_id: ::core::stringify!(#delete_fn),
+                        path_params: &["id"],
+                        success_status: 204,
+                        ..::core::default::Default::default()
+                    },
                 }
             }
         }

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -2,11 +2,15 @@
 //!
 //! Generates a companion `__autumn_route_info_{name}()` function for each
 //! annotated handler, pairing the HTTP method and path with an Axum
-//! `MethodRouter`.
+//! `MethodRouter`. The companion also carries an [`ApiDoc`] describing
+//! the route for OpenAPI auto-generation.
+//!
+//! [`ApiDoc`]: ../../autumn_web/openapi/struct.ApiDoc.html
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
+use crate::api_doc;
 use crate::parse;
 
 /// Core implementation shared by all route macros (`#[get]`, `#[post]`, etc.).
@@ -32,6 +36,14 @@ pub fn route_macro(
     // Extract #[intercept(LayerType)] attributes from the handler.
     let interceptors = parse::extract_interceptors(&mut input_fn.attrs);
 
+    // Extract #[api_doc(...)] overrides before emitting the function, so
+    // the attribute doesn't leak onto the emitted fn definition and
+    // trigger an "unknown attribute" error.
+    let api_doc_attr = match api_doc::extract(&mut input_fn.attrs) {
+        Ok(v) => v,
+        Err(err) => return err,
+    };
+
     let fn_name = &input_fn.sig.ident;
     let route_info_name = format_ident!("__autumn_route_info_{}", fn_name);
     let vis = &input_fn.vis;
@@ -55,10 +67,13 @@ pub fn route_macro(
         };
     }
 
-    // Note: we intentionally do NOT apply #[axum::debug_handler] here.
-    // That macro generates code with `::axum::` paths, which don't resolve
-    // when the user only depends on `autumn-web` (axum is a transitive dep).
-    // Custom compile_error! diagnostics (S-007) provide error guidance instead.
+    // ── OpenAPI metadata ────────────────────────────────────────
+    let path_params = api_doc::extract_path_params(&path.value());
+    let path_params_tokens = api_doc::emit_path_param_slice(&path_params);
+    let request_body = api_doc::schema_option(api_doc::infer_request_body(&input_fn));
+    let response_body = api_doc::schema_option(api_doc::infer_response_body(&input_fn));
+    let api_doc_fields = api_doc_attr.emit_ident_fields(fn_name);
+    let http_method_lit = syn::LitStr::new(http_method, proc_macro2::Span::call_site());
 
     quote! {
         // ECHO-001: We want to apply #[axum::debug_handler] but without forcing the user
@@ -73,6 +88,15 @@ pub fn route_macro(
                 path: #path,
                 handler: #handler_expr,
                 name: ::core::stringify!(#fn_name),
+                api_doc: ::autumn_web::openapi::ApiDoc {
+                    method: #http_method_lit,
+                    path: #path,
+                    path_params: #path_params_tokens,
+                    request_body: #request_body,
+                    response: #response_body,
+                    register_schemas: ::core::option::Option::None,
+                    #api_doc_fields
+                },
             }
         }
     }

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -3,7 +3,7 @@
 //! Generates a companion `__autumn_route_info_{name}()` function for each
 //! annotated handler, pairing the HTTP method and path with an Axum
 //! `MethodRouter`. The companion also carries an [`ApiDoc`] describing
-//! the route for OpenAPI auto-generation.
+//! the route for `OpenAPI` auto-generation.
 //!
 //! [`ApiDoc`]: ../../autumn_web/openapi/struct.ApiDoc.html
 

--- a/autumn-macros/src/static_route.rs
+++ b/autumn-macros/src/static_route.rs
@@ -150,6 +150,10 @@ pub fn static_get_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         },
     );
 
+    let path_value = path.value();
+    let path_params = crate::api_doc::extract_path_params(&path_value);
+    let path_params_tokens = crate::api_doc::emit_path_param_slice(&path_params);
+
     quote! {
         #input_fn
 
@@ -160,6 +164,20 @@ pub fn static_get_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 path: #path,
                 handler: ::autumn_web::reexports::axum::routing::get(#fn_name),
                 name: ::core::stringify!(#fn_name),
+                api_doc: ::autumn_web::openapi::ApiDoc {
+                    method: "GET",
+                    path: #path,
+                    operation_id: ::core::stringify!(#fn_name),
+                    summary: ::core::option::Option::None,
+                    description: ::core::option::Option::None,
+                    tags: &[],
+                    path_params: #path_params_tokens,
+                    request_body: ::core::option::Option::None,
+                    response: ::core::option::Option::None,
+                    success_status: 200,
+                    hidden: false,
+                    register_schemas: ::core::option::Option::None,
+                },
             }
         }
 

--- a/autumn-macros/src/ws.rs
+++ b/autumn-macros/src/ws.rs
@@ -112,6 +112,10 @@ pub fn ws_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
+    let path_value = path.value();
+    let path_params = crate::api_doc::extract_path_params(&path_value);
+    let path_params_tokens = crate::api_doc::emit_path_param_slice(&path_params);
+
     quote! {
         #input_fn
 
@@ -124,6 +128,24 @@ pub fn ws_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 path: #path,
                 handler: ::autumn_web::reexports::axum::routing::get(#upgrade_name),
                 name: ::core::stringify!(#fn_name),
+                // WebSocket upgrades don't have a meaningful JSON body, so
+                // they are excluded from the generated OpenAPI spec by
+                // default. Users wanting to document them can add their
+                // own entries via `OpenApiConfig::register_schema`.
+                api_doc: ::autumn_web::openapi::ApiDoc {
+                    method: "GET",
+                    path: #path,
+                    operation_id: ::core::stringify!(#fn_name),
+                    summary: ::core::option::Option::None,
+                    description: ::core::option::Option::None,
+                    tags: &[],
+                    path_params: #path_params_tokens,
+                    request_body: ::core::option::Option::None,
+                    response: ::core::option::Option::None,
+                    success_status: 101,
+                    hidden: true,
+                    register_schemas: ::core::option::Option::None,
+                },
             }
         }
     }

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -18,6 +18,7 @@ cache-moka = ["dep:moka"]
 maud = ["dep:maud"]
 htmx = []
 tailwind = []
+openapi = []
 db = [
     "dep:deadpool",
     "dep:diesel",

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -87,6 +87,7 @@ pub fn app() -> AppBuilder {
         pool_provider_factory: None,
         telemetry_provider: None,
         session_store: None,
+        openapi: None,
     }
 }
 
@@ -190,6 +191,10 @@ pub struct AppBuilder {
     /// `apply_session_layer` skips the config-driven `memory`/`redis` selection
     /// and uses this store directly.
     session_store: Option<Arc<dyn crate::session::BoxedSessionStore>>,
+    /// OpenAPI generation configuration. When `Some`, the router mounts
+    /// `/v3/api-docs` (serving `openapi.json`) and `/swagger-ui` (if the
+    /// Swagger UI path is set). When `None`, no docs endpoints are mounted.
+    openapi: Option<crate::openapi::OpenApiConfig>,
 }
 
 /// A group of routes sharing a common path prefix and middleware layer.
@@ -319,6 +324,54 @@ impl AppBuilder {
     #[must_use]
     pub fn static_routes(mut self, metas: Vec<crate::static_gen::StaticRouteMeta>) -> Self {
         self.static_metas.extend(metas);
+        self
+    }
+
+    /// Enable OpenAPI (Swagger) spec auto-generation.
+    ///
+    /// When called, the framework inspects every registered route's
+    /// [`ApiDoc`](crate::openapi::ApiDoc) metadata — inferred at compile
+    /// time from the route path, HTTP method, extractor types, and any
+    /// [`#[api_doc(...)]`](crate::api_doc) overrides — and serves an
+    /// OpenAPI 3.0 JSON document at [`OpenApiConfig::openapi_json_path`]
+    /// (default `/v3/api-docs`). If
+    /// [`OpenApiConfig::swagger_ui_path`] is set (default `/swagger-ui`),
+    /// a Swagger UI HTML page is served there too.
+    ///
+    /// Routes marked `#[api_doc(hidden)]` are excluded.
+    ///
+    /// # Examples
+    ///
+    /// Zero-config:
+    ///
+    /// ```rust,no_run
+    /// use autumn_web::prelude::*;
+    /// use autumn_web::openapi::OpenApiConfig;
+    ///
+    /// # #[get("/hello")] async fn hello() -> &'static str { "hi" }
+    /// # #[autumn_web::main]
+    /// # async fn main() {
+    /// autumn_web::app()
+    ///     .routes(routes![hello])
+    ///     .openapi(OpenApiConfig::new("My API", "1.0.0"))
+    ///     .run()
+    ///     .await;
+    /// # }
+    /// ```
+    ///
+    /// With custom paths:
+    ///
+    /// ```rust,no_run
+    /// use autumn_web::openapi::OpenApiConfig;
+    ///
+    /// let config = OpenApiConfig::new("My API", "1.0.0")
+    ///     .description("Full product API")
+    ///     .openapi_json_path("/openapi.json")
+    ///     .swagger_ui_path(Some("/docs".to_owned()));
+    /// ```
+    #[must_use]
+    pub fn openapi(mut self, config: crate::openapi::OpenApiConfig) -> Self {
+        self.openapi = Some(config);
         self
     }
 
@@ -908,6 +961,7 @@ impl AppBuilder {
             pool_provider_factory,
             telemetry_provider,
             session_store,
+            openapi,
         } = self;
 
         let all_routes = routes;
@@ -986,6 +1040,7 @@ impl AppBuilder {
                 custom_layers,
                 error_page_renderer,
                 session_store,
+                openapi,
             },
         )
         .unwrap_or_else(|error| {
@@ -1101,6 +1156,7 @@ impl AppBuilder {
             pool_provider_factory,
             telemetry_provider,
             session_store,
+            openapi: _,
         } = self;
 
         let all_routes = routes;
@@ -1156,6 +1212,7 @@ impl AppBuilder {
                 custom_layers,
                 error_page_renderer: None,
                 session_store,
+                openapi: None,
             },
         )
         .unwrap_or_else(|error| {
@@ -1855,6 +1912,13 @@ mod tests {
             path,
             handler: axum::routing::get(|| async { "ok" }),
             name,
+            api_doc: crate::openapi::ApiDoc {
+                method: "GET",
+                path,
+                operation_id: name,
+                success_status: 200,
+                ..Default::default()
+            },
         }
     }
 
@@ -2074,6 +2138,13 @@ mod tests {
             path: "/submit",
             handler: axum::routing::post(|| async { "posted" }),
             name: "submit",
+            api_doc: crate::openapi::ApiDoc {
+                method: "POST",
+                path: "/submit",
+                operation_id: "submit",
+                success_status: 200,
+                ..Default::default()
+            },
         }];
         let config = AutumnConfig::default();
         let state = AppState {
@@ -2119,12 +2190,26 @@ mod tests {
                 path: "/admin",
                 handler: axum::routing::get(|| async { "list" }),
                 name: "admin_list",
+                api_doc: crate::openapi::ApiDoc {
+                    method: "GET",
+                    path: "/admin",
+                    operation_id: "admin_list",
+                    success_status: 200,
+                    ..Default::default()
+                },
             },
             Route {
                 method: http::Method::POST,
                 path: "/admin",
                 handler: axum::routing::post(|| async { "created" }),
                 name: "create",
+                api_doc: crate::openapi::ApiDoc {
+                    method: "POST",
+                    path: "/admin",
+                    operation_id: "create",
+                    success_status: 200,
+                    ..Default::default()
+                },
             },
         ];
         let config = AutumnConfig::default();
@@ -2348,6 +2433,13 @@ mod tests {
                     path: "/about",
                     handler: axum::routing::get(|| async { "About Page Content" }),
                     name: "about",
+                    api_doc: crate::openapi::ApiDoc {
+                        method: "GET",
+                        path: "/about",
+                        operation_id: "about",
+                        success_status: 200,
+                        ..Default::default()
+                    },
                 }],
                 &config,
                 state,
@@ -2394,6 +2486,13 @@ mod tests {
                         axum::response::Html("<html><body><main>ok</main></body></html>")
                     }),
                     name: "page",
+                    api_doc: crate::openapi::ApiDoc {
+                        method: "GET",
+                        path: "/page",
+                        operation_id: "page",
+                        success_status: 200,
+                        ..Default::default()
+                    },
                 }]);
 
                 let response = router

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -191,7 +191,7 @@ pub struct AppBuilder {
     /// `apply_session_layer` skips the config-driven `memory`/`redis` selection
     /// and uses this store directly.
     session_store: Option<Arc<dyn crate::session::BoxedSessionStore>>,
-    /// OpenAPI generation configuration. When `Some`, the router mounts
+    /// `OpenAPI` generation configuration. When `Some`, the router mounts
     /// `/v3/api-docs` (serving `openapi.json`) and `/swagger-ui` (if the
     /// Swagger UI path is set). When `None`, no docs endpoints are mounted.
     openapi: Option<crate::openapi::OpenApiConfig>,
@@ -327,13 +327,13 @@ impl AppBuilder {
         self
     }
 
-    /// Enable OpenAPI (Swagger) spec auto-generation.
+    /// Enable `OpenAPI` (Swagger) spec auto-generation.
     ///
     /// When called, the framework inspects every registered route's
     /// [`ApiDoc`](crate::openapi::ApiDoc) metadata — inferred at compile
     /// time from the route path, HTTP method, extractor types, and any
     /// [`#[api_doc(...)]`](crate::api_doc) overrides — and serves an
-    /// OpenAPI 3.0 JSON document at [`OpenApiConfig::openapi_json_path`]
+    /// `OpenAPI` 3.0 JSON document at [`OpenApiConfig::openapi_json_path`]
     /// (default `/v3/api-docs`). If
     /// [`OpenApiConfig::swagger_ui_path`] is set (default `/swagger-ui`),
     /// a Swagger UI HTML page is served there too.

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -87,6 +87,7 @@ pub fn app() -> AppBuilder {
         pool_provider_factory: None,
         telemetry_provider: None,
         session_store: None,
+        #[cfg(feature = "openapi")]
         openapi: None,
     }
 }
@@ -194,6 +195,11 @@ pub struct AppBuilder {
     /// `OpenAPI` generation configuration. When `Some`, the router mounts
     /// `/v3/api-docs` (serving `openapi.json`) and `/swagger-ui` (if the
     /// Swagger UI path is set). When `None`, no docs endpoints are mounted.
+    ///
+    /// Gated behind the `openapi` feature: apps that don't need a
+    /// served `OpenAPI` document shouldn't pay for the spec types or the
+    /// runtime collision-check machinery.
+    #[cfg(feature = "openapi")]
     openapi: Option<crate::openapi::OpenApiConfig>,
 }
 
@@ -348,11 +354,16 @@ impl AppBuilder {
     ///
     /// Routes marked `#[api_doc(hidden)]` are excluded.
     ///
+    /// **Gated behind the `openapi` Cargo feature.** Add
+    /// `features = ["openapi"]` to your `autumn-web` dependency to
+    /// enable it; the default build excludes the runtime spec types
+    /// and endpoints to keep the binary small.
+    ///
     /// # Examples
     ///
     /// Zero-config:
     ///
-    /// ```rust,no_run
+    /// ```rust,ignore
     /// use autumn_web::prelude::*;
     /// use autumn_web::openapi::OpenApiConfig;
     ///
@@ -369,7 +380,7 @@ impl AppBuilder {
     ///
     /// With custom paths:
     ///
-    /// ```rust,no_run
+    /// ```rust,ignore
     /// use autumn_web::openapi::OpenApiConfig;
     ///
     /// let config = OpenApiConfig::new("My API", "1.0.0")
@@ -377,6 +388,7 @@ impl AppBuilder {
     ///     .openapi_json_path("/openapi.json")
     ///     .swagger_ui_path(Some("/docs".to_owned()));
     /// ```
+    #[cfg(feature = "openapi")]
     #[must_use]
     pub fn openapi(mut self, config: crate::openapi::OpenApiConfig) -> Self {
         self.openapi = Some(config);
@@ -989,6 +1001,7 @@ impl AppBuilder {
             pool_provider_factory,
             telemetry_provider,
             session_store,
+            #[cfg(feature = "openapi")]
             openapi,
         } = self;
 
@@ -1068,6 +1081,7 @@ impl AppBuilder {
                 custom_layers,
                 error_page_renderer,
                 session_store,
+                #[cfg(feature = "openapi")]
                 openapi,
             },
         )
@@ -1184,7 +1198,8 @@ impl AppBuilder {
             pool_provider_factory,
             telemetry_provider,
             session_store,
-            openapi: _,
+            #[cfg(feature = "openapi")]
+                openapi: _,
         } = self;
 
         let all_routes = routes;
@@ -1240,6 +1255,7 @@ impl AppBuilder {
                 custom_layers,
                 error_page_renderer: None,
                 session_store,
+                #[cfg(feature = "openapi")]
                 openapi: None,
             },
         )

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -103,6 +103,7 @@ pub mod flash;
 pub(crate) mod htmx;
 pub(crate) mod logging;
 pub mod middleware;
+pub mod openapi;
 pub mod prelude;
 pub(crate) mod route;
 pub use route::Route;
@@ -192,6 +193,24 @@ pub use validation::ValidateExt;
 /// }
 /// ```
 pub use autumn_macros::delete;
+
+/// Enrich a route handler's auto-generated OpenAPI documentation.
+///
+/// See the [`openapi`] module and the [`autumn_macros::api_doc`]
+/// attribute docs for details on the supported keys.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use autumn_web::prelude::*;
+///
+/// #[get("/users/{id}")]
+/// #[api_doc(summary = "Fetch a user by id", tag = "users")]
+/// async fn get_user(Path(id): Path<i32>) -> String {
+///     format!("User {id}")
+/// }
+/// ```
+pub use autumn_macros::api_doc;
 
 /// Annotate an async function as a `GET` route handler.
 ///

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -194,7 +194,7 @@ pub use validation::ValidateExt;
 /// ```
 pub use autumn_macros::delete;
 
-/// Enrich a route handler's auto-generated OpenAPI documentation.
+/// Enrich a route handler's auto-generated `OpenAPI` documentation.
 ///
 /// See the [`openapi`] module and the [`autumn_macros::api_doc`]
 /// attribute docs for details on the supported keys.

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -539,12 +539,17 @@ fn schema_value_for(entry: &SchemaEntry) -> serde_json::Value {
             "items": schema_value_for(items),
         }),
         SchemaKind::Nullable(inner) => {
-            // OpenAPI 3.0: apply the `nullable: true` keyword alongside
-            // the inner schema body. For `$ref` we have to wrap in an
-            // `anyOf` since a bare `$ref` can't carry siblings.
+            // OpenAPI 3.0 has no `type: "null"` (that's a 3.1 feature),
+            // so we use the 3.0-compatible patterns:
+            //   * For a `$ref`, wrap in `allOf` alongside
+            //     `nullable: true` — bare `$ref`s can't carry siblings,
+            //     and `allOf` is the standard workaround.
+            //   * For every other schema body, inject `nullable: true`
+            //     directly onto the existing object.
             if inner.kind == SchemaKind::Ref {
                 serde_json::json!({
-                    "anyOf": [schema_value_for(inner), { "type": "null" }],
+                    "nullable": true,
+                    "allOf": [schema_value_for(inner)],
                 })
             } else {
                 let mut v = schema_value_for(inner);
@@ -742,6 +747,49 @@ mod tests {
         let op = spec.paths["/users/{id}"].get.as_ref().unwrap();
         let media = op.responses["200"].content.get("application/json").unwrap();
         assert_eq!(media.schema, serde_json::json!({ "type": "string" }));
+    }
+
+    #[test]
+    fn nullable_ref_uses_openapi_3_0_shape() {
+        // OpenAPI 3.0 has no `type: "null"`, so nullable refs must use
+        // `nullable: true` + `allOf` instead. Wrapping in `anyOf` with
+        // a `type: "null"` member produces a spec that Swagger and
+        // OpenAPI validators reject.
+        static INNER: SchemaEntry = SchemaEntry {
+            name: "User",
+            kind: SchemaKind::Ref,
+        };
+        let entry = SchemaEntry {
+            name: "nullable",
+            kind: SchemaKind::Nullable(&INNER),
+        };
+        let value = schema_value_for(&entry);
+        assert_eq!(value["nullable"], true);
+        assert_eq!(
+            value["allOf"][0]["$ref"], "#/components/schemas/User",
+            "nullable refs must wrap in allOf so `$ref` can carry siblings"
+        );
+        assert!(value.get("anyOf").is_none(), "must not emit anyOf/null");
+        assert!(
+            value.get("type").is_none()
+                || value.get("type").unwrap() != &serde_json::Value::String("null".into()),
+            "must not emit type: null"
+        );
+    }
+
+    #[test]
+    fn nullable_primitive_inlines_nullable_flag() {
+        static INNER: SchemaEntry = SchemaEntry {
+            name: "integer",
+            kind: SchemaKind::Primitive("integer"),
+        };
+        let entry = SchemaEntry {
+            name: "nullable",
+            kind: SchemaKind::Nullable(&INNER),
+        };
+        let value = schema_value_for(&entry);
+        assert_eq!(value["type"], "integer");
+        assert_eq!(value["nullable"], true);
     }
 
     #[test]

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -101,7 +101,7 @@ pub struct ApiDoc {
 }
 
 /// Reference to a schema definition, produced by the route macros.
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct SchemaEntry {
     /// Short human-readable type name (used as `#/components/schemas/Name`).
     pub name: &'static str,
@@ -117,6 +117,15 @@ pub enum SchemaKind {
     Ref,
     /// A primitive JSON type inlined at the reference site.
     Primitive(&'static str),
+    /// A JSON array whose items follow the referenced sub-schema. Used
+    /// for handlers that return `Json<Vec<T>>` (or accept one as a
+    /// request body) — emitting `Ref` for those would produce an
+    /// object schema instead of the array the endpoint actually
+    /// serializes.
+    Array(&'static SchemaEntry),
+    /// A nullable schema — used when the handler wraps the payload in
+    /// `Option<T>`. The referenced sub-entry describes `T`.
+    Nullable(&'static SchemaEntry),
 }
 
 // ──────────────────────────────────────────────────────────────────
@@ -392,14 +401,10 @@ pub fn generate_spec(config: &OpenApiConfig, routes: &[&ApiDoc]) -> OpenApiSpec 
         }
 
         if let Some(entry) = &api_doc.request_body {
-            if entry.kind == SchemaKind::Ref {
-                referenced_names.insert(entry.name);
-            }
+            collect_ref_names(entry, &mut referenced_names);
         }
         if let Some(entry) = &api_doc.response {
-            if entry.kind == SchemaKind::Ref {
-                referenced_names.insert(entry.name);
-            }
+            collect_ref_names(entry, &mut referenced_names);
         }
 
         let operation = operation_for(api_doc);
@@ -529,6 +534,39 @@ fn schema_value_for(entry: &SchemaEntry) -> serde_json::Value {
         SchemaKind::Ref => {
             serde_json::json!({ "$ref": format!("#/components/schemas/{}", entry.name) })
         }
+        SchemaKind::Array(items) => serde_json::json!({
+            "type": "array",
+            "items": schema_value_for(items),
+        }),
+        SchemaKind::Nullable(inner) => {
+            // OpenAPI 3.0: apply the `nullable: true` keyword alongside
+            // the inner schema body. For `$ref` we have to wrap in an
+            // `anyOf` since a bare `$ref` can't carry siblings.
+            if inner.kind == SchemaKind::Ref {
+                serde_json::json!({
+                    "anyOf": [schema_value_for(inner), { "type": "null" }],
+                })
+            } else {
+                let mut v = schema_value_for(inner);
+                if let Some(obj) = v.as_object_mut() {
+                    obj.insert("nullable".to_owned(), serde_json::Value::Bool(true));
+                }
+                v
+            }
+        }
+    }
+}
+
+/// Walk into a `SchemaEntry` and yield every named ref reached through
+/// `Array` / `Nullable` wrappers. Back-fill logic uses this so a
+/// `Json<Vec<User>>` response registers a `User` component schema.
+fn collect_ref_names(entry: &SchemaEntry, out: &mut std::collections::BTreeSet<&'static str>) {
+    match entry.kind {
+        SchemaKind::Ref => {
+            out.insert(entry.name);
+        }
+        SchemaKind::Array(inner) | SchemaKind::Nullable(inner) => collect_ref_names(inner, out),
+        SchemaKind::Primitive(_) => {}
     }
 }
 

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -1,0 +1,731 @@
+// OpenAPI/JSON/JSON-schema all appear frequently here and are legitimate
+// acronyms, so silence clippy::doc_markdown rather than wrapping every
+// mention in backticks.
+#![allow(clippy::doc_markdown)]
+
+//! OpenAPI (Swagger) specification auto-generation.
+//!
+//! Autumn automatically infers an OpenAPI 3.0 document from your
+//! annotated routes ([`get`](crate::get), [`post`](crate::post), etc.),
+//! their path parameters, and the extractor / response types in each
+//! handler signature. The generated spec is served at `/v3/api-docs` and
+//! a Swagger UI is served at `/swagger-ui` when the feature is enabled.
+//!
+//! # Quick start
+//!
+//! ```rust,no_run
+//! use autumn_web::prelude::*;
+//!
+//! #[get("/hello")]
+//! async fn hello() -> &'static str { "hi" }
+//!
+//! # #[autumn_web::main]
+//! # async fn main() {
+//! autumn_web::app()
+//!     .routes(routes![hello])
+//!     .openapi(autumn_web::openapi::OpenApiConfig::new("My API", "1.0.0"))
+//!     .run()
+//!     .await;
+//! # }
+//! ```
+//!
+//! With `.openapi(...)` enabled, the following endpoints are mounted:
+//! * `GET /v3/api-docs` — serves the generated `openapi.json`.
+//! * `GET /swagger-ui` — serves a Swagger UI HTML page loading the JSON
+//!   above.
+//!
+//! # Enriching the auto-generated docs
+//!
+//! Decorate handlers with [`#[api_doc(...)]`](crate::api_doc) to override
+//! or add documentation fields that cannot be inferred from the signature
+//! (summaries, descriptions, tags, custom status codes, etc.):
+//!
+//! ```rust,no_run
+//! use autumn_web::prelude::*;
+//!
+//! #[get("/users/{id}")]
+//! #[api_doc(summary = "Fetch a user by id", tag = "users")]
+//! async fn get_user(_id: Path<i32>) -> &'static str { "user" }
+//! ```
+//!
+//! # Custom schemas
+//!
+//! Types that need rich schemas (beyond the generic "object" fallback)
+//! implement the [`OpenApiSchema`] trait and are registered with
+//! [`OpenApiConfig::register_schema`].
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+// ──────────────────────────────────────────────────────────────────
+// Public metadata attached to each Route
+// ──────────────────────────────────────────────────────────────────
+
+/// OpenAPI metadata emitted alongside every annotated route.
+///
+/// Populated by the route macros ([`get`](crate::get),
+/// [`post`](crate::post), etc.) from the handler's path, signature, and
+/// any [`#[api_doc(...)]`](crate::api_doc) overrides.
+#[derive(Clone, Debug, Default)]
+pub struct ApiDoc {
+    /// HTTP method as an uppercase string (e.g. `"GET"`).
+    pub method: &'static str,
+    /// Raw route path with `{param}` placeholders (e.g. `"/users/{id}"`).
+    pub path: &'static str,
+    /// Handler function name — used as the default `operationId`.
+    pub operation_id: &'static str,
+    /// Short human-readable summary (from `#[api_doc(summary = ...)]`).
+    pub summary: Option<&'static str>,
+    /// Longer free-form description.
+    pub description: Option<&'static str>,
+    /// Grouping tags. Defaults to the first path segment when unset.
+    pub tags: &'static [&'static str],
+    /// Path parameter names extracted from the URL template.
+    ///
+    /// Built at compile time from `{...}` segments in the route path.
+    pub path_params: &'static [&'static str],
+    /// Optional schema for the request body (typically the inner type of
+    /// a `Json<T>` extractor).
+    pub request_body: Option<SchemaEntry>,
+    /// Optional schema for the success response (typically the inner type
+    /// of a `Json<T>` return value).
+    pub response: Option<SchemaEntry>,
+    /// Success HTTP status code, defaults to `200`.
+    pub success_status: u16,
+    /// When `true`, the route is excluded from the generated spec.
+    pub hidden: bool,
+    /// Optional runtime hook that lets a handler register any extra
+    /// component schemas with the generator.
+    pub register_schemas: Option<fn(&mut SchemaRegistry)>,
+}
+
+/// Reference to a schema definition, produced by the route macros.
+#[derive(Clone, Debug)]
+pub struct SchemaEntry {
+    /// Short human-readable type name (used as `#/components/schemas/Name`).
+    pub name: &'static str,
+    /// Whether this is a primitive JSON type (string/number/bool/array) as
+    /// opposed to a named object ref.
+    pub kind: SchemaKind,
+}
+
+/// Classifier for how a type should appear in the spec.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum SchemaKind {
+    /// Refers to a named component schema.
+    Ref,
+    /// A primitive JSON type inlined at the reference site.
+    Primitive(&'static str),
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Configuration — users opt into OpenAPI generation explicitly.
+// ──────────────────────────────────────────────────────────────────
+
+/// User-facing configuration for OpenAPI generation.
+///
+/// Passed to [`AppBuilder::openapi`](crate::app::AppBuilder::openapi)
+/// to enable spec generation and mount the documentation endpoints.
+#[derive(Clone)]
+pub struct OpenApiConfig {
+    /// API title that appears in the Swagger UI header.
+    pub title: String,
+    /// API version (e.g. `"1.0.0"`).
+    pub version: String,
+    /// Optional free-form API description (Markdown permitted in UI).
+    pub description: Option<String>,
+    /// Path serving the raw `openapi.json`. Defaults to `/v3/api-docs`.
+    pub openapi_json_path: String,
+    /// Path serving the Swagger UI HTML. Defaults to `/swagger-ui`. Set
+    /// to `None` to disable the UI while still exposing the JSON.
+    pub swagger_ui_path: Option<String>,
+    /// User-registered component schemas keyed by schema name.
+    pub additional_schemas: BTreeMap<String, serde_json::Value>,
+}
+
+impl OpenApiConfig {
+    /// Create a new config with the required `title` and `version`.
+    #[must_use]
+    pub fn new(title: impl Into<String>, version: impl Into<String>) -> Self {
+        Self {
+            title: title.into(),
+            version: version.into(),
+            description: None,
+            openapi_json_path: "/v3/api-docs".to_owned(),
+            swagger_ui_path: Some("/swagger-ui".to_owned()),
+            additional_schemas: BTreeMap::new(),
+        }
+    }
+
+    /// Set a free-form API description.
+    #[must_use]
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Override the path serving `openapi.json`.
+    #[must_use]
+    pub fn openapi_json_path(mut self, path: impl Into<String>) -> Self {
+        self.openapi_json_path = path.into();
+        self
+    }
+
+    /// Override the Swagger UI path (or `None` to disable it).
+    #[must_use]
+    pub fn swagger_ui_path(mut self, path: Option<String>) -> Self {
+        self.swagger_ui_path = path;
+        self
+    }
+
+    /// Register a custom component schema. Useful when a handler's
+    /// payload type does not implement [`OpenApiSchema`].
+    #[must_use]
+    pub fn register_schema(mut self, name: impl Into<String>, schema: serde_json::Value) -> Self {
+        self.additional_schemas.insert(name.into(), schema);
+        self
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Schema trait + primitive impls
+// ──────────────────────────────────────────────────────────────────
+
+/// Describes a type's JSON schema for OpenAPI generation.
+///
+/// Provide a manual implementation for complex types to expose rich
+/// schemas in the generated spec. A blanket default is not provided —
+/// routes whose types do not implement this trait simply emit a generic
+/// `object` placeholder referring to the type name.
+pub trait OpenApiSchema {
+    /// Component schema name (appears under `#/components/schemas/`).
+    fn schema_name() -> &'static str;
+
+    /// Produce the JSON schema for this type.
+    fn schema() -> serde_json::Value;
+}
+
+macro_rules! impl_primitive_schema {
+    ($ty:ty, $name:literal, $json:literal) => {
+        impl OpenApiSchema for $ty {
+            fn schema_name() -> &'static str {
+                $name
+            }
+            fn schema() -> serde_json::Value {
+                serde_json::json!({ "type": $json })
+            }
+        }
+    };
+}
+
+impl_primitive_schema!(bool, "boolean", "boolean");
+impl_primitive_schema!(String, "string", "string");
+impl_primitive_schema!(&'static str, "string", "string");
+impl_primitive_schema!(i8, "integer", "integer");
+impl_primitive_schema!(i16, "integer", "integer");
+impl_primitive_schema!(i32, "integer", "integer");
+impl_primitive_schema!(i64, "integer", "integer");
+impl_primitive_schema!(u8, "integer", "integer");
+impl_primitive_schema!(u16, "integer", "integer");
+impl_primitive_schema!(u32, "integer", "integer");
+impl_primitive_schema!(u64, "integer", "integer");
+impl_primitive_schema!(f32, "number", "number");
+impl_primitive_schema!(f64, "number", "number");
+impl_primitive_schema!(serde_json::Value, "object", "object");
+
+// ──────────────────────────────────────────────────────────────────
+// Runtime registry of component schemas populated while building the spec.
+// ──────────────────────────────────────────────────────────────────
+
+/// Accumulates component schemas while a spec is being built.
+#[derive(Default)]
+pub struct SchemaRegistry {
+    schemas: BTreeMap<String, serde_json::Value>,
+}
+
+impl SchemaRegistry {
+    /// Register a type via its [`OpenApiSchema`] implementation. A
+    /// duplicate insertion is a no-op (the existing entry wins).
+    pub fn register<T: OpenApiSchema>(&mut self) {
+        let name = T::schema_name().to_owned();
+        self.schemas.entry(name).or_insert_with(T::schema);
+    }
+
+    /// Insert a raw pre-built schema by name.
+    pub fn insert(&mut self, name: impl Into<String>, schema: serde_json::Value) {
+        self.schemas.insert(name.into(), schema);
+    }
+
+    /// Drain the collected schemas, consuming the registry.
+    #[must_use]
+    pub fn into_map(self) -> BTreeMap<String, serde_json::Value> {
+        self.schemas
+    }
+
+    /// Peek at the collected schemas without consuming the registry.
+    #[must_use]
+    pub fn schemas(&self) -> &BTreeMap<String, serde_json::Value> {
+        &self.schemas
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Serializable OpenAPI 3.0 document types.
+//
+// Only the fields Autumn actually populates are modelled — unused
+// OpenAPI keys (callbacks, links, discriminators…) are intentionally
+// omitted so the generated JSON stays clean.
+// ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OpenApiSpec {
+    pub openapi: String,
+    pub info: Info,
+    pub paths: BTreeMap<String, PathItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub components: Option<Components>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Info {
+    pub title: String,
+    pub version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct PathItem {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub get: Option<Operation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post: Option<Operation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub put: Option<Operation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delete: Option<Operation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub patch: Option<Operation>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Operation {
+    #[serde(rename = "operationId")]
+    pub operation_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub parameters: Vec<Parameter>,
+    #[serde(rename = "requestBody", skip_serializing_if = "Option::is_none")]
+    pub request_body: Option<RequestBody>,
+    pub responses: BTreeMap<String, Response>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Parameter {
+    pub name: String,
+    #[serde(rename = "in")]
+    pub location: String,
+    pub required: bool,
+    pub schema: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RequestBody {
+    pub required: bool,
+    pub content: BTreeMap<String, MediaType>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Response {
+    pub description: String,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub content: BTreeMap<String, MediaType>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MediaType {
+    pub schema: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Components {
+    pub schemas: BTreeMap<String, serde_json::Value>,
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Spec generator
+// ──────────────────────────────────────────────────────────────────
+
+/// Build an [`OpenApiSpec`] from a collection of routes and user config.
+///
+/// This is the core of the auto-generation: every route's [`ApiDoc`] is
+/// translated into an [`Operation`] under the matching [`PathItem`].
+#[must_use]
+pub fn generate_spec(config: &OpenApiConfig, routes: &[&ApiDoc]) -> OpenApiSpec {
+    let mut paths: BTreeMap<String, PathItem> = BTreeMap::new();
+    let mut registry = SchemaRegistry::default();
+
+    for (name, schema) in &config.additional_schemas {
+        registry.insert(name.clone(), schema.clone());
+    }
+
+    for api_doc in routes {
+        if api_doc.hidden {
+            continue;
+        }
+        if let Some(register) = api_doc.register_schemas {
+            (register)(&mut registry);
+        }
+
+        let operation = operation_for(api_doc);
+        let entry = paths.entry(api_doc.path.to_owned()).or_default();
+        match api_doc.method {
+            "GET" => entry.get = Some(operation),
+            "POST" => entry.post = Some(operation),
+            "PUT" => entry.put = Some(operation),
+            "DELETE" => entry.delete = Some(operation),
+            "PATCH" => entry.patch = Some(operation),
+            // Unknown methods are silently skipped; Autumn's route macros
+            // only emit the five verbs above today.
+            _ => {}
+        }
+    }
+
+    let components_map = registry.into_map();
+    let components = if components_map.is_empty() {
+        None
+    } else {
+        Some(Components {
+            schemas: components_map,
+        })
+    };
+
+    OpenApiSpec {
+        openapi: "3.0.3".to_owned(),
+        info: Info {
+            title: config.title.clone(),
+            version: config.version.clone(),
+            description: config.description.clone(),
+        },
+        paths,
+        components,
+    }
+}
+
+fn operation_for(api_doc: &ApiDoc) -> Operation {
+    let tags = if api_doc.tags.is_empty() {
+        default_tag(api_doc.path)
+            .map(|t| vec![t.to_owned()])
+            .unwrap_or_default()
+    } else {
+        api_doc.tags.iter().map(|s| (*s).to_owned()).collect()
+    };
+
+    let parameters = api_doc
+        .path_params
+        .iter()
+        .map(|name| Parameter {
+            name: (*name).to_owned(),
+            location: "path".to_owned(),
+            required: true,
+            schema: serde_json::json!({ "type": "string" }),
+        })
+        .collect();
+
+    let request_body = api_doc.request_body.as_ref().map(|entry| RequestBody {
+        required: true,
+        content: std::iter::once((
+            "application/json".to_owned(),
+            MediaType {
+                schema: schema_value_for(entry),
+            },
+        ))
+        .collect(),
+    });
+
+    let mut responses: BTreeMap<String, Response> = BTreeMap::new();
+    let status = if api_doc.success_status == 0 {
+        200
+    } else {
+        api_doc.success_status
+    };
+    let response_content = api_doc
+        .response
+        .as_ref()
+        .map(|entry| {
+            let mut content = BTreeMap::new();
+            content.insert(
+                "application/json".to_owned(),
+                MediaType {
+                    schema: schema_value_for(entry),
+                },
+            );
+            content
+        })
+        .unwrap_or_default();
+    responses.insert(
+        status.to_string(),
+        Response {
+            description: status_description(status).to_owned(),
+            content: response_content,
+        },
+    );
+
+    Operation {
+        operation_id: api_doc.operation_id.to_owned(),
+        summary: api_doc.summary.map(str::to_owned),
+        description: api_doc.description.map(str::to_owned),
+        tags,
+        parameters,
+        request_body,
+        responses,
+    }
+}
+
+fn schema_value_for(entry: &SchemaEntry) -> serde_json::Value {
+    match entry.kind {
+        SchemaKind::Primitive(json_type) => serde_json::json!({ "type": json_type }),
+        SchemaKind::Ref => {
+            serde_json::json!({ "$ref": format!("#/components/schemas/{}", entry.name) })
+        }
+    }
+}
+
+fn default_tag(path: &str) -> Option<&str> {
+    path.trim_start_matches('/')
+        .split('/')
+        .find(|seg| !seg.is_empty() && !seg.starts_with('{'))
+}
+
+fn status_description(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        201 => "Created",
+        202 => "Accepted",
+        204 => "No Content",
+        301 => "Moved Permanently",
+        302 => "Found",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        403 => "Forbidden",
+        404 => "Not Found",
+        409 => "Conflict",
+        422 => "Unprocessable Entity",
+        500 => "Internal Server Error",
+        _ => "Response",
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Swagger UI HTML
+// ──────────────────────────────────────────────────────────────────
+
+/// Minimal Swagger UI bootstrap HTML that loads the generated JSON.
+///
+/// Uses the public unpkg CDN for Swagger UI assets so no static files
+/// need to be embedded in the framework binary.
+#[must_use]
+pub fn swagger_ui_html(spec_url: &str, title: &str) -> String {
+    let title = html_escape(title);
+    let spec_url = html_escape(spec_url);
+    // Assembled as a single String (not a format!()) to avoid conflicts
+    // between Rust's raw-string `#` delimiters and the CSS selector
+    // `#swagger-ui` in the embedded JS.
+    let mut out = String::with_capacity(1024);
+    out.push_str("<!DOCTYPE html>\n");
+    out.push_str("<html lang=\"en\">\n");
+    out.push_str("  <head>\n");
+    out.push_str("    <meta charset=\"utf-8\" />\n");
+    out.push_str("    <title>");
+    out.push_str(&title);
+    out.push_str("</title>\n");
+    out.push_str(
+        "    <link rel=\"stylesheet\" \
+         href=\"https://unpkg.com/swagger-ui-dist@5/swagger-ui.css\" />\n",
+    );
+    out.push_str("  </head>\n");
+    out.push_str("  <body>\n");
+    out.push_str("    <div id=\"swagger-ui\"></div>\n");
+    out.push_str(
+        "    <script src=\"https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js\" \
+         charset=\"UTF-8\"></script>\n",
+    );
+    out.push_str("    <script>\n");
+    out.push_str("      window.onload = function() {\n");
+    out.push_str("        window.ui = SwaggerUIBundle({\n");
+    out.push_str("          url: \"");
+    out.push_str(&spec_url);
+    out.push_str("\",\n");
+    out.push_str("          dom_id: \"#swagger-ui\",\n");
+    out.push_str("          deepLinking: true\n");
+    out.push_str("        });\n");
+    out.push_str("      };\n");
+    out.push_str("    </script>\n");
+    out.push_str("  </body>\n");
+    out.push_str("</html>\n");
+    out
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_doc() -> ApiDoc {
+        ApiDoc {
+            method: "GET",
+            path: "/users/{id}",
+            operation_id: "get_user",
+            summary: Some("Fetch a user"),
+            description: None,
+            tags: &[],
+            path_params: &["id"],
+            request_body: None,
+            response: None,
+            success_status: 200,
+            hidden: false,
+            register_schemas: None,
+        }
+    }
+
+    #[test]
+    fn generate_spec_builds_path_with_parameters() {
+        let doc = make_doc();
+        let config = OpenApiConfig::new("Demo", "1.0.0");
+        let spec = generate_spec(&config, &[&doc]);
+
+        assert_eq!(spec.openapi, "3.0.3");
+        assert_eq!(spec.info.title, "Demo");
+        assert!(spec.paths.contains_key("/users/{id}"));
+
+        let op = spec.paths["/users/{id}"].get.as_ref().unwrap();
+        assert_eq!(op.operation_id, "get_user");
+        assert_eq!(op.parameters.len(), 1);
+        assert_eq!(op.parameters[0].name, "id");
+        assert_eq!(op.parameters[0].location, "path");
+        assert_eq!(op.tags, vec!["users".to_owned()]);
+    }
+
+    #[test]
+    fn generate_spec_skips_hidden_routes() {
+        let mut doc = make_doc();
+        doc.hidden = true;
+        let config = OpenApiConfig::new("Demo", "1.0.0");
+        let spec = generate_spec(&config, &[&doc]);
+        assert!(spec.paths.is_empty());
+    }
+
+    #[test]
+    fn generate_spec_writes_request_body_ref() {
+        let mut doc = make_doc();
+        doc.method = "POST";
+        doc.path = "/users";
+        doc.operation_id = "create_user";
+        doc.path_params = &[];
+        doc.request_body = Some(SchemaEntry {
+            name: "CreateUser",
+            kind: SchemaKind::Ref,
+        });
+        doc.success_status = 201;
+
+        let config = OpenApiConfig::new("Demo", "1.0.0");
+        let spec = generate_spec(&config, &[&doc]);
+        let op = spec.paths["/users"].post.as_ref().unwrap();
+        let body = op.request_body.as_ref().unwrap();
+        assert!(body.required);
+        let media = body.content.get("application/json").unwrap();
+        assert_eq!(
+            media.schema,
+            serde_json::json!({ "$ref": "#/components/schemas/CreateUser" }),
+        );
+        assert!(op.responses.contains_key("201"));
+    }
+
+    #[test]
+    fn generate_spec_inlines_primitive_response() {
+        let mut doc = make_doc();
+        doc.response = Some(SchemaEntry {
+            name: "string",
+            kind: SchemaKind::Primitive("string"),
+        });
+        let config = OpenApiConfig::new("Demo", "1.0.0");
+        let spec = generate_spec(&config, &[&doc]);
+        let op = spec.paths["/users/{id}"].get.as_ref().unwrap();
+        let media = op.responses["200"].content.get("application/json").unwrap();
+        assert_eq!(media.schema, serde_json::json!({ "type": "string" }));
+    }
+
+    #[test]
+    fn generate_spec_includes_additional_schemas() {
+        let doc = make_doc();
+        let config = OpenApiConfig::new("Demo", "1.0.0")
+            .register_schema("Foo", serde_json::json!({ "type": "object" }));
+        let spec = generate_spec(&config, &[&doc]);
+        let components = spec.components.unwrap();
+        assert!(components.schemas.contains_key("Foo"));
+    }
+
+    #[test]
+    fn default_tag_picks_first_static_segment() {
+        assert_eq!(default_tag("/users/{id}"), Some("users"));
+        assert_eq!(default_tag("/api/v1/users"), Some("api"));
+        assert_eq!(default_tag("/"), None);
+        assert_eq!(default_tag("/{id}"), None);
+    }
+
+    #[test]
+    fn schema_registry_deduplicates() {
+        struct Foo;
+        impl OpenApiSchema for Foo {
+            fn schema_name() -> &'static str {
+                "Foo"
+            }
+            fn schema() -> serde_json::Value {
+                serde_json::json!({ "type": "object", "title": "Foo" })
+            }
+        }
+
+        let mut registry = SchemaRegistry::default();
+        registry.register::<Foo>();
+        registry.register::<Foo>();
+        assert_eq!(registry.schemas().len(), 1);
+    }
+
+    #[test]
+    fn primitive_impls_cover_common_types() {
+        assert_eq!(<String as OpenApiSchema>::schema_name(), "string");
+        assert_eq!(<i32 as OpenApiSchema>::schema_name(), "integer");
+        assert_eq!(<bool as OpenApiSchema>::schema_name(), "boolean");
+        assert_eq!(<f64 as OpenApiSchema>::schema_name(), "number");
+    }
+
+    #[test]
+    fn swagger_ui_html_embeds_spec_url() {
+        let html = swagger_ui_html("/v3/api-docs", "My API");
+        assert!(html.contains("/v3/api-docs"));
+        assert!(html.contains("My API"));
+    }
+
+    #[test]
+    fn swagger_ui_html_escapes_attributes() {
+        let html = swagger_ui_html("/v3/api-docs?x=<y>", "A \"cool\" & fun API");
+        assert!(html.contains("/v3/api-docs?x=&lt;y&gt;"));
+        assert!(html.contains("A &quot;cool&quot; &amp; fun API"));
+    }
+}

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -391,15 +391,15 @@ pub fn generate_spec(config: &OpenApiConfig, routes: &[&ApiDoc]) -> OpenApiSpec 
             (register)(&mut registry);
         }
 
-        if let Some(entry) = &api_doc.request_body
-            && entry.kind == SchemaKind::Ref
-        {
-            referenced_names.insert(entry.name);
+        if let Some(entry) = &api_doc.request_body {
+            if entry.kind == SchemaKind::Ref {
+                referenced_names.insert(entry.name);
+            }
         }
-        if let Some(entry) = &api_doc.response
-            && entry.kind == SchemaKind::Ref
-        {
-            referenced_names.insert(entry.name);
+        if let Some(entry) = &api_doc.response {
+            if entry.kind == SchemaKind::Ref {
+                referenced_names.insert(entry.name);
+            }
         }
 
         let operation = operation_for(api_doc);

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -265,7 +265,7 @@ impl SchemaRegistry {
 
     /// Peek at the collected schemas without consuming the registry.
     #[must_use]
-    pub fn schemas(&self) -> &BTreeMap<String, serde_json::Value> {
+    pub const fn schemas(&self) -> &BTreeMap<String, serde_json::Value> {
         &self.schemas
     }
 }
@@ -375,12 +375,31 @@ pub fn generate_spec(config: &OpenApiConfig, routes: &[&ApiDoc]) -> OpenApiSpec 
         registry.insert(name.clone(), schema.clone());
     }
 
+    // Collect every named schema reference produced by any operation so
+    // we can back-fill component entries for types the user didn't
+    // explicitly register. Without this, auto-inferred `Json<MyDto>`
+    // payloads would emit `$ref`s pointing at nonexistent component
+    // schemas — an invalid OpenAPI document.
+    let mut referenced_names: std::collections::BTreeSet<&'static str> =
+        std::collections::BTreeSet::new();
+
     for api_doc in routes {
         if api_doc.hidden {
             continue;
         }
         if let Some(register) = api_doc.register_schemas {
             (register)(&mut registry);
+        }
+
+        if let Some(entry) = &api_doc.request_body
+            && entry.kind == SchemaKind::Ref
+        {
+            referenced_names.insert(entry.name);
+        }
+        if let Some(entry) = &api_doc.response
+            && entry.kind == SchemaKind::Ref
+        {
+            referenced_names.insert(entry.name);
         }
 
         let operation = operation_for(api_doc);
@@ -394,6 +413,22 @@ pub fn generate_spec(config: &OpenApiConfig, routes: &[&ApiDoc]) -> OpenApiSpec 
             // Unknown methods are silently skipped; Autumn's route macros
             // only emit the five verbs above today.
             _ => {}
+        }
+    }
+
+    // Back-fill a minimal `{"type": "object", "title": "X"}` schema for
+    // every referenced name the user didn't already register. Types that
+    // implement OpenApiSchema can be registered explicitly via
+    // OpenApiConfig::register_schema to replace the placeholder.
+    for name in referenced_names {
+        if !registry.schemas().contains_key(name) {
+            registry.insert(
+                name,
+                serde_json::json!({
+                    "type": "object",
+                    "title": name,
+                }),
+            );
         }
     }
 
@@ -503,7 +538,7 @@ fn default_tag(path: &str) -> Option<&str> {
         .find(|seg| !seg.is_empty() && !seg.starts_with('{'))
 }
 
-fn status_description(status: u16) -> &'static str {
+const fn status_description(status: u16) -> &'static str {
     match status {
         200 => "OK",
         201 => "Created",
@@ -679,6 +714,61 @@ mod tests {
         let spec = generate_spec(&config, &[&doc]);
         let components = spec.components.unwrap();
         assert!(components.schemas.contains_key("Foo"));
+    }
+
+    #[test]
+    fn generate_spec_back_fills_unregistered_ref_schemas() {
+        // A Json<CreateUser> handler emits a `$ref` with no component
+        // schema registered. The generator must back-fill a placeholder
+        // schema so the resulting OpenAPI document is valid.
+        let mut doc = make_doc();
+        doc.method = "POST";
+        doc.path = "/users";
+        doc.path_params = &[];
+        doc.request_body = Some(SchemaEntry {
+            name: "CreateUser",
+            kind: SchemaKind::Ref,
+        });
+        doc.response = Some(SchemaEntry {
+            name: "User",
+            kind: SchemaKind::Ref,
+        });
+
+        let config = OpenApiConfig::new("Demo", "1.0.0");
+        let spec = generate_spec(&config, &[&doc]);
+        let components = spec.components.expect("components must be emitted");
+        let create = components
+            .schemas
+            .get("CreateUser")
+            .expect("CreateUser should be back-filled");
+        let user = components
+            .schemas
+            .get("User")
+            .expect("User should be back-filled");
+        assert_eq!(create["type"], "object");
+        assert_eq!(create["title"], "CreateUser");
+        assert_eq!(user["type"], "object");
+        assert_eq!(user["title"], "User");
+    }
+
+    #[test]
+    fn generate_spec_preserves_user_registered_schemas_over_backfill() {
+        let mut doc = make_doc();
+        doc.response = Some(SchemaEntry {
+            name: "User",
+            kind: SchemaKind::Ref,
+        });
+
+        let user_schema = serde_json::json!({
+            "type": "object",
+            "properties": {"id": {"type": "integer"}},
+        });
+        let config =
+            OpenApiConfig::new("Demo", "1.0.0").register_schema("User", user_schema.clone());
+        let spec = generate_spec(&config, &[&doc]);
+        let components = spec.components.unwrap();
+        let stored = components.schemas.get("User").unwrap();
+        assert_eq!(stored, &user_schema, "user schema must not be overwritten");
     }
 
     #[test]

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -13,20 +13,27 @@
 //!
 //! # Quick start
 //!
-//! ```rust,no_run
+//! Enable the `openapi` feature in `Cargo.toml`, then:
+//!
+//! ```toml
+//! [dependencies]
+//! autumn-web = { version = "0.2", features = ["openapi"] }
+//! ```
+//!
+//! ```rust,ignore
 //! use autumn_web::prelude::*;
 //!
 //! #[get("/hello")]
 //! async fn hello() -> &'static str { "hi" }
 //!
-//! # #[autumn_web::main]
-//! # async fn main() {
-//! autumn_web::app()
-//!     .routes(routes![hello])
-//!     .openapi(autumn_web::openapi::OpenApiConfig::new("My API", "1.0.0"))
-//!     .run()
-//!     .await;
-//! # }
+//! #[autumn_web::main]
+//! async fn main() {
+//!     autumn_web::app()
+//!         .routes(routes![hello])
+//!         .openapi(autumn_web::openapi::OpenApiConfig::new("My API", "1.0.0"))
+//!         .run()
+//!         .await;
+//! }
 //! ```
 //!
 //! With `.openapi(...)` enabled, the following endpoints are mounted:
@@ -56,6 +63,7 @@
 
 use std::collections::BTreeMap;
 
+#[cfg(feature = "openapi")]
 use serde::{Deserialize, Serialize};
 
 // ──────────────────────────────────────────────────────────────────
@@ -136,6 +144,7 @@ pub enum SchemaKind {
 ///
 /// Passed to [`AppBuilder::openapi`](crate::app::AppBuilder::openapi)
 /// to enable spec generation and mount the documentation endpoints.
+#[cfg(feature = "openapi")]
 #[derive(Clone)]
 pub struct OpenApiConfig {
     /// API title that appears in the Swagger UI header.
@@ -153,6 +162,7 @@ pub struct OpenApiConfig {
     pub additional_schemas: BTreeMap<String, serde_json::Value>,
 }
 
+#[cfg(feature = "openapi")]
 impl OpenApiConfig {
     /// Create a new config with the required `title` and `version`.
     #[must_use]
@@ -198,7 +208,7 @@ impl OpenApiConfig {
 }
 
 // ──────────────────────────────────────────────────────────────────
-// Schema trait + primitive impls
+// Schema trait + primitive impls (feature-gated)
 // ──────────────────────────────────────────────────────────────────
 
 /// Describes a type's JSON schema for OpenAPI generation.
@@ -207,6 +217,7 @@ impl OpenApiConfig {
 /// schemas in the generated spec. A blanket default is not provided —
 /// routes whose types do not implement this trait simply emit a generic
 /// `object` placeholder referring to the type name.
+#[cfg(feature = "openapi")]
 pub trait OpenApiSchema {
     /// Component schema name (appears under `#/components/schemas/`).
     fn schema_name() -> &'static str;
@@ -215,6 +226,7 @@ pub trait OpenApiSchema {
     fn schema() -> serde_json::Value;
 }
 
+#[cfg(feature = "openapi")]
 macro_rules! impl_primitive_schema {
     ($ty:ty, $name:literal, $json:literal) => {
         impl OpenApiSchema for $ty {
@@ -228,19 +240,33 @@ macro_rules! impl_primitive_schema {
     };
 }
 
+#[cfg(feature = "openapi")]
 impl_primitive_schema!(bool, "boolean", "boolean");
+#[cfg(feature = "openapi")]
 impl_primitive_schema!(String, "string", "string");
+#[cfg(feature = "openapi")]
 impl_primitive_schema!(&'static str, "string", "string");
+#[cfg(feature = "openapi")]
 impl_primitive_schema!(i8, "integer", "integer");
+#[cfg(feature = "openapi")]
 impl_primitive_schema!(i16, "integer", "integer");
+#[cfg(feature = "openapi")]
 impl_primitive_schema!(i32, "integer", "integer");
+#[cfg(feature = "openapi")]
 impl_primitive_schema!(i64, "integer", "integer");
+#[cfg(feature = "openapi")]
 impl_primitive_schema!(u8, "integer", "integer");
+#[cfg(feature = "openapi")]
 impl_primitive_schema!(u16, "integer", "integer");
+#[cfg(feature = "openapi")]
 impl_primitive_schema!(u32, "integer", "integer");
+#[cfg(feature = "openapi")]
 impl_primitive_schema!(u64, "integer", "integer");
+#[cfg(feature = "openapi")]
 impl_primitive_schema!(f32, "number", "number");
+#[cfg(feature = "openapi")]
 impl_primitive_schema!(f64, "number", "number");
+#[cfg(feature = "openapi")]
 impl_primitive_schema!(serde_json::Value, "object", "object");
 
 // ──────────────────────────────────────────────────────────────────
@@ -256,6 +282,7 @@ pub struct SchemaRegistry {
 impl SchemaRegistry {
     /// Register a type via its [`OpenApiSchema`] implementation. A
     /// duplicate insertion is a no-op (the existing entry wins).
+    #[cfg(feature = "openapi")]
     pub fn register<T: OpenApiSchema>(&mut self) {
         let name = T::schema_name().to_owned();
         self.schemas.entry(name).or_insert_with(T::schema);
@@ -284,9 +311,12 @@ impl SchemaRegistry {
 //
 // Only the fields Autumn actually populates are modelled — unused
 // OpenAPI keys (callbacks, links, discriminators…) are intentionally
-// omitted so the generated JSON stays clean.
+// omitted so the generated JSON stays clean. Gated behind the
+// `openapi` feature so the runtime spec builder doesn't add code
+// size / dependency pressure to apps that never serve a JSON spec.
 // ──────────────────────────────────────────────────────────────────
 
+#[cfg(feature = "openapi")]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct OpenApiSpec {
     pub openapi: String,
@@ -296,6 +326,7 @@ pub struct OpenApiSpec {
     pub components: Option<Components>,
 }
 
+#[cfg(feature = "openapi")]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Info {
     pub title: String,
@@ -304,6 +335,7 @@ pub struct Info {
     pub description: Option<String>,
 }
 
+#[cfg(feature = "openapi")]
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct PathItem {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -318,6 +350,7 @@ pub struct PathItem {
     pub patch: Option<Operation>,
 }
 
+#[cfg(feature = "openapi")]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Operation {
     #[serde(rename = "operationId")]
@@ -335,6 +368,7 @@ pub struct Operation {
     pub responses: BTreeMap<String, Response>,
 }
 
+#[cfg(feature = "openapi")]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Parameter {
     pub name: String,
@@ -344,12 +378,14 @@ pub struct Parameter {
     pub schema: serde_json::Value,
 }
 
+#[cfg(feature = "openapi")]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RequestBody {
     pub required: bool,
     pub content: BTreeMap<String, MediaType>,
 }
 
+#[cfg(feature = "openapi")]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Response {
     pub description: String,
@@ -357,11 +393,13 @@ pub struct Response {
     pub content: BTreeMap<String, MediaType>,
 }
 
+#[cfg(feature = "openapi")]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MediaType {
     pub schema: serde_json::Value,
 }
 
+#[cfg(feature = "openapi")]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Components {
     pub schemas: BTreeMap<String, serde_json::Value>,
@@ -375,6 +413,7 @@ pub struct Components {
 ///
 /// This is the core of the auto-generation: every route's [`ApiDoc`] is
 /// translated into an [`Operation`] under the matching [`PathItem`].
+#[cfg(feature = "openapi")]
 #[must_use]
 pub fn generate_spec(config: &OpenApiConfig, routes: &[&ApiDoc]) -> OpenApiSpec {
     let mut paths: BTreeMap<String, PathItem> = BTreeMap::new();
@@ -458,6 +497,7 @@ pub fn generate_spec(config: &OpenApiConfig, routes: &[&ApiDoc]) -> OpenApiSpec 
     }
 }
 
+#[cfg(feature = "openapi")]
 fn operation_for(api_doc: &ApiDoc) -> Operation {
     let tags = if api_doc.tags.is_empty() {
         default_tag(api_doc.path)
@@ -528,6 +568,7 @@ fn operation_for(api_doc: &ApiDoc) -> Operation {
     }
 }
 
+#[cfg(feature = "openapi")]
 fn schema_value_for(entry: &SchemaEntry) -> serde_json::Value {
     match entry.kind {
         SchemaKind::Primitive(json_type) => serde_json::json!({ "type": json_type }),
@@ -565,6 +606,7 @@ fn schema_value_for(entry: &SchemaEntry) -> serde_json::Value {
 /// Walk into a `SchemaEntry` and yield every named ref reached through
 /// `Array` / `Nullable` wrappers. Back-fill logic uses this so a
 /// `Json<Vec<User>>` response registers a `User` component schema.
+#[cfg(feature = "openapi")]
 fn collect_ref_names(entry: &SchemaEntry, out: &mut std::collections::BTreeSet<&'static str>) {
     match entry.kind {
         SchemaKind::Ref => {
@@ -575,12 +617,14 @@ fn collect_ref_names(entry: &SchemaEntry, out: &mut std::collections::BTreeSet<&
     }
 }
 
+#[cfg(feature = "openapi")]
 fn default_tag(path: &str) -> Option<&str> {
     path.trim_start_matches('/')
         .split('/')
         .find(|seg| !seg.is_empty() && !seg.starts_with('{'))
 }
 
+#[cfg(feature = "openapi")]
 const fn status_description(status: u16) -> &'static str {
     match status {
         200 => "OK",
@@ -608,6 +652,7 @@ const fn status_description(status: u16) -> &'static str {
 ///
 /// Uses the public unpkg CDN for Swagger UI assets so no static files
 /// need to be embedded in the framework binary.
+#[cfg(feature = "openapi")]
 #[must_use]
 pub fn swagger_ui_html(spec_url: &str, title: &str) -> String {
     let title = html_escape(title);
@@ -650,6 +695,7 @@ pub fn swagger_ui_html(spec_url: &str, title: &str) -> String {
     out
 }
 
+#[cfg(feature = "openapi")]
 fn html_escape(s: &str) -> String {
     s.replace('&', "&amp;")
         .replace('<', "&lt;")
@@ -661,7 +707,7 @@ fn html_escape(s: &str) -> String {
 // Tests
 // ──────────────────────────────────────────────────────────────────
 
-#[cfg(test)]
+#[cfg(all(test, feature = "openapi"))]
 mod tests {
     use super::*;
 

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -27,7 +27,7 @@
 pub use autumn_macros::ws;
 /// HTTP method route macros, main macro, and route collection.
 pub use autumn_macros::{
-    cached, delete, get, main, post, put, routes, scheduled, secured, service, static_get,
+    api_doc, cached, delete, get, main, post, put, routes, scheduled, secured, service, static_get,
     static_routes, tasks,
 };
 

--- a/autumn/src/route.rs
+++ b/autumn/src/route.rs
@@ -47,7 +47,7 @@ pub struct Route {
     /// (e.g., `"hello"`, `"create_item"`).
     pub name: &'static str,
 
-    /// OpenAPI metadata inferred from the handler's signature and any
+    /// `OpenAPI` metadata inferred from the handler's signature and any
     /// [`#[api_doc(...)]`](crate::api_doc) overrides. Consumed by
     /// [`AppBuilder::openapi`](crate::app::AppBuilder::openapi) when
     /// generating `/v3/api-docs`.

--- a/autumn/src/route.rs
+++ b/autumn/src/route.rs
@@ -11,6 +11,7 @@
 use axum::routing::MethodRouter;
 use http::Method;
 
+use crate::openapi::ApiDoc;
 use crate::state::AppState;
 
 /// A single route binding an HTTP method + path to an Axum handler.
@@ -45,4 +46,10 @@ pub struct Route {
     /// Handler function name, used for startup logging
     /// (e.g., `"hello"`, `"create_item"`).
     pub name: &'static str,
+
+    /// OpenAPI metadata inferred from the handler's signature and any
+    /// [`#[api_doc(...)]`](crate::api_doc) overrides. Consumed by
+    /// [`AppBuilder::openapi`](crate::app::AppBuilder::openapi) when
+    /// generating `/v3/api-docs`.
+    pub api_doc: ApiDoc,
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -50,6 +50,16 @@ pub enum RouterBuildError {
         /// The offending value from the user's config.
         value: String,
     },
+    /// `openapi_json_path` and `swagger_ui_path` collide on the same
+    /// URL. Mounting both would cause axum to panic on overlapping
+    /// method routes at startup.
+    #[error(
+        "openapi_json_path and swagger_ui_path both resolve to {path:?}; they must differ or `swagger_ui_path` must be `None`"
+    )]
+    DuplicateOpenApiPath {
+        /// The path that both fields pointed at.
+        path: String,
+    },
 }
 
 /// Build the fully-configured Axum router from routes, config, and state.
@@ -298,6 +308,12 @@ fn build_openapi_router(
     validate_route_path("openapi_json_path", &config.openapi_json_path)?;
     if let Some(path) = &config.swagger_ui_path {
         validate_route_path("swagger_ui_path", path)?;
+        // Registering two GET handlers on the same path would cause an
+        // axum `Route::route` panic, so reject collisions as a
+        // configuration error instead.
+        if path == &config.openapi_json_path {
+            return Err(RouterBuildError::DuplicateOpenApiPath { path: path.clone() });
+        }
     }
 
     // Walk both top-level routes and scoped groups. For scoped groups the
@@ -1500,5 +1516,18 @@ mod tests {
         let out = super::build_openapi_router(&[], &[], Some(&config))
             .expect("valid paths must not error");
         assert!(out.is_some());
+    }
+
+    #[test]
+    fn openapi_rejects_duplicate_json_and_swagger_paths() {
+        let config = crate::openapi::OpenApiConfig::new("Demo", "1.0.0")
+            .openapi_json_path("/docs")
+            .swagger_ui_path(Some("/docs".to_owned()));
+        let err = super::build_openapi_router(&[], &[], Some(&config))
+            .expect_err("colliding paths should be rejected before axum panics");
+        assert!(matches!(
+            err,
+            RouterBuildError::DuplicateOpenApiPath { ref path } if path == "/docs"
+        ));
     }
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -84,6 +84,10 @@ pub struct RouterContext {
     /// When `Some`, [`apply_session_layer`](crate::session::apply_session_layer)
     /// uses it directly and skips the config-driven backend selection.
     pub session_store: Option<Arc<dyn crate::session::BoxedSessionStore>>,
+    /// OpenAPI generation configuration. When `Some`, the router mounts
+    /// an `openapi.json` endpoint and (optionally) a Swagger UI page
+    /// describing the application's routes.
+    pub openapi: Option<crate::openapi::OpenApiConfig>,
 }
 
 /// Checked variant of [`build_router`] that returns configuration errors
@@ -111,6 +115,7 @@ pub fn try_build_router(
             custom_layers: Vec::new(),
             error_page_renderer: None,
             session_store: None,
+            openapi: None,
         },
     )?;
     Ok(apply_startup_barrier(
@@ -170,6 +175,7 @@ pub fn try_build_router_merged(
             custom_layers: Vec::new(),
             error_page_renderer: None,
             session_store: None,
+            openapi: None,
         },
     )?;
     Ok(apply_startup_barrier(
@@ -185,6 +191,11 @@ pub fn try_build_router_inner(
     state: AppState,
     ctx: RouterContext,
 ) -> Result<axum::Router, RouterBuildError> {
+    // Build the OpenAPI spec BEFORE moving the routes into axum, because
+    // group_and_mount_routes consumes the Route list.
+    let openapi_router =
+        build_openapi_router(&route_list, &ctx.scoped_groups, ctx.openapi.as_ref());
+
     let mut router = group_and_mount_routes(route_list);
 
     let dev_reload_enabled = dev::is_enabled_with_env(&crate::config::OsEnv);
@@ -195,6 +206,10 @@ pub fn try_build_router_inner(
     router = router_with_probes;
 
     router = mount_actuator_endpoints(router, config, &mounted_probe_paths)?;
+
+    if let Some(openapi_router) = openapi_router {
+        router = router.merge(openapi_router);
+    }
 
     // Static file serving from project's static/ directory.
     let env = crate::config::OsEnv;
@@ -222,6 +237,95 @@ pub fn try_build_router_inner(
     }
 
     Ok(router.with_state(state))
+}
+
+/// Build an Axum sub-router that serves the generated OpenAPI document
+/// and (optionally) a Swagger UI HTML page.
+///
+/// Returns `None` when OpenAPI generation is disabled, i.e. the user
+/// never called [`AppBuilder::openapi`](crate::app::AppBuilder::openapi).
+///
+/// The spec is rendered once at build time and stored in an `Arc<String>`
+/// so the `/v3/api-docs` handler performs no serialization per request.
+fn build_openapi_router(
+    route_list: &[Route],
+    scoped_groups: &[ScopedGroup],
+    openapi_config: Option<&crate::openapi::OpenApiConfig>,
+) -> Option<axum::Router<AppState>> {
+    let config = openapi_config?;
+
+    // Walk both top-level routes and scoped groups. For scoped groups the
+    // effective path is `prefix + route.path`; we materialize these into
+    // fresh `ApiDoc`s so the rendered spec reflects the actual URL the
+    // user will call.
+    let mut docs: Vec<crate::openapi::ApiDoc> = Vec::new();
+    for route in route_list {
+        docs.push(route.api_doc.clone());
+    }
+    for group in scoped_groups {
+        for route in &group.routes {
+            let mut doc = route.api_doc.clone();
+            // Leak the combined path so it fits the `&'static str` shape of
+            // ApiDoc. The spec is built once per process; the leak is
+            // bounded by the route table size.
+            let full = format!("{}{}", group.prefix, route.api_doc.path);
+            doc.path = Box::leak(full.into_boxed_str());
+            docs.push(doc);
+        }
+    }
+
+    let refs: Vec<&crate::openapi::ApiDoc> = docs.iter().collect();
+    let spec = crate::openapi::generate_spec(config, &refs);
+    let spec_json = serde_json::to_string_pretty(&spec)
+        .unwrap_or_else(|e| format!("{{\"error\": \"failed to serialize spec: {e}\"}}"));
+
+    let spec_body = Arc::new(spec_json);
+    let json_path = config.openapi_json_path.clone();
+    let swagger_path = config.swagger_ui_path.clone();
+    let title = config.title.clone();
+
+    let spec_for_handler = spec_body.clone();
+    let mut router = axum::Router::<AppState>::new().route(
+        &json_path,
+        axum::routing::get(move || {
+            let spec = spec_for_handler.clone();
+            async move {
+                use axum::response::IntoResponse;
+                (
+                    [(http::header::CONTENT_TYPE, "application/json")],
+                    (*spec).clone(),
+                )
+                    .into_response()
+            }
+        }),
+    );
+
+    if let Some(path) = swagger_path {
+        let spec_url = json_path.clone();
+        let title_for_handler = title.clone();
+        router = router.route(
+            &path,
+            axum::routing::get(move || {
+                let html = crate::openapi::swagger_ui_html(&spec_url, &title_for_handler);
+                async move {
+                    use axum::response::IntoResponse;
+                    (
+                        [(http::header::CONTENT_TYPE, "text/html; charset=utf-8")],
+                        html,
+                    )
+                        .into_response()
+                }
+            }),
+        );
+    }
+
+    tracing::debug!(
+        openapi_json = %json_path,
+        swagger_ui = ?config.swagger_ui_path,
+        "Mounted OpenAPI endpoints"
+    );
+
+    Some(router)
 }
 
 fn group_and_mount_routes(route_list: Vec<Route>) -> axum::Router<AppState> {
@@ -594,6 +698,7 @@ pub fn try_build_router_with_static(
             custom_layers: Vec::new(),
             error_page_renderer: None,
             session_store: None,
+            openapi: None,
         },
     )
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -249,16 +249,16 @@ fn extract_path_params(path: &str) -> Vec<String> {
     let bytes = path.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'{'
-            && let Some(end_rel) = bytes[i + 1..].iter().position(|b| *b == b'}')
-        {
-            let inner = &path[i + 1..i + 1 + end_rel];
-            let name = inner.split(':').next().unwrap_or(inner).trim();
-            if !name.is_empty() {
-                out.push(name.to_owned());
+        if bytes[i] == b'{' {
+            if let Some(end_rel) = bytes[i + 1..].iter().position(|b| *b == b'}') {
+                let inner = &path[i + 1..i + 1 + end_rel];
+                let name = inner.split(':').next().unwrap_or(inner).trim();
+                if !name.is_empty() {
+                    out.push(name.to_owned());
+                }
+                i += 1 + end_rel + 1;
+                continue;
             }
-            i += 1 + end_rel + 1;
-            continue;
         }
         i += 1;
     }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -229,6 +229,8 @@ pub fn try_build_router_inner(
         ctx.openapi.as_ref(),
         &route_list,
         &ctx.scoped_groups,
+        &ctx.merge_routers,
+        &ctx.nest_routers,
         config,
     )?;
 
@@ -447,13 +449,24 @@ fn validate_route_path(field: &'static str, value: &str) -> Result<(), RouterBui
 /// [`RouterBuildError::OpenApiPathCollision`] so misconfiguration
 /// produces an actionable error instead of a crash on startup.
 ///
-/// We check against user routes (both top-level and scoped groups)
-/// plus the framework's probe/actuator/htmx endpoints that will be
-/// mounted before the `OpenAPI` sub-router merges in.
+/// We check against:
+/// * user routes (top-level + scoped groups) that will be mounted
+///   before the `OpenAPI` sub-router merges in,
+/// * framework `GET`s: probes, actuator, htmx asset, and dev
+///   live-reload when enabled,
+/// * nest prefixes from [`AppBuilder::nest`](crate::app::AppBuilder::nest)
+///   when the `OpenAPI` path falls under one.
+///
+/// Raw routers passed to [`AppBuilder::merge`](crate::app::AppBuilder::merge)
+/// cannot be introspected — axum does not expose their route table.
+/// We emit a `tracing::warn!` so operators know the check is
+/// incomplete in that case.
 fn reject_openapi_path_collisions(
     openapi_config: Option<&crate::openapi::OpenApiConfig>,
     route_list: &[Route],
     scoped_groups: &[ScopedGroup],
+    merge_routers: &[axum::Router<AppState>],
+    nest_routers: &[(String, axum::Router<AppState>)],
     config: &AutumnConfig,
 ) -> Result<(), RouterBuildError> {
     let Some(openapi) = openapi_config else {
@@ -486,18 +499,68 @@ fn reject_openapi_path_collisions(
     }
     #[cfg(feature = "htmx")]
     claimed.insert("/static/js/htmx.min.js".to_owned());
+    // Dev live-reload endpoints are only mounted when the env vars
+    // that enable them are set, but reserving the paths regardless
+    // makes the error message deterministic across dev/prod.
+    if dev::is_enabled_with_env(&crate::config::OsEnv) {
+        claimed.insert(dev::LIVE_RELOAD_PATH.to_owned());
+        claimed.insert(dev::LIVE_RELOAD_SCRIPT_PATH.to_owned());
+    }
 
-    if claimed.contains(&openapi.openapi_json_path) {
+    check_openapi_path_against(
+        "openapi_json_path",
+        &openapi.openapi_json_path,
+        &claimed,
+        nest_routers,
+    )?;
+    if let Some(path) = &openapi.swagger_ui_path {
+        check_openapi_path_against("swagger_ui_path", path, &claimed, nest_routers)?;
+    }
+
+    // Raw merged routers are opaque — we can't inspect their route
+    // tables through the axum API. Warn instead of failing so users
+    // know the check doesn't cover this code path.
+    if !merge_routers.is_empty() {
+        tracing::warn!(
+            openapi_json_path = %openapi.openapi_json_path,
+            swagger_ui_path = ?openapi.swagger_ui_path,
+            merged_routers = merge_routers.len(),
+            "OpenAPI mount collision check skipped for AppBuilder::merge routers: \
+             axum does not expose their route table, so overlapping GET handlers \
+             will still panic at startup. Choose OpenAPI paths that don't overlap \
+             with any merged router's handlers."
+        );
+    }
+
+    Ok(())
+}
+
+/// Evaluate a single `OpenAPI` path against the claimed-path set plus
+/// any nest prefixes. Returns an `OpenApiPathCollision` error on
+/// collision.
+fn check_openapi_path_against(
+    field: &'static str,
+    path: &str,
+    claimed: &std::collections::HashSet<String>,
+    nest_routers: &[(String, axum::Router<AppState>)],
+) -> Result<(), RouterBuildError> {
+    if claimed.contains(path) {
         return Err(RouterBuildError::OpenApiPathCollision {
-            field: "openapi_json_path",
-            path: openapi.openapi_json_path.clone(),
+            field,
+            path: path.to_owned(),
         });
     }
-    if let Some(path) = &openapi.swagger_ui_path {
-        if claimed.contains(path) {
+    // A nest prefix P owns every route under P (`/P/...`), so any
+    // OpenAPI path that equals P or starts with `P/` will either
+    // panic on merge (exact match) or nest inside the user's router
+    // (where axum routing semantics decide which handler wins).
+    // Reject both cases so the spec endpoint can't silently vanish.
+    for (prefix, _) in nest_routers {
+        let prefix_slash = format!("{prefix}/");
+        if path == prefix || path.starts_with(&prefix_slash) {
             return Err(RouterBuildError::OpenApiPathCollision {
-                field: "swagger_ui_path",
-                path: path.clone(),
+                field,
+                path: path.to_owned(),
             });
         }
     }
@@ -1685,5 +1748,71 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[tokio::test]
+    async fn try_build_router_rejects_openapi_path_under_nest_prefix() {
+        // Nesting `/api` means that router owns everything under
+        // `/api/...`. Mounting OpenAPI at `/api/docs` would either
+        // panic on merge or silently lose one of the routes, so the
+        // collision check rejects it.
+        let config = AutumnConfig::default();
+        let openapi =
+            crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("/api/docs");
+        let nested = axum::Router::<AppState>::new()
+            .route("/inner", axum::routing::get(|| async { "inner" }));
+        let ctx = RouterContext {
+            exception_filters: Vec::new(),
+            scoped_groups: Vec::new(),
+            merge_routers: Vec::new(),
+            nest_routers: vec![("/api".to_owned(), nested)],
+            custom_layers: Vec::new(),
+            error_page_renderer: None,
+            session_store: None,
+            openapi: Some(openapi),
+        };
+        let err = super::try_build_router_inner(Vec::new(), &config, test_state(), ctx)
+            .expect_err("OpenAPI path under a nest prefix should collide");
+        assert!(matches!(
+            err,
+            RouterBuildError::OpenApiPathCollision {
+                field: "openapi_json_path",
+                ref path,
+            } if path == "/api/docs"
+        ));
+    }
+
+    #[test]
+    fn try_build_router_rejects_openapi_path_on_dev_live_reload() {
+        temp_env::with_vars(
+            [
+                ("AUTUMN_DEV_RELOAD", Some("1")),
+                ("AUTUMN_DEV_RELOAD_STATE", Some("/tmp/autumn-reload-test")),
+            ],
+            || {
+                let config = AutumnConfig::default();
+                let openapi = crate::openapi::OpenApiConfig::new("Demo", "1.0.0")
+                    .openapi_json_path("/__autumn/live-reload");
+                let ctx = RouterContext {
+                    exception_filters: Vec::new(),
+                    scoped_groups: Vec::new(),
+                    merge_routers: Vec::new(),
+                    nest_routers: Vec::new(),
+                    custom_layers: Vec::new(),
+                    error_page_renderer: None,
+                    session_store: None,
+                    openapi: Some(openapi),
+                };
+                let err = super::try_build_router_inner(Vec::new(), &config, test_state(), ctx)
+                    .expect_err("dev reload path should be reserved");
+                assert!(matches!(
+                    err,
+                    RouterBuildError::OpenApiPathCollision {
+                        field: "openapi_json_path",
+                        ..
+                    }
+                ));
+            },
+        );
     }
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -84,7 +84,7 @@ pub struct RouterContext {
     /// When `Some`, [`apply_session_layer`](crate::session::apply_session_layer)
     /// uses it directly and skips the config-driven backend selection.
     pub session_store: Option<Arc<dyn crate::session::BoxedSessionStore>>,
-    /// OpenAPI generation configuration. When `Some`, the router mounts
+    /// `OpenAPI` generation configuration. When `Some`, the router mounts
     /// an `openapi.json` endpoint and (optionally) a Swagger UI page
     /// describing the application's routes.
     pub openapi: Option<crate::openapi::OpenApiConfig>,
@@ -239,10 +239,36 @@ pub fn try_build_router_inner(
     Ok(router.with_state(state))
 }
 
-/// Build an Axum sub-router that serves the generated OpenAPI document
+/// Parse `{name}` captures from a route path.
+///
+/// Mirrors the compile-time extractor in `autumn_macros::api_doc` so
+/// runtime spec assembly (which sees scope prefixes that the macro
+/// never does) produces consistent parameter lists.
+fn extract_path_params(path: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = path.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'{'
+            && let Some(end_rel) = bytes[i + 1..].iter().position(|b| *b == b'}')
+        {
+            let inner = &path[i + 1..i + 1 + end_rel];
+            let name = inner.split(':').next().unwrap_or(inner).trim();
+            if !name.is_empty() {
+                out.push(name.to_owned());
+            }
+            i += 1 + end_rel + 1;
+            continue;
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Build an Axum sub-router that serves the generated `OpenAPI` document
 /// and (optionally) a Swagger UI HTML page.
 ///
-/// Returns `None` when OpenAPI generation is disabled, i.e. the user
+/// Returns `None` when `OpenAPI` generation is disabled, i.e. the user
 /// never called [`AppBuilder::openapi`](crate::app::AppBuilder::openapi).
 ///
 /// The spec is rendered once at build time and stored in an `Arc<String>`
@@ -263,6 +289,10 @@ fn build_openapi_router(
         docs.push(route.api_doc.clone());
     }
     for group in scoped_groups {
+        // Extract `{name}` captures from the scope prefix so parameters
+        // declared in the prefix (e.g. `/orgs/{org_id}`) show up on the
+        // generated operation alongside the child route's own params.
+        let prefix_params = extract_path_params(&group.prefix);
         for route in &group.routes {
             let mut doc = route.api_doc.clone();
             // Leak the combined path so it fits the `&'static str` shape of
@@ -270,6 +300,20 @@ fn build_openapi_router(
             // bounded by the route table size.
             let full = format!("{}{}", group.prefix, route.api_doc.path);
             doc.path = Box::leak(full.into_boxed_str());
+
+            if !prefix_params.is_empty() {
+                let mut merged: Vec<&'static str> = prefix_params
+                    .iter()
+                    .map(|p| &*Box::leak(p.clone().into_boxed_str()))
+                    .collect();
+                for existing in route.api_doc.path_params {
+                    if !merged.iter().any(|n| n == existing) {
+                        merged.push(existing);
+                    }
+                }
+                doc.path_params = Box::leak(merged.into_boxed_slice());
+            }
+
             docs.push(doc);
         }
     }
@@ -284,11 +328,10 @@ fn build_openapi_router(
     let swagger_path = config.swagger_ui_path.clone();
     let title = config.title.clone();
 
-    let spec_for_handler = spec_body.clone();
     let mut router = axum::Router::<AppState>::new().route(
         &json_path,
         axum::routing::get(move || {
-            let spec = spec_for_handler.clone();
+            let spec = spec_body.clone();
             async move {
                 use axum::response::IntoResponse;
                 (
@@ -302,11 +345,10 @@ fn build_openapi_router(
 
     if let Some(path) = swagger_path {
         let spec_url = json_path.clone();
-        let title_for_handler = title.clone();
         router = router.route(
             &path,
             axum::routing::get(move || {
-                let html = crate::openapi::swagger_ui_html(&spec_url, &title_for_handler);
+                let html = crate::openapi::swagger_ui_html(&spec_url, &title);
                 async move {
                     use axum::response::IntoResponse;
                     (
@@ -1303,5 +1345,80 @@ mod tests {
             StatusCode::OK,
             "POST without CSRF token should be rejected when CSRF is enabled"
         );
+    }
+
+    #[test]
+    fn extract_path_params_matches_macro_behavior() {
+        assert_eq!(
+            super::extract_path_params("/orgs/{org_id}/users/{id}"),
+            vec!["org_id".to_owned(), "id".to_owned()]
+        );
+        assert!(super::extract_path_params("/static").is_empty());
+        assert_eq!(
+            super::extract_path_params("/users/{id:[0-9]+}"),
+            vec!["id".to_owned()]
+        );
+    }
+
+    #[tokio::test]
+    async fn openapi_merges_scoped_prefix_path_params() {
+        use crate::openapi::{ApiDoc, OpenApiConfig};
+
+        // Scope prefix has `{org_id}`; the child route has `{id}`. The
+        // generated ApiDoc must declare BOTH parameters, or Swagger
+        // validators reject the document for referencing undeclared
+        // path params.
+        async fn handler() -> &'static str {
+            "ok"
+        }
+        let child = Route {
+            method: http::Method::GET,
+            path: "/users/{id}",
+            handler: axum::routing::get(handler),
+            name: "child",
+            api_doc: ApiDoc {
+                method: "GET",
+                path: "/users/{id}",
+                operation_id: "child",
+                path_params: &["id"],
+                success_status: 200,
+                ..Default::default()
+            },
+        };
+        let group = crate::app::ScopedGroup {
+            prefix: "/orgs/{org_id}".to_owned(),
+            routes: vec![child],
+            apply_layer: Box::new(|r| r),
+        };
+
+        let config = OpenApiConfig::new("Demo", "1.0.0");
+        let router =
+            super::build_openapi_router(&[], &[group], Some(&config)).expect("openapi sub-router");
+        let state = test_state();
+        let router = router.with_state(state);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/v3/api-docs")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let spec: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let params = &spec["paths"]["/orgs/{org_id}/users/{id}"]["get"]["parameters"];
+        let names: Vec<&str> = params
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p["name"].as_str().unwrap())
+            .collect();
+        assert!(names.contains(&"org_id"), "missing org_id: {names:?}");
+        assert!(names.contains(&"id"), "missing id: {names:?}");
     }
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -40,6 +40,16 @@ pub enum RouterBuildError {
         /// The name of the incoming user route.
         incoming: &'static str,
     },
+    /// An `OpenApiConfig` path (e.g. `openapi_json_path` or
+    /// `swagger_ui_path`) is not a valid route path (must start with `/`
+    /// and be non-empty).
+    #[error("invalid OpenAPI {field} path: {value:?} (must start with '/' and be non-empty)")]
+    InvalidOpenApiPath {
+        /// Which config field carried the invalid path.
+        field: &'static str,
+        /// The offending value from the user's config.
+        value: String,
+    },
 }
 
 /// Build the fully-configured Axum router from routes, config, and state.
@@ -194,7 +204,7 @@ pub fn try_build_router_inner(
     // Build the OpenAPI spec BEFORE moving the routes into axum, because
     // group_and_mount_routes consumes the Route list.
     let openapi_router =
-        build_openapi_router(&route_list, &ctx.scoped_groups, ctx.openapi.as_ref());
+        build_openapi_router(&route_list, &ctx.scoped_groups, ctx.openapi.as_ref())?;
 
     let mut router = group_and_mount_routes(route_list);
 
@@ -277,8 +287,18 @@ fn build_openapi_router(
     route_list: &[Route],
     scoped_groups: &[ScopedGroup],
     openapi_config: Option<&crate::openapi::OpenApiConfig>,
-) -> Option<axum::Router<AppState>> {
-    let config = openapi_config?;
+) -> Result<Option<axum::Router<AppState>>, RouterBuildError> {
+    let Some(config) = openapi_config else {
+        return Ok(None);
+    };
+
+    // Validate user-provided paths up front so a typo like
+    // `"openapi.json"` surfaces as a recoverable RouterBuildError
+    // rather than an axum panic (`Paths must start with a '/'`).
+    validate_route_path("openapi_json_path", &config.openapi_json_path)?;
+    if let Some(path) = &config.swagger_ui_path {
+        validate_route_path("swagger_ui_path", path)?;
+    }
 
     // Walk both top-level routes and scoped groups. For scoped groups the
     // effective path is `prefix + route.path`; we materialize these into
@@ -367,7 +387,18 @@ fn build_openapi_router(
         "Mounted OpenAPI endpoints"
     );
 
-    Some(router)
+    Ok(Some(router))
+}
+
+/// Shared validator for user-supplied route paths.
+fn validate_route_path(field: &'static str, value: &str) -> Result<(), RouterBuildError> {
+    if value.is_empty() || !value.starts_with('/') {
+        return Err(RouterBuildError::InvalidOpenApiPath {
+            field,
+            value: value.to_owned(),
+        });
+    }
+    Ok(())
 }
 
 fn group_and_mount_routes(route_list: Vec<Route>) -> axum::Router<AppState> {
@@ -1392,8 +1423,9 @@ mod tests {
         };
 
         let config = OpenApiConfig::new("Demo", "1.0.0");
-        let router =
-            super::build_openapi_router(&[], &[group], Some(&config)).expect("openapi sub-router");
+        let router = super::build_openapi_router(&[], &[group], Some(&config))
+            .expect("openapi sub-router builds")
+            .expect("openapi sub-router present when config is Some");
         let state = test_state();
         let router = router.with_state(state);
 
@@ -1420,5 +1452,53 @@ mod tests {
             .collect();
         assert!(names.contains(&"org_id"), "missing org_id: {names:?}");
         assert!(names.contains(&"id"), "missing id: {names:?}");
+    }
+
+    #[test]
+    fn openapi_rejects_json_path_without_leading_slash() {
+        let config =
+            crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("openapi.json");
+        let err = super::build_openapi_router(&[], &[], Some(&config))
+            .expect_err("non-slash path should be rejected");
+        assert!(matches!(
+            err,
+            RouterBuildError::InvalidOpenApiPath {
+                field: "openapi_json_path",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn openapi_rejects_swagger_ui_path_without_leading_slash() {
+        let config = crate::openapi::OpenApiConfig::new("Demo", "1.0.0")
+            .swagger_ui_path(Some("docs".to_owned()));
+        let err = super::build_openapi_router(&[], &[], Some(&config))
+            .expect_err("non-slash path should be rejected");
+        assert!(matches!(
+            err,
+            RouterBuildError::InvalidOpenApiPath {
+                field: "swagger_ui_path",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn openapi_rejects_empty_json_path() {
+        let config = crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("");
+        let err = super::build_openapi_router(&[], &[], Some(&config))
+            .expect_err("empty path should be rejected");
+        assert!(matches!(err, RouterBuildError::InvalidOpenApiPath { .. }));
+    }
+
+    #[test]
+    fn openapi_accepts_valid_paths() {
+        let config = crate::openapi::OpenApiConfig::new("Demo", "1.0.0")
+            .openapi_json_path("/api-docs")
+            .swagger_ui_path(Some("/ui".to_owned()));
+        let out = super::build_openapi_router(&[], &[], Some(&config))
+            .expect("valid paths must not error");
+        assert!(out.is_some());
     }
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -60,6 +60,17 @@ pub enum RouterBuildError {
         /// The path that both fields pointed at.
         path: String,
     },
+    /// An `OpenAPI` mount path overlaps with an existing `GET` handler,
+    /// which would panic at `axum::Router::merge` time.
+    #[error(
+        "OpenAPI {field} path {path:?} collides with an existing GET route; choose a different `OpenApiConfig::{field}`"
+    )]
+    OpenApiPathCollision {
+        /// Which config field carried the colliding path.
+        field: &'static str,
+        /// The colliding path.
+        path: String,
+    },
 }
 
 /// Build the fully-configured Axum router from routes, config, and state.
@@ -211,6 +222,16 @@ pub fn try_build_router_inner(
     state: AppState,
     ctx: RouterContext,
 ) -> Result<axum::Router, RouterBuildError> {
+    // Fail-fast if an OpenAPI mount path collides with a user or
+    // framework GET route — axum panics on overlapping method routes,
+    // so surface this as a recoverable error before we start merging.
+    reject_openapi_path_collisions(
+        ctx.openapi.as_ref(),
+        &route_list,
+        &ctx.scoped_groups,
+        config,
+    )?;
+
     // Build the OpenAPI spec BEFORE moving the routes into axum, because
     // group_and_mount_routes consumes the Route list.
     let openapi_router =
@@ -413,6 +434,72 @@ fn validate_route_path(field: &'static str, value: &str) -> Result<(), RouterBui
             field,
             value: value.to_owned(),
         });
+    }
+    Ok(())
+}
+
+/// Reject `OpenAPI` mount paths that overlap with an existing `GET`
+/// handler.
+///
+/// `axum::Router::merge` panics when the merged routers have method
+/// handlers on the same path (e.g. two `GET` handlers on
+/// `/v3/api-docs`). We surface that as a recoverable
+/// [`RouterBuildError::OpenApiPathCollision`] so misconfiguration
+/// produces an actionable error instead of a crash on startup.
+///
+/// We check against user routes (both top-level and scoped groups)
+/// plus the framework's probe/actuator/htmx endpoints that will be
+/// mounted before the `OpenAPI` sub-router merges in.
+fn reject_openapi_path_collisions(
+    openapi_config: Option<&crate::openapi::OpenApiConfig>,
+    route_list: &[Route],
+    scoped_groups: &[ScopedGroup],
+    config: &AutumnConfig,
+) -> Result<(), RouterBuildError> {
+    let Some(openapi) = openapi_config else {
+        return Ok(());
+    };
+
+    // Gather every path a GET will already own by the time we merge.
+    let mut claimed: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for route in route_list {
+        if route.method == http::Method::GET {
+            claimed.insert(route.path.to_owned());
+        }
+    }
+    for group in scoped_groups {
+        for route in &group.routes {
+            if route.method == http::Method::GET {
+                claimed.insert(format!("{}{}", group.prefix, route.path));
+            }
+        }
+    }
+    // Framework-mounted GETs.
+    claimed.insert(config.health.path.clone());
+    claimed.insert(config.health.live_path.clone());
+    claimed.insert(config.health.ready_path.clone());
+    claimed.insert(config.health.startup_path.clone());
+    for path in
+        crate::actuator::actuator_endpoint_paths(&config.actuator.prefix, config.actuator.sensitive)
+    {
+        claimed.insert(path);
+    }
+    #[cfg(feature = "htmx")]
+    claimed.insert("/static/js/htmx.min.js".to_owned());
+
+    if claimed.contains(&openapi.openapi_json_path) {
+        return Err(RouterBuildError::OpenApiPathCollision {
+            field: "openapi_json_path",
+            path: openapi.openapi_json_path.clone(),
+        });
+    }
+    if let Some(path) = &openapi.swagger_ui_path {
+        if claimed.contains(path) {
+            return Err(RouterBuildError::OpenApiPathCollision {
+                field: "swagger_ui_path",
+                path: path.clone(),
+            });
+        }
     }
     Ok(())
 }
@@ -1528,6 +1615,75 @@ mod tests {
         assert!(matches!(
             err,
             RouterBuildError::DuplicateOpenApiPath { ref path } if path == "/docs"
+        ));
+    }
+
+    async fn collision_test_handler() -> &'static str {
+        "user"
+    }
+
+    #[tokio::test]
+    async fn try_build_router_rejects_openapi_path_colliding_with_user_route() {
+        let mut config = AutumnConfig::default();
+        config.actuator.prefix = "/ops".to_owned();
+        let openapi =
+            crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("/my-api-docs");
+
+        let user_route = Route {
+            method: http::Method::GET,
+            path: "/my-api-docs",
+            handler: axum::routing::get(collision_test_handler),
+            name: "collides",
+            api_doc: crate::openapi::ApiDoc {
+                method: "GET",
+                path: "/my-api-docs",
+                operation_id: "collides",
+                success_status: 200,
+                ..Default::default()
+            },
+        };
+
+        let ctx = RouterContext {
+            exception_filters: Vec::new(),
+            scoped_groups: Vec::new(),
+            merge_routers: Vec::new(),
+            nest_routers: Vec::new(),
+            custom_layers: Vec::new(),
+            error_page_renderer: None,
+            session_store: None,
+            openapi: Some(openapi),
+        };
+        let err = super::try_build_router_inner(vec![user_route], &config, test_state(), ctx)
+            .expect_err("user-owned path should prevent OpenAPI mount");
+        assert!(matches!(
+            err,
+            RouterBuildError::OpenApiPathCollision { field: "openapi_json_path", ref path } if path == "/my-api-docs"
+        ));
+    }
+
+    #[tokio::test]
+    async fn try_build_router_rejects_openapi_path_colliding_with_framework_route() {
+        let config = AutumnConfig::default(); // /actuator/health is a GET by default
+        let openapi = crate::openapi::OpenApiConfig::new("Demo", "1.0.0")
+            .openapi_json_path("/actuator/health");
+        let ctx = RouterContext {
+            exception_filters: Vec::new(),
+            scoped_groups: Vec::new(),
+            merge_routers: Vec::new(),
+            nest_routers: Vec::new(),
+            custom_layers: Vec::new(),
+            error_page_renderer: None,
+            session_store: None,
+            openapi: Some(openapi),
+        };
+        let err = super::try_build_router_inner(Vec::new(), &config, test_state(), ctx)
+            .expect_err("framework-owned path should prevent OpenAPI mount");
+        assert!(matches!(
+            err,
+            RouterBuildError::OpenApiPathCollision {
+                field: "openapi_json_path",
+                ..
+            }
         ));
     }
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -43,6 +43,7 @@ pub enum RouterBuildError {
     /// An `OpenApiConfig` path (e.g. `openapi_json_path` or
     /// `swagger_ui_path`) is not a valid route path (must start with `/`
     /// and be non-empty).
+    #[cfg(feature = "openapi")]
     #[error("invalid OpenAPI {field} path: {value:?} (must start with '/' and be non-empty)")]
     InvalidOpenApiPath {
         /// Which config field carried the invalid path.
@@ -53,6 +54,7 @@ pub enum RouterBuildError {
     /// `openapi_json_path` and `swagger_ui_path` collide on the same
     /// URL. Mounting both would cause axum to panic on overlapping
     /// method routes at startup.
+    #[cfg(feature = "openapi")]
     #[error(
         "openapi_json_path and swagger_ui_path both resolve to {path:?}; they must differ or `swagger_ui_path` must be `None`"
     )]
@@ -62,6 +64,7 @@ pub enum RouterBuildError {
     },
     /// An `OpenAPI` mount path overlaps with an existing `GET` handler,
     /// which would panic at `axum::Router::merge` time.
+    #[cfg(feature = "openapi")]
     #[error(
         "OpenAPI {field} path {path:?} collides with an existing GET route; choose a different `OpenApiConfig::{field}`"
     )]
@@ -118,6 +121,9 @@ pub struct RouterContext {
     /// `OpenAPI` generation configuration. When `Some`, the router mounts
     /// an `openapi.json` endpoint and (optionally) a Swagger UI page
     /// describing the application's routes.
+    ///
+    /// Gated behind the `openapi` feature.
+    #[cfg(feature = "openapi")]
     pub openapi: Option<crate::openapi::OpenApiConfig>,
 }
 
@@ -146,6 +152,7 @@ pub fn try_build_router(
             custom_layers: Vec::new(),
             error_page_renderer: None,
             session_store: None,
+            #[cfg(feature = "openapi")]
             openapi: None,
         },
     )?;
@@ -206,6 +213,7 @@ pub fn try_build_router_merged(
             custom_layers: Vec::new(),
             error_page_renderer: None,
             session_store: None,
+            #[cfg(feature = "openapi")]
             openapi: None,
         },
     )?;
@@ -225,6 +233,7 @@ pub fn try_build_router_inner(
     // Fail-fast if an OpenAPI mount path collides with a user or
     // framework GET route — axum panics on overlapping method routes,
     // so surface this as a recoverable error before we start merging.
+    #[cfg(feature = "openapi")]
     reject_openapi_path_collisions(
         ctx.openapi.as_ref(),
         &route_list,
@@ -236,6 +245,7 @@ pub fn try_build_router_inner(
 
     // Build the OpenAPI spec BEFORE moving the routes into axum, because
     // group_and_mount_routes consumes the Route list.
+    #[cfg(feature = "openapi")]
     let openapi_router =
         build_openapi_router(&route_list, &ctx.scoped_groups, ctx.openapi.as_ref())?;
 
@@ -250,6 +260,7 @@ pub fn try_build_router_inner(
 
     router = mount_actuator_endpoints(router, config, &mounted_probe_paths)?;
 
+    #[cfg(feature = "openapi")]
     if let Some(openapi_router) = openapi_router {
         router = router.merge(openapi_router);
     }
@@ -287,6 +298,7 @@ pub fn try_build_router_inner(
 /// Mirrors the compile-time extractor in `autumn_macros::api_doc` so
 /// runtime spec assembly (which sees scope prefixes that the macro
 /// never does) produces consistent parameter lists.
+#[cfg(feature = "openapi")]
 fn extract_path_params(path: &str) -> Vec<String> {
     let mut out = Vec::new();
     let bytes = path.as_bytes();
@@ -316,6 +328,7 @@ fn extract_path_params(path: &str) -> Vec<String> {
 ///
 /// The spec is rendered once at build time and stored in an `Arc<String>`
 /// so the `/v3/api-docs` handler performs no serialization per request.
+#[cfg(feature = "openapi")]
 fn build_openapi_router(
     route_list: &[Route],
     scoped_groups: &[ScopedGroup],
@@ -356,8 +369,10 @@ fn build_openapi_router(
             let mut doc = route.api_doc.clone();
             // Leak the combined path so it fits the `&'static str` shape of
             // ApiDoc. The spec is built once per process; the leak is
-            // bounded by the route table size.
-            let full = format!("{}{}", group.prefix, route.api_doc.path);
+            // bounded by the route table size. Using the same
+            // normalization as `join_nested_path` keeps the spec's
+            // paths aligned with the URLs axum actually routes.
+            let full = join_nested_path(&group.prefix, route.api_doc.path);
             doc.path = Box::leak(full.into_boxed_str());
 
             if !prefix_params.is_empty() {
@@ -429,13 +444,88 @@ fn build_openapi_router(
     Ok(Some(router))
 }
 
-/// Shared validator for user-supplied route paths.
+/// Join a nest/scope prefix with a child route path, matching
+/// `axum::Router::nest` normalization.
+///
+/// `nest("/api", r)` mounts r's `/` at `/api` (not `/api/`), and any
+/// other child path `/foo` at `/api/foo`. The collision check and the
+/// path emitted into the `OpenAPI` spec must use the same shape or we
+/// end up either missing real collisions (the reviewer's case:
+/// `/api` + `/` recorded as `/api/` but axum routes it at `/api`) or
+/// generating a spec whose URLs don't match what axum serves.
+#[cfg(feature = "openapi")]
+fn join_nested_path(prefix: &str, child: &str) -> String {
+    let prefix_trimmed = prefix.trim_end_matches('/');
+    if child == "/" || child.is_empty() {
+        if prefix_trimmed.is_empty() {
+            "/".to_owned()
+        } else {
+            prefix_trimmed.to_owned()
+        }
+    } else if child.starts_with('/') {
+        format!("{prefix_trimmed}{child}")
+    } else {
+        format!("{prefix_trimmed}/{child}")
+    }
+}
+
+/// Shared validator for user-supplied `OpenAPI` mount paths.
+///
+/// Catches the common typos that would otherwise manifest as axum
+/// panics inside `Router::route` at startup:
+///
+/// * empty or missing leading slash,
+/// * unbalanced `{` / `}` pairs,
+/// * any `{…}` / `{*…}` capture or wildcard syntax (the mount points
+///   are static endpoints — a user that needs templated paths shouldn't
+///   be using this field), and
+/// * any `*` wildcard character (axum treats these as catch-alls).
+///
+/// The check intentionally stays conservative: rejecting a few valid-
+/// but-weird paths is far better than letting a typo like
+/// `"openapi.json"` or `"/docs/{id}"` crash boot.
+#[cfg(feature = "openapi")]
 fn validate_route_path(field: &'static str, value: &str) -> Result<(), RouterBuildError> {
-    if value.is_empty() || !value.starts_with('/') {
-        return Err(RouterBuildError::InvalidOpenApiPath {
+    let reject = |reason_fragment: &str| {
+        Err(RouterBuildError::InvalidOpenApiPath {
             field,
-            value: value.to_owned(),
-        });
+            value: format!("{value:?} {reason_fragment}"),
+        })
+    };
+
+    if value.is_empty() {
+        return reject("(must be non-empty)");
+    }
+    if !value.starts_with('/') {
+        return reject("(must start with '/')");
+    }
+    // Double-slash inside the path is almost always a typo (e.g.
+    // `//v3/api-docs`) and axum normalizes it away on match, so
+    // treating it as invalid avoids surprising "route can't be hit"
+    // reports in the field.
+    if value.contains("//") {
+        return reject("(must not contain '//')");
+    }
+
+    let mut depth: i32 = 0;
+    for ch in value.chars() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth < 0 {
+                    return reject("(unbalanced '}')");
+                }
+            }
+            '*' => return reject("(wildcard '*' is not allowed in an OpenAPI mount path)"),
+            _ => {}
+        }
+    }
+    if depth != 0 {
+        return reject("(unbalanced '{')");
+    }
+    if value.contains('{') {
+        return reject("(OpenAPI mount paths must be static; `{…}` captures are not allowed)");
     }
     Ok(())
 }
@@ -461,6 +551,7 @@ fn validate_route_path(field: &'static str, value: &str) -> Result<(), RouterBui
 /// cannot be introspected — axum does not expose their route table.
 /// We emit a `tracing::warn!` so operators know the check is
 /// incomplete in that case.
+#[cfg(feature = "openapi")]
 fn reject_openapi_path_collisions(
     openapi_config: Option<&crate::openapi::OpenApiConfig>,
     route_list: &[Route],
@@ -483,7 +574,7 @@ fn reject_openapi_path_collisions(
     for group in scoped_groups {
         for route in &group.routes {
             if route.method == http::Method::GET {
-                claimed.insert(format!("{}{}", group.prefix, route.path));
+                claimed.insert(join_nested_path(&group.prefix, route.path));
             }
         }
     }
@@ -538,6 +629,7 @@ fn reject_openapi_path_collisions(
 /// Evaluate a single `OpenAPI` path against the claimed-path set plus
 /// any nest prefixes. Returns an `OpenApiPathCollision` error on
 /// collision.
+#[cfg(feature = "openapi")]
 fn check_openapi_path_against(
     field: &'static str,
     path: &str,
@@ -937,6 +1029,7 @@ pub fn try_build_router_with_static(
             custom_layers: Vec::new(),
             error_page_renderer: None,
             session_store: None,
+            #[cfg(feature = "openapi")]
             openapi: None,
         },
     )
@@ -1544,6 +1637,78 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "openapi")]
+    #[test]
+    fn join_nested_path_normalizes_like_axum() {
+        // Reviewer's reported case: scope "/api" + child "/" must
+        // produce "/api", not "/api/" — otherwise a user-configured
+        // openapi_json_path("/api") won't match the effective mount
+        // point and the collision check is unreliable.
+        assert_eq!(super::join_nested_path("/api", "/"), "/api");
+        // Trailing slash on prefix is stripped.
+        assert_eq!(super::join_nested_path("/api/", "/"), "/api");
+        // Normal case: prefix + child.
+        assert_eq!(super::join_nested_path("/api", "/users"), "/api/users");
+        // Trailing slash on prefix + child starting with slash doesn't
+        // produce doubled slashes.
+        assert_eq!(super::join_nested_path("/api/", "/users"), "/api/users");
+        // Root prefix handles sensibly.
+        assert_eq!(super::join_nested_path("", "/"), "/");
+        assert_eq!(super::join_nested_path("", "/users"), "/users");
+    }
+
+    #[cfg(feature = "openapi")]
+    #[tokio::test]
+    async fn try_build_router_detects_scoped_root_collision() {
+        // Scope "/api" + child "/" mounts axum's handler at "/api"
+        // (not "/api/"). The collision check must use the same
+        // normalization or we'd miss this overlap.
+        use crate::openapi::{ApiDoc, OpenApiConfig};
+        async fn child() -> &'static str {
+            "inner"
+        }
+        let group = crate::app::ScopedGroup {
+            prefix: "/api".to_owned(),
+            routes: vec![Route {
+                method: http::Method::GET,
+                path: "/",
+                handler: axum::routing::get(child),
+                name: "root",
+                api_doc: ApiDoc {
+                    method: "GET",
+                    path: "/",
+                    operation_id: "root",
+                    success_status: 200,
+                    ..Default::default()
+                },
+            }],
+            apply_layer: Box::new(|r| r),
+        };
+
+        let openapi = OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("/api");
+        let config = AutumnConfig::default();
+        let ctx = RouterContext {
+            exception_filters: Vec::new(),
+            scoped_groups: vec![group],
+            merge_routers: Vec::new(),
+            nest_routers: Vec::new(),
+            custom_layers: Vec::new(),
+            error_page_renderer: None,
+            session_store: None,
+            openapi: Some(openapi),
+        };
+        let err = super::try_build_router_inner(Vec::new(), &config, test_state(), ctx)
+            .expect_err("scope '/api' + child '/' should collide with openapi path '/api'");
+        assert!(matches!(
+            err,
+            RouterBuildError::OpenApiPathCollision {
+                field: "openapi_json_path",
+                ..
+            }
+        ));
+    }
+
+    #[cfg(feature = "openapi")]
     #[test]
     fn extract_path_params_matches_macro_behavior() {
         assert_eq!(
@@ -1557,6 +1722,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "openapi")]
     #[tokio::test]
     async fn openapi_merges_scoped_prefix_path_params() {
         use crate::openapi::{ApiDoc, OpenApiConfig};
@@ -1620,6 +1786,7 @@ mod tests {
         assert!(names.contains(&"id"), "missing id: {names:?}");
     }
 
+    #[cfg(feature = "openapi")]
     #[test]
     fn openapi_rejects_json_path_without_leading_slash() {
         let config =
@@ -1635,6 +1802,49 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "openapi")]
+    #[test]
+    fn openapi_rejects_path_with_captures() {
+        // `{id}` captures would be a typo for a mount path — the
+        // endpoints are static. Catch it before axum panics.
+        let config =
+            crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("/docs/{id}");
+        let err = super::build_openapi_router(&[], &[], Some(&config))
+            .expect_err("captures should be rejected");
+        assert!(matches!(err, RouterBuildError::InvalidOpenApiPath { .. }));
+    }
+
+    #[cfg(feature = "openapi")]
+    #[test]
+    fn openapi_rejects_path_with_unbalanced_brace() {
+        let config =
+            crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("/docs/{id");
+        let err = super::build_openapi_router(&[], &[], Some(&config))
+            .expect_err("unbalanced brace should be rejected");
+        assert!(matches!(err, RouterBuildError::InvalidOpenApiPath { .. }));
+    }
+
+    #[cfg(feature = "openapi")]
+    #[test]
+    fn openapi_rejects_path_with_wildcard() {
+        let config =
+            crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("/docs/*rest");
+        let err = super::build_openapi_router(&[], &[], Some(&config))
+            .expect_err("wildcard should be rejected");
+        assert!(matches!(err, RouterBuildError::InvalidOpenApiPath { .. }));
+    }
+
+    #[cfg(feature = "openapi")]
+    #[test]
+    fn openapi_rejects_path_with_double_slash() {
+        let config =
+            crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("//docs");
+        let err = super::build_openapi_router(&[], &[], Some(&config))
+            .expect_err("double-slash should be rejected");
+        assert!(matches!(err, RouterBuildError::InvalidOpenApiPath { .. }));
+    }
+
+    #[cfg(feature = "openapi")]
     #[test]
     fn openapi_rejects_swagger_ui_path_without_leading_slash() {
         let config = crate::openapi::OpenApiConfig::new("Demo", "1.0.0")
@@ -1650,6 +1860,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "openapi")]
     #[test]
     fn openapi_rejects_empty_json_path() {
         let config = crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("");
@@ -1658,6 +1869,7 @@ mod tests {
         assert!(matches!(err, RouterBuildError::InvalidOpenApiPath { .. }));
     }
 
+    #[cfg(feature = "openapi")]
     #[test]
     fn openapi_accepts_valid_paths() {
         let config = crate::openapi::OpenApiConfig::new("Demo", "1.0.0")
@@ -1668,6 +1880,7 @@ mod tests {
         assert!(out.is_some());
     }
 
+    #[cfg(feature = "openapi")]
     #[test]
     fn openapi_rejects_duplicate_json_and_swagger_paths() {
         let config = crate::openapi::OpenApiConfig::new("Demo", "1.0.0")
@@ -1681,10 +1894,12 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "openapi")]
     async fn collision_test_handler() -> &'static str {
         "user"
     }
 
+    #[cfg(feature = "openapi")]
     #[tokio::test]
     async fn try_build_router_rejects_openapi_path_colliding_with_user_route() {
         let mut config = AutumnConfig::default();
@@ -1724,6 +1939,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "openapi")]
     #[tokio::test]
     async fn try_build_router_rejects_openapi_path_colliding_with_framework_route() {
         let config = AutumnConfig::default(); // /actuator/health is a GET by default
@@ -1750,6 +1966,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "openapi")]
     #[tokio::test]
     async fn try_build_router_rejects_openapi_path_under_nest_prefix() {
         // Nesting `/api` means that router owns everything under
@@ -1782,6 +1999,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "openapi")]
     #[test]
     fn try_build_router_rejects_openapi_path_on_dev_live_reload() {
         temp_env::with_vars(

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -133,7 +133,7 @@ impl TestApp {
         }
     }
 
-    /// Enable OpenAPI spec generation for the test app.
+    /// Enable `OpenAPI` spec generation for the test app.
     ///
     /// Mirrors [`crate::app::AppBuilder::openapi`] so integration tests
     /// can exercise the `/v3/api-docs` and `/swagger-ui` endpoints.

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -107,6 +107,7 @@ pub struct TestApp {
     nest_routers: Vec<(String, axum::Router<crate::state::AppState>)>,
     custom_layers: Vec<crate::app::CustomLayerApplier>,
     config: AutumnConfig,
+    openapi: Option<crate::openapi::OpenApiConfig>,
     #[cfg(feature = "db")]
     pool: Option<Pool<AsyncPgConnection>>,
 }
@@ -126,9 +127,20 @@ impl TestApp {
             nest_routers: Vec::new(),
             custom_layers: Vec::new(),
             config,
+            openapi: None,
             #[cfg(feature = "db")]
             pool: None,
         }
+    }
+
+    /// Enable OpenAPI spec generation for the test app.
+    ///
+    /// Mirrors [`crate::app::AppBuilder::openapi`] so integration tests
+    /// can exercise the `/v3/api-docs` and `/swagger-ui` endpoints.
+    #[must_use]
+    pub fn openapi(mut self, config: crate::openapi::OpenApiConfig) -> Self {
+        self.openapi = Some(config);
+        self
     }
 
     /// Merge a router into the internal application state.
@@ -238,6 +250,7 @@ impl TestApp {
                 custom_layers: self.custom_layers,
                 error_page_renderer: None,
                 session_store: None,
+                openapi: self.openapi,
             },
         )
         .unwrap();
@@ -733,18 +746,39 @@ mod tests {
                 path: "/hello",
                 handler: routing::get(hello),
                 name: "hello",
+                api_doc: crate::openapi::ApiDoc {
+                    method: "GET",
+                    path: "/hello",
+                    operation_id: "hello",
+                    success_status: 200,
+                    ..Default::default()
+                },
             },
             Route {
                 method: Method::POST,
                 path: "/echo",
                 handler: routing::post(echo_json),
                 name: "echo",
+                api_doc: crate::openapi::ApiDoc {
+                    method: "POST",
+                    path: "/echo",
+                    operation_id: "echo",
+                    success_status: 200,
+                    ..Default::default()
+                },
             },
             Route {
                 method: Method::POST,
                 path: "/create",
                 handler: routing::post(status_201),
                 name: "create",
+                api_doc: crate::openapi::ApiDoc {
+                    method: "POST",
+                    path: "/create",
+                    operation_id: "create",
+                    success_status: 201,
+                    ..Default::default()
+                },
             },
         ]
     }

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -107,6 +107,7 @@ pub struct TestApp {
     nest_routers: Vec<(String, axum::Router<crate::state::AppState>)>,
     custom_layers: Vec<crate::app::CustomLayerRegistration>,
     config: AutumnConfig,
+    #[cfg(feature = "openapi")]
     openapi: Option<crate::openapi::OpenApiConfig>,
     #[cfg(feature = "db")]
     pool: Option<Pool<AsyncPgConnection>>,
@@ -127,6 +128,7 @@ impl TestApp {
             nest_routers: Vec::new(),
             custom_layers: Vec::new(),
             config,
+            #[cfg(feature = "openapi")]
             openapi: None,
             #[cfg(feature = "db")]
             pool: None,
@@ -137,6 +139,9 @@ impl TestApp {
     ///
     /// Mirrors [`crate::app::AppBuilder::openapi`] so integration tests
     /// can exercise the `/v3/api-docs` and `/swagger-ui` endpoints.
+    ///
+    /// Gated behind the `openapi` Cargo feature.
+    #[cfg(feature = "openapi")]
     #[must_use]
     pub fn openapi(mut self, config: crate::openapi::OpenApiConfig) -> Self {
         self.openapi = Some(config);
@@ -253,6 +258,7 @@ impl TestApp {
                 custom_layers: self.custom_layers,
                 error_page_renderer: None,
                 session_store: None,
+                #[cfg(feature = "openapi")]
                 openapi: self.openapi,
             },
         )

--- a/autumn/tests/openapi.rs
+++ b/autumn/tests/openapi.rs
@@ -50,6 +50,28 @@ async fn tagged() -> &'static str {
     "tagged"
 }
 
+// Exercise the *reversed* attribute order: `#[api_doc]` above `#[get]`.
+// Rust expands `#[api_doc]` first; the standalone macro must reorder
+// so the route macro still sees the overrides.
+#[api_doc(summary = "Top-first api_doc", tag = "top")]
+#[get("/top-first")]
+async fn top_first() -> &'static str {
+    "top"
+}
+
+#[api_doc(hidden)]
+#[post("/top-hidden")]
+async fn top_hidden() -> &'static str {
+    "hidden"
+}
+
+// Responses wrapped in `(StatusCode, Json<T>)` — common for 201 Created
+// handlers — should still be inferred.
+#[post("/things")]
+async fn create_thing() -> (http::StatusCode, axum::Json<serde_json::Value>) {
+    (http::StatusCode::CREATED, axum::Json(serde_json::json!({})))
+}
+
 #[test]
 fn get_macro_populates_api_doc() {
     let route = __autumn_route_info_hello();
@@ -115,6 +137,35 @@ fn api_doc_attribute_accepts_tag_list() {
     let route = __autumn_route_info_tagged();
     assert_eq!(route.api_doc.tags, &["users", "auth"]);
     assert_eq!(route.api_doc.description, Some("Multi-tagged route"));
+}
+
+#[test]
+fn api_doc_survives_when_placed_above_route_attribute() {
+    let route = __autumn_route_info_top_first();
+    assert_eq!(
+        route.api_doc.summary,
+        Some("Top-first api_doc"),
+        "`#[api_doc]` above `#[get]` must not be dropped"
+    );
+    assert_eq!(route.api_doc.tags, &["top"]);
+}
+
+#[test]
+fn api_doc_hidden_survives_when_placed_above_route_attribute() {
+    let route = __autumn_route_info_top_hidden();
+    assert!(route.api_doc.hidden);
+}
+
+#[test]
+fn status_tuple_response_is_inferred_as_json() {
+    let route = __autumn_route_info_create_thing();
+    let resp = route
+        .api_doc
+        .response
+        .as_ref()
+        .expect("(StatusCode, Json<T>) should be inferred");
+    assert_eq!(resp.name, "Value");
+    assert_eq!(resp.kind, SchemaKind::Ref);
 }
 
 // ── Spec generation pipeline ───────────────────────────────────────

--- a/autumn/tests/openapi.rs
+++ b/autumn/tests/openapi.rs
@@ -72,6 +72,32 @@ async fn create_thing() -> (http::StatusCode, axum::Json<serde_json::Value>) {
     (http::StatusCode::CREATED, axum::Json(serde_json::json!({})))
 }
 
+// Qualified form: `#[api_doc(...)]` on top, `#[autumn_web::get(...)]`
+// qualified below. The reorder helper must recognize the qualified
+// path via its last segment so the overrides still flow through.
+#[api_doc(summary = "Fully-qualified get")]
+#[autumn_web::get("/qualified")]
+async fn qualified_get() -> &'static str {
+    "ok"
+}
+
+// `Json<Vec<T>>` — the generator must emit an array schema rather
+// than collapsing to a `$ref` to `Vec`.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Widget {
+    id: i32,
+}
+
+#[get("/widgets")]
+async fn list_widgets() -> axum::Json<Vec<Widget>> {
+    axum::Json(vec![])
+}
+
+#[post("/widgets")]
+async fn post_widgets(axum::Json(_body): axum::Json<Vec<Widget>>) -> http::StatusCode {
+    http::StatusCode::OK
+}
+
 #[test]
 fn get_macro_populates_api_doc() {
     let route = __autumn_route_info_hello();
@@ -166,6 +192,53 @@ fn status_tuple_response_is_inferred_as_json() {
         .expect("(StatusCode, Json<T>) should be inferred");
     assert_eq!(resp.name, "Value");
     assert_eq!(resp.kind, SchemaKind::Ref);
+}
+
+#[test]
+fn api_doc_survives_above_qualified_route_attribute() {
+    let route = __autumn_route_info_qualified_get();
+    assert_eq!(
+        route.api_doc.summary,
+        Some("Fully-qualified get"),
+        "qualified route attr should still be detected by the reorder helper"
+    );
+}
+
+#[test]
+fn json_vec_response_is_emitted_as_array_schema() {
+    let route = __autumn_route_info_list_widgets();
+    let resp = route
+        .api_doc
+        .response
+        .as_ref()
+        .expect("Json<Vec<T>> must infer a response");
+    assert!(
+        matches!(resp.kind, SchemaKind::Array(_)),
+        "Json<Vec<T>> must become Array, got {:?}",
+        resp.kind
+    );
+
+    // Render through the spec generator to confirm the actual JSON.
+    let config = OpenApiConfig::new("Demo", "1.0.0");
+    let spec = autumn_web::openapi::generate_spec(&config, &[&route.api_doc]);
+    let media =
+        &spec.paths["/widgets"].get.as_ref().unwrap().responses["200"].content["application/json"];
+    assert_eq!(media.schema["type"], "array");
+    assert_eq!(
+        media.schema["items"]["$ref"], "#/components/schemas/Widget",
+        "array items must still ref the element type"
+    );
+}
+
+#[test]
+fn json_vec_request_body_is_emitted_as_array_schema() {
+    let route = __autumn_route_info_post_widgets();
+    let body = route
+        .api_doc
+        .request_body
+        .as_ref()
+        .expect("Json<Vec<T>> request body must infer");
+    assert!(matches!(body.kind, SchemaKind::Array(_)));
 }
 
 // ── Spec generation pipeline ───────────────────────────────────────

--- a/autumn/tests/openapi.rs
+++ b/autumn/tests/openapi.rs
@@ -1,0 +1,226 @@
+//! Integration tests for OpenAPI auto-generation (S-056).
+//!
+//! Covers:
+//! * Route macros emit the expected `ApiDoc` metadata.
+//! * `#[api_doc(...)]` overrides flow through to the generated spec.
+//! * `AppBuilder::openapi(...)` mounts `/v3/api-docs` and `/swagger-ui`.
+
+use autumn_web::Route;
+use autumn_web::openapi::{ApiDoc, OpenApiConfig, SchemaKind};
+use autumn_web::prelude::*;
+use autumn_web::test::TestApp;
+
+// ── Route-level metadata extraction ────────────────────────────────
+
+#[get("/hello")]
+async fn hello() -> &'static str {
+    "hi"
+}
+
+#[get("/users/{id}")]
+async fn get_user(Path(id): Path<i32>) -> String {
+    format!("User {id}")
+}
+
+#[get("/posts/{year}/{slug}")]
+async fn get_post(_params: Path<(i32, String)>) -> &'static str {
+    "post"
+}
+
+#[post("/items")]
+async fn create_item(Json(body): Json<serde_json::Value>) -> axum::Json<serde_json::Value> {
+    axum::Json(body)
+}
+
+#[get("/admin")]
+#[api_doc(summary = "Admin area", tag = "admin", status = 201)]
+async fn admin() -> &'static str {
+    "admin"
+}
+
+#[get("/hidden")]
+#[api_doc(hidden)]
+async fn hidden_route() -> &'static str {
+    "hidden"
+}
+
+#[get("/tagged")]
+#[api_doc(tags = ["users", "auth"], description = "Multi-tagged route")]
+async fn tagged() -> &'static str {
+    "tagged"
+}
+
+#[test]
+fn get_macro_populates_api_doc() {
+    let route = __autumn_route_info_hello();
+    assert_eq!(route.api_doc.method, "GET");
+    assert_eq!(route.api_doc.path, "/hello");
+    assert_eq!(route.api_doc.operation_id, "hello");
+    assert_eq!(route.api_doc.success_status, 200);
+    assert!(!route.api_doc.hidden);
+    assert!(route.api_doc.path_params.is_empty());
+}
+
+#[test]
+fn path_parameters_are_extracted() {
+    let route = __autumn_route_info_get_user();
+    assert_eq!(route.api_doc.path_params, &["id"]);
+}
+
+#[test]
+fn multiple_path_parameters_are_extracted() {
+    let route = __autumn_route_info_get_post();
+    assert_eq!(route.api_doc.path_params, &["year", "slug"]);
+}
+
+#[test]
+fn json_request_body_is_inferred() {
+    let route = __autumn_route_info_create_item();
+    let body = route
+        .api_doc
+        .request_body
+        .as_ref()
+        .expect("Json<...> body should be inferred");
+    assert_eq!(body.name, "Value");
+    assert_eq!(body.kind, SchemaKind::Ref);
+}
+
+#[test]
+fn json_response_is_inferred() {
+    let route = __autumn_route_info_create_item();
+    let resp = route
+        .api_doc
+        .response
+        .as_ref()
+        .expect("Json<...> return should be inferred");
+    assert_eq!(resp.name, "Value");
+}
+
+#[test]
+fn api_doc_attribute_applies_summary_and_tag() {
+    let route = __autumn_route_info_admin();
+    assert_eq!(route.api_doc.summary, Some("Admin area"));
+    assert_eq!(route.api_doc.tags, &["admin"]);
+    assert_eq!(route.api_doc.success_status, 201);
+}
+
+#[test]
+fn api_doc_attribute_can_hide_route() {
+    let route = __autumn_route_info_hidden_route();
+    assert!(route.api_doc.hidden);
+}
+
+#[test]
+fn api_doc_attribute_accepts_tag_list() {
+    let route = __autumn_route_info_tagged();
+    assert_eq!(route.api_doc.tags, &["users", "auth"]);
+    assert_eq!(route.api_doc.description, Some("Multi-tagged route"));
+}
+
+// ── Spec generation pipeline ───────────────────────────────────────
+
+#[test]
+fn generate_spec_emits_paths_for_every_method() {
+    let routes: Vec<Route> = routes![hello, get_user, create_item, admin, hidden_route];
+    let docs: Vec<&ApiDoc> = routes.iter().map(|r| &r.api_doc).collect();
+    let config = OpenApiConfig::new("Test API", "0.1.0");
+    let spec = autumn_web::openapi::generate_spec(&config, &docs);
+
+    assert_eq!(spec.info.title, "Test API");
+    assert_eq!(spec.info.version, "0.1.0");
+    assert!(spec.paths.contains_key("/hello"));
+    assert!(spec.paths.contains_key("/users/{id}"));
+    assert!(spec.paths.contains_key("/items"));
+    assert!(spec.paths.contains_key("/admin"));
+    assert!(
+        !spec.paths.contains_key("/hidden"),
+        "`#[api_doc(hidden)]` should exclude routes"
+    );
+
+    // Admin returned a 201
+    let admin_op = spec.paths["/admin"].get.as_ref().unwrap();
+    assert!(admin_op.responses.contains_key("201"));
+    assert_eq!(admin_op.summary.as_deref(), Some("Admin area"));
+
+    // Path parameter surfaced
+    let user_op = spec.paths["/users/{id}"].get.as_ref().unwrap();
+    assert_eq!(user_op.parameters.len(), 1);
+    assert_eq!(user_op.parameters[0].name, "id");
+}
+
+// ── Endpoint integration ──────────────────────────────────────────
+
+#[tokio::test]
+async fn openapi_json_endpoint_returns_spec() {
+    let client = TestApp::new()
+        .routes(routes![hello, get_user])
+        .openapi(OpenApiConfig::new("Demo", "1.0.0"))
+        .build();
+
+    let response = client.get("/v3/api-docs").send().await;
+    response.assert_ok();
+
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["openapi"], "3.0.3");
+    assert_eq!(body["info"]["title"], "Demo");
+    assert!(body["paths"]["/hello"].is_object());
+    assert!(body["paths"]["/users/{id}"].is_object());
+}
+
+#[tokio::test]
+async fn swagger_ui_endpoint_returns_html_referencing_spec_url() {
+    let client = TestApp::new()
+        .routes(routes![hello])
+        .openapi(OpenApiConfig::new("Demo", "1.0.0"))
+        .build();
+
+    let response = client.get("/swagger-ui").send().await;
+    response.assert_ok();
+
+    let body = response.text();
+    assert!(body.contains("SwaggerUIBundle"));
+    assert!(body.contains("/v3/api-docs"));
+}
+
+#[tokio::test]
+async fn openapi_not_mounted_without_explicit_call() {
+    let client = TestApp::new().routes(routes![hello]).build();
+    let response = client.get("/v3/api-docs").send().await;
+    assert_eq!(
+        response.status,
+        http::StatusCode::NOT_FOUND,
+        "/v3/api-docs should 404 until AppBuilder::openapi(...) is called"
+    );
+}
+
+#[tokio::test]
+async fn custom_openapi_paths_are_honored() {
+    let config = OpenApiConfig::new("Demo", "1.0.0")
+        .openapi_json_path("/openapi.json")
+        .swagger_ui_path(Some("/docs".to_owned()));
+
+    let client = TestApp::new()
+        .routes(routes![hello])
+        .openapi(config)
+        .build();
+
+    client.get("/openapi.json").send().await.assert_ok();
+    client.get("/docs").send().await.assert_ok();
+
+    // The default paths should now return 404
+    let default_json = client.get("/v3/api-docs").send().await;
+    assert_eq!(default_json.status, http::StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn swagger_ui_can_be_disabled() {
+    let config = OpenApiConfig::new("Demo", "1.0.0").swagger_ui_path(None);
+    let client = TestApp::new()
+        .routes(routes![hello])
+        .openapi(config)
+        .build();
+
+    client.get("/v3/api-docs").send().await.assert_ok();
+    let ui = client.get("/swagger-ui").send().await;
+    assert_eq!(ui.status, http::StatusCode::NOT_FOUND);
+}

--- a/autumn/tests/openapi.rs
+++ b/autumn/tests/openapi.rs
@@ -5,6 +5,8 @@
 //! * `#[api_doc(...)]` overrides flow through to the generated spec.
 //! * `AppBuilder::openapi(...)` mounts `/v3/api-docs` and `/swagger-ui`.
 
+#![cfg(feature = "openapi")]
+
 use autumn_web::Route;
 use autumn_web::openapi::{ApiDoc, OpenApiConfig, SchemaKind};
 use autumn_web::prelude::*;

--- a/autumn/tests/openapi.rs
+++ b/autumn/tests/openapi.rs
@@ -1,4 +1,4 @@
-//! Integration tests for OpenAPI auto-generation (S-056).
+//! Integration tests for `OpenAPI` auto-generation (S-056).
 //!
 //! Covers:
 //! * Route macros emit the expected `ApiDoc` metadata.

--- a/autumn/tests/openapi.rs
+++ b/autumn/tests/openapi.rs
@@ -100,6 +100,22 @@ async fn post_widgets(axum::Json(_body): axum::Json<Vec<Widget>>) -> http::Statu
     http::StatusCode::OK
 }
 
+// `Valid<Json<T>>` is Autumn's documented validation pattern. The
+// generator must see straight through the wrapper so the resulting
+// spec still reports a request body.
+#[derive(serde::Deserialize, serde::Serialize, validator::Validate)]
+struct NewWidget {
+    #[validate(length(min = 1))]
+    name: String,
+}
+
+#[post("/validated-widgets")]
+async fn create_validated_widget(
+    _body: autumn_web::Valid<autumn_web::Json<NewWidget>>,
+) -> http::StatusCode {
+    http::StatusCode::CREATED
+}
+
 #[test]
 fn get_macro_populates_api_doc() {
     let route = __autumn_route_info_hello();
@@ -241,6 +257,18 @@ fn json_vec_request_body_is_emitted_as_array_schema() {
         .as_ref()
         .expect("Json<Vec<T>> request body must infer");
     assert!(matches!(body.kind, SchemaKind::Array(_)));
+}
+
+#[test]
+fn valid_json_request_body_is_inferred() {
+    let route = __autumn_route_info_create_validated_widget();
+    let body = route
+        .api_doc
+        .request_body
+        .as_ref()
+        .expect("Valid<Json<T>> request body should be inferred");
+    assert_eq!(body.name, "NewWidget");
+    assert_eq!(body.kind, SchemaKind::Ref);
 }
 
 // ── Spec generation pipeline ───────────────────────────────────────

--- a/autumn/tests/repository_openapi.rs
+++ b/autumn/tests/repository_openapi.rs
@@ -1,0 +1,102 @@
+//! Integration tests for `#[repository]` CRUD routes' `OpenAPI` metadata.
+//!
+//! The repository macro auto-generates five HTTP handlers (list, get,
+//! create, update, delete) when `api = "/path"` is supplied. This test
+//! pins their `ApiDoc` shape so the generated spec accurately reflects
+//! the JSON request/response bodies that Autumn mounts.
+
+#![cfg(feature = "db")]
+
+use autumn_web::openapi::SchemaKind;
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        widgets (id) {
+            id -> Int8,
+            name -> Text,
+        }
+    }
+}
+
+use schema::widgets;
+
+#[autumn_web::model]
+pub struct Widget {
+    #[id]
+    pub id: i64,
+    pub name: String,
+}
+
+#[autumn_web::repository(Widget, api = "/api/widgets")]
+pub trait WidgetRepository {}
+
+#[test]
+fn list_route_returns_array_of_widget() {
+    let route = __autumn_route_info_widget_api_list();
+    assert_eq!(route.api_doc.method, "GET");
+    assert_eq!(route.api_doc.path, "/api/widgets");
+    assert_eq!(route.api_doc.success_status, 200);
+    let resp = route
+        .api_doc
+        .response
+        .as_ref()
+        .expect("list must document its JSON response");
+    let inner = match resp.kind {
+        SchemaKind::Array(e) => e,
+        other => panic!("list should emit Array, got {other:?}"),
+    };
+    assert_eq!(inner.name, "Widget");
+    assert_eq!(inner.kind, SchemaKind::Ref);
+}
+
+#[test]
+fn get_route_returns_single_widget_ref() {
+    let route = __autumn_route_info_widget_api_get();
+    assert_eq!(route.api_doc.method, "GET");
+    assert_eq!(route.api_doc.path_params, &["id"]);
+    let resp = route.api_doc.response.as_ref().expect("get response");
+    assert_eq!(resp.name, "Widget");
+    assert_eq!(resp.kind, SchemaKind::Ref);
+    assert!(route.api_doc.request_body.is_none());
+}
+
+#[test]
+fn create_route_takes_new_widget_returns_widget() {
+    let route = __autumn_route_info_widget_api_create();
+    assert_eq!(route.api_doc.method, "POST");
+    assert_eq!(route.api_doc.success_status, 201);
+    let body = route
+        .api_doc
+        .request_body
+        .as_ref()
+        .expect("create must document a request body");
+    assert_eq!(body.name, "NewWidget");
+    assert_eq!(body.kind, SchemaKind::Ref);
+    let resp = route.api_doc.response.as_ref().expect("create response");
+    assert_eq!(resp.name, "Widget");
+}
+
+#[test]
+fn update_route_takes_update_widget_and_id() {
+    let route = __autumn_route_info_widget_api_update();
+    assert_eq!(route.api_doc.method, "PUT");
+    assert_eq!(route.api_doc.path_params, &["id"]);
+    let body = route
+        .api_doc
+        .request_body
+        .as_ref()
+        .expect("update must document a request body");
+    assert_eq!(body.name, "UpdateWidget");
+    let resp = route.api_doc.response.as_ref().expect("update response");
+    assert_eq!(resp.name, "Widget");
+}
+
+#[test]
+fn delete_route_has_no_body_and_uses_204() {
+    let route = __autumn_route_info_widget_api_delete();
+    assert_eq!(route.api_doc.method, "DELETE");
+    assert_eq!(route.api_doc.path_params, &["id"]);
+    assert_eq!(route.api_doc.success_status, 204);
+    assert!(route.api_doc.request_body.is_none());
+    assert!(route.api_doc.response.is_none());
+}

--- a/autumn/tests/repository_openapi.rs
+++ b/autumn/tests/repository_openapi.rs
@@ -5,7 +5,7 @@
 //! pins their `ApiDoc` shape so the generated spec accurately reflects
 //! the JSON request/response bodies that Autumn mounts.
 
-#![cfg(feature = "db")]
+#![cfg(all(feature = "db", feature = "openapi"))]
 
 use autumn_web::openapi::SchemaKind;
 


### PR DESCRIPTION
## Summary

This PR implements automatic OpenAPI 3.0 specification generation from Autumn's annotated routes. The framework now infers API documentation from route paths, HTTP methods, extractor types, and optional `#[api_doc(...)]` attributes, serving both a machine-readable JSON spec and an interactive Swagger UI.

## Key Changes

- **New `openapi` module** (`autumn/src/openapi.rs`): Core OpenAPI generation logic including:
  - `ApiDoc` struct capturing route metadata (method, path, parameters, request/response schemas)
  - `OpenApiConfig` for user-facing configuration (title, version, paths, custom schemas)
  - `OpenApiSchema` trait for types to define their JSON schemas
  - `SchemaRegistry` for accumulating component schemas at runtime
  - `generate_spec()` function that builds an OpenAPI 3.0 document from routes
  - Swagger UI HTML generation using unpkg CDN

- **New `#[api_doc(...)]` attribute** (`autumn-macros/src/api_doc.rs`): Allows enriching auto-generated docs with:
  - `summary` and `description` fields
  - `tag` / `tags` for grouping operations
  - `operation_id` override
  - `status` for custom success HTTP codes
  - `hidden` flag to exclude routes from the spec

- **Route macro integration** (`autumn-macros/src/route.rs`): Route macros now:
  - Extract path parameters from URL templates (e.g., `{id}` from `/users/{id}`)
  - Infer request body schemas from `Json<T>` extractors
  - Infer response schemas from `Json<T>` return types
  - Parse and embed `#[api_doc(...)]` metadata into generated `ApiDoc` structs
  - Emit `__autumn_route_info_{name}()` functions carrying `ApiDoc` metadata

- **AppBuilder integration** (`autumn/src/app.rs`): New `.openapi(config)` method to enable spec generation

- **Router integration** (`autumn/src/router.rs`): 
  - `build_openapi_router()` function that mounts `/v3/api-docs` (JSON) and `/swagger-ui` (HTML) endpoints
  - Spec is rendered once at build time and cached in an `Arc<String>` for zero-cost serving

- **Test support** (`autumn/src/test.rs`): `TestApp::openapi()` method for integration testing

- **Repository macro updates** (`autumn-macros/src/repository.rs`): Generated CRUD routes now include `ApiDoc` metadata

- **WebSocket & static route support** (`autumn-macros/src/ws.rs`, `autumn-macros/src/static_route.rs`): Path parameter extraction for these route types

- **Comprehensive tests** (`autumn/tests/openapi.rs`): 226 lines of integration tests covering metadata extraction, spec generation, and endpoint serving

## Notable Implementation Details

- Path parameters are extracted at compile time from route templates using regex-like parsing
- Request/response body inference works with `Json<T>`, `Result<Json<T>, _>`, and `AutumnResult<Json<T>>` patterns
- Primitive types (bool, string, integers, floats) have built-in `OpenApiSchema` implementations
- The spec is built once during router initialization, not per-request
- Routes can be hidden from the spec with `#[api_doc(hidden)]`
- Default tags are inferred from the first non-parameter path segment (e.g., `/users/{id}` → tag `"users"`)
- Swagger UI is served from unpkg CDN, requiring no static file embedding

https://claude.ai/code/session_01EHvw3uW1WVVudvzA1mxCzq