### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -1000,11 +1000,23 @@ mod tests {
     fn parse_oauth2_token_response_supports_form_encoded_payload() {
         let token = parse_oauth2_token_response(
             Some("application/x-www-form-urlencoded"),
-            "access_token=abc123&token_type=bearer",
+            "access_token=abc123&token_type=bearer&id_token=xyz789&extra_field=ignored",
         )
         .unwrap();
         assert_eq!(token.access_token, "abc123");
         assert_eq!(token.token_type.as_deref(), Some("bearer"));
+        assert_eq!(token.id_token.as_deref(), Some("xyz789"));
+    }
+
+    #[cfg(feature = "oauth2")]
+    #[test]
+    fn parse_oauth2_token_response_fails_without_access_token() {
+        let err = parse_oauth2_token_response(
+            Some("application/x-www-form-urlencoded"),
+            "token_type=bearer&id_token=xyz789",
+        )
+        .unwrap_err();
+        assert_eq!(err.to_string(), "token response missing access_token");
     }
 
     #[cfg(feature = "oauth2")]

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -726,16 +726,27 @@ fn parse_oauth2_token_response(
         });
     }
 
-    let form: HashMap<String, String> = url::form_urlencoded::parse(body.as_bytes())
-        .into_owned()
-        .collect();
-    let access_token = form.get("access_token").cloned().ok_or_else(|| {
+    let mut access_token = None;
+    let mut token_type = None;
+    let mut id_token = None;
+
+    for (k, v) in url::form_urlencoded::parse(body.as_bytes()) {
+        match k.as_ref() {
+            "access_token" => access_token = Some(v.into_owned()),
+            "token_type" => token_type = Some(v.into_owned()),
+            "id_token" => id_token = Some(v.into_owned()),
+            _ => {}
+        }
+    }
+
+    let access_token = access_token.ok_or_else(|| {
         crate::AutumnError::bad_request_msg("token response missing access_token")
     })?;
+
     Ok(OAuth2TokenResponse {
         access_token,
-        token_type: form.get("token_type").cloned(),
-        id_token: form.get("id_token").cloned(),
+        token_type,
+        id_token,
     })
 }
 


### PR DESCRIPTION
💡 What: Replaced intermediate HashMap allocation with direct iteration in `parse_oauth2_token_response`.
🎯 Why: url::form_urlencoded parsing collected all key-value pairs into an owned HashMap unnecessarily.
📊 Impact: Eliminates multiple heap allocations (the HashMap itself plus String allocations for unused fields) per OAuth callback form response.
🔬 Measurement: Verified with `cargo test -p autumn --all-features` and code inspection.

---
*PR created automatically by Jules for task [16869361081874784109](https://jules.google.com/task/16869361081874784109) started by @madmax983*