### PR TITLE
🔭 Vantage: Spec for Smart Default Error Pages

### DIFF
--- a/docs/design/spec_smart_default_error_pages.md
+++ b/docs/design/spec_smart_default_error_pages.md
@@ -1,0 +1,23 @@
+# 🔭 Vantage: Spec for Smart Default Error Pages
+
+## 👤 User Story
+As a web developer using Autumn, I want the framework to automatically provide helpful, formatted default error responses (like 404 Not Found), so that I don't have to manually wire up standard error handling plumbing for every new project.
+
+## 🎯 The "So What?" (Business Problem)
+Currently, when an unmatched route is hit, Autumn returns a completely blank response (`content-length: 0`). This causes immediate friction for new developers (as noted in the DX Audit) and leads to poor end-user experiences. By providing "smart" default error pages, we reinforce our value proposition of "ship the app, not the plumbing" and increase early adoption retention.
+
+## 📊 Success Metrics
+* **Success** = 100% of unmatched routes return a non-empty, standard response body out-of-the-box.
+* **DX Metric** = Zero user complaints about blank error pages in the next DX audit.
+
+## ✅ Acceptance Criteria
+* The framework must automatically handle 404 (Not Found) errors out-of-the-box.
+* The response format must be content-aware (respecting the `Accept` header):
+  * Requests preferring `application/json` must receive a standardized JSON error object.
+  * Requests preferring `text/html` must receive a clean, styled Autumn-branded HTML error page.
+* The default error handlers must be easily overridable by developers who want to provide custom views.
+
+## 🚫 Out of Scope
+* Automatic logging to third-party exception trackers (e.g., Sentry).
+* Building a UI for editing error pages from the admin panel.
+* Handling every single HTTP status code uniquely (focus primarily on 404 and basic 500s first).


### PR DESCRIPTION
👤 **User Story:**
As a web developer using Autumn, I want the framework to automatically provide helpful, formatted default error responses (like 404 Not Found), so that I don't have to manually wire up standard error handling plumbing for every new project.

🎯 **Business Problem ("So What?"):**
Currently, when an unmatched route is hit, Autumn returns a completely blank response (`content-length: 0`). This causes immediate friction for new developers (as noted in the DX Audit) and leads to poor end-user experiences. By providing "smart" default error pages, we reinforce our value proposition of "ship the app, not the plumbing" and increase early adoption retention.

📊 **Success Metrics:**
* **Success** = 100% of unmatched routes return a non-empty, standard response body out-of-the-box.
* **DX Metric** = Zero user complaints about blank error pages in the next DX audit.

✅ **Acceptance Criteria:**
* The framework must automatically handle 404 (Not Found) errors out-of-the-box.
* The response format must be content-aware (respecting the `Accept` header):
  * Requests preferring `application/json` must receive a standardized JSON error object.
  * Requests preferring `text/html` must receive a clean, styled Autumn-branded HTML error page.
* The default error handlers must be easily overridable by developers who want to provide custom views.

🚫 **Out of Scope:**
* Automatic logging to third-party exception trackers (e.g., Sentry).
* Building a UI for editing error pages from the admin panel.
* Handling every single HTTP status code uniquely (focus primarily on 404 and basic 500s first).

---
*PR created automatically by Jules for task [9493469865560623675](https://jules.google.com/task/9493469865560623675) started by @madmax983*