### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/error_pages/mod.rs
+++ b/autumn/src/error_pages/mod.rs
@@ -73,3 +73,86 @@ pub(crate) type SharedRenderer = Arc<dyn ErrorPageRenderer>;
 pub(crate) fn default_renderer() -> SharedRenderer {
     Arc::new(DefaultErrorPages)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use maud::html;
+
+    struct TestRenderer;
+
+    impl ErrorPageRenderer for TestRenderer {
+        fn render_error(&self, ctx: &ErrorContext) -> Markup {
+            html! { "Custom " (ctx.status.as_u16()) }
+        }
+
+        fn render_404(&self, _ctx: &ErrorContext) -> Markup {
+            html! { "Custom 404" }
+        }
+
+        fn render_422(&self, _ctx: &ErrorContext) -> Markup {
+            html! { "Custom 422" }
+        }
+
+        fn render_500(&self, _ctx: &ErrorContext) -> Markup {
+            html! { "Custom 500" }
+        }
+    }
+
+    #[test]
+    fn render_error_page_delegates_correctly() {
+        let renderer = TestRenderer;
+        let ctx = ErrorContext {
+            status: StatusCode::OK,
+            path: "/".to_string(),
+            message: "Test message".to_string(),
+            request_id: None,
+            details: None,
+            is_dev: false,
+        };
+
+        assert_eq!(
+            render_error_page(&renderer, StatusCode::NOT_FOUND, &ctx).into_string(),
+            "Custom 404"
+        );
+        assert_eq!(
+            render_error_page(&renderer, StatusCode::UNPROCESSABLE_ENTITY, &ctx).into_string(),
+            "Custom 422"
+        );
+        assert_eq!(
+            render_error_page(&renderer, StatusCode::INTERNAL_SERVER_ERROR, &ctx).into_string(),
+            "Custom 500"
+        );
+
+        let ctx_400 = ErrorContext {
+            status: StatusCode::BAD_REQUEST,
+            path: "/".to_string(),
+            message: "Test message".to_string(),
+            request_id: None,
+            details: None,
+            is_dev: false,
+        };
+        assert_eq!(
+            render_error_page(&renderer, StatusCode::BAD_REQUEST, &ctx_400).into_string(),
+            "Custom 400"
+        );
+    }
+
+    #[test]
+    fn default_renderer_creates_default_error_pages() {
+        let renderer = default_renderer();
+        let ctx = ErrorContext {
+            status: StatusCode::BAD_REQUEST,
+            path: "/".to_string(),
+            message: "Test message".to_string(),
+            request_id: None,
+            details: None,
+            is_dev: false,
+        };
+
+        // Just verify we can call it without a panic and it produces HTML
+        let html = render_error_page(&*renderer, StatusCode::BAD_REQUEST, &ctx).into_string();
+        assert!(html.contains("html"));
+        assert!(html.contains("400"));
+    }
+}


### PR DESCRIPTION
🎯 **Target:** `autumn/src/error_pages/mod.rs` (`render_error_page` and `default_renderer` functions).
💣 **Risk:** The core logic responsible for delegating HTTP status codes to the proper `ErrorPageRenderer` methods (`render_404`, `render_422`, `render_500`, and `render_error`) lacked unit test coverage. Any future refactoring of this matching logic could unknowingly break error page rendering and fallback mechanisms.
🧪 **Strategy:** Created an internal `TestRenderer` mock implementing `ErrorPageRenderer` within a `#[cfg(test)]` module. Added assertions verifying that `StatusCode::NOT_FOUND`, `StatusCode::UNPROCESSABLE_ENTITY`, and `StatusCode::INTERNAL_SERVER_ERROR` hit their specific methods, while an unhandled code (like `StatusCode::BAD_REQUEST`) falls back to `render_error`. Also added a sanity check for `default_renderer()`.
🔬 **Verification:** `cargo test -p autumn-web --lib error_pages::mod::tests`

---
*PR created automatically by Jules for task [2071587888054239123](https://jules.google.com/task/2071587888054239123) started by @madmax983*