### PR TITLE
🌟 Nova: OpenAPI Explorer Plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["autumn", "autumn-macros", "autumn-cli", "autumn-admin-plugin", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/wiki", "examples/reddit-clone", "examples/custom_config_loader", "examples/ws-echo"]
+members = ["examples/openapi-explorer", "autumn", "autumn-macros", "autumn-cli", "autumn-admin-plugin", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/wiki", "examples/reddit-clone", "examples/custom_config_loader", "examples/ws-echo", "autumn-openapi-plugin"]
 resolver = "3"
 
 # Unify autumn-web across the workspace and any transitive consumers (e.g.

--- a/autumn-openapi-plugin/Cargo.toml
+++ b/autumn-openapi-plugin/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "autumn-openapi-plugin"
+description = "Swagger UI and OpenAPI explorer plugin for autumn-web"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+autumn-web = { version = "0.3.0", path = "../autumn", features = ["openapi"] }
+
+[lints]
+workspace = true

--- a/autumn-openapi-plugin/src/lib.rs
+++ b/autumn-openapi-plugin/src/lib.rs
@@ -1,0 +1,58 @@
+//! # autumn-openapi-plugin
+//!
+//! Exposes a Swagger UI and API explorer out of the box for autumn-web applications.
+//!
+//! By simply registering this plugin, you get a fully interactive UI that consumes
+//! the generated `OpenAPI` spec provided by Autumn's `#[api_doc]` macros.
+
+use autumn_web::app::AppBuilder;
+use autumn_web::openapi::OpenApiConfig;
+use autumn_web::plugin::Plugin;
+use std::borrow::Cow;
+
+pub struct OpenApiPlugin {
+    title: String,
+    version: String,
+    path: String,
+}
+
+impl OpenApiPlugin {
+    pub fn new(title: impl Into<String>, version: impl Into<String>) -> Self {
+        Self {
+            title: title.into(),
+            version: version.into(),
+            path: "/docs".to_owned(),
+        }
+    }
+
+    #[must_use]
+    pub fn path(mut self, path: impl Into<String>) -> Self {
+        self.path = path.into();
+        self
+    }
+}
+
+impl Plugin for OpenApiPlugin {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("autumn-openapi-plugin")
+    }
+
+    fn build(self, app: AppBuilder) -> AppBuilder {
+        let config = OpenApiConfig::new(self.title, self.version).swagger_ui_path(Some(self.path));
+
+        app.openapi(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_openapi_plugin() {
+        let plugin = OpenApiPlugin::new("My API", "v1.0").path("/swagger");
+        assert_eq!(plugin.title, "My API");
+        assert_eq!(plugin.version, "v1.0");
+        assert_eq!(plugin.path, "/swagger");
+    }
+}

--- a/examples/openapi-explorer/Cargo.toml
+++ b/examples/openapi-explorer/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "openapi-explorer"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+autumn-web = { version = "0.3.0", path = "../../autumn", features = ["openapi"] }
+autumn-openapi-plugin = { version = "0.3.0", path = "../../autumn-openapi-plugin" }
+serde = { workspace = true }
+serde_json = "1"

--- a/examples/openapi-explorer/src/main.rs
+++ b/examples/openapi-explorer/src/main.rs
@@ -1,0 +1,26 @@
+use autumn_openapi_plugin::OpenApiPlugin;
+use autumn_web::prelude::*;
+
+#[api_doc(summary = "Get greeting", tag = "greeting")]
+#[get("/hello")]
+async fn hello() -> &'static str {
+    "Hello World"
+}
+
+#[api_doc(summary = "Get user by ID", tag = "users")]
+#[get("/users/{id}")]
+async fn get_user(Path(id): Path<i32>) -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "id": id,
+        "name": "Nova"
+    }))
+}
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .plugin(OpenApiPlugin::new("My API", "v1.0").path("/swagger"))
+        .routes(routes![hello, get_user])
+        .run()
+        .await;
+}


### PR DESCRIPTION
💡 **The Spark:**
I noticed Autumn has robust `#[api_doc]` macros to collect OpenAPI documentation at compile time, but it required users to manually configure and expose the generated spec and Swagger UI. Why not make it a one-line plugin integration?

🚀 **The Feature:**
Implemented `autumn-openapi-plugin`, an out-of-the-box Swagger UI and API explorer. By registering `OpenApiPlugin::new("My API", "v1.0")`, Autumn automatically exposes the OpenAPI spec and mounts the Swagger UI at `/docs`.

🔭 **The Potential:**
This creates a Spring Boot-level developer experience for documenting APIs, allowing frontend developers and API consumers to immediately interact with the Autumn application locally without manual Swagger configuration or external tools.

⚠️ **Risk:**
Low. The code is isolated in a new workspace member `autumn-openapi-plugin` and leverages the existing, well-tested `autumn_web::openapi` module without modifying any core framework logic. Includes basic tests.

---
*PR created automatically by Jules for task [3322405398785300028](https://jules.google.com/task/3322405398785300028) started by @madmax983*