### PR TITLE
🍎 Eris: [HTMX Advisories]

### DIFF
--- a/autumn/tests/security/htmx_crlf.rs
+++ b/autumn/tests/security/htmx_crlf.rs
@@ -1,0 +1,36 @@
+use axum::{body::Body, http::{Request, HeaderValue}, routing::get, Router};
+use autumn_web::prelude::HxResponseExt;
+use tower::ServiceExt;
+
+async fn handler() -> impl axum::response::IntoResponse {
+    // Attempt CRLF injection
+    "ok".hx_trigger("event\r\nInjected-Header: injected")
+}
+
+#[tokio::test]
+async fn test_htmx_crlf_blocked_by_headervalue() {
+    let app = Router::new().route("/", get(handler));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let headers = response.headers();
+
+    // The injected header should not be present
+    assert!(headers.get("Injected-Header").is_none());
+
+    // The hx-trigger header itself should not be present because `HeaderValue::from_str` failed and the error was swallowed
+    assert!(headers.get("hx-trigger").is_none());
+
+    // Verify HeaderValue blocks this at a fundamental level
+    let res = HeaderValue::from_str("event\r\nInjected-Header: injected");
+    assert!(res.is_err());
+}

--- a/autumn/tests/security/htmx_oob_escape.rs
+++ b/autumn/tests/security/htmx_oob_escape.rs
@@ -1,0 +1,15 @@
+use autumn_web::prelude::*;
+
+#[tokio::test]
+async fn test_htmx_oob_swap_injection_blocked_by_maud() {
+    let attacker_input = r#"<div hx-swap-oob="true" id="admin-panel">Hacked</div>"#;
+    let template = html! {
+        div { (attacker_input) }
+    };
+
+    let rendered = template.into_string();
+
+    // The `<` and `"` characters should be escaped by Maud
+    assert!(!rendered.contains("<div hx-swap-oob"));
+    assert!(rendered.contains("&lt;div hx-swap-oob=&quot;true&quot;"));
+}

--- a/autumn/tests/security/htmx_request_spoofing.rs
+++ b/autumn/tests/security/htmx_request_spoofing.rs
@@ -1,0 +1,51 @@
+use axum::{body::Body, http::Request, routing::get, Router};
+use autumn_web::prelude::HxRequest;
+use tower::ServiceExt;
+
+async fn handler(hx: HxRequest) -> String {
+    if hx.is_htmx {
+        "htmx_response".to_string()
+    } else {
+        "full_page_response".to_string()
+    }
+}
+
+#[tokio::test]
+async fn test_hx_request_spoofing_changes_response() {
+    let app = Router::new().route("/", get(handler));
+
+    // A normal request gets the full page
+    let normal_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let normal_body = axum::body::to_bytes(normal_response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(&normal_body[..], b"full_page_response");
+
+    // An attacker can trivially spoof the header to get the partial response
+    let spoofed_response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/")
+                .header("hx-request", "true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let spoofed_body = axum::body::to_bytes(spoofed_response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(&spoofed_body[..], b"htmx_response");
+
+    // As documented in [ERIS-NOTE], this is expected content negotiation and not a vulnerability
+    // since it does not grant access to restricted data.
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -11,3 +11,6 @@ pub mod csrf_timing;
 pub mod ctf;
 pub mod fallback_middleware_bypass;
 pub mod session_fixation;
+pub mod htmx_crlf;
+pub mod htmx_oob_escape;
+pub mod htmx_request_spoofing;

--- a/eris_advisories.md
+++ b/eris_advisories.md
@@ -1,3 +1,12 @@
 # [ERIS-NOTE] CSRF on HTMX Endpoints
 
 The hypothesis that "I can bypass CSRF protection on htmx endpoints by omitting the HX-Request header and submitting a standard form POST" was extensively tested and found to be false. The `CsrfLayer` securely applies validation on all non-safe methods regardless of the presence of htmx-specific headers, and gracefully falls back to checking the URL-encoded body if the header token is absent.
+
+# [ERIS-NOTE] HTMX Headers and CRLF Injection
+The `append_hx_header` function utilizes `HeaderValue::from_str`. The standard `http::HeaderValue` securely validates strings to ensure they contain no invalid characters like `\r` or `\n`. Attempted CRLF injections return a `Result::Err` during construction, and since `append_hx_header` simply ignores any `Err`, header injection via `hx_trigger` or `hx_location` is not possible.
+
+# [ERIS-NOTE] HTMX Out-of-Band (OOB) Swap Injection
+The Maud templating language inherently prevents HTML element injection via variable interpolation by implicitly escaping attributes like `hx-swap-oob`. Because `htmx` attribute processing relies on correct DOM insertion (not unescaped strings), XSS / DOM manipulation via user string interpolation into `hx-*` attributes is structurally impossible when using Maud templates.
+
+# [ERIS-NOTE] HTMX Request Spoofing
+While it is trivial to forge `HX-Request` headers, the only side effect is changing whether handlers render partial templates versus full pages. This does not grant access to restricted data or bypass CSRF protection. Therefore, `HX-Request` spoofing is not a vulnerability; it is standard HTTP content negotiation.


### PR DESCRIPTION
`[ERIS-NOTE]` We hypothesized HTMX endpoints could be vulnerable to multiple attack vectors:
- **HTMX Request Spoofing**: While trivial to forge `HX-Request`, the only effect is rendering partial vs. full pages.
- **HTMX Out-of-Band (OOB) Swap / Attribute Injection**: Structurally impossible due to Maud's implicit HTML escaping.
- **HTMX Headers and CRLF Injection**: Blocked because `append_hx_header` uses `HeaderValue::from_str` which drops injected headers.

Because none of these could be translated into working proof-of-concept exploits, they have been downgraded to advisories. No vulnerabilities found in HTMX integration.

---
*PR created automatically by Jules for task [17145453243617024](https://jules.google.com/task/17145453243617024) started by @madmax983*