### PR TITLE
🧪 Test missing for run_pending

### DIFF
--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -235,7 +235,7 @@ mod tests {
     fn run_pending_connection_error() {
         const MIGRATIONS: EmbeddedMigrations =
             diesel_migrations::embed_migrations!("../examples/todo-app/migrations");
-        let url = "postgres://invalid:invalid@localhost:5432/invalid_db";
+        let url = "postgres://invalid_user:invalid_password@0.0.0.0:1/invalid_db";
         let result = run_pending(url, MIGRATIONS);
 
         assert!(result.is_err());

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -230,4 +230,15 @@ mod tests {
         assert!(should_auto_apply(Some("production"), true));
         assert!(!should_auto_apply(Some("staging"), true));
     }
+
+    #[test]
+    fn run_pending_connection_error() {
+        const MIGRATIONS: EmbeddedMigrations =
+            diesel_migrations::embed_migrations!("../examples/todo-app/migrations");
+        let url = "postgres://invalid:invalid@localhost:5432/invalid_db";
+        let result = run_pending(url, MIGRATIONS);
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), MigrationError::Connection(_)));
+    }
 }


### PR DESCRIPTION
🎯 **What:** The `run_pending` function in `autumn/src/migrate.rs` lacked unit tests for its error handling path.

📊 **Coverage:** A new unit test `run_pending_connection_error` has been added which verifies that supplying an invalid connection string returns the expected `MigrationError::Connection` variant.

✨ **Result:** Test coverage for the `migrate` module has improved, ensuring proper handling and propagation of connection errors during migration setup without requiring a live dockerized database instance for this specific edge case.

---
*PR created automatically by Jules for task [16253082152053534152](https://jules.google.com/task/16253082152053534152) started by @madmax983*