### PR TITLE
Add pluggable durable backend for mail delivery_later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `#[mailer]`'s generated `deliver_later_*` helpers (#649). Implement
   `MailDeliveryQueue` for your queue (DB outbox row, Redis stream, Harvest
   job, ...) and register it via
-  `AppBuilder::with_mail_delivery_queue(queue)` before `.run()`; plugins
+  `AppBuilder::with_mail_delivery_queue(queue)` (or
+  `with_mail_delivery_queue_factory(|state| ...)` when the queue needs
+  framework-managed resources like the DB pool) before `.run()`; plugins
   call this inside `apply`. `deliver_later` then routes mail through the
   queue instead of the in-process Tokio fallback. In `prod`/`production`,
   startup now fails when no durable queue is registered and the transport is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,16 +48,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **mail:** Pluggable durable backend for `Mailer::deliver_later` and
-  `#[mailer]`'s generated `deliver_later_*` helpers (#649). Implement the new
-  `MailDeliveryQueue` trait once for your queue (DB outbox row, Redis stream,
-  Harvest job, ...) and register it via
-  `state.insert_extension(MailDeliveryQueueHandle::new(queue))` before the
-  mailer is installed; `deliver_later` then routes mail through the queue
-  instead of the in-process Tokio fallback. In `prod`/`production`, startup
-  now fails when no durable queue is registered and the transport is not
-  `disabled`, unless the new `mail.allow_in_process_deliver_later_in_production`
-  acknowledgement flag is set. The flag opts into the non-durable fallback
-  explicitly; without it, `prod` deployments must wire a real backend. See the
+  `#[mailer]`'s generated `deliver_later_*` helpers (#649). Implement
+  `MailDeliveryQueue` for your queue (DB outbox row, Redis stream, Harvest
+  job, ...) and register it via
+  `AppBuilder::with_mail_delivery_queue(queue)` before `.run()`; plugins
+  call this inside `apply`. `deliver_later` then routes mail through the
+  queue instead of the in-process Tokio fallback. In `prod`/`production`,
+  startup now fails when no durable queue is registered and the transport is
+  not `disabled`, unless the new
+  `mail.allow_in_process_deliver_later_in_production` acknowledgement flag
+  is set. The flag opts into the non-durable fallback explicitly; without
+  it, `prod` deployments must wire a real backend. See the
   [Mail guide](docs/guide/mail.md) for the outbox pattern.
 
 - **i18n:** New opt-in `i18n` feature flag on `autumn-web` for first-class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **mail:** Pluggable durable backend for `Mailer::deliver_later` and
+  `#[mailer]`'s generated `deliver_later_*` helpers (#649). Implement the new
+  `MailDeliveryQueue` trait once for your queue (DB outbox row, Redis stream,
+  Harvest job, ...) and register it via
+  `state.insert_extension(MailDeliveryQueueHandle::new(queue))` before the
+  mailer is installed; `deliver_later` then routes mail through the queue
+  instead of the in-process Tokio fallback. In `prod`/`production`, startup
+  now fails when no durable queue is registered and the transport is not
+  `disabled`, unless the new `mail.allow_in_process_deliver_later_in_production`
+  acknowledgement flag is set. The flag opts into the non-durable fallback
+  explicitly; without it, `prod` deployments must wire a real backend. See the
+  [Mail guide](docs/guide/mail.md) for the outbox pattern.
+
 - **i18n:** New opt-in `i18n` feature flag on `autumn-web` for first-class
   locale-aware text resolution (#503). Translations live at
   `i18n/<locale>.ftl` (Project Fluent format), discovered from the project

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -4155,6 +4155,32 @@ mod tests {
         assert_eq!(value, "haunted harvest");
     }
 
+    #[cfg(feature = "mail")]
+    #[test]
+    fn app_builder_with_mail_delivery_queue_stores_queue_for_install() {
+        struct NoopQueue;
+        impl crate::mail::MailDeliveryQueue for NoopQueue {
+            fn enqueue<'a>(
+                &'a self,
+                _mail: crate::mail::Mail,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<Output = Result<(), crate::mail::MailError>>
+                        + Send
+                        + 'a,
+                >,
+            > {
+                Box::pin(async { Ok(()) })
+            }
+        }
+
+        let builder = app().with_mail_delivery_queue(NoopQueue);
+        assert!(
+            builder.mail_delivery_queue.is_some(),
+            "with_mail_delivery_queue should store the queue on the builder"
+        );
+    }
+
     #[tokio::test]
     async fn startup_and_shutdown_hooks_run_in_expected_order() {
         let events = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -105,6 +105,8 @@ pub fn app() -> AppBuilder {
         #[cfg(feature = "i18n")]
         i18n_auto_load: false,
         policy_registrations: Vec::new(),
+        #[cfg(feature = "mail")]
+        mail_delivery_queue: None,
     }
 }
 
@@ -259,6 +261,11 @@ pub struct AppBuilder {
     /// built. Stored as boxed closures so we can carry the
     /// generic type parameters across the builder boundary.
     policy_registrations: Vec<PolicyRegistration>,
+    /// Durable mail delivery queue registered at builder time via
+    /// [`AppBuilder::with_mail_delivery_queue`]. Wired into [`AppState`] before
+    /// `install_mailer` runs so the production guard can see it.
+    #[cfg(feature = "mail")]
+    mail_delivery_queue: Option<Arc<dyn crate::mail::MailDeliveryQueue>>,
 }
 
 /// A group of routes sharing a common path prefix and middleware layer.
@@ -1125,6 +1132,22 @@ impl AppBuilder {
         self
     }
 
+    /// Register a durable [`MailDeliveryQueue`](crate::mail::MailDeliveryQueue) for
+    /// [`Mailer::deliver_later`](crate::mail::Mailer::deliver_later).
+    ///
+    /// Must be called before [`run`](Self::run). Plugins call this inside their
+    /// `apply` implementation to satisfy the production delivery guard without
+    /// requiring `mail.allow_in_process_deliver_later_in_production`.
+    #[cfg(feature = "mail")]
+    #[must_use]
+    pub fn with_mail_delivery_queue(
+        mut self,
+        queue: impl crate::mail::MailDeliveryQueue + 'static,
+    ) -> Self {
+        self.mail_delivery_queue = Some(Arc::new(queue));
+        self
+    }
+
     /// Register an additional audit sink for structured audit events.
     ///
     /// Multiple calls accumulate sinks. Logged events are fanned out to all
@@ -1361,6 +1384,8 @@ impl AppBuilder {
             #[cfg(feature = "i18n")]
             i18n_auto_load,
             policy_registrations,
+            #[cfg(feature = "mail")]
+            mail_delivery_queue,
         } = self;
 
         let all_routes = routes;
@@ -1473,10 +1498,15 @@ impl AppBuilder {
         // builder call" footgun before any 500 lands.
         validate_repository_policies_registered(&all_routes, &scoped_groups, &state, &config);
         #[cfg(feature = "mail")]
-        crate::mail::install_mailer(&state, &config.mail).unwrap_or_else(|error| {
-            tracing::error!(error = %error, "Failed to configure mailer");
-            std::process::exit(1);
-        });
+        {
+            if let Some(queue) = mail_delivery_queue {
+                state.insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue));
+            }
+            crate::mail::install_mailer(&state, &config.mail).unwrap_or_else(|error| {
+                tracing::error!(error = %error, "Failed to configure mailer");
+                std::process::exit(1);
+            });
+        }
         if let Some(logger) = audit_logger {
             state.insert_extension::<crate::audit::AuditLogger>((*logger).clone());
         }
@@ -1677,6 +1707,8 @@ impl AppBuilder {
             #[cfg(feature = "i18n")]
             i18n_auto_load,
             policy_registrations,
+            #[cfg(feature = "mail")]
+            mail_delivery_queue,
         } = self;
 
         let all_routes = routes;
@@ -1770,10 +1802,15 @@ impl AppBuilder {
             crate::cache::clear_global_cache();
         }
         #[cfg(feature = "mail")]
-        crate::mail::install_mailer(&state, &config.mail).unwrap_or_else(|error| {
-            eprintln!("Failed to configure mailer: {error}");
-            std::process::exit(1);
-        });
+        {
+            if let Some(queue) = mail_delivery_queue {
+                state.insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue));
+            }
+            crate::mail::install_mailer(&state, &config.mail).unwrap_or_else(|error| {
+                eprintln!("Failed to configure mailer: {error}");
+                std::process::exit(1);
+            });
+        }
         // run_build_mode used ProbeState::default(), which does not start as pending
         state.probes = crate::probe::ProbeState::default();
 
@@ -1974,6 +2011,8 @@ impl AppBuilder {
             i18n_auto_load,
             policy_registrations,
             cache_backend,
+            #[cfg(feature = "mail")]
+            mail_delivery_queue,
             ..
         } = self;
 
@@ -2044,10 +2083,15 @@ impl AppBuilder {
         }
 
         #[cfg(feature = "mail")]
-        crate::mail::install_mailer(&state, &config.mail).unwrap_or_else(|error| {
-            eprintln!("Failed to configure mailer: {error}");
-            std::process::exit(1);
-        });
+        {
+            if let Some(queue) = mail_delivery_queue {
+                state.insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue));
+            }
+            crate::mail::install_mailer(&state, &config.mail).unwrap_or_else(|error| {
+                eprintln!("Failed to configure mailer: {error}");
+                std::process::exit(1);
+            });
+        }
 
         if let Some(logger) = audit_logger {
             state.insert_extension::<crate::audit::AuditLogger>((*logger).clone());

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1845,19 +1845,13 @@ impl AppBuilder {
         }
         #[cfg(feature = "mail")]
         {
-            if let Some(factory) = mail_delivery_queue_factory {
-                match factory(&state) {
-                    Ok(queue) => state
-                        .insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue)),
-                    Err(error) => {
-                        eprintln!("mail delivery queue factory failed: {error}");
-                        std::process::exit(1);
-                    }
-                }
-            }
             // Static-site builds are short-lived and don't run the request
-            // loop; the durable deliver_later guard isn't relevant here, so
-            // skip it to avoid forcing a queue/ack just to render assets.
+            // loop, so deliver_later is never invoked. Skip the queue factory
+            // (it may open Redis/Harvest connections unavailable in the asset-
+            // build environment) and the durable-delivery guard, but still
+            // install a Mailer so static routes that extract `Mailer` for
+            // immediate `send` calls still resolve.
+            let _ = mail_delivery_queue_factory;
             crate::mail::install_mailer(&state, &config.mail, false).unwrap_or_else(|error| {
                 eprintln!("Failed to configure mailer: {error}");
                 std::process::exit(1);

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1533,22 +1533,16 @@ impl AppBuilder {
         // builder call" footgun before any 500 lands.
         validate_repository_policies_registered(&all_routes, &scoped_groups, &state, &config);
         #[cfg(feature = "mail")]
-        {
-            if let Some(factory) = mail_delivery_queue_factory {
-                match factory(&state) {
-                    Ok(queue) => state
-                        .insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue)),
-                    Err(error) => {
-                        tracing::error!(error = %error, "mail delivery queue factory failed");
-                        std::process::exit(1);
-                    }
-                }
-            }
-            crate::mail::install_mailer(&state, &config.mail, true).unwrap_or_else(|error| {
-                tracing::error!(error = %error, "Failed to configure mailer");
-                std::process::exit(1);
-            });
-        }
+        crate::mail::install_mailer_with_factory(
+            &state,
+            &config.mail,
+            mail_delivery_queue_factory,
+            true,
+        )
+        .unwrap_or_else(|error| {
+            tracing::error!(error = %error, "Failed to configure mailer");
+            std::process::exit(1);
+        });
         if let Some(logger) = audit_logger {
             state.insert_extension::<crate::audit::AuditLogger>((*logger).clone());
         }
@@ -1843,20 +1837,23 @@ impl AppBuilder {
         } else {
             crate::cache::clear_global_cache();
         }
+        // Static-site builds are short-lived and don't run the request loop,
+        // so deliver_later is never invoked. install_mailer_with_factory skips
+        // the queue factory when enforce_durable_guard is false (the factory
+        // may open Redis/Harvest connections unavailable here), and the guard
+        // itself is bypassed too — the Mailer is still installed so static
+        // routes that extract `Mailer` for immediate `send` calls resolve.
         #[cfg(feature = "mail")]
-        {
-            // Static-site builds are short-lived and don't run the request
-            // loop, so deliver_later is never invoked. Skip the queue factory
-            // (it may open Redis/Harvest connections unavailable in the asset-
-            // build environment) and the durable-delivery guard, but still
-            // install a Mailer so static routes that extract `Mailer` for
-            // immediate `send` calls still resolve.
-            let _ = mail_delivery_queue_factory;
-            crate::mail::install_mailer(&state, &config.mail, false).unwrap_or_else(|error| {
-                eprintln!("Failed to configure mailer: {error}");
-                std::process::exit(1);
-            });
-        }
+        crate::mail::install_mailer_with_factory(
+            &state,
+            &config.mail,
+            mail_delivery_queue_factory,
+            false,
+        )
+        .unwrap_or_else(|error| {
+            eprintln!("Failed to configure mailer: {error}");
+            std::process::exit(1);
+        });
         // run_build_mode used ProbeState::default(), which does not start as pending
         state.probes = crate::probe::ProbeState::default();
 
@@ -2129,22 +2126,16 @@ impl AppBuilder {
         }
 
         #[cfg(feature = "mail")]
-        {
-            if let Some(factory) = mail_delivery_queue_factory {
-                match factory(&state) {
-                    Ok(queue) => state
-                        .insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue)),
-                    Err(error) => {
-                        eprintln!("mail delivery queue factory failed: {error}");
-                        std::process::exit(1);
-                    }
-                }
-            }
-            crate::mail::install_mailer(&state, &config.mail, true).unwrap_or_else(|error| {
-                eprintln!("Failed to configure mailer: {error}");
-                std::process::exit(1);
-            });
-        }
+        crate::mail::install_mailer_with_factory(
+            &state,
+            &config.mail,
+            mail_delivery_queue_factory,
+            true,
+        )
+        .unwrap_or_else(|error| {
+            eprintln!("Failed to configure mailer: {error}");
+            std::process::exit(1);
+        });
 
         if let Some(logger) = audit_logger {
             state.insert_extension::<crate::audit::AuditLogger>((*logger).clone());

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -273,10 +273,7 @@ pub struct AppBuilder {
 /// [`AppState`].
 #[cfg(feature = "mail")]
 pub(crate) type MailDeliveryQueueFactory = Box<
-    dyn FnOnce(
-            &AppState,
-        ) -> crate::AutumnResult<Arc<dyn crate::mail::MailDeliveryQueue>>
-        + Send,
+    dyn FnOnce(&AppState) -> crate::AutumnResult<Arc<dyn crate::mail::MailDeliveryQueue>> + Send,
 >;
 
 /// A group of routes sharing a common path prefix and middleware layer.
@@ -1539,9 +1536,8 @@ impl AppBuilder {
         {
             if let Some(factory) = mail_delivery_queue_factory {
                 match factory(&state) {
-                    Ok(queue) => state.insert_extension(
-                        crate::mail::MailDeliveryQueueHandle::from_arc(queue),
-                    ),
+                    Ok(queue) => state
+                        .insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue)),
                     Err(error) => {
                         tracing::error!(error = %error, "mail delivery queue factory failed");
                         std::process::exit(1);
@@ -1851,9 +1847,8 @@ impl AppBuilder {
         {
             if let Some(factory) = mail_delivery_queue_factory {
                 match factory(&state) {
-                    Ok(queue) => state.insert_extension(
-                        crate::mail::MailDeliveryQueueHandle::from_arc(queue),
-                    ),
+                    Ok(queue) => state
+                        .insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue)),
                     Err(error) => {
                         eprintln!("mail delivery queue factory failed: {error}");
                         std::process::exit(1);
@@ -2143,9 +2138,8 @@ impl AppBuilder {
         {
             if let Some(factory) = mail_delivery_queue_factory {
                 match factory(&state) {
-                    Ok(queue) => state.insert_extension(
-                        crate::mail::MailDeliveryQueueHandle::from_arc(queue),
-                    ),
+                    Ok(queue) => state
+                        .insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue)),
                     Err(error) => {
                         eprintln!("mail delivery queue factory failed: {error}");
                         std::process::exit(1);
@@ -4306,9 +4300,7 @@ mod tests {
         }
 
         let builder = app().with_mail_delivery_queue_factory(|_state| {
-            Err::<NoopQueue, _>(crate::AutumnError::service_unavailable_msg(
-                "factory boom",
-            ))
+            Err::<NoopQueue, _>(crate::AutumnError::service_unavailable_msg("factory boom"))
         });
 
         let factory = builder

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -106,7 +106,7 @@ pub fn app() -> AppBuilder {
         i18n_auto_load: false,
         policy_registrations: Vec::new(),
         #[cfg(feature = "mail")]
-        mail_delivery_queue: None,
+        mail_delivery_queue_factory: None,
     }
 }
 
@@ -261,12 +261,23 @@ pub struct AppBuilder {
     /// built. Stored as boxed closures so we can carry the
     /// generic type parameters across the builder boundary.
     policy_registrations: Vec<PolicyRegistration>,
-    /// Durable mail delivery queue registered at builder time via
-    /// [`AppBuilder::with_mail_delivery_queue`]. Wired into [`AppState`] before
-    /// `install_mailer` runs so the production guard can see it.
+    /// Durable mail delivery queue factory registered at builder time. Invoked
+    /// with the freshly-built [`AppState`] before `install_mailer` runs so it
+    /// can capture framework-managed resources (DB pool, channels, etc.).
     #[cfg(feature = "mail")]
-    mail_delivery_queue: Option<Arc<dyn crate::mail::MailDeliveryQueue>>,
+    mail_delivery_queue_factory: Option<MailDeliveryQueueFactory>,
 }
+
+/// Boxed builder closure that constructs a durable
+/// [`MailDeliveryQueue`](crate::mail::MailDeliveryQueue) from the live
+/// [`AppState`].
+#[cfg(feature = "mail")]
+pub(crate) type MailDeliveryQueueFactory = Box<
+    dyn FnOnce(
+            &AppState,
+        ) -> crate::AutumnResult<Arc<dyn crate::mail::MailDeliveryQueue>>
+        + Send,
+>;
 
 /// A group of routes sharing a common path prefix and middleware layer.
 ///
@@ -1138,13 +1149,40 @@ impl AppBuilder {
     /// Must be called before [`run`](Self::run). Plugins call this inside their
     /// `apply` implementation to satisfy the production delivery guard without
     /// requiring `mail.allow_in_process_deliver_later_in_production`.
+    ///
+    /// Use [`Self::with_mail_delivery_queue_factory`] when the queue needs
+    /// framework-managed resources (the DB pool, channels, etc.) that only
+    /// exist after the [`AppState`] is constructed.
     #[cfg(feature = "mail")]
     #[must_use]
     pub fn with_mail_delivery_queue(
         mut self,
         queue: impl crate::mail::MailDeliveryQueue + 'static,
     ) -> Self {
-        self.mail_delivery_queue = Some(Arc::new(queue));
+        let arc: Arc<dyn crate::mail::MailDeliveryQueue> = Arc::new(queue);
+        self.mail_delivery_queue_factory = Some(Box::new(move |_state| Ok(arc)));
+        self
+    }
+
+    /// Register a factory that builds the durable
+    /// [`MailDeliveryQueue`](crate::mail::MailDeliveryQueue) from the
+    /// fully-built [`AppState`].
+    ///
+    /// Use this when the queue captures framework-managed resources — for
+    /// example a DB-outbox queue that needs the connection pool returned by
+    /// [`AppState::pool`]. The factory runs once, immediately before
+    /// `install_mailer`, with the live `AppState`. Returning `Err` aborts
+    /// startup with the propagated error.
+    #[cfg(feature = "mail")]
+    #[must_use]
+    pub fn with_mail_delivery_queue_factory<F, Q>(mut self, factory: F) -> Self
+    where
+        F: FnOnce(&AppState) -> crate::AutumnResult<Q> + Send + 'static,
+        Q: crate::mail::MailDeliveryQueue + 'static,
+    {
+        self.mail_delivery_queue_factory = Some(Box::new(move |state| {
+            factory(state).map(|q| Arc::new(q) as Arc<dyn crate::mail::MailDeliveryQueue>)
+        }));
         self
     }
 
@@ -1385,7 +1423,7 @@ impl AppBuilder {
             i18n_auto_load,
             policy_registrations,
             #[cfg(feature = "mail")]
-            mail_delivery_queue,
+            mail_delivery_queue_factory,
         } = self;
 
         let all_routes = routes;
@@ -1499,8 +1537,16 @@ impl AppBuilder {
         validate_repository_policies_registered(&all_routes, &scoped_groups, &state, &config);
         #[cfg(feature = "mail")]
         {
-            if let Some(queue) = mail_delivery_queue {
-                state.insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue));
+            if let Some(factory) = mail_delivery_queue_factory {
+                match factory(&state) {
+                    Ok(queue) => state.insert_extension(
+                        crate::mail::MailDeliveryQueueHandle::from_arc(queue),
+                    ),
+                    Err(error) => {
+                        tracing::error!(error = %error, "mail delivery queue factory failed");
+                        std::process::exit(1);
+                    }
+                }
             }
             crate::mail::install_mailer(&state, &config.mail, true).unwrap_or_else(|error| {
                 tracing::error!(error = %error, "Failed to configure mailer");
@@ -1708,7 +1754,7 @@ impl AppBuilder {
             i18n_auto_load,
             policy_registrations,
             #[cfg(feature = "mail")]
-            mail_delivery_queue,
+            mail_delivery_queue_factory,
         } = self;
 
         let all_routes = routes;
@@ -1803,8 +1849,16 @@ impl AppBuilder {
         }
         #[cfg(feature = "mail")]
         {
-            if let Some(queue) = mail_delivery_queue {
-                state.insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue));
+            if let Some(factory) = mail_delivery_queue_factory {
+                match factory(&state) {
+                    Ok(queue) => state.insert_extension(
+                        crate::mail::MailDeliveryQueueHandle::from_arc(queue),
+                    ),
+                    Err(error) => {
+                        eprintln!("mail delivery queue factory failed: {error}");
+                        std::process::exit(1);
+                    }
+                }
             }
             // Static-site builds are short-lived and don't run the request
             // loop; the durable deliver_later guard isn't relevant here, so
@@ -2015,7 +2069,7 @@ impl AppBuilder {
             policy_registrations,
             cache_backend,
             #[cfg(feature = "mail")]
-            mail_delivery_queue,
+            mail_delivery_queue_factory,
             ..
         } = self;
 
@@ -2087,8 +2141,16 @@ impl AppBuilder {
 
         #[cfg(feature = "mail")]
         {
-            if let Some(queue) = mail_delivery_queue {
-                state.insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue));
+            if let Some(factory) = mail_delivery_queue_factory {
+                match factory(&state) {
+                    Ok(queue) => state.insert_extension(
+                        crate::mail::MailDeliveryQueueHandle::from_arc(queue),
+                    ),
+                    Err(error) => {
+                        eprintln!("mail delivery queue factory failed: {error}");
+                        std::process::exit(1);
+                    }
+                }
             }
             crate::mail::install_mailer(&state, &config.mail, true).unwrap_or_else(|error| {
                 eprintln!("Failed to configure mailer: {error}");
@@ -4179,9 +4241,84 @@ mod tests {
 
         let builder = app().with_mail_delivery_queue(NoopQueue);
         assert!(
-            builder.mail_delivery_queue.is_some(),
-            "with_mail_delivery_queue should store the queue on the builder"
+            builder.mail_delivery_queue_factory.is_some(),
+            "with_mail_delivery_queue should store a factory on the builder"
         );
+    }
+
+    #[cfg(feature = "mail")]
+    #[test]
+    fn app_builder_with_mail_delivery_queue_factory_runs_with_app_state() {
+        struct ProfileBackedQueue(#[allow(dead_code)] String);
+        impl crate::mail::MailDeliveryQueue for ProfileBackedQueue {
+            fn enqueue<'a>(
+                &'a self,
+                _mail: crate::mail::Mail,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<Output = Result<(), crate::mail::MailError>>
+                        + Send
+                        + 'a,
+                >,
+            > {
+                Box::pin(async { Ok(()) })
+            }
+        }
+
+        let observed_profile: Arc<std::sync::Mutex<Option<String>>> =
+            Arc::new(std::sync::Mutex::new(None));
+        let captured = Arc::clone(&observed_profile);
+        let builder = app().with_mail_delivery_queue_factory(move |state| {
+            *captured.lock().expect("lock") = Some(state.profile().to_owned());
+            Ok::<_, crate::AutumnError>(ProfileBackedQueue(state.profile().to_owned()))
+        });
+
+        let factory = builder
+            .mail_delivery_queue_factory
+            .expect("factory should be stored on the builder");
+        let state = AppState::for_test().with_profile("dev");
+        let _queue = factory(&state).expect("factory should succeed");
+
+        assert_eq!(
+            observed_profile.lock().expect("lock").as_deref(),
+            Some("dev"),
+            "factory must run with the live AppState"
+        );
+    }
+
+    #[cfg(feature = "mail")]
+    #[test]
+    fn app_builder_with_mail_delivery_queue_factory_propagates_errors() {
+        struct NoopQueue;
+        impl crate::mail::MailDeliveryQueue for NoopQueue {
+            fn enqueue<'a>(
+                &'a self,
+                _mail: crate::mail::Mail,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<Output = Result<(), crate::mail::MailError>>
+                        + Send
+                        + 'a,
+                >,
+            > {
+                Box::pin(async { Ok(()) })
+            }
+        }
+
+        let builder = app().with_mail_delivery_queue_factory(|_state| {
+            Err::<NoopQueue, _>(crate::AutumnError::service_unavailable_msg(
+                "factory boom",
+            ))
+        });
+
+        let factory = builder
+            .mail_delivery_queue_factory
+            .expect("factory present");
+        let state = AppState::for_test();
+        match factory(&state) {
+            Ok(_) => panic!("factory should have errored"),
+            Err(err) => assert!(err.to_string().contains("factory boom")),
+        }
     }
 
     #[tokio::test]

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -3942,6 +3942,33 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tower::ServiceExt;
 
+    /// Shared no-op `MailDeliveryQueue` used by builder tests so the trait
+    /// impl body is defined once and exercised by at least one test.
+    #[cfg(feature = "mail")]
+    struct MailTestNoopQueue;
+
+    #[cfg(feature = "mail")]
+    impl crate::mail::MailDeliveryQueue for MailTestNoopQueue {
+        fn enqueue<'a>(
+            &'a self,
+            _mail: crate::mail::Mail,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<(), crate::mail::MailError>> + Send + 'a>,
+        > {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[cfg(feature = "mail")]
+    fn test_mail() -> crate::mail::Mail {
+        crate::mail::Mail::builder()
+            .to("test@example.com")
+            .subject("hi")
+            .text("hello")
+            .build()
+            .expect("test mail should build")
+    }
+
     /// Helper to build a test router with default config and no database.
     pub fn test_router(routes: Vec<Route>) -> axum::Router {
         let config = AutumnConfig::default();
@@ -4200,25 +4227,9 @@ mod tests {
     }
 
     #[cfg(feature = "mail")]
-    #[test]
-    fn app_builder_with_mail_delivery_queue_stores_queue_for_install() {
-        struct NoopQueue;
-        impl crate::mail::MailDeliveryQueue for NoopQueue {
-            fn enqueue<'a>(
-                &'a self,
-                _mail: crate::mail::Mail,
-            ) -> std::pin::Pin<
-                Box<
-                    dyn std::future::Future<Output = Result<(), crate::mail::MailError>>
-                        + Send
-                        + 'a,
-                >,
-            > {
-                Box::pin(async { Ok(()) })
-            }
-        }
-
-        let builder = app().with_mail_delivery_queue(NoopQueue);
+    #[tokio::test]
+    async fn app_builder_with_mail_delivery_queue_stores_queue_for_install() {
+        let builder = app().with_mail_delivery_queue(MailTestNoopQueue);
         let factory = builder
             .mail_delivery_queue_factory
             .expect("with_mail_delivery_queue should store a factory on the builder");
@@ -4228,33 +4239,22 @@ mod tests {
         let state = AppState::for_test();
         let queue = factory(&state).expect("trivial factory should produce the queue");
         assert!(Arc::strong_count(&queue) >= 1);
+        // Cover the enqueue method body by invoking it once.
+        queue
+            .enqueue(test_mail())
+            .await
+            .expect("noop queue should always succeed");
     }
 
     #[cfg(feature = "mail")]
     #[test]
     fn app_builder_with_mail_delivery_queue_factory_runs_with_app_state() {
-        struct ProfileBackedQueue(#[allow(dead_code)] String);
-        impl crate::mail::MailDeliveryQueue for ProfileBackedQueue {
-            fn enqueue<'a>(
-                &'a self,
-                _mail: crate::mail::Mail,
-            ) -> std::pin::Pin<
-                Box<
-                    dyn std::future::Future<Output = Result<(), crate::mail::MailError>>
-                        + Send
-                        + 'a,
-                >,
-            > {
-                Box::pin(async { Ok(()) })
-            }
-        }
-
         let observed_profile: Arc<std::sync::Mutex<Option<String>>> =
             Arc::new(std::sync::Mutex::new(None));
         let captured = Arc::clone(&observed_profile);
         let builder = app().with_mail_delivery_queue_factory(move |state| {
             *captured.lock().expect("lock") = Some(state.profile().to_owned());
-            Ok::<_, crate::AutumnError>(ProfileBackedQueue(state.profile().to_owned()))
+            Ok::<_, crate::AutumnError>(MailTestNoopQueue)
         });
 
         let factory = builder
@@ -4273,24 +4273,8 @@ mod tests {
     #[cfg(feature = "mail")]
     #[test]
     fn app_builder_with_mail_delivery_queue_factory_propagates_errors() {
-        struct NoopQueue;
-        impl crate::mail::MailDeliveryQueue for NoopQueue {
-            fn enqueue<'a>(
-                &'a self,
-                _mail: crate::mail::Mail,
-            ) -> std::pin::Pin<
-                Box<
-                    dyn std::future::Future<Output = Result<(), crate::mail::MailError>>
-                        + Send
-                        + 'a,
-                >,
-            > {
-                Box::pin(async { Ok(()) })
-            }
-        }
-
         let builder = app().with_mail_delivery_queue_factory(|_state| {
-            Err::<NoopQueue, _>(crate::AutumnError::service_unavailable_msg("factory boom"))
+            Err::<MailTestNoopQueue, _>(crate::AutumnError::service_unavailable_msg("factory boom"))
         });
 
         let factory = builder

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -4219,10 +4219,15 @@ mod tests {
         }
 
         let builder = app().with_mail_delivery_queue(NoopQueue);
-        assert!(
-            builder.mail_delivery_queue_factory.is_some(),
-            "with_mail_delivery_queue should store a factory on the builder"
-        );
+        let factory = builder
+            .mail_delivery_queue_factory
+            .expect("with_mail_delivery_queue should store a factory on the builder");
+
+        // Invoke the trivial wrapper closure built by with_mail_delivery_queue
+        // and verify it returns the wrapped queue successfully.
+        let state = AppState::for_test();
+        let queue = factory(&state).expect("trivial factory should produce the queue");
+        assert!(Arc::strong_count(&queue) >= 1);
     }
 
     #[cfg(feature = "mail")]

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1502,7 +1502,7 @@ impl AppBuilder {
             if let Some(queue) = mail_delivery_queue {
                 state.insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue));
             }
-            crate::mail::install_mailer(&state, &config.mail).unwrap_or_else(|error| {
+            crate::mail::install_mailer(&state, &config.mail, true).unwrap_or_else(|error| {
                 tracing::error!(error = %error, "Failed to configure mailer");
                 std::process::exit(1);
             });
@@ -1806,7 +1806,10 @@ impl AppBuilder {
             if let Some(queue) = mail_delivery_queue {
                 state.insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue));
             }
-            crate::mail::install_mailer(&state, &config.mail).unwrap_or_else(|error| {
+            // Static-site builds are short-lived and don't run the request
+            // loop; the durable deliver_later guard isn't relevant here, so
+            // skip it to avoid forcing a queue/ack just to render assets.
+            crate::mail::install_mailer(&state, &config.mail, false).unwrap_or_else(|error| {
                 eprintln!("Failed to configure mailer: {error}");
                 std::process::exit(1);
             });
@@ -2087,7 +2090,7 @@ impl AppBuilder {
             if let Some(queue) = mail_delivery_queue {
                 state.insert_extension(crate::mail::MailDeliveryQueueHandle::from_arc(queue));
             }
-            crate::mail::install_mailer(&state, &config.mail).unwrap_or_else(|error| {
+            crate::mail::install_mailer(&state, &config.mail, true).unwrap_or_else(|error| {
                 eprintln!("Failed to configure mailer: {error}");
                 std::process::exit(1);
             });

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1795,6 +1795,11 @@ impl AutumnConfig {
             "AUTUMN_MAIL__ALLOW_LOG_IN_PRODUCTION",
             &mut self.mail.allow_log_in_production,
         );
+        parse_env_bool(
+            env,
+            "AUTUMN_MAIL__ALLOW_IN_PROCESS_DELIVER_LATER_IN_PRODUCTION",
+            &mut self.mail.allow_in_process_deliver_later_in_production,
+        );
         if let Ok(val) = env.var("AUTUMN_MAIL__FILE_DIR") {
             self.mail.file_dir = PathBuf::from(val);
         }
@@ -4308,5 +4313,38 @@ path = "/api-spec.json"
         // In CI, FLY_MACHINE_ID and HOSTNAME may or may not be set,
         // so just verify we get a non-empty string back.
         assert!(!cfg.resolved_replica_id().is_empty());
+    }
+
+    #[cfg(feature = "mail")]
+    #[test]
+    fn mail_allow_in_process_deliver_later_in_production_is_overridable_via_env() {
+        let env = MockEnv::new()
+            .with(
+                "AUTUMN_MAIL__ALLOW_IN_PROCESS_DELIVER_LATER_IN_PRODUCTION",
+                "true",
+            )
+            .with("AUTUMN_MAIL__TRANSPORT", "smtp")
+            .with("AUTUMN_MAIL__SMTP__HOST", "smtp.example.com");
+
+        let mut config = AutumnConfig::default();
+        config.apply_mail_env_overrides_with_env(&env);
+
+        assert!(
+            config.mail.allow_in_process_deliver_later_in_production,
+            "env var should set allow_in_process_deliver_later_in_production"
+        );
+    }
+
+    #[cfg(feature = "mail")]
+    #[test]
+    fn mail_allow_in_process_deliver_later_in_production_defaults_false() {
+        let env = MockEnv::new();
+        let mut config = AutumnConfig::default();
+        config.apply_mail_env_overrides_with_env(&env);
+
+        assert!(
+            !config.mail.allow_in_process_deliver_later_in_production,
+            "flag should default to false when env var is not set"
+        );
     }
 }

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -256,7 +256,8 @@ pub use validation::Validated;
 pub use htmx::{HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HTMX_VERSION};
 #[cfg(feature = "mail")]
 pub use mail::{
-    Mail, MailConfig, MailError, MailTransport, Mailer, SmtpConfig, TlsMode, Transport,
+    Mail, MailConfig, MailDeliveryQueue, MailDeliveryQueueHandle, MailError, MailTransport, Mailer,
+    SmtpConfig, TlsMode, Transport,
 };
 /// Extension trait adding `.validate()` to all `validator::Validate` types.
 pub use validation::ValidateExt;

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -356,6 +356,19 @@ pub trait MailTransport: Send + Sync {
         &'a self,
         mail: Mail,
     ) -> Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>>;
+
+    /// Returns `true` if this transport is intentionally a no-op (e.g.
+    /// [`Transport::Disabled`] for review apps and tests).
+    ///
+    /// When `true`, [`Mailer::deliver_later`] short-circuits before the queue
+    /// or in-process fallback so deferred mail honors the same "drop
+    /// everything" contract as immediate sends. Custom transports that mean
+    /// "drop all mail" can override this to opt into the same behavior; the
+    /// default of `false` preserves the existing contract for transports that
+    /// merely capture mail (file, log, etc.) or send it (SMTP, custom APIs).
+    fn is_disabled(&self) -> bool {
+        false
+    }
 }
 
 /// Durable backend for [`Mailer::deliver_later`].
@@ -505,6 +518,14 @@ impl Mailer {
     /// Returns an error when no active Tokio runtime is available to host the
     /// background task.
     pub fn try_deliver_later(&self, mail: Mail) -> Result<(), MailError> {
+        // Honor the disabled-transport contract for deferred mail too: if the
+        // operator turned mail off for this profile, deliver_later must drop
+        // the message just like immediate `send` does — even when a queue is
+        // attached. Otherwise `Mailer::builder().transport(Disabled)
+        // .delivery_queue(...)` would persist mail through the queue branch.
+        if self.transport.is_disabled() {
+            return Ok(());
+        }
         let mail = mail.with_defaults(&self.defaults);
         let handle = tokio::runtime::Handle::try_current().map_err(|_| {
             MailError::RuntimeUnavailable(
@@ -658,6 +679,10 @@ impl MailTransport for DisabledTransport {
         _mail: Mail,
     ) -> Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>> {
         Box::pin(async { Ok(()) })
+    }
+
+    fn is_disabled(&self) -> bool {
+        true
     }
 }
 
@@ -1270,6 +1295,31 @@ mod tests {
             .expect("queue should receive the mail");
 
         assert_eq!(received.subject, "Hi");
+    }
+
+    #[tokio::test]
+    async fn deliver_later_is_noop_when_transport_disabled_even_with_queue() {
+        // The Mailer-level builder lets callers attach a queue *and* pick
+        // Transport::Disabled. The disabled-transport contract requires
+        // deliver_later to drop the message in that case — the queue must
+        // not persist mail when the operator has turned mail off entirely.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Mail>();
+        let mailer = Mailer::builder()
+            .transport(Transport::Disabled)
+            .delivery_queue(CapturingQueue { tx })
+            .build()
+            .expect("mailer should build");
+
+        mailer
+            .try_deliver_later(sample_mail())
+            .expect("disabled transport should succeed as a no-op");
+
+        // Wait briefly for any spawn that might erroneously fire to land.
+        let received = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await;
+        assert!(
+            received.is_err(),
+            "queue must not be invoked when transport is disabled"
+        );
     }
 
     #[tokio::test]

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -1333,6 +1333,26 @@ mod tests {
     }
 
     #[test]
+    fn install_mailer_does_not_run_factory_when_not_enforced_and_no_handle() {
+        // Mirrors run_build_mode: queue factory is intentionally skipped, so
+        // no MailDeliveryQueueHandle is on AppState. install_mailer must
+        // tolerate this and not try to enforce or warn about a missing queue.
+        let state = crate::AppState::for_test().with_profile("prod");
+        let config = sample_smtp_config();
+
+        install_mailer(&state, &config, false)
+            .expect("static-build mode should install cleanly with no queue handle");
+
+        let installed = state
+            .extension::<Mailer>()
+            .expect("install_mailer should store a Mailer extension");
+        assert!(
+            !installed.has_durable_delivery_queue(),
+            "no queue is expected when run_build_mode skips the factory"
+        );
+    }
+
+    #[test]
     fn install_mailer_skips_production_guard_when_not_enforced() {
         // Static-site builds (run_build_mode) call install_mailer with
         // enforce_durable_guard=false because they don't run the request

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -117,6 +117,11 @@ pub struct MailConfig {
     /// Permit log transport in `prod`.
     #[serde(default)]
     pub allow_log_in_production: bool,
+    /// Acknowledge that `deliver_later` may use the in-process Tokio fallback in
+    /// `prod`. Without a registered durable [`MailDeliveryQueue`], this is the
+    /// only way to start the app in `prod` with an active mail transport.
+    #[serde(default)]
+    pub allow_in_process_deliver_later_in_production: bool,
     /// Directory for file transport.
     #[serde(default = "default_file_dir")]
     pub file_dir: PathBuf,
@@ -132,6 +137,7 @@ impl Default for MailConfig {
             from: None,
             reply_to: None,
             allow_log_in_production: false,
+            allow_in_process_deliver_later_in_production: false,
             file_dir: default_file_dir(),
             smtp: SmtpConfig::default(),
         }
@@ -352,6 +358,57 @@ pub trait MailTransport: Send + Sync {
     ) -> Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>>;
 }
 
+/// Durable backend for [`Mailer::deliver_later`].
+///
+/// Implementors persist the mail (DB row, Redis stream, Harvest job, etc.) and
+/// return as soon as the handoff is durable. The framework's in-process Tokio
+/// fallback is intentionally not durable; production deployments should
+/// register a real implementation via [`MailDeliveryQueueHandle`] before
+/// [`install_mailer`] runs, or set
+/// [`MailConfig::allow_in_process_deliver_later_in_production`] to opt into the
+/// fallback explicitly.
+pub trait MailDeliveryQueue: Send + Sync {
+    /// Enqueue a mail for durable later delivery.
+    fn enqueue<'a>(
+        &'a self,
+        mail: Mail,
+    ) -> Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>>;
+}
+
+/// Cloneable handle to a [`MailDeliveryQueue`].
+///
+/// Designed for storage on [`AppState`](crate::AppState) extensions. Plugins
+/// (Harvest, custom Redis, etc.) install this before `install_mailer` runs and
+/// the mailer picks it up.
+#[derive(Clone)]
+pub struct MailDeliveryQueueHandle(Arc<dyn MailDeliveryQueue>);
+
+impl MailDeliveryQueueHandle {
+    /// Wrap a queue implementation in a cloneable handle.
+    #[must_use]
+    pub fn new(queue: impl MailDeliveryQueue + 'static) -> Self {
+        Self(Arc::new(queue))
+    }
+
+    /// Wrap an already-shared queue implementation.
+    #[must_use]
+    pub fn from_arc(queue: Arc<dyn MailDeliveryQueue>) -> Self {
+        Self(queue)
+    }
+
+    /// Borrow the inner queue.
+    #[must_use]
+    pub fn inner(&self) -> &Arc<dyn MailDeliveryQueue> {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for MailDeliveryQueueHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MailDeliveryQueueHandle").finish()
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 struct MailerDefaults {
     from: Option<String>,
@@ -363,6 +420,7 @@ struct MailerDefaults {
 pub struct Mailer {
     defaults: Arc<MailerDefaults>,
     transport: Arc<dyn MailTransport>,
+    delivery_queue: Option<Arc<dyn MailDeliveryQueue>>,
 }
 
 impl Mailer {
@@ -400,7 +458,21 @@ impl Mailer {
         Self {
             defaults: Arc::new(MailerDefaults::default()),
             transport: Arc::new(transport),
+            delivery_queue: None,
         }
+    }
+
+    /// Attach a durable [`MailDeliveryQueue`] used by [`Self::deliver_later`].
+    #[must_use]
+    pub fn with_delivery_queue(mut self, queue: impl MailDeliveryQueue + 'static) -> Self {
+        self.delivery_queue = Some(Arc::new(queue));
+        self
+    }
+
+    /// Returns whether a durable [`MailDeliveryQueue`] is attached.
+    #[must_use]
+    pub fn has_durable_delivery_queue(&self) -> bool {
+        self.delivery_queue.is_some()
     }
 
     /// Send mail immediately.
@@ -434,16 +506,25 @@ impl Mailer {
     /// background task.
     pub fn try_deliver_later(&self, mail: Mail) -> Result<(), MailError> {
         let mailer = self.clone();
+        let mail = mail.with_defaults(&self.defaults);
         let handle = tokio::runtime::Handle::try_current().map_err(|_| {
             MailError::RuntimeUnavailable(
                 "deliver_later requires an active Tokio runtime".to_owned(),
             )
         })?;
-        handle.spawn(async move {
-            if let Err(error) = mailer.send(mail).await {
-                tracing::error!(error = %error, "background mail delivery failed");
-            }
-        });
+        if let Some(queue) = self.delivery_queue.clone() {
+            handle.spawn(async move {
+                if let Err(error) = queue.enqueue(mail).await {
+                    tracing::error!(error = %error, "durable mail enqueue failed");
+                }
+            });
+        } else {
+            handle.spawn(async move {
+                if let Err(error) = mailer.send(mail).await {
+                    tracing::error!(error = %error, "background mail delivery failed");
+                }
+            });
+        }
         Ok(())
     }
 }
@@ -471,6 +552,7 @@ pub struct MailerBuilder {
     reply_to: Option<String>,
     file_dir: PathBuf,
     smtp: Option<SmtpConfig>,
+    delivery_queue: Option<Arc<dyn MailDeliveryQueue>>,
 }
 
 impl Default for MailerBuilder {
@@ -481,6 +563,7 @@ impl Default for MailerBuilder {
             reply_to: None,
             file_dir: default_file_dir(),
             smtp: None,
+            delivery_queue: None,
         }
     }
 }
@@ -521,6 +604,21 @@ impl MailerBuilder {
         self
     }
 
+    /// Attach a durable [`MailDeliveryQueue`] used by
+    /// [`Mailer::deliver_later`].
+    #[must_use]
+    pub fn delivery_queue(mut self, queue: impl MailDeliveryQueue + 'static) -> Self {
+        self.delivery_queue = Some(Arc::new(queue));
+        self
+    }
+
+    /// Attach an already-shared durable [`MailDeliveryQueue`].
+    #[must_use]
+    pub fn delivery_queue_arc(mut self, queue: Arc<dyn MailDeliveryQueue>) -> Self {
+        self.delivery_queue = Some(queue);
+        self
+    }
+
     /// Build the mailer.
     ///
     /// # Errors
@@ -547,6 +645,7 @@ impl MailerBuilder {
                 reply_to: self.reply_to,
             }),
             transport,
+            delivery_queue: self.delivery_queue,
         })
     }
 }
@@ -769,16 +868,41 @@ fn lettre_message(mail: &Mail) -> Result<Message, MailError> {
 
 /// Install the configured mailer into app state.
 ///
+/// Picks up a runtime-installed [`MailDeliveryQueueHandle`] from
+/// [`AppState`] extensions when present, so plugins (Harvest, Redis-backed,
+/// etc.) can register durable delivery before this runs. In `prod` with a
+/// non-`Disabled` transport, startup fails when neither a durable queue nor
+/// [`MailConfig::allow_in_process_deliver_later_in_production`] is set.
+///
 /// # Errors
 ///
-/// Returns an Autumn error when the configured transport cannot be created.
+/// Returns an Autumn error when the configured transport cannot be created or
+/// when the production `deliver_later` guard is not satisfied.
 pub(crate) fn install_mailer(state: &AppState, config: &MailConfig) -> AutumnResult<()> {
-    let mailer = Mailer::from_config(config).map_err(AutumnError::service_unavailable)?;
-    if matches!(state.profile(), "prod" | "production") && config.transport != Transport::Disabled {
-        tracing::warn!(
-            "mail deliver_later currently uses the in-process Tokio fallback unless a Harvest-backed mail queue is installed"
-        );
+    let mut mailer = Mailer::from_config(config).map_err(AutumnError::service_unavailable)?;
+
+    let queue_handle = state.extension::<MailDeliveryQueueHandle>();
+    if let Some(handle) = queue_handle.as_ref() {
+        mailer.delivery_queue = Some(Arc::clone(handle.inner()));
     }
+
+    let in_production = matches!(state.profile(), "prod" | "production");
+    let transport_sends_mail = config.transport != Transport::Disabled;
+
+    if in_production && transport_sends_mail {
+        let has_durable_queue = mailer.delivery_queue.is_some();
+        if !has_durable_queue && !config.allow_in_process_deliver_later_in_production {
+            return Err(AutumnError::service_unavailable_msg(
+                "mail.deliver_later has no durable backend in prod: register a MailDeliveryQueueHandle on AppState or set mail.allow_in_process_deliver_later_in_production = true to opt into the in-process Tokio fallback",
+            ));
+        }
+        if !has_durable_queue {
+            tracing::warn!(
+                "mail.deliver_later is using the in-process Tokio fallback in prod; this is acknowledged via mail.allow_in_process_deliver_later_in_production but is not durable across restarts or replicas"
+            );
+        }
+    }
+
     state.insert_extension(mailer);
     Ok(())
 }
@@ -974,5 +1098,140 @@ mod tests {
             .expect("mail should build");
 
         mailer.deliver_later(mail);
+    }
+
+    fn sample_smtp_config() -> MailConfig {
+        MailConfig {
+            transport: Transport::Smtp,
+            from: Some("Autumn <noreply@example.com>".to_owned()),
+            smtp: SmtpConfig {
+                host: Some("smtp.example.com".to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn sample_mail() -> Mail {
+        Mail::builder()
+            .to("user@example.com")
+            .subject("Hi")
+            .text("hello")
+            .build()
+            .expect("mail should build")
+    }
+
+    struct NoopQueue;
+
+    impl MailDeliveryQueue for NoopQueue {
+        fn enqueue<'a>(
+            &'a self,
+            _mail: Mail,
+        ) -> Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[test]
+    fn install_mailer_rejects_in_process_fallback_in_prod_without_ack() {
+        let state = crate::AppState::for_test().with_profile("prod");
+        let config = sample_smtp_config();
+
+        let error = install_mailer(&state, &config)
+            .expect_err("prod must reject in-process deliver_later fallback without ack");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("allow_in_process_deliver_later_in_production"),
+            "error should explain how to opt in: {message}"
+        );
+    }
+
+    #[test]
+    fn install_mailer_allows_in_process_fallback_in_prod_with_explicit_ack() {
+        let state = crate::AppState::for_test().with_profile("prod");
+        let config = MailConfig {
+            allow_in_process_deliver_later_in_production: true,
+            ..sample_smtp_config()
+        };
+
+        install_mailer(&state, &config).expect("explicit ack should permit fallback in prod");
+    }
+
+    #[test]
+    fn install_mailer_allows_durable_queue_in_prod_without_ack() {
+        let state = crate::AppState::for_test().with_profile("prod");
+        state.insert_extension(MailDeliveryQueueHandle::new(NoopQueue));
+        let config = sample_smtp_config();
+
+        install_mailer(&state, &config)
+            .expect("a registered durable queue should satisfy the prod guard");
+    }
+
+    #[test]
+    fn install_mailer_does_not_require_ack_outside_production() {
+        let state = crate::AppState::for_test().with_profile("dev");
+        let config = sample_smtp_config();
+
+        install_mailer(&state, &config).expect("non-prod profiles should not require an ack");
+    }
+
+    #[test]
+    fn install_mailer_does_not_require_ack_when_transport_is_disabled() {
+        let state = crate::AppState::for_test().with_profile("prod");
+        let config = MailConfig::default();
+
+        install_mailer(&state, &config)
+            .expect("disabled transport never sends mail so it should not need an ack");
+    }
+
+    #[tokio::test]
+    async fn deliver_later_routes_through_configured_queue() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Mail>();
+
+        struct CapturingQueue {
+            tx: tokio::sync::mpsc::UnboundedSender<Mail>,
+        }
+
+        impl MailDeliveryQueue for CapturingQueue {
+            fn enqueue<'a>(
+                &'a self,
+                mail: Mail,
+            ) -> Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>> {
+                let tx = self.tx.clone();
+                Box::pin(async move {
+                    tx.send(mail)
+                        .map_err(|err| MailError::RuntimeUnavailable(err.to_string()))?;
+                    Ok(())
+                })
+            }
+        }
+
+        let mailer = Mailer::builder()
+            .delivery_queue(CapturingQueue { tx })
+            .build()
+            .expect("mailer should build");
+
+        mailer
+            .try_deliver_later(sample_mail())
+            .expect("scheduling onto the queue should succeed");
+
+        let received = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("queue should receive within 1s")
+            .expect("queue should receive the mail");
+
+        assert_eq!(received.subject, "Hi");
+    }
+
+    #[tokio::test]
+    async fn deliver_later_uses_in_process_fallback_when_no_queue() {
+        // The default Mailer has no durable queue, so deliver_later should
+        // still spawn the in-process Tokio task and not call any queue.
+        let mailer = Mailer::builder().build().expect("mailer should build");
+
+        mailer
+            .try_deliver_later(sample_mail())
+            .expect("in-process fallback should still schedule");
     }
 }

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -872,13 +872,19 @@ fn lettre_message(mail: &Mail) -> Result<Message, MailError> {
 /// [`AppState`] extensions when present, so plugins (Harvest, Redis-backed,
 /// etc.) can register durable delivery before this runs. In `prod` with a
 /// non-`Disabled` transport, startup fails when neither a durable queue nor
-/// [`MailConfig::allow_in_process_deliver_later_in_production`] is set.
+/// [`MailConfig::allow_in_process_deliver_later_in_production`] is set, unless
+/// `enforce_durable_guard` is `false` (used by short-lived contexts like
+/// static-site builds where `deliver_later` semantics don't apply).
 ///
 /// # Errors
 ///
 /// Returns an Autumn error when the configured transport cannot be created or
 /// when the production `deliver_later` guard is not satisfied.
-pub(crate) fn install_mailer(state: &AppState, config: &MailConfig) -> AutumnResult<()> {
+pub(crate) fn install_mailer(
+    state: &AppState,
+    config: &MailConfig,
+    enforce_durable_guard: bool,
+) -> AutumnResult<()> {
     let mut mailer = Mailer::from_config(config).map_err(AutumnError::service_unavailable)?;
 
     let in_production = matches!(state.profile(), "prod" | "production");
@@ -894,7 +900,7 @@ pub(crate) fn install_mailer(state: &AppState, config: &MailConfig) -> AutumnRes
         }
     }
 
-    if in_production && transport_sends_mail {
+    if enforce_durable_guard && in_production && transport_sends_mail {
         let has_durable_queue = mailer.delivery_queue.is_some();
         if !has_durable_queue && !config.allow_in_process_deliver_later_in_production {
             return Err(AutumnError::service_unavailable_msg(
@@ -1142,7 +1148,7 @@ mod tests {
         let state = crate::AppState::for_test().with_profile("prod");
         let config = sample_smtp_config();
 
-        let error = install_mailer(&state, &config)
+        let error = install_mailer(&state, &config, true)
             .expect_err("prod must reject in-process deliver_later fallback without ack");
 
         let message = error.to_string();
@@ -1160,7 +1166,7 @@ mod tests {
             ..sample_smtp_config()
         };
 
-        install_mailer(&state, &config).expect("explicit ack should permit fallback in prod");
+        install_mailer(&state, &config, true).expect("explicit ack should permit fallback in prod");
     }
 
     #[test]
@@ -1169,7 +1175,7 @@ mod tests {
         state.insert_extension(MailDeliveryQueueHandle::new(NoopQueue));
         let config = sample_smtp_config();
 
-        install_mailer(&state, &config)
+        install_mailer(&state, &config, true)
             .expect("a registered durable queue should satisfy the prod guard");
     }
 
@@ -1178,7 +1184,7 @@ mod tests {
         let state = crate::AppState::for_test().with_profile("dev");
         let config = sample_smtp_config();
 
-        install_mailer(&state, &config).expect("non-prod profiles should not require an ack");
+        install_mailer(&state, &config, true).expect("non-prod profiles should not require an ack");
     }
 
     #[test]
@@ -1186,7 +1192,7 @@ mod tests {
         let state = crate::AppState::for_test().with_profile("prod");
         let config = MailConfig::default();
 
-        install_mailer(&state, &config)
+        install_mailer(&state, &config, true)
             .expect("disabled transport never sends mail so it should not need an ack");
     }
 
@@ -1298,7 +1304,7 @@ mod tests {
             ..sample_smtp_config()
         };
 
-        install_mailer(&state, &config).expect("explicit ack should permit fallback in prod");
+        install_mailer(&state, &config, true).expect("explicit ack should permit fallback in prod");
 
         let installed = state
             .extension::<Mailer>()
@@ -1315,7 +1321,7 @@ mod tests {
         state.insert_extension(MailDeliveryQueueHandle::new(NoopQueue));
         let config = sample_smtp_config();
 
-        install_mailer(&state, &config).expect("durable queue should permit prod startup");
+        install_mailer(&state, &config, true).expect("durable queue should permit prod startup");
 
         let installed = state
             .extension::<Mailer>()
@@ -1324,6 +1330,20 @@ mod tests {
             installed.has_durable_delivery_queue(),
             "registered queue handle should be attached to the installed mailer"
         );
+    }
+
+    #[test]
+    fn install_mailer_skips_production_guard_when_not_enforced() {
+        // Static-site builds (run_build_mode) call install_mailer with
+        // enforce_durable_guard=false because they don't run the request
+        // loop and don't actually defer mail. Even with a prod profile,
+        // an active SMTP transport, no queue, and no ack flag, install
+        // must succeed in this mode.
+        let state = crate::AppState::for_test().with_profile("prod");
+        let config = sample_smtp_config();
+
+        install_mailer(&state, &config, false)
+            .expect("static-build mode should not enforce the deliver_later guard");
     }
 
     #[test]
@@ -1336,7 +1356,7 @@ mod tests {
         state.insert_extension(MailDeliveryQueueHandle::new(NoopQueue));
         let config = MailConfig::default(); // transport = Disabled
 
-        install_mailer(&state, &config).expect("disabled transport should install cleanly");
+        install_mailer(&state, &config, true).expect("disabled transport should install cleanly");
 
         let installed = state
             .extension::<Mailer>()

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -1297,6 +1297,25 @@ mod tests {
         assert_eq!(received.subject, "Hi");
     }
 
+    #[test]
+    fn mailer_with_transport_starts_without_delivery_queue() {
+        let mailer = Mailer::with_transport(NoopTransport);
+        assert!(
+            !mailer.has_durable_delivery_queue(),
+            "with_transport should default to no durable queue"
+        );
+    }
+
+    struct NoopTransport;
+    impl MailTransport for NoopTransport {
+        fn send<'a>(
+            &'a self,
+            _mail: Mail,
+        ) -> Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
     #[tokio::test]
     async fn deliver_later_is_noop_when_transport_disabled_even_with_queue() {
         // The Mailer-level builder lets callers attach a queue *and* pick

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -1234,4 +1234,90 @@ mod tests {
             .try_deliver_later(sample_mail())
             .expect("in-process fallback should still schedule");
     }
+
+    #[test]
+    fn mail_delivery_queue_handle_round_trips_via_from_arc_and_inner() {
+        let arc: Arc<dyn MailDeliveryQueue> = Arc::new(NoopQueue);
+        let handle = MailDeliveryQueueHandle::from_arc(Arc::clone(&arc));
+
+        assert!(Arc::ptr_eq(handle.inner(), &arc));
+    }
+
+    #[test]
+    fn mail_delivery_queue_handle_debug_does_not_panic() {
+        let handle = MailDeliveryQueueHandle::new(NoopQueue);
+        let rendered = format!("{handle:?}");
+        assert!(rendered.contains("MailDeliveryQueueHandle"));
+    }
+
+    #[test]
+    fn mailer_has_durable_delivery_queue_reflects_attachment() {
+        let plain = Mailer::builder().build().expect("mailer should build");
+        assert!(!plain.has_durable_delivery_queue());
+
+        let with_queue = Mailer::builder()
+            .delivery_queue(NoopQueue)
+            .build()
+            .expect("mailer should build");
+        assert!(with_queue.has_durable_delivery_queue());
+    }
+
+    #[test]
+    fn mailer_with_delivery_queue_post_build_attaches_queue() {
+        let mailer = Mailer::builder()
+            .build()
+            .expect("mailer should build")
+            .with_delivery_queue(NoopQueue);
+
+        assert!(mailer.has_durable_delivery_queue());
+    }
+
+    #[test]
+    fn mailer_builder_delivery_queue_arc_attaches_shared_queue() {
+        let arc: Arc<dyn MailDeliveryQueue> = Arc::new(NoopQueue);
+        let mailer = Mailer::builder()
+            .delivery_queue_arc(arc)
+            .build()
+            .expect("mailer should build");
+
+        assert!(mailer.has_durable_delivery_queue());
+    }
+
+    #[test]
+    fn install_mailer_warns_but_succeeds_with_explicit_ack_in_prod() {
+        // Same as the explicit-ack test, but also asserts the mailer was
+        // actually inserted and has no durable queue attached.
+        let state = crate::AppState::for_test().with_profile("prod");
+        let config = MailConfig {
+            allow_in_process_deliver_later_in_production: true,
+            ..sample_smtp_config()
+        };
+
+        install_mailer(&state, &config).expect("explicit ack should permit fallback in prod");
+
+        let installed = state
+            .extension::<Mailer>()
+            .expect("install_mailer should store a Mailer extension");
+        assert!(
+            !installed.has_durable_delivery_queue(),
+            "no queue was registered, so installed mailer should fall back in-process"
+        );
+    }
+
+    #[test]
+    fn install_mailer_attaches_registered_queue_to_mailer() {
+        let state = crate::AppState::for_test().with_profile("prod");
+        state.insert_extension(MailDeliveryQueueHandle::new(NoopQueue));
+        let config = sample_smtp_config();
+
+        install_mailer(&state, &config).expect("durable queue should permit prod startup");
+
+        let installed = state
+            .extension::<Mailer>()
+            .expect("install_mailer should store a Mailer extension");
+        assert!(
+            installed.has_durable_delivery_queue(),
+            "registered queue handle should be attached to the installed mailer"
+        );
+    }
 }

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -918,6 +918,36 @@ pub(crate) fn install_mailer(
     Ok(())
 }
 
+/// Run the optional [`MailDeliveryQueue`] factory and install the configured
+/// mailer.
+///
+/// Centralizes the wiring used by every [`AppBuilder`](crate::app::AppBuilder)
+/// build path: optionally invoke `queue_factory` against the live `AppState`,
+/// register the resulting [`MailDeliveryQueueHandle`], then call
+/// [`install_mailer`]. The factory is skipped entirely when
+/// `enforce_durable_guard` is `false` (static-site builds), since the queue
+/// may capture infrastructure (Redis, Harvest, etc.) that isn't available in
+/// the asset-build environment.
+///
+/// # Errors
+///
+/// Propagates errors from the queue factory and from [`install_mailer`].
+pub(crate) fn install_mailer_with_factory<F>(
+    state: &AppState,
+    config: &MailConfig,
+    queue_factory: Option<F>,
+    enforce_durable_guard: bool,
+) -> AutumnResult<()>
+where
+    F: FnOnce(&AppState) -> AutumnResult<Arc<dyn MailDeliveryQueue>>,
+{
+    if enforce_durable_guard && let Some(factory) = queue_factory {
+        let queue = factory(state)?;
+        state.insert_extension(MailDeliveryQueueHandle::from_arc(queue));
+    }
+    install_mailer(state, config, enforce_durable_guard)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1330,6 +1360,82 @@ mod tests {
             installed.has_durable_delivery_queue(),
             "registered queue handle should be attached to the installed mailer"
         );
+    }
+
+    #[test]
+    fn install_mailer_with_factory_runs_factory_and_attaches_queue() {
+        let state = crate::AppState::for_test().with_profile("prod");
+        let config = sample_smtp_config();
+        let factory_called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let captured = Arc::clone(&factory_called);
+
+        let factory = move |_state: &crate::AppState| {
+            captured.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok::<_, crate::AutumnError>(Arc::new(NoopQueue) as Arc<dyn MailDeliveryQueue>)
+        };
+
+        install_mailer_with_factory(&state, &config, Some(factory), true)
+            .expect("factory should produce a queue and satisfy the prod guard");
+
+        assert!(
+            factory_called.load(std::sync::atomic::Ordering::SeqCst),
+            "factory must run when enforce_durable_guard is true"
+        );
+        let installed = state
+            .extension::<Mailer>()
+            .expect("install_mailer should store a Mailer extension");
+        assert!(
+            installed.has_durable_delivery_queue(),
+            "factory's queue should be wired into the installed Mailer"
+        );
+    }
+
+    #[test]
+    fn install_mailer_with_factory_skips_factory_when_not_enforced() {
+        let state = crate::AppState::for_test().with_profile("prod");
+        let config = sample_smtp_config();
+        let factory_called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let captured = Arc::clone(&factory_called);
+
+        let factory = move |_state: &crate::AppState| {
+            captured.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok::<_, crate::AutumnError>(Arc::new(NoopQueue) as Arc<dyn MailDeliveryQueue>)
+        };
+
+        install_mailer_with_factory(&state, &config, Some(factory), false)
+            .expect("static-build path should skip factory and install cleanly");
+
+        assert!(
+            !factory_called.load(std::sync::atomic::Ordering::SeqCst),
+            "factory must be skipped when enforce_durable_guard is false"
+        );
+    }
+
+    #[test]
+    fn install_mailer_with_factory_propagates_factory_errors() {
+        let state = crate::AppState::for_test().with_profile("prod");
+        let config = sample_smtp_config();
+
+        let factory = |_state: &crate::AppState| {
+            Err::<Arc<dyn MailDeliveryQueue>, _>(crate::AutumnError::service_unavailable_msg(
+                "queue offline",
+            ))
+        };
+
+        let error = install_mailer_with_factory(&state, &config, Some(factory), true)
+            .expect_err("factory error should propagate");
+        assert!(error.to_string().contains("queue offline"));
+    }
+
+    #[test]
+    fn install_mailer_with_factory_works_without_factory() {
+        type FactoryFn = fn(&crate::AppState) -> AutumnResult<Arc<dyn MailDeliveryQueue>>;
+        let state = crate::AppState::for_test().with_profile("dev");
+        let config = sample_smtp_config();
+        let no_factory: Option<FactoryFn> = None;
+
+        install_mailer_with_factory(&state, &config, no_factory, true)
+            .expect("absent factory should be fine in non-prod");
     }
 
     #[test]

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -881,13 +881,18 @@ fn lettre_message(mail: &Mail) -> Result<Message, MailError> {
 pub(crate) fn install_mailer(state: &AppState, config: &MailConfig) -> AutumnResult<()> {
     let mut mailer = Mailer::from_config(config).map_err(AutumnError::service_unavailable)?;
 
-    let queue_handle = state.extension::<MailDeliveryQueueHandle>();
-    if let Some(handle) = queue_handle.as_ref() {
-        mailer.delivery_queue = Some(Arc::clone(handle.inner()));
-    }
-
     let in_production = matches!(state.profile(), "prod" | "production");
     let transport_sends_mail = config.transport != Transport::Disabled;
+
+    // Honor the disabled transport contract: if the operator turned mail off
+    // for this profile (tests, review apps, etc.), `deliver_later` must also
+    // be a no-op — even when a durable queue was registered globally.
+    if transport_sends_mail {
+        let queue_handle = state.extension::<MailDeliveryQueueHandle>();
+        if let Some(handle) = queue_handle.as_ref() {
+            mailer.delivery_queue = Some(Arc::clone(handle.inner()));
+        }
+    }
 
     if in_production && transport_sends_mail {
         let has_durable_queue = mailer.delivery_queue.is_some();
@@ -1318,6 +1323,27 @@ mod tests {
         assert!(
             installed.has_durable_delivery_queue(),
             "registered queue handle should be attached to the installed mailer"
+        );
+    }
+
+    #[test]
+    fn install_mailer_does_not_attach_queue_when_transport_disabled() {
+        // When mail.transport = "disabled" the operator has explicitly turned
+        // mail off for this profile (tests, review apps, etc.). A globally
+        // registered queue must not turn deliver_later back into a durable
+        // persist; it should remain a no-op.
+        let state = crate::AppState::for_test().with_profile("dev");
+        state.insert_extension(MailDeliveryQueueHandle::new(NoopQueue));
+        let config = MailConfig::default(); // transport = Disabled
+
+        install_mailer(&state, &config).expect("disabled transport should install cleanly");
+
+        let installed = state
+            .extension::<Mailer>()
+            .expect("install_mailer should store a Mailer extension");
+        assert!(
+            !installed.has_durable_delivery_queue(),
+            "disabled transport must suppress queue attachment so deliver_later is a no-op"
         );
     }
 }

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -505,7 +505,6 @@ impl Mailer {
     /// Returns an error when no active Tokio runtime is available to host the
     /// background task.
     pub fn try_deliver_later(&self, mail: Mail) -> Result<(), MailError> {
-        let mailer = self.clone();
         let mail = mail.with_defaults(&self.defaults);
         let handle = tokio::runtime::Handle::try_current().map_err(|_| {
             MailError::RuntimeUnavailable(
@@ -519,6 +518,7 @@ impl Mailer {
                 }
             });
         } else {
+            let mailer = self.clone();
             handle.spawn(async move {
                 if let Err(error) = mailer.send(mail).await {
                     tracing::error!(error = %error, "background mail delivery failed");
@@ -1185,27 +1185,27 @@ mod tests {
             .expect("disabled transport never sends mail so it should not need an ack");
     }
 
+    struct CapturingQueue {
+        tx: tokio::sync::mpsc::UnboundedSender<Mail>,
+    }
+
+    impl MailDeliveryQueue for CapturingQueue {
+        fn enqueue<'a>(
+            &'a self,
+            mail: Mail,
+        ) -> Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>> {
+            let tx = self.tx.clone();
+            Box::pin(async move {
+                tx.send(mail)
+                    .map_err(|err| MailError::RuntimeUnavailable(err.to_string()))?;
+                Ok(())
+            })
+        }
+    }
+
     #[tokio::test]
     async fn deliver_later_routes_through_configured_queue() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Mail>();
-
-        struct CapturingQueue {
-            tx: tokio::sync::mpsc::UnboundedSender<Mail>,
-        }
-
-        impl MailDeliveryQueue for CapturingQueue {
-            fn enqueue<'a>(
-                &'a self,
-                mail: Mail,
-            ) -> Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>> {
-                let tx = self.tx.clone();
-                Box::pin(async move {
-                    tx.send(mail)
-                        .map_err(|err| MailError::RuntimeUnavailable(err.to_string()))?;
-                    Ok(())
-                })
-            }
-        }
 
         let mailer = Mailer::builder()
             .delivery_queue(CapturingQueue { tx })

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -941,7 +941,14 @@ pub(crate) fn install_mailer_with_factory<F>(
 where
     F: FnOnce(&AppState) -> AutumnResult<Arc<dyn MailDeliveryQueue>>,
 {
-    if enforce_durable_guard && let Some(factory) = queue_factory {
+    // Honor the disabled transport contract: a profile that turned mail off
+    // (tests, review apps, etc.) must not open queue infrastructure either,
+    // since all sends — immediate and deferred — are supposed to be no-ops.
+    let transport_sends_mail = config.transport != Transport::Disabled;
+    if enforce_durable_guard
+        && transport_sends_mail
+        && let Some(factory) = queue_factory
+    {
         let queue = factory(state)?;
         state.insert_extension(MailDeliveryQueueHandle::from_arc(queue));
     }
@@ -1425,6 +1432,32 @@ mod tests {
         let error = install_mailer_with_factory(&state, &config, Some(factory), true)
             .expect_err("factory error should propagate");
         assert!(error.to_string().contains("queue offline"));
+    }
+
+    #[test]
+    fn install_mailer_with_factory_skips_factory_when_transport_disabled() {
+        // Even when enforce_durable_guard=true (normal server path), a
+        // profile with transport=disabled must not run the factory: the
+        // factory might open Redis/Harvest/DB connections, but all mail in
+        // this profile is supposed to be a no-op.
+        let state = crate::AppState::for_test().with_profile("dev");
+        let config = MailConfig::default(); // transport = Disabled
+        let factory_called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let captured = Arc::clone(&factory_called);
+
+        let factory = move |_state: &crate::AppState| {
+            captured.store(true, std::sync::atomic::Ordering::SeqCst);
+            Err::<Arc<dyn MailDeliveryQueue>, _>(crate::AutumnError::service_unavailable_msg(
+                "queue must not be reached",
+            ))
+        };
+
+        install_mailer_with_factory(&state, &config, Some(factory), true)
+            .expect("disabled transport should bypass the factory entirely");
+        assert!(
+            !factory_called.load(std::sync::atomic::Ordering::SeqCst),
+            "factory must not run when transport = disabled"
+        );
     }
 
     #[test]

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -1297,13 +1297,18 @@ mod tests {
         assert_eq!(received.subject, "Hi");
     }
 
-    #[test]
-    fn mailer_with_transport_starts_without_delivery_queue() {
+    #[tokio::test]
+    async fn mailer_with_transport_starts_without_delivery_queue() {
         let mailer = Mailer::with_transport(NoopTransport);
         assert!(
             !mailer.has_durable_delivery_queue(),
             "with_transport should default to no durable queue"
         );
+        // Exercise NoopTransport::send so its body is also covered.
+        mailer
+            .send(sample_mail())
+            .await
+            .expect("noop transport should always succeed");
     }
 
     struct NoopTransport;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -72,7 +72,8 @@ pub use crate::htmx::{HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HxRequest};
 /// Transactional email types and extractor.
 #[cfg(feature = "mail")]
 pub use crate::mail::{
-    Mail, MailConfig, MailError, MailTransport, Mailer, SmtpConfig, TlsMode, Transport,
+    Mail, MailConfig, MailDeliveryQueue, MailDeliveryQueueHandle, MailError, MailTransport, Mailer,
+    SmtpConfig, TlsMode, Transport,
 };
 /// Server-Sent Events (SSE) support.
 pub use crate::sse::{Event, Sse};

--- a/docs/guide/cloud-native.md
+++ b/docs/guide/cloud-native.md
@@ -146,14 +146,15 @@ password_env = "SMTP_PASSWORD"
 tls = "starttls"
 ```
 
-For durable retries across replicas, register a `MailDeliveryQueueHandle` on
-`AppState` before the mailer is installed (see the [Mail
-Guide](mail.md#deferred-delivery-deliver_later) for the trait and an outbox
-example). Without one, `prod` startup fails unless you explicitly set
-`mail.allow_in_process_deliver_later_in_production = true`, which acknowledges
-the in-process Tokio fallback. The fallback is fine for local development and
-small single-process deployments but is not durable across restarts or
-replicas.
+For durable retries across replicas, register a durable
+[`MailDeliveryQueue`](mail.md#deferred-delivery-deliver_later) via
+`AppBuilder::with_mail_delivery_queue` before `.run()` (see the Mail Guide
+for the trait definition and an outbox example). Without one, `prod` startup
+fails unless you explicitly set
+`mail.allow_in_process_deliver_later_in_production = true`, which
+acknowledges the in-process Tokio fallback. The fallback is fine for local
+development and small single-process deployments but is not durable across
+restarts or replicas.
 
 When email dispatch is coordinated with DB writes, use
 [`Db::tx`](transactions.md) for the database side so the write set commits or

--- a/docs/guide/cloud-native.md
+++ b/docs/guide/cloud-native.md
@@ -146,10 +146,14 @@ password_env = "SMTP_PASSWORD"
 tls = "starttls"
 ```
 
-For durable retries across replicas, prefer a Harvest-backed delivery path once
-your app already uses Harvest. Without that, `deliver_later` falls back to an
-in-process Tokio task, which is fine for local development and small single
-process deployments but not a durable queue.
+For durable retries across replicas, register a `MailDeliveryQueueHandle` on
+`AppState` before the mailer is installed (see the [Mail
+Guide](mail.md#deferred-delivery-deliver_later) for the trait and an outbox
+example). Without one, `prod` startup fails unless you explicitly set
+`mail.allow_in_process_deliver_later_in_production = true`, which acknowledges
+the in-process Tokio fallback. The fallback is fine for local development and
+small single-process deployments but is not durable across restarts or
+replicas.
 
 When email dispatch is coordinated with DB writes, use
 [`Db::tx`](transactions.md) for the database side so the write set commits or

--- a/docs/guide/mail.md
+++ b/docs/guide/mail.md
@@ -84,6 +84,80 @@ If the route also persists DB state (for example, writing an outbox row plus
 creating a user), wrap the DB side in [`Db::tx`](transactions.md) so your write
 sequence is atomic.
 
+## Deferred Delivery (`deliver_later`)
+
+`Mailer::deliver_later` and the generated `deliver_later_*` helpers do **not**
+imply durable delivery on their own. The framework provides two paths:
+
+1. **In-process Tokio fallback (default).** The mail send is spawned onto the
+   current Tokio runtime. This is fine for local development and small
+   single-process deployments, but it is not durable: a process restart, pod
+   eviction, or deploy can drop the email after the request has already
+   returned success.
+2. **Durable backend via [`MailDeliveryQueue`].** Implement the trait once for
+   your queue of choice (DB outbox row, Redis stream, Harvest job, etc.) and
+   register it on `AppState` before the mailer is installed:
+
+   ```rust
+   use autumn_web::prelude::*;
+   use std::sync::Arc;
+
+   struct OutboxQueue { /* db handle */ }
+
+   impl MailDeliveryQueue for OutboxQueue {
+       fn enqueue<'a>(
+           &'a self,
+           mail: Mail,
+       ) -> std::pin::Pin<Box<dyn std::future::Future<
+           Output = Result<(), MailError>,
+       > + Send + 'a>> {
+           Box::pin(async move {
+               // INSERT into mail_outbox (...) VALUES (...)
+               // Return Ok(()) once the row is durably committed.
+               Ok(())
+           })
+       }
+   }
+
+   // During app boot, before the mailer is installed:
+   state.insert_extension(MailDeliveryQueueHandle::new(OutboxQueue { /* ... */ }));
+   ```
+
+   When a `MailDeliveryQueueHandle` is present, `deliver_later` routes through
+   it instead of the in-process fallback.
+
+### Production Guard
+
+In `prod`/`production`, Autumn refuses to start with an active mail transport
+and no durable backend unless you explicitly opt in:
+
+```toml
+[mail]
+transport = "smtp"
+allow_in_process_deliver_later_in_production = true
+```
+
+Without that flag, startup fails with a clear message asking you to either
+install a `MailDeliveryQueueHandle` or set the flag. The flag is intended as an
+acknowledged single-replica escape hatch, not a recommended production setup.
+
+### DB-Write + Mail Patterns (Outbox)
+
+When a request both writes to the DB and dispatches mail, send mail **after**
+the DB transaction commits, but make the dispatch idempotent so retries
+recover:
+
+1. Inside `Db::tx`, insert the user row **and** an `email_outbox` row
+   (`(id, kind, payload, status='pending')`) atomically.
+2. After commit, call `mailer.deliver_later(...)`.
+3. A `MailDeliveryQueue` implementation reads the outbox row, sends the email,
+   and marks the row `sent`. On retry, it skips already-`sent` rows. This is
+   the canonical outbox pattern: the DB transaction is the source of truth for
+   "the user signed up", and the queue worker is responsible for at-least-once
+   delivery without losing mail across restarts.
+
+For the transaction shape see [`Db::tx`](transactions.md).
+
 ## Transports
 
 - `log`: writes headers and full bodies to tracing at INFO. Default for `dev`.
@@ -102,7 +176,9 @@ build a `Mailer::with_transport(...)`.
 - Keep SMTP secrets in environment variables via `password_env`.
 - Add a plain-text fallback for every HTML email.
 - Assert file-transport `.eml` contents in integration tests.
-- Prefer a Harvest-backed queue for durable `deliver_later` retries. Without
-  Harvest, Autumn falls back to an in-process Tokio task and logs failures.
+- Register a `MailDeliveryQueueHandle` (Harvest, DB outbox, Redis, etc.) for
+  durable `deliver_later` retries. Without one, `prod` startup fails unless
+  `mail.allow_in_process_deliver_later_in_production = true` is set, in which
+  case Autumn falls back to an in-process Tokio task and logs failures.
 - For DB-write + mail-orchestration flows, use the [Transactions
   Guide](transactions.md) for the canonical atomic write pattern.

--- a/docs/guide/mail.md
+++ b/docs/guide/mail.md
@@ -125,6 +125,21 @@ imply durable delivery on their own. The framework provides two paths:
        .await;
    ```
 
+   When the queue needs framework-managed resources (the DB pool, channels,
+   etc.) that only exist after the [`AppState`] is built, use
+   [`AppBuilder::with_mail_delivery_queue_factory`] instead. The factory
+   runs once with the live `AppState` immediately before `install_mailer`:
+
+   ```rust,ignore
+   autumn_web::app()
+       .with_mail_delivery_queue_factory(|state| {
+           let pool = state.pool().expect("DB pool required").clone();
+           Ok(OutboxQueue::new(pool))
+       })
+       .run()
+       .await;
+   ```
+
    When a queue is registered, `deliver_later` routes through it instead of
    the in-process fallback.
 

--- a/docs/guide/mail.md
+++ b/docs/guide/mail.md
@@ -94,13 +94,13 @@ imply durable delivery on their own. The framework provides two paths:
    single-process deployments, but it is not durable: a process restart, pod
    eviction, or deploy can drop the email after the request has already
    returned success.
-2. **Durable backend via [`MailDeliveryQueue`].** Implement the trait once for
-   your queue of choice (DB outbox row, Redis stream, Harvest job, etc.) and
-   register it on `AppState` before the mailer is installed:
+2. **Durable backend via [`MailDeliveryQueue`].** Implement the trait once
+   for your queue of choice (DB outbox row, Redis stream, Harvest job, etc.)
+   and register it via [`AppBuilder::with_mail_delivery_queue`] before
+   `.run()`:
 
    ```rust
    use autumn_web::prelude::*;
-   use std::sync::Arc;
 
    struct OutboxQueue { /* db handle */ }
 
@@ -119,12 +119,14 @@ imply durable delivery on their own. The framework provides two paths:
        }
    }
 
-   // During app boot, before the mailer is installed:
-   state.insert_extension(MailDeliveryQueueHandle::new(OutboxQueue { /* ... */ }));
+   autumn_web::app()
+       .with_mail_delivery_queue(OutboxQueue { /* ... */ })
+       .run()
+       .await;
    ```
 
-   When a `MailDeliveryQueueHandle` is present, `deliver_later` routes through
-   it instead of the in-process fallback.
+   When a queue is registered, `deliver_later` routes through it instead of
+   the in-process fallback.
 
 ### Production Guard
 


### PR DESCRIPTION
## Summary

Introduces a pluggable `MailDeliveryQueue` trait that allows applications to implement durable backends for deferred mail delivery, replacing the non-durable in-process Tokio fallback as the primary path for production deployments.

## Key Changes

- **New `MailDeliveryQueue` trait**: Defines the interface for durable mail queue implementations (DB outbox, Redis, Harvest, etc.). Implementors persist mail and return once the handoff is durable.

- **`MailDeliveryQueueHandle`**: A cloneable, `Arc`-wrapped handle for storing queue implementations on `AppState` extensions, allowing plugins to register durable backends before the mailer is installed.

- **Production safety guard**: In `prod`/`production` profiles with an active mail transport, startup now fails unless either:
  - A `MailDeliveryQueueHandle` is registered on `AppState`, or
  - `mail.allow_in_process_deliver_later_in_production = true` is explicitly set to opt into the non-durable fallback

- **Updated `Mailer` and `MailerBuilder`**: Added `delivery_queue` field and methods (`with_delivery_queue`, `has_durable_delivery_queue`, `delivery_queue`, `delivery_queue_arc`) to attach queue implementations.

- **Routing logic in `try_deliver_later`**: When a durable queue is attached, mail is enqueued through it; otherwise, the in-process Tokio fallback is used.

- **Updated `install_mailer`**: Picks up `MailDeliveryQueueHandle` from `AppState` extensions and enforces the production guard with clear error messaging.

- **Comprehensive tests**: Added test coverage for the production guard, queue routing, and fallback behavior.

- **Documentation**: Updated the Mail guide with the deferred delivery section covering both paths, the outbox pattern, and production requirements. Updated cloud-native and best-practices guides.

## Notable Implementation Details

- The in-process fallback remains available for development and single-process deployments, but is now explicitly acknowledged in production via a config flag.
- The trait design allows queue implementations to be async and return errors, supporting various backend patterns.
- Mail defaults are applied before enqueueing to ensure consistency regardless of delivery path.
- The production guard only applies when the transport is not `Disabled`, allowing test/disabled configurations to bypass the requirement.

https://claude.ai/code/session_01WSgM4ECs23onikGor4cK75