### PR TITLE
🗺️ Atlas: [architectural change] Remove AppState circular dependencies

### DIFF
--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1342,38 +1342,85 @@ pub(crate) fn actuator_router_with_prefix<
 mod tests {
     use super::*;
     use crate::config::AutumnConfig;
-    use crate::state::AppState;
     use axum::body::Body;
     use axum::http::Request;
     use tower::ServiceExt;
 
-    fn test_state() -> AppState {
+    #[derive(Clone)]
+    struct TestActuatorState {
+        profile: String,
+        metrics: crate::middleware::MetricsCollector,
+        log_levels: LogLevels,
+        task_registry: TaskRegistry,
+        job_registry: JobRegistry,
+        config_props: ConfigProperties,
+        #[cfg(feature = "db")]
+        pool: Option<
+            diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        >,
+        #[cfg(feature = "ws")]
+        channels: crate::channels::Channels,
+        #[cfg(feature = "ws")]
+        shutdown: tokio_util::sync::CancellationToken,
+    }
+
+    impl ProvideActuatorState for TestActuatorState {
+        fn metrics(&self) -> &crate::middleware::MetricsCollector {
+            &self.metrics
+        }
+        fn log_levels(&self) -> &LogLevels {
+            &self.log_levels
+        }
+        fn task_registry(&self) -> &TaskRegistry {
+            &self.task_registry
+        }
+        fn job_registry(&self) -> &JobRegistry {
+            &self.job_registry
+        }
+        fn config_props(&self) -> &ConfigProperties {
+            &self.config_props
+        }
+        fn profile(&self) -> &str {
+            &self.profile
+        }
+        fn uptime_display(&self) -> String {
+            "test_uptime".to_string()
+        }
+        #[cfg(feature = "db")]
+        fn pool(
+            &self,
+        ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+        {
+            self.pool.as_ref()
+        }
+        #[cfg(feature = "ws")]
+        fn channels(&self) -> &crate::channels::Channels {
+            &self.channels
+        }
+        #[cfg(feature = "ws")]
+        fn shutdown_token(&self) -> tokio_util::sync::CancellationToken {
+            self.shutdown.clone()
+        }
+    }
+
+    fn test_state() -> TestActuatorState {
         test_state_with_config(&AutumnConfig::default())
     }
 
-    fn test_state_with_config(config: &AutumnConfig) -> AppState {
-        AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            #[cfg(feature = "db")]
-            pool: None,
-            profile: config.profile.clone().or_else(|| Some("dev".into())),
-            started_at: std::time::Instant::now(),
-            health_detailed: true,
-            probes: crate::probe::ProbeState::ready_for_test(),
+    fn test_state_with_config(config: &AutumnConfig) -> TestActuatorState {
+        TestActuatorState {
+            profile: config.profile.clone().unwrap_or_else(|| "dev".into()),
             metrics: crate::middleware::MetricsCollector::new(),
             log_levels: LogLevels::new("info"),
             task_registry: TaskRegistry::new(),
             job_registry: JobRegistry::new(),
             config_props: ConfigProperties::from_config(config),
+            #[cfg(feature = "db")]
+            pool: None,
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "ws")]
             shutdown: tokio_util::sync::CancellationToken::new(),
-            policy_registry: crate::authorization::PolicyRegistry::default(),
-            forbidden_response: crate::authorization::ForbiddenResponse::default(),
-            auth_session_key: "user_id".to_owned(),
         }
     }
 

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -403,9 +403,17 @@ mod tests {
         assert_eq!(timeouts.create, Some(Duration::from_secs(7)));
     }
 
+    #[derive(Clone)]
+    struct TestDbState;
+
+    impl DbState for TestDbState {
+        fn pool(&self) -> Option<&Pool<AsyncPgConnection>> {
+            None
+        }
+    }
+
     #[tokio::test]
     async fn db_extractor_rejects_when_no_pool() {
-        use crate::state::AppState;
         use axum::Router;
         use axum::body::Body;
         use axum::http::{Request, StatusCode};
@@ -416,28 +424,9 @@ mod tests {
             "ok"
         }
 
-        let app = Router::new().route("/", get(handler)).with_state(AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            pool: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: true,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            job_registry: crate::actuator::JobRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-            policy_registry: crate::authorization::PolicyRegistry::default(),
-            forbidden_response: crate::authorization::ForbiddenResponse::default(),
-            auth_session_key: "user_id".to_owned(),
-        });
+        let app = Router::new()
+            .route("/", get(handler))
+            .with_state(TestDbState);
 
         let response = app
             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())

--- a/autumn/src/health.rs
+++ b/autumn/src/health.rs
@@ -27,7 +27,7 @@
 //! Returns the same response as the readiness probe.
 
 use crate::extract::State;
-use crate::state::AppState;
+use crate::probe::ProvideProbeState;
 use axum::response::IntoResponse;
 
 /// Health check handler.
@@ -42,7 +42,9 @@ use axum::response::IntoResponse;
 /// - `200 OK` -- application is healthy.
 /// - `503 Service Unavailable` -- database pool is exhausted (all
 ///   connections in use and requests are queuing).
-pub async fn handler(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn handler<S: ProvideProbeState + Send + Sync + 'static>(
+    State(state): State<S>,
+) -> impl IntoResponse {
     crate::probe::readiness_response(&state)
 }
 
@@ -53,36 +55,53 @@ mod tests {
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
 
-    fn test_state() -> AppState {
-        AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
+    #[derive(Clone)]
+    struct TestProbeState {
+        #[cfg(feature = "db")]
+        pool: Option<
+            diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        >,
+        profile: String,
+        health_detailed: bool,
+        probes: crate::probe::ProbeState,
+    }
+
+    impl ProvideProbeState for TestProbeState {
+        fn probes(&self) -> &crate::probe::ProbeState {
+            &self.probes
+        }
+        fn health_detailed(&self) -> bool {
+            self.health_detailed
+        }
+        fn profile(&self) -> &str {
+            &self.profile
+        }
+        fn uptime_display(&self) -> String {
+            "test_uptime".to_string()
+        }
+        #[cfg(feature = "db")]
+        fn pool(
+            &self,
+        ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+        {
+            self.pool.as_ref()
+        }
+    }
+
+    fn test_state() -> TestProbeState {
+        TestProbeState {
             #[cfg(feature = "db")]
             pool: None,
-            profile: Some("dev".into()),
-            started_at: std::time::Instant::now(),
+            profile: "dev".into(),
             health_detailed: true,
             probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            job_registry: crate::actuator::JobRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-            policy_registry: crate::authorization::PolicyRegistry::default(),
-            forbidden_response: crate::authorization::ForbiddenResponse::default(),
-            auth_session_key: "user_id".to_owned(),
         }
     }
 
     #[tokio::test]
     async fn health_no_database_returns_ok() -> Result<(), Box<dyn std::error::Error>> {
         let app = axum::Router::new()
-            .route("/health", axum::routing::get(handler))
+            .route("/health", axum::routing::get(handler::<TestProbeState>))
             .with_state(test_state());
 
         let response = app
@@ -106,7 +125,7 @@ mod tests {
     async fn health_no_database_returns_json_content_type() -> Result<(), Box<dyn std::error::Error>>
     {
         let app = axum::Router::new()
-            .route("/health", axum::routing::get(handler))
+            .route("/health", axum::routing::get(handler::<TestProbeState>))
             .with_state(test_state());
 
         let response = app
@@ -136,28 +155,13 @@ mod tests {
         let pool = crate::db::create_pool(&config)?.ok_or("no pool created")?;
 
         let app = axum::Router::new()
-            .route("/health", axum::routing::get(handler))
-            .with_state(AppState {
-                extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                    std::collections::HashMap::new(),
-                )),
+            .route("/health", axum::routing::get(handler::<TestProbeState>))
+            .with_state(TestProbeState {
+                #[cfg(feature = "db")]
                 pool: Some(pool),
-                profile: Some("prod".into()),
-                started_at: std::time::Instant::now(),
+                profile: "prod".into(),
                 health_detailed: true,
                 probes: crate::probe::ProbeState::ready_for_test(),
-                metrics: crate::middleware::MetricsCollector::new(),
-                log_levels: crate::actuator::LogLevels::new("info"),
-                task_registry: crate::actuator::TaskRegistry::new(),
-                job_registry: crate::actuator::JobRegistry::new(),
-                config_props: crate::actuator::ConfigProperties::default(),
-                #[cfg(feature = "ws")]
-                channels: crate::channels::Channels::new(32),
-                #[cfg(feature = "ws")]
-                shutdown: tokio_util::sync::CancellationToken::new(),
-                policy_registry: crate::authorization::PolicyRegistry::default(),
-                forbidden_response: crate::authorization::ForbiddenResponse::default(),
-                auth_session_key: "user_id".to_owned(),
             });
 
         let response = app
@@ -179,7 +183,7 @@ mod tests {
     #[tokio::test]
     async fn health_response_includes_version() -> Result<(), Box<dyn std::error::Error>> {
         let app = axum::Router::new()
-            .route("/health", axum::routing::get(handler))
+            .route("/health", axum::routing::get(handler::<TestProbeState>))
             .with_state(test_state());
 
         let response = app
@@ -199,7 +203,7 @@ mod tests {
         state.health_detailed = false;
 
         let app = axum::Router::new()
-            .route("/health", axum::routing::get(handler))
+            .route("/health", axum::routing::get(handler::<TestProbeState>))
             .with_state(state);
 
         let response = app

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -837,7 +837,7 @@ fn mount_probe_endpoints(
     if mounted_probe_paths.insert(config.health.path.clone()) {
         router = router.route(
             &config.health.path,
-            axum::routing::get(crate::health::handler),
+            axum::routing::get(crate::health::handler::<AppState>),
         );
     }
     tracing::debug!(


### PR DESCRIPTION
🕸️ Tangle: The global `AppState` struct was being explicitly imported into child module tests (`db`, `actuator`, `health`), creating circular dependencies within the module graph and tightly coupling modules.

📐 Blueprint: Removed `AppState` imports from test modules. Handlers are now generic over dependency-injected traits (`ProvideProbeState`). Local mock structs (`TestDbState`, `TestActuatorState`, `TestProbeState`) were implemented within test modules and passed into local routers, breaking the cycles. Explicit generic constraints were added where the concrete `AppState` type is passed.

🧱 Stability: High cohesion and low coupling are enforced. Testing modules no longer rely on the root `AppState` object, reducing the 'shotgun surgery' required whenever new fields are added to `AppState`.

🔭 Verification: The workspace compiles cleanly, tests pass (`cargo test`), and formatting and strict clippy checks return zero warnings.

---
*PR created automatically by Jules for task [16174188752076932959](https://jules.google.com/task/16174188752076932959) started by @madmax983*