### PR TITLE
🔒 Warden: Assert CSRF layer path traversal bypass is mitigated by Axum routing

### DIFF
--- a/autumn/tests/security/csrf_path_traversal.rs
+++ b/autumn/tests/security/csrf_path_traversal.rs
@@ -1,0 +1,36 @@
+use autumn_web::security::CsrfLayer;
+use autumn_web::security::config::CsrfConfig;
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+    routing::post,
+};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn eris_csrf_path_traversal_bypass() {
+    let config = CsrfConfig {
+        enabled: true,
+        exempt_paths: vec!["/api/".to_string()],
+        ..Default::default()
+    };
+
+    let app = Router::new()
+        .route("/submit", post(|| async { "created" }))
+        .route("/api/items", post(|| async { "created" }))
+        .layer(CsrfLayer::from_config(&config));
+
+    let malicious_req = Request::builder()
+        .method("POST")
+        .uri("/api/../submit")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(malicious_req).await.unwrap();
+
+    // Axum routes strictly based on exact URI match and does not resolve '..'.
+    // Therefore, the request to /api/../submit safely falls through to a 404
+    // instead of executing the /submit handler, averting the CSRF bypass entirely.
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -5,6 +5,7 @@ pub mod csrf_cookie_tossing;
 pub mod csrf_empty_bypass;
 pub mod csrf_form_bypass;
 pub mod csrf_length_timing;
+pub mod csrf_path_traversal;
 pub mod csrf_timing;
 pub mod ctf;
 pub mod session_fixation;


### PR DESCRIPTION
🦠 Threat: An attacker might attempt to bypass CSRF protection by utilizing path traversal segments to match an exempt path prefix in the `CsrfLayer` while actually executing a protected route (e.g., requesting `/api/../submit` to match the `/api/` exemption but execute `/submit`).
🛡️ Defense: Axum's underlying router evaluates paths literally and does not implicitly resolve dot segments. Therefore, such path traversal requests safely fall through to a 404 Not Found rather than executing the protected handler. No custom normalization in the middleware is needed or desired (as it could introduce a parser differential vulnerability).
💥 Severity: 0.0 (None). 
🧪 Verification: Added `eris_csrf_path_traversal_bypass` to assert that the request correctly results in a 404 Not Found.

---
*PR created automatically by Jules for task [9931830870959419782](https://jules.google.com/task/9931830870959419782) started by @madmax983*