### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn-admin-plugin/src/registry.rs
+++ b/autumn-admin-plugin/src/registry.rs
@@ -1,7 +1,7 @@
 //! Runtime registry that collects admin-enabled models.
 //!
 //! The [`AdminRegistry`] is built during plugin construction and stored
-//! in [`AppState`] via `with_extension`. Route handlers retrieve it to
+//! in [`AppState`](autumn_web::AppState) via `with_extension`. Route handlers retrieve it to
 //! discover which models are available and how to render them.
 
 use std::collections::btree_map::{BTreeMap, Entry};

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -88,7 +88,7 @@ enum Commands {
     ///   f32, f64                     (REAL, DOUBLE PRECISION)
     ///   Uuid                         (UUID)
     ///   `NaiveDateTime`, `DateTime`      (TIMESTAMP, TIMESTAMPTZ)
-    ///   Vec<u8>, Bytea               (BYTEA)
+    ///   `Vec<u8>`, Bytea               (BYTEA)
     ///   Option<...>                  (any of the above, nullable)
     ///
     /// # Example

--- a/autumn-macros/src/authorize.rs
+++ b/autumn-macros/src/authorize.rs
@@ -2,7 +2,7 @@
 //!
 //! Generates a record-level authorization guard that runs as the
 //! first statement of the handler body. Resolves the
-//! [`Policy`](autumn_web::authorization::Policy) registered for the
+//! `Policy` registered for the
 //! resource type, calls the matching action method, and returns
 //! the configured deny response (`403` or `404`) on failure.
 //!

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -328,7 +328,7 @@ pub fn secured(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Enforce a record-level authorization policy on a route handler.
 ///
-/// Resolves the [`Policy`](autumn_web::authorization::Policy)
+/// Resolves the `Policy`
 /// registered for the named resource type and calls the matching
 /// action method. Short-circuits with the configured deny response
 /// (default `404`, optionally `403`) before the handler body runs.

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -133,8 +133,8 @@ type PoolProviderFactory = Box<
 
 /// Builder for configuring and launching an Autumn application.
 ///
-/// Created by [`app()`]. Collect routes with [`.routes()`](Self::routes),
-/// then call [`.run()`](Self::run) to start the HTTP server.
+/// Created by [`app()`]. Collect routes with [`.routes()`](AppBuilder::routes),
+/// then call [`.run()`](AppBuilder::run) to start the HTTP server.
 ///
 /// The builder follows the **builder pattern**: each method consumes `self`
 /// and returns a new `AppBuilder`, allowing chained calls.
@@ -1051,7 +1051,7 @@ impl AppBuilder {
     ///
     /// # Panics
     ///
-    /// Panics if no routes have been registered via [`.routes()`](Self::routes).
+    /// Panics if no routes have been registered via [`.routes()`](AppBuilder::routes).
     /// This is intentional -- an application with no routes is always a
     /// developer error.
     #[allow(clippy::too_many_lines)]
@@ -2159,7 +2159,7 @@ fn validate_repository_api_policies(
 /// Refuse to start when a `#[repository(policy = X)]`-annotated
 /// route exists but the corresponding `.policy::<R, _>(X)`
 /// registration was never actually applied to the live
-/// [`PolicyRegistry`].
+/// [`PolicyRegistry`](crate::authorization::PolicyRegistry).
 ///
 /// `validate_repository_api_policies` runs *before* the registry is
 /// populated and only checks the macro-set `has_policy` flag. This

--- a/autumn/src/route.rs
+++ b/autumn/src/route.rs
@@ -39,7 +39,7 @@ pub struct RepositoryApiMeta {
     pub has_policy: bool,
 
     /// Type-erased registry probe emitted by the macro when
-    /// `policy = ...` is set. Returns `true` if a [`Policy`] is
+    /// `policy = ...` is set. Returns `true` if a [`Policy`](crate::authorization::Policy) is
     /// registered on the runtime
     /// [`PolicyRegistry`](crate::authorization::PolicyRegistry) for
     /// the resource type. Lets the app builder fail fast at
@@ -52,7 +52,7 @@ pub struct RepositoryApiMeta {
     pub policy_check: Option<fn(&crate::authorization::PolicyRegistry) -> bool>,
 
     /// Type-erased registry probe emitted by the macro when
-    /// `scope = ...` is set. Returns `true` if a [`Scope`] is
+    /// `scope = ...` is set. Returns `true` if a [`Scope`](crate::authorization::Scope) is
     /// registered for the resource type. Companion to
     /// [`Self::policy_check`] for the scope-list code path: the
     /// generated `GET /<api>` handler resolves the scope from the

--- a/autumn/src/storage/local.rs
+++ b/autumn/src/storage/local.rs
@@ -1,4 +1,4 @@
-//! Local-disk implementation of [`BlobStore`](super::BlobStore).
+//! Local-disk implementation of [`BlobStore`].
 //!
 //! Bytes land under a configurable `root` directory; URLs are
 //! HMAC-SHA256-signed and time-bounded, served by an axum router mounted

--- a/autumn/src/storage/mod.rs
+++ b/autumn/src/storage/mod.rs
@@ -7,7 +7,7 @@
 //!   directory and serves bytes through an autumn-mounted route at
 //!   `[storage.local].mount_path` (default `/_blobs`). URLs are signed
 //!   with HMAC-SHA256 and time-bounded.
-//! - **[`S3`](s3::S3BlobStore)** (gated behind `storage-s3`) — talks to
+//! - **`S3`** (gated behind `storage-s3`) — talks to
 //!   any S3-compatible endpoint (AWS S3, Cloudflare R2, `MinIO`,
 //!   `DigitalOcean` Spaces, Wasabi) and emits real S3 presigned URLs.
 //!
@@ -176,7 +176,7 @@ impl BlobStoreError {
 ///
 /// Implement this trait to add new backends. Two are provided
 /// out of the box: [`LocalBlobStore`] and (with feature `storage-s3`)
-/// [`s3::S3BlobStore`].
+/// `S3BlobStore`.
 ///
 /// The trait is **dyn-safe** so apps can hold `Arc<dyn BlobStore>` and
 /// swap backends at runtime — for example, choosing local in tests and


### PR DESCRIPTION
📖 Chapter: Documentation links and formatting
🔦 Insight: Removed unresolvable intra-doc links across macro crates referencing main framework types to fix `rustdoc::broken-intra-doc-links` warnings, correctly formatted primitive arrays like `Vec<u8>` using backticks to resolve `rustdoc::invalid-html-tags`, and fixed missing module scope paths in intra-doc links.
🧪 Example: Run `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items` to verify output correctly compiles without warnings.
🖼️ Preview: Documentation renders accurately locally.

---
*PR created automatically by Jules for task [2471178426883521210](https://jules.google.com/task/2471178426883521210) started by @madmax983*