### PR TITLE
⚒️ Forge: [flatten actuator nesting]

### DIFF
--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -113,26 +113,25 @@ impl LogLevels {
     /// Set the level for a specific logger. Returns the previous level if any.
     #[must_use]
     pub fn set_logger_level(&self, name: &str, level: &str) -> Option<String> {
-        if let Ok(mut guard) = self.inner.write() {
-            // Prevent unbounded memory growth from arbitrary logger names
-            if guard.logger_overrides.len() >= 1000 && !guard.logger_overrides.contains_key(name) {
-                return None;
-            }
-
-            let previous = guard.logger_overrides.get(name).cloned();
-            guard
-                .logger_overrides
-                .insert(name.to_string(), level.to_string());
-            // If setting the root level, update current_level too
-            if name == "root" || name.is_empty() {
-                let prev = Some(guard.current_level.clone());
-                guard.current_level = level.to_string();
-                return prev;
-            }
-            previous
-        } else {
-            None
+        let Ok(mut guard) = self.inner.write() else {
+            return None;
+        };
+        // Prevent unbounded memory growth from arbitrary logger names
+        if guard.logger_overrides.len() >= 1000 && !guard.logger_overrides.contains_key(name) {
+            return None;
         }
+
+        let previous = guard.logger_overrides.get(name).cloned();
+        guard
+            .logger_overrides
+            .insert(name.to_string(), level.to_string());
+        // If setting the root level, update current_level too
+        if name == "root" || name.is_empty() {
+            let prev = Some(guard.current_level.clone());
+            guard.current_level = level.to_string();
+            return prev;
+        }
+        previous
     }
 }
 
@@ -186,59 +185,66 @@ impl TaskRegistry {
 
     /// Register a task with its schedule description.
     pub fn register(&self, name: &str, schedule: &str) {
-        if let Ok(mut guard) = self.inner.write() {
-            guard.insert(
-                name.to_string(),
-                TaskStatus {
-                    schedule: schedule.to_string(),
-                    status: "idle".to_string(),
-                    last_run: None,
-                    last_duration_ms: None,
-                    last_result: None,
-                    last_error: None,
-                    total_runs: 0,
-                    total_failures: 0,
-                },
-            );
-        }
+        let Ok(mut guard) = self.inner.write() else {
+            return;
+        };
+        guard.insert(
+            name.to_string(),
+            TaskStatus {
+                schedule: schedule.to_string(),
+                status: "idle".to_string(),
+                last_run: None,
+                last_duration_ms: None,
+                last_result: None,
+                last_error: None,
+                total_runs: 0,
+                total_failures: 0,
+            },
+        );
     }
 
     /// Record that a task started running.
     pub fn record_start(&self, name: &str) {
-        if let Ok(mut guard) = self.inner.write()
-            && let Some(task) = guard.get_mut(name)
-        {
-            task.status = "running".to_string();
-        }
+        let Ok(mut guard) = self.inner.write() else {
+            return;
+        };
+        let Some(task) = guard.get_mut(name) else {
+            return;
+        };
+        task.status = "running".to_string();
     }
 
     /// Record that a task completed successfully.
     pub fn record_success(&self, name: &str, duration_ms: u64) {
-        if let Ok(mut guard) = self.inner.write()
-            && let Some(task) = guard.get_mut(name)
-        {
-            task.status = "idle".to_string();
-            task.last_run = Some(chrono::Utc::now().to_rfc3339());
-            task.last_duration_ms = Some(duration_ms);
-            task.last_result = Some("ok".to_string());
-            task.last_error = None;
-            task.total_runs += 1;
-        }
+        let Ok(mut guard) = self.inner.write() else {
+            return;
+        };
+        let Some(task) = guard.get_mut(name) else {
+            return;
+        };
+        task.status = "idle".to_string();
+        task.last_run = Some(chrono::Utc::now().to_rfc3339());
+        task.last_duration_ms = Some(duration_ms);
+        task.last_result = Some("ok".to_string());
+        task.last_error = None;
+        task.total_runs += 1;
     }
 
     /// Record that a task failed.
     pub fn record_failure(&self, name: &str, duration_ms: u64, error: &str) {
-        if let Ok(mut guard) = self.inner.write()
-            && let Some(task) = guard.get_mut(name)
-        {
-            task.status = "idle".to_string();
-            task.last_run = Some(chrono::Utc::now().to_rfc3339());
-            task.last_duration_ms = Some(duration_ms);
-            task.last_result = Some("failed".to_string());
-            task.last_error = Some(error.to_string());
-            task.total_runs += 1;
-            task.total_failures += 1;
-        }
+        let Ok(mut guard) = self.inner.write() else {
+            return;
+        };
+        let Some(task) = guard.get_mut(name) else {
+            return;
+        };
+        task.status = "idle".to_string();
+        task.last_run = Some(chrono::Utc::now().to_rfc3339());
+        task.last_duration_ms = Some(duration_ms);
+        task.last_result = Some("failed".to_string());
+        task.last_error = Some(error.to_string());
+        task.total_runs += 1;
+        task.total_failures += 1;
     }
 
     /// Get a snapshot of all task statuses.


### PR DESCRIPTION
🚽 Smell: Deeply nested `if let Ok(mut guard) = self.inner.write() { ... }` blocks in `autumn/src/actuator.rs` functions, creating a visual Pyramid of Doom and violating the Forge persona's principle of flat structure over nesting.

✨ Solution: Replaced the nested `if let` blocks with idiomatic `let else` guard clauses (e.g., `let Ok(mut guard) = self.inner.write() else { return; };`) to return early on lock acquisition failures, drastically reducing the nesting level and flattening the function body.

🧱 Benefit: Significantly reduces cognitive load and improves readability. The core logic of the functions is no longer hidden behind indentation, adhering strictly to idiomatic Rust patterns without changing any runtime behavior.

🛡️ Verification: Tests passed. No logic changed. `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all`, and `cargo test --lib actuator --all-features` were successfully run to verify the refactoring.

---
*PR created automatically by Jules for task [16656613343767267377](https://jules.google.com/task/16656613343767267377) started by @madmax983*