### PR TITLE
🗺️ Atlas: Enforce workspace feature separation for tests and unused code

### DIFF
--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -129,3 +129,7 @@ rusty-fork = "0.3.1"
 
 [lints]
 workspace = true
+
+[[test]]
+name = "factory_integration"
+required-features = ["db", "test-support"]

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -1408,6 +1408,7 @@ mod tests {
     use tokio::sync::mpsc;
     use tokio::time::{Duration, timeout};
 
+    #[cfg(feature = "redis")]
     static REDIS_HANDLER_CALLS: AtomicUsize = AtomicUsize::new(0);
 
     fn always_fail_handler(
@@ -1421,6 +1422,7 @@ mod tests {
         })
     }
 
+    #[cfg(feature = "redis")]
     fn redis_counting_success_handler(
         _state: AppState,
         _payload: Value,
@@ -1431,6 +1433,7 @@ mod tests {
         })
     }
 
+    #[cfg(feature = "redis")]
     fn redis_counting_failure_handler(
         _state: AppState,
         _payload: Value,


### PR DESCRIPTION
🕸️ Tangle: The `factory_integration` test was failing because it was missing the required feature flag (`test-support`), and `job.rs` had dead code warnings when the `redis` feature wasn't enabled.
📐 Blueprint: Enforced `test-support` feature in `Cargo.toml` for `factory_integration` test and properly gated test functions under `cfg(feature = "redis")` in `job.rs`.
🧱 Stability: Strict feature separation enforced, reduced test failures when compiling specific targets without all-features.
🔬 Verification: Builds successfully, strict separation enforced, tests run cleanly without warnings.

---
*PR created automatically by Jules for task [932400319445262829](https://jules.google.com/task/932400319445262829) started by @madmax983*