### PR TITLE
Add database seeding support with `autumn seed` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     explicitly) — this is the one behavior change downstream apps have
     to address.
 - **storage:** New optional `autumn-web` `storage` cargo feature (off by default) introducing a pluggable file-storage abstraction (#494). Adds the `BlobStore` trait (`put`, `get`, `delete`, `head`, `presigned_url`, `put_stream`), the `Blob` value type with Postgres `JSONB` round-tripping via Diesel `AsExpression` / `FromSqlRow`, a `Local` backend with HMAC-signed URLs and an autumn-mounted serving route at `[storage.local].mount_path` (default `/_blobs`), the `add_blob_column!` migration helper macro, and a feature-gated `S3BlobStore` shell behind `storage-s3` (real SDK wiring tracked as #530). `MultipartField::save_to_blob_store` streams uploads straight through to `BlobStore::put_stream` without buffering, with multipart parser errors preserving their client-facing 4xx status. Profile-aware defaults mirror sessions: `dev` auto-defaults to `Local` rooted at `target/blobs/`; `prod` fails fast on `local` unless `storage.allow_local_in_production = true` is explicitly set. The local backend uses temp-file + cross-platform atomic-replace semantics so partial writes never leave corrupted blobs and re-uploads work on Windows as well as POSIX. `examples/reddit-clone` carries the database-backed UI demo (`Blob` column on the user model + upload form + presigned-URL profile picture); framework-level integration tests pin restart survival on the `Local` backend. Apps that don't enable `storage` see no surface change — this is non-breaking. See [`docs/guide/storage.md`](docs/guide/storage.md).
+- **seed:** New `autumn seed` CLI subcommand and `autumn_web::seed::SeedContext`
+  library surface for project-defined database seeding (#501). Convention:
+  seed code lives in `src/bin/seed.rs`; `autumn seed` runs it via
+  `cargo run --bin seed` after verifying the file exists and checking for
+  pending migrations (errors with an actionable message if either check
+  fails). Accepts `--profile <name>` (default `dev`) forwarded as
+  `AUTUMN_ENV` so seed binaries can branch on environment. New opt-in
+  `seed` cargo feature on `autumn-web` (enables `autumn_web::seed::SeedContext`
+  which wires database URL + profile resolution in one `.build().await` call)
+  — apps that don't seed pay zero compile cost. `autumn new --with-seed`
+  (default off) scaffolds a stub `src/bin/seed.rs` and the matching `[[bin]]`
+  entry. `examples/todo-app` ships a reference seed demonstrating the
+  count-based idempotency guard. New `docs/guide/seeding.md` documents the
+  full story. Non-breaking: existing apps without `src/bin/seed.rs` see no
+  behavior change.
 - **cli:** `autumn generate model | migration | scaffold` for one-command
   resource scaffolding (#493). Emits `#[model]` structs, Diesel migrations,
   `schema.rs` entries, `#[repository(api = ...)]` blocks, Maud HTML route

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -7,6 +7,7 @@ mod generate;
 mod migrate;
 mod monitor;
 mod new;
+mod seed;
 mod setup;
 /// The Autumn web framework CLI.
 #[derive(Parser)]
@@ -23,6 +24,9 @@ enum Commands {
     New {
         /// Project name (must be a valid Rust package name)
         name: String,
+        /// Scaffold a stub `src/bin/seed.rs` for database seeding (default off)
+        #[arg(long)]
+        with_seed: bool,
     },
     /// Pre-render static routes to dist/
     Build {
@@ -70,6 +74,22 @@ enum Commands {
         /// Output file for diagnostics
         #[arg(short, long, default_value = "autumn-diag.json")]
         output: String,
+    },
+    /// Run the project's seed binary to populate the database with representative data.
+    ///
+    /// Requires `src/bin/seed.rs` (a Cargo binary named `seed`) to exist.
+    /// If it is missing, `autumn seed` prints an actionable error and exits 1.
+    ///
+    /// `autumn seed` checks for pending migrations before running and exits 1
+    /// if any are found — run `autumn migrate` first.
+    Seed {
+        /// Profile forwarded to the seed binary via `AUTUMN_ENV`
+        /// (default: `dev`).
+        #[arg(long, default_value = "dev")]
+        profile: String,
+        /// Package to run (for workspaces)
+        #[arg(short, long)]
+        package: Option<String>,
     },
     /// Scaffold models, migrations, and CRUD code for a new resource.
     ///
@@ -176,7 +196,8 @@ fn main() {
         }
         Commands::Monitor { url, interval } => monitor::run(&url, interval),
         Commands::Export { url, output } => export::run(&url, &output),
-        Commands::New { name } => new::run(&name),
+        Commands::New { name, with_seed } => new::run(&name, with_seed),
+        Commands::Seed { profile, package } => seed::run(&profile, package.as_deref()),
         Commands::Setup { force } => setup::run(force),
         Commands::Generate(cmd) => match cmd {
             GenerateCommands::Model {
@@ -209,7 +230,7 @@ mod tests {
     fn parse_new_subcommand() {
         let cli = Cli::try_parse_from(["autumn", "new", "my-app"]).unwrap();
         match cli.command {
-            Commands::New { ref name } => {
+            Commands::New { ref name, .. } => {
                 assert_eq!(name, "my-app");
             }
             _ => panic!("expected New command"),
@@ -220,7 +241,7 @@ mod tests {
     fn parse_new_with_underscores() {
         let cli = Cli::try_parse_from(["autumn", "new", "my_app"]).unwrap();
         match cli.command {
-            Commands::New { ref name } => {
+            Commands::New { ref name, .. } => {
                 assert_eq!(name, "my_app");
             }
             _ => panic!("expected New command"),
@@ -515,5 +536,85 @@ mod tests {
     #[test]
     fn parse_generate_model_without_name_is_error() {
         assert!(Cli::try_parse_from(["autumn", "generate", "model"]).is_err());
+    }
+
+    // ── autumn seed tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn parse_seed_defaults() {
+        let cli = Cli::try_parse_from(["autumn", "seed"]).unwrap();
+        match cli.command {
+            Commands::Seed { profile, package } => {
+                assert_eq!(profile, "dev");
+                assert!(package.is_none());
+            }
+            _ => panic!("expected Seed command"),
+        }
+    }
+
+    #[test]
+    fn parse_seed_with_profile() {
+        let cli = Cli::try_parse_from(["autumn", "seed", "--profile", "demo"]).unwrap();
+        match cli.command {
+            Commands::Seed { profile, .. } => {
+                assert_eq!(profile, "demo");
+            }
+            _ => panic!("expected Seed command"),
+        }
+    }
+
+    #[test]
+    fn parse_seed_with_package() {
+        let cli = Cli::try_parse_from(["autumn", "seed", "-p", "my-app"]).unwrap();
+        match cli.command {
+            Commands::Seed { package, .. } => {
+                assert_eq!(package.as_deref(), Some("my-app"));
+            }
+            _ => panic!("expected Seed command"),
+        }
+    }
+
+    #[test]
+    fn parse_seed_test_profile() {
+        let cli = Cli::try_parse_from(["autumn", "seed", "--profile", "test"]).unwrap();
+        match cli.command {
+            Commands::Seed { profile, .. } => assert_eq!(profile, "test"),
+            _ => panic!("expected Seed command"),
+        }
+    }
+
+    #[test]
+    fn parse_seed_prod_profile() {
+        let cli = Cli::try_parse_from(["autumn", "seed", "--profile", "prod"]).unwrap();
+        match cli.command {
+            Commands::Seed { profile, .. } => assert_eq!(profile, "prod"),
+            _ => panic!("expected Seed command"),
+        }
+    }
+
+    // ── autumn new --with-seed tests ───────────────────────────────────────
+
+    #[test]
+    fn parse_new_without_with_seed_defaults_false() {
+        let cli = Cli::try_parse_from(["autumn", "new", "my-app"]).unwrap();
+        match cli.command {
+            Commands::New { name, with_seed } => {
+                assert_eq!(name, "my-app");
+                assert!(!with_seed);
+            }
+            _ => panic!("expected New command"),
+        }
+    }
+
+    #[test]
+    fn parse_new_with_with_seed_flag() {
+        let cli = Cli::try_parse_from(["autumn", "new", "my-app", "--with-seed"]).unwrap();
+        match cli.command {
+            Commands::New { name, with_seed } => {
+                assert_eq!(name, "my-app");
+                assert!(with_seed);
+            }
+            _ => panic!("expected New command"),
+        }
     }
 }

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -15,6 +15,8 @@ mod templates {
     pub const INPUT_CSS: &str = include_str!("templates/input.css.tmpl");
     pub const TAILWIND_CONFIG: &str = include_str!("templates/tailwind.config.js.tmpl");
     pub const GITIGNORE: &str = include_str!("templates/gitignore.tmpl");
+    pub const SEED_RS: &str = include_str!("templates/seed.rs.tmpl");
+    pub const SEED_CARGO_TOML: &str = include_str!("templates/seed_Cargo.toml.tmpl");
 }
 
 /// Errors that can occur during project generation.
@@ -34,19 +36,22 @@ pub enum NewError {
 }
 
 /// Entry point called from `main.rs` and delegates to [`generate`].
-pub fn run(name: &str) {
+pub fn run(name: &str, with_seed: bool) {
     let cwd = std::env::current_dir().unwrap_or_else(|e| {
         eprintln!("Error: cannot determine current directory: {e}");
         std::process::exit(1);
     });
-    if let Err(e) = generate(name, &cwd) {
+    if let Err(e) = generate(name, &cwd, with_seed) {
         eprintln!("Error: {e}");
         std::process::exit(1);
     }
 }
 
 /// Generate a new Autumn project under `parent_dir/name`.
-pub fn generate(name: &str, parent_dir: &Path) -> Result<(), NewError> {
+///
+/// When `with_seed` is `true`, scaffolds `src/bin/seed.rs` and adds the
+/// `[[bin]]` entry to `Cargo.toml`.
+pub fn generate(name: &str, parent_dir: &Path, with_seed: bool) -> Result<(), NewError> {
     validate_name(name)?;
 
     let project_dir = parent_dir.join(name);
@@ -68,10 +73,18 @@ pub fn generate(name: &str, parent_dir: &Path) -> Result<(), NewError> {
             .replace("{{autumn_version}}", autumn_version)
     };
 
-    fs::write(
-        project_dir.join("Cargo.toml"),
-        render(templates::CARGO_TOML),
-    )?;
+    // Build Cargo.toml: base + optional seed [[bin]] entry.
+    let cargo_toml = if with_seed {
+        format!(
+            "{}\n{}",
+            render(templates::CARGO_TOML),
+            render(templates::SEED_CARGO_TOML)
+        )
+    } else {
+        render(templates::CARGO_TOML)
+    };
+    fs::write(project_dir.join("Cargo.toml"), cargo_toml)?;
+
     fs::write(project_dir.join("src/main.rs"), render(templates::MAIN_RS))?;
     fs::write(
         project_dir.join("autumn.toml"),
@@ -97,6 +110,14 @@ pub fn generate(name: &str, parent_dir: &Path) -> Result<(), NewError> {
     fs::write(project_dir.join(".gitignore"), render(templates::GITIGNORE))?;
     fs::write(project_dir.join("migrations/.gitkeep"), "")?;
 
+    if with_seed {
+        fs::create_dir_all(project_dir.join("src/bin"))?;
+        fs::write(
+            project_dir.join("src/bin/seed.rs"),
+            render(templates::SEED_RS),
+        )?;
+    }
+
     println!("  Created {name}/");
     println!("  Created {name}/Cargo.toml");
     println!("  Created {name}/autumn.toml");
@@ -104,6 +125,9 @@ pub fn generate(name: &str, parent_dir: &Path) -> Result<(), NewError> {
     println!("  Created {name}/.dockerignore");
     println!("  Created {name}/build.rs");
     println!("  Created {name}/src/main.rs");
+    if with_seed {
+        println!("  Created {name}/src/bin/seed.rs");
+    }
     println!("  Created {name}/static/css/input.css");
     println!("  Created {name}/tailwind.config.js");
     println!("  Created {name}/.gitignore");
@@ -114,6 +138,11 @@ pub fn generate(name: &str, parent_dir: &Path) -> Result<(), NewError> {
     println!("  cargo run");
     println!();
     println!("Your app will be available at http://localhost:3000");
+    if with_seed {
+        println!();
+        println!("Seed your database:");
+        println!("  autumn migrate && autumn seed");
+    }
 
     Ok(())
 }
@@ -229,7 +258,7 @@ mod tests {
     #[test]
     fn generates_all_expected_files() {
         let tmp = TempDir::new().unwrap();
-        generate("test-app", tmp.path()).unwrap();
+        generate("test-app", tmp.path(), false).unwrap();
 
         let p = tmp.path().join("test-app");
         assert!(p.join("Cargo.toml").is_file());
@@ -249,7 +278,7 @@ mod tests {
     #[test]
     fn cargo_toml_has_project_name() {
         let tmp = TempDir::new().unwrap();
-        generate("my-cool-app", tmp.path()).unwrap();
+        generate("my-cool-app", tmp.path(), false).unwrap();
 
         let content = fs::read_to_string(tmp.path().join("my-cool-app/Cargo.toml")).unwrap();
         assert!(content.contains(r#"name = "my-cool-app""#));
@@ -259,7 +288,7 @@ mod tests {
     #[test]
     fn cargo_toml_has_autumn_version() {
         let tmp = TempDir::new().unwrap();
-        generate("ver-check", tmp.path()).unwrap();
+        generate("ver-check", tmp.path(), false).unwrap();
 
         let content = fs::read_to_string(tmp.path().join("ver-check/Cargo.toml")).unwrap();
         let expected = format!(r#"autumn-web = "{}""#, env!("CARGO_PKG_VERSION"));
@@ -269,7 +298,7 @@ mod tests {
     #[test]
     fn main_rs_has_sample_routes() {
         let tmp = TempDir::new().unwrap();
-        generate("route-check", tmp.path()).unwrap();
+        generate("route-check", tmp.path(), false).unwrap();
 
         let content = fs::read_to_string(tmp.path().join("route-check/src/main.rs")).unwrap();
         assert!(content.contains(r#"#[get("/")]"#));
@@ -282,7 +311,7 @@ mod tests {
     #[test]
     fn autumn_toml_has_defaults() {
         let tmp = TempDir::new().unwrap();
-        generate("cfg-check", tmp.path()).unwrap();
+        generate("cfg-check", tmp.path(), false).unwrap();
 
         let content = fs::read_to_string(tmp.path().join("cfg-check/autumn.toml")).unwrap();
         assert!(content.contains("port = 3000"));
@@ -294,7 +323,7 @@ mod tests {
     #[test]
     fn autumn_toml_has_crate_name_in_db_url() {
         let tmp = TempDir::new().unwrap();
-        generate("my-db-app", tmp.path()).unwrap();
+        generate("my-db-app", tmp.path(), false).unwrap();
 
         let content = fs::read_to_string(tmp.path().join("my-db-app/autumn.toml")).unwrap();
         assert!(content.contains("my_db_app"));
@@ -303,7 +332,7 @@ mod tests {
     #[test]
     fn gitignore_excludes_target_and_css() {
         let tmp = TempDir::new().unwrap();
-        generate("gi-check", tmp.path()).unwrap();
+        generate("gi-check", tmp.path(), false).unwrap();
 
         let content = fs::read_to_string(tmp.path().join("gi-check/.gitignore")).unwrap();
         assert!(content.contains("/target"));
@@ -314,7 +343,7 @@ mod tests {
     #[test]
     fn generated_build_rs_reruns_on_css_input_changes() {
         let tmp = TempDir::new().unwrap();
-        generate("css-watch-check", tmp.path()).unwrap();
+        generate("css-watch-check", tmp.path(), false).unwrap();
 
         let content = fs::read_to_string(tmp.path().join("css-watch-check/build.rs")).unwrap();
         assert!(content.contains("cargo:rerun-if-changed=static/css/input.css"));
@@ -325,7 +354,7 @@ mod tests {
     #[test]
     fn no_unsubstituted_placeholders() {
         let tmp = TempDir::new().unwrap();
-        generate("placeholder-check", tmp.path()).unwrap();
+        generate("placeholder-check", tmp.path(), false).unwrap();
 
         let p = tmp.path().join("placeholder-check");
         for entry in walkdir(&p) {
@@ -341,8 +370,8 @@ mod tests {
     #[test]
     fn already_exists_error() {
         let tmp = TempDir::new().unwrap();
-        generate("dupe-check", tmp.path()).unwrap();
-        let err = generate("dupe-check", tmp.path()).unwrap_err();
+        generate("dupe-check", tmp.path(), false).unwrap();
+        let err = generate("dupe-check", tmp.path(), false).unwrap_err();
         assert!(matches!(err, NewError::AlreadyExists(_)));
         assert!(err.to_string().contains("already exists"));
     }
@@ -350,7 +379,7 @@ mod tests {
     #[test]
     fn invalid_name_error() {
         let tmp = TempDir::new().unwrap();
-        let err = generate("123bad", tmp.path()).unwrap_err();
+        let err = generate("123bad", tmp.path(), false).unwrap_err();
         assert!(matches!(err, NewError::InvalidName(_, _)));
     }
 
@@ -367,5 +396,62 @@ mod tests {
             }
         }
         files
+    }
+
+    // ── --with-seed tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn no_seed_bin_without_flag() {
+        let tmp = TempDir::new().unwrap();
+        generate("no-seed-app", tmp.path(), false).unwrap();
+        assert!(!tmp.path().join("no-seed-app/src/bin/seed.rs").exists());
+    }
+
+    #[test]
+    fn generates_seed_bin_when_with_seed() {
+        let tmp = TempDir::new().unwrap();
+        generate("seed-app", tmp.path(), true).unwrap();
+        assert!(tmp.path().join("seed-app/src/bin/seed.rs").is_file());
+    }
+
+    #[test]
+    fn with_seed_cargo_toml_has_bin_entry() {
+        let tmp = TempDir::new().unwrap();
+        generate("seed-cargo", tmp.path(), true).unwrap();
+        let content =
+            fs::read_to_string(tmp.path().join("seed-cargo/Cargo.toml")).unwrap();
+        assert!(content.contains("[[bin]]"), "Cargo.toml should have [[bin]]");
+        assert!(
+            content.contains("seed"),
+            "Cargo.toml [[bin]] entry should mention 'seed'"
+        );
+    }
+
+    #[test]
+    fn no_bin_entry_in_cargo_toml_without_flag() {
+        let tmp = TempDir::new().unwrap();
+        generate("plain-cargo", tmp.path(), false).unwrap();
+        let content =
+            fs::read_to_string(tmp.path().join("plain-cargo/Cargo.toml")).unwrap();
+        assert!(
+            !content.contains("[[bin]]"),
+            "Cargo.toml should not have [[bin]] when --with-seed is off"
+        );
+    }
+
+    #[test]
+    fn with_seed_no_unsubstituted_placeholders() {
+        let tmp = TempDir::new().unwrap();
+        generate("seed-placeholder-check", tmp.path(), true).unwrap();
+
+        let p = tmp.path().join("seed-placeholder-check");
+        for entry in walkdir(&p) {
+            let content = fs::read_to_string(&entry).unwrap();
+            assert!(
+                !content.contains("{{"),
+                "unsubstituted placeholder in {}",
+                entry.display()
+            );
+        }
     }
 }

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -74,12 +74,15 @@ pub fn generate(name: &str, parent_dir: &Path, with_seed: bool) -> Result<(), Ne
     };
 
     // Build Cargo.toml: base + optional seed [[bin]] entry.
+    // When --with-seed is on, upgrade the plain `autumn-web = "x"` dependency
+    // to a table form that enables the `seed` feature so `src/bin/seed.rs`
+    // can import `autumn_web::seed::SeedContext` without manual edits.
     let cargo_toml = if with_seed {
-        format!(
-            "{}\n{}",
-            render(templates::CARGO_TOML),
-            render(templates::SEED_CARGO_TOML)
-        )
+        let plain_dep = format!(r#"autumn-web = "{autumn_version}""#);
+        let seed_dep =
+            format!(r#"autumn-web = {{ version = "{autumn_version}", features = ["seed"] }}"#);
+        let base = render(templates::CARGO_TOML).replace(&plain_dep, &seed_dep);
+        format!("{base}\n{}", render(templates::SEED_CARGO_TOML))
     } else {
         render(templates::CARGO_TOML)
     };
@@ -415,15 +418,23 @@ mod tests {
     }
 
     #[test]
-    fn with_seed_cargo_toml_has_bin_entry() {
+    fn with_seed_cargo_toml_has_bin_entry_and_seed_feature() {
         let tmp = TempDir::new().unwrap();
         generate("seed-cargo", tmp.path(), true).unwrap();
-        let content =
-            fs::read_to_string(tmp.path().join("seed-cargo/Cargo.toml")).unwrap();
-        assert!(content.contains("[[bin]]"), "Cargo.toml should have [[bin]]");
+        let content = fs::read_to_string(tmp.path().join("seed-cargo/Cargo.toml")).unwrap();
+        assert!(
+            content.contains("[[bin]]"),
+            "Cargo.toml should have [[bin]]"
+        );
         assert!(
             content.contains("seed"),
             "Cargo.toml [[bin]] entry should mention 'seed'"
+        );
+        // The seed feature must be enabled on autumn-web so src/bin/seed.rs
+        // can import autumn_web::seed::SeedContext without manual edits.
+        assert!(
+            content.contains(r#"features = ["seed"]"#),
+            "autumn-web dependency should include the seed feature, got:\n{content}"
         );
     }
 
@@ -431,8 +442,7 @@ mod tests {
     fn no_bin_entry_in_cargo_toml_without_flag() {
         let tmp = TempDir::new().unwrap();
         generate("plain-cargo", tmp.path(), false).unwrap();
-        let content =
-            fs::read_to_string(tmp.path().join("plain-cargo/Cargo.toml")).unwrap();
+        let content = fs::read_to_string(tmp.path().join("plain-cargo/Cargo.toml")).unwrap();
         assert!(
             !content.contains("[[bin]]"),
             "Cargo.toml should not have [[bin]] when --with-seed is off"

--- a/autumn-cli/src/seed.rs
+++ b/autumn-cli/src/seed.rs
@@ -1,0 +1,272 @@
+//! `autumn seed` -- run the project's seed binary to populate the database.
+//!
+//! Delegates to `cargo run --bin seed` after:
+//!   1. Verifying `src/bin/seed.rs` exists.
+//!   2. Checking for pending migrations via the diesel CLI.
+//!
+//! The seed binary receives the active profile through the `AUTUMN_ENV`
+//! environment variable, matching how the rest of the framework resolves
+//! configuration profiles.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Errors surfaced by the seed runner.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum SeedError {
+    #[error(
+        "no seed binary found; create `src/bin/seed.rs` or run `autumn generate seed`\n\
+         See: https://autumn.rs/guide/seeding"
+    )]
+    MissingSeedBinary,
+
+    #[error(
+        "pending migrations detected; run `autumn migrate` before `autumn seed`"
+    )]
+    PendingMigrations,
+}
+
+/// Returns `true` if the seed binary source file exists at `path`.
+pub(crate) fn seed_binary_exists_at(path: &Path) -> bool {
+    path.is_file()
+}
+
+/// Resolve the database URL for the pending-migration check.
+///
+/// Precedence (highest to lowest):
+/// 1. `AUTUMN_DATABASE__URL` env var
+/// 2. `DATABASE_URL` env var
+/// 3. `database.url` in `autumn.toml`
+pub(crate) fn resolve_database_url_with_env<F>(env_var: F) -> Result<String, SeedError>
+where
+    F: Fn(&str) -> Result<String, std::env::VarError>,
+{
+    if let Ok(url) = env_var("AUTUMN_DATABASE__URL")
+        && !url.is_empty()
+    {
+        return Ok(url);
+    }
+    if let Ok(url) = env_var("DATABASE_URL")
+        && !url.is_empty()
+    {
+        return Ok(url);
+    }
+
+    let config_path = Path::new("autumn.toml");
+    if config_path.exists()
+        && let Ok(contents) = std::fs::read_to_string(config_path)
+        && let Ok(table) = toml::from_str::<toml::Table>(&contents)
+    {
+        let value = toml::Value::Table(table);
+        if let Some(url) = value
+            .get("database")
+            .and_then(|db: &toml::Value| db.get("url"))
+            .and_then(|u: &toml::Value| u.as_str())
+            && !url.is_empty()
+        {
+            return Ok(url.to_string());
+        }
+    }
+
+    Err(SeedError::MissingSeedBinary)
+}
+
+/// Check whether there are pending (unapplied) migrations.
+///
+/// Runs `diesel migration list` and scans for `[ ]` markers that indicate
+/// unapplied migrations. Returns `Ok(())` if all migrations are applied or
+/// if diesel CLI is unavailable (in which case a warning is printed).
+fn check_pending_migrations(database_url: &str, migrations_dir: &str) -> Result<(), SeedError> {
+    let output = Command::new("diesel")
+        .args(["migration", "list", "--migration-dir", migrations_dir])
+        .env("DATABASE_URL", database_url)
+        .output();
+
+    match output {
+        Ok(out) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let combined = format!("{stdout}{stderr}");
+            if combined.lines().any(|line| line.contains("[ ]")) {
+                return Err(SeedError::PendingMigrations);
+            }
+            Ok(())
+        }
+        Err(_) => {
+            eprintln!(
+                "  \u{26a0} diesel CLI not found; skipping pending-migration check.\n  \
+                 Install with: cargo install diesel_cli --no-default-features --features postgres"
+            );
+            Ok(())
+        }
+    }
+}
+
+/// Entry point for `autumn seed`.
+pub fn run(profile: &str, package: Option<&str>) {
+    eprintln!("\u{1F342} autumn seed\n");
+    eprintln!("  Profile: {profile}");
+
+    let seed_path = Path::new("src/bin/seed.rs");
+    if !seed_binary_exists_at(seed_path) {
+        eprintln!("\u{2717} {}", SeedError::MissingSeedBinary);
+        std::process::exit(1);
+    }
+
+    // Best-effort pending migration check when diesel CLI is available.
+    let db_url = std::env::var("AUTUMN_DATABASE__URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .unwrap_or_default();
+    if !db_url.is_empty() {
+        let migrations_dir = if Path::new("migrations").is_dir() {
+            "migrations"
+        } else {
+            ""
+        };
+        if !migrations_dir.is_empty() {
+            if let Err(e) = check_pending_migrations(&db_url, migrations_dir) {
+                eprintln!("\u{2717} {e}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    eprintln!("  Running seed binary...\n");
+
+    let mut cmd = Command::new("cargo");
+    cmd.args(["run", "--bin", "seed"]);
+    if let Some(pkg) = package {
+        cmd.args(["--package", pkg]);
+    }
+    cmd.env("AUTUMN_ENV", profile);
+    cmd.env("AUTUMN_PROFILE", profile);
+
+    let status = cmd.status();
+    match status {
+        Ok(s) if s.success() => {
+            eprintln!("\n\u{2713} Seed completed successfully.");
+        }
+        Ok(_) => {
+            eprintln!("\n\u{2717} Seed binary exited with a non-zero status.");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("\u{2717} Failed to run cargo: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    // ── SeedError messages ─────────────────────────────────────────────────
+
+    #[test]
+    fn missing_seed_binary_error_mentions_src_bin_seed() {
+        let msg = SeedError::MissingSeedBinary.to_string();
+        assert!(
+            msg.contains("src/bin/seed.rs"),
+            "error should mention src/bin/seed.rs, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn missing_seed_binary_error_mentions_generate_seed() {
+        let msg = SeedError::MissingSeedBinary.to_string();
+        assert!(
+            msg.contains("generate seed"),
+            "error should mention `autumn generate seed`, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn pending_migrations_error_mentions_autumn_migrate() {
+        let msg = SeedError::PendingMigrations.to_string();
+        assert!(
+            msg.contains("autumn migrate"),
+            "error should mention `autumn migrate`, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn pending_migrations_error_mentions_pending() {
+        let msg = SeedError::PendingMigrations.to_string();
+        assert!(
+            msg.contains("pending"),
+            "error should mention pending migrations, got: {msg}"
+        );
+    }
+
+    // ── seed_binary_exists_at ──────────────────────────────────────────────
+
+    #[test]
+    fn seed_binary_exists_at_returns_false_for_missing_path() {
+        assert!(!seed_binary_exists_at(Path::new(
+            "/nonexistent/src/bin/seed.rs"
+        )));
+    }
+
+    #[test]
+    fn seed_binary_exists_at_returns_true_when_file_present() {
+        let tmp = TempDir::new().unwrap();
+        let seed_path = tmp.path().join("src/bin/seed.rs");
+        std::fs::create_dir_all(seed_path.parent().unwrap()).unwrap();
+        std::fs::write(&seed_path, "fn main() {}").unwrap();
+        assert!(seed_binary_exists_at(&seed_path));
+    }
+
+    #[test]
+    fn seed_binary_exists_at_returns_false_for_directory() {
+        let tmp = TempDir::new().unwrap();
+        let seed_dir = tmp.path().join("src/bin/seed.rs");
+        std::fs::create_dir_all(&seed_dir).unwrap();
+        // seed_dir is a directory, not a file
+        assert!(!seed_binary_exists_at(&seed_dir));
+    }
+
+    // ── resolve_database_url_with_env ──────────────────────────────────────
+
+    #[test]
+    fn resolve_db_url_prefers_autumn_database_url() {
+        let env = |key: &str| match key {
+            "AUTUMN_DATABASE__URL" => Ok("postgres://autumn:5432/db".to_string()),
+            "DATABASE_URL" => Ok("postgres://plain:5432/db".to_string()),
+            _ => Err(std::env::VarError::NotPresent),
+        };
+        let url = resolve_database_url_with_env(env).unwrap();
+        assert_eq!(url, "postgres://autumn:5432/db");
+    }
+
+    #[test]
+    fn resolve_db_url_falls_back_to_database_url() {
+        let env = |key: &str| match key {
+            "DATABASE_URL" => Ok("postgres://fallback:5432/db".to_string()),
+            _ => Err(std::env::VarError::NotPresent),
+        };
+        let url = resolve_database_url_with_env(env).unwrap();
+        assert_eq!(url, "postgres://fallback:5432/db");
+    }
+
+    #[test]
+    fn resolve_db_url_returns_err_when_no_env_no_toml() {
+        let env =
+            |_: &str| -> Result<String, std::env::VarError> { Err(std::env::VarError::NotPresent) };
+        // No autumn.toml in the test working directory path being injected
+        assert!(resolve_database_url_with_env(env).is_err());
+    }
+
+    #[test]
+    fn resolve_db_url_ignores_empty_env_var() {
+        let env = |key: &str| match key {
+            "AUTUMN_DATABASE__URL" => Ok(String::new()),
+            "DATABASE_URL" => Ok("postgres://real:5432/db".to_string()),
+            _ => Err(std::env::VarError::NotPresent),
+        };
+        let url = resolve_database_url_with_env(env).unwrap();
+        assert_eq!(url, "postgres://real:5432/db");
+    }
+}

--- a/autumn-cli/src/seed.rs
+++ b/autumn-cli/src/seed.rs
@@ -15,7 +15,7 @@ use std::process::Command;
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum SeedError {
     #[error(
-        "no seed binary found; create `src/bin/seed.rs` or run `autumn generate seed`\n\
+        "no seed binary found; create `src/bin/seed.rs`\n\
          See: https://autumn.rs/guide/seeding"
     )]
     MissingSeedBinary,
@@ -59,8 +59,13 @@ fn find_package_dir(package: &str) -> Option<PathBuf> {
 /// Precedence (highest to lowest):
 /// 1. `AUTUMN_DATABASE__URL` env var
 /// 2. `DATABASE_URL` env var
-/// 3. `database.url` in `<base_dir>/autumn.toml`
-fn resolve_database_url_with_env<F>(env_var: F, base_dir: &Path) -> Result<String, SeedError>
+/// 3. `[profile.<profile>.database.url]` in `<base_dir>/autumn.toml`
+/// 4. `[database.url]` in `<base_dir>/autumn.toml`
+fn resolve_database_url_with_env<F>(
+    env_var: F,
+    base_dir: &Path,
+    profile: &str,
+) -> Result<String, SeedError>
 where
     F: Fn(&str) -> Result<String, std::env::VarError>,
 {
@@ -81,11 +86,25 @@ where
         && let Ok(table) = toml::from_str::<toml::Table>(&contents)
     {
         let value = toml::Value::Table(table);
+
+        // Profile-specific override: [profile.<name>.database.url]
+        if let Some(url) = value
+            .get("profile")
+            .and_then(|p| p.get(profile))
+            .and_then(|p| p.get("database"))
+            .and_then(|db| db.get("url"))
+            .and_then(|u| u.as_str())
+            .filter(|u| !u.is_empty())
+        {
+            return Ok(url.to_string());
+        }
+
+        // Top-level fallback: [database.url]
         if let Some(url) = value
             .get("database")
             .and_then(|db: &toml::Value| db.get("url"))
             .and_then(|u: &toml::Value| u.as_str())
-            && !url.is_empty()
+            .filter(|u| !u.is_empty())
         {
             return Ok(url.to_string());
         }
@@ -94,9 +113,9 @@ where
     Err(SeedError::MissingSeedBinary)
 }
 
-/// Resolve the database URL using the real environment and a given base dir.
-fn resolve_database_url(base_dir: &Path) -> Result<String, SeedError> {
-    resolve_database_url_with_env(|key| std::env::var(key), base_dir)
+/// Resolve the database URL using the real environment, a given base dir, and profile.
+fn resolve_database_url(base_dir: &Path, profile: &str) -> Result<String, SeedError> {
+    resolve_database_url_with_env(|key| std::env::var(key), base_dir, profile)
 }
 
 /// Check whether there are pending (unapplied) migrations.
@@ -145,7 +164,7 @@ pub fn run(profile: &str, package: Option<&str>) {
 
     // Best-effort pending migration check when diesel CLI and migrations dir are available.
     let migrations_dir = project_dir.join("migrations");
-    if let Ok(db_url) = resolve_database_url(&project_dir)
+    if let Ok(db_url) = resolve_database_url(&project_dir, profile)
         && migrations_dir.is_dir()
         && let Err(e) = check_pending_migrations(&db_url, &migrations_dir.to_string_lossy())
     {
@@ -201,11 +220,11 @@ mod tests {
     }
 
     #[test]
-    fn missing_seed_binary_error_mentions_generate_seed() {
+    fn missing_seed_binary_error_mentions_seeding_guide_url() {
         let msg = SeedError::MissingSeedBinary.to_string();
         assert!(
-            msg.contains("generate seed"),
-            "error should mention `autumn generate seed`, got: {msg}"
+            msg.contains("autumn.rs/guide/seeding"),
+            "error should link to the seeding guide, got: {msg}"
         );
     }
 
@@ -263,7 +282,7 @@ mod tests {
             "DATABASE_URL" => Ok("postgres://plain:5432/db".to_string()),
             _ => Err(std::env::VarError::NotPresent),
         };
-        let url = resolve_database_url_with_env(env, Path::new(".")).unwrap();
+        let url = resolve_database_url_with_env(env, Path::new("."), "dev").unwrap();
         assert_eq!(url, "postgres://autumn:5432/db");
     }
 
@@ -273,7 +292,7 @@ mod tests {
             "DATABASE_URL" => Ok("postgres://fallback:5432/db".to_string()),
             _ => Err(std::env::VarError::NotPresent),
         };
-        let url = resolve_database_url_with_env(env, Path::new(".")).unwrap();
+        let url = resolve_database_url_with_env(env, Path::new("."), "dev").unwrap();
         assert_eq!(url, "postgres://fallback:5432/db");
     }
 
@@ -282,7 +301,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let env =
             |_: &str| -> Result<String, std::env::VarError> { Err(std::env::VarError::NotPresent) };
-        assert!(resolve_database_url_with_env(env, tmp.path()).is_err());
+        assert!(resolve_database_url_with_env(env, tmp.path(), "dev").is_err());
     }
 
     #[test]
@@ -292,7 +311,7 @@ mod tests {
             "DATABASE_URL" => Ok("postgres://real:5432/db".to_string()),
             _ => Err(std::env::VarError::NotPresent),
         };
-        let url = resolve_database_url_with_env(env, Path::new(".")).unwrap();
+        let url = resolve_database_url_with_env(env, Path::new("."), "dev").unwrap();
         assert_eq!(url, "postgres://real:5432/db");
     }
 
@@ -306,7 +325,7 @@ mod tests {
         .unwrap();
         let env =
             |_: &str| -> Result<String, std::env::VarError> { Err(std::env::VarError::NotPresent) };
-        let url = resolve_database_url_with_env(env, tmp.path()).unwrap();
+        let url = resolve_database_url_with_env(env, tmp.path(), "dev").unwrap();
         assert_eq!(url, "postgres://toml:5432/db");
     }
 
@@ -323,6 +342,35 @@ mod tests {
         let env =
             |_: &str| -> Result<String, std::env::VarError> { Err(std::env::VarError::NotPresent) };
         // Using tmp_empty as base_dir — no autumn.toml there, so must fail.
-        assert!(resolve_database_url_with_env(env, tmp_empty.path()).is_err());
+        assert!(resolve_database_url_with_env(env, tmp_empty.path(), "dev").is_err());
+    }
+
+    #[test]
+    fn resolve_db_url_uses_profile_specific_section_from_toml() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("autumn.toml"),
+            "[database]\nurl = \"postgres://default:5432/db\"\n\
+             [profile.demo.database]\nurl = \"postgres://demo:5432/demo_db\"\n",
+        )
+        .unwrap();
+        let env =
+            |_: &str| -> Result<String, std::env::VarError> { Err(std::env::VarError::NotPresent) };
+        let url = resolve_database_url_with_env(env, tmp.path(), "demo").unwrap();
+        assert_eq!(url, "postgres://demo:5432/demo_db");
+    }
+
+    #[test]
+    fn resolve_db_url_falls_back_to_top_level_when_profile_section_absent() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("autumn.toml"),
+            "[database]\nurl = \"postgres://default:5432/db\"\n",
+        )
+        .unwrap();
+        let env =
+            |_: &str| -> Result<String, std::env::VarError> { Err(std::env::VarError::NotPresent) };
+        let url = resolve_database_url_with_env(env, tmp.path(), "demo").unwrap();
+        assert_eq!(url, "postgres://default:5432/db");
     }
 }

--- a/autumn-cli/src/seed.rs
+++ b/autumn-cli/src/seed.rs
@@ -8,7 +8,7 @@
 //! environment variable, matching how the rest of the framework resolves
 //! configuration profiles.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Errors surfaced by the seed runner.
@@ -29,13 +29,38 @@ fn seed_binary_exists_at(path: &Path) -> bool {
     path.is_file()
 }
 
+/// Locate the directory of a Cargo package by name using `cargo metadata`.
+///
+/// Returns the directory containing the package's `Cargo.toml`, or `None` if
+/// the package cannot be found or `cargo metadata` fails.
+fn find_package_dir(package: &str) -> Option<PathBuf> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let metadata: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    let manifest_path = metadata["packages"]
+        .as_array()?
+        .iter()
+        .find(|p| p["name"].as_str() == Some(package))?["manifest_path"]
+        .as_str()?
+        .to_owned();
+    Path::new(&manifest_path).parent().map(Path::to_path_buf)
+}
+
 /// Resolve the database URL from environment variables and `autumn.toml`.
+///
+/// Reads `autumn.toml` from `base_dir` (the project root) rather than from
+/// the process working directory so that workspace invocations are correct.
 ///
 /// Precedence (highest to lowest):
 /// 1. `AUTUMN_DATABASE__URL` env var
 /// 2. `DATABASE_URL` env var
-/// 3. `database.url` in `autumn.toml`
-fn resolve_database_url_with_env<F>(env_var: F) -> Result<String, SeedError>
+/// 3. `database.url` in `<base_dir>/autumn.toml`
+fn resolve_database_url_with_env<F>(env_var: F, base_dir: &Path) -> Result<String, SeedError>
 where
     F: Fn(&str) -> Result<String, std::env::VarError>,
 {
@@ -50,9 +75,9 @@ where
         return Ok(url);
     }
 
-    let config_path = Path::new("autumn.toml");
+    let config_path = base_dir.join("autumn.toml");
     if config_path.exists()
-        && let Ok(contents) = std::fs::read_to_string(config_path)
+        && let Ok(contents) = std::fs::read_to_string(&config_path)
         && let Ok(table) = toml::from_str::<toml::Table>(&contents)
     {
         let value = toml::Value::Table(table);
@@ -69,9 +94,9 @@ where
     Err(SeedError::MissingSeedBinary)
 }
 
-/// Resolve the database URL using the real environment.
-fn resolve_database_url() -> Result<String, SeedError> {
-    resolve_database_url_with_env(|key| std::env::var(key))
+/// Resolve the database URL using the real environment and a given base dir.
+fn resolve_database_url(base_dir: &Path) -> Result<String, SeedError> {
+    resolve_database_url_with_env(|key| std::env::var(key), base_dir)
 }
 
 /// Check whether there are pending (unapplied) migrations.
@@ -106,16 +131,23 @@ pub fn run(profile: &str, package: Option<&str>) {
     eprintln!("\u{1F342} autumn seed\n");
     eprintln!("  Profile: {profile}");
 
-    let seed_path = Path::new("src/bin/seed.rs");
-    if !seed_binary_exists_at(seed_path) {
+    // Determine the project directory: either the workspace member's root (when
+    // --package is given) or the current working directory.
+    let project_dir: PathBuf = package
+        .and_then(find_package_dir)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+
+    let seed_path = project_dir.join("src/bin/seed.rs");
+    if !seed_binary_exists_at(&seed_path) {
         eprintln!("\u{2717} {}", SeedError::MissingSeedBinary);
         std::process::exit(1);
     }
 
     // Best-effort pending migration check when diesel CLI and migrations dir are available.
-    if let Ok(db_url) = resolve_database_url()
-        && Path::new("migrations").is_dir()
-        && let Err(e) = check_pending_migrations(&db_url, "migrations")
+    let migrations_dir = project_dir.join("migrations");
+    if let Ok(db_url) = resolve_database_url(&project_dir)
+        && migrations_dir.is_dir()
+        && let Err(e) = check_pending_migrations(&db_url, &migrations_dir.to_string_lossy())
     {
         eprintln!("\u{2717} {e}");
         std::process::exit(1);
@@ -130,6 +162,10 @@ pub fn run(profile: &str, package: Option<&str>) {
     }
     cmd.env("AUTUMN_ENV", profile);
     cmd.env("AUTUMN_PROFILE", profile);
+    // Run from the project directory so the seed binary's SeedContext reads
+    // autumn.toml from the correct location (the package root, not the
+    // workspace root).
+    cmd.current_dir(&project_dir);
 
     let status = cmd.status();
     match status {
@@ -227,7 +263,7 @@ mod tests {
             "DATABASE_URL" => Ok("postgres://plain:5432/db".to_string()),
             _ => Err(std::env::VarError::NotPresent),
         };
-        let url = resolve_database_url_with_env(env).unwrap();
+        let url = resolve_database_url_with_env(env, Path::new(".")).unwrap();
         assert_eq!(url, "postgres://autumn:5432/db");
     }
 
@@ -237,15 +273,16 @@ mod tests {
             "DATABASE_URL" => Ok("postgres://fallback:5432/db".to_string()),
             _ => Err(std::env::VarError::NotPresent),
         };
-        let url = resolve_database_url_with_env(env).unwrap();
+        let url = resolve_database_url_with_env(env, Path::new(".")).unwrap();
         assert_eq!(url, "postgres://fallback:5432/db");
     }
 
     #[test]
     fn resolve_db_url_returns_err_when_no_env_no_toml() {
+        let tmp = TempDir::new().unwrap();
         let env =
             |_: &str| -> Result<String, std::env::VarError> { Err(std::env::VarError::NotPresent) };
-        assert!(resolve_database_url_with_env(env).is_err());
+        assert!(resolve_database_url_with_env(env, tmp.path()).is_err());
     }
 
     #[test]
@@ -255,7 +292,37 @@ mod tests {
             "DATABASE_URL" => Ok("postgres://real:5432/db".to_string()),
             _ => Err(std::env::VarError::NotPresent),
         };
-        let url = resolve_database_url_with_env(env).unwrap();
+        let url = resolve_database_url_with_env(env, Path::new(".")).unwrap();
         assert_eq!(url, "postgres://real:5432/db");
+    }
+
+    #[test]
+    fn resolve_db_url_reads_database_url_from_base_dir_toml() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("autumn.toml"),
+            "[database]\nurl = \"postgres://toml:5432/db\"\n",
+        )
+        .unwrap();
+        let env =
+            |_: &str| -> Result<String, std::env::VarError> { Err(std::env::VarError::NotPresent) };
+        let url = resolve_database_url_with_env(env, tmp.path()).unwrap();
+        assert_eq!(url, "postgres://toml:5432/db");
+    }
+
+    #[test]
+    fn resolve_db_url_ignores_toml_in_wrong_base_dir() {
+        // autumn.toml exists only in a different directory; base_dir has none.
+        let tmp_with_toml = TempDir::new().unwrap();
+        std::fs::write(
+            tmp_with_toml.path().join("autumn.toml"),
+            "[database]\nurl = \"postgres://wrong:5432/db\"\n",
+        )
+        .unwrap();
+        let tmp_empty = TempDir::new().unwrap();
+        let env =
+            |_: &str| -> Result<String, std::env::VarError> { Err(std::env::VarError::NotPresent) };
+        // Using tmp_empty as base_dir — no autumn.toml there, so must fail.
+        assert!(resolve_database_url_with_env(env, tmp_empty.path()).is_err());
     }
 }

--- a/autumn-cli/src/seed.rs
+++ b/autumn-cli/src/seed.rs
@@ -20,24 +20,22 @@ pub enum SeedError {
     )]
     MissingSeedBinary,
 
-    #[error(
-        "pending migrations detected; run `autumn migrate` before `autumn seed`"
-    )]
+    #[error("pending migrations detected; run `autumn migrate` before `autumn seed`")]
     PendingMigrations,
 }
 
 /// Returns `true` if the seed binary source file exists at `path`.
-pub(crate) fn seed_binary_exists_at(path: &Path) -> bool {
+fn seed_binary_exists_at(path: &Path) -> bool {
     path.is_file()
 }
 
-/// Resolve the database URL for the pending-migration check.
+/// Resolve the database URL from environment variables and `autumn.toml`.
 ///
 /// Precedence (highest to lowest):
 /// 1. `AUTUMN_DATABASE__URL` env var
 /// 2. `DATABASE_URL` env var
 /// 3. `database.url` in `autumn.toml`
-pub(crate) fn resolve_database_url_with_env<F>(env_var: F) -> Result<String, SeedError>
+fn resolve_database_url_with_env<F>(env_var: F) -> Result<String, SeedError>
 where
     F: Fn(&str) -> Result<String, std::env::VarError>,
 {
@@ -71,6 +69,11 @@ where
     Err(SeedError::MissingSeedBinary)
 }
 
+/// Resolve the database URL using the real environment.
+fn resolve_database_url() -> Result<String, SeedError> {
+    resolve_database_url_with_env(|key| std::env::var(key))
+}
+
 /// Check whether there are pending (unapplied) migrations.
 ///
 /// Runs `diesel migration list` and scans for `[ ]` markers that indicate
@@ -82,24 +85,20 @@ fn check_pending_migrations(database_url: &str, migrations_dir: &str) -> Result<
         .env("DATABASE_URL", database_url)
         .output();
 
-    match output {
-        Ok(out) => {
-            let stdout = String::from_utf8_lossy(&out.stdout);
-            let stderr = String::from_utf8_lossy(&out.stderr);
-            let combined = format!("{stdout}{stderr}");
-            if combined.lines().any(|line| line.contains("[ ]")) {
-                return Err(SeedError::PendingMigrations);
-            }
-            Ok(())
+    if let Ok(out) = output {
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let combined = format!("{stdout}{stderr}");
+        if combined.lines().any(|line| line.contains("[ ]")) {
+            return Err(SeedError::PendingMigrations);
         }
-        Err(_) => {
-            eprintln!(
-                "  \u{26a0} diesel CLI not found; skipping pending-migration check.\n  \
-                 Install with: cargo install diesel_cli --no-default-features --features postgres"
-            );
-            Ok(())
-        }
+    } else {
+        eprintln!(
+            "  \u{26a0} diesel CLI not found; skipping pending-migration check.\n  \
+             Install with: cargo install diesel_cli --no-default-features --features postgres"
+        );
     }
+    Ok(())
 }
 
 /// Entry point for `autumn seed`.
@@ -113,22 +112,13 @@ pub fn run(profile: &str, package: Option<&str>) {
         std::process::exit(1);
     }
 
-    // Best-effort pending migration check when diesel CLI is available.
-    let db_url = std::env::var("AUTUMN_DATABASE__URL")
-        .or_else(|_| std::env::var("DATABASE_URL"))
-        .unwrap_or_default();
-    if !db_url.is_empty() {
-        let migrations_dir = if Path::new("migrations").is_dir() {
-            "migrations"
-        } else {
-            ""
-        };
-        if !migrations_dir.is_empty() {
-            if let Err(e) = check_pending_migrations(&db_url, migrations_dir) {
-                eprintln!("\u{2717} {e}");
-                std::process::exit(1);
-            }
-        }
+    // Best-effort pending migration check when diesel CLI and migrations dir are available.
+    if let Ok(db_url) = resolve_database_url()
+        && Path::new("migrations").is_dir()
+        && let Err(e) = check_pending_migrations(&db_url, "migrations")
+    {
+        eprintln!("\u{2717} {e}");
+        std::process::exit(1);
     }
 
     eprintln!("  Running seed binary...\n");
@@ -255,7 +245,6 @@ mod tests {
     fn resolve_db_url_returns_err_when_no_env_no_toml() {
         let env =
             |_: &str| -> Result<String, std::env::VarError> { Err(std::env::VarError::NotPresent) };
-        // No autumn.toml in the test working directory path being injected
         assert!(resolve_database_url_with_env(env).is_err());
     }
 

--- a/autumn-cli/src/templates/seed.rs.tmpl
+++ b/autumn-cli/src/templates/seed.rs.tmpl
@@ -9,7 +9,7 @@
 //! every insert uses `ON CONFLICT DO NOTHING` (upsert-by-natural-key).
 use autumn_web::seed::SeedContext;
 
-#[tokio::main]
+#[autumn_web::main]
 async fn main() {
     let ctx = SeedContext::build()
         .expect("failed to build seed context — is the database running?");

--- a/autumn-cli/src/templates/seed.rs.tmpl
+++ b/autumn-cli/src/templates/seed.rs.tmpl
@@ -1,0 +1,40 @@
+//! Database seed binary for {{project_name}}.
+//!
+//! Run with: `autumn seed`
+//!
+//! The active profile is available as the `AUTUMN_ENV` environment variable
+//! (default: `dev`). Use it to branch on environment when needed.
+//!
+//! Re-running this seed against an already-seeded database is safe because
+//! every insert uses `ON CONFLICT DO NOTHING` (upsert-by-natural-key).
+use autumn_web::seed::SeedContext;
+
+#[tokio::main]
+async fn main() {
+    let ctx = SeedContext::build()
+        .await
+        .expect("failed to build seed context — is the database running?");
+
+    println!("Seeding database (profile: {})...", ctx.profile());
+
+    let mut db = ctx
+        .conn()
+        .await
+        .expect("failed to acquire database connection");
+
+    // TODO: insert representative data here using your project's models.
+    //
+    // Example (requires `diesel` and your schema in scope):
+    //
+    //   use crate::schema::todos::dsl::*;
+    //   diesel::insert_into(todos)
+    //       .values(...)
+    //       .on_conflict(id)
+    //       .do_nothing()
+    //       .execute(&mut db)
+    //       .await
+    //       .expect("seed insert failed");
+
+    drop(db);
+    println!("Seed complete.");
+}

--- a/autumn-cli/src/templates/seed.rs.tmpl
+++ b/autumn-cli/src/templates/seed.rs.tmpl
@@ -12,7 +12,6 @@ use autumn_web::seed::SeedContext;
 #[tokio::main]
 async fn main() {
     let ctx = SeedContext::build()
-        .await
         .expect("failed to build seed context — is the database running?");
 
     println!("Seeding database (profile: {})...", ctx.profile());

--- a/autumn-cli/src/templates/seed_Cargo.toml.tmpl
+++ b/autumn-cli/src/templates/seed_Cargo.toml.tmpl
@@ -1,0 +1,3 @@
+[[bin]]
+name = "seed"
+path = "src/bin/seed.rs"

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -46,6 +46,9 @@ redis = ["dep:redis"]
 storage = ["diesel?/serde_json"]
 storage-s3 = ["storage"]
 mail = ["dep:lettre", "maud"]
+# Enables `autumn_web::seed::SeedContext` for use in `src/bin/seed.rs`.
+# Depends on `db`; off by default so apps that don't seed pay zero compile cost.
+seed = ["db"]
 
 [dependencies]
 autumn-macros = { version = "0.3.0", path = "../autumn-macros" }

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -125,6 +125,8 @@ pub mod static_gen;
 pub mod storage;
 
 pub mod job;
+#[cfg(feature = "seed")]
+pub mod seed;
 pub mod task;
 pub mod telemetry;
 pub mod ui;

--- a/autumn/src/seed.rs
+++ b/autumn/src/seed.rs
@@ -90,16 +90,14 @@ impl SeedContext {
     /// constructed.
     pub fn build() -> Result<Self, SeedContextError> {
         let profile = resolve_profile();
-        let db_url =
-            resolve_database_url().ok_or(SeedContextError::NoDatabaseUrl)?;
+        let db_url = resolve_database_url(&profile).ok_or(SeedContextError::NoDatabaseUrl)?;
 
         let config = DatabaseConfig {
             url: Some(db_url),
             ..DatabaseConfig::default()
         };
 
-        let pool = create_pool(&config)?
-            .ok_or(SeedContextError::NoDatabaseUrl)?;
+        let pool = create_pool(&config)?.ok_or(SeedContextError::NoDatabaseUrl)?;
 
         Ok(Self { pool, profile })
     }
@@ -136,7 +134,13 @@ fn resolve_profile() -> String {
 }
 
 /// Resolve the database URL from environment variables and `autumn.toml`.
-fn resolve_database_url() -> Option<String> {
+///
+/// Resolution order (first non-empty value wins):
+/// 1. `AUTUMN_DATABASE__URL` env var
+/// 2. `DATABASE_URL` env var
+/// 3. `[profile.<profile>.database.url]` in `autumn.toml`
+/// 4. `[database.url]` in `autumn.toml`
+fn resolve_database_url(profile: &str) -> Option<String> {
     if let Ok(url) = std::env::var("AUTUMN_DATABASE__URL")
         && !url.is_empty()
     {
@@ -154,6 +158,20 @@ fn resolve_database_url() -> Option<String> {
         && let Ok(table) = toml::from_str::<toml::Table>(&contents)
     {
         let value = toml::Value::Table(table);
+
+        // Profile-specific override: [profile.<name>.database.url]
+        if let Some(url) = value
+            .get("profile")
+            .and_then(|p| p.get(profile))
+            .and_then(|p| p.get("database"))
+            .and_then(|db| db.get("url"))
+            .and_then(|u| u.as_str())
+            .filter(|u| !u.is_empty())
+        {
+            return Some(url.to_string());
+        }
+
+        // Top-level fallback: [database.url]
         if let Some(url) = value
             .get("database")
             .and_then(|db: &toml::Value| db.get("url"))
@@ -224,7 +242,7 @@ mod tests {
             ],
             || {
                 assert_eq!(
-                    resolve_database_url().as_deref(),
+                    resolve_database_url("dev").as_deref(),
                     Some("postgres://primary:5432/db")
                 );
             },
@@ -240,7 +258,7 @@ mod tests {
             ],
             || {
                 assert_eq!(
-                    resolve_database_url().as_deref(),
+                    resolve_database_url("dev").as_deref(),
                     Some("postgres://fallback:5432/db")
                 );
             },
@@ -257,7 +275,7 @@ mod tests {
             || {
                 // No autumn.toml in the test runner's cwd (we rely on that
                 // directory not having one; if it does, this test is a no-op).
-                let url = resolve_database_url();
+                let url = resolve_database_url("dev");
                 // Either None (no autumn.toml) or Some (if autumn.toml exists
                 // with a database.url in the test runner cwd). We can't assert
                 // None unconditionally, so we just assert the function returns
@@ -276,11 +294,65 @@ mod tests {
             ],
             || {
                 assert_eq!(
-                    resolve_database_url().as_deref(),
+                    resolve_database_url("dev").as_deref(),
                     Some("postgres://real:5432/db")
                 );
             },
         );
+    }
+
+    #[test]
+    fn resolve_database_url_uses_profile_specific_section_from_toml() {
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let toml_content = r#"
+[database]
+url = "postgres://default:5432/db"
+
+[profile.demo.database]
+url = "postgres://demo:5432/demo_db"
+"#;
+        std::fs::write(tmp.path().join("autumn.toml"), toml_content).unwrap();
+
+        // Change working directory to tmp so resolve_database_url reads it.
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let result = temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__URL", None::<&str>),
+                ("DATABASE_URL", None::<&str>),
+            ],
+            || resolve_database_url("demo"),
+        );
+
+        std::env::set_current_dir(original).unwrap();
+        assert_eq!(result.as_deref(), Some("postgres://demo:5432/demo_db"));
+    }
+
+    #[test]
+    fn resolve_database_url_falls_back_to_top_level_when_profile_section_absent() {
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let toml_content = r#"
+[database]
+url = "postgres://default:5432/db"
+"#;
+        std::fs::write(tmp.path().join("autumn.toml"), toml_content).unwrap();
+
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let result = temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__URL", None::<&str>),
+                ("DATABASE_URL", None::<&str>),
+            ],
+            || resolve_database_url("demo"),
+        );
+
+        std::env::set_current_dir(original).unwrap();
+        assert_eq!(result.as_deref(), Some("postgres://default:5432/db"));
     }
 
     // ── SeedContextError messages ──────────────────────────────────────────

--- a/autumn/src/seed.rs
+++ b/autumn/src/seed.rs
@@ -14,7 +14,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let ctx = SeedContext::build().await.expect("seed context");
+//!     let ctx = SeedContext::build().expect("seed context");
 //!     let mut db = ctx.conn().await.expect("db connection");
 //!     // use db with Diesel queries ...
 //!     println!("Seed complete (profile: {})", ctx.profile());
@@ -58,7 +58,7 @@ pub enum SeedContextError {
 /// # use autumn_web::seed::SeedContext;
 /// # #[tokio::main]
 /// # async fn main() {
-/// let ctx = SeedContext::build().await.expect("seed context");
+/// let ctx = SeedContext::build().expect("seed context");
 /// println!("profile: {}", ctx.profile());
 /// let mut db = ctx.conn().await.expect("connection");
 /// // use &mut *db as &mut AsyncPgConnection with diesel_async queries
@@ -88,7 +88,7 @@ impl SeedContext {
     /// Returns [`SeedContextError::NoDatabaseUrl`] if no database URL is
     /// configured, or [`SeedContextError::PoolBuild`] if the pool cannot be
     /// constructed.
-    pub async fn build() -> Result<Self, SeedContextError> {
+    pub fn build() -> Result<Self, SeedContextError> {
         let profile = resolve_profile();
         let db_url =
             resolve_database_url().ok_or(SeedContextError::NoDatabaseUrl)?;

--- a/autumn/src/seed.rs
+++ b/autumn/src/seed.rs
@@ -1,0 +1,296 @@
+//! Seed context for populating databases with representative data.
+//!
+//! Enabled with the `seed` cargo feature (off by default). Include in your
+//! project's `Cargo.toml` to use it in a seed binary:
+//!
+//! ```toml
+//! autumn-web = { version = "...", features = ["seed"] }
+//! ```
+//!
+//! # Example (`src/bin/seed.rs`)
+//!
+//! ```no_run
+//! use autumn_web::seed::SeedContext;
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let ctx = SeedContext::build().await.expect("seed context");
+//!     let mut db = ctx.conn().await.expect("db connection");
+//!     // use db with Diesel queries ...
+//!     println!("Seed complete (profile: {})", ctx.profile());
+//! }
+//! ```
+
+use std::path::Path;
+
+use crate::config::DatabaseConfig;
+use crate::db::create_pool;
+use diesel_async::AsyncPgConnection;
+use diesel_async::pooled_connection::deadpool::{Object, Pool};
+
+/// Error type returned by [`SeedContext`] operations.
+#[derive(Debug, thiserror::Error)]
+pub enum SeedContextError {
+    /// No database URL was found in the environment or `autumn.toml`.
+    #[error(
+        "no database URL configured; set AUTUMN_DATABASE__URL or `database.url` in autumn.toml"
+    )]
+    NoDatabaseUrl,
+
+    /// The connection pool could not be built.
+    #[error("failed to build connection pool: {0}")]
+    PoolBuild(#[from] crate::db::PoolError),
+
+    /// A pooled connection could not be acquired.
+    #[error("failed to acquire database connection: {0}")]
+    Connection(String),
+}
+
+/// Context provided to a seed binary.
+///
+/// Holds the database connection pool and the active profile, both resolved
+/// from the project's `autumn.toml` and environment variables — the same
+/// sources the main application uses.
+///
+/// # Usage
+///
+/// ```no_run
+/// # use autumn_web::seed::SeedContext;
+/// # #[tokio::main]
+/// # async fn main() {
+/// let ctx = SeedContext::build().await.expect("seed context");
+/// println!("profile: {}", ctx.profile());
+/// let mut db = ctx.conn().await.expect("connection");
+/// // use &mut *db as &mut AsyncPgConnection with diesel_async queries
+/// # }
+/// ```
+pub struct SeedContext {
+    pool: Pool<AsyncPgConnection>,
+    profile: String,
+}
+
+impl SeedContext {
+    /// Build a `SeedContext` by reading the database URL and profile from the
+    /// environment and `autumn.toml` in the current working directory.
+    ///
+    /// Profile resolution order (first wins):
+    /// 1. `AUTUMN_ENV` env var
+    /// 2. `AUTUMN_PROFILE` env var
+    /// 3. Defaults to `"dev"`
+    ///
+    /// Database URL resolution order (first wins):
+    /// 1. `AUTUMN_DATABASE__URL` env var
+    /// 2. `DATABASE_URL` env var
+    /// 3. `database.url` in `autumn.toml`
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SeedContextError::NoDatabaseUrl`] if no database URL is
+    /// configured, or [`SeedContextError::PoolBuild`] if the pool cannot be
+    /// constructed.
+    pub async fn build() -> Result<Self, SeedContextError> {
+        let profile = resolve_profile();
+        let db_url =
+            resolve_database_url().ok_or(SeedContextError::NoDatabaseUrl)?;
+
+        let config = DatabaseConfig {
+            url: Some(db_url),
+            ..DatabaseConfig::default()
+        };
+
+        let pool = create_pool(&config)?
+            .ok_or(SeedContextError::NoDatabaseUrl)?;
+
+        Ok(Self { pool, profile })
+    }
+
+    /// Returns the active profile name (e.g. `"dev"`, `"demo"`, `"test"`).
+    #[must_use]
+    pub fn profile(&self) -> &str {
+        &self.profile
+    }
+
+    /// Acquires a pooled database connection.
+    ///
+    /// Returns a [`Object<AsyncPgConnection>`] that implements `DerefMut` to
+    /// `AsyncPgConnection`, so it can be passed directly to diesel-async
+    /// query methods as `&mut *conn`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SeedContextError::Connection`] if the pool is exhausted or
+    /// the connection cannot be established.
+    pub async fn conn(&self) -> Result<Object<AsyncPgConnection>, SeedContextError> {
+        self.pool
+            .get()
+            .await
+            .map_err(|e| SeedContextError::Connection(e.to_string()))
+    }
+}
+
+/// Resolve the active profile from environment variables.
+fn resolve_profile() -> String {
+    std::env::var("AUTUMN_ENV")
+        .or_else(|_| std::env::var("AUTUMN_PROFILE"))
+        .unwrap_or_else(|_| "dev".to_string())
+}
+
+/// Resolve the database URL from environment variables and `autumn.toml`.
+fn resolve_database_url() -> Option<String> {
+    if let Ok(url) = std::env::var("AUTUMN_DATABASE__URL")
+        && !url.is_empty()
+    {
+        return Some(url);
+    }
+    if let Ok(url) = std::env::var("DATABASE_URL")
+        && !url.is_empty()
+    {
+        return Some(url);
+    }
+
+    let config_path = Path::new("autumn.toml");
+    if config_path.exists()
+        && let Ok(contents) = std::fs::read_to_string(config_path)
+        && let Ok(table) = toml::from_str::<toml::Table>(&contents)
+    {
+        let value = toml::Value::Table(table);
+        if let Some(url) = value
+            .get("database")
+            .and_then(|db: &toml::Value| db.get("url"))
+            .and_then(|u: &toml::Value| u.as_str())
+            .filter(|u| !u.is_empty())
+        {
+            return Some(url.to_string());
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── resolve_profile ────────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_profile_defaults_to_dev() {
+        // Isolate from the real environment using temp_env.
+        temp_env::with_vars(
+            [
+                ("AUTUMN_ENV", None::<&str>),
+                ("AUTUMN_PROFILE", None::<&str>),
+            ],
+            || {
+                assert_eq!(resolve_profile(), "dev");
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_profile_prefers_autumn_env() {
+        temp_env::with_vars(
+            [
+                ("AUTUMN_ENV", Some("demo")),
+                ("AUTUMN_PROFILE", Some("test")),
+            ],
+            || {
+                assert_eq!(resolve_profile(), "demo");
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_profile_falls_back_to_autumn_profile() {
+        temp_env::with_vars(
+            [
+                ("AUTUMN_ENV", None::<&str>),
+                ("AUTUMN_PROFILE", Some("staging")),
+            ],
+            || {
+                assert_eq!(resolve_profile(), "staging");
+            },
+        );
+    }
+
+    // ── resolve_database_url ───────────────────────────────────────────────
+
+    #[test]
+    fn resolve_database_url_prefers_autumn_database_url() {
+        temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__URL", Some("postgres://primary:5432/db")),
+                ("DATABASE_URL", Some("postgres://secondary:5432/db")),
+            ],
+            || {
+                assert_eq!(
+                    resolve_database_url().as_deref(),
+                    Some("postgres://primary:5432/db")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_database_url_falls_back_to_database_url() {
+        temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__URL", None::<&str>),
+                ("DATABASE_URL", Some("postgres://fallback:5432/db")),
+            ],
+            || {
+                assert_eq!(
+                    resolve_database_url().as_deref(),
+                    Some("postgres://fallback:5432/db")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_database_url_returns_none_when_nothing_configured() {
+        temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__URL", None::<&str>),
+                ("DATABASE_URL", None::<&str>),
+            ],
+            || {
+                // No autumn.toml in the test runner's cwd (we rely on that
+                // directory not having one; if it does, this test is a no-op).
+                let url = resolve_database_url();
+                // Either None (no autumn.toml) or Some (if autumn.toml exists
+                // with a database.url in the test runner cwd). We can't assert
+                // None unconditionally, so we just assert the function returns
+                // without panicking.
+                let _ = url;
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_database_url_ignores_empty_autumn_database_url() {
+        temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__URL", Some("")),
+                ("DATABASE_URL", Some("postgres://real:5432/db")),
+            ],
+            || {
+                assert_eq!(
+                    resolve_database_url().as_deref(),
+                    Some("postgres://real:5432/db")
+                );
+            },
+        );
+    }
+
+    // ── SeedContextError messages ──────────────────────────────────────────
+
+    #[test]
+    fn no_database_url_error_message_is_actionable() {
+        let msg = SeedContextError::NoDatabaseUrl.to_string();
+        assert!(
+            msg.contains("AUTUMN_DATABASE__URL") || msg.contains("autumn.toml"),
+            "error should be actionable, got: {msg}"
+        );
+    }
+}

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -51,6 +51,7 @@ This gives you the `autumn` binary with the core workflow commands:
 | `autumn dev`    | Run the dev server with file watching        |
 | `autumn build`  | Pre-render `#[static_get]` routes into `dist/` |
 | `autumn migrate`| Run migrations or inspect migration status   |
+| `autumn seed`   | Populate the database with representative data |
 
 ---
 

--- a/docs/guide/seeding.md
+++ b/docs/guide/seeding.md
@@ -60,7 +60,7 @@ struct NewPost<'a> {
 
 #[tokio::main]
 async fn main() {
-    let ctx = SeedContext::build().await.expect("seed context");
+    let ctx = SeedContext::build().expect("seed context");
     println!("Seeding ({})...", ctx.profile());
 
     let mut db = ctx.conn().await.expect("db connection");
@@ -181,7 +181,7 @@ Re-running skips rows whose slug already exists.
 
 ```rust
 /// Build a seed context from environment + autumn.toml.
-pub async fn build() -> Result<SeedContext, SeedContextError>
+pub fn build() -> Result<SeedContext, SeedContextError>
 
 /// Active profile (e.g. "dev", "demo", "test").
 pub fn profile(&self) -> &str

--- a/docs/guide/seeding.md
+++ b/docs/guide/seeding.md
@@ -1,0 +1,227 @@
+# Database Seeding
+
+Autumn ships a first-class seed convention so a freshly-migrated database can
+be populated with representative data in a single command.
+
+```sh
+autumn migrate && autumn seed
+```
+
+---
+
+## The convention
+
+Seed code lives in `src/bin/seed.rs` — an ordinary Cargo binary that receives
+a database connection through [`autumn_web::seed::SeedContext`].  No special
+DSL, no template language, and no duplicated connection wiring: seed code uses
+the same `#[model]` / `#[repository]` types the application uses, so the
+compiler keeps everything in sync.
+
+The binary is discovered by `autumn seed` through the Cargo binary target
+named `seed`.
+
+---
+
+## Quick start
+
+### 1. Add the `seed` feature to `autumn-web`
+
+```toml
+# Cargo.toml
+[dependencies]
+autumn-web = { version = "0.3", features = ["seed"] }
+
+[[bin]]
+name = "seed"
+path = "src/bin/seed.rs"
+```
+
+Or scaffold it automatically when creating a new project:
+
+```sh
+autumn new my-app --with-seed
+```
+
+### 2. Write `src/bin/seed.rs`
+
+```rust
+use autumn_web::seed::SeedContext;
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+
+use my_app::schema::posts;
+
+#[derive(Insertable)]
+#[diesel(table_name = posts)]
+struct NewPost<'a> {
+    title: &'a str,
+    body: &'a str,
+}
+
+#[tokio::main]
+async fn main() {
+    let ctx = SeedContext::build().await.expect("seed context");
+    println!("Seeding ({})...", ctx.profile());
+
+    let mut db = ctx.conn().await.expect("db connection");
+
+    // Idempotency guard — skip if the table already has data.
+    let count: i64 = posts::table.count().get_result(&mut *db).await.unwrap_or(0);
+    if count > 0 {
+        println!("Already seeded; skipping.");
+        return;
+    }
+
+    diesel::insert_into(posts::table)
+        .values(&[
+            NewPost { title: "Hello, world!", body: "My first post." },
+            NewPost { title: "Getting started", body: "Autumn makes it easy." },
+        ])
+        .execute(&mut *db)
+        .await
+        .expect("insert failed");
+
+    println!("Seeded 2 posts.");
+}
+```
+
+### 3. Run
+
+```sh
+# Run migrations first (autumn seed will error if pending migrations exist)
+autumn migrate
+
+# Seed the database
+autumn seed
+
+# Use a non-default profile
+autumn seed --profile demo
+```
+
+---
+
+## How it works
+
+`autumn seed` does four things:
+
+1. **Checks that `src/bin/seed.rs` exists.** If it does not, you get a clear
+   error:
+   ```
+   ✗ no seed binary found; create `src/bin/seed.rs` or run `autumn generate seed`
+   ```
+
+2. **Checks for pending migrations** (when the `diesel` CLI is available).
+   Seeds run *after* migrations; if any are pending, you see:
+   ```
+   ✗ pending migrations detected; run `autumn migrate` before `autumn seed`
+   ```
+
+3. **Sets the profile** via the `AUTUMN_ENV` environment variable (default:
+   `dev`). Your seed binary reads `ctx.profile()` to branch on environment.
+
+4. **Delegates to `cargo run --bin seed`**. All Cargo flags such as `--package`
+   work:
+   ```sh
+   autumn seed --profile demo --package my-workspace-member
+   ```
+
+---
+
+## Profile-aware seeding
+
+`SeedContext::build()` reads the profile from `AUTUMN_ENV` (or `AUTUMN_PROFILE`
+as a legacy alias), which `autumn seed` sets automatically. Use `ctx.profile()`
+to vary the seed data between environments:
+
+```rust
+let items: Vec<_> = match ctx.profile() {
+    "demo" => demo_items(),
+    _ => dev_items(),
+};
+```
+
+---
+
+## Idempotency pattern
+
+Autumn does not enforce idempotency — that is your responsibility. Two common
+patterns:
+
+### Count-based guard (simplest)
+
+```rust
+let count: i64 = my_table::table.count().get_result(&mut *db).await.unwrap_or(0);
+if count > 0 {
+    println!("Already seeded; skipping.");
+    return;
+}
+```
+
+Re-running inserts nothing if the table already has rows.
+
+### Upsert-by-natural-key
+
+If your table has a unique index on a natural key (e.g. `slug`), use
+`ON CONFLICT DO NOTHING`:
+
+```rust
+diesel::insert_into(posts::table)
+    .values(&seed_data)
+    .on_conflict(posts::slug)
+    .do_nothing()
+    .execute(&mut *db)
+    .await?;
+```
+
+Re-running skips rows whose slug already exists.
+
+---
+
+## `SeedContext` API reference
+
+```rust
+/// Build a seed context from environment + autumn.toml.
+pub async fn build() -> Result<SeedContext, SeedContextError>
+
+/// Active profile (e.g. "dev", "demo", "test").
+pub fn profile(&self) -> &str
+
+/// Acquire a pooled connection.
+pub async fn conn(&self) -> Result<Object<AsyncPgConnection>, SeedContextError>
+```
+
+`Object<AsyncPgConnection>` implements `DerefMut` to `AsyncPgConnection`, so
+pass it to diesel-async query methods as `&mut *conn`.
+
+---
+
+## Example: `examples/todo-app`
+
+The canonical `todo-app` example ships a complete seed at
+`examples/todo-app/src/bin/seed.rs`.  Its idempotency guard uses the
+count-based pattern: if any todos already exist, the seed exits early.
+
+```sh
+cd examples/todo-app
+autumn migrate && autumn seed && autumn dev
+# → localhost:3000 shows five pre-populated todos
+```
+
+---
+
+## Out of scope
+
+- **Test fixtures** — use `autumn_web::test` helpers for integration test data.
+- **YAML/JSON/CSV loaders** — author a thin loader inside your seed binary if
+  you want declarative fixtures.
+- **Faker / factory libraries** — compose with `fake`, `proptest`, `rand`, or
+  whatever you prefer; Autumn owns the runner, not the data generation.
+- **`autumn generate seed`** — tracked in #493 follow-up work.
+
+---
+
+## See also
+
+- [`docs/guide/getting-started.md`](getting-started.md) — includes
+  `autumn seed` in the quickstart flow
+- [`docs/guide/generators.md`](generators.md) — `autumn generate model` / scaffold

--- a/examples/todo-app/Cargo.toml
+++ b/examples/todo-app/Cargo.toml
@@ -4,8 +4,12 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[[bin]]
+name = "seed"
+path = "src/bin/seed.rs"
+
 [dependencies]
-autumn-web = { path = "../../autumn" }
+autumn-web = { path = "../../autumn", features = ["seed"] }
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "2", features = ["postgres", "chrono"] }
 diesel-async = { version = "0.8", features = ["postgres"] }

--- a/examples/todo-app/README.md
+++ b/examples/todo-app/README.md
@@ -8,6 +8,7 @@ A full-stack reference application demonstrating the classic Autumn stack:
 - **JSON API** alongside server-rendered HTML
 - **AutumnError** for consistent error handling (404, 422, 500)
 - **Embedded migrations** so the schema comes up with the app
+- **`autumn seed`** for one-command database bootstrap with representative data
 - **Framework ops endpoints** via `/health` and `/actuator/*`
 
 ## Prerequisites
@@ -26,11 +27,22 @@ cargo run -p autumn-cli -- setup
 # 2. Start Postgres
 docker compose -f examples/todo-app/docker-compose.yml up -d
 
-# 3. Run the application
+# 3. Run database migrations
+cargo run -p autumn-cli -- migrate
+
+# 4. Seed the database with representative todos (optional but recommended)
+cargo run -p autumn-cli -- seed --package todo-app
+
+# 5. Run the application
 cargo run -p todo-app
 ```
 
-The server starts at <http://localhost:3000>.
+The server starts at <http://localhost:3000>.  If you ran `autumn seed`, the
+todo list is pre-populated with five representative items so the app looks
+like a working product on first visit.
+
+**Re-seeding is safe**: the seed binary uses a count-based idempotency guard
+and skips silently if any todos already exist.
 
 ## Available routes
 

--- a/examples/todo-app/src/bin/seed.rs
+++ b/examples/todo-app/src/bin/seed.rs
@@ -1,0 +1,94 @@
+//! Seed binary for todo-app.
+//!
+//! Populates the database with representative todo items so the app looks
+//! like a working product on first run. Safe to run multiple times — if any
+//! todos already exist, the seed is a no-op.
+//!
+//! Run with:
+//!   autumn migrate && autumn seed
+//!
+//! Or directly:
+//!   cargo run --bin seed
+
+use autumn_web::seed::SeedContext;
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+
+diesel::table! {
+    todos (id) {
+        id -> Int8,
+        title -> Text,
+        completed -> Bool,
+        created_at -> Timestamp,
+    }
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = todos)]
+struct NewTodo<'a> {
+    title: &'a str,
+    completed: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    let ctx = SeedContext::build()
+        .await
+        .expect("failed to build seed context — is the database running and AUTUMN_DATABASE__URL set?");
+
+    println!("Seeding todo-app (profile: {})...", ctx.profile());
+
+    let mut db = ctx
+        .conn()
+        .await
+        .expect("failed to acquire database connection");
+
+    // Idempotency guard: skip if the table is already populated.
+    let existing_count: i64 = todos::table
+        .count()
+        .get_result(&mut *db)
+        .await
+        .unwrap_or(0);
+
+    if existing_count > 0 {
+        println!(
+            "Database already has {existing_count} todo(s); skipping seed. \
+             Delete all rows to re-seed."
+        );
+        return;
+    }
+
+    let seed_todos = vec![
+        NewTodo {
+            title: "Buy groceries",
+            completed: false,
+        },
+        NewTodo {
+            title: "Write unit tests",
+            completed: true,
+        },
+        NewTodo {
+            title: "Read the Autumn docs",
+            completed: false,
+        },
+        NewTodo {
+            title: "Ship the feature",
+            completed: false,
+        },
+        NewTodo {
+            title: "Review pull requests",
+            completed: true,
+        },
+    ];
+
+    diesel::insert_into(todos::table)
+        .values(&seed_todos)
+        .execute(&mut *db)
+        .await
+        .expect("failed to insert seed todos");
+
+    println!(
+        "Seeded {} todo(s) successfully.",
+        seed_todos.len()
+    );
+}

--- a/examples/todo-app/src/bin/seed.rs
+++ b/examples/todo-app/src/bin/seed.rs
@@ -32,8 +32,9 @@ struct NewTodo<'a> {
 
 #[tokio::main]
 async fn main() {
-    let ctx = SeedContext::build()
-        .expect("failed to build seed context — is the database running and AUTUMN_DATABASE__URL set?");
+    let ctx = SeedContext::build().expect(
+        "failed to build seed context — is the database running and AUTUMN_DATABASE__URL set?",
+    );
 
     println!("Seeding todo-app (profile: {})...", ctx.profile());
 
@@ -43,11 +44,7 @@ async fn main() {
         .expect("failed to acquire database connection");
 
     // Idempotency guard: skip if the table is already populated.
-    let existing_count: i64 = todos::table
-        .count()
-        .get_result(&mut *db)
-        .await
-        .unwrap_or(0);
+    let existing_count: i64 = todos::table.count().get_result(&mut *db).await.unwrap_or(0);
 
     if existing_count > 0 {
         println!(
@@ -86,8 +83,5 @@ async fn main() {
         .await
         .expect("failed to insert seed todos");
 
-    println!(
-        "Seeded {} todo(s) successfully.",
-        seed_todos.len()
-    );
+    println!("Seeded {} todo(s) successfully.", seed_todos.len());
 }

--- a/examples/todo-app/src/bin/seed.rs
+++ b/examples/todo-app/src/bin/seed.rs
@@ -33,7 +33,6 @@ struct NewTodo<'a> {
 #[tokio::main]
 async fn main() {
     let ctx = SeedContext::build()
-        .await
         .expect("failed to build seed context — is the database running and AUTUMN_DATABASE__URL set?");
 
     println!("Seeding todo-app (profile: {})...", ctx.profile());


### PR DESCRIPTION
## Summary

Introduces first-class database seeding support to Autumn, enabling projects to populate freshly-migrated databases with representative data in a single command. Adds a new `autumn seed` CLI command, a `SeedContext` API for seed binaries, and scaffolding support in `autumn new`.

## Key Changes

- **New `autumn_web::seed` module** (gated by `seed` feature):
  - `SeedContext` struct that builds from environment + `autumn.toml`, providing database connection pool and active profile
  - Resolves database URL and profile with the same precedence as the main application
  - Comprehensive error types with actionable messages

- **New `autumn seed` CLI command**:
  - Validates `src/bin/seed.rs` exists before running
  - Checks for pending migrations via `diesel migration list` (gracefully skips if diesel CLI unavailable)
  - Sets `AUTUMN_ENV` and `AUTUMN_PROFILE` environment variables for the seed binary
  - Delegates to `cargo run --bin seed` with support for `--profile` and `--package` flags

- **Project scaffolding enhancements**:
  - `autumn new --with-seed` flag to scaffold `src/bin/seed.rs` and add `[[bin]]` entry to `Cargo.toml`
  - Template files for seed binary stub and Cargo.toml configuration
  - Updated `todo-app` example with complete seed implementation

- **Documentation**:
  - New `docs/guide/seeding.md` with quick start, API reference, and idempotency patterns
  - Updated getting-started guide to include `autumn seed` in workflow
  - Example seed binary in `examples/todo-app/src/bin/seed.rs`

## Implementation Details

- Profile resolution order: `AUTUMN_ENV` → `AUTUMN_PROFILE` → `"dev"` (default)
- Database URL resolution: `AUTUMN_DATABASE__URL` → `DATABASE_URL` → `autumn.toml` `database.url`
- Seed binaries use `diesel-async` with pooled connections, matching the main application's database layer
- Idempotency is the seed author's responsibility; documentation covers count-based guards and upsert patterns
- Comprehensive test coverage for environment variable resolution, error messages, and CLI parsing

https://claude.ai/code/session_0138aYixm3FzanotxAkj4cj8