### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/storage/config.rs
+++ b/autumn/src/storage/config.rs
@@ -421,4 +421,22 @@ mod tests {
             Err(StorageBackendConfigError::MissingS3Region)
         );
     }
+
+    #[test]
+    #[cfg(not(feature = "storage-s3"))]
+    fn s3_plan_yields_feature_disabled_error() {
+        let cfg = StorageConfig {
+            backend: StorageBackend::S3,
+            s3: StorageS3Config {
+                bucket: Some("b".into()),
+                region: Some("r".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(
+            cfg.backend_plan(Some("prod")),
+            Err(StorageBackendConfigError::S3FeatureDisabled)
+        );
+    }
 }


### PR DESCRIPTION
🎯 Target: `autumn_web::storage::config::StorageConfig::backend_plan`
💣 Risk: Missing test coverage for S3 configuration when the `storage-s3` feature is disabled, potentially hiding regressions.
🧪 Strategy: Added a conditional test module for the `not(feature = "storage-s3")` configuration.
🔬 Verification: `cargo test -p autumn-web --lib storage`

---
*PR created automatically by Jules for task [6569210835655559076](https://jules.google.com/task/6569210835655559076) started by @madmax983*