### PR TITLE
🧪 Add tests for logging init formats and fallback behavior

### DIFF
--- a/autumn/src/logging.rs
+++ b/autumn/src/logging.rs
@@ -90,6 +90,34 @@ mod tests {
             let msg = err.downcast_ref::<&str>().map_or_else(|| err.downcast_ref::<String>().map_or("unknown", |s| s.as_str()), |s| *s);
             assert!(msg.contains("failed to initialize logging"), "Unexpected panic message: {msg}");
         }
+
+        #[test]
+        fn init_with_json_format_succeeds() {
+            let config = LogConfig {
+                level: "debug".to_owned(),
+                format: LogFormat::Json,
+            };
+            init(&config);
+        }
+
+        #[test]
+        fn init_with_auto_format_succeeds() {
+            let config = LogConfig {
+                level: "debug".to_owned(),
+                format: LogFormat::Auto,
+            };
+            init(&config);
+        }
+
+        #[test]
+        fn init_with_invalid_level_falls_back_without_panic() {
+            let config = LogConfig {
+                level: "invalid_level_format_[without_equal]".to_owned(),
+                format: LogFormat::Pretty,
+            };
+            init(&config);
+        }
+
     }
 
     use super::*;


### PR DESCRIPTION
🎯 **What:** The `autumn/src/logging.rs` `init()` function had tests for success on first call and panicking on second call, but lacked branch coverage for its format parsing and its fallback handling. This was because `init` utilizes global process-state initialization paths that branch out internally for `Json` formats, `Auto` formats, and parsing an invalid directive fallback to `"info"`.

📊 **Coverage:** Now tests the `init()` function with `LogFormat::Json`, `LogFormat::Auto`, and an invalid `LogConfig` level directive (triggering the fallback without a panic or crash). These were added within the `rusty_fork_test!` isolation block to prevent testing interference due to the one-time global tracing subscriber rule.

✨ **Result:** Improved robustness by confirming the global tracing subscriber initializes cleanly and deterministicly regardless of the configured configuration or output format.

---
*PR created automatically by Jules for task [2704937799210887985](https://jules.google.com/task/2704937799210887985) started by @madmax983*