### PR TITLE
⚡ Bolt: Remove intermediate vector allocations in string concatenation

### DIFF
--- a/autumn-cli/src/generate/mod.rs
+++ b/autumn-cli/src/generate/mod.rs
@@ -49,12 +49,19 @@ pub enum GenerateError {
     Io(#[from] std::io::Error),
 }
 
+/// ⚡ Bolt optimization: Formats collision paths directly into a pre-allocated
+/// String buffer to avoid multiple intermediate `String` and `Vec` allocations.
 fn format_collisions(paths: &[PathBuf]) -> String {
-    paths
-        .iter()
-        .map(|p| format!("  {}", p.display().to_string().replace('\\', "/")))
-        .collect::<Vec<_>>()
-        .join("\n")
+    use std::fmt::Write;
+    // Estimate ~60 bytes per path
+    let mut out = String::with_capacity(paths.len() * 60);
+    for (i, p) in paths.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        write!(out, "  {}", p.display().to_string().replace('\\', "/")).unwrap();
+    }
+    out
 }
 
 /// Common flags shared by every `generate` subcommand.

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -311,12 +311,25 @@ fn render_form_inputs(fields: &[Field]) -> String {
 /// `tablename::field.eq(form.field.clone()), …` per user field, leaving the
 /// auto-managed `id` and `created_at` columns alone. With no user fields the
 /// body is empty (Diesel accepts `set(())` as a no-op update).
+///
+/// ⚡ Bolt optimization: Avoids intermediate `Vec` allocations during string formatting
+/// by pre-allocating capacity and utilizing `std::fmt::Write` sequentially.
 fn render_update_columns(plural: &str, fields: &[Field]) -> String {
-    fields
-        .iter()
-        .map(|f| format!("{plural}::{name}.eq(form.{name}.clone())", name = f.name))
-        .collect::<Vec<_>>()
-        .join(", ")
+    use std::fmt::Write;
+    // Estimate 50 chars per field
+    let mut out = String::with_capacity(fields.len() * 50);
+    for (i, f) in fields.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        write!(
+            out,
+            "{plural}::{name}.eq(form.{name}.clone())",
+            name = f.name
+        )
+        .unwrap();
+    }
+    out
 }
 
 fn render_smoke_test(pascal_name: &str, plural: &str) -> String {

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -225,7 +225,11 @@ pub fn update_main_rs(existing: &str, mods: &[&str], route_entries: &[String]) -
 
 /// Insert `mod <name>;` lines near the top of `main.rs`, preserving any that
 /// already exist.
+///
+/// ⚡ Bolt optimization: Pre-allocates string buffer based on mod count
+/// and writes sequentially instead of creating intermediate vectors of strings.
 fn ensure_mods(existing: &str, mods: &[&str]) -> String {
+    use std::fmt::Write;
     let mut needed: Vec<&str> = mods
         .iter()
         .copied()
@@ -235,11 +239,13 @@ fn ensure_mods(existing: &str, mods: &[&str]) -> String {
         return existing.to_owned();
     }
     needed.sort_unstable();
-    let block = needed
-        .iter()
-        .map(|m| format!("mod {m};"))
-        .collect::<Vec<_>>()
-        .join("\n");
+    let mut block = String::with_capacity(needed.len() * 15);
+    for (i, m) in needed.iter().enumerate() {
+        if i > 0 {
+            block.push('\n');
+        }
+        write!(block, "mod {m};").unwrap();
+    }
 
     // Mod declarations are *items* and must follow any crate-level inner
     // attributes (`#![allow(...)]`, `//!` doc comments) — Rust rejects the

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -195,6 +195,7 @@ fn render_cargo_toml(
     mut cargo_toml: String,
     seed_bin_toml: &str,
 ) -> String {
+    use std::fmt::Write;
     let mut features = Vec::new();
     if opts.with_i18n {
         features.push("i18n");
@@ -204,13 +205,17 @@ fn render_cargo_toml(
     }
     if !features.is_empty() {
         let plain_dep = format!(r#"autumn-web = "{autumn_version}""#);
-        let features = features
-            .iter()
-            .map(|feature| format!(r#""{feature}""#))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let feature_dep =
-            format!(r#"autumn-web = {{ version = "{autumn_version}", features = [{features}] }}"#);
+        // ⚡ Bolt optimization: Pre-allocate capacity for comma-separated feature strings
+        let mut features_str = String::with_capacity(features.len() * 10);
+        for (i, feature) in features.iter().enumerate() {
+            if i > 0 {
+                features_str.push_str(", ");
+            }
+            write!(features_str, r#""{feature}""#).unwrap();
+        }
+        let feature_dep = format!(
+            r#"autumn-web = {{ version = "{autumn_version}", features = [{features_str}] }}"#
+        );
         cargo_toml = cargo_toml.replace(&plain_dep, &feature_dep);
     }
     if opts.with_seed {


### PR DESCRIPTION
💡 What: Replaced multiple instances of `.map(|x| format!(...)).collect::<Vec<_>>().join(...)` with `std::fmt::Write` loops on pre-allocated `String` buffers.
🎯 Why: To eliminate multiple intermediate heap allocations (both `String` elements and the `Vec` itself) during string concatenation operations in the CLI codebase.
📊 Impact: Reduces heap allocations significantly during code generation commands.
🔬 Measurement: Run `cargo test -p autumn-cli` to verify correctness and no regressions.

---
*PR created automatically by Jules for task [7169273123392351628](https://jules.google.com/task/7169273123392351628) started by @madmax983*