### PR TITLE
Add `autumn routes` CLI command for route introspection

### DIFF
--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -7,6 +7,7 @@ mod generate;
 mod migrate;
 mod monitor;
 mod new;
+mod routes;
 mod seed;
 mod setup;
 /// The Autumn web framework CLI.
@@ -116,6 +117,32 @@ enum Commands {
     ///   autumn generate scaffold Post title:String body:Text published:bool
     #[command(subcommand, verbatim_doc_comment)]
     Generate(GenerateCommands),
+
+    /// Print every mounted route — method, path, handler, source, middleware.
+    ///
+    /// Compiles the application (debug profile) and introspects its route
+    /// table without starting the HTTP server or connecting to a database.
+    ///
+    /// Rows are stable-sorted by path, then method, so the output is
+    /// diff-friendly. Redirect to a file and `git diff` two snapshots to
+    /// audit route changes between commits.
+    Routes {
+        /// Package to inspect (for workspaces).
+        #[arg(short, long)]
+        package: Option<String>,
+        /// Output format.
+        #[arg(long, default_value = "table", value_name = "FORMAT")]
+        format: String,
+        /// Show only routes whose path starts with FILTER.
+        #[arg(long, value_name = "FILTER")]
+        filter: Option<String>,
+        /// Restrict to one or more HTTP methods (comma-separated, e.g. `GET,POST`).
+        #[arg(long, value_delimiter = ',', value_name = "METHOD")]
+        method: Vec<String>,
+        /// Hide framework-internal routes (`/actuator/*`, probes, htmx assets).
+        #[arg(long)]
+        user_only: bool,
+    },
 }
 
 /// Subcommands for `autumn migrate`.
@@ -199,6 +226,25 @@ fn main() {
         Commands::New { name, with_seed } => new::run(&name, with_seed),
         Commands::Seed { profile, package } => seed::run(&profile, package.as_deref()),
         Commands::Setup { force } => setup::run(force),
+        Commands::Routes {
+            package,
+            format,
+            filter,
+            method,
+            user_only,
+        } => {
+            let fmt = format.parse().unwrap_or_else(|e| {
+                eprintln!("autumn routes: {e}");
+                std::process::exit(1);
+            });
+            routes::run(&routes::RoutesOptions {
+                package: package.as_deref(),
+                format: fmt,
+                filter: filter.as_deref(),
+                methods: &method,
+                user_only,
+            });
+        }
         Commands::Generate(cmd) => match cmd {
             GenerateCommands::Model {
                 name,
@@ -589,6 +635,141 @@ mod tests {
         match cli.command {
             Commands::Seed { profile, .. } => assert_eq!(profile, "prod"),
             _ => panic!("expected Seed command"),
+        }
+    }
+
+    // ── autumn routes tests ────────────────────────────────────────────────
+
+    #[test]
+    fn parse_routes_defaults() {
+        let cli = Cli::try_parse_from(["autumn", "routes"]).unwrap();
+        match cli.command {
+            Commands::Routes {
+                package,
+                format,
+                filter,
+                method,
+                user_only,
+            } => {
+                assert!(package.is_none());
+                assert_eq!(format, "table");
+                assert!(filter.is_none());
+                assert!(method.is_empty());
+                assert!(!user_only);
+            }
+            _ => panic!("expected Routes command"),
+        }
+    }
+
+    #[test]
+    fn parse_routes_with_package() {
+        let cli = Cli::try_parse_from(["autumn", "routes", "-p", "blog"]).unwrap();
+        match cli.command {
+            Commands::Routes { package, .. } => {
+                assert_eq!(package.as_deref(), Some("blog"));
+            }
+            _ => panic!("expected Routes command"),
+        }
+    }
+
+    #[test]
+    fn parse_routes_with_long_package() {
+        let cli = Cli::try_parse_from(["autumn", "routes", "--package", "my-app"]).unwrap();
+        match cli.command {
+            Commands::Routes { package, .. } => {
+                assert_eq!(package.as_deref(), Some("my-app"));
+            }
+            _ => panic!("expected Routes command"),
+        }
+    }
+
+    #[test]
+    fn parse_routes_format_json() {
+        let cli = Cli::try_parse_from(["autumn", "routes", "--format", "json"]).unwrap();
+        match cli.command {
+            Commands::Routes { format, .. } => {
+                assert_eq!(format, "json");
+            }
+            _ => panic!("expected Routes command"),
+        }
+    }
+
+    #[test]
+    fn parse_routes_with_filter() {
+        let cli = Cli::try_parse_from(["autumn", "routes", "--filter", "/api"]).unwrap();
+        match cli.command {
+            Commands::Routes { filter, .. } => {
+                assert_eq!(filter.as_deref(), Some("/api"));
+            }
+            _ => panic!("expected Routes command"),
+        }
+    }
+
+    #[test]
+    fn parse_routes_with_method() {
+        let cli = Cli::try_parse_from(["autumn", "routes", "--method", "GET"]).unwrap();
+        match cli.command {
+            Commands::Routes { method, .. } => {
+                assert_eq!(method, vec!["GET"]);
+            }
+            _ => panic!("expected Routes command"),
+        }
+    }
+
+    #[test]
+    fn parse_routes_with_multiple_methods() {
+        let cli =
+            Cli::try_parse_from(["autumn", "routes", "--method", "GET,POST"]).unwrap();
+        match cli.command {
+            Commands::Routes { method, .. } => {
+                assert_eq!(method, vec!["GET", "POST"]);
+            }
+            _ => panic!("expected Routes command"),
+        }
+    }
+
+    #[test]
+    fn parse_routes_with_user_only() {
+        let cli = Cli::try_parse_from(["autumn", "routes", "--user-only"]).unwrap();
+        match cli.command {
+            Commands::Routes { user_only, .. } => {
+                assert!(user_only);
+            }
+            _ => panic!("expected Routes command"),
+        }
+    }
+
+    #[test]
+    fn parse_routes_all_options() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "routes",
+            "-p",
+            "blog",
+            "--format",
+            "json",
+            "--filter",
+            "/api",
+            "--method",
+            "GET,POST",
+            "--user-only",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Routes {
+                package,
+                format,
+                filter,
+                method,
+                user_only,
+            } => {
+                assert_eq!(package.as_deref(), Some("blog"));
+                assert_eq!(format, "json");
+                assert_eq!(filter.as_deref(), Some("/api"));
+                assert_eq!(method, vec!["GET", "POST"]);
+                assert!(user_only);
+            }
+            _ => panic!("expected Routes command"),
         }
     }
 

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -726,8 +726,7 @@ mod tests {
 
     #[test]
     fn parse_routes_with_multiple_methods() {
-        let cli =
-            Cli::try_parse_from(["autumn", "routes", "--method", "GET,POST"]).unwrap();
+        let cli = Cli::try_parse_from(["autumn", "routes", "--method", "GET,POST"]).unwrap();
         match cli.command {
             Commands::Routes { method, .. } => {
                 assert_eq!(method, vec!["GET", "POST"]);
@@ -797,10 +796,11 @@ mod tests {
 
     #[test]
     fn parse_routes_positional_prefix_with_package() {
-        let cli =
-            Cli::try_parse_from(["autumn", "routes", "-p", "blog", "/api"]).unwrap();
+        let cli = Cli::try_parse_from(["autumn", "routes", "-p", "blog", "/api"]).unwrap();
         match cli.command {
-            Commands::Routes { package, prefix, .. } => {
+            Commands::Routes {
+                package, prefix, ..
+            } => {
                 assert_eq!(package.as_deref(), Some("blog"));
                 assert_eq!(prefix.as_deref(), Some("/api"));
             }

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -130,6 +130,9 @@ enum Commands {
         /// Package to inspect (for workspaces).
         #[arg(short, long)]
         package: Option<String>,
+        /// Binary target to inspect (for packages with multiple bin targets).
+        #[arg(long, value_name = "BIN")]
+        bin: Option<String>,
         /// Output format.
         #[arg(long, default_value = "table", value_name = "FORMAT")]
         format: String,
@@ -231,6 +234,7 @@ fn main() {
         Commands::Setup { force } => setup::run(force),
         Commands::Routes {
             package,
+            bin,
             format,
             prefix,
             filter,
@@ -245,6 +249,7 @@ fn main() {
             let effective_filter = prefix.as_deref().or(filter.as_deref());
             routes::run(&routes::RoutesOptions {
                 package: package.as_deref(),
+                bin: bin.as_deref(),
                 format: fmt,
                 filter: effective_filter,
                 methods: &method,
@@ -652,6 +657,7 @@ mod tests {
         match cli.command {
             Commands::Routes {
                 package,
+                bin,
                 format,
                 prefix,
                 filter,
@@ -659,6 +665,7 @@ mod tests {
                 user_only,
             } => {
                 assert!(package.is_none());
+                assert!(bin.is_none());
                 assert_eq!(format, "table");
                 assert!(prefix.is_none());
                 assert!(filter.is_none());
@@ -747,6 +754,17 @@ mod tests {
     }
 
     #[test]
+    fn parse_routes_with_bin() {
+        let cli = Cli::try_parse_from(["autumn", "routes", "--bin", "server"]).unwrap();
+        match cli.command {
+            Commands::Routes { bin, .. } => {
+                assert_eq!(bin.as_deref(), Some("server"));
+            }
+            _ => panic!("expected Routes command"),
+        }
+    }
+
+    #[test]
     fn parse_routes_all_options() {
         let cli = Cli::try_parse_from([
             "autumn",
@@ -765,6 +783,7 @@ mod tests {
         match cli.command {
             Commands::Routes {
                 package,
+                bin,
                 format,
                 prefix,
                 filter,
@@ -772,6 +791,7 @@ mod tests {
                 user_only,
             } => {
                 assert_eq!(package.as_deref(), Some("blog"));
+                assert!(bin.is_none());
                 assert_eq!(format, "json");
                 assert!(prefix.is_none());
                 assert_eq!(filter.as_deref(), Some("/api"));

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -133,6 +133,9 @@ enum Commands {
         /// Output format.
         #[arg(long, default_value = "table", value_name = "FORMAT")]
         format: String,
+        /// Show only routes whose path starts with PREFIX (positional shorthand for --filter).
+        #[arg(value_name = "PREFIX")]
+        prefix: Option<String>,
         /// Show only routes whose path starts with FILTER.
         #[arg(long, value_name = "FILTER")]
         filter: Option<String>,
@@ -229,6 +232,7 @@ fn main() {
         Commands::Routes {
             package,
             format,
+            prefix,
             filter,
             method,
             user_only,
@@ -237,10 +241,12 @@ fn main() {
                 eprintln!("autumn routes: {e}");
                 std::process::exit(1);
             });
+            // Positional prefix takes precedence over --filter when both are given.
+            let effective_filter = prefix.as_deref().or(filter.as_deref());
             routes::run(&routes::RoutesOptions {
                 package: package.as_deref(),
                 format: fmt,
-                filter: filter.as_deref(),
+                filter: effective_filter,
                 methods: &method,
                 user_only,
             });
@@ -647,12 +653,14 @@ mod tests {
             Commands::Routes {
                 package,
                 format,
+                prefix,
                 filter,
                 method,
                 user_only,
             } => {
                 assert!(package.is_none());
                 assert_eq!(format, "table");
+                assert!(prefix.is_none());
                 assert!(filter.is_none());
                 assert!(method.is_empty());
                 assert!(!user_only);
@@ -759,15 +767,42 @@ mod tests {
             Commands::Routes {
                 package,
                 format,
+                prefix,
                 filter,
                 method,
                 user_only,
             } => {
                 assert_eq!(package.as_deref(), Some("blog"));
                 assert_eq!(format, "json");
+                assert!(prefix.is_none());
                 assert_eq!(filter.as_deref(), Some("/api"));
                 assert_eq!(method, vec!["GET", "POST"]);
                 assert!(user_only);
+            }
+            _ => panic!("expected Routes command"),
+        }
+    }
+
+    #[test]
+    fn parse_routes_positional_prefix() {
+        let cli = Cli::try_parse_from(["autumn", "routes", "/api"]).unwrap();
+        match cli.command {
+            Commands::Routes { prefix, filter, .. } => {
+                assert_eq!(prefix.as_deref(), Some("/api"));
+                assert!(filter.is_none());
+            }
+            _ => panic!("expected Routes command"),
+        }
+    }
+
+    #[test]
+    fn parse_routes_positional_prefix_with_package() {
+        let cli =
+            Cli::try_parse_from(["autumn", "routes", "-p", "blog", "/api"]).unwrap();
+        match cli.command {
+            Commands::Routes { package, prefix, .. } => {
+                assert_eq!(package.as_deref(), Some("blog"));
+                assert_eq!(prefix.as_deref(), Some("/api"));
             }
             _ => panic!("expected Routes command"),
         }

--- a/autumn-cli/src/routes.rs
+++ b/autumn-cli/src/routes.rs
@@ -24,7 +24,9 @@ impl std::str::FromStr for OutputFormat {
         match s.to_lowercase().as_str() {
             "table" => Ok(Self::Table),
             "json" => Ok(Self::Json),
-            other => Err(format!("unknown format '{other}'; expected 'table' or 'json'")),
+            other => Err(format!(
+                "unknown format '{other}'; expected 'table' or 'json'"
+            )),
         }
     }
 }
@@ -102,11 +104,7 @@ pub fn apply_filters(
             if filter.is_some_and(|prefix| !r.path.starts_with(prefix)) {
                 return false;
             }
-            if !methods.is_empty()
-                && !methods
-                    .iter()
-                    .any(|m| m.eq_ignore_ascii_case(&r.method))
-            {
+            if !methods.is_empty() && !methods.iter().any(|m| m.eq_ignore_ascii_case(&r.method)) {
                 return false;
             }
             if user_only && r.source == "framework" {
@@ -225,8 +223,8 @@ fn format_row(cells: &[String; 5], widths: &[usize; 5]) -> String {
 
 /// Print routes as pretty JSON.
 pub fn print_json(routes: &[RouteInfo]) {
-    let json = serde_json::to_string_pretty(routes)
-        .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"));
+    let json =
+        serde_json::to_string_pretty(routes).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"));
     println!("{json}");
 }
 
@@ -432,7 +430,11 @@ mod tests {
         let routes = sample_routes();
         let methods = vec!["GET".to_owned(), "POST".to_owned()];
         let result = apply_filters(routes, None, &methods, false);
-        assert!(result.iter().all(|r| r.method == "GET" || r.method == "POST"));
+        assert!(
+            result
+                .iter()
+                .all(|r| r.method == "GET" || r.method == "POST")
+        );
     }
 
     #[test]
@@ -466,7 +468,11 @@ mod tests {
         let routes = sample_routes();
         let methods = vec!["GET".to_owned()];
         let result = apply_filters(routes, Some("/posts"), &methods, false);
-        assert!(result.iter().all(|r| r.path.starts_with("/posts") && r.method == "GET"));
+        assert!(
+            result
+                .iter()
+                .all(|r| r.path.starts_with("/posts") && r.method == "GET")
+        );
         assert_eq!(result.len(), 2);
     }
 
@@ -563,8 +569,7 @@ mod tests {
                 }]
             }]
         });
-        let result =
-            resolve_binary_from_metadata(&metadata, Some("hello"), Path::new("/projects"));
+        let result = resolve_binary_from_metadata(&metadata, Some("hello"), Path::new("/projects"));
         let expected = if cfg!(windows) {
             PathBuf::from("/tmp/target/debug/hello.exe")
         } else {
@@ -587,8 +592,7 @@ mod tests {
                 }]
             }]
         });
-        let result =
-            resolve_binary_from_metadata(&metadata, None, Path::new("/projects/hello"));
+        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/projects/hello"));
         let expected = if cfg!(windows) {
             PathBuf::from("/tmp/target/debug/hello.exe")
         } else {

--- a/autumn-cli/src/routes.rs
+++ b/autumn-cli/src/routes.rs
@@ -455,11 +455,10 @@ mod tests {
     fn filter_user_only_keeps_plugin_routes() {
         let routes = sample_routes();
         let result = apply_filters(routes, None, &[], true);
-        let plugin_routes: Vec<_> = result
-            .iter()
-            .filter(|r| r.source.starts_with("plugin:"))
-            .collect();
-        assert!(!plugin_routes.is_empty(), "plugin routes should be kept with --user-only");
+        assert!(
+            result.iter().any(|r| r.source.starts_with("plugin:")),
+            "plugin routes should be kept with --user-only"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/routes.rs
+++ b/autumn-cli/src/routes.rs
@@ -1,0 +1,615 @@
+//! `autumn routes` -- list mounted routes without booting the dev server.
+//!
+//! Compiles the target binary (debug profile), runs it with
+//! `AUTUMN_DUMP_ROUTES=1`, and parses the JSON route listing from its
+//! stdout. Applies any user-requested filters, then displays the result
+//! as either a human-readable table or machine-readable JSON.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+/// Output format for `autumn routes`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OutputFormat {
+    Table,
+    Json,
+}
+
+impl std::str::FromStr for OutputFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "table" => Ok(Self::Table),
+            "json" => Ok(Self::Json),
+            other => Err(format!("unknown format '{other}'; expected 'table' or 'json'")),
+        }
+    }
+}
+
+/// Deserialized route entry received from the binary's JSON output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RouteInfo {
+    pub method: String,
+    pub path: String,
+    pub handler: String,
+    pub source: String,
+    pub middleware: Vec<String>,
+}
+
+/// Options controlling `autumn routes` behaviour.
+pub struct RoutesOptions<'a> {
+    pub package: Option<&'a str>,
+    pub format: OutputFormat,
+    pub filter: Option<&'a str>,
+    pub methods: &'a [String],
+    pub user_only: bool,
+}
+
+/// Run `autumn routes`.
+pub fn run(opts: &RoutesOptions<'_>) {
+    eprintln!("\u{1F342} autumn routes\n");
+    compile_binary(opts.package);
+    let binary = find_binary(opts.package);
+
+    let output = Command::new(&binary)
+        .env("AUTUMN_DUMP_ROUTES", "1")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .unwrap_or_else(|e| {
+            eprintln!("\u{2717} Failed to run {}: {e}", binary.display());
+            std::process::exit(1);
+        });
+
+    if !output.status.success() {
+        eprintln!(
+            "\u{2717} Binary exited with status {} while dumping routes",
+            output.status
+        );
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut routes: Vec<RouteInfo> = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        eprintln!("\u{2717} Failed to parse route listing JSON: {e}");
+        eprintln!("Raw output: {stdout}");
+        std::process::exit(1);
+    });
+
+    // Apply filters and sort
+    routes = apply_filters(routes, opts.filter, opts.methods, opts.user_only);
+    sort_routes(&mut routes);
+
+    match &opts.format {
+        OutputFormat::Table => print_table(&routes),
+        OutputFormat::Json => print_json(&routes),
+    }
+}
+
+/// Filter routes by path prefix, HTTP methods, and/or source.
+pub fn apply_filters(
+    routes: Vec<RouteInfo>,
+    filter: Option<&str>,
+    methods: &[String],
+    user_only: bool,
+) -> Vec<RouteInfo> {
+    routes
+        .into_iter()
+        .filter(|r| {
+            if filter.is_some_and(|prefix| !r.path.starts_with(prefix)) {
+                return false;
+            }
+            if !methods.is_empty()
+                && !methods
+                    .iter()
+                    .any(|m| m.eq_ignore_ascii_case(&r.method))
+            {
+                return false;
+            }
+            if user_only && r.source == "framework" {
+                return false;
+            }
+            true
+        })
+        .collect()
+}
+
+/// Sort routes by path (lexicographic) then method (lexicographic).
+pub fn sort_routes(routes: &mut [RouteInfo]) {
+    routes.sort_by(|a, b| a.path.cmp(&b.path).then_with(|| a.method.cmp(&b.method)));
+}
+
+/// Print routes as a human-readable aligned table.
+pub fn print_table(routes: &[RouteInfo]) {
+    if routes.is_empty() {
+        println!("No routes found.");
+        return;
+    }
+
+    let table = format_table(routes);
+    print!("{table}");
+}
+
+/// Build the table string (extracted for testability).
+pub fn format_table(routes: &[RouteInfo]) -> String {
+    const HEADERS: [&str; 5] = ["Method", "Path", "Handler", "Source", "Middleware"];
+
+    // Compute column widths
+    let widths = compute_column_widths(routes, &HEADERS);
+
+    let mut out = String::new();
+
+    // Header row
+    out.push_str(&format_row(
+        &HEADERS.map(std::borrow::ToOwned::to_owned),
+        &widths,
+    ));
+    out.push('\n');
+
+    // Separator row
+    for (i, &w) in widths.iter().enumerate() {
+        if i > 0 {
+            out.push_str("  ");
+        }
+        out.push_str(&"-".repeat(w));
+    }
+    out.push('\n');
+
+    // Data rows
+    for route in routes {
+        let middleware = if route.middleware.is_empty() {
+            String::new()
+        } else {
+            route.middleware.join(", ")
+        };
+        let cells = [
+            route.method.clone(),
+            route.path.clone(),
+            route.handler.clone(),
+            route.source.clone(),
+            middleware,
+        ];
+        out.push_str(&format_row(&cells, &widths));
+        out.push('\n');
+    }
+
+    out
+}
+
+fn compute_column_widths(routes: &[RouteInfo], headers: &[&str; 5]) -> [usize; 5] {
+    let mut widths = [0usize; 5];
+    for (i, h) in headers.iter().enumerate() {
+        widths[i] = h.len();
+    }
+    for route in routes {
+        let middleware = if route.middleware.is_empty() {
+            String::new()
+        } else {
+            route.middleware.join(", ")
+        };
+        let cols = [
+            route.method.len(),
+            route.path.len(),
+            route.handler.len(),
+            route.source.len(),
+            middleware.len(),
+        ];
+        for (i, &w) in cols.iter().enumerate() {
+            if w > widths[i] {
+                widths[i] = w;
+            }
+        }
+    }
+    widths
+}
+
+fn format_row(cells: &[String; 5], widths: &[usize; 5]) -> String {
+    cells
+        .iter()
+        .zip(widths.iter())
+        .enumerate()
+        .map(|(i, (cell, &w))| {
+            if i == 0 {
+                format!("{cell:<w$}")
+            } else {
+                format!("  {cell:<w$}")
+            }
+        })
+        .collect::<String>()
+        .trim_end()
+        .to_owned()
+}
+
+/// Print routes as pretty JSON.
+pub fn print_json(routes: &[RouteInfo]) {
+    let json = serde_json::to_string_pretty(routes)
+        .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"));
+    println!("{json}");
+}
+
+// ── Binary discovery (mirrored from build.rs) ──────────────────────────────
+
+fn find_binary(package: Option<&str>) -> PathBuf {
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version=1", "--no-deps"])
+        .output()
+        .expect("failed to run cargo metadata");
+
+    if !output.status.success() {
+        eprintln!("\u{2717} Failed to read cargo metadata");
+        std::process::exit(1);
+    }
+
+    let metadata: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse cargo metadata");
+    let cwd = std::env::current_dir().expect("current dir");
+
+    resolve_binary_from_metadata(&metadata, package, &cwd).unwrap_or_else(|error| {
+        eprintln!("\u{2717} {error}");
+        std::process::exit(1);
+    })
+}
+
+fn resolve_binary_from_metadata(
+    metadata: &serde_json::Value,
+    package: Option<&str>,
+    cwd: &Path,
+) -> Result<PathBuf, String> {
+    let target_dir = metadata["target_directory"]
+        .as_str()
+        .ok_or("target_directory missing from cargo metadata")?;
+    let packages = metadata["packages"]
+        .as_array()
+        .ok_or("packages missing from cargo metadata")?;
+
+    let matching_packages: Vec<_> = package.map_or_else(
+        || {
+            packages
+                .iter()
+                .filter(|pkg| {
+                    pkg["manifest_path"]
+                        .as_str()
+                        .and_then(|manifest| Path::new(manifest).parent())
+                        .is_some_and(|dir| dir.starts_with(cwd))
+                })
+                .collect()
+        },
+        |pkg_name| {
+            packages
+                .iter()
+                .filter(|pkg| pkg["name"].as_str() == Some(pkg_name))
+                .collect()
+        },
+    );
+
+    let bin_name = matching_packages
+        .iter()
+        .find_map(|pkg| {
+            pkg["targets"].as_array()?.iter().find_map(|t| {
+                let is_bin = t["kind"].as_array()?.iter().any(|k| k == "bin");
+                if is_bin {
+                    t["name"].as_str().map(String::from)
+                } else {
+                    None
+                }
+            })
+        })
+        .ok_or_else(|| {
+            package.map_or_else(
+                || "no binary target found in current package".to_owned(),
+                |pkg_name| format!("no binary target found in package '{pkg_name}'"),
+            )
+        })?;
+
+    let mut path = PathBuf::from(target_dir);
+    path.push("debug");
+    path.push(bin_name);
+
+    if cfg!(windows) {
+        path.set_extension("exe");
+    }
+
+    Ok(path)
+}
+
+// ── Also compile the binary before running ─────────────────────────────────
+
+fn compile_binary(package: Option<&str>) {
+    let mut cargo = Command::new("cargo");
+    cargo.arg("build");
+    if let Some(pkg) = package {
+        cargo.args(["-p", pkg]);
+    }
+
+    let status = cargo.status().expect("failed to run cargo build");
+    if !status.success() {
+        eprintln!("\u{2717} Compilation failed");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_route(method: &str, path: &str, source: &str) -> RouteInfo {
+        RouteInfo {
+            method: method.to_owned(),
+            path: path.to_owned(),
+            handler: format!("{}_handler", path.trim_start_matches('/').replace('/', "_")),
+            source: source.to_owned(),
+            middleware: vec![],
+        }
+    }
+
+    fn sample_routes() -> Vec<RouteInfo> {
+        vec![
+            make_route("GET", "/posts", "user"),
+            make_route("POST", "/posts", "user"),
+            make_route("GET", "/posts/{id}", "user"),
+            make_route("GET", "/actuator/health", "framework"),
+            make_route("GET", "/about", "user"),
+            make_route("GET", "/api/posts", "plugin:harvest"),
+        ]
+    }
+
+    // ── OutputFormat parsing ───────────────────────────────────────────────
+
+    #[test]
+    fn parse_format_table() {
+        let f: OutputFormat = "table".parse().unwrap();
+        assert_eq!(f, OutputFormat::Table);
+    }
+
+    #[test]
+    fn parse_format_json() {
+        let f: OutputFormat = "json".parse().unwrap();
+        assert_eq!(f, OutputFormat::Json);
+    }
+
+    #[test]
+    fn parse_format_case_insensitive() {
+        let f: OutputFormat = "JSON".parse().unwrap();
+        assert_eq!(f, OutputFormat::Json);
+        let f: OutputFormat = "Table".parse().unwrap();
+        assert_eq!(f, OutputFormat::Table);
+    }
+
+    #[test]
+    fn parse_format_unknown_is_error() {
+        let result: Result<OutputFormat, _> = "xml".parse();
+        assert!(result.is_err());
+    }
+
+    // ── apply_filters ──────────────────────────────────────────────────────
+
+    #[test]
+    fn filter_no_constraints_returns_all() {
+        let routes = sample_routes();
+        let count = routes.len();
+        let result = apply_filters(routes, None, &[], false);
+        assert_eq!(result.len(), count);
+    }
+
+    #[test]
+    fn filter_by_path_prefix() {
+        let routes = sample_routes();
+        let result = apply_filters(routes, Some("/posts"), &[], false);
+        assert!(result.iter().all(|r| r.path.starts_with("/posts")));
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn filter_path_prefix_exact_match() {
+        let routes = sample_routes();
+        let result = apply_filters(routes, Some("/about"), &[], false);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].path, "/about");
+    }
+
+    #[test]
+    fn filter_by_method_get() {
+        let routes = sample_routes();
+        let methods = vec!["GET".to_owned()];
+        let result = apply_filters(routes, None, &methods, false);
+        assert!(result.iter().all(|r| r.method == "GET"));
+    }
+
+    #[test]
+    fn filter_by_method_post() {
+        let routes = sample_routes();
+        let methods = vec!["POST".to_owned()];
+        let result = apply_filters(routes, None, &methods, false);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].method, "POST");
+    }
+
+    #[test]
+    fn filter_by_multiple_methods() {
+        let routes = sample_routes();
+        let methods = vec!["GET".to_owned(), "POST".to_owned()];
+        let result = apply_filters(routes, None, &methods, false);
+        assert!(result.iter().all(|r| r.method == "GET" || r.method == "POST"));
+    }
+
+    #[test]
+    fn filter_method_case_insensitive() {
+        let routes = sample_routes();
+        let methods = vec!["get".to_owned()];
+        let result = apply_filters(routes, None, &methods, false);
+        assert!(!result.is_empty());
+        assert!(result.iter().all(|r| r.method == "GET"));
+    }
+
+    #[test]
+    fn filter_user_only_excludes_framework() {
+        let routes = sample_routes();
+        let result = apply_filters(routes, None, &[], true);
+        assert!(result.iter().all(|r| r.source != "framework"));
+    }
+
+    #[test]
+    fn filter_user_only_keeps_plugin_routes() {
+        let routes = sample_routes();
+        let result = apply_filters(routes, None, &[], true);
+        let plugin_routes: Vec<_> = result
+            .iter()
+            .filter(|r| r.source.starts_with("plugin:"))
+            .collect();
+        assert!(!plugin_routes.is_empty(), "plugin routes should be kept with --user-only");
+    }
+
+    #[test]
+    fn filter_combines_path_and_method() {
+        let routes = sample_routes();
+        let methods = vec!["GET".to_owned()];
+        let result = apply_filters(routes, Some("/posts"), &methods, false);
+        assert!(result.iter().all(|r| r.path.starts_with("/posts") && r.method == "GET"));
+        assert_eq!(result.len(), 2);
+    }
+
+    // ── sort_routes ────────────────────────────────────────────────────────
+
+    #[test]
+    fn sort_routes_by_path_then_method() {
+        let mut routes = vec![
+            make_route("POST", "/posts", "user"),
+            make_route("GET", "/about", "user"),
+            make_route("GET", "/posts", "user"),
+        ];
+        sort_routes(&mut routes);
+        assert_eq!(routes[0].path, "/about");
+        assert_eq!(routes[1].path, "/posts");
+        assert_eq!(routes[1].method, "GET");
+        assert_eq!(routes[2].path, "/posts");
+        assert_eq!(routes[2].method, "POST");
+    }
+
+    // ── format_table ──────────────────────────────────────────────────────
+
+    #[test]
+    fn format_table_contains_headers() {
+        let routes = vec![make_route("GET", "/posts", "user")];
+        let table = format_table(&routes);
+        assert!(table.contains("Method"), "missing Method header");
+        assert!(table.contains("Path"), "missing Path header");
+        assert!(table.contains("Handler"), "missing Handler header");
+        assert!(table.contains("Source"), "missing Source header");
+        assert!(table.contains("Middleware"), "missing Middleware header");
+    }
+
+    #[test]
+    fn format_table_contains_route_data() {
+        let routes = vec![make_route("GET", "/posts", "user")];
+        let table = format_table(&routes);
+        assert!(table.contains("GET"), "missing method");
+        assert!(table.contains("/posts"), "missing path");
+        assert!(table.contains("user"), "missing source");
+    }
+
+    #[test]
+    fn format_table_has_separator_line() {
+        let routes = vec![make_route("GET", "/", "user")];
+        let table = format_table(&routes);
+        assert!(table.contains("---"), "missing separator line");
+    }
+
+    #[test]
+    fn format_table_empty_routes_still_has_headers() {
+        let routes: Vec<RouteInfo> = vec![];
+        let table = format_table(&routes);
+        assert!(table.contains("Method"));
+    }
+
+    #[test]
+    fn format_table_middleware_shown_when_present() {
+        let route = RouteInfo {
+            method: "GET".to_owned(),
+            path: "/admin".to_owned(),
+            handler: "admin".to_owned(),
+            source: "user".to_owned(),
+            middleware: vec!["secured".to_owned(), "cached(60s)".to_owned()],
+        };
+        let table = format_table(&[route]);
+        assert!(table.contains("secured"), "missing middleware label");
+        assert!(table.contains("cached(60s)"), "missing middleware label");
+    }
+
+    // ── print_json ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn print_json_produces_valid_json() {
+        let routes = sample_routes();
+        let json_str = serde_json::to_string_pretty(&routes).unwrap();
+        let parsed: Vec<RouteInfo> = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed.len(), routes.len());
+    }
+
+    // ── resolve_binary_from_metadata ──────────────────────────────────────
+
+    #[test]
+    fn resolve_binary_by_package_name() {
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [{
+                "name": "hello",
+                "manifest_path": "/projects/hello/Cargo.toml",
+                "targets": [{
+                    "name": "hello",
+                    "kind": ["bin"],
+                    "src_path": "/projects/hello/src/main.rs"
+                }]
+            }]
+        });
+        let result =
+            resolve_binary_from_metadata(&metadata, Some("hello"), Path::new("/projects"));
+        let expected = if cfg!(windows) {
+            PathBuf::from("/tmp/target/debug/hello.exe")
+        } else {
+            PathBuf::from("/tmp/target/debug/hello")
+        };
+        assert_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn resolve_binary_by_cwd() {
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [{
+                "name": "hello",
+                "manifest_path": "/projects/hello/Cargo.toml",
+                "targets": [{
+                    "name": "hello",
+                    "kind": ["bin"],
+                    "src_path": "/projects/hello/src/main.rs"
+                }]
+            }]
+        });
+        let result =
+            resolve_binary_from_metadata(&metadata, None, Path::new("/projects/hello"));
+        let expected = if cfg!(windows) {
+            PathBuf::from("/tmp/target/debug/hello.exe")
+        } else {
+            PathBuf::from("/tmp/target/debug/hello")
+        };
+        assert_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn resolve_binary_reports_missing_package() {
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [{
+                "name": "hello",
+                "manifest_path": "/projects/hello/Cargo.toml",
+                "targets": [{"name": "hello", "kind": ["bin"]}]
+            }]
+        });
+        let result =
+            resolve_binary_from_metadata(&metadata, Some("missing"), Path::new("/projects"));
+        assert!(result.unwrap_err().contains("package 'missing'"));
+    }
+}

--- a/autumn-cli/src/routes.rs
+++ b/autumn-cli/src/routes.rs
@@ -271,7 +271,7 @@ fn resolve_binary_from_metadata(
                     pkg["manifest_path"]
                         .as_str()
                         .and_then(|manifest| Path::new(manifest).parent())
-                        .is_some_and(|dir| dir.starts_with(cwd))
+                        .is_some_and(|dir| cwd.starts_with(dir) || dir.starts_with(cwd))
                 })
                 .collect()
         },
@@ -284,22 +284,42 @@ fn resolve_binary_from_metadata(
     );
 
     // Collect (package-name, binary-name) pairs for every matching package
-    // that has at least one `bin` target.
-    let mut candidates: Vec<(String, String)> = matching_packages
-        .iter()
-        .filter_map(|pkg| {
-            let pkg_name = pkg["name"].as_str()?.to_owned();
-            let bin_name = pkg["targets"].as_array()?.iter().find_map(|t| {
-                let is_bin = t["kind"].as_array()?.iter().any(|k| k == "bin");
-                if is_bin {
-                    t["name"].as_str().map(String::from)
-                } else {
-                    None
-                }
-            })?;
-            Some((pkg_name, bin_name))
-        })
-        .collect();
+    // that has at least one `bin` target. Error if any package exposes more
+    // than one binary — the caller must disambiguate with --bin.
+    let mut candidates: Vec<(String, String)> = Vec::new();
+    for pkg in &matching_packages {
+        let pkg_name = match pkg["name"].as_str() {
+            Some(n) => n.to_owned(),
+            None => continue,
+        };
+        let bins: Vec<String> = pkg["targets"]
+            .as_array()
+            .map(|targets| {
+                targets
+                    .iter()
+                    .filter_map(|t| {
+                        let is_bin = t["kind"].as_array()?.iter().any(|k| k == "bin");
+                        if is_bin {
+                            t["name"].as_str().map(String::from)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        if bins.len() > 1 {
+            return Err(format!(
+                "package '{pkg_name}' has multiple binary targets ({}); \
+                 use --bin to select one",
+                bins.join(", ")
+            ));
+        }
+        if let Some(bin_name) = bins.into_iter().next() {
+            candidates.push((pkg_name, bin_name));
+        }
+    }
 
     // When no explicit --package was given and multiple workspace members each
     // have a binary, we can't pick one safely — ask the user to be explicit.
@@ -717,5 +737,49 @@ mod tests {
         });
         let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws/mylib"));
         assert!(result.unwrap_err().contains("no binary target"));
+    }
+
+    #[test]
+    fn resolve_binary_from_subdirectory_finds_parent_package() {
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [{
+                "name": "hello",
+                "manifest_path": "/projects/hello/Cargo.toml",
+                "targets": [{"name": "hello", "kind": ["bin"]}]
+            }]
+        });
+        // Running from a subdirectory of the package root should still find it.
+        let result =
+            resolve_binary_from_metadata(&metadata, None, Path::new("/projects/hello/src"));
+        assert!(
+            result.unwrap().to_string_lossy().contains("hello"),
+            "should resolve binary from subdirectory"
+        );
+    }
+
+    #[test]
+    fn resolve_binary_errors_on_multi_bin_package() {
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [{
+                "name": "myapp",
+                "manifest_path": "/ws/myapp/Cargo.toml",
+                "targets": [
+                    {"name": "server", "kind": ["bin"]},
+                    {"name": "migrate", "kind": ["bin"]}
+                ]
+            }]
+        });
+        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws/myapp"));
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("multiple binary targets"),
+            "expected multi-bin error, got: {err}"
+        );
+        assert!(
+            err.contains("--bin"),
+            "should hint at --bin flag, got: {err}"
+        );
     }
 }

--- a/autumn-cli/src/routes.rs
+++ b/autumn-cli/src/routes.rs
@@ -59,7 +59,7 @@ pub fn run(opts: &RoutesOptions<'_>) {
     let output = Command::new(&binary)
         .env("AUTUMN_DUMP_ROUTES", "1")
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::inherit())
         .output()
         .unwrap_or_else(|e| {
             eprintln!("\u{2717} Failed to run {}: {e}", binary.display());
@@ -283,24 +283,41 @@ fn resolve_binary_from_metadata(
         },
     );
 
-    let bin_name = matching_packages
+    // Collect (package-name, binary-name) pairs for every matching package
+    // that has at least one `bin` target.
+    let mut candidates: Vec<(String, String)> = matching_packages
         .iter()
-        .find_map(|pkg| {
-            pkg["targets"].as_array()?.iter().find_map(|t| {
+        .filter_map(|pkg| {
+            let pkg_name = pkg["name"].as_str()?.to_owned();
+            let bin_name = pkg["targets"].as_array()?.iter().find_map(|t| {
                 let is_bin = t["kind"].as_array()?.iter().any(|k| k == "bin");
                 if is_bin {
                     t["name"].as_str().map(String::from)
                 } else {
                     None
                 }
-            })
+            })?;
+            Some((pkg_name, bin_name))
         })
-        .ok_or_else(|| {
-            package.map_or_else(
-                || "no binary target found in current package".to_owned(),
-                |pkg_name| format!("no binary target found in package '{pkg_name}'"),
-            )
-        })?;
+        .collect();
+
+    // When no explicit --package was given and multiple workspace members each
+    // have a binary, we can't pick one safely — ask the user to be explicit.
+    if package.is_none() && candidates.len() > 1 {
+        let names: Vec<&str> = candidates.iter().map(|(n, _)| n.as_str()).collect();
+        return Err(format!(
+            "multiple binary packages found in workspace ({}); \
+             use -p / --package to select one",
+            names.join(", ")
+        ));
+    }
+
+    let bin_name = candidates.pop().map(|(_, b)| b).ok_or_else(|| {
+        package.map_or_else(
+            || "no binary target found in current package".to_owned(),
+            |pkg_name| format!("no binary target found in package '{pkg_name}'"),
+        )
+    })?;
 
     let mut path = PathBuf::from(target_dir);
     path.push("debug");
@@ -614,5 +631,91 @@ mod tests {
         let result =
             resolve_binary_from_metadata(&metadata, Some("missing"), Path::new("/projects"));
         assert!(result.unwrap_err().contains("package 'missing'"));
+    }
+
+    #[test]
+    fn resolve_binary_errors_on_multiple_workspace_candidates() {
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [
+                {
+                    "name": "alpha",
+                    "manifest_path": "/ws/alpha/Cargo.toml",
+                    "targets": [{"name": "alpha", "kind": ["bin"]}]
+                },
+                {
+                    "name": "beta",
+                    "manifest_path": "/ws/beta/Cargo.toml",
+                    "targets": [{"name": "beta", "kind": ["bin"]}]
+                }
+            ]
+        });
+        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws"));
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("multiple binary packages"),
+            "expected ambiguity error, got: {err}"
+        );
+        assert!(
+            err.contains("-p") || err.contains("--package"),
+            "should hint at -p flag"
+        );
+    }
+
+    #[test]
+    fn resolve_binary_cwd_with_single_match_succeeds() {
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [
+                {
+                    "name": "alpha",
+                    "manifest_path": "/ws/alpha/Cargo.toml",
+                    "targets": [{"name": "alpha", "kind": ["bin"]}]
+                },
+                {
+                    "name": "beta",
+                    "manifest_path": "/ws/beta/Cargo.toml",
+                    "targets": [{"name": "beta", "kind": ["bin"]}]
+                }
+            ]
+        });
+        // Narrowing cwd to /ws/alpha means only "alpha" matches.
+        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws/alpha")).unwrap();
+        assert!(result.to_string_lossy().contains("alpha"));
+    }
+
+    #[test]
+    fn resolve_binary_lib_only_package_is_skipped() {
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [
+                {
+                    "name": "mylib",
+                    "manifest_path": "/ws/mylib/Cargo.toml",
+                    "targets": [{"name": "mylib", "kind": ["lib"]}]
+                },
+                {
+                    "name": "myapp",
+                    "manifest_path": "/ws/myapp/Cargo.toml",
+                    "targets": [{"name": "myapp", "kind": ["bin"]}]
+                }
+            ]
+        });
+        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws")).unwrap();
+        assert!(result.to_string_lossy().contains("myapp"));
+    }
+
+    #[test]
+    fn resolve_binary_no_binary_target_errors() {
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [{
+                "name": "mylib",
+                "manifest_path": "/ws/mylib/Cargo.toml",
+                "targets": [{"name": "mylib", "kind": ["lib"]}]
+            }]
+        });
+        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws/mylib"));
+        assert!(result.unwrap_err().contains("no binary target"));
     }
 }

--- a/autumn-cli/src/routes.rs
+++ b/autumn-cli/src/routes.rs
@@ -44,6 +44,8 @@ pub struct RouteInfo {
 /// Options controlling `autumn routes` behaviour.
 pub struct RoutesOptions<'a> {
     pub package: Option<&'a str>,
+    /// Binary target name for packages that expose multiple bin targets.
+    pub bin: Option<&'a str>,
     pub format: OutputFormat,
     pub filter: Option<&'a str>,
     pub methods: &'a [String],
@@ -54,7 +56,7 @@ pub struct RoutesOptions<'a> {
 pub fn run(opts: &RoutesOptions<'_>) {
     eprintln!("\u{1F342} autumn routes\n");
     compile_binary(opts.package);
-    let binary = find_binary(opts.package);
+    let binary = find_binary(opts.package, opts.bin);
 
     let output = Command::new(&binary)
         .env("AUTUMN_DUMP_ROUTES", "1")
@@ -230,7 +232,7 @@ pub fn print_json(routes: &[RouteInfo]) {
 
 // ── Binary discovery (mirrored from build.rs) ──────────────────────────────
 
-fn find_binary(package: Option<&str>) -> PathBuf {
+fn find_binary(package: Option<&str>, bin: Option<&str>) -> PathBuf {
     let output = Command::new("cargo")
         .args(["metadata", "--format-version=1", "--no-deps"])
         .output()
@@ -245,7 +247,7 @@ fn find_binary(package: Option<&str>) -> PathBuf {
         serde_json::from_slice(&output.stdout).expect("parse cargo metadata");
     let cwd = std::env::current_dir().expect("current dir");
 
-    resolve_binary_from_metadata(&metadata, package, &cwd).unwrap_or_else(|error| {
+    resolve_binary_from_metadata(&metadata, package, &cwd, bin).unwrap_or_else(|error| {
         eprintln!("\u{2717} {error}");
         std::process::exit(1);
     })
@@ -255,6 +257,7 @@ fn resolve_binary_from_metadata(
     metadata: &serde_json::Value,
     package: Option<&str>,
     cwd: &Path,
+    bin: Option<&str>,
 ) -> Result<PathBuf, String> {
     let target_dir = metadata["target_directory"]
         .as_str()
@@ -284,8 +287,8 @@ fn resolve_binary_from_metadata(
     );
 
     // Collect (package-name, binary-name) pairs for every matching package
-    // that has at least one `bin` target. Error if any package exposes more
-    // than one binary — the caller must disambiguate with --bin.
+    // that has at least one `bin` target.  When --bin is given, pick that
+    // specific target; otherwise error if a package exposes more than one.
     let mut candidates: Vec<(String, String)> = Vec::new();
     for pkg in &matching_packages {
         let pkg_name = match pkg["name"].as_str() {
@@ -309,15 +312,30 @@ fn resolve_binary_from_metadata(
             })
             .unwrap_or_default();
 
-        if bins.len() > 1 {
+        let chosen = if let Some(bin_name) = bin {
+            if bins.iter().any(|b| b == bin_name) {
+                Some(bin_name.to_owned())
+            } else if !bins.is_empty() {
+                return Err(format!(
+                    "package '{pkg_name}' has no binary named '{bin_name}' \
+                     (available: {})",
+                    bins.join(", ")
+                ));
+            } else {
+                None
+            }
+        } else if bins.len() > 1 {
             return Err(format!(
                 "package '{pkg_name}' has multiple binary targets ({}); \
                  use --bin to select one",
                 bins.join(", ")
             ));
-        }
-        if let Some(bin_name) = bins.into_iter().next() {
-            candidates.push((pkg_name, bin_name));
+        } else {
+            bins.into_iter().next()
+        };
+
+        if let Some(b) = chosen {
+            candidates.push((pkg_name, b));
         }
     }
 
@@ -606,7 +624,8 @@ mod tests {
                 }]
             }]
         });
-        let result = resolve_binary_from_metadata(&metadata, Some("hello"), Path::new("/projects"));
+        let result =
+            resolve_binary_from_metadata(&metadata, Some("hello"), Path::new("/projects"), None);
         let expected = if cfg!(windows) {
             PathBuf::from("/tmp/target/debug/hello.exe")
         } else {
@@ -629,7 +648,8 @@ mod tests {
                 }]
             }]
         });
-        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/projects/hello"));
+        let result =
+            resolve_binary_from_metadata(&metadata, None, Path::new("/projects/hello"), None);
         let expected = if cfg!(windows) {
             PathBuf::from("/tmp/target/debug/hello.exe")
         } else {
@@ -649,7 +669,7 @@ mod tests {
             }]
         });
         let result =
-            resolve_binary_from_metadata(&metadata, Some("missing"), Path::new("/projects"));
+            resolve_binary_from_metadata(&metadata, Some("missing"), Path::new("/projects"), None);
         assert!(result.unwrap_err().contains("package 'missing'"));
     }
 
@@ -670,7 +690,7 @@ mod tests {
                 }
             ]
         });
-        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws"));
+        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws"), None);
         let err = result.unwrap_err();
         assert!(
             err.contains("multiple binary packages"),
@@ -700,7 +720,8 @@ mod tests {
             ]
         });
         // Narrowing cwd to /ws/alpha means only "alpha" matches.
-        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws/alpha")).unwrap();
+        let result =
+            resolve_binary_from_metadata(&metadata, None, Path::new("/ws/alpha"), None).unwrap();
         assert!(result.to_string_lossy().contains("alpha"));
     }
 
@@ -721,7 +742,7 @@ mod tests {
                 }
             ]
         });
-        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws")).unwrap();
+        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws"), None).unwrap();
         assert!(result.to_string_lossy().contains("myapp"));
     }
 
@@ -735,7 +756,7 @@ mod tests {
                 "targets": [{"name": "mylib", "kind": ["lib"]}]
             }]
         });
-        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws/mylib"));
+        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws/mylib"), None);
         assert!(result.unwrap_err().contains("no binary target"));
     }
 
@@ -751,7 +772,7 @@ mod tests {
         });
         // Running from a subdirectory of the package root should still find it.
         let result =
-            resolve_binary_from_metadata(&metadata, None, Path::new("/projects/hello/src"));
+            resolve_binary_from_metadata(&metadata, None, Path::new("/projects/hello/src"), None);
         assert!(
             result.unwrap().to_string_lossy().contains("hello"),
             "should resolve binary from subdirectory"
@@ -771,7 +792,7 @@ mod tests {
                 ]
             }]
         });
-        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws/myapp"));
+        let result = resolve_binary_from_metadata(&metadata, None, Path::new("/ws/myapp"), None);
         let err = result.unwrap_err();
         assert!(
             err.contains("multiple binary targets"),
@@ -780,6 +801,51 @@ mod tests {
         assert!(
             err.contains("--bin"),
             "should hint at --bin flag, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_binary_bin_flag_selects_named_target() {
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [{
+                "name": "myapp",
+                "manifest_path": "/ws/myapp/Cargo.toml",
+                "targets": [
+                    {"name": "server", "kind": ["bin"]},
+                    {"name": "migrate", "kind": ["bin"]}
+                ]
+            }]
+        });
+        let result =
+            resolve_binary_from_metadata(&metadata, None, Path::new("/ws/myapp"), Some("migrate"))
+                .unwrap();
+        assert!(
+            result.to_string_lossy().contains("migrate"),
+            "should resolve to the named binary"
+        );
+    }
+
+    #[test]
+    fn resolve_binary_bin_flag_wrong_name_errors() {
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [{
+                "name": "myapp",
+                "manifest_path": "/ws/myapp/Cargo.toml",
+                "targets": [{"name": "server", "kind": ["bin"]}]
+            }]
+        });
+        let result =
+            resolve_binary_from_metadata(&metadata, None, Path::new("/ws/myapp"), Some("missing"));
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("no binary named 'missing'"),
+            "expected named-binary error, got: {err}"
+        );
+        assert!(
+            err.contains("server"),
+            "should list available binaries, got: {err}"
         );
     }
 }

--- a/autumn-macros/src/ws.rs
+++ b/autumn-macros/src/ws.rs
@@ -124,7 +124,8 @@ pub fn ws_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         #[doc(hidden)]
         #vis fn #route_info_name() -> ::autumn_web::Route {
             ::autumn_web::Route {
-                method: ::autumn_web::reexports::http::Method::GET,
+                method: ::autumn_web::reexports::http::Method::from_bytes(b"WS")
+                    .expect("WS is a valid method token"),
                 path: #path,
                 handler: ::autumn_web::reexports::axum::routing::get(#upgrade_name),
                 name: ::core::stringify!(#fn_name),

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -341,10 +341,12 @@ impl AppBuilder {
     /// ```
     #[must_use]
     pub fn routes(mut self, routes: Vec<Route>) -> Self {
-        let source = self.current_plugin.as_ref().map_or(
-            crate::route_listing::RouteSource::User,
-            |name| crate::route_listing::RouteSource::Plugin(name.clone()),
-        );
+        let source = self
+            .current_plugin
+            .as_ref()
+            .map_or(crate::route_listing::RouteSource::User, |name| {
+                crate::route_listing::RouteSource::Plugin(name.clone())
+            });
         for _ in &routes {
             self.route_sources.push(source.clone());
         }
@@ -550,10 +552,12 @@ impl AppBuilder {
         <L::Service as tower::Service<axum::http::Request<axum::body::Body>>>::Future:
             Send + 'static,
     {
-        let source = self.current_plugin.as_ref().map_or(
-            crate::route_listing::RouteSource::User,
-            |name| crate::route_listing::RouteSource::Plugin(name.clone()),
-        );
+        let source = self
+            .current_plugin
+            .as_ref()
+            .map_or(crate::route_listing::RouteSource::User, |name| {
+                crate::route_listing::RouteSource::Plugin(name.clone())
+            });
         self.scoped_groups.push(ScopedGroup {
             prefix: prefix.to_owned(),
             routes,

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -4709,4 +4709,103 @@ mod tests {
             assert!(state.extension::<BlobStoreState>().is_some());
         }
     }
+
+    // ── Route source attribution ───────────────────────────────────────────
+
+    /// A minimal plugin that registers one route with a known name.
+    struct TestPlugin {
+        name: &'static str,
+        route: Route,
+    }
+
+    impl crate::plugin::Plugin for TestPlugin {
+        fn name(&self) -> std::borrow::Cow<'static, str> {
+            std::borrow::Cow::Borrowed(self.name)
+        }
+
+        fn build(self, app: AppBuilder) -> AppBuilder {
+            app.routes(vec![self.route])
+        }
+    }
+
+    #[test]
+    fn routes_registered_before_plugin_are_user_sourced() {
+        let user_route = test_get_route("/home", "home");
+        let builder = app().routes(vec![user_route]);
+        assert_eq!(builder.route_sources.len(), 1);
+        assert_eq!(
+            builder.route_sources[0],
+            crate::route_listing::RouteSource::User
+        );
+    }
+
+    #[test]
+    fn routes_registered_inside_plugin_are_plugin_sourced() {
+        let plugin_route = test_get_route("/plugin-page", "plugin_page");
+        let plugin = TestPlugin {
+            name: "my-plugin",
+            route: plugin_route,
+        };
+        let builder = app().plugin(plugin);
+        assert_eq!(builder.route_sources.len(), 1);
+        assert_eq!(
+            builder.route_sources[0],
+            crate::route_listing::RouteSource::Plugin("my-plugin".to_owned())
+        );
+    }
+
+    #[test]
+    fn routes_registered_after_plugin_revert_to_user_sourced() {
+        let plugin_route = test_get_route("/plugin-page", "plugin_page");
+        let user_route = test_get_route("/home", "home");
+        let plugin = TestPlugin {
+            name: "my-plugin",
+            route: plugin_route,
+        };
+        let builder = app().plugin(plugin).routes(vec![user_route]);
+        assert_eq!(builder.route_sources.len(), 2);
+        assert_eq!(
+            builder.route_sources[0],
+            crate::route_listing::RouteSource::Plugin("my-plugin".to_owned())
+        );
+        assert_eq!(
+            builder.route_sources[1],
+            crate::route_listing::RouteSource::User
+        );
+    }
+
+    /// A plugin that registers a route and then registers a nested plugin.
+    struct OuterPlugin;
+
+    impl crate::plugin::Plugin for OuterPlugin {
+        fn name(&self) -> std::borrow::Cow<'static, str> {
+            "outer".into()
+        }
+
+        fn build(self, app: AppBuilder) -> AppBuilder {
+            let inner = TestPlugin {
+                name: "inner",
+                route: test_get_route("/inner", "inner"),
+            };
+            app.plugin(inner)
+                .routes(vec![test_get_route("/outer-after", "outer_after")])
+        }
+    }
+
+    #[test]
+    fn outer_plugin_source_restored_after_nested_plugin() {
+        let builder = app().plugin(OuterPlugin);
+        // Routes: [/inner from "inner", /outer-after from "outer"]
+        assert_eq!(builder.route_sources.len(), 2);
+        assert_eq!(
+            builder.route_sources[0],
+            crate::route_listing::RouteSource::Plugin("inner".to_owned()),
+            "first route should be attributed to inner plugin"
+        );
+        assert_eq!(
+            builder.route_sources[1],
+            crate::route_listing::RouteSource::Plugin("outer".to_owned()),
+            "second route should be re-attributed to outer plugin after nested build"
+        );
+    }
 }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1016,9 +1016,11 @@ impl AppBuilder {
         }
         let name_str = name.into_owned();
         self.registered_plugins.insert(name_str.clone());
-        self.current_plugin = Some(name_str);
+        // Save outer plugin context so nested plugin() calls don't permanently
+        // clear it; restore it after this plugin's build() returns.
+        let outer_plugin = self.current_plugin.replace(name_str);
         let mut result = plugin.build(self);
-        result.current_plugin = None;
+        result.current_plugin = outer_plugin;
         result
     }
 
@@ -1530,12 +1532,25 @@ impl AppBuilder {
             routes,
             route_sources,
             scoped_groups,
+            merge_routers,
+            nest_routers,
             config_loader_factory,
             telemetry_provider,
             #[cfg(feature = "openapi")]
             openapi,
             ..
         } = self;
+
+        // Raw Axum routers registered via .merge()/.nest() are opaque: there is
+        // no public API to enumerate their routes. Warn so callers know the
+        // snapshot may be incomplete.
+        let hidden = merge_routers.len() + nest_routers.len();
+        if hidden > 0 {
+            eprintln!(
+                "[autumn routes] warning: {hidden} raw router(s) added via \
+                 .merge()/.nest() are not enumerable and are omitted from this listing"
+            );
+        }
 
         let (config, _telemetry_guard) =
             load_config_and_telemetry(config_loader_factory, telemetry_provider).await;

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1074,6 +1074,15 @@ impl AppBuilder {
             return;
         }
 
+        // ── Route dump mode ────────────────────────────────────────────
+        // When AUTUMN_DUMP_ROUTES=1, print the route listing JSON and exit.
+        // This is triggered by `autumn routes` to introspect the app's
+        // route table without booting the server or connecting to a database.
+        if is_dump_routes_mode() {
+            self.run_dump_routes_mode().await;
+            return;
+        }
+
         let Self {
             routes,
             tasks,
@@ -1481,10 +1490,44 @@ impl AppBuilder {
             }
         }
     }
+
+    /// Dump the application's route listing as JSON and exit.
+    ///
+    /// Triggered when `AUTUMN_DUMP_ROUTES=1` is set (by `autumn routes`).
+    /// Exits with code 0 on success, code 1 on JSON serialization failure.
+    /// Does not connect to a database or bind a TCP port.
+    async fn run_dump_routes_mode(self) {
+        let Self {
+            routes,
+            scoped_groups,
+            config_loader_factory,
+            telemetry_provider,
+            ..
+        } = self;
+
+        let (config, _telemetry_guard) =
+            load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
+
+        let mut infos =
+            crate::route_listing::collect_route_infos(&routes, &scoped_groups);
+        crate::route_listing::append_framework_routes(&mut infos, &config);
+        crate::route_listing::sort_route_infos(&mut infos);
+
+        let json = serde_json::to_string_pretty(&infos).unwrap_or_else(|e| {
+            eprintln!("Failed to serialize route listing: {e}");
+            std::process::exit(1);
+        });
+        println!("{json}");
+        std::process::exit(0);
+    }
 }
 
 pub(crate) fn is_static_build_mode() -> bool {
     std::env::var("AUTUMN_BUILD_STATIC").as_deref() == Ok("1")
+}
+
+pub(crate) fn is_dump_routes_mode() -> bool {
+    std::env::var("AUTUMN_DUMP_ROUTES").as_deref() == Ok("1")
 }
 
 /// Start scheduled tasks in background Tokio tasks.

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -68,6 +68,8 @@ use crate::state::AppState;
 pub fn app() -> AppBuilder {
     AppBuilder {
         routes: Vec::new(),
+        route_sources: Vec::new(),
+        current_plugin: None,
         tasks: Vec::new(),
         jobs: Vec::new(),
         static_metas: Vec::new(),
@@ -166,6 +168,11 @@ type PolicyRegistration = Box<dyn FnOnce(&crate::authorization::PolicyRegistry) 
 /// ```
 pub struct AppBuilder {
     routes: Vec<Route>,
+    /// Parallel to `routes`: registration origin for each route.
+    route_sources: Vec<crate::route_listing::RouteSource>,
+    /// Non-None while a plugin's `build()` is executing; routes and scoped
+    /// groups added during that window are attributed to this plugin.
+    current_plugin: Option<String>,
     tasks: Vec<crate::task::TaskInfo>,
     jobs: Vec<crate::job::JobInfo>,
     pub(crate) static_metas: Vec<crate::static_gen::StaticRouteMeta>,
@@ -226,6 +233,8 @@ pub struct AppBuilder {
 pub(crate) struct ScopedGroup {
     pub(crate) prefix: String,
     pub(crate) routes: Vec<Route>,
+    /// Registration origin: user application or a named plugin.
+    pub(crate) source: crate::route_listing::RouteSource,
     /// Closure that applies the layer to a sub-router.
     pub(crate) apply_layer:
         Box<dyn FnOnce(axum::Router<AppState>) -> axum::Router<AppState> + Send>,
@@ -332,6 +341,13 @@ impl AppBuilder {
     /// ```
     #[must_use]
     pub fn routes(mut self, routes: Vec<Route>) -> Self {
+        let source = self.current_plugin.as_ref().map_or(
+            crate::route_listing::RouteSource::User,
+            |name| crate::route_listing::RouteSource::Plugin(name.clone()),
+        );
+        for _ in &routes {
+            self.route_sources.push(source.clone());
+        }
         self.routes.extend(routes);
         self
     }
@@ -534,9 +550,14 @@ impl AppBuilder {
         <L::Service as tower::Service<axum::http::Request<axum::body::Body>>>::Future:
             Send + 'static,
     {
+        let source = self.current_plugin.as_ref().map_or(
+            crate::route_listing::RouteSource::User,
+            |name| crate::route_listing::RouteSource::Plugin(name.clone()),
+        );
         self.scoped_groups.push(ScopedGroup {
             prefix: prefix.to_owned(),
             routes,
+            source,
             apply_layer: Box::new(move |router| router.layer(layer)),
         });
         self
@@ -993,8 +1014,12 @@ impl AppBuilder {
             );
             return self;
         }
-        self.registered_plugins.insert(name.into_owned());
-        plugin.build(self)
+        let name_str = name.into_owned();
+        self.registered_plugins.insert(name_str.clone());
+        self.current_plugin = Some(name_str);
+        let mut result = plugin.build(self);
+        result.current_plugin = None;
+        result
     }
 
     /// Apply a [`Plugins`](crate::plugin::Plugins) bundle (a plugin or tuple
@@ -1085,6 +1110,8 @@ impl AppBuilder {
 
         let Self {
             routes,
+            route_sources: _,
+            current_plugin: _,
             tasks,
             jobs,
             static_metas: _,
@@ -1346,6 +1373,8 @@ impl AppBuilder {
     async fn run_build_mode(self) {
         let Self {
             routes,
+            route_sources: _,
+            current_plugin: _,
             tasks: _,
             jobs: _,
             static_metas,
@@ -1499,9 +1528,12 @@ impl AppBuilder {
     async fn run_dump_routes_mode(self) {
         let Self {
             routes,
+            route_sources,
             scoped_groups,
             config_loader_factory,
             telemetry_provider,
+            #[cfg(feature = "openapi")]
+            openapi,
             ..
         } = self;
 
@@ -1509,8 +1541,13 @@ impl AppBuilder {
             load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
 
         let mut infos =
-            crate::route_listing::collect_route_infos(&routes, &scoped_groups);
+            crate::route_listing::collect_route_infos(&routes, &route_sources, &scoped_groups);
         crate::route_listing::append_framework_routes(&mut infos, &config);
+        #[cfg(feature = "openapi")]
+        if let Some(ref oa) = openapi {
+            crate::route_listing::append_openapi_routes(&mut infos, oa);
+        }
+        crate::route_listing::append_dev_reload_routes(&mut infos);
         crate::route_listing::sort_route_infos(&mut infos);
 
         let json = serde_json::to_string_pretty(&infos).unwrap_or_else(|e| {
@@ -2742,6 +2779,7 @@ mod validate_repository_api_policies_tests {
         let group = ScopedGroup {
             prefix: "/scoped".to_owned(),
             routes: vec![group_route],
+            source: crate::route_listing::RouteSource::User,
             apply_layer: Box::new(|r| r),
         };
         let offenders = collect_unguarded_repository_writes(&[], std::slice::from_ref(&group));
@@ -2759,6 +2797,7 @@ mod validate_repository_api_policies_tests {
         let group = ScopedGroup {
             prefix: "/scoped".to_owned(),
             routes: vec![group_route],
+            source: crate::route_listing::RouteSource::User,
             apply_layer: Box::new(|r| r),
         };
         let registry = PolicyRegistry::default();

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -92,6 +92,8 @@ pub mod plugin;
 pub mod probe;
 pub use plugin::{Plugin, Plugins};
 
+pub mod route_listing;
+
 /// Router construction and integration with Axum.
 ///
 /// This module is responsible for taking the application's configuration,

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -169,7 +169,7 @@ pub(crate) fn append_framework_routes(
     }
 }
 
-/// Append OpenAPI documentation routes (`/v3/api-docs`, `/swagger-ui`).
+/// Append `OpenAPI` documentation routes (`/v3/api-docs`, `/swagger-ui`).
 ///
 /// Only compiled when the `openapi` feature is enabled.
 #[cfg(feature = "openapi")]
@@ -265,7 +265,7 @@ mod tests {
         Route {
             method,
             path,
-            handler: get(handler).into(),
+            handler: get(handler),
             name,
             api_doc: dummy_api_doc(),
             repository: None,

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -167,6 +167,15 @@ pub(crate) fn append_framework_routes(
             middleware: Vec::new(),
         });
     }
+
+    // Static file serving is unconditionally mounted at /static.
+    infos.push(RouteInfo {
+        method: "GET".to_owned(),
+        path: "/static/{*path}".to_owned(),
+        handler: "static_files".to_owned(),
+        source: RouteSource::Framework,
+        middleware: Vec::new(),
+    });
 }
 
 /// Append `OpenAPI` documentation routes (`/v3/api-docs`, `/swagger-ui`).
@@ -623,6 +632,24 @@ mod tests {
         // Only the JSON endpoint; no swagger-ui entry.
         assert_eq!(infos.len(), 1);
         assert_eq!(infos[0].path, "/v3/api-docs");
+    }
+
+    // ── append_framework_routes static ────────────────────────────────────
+
+    #[test]
+    fn append_framework_routes_includes_static_catch_all() {
+        let config = AutumnConfig::default();
+        let mut infos = Vec::new();
+        append_framework_routes(&mut infos, &config);
+        let static_route = infos.iter().find(|r| r.path == "/static/{*path}");
+        assert!(
+            static_route.is_some(),
+            "framework routes should include /static/{{*path}}"
+        );
+        let r = static_route.unwrap();
+        assert_eq!(r.method, "GET");
+        assert_eq!(r.handler, "static_files");
+        assert_eq!(r.source, RouteSource::Framework);
     }
 
     // ── append_dev_reload_routes ───────────────────────────────────────────

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -82,10 +82,7 @@ pub(crate) fn collect_route_infos(
     let mut infos = Vec::with_capacity(routes.len());
 
     for (i, route) in routes.iter().enumerate() {
-        let source = route_sources
-            .get(i)
-            .cloned()
-            .unwrap_or(RouteSource::User);
+        let source = route_sources.get(i).cloned().unwrap_or(RouteSource::User);
         infos.push(RouteInfo {
             method: route.method.to_string(),
             path: route.path.to_owned(),
@@ -137,10 +134,9 @@ pub(crate) fn append_framework_routes(
         }
     }
 
-    for path in crate::actuator::actuator_endpoint_paths(
-        &config.actuator.prefix,
-        config.actuator.sensitive,
-    ) {
+    for path in
+        crate::actuator::actuator_endpoint_paths(&config.actuator.prefix, config.actuator.sensitive)
+    {
         infos.push(RouteInfo {
             method: "GET".to_owned(),
             path,
@@ -202,10 +198,7 @@ pub(crate) fn append_openapi_routes(
 pub(crate) fn append_dev_reload_routes(infos: &mut Vec<RouteInfo>) {
     if crate::middleware::dev::is_enabled_with_env(&crate::config::OsEnv) {
         for (path, handler) in [
-            (
-                crate::middleware::dev::LIVE_RELOAD_PATH,
-                "dev_live_reload",
-            ),
+            (crate::middleware::dev::LIVE_RELOAD_PATH, "dev_live_reload"),
             (
                 crate::middleware::dev::LIVE_RELOAD_SCRIPT_PATH,
                 "dev_live_reload_js",
@@ -233,7 +226,11 @@ pub(crate) fn sort_route_infos(infos: &mut [RouteInfo]) {
 fn join_scope_path(prefix: &str, path: &str) -> String {
     let prefix = prefix.trim_end_matches('/');
     if path == "/" || path.is_empty() {
-        if prefix.is_empty() { "/".to_owned() } else { prefix.to_owned() }
+        if prefix.is_empty() {
+            "/".to_owned()
+        } else {
+            prefix.to_owned()
+        }
     } else if path.starts_with('/') {
         format!("{prefix}{path}")
     } else {
@@ -519,7 +516,10 @@ mod tests {
         let mut infos = Vec::new();
         append_framework_routes(&mut infos, &config);
         let paths: Vec<&str> = infos.iter().map(|i| i.path.as_str()).collect();
-        assert!(paths.contains(&"/ping"), "custom health path missing: {paths:?}");
+        assert!(
+            paths.contains(&"/ping"),
+            "custom health path missing: {paths:?}"
+        );
     }
 
     // ── join_scope_path ────────────────────────────────────────────────────

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -88,6 +88,10 @@ pub(crate) fn collect_route_infos(
             path: route.path.to_owned(),
             handler: route.name.to_owned(),
             source,
+            // Tower layers are opaque — there is no runtime API to enumerate
+            // which layers a MethodRouter carries. The middleware field is
+            // reserved for future population via proc-macro attributes (e.g.
+            // `#[middleware("secured")]`) on route handler functions.
             middleware: Vec::new(),
         });
     }
@@ -572,5 +576,70 @@ mod tests {
         assert_eq!(decoded.handler, "posts::show");
         assert_eq!(decoded.source, RouteSource::User);
         assert_eq!(decoded.middleware, vec!["secured"]);
+    }
+
+    // ── append_openapi_routes ──────────────────────────────────────────────
+
+    #[cfg(feature = "openapi")]
+    #[test]
+    fn append_openapi_routes_adds_json_and_ui_paths() {
+        let config = crate::openapi::OpenApiConfig::new("Test", "1.0.0");
+        let mut infos = Vec::new();
+        append_openapi_routes(&mut infos, &config);
+        let paths: Vec<&str> = infos.iter().map(|i| i.path.as_str()).collect();
+        assert!(
+            paths.contains(&"/v3/api-docs"),
+            "openapi json path missing: {paths:?}"
+        );
+        assert!(
+            paths.contains(&"/swagger-ui"),
+            "swagger ui path missing: {paths:?}"
+        );
+        for info in &infos {
+            assert_eq!(info.source, RouteSource::Framework);
+            assert_eq!(info.method, "GET");
+        }
+    }
+
+    #[cfg(feature = "openapi")]
+    #[test]
+    fn append_openapi_routes_custom_paths() {
+        let config = crate::openapi::OpenApiConfig::new("Test", "1.0.0")
+            .openapi_json_path("/docs/openapi.json")
+            .swagger_ui_path(Some("/docs/ui".to_owned()));
+        let mut infos = Vec::new();
+        append_openapi_routes(&mut infos, &config);
+        let paths: Vec<&str> = infos.iter().map(|i| i.path.as_str()).collect();
+        assert!(paths.contains(&"/docs/openapi.json"));
+        assert!(paths.contains(&"/docs/ui"));
+    }
+
+    #[cfg(feature = "openapi")]
+    #[test]
+    fn append_openapi_routes_no_swagger_ui_when_none() {
+        let config = crate::openapi::OpenApiConfig::new("Test", "1.0.0").swagger_ui_path(None);
+        let mut infos = Vec::new();
+        append_openapi_routes(&mut infos, &config);
+        // Only the JSON endpoint; no swagger-ui entry.
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].path, "/v3/api-docs");
+    }
+
+    // ── append_dev_reload_routes ───────────────────────────────────────────
+
+    #[test]
+    fn append_dev_reload_routes_empty_when_dev_disabled() {
+        // In the test environment AUTUMN_DEV is not set, so this should be a no-op.
+        let guard = std::env::var("AUTUMN_DEV");
+        if guard.is_ok() {
+            // Skip: dev mode is active in this test process.
+            return;
+        }
+        let mut infos = Vec::new();
+        append_dev_reload_routes(&mut infos);
+        assert!(
+            infos.is_empty(),
+            "expected no dev routes when AUTUMN_DEV unset"
+        );
     }
 }

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -1,0 +1,480 @@
+//! Route listing types and collection logic for `autumn routes`.
+//!
+//! Collects route metadata from an [`AppBuilder`](crate::app::AppBuilder) into
+//! serializable [`RouteInfo`] values that the CLI can consume without booting
+//! the full HTTP server.
+
+use serde::{Deserialize, Serialize};
+
+use crate::app::ScopedGroup;
+use crate::route::Route;
+
+/// Where a route was registered: by the user application, by a named plugin,
+/// or by the framework itself (probes, actuator, htmx assets, dev reload).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RouteSource {
+    /// Registered directly by the user application.
+    User,
+    /// Registered by a named autumn plugin (e.g. `"admin"` for autumn-admin-plugin).
+    Plugin(String),
+    /// Registered by the framework (probes, actuator, htmx assets, dev reload).
+    Framework,
+}
+
+impl std::fmt::Display for RouteSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::User => write!(f, "user"),
+            Self::Plugin(name) => write!(f, "plugin:{name}"),
+            Self::Framework => write!(f, "framework"),
+        }
+    }
+}
+
+impl Serialize for RouteSource {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for RouteSource {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(if s == "framework" {
+            Self::Framework
+        } else if let Some(name) = s.strip_prefix("plugin:") {
+            Self::Plugin(name.to_owned())
+        } else {
+            Self::User
+        })
+    }
+}
+
+/// Metadata for a single mounted route, suitable for display and JSON export.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RouteInfo {
+    /// HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `WS`, etc.).
+    pub method: String,
+    /// Full mounted URL path (e.g. `/api/posts/{id}`), reflecting the
+    /// final URL after any scope prefix is applied.
+    pub path: String,
+    /// Handler function name (e.g. `"posts::show"`).
+    pub handler: String,
+    /// Registration origin: user application, a named plugin, or the framework.
+    pub source: RouteSource,
+    /// Active middleware on this route (compact labels, e.g. `"secured"`, `"cached(60s)"`).
+    pub middleware: Vec<String>,
+}
+
+/// Collect [`RouteInfo`] entries from user routes and scoped groups.
+///
+/// Does not include framework-internal routes (probes, actuator, htmx).
+/// Call [`append_framework_routes`] with a loaded config to add those.
+pub(crate) fn collect_route_infos(routes: &[Route], scoped_groups: &[ScopedGroup]) -> Vec<RouteInfo> {
+    let mut infos = Vec::with_capacity(routes.len());
+
+    for route in routes {
+        infos.push(RouteInfo {
+            method: route.method.to_string(),
+            path: route.path.to_owned(),
+            handler: route.name.to_owned(),
+            source: RouteSource::User,
+            middleware: Vec::new(),
+        });
+    }
+
+    for group in scoped_groups {
+        for route in &group.routes {
+            let full_path = join_scope_path(&group.prefix, route.path);
+            infos.push(RouteInfo {
+                method: route.method.to_string(),
+                path: full_path,
+                handler: route.name.to_owned(),
+                source: RouteSource::User,
+                middleware: Vec::new(),
+            });
+        }
+    }
+
+    infos
+}
+
+/// Append framework-internal routes (probes, actuator, htmx assets).
+///
+/// Paths are taken from `config` so custom probe/actuator prefix settings
+/// are reflected accurately.
+pub(crate) fn append_framework_routes(
+    infos: &mut Vec<RouteInfo>,
+    config: &crate::config::AutumnConfig,
+) {
+    let mut probe_paths = std::collections::HashSet::new();
+    for (path, name) in [
+        (config.health.live_path.as_str(), "live"),
+        (config.health.ready_path.as_str(), "ready"),
+        (config.health.startup_path.as_str(), "startup"),
+        (config.health.path.as_str(), "health"),
+    ] {
+        if probe_paths.insert(path) {
+            infos.push(RouteInfo {
+                method: "GET".to_owned(),
+                path: path.to_owned(),
+                handler: name.to_owned(),
+                source: RouteSource::Framework,
+                middleware: Vec::new(),
+            });
+        }
+    }
+
+    for path in crate::actuator::actuator_endpoint_paths(
+        &config.actuator.prefix,
+        config.actuator.sensitive,
+    ) {
+        infos.push(RouteInfo {
+            method: "GET".to_owned(),
+            path,
+            handler: "actuator".to_owned(),
+            source: RouteSource::Framework,
+            middleware: Vec::new(),
+        });
+    }
+
+    #[cfg(feature = "htmx")]
+    {
+        infos.push(RouteInfo {
+            method: "GET".to_owned(),
+            path: crate::htmx::HTMX_JS_PATH.to_owned(),
+            handler: "htmx".to_owned(),
+            source: RouteSource::Framework,
+            middleware: Vec::new(),
+        });
+        infos.push(RouteInfo {
+            method: "GET".to_owned(),
+            path: crate::htmx::HTMX_CSRF_JS_PATH.to_owned(),
+            handler: "htmx_csrf".to_owned(),
+            source: RouteSource::Framework,
+            middleware: Vec::new(),
+        });
+    }
+}
+
+/// Stable-sort route infos: primary key is path (lexicographic), secondary
+/// key is HTTP method (lexicographic). This makes output diff-friendly.
+pub(crate) fn sort_route_infos(infos: &mut [RouteInfo]) {
+    infos.sort_by(|a, b| a.path.cmp(&b.path).then_with(|| a.method.cmp(&b.method)));
+}
+
+/// Join a scope prefix with a child route path, mirroring axum's nest
+/// normalization: `/api` + `/` → `/api`, `/api` + `/posts` → `/api/posts`.
+fn join_scope_path(prefix: &str, path: &str) -> String {
+    let prefix = prefix.trim_end_matches('/');
+    if path == "/" || path.is_empty() {
+        if prefix.is_empty() { "/".to_owned() } else { prefix.to_owned() }
+    } else if path.starts_with('/') {
+        format!("{prefix}{path}")
+    } else {
+        format!("{prefix}/{path}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AutumnConfig;
+    use axum::routing::get;
+    use http::Method;
+
+    fn dummy_api_doc() -> crate::openapi::ApiDoc {
+        crate::openapi::ApiDoc {
+            method: "GET",
+            path: "/dummy",
+            operation_id: "dummy",
+            success_status: 200,
+            ..Default::default()
+        }
+    }
+
+    fn make_route(method: Method, path: &'static str, name: &'static str) -> Route {
+        async fn handler() -> &'static str {
+            "ok"
+        }
+        Route {
+            method,
+            path,
+            handler: get(handler).into(),
+            name,
+            api_doc: dummy_api_doc(),
+            repository: None,
+        }
+    }
+
+    // ── collect_route_infos ────────────────────────────────────────────────
+
+    #[test]
+    fn collect_route_infos_empty_produces_empty() {
+        let infos = collect_route_infos(&[], &[]);
+        assert!(infos.is_empty());
+    }
+
+    #[test]
+    fn collect_route_infos_single_user_route() {
+        let routes = vec![make_route(Method::GET, "/posts", "list_posts")];
+        let infos = collect_route_infos(&routes, &[]);
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].method, "GET");
+        assert_eq!(infos[0].path, "/posts");
+        assert_eq!(infos[0].handler, "list_posts");
+        assert_eq!(infos[0].source, RouteSource::User);
+        assert!(infos[0].middleware.is_empty());
+    }
+
+    #[test]
+    fn collect_route_infos_multiple_methods_same_path() {
+        let routes = vec![
+            make_route(Method::GET, "/posts", "list_posts"),
+            make_route(Method::POST, "/posts", "create_post"),
+        ];
+        let infos = collect_route_infos(&routes, &[]);
+        assert_eq!(infos.len(), 2);
+    }
+
+    #[test]
+    fn collect_route_infos_scoped_group_prepends_prefix() {
+        async fn handler() -> &'static str {
+            "ok"
+        }
+        let group = ScopedGroup {
+            prefix: "/api".to_owned(),
+            routes: vec![make_route(Method::GET, "/posts", "api_list_posts")],
+            apply_layer: Box::new(|r| r),
+        };
+        let infos = collect_route_infos(&[], &[group]);
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].path, "/api/posts");
+        assert_eq!(infos[0].handler, "api_list_posts");
+    }
+
+    #[test]
+    fn collect_route_infos_scoped_root_child() {
+        let group = ScopedGroup {
+            prefix: "/api".to_owned(),
+            routes: vec![make_route(Method::GET, "/", "api_root")],
+            apply_layer: Box::new(|r| r),
+        };
+        let infos = collect_route_infos(&[], &[group]);
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].path, "/api");
+    }
+
+    #[test]
+    fn collect_route_infos_marks_user_source() {
+        let routes = vec![make_route(Method::POST, "/items", "create_item")];
+        let infos = collect_route_infos(&routes, &[]);
+        assert_eq!(infos[0].source, RouteSource::User);
+    }
+
+    // ── sort_route_infos ───────────────────────────────────────────────────
+
+    #[test]
+    fn sort_route_infos_by_path_then_method() {
+        let mut infos = vec![
+            RouteInfo {
+                method: "POST".to_owned(),
+                path: "/posts".to_owned(),
+                handler: "create".to_owned(),
+                source: RouteSource::User,
+                middleware: vec![],
+            },
+            RouteInfo {
+                method: "GET".to_owned(),
+                path: "/posts".to_owned(),
+                handler: "list".to_owned(),
+                source: RouteSource::User,
+                middleware: vec![],
+            },
+            RouteInfo {
+                method: "GET".to_owned(),
+                path: "/about".to_owned(),
+                handler: "about".to_owned(),
+                source: RouteSource::User,
+                middleware: vec![],
+            },
+        ];
+        sort_route_infos(&mut infos);
+        assert_eq!(infos[0].path, "/about");
+        assert_eq!(infos[1].path, "/posts");
+        assert_eq!(infos[1].method, "GET");
+        assert_eq!(infos[2].path, "/posts");
+        assert_eq!(infos[2].method, "POST");
+    }
+
+    #[test]
+    fn sort_route_infos_stable_on_equal() {
+        let mut infos = vec![
+            RouteInfo {
+                method: "GET".to_owned(),
+                path: "/z".to_owned(),
+                handler: "z".to_owned(),
+                source: RouteSource::User,
+                middleware: vec![],
+            },
+            RouteInfo {
+                method: "GET".to_owned(),
+                path: "/a".to_owned(),
+                handler: "a".to_owned(),
+                source: RouteSource::User,
+                middleware: vec![],
+            },
+        ];
+        sort_route_infos(&mut infos);
+        assert_eq!(infos[0].path, "/a");
+        assert_eq!(infos[1].path, "/z");
+    }
+
+    // ── RouteSource serialization ──────────────────────────────────────────
+
+    #[test]
+    fn route_source_user_serializes_to_string() {
+        let s = serde_json::to_string(&RouteSource::User).unwrap();
+        assert_eq!(s, "\"user\"");
+    }
+
+    #[test]
+    fn route_source_framework_serializes_to_string() {
+        let s = serde_json::to_string(&RouteSource::Framework).unwrap();
+        assert_eq!(s, "\"framework\"");
+    }
+
+    #[test]
+    fn route_source_plugin_serializes_with_name() {
+        let s = serde_json::to_string(&RouteSource::Plugin("admin".to_owned())).unwrap();
+        assert_eq!(s, "\"plugin:admin\"");
+    }
+
+    #[test]
+    fn route_source_roundtrips_user() {
+        let original = RouteSource::User;
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: RouteSource = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn route_source_roundtrips_plugin() {
+        let original = RouteSource::Plugin("harvest".to_owned());
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: RouteSource = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn route_source_roundtrips_framework() {
+        let original = RouteSource::Framework;
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: RouteSource = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    // ── append_framework_routes ────────────────────────────────────────────
+
+    #[test]
+    fn append_framework_routes_includes_probe_paths() {
+        let config = AutumnConfig::default();
+        let mut infos = Vec::new();
+        append_framework_routes(&mut infos, &config);
+        let paths: Vec<&str> = infos.iter().map(|i| i.path.as_str()).collect();
+        assert!(
+            paths.contains(&config.health.path.as_str()),
+            "health path missing: {paths:?}"
+        );
+        assert!(
+            paths.contains(&config.health.live_path.as_str()),
+            "live path missing: {paths:?}"
+        );
+        assert!(
+            paths.contains(&config.health.ready_path.as_str()),
+            "ready path missing: {paths:?}"
+        );
+        assert!(
+            paths.contains(&config.health.startup_path.as_str()),
+            "startup path missing: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn append_framework_routes_marks_framework_source() {
+        let config = AutumnConfig::default();
+        let mut infos = Vec::new();
+        append_framework_routes(&mut infos, &config);
+        for info in &infos {
+            assert_eq!(
+                info.source,
+                RouteSource::Framework,
+                "expected Framework source for {}: {:?}",
+                info.path,
+                info.source
+            );
+        }
+    }
+
+    #[test]
+    fn append_framework_routes_custom_health_path() {
+        let mut config = AutumnConfig::default();
+        config.health.path = "/ping".to_owned();
+        let mut infos = Vec::new();
+        append_framework_routes(&mut infos, &config);
+        let paths: Vec<&str> = infos.iter().map(|i| i.path.as_str()).collect();
+        assert!(paths.contains(&"/ping"), "custom health path missing: {paths:?}");
+    }
+
+    // ── join_scope_path ────────────────────────────────────────────────────
+
+    #[test]
+    fn join_scope_path_normal() {
+        assert_eq!(join_scope_path("/api", "/posts"), "/api/posts");
+    }
+
+    #[test]
+    fn join_scope_path_root_child() {
+        assert_eq!(join_scope_path("/api", "/"), "/api");
+    }
+
+    #[test]
+    fn join_scope_path_empty_child() {
+        assert_eq!(join_scope_path("/api", ""), "/api");
+    }
+
+    #[test]
+    fn join_scope_path_trailing_slash_on_prefix() {
+        assert_eq!(join_scope_path("/api/", "/posts"), "/api/posts");
+    }
+
+    #[test]
+    fn join_scope_path_empty_prefix() {
+        assert_eq!(join_scope_path("", "/posts"), "/posts");
+    }
+
+    #[test]
+    fn join_scope_path_root_prefix_root_child() {
+        assert_eq!(join_scope_path("", "/"), "/");
+    }
+
+    // ── RouteInfo JSON roundtrip ───────────────────────────────────────────
+
+    #[test]
+    fn route_info_roundtrips_json() {
+        let info = RouteInfo {
+            method: "GET".to_owned(),
+            path: "/posts/{id}".to_owned(),
+            handler: "posts::show".to_owned(),
+            source: RouteSource::User,
+            middleware: vec!["secured".to_owned()],
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        let decoded: RouteInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.method, "GET");
+        assert_eq!(decoded.path, "/posts/{id}");
+        assert_eq!(decoded.handler, "posts::show");
+        assert_eq!(decoded.source, RouteSource::User);
+        assert_eq!(decoded.middleware, vec!["secured"]);
+    }
+}

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -68,17 +68,29 @@ pub struct RouteInfo {
 
 /// Collect [`RouteInfo`] entries from user routes and scoped groups.
 ///
+/// `route_sources` is a parallel slice to `routes`; each element is the
+/// [`RouteSource`] for the corresponding route. If the slice is shorter than
+/// `routes`, remaining routes are attributed to [`RouteSource::User`].
+///
 /// Does not include framework-internal routes (probes, actuator, htmx).
 /// Call [`append_framework_routes`] with a loaded config to add those.
-pub(crate) fn collect_route_infos(routes: &[Route], scoped_groups: &[ScopedGroup]) -> Vec<RouteInfo> {
+pub(crate) fn collect_route_infos(
+    routes: &[Route],
+    route_sources: &[RouteSource],
+    scoped_groups: &[ScopedGroup],
+) -> Vec<RouteInfo> {
     let mut infos = Vec::with_capacity(routes.len());
 
-    for route in routes {
+    for (i, route) in routes.iter().enumerate() {
+        let source = route_sources
+            .get(i)
+            .cloned()
+            .unwrap_or(RouteSource::User);
         infos.push(RouteInfo {
             method: route.method.to_string(),
             path: route.path.to_owned(),
             handler: route.name.to_owned(),
-            source: RouteSource::User,
+            source,
             middleware: Vec::new(),
         });
     }
@@ -90,7 +102,7 @@ pub(crate) fn collect_route_infos(routes: &[Route], scoped_groups: &[ScopedGroup
                 method: route.method.to_string(),
                 path: full_path,
                 handler: route.name.to_owned(),
-                source: RouteSource::User,
+                source: group.source.clone(),
                 middleware: Vec::new(),
             });
         }
@@ -157,6 +169,59 @@ pub(crate) fn append_framework_routes(
     }
 }
 
+/// Append OpenAPI documentation routes (`/v3/api-docs`, `/swagger-ui`).
+///
+/// Only compiled when the `openapi` feature is enabled.
+#[cfg(feature = "openapi")]
+pub(crate) fn append_openapi_routes(
+    infos: &mut Vec<RouteInfo>,
+    openapi: &crate::openapi::OpenApiConfig,
+) {
+    infos.push(RouteInfo {
+        method: "GET".to_owned(),
+        path: openapi.openapi_json_path.clone(),
+        handler: "openapi_json".to_owned(),
+        source: RouteSource::Framework,
+        middleware: Vec::new(),
+    });
+    if let Some(ui_path) = &openapi.swagger_ui_path {
+        infos.push(RouteInfo {
+            method: "GET".to_owned(),
+            path: ui_path.clone(),
+            handler: "swagger_ui".to_owned(),
+            source: RouteSource::Framework,
+            middleware: Vec::new(),
+        });
+    }
+}
+
+/// Append dev live-reload routes (`/__autumn/live-reload`, `/__autumn/live-reload.js`).
+///
+/// Routes are only appended when the Autumn dev server is active
+/// (`AUTUMN_DEV=1` and `AUTUMN_ENV != production`).
+pub(crate) fn append_dev_reload_routes(infos: &mut Vec<RouteInfo>) {
+    if crate::middleware::dev::is_enabled_with_env(&crate::config::OsEnv) {
+        for (path, handler) in [
+            (
+                crate::middleware::dev::LIVE_RELOAD_PATH,
+                "dev_live_reload",
+            ),
+            (
+                crate::middleware::dev::LIVE_RELOAD_SCRIPT_PATH,
+                "dev_live_reload_js",
+            ),
+        ] {
+            infos.push(RouteInfo {
+                method: "GET".to_owned(),
+                path: path.to_owned(),
+                handler: handler.to_owned(),
+                source: RouteSource::Framework,
+                middleware: Vec::new(),
+            });
+        }
+    }
+}
+
 /// Stable-sort route infos: primary key is path (lexicographic), secondary
 /// key is HTTP method (lexicographic). This makes output diff-friendly.
 pub(crate) fn sort_route_infos(infos: &mut [RouteInfo]) {
@@ -211,14 +276,15 @@ mod tests {
 
     #[test]
     fn collect_route_infos_empty_produces_empty() {
-        let infos = collect_route_infos(&[], &[]);
+        let infos = collect_route_infos(&[], &[], &[]);
         assert!(infos.is_empty());
     }
 
     #[test]
     fn collect_route_infos_single_user_route() {
         let routes = vec![make_route(Method::GET, "/posts", "list_posts")];
-        let infos = collect_route_infos(&routes, &[]);
+        let sources = vec![RouteSource::User];
+        let infos = collect_route_infos(&routes, &sources, &[]);
         assert_eq!(infos.len(), 1);
         assert_eq!(infos[0].method, "GET");
         assert_eq!(infos[0].path, "/posts");
@@ -233,21 +299,20 @@ mod tests {
             make_route(Method::GET, "/posts", "list_posts"),
             make_route(Method::POST, "/posts", "create_post"),
         ];
-        let infos = collect_route_infos(&routes, &[]);
+        let sources = vec![RouteSource::User, RouteSource::User];
+        let infos = collect_route_infos(&routes, &sources, &[]);
         assert_eq!(infos.len(), 2);
     }
 
     #[test]
     fn collect_route_infos_scoped_group_prepends_prefix() {
-        async fn handler() -> &'static str {
-            "ok"
-        }
         let group = ScopedGroup {
             prefix: "/api".to_owned(),
             routes: vec![make_route(Method::GET, "/posts", "api_list_posts")],
+            source: RouteSource::User,
             apply_layer: Box::new(|r| r),
         };
-        let infos = collect_route_infos(&[], &[group]);
+        let infos = collect_route_infos(&[], &[], &[group]);
         assert_eq!(infos.len(), 1);
         assert_eq!(infos[0].path, "/api/posts");
         assert_eq!(infos[0].handler, "api_list_posts");
@@ -258,9 +323,10 @@ mod tests {
         let group = ScopedGroup {
             prefix: "/api".to_owned(),
             routes: vec![make_route(Method::GET, "/", "api_root")],
+            source: RouteSource::User,
             apply_layer: Box::new(|r| r),
         };
-        let infos = collect_route_infos(&[], &[group]);
+        let infos = collect_route_infos(&[], &[], &[group]);
         assert_eq!(infos.len(), 1);
         assert_eq!(infos[0].path, "/api");
     }
@@ -268,7 +334,37 @@ mod tests {
     #[test]
     fn collect_route_infos_marks_user_source() {
         let routes = vec![make_route(Method::POST, "/items", "create_item")];
-        let infos = collect_route_infos(&routes, &[]);
+        let sources = vec![RouteSource::User];
+        let infos = collect_route_infos(&routes, &sources, &[]);
+        assert_eq!(infos[0].source, RouteSource::User);
+    }
+
+    #[test]
+    fn collect_route_infos_plugin_source_from_parallel_slice() {
+        let routes = vec![make_route(Method::GET, "/admin", "admin_index")];
+        let sources = vec![RouteSource::Plugin("admin".to_owned())];
+        let infos = collect_route_infos(&routes, &sources, &[]);
+        assert_eq!(infos[0].source, RouteSource::Plugin("admin".to_owned()));
+    }
+
+    #[test]
+    fn collect_route_infos_plugin_source_on_scoped_group() {
+        let group = ScopedGroup {
+            prefix: "/admin".to_owned(),
+            routes: vec![make_route(Method::GET, "/users", "admin_users")],
+            source: RouteSource::Plugin("admin".to_owned()),
+            apply_layer: Box::new(|r| r),
+        };
+        let infos = collect_route_infos(&[], &[], &[group]);
+        assert_eq!(infos[0].source, RouteSource::Plugin("admin".to_owned()));
+        assert_eq!(infos[0].path, "/admin/users");
+    }
+
+    #[test]
+    fn collect_route_infos_missing_source_defaults_to_user() {
+        let routes = vec![make_route(Method::GET, "/x", "x")];
+        // empty sources slice — should fall back to User
+        let infos = collect_route_infos(&routes, &[], &[]);
         assert_eq!(infos[0].source, RouteSource::User);
     }
 

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1853,6 +1853,7 @@ mod tests {
                 },
                 repository: None,
             }],
+            source: crate::route_listing::RouteSource::User,
             apply_layer: Box::new(|r| r),
         };
 
@@ -1923,6 +1924,7 @@ mod tests {
         let group = crate::app::ScopedGroup {
             prefix: "/orgs/{org_id}".to_owned(),
             routes: vec![child],
+            source: crate::route_listing::RouteSource::User,
             apply_layer: Box::new(|r| r),
         };
 

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -624,16 +624,17 @@ fn reject_openapi_path_collisions(
         return Ok(());
     };
 
-    // Gather every path a GET will already own by the time we merge.
+    // Gather every path a GET (or WS, which mounts as GET) will already
+    // own by the time we merge.
     let mut claimed: std::collections::HashSet<String> = std::collections::HashSet::new();
     for route in route_list {
-        if route.method == http::Method::GET {
+        if route.method == http::Method::GET || route.method.as_str() == "WS" {
             claimed.insert(route.path.to_owned());
         }
     }
     for group in scoped_groups {
         for route in &group.routes {
-            if route.method == http::Method::GET {
+            if route.method == http::Method::GET || route.method.as_str() == "WS" {
                 claimed.insert(join_nested_path(&group.prefix, route.path));
             }
         }

--- a/docs/guide/routes-cli.md
+++ b/docs/guide/routes-cli.md
@@ -157,3 +157,19 @@ This means:
   prefix) are read from `autumn.toml`, so the output mirrors production.
 - **Plugin routes attributed** — routes registered by plugins show
   `source = "plugin:<name>"` rather than `"user"`.
+
+## Known limitations
+
+Routes added via `.merge(router)` or `.nest(prefix, router)` with a raw
+`axum::Router` are **not included** in the listing. Axum provides no public API
+to enumerate a router's registered routes. `autumn routes` prints a warning to
+stderr when such routers are detected:
+
+```
+[autumn routes] warning: 1 raw router(s) added via .merge()/.nest() are not
+enumerable and are omitted from this listing
+```
+
+If your application relies heavily on merged/nested raw routers, use `autumn
+routes` output as a partial snapshot and supplement it with manual
+documentation for those routes.

--- a/docs/guide/routes-cli.md
+++ b/docs/guide/routes-cli.md
@@ -1,0 +1,159 @@
+# `autumn routes` — Route Inspection CLI
+
+`autumn routes` prints every mounted route — method, path, handler name,
+registration source, and active middleware — without starting the HTTP server
+or connecting to a database.
+
+## Quick start
+
+```bash
+# In a single-crate project
+autumn routes
+
+# In a Cargo workspace
+autumn routes -p blog
+```
+
+Output (table format, sorted by path then method):
+
+```
+METHOD    PATH                        HANDLER                  SOURCE
+DELETE    /admin/{id}                 delete_post              user
+GET       /                           list_posts               user
+GET       /about                      about                    user
+GET       /actuator/health            actuator                 framework
+GET       /actuator/info              actuator                 framework
+GET       /actuator/metrics           actuator                 framework
+GET       /admin                      admin_posts              user
+GET       /admin/new                  new_post_form            user
+GET       /admin/{id}/edit            edit_post_form           user
+GET       /api/posts                  api_list_posts           user
+GET       /backoffice/posts           backoffice_list_posts    plugin:autumn-admin
+GET       /health                     health                   framework
+GET       /posts/{slug}               show_post                user
+POST      /admin                      create_post              user
+POST      /api/posts                  api_create_post          user
+```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `-p, --package <PKG>` | Workspace package to inspect |
+| `[PREFIX]` | Show only routes whose path starts with PREFIX (positional shorthand for `--filter`) |
+| `--filter <FILTER>` | Show only routes whose path starts with FILTER |
+| `--method <METHOD,...>` | Restrict to one or more HTTP methods (comma-separated, e.g. `GET,POST`) |
+| `--user-only` | Hide framework-internal routes (`/actuator/*`, probes, htmx assets) |
+| `--format <FORMAT>` | Output format: `table` (default) or `json` |
+
+## Filtering routes
+
+### By path prefix
+
+Positional shorthand:
+
+```bash
+autumn routes /api
+```
+
+Equivalent long form:
+
+```bash
+autumn routes --filter /api
+```
+
+### By HTTP method
+
+```bash
+autumn routes --method GET
+autumn routes --method GET,POST
+```
+
+Filters are composable — prefix and method can be combined:
+
+```bash
+autumn routes /admin --method POST
+```
+
+### User routes only
+
+Hide all framework-managed routes (health probes, actuator, htmx assets,
+OpenAPI docs, dev live-reload):
+
+```bash
+autumn routes --user-only
+```
+
+`--user-only` keeps plugin routes (source `plugin:<name>`); it only strips
+`framework` routes.
+
+## JSON output
+
+Emit machine-readable JSON for scripting, CI, or tooling integration:
+
+```bash
+autumn routes --format json
+```
+
+Each entry in the JSON array follows this schema:
+
+```json
+{
+  "method": "GET",
+  "path": "/api/posts",
+  "handler": "api_list_posts",
+  "source": "user",
+  "middleware": []
+}
+```
+
+`source` is one of:
+
+| Value | Meaning |
+|-------|---------|
+| `"user"` | Registered directly by the application |
+| `"plugin:<name>"` | Registered by a named Autumn plugin (e.g. `"plugin:autumn-admin"`) |
+| `"framework"` | Registered by the Autumn framework itself |
+
+## WebSocket routes
+
+Routes registered with `#[ws]` appear with method `WS`:
+
+```
+WS    /ws/chat    chat_handler    user
+```
+
+## CI snapshot recipe
+
+Capture a baseline and diff it on every pull request to catch unintended
+route changes:
+
+```bash
+# Record a baseline (commit this file)
+autumn routes --format json > routes-snapshot.json
+
+# In CI — diff against the committed snapshot
+autumn routes --format json > routes-current.json
+diff routes-snapshot.json routes-current.json
+```
+
+Because rows are stable-sorted by path then method, `git diff` and `diff`
+output is minimal and easy to review.
+
+## How it works
+
+`autumn routes` compiles your application in debug mode, then runs the
+resulting binary with `AUTUMN_DUMP_ROUTES=1`. The binary detects this
+variable during `AppBuilder::run()`, collects all registered routes (user,
+plugin, and framework), serialises them to JSON, writes to stdout, and
+exits 0 — without binding a TCP port, connecting to a database, or
+running any startup hooks.
+
+This means:
+
+- **No running server required** — safe to run in CI or pre-deploy scripts.
+- **No database needed** — routes are inspected before any pool is created.
+- **Reflects real config** — framework route paths (e.g. custom actuator
+  prefix) are read from `autumn.toml`, so the output mirrors production.
+- **Plugin routes attributed** — routes registered by plugins show
+  `source = "plugin:<name>"` rather than `"user"`.

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -101,6 +101,54 @@ If `static/.autumn-manifest.json` is absent (e.g. on a dev machine that never
 ran `autumn build --release`), `asset_url` falls back to the plain
 `/static/...` URL — so the app keeps running without any manual configuration.
 
+## Inspecting routes with `autumn routes`
+
+Print every mounted route without starting the server:
+
+```bash
+cargo run -p autumn-cli -- routes -p blog
+```
+
+Example output:
+
+```
+METHOD    PATH                        HANDLER                  SOURCE
+DELETE    /admin/{id}                 delete_post              user
+GET       /                           list_posts               user
+GET       /about                      about                    user
+GET       /actuator/health            actuator                 framework
+GET       /actuator/info              actuator                 framework
+GET       /actuator/metrics           actuator                 framework
+GET       /admin                      admin_posts              user
+GET       /admin/new                  new_post_form            user
+GET       /admin/{id}/edit            edit_post_form           user
+GET       /api/posts                  api_list_posts           user
+GET       /backoffice/posts           backoffice_list_posts    plugin:autumn-admin
+GET       /health                     health                   framework
+GET       /posts/{slug}               show_post                user
+POST      /admin                      create_post              user
+POST      /api/posts                  api_create_post          user
+```
+
+Filter to just the JSON API routes and emit machine-readable JSON:
+
+```bash
+cargo run -p autumn-cli -- routes -p blog /api --format json
+```
+
+Hide framework-internal routes to review only application routes:
+
+```bash
+cargo run -p autumn-cli -- routes -p blog --user-only
+```
+
+Capture a snapshot for `git diff` auditing:
+
+```bash
+cargo run -p autumn-cli -- routes -p blog > routes.txt
+git diff routes.txt
+```
+
 ## Routes
 
 ### HTML


### PR DESCRIPTION
## Summary

Adds a new `autumn routes` CLI command that lists all mounted routes without starting the HTTP server or connecting to a database. Routes are displayed as a human-readable table or machine-readable JSON, with support for filtering by path prefix, HTTP method, and route source.

## Key Changes

- **New CLI command**: `autumn routes` with options for package selection, output format, path filtering, method filtering, and user-only mode
- **Route listing infrastructure**: New `autumn/src/route_listing.rs` module that collects route metadata from `AppBuilder` into serializable `RouteInfo` structures
- **Route source tracking**: Extended `AppBuilder` to track the origin of each route (user application, named plugin, or framework) via parallel `route_sources` and `current_plugin` fields
- **CLI implementation**: New `autumn-cli/src/routes.rs` module that compiles the binary, runs it with `AUTUMN_DUMP_ROUTES=1`, parses JSON output, applies filters, and formats results
- **Framework route collection**: Functions to append framework-internal routes (health probes, actuator endpoints, htmx assets, OpenAPI docs, dev live-reload) with proper configuration awareness
- **Scoped group source tracking**: `ScopedGroup` now carries a `source` field to attribute nested routes to their registration origin
- **Comprehensive testing**: 50+ unit tests covering output format parsing, filtering logic, sorting, table formatting, JSON serialization, and route collection
- **Documentation**: New guide at `docs/guide/routes-cli.md` with usage examples, filtering patterns, JSON schema, and CI snapshot recipes

## Implementation Details

- Routes are stable-sorted by path (lexicographic) then method, making output diff-friendly for CI snapshots
- Filtering is composable: path prefix, HTTP methods, and user-only mode can be combined
- The `RouteSource` enum distinguishes between user routes, plugin routes (with plugin name), and framework routes
- Binary discovery mirrors the logic from `build.rs` using `cargo metadata`
- Framework routes are only included when appropriate (e.g., dev reload routes only when `AUTUMN_DEV=1`)
- The command exits cleanly without binding ports or running startup hooks

https://claude.ai/code/session_01KvvQED2SfYKe3hyNRJnxVE