### PR TITLE
⚒️ Forge: Flatten Pyramids of Doom and modernize string extractors

### DIFF
--- a/autumn-macros/src/api_doc.rs
+++ b/autumn-macros/src/api_doc.rs
@@ -267,22 +267,23 @@ fn slice_str(items: &[LitStr]) -> TokenStream {
 /// contain regex (`{id:[0-9]+}`) take only the name before the colon.
 pub fn extract_path_params(path: &str) -> Vec<String> {
     let mut out = Vec::new();
-    let bytes = path.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'{' {
-            if let Some(end_rel) = bytes[i + 1..].iter().position(|b| *b == b'}') {
-                let inner = &path[i + 1..i + 1 + end_rel];
-                let name = inner.split(':').next().unwrap_or(inner).trim();
-                if !name.is_empty() {
-                    out.push(name.to_owned());
-                }
-                i += 1 + end_rel + 1;
-                continue;
-            }
+    let mut remaining = path;
+
+    while let Some(start) = remaining.find('{') {
+        let after_brace = &remaining[start + 1..];
+        let Some(end_rel) = after_brace.find('}') else {
+            break;
+        };
+
+        let inner = &after_brace[..end_rel];
+        let name = inner.split(':').next().unwrap_or(inner).trim();
+        if !name.is_empty() {
+            out.push(name.to_owned());
         }
-        i += 1;
+
+        remaining = &after_brace[end_rel + 1..];
     }
+
     out
 }
 

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -303,22 +303,23 @@ pub fn try_build_router_inner(
 #[cfg(feature = "openapi")]
 fn extract_path_params(path: &str) -> Vec<String> {
     let mut out = Vec::new();
-    let bytes = path.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'{' {
-            if let Some(end_rel) = bytes[i + 1..].iter().position(|b| *b == b'}') {
-                let inner = &path[i + 1..i + 1 + end_rel];
-                let name = inner.split(':').next().unwrap_or(inner).trim();
-                if !name.is_empty() {
-                    out.push(name.to_owned());
-                }
-                i += 1 + end_rel + 1;
-                continue;
-            }
+    let mut remaining = path;
+
+    while let Some(start) = remaining.find('{') {
+        let after_brace = &remaining[start + 1..];
+        let Some(end_rel) = after_brace.find('}') else {
+            break;
+        };
+
+        let inner = &after_brace[..end_rel];
+        let name = inner.split(':').next().unwrap_or(inner).trim();
+        if !name.is_empty() {
+            out.push(name.to_owned());
         }
-        i += 1;
+
+        remaining = &after_brace[end_rel + 1..];
     }
+
     out
 }
 

--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -213,21 +213,28 @@ fn extract_cookie_token(req_headers: &http::HeaderMap, cookie_name: &str) -> Opt
     let mut found_token = None;
 
     for cookie_header in &req_headers.get_all(http::header::COOKIE) {
-        if let Ok(cookie_str) = cookie_header.to_str() {
-            for pair in cookie_str.split(';') {
-                let pair = pair.trim();
-                if let Some((name, value)) = pair.split_once('=') {
-                    if name.trim() == cookie_name {
-                        if found_token.is_some() {
-                            // Multiple cookies with the same name found.
-                            // This indicates a potential Cookie Tossing attack!
-                            // Reject by returning None.
-                            return None;
-                        }
-                        found_token = Some(value.trim().to_owned());
-                    }
-                }
+        let Ok(cookie_str) = cookie_header.to_str() else {
+            continue;
+        };
+
+        for pair in cookie_str.split(';') {
+            let pair = pair.trim();
+            let Some((name, value)) = pair.split_once('=') else {
+                continue;
+            };
+
+            if name.trim() != cookie_name {
+                continue;
             }
+
+            if found_token.is_some() {
+                // Multiple cookies with the same name found.
+                // This indicates a potential Cookie Tossing attack!
+                // Reject by returning None.
+                return None;
+            }
+
+            found_token = Some(value.trim().to_owned());
         }
     }
 

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -559,21 +559,28 @@ fn get_cookie(headers: &http::HeaderMap, name: &str) -> Option<String> {
     let mut found_token = None;
 
     for cookie_header in headers.get_all(COOKIE) {
-        if let Ok(cookie_str) = cookie_header.to_str() {
-            for pair in cookie_str.split(';') {
-                let pair = pair.trim();
-                if let Some((k, v)) = pair.split_once('=') {
-                    if k.trim() == name {
-                        if found_token.is_some() {
-                            // Multiple cookies with the same name found.
-                            // This indicates a potential Cookie Tossing attack!
-                            // Reject by returning None.
-                            return None;
-                        }
-                        found_token = Some(v.trim().to_owned());
-                    }
-                }
+        let Ok(cookie_str) = cookie_header.to_str() else {
+            continue;
+        };
+
+        for pair in cookie_str.split(';') {
+            let pair = pair.trim();
+            let Some((k, v)) = pair.split_once('=') else {
+                continue;
+            };
+
+            if k.trim() != name {
+                continue;
             }
+
+            if found_token.is_some() {
+                // Multiple cookies with the same name found.
+                // This indicates a potential Cookie Tossing attack!
+                // Reject by returning None.
+                return None;
+            }
+
+            found_token = Some(v.trim().to_owned());
         }
     }
     found_token


### PR DESCRIPTION
🚮 Smell: `extract_cookie_token` and `get_cookie` suffered from deep nesting (Pyramid of Doom). `extract_path_params` used manual byte-wise `while` loop iteration with error-prone index math.
✨ Solution: Extracted the loops using idiomatic `let else` early returns for cookie parsing. Modernized path extraction to leverage `str::find` and safe string slicing.
🧼 Benefit: Significantly reduces cognitive load, removes pyramids of doom, and aligns with idiomatic Rust without mutating any runtime behavior.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [7511903360051381089](https://jules.google.com/task/7511903360051381089) started by @madmax983*