### PR TITLE
🧪 [testing] add missing test for live_reload_state_handler env reading

### DIFF
--- a/autumn/src/middleware/dev.rs
+++ b/autumn/src/middleware/dev.rs
@@ -562,4 +562,34 @@ mod tests {
         assert!(body_str.contains(r#""version""#));
         assert!(body_str.contains(r#""kind""#));
     }
+
+    #[tokio::test]
+    async fn live_reload_state_handler_reads_state_from_file_with_env() {
+        let tmp_file = tempfile::NamedTempFile::new().expect("failed to create temp file");
+        let content = r#"{"version":123,"kind":"css"}"#;
+        std::fs::write(tmp_file.path(), content).expect("failed to write to temp file");
+
+        temp_env::async_with_vars(
+            [
+                (DEV_RELOAD_ENV, Some("1")),
+                (
+                    DEV_RELOAD_STATE_ENV,
+                    Some(tmp_file.path().to_str().unwrap()),
+                ),
+            ],
+            async {
+                let response = super::live_reload_state_handler().await.into_response();
+
+                assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+                let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let body_str = std::str::from_utf8(&body_bytes).unwrap();
+
+                assert_eq!(body_str, content);
+            },
+        )
+        .await;
+    }
 }


### PR DESCRIPTION
🎯 **What:** 
The `live_reload_state_handler` function in `autumn/src/middleware/dev.rs` is a public API that lacked comprehensive unit test coverage, specifically when reading a custom state file using actual environment variables via `crate::config::OsEnv`. This PR introduces a unit test `live_reload_state_handler_reads_state_from_file_with_env` that covers this logic gap.

📊 **Coverage:** 
Previously, only the default fallback state (`{"version":0,"kind":"full"}`) was effectively exercised. The new test validates the scenario where both `AUTUMN_DEV_RELOAD` and `AUTUMN_DEV_RELOAD_STATE` environment variables are correctly read by the system environment, and it successfully reads the dynamically supplied temporary state file configuration and parses the custom JSON correctly.

✨ **Result:** 
The coverage and reliability of `live_reload_state_handler` behavior in dynamically resolving custom live-reload states is explicitly verified and safeguarded against regressions. All tests in `middleware::dev` successfully pass and the codebase is completely clear of linting/formatting issues.

---
*PR created automatically by Jules for task [6251903783778151910](https://jules.google.com/task/6251903783778151910) started by @madmax983*