### PR TITLE
⚡ Bolt: Use zero-cost HeaderValue conversion in dev middleware

### DIFF
--- a/autumn/src/middleware/dev.rs
+++ b/autumn/src/middleware/dev.rs
@@ -91,11 +91,10 @@ async fn inject_live_reload_into_response(response: Response<Body>) -> Response<
         return Response::from_parts(parts, Body::from(body));
     }
 
-    if let Ok(value) = HeaderValue::from_str(&updated.len().to_string()) {
-        parts.headers.insert(CONTENT_LENGTH, value);
-    } else {
-        parts.headers.remove(CONTENT_LENGTH);
-    }
+    // Avoids heap allocation by using zero-cost numeric conversion
+    parts
+        .headers
+        .insert(CONTENT_LENGTH, HeaderValue::from(updated.len()));
 
     Response::from_parts(parts, Body::from(updated))
 }


### PR DESCRIPTION
💡 What: Switched `HeaderValue::from_str(&length.to_string())` to `HeaderValue::from(length)` in `dev.rs`.
🎯 Why: Creating a `HeaderValue` for Content-Length previously involved formatting the length into a heap-allocated `String` and parsing it, which was unnecessary for integers.
📊 Impact: Reduces heap allocs by removing a `String` allocation per HTML response processed by the live-reload middleware.
🔬 Measurement: Run `cargo test -p autumn-web --lib middleware::dev` to verify the logic remains identical.

---
*PR created automatically by Jules for task [18382885845645267410](https://jules.google.com/task/18382885845645267410) started by @madmax983*