### PR TITLE
⚡ Bolt: [Remove heap allocation in Bundle Debug format]

### DIFF
--- a/autumn/src/i18n.rs
+++ b/autumn/src/i18n.rs
@@ -311,7 +311,8 @@ pub struct Bundle {
 impl fmt::Debug for Bundle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Bundle")
-            .field("locales", &self.messages.keys().collect::<Vec<_>>())
+            // Iterators natively implement fmt::Debug, avoiding unnecessary heap allocations.
+            .field("locales", &self.messages.keys())
             .field("default_locale", &self.default_locale)
             .field("supported_locales", &self.supported_locales)
             .field("miss_count", &self.miss_count.load(Ordering::Relaxed))


### PR DESCRIPTION
💡 What: Removed `.collect::<Vec<_>>()` when debug formatting `Bundle`'s locales.
🎯 Why: Iterators natively implement `fmt::Debug`. Collecting them into a `Vec` for debug printing forces an unnecessary heap allocation.
📊 Impact: Eliminates a heap allocation every time `Bundle` is formatted with `Debug`.
🔬 Measurement: Code continues to pass `cargo check` and `cargo test` while avoiding the allocation.

---
*PR created automatically by Jules for task [15935850939969207610](https://jules.google.com/task/15935850939969207610) started by @madmax983*