### PR TITLE
⚒️ Forge: Flatten Pyramids of Doom

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2128,8 +2128,10 @@ fn collect_unguarded_repository_writes(
     let mut seen: std::collections::HashSet<(&'static str, &'static str)> =
         std::collections::HashSet::new();
     let mut record_route = |route: &Route| {
-        if let Some(meta) = route.repository
-            && !meta.has_policy
+        let Some(meta) = route.repository else {
+            return;
+        };
+        if !meta.has_policy
             && is_mutating_method(&route.method)
             && seen.insert((meta.resource_type_name, meta.api_path))
         {
@@ -2229,20 +2231,22 @@ fn collect_unregistered_repository_handlers(
     let mut seen_scopes: std::collections::HashSet<(&'static str, &'static str)> =
         std::collections::HashSet::new();
     let mut record_route = |route: &Route| {
-        if let Some(meta) = route.repository {
-            if let Some(check) = meta.policy_check
-                && !check(registry)
-                && seen_policies.insert((meta.resource_type_name, meta.api_path))
-            {
-                missing_policies
-                    .push((meta.resource_type_name.to_owned(), meta.api_path.to_owned()));
-            }
-            if let Some(check) = meta.scope_check
-                && !check(registry)
-                && seen_scopes.insert((meta.resource_type_name, meta.api_path))
-            {
-                missing_scopes.push((meta.resource_type_name.to_owned(), meta.api_path.to_owned()));
-            }
+        let Some(meta) = route.repository else {
+            return;
+        };
+
+        if let Some(check) = meta.policy_check
+            && !check(registry)
+            && seen_policies.insert((meta.resource_type_name, meta.api_path))
+        {
+            missing_policies.push((meta.resource_type_name.to_owned(), meta.api_path.to_owned()));
+        }
+
+        if let Some(check) = meta.scope_check
+            && !check(registry)
+            && seen_scopes.insert((meta.resource_type_name, meta.api_path))
+        {
+            missing_scopes.push((meta.resource_type_name.to_owned(), meta.api_path.to_owned()));
         }
     };
     for route in routes {

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -338,30 +338,29 @@ where
             // Check if session has the required key
             let session = req.extensions().get::<crate::session::Session>().cloned();
 
-            let is_authenticated = if let Some(ref session) = session {
-                session.contains_key(&session_key).await
-            } else {
-                false
+            let is_authenticated = match session {
+                Some(ref s) => s.contains_key(&session_key).await,
+                None => false,
             };
 
             if is_authenticated {
-                inner.call(req).await
-            } else {
-                let body = serde_json::json!({
-                    "error": {
-                        "status": 401,
-                        "message": "authentication required"
-                    }
-                });
-                let response = Response::builder()
-                    .status(StatusCode::UNAUTHORIZED)
-                    .header(http::header::CONTENT_TYPE, "application/json")
-                    .body(ResBody::from(
-                        serde_json::to_string(&body).unwrap_or_default(),
-                    ))
-                    .unwrap_or_default();
-                Ok(response)
+                return inner.call(req).await;
             }
+
+            let body = serde_json::json!({
+                "error": {
+                    "status": 401,
+                    "message": "authentication required"
+                }
+            });
+            let response = Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .body(ResBody::from(
+                    serde_json::to_string(&body).unwrap_or_default(),
+                ))
+                .unwrap_or_default();
+            Ok(response)
         })
     }
 }

--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -359,21 +359,26 @@ async fn verify_csrf_token(
         .await
         .unwrap_or_else(|_| axum::body::Bytes::new());
 
-    if let Ok(body_str) = std::str::from_utf8(&bytes) {
-        for pair in body_str.split('&') {
-            if let Some((key, value)) = pair.split_once('=')
-                && key == settings.form_field
-            {
-                if let Some(c) = cookie_token
-                    && !c.is_empty()
-                    && !value.is_empty()
-                    && constant_time_eq(c, value)
-                {
-                    token_found = true;
-                }
-                break;
-            }
+    let Ok(body_str) = std::str::from_utf8(&bytes) else {
+        *req.body_mut() = axum::body::Body::from(bytes);
+        return false;
+    };
+
+    for pair in body_str.split('&') {
+        let Some((key, value)) = pair.split_once('=') else {
+            continue;
+        };
+        if key != settings.form_field {
+            continue;
         }
+
+        let Some(c) = cookie_token else {
+            break;
+        };
+        if !c.is_empty() && !value.is_empty() && constant_time_eq(c, value) {
+            token_found = true;
+        }
+        break;
     }
 
     // Restore request body


### PR DESCRIPTION
🚮 Smell: Pyramids of Doom. Deeply nested `if let` guard clauses inside logic.
✨ Solution: Used the `let else` guard clause pattern to exit early and flatten logic across multiple modules, most notably in `autumn/src/security/csrf.rs`.
🧼 Benefit: Greatly improves readability by avoiding right-ward drift and separating "happy path" logic from the error/exit scenarios.
🛡️ Verification: `cargo test` passed with no functionality or logical behavior changes.

---
*PR created automatically by Jules for task [4440234186319731763](https://jules.google.com/task/4440234186319731763) started by @madmax983*