### PR TITLE
🔒 Warden: [security fix] Fix CSRF URL-encoded token parsing vulnerability

### DIFF
--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -359,20 +359,16 @@ async fn verify_csrf_token(
         .await
         .unwrap_or_else(|_| axum::body::Bytes::new());
 
-    if let Ok(body_str) = std::str::from_utf8(&bytes) {
-        for pair in body_str.split('&') {
-            if let Some((key, value)) = pair.split_once('=')
-                && key == settings.form_field
+    for (key, value) in url::form_urlencoded::parse(&bytes) {
+        if key == settings.form_field {
+            if let Some(c) = cookie_token
+                && !c.is_empty()
+                && !value.is_empty()
+                && constant_time_eq(c, value.as_ref())
             {
-                if let Some(c) = cookie_token
-                    && !c.is_empty()
-                    && !value.is_empty()
-                    && constant_time_eq(c, value)
-                {
-                    token_found = true;
-                }
-                break;
+                token_found = true;
             }
+            break;
         }
     }
 
@@ -384,6 +380,30 @@ async fn verify_csrf_token(
 
 #[cfg(test)]
 mod tests {
+    #[tokio::test]
+    async fn post_with_url_encoded_token_passes() {
+        let raw_token = "abc+123/xyz=456";
+        let encoded_token = "abc%2B123%2Fxyz%3D456";
+        let app = Router::new()
+            .route("/submit", post(|| async { "created" }))
+            .layer(CsrfLayer::from_config(&default_csrf_config()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/submit")
+                    .header("Cookie", format!("autumn-csrf={raw_token}"))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(Body::from(format!("_csrf={encoded_token}")))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
     use super::*;
     use axum::Router;
     use axum::body::Body;


### PR DESCRIPTION
🦠 **Threat:** In `autumn/src/security/csrf.rs`, the CSRF middleware manually parsed the `application/x-www-form-urlencoded` POST body by splitting on `&` and `=`, but *did not* URL-decode the extracted form field value. When browsers submit forms, they URL-encode the payload. If the generated CSRF token contained URL-sensitive characters (like `+`, `/`, or `=`), the manual parsing yielded the raw encoded string (e.g., `%2B`), which would fail the `constant_time_eq` check against the unencoded token in the user's session cookie. This would falsely reject valid requests from legitimate users.

🛡️ **Defense:** Replaced the vulnerable manual string splitting loop with the standard `url::form_urlencoded::parse(&bytes)`. This robustly decodes the percent-encoded payload and securely extracts the form field. Because it iterates over `Cow<str>`, it only allocates when necessary and gracefully ignores malformed UTF-8 byte sequences without panicking.

💥 **Severity:** High. A denial of service against legitimate users trying to submit state-changing forms, causing intermittent and difficult-to-debug "Forbidden" errors depending on the random characters present in their session's CSRF token.

🧪 **Verification:**
- Wrote the `post_with_url_encoded_token_passes` unit test simulating a browser submitting an `application/x-www-form-urlencoded` token with `+`, `/`, and `=`.
- Confirmed the test fails under the old logic and passes under the new logic.
- Ran `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test -p autumn-web --lib security::csrf`, and `cargo fmt --all`.

---
*PR created automatically by Jules for task [1752058173225858615](https://jules.google.com/task/1752058173225858615) started by @madmax983*