### PR TITLE
🗺️ Atlas: [architectural change] Enforce Module Boundaries

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -402,7 +402,7 @@ fn default_session_key() -> String {
 }
 
 #[cfg(feature = "oauth2")]
-fn default_provider_scope() -> String {
+const fn default_provider_scope() -> String {
     String::new()
 }
 

--- a/autumn/src/middleware/mod.rs
+++ b/autumn/src/middleware/mod.rs
@@ -18,11 +18,11 @@
 
 pub(crate) mod dev;
 pub(crate) mod error_page_filter;
-pub mod exception_filter;
-pub mod metrics;
-pub mod request_id;
+pub(crate) mod exception_filter;
+pub(crate) mod metrics;
+pub(crate) mod request_id;
 #[cfg(feature = "telemetry-otlp")]
-pub mod trace_context;
+pub(crate) mod trace_context;
 
 pub use exception_filter::{AutumnErrorInfo, ExceptionFilter, ExceptionFilterLayer};
 pub use metrics::{MetricsCollector, MetricsLayer};

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -54,7 +54,7 @@ use serde::Deserialize;
 /// # Examples
 ///
 /// ```rust
-/// use autumn_web::security::config::SecurityConfig;
+/// use autumn_web::security::SecurityConfig;
 ///
 /// let config = SecurityConfig::default();
 /// assert_eq!(config.headers.x_frame_options, "DENY");

--- a/autumn/src/security/headers.rs
+++ b/autumn/src/security/headers.rs
@@ -22,8 +22,8 @@
 //! For custom Axum routers:
 //!
 //! ```rust,no_run
-//! use autumn_web::security::headers::SecurityHeadersLayer;
-//! use autumn_web::security::config::HeadersConfig;
+//! use autumn_web::security::SecurityHeadersLayer;
+//! use autumn_web::security::HeadersConfig;
 //!
 //! let config = HeadersConfig::default();
 //! let app = axum::Router::<()>::new()

--- a/autumn/src/security/mod.rs
+++ b/autumn/src/security/mod.rs
@@ -73,14 +73,14 @@
 //! }
 //! ```
 
-pub mod config;
-pub mod csrf;
-pub mod headers;
-pub mod rate_limit;
+pub(crate) mod config;
+pub(crate) mod csrf;
+pub(crate) mod headers;
+pub(crate) mod rate_limit;
 
 // Re-export commonly used types at the module level.
 pub use config::{
-    CsrfConfig, HeadersConfig, RateLimitConfig, SecurityConfig, default_content_security_policy,
+    CsrfConfig, UploadConfig, HeadersConfig, RateLimitConfig, SecurityConfig, default_content_security_policy,
 };
 pub use csrf::{CsrfLayer, CsrfToken};
 pub use headers::SecurityHeadersLayer;

--- a/autumn/src/security/mod.rs
+++ b/autumn/src/security/mod.rs
@@ -80,7 +80,8 @@ pub(crate) mod rate_limit;
 
 // Re-export commonly used types at the module level.
 pub use config::{
-    CsrfConfig, UploadConfig, HeadersConfig, RateLimitConfig, SecurityConfig, default_content_security_policy,
+    CsrfConfig, HeadersConfig, RateLimitConfig, SecurityConfig, UploadConfig,
+    default_content_security_policy,
 };
 pub use csrf::{CsrfLayer, CsrfToken};
 pub use headers::SecurityHeadersLayer;

--- a/autumn/src/static_gen/mod.rs
+++ b/autumn/src/static_gen/mod.rs
@@ -12,7 +12,7 @@
 //! 1. **Build phase:** `autumn build` discovers your `#[static_get]` routes and runs them, saving the HTML to `dist/`.
 //! 2. **Runtime phase:** The `StaticFileLayer` intercepts requests. If a pre-rendered file exists, it serves it directly!
 
-pub mod build;
+pub(crate) mod build;
 mod middleware;
 mod types;
 

--- a/autumn/tests/extractors.rs
+++ b/autumn/tests/extractors.rs
@@ -189,9 +189,9 @@ async fn multipart_mime_allow_list_skips_non_file_fields() {
         .layer(axum::middleware::from_fn(
             |mut req: axum::extract::Request, next: axum::middleware::Next| async move {
                 req.extensions_mut()
-                    .insert(autumn_web::security::config::UploadConfig {
+                    .insert(autumn_web::security::UploadConfig {
                         allowed_mime_types: vec!["text/plain".to_owned()],
-                        ..autumn_web::security::config::UploadConfig::default()
+                        ..autumn_web::security::UploadConfig::default()
                     });
                 next.run(req).await
             },
@@ -238,9 +238,9 @@ async fn multipart_file_size_limit_returns_413() {
         .layer(axum::middleware::from_fn(
             |mut req: axum::extract::Request, next: axum::middleware::Next| async move {
                 req.extensions_mut()
-                    .insert(autumn_web::security::config::UploadConfig {
+                    .insert(autumn_web::security::UploadConfig {
                         max_file_size_bytes: 4,
-                        ..autumn_web::security::config::UploadConfig::default()
+                        ..autumn_web::security::UploadConfig::default()
                     });
                 next.run(req).await
             },
@@ -282,9 +282,9 @@ async fn multipart_request_size_limit_returns_413() {
         .layer(axum::middleware::from_fn(
             |mut req: axum::extract::Request, next: axum::middleware::Next| async move {
                 req.extensions_mut()
-                    .insert(autumn_web::security::config::UploadConfig {
+                    .insert(autumn_web::security::UploadConfig {
                         max_request_size_bytes: 8,
-                        ..autumn_web::security::config::UploadConfig::default()
+                        ..autumn_web::security::UploadConfig::default()
                     });
                 next.run(req).await
             },

--- a/autumn/tests/security/csrf_cookie_tossing.rs
+++ b/autumn/tests/security/csrf_cookie_tossing.rs
@@ -1,5 +1,5 @@
-use autumn_web::security::CsrfLayer;
 use autumn_web::security::CsrfConfig;
+use autumn_web::security::CsrfLayer;
 use axum::{
     Router,
     body::Body,

--- a/autumn/tests/security/csrf_cookie_tossing.rs
+++ b/autumn/tests/security/csrf_cookie_tossing.rs
@@ -1,5 +1,5 @@
 use autumn_web::security::CsrfLayer;
-use autumn_web::security::config::CsrfConfig;
+use autumn_web::security::CsrfConfig;
 use axum::{
     Router,
     body::Body,

--- a/autumn/tests/security/csrf_empty_bypass.rs
+++ b/autumn/tests/security/csrf_empty_bypass.rs
@@ -1,5 +1,5 @@
-use autumn_web::security::CsrfLayer;
 use autumn_web::security::CsrfConfig;
+use autumn_web::security::CsrfLayer;
 use axum::http::Request;
 use axum::{Router, body::Body, routing::post};
 use tower::ServiceExt;

--- a/autumn/tests/security/csrf_empty_bypass.rs
+++ b/autumn/tests/security/csrf_empty_bypass.rs
@@ -1,5 +1,5 @@
 use autumn_web::security::CsrfLayer;
-use autumn_web::security::config::CsrfConfig;
+use autumn_web::security::CsrfConfig;
 use axum::http::Request;
 use axum::{Router, body::Body, routing::post};
 use tower::ServiceExt;

--- a/autumn/tests/security/csrf_form_bypass.rs
+++ b/autumn/tests/security/csrf_form_bypass.rs
@@ -1,5 +1,5 @@
-use autumn_web::security::CsrfLayer;
 use autumn_web::security::CsrfConfig;
+use autumn_web::security::CsrfLayer;
 use axum::{
     Router,
     body::Body,

--- a/autumn/tests/security/csrf_form_bypass.rs
+++ b/autumn/tests/security/csrf_form_bypass.rs
@@ -1,5 +1,5 @@
 use autumn_web::security::CsrfLayer;
-use autumn_web::security::config::CsrfConfig;
+use autumn_web::security::CsrfConfig;
 use axum::{
     Router,
     body::Body,

--- a/autumn/tests/security/csrf_length_timing.rs
+++ b/autumn/tests/security/csrf_length_timing.rs
@@ -1,5 +1,5 @@
-use autumn_web::security::CsrfLayer;
 use autumn_web::security::CsrfConfig;
+use autumn_web::security::CsrfLayer;
 use axum::{
     Router,
     body::Body,

--- a/autumn/tests/security/csrf_length_timing.rs
+++ b/autumn/tests/security/csrf_length_timing.rs
@@ -1,5 +1,5 @@
 use autumn_web::security::CsrfLayer;
-use autumn_web::security::config::CsrfConfig;
+use autumn_web::security::CsrfConfig;
 use axum::{
     Router,
     body::Body,

--- a/autumn/tests/security/csrf_path_traversal.rs
+++ b/autumn/tests/security/csrf_path_traversal.rs
@@ -1,5 +1,5 @@
-use autumn_web::security::CsrfLayer;
 use autumn_web::security::CsrfConfig;
+use autumn_web::security::CsrfLayer;
 use axum::{
     Router,
     body::Body,

--- a/autumn/tests/security/csrf_path_traversal.rs
+++ b/autumn/tests/security/csrf_path_traversal.rs
@@ -1,5 +1,5 @@
 use autumn_web::security::CsrfLayer;
-use autumn_web::security::config::CsrfConfig;
+use autumn_web::security::CsrfConfig;
 use axum::{
     Router,
     body::Body,

--- a/autumn/tests/security/csrf_timing.rs
+++ b/autumn/tests/security/csrf_timing.rs
@@ -1,5 +1,5 @@
-use autumn_web::security::CsrfLayer;
 use autumn_web::security::CsrfConfig;
+use autumn_web::security::CsrfLayer;
 use axum::{
     Router,
     body::Body,

--- a/autumn/tests/security/csrf_timing.rs
+++ b/autumn/tests/security/csrf_timing.rs
@@ -1,5 +1,5 @@
 use autumn_web::security::CsrfLayer;
-use autumn_web::security::config::CsrfConfig;
+use autumn_web::security::CsrfConfig;
 use axum::{
     Router,
     body::Body,

--- a/autumn/tests/security/ctf.rs
+++ b/autumn/tests/security/ctf.rs
@@ -30,7 +30,7 @@
 use autumn_web::auth::{hash_password, verify_password};
 use autumn_web::security::CsrfLayer;
 use autumn_web::security::SecurityHeadersLayer;
-use autumn_web::security::config::{CsrfConfig, HeadersConfig};
+use autumn_web::security::{CsrfConfig, HeadersConfig};
 use autumn_web::session::{MemoryStore, Session, SessionConfig, SessionLayer, SessionStore};
 use axum::{
     Router,


### PR DESCRIPTION
This PR enforces strong architectural boundaries by converting several internal `pub mod` declarations to `pub(crate) mod` within `security`, `middleware`, and `static_gen`. The relevant public APIs remain exposed through the `pub use` facade. This architectural adjustment ensures higher cohesion and prevents leaky abstractions. It also patches a missing `const fn` clippy warning and updates all the affected test imports.

---
*PR created automatically by Jules for task [4496801010315124309](https://jules.google.com/task/4496801010315124309) started by @madmax983*