### PR TITLE
Add AUTUMN_ENV and support inline `[profile.*]` in autumn.toml, default to dev

### DIFF
--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -430,6 +430,10 @@ fn warn_profile_typo(profile: &str) {
     }
 }
 
+fn should_warn_missing_profile_file(profile: &str, has_inline_profile_section: bool) -> bool {
+    profile != "dev" && profile != "prod" && !has_inline_profile_section
+}
+
 /// Levenshtein edit distance between two strings.
 ///
 /// ⚡ Bolt Optimization:
@@ -594,6 +598,7 @@ impl AutumnConfig {
     /// Panics if the internally-built TOML table fails to re-serialize.
     pub fn load_with_env(env: &dyn Env) -> Result<Self, ConfigError> {
         let profile = resolve_profile(env);
+        let mut has_inline_profile_section = false;
 
         // Build merged TOML:
         // profile smart defaults ← autumn.toml ← [profile.{name}] ← autumn-{profile}.toml
@@ -610,6 +615,7 @@ impl AutumnConfig {
             if let Some(ref p) = profile {
                 if let Some(inline_profile) = profile_section_from_base_toml(&base, p) {
                     deep_merge(&mut merged, inline_profile);
+                    has_inline_profile_section = true;
                 }
             }
         }
@@ -619,7 +625,9 @@ impl AutumnConfig {
             let profile_path = find_config_file_named(&format!("autumn-{p}.toml"), env);
             match load_raw_toml(&profile_path)? {
                 Some(profile_toml) => deep_merge(&mut merged, profile_toml),
-                None if p != "dev" && p != "prod" => warn_profile_typo(p),
+                None if should_warn_missing_profile_file(p, has_inline_profile_section) => {
+                    warn_profile_typo(p)
+                }
                 None => {}
             }
         }
@@ -2695,6 +2703,22 @@ path = "/healthz"
     }
 
     #[test]
+    fn should_warn_missing_profile_file_custom_without_inline() {
+        assert!(should_warn_missing_profile_file("staging", false));
+    }
+
+    #[test]
+    fn should_not_warn_missing_profile_file_custom_with_inline() {
+        assert!(!should_warn_missing_profile_file("staging", true));
+    }
+
+    #[test]
+    fn should_not_warn_missing_profile_file_dev_or_prod() {
+        assert!(!should_warn_missing_profile_file("dev", false));
+        assert!(!should_warn_missing_profile_file("prod", false));
+    }
+
+    #[test]
     fn levenshtein_threshold_in_warn_profile_typo() {
         assert!(levenshtein("dve", "dev") <= 2);
         assert!(levenshtein("xyz", "dev") > 2);
@@ -2801,6 +2825,31 @@ path = "/healthz"
 
         let config = AutumnConfig::load_with_env(&env).unwrap();
         assert_eq!(config.profile.as_deref(), Some("dev"));
+    }
+
+    #[test]
+    fn load_custom_profile_uses_inline_profile_without_legacy_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_path = dir.path().join("autumn.toml");
+        std::fs::write(
+            &base_path,
+            r#"
+            [server]
+            port = 3000
+
+            [profile.staging.server]
+            port = 4100
+            "#,
+        )
+        .unwrap();
+
+        let env = MockEnv::new()
+            .with("AUTUMN_ENV", "staging")
+            .with("AUTUMN_MANIFEST_DIR", dir.path().to_str().unwrap());
+
+        let config = AutumnConfig::load_with_env(&env).unwrap();
+        assert_eq!(config.profile.as_deref(), Some("staging"));
+        assert_eq!(config.server.port, 4100);
     }
 
     #[test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -265,14 +265,15 @@ fn normalize_profile_name(profile: &str) -> Option<String> {
         return None;
     }
 
-    let lowered = trimmed.to_ascii_lowercase();
-    let normalized = match lowered.as_str() {
-        "production" => "prod",
-        "development" => "dev",
-        other => other,
-    };
+    if trimmed.eq_ignore_ascii_case("production") {
+        return Some("prod".to_owned());
+    }
+    if trimmed.eq_ignore_ascii_case("development") {
+        return Some("dev".to_owned());
+    }
 
-    Some(normalized.to_owned())
+    // Preserve user-specified case for custom profile names.
+    Some(trimmed.to_owned())
 }
 
 /// Extract `[profile.<name>]` table from a parsed `autumn.toml`.
@@ -2367,6 +2368,13 @@ path = "/healthz"
         let env = MockEnv::new().with("AUTUMN_ENV", "  development  ");
         let profile = resolve_profile(&env);
         assert_eq!(profile.as_deref(), Some("dev"));
+    }
+
+    #[test]
+    fn resolve_profile_preserves_case_for_custom_profiles() {
+        let env = MockEnv::new().with("AUTUMN_ENV", "QA");
+        let profile = resolve_profile(&env);
+        assert_eq!(profile.as_deref(), Some("QA"));
     }
 
     #[test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -6,8 +6,9 @@
 //! 1. **Framework defaults** (this module) -- compiled into the binary.
 //! 2. **Profile smart defaults** -- per-profile values for `dev`/`prod`.
 //! 3. **`autumn.toml`** -- project-level overrides checked into source control.
-//! 4. **`autumn-{profile}.toml`** -- profile-specific overrides.
-//! 5. **`AUTUMN_*` environment variables** -- deployment/CI overrides.
+//! 4. **`[profile.{name}]` in `autumn.toml`** -- profile-specific overrides.
+//! 5. **`autumn-{profile}.toml`** -- legacy profile-specific overrides.
+//! 6. **`AUTUMN_*` environment variables** -- deployment/CI overrides.
 //!
 //! An Autumn application runs with zero configuration -- every field
 //! has a sensible default value. Override only what you need.
@@ -15,9 +16,10 @@
 //! # Profiles
 //!
 //! Profiles are resolved in precedence order:
-//! 1. `AUTUMN_PROFILE` environment variable
-//! 2. `--profile` CLI flag
-//! 3. Auto-detect from debug/release build mode
+//! 1. `AUTUMN_ENV` environment variable
+//! 2. `AUTUMN_PROFILE` environment variable (legacy alias)
+//! 3. `--profile` CLI flag
+//! 4. Auto-detect from debug/release build mode
 //!
 //! # Example
 //!
@@ -76,7 +78,8 @@
 //! | `AUTUMN_SECURITY__RATE_LIMIT__REQUESTS_PER_SECOND` | `security.rate_limit.requests_per_second` | `f64` |
 //! | `AUTUMN_SECURITY__RATE_LIMIT__BURST` | `security.rate_limit.burst` | `u32` |
 //! | `AUTUMN_SECURITY__RATE_LIMIT__TRUST_FORWARDED_HEADERS` | `security.rate_limit.trust_forwarded_headers` | `bool` |
-//! | `AUTUMN_PROFILE` | active profile | `String` |
+//! | `AUTUMN_ENV` | active profile | `String` |
+//! | `AUTUMN_PROFILE` | active profile (legacy alias) | `String` |
 
 use std::path::{Path, PathBuf};
 
@@ -204,20 +207,29 @@ fn load_raw_toml(path: &Path) -> Result<Option<toml::Value>, ConfigError> {
     }
 }
 
-/// Resolve the active profile using the three-mechanism precedence chain.
+/// Resolve the active profile using the precedence chain.
 ///
-/// 1. `AUTUMN_PROFILE` env var (highest priority)
-/// 2. `--profile <name>` CLI flag
-/// 3. Auto-detect from build mode (`AUTUMN_IS_DEBUG` set by `#[autumn_web::main]`)
+/// 1. `AUTUMN_ENV` env var (highest priority)
+/// 2. `AUTUMN_PROFILE` env var (legacy alias)
+/// 3. `--profile <name>` CLI flag
+/// 4. Auto-detect from build mode (`AUTUMN_IS_DEBUG` set by `#[autumn_web::main]`)
+/// 5. Fallback to `dev`
 pub(crate) fn resolve_profile(env: &dyn Env) -> Option<String> {
-    // 1. Env var
+    // 1. Preferred env var
+    if let Ok(profile) = env.var("AUTUMN_ENV") {
+        if !profile.is_empty() {
+            return Some(profile);
+        }
+    }
+
+    // 2. Legacy env var
     if let Ok(profile) = env.var("AUTUMN_PROFILE") {
         if !profile.is_empty() {
             return Some(profile);
         }
     }
 
-    // 2. CLI flag
+    // 3. CLI flag
     let args: Vec<String> = std::env::args().collect();
     for (i, arg) in args.iter().enumerate() {
         if arg == "--profile" {
@@ -230,12 +242,21 @@ pub(crate) fn resolve_profile(env: &dyn Env) -> Option<String> {
         }
     }
 
-    // 3. Auto-detect from build mode
+    // 4. Auto-detect from build mode
     match env.var("AUTUMN_IS_DEBUG").ok().as_deref() {
         Some("1") => Some("dev".to_owned()),
         Some("0") => Some("prod".to_owned()),
-        _ => None,
+        _ => Some("dev".to_owned()),
     }
+}
+
+/// Extract `[profile.<name>]` table from a parsed `autumn.toml`.
+fn profile_section_from_base_toml(base: &toml::Value, profile: &str) -> Option<toml::Value> {
+    base.get("profile")
+        .and_then(toml::Value::as_table)
+        .and_then(|profiles| profiles.get(profile))
+        .and_then(toml::Value::as_table)
+        .map(|table| toml::Value::Table(table.clone()))
 }
 
 /// Profile-specific smart defaults as a TOML table.
@@ -513,12 +534,13 @@ pub struct AutumnConfig {
 impl AutumnConfig {
     /// Load configuration with profile-aware layering.
     ///
-    /// Applies the five-layer configuration system:
+    /// Applies the six-layer configuration system:
     /// 1. Framework defaults
     /// 2. Profile smart defaults (dev/prod)
     /// 3. `autumn.toml` (base config)
-    /// 4. `autumn-{profile}.toml` (profile overrides)
-    /// 5. `AUTUMN_*` environment variables
+    /// 4. `[profile.{name}]` section in `autumn.toml`
+    /// 5. `autumn-{profile}.toml` (legacy profile overrides)
+    /// 6. `AUTUMN_*` environment variables
     ///
     /// # Errors
     ///
@@ -547,7 +569,8 @@ impl AutumnConfig {
     pub fn load_with_env(env: &dyn Env) -> Result<Self, ConfigError> {
         let profile = resolve_profile(env);
 
-        // Build merged TOML: profile smart defaults ← autumn.toml ← autumn-{profile}.toml
+        // Build merged TOML:
+        // profile smart defaults ← autumn.toml ← [profile.{name}] ← autumn-{profile}.toml
         let mut merged = profile.as_ref().map_or_else(
             || toml::Value::Table(toml::map::Map::new()),
             |p| profile_defaults_as_toml(p),
@@ -555,10 +578,17 @@ impl AutumnConfig {
 
         // Layer 3: base autumn.toml
         if let Some(base) = load_raw_toml(&find_config_file_named("autumn.toml", env))? {
-            deep_merge(&mut merged, base);
+            deep_merge(&mut merged, base.clone());
+
+            // Layer 4: [profile.{name}] in autumn.toml
+            if let Some(ref p) = profile {
+                if let Some(inline_profile) = profile_section_from_base_toml(&base, p) {
+                    deep_merge(&mut merged, inline_profile);
+                }
+            }
         }
 
-        // Layer 4: autumn-{profile}.toml
+        // Layer 5: autumn-{profile}.toml (legacy compatibility)
         if let Some(ref p) = profile {
             let profile_path = find_config_file_named(&format!("autumn-{p}.toml"), env);
             match load_raw_toml(&profile_path)? {
@@ -574,7 +604,7 @@ impl AutumnConfig {
         let mut config: Self = toml::from_str(&toml_str)?;
         config.profile = profile;
 
-        // Layer 5: env var overrides (highest priority)
+        // Layer 6: env var overrides (highest priority)
         config.apply_env_overrides_with_env(env);
 
         config.validate()?;
@@ -2278,10 +2308,26 @@ path = "/healthz"
     // ── Profile tests ──────────────────────────────────────────
 
     #[test]
-    fn resolve_profile_from_env() {
+    fn resolve_profile_from_autumn_env() {
+        let env = MockEnv::new().with("AUTUMN_ENV", "prod");
+        let profile = resolve_profile(&env);
+        assert_eq!(profile.as_deref(), Some("prod"));
+    }
+
+    #[test]
+    fn resolve_profile_from_legacy_env() {
         let env = MockEnv::new().with("AUTUMN_PROFILE", "staging");
         let profile = resolve_profile(&env);
         assert_eq!(profile.as_deref(), Some("staging"));
+    }
+
+    #[test]
+    fn resolve_profile_prefers_autumn_env_over_legacy_alias() {
+        let env = MockEnv::new()
+            .with("AUTUMN_ENV", "dev")
+            .with("AUTUMN_PROFILE", "prod");
+        let profile = resolve_profile(&env);
+        assert_eq!(profile.as_deref(), Some("dev"));
     }
 
     #[test]
@@ -2296,6 +2342,13 @@ path = "/healthz"
         let env = MockEnv::new().with("AUTUMN_IS_DEBUG", "0");
         let profile = resolve_profile(&env);
         assert_eq!(profile.as_deref(), Some("prod"));
+    }
+
+    #[test]
+    fn resolve_profile_defaults_to_dev_when_no_signal_present() {
+        let env = MockEnv::new();
+        let profile = resolve_profile(&env);
+        assert_eq!(profile.as_deref(), Some("dev"));
     }
 
     #[test]
@@ -2437,6 +2490,33 @@ path = "/healthz"
             config.database.url.as_deref(),
             Some("postgres://localhost/myapp_dev")
         ); // from profile
+    }
+
+    #[test]
+    fn inline_profile_section_overrides_base_toml() {
+        let mut merged = toml::Value::Table(toml::map::Map::new());
+        let base: toml::Value = toml::from_str(
+            r#"
+            [server]
+            port = 3000
+
+            [log]
+            level = "info"
+
+            [profile.dev.log]
+            level = "debug"
+            "#,
+        )
+        .unwrap();
+
+        deep_merge(&mut merged, base.clone());
+        let inline = profile_section_from_base_toml(&base, "dev").unwrap();
+        deep_merge(&mut merged, inline);
+
+        let toml_str = toml::to_string(&merged).unwrap();
+        let config: AutumnConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(config.server.port, 3000);
+        assert_eq!(config.log.level, "debug");
     }
 
     #[test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -217,14 +217,14 @@ fn load_raw_toml(path: &Path) -> Result<Option<toml::Value>, ConfigError> {
 pub(crate) fn resolve_profile(env: &dyn Env) -> Option<String> {
     // 1. Preferred env var
     if let Ok(profile) = env.var("AUTUMN_ENV") {
-        if !profile.is_empty() {
+        if let Some(profile) = normalize_profile_name(&profile) {
             return Some(profile);
         }
     }
 
     // 2. Legacy env var
     if let Ok(profile) = env.var("AUTUMN_PROFILE") {
-        if !profile.is_empty() {
+        if let Some(profile) = normalize_profile_name(&profile) {
             return Some(profile);
         }
     }
@@ -234,11 +234,15 @@ pub(crate) fn resolve_profile(env: &dyn Env) -> Option<String> {
     for (i, arg) in args.iter().enumerate() {
         if arg == "--profile" {
             if let Some(profile) = args.get(i + 1) {
-                return Some(profile.clone());
+                if let Some(profile) = normalize_profile_name(profile) {
+                    return Some(profile);
+                }
             }
         }
         if let Some(profile) = arg.strip_prefix("--profile=") {
-            return Some(profile.to_owned());
+            if let Some(profile) = normalize_profile_name(profile) {
+                return Some(profile);
+            }
         }
     }
 
@@ -248,6 +252,27 @@ pub(crate) fn resolve_profile(env: &dyn Env) -> Option<String> {
         Some("0") => Some("prod".to_owned()),
         _ => Some("dev".to_owned()),
     }
+}
+
+/// Normalize profile aliases and trim whitespace.
+///
+/// Supported aliases:
+/// - `production` -> `prod`
+/// - `development` -> `dev`
+fn normalize_profile_name(profile: &str) -> Option<String> {
+    let trimmed = profile.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let lowered = trimmed.to_ascii_lowercase();
+    let normalized = match lowered.as_str() {
+        "production" => "prod",
+        "development" => "dev",
+        other => other,
+    };
+
+    Some(normalized.to_owned())
 }
 
 /// Extract `[profile.<name>]` table from a parsed `autumn.toml`.
@@ -2326,6 +2351,20 @@ path = "/healthz"
         let env = MockEnv::new()
             .with("AUTUMN_ENV", "dev")
             .with("AUTUMN_PROFILE", "prod");
+        let profile = resolve_profile(&env);
+        assert_eq!(profile.as_deref(), Some("dev"));
+    }
+
+    #[test]
+    fn resolve_profile_normalizes_production_alias() {
+        let env = MockEnv::new().with("AUTUMN_ENV", "production");
+        let profile = resolve_profile(&env);
+        assert_eq!(profile.as_deref(), Some("prod"));
+    }
+
+    #[test]
+    fn resolve_profile_normalizes_development_alias_with_whitespace() {
+        let env = MockEnv::new().with("AUTUMN_ENV", "  development  ");
         let profile = resolve_profile(&env);
         assert_eq!(profile.as_deref(), Some("dev"));
     }

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -214,18 +214,18 @@ fn load_raw_toml(path: &Path) -> Result<Option<toml::Value>, ConfigError> {
 /// 3. `--profile <name>` CLI flag
 /// 4. Auto-detect from build mode (`AUTUMN_IS_DEBUG` set by `#[autumn_web::main]`)
 /// 5. Fallback to `dev`
-pub(crate) fn resolve_profile(env: &dyn Env) -> Option<String> {
+pub(crate) fn resolve_profile(env: &dyn Env) -> String {
     // 1. Preferred env var
     if let Ok(profile) = env.var("AUTUMN_ENV") {
         if let Some(profile) = normalize_profile_name(&profile) {
-            return Some(profile);
+            return profile;
         }
     }
 
     // 2. Legacy env var
     if let Ok(profile) = env.var("AUTUMN_PROFILE") {
         if let Some(profile) = normalize_profile_name(&profile) {
-            return Some(profile);
+            return profile;
         }
     }
 
@@ -235,23 +235,22 @@ pub(crate) fn resolve_profile(env: &dyn Env) -> Option<String> {
         if arg == "--profile" {
             if let Some(profile) = args.get(i + 1) {
                 if let Some(profile) = normalize_profile_name(profile) {
-                    return Some(profile);
+                    return profile;
                 }
             }
         }
         if let Some(profile) = arg.strip_prefix("--profile=") {
             if let Some(profile) = normalize_profile_name(profile) {
-                return Some(profile);
+                return profile;
             }
         }
     }
 
     // 4. Auto-detect from build mode
-    match env.var("AUTUMN_IS_DEBUG").ok().as_deref() {
-        Some("1") => Some("dev".to_owned()),
-        Some("0") => Some("prod".to_owned()),
-        _ => Some("dev".to_owned()),
+    if env.var("AUTUMN_IS_DEBUG").ok().as_deref() == Some("0") {
+        return "prod".to_owned();
     }
+    "dev".to_owned()
 }
 
 /// Normalize profile aliases and trim whitespace.
@@ -602,41 +601,34 @@ impl AutumnConfig {
 
         // Build merged TOML:
         // profile smart defaults ← autumn.toml ← [profile.{name}] ← autumn-{profile}.toml
-        let mut merged = profile.as_ref().map_or_else(
-            || toml::Value::Table(toml::map::Map::new()),
-            |p| profile_defaults_as_toml(p),
-        );
+        let mut merged = profile_defaults_as_toml(&profile);
 
         // Layer 3: base autumn.toml
         if let Some(base) = load_raw_toml(&find_config_file_named("autumn.toml", env))? {
             deep_merge(&mut merged, base.clone());
 
             // Layer 4: [profile.{name}] in autumn.toml
-            if let Some(ref p) = profile {
-                if let Some(inline_profile) = profile_section_from_base_toml(&base, p) {
-                    deep_merge(&mut merged, inline_profile);
-                    has_inline_profile_section = true;
-                }
+            if let Some(inline_profile) = profile_section_from_base_toml(&base, &profile) {
+                deep_merge(&mut merged, inline_profile);
+                has_inline_profile_section = true;
             }
         }
 
         // Layer 5: autumn-{profile}.toml (legacy compatibility)
-        if let Some(ref p) = profile {
-            let profile_path = find_config_file_named(&format!("autumn-{p}.toml"), env);
-            match load_raw_toml(&profile_path)? {
-                Some(profile_toml) => deep_merge(&mut merged, profile_toml),
-                None if should_warn_missing_profile_file(p, has_inline_profile_section) => {
-                    warn_profile_typo(p)
-                }
-                None => {}
+        let profile_path = find_config_file_named(&format!("autumn-{profile}.toml"), env);
+        match load_raw_toml(&profile_path)? {
+            Some(profile_toml) => deep_merge(&mut merged, profile_toml),
+            None if should_warn_missing_profile_file(&profile, has_inline_profile_section) => {
+                warn_profile_typo(&profile);
             }
+            None => {}
         }
 
         // Deserialize the merged TOML table into AutumnConfig
         let toml_str =
             toml::to_string(&merged).expect("internal error: failed to serialize merged config");
         let mut config: Self = toml::from_str(&toml_str)?;
-        config.profile = profile;
+        config.profile = Some(profile);
 
         // Layer 6: env var overrides (highest priority)
         config.apply_env_overrides_with_env(env);
@@ -2345,14 +2337,14 @@ path = "/healthz"
     fn resolve_profile_from_autumn_env() {
         let env = MockEnv::new().with("AUTUMN_ENV", "prod");
         let profile = resolve_profile(&env);
-        assert_eq!(profile.as_deref(), Some("prod"));
+        assert_eq!(profile, "prod");
     }
 
     #[test]
     fn resolve_profile_from_legacy_env() {
         let env = MockEnv::new().with("AUTUMN_PROFILE", "staging");
         let profile = resolve_profile(&env);
-        assert_eq!(profile.as_deref(), Some("staging"));
+        assert_eq!(profile, "staging");
     }
 
     #[test]
@@ -2361,49 +2353,49 @@ path = "/healthz"
             .with("AUTUMN_ENV", "dev")
             .with("AUTUMN_PROFILE", "prod");
         let profile = resolve_profile(&env);
-        assert_eq!(profile.as_deref(), Some("dev"));
+        assert_eq!(profile, "dev");
     }
 
     #[test]
     fn resolve_profile_normalizes_production_alias() {
         let env = MockEnv::new().with("AUTUMN_ENV", "production");
         let profile = resolve_profile(&env);
-        assert_eq!(profile.as_deref(), Some("prod"));
+        assert_eq!(profile, "prod");
     }
 
     #[test]
     fn resolve_profile_normalizes_development_alias_with_whitespace() {
         let env = MockEnv::new().with("AUTUMN_ENV", "  development  ");
         let profile = resolve_profile(&env);
-        assert_eq!(profile.as_deref(), Some("dev"));
+        assert_eq!(profile, "dev");
     }
 
     #[test]
     fn resolve_profile_preserves_case_for_custom_profiles() {
         let env = MockEnv::new().with("AUTUMN_ENV", "QA");
         let profile = resolve_profile(&env);
-        assert_eq!(profile.as_deref(), Some("QA"));
+        assert_eq!(profile, "QA");
     }
 
     #[test]
     fn resolve_profile_auto_detect_debug() {
         let env = MockEnv::new().with("AUTUMN_IS_DEBUG", "1");
         let profile = resolve_profile(&env);
-        assert_eq!(profile.as_deref(), Some("dev"));
+        assert_eq!(profile, "dev");
     }
 
     #[test]
     fn resolve_profile_auto_detect_release() {
         let env = MockEnv::new().with("AUTUMN_IS_DEBUG", "0");
         let profile = resolve_profile(&env);
-        assert_eq!(profile.as_deref(), Some("prod"));
+        assert_eq!(profile, "prod");
     }
 
     #[test]
     fn resolve_profile_defaults_to_dev_when_no_signal_present() {
         let env = MockEnv::new();
         let profile = resolve_profile(&env);
-        assert_eq!(profile.as_deref(), Some("dev"));
+        assert_eq!(profile, "dev");
     }
 
     #[test]
@@ -2833,13 +2825,13 @@ path = "/healthz"
         let base_path = dir.path().join("autumn.toml");
         std::fs::write(
             &base_path,
-            r#"
+            r"
             [server]
             port = 3000
 
             [profile.staging.server]
             port = 4100
-            "#,
+            ",
         )
         .unwrap();
 

--- a/autumn/src/logging.rs
+++ b/autumn/src/logging.rs
@@ -26,7 +26,7 @@ use crate::config::{LogConfig, TelemetryConfig};
 #[allow(dead_code)]
 pub fn init(config: &LogConfig) {
     let profile = crate::config::resolve_profile(&crate::config::OsEnv);
-    let _ = init_with_telemetry(config, &TelemetryConfig::default(), profile.as_deref())
+    let _ = init_with_telemetry(config, &TelemetryConfig::default(), Some(profile.as_str()))
         .unwrap_or_else(|error| panic!("failed to initialize logging: {error}"));
 }
 


### PR DESCRIPTION
### Motivation
- Implement the dev/prod profile story (S-060) so applications can get sensible framework defaults for `dev` and `prod` and easily override base config per-profile without separate files.

### Description
- Use `AUTUMN_ENV` as the primary profile selector with `AUTUMN_PROFILE` as a legacy alias and fall back to `dev` when no signal is present by updating `resolve_profile` in `autumn/src/config.rs`.
- Add support for inline profile sections in `autumn.toml` via a new `profile_section_from_base_toml` helper and merge `[profile.<name>]` into the layered config before falling back to legacy `autumn-<profile>.toml` files.
- Update documentation comments and the environment variable reference in `autumn/src/config.rs` to reflect the new six-layer merge order and new precedence rules.
- Add and adjust unit tests covering `AUTUMN_ENV` behavior, legacy alias precedence, default-to-`dev`, and inline `[profile.*]` override semantics.

### Testing
- Ran `cargo fmt --all` successfully to normalize formatting.
- Executed focused unit tests under the `autumn-web` package (e.g. `inline_profile_section_overrides_base_toml`, `resolve_profile_*`, and `load_uses_profile_layering`) and they all passed.
- There were a couple of earlier `cargo test` invocations that failed due to user-invocation issues (wrong package id or passing multiple positional test filters), but the corrected test runs reported passing results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaac3b2e68832aa4279821eb64c66b)