### PR TITLE
⚡ Bolt: Optimize string concatenation in route formatting

### DIFF
--- a/autumn-cli/src/routes.rs
+++ b/autumn-cli/src/routes.rs
@@ -206,21 +206,25 @@ fn compute_column_widths(routes: &[RouteInfo], headers: &[&str; 5]) -> [usize; 5
     widths
 }
 
+/// Formats a single row of the routes table.
+///
+/// ⚡ Bolt Optimization: Building rows using `format!` iterators collected into
+/// an intermediate vector and then joined to a `String` results in multiple
+/// heap allocations per cell. We avoid this by pre-allocating the required capacity
+/// based on column widths and writing directly into the buffer, saving N allocations per row.
 fn format_row(cells: &[String; 5], widths: &[usize; 5]) -> String {
-    cells
-        .iter()
-        .zip(widths.iter())
-        .enumerate()
-        .map(|(i, (cell, &w))| {
-            if i == 0 {
-                format!("{cell:<w$}")
-            } else {
-                format!("  {cell:<w$}")
-            }
-        })
-        .collect::<String>()
-        .trim_end()
-        .to_owned()
+    use std::fmt::Write;
+    let mut out = String::with_capacity(widths.iter().sum::<usize>() + 8);
+    for (i, (cell, &w)) in cells.iter().zip(widths.iter()).enumerate() {
+        if i == 0 {
+            let _ = write!(out, "{cell:<w$}");
+        } else {
+            let _ = write!(out, "  {cell:<w$}");
+        }
+    }
+    let len = out.trim_end().len();
+    out.truncate(len);
+    out
 }
 
 /// Print routes as pretty JSON.


### PR DESCRIPTION
💡 What: Replaced inefficient `.collect::<String>()` chaining in `format_row` in `autumn-cli/src/routes.rs` with `std::fmt::Write` into a pre-allocated string.
🎯 Why: Building rows using iterators mapped to `format!` and then collecting to a `String` results in multiple intermediate allocations per cell.
📊 Impact: Eliminates multiple heap allocations per formatted row when printing routes to the console, allocating only exactly what is needed upfront.
🔬 Measurement: Run `cargo test -p autumn-cli` to verify correctness and `cargo bench -p autumn-cli` if benchmarking is available.

---
*PR created automatically by Jules for task [9062427806728390266](https://jules.google.com/task/9062427806728390266) started by @madmax983*