### PR TITLE
📣 Echo: Improve TestResponse panic messages

### DIFF
--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -619,7 +619,12 @@ impl TestResponse {
     /// Panics if the body is not valid UTF-8.
     #[must_use]
     pub fn text(&self) -> String {
-        String::from_utf8(self.body.clone()).expect("response body is not valid UTF-8")
+        String::from_utf8(self.body.clone()).unwrap_or_else(|e| {
+            panic!(
+                "response body is not valid UTF-8: {e}\nRaw bytes: {:?}",
+                self.body
+            )
+        })
     }
 
     /// Deserialize the response body as JSON.
@@ -630,7 +635,12 @@ impl TestResponse {
     /// into `T`.
     #[must_use]
     pub fn json<T: serde::de::DeserializeOwned>(&self) -> T {
-        serde_json::from_slice(&self.body).expect("failed to parse response body as JSON")
+        serde_json::from_slice(&self.body).unwrap_or_else(|e| {
+            panic!(
+                "failed to parse response body as JSON: {e}\nBody: {}",
+                String::from_utf8_lossy(&self.body)
+            )
+        })
     }
 
     /// Get the value of a response header.
@@ -686,9 +696,12 @@ impl TestResponse {
     /// Assert a response header exists and equals the expected value.
     #[track_caller]
     pub fn assert_header(&self, name: &str, expected: &str) -> &Self {
-        let value = self
-            .header(name)
-            .unwrap_or_else(|| panic!("expected header `{name}` to be present"));
+        let value = self.header(name).unwrap_or_else(|| {
+            panic!(
+                "expected header `{name}` to be present.\nAvailable headers: {:?}",
+                self.headers
+            )
+        });
         assert_eq!(
             value, expected,
             "header `{name}`: expected `{expected}`, got `{value}`"
@@ -699,9 +712,12 @@ impl TestResponse {
     /// Assert a response header exists and contains the expected substring.
     #[track_caller]
     pub fn assert_header_contains(&self, name: &str, substring: &str) -> &Self {
-        let value = self
-            .header(name)
-            .unwrap_or_else(|| panic!("expected header `{name}` to be present"));
+        let value = self.header(name).unwrap_or_else(|| {
+            panic!(
+                "expected header `{name}` to be present.\nAvailable headers: {:?}",
+                self.headers
+            )
+        });
         assert!(
             value.contains(substring),
             "header `{name}`: expected `{value}` to contain `{substring}`"
@@ -724,7 +740,7 @@ impl TestResponse {
     #[track_caller]
     pub fn assert_body_eq(&self, expected: &str) -> &Self {
         let body = self.text();
-        assert_eq!(body, expected, "body mismatch");
+        assert_eq!(body, expected, "body mismatch.\nActual Body: {body}");
         self
     }
 


### PR DESCRIPTION
1. 🔎 EXPERIENCE
Tested the `TestResponse` assertions in the Autumn framework to ensure error messages are helpful when tests fail.

2. 🚧 STUMBLE
When an assertion failed (like a missing header, invalid JSON, or invalid UTF-8), the panic message lacked crucial context. For example, `assert_json` failed with a generic Serde error without showing the actual body, and `assert_header` didn't show what headers *were* present. This required manual debugging to find out why the assertion failed.

3. 📢 REPORT
The `TestResponse` assertion methods need to provide more context in their panic messages to improve the developer experience.

4. 🧪 VERIFY
Updated `text()`, `json()`, `assert_header()`, `assert_header_contains()`, and `assert_body_eq()` to include relevant context (raw bytes, response body, or available headers) in their panic messages. Ran tests to verify the new output.

---
*PR created automatically by Jules for task [9036816495532632604](https://jules.google.com/task/9036816495532632604) started by @madmax983*