### PR TITLE
⚡ Bolt: Remove Vec allocation in i18n Bundle Debug impl

### DIFF
--- a/autumn/src/i18n.rs
+++ b/autumn/src/i18n.rs
@@ -311,7 +311,7 @@ pub struct Bundle {
 impl fmt::Debug for Bundle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Bundle")
-            .field("locales", &self.messages.keys().collect::<Vec<_>>())
+            .field("locales", &self.messages.keys())
             .field("default_locale", &self.default_locale)
             .field("supported_locales", &self.supported_locales)
             .field("miss_count", &self.miss_count.load(Ordering::Relaxed))


### PR DESCRIPTION
💡 What: Removed `.collect::<Vec<_>>()` for `.keys()` in `Bundle`'s `Debug` implementation.
🎯 Why: `std::collections::HashMap::keys()` returns an iterator that implements `Debug` natively, so allocating an intermediate `Vec` is unnecessary.
📊 Impact: Removes one heap allocation each time `Bundle` is formatted using `{:?}`.
🔬 Measurement: Observe memory allocations in profiling or standard formatting, verify behavior with `cargo test -p autumn-web --lib i18n`.

---
*PR created automatically by Jules for task [9131339931532298915](https://jules.google.com/task/9131339931532298915) started by @madmax983*