### PR TITLE
Add configurable watch_dirs support to `autumn dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ autumn dev
 # cargo run
 ```
 
+`autumn dev` watches these directories by default: `src/`, `static/`,
+`templates/`, and `migrations/`.
+
+You can add extra watch paths in `autumn.toml`:
+
+```toml
+[dev]
+watch_dirs = ["views", "locales"]
+```
+
+Custom entries are additive: the four default directories are still watched.
+
 Visit <http://localhost:3000>. Autumn also auto-mounts `/health`,
 `/actuator/health`, `/actuator/info`, and `/static/js/htmx.min.js`.
 
@@ -128,4 +140,3 @@ Autumn can still run without a database if you omit the `[database]` section.
 ## License
 
 MIT OR Apache-2.0
-

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -599,19 +599,27 @@ fn has_component(path: &Path, target: &str) -> bool {
 
 fn path_contains_dir(path: &Path, dir: &str) -> bool {
     let dir = Path::new(dir);
-    if dir.components().count() == 1 {
-        return has_component(path, dir.as_os_str().to_str().unwrap_or_default());
+    if path_starts_with_watch_dir(path, dir) {
+        return true;
     }
 
-    let path_components: Vec<_> = path.components().collect();
-    let dir_components: Vec<_> = dir.components().collect();
-    if dir_components.is_empty() || path_components.len() < dir_components.len() {
-        return false;
+    // notify can emit absolute paths on some backends/platforms. Anchor custom
+    // matching to the workspace-relative watched prefix when possible.
+    if path.is_absolute()
+        && let Ok(cwd) = std::env::current_dir()
+        && let Ok(relative) = path.strip_prefix(&cwd)
+    {
+        return path_starts_with_watch_dir(relative, dir);
     }
 
-    path_components
-        .windows(dir_components.len())
-        .any(|window| window == dir_components.as_slice())
+    false
+}
+
+fn path_starts_with_watch_dir(path: &Path, watch_dir: &Path) -> bool {
+    path.starts_with(watch_dir)
+        || path
+            .strip_prefix(Path::new("."))
+            .is_ok_and(|relative| relative.starts_with(watch_dir))
 }
 
 fn default_watch_dirs() -> Vec<String> {
@@ -1102,6 +1110,25 @@ mod tests {
                 &watch_dirs
             ),
             ChangeEffect::BuildRestart
+        );
+    }
+
+    #[test]
+    fn custom_watch_dir_does_not_match_nested_component_name() {
+        let watch_dirs = vec![
+            "src".to_owned(),
+            "static".to_owned(),
+            "templates".to_owned(),
+            "migrations".to_owned(),
+            "views".to_owned(),
+        ];
+        assert_eq!(
+            classify_change_with_watch_dirs(
+                Path::new("src/views/readme.txt"),
+                DebouncedEventKind::Any,
+                &watch_dirs
+            ),
+            ChangeEffect::Ignore
         );
     }
 
@@ -1630,6 +1657,14 @@ watch_dirs = ["views", "locales", "src"]
 
     #[test]
     fn path_contains_dir_supports_nested_dirs() {
+        assert!(path_contains_dir(
+            Path::new("views/home/index.html"),
+            "views"
+        ));
+        assert!(!path_contains_dir(
+            Path::new("src/views/home/index.html"),
+            "views"
+        ));
         assert!(path_contains_dir(
             Path::new("frontend/views/home/index.html"),
             "frontend/views"

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -607,9 +607,20 @@ fn path_contains_dir(path: &Path, dir: &str) -> bool {
     // matching to the workspace-relative watched prefix when possible.
     if path.is_absolute()
         && let Ok(cwd) = std::env::current_dir()
-        && let Ok(relative) = path.strip_prefix(&cwd)
     {
-        return path_starts_with_watch_dir(relative, dir);
+        if let Ok(relative) = path.strip_prefix(&cwd)
+            && path_starts_with_watch_dir(relative, dir)
+        {
+            return true;
+        }
+
+        if dir.is_relative() {
+            let absolute_dir = cwd.join(dir);
+            let absolute_dir = std::fs::canonicalize(&absolute_dir).unwrap_or(absolute_dir);
+            if path_starts_with_watch_dir(path, &absolute_dir) {
+                return true;
+            }
+        }
     }
 
     false
@@ -1705,6 +1716,27 @@ watch_dirs = ["./views", "locales", "src"]
             Path::new("frontend/view/home/index.html"),
             "frontend/views"
         ));
+    }
+
+    #[test]
+    fn path_contains_dir_matches_parent_relative_watch_dir_for_absolute_paths() {
+        let root = tempfile::tempdir().expect("temp root");
+        let workspace = root.path().join("workspace");
+        let repo = workspace.join("autumn");
+        let shared = workspace.join("shared");
+        std::fs::create_dir_all(&repo).expect("create repo dir");
+        std::fs::create_dir_all(shared.join("nested")).expect("create shared dir");
+
+        let cwd = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(&repo).expect("set cwd");
+
+        let file = shared.join("nested").join("data.json");
+        assert!(
+            path_contains_dir(&file, "../shared"),
+            "absolute event path under ../shared should match custom watch dir"
+        );
+
+        std::env::set_current_dir(cwd).expect("restore cwd");
     }
 
     #[test]

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -664,10 +664,33 @@ fn load_custom_watch_dirs(config_path: &Path) -> Vec<String> {
     watch_dirs
         .iter()
         .filter_map(toml::Value::as_str)
-        .map(str::trim)
-        .filter(|dir| !dir.is_empty())
-        .map(ToOwned::to_owned)
+        .filter_map(normalize_watch_dir)
         .collect()
+}
+
+fn normalize_watch_dir(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in Path::new(raw).components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => normalized.push(".."),
+            std::path::Component::Normal(name) => normalized.push(name),
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        None
+    } else {
+        Some(normalized.to_string_lossy().to_string())
+    }
 }
 
 fn is_profile_config_file(file_name: &str) -> bool {
@@ -1554,7 +1577,7 @@ mod tests {
         std::fs::write(
             dir.path().join("autumn.toml"),
             r#"[dev]
-watch_dirs = ["views", "locales", "src"]
+watch_dirs = ["./views", "locales", "src"]
 "#,
         )
         .expect("write config");
@@ -1576,6 +1599,15 @@ watch_dirs = ["views", "locales", "src"]
             dirs.iter().filter(|d| d.as_str() == "src").count(),
             1,
             "default dirs should not be duplicated"
+        );
+    }
+
+    #[test]
+    fn normalize_watch_dir_strips_leading_dot_slash() {
+        assert_eq!(normalize_watch_dir("./views"), Some("views".to_string()));
+        assert_eq!(
+            normalize_watch_dir("./frontend/views/"),
+            Some("frontend/views".to_string())
         );
     }
 

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -605,20 +605,20 @@ fn path_contains_dir(path: &Path, dir: &str) -> bool {
 
     // notify can emit absolute paths on some backends/platforms. Anchor custom
     // matching to the workspace-relative watched prefix when possible.
-    if path.is_absolute()
-        && let Ok(cwd) = std::env::current_dir()
-    {
-        if let Ok(relative) = path.strip_prefix(&cwd)
-            && path_starts_with_watch_dir(relative, dir)
-        {
-            return true;
-        }
+    if path.is_absolute() {
+        if let Ok(cwd) = std::env::current_dir() {
+            if let Ok(relative) = path.strip_prefix(&cwd) {
+                if path_starts_with_watch_dir(relative, dir) {
+                    return true;
+                }
+            }
 
-        if dir.is_relative() {
-            let absolute_dir = cwd.join(dir);
-            let absolute_dir = std::fs::canonicalize(&absolute_dir).unwrap_or(absolute_dir);
-            if path_starts_with_watch_dir(path, &absolute_dir) {
-                return true;
+            if dir.is_relative() {
+                let absolute_dir = cwd.join(dir);
+                let absolute_dir = std::fs::canonicalize(&absolute_dir).unwrap_or(absolute_dir);
+                if path_starts_with_watch_dir(path, &absolute_dir) {
+                    return true;
+                }
             }
         }
     }

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -38,7 +38,7 @@ const WATCH_FILES: &[&str] = &[
     "tailwind.config.js",
 ];
 
-/// Directories to watch recursively.
+/// Default directories watched recursively by `autumn dev`.
 const WATCH_DIRS: &[&str] = &["src", "static", "templates", "migrations"];
 
 const DEV_RELOAD_ENV: &str = "AUTUMN_DEV_RELOAD";
@@ -174,6 +174,7 @@ pub fn run(package: Option<&str>, show_config: bool) {
             None
         }
     };
+    let watch_dirs = resolve_watch_dirs();
     // Initial build
     if !cargo_build(package) {
         eprintln!("\u{2717} Initial build failed. Fix errors and save to retry.\n");
@@ -194,7 +195,7 @@ pub fn run(package: Option<&str>, show_config: bool) {
     let watcher = debouncer.watcher();
 
     // Watch relevant directories
-    for dir in WATCH_DIRS {
+    for dir in &watch_dirs {
         let path = Path::new(dir);
         if path.exists() {
             if let Err(e) = watcher.watch(path, notify::RecursiveMode::Recursive) {
@@ -219,7 +220,14 @@ pub fn run(package: Option<&str>, show_config: bool) {
             break;
         }
 
-        if !process_events(&rx, package, &mut child, reload_state.as_mut(), show_config) {
+        if !process_events(
+            &rx,
+            package,
+            &mut child,
+            reload_state.as_mut(),
+            show_config,
+            &watch_dirs,
+        ) {
             break;
         }
     }
@@ -235,15 +243,16 @@ fn process_events(
     child: &mut Option<Child>,
     reload_state: Option<&mut DevReloadState>,
     show_config: bool,
+    watch_dirs: &[String],
 ) -> bool {
     match rx.recv_timeout(Duration::from_millis(SHUTDOWN_CHECK_INTERVAL_MS)) {
         Ok(Ok(events)) => {
-            let plan = plan_changes(&events);
+            let plan = plan_changes_with_watch_dirs(&events, watch_dirs);
             if plan.is_empty() {
                 return true;
             }
 
-            let changed = collect_relevant_changes(&events);
+            let changed = collect_relevant_changes_with_watch_dirs(&events, watch_dirs);
             if changed.is_empty() {
                 return true;
             }
@@ -322,18 +331,40 @@ fn execute_plan(
 /// Collect display paths for all relevant file changes from a debounced batch.
 ///
 /// Returns an empty vec if no changes are relevant.
+#[cfg(test)]
 fn collect_relevant_changes(events: &[notify_debouncer_mini::DebouncedEvent]) -> Vec<String> {
+    let watch_dirs = default_watch_dirs();
+    collect_relevant_changes_with_watch_dirs(events, &watch_dirs)
+}
+
+fn collect_relevant_changes_with_watch_dirs(
+    events: &[notify_debouncer_mini::DebouncedEvent],
+    watch_dirs: &[String],
+) -> Vec<String> {
     events
         .iter()
-        .filter(|e| is_relevant_change(&e.path, e.kind))
+        .filter(|e| is_relevant_change_with_watch_dirs(&e.path, e.kind, watch_dirs))
         .map(|e| e.path.display().to_string())
         .collect()
 }
 
+#[cfg(test)]
 fn plan_changes(events: &[notify_debouncer_mini::DebouncedEvent]) -> ChangePlan {
+    let watch_dirs = default_watch_dirs();
+    plan_changes_with_watch_dirs(events, &watch_dirs)
+}
+
+fn plan_changes_with_watch_dirs(
+    events: &[notify_debouncer_mini::DebouncedEvent],
+    watch_dirs: &[String],
+) -> ChangePlan {
     let mut plan = ChangePlan::default();
     for event in events {
-        plan.register(classify_change(&event.path, event.kind));
+        plan.register(classify_change_with_watch_dirs(
+            &event.path,
+            event.kind,
+            watch_dirs,
+        ));
     }
     plan.finalize()
 }
@@ -449,11 +480,31 @@ fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Result<(), ()> {
 }
 
 /// Check if a file change event is relevant enough to trigger a rebuild.
+#[cfg(test)]
 fn is_relevant_change(path: &Path, kind: DebouncedEventKind) -> bool {
-    classify_change(path, kind) != ChangeEffect::Ignore
+    let watch_dirs = default_watch_dirs();
+    is_relevant_change_with_watch_dirs(path, kind, &watch_dirs)
 }
 
+#[cfg(test)]
 fn classify_change(path: &Path, kind: DebouncedEventKind) -> ChangeEffect {
+    let watch_dirs = default_watch_dirs();
+    classify_change_with_watch_dirs(path, kind, &watch_dirs)
+}
+
+fn is_relevant_change_with_watch_dirs(
+    path: &Path,
+    kind: DebouncedEventKind,
+    watch_dirs: &[String],
+) -> bool {
+    classify_change_with_watch_dirs(path, kind, watch_dirs) != ChangeEffect::Ignore
+}
+
+fn classify_change_with_watch_dirs(
+    path: &Path,
+    kind: DebouncedEventKind,
+    watch_dirs: &[String],
+) -> ChangeEffect {
     if !matches!(kind, DebouncedEventKind::Any) || should_ignore_path(path) {
         return ChangeEffect::Ignore;
     }
@@ -500,6 +551,15 @@ fn classify_change(path: &Path, kind: DebouncedEventKind) -> ChangeEffect {
         return ChangeEffect::BrowserReloadOnly;
     }
 
+    for dir in watch_dirs {
+        if WATCH_DIRS.contains(&dir.as_str()) {
+            continue;
+        }
+        if path_contains_dir(path, dir) {
+            return ChangeEffect::BuildRestart;
+        }
+    }
+
     ChangeEffect::Ignore
 }
 
@@ -535,6 +595,71 @@ fn has_component(path: &Path, target: &str) -> bool {
             std::path::Component::Normal(name) if name == std::ffi::OsStr::new(target)
         )
     })
+}
+
+fn path_contains_dir(path: &Path, dir: &str) -> bool {
+    let dir = Path::new(dir);
+    if dir.components().count() == 1 {
+        return has_component(path, dir.as_os_str().to_str().unwrap_or_default());
+    }
+
+    let path_components: Vec<_> = path.components().collect();
+    let dir_components: Vec<_> = dir.components().collect();
+    if dir_components.is_empty() || path_components.len() < dir_components.len() {
+        return false;
+    }
+
+    path_components
+        .windows(dir_components.len())
+        .any(|window| window == dir_components.as_slice())
+}
+
+fn default_watch_dirs() -> Vec<String> {
+    WATCH_DIRS.iter().map(|dir| (*dir).to_owned()).collect()
+}
+
+fn resolve_watch_dirs() -> Vec<String> {
+    let mut dirs = default_watch_dirs();
+    let custom = load_custom_watch_dirs(Path::new("autumn.toml"));
+    for dir in custom {
+        if !dirs.iter().any(|existing| existing == &dir) {
+            dirs.push(dir);
+        }
+    }
+    dirs
+}
+
+fn load_custom_watch_dirs(config_path: &Path) -> Vec<String> {
+    let Ok(contents) = std::fs::read_to_string(config_path) else {
+        return Vec::new();
+    };
+
+    let parsed: toml::Value = match toml::from_str(&contents) {
+        Ok(value) => value,
+        Err(error) => {
+            eprintln!(
+                "  Warning: could not parse {} for [dev].watch_dirs: {error}",
+                config_path.display()
+            );
+            return Vec::new();
+        }
+    };
+
+    let Some(watch_dirs) = parsed
+        .get("dev")
+        .and_then(|dev| dev.get("watch_dirs"))
+        .and_then(toml::Value::as_array)
+    else {
+        return Vec::new();
+    };
+
+    watch_dirs
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .map(str::trim)
+        .filter(|dir| !dir.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
 }
 
 fn is_profile_config_file(file_name: &str) -> bool {
@@ -962,6 +1087,25 @@ mod tests {
     }
 
     #[test]
+    fn custom_watch_dir_change_triggers_build_restart() {
+        let watch_dirs = vec![
+            "src".to_owned(),
+            "static".to_owned(),
+            "templates".to_owned(),
+            "migrations".to_owned(),
+            "views".to_owned(),
+        ];
+        assert_eq!(
+            classify_change_with_watch_dirs(
+                Path::new("views/home/index.html"),
+                DebouncedEventKind::Any,
+                &watch_dirs
+            ),
+            ChangeEffect::BuildRestart
+        );
+    }
+
+    #[test]
     fn ignores_target_directory() {
         assert!(!is_relevant_change(
             Path::new("target/debug/build/main.rs"),
@@ -1378,6 +1522,37 @@ mod tests {
     }
 
     #[test]
+    fn resolve_watch_dirs_keeps_defaults_and_adds_custom() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            r#"[dev]
+watch_dirs = ["views", "locales", "src"]
+"#,
+        )
+        .expect("write config");
+
+        let cwd = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(dir.path()).expect("set cwd");
+        let dirs = resolve_watch_dirs();
+        std::env::set_current_dir(cwd).expect("restore cwd");
+
+        for default in WATCH_DIRS {
+            assert!(
+                dirs.contains(&default.to_string()),
+                "missing default watch dir: {default}"
+            );
+        }
+        assert!(dirs.contains(&"views".to_string()));
+        assert!(dirs.contains(&"locales".to_string()));
+        assert_eq!(
+            dirs.iter().filter(|d| d.as_str() == "src").count(),
+            1,
+            "default dirs should not be duplicated"
+        );
+    }
+
+    #[test]
     fn watch_files_are_non_empty() {
         for f in WATCH_FILES {
             assert!(!f.is_empty());
@@ -1450,6 +1625,18 @@ mod tests {
         assert!(!has_component(
             Path::new("template/index.html"),
             "templates"
+        ));
+    }
+
+    #[test]
+    fn path_contains_dir_supports_nested_dirs() {
+        assert!(path_contains_dir(
+            Path::new("frontend/views/home/index.html"),
+            "frontend/views"
+        ));
+        assert!(!path_contains_dir(
+            Path::new("frontend/view/home/index.html"),
+            "frontend/views"
         ));
     }
 


### PR DESCRIPTION
### Motivation

- Make `autumn dev` adaptable to non-standard project layouts by allowing developers to add extra watch paths via config instead of being limited to hardcoded directories. 
- Preserve the existing default watch list (`src`, `static`, `templates`, `migrations`) while allowing additive, deduplicated custom entries. 
- Ensure changes in custom watch directories reliably trigger a rebuild/restart so hot-reload behavior matches developer expectations.

### Description

- Added config parsing for `[dev].watch_dirs` in `autumn.toml` via `load_custom_watch_dirs` and merged results with defaults in `resolve_watch_dirs` while deduplicating entries. 
- Wired resolved watch dirs into the file watcher setup so `autumn dev` watches defaults plus user-provided paths (`run` uses `resolve_watch_dirs`).
- Extended change classification to accept watch-dir context: introduced `classify_change_with_watch_dirs`, `is_relevant_change_with_watch_dirs`, and `plan_changes_with_watch_dirs`, and added `path_contains_dir` helper to match nested custom paths; files inside custom watch dirs route to `BuildRestart` to trigger rebuild+restart. 
- Added unit tests covering custom watch-dir matching, `resolve_watch_dirs` merging behavior, and nested directory matching, and documented the feature in `README.md` with an example `autumn.toml` snippet.

### Testing

- Ran formatting with `cargo fmt` successfully.
- Ran targeted unit tests with `cargo test -p autumn-cli dev::tests:: -- --nocapture`, which passed (`65` tests passed, `0` failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaac54ca4c832a84b3bec4468b1bb3)