### PR TITLE
🧪 Add test for actuator_router convenience function

### DIFF
--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1933,6 +1933,24 @@ mod tests {
             assert_eq!(res.status(), StatusCode::NOT_IMPLEMENTED);
         }
     }
+
+    #[tokio::test]
+    async fn test_actuator_router_calls_prefix_variant() {
+        // The `actuator_router` function is a convenience wrapper around `actuator_router_with_prefix`
+        // using "/actuator" as the prefix. We can test it by building it and hitting one of the endpoints.
+        let app = actuator_router(false).with_state(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🎯 **What:** The public API function `actuator_router` inside `autumn/src/actuator.rs` was not covered by any test despite being part of the public interface. It is a convenience wrapper calling `actuator_router_with_prefix` underneath.

📊 **Coverage:** A new tokio test was added to verify `actuator_router` with `sensitive` mode `false`. It hits the `/actuator/health` endpoint and verifies that a 200 OK status is returned, confirming that the default "/actuator" prefix is used as expected.

✨ **Result:** Test coverage for the actuator router module has been improved. This increases confidence in modifying this module in the future.

---
*PR created automatically by Jules for task [2391002174515929770](https://jules.google.com/task/2391002174515929770) started by @madmax983*