### PR TITLE
feat(audit): add first-class structured audit logging API

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -87,6 +87,7 @@ pub fn app() -> AppBuilder {
         pool_provider_factory: None,
         telemetry_provider: None,
         session_store: None,
+        audit_logger: None,
     }
 }
 
@@ -190,6 +191,8 @@ pub struct AppBuilder {
     /// `apply_session_layer` skips the config-driven `memory`/`redis` selection
     /// and uses this store directly.
     session_store: Option<Arc<dyn crate::session::BoxedSessionStore>>,
+    /// Shared audit logger used for append-only compliance events.
+    audit_logger: Option<Arc<crate::audit::AuditLogger>>,
 }
 
 /// A group of routes sharing a common path prefix and middleware layer.
@@ -785,6 +788,24 @@ impl AppBuilder {
         self
     }
 
+    /// Register an additional audit sink for structured audit events.
+    ///
+    /// Multiple calls accumulate sinks. Logged events are fanned out to all
+    /// configured sinks.
+    #[must_use]
+    pub fn with_audit_sink<S>(mut self, sink: S) -> Self
+    where
+        S: crate::audit::AuditSink,
+    {
+        let logger = self
+            .audit_logger
+            .take()
+            .map_or_else(crate::audit::AuditLogger::new, |logger| (*logger).clone())
+            .with_sink(Arc::new(sink));
+        self.audit_logger = Some(Arc::new(logger));
+        self
+    }
+
     /// Apply a [`Plugin`](crate::plugin::Plugin) to the builder.
     ///
     /// The plugin's [`build`](crate::plugin::Plugin::build) runs exactly once
@@ -908,6 +929,7 @@ impl AppBuilder {
             pool_provider_factory,
             telemetry_provider,
             session_store,
+            audit_logger,
         } = self;
 
         let all_routes = routes;
@@ -966,6 +988,9 @@ impl AppBuilder {
             #[cfg(feature = "db")]
             pool,
         );
+        if let Some(logger) = audit_logger {
+            state.insert_extension::<crate::audit::AuditLogger>((*logger).clone());
+        }
         let env = crate::config::OsEnv;
         let dist_dir = project_dir("dist", &env);
         let dist_ref = if dist_dir.exists() {
@@ -1101,6 +1126,7 @@ impl AppBuilder {
             pool_provider_factory,
             telemetry_provider,
             session_store,
+            audit_logger: _,
         } = self;
 
         let all_routes = routes;

--- a/autumn/src/audit.rs
+++ b/autumn/src/audit.rs
@@ -30,7 +30,7 @@ pub enum AuditStatus {
 }
 
 /// A structured audit log entry.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AuditEvent {
     /// UTC timestamp recorded when the event was created.
     pub timestamp: DateTime<Utc>,
@@ -94,7 +94,7 @@ type AuditWriteFuture<'a> = Pin<Box<dyn Future<Output = Result<(), AuditError>> 
 pub trait AuditSink: Send + Sync + 'static {
     /// Persist one audit event. Implementations must treat events as immutable,
     /// append-only records.
-    fn write<'a>(&'a self, event: AuditEvent) -> AuditWriteFuture<'a>;
+    fn write(&self, event: AuditEvent) -> AuditWriteFuture<'_>;
 }
 
 /// Shared audit writer that fans out to multiple sinks.
@@ -118,6 +118,11 @@ impl AuditLogger {
     }
 
     /// Append an event to all configured sinks.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuditError`] when one or more configured sinks fail. All
+    /// sinks are still attempted; failures are aggregated into one error.
     pub async fn write(&self, event: AuditEvent) -> Result<(), AuditError> {
         let mut errors = Vec::new();
         for sink in &self.sinks {
@@ -152,7 +157,7 @@ impl AuditLogger {
 pub struct TracingAuditSink;
 
 impl AuditSink for TracingAuditSink {
-    fn write<'a>(&'a self, event: AuditEvent) -> AuditWriteFuture<'a> {
+    fn write(&self, event: AuditEvent) -> AuditWriteFuture<'_> {
         Box::pin(async move {
             tracing::info!(
                 target: "autumn.audit",
@@ -188,7 +193,7 @@ impl JsonlFileAuditSink {
 }
 
 impl AuditSink for JsonlFileAuditSink {
-    fn write<'a>(&'a self, event: AuditEvent) -> AuditWriteFuture<'a> {
+    fn write(&self, event: AuditEvent) -> AuditWriteFuture<'_> {
         Box::pin(async move {
             let mut encoded = serde_json::to_vec(&event).map_err(|error| {
                 AuditError::new(format!("failed to encode audit event: {error}"))
@@ -212,6 +217,12 @@ impl AuditSink for JsonlFileAuditSink {
 }
 
 /// Helper to write an audit event using the logger stored in [`AppState`].
+///
+/// # Errors
+///
+/// Returns [`AuditError`] when the installed logger fails to persist to one or
+/// more sinks. If no logger is installed in state, this is a no-op and returns
+/// `Ok(())`.
 pub async fn write_from_state(state: &AppState, event: AuditEvent) -> Result<(), AuditError> {
     if let Some(logger) = state.extension::<AuditLogger>() {
         logger.write(event).await
@@ -229,7 +240,7 @@ mod tests {
     struct FailingSink;
 
     impl AuditSink for FailingSink {
-        fn write<'a>(&'a self, _event: AuditEvent) -> AuditWriteFuture<'a> {
+        fn write(&self, _event: AuditEvent) -> AuditWriteFuture<'_> {
             Box::pin(async { Err(AuditError::new("boom")) })
         }
     }
@@ -239,7 +250,7 @@ mod tests {
     }
 
     impl AuditSink for CountingSink {
-        fn write<'a>(&'a self, _event: AuditEvent) -> AuditWriteFuture<'a> {
+        fn write(&self, _event: AuditEvent) -> AuditWriteFuture<'_> {
             let writes = self.writes.clone();
             Box::pin(async move {
                 writes.fetch_add(1, Ordering::SeqCst);

--- a/autumn/src/audit.rs
+++ b/autumn/src/audit.rs
@@ -15,6 +15,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
 
 use crate::state::AppState;
 
@@ -81,6 +82,10 @@ impl AuditError {
             message: message.into(),
         }
     }
+
+    fn message(&self) -> &str {
+        &self.message
+    }
 }
 
 type AuditWriteFuture<'a> = Pin<Box<dyn Future<Output = Result<(), AuditError>> + Send + 'a>>;
@@ -114,10 +119,25 @@ impl AuditLogger {
 
     /// Append an event to all configured sinks.
     pub async fn write(&self, event: AuditEvent) -> Result<(), AuditError> {
+        let mut errors = Vec::new();
         for sink in &self.sinks {
-            sink.write(event.clone()).await?;
+            if let Err(error) = sink.write(event.clone()).await {
+                errors.push(error);
+            }
         }
-        Ok(())
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            let details = errors
+                .iter()
+                .map(|error| error.message().to_owned())
+                .collect::<Vec<_>>()
+                .join(" | ");
+            Err(AuditError::new(format!(
+                "{} audit sink(s) failed: {details}",
+                errors.len()
+            )))
+        }
     }
 
     /// Returns true when at least one sink is configured.
@@ -153,6 +173,7 @@ impl AuditSink for TracingAuditSink {
 #[derive(Debug)]
 pub struct JsonlFileAuditSink {
     path: PathBuf,
+    write_lock: Mutex<()>,
 }
 
 impl JsonlFileAuditSink {
@@ -161,6 +182,7 @@ impl JsonlFileAuditSink {
     pub fn new(path: impl AsRef<Path>) -> Self {
         Self {
             path: path.as_ref().to_path_buf(),
+            write_lock: Mutex::new(()),
         }
     }
 }
@@ -168,9 +190,11 @@ impl JsonlFileAuditSink {
 impl AuditSink for JsonlFileAuditSink {
     fn write<'a>(&'a self, event: AuditEvent) -> AuditWriteFuture<'a> {
         Box::pin(async move {
-            let encoded = serde_json::to_vec(&event).map_err(|error| {
+            let mut encoded = serde_json::to_vec(&event).map_err(|error| {
                 AuditError::new(format!("failed to encode audit event: {error}"))
             })?;
+            encoded.push(b'\n');
+            let _guard = self.write_lock.lock().await;
             let mut file = tokio::fs::OpenOptions::new()
                 .create(true)
                 .append(true)
@@ -181,9 +205,6 @@ impl AuditSink for JsonlFileAuditSink {
                 })?;
             file.write_all(&encoded).await.map_err(|error| {
                 AuditError::new(format!("failed to write audit event: {error}"))
-            })?;
-            file.write_all(b"\n").await.map_err(|error| {
-                AuditError::new(format!("failed to flush audit newline: {error}"))
             })?;
             Ok(())
         })
@@ -202,6 +223,30 @@ pub async fn write_from_state(state: &AppState, event: AuditEvent) -> Result<(),
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Default)]
+    struct FailingSink;
+
+    impl AuditSink for FailingSink {
+        fn write<'a>(&'a self, _event: AuditEvent) -> AuditWriteFuture<'a> {
+            Box::pin(async { Err(AuditError::new("boom")) })
+        }
+    }
+
+    struct CountingSink {
+        writes: Arc<AtomicUsize>,
+    }
+
+    impl AuditSink for CountingSink {
+        fn write<'a>(&'a self, _event: AuditEvent) -> AuditWriteFuture<'a> {
+            let writes = self.writes.clone();
+            Box::pin(async move {
+                writes.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+        }
+    }
 
     #[tokio::test]
     async fn jsonl_sink_appends_events() {
@@ -244,5 +289,36 @@ mod tests {
         )
         .await
         .expect("no-op write should succeed");
+    }
+
+    #[tokio::test]
+    async fn audit_logger_continues_fan_out_after_sink_failure() {
+        let writes = Arc::new(AtomicUsize::new(0));
+        let logger = AuditLogger::new()
+            .with_sink(Arc::new(FailingSink))
+            .with_sink(Arc::new(CountingSink {
+                writes: writes.clone(),
+            }));
+
+        let error = logger
+            .write(AuditEvent::new(
+                "u1",
+                "auth.login",
+                "session-1",
+                None,
+                AuditStatus::Failure,
+            ))
+            .await
+            .expect_err("first sink should fail");
+
+        assert!(
+            error.to_string().contains("1 audit sink(s) failed"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            writes.load(Ordering::SeqCst),
+            1,
+            "second sink should still receive event"
+        );
     }
 }

--- a/autumn/src/audit.rs
+++ b/autumn/src/audit.rs
@@ -1,0 +1,248 @@
+//! Structured audit logging with pluggable sinks.
+//!
+//! Audit logs are intentionally separate from regular application logs and
+//! should capture security-sensitive, compliance-relevant actions.
+//! Autumn models audit writes as append-only events sent to one or more
+//! sinks (database, SIEM adapter, dedicated file, etc.).
+
+use std::future::Future;
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::io::AsyncWriteExt;
+
+use crate::state::AppState;
+
+/// Outcome of an audited action.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditStatus {
+    /// The action completed successfully.
+    Success,
+    /// The action was attempted but failed.
+    Failure,
+}
+
+/// A structured audit log entry.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AuditEvent {
+    /// UTC timestamp recorded when the event was created.
+    pub timestamp: DateTime<Utc>,
+    /// Actor identifier (user ID, service account ID, or API key ID).
+    pub actor_id: String,
+    /// Canonical action name (for example, `"user.role.update"`).
+    pub action: String,
+    /// Target resource identifier affected by the action.
+    pub target_resource_id: String,
+    /// Caller IP address if known.
+    pub ip_address: Option<IpAddr>,
+    /// Final action status.
+    pub status: AuditStatus,
+}
+
+impl AuditEvent {
+    /// Create a new audit event with the current UTC timestamp.
+    #[must_use]
+    pub fn new(
+        actor_id: impl Into<String>,
+        action: impl Into<String>,
+        target_resource_id: impl Into<String>,
+        ip_address: Option<IpAddr>,
+        status: AuditStatus,
+    ) -> Self {
+        Self {
+            timestamp: Utc::now(),
+            actor_id: actor_id.into(),
+            action: action.into(),
+            target_resource_id: target_resource_id.into(),
+            ip_address,
+            status,
+        }
+    }
+}
+
+/// Error returned by audit sinks.
+#[derive(Debug, Error)]
+#[error("audit sink write failed: {message}")]
+pub struct AuditError {
+    message: String,
+}
+
+impl AuditError {
+    /// Create a new sink error with a human-readable message.
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+type AuditWriteFuture<'a> = Pin<Box<dyn Future<Output = Result<(), AuditError>> + Send + 'a>>;
+
+/// A destination for append-only audit events.
+pub trait AuditSink: Send + Sync + 'static {
+    /// Persist one audit event. Implementations must treat events as immutable,
+    /// append-only records.
+    fn write<'a>(&'a self, event: AuditEvent) -> AuditWriteFuture<'a>;
+}
+
+/// Shared audit writer that fans out to multiple sinks.
+#[derive(Clone, Default)]
+pub struct AuditLogger {
+    sinks: Vec<Arc<dyn AuditSink>>,
+}
+
+impl AuditLogger {
+    /// Create an empty logger with no sinks.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { sinks: Vec::new() }
+    }
+
+    /// Register an audit sink.
+    #[must_use]
+    pub fn with_sink(mut self, sink: Arc<dyn AuditSink>) -> Self {
+        self.sinks.push(sink);
+        self
+    }
+
+    /// Append an event to all configured sinks.
+    pub async fn write(&self, event: AuditEvent) -> Result<(), AuditError> {
+        for sink in &self.sinks {
+            sink.write(event.clone()).await?;
+        }
+        Ok(())
+    }
+
+    /// Returns true when at least one sink is configured.
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        !self.sinks.is_empty()
+    }
+}
+
+/// Tracing-based sink that emits JSON fields on a dedicated `autumn.audit` target.
+#[derive(Debug, Default)]
+pub struct TracingAuditSink;
+
+impl AuditSink for TracingAuditSink {
+    fn write<'a>(&'a self, event: AuditEvent) -> AuditWriteFuture<'a> {
+        Box::pin(async move {
+            tracing::info!(
+                target: "autumn.audit",
+                timestamp = %event.timestamp,
+                actor_id = %event.actor_id,
+                action = %event.action,
+                target_resource_id = %event.target_resource_id,
+                ip_address = ?event.ip_address,
+                status = ?event.status,
+                "audit_event"
+            );
+            Ok(())
+        })
+    }
+}
+
+/// JSON-lines file sink suitable for immutable append-only audit archives.
+#[derive(Debug)]
+pub struct JsonlFileAuditSink {
+    path: PathBuf,
+}
+
+impl JsonlFileAuditSink {
+    /// Create a JSONL sink writing to `path` in append-only mode.
+    #[must_use]
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+}
+
+impl AuditSink for JsonlFileAuditSink {
+    fn write<'a>(&'a self, event: AuditEvent) -> AuditWriteFuture<'a> {
+        Box::pin(async move {
+            let encoded = serde_json::to_vec(&event).map_err(|error| {
+                AuditError::new(format!("failed to encode audit event: {error}"))
+            })?;
+            let mut file = tokio::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&self.path)
+                .await
+                .map_err(|error| {
+                    AuditError::new(format!("failed to open audit log file: {error}"))
+                })?;
+            file.write_all(&encoded).await.map_err(|error| {
+                AuditError::new(format!("failed to write audit event: {error}"))
+            })?;
+            file.write_all(b"\n").await.map_err(|error| {
+                AuditError::new(format!("failed to flush audit newline: {error}"))
+            })?;
+            Ok(())
+        })
+    }
+}
+
+/// Helper to write an audit event using the logger stored in [`AppState`].
+pub async fn write_from_state(state: &AppState, event: AuditEvent) -> Result<(), AuditError> {
+    if let Some(logger) = state.extension::<AuditLogger>() {
+        logger.write(event).await
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn jsonl_sink_appends_events() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("audit.log");
+        let sink = JsonlFileAuditSink::new(&path);
+
+        sink.write(AuditEvent::new(
+            "admin-1",
+            "user.role.update",
+            "user-99",
+            None,
+            AuditStatus::Success,
+        ))
+        .await
+        .expect("write first event");
+
+        sink.write(AuditEvent::new(
+            "api-key-1",
+            "export.create",
+            "export-42",
+            None,
+            AuditStatus::Failure,
+        ))
+        .await
+        .expect("write second event");
+
+        let content = tokio::fs::read_to_string(&path)
+            .await
+            .expect("read audit file");
+        assert_eq!(content.lines().count(), 2);
+    }
+
+    #[tokio::test]
+    async fn write_from_state_no_logger_is_noop() {
+        let state = AppState::for_test();
+        write_from_state(
+            &state,
+            AuditEvent::new("u1", "auth.login", "session-1", None, AuditStatus::Success),
+        )
+        .await
+        .expect("no-op write should succeed");
+    }
+}

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -67,6 +67,7 @@ extern crate self as autumn_web;
 
 pub mod actuator;
 pub mod app;
+pub mod audit;
 pub mod auth;
 pub mod cache;
 #[cfg(feature = "ws")]

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -63,6 +63,8 @@ pub use crate::sse::{Event, Sse};
 pub use axum::extract::State;
 
 // ── Error handling ───────────────────────────────────────────────
+/// Structured audit event types.
+pub use crate::audit::{AuditEvent, AuditStatus};
 /// Framework error and result types.
 pub use crate::error::{AutumnError, AutumnResult};
 


### PR DESCRIPTION
### Motivation
- Provide a first-class, append-only audit logging facility separate from application logs to satisfy compliance and incident investigation needs. 
- Make audit destinations pluggable so audit events can be routed to files, tracing targets, or external SIEM/DB backends. 
- Expose a simple, framework-level API so apps and plugins can emit structured, immutable audit events via `AppState`.

### Description
- Introduce a new `audit` module with `AuditEvent` and `AuditStatus` models capturing `timestamp`, `actor_id`, `action`, `target_resource_id`, `ip_address`, and `status`, plus `AuditEvent::new` for consistent construction. 
- Add the `AuditSink` trait and `AuditLogger` fan-out writer to model append-only sinks and to deliver events to multiple configured destinations. 
- Ship two built-in sinks: `TracingAuditSink` (emits structured fields on `autumn.audit`) and `JsonlFileAuditSink` (append-only JSONL file writes). 
- Add `write_from_state` helper to emit events using the `AuditLogger` installed in `AppState`. 
- Extend `AppBuilder` with `with_audit_sink(...)` to register sinks and install the consolidated `AuditLogger` into `AppState` during startup (and account for static build mode). 
- Export the module publicly and re-export `AuditEvent`/`AuditStatus` from the prelude for easy consumption by applications.

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- Ran unit tests for the audit module with `cargo test -p autumn-web audit::` and the audit tests passed (`jsonl_sink_appends_events` and `write_from_state_no_logger_is_noop`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaabdb8480832ab8da082d198a5782)