### PR TITLE
🗺️ Atlas: Break cyclical dependencies in AppState imports

### DIFF
--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1199,36 +1199,79 @@ pub(crate) fn actuator_router_with_prefix<
 mod tests {
     use super::*;
     use crate::config::AutumnConfig;
-    use crate::state::AppState;
-    use axum::body::Body;
-    use axum::http::Request;
-    use tower::ServiceExt;
 
-    fn test_state() -> AppState {
+    #[derive(Clone)]
+    struct MockState {
+        metrics: crate::middleware::MetricsCollector,
+        log_levels: LogLevels,
+        task_registry: TaskRegistry,
+        config_props: ConfigProperties,
+        profile: String,
+        #[cfg(feature = "ws")]
+        channels: crate::channels::Channels,
+        #[cfg(feature = "db")]
+        pool: Option<
+            diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        >,
+    }
+
+    impl ProvideActuatorState for MockState {
+        fn metrics(&self) -> &crate::middleware::MetricsCollector {
+            &self.metrics
+        }
+        fn log_levels(&self) -> &LogLevels {
+            &self.log_levels
+        }
+        fn task_registry(&self) -> &TaskRegistry {
+            &self.task_registry
+        }
+        fn config_props(&self) -> &ConfigProperties {
+            &self.config_props
+        }
+        fn profile(&self) -> &str {
+            &self.profile
+        }
+        fn uptime_display(&self) -> String {
+            "0s".into()
+        }
+        #[cfg(feature = "ws")]
+        fn channels(&self) -> &crate::channels::Channels {
+            &self.channels
+        }
+        #[cfg(feature = "ws")]
+        fn shutdown_token(&self) -> tokio_util::sync::CancellationToken {
+            tokio_util::sync::CancellationToken::new()
+        }
+        #[cfg(feature = "db")]
+        fn pool(
+            &self,
+        ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+        {
+            self.pool.as_ref()
+        }
+    }
+
+    fn test_state() -> MockState {
         test_state_with_config(&AutumnConfig::default())
     }
 
-    fn test_state_with_config(config: &AutumnConfig) -> AppState {
-        AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            #[cfg(feature = "db")]
-            pool: None,
-            profile: config.profile.clone().or_else(|| Some("dev".into())),
-            started_at: std::time::Instant::now(),
-            health_detailed: true,
-            probes: crate::probe::ProbeState::ready_for_test(),
+    fn test_state_with_config(config: &AutumnConfig) -> MockState {
+        MockState {
             metrics: crate::middleware::MetricsCollector::new(),
             log_levels: LogLevels::new("info"),
             task_registry: TaskRegistry::new(),
             config_props: ConfigProperties::from_config(config),
+            profile: config.profile.clone().unwrap_or_else(|| "dev".to_string()),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
+            #[cfg(feature = "db")]
+            pool: None,
         }
     }
+
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
 
     #[tokio::test]
     async fn actuator_health_returns_ok() {

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -405,7 +405,26 @@ mod tests {
 
     #[tokio::test]
     async fn db_extractor_rejects_when_no_pool() {
-        use crate::state::AppState;
+        #[derive(Clone)]
+        struct MockState {
+            pool: Option<
+                deadpool::managed::Pool<
+                    AsyncDieselConnectionManager<diesel_async::AsyncPgConnection>,
+                >,
+            >,
+        }
+        impl DbState for MockState {
+            fn pool(
+                &self,
+            ) -> Option<
+                &deadpool::managed::Pool<
+                    AsyncDieselConnectionManager<diesel_async::AsyncPgConnection>,
+                >,
+            > {
+                self.pool.as_ref()
+            }
+        }
+
         use axum::Router;
         use axum::body::Body;
         use axum::http::{Request, StatusCode};
@@ -416,24 +435,9 @@ mod tests {
             "ok"
         }
 
-        let app = Router::new().route("/", get(handler)).with_state(AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            pool: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: true,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-        });
+        let app = Router::new()
+            .route("/", get(handler))
+            .with_state(MockState { pool: None });
 
         let response = app
             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())


### PR DESCRIPTION
🕸️ Tangle: `autumn/src/db.rs` and `autumn/src/actuator.rs` unit tests were directly importing `crate::state::AppState`, creating circular dependencies in the module graph (`state` <-> `db`, `state` <-> `actuator`).
📐 Blueprint: Removed `use crate::state::AppState` from both files. Replaced the `AppState` test constructors with locally scoped `MockState` structs that implement only the required `DbState` and `ProvideActuatorState` traits for the isolated unit tests.
🧱 Stability: Decoupled core modules from the global application state. Ensures an acyclic directed module graph and prevents test-only imports from leaking structural debt. 
🔬 Verification: Cycle detection script (`detect_cycles.py`) verifies the cycles are broken. Run `cargo check` and `cargo test -p autumn-web --all-targets --all-features` pass successfully.

---
*PR created automatically by Jules for task [637096357700196485](https://jules.google.com/task/637096357700196485) started by @madmax983*