### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -873,7 +873,7 @@ impl AppBuilder {
 
     /// Auto-load the i18n translation bundle from the configured directory
     /// (`i18n/` by default), reading the `[i18n]` block from the active
-    /// [`AutumnConfig`](crate::config::AutumnConfig).
+    /// [`AutumnConfig`].
     ///
     /// Fails fast during [`Self::run`] if the configured default locale's file is
     /// missing — the spec calls out this as the desired behaviour: a

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -165,7 +165,7 @@ impl Db {
     ///
     /// # Errors
     ///
-    /// Returns [`AutumnError`](crate::error::AutumnError) when:
+    /// Returns [`AutumnError`] when:
     ///
     /// - the underlying transaction returns an error,
     /// - the closure returns an error that converts into `AutumnError`,

--- a/autumn/src/i18n.rs
+++ b/autumn/src/i18n.rs
@@ -783,7 +783,7 @@ fn push_percent_encoded(output: &mut String, byte: u8) {
 /// that the key exists in the default locale's `.ftl` file.
 ///
 /// The macro itself lives in [`autumn_macros`] (the proc-macro crate). See
-/// its [`t`](autumn_macros::t) docs for the compile-time check semantics
+/// its [`t`] docs for the compile-time check semantics
 /// and the env-var contract used to locate the default-locale bundle.
 ///
 /// # Forms

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -563,7 +563,7 @@ pub use autumn_macros::ws;
 
 /// Declare an on-demand background job. See [`mod@job`] module.
 pub use autumn_macros::job;
-/// Declare a scheduled background task. See [`task`] module.
+/// Declare a scheduled background task. See [`mod@task`] module.
 pub use autumn_macros::scheduled;
 /// Declare a one-off operational task. See [`task::OneOffTaskInfo`].
 pub use autumn_macros::task;


### PR DESCRIPTION
📖 Chapter: Fix explicitly redundant doc links and ambiguous mod/macro links.

🔦 Insight: Fixed compiler warnings `redundant_explicit_links` and `broken_intra_doc_links` in `autumn_web`.

🧪 Example: Removed explicit link targets that resolved to the same destination in `app.rs`, `db.rs` and `i18n.rs`, and differentiated between `mod@task` and `macro@task` in `lib.rs`.

🖼️ Preview: N/A

---
*PR created automatically by Jules for task [880037692336851326](https://jules.google.com/task/880037692336851326) started by @madmax983*