### PR TITLE
🔒 Warden: Prevent unsafe code at crate root

### DIFF
--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_code)]
 //! # Autumn
 //!
 //! An opinionated, convention-over-configuration web framework for Rust.


### PR DESCRIPTION
👾 Threat: The framework crate permitted arbitrary `unsafe` code injections, violating the secure-by-default mandate.
🛡️ Defense: Added `#![deny(unsafe_code)]` to the crate root to ensure no unsafe blocks bypass scrutiny.
💥 Severity: Critical - could allow memory safety vulnerabilities to slip into the core framework.
🧪 Verification: Confirmed `cargo clippy`, `cargo fmt`, and `cargo test -p autumn-web` pass with the lint in place.

---
*PR created automatically by Jules for task [13991872998892761348](https://jules.google.com/task/13991872998892761348) started by @madmax983*