### PR TITLE
Support primitive return types in route handlers

### DIFF
--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -73,10 +73,10 @@ pub fn route_macro(
         None
     };
 
-    let handler_name = primitive_wrapper
-        .as_ref()
-        .map(|_| format_ident!("__autumn_primitive_handler_{}", fn_name))
-        .unwrap_or_else(|| fn_name.clone());
+    let handler_name = primitive_wrapper.as_ref().map_or_else(
+        || fn_name.clone(),
+        |_| format_ident!("__autumn_primitive_handler_{}", fn_name),
+    );
 
     // Build the handler expression, chaining .layer() for each interceptor.
     // Interceptors are applied in reverse attribute order so that the first

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -6,7 +6,7 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{ReturnType, Type};
+use syn::{FnArg, ReturnType, Type};
 
 use crate::parse;
 
@@ -40,11 +40,49 @@ pub fn route_macro(
     let method_const = format_ident!("{}", http_method); // e.g., GET
     let routing_fn = format_ident!("{}", axum_fn); // e.g., get
 
+    let primitive_wrapper = if should_stringify_primitive_output(&input_fn.sig.output) {
+        let wrapper_name = format_ident!("__autumn_primitive_handler_{}", fn_name);
+        let mut wrapper_inputs = Vec::new();
+        let mut call_args = Vec::new();
+
+        for (idx, arg) in input_fn.sig.inputs.iter().enumerate() {
+            match arg {
+                FnArg::Typed(pat_type) => {
+                    let arg_name = format_ident!("__autumn_arg_{idx}");
+                    let ty = &pat_type.ty;
+                    wrapper_inputs.push(quote! { #arg_name: #ty });
+                    call_args.push(quote! { #arg_name });
+                }
+                FnArg::Receiver(receiver) => {
+                    return syn::Error::new_spanned(
+                        receiver,
+                        "Autumn route handlers cannot take a self receiver",
+                    )
+                    .to_compile_error();
+                }
+            }
+        }
+
+        Some(quote! {
+            #[doc(hidden)]
+            async fn #wrapper_name(#(#wrapper_inputs),*) -> ::std::string::String {
+                #fn_name(#(#call_args),*).await.to_string()
+            }
+        })
+    } else {
+        None
+    };
+
+    let handler_name = primitive_wrapper
+        .as_ref()
+        .map(|_| format_ident!("__autumn_primitive_handler_{}", fn_name))
+        .unwrap_or_else(|| fn_name.clone());
+
     // Build the handler expression, chaining .layer() for each interceptor.
     // Interceptors are applied in reverse attribute order so that the first
     // #[intercept(...)] listed is the outermost layer (runs first).
     let mut handler_expr: TokenStream =
-        quote! { ::autumn_web::reexports::axum::routing::#routing_fn(#fn_name) };
+        quote! { ::autumn_web::reexports::axum::routing::#routing_fn(#handler_name) };
 
     for interceptor in interceptors.iter().rev() {
         // Explicit error type annotation avoids inference ambiguity when
@@ -56,24 +94,12 @@ pub fn route_macro(
         };
     }
 
-    // Note: we intentionally do NOT apply #[axum::debug_handler] here.
-    // That macro generates code with `::axum::` paths, which don't resolve
-    // when the user only depends on `autumn-web` (axum is a transitive dep).
-    // Custom compile_error! diagnostics (S-007) provide error guidance instead.
-    if should_stringify_primitive_output(&input_fn.sig.output) {
-        let original_block = input_fn.block.clone();
-        input_fn.sig.output = syn::parse_quote!(-> ::std::string::String);
-        input_fn.block = syn::parse_quote!({
-            let __autumn_primitive_response = (async move #original_block).await;
-            __autumn_primitive_response.to_string()
-        });
-    }
-
     quote! {
         // ECHO-001: We want to apply #[axum::debug_handler] but without forcing the user
         // to import axum manually. However, the path resolution in Axum macros makes this impossible
         // natively. Custom compile errors handle the type checks.
         #input_fn
+        #primitive_wrapper
 
         #[doc(hidden)]
         #vis fn #route_info_name() -> ::autumn_web::Route {

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -6,6 +6,7 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
+use syn::{ReturnType, Type};
 
 use crate::parse;
 
@@ -59,6 +60,14 @@ pub fn route_macro(
     // That macro generates code with `::axum::` paths, which don't resolve
     // when the user only depends on `autumn-web` (axum is a transitive dep).
     // Custom compile_error! diagnostics (S-007) provide error guidance instead.
+    if should_stringify_primitive_output(&input_fn.sig.output) {
+        let original_block = input_fn.block.clone();
+        input_fn.sig.output = syn::parse_quote!(-> ::std::string::String);
+        input_fn.block = syn::parse_quote!({
+            let __autumn_primitive_response = (async move #original_block).await;
+            __autumn_primitive_response.to_string()
+        });
+    }
 
     quote! {
         // ECHO-001: We want to apply #[axum::debug_handler] but without forcing the user
@@ -76,4 +85,38 @@ pub fn route_macro(
             }
         }
     }
+}
+
+fn should_stringify_primitive_output(output: &ReturnType) -> bool {
+    let ReturnType::Type(_, ty) = output else {
+        return false;
+    };
+
+    let Type::Path(path) = ty.as_ref() else {
+        return false;
+    };
+
+    if path.qself.is_some() || path.path.segments.len() != 1 {
+        return false;
+    }
+
+    let ident = path.path.segments[0].ident.to_string();
+    matches!(
+        ident.as_str(),
+        "bool"
+            | "i8"
+            | "i16"
+            | "i32"
+            | "i64"
+            | "i128"
+            | "isize"
+            | "u8"
+            | "u16"
+            | "u32"
+            | "u64"
+            | "u128"
+            | "usize"
+            | "f32"
+            | "f64"
+    )
 }

--- a/autumn/tests/route_macro.rs
+++ b/autumn/tests/route_macro.rs
@@ -214,6 +214,18 @@ fn primitive_bool_return_type_compiles_with_route_macro() {
     assert_eq!(route.name, "returns_primitive_bool");
 }
 
+#[tokio::test]
+async fn primitive_int_handler_keeps_declared_return_type_for_direct_calls() {
+    let value: i32 = returns_primitive_int().await;
+    assert_eq!(value, 42);
+}
+
+#[tokio::test]
+async fn primitive_bool_handler_keeps_declared_return_type_for_direct_calls() {
+    let value: bool = returns_primitive_bool().await;
+    assert!(value);
+}
+
 // ── Path parameter tests (S-006) ────────────────────────────────────
 
 #[test]

--- a/autumn/tests/route_macro.rs
+++ b/autumn/tests/route_macro.rs
@@ -56,11 +56,13 @@ async fn returns_status() -> http::StatusCode {
 }
 
 #[get("/primitive-int")]
+#[allow(clippy::unused_async)]
 async fn returns_primitive_int() -> i32 {
     42
 }
 
 #[get("/primitive-bool")]
+#[allow(clippy::unused_async)]
 async fn returns_primitive_bool() -> bool {
     true
 }

--- a/autumn/tests/route_macro.rs
+++ b/autumn/tests/route_macro.rs
@@ -55,6 +55,16 @@ async fn returns_status() -> http::StatusCode {
     http::StatusCode::NO_CONTENT
 }
 
+#[get("/primitive-int")]
+async fn returns_primitive_int() -> i32 {
+    42
+}
+
+#[get("/primitive-bool")]
+async fn returns_primitive_bool() -> bool {
+    true
+}
+
 // ── GET tests ────────────────────────────────────────────────────────
 
 #[test]
@@ -186,6 +196,22 @@ fn status_code_return_type_compiles_with_debug_handler() {
     assert_eq!(route.method, http::Method::GET);
     assert_eq!(route.path, "/status");
     assert_eq!(route.name, "returns_status");
+}
+
+#[test]
+fn primitive_int_return_type_compiles_with_route_macro() {
+    let route = __autumn_route_info_returns_primitive_int();
+    assert_eq!(route.method, http::Method::GET);
+    assert_eq!(route.path, "/primitive-int");
+    assert_eq!(route.name, "returns_primitive_int");
+}
+
+#[test]
+fn primitive_bool_return_type_compiles_with_route_macro() {
+    let route = __autumn_route_info_returns_primitive_bool();
+    assert_eq!(route.method, http::Method::GET);
+    assert_eq!(route.path, "/primitive-bool");
+    assert_eq!(route.name, "returns_primitive_bool");
 }
 
 // ── Path parameter tests (S-006) ────────────────────────────────────

--- a/autumn/tests/test_app_integration.rs
+++ b/autumn/tests/test_app_integration.rs
@@ -52,11 +52,13 @@ async fn delete_user(axum::extract::Path(_id): axum::extract::Path<i64>) -> Stat
 }
 
 #[get("/primitive/int")]
+#[allow(clippy::unused_async)]
 async fn primitive_int() -> i32 {
     42
 }
 
 #[get("/primitive/bool")]
+#[allow(clippy::unused_async)]
 async fn primitive_bool() -> bool {
     true
 }

--- a/autumn/tests/test_app_integration.rs
+++ b/autumn/tests/test_app_integration.rs
@@ -51,6 +51,16 @@ async fn delete_user(axum::extract::Path(_id): axum::extract::Path<i64>) -> Stat
     StatusCode::NO_CONTENT
 }
 
+#[get("/primitive/int")]
+async fn primitive_int() -> i32 {
+    42
+}
+
+#[get("/primitive/bool")]
+async fn primitive_bool() -> bool {
+    true
+}
+
 #[post("/validate")]
 async fn validate_input(
     Json(body): Json<serde_json::Value>,
@@ -76,7 +86,9 @@ fn app() -> autumn_web::test::TestClient {
             get_user,
             update_user,
             delete_user,
-            validate_input
+            validate_input,
+            primitive_int,
+            primitive_bool
         ])
         .build()
 }
@@ -213,6 +225,30 @@ async fn validation_success() {
             assert_eq!(v["valid"], true);
             assert_eq!(v["name"], "Alice");
         });
+}
+
+#[tokio::test]
+async fn primitive_integer_return_is_plain_text() {
+    let client = app();
+
+    client
+        .get("/primitive/int")
+        .send()
+        .await
+        .assert_ok()
+        .assert_body_eq("42");
+}
+
+#[tokio::test]
+async fn primitive_bool_return_is_plain_text() {
+    let client = app();
+
+    client
+        .get("/primitive/bool")
+        .send()
+        .await
+        .assert_ok()
+        .assert_body_eq("true");
 }
 
 // ── Full CRUD lifecycle test ───────────────────────────────────


### PR DESCRIPTION
### Motivation
- Users should be able to return primitive types (e.g., `i32`, `bool`, `f32`, `f64`, etc.) directly from async route handlers and receive plain-text HTTP responses without exposing Axum internal trait errors or requiring manual `to_string()`/`Json` wrapping.

### Description
- Update the route macro expansion in `autumn-macros/src/route.rs` to detect primitive return types and rewrite the emitted handler to return `String`, converting the computed primitive via `.to_string()` at runtime.
- Add a helper `should_stringify_primitive_output` that recognizes `bool`, all integer primitives, and `f32`/`f64` as targets for automatic stringification.
- Add compile-time coverage tests in `autumn/tests/route_macro.rs` to verify primitive-return handlers compile and produce correct route metadata.
- Add integration routes and tests in `autumn/tests/test_app_integration.rs` to assert primitive responses are returned as plain text (`"42"` and `"true"`).

### Testing
- Ran `cargo test -p autumn-web --test route_macro --test test_app_integration`, and the route-macro unit tests completed with `22 passed; 0 failed` and the app integration tests completed with `18 passed; 0 failed`.
- The modified files tested were `autumn-macros/src/route.rs`, `autumn/tests/route_macro.rs`, and `autumn/tests/test_app_integration.rs`, and all added tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaac5ee5e4832abadb328b92b4f798)