### PR TITLE
🔒 Warden: [security fix] Patch HTMX cross-origin CSRF token leakage

### DIFF
--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -47,6 +47,24 @@ pub const HTMX_CSRF_JS_PATH: &str = "/static/js/autumn-htmx-csrf.js";
 /// JavaScript under Autumn's default `script-src 'self'` policy.
 pub const HTMX_CSRF_JS: &str = r#"(function () {
   document.addEventListener("htmx:configRequest", function (evt) {
+    if (evt.detail && evt.detail.path) {
+      var path = evt.detail.path;
+      var isSameOrigin = false;
+      if (path.startsWith("/") && !path.startsWith("//")) {
+        isSameOrigin = true;
+      } else {
+        try {
+          var url = new URL(path, window.location.origin);
+          isSameOrigin = (url.origin === window.location.origin);
+        } catch (e) {
+          isSameOrigin = false;
+        }
+      }
+      if (!isSameOrigin) {
+        return;
+      }
+    }
+
     var meta = document.querySelector('meta[name="csrf-token"], meta[name="autumn-csrf-token"]');
 
     if (!meta || !evt.detail || !evt.detail.headers) {

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -184,7 +184,7 @@ pub use validation::Validated;
 /// Useful for cache-busting or diagnostic logging. The corresponding
 /// minified JS is served automatically at `/static/js/htmx.min.js`.
 #[cfg(feature = "htmx")]
-pub use htmx::{HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HTMX_VERSION, HTMX_CSRF_JS};
+pub use htmx::{HTMX_CSRF_JS, HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HTMX_VERSION};
 /// Extension trait adding `.validate()` to all `validator::Validate` types.
 pub use validation::ValidateExt;
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -184,7 +184,7 @@ pub use validation::Validated;
 /// Useful for cache-busting or diagnostic logging. The corresponding
 /// minified JS is served automatically at `/static/js/htmx.min.js`.
 #[cfg(feature = "htmx")]
-pub use htmx::{HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HTMX_VERSION};
+pub use htmx::{HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HTMX_VERSION, HTMX_CSRF_JS};
 /// Extension trait adding `.validate()` to all `validator::Validate` types.
 pub use validation::ValidateExt;
 

--- a/autumn/tests/security/htmx_csrf_leak.rs
+++ b/autumn/tests/security/htmx_csrf_leak.rs
@@ -1,0 +1,19 @@
+#[tokio::test]
+async fn eris_htmx_csrf_leak_is_blocked() {
+    #[cfg(feature = "htmx")]
+    {
+        // HTMX CSRF JS must ensure it only sends the CSRF token to same-origin URLs
+        // to prevent token leakage to attacker-controlled domains (e.g. via hx-post="https://attacker.com").
+        let js = std::str::from_utf8(autumn_web::HTMX_CSRF_JS.as_bytes()).unwrap();
+
+        assert!(
+            js.contains("window.location.origin"),
+            "VULNERABILITY: HTMX CSRF JavaScript lacks a same-origin check, leaking CSRF tokens to cross-origin targets!"
+        );
+
+        assert!(
+            js.contains("isSameOrigin"),
+            "VULNERABILITY: HTMX CSRF JavaScript lacks a same-origin check, leaking CSRF tokens to cross-origin targets!"
+        );
+    }
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -9,3 +9,4 @@ pub mod csrf_path_traversal;
 pub mod csrf_timing;
 pub mod ctf;
 pub mod session_fixation;
+pub mod htmx_csrf_leak;

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -8,5 +8,5 @@ pub mod csrf_length_timing;
 pub mod csrf_path_traversal;
 pub mod csrf_timing;
 pub mod ctf;
-pub mod session_fixation;
 pub mod htmx_csrf_leak;
+pub mod session_fixation;


### PR DESCRIPTION
This PR patches a critical Cross-Origin CSRF Token Leakage vulnerability discovered by Eris within the HTMX JavaScript integration for the Autumn web framework.

### Vulnerability Context
Prior to this fix, the inline `HTMX_CSRF_JS` injected into frontend sessions blindly attached the `X-CSRF-Token` header to all outbound HTMX HTTP requests via the `htmx:configRequest` event listener. This failed to account for situations where a user-provided or dynamic value landed in an `hx-*` attribute, sending the CSRF token to external, attacker-controlled domains.

### Resolution
This PR enforces a strict same-origin check immediately inside the event listener:
* Extracts `evt.detail.path` and asserts that paths strictly begin with `/` (excluding `//` protocol relative urls).
* Employs the native JS `URL()` parsing API falling back to `window.location.origin` evaluations to strictly verify target addresses.
* Only continues with token attachment once these safe conditions are met.

A regression test asserting the script patch was properly embedded has been added in `autumn/tests/security/htmx_csrf_leak.rs`.

---
*PR created automatically by Jules for task [551211765675862616](https://jules.google.com/task/551211765675862616) started by @madmax983*