### PR TITLE
🧪 Add test coverage for HEAD requests in fallback_404_handler

### DIFF
--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -749,6 +749,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fallback_404_handler_returns_empty_no_content_for_favicon_head() {
+        let response = fallback_404_handler(
+            axum::http::Method::HEAD,
+            axum::http::Uri::from_static(crate::router::DEFAULT_FAVICON_PATH),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
     async fn fallback_404_handler_keeps_non_get_favicon_requests_as_not_found() {
         let response = fallback_404_handler(
             axum::http::Method::POST,


### PR DESCRIPTION
🎯 **What:** `fallback_404_handler` in `error_page_filter.rs` was not fully tested. The handler explicitly handles `HEAD` requests for the default favicon path and returns a `204 No Content` response, but this specific behavior was completely untested.
📊 **Coverage:** A test `fallback_404_handler_returns_empty_no_content_for_favicon_head` was added to verify the `axum::http::Method::HEAD` handling logic for the favicon path.
✨ **Result:** Test coverage for `fallback_404_handler` is improved by explicitly exercising the `HEAD` method branch.

---
*PR created automatically by Jules for task [17688332089627619338](https://jules.google.com/task/17688332089627619338) started by @madmax983*