### PR TITLE
🗣️ Echo: Fix hot reloading for views and locales dirs

### DIFF
--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -40,7 +40,14 @@ const WATCH_FILES: &[&str] = &[
 ];
 
 /// Directories that are always watched recursively, regardless of config.
-const DEFAULT_WATCH_DIRS: &[&str] = &["src", "static", "templates", "migrations"];
+const DEFAULT_WATCH_DIRS: &[&str] = &[
+    "src",
+    "static",
+    "templates",
+    "migrations",
+    "views",
+    "locales",
+];
 
 /// Path of the project config file relative to the dev server's working directory.
 const AUTUMN_TOML: &str = "autumn.toml";
@@ -1840,7 +1847,7 @@ watch_dirs = ["views", "locales"]
         let dirs = sanitize_custom_watch_dirs(DevConfig {
             watch_dirs: vec!["src".into(), "static".into(), "views".into()],
         });
-        assert_eq!(dirs, vec!["views"]);
+        assert_eq!(dirs, vec![] as Vec<String>);
     }
 
     #[test]
@@ -1854,7 +1861,7 @@ watch_dirs = ["views", "locales"]
                 String::new(),
             ],
         });
-        assert_eq!(dirs, vec!["views", "locales"]);
+        assert_eq!(dirs, vec![] as Vec<String>);
     }
 
     // ── classify_change with custom dirs ───────────────────────────
@@ -2144,7 +2151,7 @@ watch_dirs = ["views", "locales"]
                 "./locales".into(),
             ],
         });
-        let expected_locales = "locales".to_owned();
-        assert_eq!(dirs, vec!["views".to_owned(), expected_locales]);
+
+        assert_eq!(dirs, vec![] as Vec<String>);
     }
 }


### PR DESCRIPTION
1. 🔎 EXPERIENCE: Ran 'autumn dev' with custom views directory.
2. 🚧 STUMBLE: Expected hot reload to trigger for 'views' folder, but nothing happened.
3. 📢 REPORT: Added 'views' and 'locales' to 'DEFAULT_WATCH_DIRS' array in 'autumn-cli/src/dev.rs' to match common web conventions and work out of the box.
4. 🧪 VERIFY: Ran 'cargo test -p autumn-cli' and modified failing tests that assumed 'views' was a custom directory.

---
*PR created automatically by Jules for task [8509908574290603270](https://jules.google.com/task/8509908574290603270) started by @madmax983*