### PR TITLE
Add middleware layer introspection on AppBuilder

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -165,7 +165,7 @@ pub struct AppBuilder {
     nest_routers: Vec<(String, axum::Router<AppState>)>,
     /// Custom Tower layers registered via [`AppBuilder::layer`], applied
     /// inside `RequestIdLayer` on ingress so they observe the request ID.
-    custom_layers: Vec<CustomLayerApplier>,
+    custom_layers: Vec<CustomLayerRegistration>,
     startup_hooks: Vec<StartupHook>,
     shutdown_hooks: Vec<ShutdownHook>,
     extensions: HashMap<TypeId, Box<dyn Any + Send>>,
@@ -211,6 +211,14 @@ pub(crate) struct ScopedGroup {
 /// `apply_middleware` where the final layer stack is assembled.
 pub(crate) type CustomLayerApplier =
     Box<dyn FnOnce(axum::Router<AppState>) -> axum::Router<AppState> + Send>;
+
+/// Metadata and deferred application closure for a user-registered layer.
+pub(crate) struct CustomLayerRegistration {
+    /// Concrete type for the registered layer.
+    pub(crate) type_id: TypeId,
+    /// Deferred router mutation that applies the layer.
+    pub(crate) apply: CustomLayerApplier,
+}
 
 mod sealed {
     pub trait Sealed {}
@@ -519,15 +527,35 @@ impl AppBuilder {
     /// ```
     #[must_use]
     pub fn layer<L: IntoAppLayer>(mut self, layer: L) -> Self {
-        // TODO(0.x): consider retaining a TypeId alongside the closure so
-        // plugins can introspect which layers are already registered
-        // (e.g. warn when auth is installed after rate-limiting). Requires
-        // replacing CustomLayerApplier with a small trait that carries type
-        // metadata. Deliberately deferred — pure closures keep the public
-        // surface minimal until a concrete introspection use case appears.
-        self.custom_layers
-            .push(Box::new(move |router| layer.apply_to(router)));
+        self.custom_layers.push(CustomLayerRegistration {
+            type_id: TypeId::of::<L>(),
+            apply: Box::new(move |router| layer.apply_to(router)),
+        });
         self
+    }
+
+    /// Returns `true` when a custom layer of type `L` has already been
+    /// registered via [`AppBuilder::layer`].
+    ///
+    /// Intended for plugin pre-flight validation before the app is started.
+    #[must_use]
+    pub fn has_layer<L: 'static>(&self) -> bool {
+        let layer_type = TypeId::of::<L>();
+        self.custom_layers
+            .iter()
+            .any(|registered| registered.type_id == layer_type)
+    }
+
+    /// Returns the registered custom layer types in registration order.
+    ///
+    /// This includes only user-installed layers from
+    /// [`AppBuilder::layer`], not framework-managed middleware.
+    #[must_use]
+    pub fn get_layer_types(&self) -> Vec<TypeId> {
+        self.custom_layers
+            .iter()
+            .map(|registered| registered.type_id)
+            .collect()
     }
 
     /// Merge a raw Axum router into the application.

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -77,7 +77,7 @@ pub struct RouterContext {
     /// [`AppBuilder::layer`](crate::app::AppBuilder::layer). Applied inside
     /// [`RequestIdLayer`](crate::middleware::RequestIdLayer) on the ingress
     /// path so user middleware observes the generated request ID.
-    pub custom_layers: Vec<crate::app::CustomLayerApplier>,
+    pub custom_layers: Vec<crate::app::CustomLayerRegistration>,
     pub error_page_renderer: Option<SharedRenderer>,
     /// Custom session store installed via
     /// [`AppBuilder::with_session_store`](crate::app::AppBuilder::with_session_store).
@@ -458,7 +458,7 @@ fn apply_middleware(
     config: &AutumnConfig,
     state: &AppState,
     exception_filters: Vec<Arc<dyn ExceptionFilter>>,
-    custom_layers: Vec<crate::app::CustomLayerApplier>,
+    custom_layers: Vec<crate::app::CustomLayerRegistration>,
     error_page_renderer: Option<SharedRenderer>,
     session_store: Option<Arc<dyn crate::session::BoxedSessionStore>>,
 ) -> Result<axum::Router<AppState>, RouterBuildError> {
@@ -480,8 +480,8 @@ fn apply_middleware(
     // request extensions. Iterate in reverse so the first registered layer
     // ends up outermost among user layers — matching tower::ServiceBuilder.
     let custom_layer_count = custom_layers.len();
-    for applier in custom_layers.into_iter().rev() {
-        router = applier(router);
+    for registered in custom_layers.into_iter().rev() {
+        router = (registered.apply)(router);
     }
     if custom_layer_count > 0 {
         tracing::debug!(count = custom_layer_count, "Custom Tower layers applied");

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -105,7 +105,7 @@ pub struct TestApp {
     routes: Vec<Route>,
     merge_routers: Vec<axum::Router<crate::state::AppState>>,
     nest_routers: Vec<(String, axum::Router<crate::state::AppState>)>,
-    custom_layers: Vec<crate::app::CustomLayerApplier>,
+    custom_layers: Vec<crate::app::CustomLayerRegistration>,
     config: AutumnConfig,
     #[cfg(feature = "db")]
     pool: Option<Pool<AsyncPgConnection>>,
@@ -157,7 +157,10 @@ impl TestApp {
     #[must_use]
     pub fn layer<L: crate::app::IntoAppLayer>(mut self, layer: L) -> Self {
         self.custom_layers
-            .push(Box::new(move |router| layer.apply_to(router)));
+            .push(crate::app::CustomLayerRegistration {
+                type_id: std::any::TypeId::of::<L>(),
+                apply: Box::new(move |router| layer.apply_to(router)),
+            });
         self
     }
 

--- a/autumn/tests/middleware_introspection.rs
+++ b/autumn/tests/middleware_introspection.rs
@@ -1,0 +1,76 @@
+use std::any::TypeId;
+use std::borrow::Cow;
+
+use autumn_web::app;
+use autumn_web::app::AppBuilder;
+use autumn_web::plugin::Plugin;
+
+#[derive(Clone)]
+struct AuthLayer;
+
+impl<S> tower::Layer<S> for AuthLayer {
+    type Service = S;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        inner
+    }
+}
+
+#[derive(Clone)]
+struct RateLimitLayer;
+
+impl<S> tower::Layer<S> for RateLimitLayer {
+    type Service = S;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        inner
+    }
+}
+
+struct RequireAuthPlugin;
+
+impl Plugin for RequireAuthPlugin {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("require-auth-plugin")
+    }
+
+    fn build(self, app: AppBuilder) -> AppBuilder {
+        assert!(
+            app.has_layer::<AuthLayer>(),
+            "AuthLayer must be registered before RequireAuthPlugin"
+        );
+        app
+    }
+}
+
+#[test]
+fn has_layer_detects_presence_and_absence() {
+    let with_auth = app().layer(AuthLayer);
+    assert!(with_auth.has_layer::<AuthLayer>());
+    assert!(!with_auth.has_layer::<RateLimitLayer>());
+
+    let without_auth = app();
+    assert!(!without_auth.has_layer::<AuthLayer>());
+}
+
+#[test]
+fn get_layer_types_returns_registration_order() {
+    let builder = app().layer(AuthLayer).layer(RateLimitLayer);
+
+    assert_eq!(
+        builder.get_layer_types(),
+        vec![TypeId::of::<AuthLayer>(), TypeId::of::<RateLimitLayer>()]
+    );
+}
+
+#[test]
+fn plugin_can_preflight_check_for_required_layer() {
+    let builder = app().layer(AuthLayer);
+    let _ = builder.plugin(RequireAuthPlugin);
+}
+
+#[test]
+#[should_panic(expected = "AuthLayer must be registered before RequireAuthPlugin")]
+fn plugin_preflight_panics_when_required_layer_is_missing() {
+    let _ = app().plugin(RequireAuthPlugin);
+}


### PR DESCRIPTION
### Motivation
- Enable plugin and pre-flight checks to detect which user-registered Tower middleware types are present and in what order so misconfigurations (e.g. auth registered after rate-limiting) can be caught at startup.
- Provide a zero-cost bootstrap-time introspection abstraction that preserves existing `AppBuilder::layer` ergonomics and runtime semantics.

### Description
- Introduce `CustomLayerRegistration` that stores a `TypeId` and the deferred applier closure, and replace `AppBuilder::custom_layers` with `Vec<CustomLayerRegistration>` so type metadata is retained alongside the closure.
- Add `AppBuilder::has_layer::<L>()` and `AppBuilder::get_layer_types()` to allow plugins and build-time logic to query registered layer types before `run()`.
- Update router assembly and `TestApp` plumbing to consume `CustomLayerRegistration` and invoke the stored `apply` closure while preserving original middleware application order.
- Add integration tests `autumn/tests/middleware_introspection.rs` that assert presence/absence detection, registration-order reporting, and plugin preflight checks (including panic on missing required middleware).

### Testing
- Running `cargo fmt --all` in the `autumn` crate completed successfully.
- An initial automated test attempt `cargo test -p autumn_web middleware_introspection` failed due to the package being named `autumn-web` (diagnostic only).
- `cargo test -p autumn-web --test middleware_introspection` ran the new tests and reported `4 passed; 0 failed`.
- `cargo test -p autumn-web --test custom_layer` ran existing middleware tests and reported `3 passed; 0 failed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaac4a2e84832aa5939584b47f94c5)