### PR TITLE
Add admin plugin docs and blog example integration

### DIFF
--- a/autumn-admin-plugin/Cargo.toml
+++ b/autumn-admin-plugin/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 version.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "README.md"
 
 [dependencies]
 autumn-web = { version = "0.3.0", path = "../autumn", features = ["maud", "htmx", "db", "flash"] }

--- a/autumn-admin-plugin/README.md
+++ b/autumn-admin-plugin/README.md
@@ -1,0 +1,123 @@
+# autumn-admin-plugin
+
+`autumn-admin-plugin` adds a server-rendered admin panel to an `autumn-web`
+ application. Register one or more models, mount the plugin, and it serves a
+ CRUD UI with list/detail/edit screens, search, filtering, bulk actions, CSRF
+ integration, and HTMX-driven interactions with no frontend build step.
+
+## Features
+
+- Mounts an admin UI under `/admin` by default
+- Generates list, create, detail, edit, delete, and bulk-action flows
+- Uses Maud + HTMX and works under Autumn's default `Content-Security-Policy`
+- Reads and writes model data through a small `AdminModel` trait
+- Requires an authenticated session with the `"admin"` role by default
+
+## Installation
+
+Add the plugin alongside `autumn-web`:
+
+```toml
+[dependencies]
+autumn-web = { version = "0.3", features = ["db", "flash", "htmx", "maud"] }
+autumn-admin-plugin = "0.3"
+```
+
+`autumn-admin-plugin` expects a configured Autumn database pool because all
+ admin model operations receive the app's Postgres pool.
+
+## Quick Start
+
+```rust,ignore
+struct ProjectAdmin;
+// Implement `autumn_admin_plugin::AdminModel` for your type.
+// Supply field metadata plus `list`, `get`, `create`, `update`, and `delete`.
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .plugin(AdminPlugin::new().register(ProjectAdmin))
+        .run()
+        .await;
+}
+```
+
+## What the Plugin Mounts
+
+When mounted at the default `/admin` prefix, the plugin serves:
+
+- `GET /admin/` — dashboard
+- `GET /admin/{slug}` — paginated list view
+- `POST /admin/{slug}` — create record
+- `GET /admin/{slug}/new` — new-record form
+- `GET /admin/{slug}/{id}` — detail view
+- `POST /admin/{slug}/{id}` — update record
+- `DELETE /admin/{slug}/{id}` — delete record
+- `GET /admin/{slug}/{id}/edit` — edit form
+- `POST /admin/{slug}/actions` — bulk actions
+
+The plugin also serves a hashed same-origin JavaScript asset under
+`/admin/static/admin.<hash>.js` so long-lived caching stays safe across deploys.
+
+## `AdminModel` Contract
+
+Each registered model supplies:
+
+- A URL slug and singular/plural display names
+- A field schema via `Vec<AdminField>`
+- `list`, `get`, `create`, `update`, and `delete` operations
+
+`AdminField` covers the common form/display shapes: `Text`, `TextArea`,
+`Integer`, `Float`, `Boolean`, `Date`, `DateTime`, `Select`, `Hidden`,
+`Password`, and `Json`.
+
+Optional hooks let you customize:
+
+- `actions()` for extra bulk actions beyond the built-in delete action
+- `execute_action()` to implement those custom actions
+- `record_display()` for breadcrumbs and page titles
+- `per_page()` and `count()` for pagination behavior
+
+All values flow through `serde_json::Value` so the plugin stays object-safe and
+does not need to know your application's concrete model types.
+
+## Configuration
+
+`AdminPlugin::new()` defaults to:
+
+- Prefix: `/admin`
+- Required role: `"admin"`
+- Session auth key: `"user_id"`
+- Actuator prefix: `/actuator`
+
+You can override those defaults with:
+
+- `prefix(...)`
+- `require_role(...)`
+- `auth_session_key(...)`
+- `actuator_prefix(...)`
+
+Example:
+
+```rust,ignore
+let plugin = AdminPlugin::new()
+    .prefix("/backoffice")
+    .actuator_prefix("/ops")
+    .auth_session_key("uid")
+    .require_role(Some("staff".to_owned()));
+```
+
+## Security Notes
+
+- The plugin assumes Autumn session/auth middleware is already configured
+- Role checks run before any admin handler by default
+- CSRF tokens are rendered automatically when Autumn's `CsrfLayer` is enabled
+- No inline JavaScript is used; the UI is compatible with Autumn's default CSP
+- `Password` fields are treated as write-only and never rendered back to users
+
+## Status
+
+This crate is intended as the first-party admin plugin for `autumn-web`. The
+API is pragmatic and functional, but still young enough that you should expect
+incremental improvements around model ergonomics, docs, and batteries-included
+examples.

--- a/autumn-admin-plugin/README.md
+++ b/autumn-admin-plugin/README.md
@@ -29,8 +29,10 @@ autumn-admin-plugin = "0.3"
 ## Quick Start
 
 ```rust,ignore
+use autumn_admin_plugin::{prelude::*, AdminPlugin};
+
 struct ProjectAdmin;
-// Implement `autumn_admin_plugin::AdminModel` for your type.
+// Implement `AdminModel` for your type.
 // Supply field metadata plus `list`, `get`, `create`, `update`, and `delete`.
 
 #[autumn_web::main]

--- a/autumn-admin-plugin/src/lib.rs
+++ b/autumn-admin-plugin/src/lib.rs
@@ -9,7 +9,7 @@
 //! # Quick start
 //!
 //! ```rust,ignore
-//! use autumn_admin_plugin::AdminPlugin;
+//! use autumn_admin_plugin::{prelude::*, AdminPlugin};
 //!
 //! autumn_web::app()
 //!     .plugin(
@@ -43,6 +43,14 @@ pub use traits::{
     AdminAction, AdminError, AdminField, AdminFieldKind, AdminFuture, AdminModel, ListParams,
     ListResult, SortDirection,
 };
+
+/// Common downstream imports for implementing admin models.
+pub mod prelude {
+    pub use crate::{
+        AdminError, AdminField, AdminFieldKind, AdminFuture, AdminModel, ListParams, ListResult,
+        SortDirection,
+    };
+}
 
 use std::borrow::Cow;
 use std::sync::Arc;

--- a/autumn-admin-plugin/src/lib.rs
+++ b/autumn-admin-plugin/src/lib.rs
@@ -39,7 +39,10 @@ mod templates;
 mod traits;
 
 pub use registry::AdminRegistry;
-pub use traits::{AdminAction, AdminField, AdminFieldKind, AdminModel};
+pub use traits::{
+    AdminAction, AdminError, AdminField, AdminFieldKind, AdminFuture, AdminModel, ListParams,
+    ListResult, SortDirection,
+};
 
 use std::borrow::Cow;
 use std::sync::Arc;

--- a/examples/blog/Cargo.toml
+++ b/examples/blog/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
+autumn-admin-plugin = { path = "../../autumn-admin-plugin" }
 autumn-web = { path = "../../autumn" }
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "2", features = ["postgres", "chrono"] }

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -7,6 +7,7 @@ htmx, embedded migrations, and the new hybrid-rendering pipeline.
 
 - Public blog listing and slug-based post pages
 - Admin UI for create, edit, publish, and delete
+- First-party `autumn-admin-plugin` mounted at `/backoffice`
 - JSON endpoints alongside server-rendered HTML
 - Validation before insert/update
 - `#[static_get]` + `static_routes![]` for build-time rendering
@@ -57,6 +58,7 @@ static routes get written to `dist/` for deployment or CDN serving.
 | GET | `/admin/{id}/edit` | Edit post form |
 | POST | `/admin/{id}` | Update a post |
 | DELETE | `/admin/{id}` | Delete a post with htmx |
+| GET | `/backoffice/posts` | Admin plugin list view for posts |
 
 ### JSON API
 

--- a/examples/blog/src/admin.rs
+++ b/examples/blog/src/admin.rs
@@ -1,7 +1,4 @@
-use autumn_admin_plugin::{
-    AdminError, AdminField, AdminFieldKind, AdminFuture, AdminModel, ListParams, ListResult,
-    SortDirection,
-};
+use autumn_admin_plugin::prelude::*;
 use diesel::OptionalExtension;
 use diesel::prelude::*;
 use diesel_async::AsyncPgConnection;

--- a/examples/blog/src/admin.rs
+++ b/examples/blog/src/admin.rs
@@ -1,0 +1,255 @@
+use autumn_admin_plugin::{
+    AdminError, AdminField, AdminFieldKind, AdminFuture, AdminModel, ListParams, ListResult,
+    SortDirection,
+};
+use diesel::OptionalExtension;
+use diesel::prelude::*;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use diesel_async::pooled_connection::deadpool::Pool;
+use serde_json::Value;
+
+use crate::models::{NewPost, Post, UpdatePost};
+use crate::schema::posts;
+
+#[derive(Clone, Copy, Default)]
+pub struct PostAdmin;
+
+impl PostAdmin {
+    fn pool_error(error: impl std::fmt::Display) -> AdminError {
+        AdminError::Database(error.to_string())
+    }
+
+    fn validation_error(error: impl std::fmt::Display) -> AdminError {
+        AdminError::Validation(error.to_string())
+    }
+
+    fn other_error(error: impl std::fmt::Display) -> AdminError {
+        AdminError::Other(error.to_string())
+    }
+
+    fn serialize_post(post: Post) -> Result<Value, AdminError> {
+        serde_json::to_value(post).map_err(Self::other_error)
+    }
+
+    fn apply_filters<'a>(
+        mut query: posts::BoxedQuery<'a, diesel::pg::Pg>,
+        params: &'a ListParams,
+    ) -> posts::BoxedQuery<'a, diesel::pg::Pg> {
+        if let Some(search) = params.search.as_deref() {
+            let pattern = format!("%{search}%");
+            query = query.filter(
+                posts::title
+                    .ilike(pattern.clone())
+                    .or(posts::slug.ilike(pattern.clone()))
+                    .or(posts::body.ilike(pattern)),
+            );
+        }
+
+        for (name, value) in &params.filters {
+            match name.as_str() {
+                "published" => match value.as_str() {
+                    "true" | "1" | "yes" => query = query.filter(posts::published.eq(true)),
+                    "false" | "0" | "no" => query = query.filter(posts::published.eq(false)),
+                    _ => {}
+                },
+                "slug" => query = query.filter(posts::slug.ilike(value)),
+                _ => {}
+            }
+        }
+
+        query
+    }
+
+    fn apply_sort<'a>(
+        mut query: posts::BoxedQuery<'a, diesel::pg::Pg>,
+        params: &ListParams,
+    ) -> posts::BoxedQuery<'a, diesel::pg::Pg> {
+        match (params.sort_by.as_deref(), params.sort_dir) {
+            (Some("id"), SortDirection::Asc) => query = query.order(posts::id.asc()),
+            (Some("id"), SortDirection::Desc) => query = query.order(posts::id.desc()),
+            (Some("title"), SortDirection::Asc) => query = query.order(posts::title.asc()),
+            (Some("title"), SortDirection::Desc) => query = query.order(posts::title.desc()),
+            (Some("slug"), SortDirection::Asc) => query = query.order(posts::slug.asc()),
+            (Some("slug"), SortDirection::Desc) => query = query.order(posts::slug.desc()),
+            (Some("published"), SortDirection::Asc) => query = query.order(posts::published.asc()),
+            (Some("published"), SortDirection::Desc) => {
+                query = query.order(posts::published.desc())
+            }
+            (Some("updated_at"), SortDirection::Asc) => {
+                query = query.order(posts::updated_at.asc())
+            }
+            (Some("updated_at"), SortDirection::Desc) => {
+                query = query.order(posts::updated_at.desc())
+            }
+            (_, SortDirection::Asc) => query = query.order(posts::created_at.asc()),
+            _ => query = query.order(posts::created_at.desc()),
+        }
+
+        query
+    }
+}
+
+impl AdminModel for PostAdmin {
+    fn slug(&self) -> &'static str {
+        "posts"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Post"
+    }
+
+    fn display_name_plural(&self) -> &'static str {
+        "Posts"
+    }
+
+    fn fields(&self) -> Vec<AdminField> {
+        vec![
+            AdminField::new("id", AdminFieldKind::Hidden)
+                .readonly()
+                .hide_from_list(),
+            AdminField::new("title", AdminFieldKind::Text).searchable(),
+            AdminField::new("slug", AdminFieldKind::Text).filterable(),
+            AdminField::new("body", AdminFieldKind::TextArea)
+                .searchable()
+                .hide_from_list(),
+            AdminField::new("published", AdminFieldKind::Boolean).filterable(),
+            AdminField::new("created_at", AdminFieldKind::DateTime)
+                .readonly()
+                .optional(),
+            AdminField::new("updated_at", AdminFieldKind::DateTime)
+                .readonly()
+                .optional()
+                .hide_from_list(),
+        ]
+    }
+
+    fn list(
+        &self,
+        pool: &Pool<AsyncPgConnection>,
+        params: ListParams,
+    ) -> AdminFuture<'_, ListResult> {
+        let pool = pool.clone();
+        Box::pin(async move {
+            let mut conn = pool.get().await.map_err(Self::pool_error)?;
+
+            let total: i64 = Self::apply_filters(posts::table.into_boxed(), &params)
+                .count()
+                .get_result(&mut conn)
+                .await
+                .map_err(Self::pool_error)?;
+
+            let mut query = Self::apply_sort(
+                Self::apply_filters(posts::table.into_boxed(), &params),
+                &params,
+            );
+            if params.per_page > 0 {
+                let offset = params
+                    .page
+                    .saturating_sub(1)
+                    .saturating_mul(params.per_page);
+                query = query.limit(params.per_page as i64).offset(offset as i64);
+            }
+
+            let records = query
+                .select(Post::as_select())
+                .load::<Post>(&mut conn)
+                .await
+                .map_err(Self::pool_error)?
+                .into_iter()
+                .map(Self::serialize_post)
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(ListResult {
+                records,
+                total: total as u64,
+                page: params.page,
+                per_page: params.per_page,
+            })
+        })
+    }
+
+    fn get(&self, pool: &Pool<AsyncPgConnection>, id: i64) -> AdminFuture<'_, Option<Value>> {
+        let pool = pool.clone();
+        Box::pin(async move {
+            let mut conn = pool.get().await.map_err(Self::pool_error)?;
+            let post = posts::table
+                .find(id)
+                .select(Post::as_select())
+                .first::<Post>(&mut conn)
+                .await
+                .optional()
+                .map_err(Self::pool_error)?;
+            post.map(Self::serialize_post).transpose()
+        })
+    }
+
+    fn create(&self, pool: &Pool<AsyncPgConnection>, data: Value) -> AdminFuture<'_, Value> {
+        let pool = pool.clone();
+        Box::pin(async move {
+            let new_post: NewPost = serde_json::from_value(data).map_err(Self::validation_error)?;
+            let new_post = new_post
+                .validated()
+                .map_err(|error| Self::validation_error(error))?;
+            let mut conn = pool.get().await.map_err(Self::pool_error)?;
+
+            let created = diesel::insert_into(posts::table)
+                .values(&new_post)
+                .returning(Post::as_returning())
+                .get_result::<Post>(&mut conn)
+                .await
+                .map_err(Self::pool_error)?;
+
+            Self::serialize_post(created)
+        })
+    }
+
+    fn update(
+        &self,
+        pool: &Pool<AsyncPgConnection>,
+        id: i64,
+        data: Value,
+    ) -> AdminFuture<'_, Value> {
+        let pool = pool.clone();
+        Box::pin(async move {
+            let new_post: NewPost = serde_json::from_value(data).map_err(Self::validation_error)?;
+            let new_post = new_post
+                .validated()
+                .map_err(|error| Self::validation_error(error))?;
+            let changes = UpdatePost {
+                title: Some(new_post.title),
+                slug: Some(new_post.slug),
+                body: Some(new_post.body),
+                published: Some(new_post.published),
+            };
+            let mut conn = pool.get().await.map_err(Self::pool_error)?;
+
+            let updated = diesel::update(posts::table.find(id))
+                .set(&changes)
+                .returning(Post::as_returning())
+                .get_result::<Post>(&mut conn)
+                .await
+                .optional()
+                .map_err(Self::pool_error)?;
+
+            updated
+                .ok_or(AdminError::NotFound)
+                .and_then(Self::serialize_post)
+        })
+    }
+
+    fn delete(&self, pool: &Pool<AsyncPgConnection>, id: i64) -> AdminFuture<'_, ()> {
+        let pool = pool.clone();
+        Box::pin(async move {
+            let mut conn = pool.get().await.map_err(Self::pool_error)?;
+            let deleted = diesel::delete(posts::table.find(id))
+                .execute(&mut conn)
+                .await
+                .map_err(Self::pool_error)?;
+            if deleted == 0 {
+                return Err(AdminError::NotFound);
+            }
+            Ok(())
+        })
+    }
+}

--- a/examples/blog/src/main.rs
+++ b/examples/blog/src/main.rs
@@ -1,7 +1,9 @@
+mod admin;
 mod models;
 mod routes;
 mod schema;
 
+use autumn_admin_plugin::AdminPlugin;
 use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
 use autumn_web::{routes, static_routes};
 
@@ -11,6 +13,12 @@ const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 async fn main() {
     autumn_web::app()
         .migrations(MIGRATIONS)
+        .plugin(
+            AdminPlugin::new()
+                .prefix("/backoffice")
+                .require_role(None::<String>)
+                .register(admin::PostAdmin),
+        )
         .routes(routes![
             // Public routes
             routes::about::about, // #[static_get] — pre-rendered
@@ -36,6 +44,8 @@ async fn main() {
 mod tests {
     use std::path::Path;
 
+    use autumn_admin_plugin::{AdminFieldKind, AdminModel};
+
     const MIGRATION_SQL: &str = include_str!("../migrations/00000000000000_create_posts/up.sql");
 
     #[test]
@@ -60,6 +70,35 @@ mod tests {
         assert!(
             sql.contains("ALTER SEQUENCE posts_id_seq AS BIGINT"),
             "post upgrade migration must widen the backing sequence to BIGINT",
+        );
+    }
+
+    #[test]
+    fn backoffice_admin_fields_match_blog_post_shape() {
+        let fields = super::admin::PostAdmin.fields();
+        assert!(
+            fields.iter().any(|field| {
+                field.name == "title"
+                    && matches!(field.kind, AdminFieldKind::Text)
+                    && field.searchable
+            }),
+            "expected searchable title field in admin schema"
+        );
+        assert!(
+            fields.iter().any(|field| {
+                field.name == "published"
+                    && matches!(field.kind, AdminFieldKind::Boolean)
+                    && field.filterable
+            }),
+            "expected filterable published field in admin schema"
+        );
+        assert!(
+            fields.iter().any(|field| {
+                field.name == "created_at"
+                    && matches!(field.kind, AdminFieldKind::DateTime)
+                    && !field.editable
+            }),
+            "expected readonly created_at field in admin schema"
         );
     }
 }

--- a/examples/blog/src/main.rs
+++ b/examples/blog/src/main.rs
@@ -44,7 +44,7 @@ async fn main() {
 mod tests {
     use std::path::Path;
 
-    use autumn_admin_plugin::{AdminFieldKind, AdminModel};
+    use autumn_admin_plugin::prelude::*;
 
     const MIGRATION_SQL: &str = include_str!("../migrations/00000000000000_create_posts/up.sql");
 

--- a/examples/blog/src/routes/posts.rs
+++ b/examples/blog/src/routes/posts.rs
@@ -48,6 +48,7 @@ pub fn layout(title: &str, content: Markup) -> Markup {
                             a href="/" class="text-sm text-stone-600 hover:text-amber-700 transition-colors" { "Home" }
                             a href="/about" class="text-sm text-stone-600 hover:text-amber-700 transition-colors" { "About" }
                             a href="/admin" class="text-sm text-stone-600 hover:text-amber-700 transition-colors" { "Admin" }
+                            a href="/backoffice/posts" class="text-sm text-stone-600 hover:text-amber-700 transition-colors" { "Plugin Admin" }
                             a href="/admin/new" class="text-sm px-3 py-1.5 bg-amber-700 text-white rounded-lg hover:bg-amber-800 transition-colors" { "New Post" }
                         }
                     }


### PR DESCRIPTION
## Summary
- add a crates.io README for autumn-admin-plugin and wire it into package metadata
- re-export admin trait types needed by downstream implementers
- mount the admin plugin in the blog example at /backoffice with a concrete PostAdmin model
- document the new example route and add a regression test for the admin field schema

## Verification
- cargo check -p blog --offline
- cargo test -p blog --offline -- --nocapture
- cargo fmt --all