### PR TITLE
🗣️ Echo: [Developer Experience fixes]

### DIFF
--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -40,7 +40,7 @@ const WATCH_FILES: &[&str] = &[
 ];
 
 /// Directories that are always watched recursively, regardless of config.
-const DEFAULT_WATCH_DIRS: &[&str] = &["src", "static", "templates", "migrations"];
+const DEFAULT_WATCH_DIRS: &[&str] = &["src", "static", "templates", "migrations", "views"];
 
 /// Path of the project config file relative to the dev server's working directory.
 const AUTUMN_TOML: &str = "autumn.toml";
@@ -1840,7 +1840,7 @@ watch_dirs = ["views", "locales"]
         let dirs = sanitize_custom_watch_dirs(DevConfig {
             watch_dirs: vec!["src".into(), "static".into(), "views".into()],
         });
-        assert_eq!(dirs, vec!["views"]);
+        assert_eq!(dirs, Vec::<String>::new());
     }
 
     #[test]
@@ -1854,7 +1854,7 @@ watch_dirs = ["views", "locales"]
                 String::new(),
             ],
         });
-        assert_eq!(dirs, vec!["views", "locales"]);
+        assert_eq!(dirs, vec!["locales"]);
     }
 
     // ── classify_change with custom dirs ───────────────────────────
@@ -2145,6 +2145,6 @@ watch_dirs = ["views", "locales"]
             ],
         });
         let expected_locales = "locales".to_owned();
-        assert_eq!(dirs, vec!["views".to_owned(), expected_locales]);
+        assert_eq!(dirs, vec![expected_locales]);
     }
 }

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -491,6 +491,11 @@ pub use autumn_macros::put;
 /// [`post`], [`put`], [`delete`]) which generates a companion
 /// `__autumn_route_info_{name}()` function.
 ///
+/// **Note on Typos**: If you misspell a route handler name in this macro, you will
+/// see two compiler errors: one indicating the missing handler name, and a second
+/// indicating that `__autumn_route_info_{missing_name}` cannot be found. This second
+/// error exposes internal generation details but is an unavoidable artifact of eager macro expansion.
+///
 /// # Examples
 ///
 /// ```rust,no_run

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -296,8 +296,22 @@ pub async fn fallback_404_handler(method: axum::http::Method, uri: axum::http::U
         return axum::http::StatusCode::NO_CONTENT.into_response();
     }
 
-    crate::error::AutumnError::not_found_msg(format!("No route matches {}", uri.path()))
-        .into_response()
+    // For missing paths, we always return a structured 404 response.
+    // If the client requested HTML, the ErrorPageFilter middleware
+    // will automatically intercept this and render the styled 404 HTML page.
+    let mut res =
+        crate::error::AutumnError::not_found_msg(format!("No route matches {}", uri.path()))
+            .into_response();
+
+    // Ensure content length is set for the fallback JSON response.
+    if let Some(body_bytes) = axum::body::HttpBody::size_hint(res.body()).exact() {
+        res.headers_mut().insert(
+            axum::http::header::CONTENT_LENGTH,
+            axum::http::HeaderValue::from(body_bytes),
+        );
+    }
+
+    res
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR addresses the friction points identified in the DX audit:

1. **404 Default Response Issue**: The `fallback_404_handler` in `error_page_filter.rs` was updated to explicitly set the `Content-Length` header on the default JSON response payload when returning `AutumnError::not_found_msg(...)`. This ensures the fallback route renders a valid body instead of an empty payload.
2. **`autumn dev` File Watching Issue**: Modified the `DEFAULT_WATCH_DIRS` array in `autumn-cli/src/dev.rs` to include the `views` directory, which accommodates the standard template organization out-of-the-box. We also updated the associated unit tests.
3. **`routes!` Macro Typos**: Added documentation to the `routes!` macro noting that the secondary `__autumn_route_info_{name}` compiler error is an expected artifact of macro generation when making typo's.
4. **Returning Primitives from routes**: Verified that returning standard primitive types directly from a route handler (e.g. `i32`) properly compiles and runs, thanks to the existing `should_stringify_primitive_output` transformation. If type aliases or unusual paths are used, standard Axum compilation errors apply.

### ECHO'S VERIFICATION:
- **README Run**: Verified the quickstart and routing functionality.
- **Error Check**: Triggered invalid routes to ensure a non-empty `404` JSON/HTML response.

**Testing:**
Ran `cargo test -p autumn-web --lib` and `cargo test -p autumn-cli` to ensure functionality is maintained.

---
*PR created automatically by Jules for task [5220744447586360157](https://jules.google.com/task/5220744447586360157) started by @madmax983*