### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -545,7 +545,7 @@ pub use autumn_macros::cached;
 #[cfg(feature = "ws")]
 pub use autumn_macros::ws;
 
-/// Declare an on-demand background job. See [`job`] module.
+/// Declare an on-demand background job. See [`mod@job`] module.
 pub use autumn_macros::job;
 /// Declare a scheduled background task. See [`task`] module.
 pub use autumn_macros::scheduled;

--- a/autumn/src/ui/tokens.rs
+++ b/autumn/src/ui/tokens.rs
@@ -25,7 +25,7 @@ pub const TOKENS_CSS: &str = include_str!("tokens.css");
 
 /// Flash-message CSS consuming the shared tokens.
 ///
-/// Paired with [`crate::flash::FlashLevel::as_str`] (`"success"` /
+/// Paired with `FlashLevel::as_str` (if the `flash` feature is enabled) (`"success"` /
 /// `"error"` / `"warning"` / `"info"`). Render a flash like:
 ///
 /// ```html


### PR DESCRIPTION
📖 Chapter: `lib.rs` macro links and `ui::tokens.rs` flash tokens
🔦 Insight: Removed ambiguous `job` macro link in `lib.rs` by specifying `mod@job` and fixed broken intra-doc link to `crate::flash::FlashLevel::as_str` in `tokens.rs` which was causing doc build warnings.
🧪 Example: Replaced `[crate::flash::FlashLevel::as_str]` with `FlashLevel::as_str` as an inline code reference to avoid rustdoc warnings when the `flash` feature is omitted.
🖼️ Preview: Documentation now builds completely cleanly without any `rustdoc::broken_intra_doc_links` warnings.

---
*PR created automatically by Jules for task [9803631507147962006](https://jules.google.com/task/9803631507147962006) started by @madmax983*