### PR TITLE
🌟 Nova: CSV Exporter for Admin Models

### DIFF
--- a/autumn-admin-plugin/Cargo.toml
+++ b/autumn-admin-plugin/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
+csv = "1.4.0"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/autumn-admin-plugin/src/routes.rs
+++ b/autumn-admin-plugin/src/routes.rs
@@ -106,6 +106,7 @@ pub fn admin_router(
         .route("/", routing::get(dashboard))
         // Model routes (dynamic dispatch via slug)
         .route("/{slug}", routing::get(model_list).post(model_create))
+        .route("/{slug}/export", routing::get(model_export))
         .route("/{slug}/new", routing::get(model_new_form))
         .route(
             "/{slug}/{id}",
@@ -357,6 +358,90 @@ async fn model_list(
         &prefix,
         &actuator_prefix,
     )))
+}
+
+/// `GET /admin/{slug}/export` — Export model list as CSV.
+#[allow(clippy::too_many_arguments)]
+async fn model_export(
+    State(state): State<AppState>,
+    axum::Extension(registry): axum::Extension<Arc<AdminRegistry>>,
+    Path(slug): Path<String>,
+    Query(query): Query<ListQuery>,
+    Query(raw_query): Query<HashMap<String, String>>,
+) -> AutumnResult<Response> {
+    let (pool, model) = resolve(&state, &registry, &slug)?;
+
+    let ListQuery { q, sort, dir, .. } = query;
+    let fields = model.fields();
+    let sort = validate_sort_key(sort, &fields);
+    let filters = extract_filters(&raw_query, &fields);
+
+    let params = ListParams {
+        page: 1,
+        // hard limit for export to avoid blowing up memory
+        per_page: 10_000,
+        search: (!q.is_empty()).then_some(q),
+        sort_by: sort,
+        sort_dir: dir,
+        filters,
+    };
+
+    let result = model.list(&pool, params).await?;
+
+    // Determine which fields should be exported.
+    let export_fields: Vec<_> = fields
+        .iter()
+        .filter(|f| {
+            f.list_display && !matches!(f.kind, AdminFieldKind::Password | AdminFieldKind::Hidden)
+        })
+        .collect();
+
+    let mut wtr = csv::Writer::from_writer(vec![]);
+
+    // Write headers
+    let headers: Vec<&str> = export_fields.iter().map(|f| f.label.as_str()).collect();
+    if let Err(e) = wtr.write_record(&headers) {
+        return Err(AutumnError::internal_server_error_msg(format!(
+            "CSV header error: {e}"
+        )));
+    }
+
+    // Write rows
+    for record in &result.records {
+        let mut row = Vec::new();
+        for field in &export_fields {
+            let val_str = match record.get(field.name) {
+                Some(Value::Null) | None => String::new(),
+                Some(Value::String(s)) => s.clone(),
+                Some(Value::Number(n)) => n.to_string(),
+                Some(Value::Bool(b)) => b.to_string(),
+                Some(v) => v.to_string(), // Arrays or objects as JSON string
+            };
+            row.push(val_str);
+        }
+        if let Err(e) = wtr.write_record(&row) {
+            return Err(AutumnError::internal_server_error_msg(format!(
+                "CSV row error: {e}"
+            )));
+        }
+    }
+
+    let csv_data = wtr
+        .into_inner()
+        .map_err(|e| AutumnError::internal_server_error_msg(format!("CSV finish error: {e}")))?;
+
+    let filename = format!("{slug}.csv");
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/csv; charset=utf-8")
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{filename}\""),
+        )
+        .body(axum::body::Body::from(csv_data))
+        .unwrap();
+
+    Ok(response)
 }
 
 /// `GET /admin/{slug}/new` — Create form.

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -508,8 +508,18 @@ pub fn model_list_page(
                         "(" (result.total) ")"
                     }
                 }
-                a href={ (prefix) "/" (model_slug) "/new" } class="btn btn-primary" {
-                    "+ Add " (model_slug.trim_end_matches('s'))
+
+                div style="display: flex; gap: 0.5rem;" {
+                    a href={ (prefix) "/" (model_slug) "/export?dir=" (sort_dir.as_str())
+                        @if let Some(s) = sort_by { "&sort=" (s) }
+                        @if !search_enc.is_empty() { "&q=" (search_enc) }
+                        (filters_enc)
+                    } class="btn" {
+                        "Export to CSV"
+                    }
+                    a href={ (prefix) "/" (model_slug) "/new" } class="btn btn-primary" {
+                        "+ Add " (model_slug.trim_end_matches('s'))
+                    }
                 }
             }
 
@@ -1953,6 +1963,45 @@ mod tests {
         assert!(
             js.contains("removeAttribute(\"name\")"),
             "admin.js should strip blank password input names"
+        );
+    }
+
+    #[test]
+    fn list_page_renders_export_csv_button() {
+        use crate::traits::ListResult;
+        let r = dummy_registry();
+        let fields = vec![AdminField::new("name", AdminFieldKind::Text)];
+        let result = ListResult {
+            records: vec![],
+            total: 0,
+            page: 1,
+            per_page: 25,
+        };
+        let html = model_list_page(
+            &r,
+            "widgets",
+            "Widgets",
+            &fields,
+            &[],
+            &result,
+            "search_query_test",
+            Some("name"),
+            SortDirection::Desc,
+            &[("status".to_string(), "active".to_string())],
+            &[],
+            "tok",
+            "/admin",
+            "/actuator",
+        )
+        .into_string();
+
+        assert!(
+            html.contains("Export to CSV"),
+            "list view must render an Export to CSV button: {html}"
+        );
+        assert!(
+            html.contains(r#"href="/admin/widgets/export?dir=desc&amp;sort=name&amp;q=search_query_test&amp;filter.status=active""#),
+            "export link must preserve search, sort, and filters: {html}"
         );
     }
 }


### PR DESCRIPTION
💡 **The Spark:** "I noticed we can filter and sort admin models but can't export the results for offline analysis."
🚀 **The Feature:** "Added a CSV exporter route (`/{slug}/export`) and an 'Export to CSV' button in the list view that respects active filters/sort."
🔭 **The Potential:** "Users can dump data for spreadsheet analysis or reporting without building custom endpoints."
⚠️ **Risk:** "Low. Isolated to a new route in the admin plugin. Uses a hard limit to prevent memory exhaustion."

*Assumptions made during autonomous implementation: The code review tool flagged a borrow error for `field.name` in `record.get(field.name)`, but this is a hallucination since `AdminField::name` is a `&'static str`, which is `Copy`, and `record.get()` accepts string slices seamlessly. Local `cargo check` and `cargo test` pass successfully.*

---
*PR created automatically by Jules for task [15612223514274775122](https://jules.google.com/task/15612223514274775122) started by @madmax983*