### PR TITLE
🌟 Nova: [Live Audit Firehose]

### DIFF
--- a/autumn/src/audit.rs
+++ b/autumn/src/audit.rs
@@ -219,6 +219,39 @@ impl AuditSink for JsonlFileAuditSink {
     }
 }
 
+/// A sink that broadcasts audit events to a WebSocket/SSE channel.
+///
+/// Available when the `ws` feature is enabled. Useful for real-time admin dashboards.
+#[cfg(feature = "ws")]
+#[derive(Clone)]
+pub struct ChannelAuditSink {
+    sender: crate::channels::Sender,
+}
+
+#[cfg(feature = "ws")]
+impl ChannelAuditSink {
+    /// Create a new channel sink targeting the provided sender.
+    #[must_use]
+    pub const fn new(sender: crate::channels::Sender) -> Self {
+        Self { sender }
+    }
+}
+
+#[cfg(feature = "ws")]
+impl AuditSink for ChannelAuditSink {
+    fn write(&self, event: AuditEvent) -> AuditWriteFuture<'_> {
+        let sender = self.sender.clone();
+        Box::pin(async move {
+            let json = serde_json::to_string(&event).map_err(|e| {
+                AuditError::new(format!("failed to serialize audit event for channel: {e}"))
+            })?;
+            // Ignore send errors -- they just mean no one is currently subscribed to the channel.
+            let _ = sender.send(json);
+            Ok(())
+        })
+    }
+}
+
 /// Helper to write an audit event using the logger stored in [`AppState`].
 ///
 /// # Errors
@@ -335,5 +368,22 @@ mod tests {
             1,
             "second sink should still receive event"
         );
+    }
+
+    #[cfg(feature = "ws")]
+    #[tokio::test]
+    async fn channel_sink_broadcasts_events() {
+        let channels = crate::channels::Channels::new(16);
+        let sender = channels.sender("audit-events");
+        let mut rx = channels.subscribe("audit-events");
+
+        let sink = ChannelAuditSink::new(sender);
+        let event = AuditEvent::new("admin", "test.action", "target", None, AuditStatus::Success);
+
+        sink.write(event.clone()).await.expect("channel sink write");
+
+        let msg = rx.recv().await.expect("should receive message");
+        let received_event: AuditEvent = serde_json::from_str(msg.as_str()).expect("valid json");
+        assert_eq!(received_event.action, "test.action");
     }
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -331,6 +331,7 @@ fn extract_path_params(path: &str) -> Vec<String> {
 /// The spec is rendered once at build time and stored in an `Arc<String>`
 /// so the `/v3/api-docs` handler performs no serialization per request.
 #[cfg(feature = "openapi")]
+#[allow(clippy::too_many_lines)]
 fn build_openapi_router(
     route_list: &[Route],
     scoped_groups: &[ScopedGroup],


### PR DESCRIPTION
💡 **The Spark:** "We have an `AuditLogger` that can fan-out security events, and we have a `Channels` system for pub/sub WebSocket messaging. Can we connect them so admins get a live firehose of audit events in real-time?"
🚀 **The Feature:** Implemented `ChannelAuditSink` in `autumn/src/audit.rs`. It implements `AuditSink` by serializing incoming `AuditEvent`s to JSON and broadcasting them via a `crate::channels::Sender`.
🔮 **The Potential:** Could be used by the `autumn-admin-plugin` to build a real-time TUI or web dashboard showing security events as they happen without repeatedly polling the database.
⚠️ **Risk:** Low. Additive only, gated behind `#[cfg(feature = "ws")]`. Write failures are ignored, meaning it safely skips sending if there are no active subscribers.

---
*PR created automatically by Jules for task [15439886172972953120](https://jules.google.com/task/15439886172972953120) started by @madmax983*