### PR TITLE
🎻 Bard: Fix missing docs

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -402,7 +402,7 @@ fn default_session_key() -> String {
 }
 
 #[cfg(feature = "oauth2")]
-fn default_provider_scope() -> String {
+const fn default_provider_scope() -> String {
     String::new()
 }
 
@@ -435,13 +435,20 @@ pub struct OAuth2Config {
 /// A single OAuth2/OIDC provider configuration entry.
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct OAuth2ProviderConfig {
+    /// The client ID provided by the `OAuth2` identity provider.
     pub client_id: String,
+    /// The client secret provided by the `OAuth2` identity provider.
     pub client_secret: String,
+    /// The authorization endpoint URL where users are redirected to authenticate.
     pub authorize_url: String,
+    /// The token endpoint URL used to exchange an authorization code for tokens.
     pub token_url: String,
+    /// The optional userinfo endpoint URL used to fetch profile details.
     #[serde(default)]
     pub userinfo_url: Option<String>,
+    /// The local redirect URI registered with the identity provider (e.g., `http://localhost/auth/callback`).
     pub redirect_uri: String,
+    /// The requested scope string (e.g., `openid profile email`).
     #[serde(default = "default_provider_scope")]
     pub scope: String,
     /// Expected OIDC issuer (`iss`) used for ID token validation.
@@ -456,7 +463,9 @@ pub struct OAuth2ProviderConfig {
 /// Query extractor payload for `OAuth2` callback handlers.
 #[derive(Debug, Clone, Deserialize)]
 pub struct OAuth2Callback {
+    /// The authorization code returned by the provider.
     pub code: String,
+    /// The anti-CSRF state token passed during the authorization request.
     pub state: String,
 }
 
@@ -464,10 +473,15 @@ pub struct OAuth2Callback {
 /// Identity information extracted from an OIDC ID token or userinfo endpoint.
 #[derive(Debug, Clone)]
 pub struct OidcIdentity {
+    /// The primary subject identifier (`sub` claim) representing the user.
     pub subject: String,
+    /// The user's email address, if available in the claims.
     pub email: Option<String>,
+    /// The user's full name, if available in the claims.
     pub name: Option<String>,
+    /// The user's preferred username or nickname, if available in the claims.
     pub preferred_username: Option<String>,
+    /// The raw JSON claims extracted from the token or userinfo response.
     pub raw_claims: serde_json::Value,
 }
 

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -317,91 +317,129 @@ impl SchemaRegistry {
 // ──────────────────────────────────────────────────────────────────
 
 #[cfg(feature = "openapi")]
+/// Represents a root OpenAPI 3.0 specification document.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct OpenApiSpec {
+    /// The OpenAPI version string (e.g., `3.0.3`).
     pub openapi: String,
+    /// General information about the API.
     pub info: Info,
+    /// The available paths and operations for the API.
     pub paths: BTreeMap<String, PathItem>,
+    /// Reusable schemas, parameters, and other components.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub components: Option<Components>,
 }
 
 #[cfg(feature = "openapi")]
+/// Provides metadata about the API.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Info {
+    /// The title of the API.
     pub title: String,
+    /// The version of the OpenAPI document.
     pub version: String,
+    /// A description of the API.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }
 
 #[cfg(feature = "openapi")]
+/// Describes the operations available on a single path.
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct PathItem {
+    /// A definition of a GET operation on this path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub get: Option<Operation>,
+    /// A definition of a POST operation on this path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post: Option<Operation>,
+    /// A definition of a PUT operation on this path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub put: Option<Operation>,
+    /// A definition of a DELETE operation on this path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delete: Option<Operation>,
+    /// A definition of a PATCH operation on this path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub patch: Option<Operation>,
 }
 
 #[cfg(feature = "openapi")]
+/// Describes a single API operation on a path.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Operation {
+    /// Unique string used to identify the operation.
     #[serde(rename = "operationId")]
     pub operation_id: String,
+    /// A short summary of what the operation does.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
+    /// A verbose explanation of the operation behavior.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// A list of tags for API documentation control.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    /// A list of parameters that are applicable for this operation.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub parameters: Vec<Parameter>,
+    /// The request body applicable for this operation.
     #[serde(rename = "requestBody", skip_serializing_if = "Option::is_none")]
     pub request_body: Option<RequestBody>,
+    /// The list of possible responses as they are returned from executing this operation.
     pub responses: BTreeMap<String, Response>,
 }
 
 #[cfg(feature = "openapi")]
+/// Describes a single operation parameter.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Parameter {
+    /// The name of the parameter.
     pub name: String,
+    /// The location of the parameter. Possible values are "query", "header", "path" or "cookie".
     #[serde(rename = "in")]
     pub location: String,
+    /// Determines whether this parameter is mandatory.
     pub required: bool,
+    /// The schema defining the type used for the parameter.
     pub schema: serde_json::Value,
 }
 
 #[cfg(feature = "openapi")]
+/// Describes a single request body.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RequestBody {
+    /// Determines if the request body is required in the request.
     pub required: bool,
+    /// The content of the request body, keyed by media type.
     pub content: BTreeMap<String, MediaType>,
 }
 
 #[cfg(feature = "openapi")]
+/// Describes a single response from an API Operation.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Response {
+    /// A short description of the response.
     pub description: String,
+    /// A map containing descriptions of potential response payloads, keyed by media type.
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub content: BTreeMap<String, MediaType>,
 }
 
 #[cfg(feature = "openapi")]
+/// Provides schema and examples for the media type identified by its key.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MediaType {
+    /// The schema defining the content of the request, response, or parameter.
     pub schema: serde_json::Value,
 }
 
 #[cfg(feature = "openapi")]
+/// Holds a set of reusable objects for different aspects of the OAS.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Components {
+    /// Reusable Schema Objects.
     pub schemas: BTreeMap<String, serde_json::Value>,
 }
 

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -341,7 +341,7 @@ impl Default for RateLimitConfig {
 /// Applies framework-level guardrails for `multipart/form-data` requests:
 ///
 /// - `max_request_size_bytes`: global request body cap (enforced by middleware)
-/// - `max_file_size_bytes`: per-file cap for [`crate::extract::MultipartField`] helpers
+/// - `max_file_size_bytes`: per-file cap for [`crate::extract::Multipart`] helpers
 /// - `allowed_mime_types`: optional MIME-type allow list for uploaded parts
 ///
 /// Leave `allowed_mime_types` empty to allow any content type.

--- a/examples/wiki/src/main.rs
+++ b/examples/wiki/src/main.rs
@@ -1,3 +1,8 @@
+//! Example Wiki application demonstrating the Autumn web framework.
+//!
+//! This example shows how to build a typical server-side rendered application
+//! with forms, database access, and HTML templates.
+
 mod hooks;
 mod models;
 mod repositories;


### PR DESCRIPTION
📖 Chapter: `auth` and `openapi` module, and `wiki` example.
🔦 Insight: Added missing structure field documentation to make APIs discoverable. Fixed a broken `MultipartField` intra-doc link and provided missing crate-level docs to the wiki example.
🧪 Example: Made documentation accessible and straightforward.
🖼️ Preview: All undocumented warnings from `-D missing_docs` are resolved and docs build cleanly.

---
*PR created automatically by Jules for task [15776796719226161885](https://jules.google.com/task/15776796719226161885) started by @madmax983*