### PR TITLE
[codex] Forbid unsafe code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
 
+[workspace.lints.rust]
+unsafe_code = "forbid"
+
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }

--- a/autumn-cli/tests/repo_hygiene.rs
+++ b/autumn-cli/tests/repo_hygiene.rs
@@ -26,6 +26,61 @@ fn git(root: &Path, args: &[&str]) -> Output {
 }
 
 #[test]
+fn workspace_forbids_unsafe_code_for_all_members() {
+    let root = workspace_root();
+    let root_manifest_path = root.join("Cargo.toml");
+    let root_manifest = std::fs::read_to_string(&root_manifest_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", root_manifest_path.display()));
+    let root_toml: toml::Value =
+        toml::from_str(&root_manifest).expect("workspace Cargo.toml should parse as TOML");
+
+    let unsafe_code_lint = root_toml
+        .get("workspace")
+        .and_then(|workspace| workspace.get("lints"))
+        .and_then(|lints| lints.get("rust"))
+        .and_then(|rust| rust.get("unsafe_code"))
+        .and_then(toml::Value::as_str);
+    assert_eq!(
+        unsafe_code_lint,
+        Some("forbid"),
+        "workspace root must set [workspace.lints.rust] unsafe_code = \"forbid\"",
+    );
+
+    let members = root_toml["workspace"]["members"]
+        .as_array()
+        .expect("workspace.members should be an array");
+
+    for member in members {
+        let member = member
+            .as_str()
+            .expect("workspace member entries should be strings");
+        let manifest_path = root.join(member).join("Cargo.toml");
+        let manifest = std::fs::read_to_string(&manifest_path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", manifest_path.display()));
+        let manifest_toml: toml::Value = toml::from_str(&manifest).unwrap_or_else(|err| {
+            panic!("{} should parse as TOML: {err}", manifest_path.display())
+        });
+
+        let inherits_workspace_lints = manifest_toml
+            .get("lints")
+            .and_then(|lints| lints.get("workspace"))
+            .and_then(toml::Value::as_bool)
+            == Some(true);
+        let local_unsafe_code_lint = manifest_toml
+            .get("lints")
+            .and_then(|lints| lints.get("rust"))
+            .and_then(|rust| rust.get("unsafe_code"))
+            .and_then(toml::Value::as_str);
+
+        assert!(
+            inherits_workspace_lints || local_unsafe_code_lint == Some("forbid"),
+            "{member}/Cargo.toml must either inherit workspace lints or set \
+             [lints.rust] unsafe_code = \"forbid\"",
+        );
+    }
+}
+
+#[test]
 fn generated_example_css_is_ignored_and_untracked() {
     let root = workspace_root();
 

--- a/autumn-cli/tests/repo_hygiene.rs
+++ b/autumn-cli/tests/repo_hygiene.rs
@@ -25,6 +25,21 @@ fn git(root: &Path, args: &[&str]) -> Output {
         .expect("failed to run git")
 }
 
+fn member_manifest_forbids_unsafe_code(manifest_toml: &toml::Value) -> bool {
+    let inherits_workspace_lints = manifest_toml
+        .get("lints")
+        .and_then(|lints| lints.get("workspace"))
+        .and_then(toml::Value::as_bool)
+        == Some(true);
+    let local_unsafe_code_lint = manifest_toml
+        .get("lints")
+        .and_then(|lints| lints.get("rust"))
+        .and_then(|rust| rust.get("unsafe_code"))
+        .and_then(toml::Value::as_str);
+
+    local_unsafe_code_lint.map_or(inherits_workspace_lints, |level| level == "forbid")
+}
+
 #[test]
 fn workspace_forbids_unsafe_code_for_all_members() {
     let root = workspace_root();
@@ -46,8 +61,10 @@ fn workspace_forbids_unsafe_code_for_all_members() {
         "workspace root must set [workspace.lints.rust] unsafe_code = \"forbid\"",
     );
 
-    let members = root_toml["workspace"]["members"]
-        .as_array()
+    let members = root_toml
+        .get("workspace")
+        .and_then(|workspace| workspace.get("members"))
+        .and_then(toml::Value::as_array)
         .expect("workspace.members should be an array");
 
     for member in members {
@@ -61,23 +78,41 @@ fn workspace_forbids_unsafe_code_for_all_members() {
             panic!("{} should parse as TOML: {err}", manifest_path.display())
         });
 
-        let inherits_workspace_lints = manifest_toml
-            .get("lints")
-            .and_then(|lints| lints.get("workspace"))
-            .and_then(toml::Value::as_bool)
-            == Some(true);
-        let local_unsafe_code_lint = manifest_toml
-            .get("lints")
-            .and_then(|lints| lints.get("rust"))
-            .and_then(|rust| rust.get("unsafe_code"))
-            .and_then(toml::Value::as_str);
-
         assert!(
-            inherits_workspace_lints || local_unsafe_code_lint == Some("forbid"),
+            member_manifest_forbids_unsafe_code(&manifest_toml),
             "{member}/Cargo.toml must either inherit workspace lints or set \
              [lints.rust] unsafe_code = \"forbid\"",
         );
     }
+}
+
+#[test]
+fn member_manifest_forbid_check_rejects_local_override_of_workspace_lints() {
+    let manifest_toml: toml::Value = toml::from_str(
+        r#"
+        [lints]
+        workspace = true
+
+        [lints.rust]
+        unsafe_code = "warn"
+        "#,
+    )
+    .expect("manifest snippet should parse");
+
+    assert!(!member_manifest_forbids_unsafe_code(&manifest_toml));
+}
+
+#[test]
+fn member_manifest_forbid_check_allows_workspace_lints_without_override() {
+    let manifest_toml: toml::Value = toml::from_str(
+        r"
+        [lints]
+        workspace = true
+        ",
+    )
+    .expect("manifest snippet should parse");
+
+    assert!(member_manifest_forbids_unsafe_code(&manifest_toml));
 }
 
 #[test]

--- a/examples/blog/Cargo.toml
+++ b/examples/blog/Cargo.toml
@@ -22,3 +22,6 @@ tokio = { version = "1", features = ["full"] }
 # The `db` feature is inherited from [dependencies]; test-support adds TestDb.
 autumn-web = { path = "../../autumn", features = ["test-support"] }
 serde_json = "1"
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/examples/blog/build.rs
+++ b/examples/blog/build.rs
@@ -24,9 +24,7 @@ fn main() {
         .status()
         .expect("Failed to run Tailwind CLI");
 
-    if !status.success() {
-        panic!("Tailwind CSS compilation failed");
-    }
+    assert!(status.success(), "Tailwind CSS compilation failed");
 }
 
 fn find_tailwind_cli() -> Option<std::path::PathBuf> {

--- a/examples/bookmarks-distributed/Cargo.toml
+++ b/examples/bookmarks-distributed/Cargo.toml
@@ -23,3 +23,6 @@ validator = { version = "0.20", features = ["derive"] }
 
 [dev-dependencies]
 autumn-web = { path = "../../autumn", features = ["test-support"] }
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/examples/bookmarks-distributed/build.rs
+++ b/examples/bookmarks-distributed/build.rs
@@ -24,9 +24,7 @@ fn main() {
         .status()
         .expect("Failed to run Tailwind CLI");
 
-    if !status.success() {
-        panic!("Tailwind CSS compilation failed");
-    }
+    assert!(status.success(), "Tailwind CSS compilation failed");
 }
 
 fn find_tailwind_cli() -> Option<std::path::PathBuf> {

--- a/examples/bookmarks/Cargo.toml
+++ b/examples/bookmarks/Cargo.toml
@@ -25,3 +25,6 @@ autumn-web = { path = "../../autumn", features = ["test-support"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "2", features = ["postgres", "chrono"] }
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/examples/bookmarks/build.rs
+++ b/examples/bookmarks/build.rs
@@ -24,9 +24,7 @@ fn main() {
         .status()
         .expect("Failed to run Tailwind CLI");
 
-    if !status.success() {
-        panic!("Tailwind CSS compilation failed");
-    }
+    assert!(status.success(), "Tailwind CSS compilation failed");
 }
 
 fn find_tailwind_cli() -> Option<std::path::PathBuf> {

--- a/examples/custom_config_loader/Cargo.toml
+++ b/examples/custom_config_loader/Cargo.toml
@@ -7,3 +7,6 @@ publish = false
 [dependencies]
 autumn-web = { path = "../../autumn" }
 serde_json = "1"
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -6,3 +6,6 @@ publish = false
 
 [dependencies]
 autumn-web = { path = "../../autumn" }
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/examples/reddit-clone/Cargo.toml
+++ b/examples/reddit-clone/Cargo.toml
@@ -31,3 +31,6 @@ uuid = { version = "1", features = ["v4"] }
 tempfile = "3"
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/examples/todo-app/Cargo.toml
+++ b/examples/todo-app/Cargo.toml
@@ -25,3 +25,6 @@ validator = { version = "0.20", features = ["derive"] }
 # Enables TestDb (shared Postgres testcontainer) for integration tests.
 autumn-web = { path = "../../autumn", features = ["test-support"] }
 serde_json = "1"
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/examples/todo-app/build.rs
+++ b/examples/todo-app/build.rs
@@ -24,9 +24,7 @@ fn main() {
         .status()
         .expect("Failed to run Tailwind CLI");
 
-    if !status.success() {
-        panic!("Tailwind CSS compilation failed");
-    }
+    assert!(status.success(), "Tailwind CSS compilation failed");
 }
 
 fn find_tailwind_cli() -> Option<std::path::PathBuf> {

--- a/examples/wiki/Cargo.toml
+++ b/examples/wiki/Cargo.toml
@@ -16,3 +16,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/examples/wiki/build.rs
+++ b/examples/wiki/build.rs
@@ -24,9 +24,7 @@ fn main() {
         .status()
         .expect("Failed to run Tailwind CLI");
 
-    if !status.success() {
-        panic!("Tailwind CSS compilation failed");
-    }
+    assert!(status.success(), "Tailwind CSS compilation failed");
 }
 
 fn find_tailwind_cli() -> Option<std::path::PathBuf> {

--- a/examples/ws-echo/Cargo.toml
+++ b/examples/ws-echo/Cargo.toml
@@ -8,3 +8,6 @@ publish = false
 autumn-web = { path = "../../autumn", features = ["ws"] }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"


### PR DESCRIPTION
## Summary

- Forbid unsafe code at the workspace lint layer for core crates.
- Add local `unsafe_code = "forbid"` lints to example crates without inheriting the full clippy pedantic/nursery policy.
- Add a repo hygiene regression test that verifies every workspace member is covered by the unsafe-code ban.
- Clean up repeated example Tailwind build-script `manual_assert` clippy warnings exposed during validation.

## Why

The repo wanted a `#![forbid(unsafe_code)]`-equivalent policy. Cargo lints are the cleaner control point for this workspace, but examples needed explicit coverage so they did not drift outside the ban.

## Validation

- `cargo fmt --all`
- `cargo test -p autumn-cli --test repo_hygiene`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`
