### PR TITLE
[codex] Address reddit clone job enqueue review

### DIFF
--- a/examples/reddit-clone/src/jobs.rs
+++ b/examples/reddit-clone/src/jobs.rs
@@ -11,7 +11,7 @@ use diesel_async::RunQueryDsl;
 use serde::{Deserialize, Serialize};
 
 use crate::live_events::{
-    post_created_event, publish_stored_live_event_best_effort, store_activity_event,
+    post_created_event, publish_stored_live_event_best_effort, store_activity_event_for_state,
 };
 use crate::models::User;
 use crate::schema::{posts, users};
@@ -70,10 +70,16 @@ pub async fn user_onboarding(state: AppState, args: UserOnboardingArgs) -> Autum
         .ok_or_else(|| AutumnError::service_unavailable_msg("No database pool"))?;
     let mut conn = pool.get().await.map_err(AutumnError::from)?;
 
-    diesel::update(users::table.filter(users::id.eq(args.user_id)))
+    let affected = diesel::update(users::table.filter(users::id.eq(args.user_id)))
         .set(users::karma.eq(STARTER_KARMA))
         .execute(&mut conn)
         .await?;
+    if affected != 1 {
+        return Err(AutumnError::service_unavailable_msg(format!(
+            "user {} was not visible to onboarding job",
+            args.user_id
+        )));
+    }
 
     tracing::info!(
         user_id = args.user_id,
@@ -110,7 +116,8 @@ pub async fn post_publication(state: AppState, args: PostPublicationArgs) -> Aut
         &args.subreddit_slug,
         &args.author_username,
     );
-    let event_id = store_activity_event(&mut conn, &args.subreddit_slug, &event).await?;
+    let event_id =
+        store_activity_event_for_state(&state, &mut conn, &args.subreddit_slug, &event).await?;
     publish_stored_live_event_best_effort(&state, event_id).await;
 
     tracing::info!(

--- a/examples/reddit-clone/src/live_events.rs
+++ b/examples/reddit-clone/src/live_events.rs
@@ -321,7 +321,9 @@ struct LiveEventBusPublisher {
 
 #[derive(Clone)]
 enum LiveEventBusPublisherInner {
-    PostgresNotify,
+    PostgresNotify {
+        channel: String,
+    },
     RedisPubSub {
         channel: String,
         client: redis::Client,
@@ -399,7 +401,9 @@ impl LiveEventBusPublisher {
         health: Arc<LiveFeedRelayHealth>,
     ) -> AutumnResult<Self> {
         let inner = match config.kind {
-            LiveFeedBusKind::PostgresNotify => LiveEventBusPublisherInner::PostgresNotify,
+            LiveFeedBusKind::PostgresNotify => LiveEventBusPublisherInner::PostgresNotify {
+                channel: config.channel.clone(),
+            },
             LiveFeedBusKind::RedisPubSub => {
                 let redis_url = config.redis_url.as_deref().ok_or_else(|| {
                     AutumnError::service_unavailable_msg(
@@ -418,9 +422,17 @@ impl LiveEventBusPublisher {
         Ok(Self { inner, health })
     }
 
+    fn postgres_notify_channel(&self) -> String {
+        let channel = match &self.inner {
+            LiveEventBusPublisherInner::PostgresNotify { channel }
+            | LiveEventBusPublisherInner::RedisPubSub { channel, .. } => channel,
+        };
+        live_event_notify_channel(channel)
+    }
+
     async fn publish(&self, event_id: i64) -> AutumnResult<()> {
         let result = match &self.inner {
-            LiveEventBusPublisherInner::PostgresNotify => Ok(()),
+            LiveEventBusPublisherInner::PostgresNotify { .. } => Ok(()),
             LiveEventBusPublisherInner::RedisPubSub { channel, client } => {
                 let payload = serde_json::to_string(&LiveEventBusMessage { event_id })
                     .expect("live-event bus payload should serialize");
@@ -442,6 +454,13 @@ impl LiveEventBusPublisher {
         let _ = event_id;
         result
     }
+}
+
+fn live_event_notify_channel_for_state(state: &AppState) -> String {
+    state
+        .extension::<LiveEventBusPublisher>()
+        .map(|publisher| publisher.postgres_notify_channel())
+        .unwrap_or_else(|| live_event_notify_channel(LIVE_EVENT_NOTIFY_QUEUE))
 }
 
 type LiveEventConnectFuture<'a> =
@@ -796,6 +815,36 @@ pub async fn store_activity_event(
     subreddit_slug: &str,
     event: &Value,
 ) -> Result<i64, diesel::result::Error> {
+    store_activity_event_on_channel(
+        conn,
+        subreddit_slug,
+        event,
+        &live_event_notify_channel(LIVE_EVENT_NOTIFY_QUEUE),
+    )
+    .await
+}
+
+pub async fn store_activity_event_for_state(
+    state: &AppState,
+    conn: &mut AsyncPgConnection,
+    subreddit_slug: &str,
+    event: &Value,
+) -> Result<i64, diesel::result::Error> {
+    store_activity_event_on_channel(
+        conn,
+        subreddit_slug,
+        event,
+        &live_event_notify_channel_for_state(state),
+    )
+    .await
+}
+
+async fn store_activity_event_on_channel(
+    conn: &mut AsyncPgConnection,
+    subreddit_slug: &str,
+    event: &Value,
+    notify_channel: &str,
+) -> Result<i64, diesel::result::Error> {
     let event_id: i64 = diesel::insert_into(live_feed_events::table)
         .values(NewLiveFeedEventRow {
             subreddit_slug,
@@ -804,7 +853,7 @@ pub async fn store_activity_event(
         .returning(live_feed_events::id)
         .get_result(conn)
         .await?;
-    notify_live_event_stored(conn, event_id).await?;
+    notify_live_event_stored(conn, event_id, notify_channel).await?;
 
     Ok(event_id)
 }
@@ -893,8 +942,8 @@ async fn load_current_live_event_cursor(
 async fn notify_live_event_stored(
     conn: &mut AsyncPgConnection,
     event_id: i64,
+    channel: &str,
 ) -> Result<(), diesel::result::Error> {
-    let channel = live_event_notify_channel(LIVE_EVENT_NOTIFY_QUEUE);
     let payload = serde_json::to_string(&LiveEventBusMessage { event_id })
         .expect("live-feed notify payload should serialize");
 
@@ -1502,6 +1551,26 @@ mod tests {
 
         web_state.trigger_shutdown_for_test();
         relay.await.expect("relay task should shut down cleanly");
+    }
+
+    #[tokio::test]
+    async fn postgres_notify_channel_uses_installed_bus_channel() {
+        let state = AppState::detached();
+        install_live_event_bus_with_config(
+            &state,
+            LiveFeedBusConfig {
+                kind: LiveFeedBusKind::PostgresNotify,
+                redis_url: None,
+                channel: "custom_live_feed".to_owned(),
+            },
+        )
+        .await
+        .expect("custom live-event bus should install");
+
+        assert_eq!(
+            live_event_notify_channel_for_state(&state),
+            "autumn_live_event_custom_live_feed"
+        );
     }
 
     #[tokio::test]

--- a/examples/reddit-clone/src/routes/auth.rs
+++ b/examples/reddit-clone/src/routes/auth.rs
@@ -154,8 +154,7 @@ pub async fn register(
     };
 
     let user = (*db)
-        .transaction::<User, AutumnError, _>(|conn| {
-            let new_user = new_user.clone();
+        .transaction::<User, AutumnError, _>(move |conn| {
             async move {
                 let user: User = diesel::insert_into(users::table)
                     .values(&new_user)

--- a/examples/reddit-clone/src/routes/auth.rs
+++ b/examples/reddit-clone/src/routes/auth.rs
@@ -8,8 +8,9 @@ use autumn_web::extract::Path;
 use autumn_web::extract::State;
 use autumn_web::prelude::*;
 use diesel::prelude::*;
+use diesel_async::AsyncConnection;
 use diesel_async::RunQueryDsl;
-use tracing::warn;
+use scoped_futures::ScopedFutureExt;
 
 use crate::jobs::{UserOnboardingArgs, UserOnboardingJob};
 use crate::models::{NewUser, User};
@@ -152,21 +153,24 @@ pub async fn register(
         password_hash: hashed,
     };
 
-    let user: User = diesel::insert_into(users::table)
-        .values(&new_user)
-        .returning(User::as_returning())
-        .get_result(&mut *db)
-        .await
-        .map_err(|_| AutumnError::unprocessable_msg("Username already taken"))?;
+    let user = (*db)
+        .transaction::<User, AutumnError, _>(|conn| {
+            let new_user = new_user.clone();
+            async move {
+                let user: User = diesel::insert_into(users::table)
+                    .values(&new_user)
+                    .returning(User::as_returning())
+                    .get_result(conn)
+                    .await
+                    .map_err(|_| AutumnError::unprocessable_msg("Username already taken"))?;
 
-    if let Err(error) = UserOnboardingJob::enqueue(UserOnboardingArgs::from_user(&user)).await {
-        warn!(
-            user_id = user.id,
-            username = %user.username,
-            error = %error,
-            "failed to enqueue user onboarding job"
-        );
-    }
+                enqueue_user_onboarding(&user).await?;
+
+                Ok(user)
+            }
+            .scope_boxed()
+        })
+        .await?;
 
     // Log in immediately after registration
     session.rotate_id().await;
@@ -177,6 +181,10 @@ pub async fn register(
     AccountMailer.deliver_later_welcome(&mailer, email, user.username.clone());
 
     Ok(Redirect::to("/"))
+}
+
+async fn enqueue_user_onboarding(user: &User) -> AutumnResult<()> {
+    UserOnboardingJob::enqueue(UserOnboardingArgs::from_user(user)).await
 }
 
 // ── Login ──────────────────────────────────────────────────────
@@ -217,6 +225,28 @@ mod tests {
         );
         assert!(eml.contains("Subject: Welcome to Autumn Reddit"));
         assert!(eml.contains("cool_rustacean"));
+    }
+
+    #[tokio::test]
+    async fn onboarding_enqueue_failure_is_returned_to_registration() {
+        let user = User {
+            id: 42,
+            username: "ferris".to_owned(),
+            password_hash: "hashed".to_owned(),
+            karma: 0,
+            role: "user".to_owned(),
+            created_at: chrono::DateTime::UNIX_EPOCH.naive_utc(),
+            avatar: None,
+        };
+
+        let error = enqueue_user_onboarding(&user)
+            .await
+            .expect_err("missing job runtime should fail registration");
+
+        assert!(
+            error.to_string().contains("job runtime is not initialized"),
+            "unexpected error: {error}"
+        );
     }
 }
 

--- a/examples/reddit-clone/src/routes/comments.rs
+++ b/examples/reddit-clone/src/routes/comments.rs
@@ -13,7 +13,7 @@ use diesel_async::RunQueryDsl;
 use scoped_futures::ScopedFutureExt;
 
 use crate::live_events::{
-    comment_created_event, publish_stored_live_event_best_effort, store_activity_event,
+    comment_created_event, publish_stored_live_event_best_effort, store_activity_event_for_state,
 };
 use crate::models::Comment;
 use crate::schema::{comments, posts, subreddits, users};
@@ -55,12 +55,14 @@ pub async fn create(
     let post_slug_for_event = post_slug.clone();
     let body_for_insert = body.clone();
     let author_username_for_event = author_username.clone();
+    let state_for_event = state.clone();
     let event_id = (*db)
         .transaction::<i64, AutumnError, _>(|conn| {
             let sub_slug = sub_slug_for_event.clone();
             let post_slug = post_slug_for_event.clone();
             let body = body_for_insert.clone();
             let author_username = author_username_for_event.clone();
+            let state = state_for_event.clone();
             async move {
                 let post_id: i64 = posts::table
                     .inner_join(subreddits::table.on(posts::subreddit_id.eq(subreddits::id)))
@@ -95,7 +97,8 @@ pub async fn create(
                     &author_username,
                     &body,
                 );
-                let event_id = store_activity_event(conn, &sub_slug, &event).await?;
+                let event_id =
+                    store_activity_event_for_state(&state, conn, &sub_slug, &event).await?;
 
                 Ok(event_id)
             }

--- a/examples/reddit-clone/src/routes/posts.rs
+++ b/examples/reddit-clone/src/routes/posts.rs
@@ -11,7 +11,6 @@ use diesel::prelude::*;
 use diesel_async::AsyncConnection;
 use diesel_async::RunQueryDsl;
 use scoped_futures::ScopedFutureExt;
-use tracing::warn;
 
 use crate::jobs::{PostPublicationArgs, PostPublicationJob};
 use crate::models::{Post, Subreddit, User};
@@ -334,12 +333,16 @@ pub async fn submit(
     let url_for_insert = url.clone();
     let title_for_insert = title.clone();
     let slug_for_insert = slug.clone();
-    let post_id = (*db)
-        .transaction::<i64, AutumnError, _>(|conn| {
+    let subreddit_slug_for_job = subreddit_slug.clone();
+    let author_username_for_job = author_username.clone();
+    (*db)
+        .transaction::<(), AutumnError, _>(|conn| {
             let title = title_for_insert.clone();
             let slug = slug_for_insert.clone();
             let body = body.clone();
             let url = url_for_insert.clone();
+            let subreddit_slug = subreddit_slug_for_job.clone();
+            let author_username = author_username_for_job.clone();
             async move {
                 let post_id: i64 = diesel::insert_into(posts::table)
                     .values((
@@ -364,31 +367,14 @@ pub async fn submit(
                     .execute(conn)
                     .await?;
 
-                Ok(post_id)
+                enqueue_post_publication(post_id, &title, &slug, &subreddit_slug, &author_username)
+                    .await?;
+
+                Ok(())
             }
             .scope_boxed()
         })
         .await?;
-
-    if let Err(error) = PostPublicationJob::enqueue(PostPublicationArgs::new(
-        post_id,
-        title.clone(),
-        slug.clone(),
-        subreddit_slug.clone(),
-        author_username.clone(),
-    ))
-    .await
-    {
-        warn!(
-            post_id,
-            title = %title,
-            post_slug = %slug,
-            subreddit_slug = %sub.slug,
-            author_username = %author_username,
-            error = %error,
-            "failed to enqueue post publication job"
-        );
-    }
 
     Ok(Redirect::to(&super::subreddits::__autumn_path_show(
         &sub.slug,
@@ -740,6 +726,23 @@ async fn unique_slug(
     }
 }
 
+async fn enqueue_post_publication(
+    post_id: i64,
+    title: &str,
+    post_slug: &str,
+    subreddit_slug: &str,
+    author_username: &str,
+) -> AutumnResult<()> {
+    PostPublicationJob::enqueue(PostPublicationArgs::new(
+        post_id,
+        title,
+        post_slug,
+        subreddit_slug,
+        author_username,
+    ))
+    .await
+}
+
 /// Like `unique_slug`, but excludes a specific post ID (for updates).
 async fn unique_slug_excluding(
     base: &str,
@@ -775,3 +778,21 @@ autumn_web::paths![
     update,
     delete_post
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn post_publication_enqueue_failure_is_returned_to_submit() {
+        let error =
+            enqueue_post_publication(99, "Ferris arrives", "ferris-arrives", "rust", "ferris")
+                .await
+                .expect_err("missing job runtime should fail post submission");
+
+        assert!(
+            error.to_string().contains("job runtime is not initialized"),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/examples/reddit-clone/src/routes/posts.rs
+++ b/examples/reddit-clone/src/routes/posts.rs
@@ -330,19 +330,8 @@ pub async fn submit(
     let body = form.0.body.trim().to_string();
     let subreddit_id = form.0.subreddit_id;
     let subreddit_slug = sub.slug.clone();
-    let url_for_insert = url.clone();
-    let title_for_insert = title.clone();
-    let slug_for_insert = slug.clone();
-    let subreddit_slug_for_job = subreddit_slug.clone();
-    let author_username_for_job = author_username.clone();
     (*db)
-        .transaction::<(), AutumnError, _>(|conn| {
-            let title = title_for_insert.clone();
-            let slug = slug_for_insert.clone();
-            let body = body.clone();
-            let url = url_for_insert.clone();
-            let subreddit_slug = subreddit_slug_for_job.clone();
-            let author_username = author_username_for_job.clone();
+        .transaction::<(), AutumnError, _>(move |conn| {
             async move {
                 let post_id: i64 = diesel::insert_into(posts::table)
                     .values((


### PR DESCRIPTION
## Summary
- Fail registration and post submission when request-triggered job enqueue cannot be accepted, so side effects are not silently dropped.
- Keep the post/user writes in the same DB transaction as the enqueue attempt, allowing rollback on enqueue failure.
- Make onboarding retry if the user row is not yet visible to the job handler.
- Keep Postgres live-feed wakeups on the installed bus channel so custom `distributed.live_feed_bus.channel` values do not fall back to polling.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p reddit-clone --lib` (26 passed, 8 ignored)
- `cargo check -p reddit-clone --all-targets`
- `rg -n "TODO|FIXME|Stub:" examples\reddit-clone\src -S` (no matches)
- `rg -n "autumn-harvest|autumn_harvest|HarvestPlugin|HarvestRuntime|HarvestMode|reddit-clone-harvest-runner" Cargo.toml examples\reddit-clone\Cargo.toml examples\reddit-clone\src -S` (no matches)

## Notes
- Follow-up to #580 after Codex review comments on commit `5bb03d7b33`.
- Local `.gitignore` and generated `examples/reddit-clone/static/css/autumn.css` changes remain uncommitted and are not part of this PR.