### PR TITLE
⚒️ Forge: [Guard Clauses Refactor]

### DIFF
--- a/autumn/src/flash.rs
+++ b/autumn/src/flash.rs
@@ -158,10 +158,11 @@ impl Flash {
             let payload = serde_json::json!({
                 "flash": messages
             });
-            if let Ok(v) = http::header::HeaderValue::from_str(&payload.to_string()) {
-                res.headers_mut()
-                    .insert(http::header::HeaderName::from_static("hx-trigger"), v);
-            }
+            let Ok(v) = http::header::HeaderValue::from_str(&payload.to_string()) else {
+                return res;
+            };
+            res.headers_mut()
+                .insert(http::header::HeaderName::from_static("hx-trigger"), v);
         }
         res
     }

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -251,11 +251,13 @@ fn accepts_html<B>(req: &axum::http::Request<B>) -> bool {
                 continue;
             }
 
-            if let Some(value) = segment.strip_prefix("q=") {
-                if let Ok(parsed) = value.trim().parse::<f32>() {
-                    q = parsed.clamp(0.0, 1.0);
-                }
-            }
+            let Some(value) = segment.strip_prefix("q=") else {
+                continue;
+            };
+            let Ok(parsed) = value.trim().parse::<f32>() else {
+                continue;
+            };
+            q = parsed.clamp(0.0, 1.0);
         }
 
         match mime {

--- a/autumn/src/middleware/request_id.rs
+++ b/autumn/src/middleware/request_id.rs
@@ -153,9 +153,10 @@ where
                     // Format UUID directly into a stack buffer to avoid a String allocation.
                     let mut buf = [0u8; uuid::fmt::Hyphenated::LENGTH];
                     let s = id.0.as_hyphenated().encode_lower(&mut buf);
-                    if let Ok(value) = HeaderValue::from_bytes(s.as_bytes()) {
-                        response.headers_mut().insert(X_REQUEST_ID.clone(), value);
-                    }
+                    let Ok(value) = HeaderValue::from_bytes(s.as_bytes()) else {
+                        return Poll::Ready(Ok(response));
+                    };
+                    response.headers_mut().insert(X_REQUEST_ID.clone(), value);
                 }
                 Poll::Ready(Ok(response))
             }

--- a/autumn/src/pagination.rs
+++ b/autumn/src/pagination.rs
@@ -256,14 +256,16 @@ fn parse_query(query: &str) -> PageRequest {
         };
         match key.as_str() {
             "page" => {
-                if let Ok(n) = value.parse::<u32>() {
-                    req.page = Some(n);
-                }
+                let Ok(n) = value.parse::<u32>() else {
+                    continue;
+                };
+                req.page = Some(n);
             }
             "size" => {
-                if let Ok(n) = value.parse::<u32>() {
-                    req.size = Some(n);
-                }
+                let Ok(n) = value.parse::<u32>() else {
+                    continue;
+                };
+                req.size = Some(n);
             }
             _ => {}
         }
@@ -287,15 +289,15 @@ fn percent_decode(input: &str) -> Result<String, std::str::Utf8Error> {
             b'%' if i + 2 < bytes.len() => {
                 let hi = (bytes[i + 1] as char).to_digit(16);
                 let lo = (bytes[i + 2] as char).to_digit(16);
-                if let (Some(h), Some(l)) = (hi, lo) {
-                    // h and l are both `0..=15` from `to_digit(16)`, so
-                    // `(h << 4) | l` fits in a u8 by construction.
-                    out.push(u8::try_from((h << 4) | l).unwrap_or(0));
-                    i += 3;
-                } else {
+                let (Some(h), Some(l)) = (hi, lo) else {
                     out.push(bytes[i]);
                     i += 1;
-                }
+                    continue;
+                };
+                // h and l are both `0..=15` from `to_digit(16)`, so
+                // `(h << 4) | l` fits in a u8 by construction.
+                out.push(u8::try_from((h << 4) | l).unwrap_or(0));
+                i += 3;
             }
             b => {
                 out.push(b);
@@ -723,9 +725,10 @@ fn parse_cursor_query(query: &str) -> CursorRequest {
                 req.cursor = Some(value);
             }
             "size" => {
-                if let Ok(n) = value.parse::<u32>() {
-                    req.size = Some(n);
-                }
+                let Ok(n) = value.parse::<u32>() else {
+                    continue;
+                };
+                req.size = Some(n);
             }
             _ => {}
         }

--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -359,15 +359,16 @@ async fn verify_csrf_token(
 
     if let Ok(body_str) = std::str::from_utf8(&bytes) {
         for pair in body_str.split('&') {
-            if let Some((key, value)) = pair.split_once('=') {
-                if key == settings.form_field {
-                    if let Some(c) = cookie_token {
-                        if !c.is_empty() && !value.is_empty() && constant_time_eq(c, value) {
-                            token_found = true;
-                        }
+            let Some((key, value)) = pair.split_once('=') else {
+                continue;
+            };
+            if key == settings.form_field {
+                if let Some(c) = cookie_token {
+                    if !c.is_empty() && !value.is_empty() && constant_time_eq(c, value) {
+                        token_found = true;
                     }
-                    break;
                 }
+                break;
             }
         }
     }


### PR DESCRIPTION
🚮 Smell: Nested `if let Ok` and `if let Some` blocks causing deep nesting and "Pyramid of Doom" style logic flow across several core modules (pagination, csrf, flash, htmx, error filter).
✨ Solution: Extracted and flattened the nested blocks using Rust's idiomatic `let ... else { return / continue; }` guard clauses.
🧼 Benefit: Significantly reduces cognitive load, flattening the structure according to Forge's "Nesting is the mind-killer" philosophy, and bringing the codebase closer to modern Rust idioms without altering runtime behavior.
🛡️ Verification: Tests passed (`cargo test` across all features and modules modified). No logic changed, only syntax and scope.

---
*PR created automatically by Jules for task [5291736216212878460](https://jules.google.com/task/5291736216212878460) started by @madmax983*