### PR TITLE
🎻 Bard: Fix broken intra-doc links in rustdoc

### DIFF
--- a/autumn-macros/src/api_doc.rs
+++ b/autumn-macros/src/api_doc.rs
@@ -18,7 +18,7 @@
 //!   the route macro strips it from the function's attribute list,
 //!   parses it here, and embeds the result in the generated `ApiDoc`
 //!   struct.
-//! * As a **standalone proc-macro** (see [`crate::api_doc`]) so Rust
+//! * As a **standalone proc-macro** (see [`macro@crate::api_doc`]) so Rust
 //!   accepts the attribute on its own. That entry point is a no-op
 //!   wrapper — the real work happens when a route macro is also
 //!   applied, since routes are the only places metadata is collected.

--- a/autumn/src/middleware/metrics.rs
+++ b/autumn/src/middleware/metrics.rs
@@ -346,7 +346,7 @@ fn compute_percentiles(latencies: &VecDeque<u64>) -> Percentiles {
 
 // ── Tower Layer / Service ───────────────────────────────────────
 
-/// Tower [`Layer`] that wraps a service with [`MetricsService`].
+/// Tower [`Layer`] that wraps a service with `MetricsService`.
 ///
 /// Records request count, latency, active connections, and status code
 /// distribution into a shared [`MetricsCollector`].

--- a/autumn/src/middleware/request_id.rs
+++ b/autumn/src/middleware/request_id.rs
@@ -73,7 +73,7 @@ impl fmt::Display for RequestId {
     }
 }
 
-/// Tower [`Layer`] that wraps a service with [`RequestIdService`].
+/// Tower [`Layer`] that wraps a service with `RequestIdService`.
 ///
 /// Applied automatically by [`AppBuilder::run`](crate::app::AppBuilder::run).
 /// If you are building a custom Axum router, you can add it manually:

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -111,7 +111,7 @@ pub struct RouterContext {
     pub nest_routers: Vec<(String, axum::Router<AppState>)>,
     /// Custom Tower layers registered via
     /// [`AppBuilder::layer`](crate::app::AppBuilder::layer). Applied inside
-    /// [`RequestIdLayer`](crate::middleware::RequestIdLayer) on the ingress
+    /// [`RequestIdLayer`] on the ingress
     /// path so user middleware observes the generated request ID.
     pub custom_layers: Vec<crate::app::CustomLayerRegistration>,
     pub error_page_renderer: Option<SharedRenderer>,

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -341,7 +341,7 @@ impl Default for RateLimitConfig {
 /// Applies framework-level guardrails for `multipart/form-data` requests:
 ///
 /// - `max_request_size_bytes`: global request body cap (enforced by middleware)
-/// - `max_file_size_bytes`: per-file cap for [`crate::extract::Multipart`] helpers
+/// - `max_file_size_bytes`: per-file cap for `crate::extract::Multipart` helpers
 /// - `allowed_mime_types`: optional MIME-type allow list for uploaded parts
 ///
 /// Leave `allowed_mime_types` empty to allow any content type.

--- a/autumn/src/security/mod.rs
+++ b/autumn/src/security/mod.rs
@@ -8,10 +8,10 @@
 //!
 //! | Component | Module | Description |
 //! |-----------|--------|-------------|
-//! | Security headers | [`headers`] | X-Frame-Options, X-Content-Type-Options, HSTS, CSP, etc. |
-//! | CSRF protection | [`csrf`] | Token-based CSRF validation for mutating requests |
-//! | Rate limiting | [`rate_limit`] | Per-client-IP token-bucket throttling with `429` + `Retry-After` |
-//! | Configuration | [`config`] | `[security]` section in `autumn.toml` |
+//! | Security headers | `headers` | X-Frame-Options, X-Content-Type-Options, HSTS, CSP, etc. |
+//! | CSRF protection | `csrf` | Token-based CSRF validation for mutating requests |
+//! | Rate limiting | `rate_limit` | Per-client-IP token-bucket throttling with `429` + `Retry-After` |
+//! | Configuration | `config` | `[security]` section in `autumn.toml` |
 //!
 //! Authentication, session management, and password hashing live in
 //! their own top-level modules ([`crate::auth`], [`crate::session`]).


### PR DESCRIPTION
📖 Chapter: `autumn-web` and `autumn-macros` core framework modules.
🔦 Insight: Fixed compiler warnings generated by `cargo doc` due to broken intra-doc links. Addressed issues where public documentation attempted to link to private structs/modules (like `MetricsService` or `security::csrf`) and resolved an ambiguous proc-macro reference by prefixing it with `macro@`. 
🧪 Example: Running `cargo doc --workspace --no-deps` now passes without emitting `rustdoc::broken_intra_doc_links` or `rustdoc::private_intra_doc_links` warnings for these modules.
🖼️ Preview: Documentation renders correctly with private components properly formatted as inline code rather than unresolvable hyperlinks.

---
*PR created automatically by Jules for task [4595654563546498542](https://jules.google.com/task/4595654563546498542) started by @madmax983*