### PR TITLE
🔒 Warden: Fix fallback middleware bypass

### DIFF
--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -999,6 +999,9 @@ fn apply_middleware(
     error_page_renderer: Option<SharedRenderer>,
     session_store: Option<Arc<dyn crate::session::BoxedSessionStore>>,
 ) -> Result<axum::Router<AppState>, RouterBuildError> {
+    // 404 fallback handler for unmatched routes
+    router = router.fallback(crate::middleware::error_page_filter::fallback_404_handler);
+
     router = apply_cors_middleware(router, config);
     router = apply_csrf_middleware(router, config);
     router = apply_rate_limit_middleware(router, config);
@@ -1008,9 +1011,6 @@ fn apply_middleware(
     let security_headers =
         crate::security::SecurityHeadersLayer::from_config(&config.security.headers);
     tracing::debug!("Security headers enabled");
-
-    // 404 fallback handler for unmatched routes
-    router = router.fallback(crate::middleware::error_page_filter::fallback_404_handler);
 
     // User-registered Tower layers (AppBuilder::layer). Applied BEFORE
     // RequestIdLayer wraps the router, so user middleware sits INNER to

--- a/autumn/tests/security/fallback_middleware_bypass.rs
+++ b/autumn/tests/security/fallback_middleware_bypass.rs
@@ -1,0 +1,56 @@
+use autumn_macros::get;
+use autumn_web::test::TestApp;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+#[get("/")]
+pub async fn index() -> &'static str {
+    "hello"
+}
+
+#[tokio::test]
+async fn test_fallback_middleware_bypass_csrf() {
+    let mut config = autumn_web::config::AutumnConfig::default();
+    config.security.csrf.enabled = true; // ensure CSRF is enabled
+
+    let app = TestApp::new()
+        .config(config)
+        .routes(autumn_web::routes![index])
+        .build();
+    let router = app.into_router();
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/nonexistent")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = router.clone().oneshot(req).await.unwrap();
+
+    // CSRF should apply to the 404 fallback route as well and return 403.
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_valid_route_csrf() {
+    let mut config = autumn_web::config::AutumnConfig::default();
+    config.security.csrf.enabled = true; // ensure CSRF is enabled
+
+    let app = TestApp::new()
+        .config(config)
+        .routes(autumn_web::routes![index])
+        .build();
+    let router = app.into_router();
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = router.clone().oneshot(req).await.unwrap();
+
+    // valid routes are protected and return 403
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -9,4 +9,5 @@ pub mod csrf_length_timing;
 pub mod csrf_path_traversal;
 pub mod csrf_timing;
 pub mod ctf;
+pub mod fallback_middleware_bypass;
 pub mod session_fixation;


### PR DESCRIPTION
🦠 Threat: Fallback routes (404) bypassed all framework security middlewares (Rate Limiting, CSRF, CORS, Upload Limits) because `.fallback()` was applied after `.layer()`.
🛡️ Defense: Moved the `.fallback()` definition before applying framework middlewares so that tower layers properly wrap the fallback route.
💥 Severity: High. Allowed attackers to bypass rate limits and potentially other security protections by targeting non-existent endpoints.
🧪 Verification: Added regression test in `autumn/tests/security/fallback_middleware_bypass.rs` to verify CSRF layer applies to 404 routes. Run `cargo test -p autumn-web --test security_tests fallback_middleware_bypass`.

---
*PR created automatically by Jules for task [13767471740363202937](https://jules.google.com/task/13767471740363202937) started by @madmax983*