### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn-admin-plugin/src/registry.rs
+++ b/autumn-admin-plugin/src/registry.rs
@@ -1,7 +1,7 @@
 //! Runtime registry that collects admin-enabled models.
 //!
 //! The [`AdminRegistry`] is built during plugin construction and stored
-//! in [`AppState`] via `with_extension`. Route handlers retrieve it to
+//! in [`AppState`](autumn_web::AppState) via `with_extension`. Route handlers retrieve it to
 //! discover which models are available and how to render them.
 
 use std::collections::btree_map::{BTreeMap, Entry};

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -88,7 +88,7 @@ enum Commands {
     ///   f32, f64                     (REAL, DOUBLE PRECISION)
     ///   Uuid                         (UUID)
     ///   `NaiveDateTime`, `DateTime`      (TIMESTAMP, TIMESTAMPTZ)
-    ///   Vec<u8>, Bytea               (BYTEA)
+    ///   `Vec<u8>`, Bytea               (BYTEA)
     ///   Option<...>                  (any of the above, nullable)
     ///
     /// # Example

--- a/autumn-macros/src/authorize.rs
+++ b/autumn-macros/src/authorize.rs
@@ -2,7 +2,7 @@
 //!
 //! Generates a record-level authorization guard that runs as the
 //! first statement of the handler body. Resolves the
-//! [`Policy`](autumn_web::authorization::Policy) registered for the
+//! `Policy` registered for the
 //! resource type, calls the matching action method, and returns
 //! the configured deny response (`403` or `404`) on failure.
 //!

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -328,7 +328,7 @@ pub fn secured(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Enforce a record-level authorization policy on a route handler.
 ///
-/// Resolves the [`Policy`](autumn_web::authorization::Policy)
+/// Resolves the `Policy`
 /// registered for the named resource type and calls the matching
 /// action method. Short-circuits with the configured deny response
 /// (default `404`, optionally `403`) before the handler body runs.

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -131,6 +131,10 @@ type PoolProviderFactory = Box<
         > + Send,
 >;
 
+/// Closure that registers a policy or scope on the runtime
+/// [`PolicyRegistry`](crate::authorization::PolicyRegistry).
+type PolicyRegistration = Box<dyn FnOnce(&crate::authorization::PolicyRegistry) + Send>;
+
 /// Builder for configuring and launching an Autumn application.
 ///
 /// Created by [`app()`]. Collect routes with [`.routes()`](Self::routes),
@@ -159,10 +163,6 @@ type PoolProviderFactory = Box<
 ///         .await;
 /// }
 /// ```
-/// Closure that registers a policy or scope on the runtime
-/// [`PolicyRegistry`](crate::authorization::PolicyRegistry).
-type PolicyRegistration = Box<dyn FnOnce(&crate::authorization::PolicyRegistry) + Send>;
-
 pub struct AppBuilder {
     routes: Vec<Route>,
     tasks: Vec<crate::task::TaskInfo>,
@@ -2159,7 +2159,7 @@ fn validate_repository_api_policies(
 /// Refuse to start when a `#[repository(policy = X)]`-annotated
 /// route exists but the corresponding `.policy::<R, _>(X)`
 /// registration was never actually applied to the live
-/// [`PolicyRegistry`].
+/// [`PolicyRegistry`](crate::authorization::PolicyRegistry).
 ///
 /// `validate_repository_api_policies` runs *before* the registry is
 /// populated and only checks the macro-set `has_policy` flag. This

--- a/autumn/src/route.rs
+++ b/autumn/src/route.rs
@@ -39,7 +39,7 @@ pub struct RepositoryApiMeta {
     pub has_policy: bool,
 
     /// Type-erased registry probe emitted by the macro when
-    /// `policy = ...` is set. Returns `true` if a [`Policy`] is
+    /// `policy = ...` is set. Returns `true` if a [`Policy`](crate::authorization::Policy) is
     /// registered on the runtime
     /// [`PolicyRegistry`](crate::authorization::PolicyRegistry) for
     /// the resource type. Lets the app builder fail fast at
@@ -52,7 +52,7 @@ pub struct RepositoryApiMeta {
     pub policy_check: Option<fn(&crate::authorization::PolicyRegistry) -> bool>,
 
     /// Type-erased registry probe emitted by the macro when
-    /// `scope = ...` is set. Returns `true` if a [`Scope`] is
+    /// `scope = ...` is set. Returns `true` if a [`Scope`](crate::authorization::Scope) is
     /// registered for the resource type. Companion to
     /// [`Self::policy_check`] for the scope-list code path: the
     /// generated `GET /<api>` handler resolves the scope from the

--- a/autumn/src/storage/local.rs
+++ b/autumn/src/storage/local.rs
@@ -1,4 +1,4 @@
-//! Local-disk implementation of [`BlobStore`](super::BlobStore).
+//! Local-disk implementation of [`BlobStore`].
 //!
 //! Bytes land under a configurable `root` directory; URLs are
 //! HMAC-SHA256-signed and time-bounded, served by an axum router mounted

--- a/autumn/src/storage/mod.rs
+++ b/autumn/src/storage/mod.rs
@@ -7,7 +7,7 @@
 //!   directory and serves bytes through an autumn-mounted route at
 //!   `[storage.local].mount_path` (default `/_blobs`). URLs are signed
 //!   with HMAC-SHA256 and time-bounded.
-//! - **[`S3`](s3::S3BlobStore)** (gated behind `storage-s3`) — talks to
+//! - **`S3`** (gated behind `storage-s3`) — talks to
 //!   any S3-compatible endpoint (AWS S3, Cloudflare R2, `MinIO`,
 //!   `DigitalOcean` Spaces, Wasabi) and emits real S3 presigned URLs.
 //!
@@ -176,7 +176,7 @@ impl BlobStoreError {
 ///
 /// Implement this trait to add new backends. Two are provided
 /// out of the box: [`LocalBlobStore`] and (with feature `storage-s3`)
-/// [`s3::S3BlobStore`].
+/// `s3::S3BlobStore`.
 ///
 /// The trait is **dyn-safe** so apps can hold `Arc<dyn BlobStore>` and
 /// swap backends at runtime — for example, choosing local in tests and

--- a/autumn/tests/compile-fail/repository_hooks_not_default.stderr
+++ b/autumn/tests/compile-fail/repository_hooks_not_default.stderr
@@ -1,21 +1,23 @@
-error[E0277]: the trait bound `BadHooks: std::default::Default` is not satisfied
+error[E0277]: the trait bound `BadHooks: RepositoryHooksDefault` is not satisfied
   --> tests/compile-fail/repository_hooks_not_default.rs:29:40
    |
 29 | #[autumn_web::repository(Item, hooks = BadHooks)]
    |                                        ^^^^^^^^ the trait `std::default::Default` is not implemented for `BadHooks`
    |
+   = note: required for `BadHooks` to implement `RepositoryHooksDefault`
 help: consider annotating `BadHooks` with `#[derive(Default)]`
    |
 21 + #[derive(Default)]
 22 | pub struct BadHooks;
    |
 
-error[E0277]: the trait bound `BadHooks: Clone` is not satisfied
-  --> tests/compile-fail/repository_hooks_not_default.rs:29:1
+error[E0277]: the trait bound `BadHooks: RepositoryHooksClone` is not satisfied
+  --> tests/compile-fail/repository_hooks_not_default.rs:29:40
    |
 29 | #[autumn_web::repository(Item, hooks = BadHooks)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `BadHooks`
+   |                                        ^^^^^^^^ the trait `Clone` is not implemented for `BadHooks`
    |
+   = note: required for `BadHooks` to implement `RepositoryHooksClone`
 help: consider annotating `BadHooks` with `#[derive(Clone)]`
    |
 21 + #[derive(Clone)]


### PR DESCRIPTION
📖 **Chapter:** Workspace Documentation
🔦 **Insight:** Several `cargo doc` warnings were triggered due to broken intra-doc links across workspace crates, such as linking to `Policy` from `autumn-macros` (which doesn't depend on `autumn-web`), unclosed HTML tags in the CLI usage docs, misplaced doc comments in `app.rs`, and out-of-date `trybuild` snapshot expectations.
🧪 **Example:** Replaced `[`Policy`](autumn_web::authorization::Policy)` with `` `Policy` `` and fully qualified `[`AppState`](autumn_web::AppState)`.
🖼️ **Preview:** `cargo doc --no-deps --document-private-items` now generates completely warning-free documentation for the entire workspace.

---
*PR created automatically by Jules for task [5173232898632321362](https://jules.google.com/task/5173232898632321362) started by @madmax983*