### PR TITLE
⚒️ Forge: Refactor `client_ip` extraction in rate limiter

### DIFF
--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -160,24 +160,29 @@ impl Limiter {
     /// used.
     fn client_ip<B>(&self, req: &Request<B>) -> Option<String> {
         if self.trust_forwarded_headers {
-            if let Some(value) = req.headers().get("x-forwarded-for") {
-                if let Ok(s) = value.to_str() {
-                    if let Some(first) = s.split(',').next() {
-                        let trimmed = first.trim();
-                        if !trimmed.is_empty() {
-                            return Some(trimmed.to_owned());
-                        }
-                    }
-                }
+            let xff_ip = req
+                .headers()
+                .get("x-forwarded-for")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.split(',').next())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned);
+
+            if xff_ip.is_some() {
+                return xff_ip;
             }
 
-            if let Some(value) = req.headers().get("x-real-ip") {
-                if let Ok(s) = value.to_str() {
-                    let trimmed = s.trim();
-                    if !trimmed.is_empty() {
-                        return Some(trimmed.to_owned());
-                    }
-                }
+            let real_ip = req
+                .headers()
+                .get("x-real-ip")
+                .and_then(|v| v.to_str().ok())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned);
+
+            if real_ip.is_some() {
+                return real_ip;
             }
         }
 


### PR DESCRIPTION
🚮 Smell
The `client_ip` method in `Limiter` (`autumn/src/security/rate_limit.rs`) had a classic "Pyramid of Doom" structure: deeply nested `if let` statements handling the extraction, string conversion, splitting, trimming, and emptiness checks for the `X-Forwarded-For` and `X-Real-IP` headers. This created unnecessary visual noise and made the logic harder to follow.

✨ Solution
Refactored the IP extraction logic to use idiomatic Rust `Option` combinators (`and_then`, `map`, `filter`). The extraction pipeline for both `X-Forwarded-For` and `X-Real-IP` is now expressed as a clear chain of operations. Early returns (`if xff_ip.is_some() { return xff_ip; }`) were utilized to flatten the structure entirely.

🧼 Benefit
Significantly reduces cognitive load by eliminating rightward drift. The code now clearly expresses the intent as a data transformation pipeline rather than a series of nested conditional checks, adhering strongly to idiomatic Rust patterns.

🛡️ Verification
Ran `cargo clippy -p autumn-web --all-targets --all-features -- -D warnings`, `cargo test -p autumn-web --lib security::rate_limit`, and `cargo fmt --all`. All tests passed, confirming that the runtime behavior (including IP trimming and fallback logic) remains exactly the same. No logic changed.

---
*PR created automatically by Jules for task [11083080314016908922](https://jules.google.com/task/11083080314016908922) started by @madmax983*