### PR TITLE
feat(scheduler): coordinate scheduled tasks across replicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ If you add `#[static_get]` routes, `autumn build` pre-renders them into
 Autumn still distinguishes between "works on your laptop" and "safe to run in a
 multi-replica deployment":
 
-- Local-safe defaults: in-memory sessions, pretty logs in `dev`, process-local `#[scheduled]` tasks, and single-binary startup.
-- Production-safe defaults: `/live`, `/ready`, `/startup` probes, OTLP telemetry config, Redis-backed sessions, container scaffolding from `autumn new`, and explicit migration jobs before web replicas roll.
+- Local-safe defaults: in-memory sessions, pretty logs in `dev`, `scheduler.backend = "in_process"` for `#[scheduled]`, and single-binary startup.
+- Production-safe options: `/live`, `/ready`, `/startup` probes, OTLP telemetry config, Redis-backed sessions, Redis-backed channels/jobs, Postgres-coordinated scheduled tasks, container scaffolding from `autumn new`, and explicit migration jobs before web replicas roll.
 
 If you are deploying beyond a single process, read the
 [Cloud-Native Guide](docs/guide/cloud-native.md) before treating the defaults as
@@ -159,6 +159,7 @@ async fn main() {
 - [Getting Started Guide](docs/guide/getting-started.md)
 - [Code Generators](docs/guide/generators.md) — `autumn generate model | migration | scaffold`
 - [One-Off Tasks](docs/guide/tasks.md) - `#[task]`, `one_off_tasks![]`, and `autumn task`
+- [Multi-Replica Scheduled Tasks](docs/guide/scheduled-multi-replica.md) - `#[scheduled]` with Postgres advisory-lock coordination
 - [Mail Guide](docs/guide/mail.md)
 - [Cloud-Native Guide](docs/guide/cloud-native.md)
 - [Todo Tutorial](docs/guide/tutorial/index.md)

--- a/autumn-macros/src/scheduled.rs
+++ b/autumn-macros/src/scheduled.rs
@@ -13,6 +13,7 @@ struct ScheduledAttrs {
     cron: Option<String>,
     name: Option<String>,
     tz: Option<String>,
+    coordination: Option<String>,
 }
 
 fn parse_scheduled_args(attr: TokenStream) -> syn::Result<ScheduledAttrs> {
@@ -21,6 +22,7 @@ fn parse_scheduled_args(attr: TokenStream) -> syn::Result<ScheduledAttrs> {
         cron: None,
         name: None,
         tz: None,
+        coordination: None,
     };
 
     syn::meta::parser(|meta| {
@@ -40,8 +42,13 @@ fn parse_scheduled_args(attr: TokenStream) -> syn::Result<ScheduledAttrs> {
             let value: LitStr = meta.value()?.parse()?;
             result.tz = Some(value.value());
             Ok(())
+        } else if meta.path.is_ident("coordination") {
+            let value: LitStr = meta.value()?.parse()?;
+            result.coordination = Some(value.value());
+            Ok(())
         } else {
-            Err(meta.error("unsupported attribute: expected every, cron, name, or tz"))
+            Err(meta
+                .error("unsupported attribute: expected every, cron, name, tz, or coordination"))
         }
     })
     .parse2(attr)?;
@@ -110,6 +117,19 @@ pub fn scheduled_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let task_name_str = task_name;
+    let coordination_expr = match attrs.coordination.as_deref() {
+        None | Some("fleet") => quote! { ::autumn_web::task::TaskCoordination::Fleet },
+        Some("per_replica") => quote! { ::autumn_web::task::TaskCoordination::PerReplica },
+        Some(other) => {
+            return syn::Error::new(
+                proc_macro2::Span::call_site(),
+                format!(
+                    "invalid #[scheduled(coordination = {other:?})]; expected \"fleet\" or \"per_replica\""
+                ),
+            )
+            .to_compile_error();
+        }
+    };
 
     quote! {
         #input_fn
@@ -119,6 +139,7 @@ pub fn scheduled_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             ::autumn_web::task::TaskInfo {
                 name: #task_name_str.to_string(),
                 schedule: #schedule_expr,
+                coordination: #coordination_expr,
                 handler: |state: ::autumn_web::AppState| {
                     Box::pin(async move {
                         #fn_name(state).await

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -92,6 +92,7 @@ validator.workspace = true
 uuid = { version = "1", features = ["v4"] }
 chrono = { workspace = true }
 chrono-tz.workspace = true
+croner = "3.0.1"
 testcontainers = { workspace = true, optional = true }
 testcontainers-modules = { workspace = true, optional = true }
 serde_urlencoded = "0.7"

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -152,6 +152,21 @@ impl std::fmt::Debug for LogLevels {
 pub struct TaskStatus {
     /// The schedule description (e.g., "every 5m" or "cron 0 0 * * *").
     pub schedule: String,
+    /// Whether this task is coordinated across the fleet or per replica.
+    pub coordination: crate::task::TaskCoordination,
+    /// Scheduler backend currently coordinating this task.
+    pub scheduler_backend: String,
+    /// Replica id for this process.
+    pub replica_id: String,
+    /// Replica id that last acquired leadership for this task.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_leader: Option<String>,
+    /// Last global tick key observed for this task.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_tick: Option<String>,
+    /// Last time this task fired (ISO 8601), if ever.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_fired_at: Option<String>,
     /// Current task state.
     pub status: String,
     /// Last time the task ran (ISO 8601), if ever.
@@ -309,6 +324,24 @@ impl TaskRegistry {
 
     /// Register a task with its schedule description.
     pub fn register(&self, name: &str, schedule: &str) {
+        self.register_scheduled(
+            name,
+            schedule,
+            crate::task::TaskCoordination::Fleet,
+            "in_process",
+            "unknown",
+        );
+    }
+
+    /// Register a scheduled task with scheduler coordination metadata.
+    pub fn register_scheduled(
+        &self,
+        name: &str,
+        schedule: &str,
+        coordination: crate::task::TaskCoordination,
+        scheduler_backend: &str,
+        replica_id: &str,
+    ) {
         let Ok(mut guard) = self.inner.write() else {
             return;
         };
@@ -316,6 +349,12 @@ impl TaskRegistry {
             name.to_string(),
             TaskStatus {
                 schedule: schedule.to_string(),
+                coordination,
+                scheduler_backend: scheduler_backend.to_string(),
+                replica_id: replica_id.to_string(),
+                current_leader: None,
+                last_tick: None,
+                last_fired_at: None,
                 status: "idle".to_string(),
                 last_run: None,
                 last_duration_ms: None,
@@ -325,6 +364,18 @@ impl TaskRegistry {
                 total_failures: 0,
             },
         );
+    }
+
+    /// Record the replica that acquired leadership for a global task tick.
+    pub fn record_leader(&self, name: &str, leader_id: &str, tick_key: &str) {
+        let Ok(mut guard) = self.inner.write() else {
+            return;
+        };
+        let Some(task) = guard.get_mut(name) else {
+            return;
+        };
+        task.current_leader = Some(leader_id.to_string());
+        task.last_tick = Some(tick_key.to_string());
     }
 
     /// Record that a task started running.
@@ -347,7 +398,9 @@ impl TaskRegistry {
             return;
         };
         task.status = "idle".to_string();
-        task.last_run = Some(chrono::Utc::now().to_rfc3339());
+        let now = chrono::Utc::now().to_rfc3339();
+        task.last_run = Some(now.clone());
+        task.last_fired_at = Some(now);
         task.last_duration_ms = Some(duration_ms);
         task.last_result = Some("ok".to_string());
         task.last_error = None;
@@ -363,7 +416,9 @@ impl TaskRegistry {
             return;
         };
         task.status = "idle".to_string();
-        task.last_run = Some(chrono::Utc::now().to_rfc3339());
+        let now = chrono::Utc::now().to_rfc3339();
+        task.last_run = Some(now.clone());
+        task.last_fired_at = Some(now);
         task.last_duration_ms = Some(duration_ms);
         task.last_result = Some("failed".to_string());
         task.last_error = Some(error.to_string());

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1558,8 +1558,18 @@ impl AppBuilder {
         }
 
         if !state.probes().is_shutting_down() {
-            if !tasks.is_empty() {
-                start_task_scheduler(tasks, &state, server_shutdown.clone());
+            if !tasks.is_empty()
+                && let Err(error) = start_task_scheduler_with_config(
+                    tasks,
+                    &state,
+                    server_shutdown.clone(),
+                    &config.scheduler,
+                )
+            {
+                tracing::error!(error = %error, "scheduled task runtime initialization failed");
+                server_shutdown.cancel();
+                server_task.abort();
+                std::process::exit(1);
             }
             state.probes().mark_startup_complete();
         }
@@ -2081,35 +2091,83 @@ fn print_available_one_off_tasks(tasks: &[crate::task::OneOffTaskInfo]) {
 /// scheduler gracefully when the server receives a termination signal.
 #[allow(clippy::cast_possible_truncation)]
 #[allow(clippy::cognitive_complexity)]
+#[allow(dead_code)]
 fn start_task_scheduler(
     tasks: Vec<crate::task::TaskInfo>,
     state: &AppState,
     shutdown: tokio_util::sync::CancellationToken,
 ) {
+    if let Err(error) = start_task_scheduler_with_config(
+        tasks,
+        state,
+        shutdown,
+        &crate::config::SchedulerConfig::default(),
+    ) {
+        tracing::error!(error = %error, "scheduled task runtime initialization failed");
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cognitive_complexity)]
+fn start_task_scheduler_with_config(
+    tasks: Vec<crate::task::TaskInfo>,
+    state: &AppState,
+    shutdown: tokio_util::sync::CancellationToken,
+    scheduler_config: &crate::config::SchedulerConfig,
+) -> crate::AutumnResult<()> {
     tracing::info!(count = tasks.len(), "Starting scheduled tasks");
+    let coordinator = crate::scheduler::coordinator_from_config(scheduler_config, state)?;
+    let lease_ttl = std::time::Duration::from_secs(scheduler_config.lease_ttl_secs);
     for task_info in &tasks {
         let schedule_desc = task_info.schedule.to_string();
-        tracing::info!(name = %task_info.name, schedule = %schedule_desc, "Registered task");
+        tracing::info!(
+            name = %task_info.name,
+            schedule = %schedule_desc,
+            coordination = %task_info.coordination,
+            scheduler_backend = coordinator.backend(),
+            replica_id = coordinator.replica_id(),
+            lease_ttl_secs = scheduler_config.lease_ttl_secs,
+            "Registered task"
+        );
     }
 
-    let mut cron_tasks: Vec<(String, String, Option<String>, crate::task::TaskHandler)> =
-        Vec::new();
+    let mut cron_tasks: Vec<CronTaskSpec> = Vec::new();
 
     for task_info in tasks {
         let state = state.clone();
         let name = task_info.name.clone();
         let handler = task_info.handler;
+        let coordination = task_info.coordination;
         let schedule_desc = task_info.schedule.to_string();
+        state.task_registry.register_scheduled(
+            &name,
+            &schedule_desc,
+            coordination,
+            coordinator.backend(),
+            coordinator.replica_id(),
+        );
 
         match task_info.schedule {
             crate::task::Schedule::FixedDelay(delay) => {
-                // Register with the task registry for /actuator/tasks
-                state.task_registry.register(&name, &schedule_desc);
-
+                let coordinator = Arc::clone(&coordinator);
+                let shutdown = shutdown.child_token();
                 tokio::spawn(async move {
                     loop {
-                        tokio::time::sleep(delay).await;
-                        execute_fixed_delay_task(name.clone(), state.clone(), handler).await;
+                        tokio::select! {
+                            () = shutdown.cancelled() => break,
+                            () = tokio::time::sleep(delay) => {
+                                execute_fixed_delay_task(
+                                    name.clone(),
+                                    state.clone(),
+                                    handler,
+                                    delay,
+                                    coordination,
+                                    Arc::clone(&coordinator),
+                                    lease_ttl,
+                                )
+                                .await;
+                            }
+                        }
                     }
                 });
             }
@@ -2117,18 +2175,26 @@ fn start_task_scheduler(
                 expression,
                 timezone,
             } => {
-                state.task_registry.register(&name, &schedule_desc);
-                cron_tasks.push((name, expression, timezone, handler));
+                cron_tasks.push(CronTaskSpec {
+                    name,
+                    expression,
+                    timezone,
+                    coordination,
+                    handler,
+                });
             }
         }
     }
 
     if !cron_tasks.is_empty() {
         let state = state.clone();
+        let coordinator = Arc::clone(&coordinator);
         tokio::spawn(async move {
-            run_cron_scheduler(cron_tasks, state, shutdown).await;
+            run_cron_scheduler(cron_tasks, state, shutdown, coordinator, lease_ttl).await;
         });
     }
+
+    Ok(())
 }
 
 #[allow(unused_variables, clippy::needless_pass_by_value)]
@@ -2183,19 +2249,79 @@ async fn execute_task_result(
     }
 }
 
+async fn execute_task_result_with_lease_ttl(
+    state: &AppState,
+    handler: crate::task::TaskHandler,
+    start: std::time::Instant,
+    name: &str,
+    schedule: &'static str,
+    lease_ttl: std::time::Duration,
+) -> Result<u64, (u64, String)> {
+    tokio::time::timeout(
+        lease_ttl,
+        execute_task_result(state, handler, start, name, schedule),
+    )
+    .await
+    .map_or_else(
+        |_| {
+            let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+            Err((
+                duration_ms,
+                format!(
+                    "scheduled task exceeded lease TTL of {}s",
+                    lease_ttl.as_secs()
+                ),
+            ))
+        },
+        std::convert::identity,
+    )
+}
+
 /// Handle the execution of a single fixed-delay task.
 async fn execute_fixed_delay_task(
     name: String,
     state: AppState,
     handler: crate::task::TaskHandler,
+    delay: std::time::Duration,
+    coordination: crate::task::TaskCoordination,
+    coordinator: Arc<dyn crate::scheduler::SchedulerCoordinator>,
+    lease_ttl: std::time::Duration,
 ) {
+    let tick_key =
+        crate::scheduler::fixed_delay_tick_key(&name, delay, crate::scheduler::now_unix_secs());
+    let lease = match coordinator
+        .try_acquire(&name, &tick_key, coordination)
+        .await
+    {
+        Ok(Some(lease)) => lease,
+        Ok(None) => {
+            tracing::debug!(task = %name, tick = %tick_key, "Scheduled task tick already claimed");
+            return;
+        }
+        Err(error) => {
+            tracing::warn!(task = %name, tick = %tick_key, error = %error, "Failed to acquire scheduled task lease");
+            return;
+        }
+    };
+    state
+        .task_registry
+        .record_leader(&name, lease.leader_id(), &tick_key);
     tracing::debug!(task = %name, "Running scheduled task");
     state.task_registry.record_start(&name);
 
     send_ws_sys_task_msg(&state, "started", &name, vec![]);
 
     let start = std::time::Instant::now();
-    match execute_task_result(&state, handler, start, &name, "fixed_delay").await {
+    match execute_task_result_with_lease_ttl(
+        &state,
+        handler,
+        start,
+        &name,
+        "fixed_delay",
+        lease_ttl,
+    )
+    .await
+    {
         Ok(duration_ms) => {
             state.task_registry.record_success(&name, duration_ms);
             tracing::debug!(task = %name, "Task completed");
@@ -2222,17 +2348,47 @@ async fn execute_fixed_delay_task(
             );
         }
     }
+
+    if let Err(error) = lease.release().await {
+        tracing::warn!(task = %name, tick = %tick_key, error = %error, "Failed to release scheduled task lease");
+    }
 }
 
 /// Handle the execution of a single cron task.
-async fn execute_cron_task(name: String, state: AppState, handler: crate::task::TaskHandler) {
+async fn execute_cron_task(
+    name: String,
+    state: AppState,
+    handler: crate::task::TaskHandler,
+    coordination: crate::task::TaskCoordination,
+    coordinator: Arc<dyn crate::scheduler::SchedulerCoordinator>,
+    lease_ttl: std::time::Duration,
+) {
+    let tick_key = crate::scheduler::cron_tick_key(&name, crate::scheduler::now_unix_secs());
+    let lease = match coordinator
+        .try_acquire(&name, &tick_key, coordination)
+        .await
+    {
+        Ok(Some(lease)) => lease,
+        Ok(None) => {
+            tracing::debug!(task = %name, tick = %tick_key, "Cron task tick already claimed");
+            return;
+        }
+        Err(error) => {
+            tracing::warn!(task = %name, tick = %tick_key, error = %error, "Failed to acquire cron task lease");
+            return;
+        }
+    };
+    state
+        .task_registry
+        .record_leader(&name, lease.leader_id(), &tick_key);
     tracing::debug!(task = %name, "Running cron task");
     state.task_registry.record_start(&name);
 
     send_ws_sys_task_msg(&state, "started", &name, vec![]);
 
     let start = std::time::Instant::now();
-    match execute_task_result(&state, handler, start, &name, "cron").await {
+    match execute_task_result_with_lease_ttl(&state, handler, start, &name, "cron", lease_ttl).await
+    {
         Ok(duration_ms) => {
             state.task_registry.record_success(&name, duration_ms);
             tracing::debug!(task = %name, "Cron task completed");
@@ -2259,24 +2415,44 @@ async fn execute_cron_task(name: String, state: AppState, handler: crate::task::
             );
         }
     }
+
+    if let Err(error) = lease.release().await {
+        tracing::warn!(task = %name, tick = %tick_key, error = %error, "Failed to release cron task lease");
+    }
+}
+
+struct CronTaskSpec {
+    name: String,
+    expression: String,
+    timezone: Option<String>,
+    coordination: crate::task::TaskCoordination,
+    handler: crate::task::TaskHandler,
 }
 
 async fn register_cron_task(
     sched: &tokio_cron_scheduler::JobScheduler,
-    name: String,
-    expression: String,
-    timezone: Option<String>,
-    handler: crate::task::TaskHandler,
+    task: CronTaskSpec,
     state: AppState,
+    coordinator: Arc<dyn crate::scheduler::SchedulerCoordinator>,
+    lease_ttl: std::time::Duration,
 ) {
+    let CronTaskSpec {
+        name,
+        expression,
+        timezone,
+        coordination,
+        handler,
+    } = task;
     let state_clone = state.clone();
     let name_clone = name.clone();
+    let coordinator_clone = Arc::clone(&coordinator);
 
     let job_result = build_cron_job(&expression, timezone.as_deref(), move |_uuid, _lock| {
         let state = state_clone.clone();
         let name = name_clone.clone();
+        let coordinator = Arc::clone(&coordinator_clone);
         Box::pin(async move {
-            execute_cron_task(name, state, handler).await;
+            execute_cron_task(name, state, handler, coordination, coordinator, lease_ttl).await;
         }) as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
     });
 
@@ -2293,8 +2469,10 @@ async fn register_cron_task(
 }
 
 async fn setup_cron_scheduler(
-    tasks: Vec<(String, String, Option<String>, crate::task::TaskHandler)>,
+    tasks: Vec<CronTaskSpec>,
     state: AppState,
+    coordinator: Arc<dyn crate::scheduler::SchedulerCoordinator>,
+    lease_ttl: std::time::Duration,
 ) -> Option<tokio_cron_scheduler::JobScheduler> {
     use tokio_cron_scheduler::JobScheduler;
 
@@ -2306,8 +2484,15 @@ async fn setup_cron_scheduler(
         }
     };
 
-    for (name, expression, timezone, handler) in tasks {
-        register_cron_task(&sched, name, expression, timezone, handler, state.clone()).await;
+    for task in tasks {
+        register_cron_task(
+            &sched,
+            task,
+            state.clone(),
+            Arc::clone(&coordinator),
+            lease_ttl,
+        )
+        .await;
     }
 
     if let Err(e) = sched.start().await {
@@ -2322,11 +2507,13 @@ async fn setup_cron_scheduler(
 /// `shutdown` token is cancelled.
 #[allow(clippy::cognitive_complexity)]
 async fn run_cron_scheduler(
-    tasks: Vec<(String, String, Option<String>, crate::task::TaskHandler)>,
+    tasks: Vec<CronTaskSpec>,
     state: AppState,
     shutdown: tokio_util::sync::CancellationToken,
+    coordinator: Arc<dyn crate::scheduler::SchedulerCoordinator>,
+    lease_ttl: std::time::Duration,
 ) {
-    let Some(mut sched) = setup_cron_scheduler(tasks, state).await else {
+    let Some(mut sched) = setup_cron_scheduler(tasks, state, coordinator, lease_ttl).await else {
         return;
     };
 
@@ -3573,6 +3760,7 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tower::ServiceExt;
 
     /// Helper to build a test router with default config and no database.
@@ -5041,6 +5229,7 @@ mod tests {
         let tasks = vec![crate::task::TaskInfo {
             name: "cleanup".into(),
             schedule: crate::task::Schedule::FixedDelay(std::time::Duration::from_secs(300)),
+            coordination: crate::task::TaskCoordination::Fleet,
             handler: |_| Box::pin(async { Ok(()) }),
         }];
         let output = format_task_lines(&tasks).unwrap();
@@ -5055,6 +5244,7 @@ mod tests {
                 expression: "0 0 * * *".into(),
                 timezone: None,
             },
+            coordination: crate::task::TaskCoordination::Fleet,
             handler: |_| Box::pin(async { Ok(()) }),
         }];
         let output = format_task_lines(&tasks).unwrap();
@@ -5201,6 +5391,7 @@ mod tests {
         let tasks = vec![crate::task::TaskInfo {
             name: "cleanup".into(),
             schedule: crate::task::Schedule::FixedDelay(std::time::Duration::from_secs(60)),
+            coordination: crate::task::TaskCoordination::Fleet,
             handler: |_| Box::pin(async { Ok(()) }),
         }];
         let config = AutumnConfig::default();
@@ -5245,6 +5436,7 @@ mod tests {
             name: "test_broadcaster".into(),
             // 1ms delay so it fires immediately
             schedule: crate::task::Schedule::FixedDelay(std::time::Duration::from_millis(1)),
+            coordination: crate::task::TaskCoordination::Fleet,
             handler: |_| Box::pin(async { Ok(()) }),
         };
 
@@ -5308,6 +5500,7 @@ mod tests {
         let task = crate::task::TaskInfo {
             name: "test_failing_task".into(),
             schedule: crate::task::Schedule::FixedDelay(std::time::Duration::from_millis(1)),
+            coordination: crate::task::TaskCoordination::Fleet,
             handler: |_| {
                 Box::pin(async { Err(crate::AutumnError::bad_request_msg("forced error")) })
             },
@@ -5360,6 +5553,118 @@ mod tests {
         let (duration_ms, msg) = result.unwrap_err();
         assert!(duration_ms < u64::MAX);
         assert!(msg.contains("test error"));
+    }
+
+    #[tokio::test]
+    async fn execute_fixed_delay_task_records_lease_ttl_timeout() {
+        let state = AppState::for_test();
+        state.task_registry.register_scheduled(
+            "slow_task",
+            "every 1s",
+            crate::task::TaskCoordination::Fleet,
+            "in_process",
+            "replica-a",
+        );
+        let handler: crate::task::TaskHandler = |_| {
+            Box::pin(async {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                Ok(())
+            })
+        };
+        let coordinator = std::sync::Arc::new(
+            crate::scheduler::InProcessSchedulerCoordinator::new("replica-a"),
+        );
+
+        super::execute_fixed_delay_task(
+            "slow_task".to_owned(),
+            state.clone(),
+            handler,
+            std::time::Duration::from_secs(1),
+            crate::task::TaskCoordination::Fleet,
+            coordinator,
+            std::time::Duration::from_millis(10),
+        )
+        .await;
+
+        let snapshot = state.task_registry.snapshot();
+        let status = &snapshot["slow_task"];
+        assert_eq!(status.status, "idle");
+        assert_eq!(status.last_result.as_deref(), Some("failed"));
+        assert_eq!(status.total_runs, 1);
+        assert_eq!(status.total_failures, 1);
+        assert!(
+            status
+                .last_error
+                .as_deref()
+                .is_some_and(|error| error.contains("lease TTL"))
+        );
+    }
+
+    static SKIPPED_LEASE_HANDLER_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    struct DenyingSchedulerCoordinator;
+
+    impl crate::scheduler::SchedulerCoordinator for DenyingSchedulerCoordinator {
+        fn backend(&self) -> &'static str {
+            "postgres"
+        }
+
+        fn replica_id(&self) -> &str {
+            "replica-a"
+        }
+
+        fn try_acquire<'a>(
+            &'a self,
+            _task_name: &'a str,
+            _tick_key: &'a str,
+            _coordination: crate::task::TaskCoordination,
+        ) -> crate::scheduler::SchedulerFuture<
+            'a,
+            crate::AutumnResult<Option<crate::scheduler::SchedulerLease>>,
+        > {
+            Box::pin(async { Ok(None) })
+        }
+    }
+
+    fn counted_scheduled_handler(
+        _state: AppState,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send>> {
+        Box::pin(async {
+            SKIPPED_LEASE_HANDLER_CALLS.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+    }
+
+    #[tokio::test]
+    async fn execute_fixed_delay_task_skips_handler_when_lease_is_not_acquired() {
+        SKIPPED_LEASE_HANDLER_CALLS.store(0, Ordering::SeqCst);
+        let state = AppState::for_test();
+        state.task_registry.register_scheduled(
+            "claimed_elsewhere",
+            "every 1s",
+            crate::task::TaskCoordination::Fleet,
+            "postgres",
+            "replica-a",
+        );
+        let coordinator = std::sync::Arc::new(DenyingSchedulerCoordinator);
+
+        super::execute_fixed_delay_task(
+            "claimed_elsewhere".to_owned(),
+            state.clone(),
+            counted_scheduled_handler,
+            std::time::Duration::from_secs(1),
+            crate::task::TaskCoordination::Fleet,
+            coordinator,
+            std::time::Duration::from_secs(1),
+        )
+        .await;
+
+        let snapshot = state.task_registry.snapshot();
+        let status = &snapshot["claimed_elsewhere"];
+        assert_eq!(SKIPPED_LEASE_HANDLER_CALLS.load(Ordering::SeqCst), 0);
+        assert_eq!(status.total_runs, 0);
+        assert!(status.current_leader.is_none());
+        assert!(status.last_tick.is_none());
     }
 
     #[cfg(feature = "storage")]

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -30,6 +30,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use futures::FutureExt as _;
 use tracing::Instrument as _;
 
 use crate::config::{AutumnConfig, ConfigLoader};
@@ -2234,13 +2235,32 @@ async fn execute_task_result(
         task = %name,
         schedule = schedule,
     );
-    let result = (handler)(state.clone()).instrument(task_span).await;
+    let future = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        (handler)(state.clone()).instrument(task_span)
+    })) {
+        Ok(future) => future,
+        Err(panic) => {
+            let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+            return Err((duration_ms, format_scheduled_task_panic(panic.as_ref())));
+        }
+    };
+    let result = std::panic::AssertUnwindSafe(future).catch_unwind().await;
     let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
     match result {
-        Ok(()) => Ok(duration_ms),
-        Err(e) => Err((duration_ms, e.to_string())),
+        Ok(Ok(())) => Ok(duration_ms),
+        Ok(Err(e)) => Err((duration_ms, e.to_string())),
+        Err(panic) => Err((duration_ms, format_scheduled_task_panic(panic.as_ref()))),
     }
+}
+
+fn format_scheduled_task_panic(panic: &(dyn Any + Send)) -> String {
+    let detail = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&'static str>().copied())
+        .unwrap_or("non-string panic payload");
+    format!("scheduled task handler panicked: {detail}")
 }
 
 async fn execute_task_result_with_optional_lease_ttl(
@@ -5570,6 +5590,30 @@ mod tests {
         assert!(msg.contains("test error"));
     }
 
+    fn instantly_panicking_scheduled_handler(
+        _state: AppState,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send>> {
+        panic!("panic before scheduled future")
+    }
+
+    #[tokio::test]
+    async fn execute_task_result_reports_immediate_handler_panics() {
+        let state = AppState::for_test();
+        let start = std::time::Instant::now();
+        let result = super::execute_task_result(
+            &state,
+            instantly_panicking_scheduled_handler,
+            start,
+            "test_task",
+            "fixed_delay",
+        )
+        .await;
+
+        let (duration_ms, msg) = result.expect_err("expected Err from panicking handler");
+        assert!(duration_ms < u64::MAX);
+        assert!(msg.contains("scheduled task handler panicked: panic before scheduled future"));
+    }
+
     #[tokio::test]
     async fn execute_fixed_delay_task_does_not_timeout_in_process_runs() {
         let state = AppState::for_test();
@@ -5639,6 +5683,7 @@ mod tests {
     struct GrantingSchedulerCoordinator {
         backend: &'static str,
         tick_keys: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+        release_count: Option<std::sync::Arc<AtomicUsize>>,
     }
 
     impl crate::scheduler::SchedulerCoordinator for GrantingSchedulerCoordinator {
@@ -5661,10 +5706,17 @@ mod tests {
         > {
             Box::pin(async move {
                 self.tick_keys.lock().unwrap().push(tick_key.to_owned());
-                Ok(Some(crate::scheduler::SchedulerLease::local(
-                    self.backend,
-                    "replica-a",
-                )))
+                let lease = self.release_count.as_ref().map_or_else(
+                    || crate::scheduler::SchedulerLease::local(self.backend, "replica-a"),
+                    |release_count| {
+                        crate::scheduler::SchedulerLease::tracked(
+                            self.backend,
+                            "replica-a",
+                            std::sync::Arc::clone(release_count),
+                        )
+                    },
+                );
+                Ok(Some(lease))
             })
         }
     }
@@ -5729,6 +5781,7 @@ mod tests {
         let coordinator = std::sync::Arc::new(GrantingSchedulerCoordinator {
             backend: "postgres",
             tick_keys: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            release_count: None,
         });
 
         super::execute_fixed_delay_task(
@@ -5770,6 +5823,7 @@ mod tests {
         let coordinator = std::sync::Arc::new(GrantingSchedulerCoordinator {
             backend: "postgres",
             tick_keys: std::sync::Arc::clone(&tick_keys),
+            release_count: None,
         });
         let handler: crate::task::TaskHandler = |_| Box::pin(async { Ok(()) });
         let scheduled_unix_secs = 1_700_000_000;
@@ -5788,6 +5842,56 @@ mod tests {
         assert_eq!(
             tick_keys.lock().unwrap().as_slice(),
             ["cron_review_task:1700000000"]
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_fixed_delay_task_releases_lease_when_handler_panics() {
+        let state = AppState::for_test();
+        state.task_registry.register_scheduled(
+            "panic_task",
+            "every 1s",
+            crate::task::TaskCoordination::Fleet,
+            "postgres",
+            "replica-a",
+        );
+        let release_count = std::sync::Arc::new(AtomicUsize::new(0));
+        let coordinator = std::sync::Arc::new(GrantingSchedulerCoordinator {
+            backend: "postgres",
+            tick_keys: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            release_count: Some(std::sync::Arc::clone(&release_count)),
+        });
+        let handler: crate::task::TaskHandler = |_| {
+            Box::pin(async {
+                panic!("forced scheduled panic");
+                #[allow(unreachable_code)]
+                Ok(())
+            })
+        };
+
+        super::execute_fixed_delay_task(
+            "panic_task".to_owned(),
+            state.clone(),
+            handler,
+            std::time::Duration::from_secs(1),
+            crate::task::TaskCoordination::Fleet,
+            coordinator,
+            std::time::Duration::from_secs(30),
+        )
+        .await;
+
+        let snapshot = state.task_registry.snapshot();
+        let status = &snapshot["panic_task"];
+        assert_eq!(release_count.load(Ordering::SeqCst), 1);
+        assert_eq!(status.status, "idle");
+        assert_eq!(status.last_result.as_deref(), Some("failed"));
+        assert_eq!(status.total_runs, 1);
+        assert_eq!(status.total_failures, 1);
+        assert!(
+            status
+                .last_error
+                .as_deref()
+                .is_some_and(|error| error.contains("scheduled task handler panicked"))
         );
     }
 

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -5609,7 +5609,7 @@ mod tests {
             "postgres"
         }
 
-        fn replica_id(&self) -> &str {
+        fn replica_id(&self) -> &'static str {
             "replica-a"
         }
 

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1562,7 +1562,7 @@ impl AppBuilder {
                 && let Err(error) = start_task_scheduler_with_config(
                     tasks,
                     &state,
-                    server_shutdown.clone(),
+                    &server_shutdown,
                     &config.scheduler,
                 )
             {
@@ -2086,16 +2086,16 @@ fn print_available_one_off_tasks(tasks: &[crate::task::OneOffTaskInfo]) {
 /// Start scheduled tasks in background Tokio tasks.
 ///
 /// Each task runs in its own spawned task with error logging.
-/// Uses `tokio::time` for fixed-delay scheduling and `tokio-cron-scheduler`
-/// for cron-based scheduling. The `shutdown` token is used to stop the cron
-/// scheduler gracefully when the server receives a termination signal.
+/// Uses `tokio::time` for fixed-delay scheduling and `croner` for cron-based
+/// scheduling. The `shutdown` token is used to stop cron loops gracefully when
+/// the server receives a termination signal.
 #[allow(clippy::cast_possible_truncation)]
 #[allow(clippy::cognitive_complexity)]
 #[allow(dead_code)]
 fn start_task_scheduler(
     tasks: Vec<crate::task::TaskInfo>,
     state: &AppState,
-    shutdown: tokio_util::sync::CancellationToken,
+    shutdown: &tokio_util::sync::CancellationToken,
 ) {
     if let Err(error) = start_task_scheduler_with_config(
         tasks,
@@ -2112,7 +2112,7 @@ fn start_task_scheduler(
 fn start_task_scheduler_with_config(
     tasks: Vec<crate::task::TaskInfo>,
     state: &AppState,
-    shutdown: tokio_util::sync::CancellationToken,
+    shutdown: &tokio_util::sync::CancellationToken,
     scheduler_config: &crate::config::SchedulerConfig,
 ) -> crate::AutumnResult<()> {
     tracing::info!(count = tasks.len(), "Starting scheduled tasks");
@@ -2186,13 +2186,7 @@ fn start_task_scheduler_with_config(
         }
     }
 
-    if !cron_tasks.is_empty() {
-        let state = state.clone();
-        let coordinator = Arc::clone(&coordinator);
-        tokio::spawn(async move {
-            run_cron_scheduler(cron_tasks, state, shutdown, coordinator, lease_ttl).await;
-        });
-    }
+    run_cron_scheduler(cron_tasks, state, shutdown, &coordinator, lease_ttl);
 
     Ok(())
 }
@@ -2249,14 +2243,18 @@ async fn execute_task_result(
     }
 }
 
-async fn execute_task_result_with_lease_ttl(
+async fn execute_task_result_with_optional_lease_ttl(
     state: &AppState,
     handler: crate::task::TaskHandler,
     start: std::time::Instant,
     name: &str,
     schedule: &'static str,
-    lease_ttl: std::time::Duration,
+    lease_ttl: Option<std::time::Duration>,
 ) -> Result<u64, (u64, String)> {
+    let Some(lease_ttl) = lease_ttl else {
+        return execute_task_result(state, handler, start, name, schedule).await;
+    };
+
     tokio::time::timeout(
         lease_ttl,
         execute_task_result(state, handler, start, name, schedule),
@@ -2312,7 +2310,8 @@ async fn execute_fixed_delay_task(
     send_ws_sys_task_msg(&state, "started", &name, vec![]);
 
     let start = std::time::Instant::now();
-    match execute_task_result_with_lease_ttl(
+    let lease_ttl = lease_ttl_for_run(&lease, coordination, lease_ttl);
+    match execute_task_result_with_optional_lease_ttl(
         &state,
         handler,
         start,
@@ -2362,8 +2361,9 @@ async fn execute_cron_task(
     coordination: crate::task::TaskCoordination,
     coordinator: Arc<dyn crate::scheduler::SchedulerCoordinator>,
     lease_ttl: std::time::Duration,
+    scheduled_unix_secs: u64,
 ) {
-    let tick_key = crate::scheduler::cron_tick_key(&name, crate::scheduler::now_unix_secs());
+    let tick_key = crate::scheduler::cron_tick_key(&name, scheduled_unix_secs);
     let lease = match coordinator
         .try_acquire(&name, &tick_key, coordination)
         .await
@@ -2387,7 +2387,11 @@ async fn execute_cron_task(
     send_ws_sys_task_msg(&state, "started", &name, vec![]);
 
     let start = std::time::Instant::now();
-    match execute_task_result_with_lease_ttl(&state, handler, start, &name, "cron", lease_ttl).await
+    let lease_ttl = lease_ttl_for_run(&lease, coordination, lease_ttl);
+    match execute_task_result_with_optional_lease_ttl(
+        &state, handler, start, &name, "cron", lease_ttl,
+    )
+    .await
     {
         Ok(duration_ms) => {
             state.task_registry.record_success(&name, duration_ms);
@@ -2429,10 +2433,41 @@ struct CronTaskSpec {
     handler: crate::task::TaskHandler,
 }
 
-async fn register_cron_task(
-    sched: &tokio_cron_scheduler::JobScheduler,
+fn lease_ttl_for_run(
+    lease: &crate::scheduler::SchedulerLease,
+    coordination: crate::task::TaskCoordination,
+    lease_ttl: std::time::Duration,
+) -> Option<std::time::Duration> {
+    (coordination == crate::task::TaskCoordination::Fleet && lease.backend() == "postgres")
+        .then_some(lease_ttl)
+}
+
+fn run_cron_scheduler(
+    tasks: Vec<CronTaskSpec>,
+    state: &AppState,
+    shutdown: &tokio_util::sync::CancellationToken,
+    coordinator: &Arc<dyn crate::scheduler::SchedulerCoordinator>,
+    lease_ttl: std::time::Duration,
+) {
+    if tasks.is_empty() {
+        return;
+    }
+
+    tracing::info!(count = tasks.len(), "Cron scheduler started");
+    for task in tasks {
+        let state = state.clone();
+        let coordinator = Arc::clone(coordinator);
+        let shutdown = shutdown.child_token();
+        tokio::spawn(async move {
+            run_cron_task_loop(task, state, shutdown, coordinator, lease_ttl).await;
+        });
+    }
+}
+
+async fn run_cron_task_loop(
     task: CronTaskSpec,
     state: AppState,
+    shutdown: tokio_util::sync::CancellationToken,
     coordinator: Arc<dyn crate::scheduler::SchedulerCoordinator>,
     lease_ttl: std::time::Duration,
 ) {
@@ -2443,121 +2478,64 @@ async fn register_cron_task(
         coordination,
         handler,
     } = task;
-    let state_clone = state.clone();
-    let name_clone = name.clone();
-    let coordinator_clone = Arc::clone(&coordinator);
 
-    let job_result = build_cron_job(&expression, timezone.as_deref(), move |_uuid, _lock| {
-        let state = state_clone.clone();
-        let name = name_clone.clone();
-        let coordinator = Arc::clone(&coordinator_clone);
-        Box::pin(async move {
-            execute_cron_task(name, state, handler, coordination, coordinator, lease_ttl).await;
-        }) as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
-    });
+    let cron = match expression.parse::<croner::Cron>() {
+        Ok(cron) => cron,
+        Err(error) => {
+            tracing::error!(task = %name, expression = %expression, error = %error, "Failed to create cron job");
+            return;
+        }
+    };
+    let timezone = timezone
+        .as_deref()
+        .and_then(|timezone| {
+            timezone.parse::<chrono_tz::Tz>().map_or_else(
+                |_| {
+                    tracing::warn!(task = %name, timezone = %timezone, "Unrecognized timezone; falling back to UTC");
+                    None
+                },
+                Some,
+            )
+        })
+        .unwrap_or(chrono_tz::UTC);
+    let mut cursor = chrono::Utc::now().with_timezone(&timezone);
 
-    match job_result {
-        Ok(job) => {
-            if let Err(e) = sched.add(job).await {
-                tracing::error!(task = %name, error = %e, "Failed to add cron task to scheduler");
+    loop {
+        let scheduled_at = match cron.find_next_occurrence(&cursor, false) {
+            Ok(scheduled_at) => scheduled_at,
+            Err(error) => {
+                tracing::error!(task = %name, expression = %expression, error = %error, "Failed to compute next cron tick");
+                return;
             }
-        }
-        Err(e) => {
-            tracing::error!(task = %name, error = %e, "Failed to create cron job");
-        }
-    }
-}
-
-async fn setup_cron_scheduler(
-    tasks: Vec<CronTaskSpec>,
-    state: AppState,
-    coordinator: Arc<dyn crate::scheduler::SchedulerCoordinator>,
-    lease_ttl: std::time::Duration,
-) -> Option<tokio_cron_scheduler::JobScheduler> {
-    use tokio_cron_scheduler::JobScheduler;
-
-    let sched = match JobScheduler::new().await {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::error!(error = %e, "Failed to create cron job scheduler");
-            return None;
-        }
-    };
-
-    for task in tasks {
-        register_cron_task(
-            &sched,
-            task,
-            state.clone(),
-            Arc::clone(&coordinator),
-            lease_ttl,
-        )
-        .await;
-    }
-
-    if let Err(e) = sched.start().await {
-        tracing::error!(error = %e, "Failed to start cron scheduler");
-        return None;
-    }
-
-    Some(sched)
-}
-
-/// Run the `tokio-cron-scheduler` for all cron tasks, shutting down when the
-/// `shutdown` token is cancelled.
-#[allow(clippy::cognitive_complexity)]
-async fn run_cron_scheduler(
-    tasks: Vec<CronTaskSpec>,
-    state: AppState,
-    shutdown: tokio_util::sync::CancellationToken,
-    coordinator: Arc<dyn crate::scheduler::SchedulerCoordinator>,
-    lease_ttl: std::time::Duration,
-) {
-    let Some(mut sched) = setup_cron_scheduler(tasks, state, coordinator, lease_ttl).await else {
-        return;
-    };
-
-    tracing::info!("Cron scheduler started");
-    shutdown.cancelled().await;
-    tracing::info!("Shutting down cron scheduler");
-
-    if let Err(e) = sched.shutdown().await {
-        tracing::error!(error = %e, "Failed to shut down cron scheduler");
-    }
-}
-
-/// Build a cron [`Job`](tokio_cron_scheduler::Job) for the given expression and optional
-/// IANA timezone string.
-///
-/// If `timezone` is `None` or cannot be parsed, UTC is used.
-fn build_cron_job<F>(
-    expression: &str,
-    timezone: Option<&str>,
-    run: F,
-) -> Result<tokio_cron_scheduler::Job, tokio_cron_scheduler::JobSchedulerError>
-where
-    F: 'static
-        + FnMut(
-            uuid::Uuid,
-            tokio_cron_scheduler::JobScheduler,
-        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
-        + Send
-        + Sync,
-{
-    use tokio_cron_scheduler::Job;
-
-    if let Some(tz_str) = timezone {
-        match tz_str.parse::<chrono_tz::Tz>() {
-            Ok(tz) => return Job::new_async_tz(expression, tz, run),
-            Err(_) => {
-                tracing::warn!(
-                    timezone = %tz_str,
-                    "Unrecognized timezone; falling back to UTC"
-                );
+        };
+        let sleep_for = cron_sleep_duration_until(&scheduled_at);
+        tokio::select! {
+            () = shutdown.cancelled() => break,
+            () = tokio::time::sleep(sleep_for) => {
+                let scheduled_unix_secs = u64::try_from(scheduled_at.timestamp()).unwrap_or_default();
+                tokio::spawn(execute_cron_task(
+                    name.clone(),
+                    state.clone(),
+                    handler,
+                    coordination,
+                    Arc::clone(&coordinator),
+                    lease_ttl,
+                    scheduled_unix_secs,
+                ));
+                cursor = scheduled_at;
             }
         }
     }
-    Job::new_async(expression, run)
+}
+
+fn cron_sleep_duration_until<Tz: chrono::TimeZone>(
+    scheduled_at: &chrono::DateTime<Tz>,
+) -> std::time::Duration {
+    scheduled_at
+        .with_timezone(&chrono::Utc)
+        .signed_duration_since(chrono::Utc::now())
+        .to_std()
+        .unwrap_or_default()
 }
 
 async fn run_startup_hooks(hooks: &[StartupHook], state: AppState) -> crate::AutumnResult<()> {
@@ -5446,7 +5424,7 @@ mod tests {
             super::start_task_scheduler(
                 vec![task],
                 &state_clone,
-                tokio_util::sync::CancellationToken::new(),
+                &tokio_util::sync::CancellationToken::new(),
             );
         });
 
@@ -5511,7 +5489,7 @@ mod tests {
             super::start_task_scheduler(
                 vec![task],
                 &state_clone,
-                tokio_util::sync::CancellationToken::new(),
+                &tokio_util::sync::CancellationToken::new(),
             );
         });
 
@@ -5556,7 +5534,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_fixed_delay_task_records_lease_ttl_timeout() {
+    async fn execute_fixed_delay_task_does_not_timeout_in_process_runs() {
         let state = AppState::for_test();
         state.task_registry.register_scheduled(
             "slow_task",
@@ -5567,7 +5545,7 @@ mod tests {
         );
         let handler: crate::task::TaskHandler = |_| {
             Box::pin(async {
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
                 Ok(())
             })
         };
@@ -5589,15 +5567,10 @@ mod tests {
         let snapshot = state.task_registry.snapshot();
         let status = &snapshot["slow_task"];
         assert_eq!(status.status, "idle");
-        assert_eq!(status.last_result.as_deref(), Some("failed"));
+        assert_eq!(status.last_result.as_deref(), Some("ok"));
         assert_eq!(status.total_runs, 1);
-        assert_eq!(status.total_failures, 1);
-        assert!(
-            status
-                .last_error
-                .as_deref()
-                .is_some_and(|error| error.contains("lease TTL"))
-        );
+        assert_eq!(status.total_failures, 0);
+        assert!(status.last_error.is_none());
     }
 
     static SKIPPED_LEASE_HANDLER_CALLS: AtomicUsize = AtomicUsize::new(0);
@@ -5623,6 +5596,39 @@ mod tests {
             crate::AutumnResult<Option<crate::scheduler::SchedulerLease>>,
         > {
             Box::pin(async { Ok(None) })
+        }
+    }
+
+    struct GrantingSchedulerCoordinator {
+        backend: &'static str,
+        tick_keys: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    impl crate::scheduler::SchedulerCoordinator for GrantingSchedulerCoordinator {
+        fn backend(&self) -> &'static str {
+            self.backend
+        }
+
+        fn replica_id(&self) -> &'static str {
+            "replica-a"
+        }
+
+        fn try_acquire<'a>(
+            &'a self,
+            _task_name: &'a str,
+            tick_key: &'a str,
+            _coordination: crate::task::TaskCoordination,
+        ) -> crate::scheduler::SchedulerFuture<
+            'a,
+            crate::AutumnResult<Option<crate::scheduler::SchedulerLease>>,
+        > {
+            Box::pin(async move {
+                self.tick_keys.lock().unwrap().push(tick_key.to_owned());
+                Ok(Some(crate::scheduler::SchedulerLease::local(
+                    self.backend,
+                    "replica-a",
+                )))
+            })
         }
     }
 
@@ -5665,6 +5671,87 @@ mod tests {
         assert_eq!(status.total_runs, 0);
         assert!(status.current_leader.is_none());
         assert!(status.last_tick.is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_fixed_delay_task_records_distributed_lease_ttl_timeout() {
+        let state = AppState::for_test();
+        state.task_registry.register_scheduled(
+            "slow_distributed_task",
+            "every 1s",
+            crate::task::TaskCoordination::Fleet,
+            "postgres",
+            "replica-a",
+        );
+        let handler: crate::task::TaskHandler = |_| {
+            Box::pin(async {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                Ok(())
+            })
+        };
+        let coordinator = std::sync::Arc::new(GrantingSchedulerCoordinator {
+            backend: "postgres",
+            tick_keys: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+        });
+
+        super::execute_fixed_delay_task(
+            "slow_distributed_task".to_owned(),
+            state.clone(),
+            handler,
+            std::time::Duration::from_secs(1),
+            crate::task::TaskCoordination::Fleet,
+            coordinator,
+            std::time::Duration::from_millis(10),
+        )
+        .await;
+
+        let snapshot = state.task_registry.snapshot();
+        let status = &snapshot["slow_distributed_task"];
+        assert_eq!(status.status, "idle");
+        assert_eq!(status.last_result.as_deref(), Some("failed"));
+        assert_eq!(status.total_runs, 1);
+        assert_eq!(status.total_failures, 1);
+        assert!(
+            status
+                .last_error
+                .as_deref()
+                .is_some_and(|error| error.contains("lease TTL"))
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_cron_task_uses_scheduled_occurrence_for_tick_key() {
+        let state = AppState::for_test();
+        state.task_registry.register_scheduled(
+            "cron_review_task",
+            "cron */10 * * * * *",
+            crate::task::TaskCoordination::Fleet,
+            "postgres",
+            "replica-a",
+        );
+        let tick_keys = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let coordinator = std::sync::Arc::new(GrantingSchedulerCoordinator {
+            backend: "postgres",
+            tick_keys: std::sync::Arc::clone(&tick_keys),
+        });
+        let handler: crate::task::TaskHandler = |_| Box::pin(async { Ok(()) });
+        let scheduled_unix_secs = 1_700_000_000;
+
+        super::execute_cron_task(
+            "cron_review_task".to_owned(),
+            state.clone(),
+            handler,
+            crate::task::TaskCoordination::Fleet,
+            coordinator,
+            std::time::Duration::from_secs(30),
+            scheduled_unix_secs,
+        )
+        .await;
+
+        assert_eq!(
+            tick_keys.lock().unwrap().as_slice(),
+            ["cron_review_task:1700000000"]
+        );
     }
 
     #[cfg(feature = "storage")]

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2286,7 +2286,7 @@ async fn execute_fixed_delay_task(
     lease_ttl: std::time::Duration,
 ) {
     let tick_key =
-        crate::scheduler::fixed_delay_tick_key(&name, delay, crate::scheduler::now_unix_secs());
+        crate::scheduler::fixed_delay_tick_key(&name, delay, crate::scheduler::now_unix_duration());
     let lease = match coordinator
         .try_acquire(&name, &tick_key, coordination)
         .await
@@ -2501,7 +2501,8 @@ async fn run_cron_task_loop(
     let mut cursor = chrono::Utc::now().with_timezone(&timezone);
 
     loop {
-        let scheduled_at = match cron.find_next_occurrence(&cursor, false) {
+        let now = chrono::Utc::now().with_timezone(&timezone);
+        let scheduled_at = match next_cron_occurrence_after(&cron, &cursor, &now) {
             Ok(scheduled_at) => scheduled_at,
             Err(error) => {
                 tracing::error!(task = %name, expression = %expression, error = %error, "Failed to compute next cron tick");
@@ -2512,6 +2513,24 @@ async fn run_cron_task_loop(
         tokio::select! {
             () = shutdown.cancelled() => break,
             () = tokio::time::sleep(sleep_for) => {
+                let woke_at = chrono::Utc::now().with_timezone(&timezone);
+                match cron_occurrence_is_overdue(&cron, &scheduled_at, &woke_at) {
+                    Ok(true) => {
+                        tracing::warn!(
+                            task = %name,
+                            scheduled_at = %scheduled_at,
+                            woke_at = %woke_at,
+                            "Skipping overdue cron task tick"
+                        );
+                        cursor = woke_at;
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(error) => {
+                        tracing::error!(task = %name, expression = %expression, error = %error, "Failed to evaluate cron tick lateness");
+                        return;
+                    }
+                }
                 let scheduled_unix_secs = u64::try_from(scheduled_at.timestamp()).unwrap_or_default();
                 tokio::spawn(execute_cron_task(
                     name.clone(),
@@ -2526,6 +2545,24 @@ async fn run_cron_task_loop(
             }
         }
     }
+}
+
+fn next_cron_occurrence_after<Tz: chrono::TimeZone>(
+    cron: &croner::Cron,
+    cursor: &chrono::DateTime<Tz>,
+    now: &chrono::DateTime<Tz>,
+) -> Result<chrono::DateTime<Tz>, croner::errors::CronError> {
+    let anchor = if cursor < now { now } else { cursor };
+    cron.find_next_occurrence(anchor, false)
+}
+
+fn cron_occurrence_is_overdue<Tz: chrono::TimeZone>(
+    cron: &croner::Cron,
+    scheduled_at: &chrono::DateTime<Tz>,
+    now: &chrono::DateTime<Tz>,
+) -> Result<bool, croner::errors::CronError> {
+    let next_after_scheduled = cron.find_next_occurrence(scheduled_at, false)?;
+    Ok(&next_after_scheduled <= now)
 }
 
 fn cron_sleep_duration_until<Tz: chrono::TimeZone>(
@@ -5751,6 +5788,57 @@ mod tests {
         assert_eq!(
             tick_keys.lock().unwrap().as_slice(),
             ["cron_review_task:1700000000"]
+        );
+    }
+
+    #[test]
+    fn next_cron_occurrence_skips_overdue_slots() {
+        use chrono::TimeZone as _;
+
+        let cron = "0 * * * * *"
+            .parse::<croner::Cron>()
+            .expect("cron expression should parse");
+        let stale_cursor = chrono_tz::UTC
+            .with_ymd_and_hms(2026, 5, 5, 12, 0, 0)
+            .unwrap();
+        let now = chrono_tz::UTC
+            .with_ymd_and_hms(2026, 5, 5, 12, 30, 5)
+            .unwrap();
+        let next = super::next_cron_occurrence_after(&cron, &stale_cursor, &now)
+            .expect("next cron occurrence should resolve");
+
+        assert_eq!(
+            next,
+            chrono_tz::UTC
+                .with_ymd_and_hms(2026, 5, 5, 12, 31, 0)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn cron_occurrence_is_overdue_after_later_slot_passed() {
+        use chrono::TimeZone as _;
+
+        let cron = "0 * * * * *"
+            .parse::<croner::Cron>()
+            .expect("cron expression should parse");
+        let scheduled_at = chrono_tz::UTC
+            .with_ymd_and_hms(2026, 5, 5, 12, 1, 0)
+            .unwrap();
+        let slightly_late = chrono_tz::UTC
+            .with_ymd_and_hms(2026, 5, 5, 12, 1, 5)
+            .unwrap();
+        let after_later_slot = chrono_tz::UTC
+            .with_ymd_and_hms(2026, 5, 5, 12, 30, 5)
+            .unwrap();
+
+        assert!(
+            !super::cron_occurrence_is_overdue(&cron, &scheduled_at, &slightly_late)
+                .expect("overdue check should resolve")
+        );
+        assert!(
+            super::cron_occurrence_is_overdue(&cron, &scheduled_at, &after_later_slot)
+                .expect("overdue check should resolve")
         );
     }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -84,6 +84,10 @@
 //! | `AUTUMN_JOBS__INITIAL_BACKOFF_MS` | `jobs.initial_backoff_ms` | `u64` |
 //! | `AUTUMN_JOBS__REDIS__URL` | `jobs.redis.url` | `String` |
 //! | `AUTUMN_JOBS__REDIS__KEY_PREFIX` | `jobs.redis.key_prefix` | `String` |
+//! | `AUTUMN_SCHEDULER__BACKEND` | `scheduler.backend` | `in_process` / `postgres` |
+//! | `AUTUMN_SCHEDULER__LEASE_TTL_SECS` | `scheduler.lease_ttl_secs` | `u64` |
+//! | `AUTUMN_SCHEDULER__REPLICA_ID` | `scheduler.replica_id` | `String` |
+//! | `AUTUMN_SCHEDULER__KEY_PREFIX` | `scheduler.key_prefix` | `String` |
 //! | `AUTUMN_SECURITY__RATE_LIMIT__ENABLED` | `security.rate_limit.enabled` | `bool` |
 //! | `AUTUMN_SECURITY__RATE_LIMIT__REQUESTS_PER_SECOND` | `security.rate_limit.requests_per_second` | `f64` |
 //! | `AUTUMN_SECURITY__RATE_LIMIT__BURST` | `security.rate_limit.burst` | `u32` |
@@ -644,6 +648,10 @@ pub struct AutumnConfig {
     #[serde(default)]
     pub jobs: JobConfig,
 
+    /// Scheduled task coordination backend settings.
+    #[serde(default)]
+    pub scheduler: SchedulerConfig,
+
     /// Authentication settings.
     #[serde(default)]
     pub auth: crate::auth::AuthConfig,
@@ -765,6 +773,100 @@ const fn default_channel_capacity() -> usize {
 
 fn default_channels_redis_prefix() -> String {
     "autumn:channels".to_owned()
+}
+
+/// Scheduled task coordination backend selection.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SchedulerBackend {
+    /// Per-process scheduler timers. This preserves existing single-replica behavior.
+    #[serde(alias = "local", alias = "memory")]
+    #[default]
+    InProcess,
+    /// Fleet coordination with Postgres advisory locks.
+    Postgres,
+}
+
+impl SchedulerBackend {
+    /// Parse an environment variable value for scheduler backend selection.
+    #[must_use]
+    pub fn from_env_value(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "in_process" | "in-process" | "local" | "memory" => Some(Self::InProcess),
+            "postgres" | "postgresql" => Some(Self::Postgres),
+            _ => None,
+        }
+    }
+}
+
+/// Scheduled task coordination runtime configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SchedulerConfig {
+    /// Runtime backend selection.
+    #[serde(default)]
+    pub backend: SchedulerBackend,
+    /// Lease duration used by distributed backends for run visibility and timeout guidance.
+    #[serde(default = "default_scheduler_lease_ttl_secs")]
+    pub lease_ttl_secs: u64,
+    /// Stable replica identifier surfaced in actuator metadata.
+    #[serde(default)]
+    pub replica_id: Option<String>,
+    /// Prefix included when deriving Postgres advisory lock keys.
+    #[serde(default = "default_scheduler_key_prefix")]
+    pub key_prefix: String,
+}
+
+impl SchedulerConfig {
+    /// Resolve a stable-ish replica identifier for actuator metadata and lock ownership.
+    #[must_use]
+    pub fn resolved_replica_id(&self) -> String {
+        self.replica_id
+            .as_ref()
+            .filter(|id| !id.trim().is_empty())
+            .cloned()
+            .or_else(|| std::env::var("FLY_MACHINE_ID").ok())
+            .or_else(|| std::env::var("HOSTNAME").ok())
+            .unwrap_or_else(|| format!("pid-{}", std::process::id()))
+    }
+
+    /// Validate scheduler-specific config shape.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError::Validation`] when values are syntactically valid TOML
+    /// but cannot be used by the runtime.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.lease_ttl_secs == 0 {
+            return Err(ConfigError::Validation(
+                "scheduler.lease_ttl_secs must be greater than zero".to_owned(),
+            ));
+        }
+        if self.key_prefix.trim().is_empty() {
+            return Err(ConfigError::Validation(
+                "scheduler.key_prefix must not be empty".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Default for SchedulerConfig {
+    fn default() -> Self {
+        Self {
+            backend: SchedulerBackend::default(),
+            lease_ttl_secs: default_scheduler_lease_ttl_secs(),
+            replica_id: None,
+            key_prefix: default_scheduler_key_prefix(),
+        }
+    }
+}
+
+const fn default_scheduler_lease_ttl_secs() -> u64 {
+    300
+}
+
+fn default_scheduler_key_prefix() -> String {
+    "autumn:scheduler".to_owned()
 }
 
 /// `OpenAPI` spec runtime exposure settings.
@@ -1009,6 +1111,7 @@ impl AutumnConfig {
     pub fn validate(&self) -> Result<(), ConfigError> {
         self.database.validate()?;
         self.cors.validate()?;
+        self.scheduler.validate()?;
         #[cfg(feature = "mail")]
         self.mail.validate(self.profile.as_deref())?;
         // Session backend validation deliberately lives in
@@ -1082,6 +1185,7 @@ impl AutumnConfig {
         self.apply_session_env_overrides_with_env(env);
         self.apply_channels_env_overrides_with_env(env);
         self.apply_jobs_env_overrides_with_env(env);
+        self.apply_scheduler_env_overrides_with_env(env);
         self.apply_auth_env_overrides_with_env(env);
         self.apply_security_env_overrides_with_env(env);
         #[cfg(feature = "storage")]
@@ -1318,6 +1422,33 @@ impl AutumnConfig {
             env,
             "AUTUMN_JOBS__REDIS__KEY_PREFIX",
             &mut self.jobs.redis.key_prefix,
+        );
+    }
+
+    fn apply_scheduler_env_overrides_with_env(&mut self, env: &dyn Env) {
+        if let Ok(val) = env.var("AUTUMN_SCHEDULER__BACKEND") {
+            match SchedulerBackend::from_env_value(&val) {
+                Some(backend) => self.scheduler.backend = backend,
+                None => eprintln!(
+                    "Warning: AUTUMN_SCHEDULER__BACKEND={val:?} is not valid \
+                     (expected in_process or postgres), ignoring"
+                ),
+            }
+        }
+        parse_env(
+            env,
+            "AUTUMN_SCHEDULER__LEASE_TTL_SECS",
+            &mut self.scheduler.lease_ttl_secs,
+        );
+        parse_env_option_string(
+            env,
+            "AUTUMN_SCHEDULER__REPLICA_ID",
+            &mut self.scheduler.replica_id,
+        );
+        parse_env_string(
+            env,
+            "AUTUMN_SCHEDULER__KEY_PREFIX",
+            &mut self.scheduler.key_prefix,
         );
     }
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -131,6 +131,7 @@ pub mod prelude;
 pub use paths::PathExt;
 pub(crate) mod route;
 pub use route::{RepositoryApiMeta, Route};
+pub mod scheduler;
 pub mod security;
 pub mod session;
 #[cfg(feature = "redis")]

--- a/autumn/src/scheduler.rs
+++ b/autumn/src/scheduler.rs
@@ -1,0 +1,362 @@
+//! Scheduled-task coordination backends.
+//!
+//! The in-process backend preserves the original single-process behavior.
+//! The Postgres backend uses advisory locks so each fleet-wide task tick is
+//! claimed by at most one replica under normal operation.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use sha2::{Digest as _, Sha256};
+
+use crate::config::{SchedulerBackend, SchedulerConfig};
+use crate::state::AppState;
+use crate::task::TaskCoordination;
+use crate::{AutumnError, AutumnResult};
+
+/// Boxed future returned by scheduler coordination operations.
+pub type SchedulerFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// A configured scheduler backend that decides whether this replica may run a tick.
+pub trait SchedulerCoordinator: Send + Sync {
+    /// Backend identifier surfaced in logs and actuator metadata.
+    fn backend(&self) -> &'static str;
+
+    /// Stable replica identifier surfaced in actuator metadata.
+    fn replica_id(&self) -> &str;
+
+    /// Try to acquire permission to run `task_name` for `tick_key`.
+    fn try_acquire<'a>(
+        &'a self,
+        task_name: &'a str,
+        tick_key: &'a str,
+        coordination: TaskCoordination,
+    ) -> SchedulerFuture<'a, AutumnResult<Option<SchedulerLease>>>;
+}
+
+/// Acquired permission to run a scheduled task tick.
+pub struct SchedulerLease {
+    backend: String,
+    leader_id: String,
+    #[cfg(feature = "db")]
+    postgres: Option<PostgresAdvisoryLease>,
+}
+
+impl SchedulerLease {
+    fn local(backend: impl Into<String>, leader_id: impl Into<String>) -> Self {
+        Self {
+            backend: backend.into(),
+            leader_id: leader_id.into(),
+            #[cfg(feature = "db")]
+            postgres: None,
+        }
+    }
+
+    #[cfg(feature = "db")]
+    fn postgres(leader_id: impl Into<String>, lease: PostgresAdvisoryLease) -> Self {
+        Self {
+            backend: "postgres".to_owned(),
+            leader_id: leader_id.into(),
+            postgres: Some(lease),
+        }
+    }
+
+    /// Backend that granted this lease.
+    #[must_use]
+    pub fn backend(&self) -> &str {
+        &self.backend
+    }
+
+    /// Replica currently considered leader for this tick.
+    #[must_use]
+    pub fn leader_id(&self) -> &str {
+        &self.leader_id
+    }
+
+    /// Release backend resources associated with this lease.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AutumnError`] when the backend cannot release its lock.
+    pub async fn release(self) -> AutumnResult<()> {
+        #[cfg(feature = "db")]
+        if let Some(lease) = self.postgres {
+            return lease.release().await;
+        }
+
+        Ok(())
+    }
+}
+
+/// Local coordinator that always lets this process run.
+#[derive(Debug, Clone)]
+pub struct InProcessSchedulerCoordinator {
+    replica_id: String,
+}
+
+impl InProcessSchedulerCoordinator {
+    /// Create an in-process coordinator for a replica id.
+    #[must_use]
+    pub fn new(replica_id: impl Into<String>) -> Self {
+        Self {
+            replica_id: replica_id.into(),
+        }
+    }
+}
+
+impl SchedulerCoordinator for InProcessSchedulerCoordinator {
+    fn backend(&self) -> &'static str {
+        "in_process"
+    }
+
+    fn replica_id(&self) -> &str {
+        &self.replica_id
+    }
+
+    fn try_acquire<'a>(
+        &'a self,
+        _task_name: &'a str,
+        _tick_key: &'a str,
+        coordination: TaskCoordination,
+    ) -> SchedulerFuture<'a, AutumnResult<Option<SchedulerLease>>> {
+        Box::pin(async move {
+            let backend = match coordination {
+                TaskCoordination::Fleet => "in_process",
+                TaskCoordination::PerReplica => "per_replica",
+            };
+            Ok(Some(SchedulerLease::local(
+                backend,
+                self.replica_id.clone(),
+            )))
+        })
+    }
+}
+
+/// Postgres advisory-lock coordinator.
+#[cfg(feature = "db")]
+#[derive(Clone)]
+pub struct PostgresAdvisorySchedulerCoordinator {
+    pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+    replica_id: String,
+    key_prefix: String,
+}
+
+#[cfg(feature = "db")]
+impl PostgresAdvisorySchedulerCoordinator {
+    /// Create a Postgres advisory-lock coordinator.
+    #[must_use]
+    pub fn new(
+        pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        replica_id: impl Into<String>,
+        key_prefix: impl Into<String>,
+    ) -> Self {
+        Self {
+            pool,
+            replica_id: replica_id.into(),
+            key_prefix: key_prefix.into(),
+        }
+    }
+}
+
+#[cfg(feature = "db")]
+impl SchedulerCoordinator for PostgresAdvisorySchedulerCoordinator {
+    fn backend(&self) -> &'static str {
+        "postgres"
+    }
+
+    fn replica_id(&self) -> &str {
+        &self.replica_id
+    }
+
+    fn try_acquire<'a>(
+        &'a self,
+        task_name: &'a str,
+        tick_key: &'a str,
+        coordination: TaskCoordination,
+    ) -> SchedulerFuture<'a, AutumnResult<Option<SchedulerLease>>> {
+        Box::pin(async move {
+            if coordination == TaskCoordination::PerReplica {
+                return Ok(Some(SchedulerLease::local(
+                    "per_replica",
+                    self.replica_id.clone(),
+                )));
+            }
+
+            let key = advisory_lock_key(&self.key_prefix, task_name, tick_key);
+            let mut conn = self.pool.get().await.map_err(|error| {
+                AutumnError::service_unavailable_msg(format!(
+                    "scheduler postgres lock connection unavailable: {error}"
+                ))
+            })?;
+            let acquired = try_pg_advisory_lock(&mut conn, key).await?;
+            if acquired {
+                Ok(Some(SchedulerLease::postgres(
+                    self.replica_id.clone(),
+                    PostgresAdvisoryLease {
+                        conn: Some(conn),
+                        key,
+                    },
+                )))
+            } else {
+                Ok(None)
+            }
+        })
+    }
+}
+
+#[cfg(feature = "db")]
+struct PostgresAdvisoryLease {
+    conn:
+        Option<diesel_async::pooled_connection::deadpool::Object<diesel_async::AsyncPgConnection>>,
+    key: i64,
+}
+
+#[cfg(feature = "db")]
+impl PostgresAdvisoryLease {
+    async fn release(mut self) -> AutumnResult<()> {
+        let Some(mut conn) = self.conn.take() else {
+            return Ok(());
+        };
+        let released = unlock_pg_advisory_lock(&mut conn, self.key).await?;
+        if !released {
+            tracing::warn!(
+                lock_key = self.key,
+                "Postgres advisory scheduler lock was already released"
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Build the scheduler coordinator for the current application state.
+///
+/// # Errors
+///
+/// Returns [`AutumnError`] when a distributed backend is selected without the
+/// required runtime dependency.
+pub fn coordinator_from_config(
+    config: &SchedulerConfig,
+    state: &AppState,
+) -> AutumnResult<Arc<dyn SchedulerCoordinator>> {
+    let replica_id = config.resolved_replica_id();
+    match config.backend {
+        SchedulerBackend::InProcess => Ok(Arc::new(InProcessSchedulerCoordinator::new(replica_id))),
+        SchedulerBackend::Postgres => {
+            #[cfg(feature = "db")]
+            {
+                let pool = state.pool().cloned().ok_or_else(|| {
+                    AutumnError::service_unavailable_msg(
+                        "scheduler.backend = \"postgres\" requires a configured database pool",
+                    )
+                })?;
+                Ok(Arc::new(PostgresAdvisorySchedulerCoordinator::new(
+                    pool,
+                    replica_id,
+                    config.key_prefix.clone(),
+                )))
+            }
+
+            #[cfg(not(feature = "db"))]
+            {
+                let _ = state;
+                Err(AutumnError::service_unavailable_msg(
+                    "scheduler.backend = \"postgres\" requires the autumn-web db feature",
+                ))
+            }
+        }
+    }
+}
+
+/// Derive the global tick key for a fixed-delay task and a Unix timestamp.
+#[must_use]
+pub fn fixed_delay_tick_key(task_name: &str, delay: Duration, unix_secs: u64) -> String {
+    let interval = delay.as_secs().max(1);
+    let bucket = unix_secs / interval;
+    format!("{task_name}:{bucket}")
+}
+
+/// Derive the global tick key for a cron task and a Unix timestamp.
+#[must_use]
+pub fn cron_tick_key(task_name: &str, unix_secs: u64) -> String {
+    format!("{task_name}:{unix_secs}")
+}
+
+/// Compute a stable signed 64-bit advisory lock key for a task tick.
+#[must_use]
+pub fn advisory_lock_key(key_prefix: &str, task_name: &str, tick_key: &str) -> i64 {
+    let mut hasher = Sha256::new();
+    hasher.update(key_prefix.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(task_name.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(tick_key.as_bytes());
+    let digest = hasher.finalize();
+    let mut bytes = [0_u8; 8];
+    bytes.copy_from_slice(&digest[..8]);
+    i64::from_be_bytes(bytes)
+}
+
+/// Current Unix timestamp in seconds.
+#[must_use]
+pub fn now_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(feature = "db")]
+#[derive(diesel::QueryableByName)]
+struct AdvisoryLockRow {
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    acquired: bool,
+}
+
+#[cfg(feature = "db")]
+async fn try_pg_advisory_lock(
+    conn: &mut diesel_async::pooled_connection::deadpool::Object<diesel_async::AsyncPgConnection>,
+    key: i64,
+) -> AutumnResult<bool> {
+    use diesel_async::RunQueryDsl as _;
+
+    let row = diesel::sql_query("SELECT pg_try_advisory_lock($1) AS acquired")
+        .bind::<diesel::sql_types::BigInt, _>(key)
+        .get_result::<AdvisoryLockRow>(&mut **conn)
+        .await
+        .map_err(|error| AutumnError::internal_server_error_msg(error.to_string()))?;
+    Ok(row.acquired)
+}
+
+#[cfg(feature = "db")]
+#[derive(diesel::QueryableByName)]
+struct AdvisoryUnlockRow {
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    released: bool,
+}
+
+#[cfg(feature = "db")]
+async fn unlock_pg_advisory_lock(
+    conn: &mut diesel_async::pooled_connection::deadpool::Object<diesel_async::AsyncPgConnection>,
+    key: i64,
+) -> AutumnResult<bool> {
+    use diesel_async::RunQueryDsl as _;
+
+    let row = diesel::sql_query("SELECT pg_advisory_unlock($1) AS released")
+        .bind::<diesel::sql_types::BigInt, _>(key)
+        .get_result::<AdvisoryUnlockRow>(&mut **conn)
+        .await
+        .map_err(|error| AutumnError::internal_server_error_msg(error.to_string()))?;
+    Ok(row.released)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cron_tick_key_uses_task_name_and_second() {
+        assert_eq!(cron_tick_key("digest", 1_700_000_000), "digest:1700000000");
+    }
+}

--- a/autumn/src/scheduler.rs
+++ b/autumn/src/scheduler.rs
@@ -269,11 +269,11 @@ pub fn coordinator_from_config(
     }
 }
 
-/// Derive the global tick key for a fixed-delay task and a Unix timestamp.
+/// Derive the global tick key for a fixed-delay task and Unix elapsed time.
 #[must_use]
-pub fn fixed_delay_tick_key(task_name: &str, delay: Duration, unix_secs: u64) -> String {
-    let interval = delay.as_secs().max(1);
-    let bucket = unix_secs / interval;
+pub fn fixed_delay_tick_key(task_name: &str, delay: Duration, unix_elapsed: Duration) -> String {
+    let interval = delay.as_nanos().max(1);
+    let bucket = unix_elapsed.as_nanos() / interval;
     format!("{task_name}:{bucket}")
 }
 
@@ -301,10 +301,15 @@ pub fn advisory_lock_key(key_prefix: &str, task_name: &str, tick_key: &str) -> i
 /// Current Unix timestamp in seconds.
 #[must_use]
 pub fn now_unix_secs() -> u64 {
+    now_unix_duration().as_secs()
+}
+
+/// Current elapsed time since the Unix epoch.
+#[must_use]
+pub fn now_unix_duration() -> Duration {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
-        .as_secs()
 }
 
 #[cfg(feature = "db")]

--- a/autumn/src/scheduler.rs
+++ b/autumn/src/scheduler.rs
@@ -45,7 +45,7 @@ pub struct SchedulerLease {
 }
 
 impl SchedulerLease {
-    fn local(backend: impl Into<String>, leader_id: impl Into<String>) -> Self {
+    pub(crate) fn local(backend: impl Into<String>, leader_id: impl Into<String>) -> Self {
         Self {
             backend: backend.into(),
             leader_id: leader_id.into(),

--- a/autumn/src/scheduler.rs
+++ b/autumn/src/scheduler.rs
@@ -40,6 +40,8 @@ pub trait SchedulerCoordinator: Send + Sync {
 pub struct SchedulerLease {
     backend: String,
     leader_id: String,
+    #[cfg(test)]
+    release_count: Option<Arc<std::sync::atomic::AtomicUsize>>,
     #[cfg(feature = "db")]
     postgres: Option<PostgresAdvisoryLease>,
 }
@@ -49,6 +51,23 @@ impl SchedulerLease {
         Self {
             backend: backend.into(),
             leader_id: leader_id.into(),
+            #[cfg(test)]
+            release_count: None,
+            #[cfg(feature = "db")]
+            postgres: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tracked(
+        backend: impl Into<String>,
+        leader_id: impl Into<String>,
+        release_count: Arc<std::sync::atomic::AtomicUsize>,
+    ) -> Self {
+        Self {
+            backend: backend.into(),
+            leader_id: leader_id.into(),
+            release_count: Some(release_count),
             #[cfg(feature = "db")]
             postgres: None,
         }
@@ -59,6 +78,8 @@ impl SchedulerLease {
         Self {
             backend: "postgres".to_owned(),
             leader_id: leader_id.into(),
+            #[cfg(test)]
+            release_count: None,
             postgres: Some(lease),
         }
     }
@@ -81,6 +102,11 @@ impl SchedulerLease {
     ///
     /// Returns [`AutumnError`] when the backend cannot release its lock.
     pub async fn release(self) -> AutumnResult<()> {
+        #[cfg(test)]
+        if let Some(release_count) = self.release_count {
+            release_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+
         #[cfg(feature = "db")]
         if let Some(lease) = self.postgres {
             return lease.release().await;

--- a/autumn/src/task.rs
+++ b/autumn/src/task.rs
@@ -100,8 +100,30 @@ pub struct TaskInfo {
     pub name: String,
     /// When/how often to run.
     pub schedule: Schedule,
+    /// Whether this task is coordinated fleet-wide or intentionally per-replica.
+    pub coordination: TaskCoordination,
     /// The task handler, invoked with a clone of `AppState` each run.
     pub handler: TaskHandler,
+}
+
+/// Cross-replica coordination mode for a scheduled task.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskCoordination {
+    /// Run at most once per scheduled tick across the configured scheduler backend.
+    #[default]
+    Fleet,
+    /// Run on every replica, bypassing fleet coordination.
+    PerReplica,
+}
+
+impl std::fmt::Display for TaskCoordination {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Fleet => f.write_str("fleet"),
+            Self::PerReplica => f.write_str("per_replica"),
+        }
+    }
 }
 
 /// How a scheduled task is triggered.

--- a/autumn/src/task.rs
+++ b/autumn/src/task.rs
@@ -4,7 +4,7 @@
 //! macro and `tasks![]` collection macro.
 //!
 //! Tasks are registered via [`AppBuilder::tasks`](crate::app::AppBuilder::tasks)
-//! and run alongside the HTTP server using `tokio-cron-scheduler`.
+//! and run alongside the HTTP server using Tokio timers.
 
 use std::future::Future;
 use std::pin::Pin;

--- a/autumn/tests/compile-pass/scheduled_coordination.rs
+++ b/autumn/tests/compile-pass/scheduled_coordination.rs
@@ -1,0 +1,19 @@
+use autumn_web::prelude::*;
+use autumn_web::task::TaskCoordination;
+
+#[scheduled(every = "10s", name = "cache-warm", coordination = "per_replica")]
+async fn cache_warm(_state: AppState) -> AutumnResult<()> {
+    Ok(())
+}
+
+#[scheduled(every = "10s", name = "fleet-cleanup")]
+async fn fleet_cleanup(_state: AppState) -> AutumnResult<()> {
+    Ok(())
+}
+
+fn main() {
+    let tasks = tasks![cache_warm, fleet_cleanup];
+
+    assert_eq!(tasks[0].coordination, TaskCoordination::PerReplica);
+    assert_eq!(tasks[1].coordination, TaskCoordination::Fleet);
+}

--- a/autumn/tests/compile_fail.rs
+++ b/autumn/tests/compile_fail.rs
@@ -94,6 +94,7 @@ fn compile_pass_tests() {
 
     // One-off operational task macro
     t.pass("tests/compile-pass/task_basic.rs");
+    t.pass("tests/compile-pass/scheduled_coordination.rs");
 
     // WebSocket macro (requires ws feature)
     #[cfg(feature = "ws")]

--- a/autumn/tests/scheduled_coordination.rs
+++ b/autumn/tests/scheduled_coordination.rs
@@ -138,9 +138,8 @@ fn postgres_scheduler_requires_a_database_pool() {
         ..SchedulerConfig::default()
     };
 
-    let error = match autumn_web::scheduler::coordinator_from_config(&config, &state) {
-        Ok(_) => panic!("postgres scheduler should fail before boot without a database pool"),
-        Err(error) => error,
+    let Err(error) = autumn_web::scheduler::coordinator_from_config(&config, &state) else {
+        panic!("postgres scheduler should fail before boot without a database pool");
     };
 
     assert!(error.to_string().contains("postgres"));

--- a/autumn/tests/scheduled_coordination.rs
+++ b/autumn/tests/scheduled_coordination.rs
@@ -1,0 +1,147 @@
+use std::time::Duration;
+
+use autumn_web::actuator::TaskRegistry;
+use autumn_web::config::{AutumnConfig, MockEnv, SchedulerBackend, SchedulerConfig};
+use autumn_web::scheduler::{
+    InProcessSchedulerCoordinator, SchedulerCoordinator, advisory_lock_key, fixed_delay_tick_key,
+};
+use autumn_web::task::TaskCoordination;
+
+#[test]
+fn scheduler_config_defaults_to_in_process_backend() {
+    let config = AutumnConfig::default();
+
+    assert_eq!(config.scheduler.backend, SchedulerBackend::InProcess);
+    assert_eq!(config.scheduler.lease_ttl_secs, 300);
+    assert_eq!(config.scheduler.key_prefix, "autumn:scheduler");
+}
+
+#[test]
+fn scheduler_config_deserializes_postgres_backend() {
+    let config: AutumnConfig = toml::from_str(
+        r#"
+        [scheduler]
+        backend = "postgres"
+        lease_ttl_secs = 45
+        replica_id = "pod-a"
+        key_prefix = "orders:scheduler"
+        "#,
+    )
+    .expect("scheduler config should deserialize");
+
+    assert_eq!(config.scheduler.backend, SchedulerBackend::Postgres);
+    assert_eq!(config.scheduler.lease_ttl_secs, 45);
+    assert_eq!(config.scheduler.replica_id.as_deref(), Some("pod-a"));
+    assert_eq!(config.scheduler.key_prefix, "orders:scheduler");
+}
+
+#[test]
+fn scheduler_config_supports_env_overrides() {
+    let env = MockEnv::new()
+        .with("AUTUMN_SCHEDULER__BACKEND", "postgres")
+        .with("AUTUMN_SCHEDULER__LEASE_TTL_SECS", "60")
+        .with("AUTUMN_SCHEDULER__REPLICA_ID", "machine-2")
+        .with("AUTUMN_SCHEDULER__KEY_PREFIX", "billing:scheduler");
+    let mut config = AutumnConfig::default();
+
+    config.apply_env_overrides_with_env(&env);
+
+    assert_eq!(config.scheduler.backend, SchedulerBackend::Postgres);
+    assert_eq!(config.scheduler.lease_ttl_secs, 60);
+    assert_eq!(config.scheduler.replica_id.as_deref(), Some("machine-2"));
+    assert_eq!(config.scheduler.key_prefix, "billing:scheduler");
+}
+
+#[test]
+fn fixed_delay_tick_key_is_stable_within_interval() {
+    let first = fixed_delay_tick_key("cleanup", Duration::from_secs(10), 1_700_000_004);
+    let second = fixed_delay_tick_key("cleanup", Duration::from_secs(10), 1_700_000_009);
+    let next = fixed_delay_tick_key("cleanup", Duration::from_secs(10), 1_700_000_010);
+
+    assert_eq!(first, second);
+    assert_ne!(first, next);
+    assert!(first.contains("cleanup"));
+}
+
+#[test]
+fn advisory_lock_key_is_deterministic_and_prefix_scoped() {
+    let first = advisory_lock_key("autumn:scheduler", "cleanup", "cleanup:170000000");
+    let second = advisory_lock_key("autumn:scheduler", "cleanup", "cleanup:170000000");
+    let different_prefix = advisory_lock_key("other:scheduler", "cleanup", "cleanup:170000000");
+
+    assert_eq!(first, second);
+    assert_ne!(first, different_prefix);
+}
+
+#[tokio::test]
+async fn in_process_coordinator_acquires_fleet_tasks_locally() {
+    let coordinator = InProcessSchedulerCoordinator::new("replica-a");
+
+    let lease = coordinator
+        .try_acquire("cleanup", "cleanup:170000000", TaskCoordination::Fleet)
+        .await
+        .expect("in-process acquisition should not fail")
+        .expect("in-process backend should acquire locally");
+
+    assert_eq!(lease.backend(), "in_process");
+    assert_eq!(lease.leader_id(), "replica-a");
+}
+
+#[tokio::test]
+async fn in_process_coordinator_marks_per_replica_tasks_as_uncoordinated() {
+    let coordinator = InProcessSchedulerCoordinator::new("replica-a");
+
+    let lease = coordinator
+        .try_acquire(
+            "cache-warm",
+            "cache-warm:170000000",
+            TaskCoordination::PerReplica,
+        )
+        .await
+        .expect("in-process acquisition should not fail")
+        .expect("per-replica task should run on this replica");
+
+    assert_eq!(lease.backend(), "per_replica");
+    assert_eq!(lease.leader_id(), "replica-a");
+}
+
+#[test]
+fn task_registry_exposes_scheduler_coordination_metadata() {
+    let registry = TaskRegistry::new();
+
+    registry.register_scheduled(
+        "cleanup",
+        "every 10s",
+        TaskCoordination::Fleet,
+        "postgres",
+        "replica-a",
+    );
+    registry.record_leader("cleanup", "replica-b", "cleanup:170000000");
+    registry.record_success("cleanup", 12);
+
+    let snapshot = registry.snapshot();
+    let cleanup = &snapshot["cleanup"];
+
+    assert_eq!(cleanup.coordination, TaskCoordination::Fleet);
+    assert_eq!(cleanup.scheduler_backend, "postgres");
+    assert_eq!(cleanup.replica_id, "replica-a");
+    assert_eq!(cleanup.current_leader.as_deref(), Some("replica-b"));
+    assert_eq!(cleanup.last_tick.as_deref(), Some("cleanup:170000000"));
+    assert!(cleanup.last_fired_at.is_some());
+}
+
+#[test]
+fn postgres_scheduler_requires_a_database_pool() {
+    let state = autumn_web::AppState::for_test();
+    let config = SchedulerConfig {
+        backend: SchedulerBackend::Postgres,
+        ..SchedulerConfig::default()
+    };
+
+    let error = match autumn_web::scheduler::coordinator_from_config(&config, &state) {
+        Ok(_) => panic!("postgres scheduler should fail before boot without a database pool"),
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("postgres"));
+}

--- a/autumn/tests/scheduled_coordination.rs
+++ b/autumn/tests/scheduled_coordination.rs
@@ -54,13 +54,48 @@ fn scheduler_config_supports_env_overrides() {
 
 #[test]
 fn fixed_delay_tick_key_is_stable_within_interval() {
-    let first = fixed_delay_tick_key("cleanup", Duration::from_secs(10), 1_700_000_004);
-    let second = fixed_delay_tick_key("cleanup", Duration::from_secs(10), 1_700_000_009);
-    let next = fixed_delay_tick_key("cleanup", Duration::from_secs(10), 1_700_000_010);
+    let first = fixed_delay_tick_key(
+        "cleanup",
+        Duration::from_secs(10),
+        Duration::from_secs(1_700_000_004),
+    );
+    let second = fixed_delay_tick_key(
+        "cleanup",
+        Duration::from_secs(10),
+        Duration::from_secs(1_700_000_009),
+    );
+    let next = fixed_delay_tick_key(
+        "cleanup",
+        Duration::from_secs(10),
+        Duration::from_secs(1_700_000_010),
+    );
 
     assert_eq!(first, second);
     assert_ne!(first, next);
     assert!(first.contains("cleanup"));
+}
+
+#[test]
+fn fixed_delay_tick_key_uses_sub_second_precision() {
+    let delay = Duration::from_millis(100);
+    let first = fixed_delay_tick_key(
+        "fast",
+        delay,
+        Duration::from_secs(1_700_000_000) + Duration::from_millis(100),
+    );
+    let same = fixed_delay_tick_key(
+        "fast",
+        delay,
+        Duration::from_secs(1_700_000_000) + Duration::from_millis(199),
+    );
+    let next = fixed_delay_tick_key(
+        "fast",
+        delay,
+        Duration::from_secs(1_700_000_000) + Duration::from_millis(200),
+    );
+
+    assert_eq!(first, same);
+    assert_ne!(first, next);
 }
 
 #[test]

--- a/docs/guide/scheduled-multi-replica.md
+++ b/docs/guide/scheduled-multi-replica.md
@@ -1,0 +1,124 @@
+# Multi-Replica Scheduled Tasks
+
+`#[scheduled]` defaults to the original in-process behavior: every running
+replica owns its own timer. That is convenient in development and preserves
+existing `0.3.x` behavior, but it is not safe for tasks that send emails, call
+paid APIs, expire tokens, charge cards, or mutate shared state.
+
+For multi-replica deployments, configure the scheduler backend to `postgres`.
+Autumn then derives a global tick key for each scheduled task invocation and
+uses Postgres advisory locks through the existing `Db` pool. Only the replica
+that acquires the lock runs that tick.
+
+## Configure Postgres Coordination
+
+```toml
+[database]
+url = "postgres://postgres:postgres@db:5432/app"
+
+[scheduler]
+backend = "postgres"
+lease_ttl_secs = 300
+key_prefix = "myapp:scheduler"
+```
+
+The same settings can be supplied with environment variables:
+
+```bash
+AUTUMN_SCHEDULER__BACKEND=postgres
+AUTUMN_SCHEDULER__LEASE_TTL_SECS=300
+AUTUMN_SCHEDULER__KEY_PREFIX=myapp:scheduler
+AUTUMN_SCHEDULER__REPLICA_ID=web-1
+```
+
+`replica_id` is optional. If it is not configured, Autumn uses platform
+metadata such as `FLY_MACHINE_ID` or `HOSTNAME`, then falls back to the process
+id. Set it explicitly when you want stable names in `/actuator/tasks`.
+
+## Declare Scheduled Tasks
+
+Fleet coordination is the default task mode:
+
+```rust
+use autumn_web::prelude::*;
+
+#[scheduled(every = "10s", name = "increment-counter")]
+async fn increment_counter(_state: AppState) -> AutumnResult<()> {
+    // Update shared state, send one digest, charge one batch, etc.
+    Ok(())
+}
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .tasks(tasks![increment_counter])
+        .run()
+        .await;
+}
+```
+
+Use `coordination = "per_replica"` only for work that should run on every
+replica, such as warming in-memory caches:
+
+```rust
+#[scheduled(every = "1m", name = "warm-local-cache", coordination = "per_replica")]
+async fn warm_local_cache(_state: AppState) -> AutumnResult<()> {
+    Ok(())
+}
+```
+
+## Verify With Three Replicas
+
+With a Docker Compose file that has a `db` service and a `web` service using
+the same `DATABASE_URL`, run three web replicas:
+
+```bash
+docker compose up --build --scale web=3
+```
+
+For a `#[scheduled(every = "10s")]` task, check the shared side effect after
+one minute. You should see roughly six executions, not eighteen. A restart can
+add or miss one tick because the system provides at-most-once per tick under
+normal operation and best-effort recovery around process churn.
+
+You can also inspect runtime state:
+
+```bash
+curl http://localhost:3000/actuator/tasks
+```
+
+The task entry includes the configured backend, this replica id, the last
+leader, the last global tick key, and the last fired timestamp:
+
+```json
+{
+  "scheduled_tasks": {
+    "increment-counter": {
+      "schedule": "every 10s",
+      "coordination": "fleet",
+      "scheduler_backend": "postgres",
+      "replica_id": "web-1",
+      "current_leader": "web-2",
+      "last_tick": "increment-counter:170000000",
+      "last_fired_at": "2026-05-05T14:00:00Z",
+      "status": "idle",
+      "total_runs": 6,
+      "total_failures": 0
+    }
+  }
+}
+```
+
+## Failure Semantics
+
+Postgres advisory locks are held by the database connection used for the task
+tick and are released when the task completes. If the process crashes, Postgres
+releases the connection lock. `lease_ttl_secs` also bounds how long Autumn will
+wait for a single scheduled invocation before recording it as failed and
+releasing the lease. Tick keys include the schedule bucket, so a stuck older
+tick does not block the next global tick from being claimed.
+
+This is not distributed exactly-once delivery. Under partitions, clock skew, or
+hard restarts near a boundary, design scheduled tasks to be idempotent. If the
+workflow needs durable retries, history, and stronger orchestration semantics,
+use Autumn Harvest instead of `#[scheduled]`.

--- a/docs/plans/2026-05-05-scheduled-multi-replica.md
+++ b/docs/plans/2026-05-05-scheduled-multi-replica.md
@@ -1,0 +1,83 @@
+# Scheduled Multi-Replica Safety Implementation Plan
+
+**Goal:** Make `#[scheduled]` tasks optionally fleet-coordinated so a multi-replica deployment can run one task invocation per scheduled tick.
+
+**Architecture:** Keep current per-process behavior as the default `scheduler.backend = "in_process"`. Add scheduler coordination metadata to `TaskInfo`, a config-driven coordinator abstraction, and a Postgres advisory-lock backend that reuses the existing `Db` pool. Extend `/actuator/tasks` with backend, replica, leader, and last-fired visibility.
+
+**Tech Stack:** Rust 2024, Tokio, Diesel async Postgres pool, `tokio-cron-scheduler`, Axum actuator JSON, proc macros, TDD red/green/refactor.
+
+---
+
+### Task 1: Runtime Coordination Types
+
+**Files:**
+- Modify: `autumn/src/task.rs`
+- Create: `autumn/src/scheduler.rs`
+- Modify: `autumn/src/lib.rs`
+
+**Steps:**
+1. Write failing unit tests for default fleet coordination metadata, per-replica opt-out metadata, deterministic tick keys, and in-process coordinator acquisition.
+2. Run `cargo test -p autumn-web task:: scheduler::`.
+3. Implement `TaskCoordination`, `SchedulerCoordinator`, in-process coordinator, tick-key helpers, and exported module wiring.
+4. Re-run the same targeted tests.
+
+### Task 2: Config Surface
+
+**Files:**
+- Modify: `autumn/src/config.rs`
+- Test: `autumn/src/config.rs`
+
+**Steps:**
+1. Write failing tests for `[scheduler] backend = "postgres"`, default `in_process`, `lease_ttl_secs`, `replica_id`, and env overrides.
+2. Run targeted config tests.
+3. Implement `SchedulerConfig`, `SchedulerBackend`, defaults, deserialization, validation, and env overrides.
+4. Re-run targeted config tests.
+
+### Task 3: Macro Metadata
+
+**Files:**
+- Modify: `autumn-macros/src/scheduled.rs`
+- Test: `autumn/tests/compile-pass/task_basic.rs` or a new compile-pass file
+
+**Steps:**
+1. Add a failing compile-pass test proving `#[scheduled(..., coordination = "per_replica")]` compiles and `tasks![]` returns metadata.
+2. Run the compile-pass test.
+3. Parse the optional coordination attribute and populate `TaskInfo`.
+4. Re-run the compile-pass test.
+
+### Task 4: Scheduler Execution And Postgres Locks
+
+**Files:**
+- Modify: `autumn/src/app.rs`
+- Modify: `autumn/src/scheduler.rs`
+- Test: `autumn/src/app.rs`, `autumn/src/scheduler.rs`
+
+**Steps:**
+1. Write failing tests showing a skipped lease does not invoke the handler and a per-replica task bypasses fleet locking.
+2. Write Postgres advisory-lock unit tests around deterministic lock-key hashing; integration with a real pool remains best-effort if local Docker/Testcontainers is available.
+3. Implement coordinator construction from config, acquisition before each fixed-delay or cron run, Postgres advisory lock acquire/release, and task-registry leader updates.
+4. Re-run targeted scheduler/app tests.
+
+### Task 5: Actuator And Docs
+
+**Files:**
+- Modify: `autumn/src/actuator.rs`
+- Modify: `docs/guide/scheduled-multi-replica.md`
+- Modify: `README.md`
+
+**Steps:**
+1. Write failing actuator tests for leader/replica/last-fired fields in `/actuator/tasks`.
+2. Extend `TaskStatus` and `TaskRegistry` to expose coordination fields.
+3. Add production guidance and README Local-Safe vs Production-Safe coverage.
+4. Run formatting, targeted tests, and affected-area stub scan.
+
+---
+
+### Verification
+
+- `cargo fmt`
+- `cargo clippy -p autumn-web --lib -- -D warnings`
+- `cargo test -p autumn-web --lib`
+- `cargo test -p autumn-web --test scheduled_coordination`
+- `cargo test -p autumn-web --test compile_fail`
+- Affected-area scan for unfinished-work markers

--- a/docs/plans/2026-05-05-scheduled-multi-replica.md
+++ b/docs/plans/2026-05-05-scheduled-multi-replica.md
@@ -4,7 +4,7 @@
 
 **Architecture:** Keep current per-process behavior as the default `scheduler.backend = "in_process"`. Add scheduler coordination metadata to `TaskInfo`, a config-driven coordinator abstraction, and a Postgres advisory-lock backend that reuses the existing `Db` pool. Extend `/actuator/tasks` with backend, replica, leader, and last-fired visibility.
 
-**Tech Stack:** Rust 2024, Tokio, Diesel async Postgres pool, `tokio-cron-scheduler`, Axum actuator JSON, proc macros, TDD red/green/refactor.
+**Tech Stack:** Rust 2024, Tokio, Diesel async Postgres pool, Croner, Axum actuator JSON, proc macros, TDD red/green/refactor.
 
 ---
 


### PR DESCRIPTION
  Add config-driven scheduler coordination with an in-process default and a
  Postgres advisory-lock backend. Extend #[scheduled] metadata with fleet vs
  per-replica coordination, surface leader/backend state in /actuator/tasks,
  and document multi-replica deployment behavior.

  Includes TDD coverage for config, macro metadata, lock key derivation,
  lease skipping, TTL timeout handling, and actuator metadata.