### PR TITLE
autumn dev: support custom watch_dirs from autumn.toml and dynamic watcher registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ autumn dev
 # cargo run
 ```
 
+`autumn dev` watches these directories by default: `src/`, `static/`,
+`templates/`, and `migrations/`.
+
+You can add extra watch paths in `autumn.toml`:
+
+```toml
+[dev]
+watch_dirs = ["views", "locales"]
+```
+
+Custom entries are additive: the four default directories are still watched.
+
 Visit <http://localhost:3000>. Autumn also auto-mounts `/health`,
 `/actuator/health`, `/actuator/info`, and `/static/js/htmx.min.js`.
 
@@ -128,4 +140,3 @@ Autumn can still run without a database if you omit the `[database]` section.
 ## License
 
 MIT OR Apache-2.0
-

--- a/autumn-cli/Cargo.toml
+++ b/autumn-cli/Cargo.toml
@@ -32,7 +32,6 @@ toml = "1.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-nix = { version = "0.31.2", features = ["signal"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/autumn-cli/Cargo.toml
+++ b/autumn-cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"
-ctrlc = "3.5.2"
+ctrlc = { version = "3.5.2", features = ["termination"] }
 hex = "0.4"
 indicatif = "0.18"
 notify = "8"

--- a/autumn-cli/Cargo.toml
+++ b/autumn-cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"
-ctrlc = { version = "3.5.2", features = ["termination"] }
+ctrlc = "3.5.2"
 hex = "0.4"
 indicatif = "0.18"
 notify = "8"
@@ -32,6 +32,7 @@ toml = "1.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+nix = { version = "0.31.2", features = ["signal"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -115,16 +115,17 @@ fn resolve_binary_from_metadata(
                 .parent()
                 .unwrap_or_else(|| Path::new(""));
 
+            let is_bin =
+                |t: &&serde_json::Value| -> bool {
+                    t["kind"]
+                        .as_array()
+                        .is_some_and(|k| k.iter().any(|k| k == "bin"))
+                };
+
             // Prefer the binary whose src_path is exactly `src/main.rs` so
             // that secondary targets (e.g. a WASM client bin) are not
             // accidentally picked as the server binary.
-            let preferred = targets.iter().find(|t| {
-                let is_bin = t["kind"]
-                    .as_array()
-                    .is_some_and(|k| k.iter().any(|k| k == "bin"));
-                if !is_bin {
-                    return false;
-                }
+            let preferred = targets.iter().filter(|t| is_bin(t)).find(|t| {
                 t["src_path"]
                     .as_str()
                     .is_some_and(|p| Path::new(p) == manifest_dir.join("src/main.rs"))
@@ -135,16 +136,10 @@ fn resolve_binary_from_metadata(
             }
 
             // Fall back to the first bin target if no `src/main.rs` match.
-            targets.iter().find_map(|t| {
-                let is_bin = t["kind"]
-                    .as_array()
-                    .is_some_and(|k| k.iter().any(|k| k == "bin"));
-                if is_bin {
-                    t["name"].as_str().map(String::from)
-                } else {
-                    None
-                }
-            })
+            targets
+                .iter()
+                .filter(|t| is_bin(t))
+                .find_map(|t| t["name"].as_str().map(String::from))
         })
         .ok_or_else(|| {
             package.map_or_else(

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -115,12 +115,11 @@ fn resolve_binary_from_metadata(
                 .parent()
                 .unwrap_or_else(|| Path::new(""));
 
-            let is_bin =
-                |t: &&serde_json::Value| -> bool {
-                    t["kind"]
-                        .as_array()
-                        .is_some_and(|k| k.iter().any(|k| k == "bin"))
-                };
+            let is_bin = |t: &&serde_json::Value| -> bool {
+                t["kind"]
+                    .as_array()
+                    .is_some_and(|k| k.iter().any(|k| k == "bin"))
+            };
 
             // Prefer the binary whose src_path is exactly `src/main.rs` so
             // that secondary targets (e.g. a WASM client bin) are not

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -110,8 +110,35 @@ fn resolve_binary_from_metadata(
     let bin_name = matching_packages
         .iter()
         .find_map(|pkg| {
-            pkg["targets"].as_array()?.iter().find_map(|t| {
-                let is_bin = t["kind"].as_array()?.iter().any(|k| k == "bin");
+            let targets = pkg["targets"].as_array()?;
+            let manifest_dir = Path::new(pkg["manifest_path"].as_str()?)
+                .parent()
+                .unwrap_or_else(|| Path::new(""));
+
+            // Prefer the binary whose src_path is exactly `src/main.rs` so
+            // that secondary targets (e.g. a WASM client bin) are not
+            // accidentally picked as the server binary.
+            let preferred = targets.iter().find(|t| {
+                let is_bin = t["kind"]
+                    .as_array()
+                    .is_some_and(|k| k.iter().any(|k| k == "bin"));
+                if !is_bin {
+                    return false;
+                }
+                t["src_path"]
+                    .as_str()
+                    .is_some_and(|p| Path::new(p) == manifest_dir.join("src/main.rs"))
+            });
+
+            if let Some(t) = preferred {
+                return t["name"].as_str().map(String::from);
+            }
+
+            // Fall back to the first bin target if no `src/main.rs` match.
+            targets.iter().find_map(|t| {
+                let is_bin = t["kind"]
+                    .as_array()
+                    .is_some_and(|k| k.iter().any(|k| k == "bin"));
                 if is_bin {
                     t["name"].as_str().map(String::from)
                 } else {
@@ -214,5 +241,37 @@ mod tests {
         let result =
             resolve_binary_from_metadata(&metadata, true, Some("hello"), Path::new("/projects"));
         assert!(result.unwrap_err().contains("package 'hello'"));
+    }
+
+    #[test]
+    fn resolve_binary_prefers_main_rs_over_other_bins() {
+        // When a package has multiple bin targets, the one whose src_path is
+        // `src/main.rs` should be selected even if it is not listed first.
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [{
+                "name": "myapp",
+                "manifest_path": "/projects/myapp/Cargo.toml",
+                "targets": [
+                    {
+                        "name": "client",
+                        "kind": ["bin"],
+                        "src_path": "/projects/myapp/src/client.rs"
+                    },
+                    {
+                        "name": "server",
+                        "kind": ["bin"],
+                        "src_path": "/projects/myapp/src/main.rs"
+                    }
+                ]
+            }]
+        });
+        let result = resolve_binary_from_metadata(
+            &metadata,
+            true,
+            Some("myapp"),
+            Path::new("/projects/myapp"),
+        );
+        assert_eq!(result.unwrap(), expected_binary("/tmp/target/debug/server"));
     }
 }

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -438,10 +438,18 @@ fn sync_watch_dirs<W: notify::Watcher + ?Sized>(
         if let Err(e) = watcher.unwatch(Path::new(&dir)) {
             eprintln!("  Warning: could not unwatch {dir}/: {e}");
         }
-        watched_dirs.remove(&dir);
+        invalidate_watch_cache_for_removed_dir(watched_dirs, &dir);
     }
 
     ensure_watch_dirs_registered(watcher, watch_dirs, watched_dirs);
+}
+
+fn invalidate_watch_cache_for_removed_dir(watched_dirs: &mut HashSet<String>, removed_dir: &str) {
+    let removed_path = Path::new(removed_dir);
+    watched_dirs.retain(|cached| {
+        let cached_path = Path::new(cached);
+        !(cached_path == removed_path || cached_path.starts_with(removed_path))
+    });
 }
 
 fn removed_watch_dirs(
@@ -1438,6 +1446,23 @@ mod tests {
 
         let removed = removed_watch_dirs(&watched, &desired);
         assert_eq!(removed, vec!["views".to_string()]);
+    }
+
+    #[test]
+    fn invalidate_watch_cache_for_removed_parent_clears_nested_entries() {
+        let mut watched = HashSet::from([
+            "frontend".to_string(),
+            "frontend/assets".to_string(),
+            "frontend/assets/images".to_string(),
+            "src".to_string(),
+        ]);
+
+        invalidate_watch_cache_for_removed_dir(&mut watched, "frontend");
+
+        assert!(!watched.contains("frontend"));
+        assert!(!watched.contains("frontend/assets"));
+        assert!(!watched.contains("frontend/assets/images"));
+        assert!(watched.contains("src"));
     }
 
     #[test]

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -213,6 +213,12 @@ pub fn run(package: Option<&str>, show_config: bool) {
             break;
         }
 
+        // Re-attempt registration for configured dirs that may have been
+        // missing earlier (e.g. custom watch dir added to config before
+        // creating the directory on disk).
+        let watcher = debouncer.watcher();
+        ensure_watch_dirs_registered(watcher, &watch_dirs, &mut watched_dirs);
+
         let result = process_events(
             &rx,
             package,
@@ -1416,6 +1422,30 @@ mod tests {
 
         let removed = removed_watch_dirs(&watched, &desired);
         assert_eq!(removed, vec!["views".to_string()]);
+    }
+
+    #[test]
+    fn ensure_watch_dirs_registered_retries_dirs_once_created() {
+        let root = tempfile::tempdir().expect("temp root");
+        let watch_dir = root.path().join("future-dir");
+        let dir = watch_dir.display().to_string();
+        let watch_dirs = vec![dir.clone()];
+        let mut watched_dirs = HashSet::new();
+
+        let mut watcher = notify::recommended_watcher(|_| {}).expect("watcher");
+
+        ensure_watch_dirs_registered(&mut watcher, &watch_dirs, &mut watched_dirs);
+        assert!(
+            !watched_dirs.contains(&dir),
+            "missing dir should not be marked watched"
+        );
+
+        std::fs::create_dir_all(&watch_dir).expect("create watch dir");
+        ensure_watch_dirs_registered(&mut watcher, &watch_dirs, &mut watched_dirs);
+        assert!(
+            watched_dirs.contains(&dir),
+            "dir should be registered once it exists"
+        );
     }
 
     // ── build_cargo_command tests ──────────────────────────────────

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -225,7 +225,7 @@ pub fn run(package: Option<&str>, show_config: bool) {
         if result.refresh_watch_dirs {
             watch_dirs = resolve_watch_dirs();
             let watcher = debouncer.watcher();
-            ensure_watch_dirs_registered(watcher, &watch_dirs, &mut watched_dirs);
+            sync_watch_dirs(watcher, &watch_dirs, &mut watched_dirs);
         }
 
         if !result.keep_running {
@@ -418,6 +418,35 @@ fn ensure_watch_dirs_registered<W: notify::Watcher + ?Sized>(
             }
         }
     }
+}
+
+fn sync_watch_dirs<W: notify::Watcher + ?Sized>(
+    watcher: &mut W,
+    watch_dirs: &[String],
+    watched_dirs: &mut HashSet<String>,
+) {
+    let desired_dirs: HashSet<String> = watch_dirs.iter().cloned().collect();
+    let to_remove = removed_watch_dirs(watched_dirs, &desired_dirs);
+
+    for dir in to_remove {
+        if let Err(e) = watcher.unwatch(Path::new(&dir)) {
+            eprintln!("  Warning: could not unwatch {dir}/: {e}");
+        }
+        watched_dirs.remove(&dir);
+    }
+
+    ensure_watch_dirs_registered(watcher, watch_dirs, watched_dirs);
+}
+
+fn removed_watch_dirs(
+    watched_dirs: &HashSet<String>,
+    desired_dirs: &HashSet<String>,
+) -> Vec<String> {
+    watched_dirs
+        .iter()
+        .filter(|dir| !desired_dirs.contains(*dir))
+        .cloned()
+        .collect()
 }
 
 /// Build a `cargo build` command for the given package.
@@ -1367,6 +1396,26 @@ mod tests {
             kind: DebouncedEventKind::AnyContinuous,
         }];
         assert!(!includes_autumn_toml_change(&events));
+    }
+
+    #[test]
+    fn removed_watch_dirs_reports_entries_missing_from_new_config() {
+        let watched = HashSet::from([
+            "src".to_string(),
+            "static".to_string(),
+            "templates".to_string(),
+            "migrations".to_string(),
+            "views".to_string(),
+        ]);
+        let desired = HashSet::from([
+            "src".to_string(),
+            "static".to_string(),
+            "templates".to_string(),
+            "migrations".to_string(),
+        ]);
+
+        let removed = removed_watch_dirs(&watched, &desired);
+        assert_eq!(removed, vec!["views".to_string()]);
     }
 
     // ── build_cargo_command tests ──────────────────────────────────

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -534,10 +534,9 @@ fn stop_server(child: &mut Option<Child>) {
         #[cfg(unix)]
         {
             if let Some(pid) = validate_pid_for_kill(proc.id()) {
-                if let Err(e) = nix::sys::signal::kill(
-                    nix::unistd::Pid::from_raw(pid),
-                    nix::sys::signal::Signal::SIGTERM,
-                ) {
+                // SAFETY: pid > 0 (validated above); SIGTERM is a valid signal number.
+                if unsafe { libc::kill(pid, libc::SIGTERM) } != 0 {
+                    let e = std::io::Error::last_os_error();
                     eprintln!("  Warning: failed to send SIGTERM to process: {e}");
                 }
             }

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -14,6 +14,7 @@
 //! unnecessary rebuilds.
 
 use notify_debouncer_mini::{DebouncedEventKind, new_debouncer};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -38,7 +39,7 @@ const WATCH_FILES: &[&str] = &[
     "tailwind.config.js",
 ];
 
-/// Directories to watch recursively.
+/// Default directories watched recursively by `autumn dev`.
 const WATCH_DIRS: &[&str] = &["src", "static", "templates", "migrations"];
 
 const DEV_RELOAD_ENV: &str = "AUTUMN_DEV_RELOAD";
@@ -174,6 +175,7 @@ pub fn run(package: Option<&str>, show_config: bool) {
             None
         }
     };
+    let mut watch_dirs = resolve_watch_dirs();
     // Initial build
     if !cargo_build(package) {
         eprintln!("\u{2717} Initial build failed. Fix errors and save to retry.\n");
@@ -192,16 +194,8 @@ pub fn run(package: Option<&str>, show_config: bool) {
         .expect("failed to create file watcher");
 
     let watcher = debouncer.watcher();
-
-    // Watch relevant directories
-    for dir in WATCH_DIRS {
-        let path = Path::new(dir);
-        if path.exists() {
-            if let Err(e) = watcher.watch(path, notify::RecursiveMode::Recursive) {
-                eprintln!("  Warning: could not watch {dir}/: {e}");
-            }
-        }
-    }
+    let mut watched_dirs = HashSet::new();
+    ensure_watch_dirs_registered(watcher, &watch_dirs, &mut watched_dirs);
 
     // Watch the project root for config and build script changes.
     if let Err(e) = watcher.watch(Path::new("."), notify::RecursiveMode::NonRecursive) {
@@ -219,7 +213,22 @@ pub fn run(package: Option<&str>, show_config: bool) {
             break;
         }
 
-        if !process_events(&rx, package, &mut child, reload_state.as_mut(), show_config) {
+        let result = process_events(
+            &rx,
+            package,
+            &mut child,
+            reload_state.as_mut(),
+            show_config,
+            &watch_dirs,
+        );
+
+        if result.refresh_watch_dirs {
+            watch_dirs = resolve_watch_dirs();
+            let watcher = debouncer.watcher();
+            ensure_watch_dirs_registered(watcher, &watch_dirs, &mut watched_dirs);
+        }
+
+        if !result.keep_running {
             break;
         }
     }
@@ -229,39 +238,63 @@ pub fn run(package: Option<&str>, show_config: bool) {
 
 /// Process a single batch of events from the debouncer channel.
 /// Returns false if the channel was closed and the loop should exit.
+struct ProcessEventsResult {
+    keep_running: bool,
+    refresh_watch_dirs: bool,
+}
+
 fn process_events(
     rx: &mpsc::Receiver<Result<Vec<notify_debouncer_mini::DebouncedEvent>, notify::Error>>,
     package: Option<&str>,
     child: &mut Option<Child>,
     reload_state: Option<&mut DevReloadState>,
     show_config: bool,
-) -> bool {
+    watch_dirs: &[String],
+) -> ProcessEventsResult {
     match rx.recv_timeout(Duration::from_millis(SHUTDOWN_CHECK_INTERVAL_MS)) {
         Ok(Ok(events)) => {
-            let plan = plan_changes(&events);
+            let plan = plan_changes_with_watch_dirs(&events, watch_dirs);
             if plan.is_empty() {
-                return true;
+                return ProcessEventsResult {
+                    keep_running: true,
+                    refresh_watch_dirs: false,
+                };
             }
 
-            let changed = collect_relevant_changes(&events);
+            let changed = collect_relevant_changes_with_watch_dirs(&events, watch_dirs);
             if changed.is_empty() {
-                return true;
+                return ProcessEventsResult {
+                    keep_running: true,
+                    refresh_watch_dirs: false,
+                };
             }
 
             eprintln!("\n  Changed: {}", changed.join(", "));
             eprintln!("  Action: {}", describe_plan(plan));
 
             execute_plan(plan, package, child, reload_state, show_config);
-            true
+            ProcessEventsResult {
+                keep_running: true,
+                refresh_watch_dirs: includes_autumn_toml_change(&events),
+            }
         }
         Ok(Err(error)) => {
             eprintln!("  Watch error: {error:?}");
-            true
+            ProcessEventsResult {
+                keep_running: true,
+                refresh_watch_dirs: false,
+            }
         }
-        Err(mpsc::RecvTimeoutError::Timeout) => true,
+        Err(mpsc::RecvTimeoutError::Timeout) => ProcessEventsResult {
+            keep_running: true,
+            refresh_watch_dirs: false,
+        },
         Err(mpsc::RecvTimeoutError::Disconnected) => {
             eprintln!("  Watch channel error: channel disconnected");
-            false
+            ProcessEventsResult {
+                keep_running: false,
+                refresh_watch_dirs: false,
+            }
         }
     }
 }
@@ -322,20 +355,69 @@ fn execute_plan(
 /// Collect display paths for all relevant file changes from a debounced batch.
 ///
 /// Returns an empty vec if no changes are relevant.
+#[cfg(test)]
 fn collect_relevant_changes(events: &[notify_debouncer_mini::DebouncedEvent]) -> Vec<String> {
+    let watch_dirs = default_watch_dirs();
+    collect_relevant_changes_with_watch_dirs(events, &watch_dirs)
+}
+
+fn collect_relevant_changes_with_watch_dirs(
+    events: &[notify_debouncer_mini::DebouncedEvent],
+    watch_dirs: &[String],
+) -> Vec<String> {
     events
         .iter()
-        .filter(|e| is_relevant_change(&e.path, e.kind))
+        .filter(|e| is_relevant_change_with_watch_dirs(&e.path, e.kind, watch_dirs))
         .map(|e| e.path.display().to_string())
         .collect()
 }
 
+#[cfg(test)]
 fn plan_changes(events: &[notify_debouncer_mini::DebouncedEvent]) -> ChangePlan {
+    let watch_dirs = default_watch_dirs();
+    plan_changes_with_watch_dirs(events, &watch_dirs)
+}
+
+fn plan_changes_with_watch_dirs(
+    events: &[notify_debouncer_mini::DebouncedEvent],
+    watch_dirs: &[String],
+) -> ChangePlan {
     let mut plan = ChangePlan::default();
     for event in events {
-        plan.register(classify_change(&event.path, event.kind));
+        plan.register(classify_change_with_watch_dirs(
+            &event.path,
+            event.kind,
+            watch_dirs,
+        ));
     }
     plan.finalize()
+}
+
+fn includes_autumn_toml_change(events: &[notify_debouncer_mini::DebouncedEvent]) -> bool {
+    events.iter().any(|event| {
+        matches!(event.kind, DebouncedEventKind::Any)
+            && event.path.file_name().and_then(|name| name.to_str()) == Some("autumn.toml")
+    })
+}
+
+fn ensure_watch_dirs_registered<W: notify::Watcher + ?Sized>(
+    watcher: &mut W,
+    watch_dirs: &[String],
+    watched_dirs: &mut HashSet<String>,
+) {
+    for dir in watch_dirs {
+        if watched_dirs.contains(dir) {
+            continue;
+        }
+        let path = Path::new(dir);
+        if path.exists() {
+            if let Err(e) = watcher.watch(path, notify::RecursiveMode::Recursive) {
+                eprintln!("  Warning: could not watch {dir}/: {e}");
+            } else {
+                watched_dirs.insert(dir.clone());
+            }
+        }
+    }
 }
 
 /// Build a `cargo build` command for the given package.
@@ -449,11 +531,31 @@ fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Result<(), ()> {
 }
 
 /// Check if a file change event is relevant enough to trigger a rebuild.
+#[cfg(test)]
 fn is_relevant_change(path: &Path, kind: DebouncedEventKind) -> bool {
-    classify_change(path, kind) != ChangeEffect::Ignore
+    let watch_dirs = default_watch_dirs();
+    is_relevant_change_with_watch_dirs(path, kind, &watch_dirs)
 }
 
+#[cfg(test)]
 fn classify_change(path: &Path, kind: DebouncedEventKind) -> ChangeEffect {
+    let watch_dirs = default_watch_dirs();
+    classify_change_with_watch_dirs(path, kind, &watch_dirs)
+}
+
+fn is_relevant_change_with_watch_dirs(
+    path: &Path,
+    kind: DebouncedEventKind,
+    watch_dirs: &[String],
+) -> bool {
+    classify_change_with_watch_dirs(path, kind, watch_dirs) != ChangeEffect::Ignore
+}
+
+fn classify_change_with_watch_dirs(
+    path: &Path,
+    kind: DebouncedEventKind,
+    watch_dirs: &[String],
+) -> ChangeEffect {
     if !matches!(kind, DebouncedEventKind::Any) || should_ignore_path(path) {
         return ChangeEffect::Ignore;
     }
@@ -476,6 +578,15 @@ fn classify_change(path: &Path, kind: DebouncedEventKind) -> ChangeEffect {
         || is_profile_config_file(file_name)
     {
         return ChangeEffect::RestartOnly;
+    }
+
+    for dir in watch_dirs {
+        if WATCH_DIRS.contains(&dir.as_str()) {
+            continue;
+        }
+        if path_contains_dir(path, dir) {
+            return ChangeEffect::BuildRestart;
+        }
     }
 
     if has_component(path, "src") && path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
@@ -535,6 +646,113 @@ fn has_component(path: &Path, target: &str) -> bool {
             std::path::Component::Normal(name) if name == std::ffi::OsStr::new(target)
         )
     })
+}
+
+fn path_contains_dir(path: &Path, dir: &str) -> bool {
+    let dir = Path::new(dir);
+    if path_starts_with_watch_dir(path, dir) {
+        return true;
+    }
+
+    // notify can emit absolute paths on some backends/platforms. Anchor custom
+    // matching to the workspace-relative watched prefix when possible.
+    if path.is_absolute() {
+        if let Ok(cwd) = std::env::current_dir() {
+            if let Ok(relative) = path.strip_prefix(&cwd) {
+                if path_starts_with_watch_dir(relative, dir) {
+                    return true;
+                }
+            }
+
+            if dir.is_relative() {
+                let absolute_dir = cwd.join(dir);
+                let absolute_dir = std::fs::canonicalize(&absolute_dir).unwrap_or(absolute_dir);
+                if path_starts_with_watch_dir(path, &absolute_dir) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+fn path_starts_with_watch_dir(path: &Path, watch_dir: &Path) -> bool {
+    path.starts_with(watch_dir)
+        || path
+            .strip_prefix(Path::new("."))
+            .is_ok_and(|relative| relative.starts_with(watch_dir))
+}
+
+fn default_watch_dirs() -> Vec<String> {
+    WATCH_DIRS.iter().map(|dir| (*dir).to_owned()).collect()
+}
+
+fn resolve_watch_dirs() -> Vec<String> {
+    let mut dirs = default_watch_dirs();
+    let custom = load_custom_watch_dirs(Path::new("autumn.toml"));
+    for dir in custom {
+        if !dirs.iter().any(|existing| existing == &dir) {
+            dirs.push(dir);
+        }
+    }
+    dirs
+}
+
+fn load_custom_watch_dirs(config_path: &Path) -> Vec<String> {
+    let Ok(contents) = std::fs::read_to_string(config_path) else {
+        return Vec::new();
+    };
+
+    let parsed: toml::Value = match toml::from_str(&contents) {
+        Ok(value) => value,
+        Err(error) => {
+            eprintln!(
+                "  Warning: could not parse {} for [dev].watch_dirs: {error}",
+                config_path.display()
+            );
+            return Vec::new();
+        }
+    };
+
+    let Some(watch_dirs) = parsed
+        .get("dev")
+        .and_then(|dev| dev.get("watch_dirs"))
+        .and_then(toml::Value::as_array)
+    else {
+        return Vec::new();
+    };
+
+    watch_dirs
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .filter_map(normalize_watch_dir)
+        .collect()
+}
+
+fn normalize_watch_dir(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in Path::new(raw).components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => normalized.push(".."),
+            std::path::Component::Normal(name) => normalized.push(name),
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        None
+    } else {
+        Some(normalized.to_string_lossy().to_string())
+    }
 }
 
 fn is_profile_config_file(file_name: &str) -> bool {
@@ -962,6 +1180,63 @@ mod tests {
     }
 
     #[test]
+    fn custom_watch_dir_change_triggers_build_restart() {
+        let watch_dirs = vec![
+            "src".to_owned(),
+            "static".to_owned(),
+            "templates".to_owned(),
+            "migrations".to_owned(),
+            "views".to_owned(),
+        ];
+        assert_eq!(
+            classify_change_with_watch_dirs(
+                Path::new("views/home/index.html"),
+                DebouncedEventKind::Any,
+                &watch_dirs
+            ),
+            ChangeEffect::BuildRestart
+        );
+    }
+
+    #[test]
+    fn custom_watch_dir_does_not_match_nested_component_name() {
+        let watch_dirs = vec![
+            "src".to_owned(),
+            "static".to_owned(),
+            "templates".to_owned(),
+            "migrations".to_owned(),
+            "views".to_owned(),
+        ];
+        assert_eq!(
+            classify_change_with_watch_dirs(
+                Path::new("src/views/readme.txt"),
+                DebouncedEventKind::Any,
+                &watch_dirs
+            ),
+            ChangeEffect::Ignore
+        );
+    }
+
+    #[test]
+    fn custom_watch_dir_takes_priority_over_default_static_routing() {
+        let watch_dirs = vec![
+            "src".to_owned(),
+            "static".to_owned(),
+            "templates".to_owned(),
+            "migrations".to_owned(),
+            "frontend".to_owned(),
+        ];
+        assert_eq!(
+            classify_change_with_watch_dirs(
+                Path::new("frontend/static/logo.png"),
+                DebouncedEventKind::Any,
+                &watch_dirs
+            ),
+            ChangeEffect::BuildRestart
+        );
+    }
+
+    #[test]
     fn ignores_target_directory() {
         assert!(!is_relevant_change(
             Path::new("target/debug/build/main.rs"),
@@ -1077,6 +1352,21 @@ mod tests {
     fn collect_changes_handles_empty_events() {
         let changed = collect_relevant_changes(&[]);
         assert!(changed.is_empty());
+    }
+
+    #[test]
+    fn includes_autumn_toml_change_detects_config_updates() {
+        let events = vec![notify_debouncer_mini::DebouncedEvent {
+            path: PathBuf::from("autumn.toml"),
+            kind: DebouncedEventKind::Any,
+        }];
+        assert!(includes_autumn_toml_change(&events));
+
+        let events = vec![notify_debouncer_mini::DebouncedEvent {
+            path: PathBuf::from("autumn.toml"),
+            kind: DebouncedEventKind::AnyContinuous,
+        }];
+        assert!(!includes_autumn_toml_change(&events));
     }
 
     // ── build_cargo_command tests ──────────────────────────────────
@@ -1378,6 +1668,46 @@ mod tests {
     }
 
     #[test]
+    fn resolve_watch_dirs_keeps_defaults_and_adds_custom() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            r#"[dev]
+watch_dirs = ["./views", "locales", "src"]
+"#,
+        )
+        .expect("write config");
+
+        let cwd = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(dir.path()).expect("set cwd");
+        let dirs = resolve_watch_dirs();
+        std::env::set_current_dir(cwd).expect("restore cwd");
+
+        for default in WATCH_DIRS {
+            assert!(
+                dirs.contains(&default.to_string()),
+                "missing default watch dir: {default}"
+            );
+        }
+        assert!(dirs.contains(&"views".to_string()));
+        assert!(dirs.contains(&"locales".to_string()));
+        assert_eq!(
+            dirs.iter().filter(|d| d.as_str() == "src").count(),
+            1,
+            "default dirs should not be duplicated"
+        );
+    }
+
+    #[test]
+    fn normalize_watch_dir_strips_leading_dot_slash() {
+        assert_eq!(normalize_watch_dir("./views"), Some("views".to_string()));
+        assert_eq!(
+            normalize_watch_dir("./frontend/views/"),
+            Some("frontend/views".to_string())
+        );
+    }
+
+    #[test]
     fn watch_files_are_non_empty() {
         for f in WATCH_FILES {
             assert!(!f.is_empty());
@@ -1451,6 +1781,47 @@ mod tests {
             Path::new("template/index.html"),
             "templates"
         ));
+    }
+
+    #[test]
+    fn path_contains_dir_supports_nested_dirs() {
+        assert!(path_contains_dir(
+            Path::new("views/home/index.html"),
+            "views"
+        ));
+        assert!(!path_contains_dir(
+            Path::new("src/views/home/index.html"),
+            "views"
+        ));
+        assert!(path_contains_dir(
+            Path::new("frontend/views/home/index.html"),
+            "frontend/views"
+        ));
+        assert!(!path_contains_dir(
+            Path::new("frontend/view/home/index.html"),
+            "frontend/views"
+        ));
+    }
+
+    #[test]
+    fn path_contains_dir_matches_parent_relative_watch_dir_for_absolute_paths() {
+        let root = tempfile::tempdir().expect("temp root");
+        let workspace = root.path().join("workspace");
+        let repo = workspace.join("autumn");
+        let shared = workspace.join("shared");
+        std::fs::create_dir_all(&repo).expect("create repo dir");
+        std::fs::create_dir_all(shared.join("nested")).expect("create shared dir");
+
+        let cwd = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(&repo).expect("set cwd");
+
+        let file = shared.join("nested").join("data.json");
+        assert!(
+            path_contains_dir(&file, "../shared"),
+            "absolute event path under ../shared should match custom watch dir"
+        );
+
+        std::env::set_current_dir(cwd).expect("restore cwd");
     }
 
     #[test]

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -689,6 +689,22 @@ fn path_contains_dir(path: &Path, dir: &str) -> bool {
         return true;
     }
 
+    if dir.is_absolute() {
+        let canonical_dir = std::fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
+
+        if path_starts_with_watch_dir(path, &canonical_dir) {
+            return true;
+        }
+
+        if path.is_absolute() {
+            if let Ok(canonical_path) = std::fs::canonicalize(path) {
+                if path_starts_with_watch_dir(&canonical_path, &canonical_dir) {
+                    return true;
+                }
+            }
+        }
+    }
+
     // notify can emit absolute paths on some backends/platforms. Anchor custom
     // matching to the workspace-relative watched prefix when possible.
     if path.is_absolute() {
@@ -1901,6 +1917,23 @@ watch_dirs = ["./views", "locales", "src"]
         );
 
         std::env::set_current_dir(cwd).expect("restore cwd");
+    }
+
+    #[test]
+    fn path_contains_dir_matches_canonical_event_for_noncanonical_absolute_watch_dir() {
+        let root = tempfile::tempdir().expect("temp root");
+        let watch_root = root.path().join("shared");
+        std::fs::create_dir_all(watch_root.join("nested")).expect("create shared dir");
+
+        let noncanonical_watch_dir = watch_root.join("..").join("shared");
+        let file = watch_root.join("nested").join("data.json");
+        std::fs::write(&file, "{}").expect("write file");
+        let canonical_file = std::fs::canonicalize(&file).expect("canonicalize file");
+
+        assert!(path_contains_dir(
+            &canonical_file,
+            &noncanonical_watch_dir.to_string_lossy()
+        ));
     }
 
     #[test]

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -599,7 +599,12 @@ fn classify_change_with_watch_dirs(
     kind: DebouncedEventKind,
     watch_dirs: &[String],
 ) -> ChangeEffect {
-    if !matches!(kind, DebouncedEventKind::Any) || should_ignore_path(path) {
+    if !matches!(kind, DebouncedEventKind::Any) {
+        return ChangeEffect::Ignore;
+    }
+
+    let custom_watch_match = matches_custom_watch_dir(path, watch_dirs);
+    if should_ignore_path(path) && !custom_watch_match {
         return ChangeEffect::Ignore;
     }
 
@@ -623,13 +628,8 @@ fn classify_change_with_watch_dirs(
         return ChangeEffect::RestartOnly;
     }
 
-    for dir in watch_dirs {
-        if WATCH_DIRS.contains(&dir.as_str()) {
-            continue;
-        }
-        if path_contains_dir(path, dir) {
-            return ChangeEffect::BuildRestart;
-        }
+    if custom_watch_match {
+        return ChangeEffect::BuildRestart;
     }
 
     if has_component(path, "src") && path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
@@ -655,6 +655,15 @@ fn classify_change_with_watch_dirs(
     }
 
     ChangeEffect::Ignore
+}
+
+fn matches_custom_watch_dir(path: &Path, watch_dirs: &[String]) -> bool {
+    watch_dirs.iter().any(|dir| {
+        if is_default_watch_dir_or_alias(dir) {
+            return false;
+        }
+        path_contains_dir(path, dir)
+    })
 }
 
 fn should_ignore_path(path: &Path) -> bool {
@@ -751,11 +760,49 @@ fn resolve_watch_dirs() -> Vec<String> {
     let mut dirs = default_watch_dirs();
     let custom = load_custom_watch_dirs(Path::new("autumn.toml"));
     for dir in custom {
-        if !dirs.iter().any(|existing| existing == &dir) {
+        if !dirs
+            .iter()
+            .any(|existing| watch_dirs_equivalent(existing, &dir))
+        {
             dirs.push(dir);
         }
     }
     dirs
+}
+
+fn is_default_watch_dir_or_alias(dir: &str) -> bool {
+    WATCH_DIRS
+        .iter()
+        .any(|default| watch_dirs_equivalent(default, dir))
+}
+
+fn watch_dirs_equivalent(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+
+    let a = Path::new(a);
+    let b = Path::new(b);
+    if a == b {
+        return true;
+    }
+
+    let Some(a) = canonicalize_watch_dir(a) else {
+        return false;
+    };
+    let Some(b) = canonicalize_watch_dir(b) else {
+        return false;
+    };
+
+    a == b
+}
+
+fn canonicalize_watch_dir(path: &Path) -> Option<PathBuf> {
+    if path.is_absolute() {
+        return std::fs::canonicalize(path).ok();
+    }
+    let cwd = std::env::current_dir().ok()?;
+    std::fs::canonicalize(cwd.join(path)).ok()
 }
 
 fn load_custom_watch_dirs(config_path: &Path) -> Vec<String> {
@@ -1059,7 +1106,7 @@ mod tests {
         let _guard = LOCK
             .get_or_init(|| Mutex::new(()))
             .lock()
-            .expect("cwd mutex poisoned");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
 
         let previous = std::env::current_dir().expect("current cwd");
         std::env::set_current_dir(cwd).expect("set cwd");
@@ -1313,6 +1360,50 @@ mod tests {
             ),
             ChangeEffect::BuildRestart
         );
+    }
+
+    #[test]
+    fn explicit_hidden_custom_watch_dir_is_not_ignored() {
+        let watch_dirs = vec![
+            "src".to_owned(),
+            "static".to_owned(),
+            "templates".to_owned(),
+            "migrations".to_owned(),
+            ".storybook".to_owned(),
+        ];
+        assert_eq!(
+            classify_change_with_watch_dirs(
+                Path::new(".storybook/main.js"),
+                DebouncedEventKind::Any,
+                &watch_dirs
+            ),
+            ChangeEffect::BuildRestart
+        );
+    }
+
+    #[test]
+    fn default_dir_absolute_alias_is_not_treated_as_custom_watch_dir() {
+        let root = tempfile::tempdir().expect("temp root");
+        std::fs::create_dir_all(root.path().join("static").join("js")).expect("create static");
+        let static_alias = root.path().join("static").display().to_string();
+
+        with_cwd(root.path(), || {
+            let watch_dirs = vec![
+                "src".to_owned(),
+                "static".to_owned(),
+                "templates".to_owned(),
+                "migrations".to_owned(),
+                static_alias.clone(),
+            ];
+            assert_eq!(
+                classify_change_with_watch_dirs(
+                    Path::new("static/js/app.js"),
+                    DebouncedEventKind::Any,
+                    &watch_dirs
+                ),
+                ChangeEffect::BrowserReloadOnly
+            );
+        });
     }
 
     #[test]
@@ -1842,6 +1933,22 @@ watch_dirs = ["./views", "locales", "src"]
             normalize_watch_dir("./frontend/views/"),
             Some("frontend/views".to_string())
         );
+    }
+
+    #[test]
+    fn resolve_watch_dirs_deduplicates_default_aliases() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::create_dir_all(dir.path().join("static")).expect("create static");
+        let static_alias = dir.path().join("static").display().to_string();
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            format!("[dev]\nwatch_dirs = [\"{static_alias}\"]\n"),
+        )
+        .expect("write config");
+
+        let dirs = with_cwd(dir.path(), resolve_watch_dirs);
+        assert_eq!(dirs.iter().filter(|d| d.as_str() == "static").count(), 1);
+        assert_eq!(dirs.len(), WATCH_DIRS.len());
     }
 
     #[test]

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 /// Debounce interval for checking the shutdown flag in the watch loop.
 const SHUTDOWN_CHECK_INTERVAL_MS: u64 = 200;
 
-/// Set to `true` by the SIGINT/SIGTERM handler to request a clean shutdown.
+/// Set to `true` by the SIGINT handler to request a clean shutdown.
 static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 /// Default debounce interval for file change events.
@@ -160,10 +160,8 @@ impl DevReloadState {
 pub fn run(package: Option<&str>, show_config: bool) {
     eprintln!("\u{1F342} autumn dev\n");
 
-    // Register SIGINT/SIGTERM handler so Ctrl+C or `kill <pid>` triggers a
-    // graceful shutdown instead of immediately terminating the process (and
-    // leaving the child running).  The `termination` feature of ctrlc also
-    // catches SIGTERM and SIGHUP on Unix without requiring unsafe code.
+    // Register SIGINT handler so Ctrl+C triggers a graceful shutdown instead
+    // of immediately terminating the process (and leaving the child running).
     if let Err(err) = ctrlc::set_handler(move || {
         SHUTDOWN_REQUESTED.store(true, Ordering::SeqCst);
     }) {
@@ -534,9 +532,10 @@ fn stop_server(child: &mut Option<Child>) {
         #[cfg(unix)]
         {
             if let Some(pid) = validate_pid_for_kill(proc.id()) {
-                // SAFETY: pid > 0 (validated above); SIGTERM is a valid signal number.
-                if unsafe { libc::kill(pid, libc::SIGTERM) } != 0 {
-                    let e = std::io::Error::last_os_error();
+                if let Err(e) = nix::sys::signal::kill(
+                    nix::unistd::Pid::from_raw(pid),
+                    nix::sys::signal::Signal::SIGTERM,
+                ) {
                     eprintln!("  Warning: failed to send SIGTERM to process: {e}");
                 }
             }
@@ -1058,12 +1057,11 @@ fn resolve_binary_from_metadata(
                 .parent()
                 .unwrap_or_else(|| Path::new(""));
 
-            let is_bin =
-                |t: &&serde_json::Value| -> bool {
-                    t["kind"]
-                        .as_array()
-                        .is_some_and(|k| k.iter().any(|k| k == "bin"))
-                };
+            let is_bin = |t: &&serde_json::Value| -> bool {
+                t["kind"]
+                    .as_array()
+                    .is_some_and(|k| k.iter().any(|k| k == "bin"))
+            };
 
             // Prefer the binary whose src_path is exactly `src/main.rs` so
             // that secondary targets (e.g. a WASM client bin) are not

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -27,16 +27,6 @@ const SHUTDOWN_CHECK_INTERVAL_MS: u64 = 200;
 /// Set to `true` by the SIGINT/SIGTERM handler to request a clean shutdown.
 static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
 
-/// SIGTERM handler – stores the shutdown flag using only async-signal-safe
-/// operations (an atomic store), then returns so the main loop can clean up.
-///
-/// SAFETY: `AtomicBool::store` is async-signal-safe; no heap allocation or
-/// lock acquisition is performed.
-#[cfg(unix)]
-extern "C" fn handle_sigterm(_signum: libc::c_int) {
-    SHUTDOWN_REQUESTED.store(true, Ordering::SeqCst);
-}
-
 /// Default debounce interval for file change events.
 const DEBOUNCE_MS: u64 = 500;
 
@@ -170,23 +160,14 @@ impl DevReloadState {
 pub fn run(package: Option<&str>, show_config: bool) {
     eprintln!("\u{1F342} autumn dev\n");
 
-    // Register SIGINT handler so Ctrl+C triggers a graceful shutdown instead
-    // of immediately terminating the process (and leaving the child running).
+    // Register SIGINT/SIGTERM handler so Ctrl+C or `kill <pid>` triggers a
+    // graceful shutdown instead of immediately terminating the process (and
+    // leaving the child running).  The `termination` feature of ctrlc also
+    // catches SIGTERM and SIGHUP on Unix without requiring unsafe code.
     if let Err(err) = ctrlc::set_handler(move || {
         SHUTDOWN_REQUESTED.store(true, Ordering::SeqCst);
     }) {
         eprintln!("  Warning: failed to set Ctrl-C handler: {err}");
-    }
-
-    // Also handle SIGTERM so that `kill <pid>` stops the child server cleanly.
-    // SAFETY: the handler only performs an atomic store, which is
-    // async-signal-safe per POSIX.
-    #[cfg(unix)]
-    unsafe {
-        let _ = nix::sys::signal::signal(
-            nix::sys::signal::Signal::SIGTERM,
-            nix::sys::signal::SigHandler::Handler(handle_sigterm),
-        );
     }
 
     let mut reload_state = match DevReloadState::initialize() {

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -1052,6 +1052,26 @@ fn find_binary(package: Option<&str>) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn with_cwd<R>(cwd: &Path, f: impl FnOnce() -> R) -> R {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let _guard = LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("cwd mutex poisoned");
+
+        let previous = std::env::current_dir().expect("current cwd");
+        std::env::set_current_dir(cwd).expect("set cwd");
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        std::env::set_current_dir(previous).expect("restore cwd");
+
+        match result {
+            Ok(value) => value,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
 
     // ── is_relevant_change tests ───────────────────────────────────
 
@@ -1798,10 +1818,7 @@ watch_dirs = ["./views", "locales", "src"]
         )
         .expect("write config");
 
-        let cwd = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(dir.path()).expect("set cwd");
-        let dirs = resolve_watch_dirs();
-        std::env::set_current_dir(cwd).expect("restore cwd");
+        let dirs = with_cwd(dir.path(), resolve_watch_dirs);
 
         for default in WATCH_DIRS {
             assert!(
@@ -1932,16 +1949,13 @@ watch_dirs = ["./views", "locales", "src"]
         std::fs::create_dir_all(&repo).expect("create repo dir");
         std::fs::create_dir_all(shared.join("nested")).expect("create shared dir");
 
-        let cwd = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(&repo).expect("set cwd");
-
-        let file = shared.join("nested").join("data.json");
-        assert!(
-            path_contains_dir(&file, "../shared"),
-            "absolute event path under ../shared should match custom watch dir"
-        );
-
-        std::env::set_current_dir(cwd).expect("restore cwd");
+        with_cwd(&repo, || {
+            let file = shared.join("nested").join("data.json");
+            assert!(
+                path_contains_dir(&file, "../shared"),
+                "absolute event path under ../shared should match custom watch dir"
+            );
+        });
     }
 
     #[test]

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -24,8 +24,18 @@ use std::time::Duration;
 /// Debounce interval for checking the shutdown flag in the watch loop.
 const SHUTDOWN_CHECK_INTERVAL_MS: u64 = 200;
 
-/// Set to `true` by the SIGINT handler to request a clean shutdown.
+/// Set to `true` by the SIGINT/SIGTERM handler to request a clean shutdown.
 static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// SIGTERM handler – stores the shutdown flag using only async-signal-safe
+/// operations (an atomic store), then returns so the main loop can clean up.
+///
+/// SAFETY: `AtomicBool::store` is async-signal-safe; no heap allocation or
+/// lock acquisition is performed.
+#[cfg(unix)]
+extern "C" fn handle_sigterm(_signum: libc::c_int) {
+    SHUTDOWN_REQUESTED.store(true, Ordering::SeqCst);
+}
 
 /// Default debounce interval for file change events.
 const DEBOUNCE_MS: u64 = 500;
@@ -166,6 +176,17 @@ pub fn run(package: Option<&str>, show_config: bool) {
         SHUTDOWN_REQUESTED.store(true, Ordering::SeqCst);
     }) {
         eprintln!("  Warning: failed to set Ctrl-C handler: {err}");
+    }
+
+    // Also handle SIGTERM so that `kill <pid>` stops the child server cleanly.
+    // SAFETY: the handler only performs an atomic store, which is
+    // async-signal-safe per POSIX.
+    #[cfg(unix)]
+    unsafe {
+        let _ = nix::sys::signal::signal(
+            nix::sys::signal::Signal::SIGTERM,
+            nix::sys::signal::SigHandler::Handler(handle_sigterm),
+        );
     }
 
     let mut reload_state = match DevReloadState::initialize() {
@@ -1052,8 +1073,35 @@ fn resolve_binary_from_metadata(
     let bin_name = matching_packages
         .iter()
         .find_map(|pkg| {
-            pkg["targets"].as_array()?.iter().find_map(|t| {
-                let is_bin = t["kind"].as_array()?.iter().any(|k| k == "bin");
+            let targets = pkg["targets"].as_array()?;
+            let manifest_dir = Path::new(pkg["manifest_path"].as_str()?)
+                .parent()
+                .unwrap_or_else(|| Path::new(""));
+
+            // Prefer the binary whose src_path is exactly `src/main.rs` so
+            // that secondary targets (e.g. a WASM client bin) are not
+            // accidentally picked as the server binary.
+            let preferred = targets.iter().find(|t| {
+                let is_bin = t["kind"]
+                    .as_array()
+                    .is_some_and(|k| k.iter().any(|k| k == "bin"));
+                if !is_bin {
+                    return false;
+                }
+                t["src_path"]
+                    .as_str()
+                    .is_some_and(|p| Path::new(p) == manifest_dir.join("src/main.rs"))
+            });
+
+            if let Some(t) = preferred {
+                return t["name"].as_str().map(String::from);
+            }
+
+            // Fall back to the first bin target if no `src/main.rs` match.
+            targets.iter().find_map(|t| {
+                let is_bin = t["kind"]
+                    .as_array()
+                    .is_some_and(|k| k.iter().any(|k| k == "bin"));
                 if is_bin {
                     t["name"].as_str().map(String::from)
                 } else {
@@ -1780,6 +1828,35 @@ mod tests {
         });
         let result =
             resolve_binary_from_metadata(&metadata, Some("multi"), Path::new("/projects/multi"));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), expected_binary("/tmp/target/debug/server"));
+    }
+
+    #[test]
+    fn resolve_binary_prefers_main_rs_over_other_bins() {
+        // When a package has multiple bin targets, the one whose src_path is
+        // `src/main.rs` should be selected even if it is not listed first.
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [{
+                "name": "myapp",
+                "manifest_path": "/projects/myapp/Cargo.toml",
+                "targets": [
+                    {
+                        "name": "client",
+                        "kind": ["bin"],
+                        "src_path": "/projects/myapp/src/client.rs"
+                    },
+                    {
+                        "name": "server",
+                        "kind": ["bin"],
+                        "src_path": "/projects/myapp/src/main.rs"
+                    }
+                ]
+            }]
+        });
+        let result =
+            resolve_binary_from_metadata(&metadata, Some("myapp"), Path::new("/projects/myapp"));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), expected_binary("/tmp/target/debug/server"));
     }

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -1078,16 +1078,17 @@ fn resolve_binary_from_metadata(
                 .parent()
                 .unwrap_or_else(|| Path::new(""));
 
+            let is_bin =
+                |t: &&serde_json::Value| -> bool {
+                    t["kind"]
+                        .as_array()
+                        .is_some_and(|k| k.iter().any(|k| k == "bin"))
+                };
+
             // Prefer the binary whose src_path is exactly `src/main.rs` so
             // that secondary targets (e.g. a WASM client bin) are not
             // accidentally picked as the server binary.
-            let preferred = targets.iter().find(|t| {
-                let is_bin = t["kind"]
-                    .as_array()
-                    .is_some_and(|k| k.iter().any(|k| k == "bin"));
-                if !is_bin {
-                    return false;
-                }
+            let preferred = targets.iter().filter(|t| is_bin(t)).find(|t| {
                 t["src_path"]
                     .as_str()
                     .is_some_and(|p| Path::new(p) == manifest_dir.join("src/main.rs"))
@@ -1098,16 +1099,10 @@ fn resolve_binary_from_metadata(
             }
 
             // Fall back to the first bin target if no `src/main.rs` match.
-            targets.iter().find_map(|t| {
-                let is_bin = t["kind"]
-                    .as_array()
-                    .is_some_and(|k| k.iter().any(|k| k == "bin"));
-                if is_bin {
-                    t["name"].as_str().map(String::from)
-                } else {
-                    None
-                }
-            })
+            targets
+                .iter()
+                .filter(|t| is_bin(t))
+                .find_map(|t| t["name"].as_str().map(String::from))
         })
         .ok_or_else(|| {
             package.map_or_else(
@@ -1735,18 +1730,14 @@ mod tests {
         let metadata = sample_metadata("/tmp/target", "hello", "/projects/hello");
         let result =
             resolve_binary_from_metadata(&metadata, Some("hello"), Path::new("/projects/hello"));
-        assert!(result.is_ok());
-        let path = result.unwrap();
-        assert_eq!(path, expected_binary("/tmp/target/debug/hello"));
+        assert_eq!(result.unwrap(), expected_binary("/tmp/target/debug/hello"));
     }
 
     #[test]
     fn resolve_binary_by_cwd() {
         let metadata = sample_metadata("/tmp/target", "hello", "/projects/hello");
         let result = resolve_binary_from_metadata(&metadata, None, Path::new("/projects/hello"));
-        assert!(result.is_ok());
-        let path = result.unwrap();
-        assert_eq!(path, expected_binary("/tmp/target/debug/hello"));
+        assert_eq!(result.unwrap(), expected_binary("/tmp/target/debug/hello"));
     }
 
     #[test]
@@ -1857,7 +1848,6 @@ mod tests {
         });
         let result =
             resolve_binary_from_metadata(&metadata, Some("myapp"), Path::new("/projects/myapp"));
-        assert!(result.is_ok());
         assert_eq!(result.unwrap(), expected_binary("/tmp/target/debug/server"));
     }
 
@@ -1879,7 +1869,6 @@ mod tests {
             ]
         });
         let result = resolve_binary_from_metadata(&metadata, Some("app-b"), Path::new("/projects"));
-        assert!(result.is_ok());
         assert_eq!(result.unwrap(), expected_binary("/tmp/target/debug/app-b"));
     }
 

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -1127,7 +1127,7 @@ mod tests {
         let _guard = LOCK
             .get_or_init(|| Mutex::new(()))
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let previous = std::env::current_dir().expect("current cwd");
         std::env::set_current_dir(cwd).expect("set cwd");


### PR DESCRIPTION
### Motivation
- Allow `autumn dev` to watch additional user-specified directories in addition to the four defaults (`src`, `static`, `templates`, `migrations`).
- Ensure the watcher adapts when `autumn.toml` is changed and avoid duplicate registrations or missing matches for absolute/relative paths.

### Description
- Documented default watched directories in `README.md` and showed how to add custom paths via `autumn.toml` under `[dev].watch_dirs` while keeping defaults additive.
- Implemented runtime loading and normalization of custom watch dirs with `resolve_watch_dirs`, `load_custom_watch_dirs`, and `normalize_watch_dir`, and merged them with the default `WATCH_DIRS` without duplicating entries.
- Made the file-watcher dynamically register new watch paths via `ensure_watch_dirs_registered`, improved path matching for custom and absolute paths with `path_contains_dir` / `path_starts_with_watch_dir`, and updated change classification to use the watch-dir-aware functions (e.g., `classify_change_with_watch_dirs`).
- Updated event processing to return a `ProcessEventsResult` so `process_events` can signal when `autumn.toml` changed and the runtime should refresh registered watch directories.

### Testing
- Added unit tests covering custom watch dir behavior and path matching such as `custom_watch_dir_change_triggers_build_restart`, `custom_watch_dir_does_not_match_nested_component_name`, `resolve_watch_dirs_keeps_defaults_and_adds_custom`, and `path_contains_dir_supports_nested_dirs`.
- Ran the crate tests with `cargo test` for the `autumn-cli` crate and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaac54ca4c832a84b3bec4468b1bb3)