### PR TITLE
Add ISR coordination for multi-replica deployments

### DIFF
--- a/autumn/src/static_gen/isr_coordinator.rs
+++ b/autumn/src/static_gen/isr_coordinator.rs
@@ -1,9 +1,9 @@
 //! ISR coordination backends.
 //!
 //! Controls which replica may regenerate a given route within a revalidation
-//! window. The [`LocalIsrCoordinator`] is an in-process no-op suitable for
-//! single-replica / development deployments -- all local deduplication is
-//! already handled by the per-route `AtomicBool` in `StaticFileLayer`.
+//! window. The [`LocalIsrCoordinator`] is a true no-op: all local
+//! deduplication is already handled by the per-route `AtomicBool` in
+//! `StaticFileLayer`, so a single process never needs an additional lock.
 //! The [`PostgresIsrCoordinator`] uses `pg_try_advisory_lock` to ensure that
 //! at most one replica regenerates a given route per revalidation window
 //! across the entire fleet.
@@ -22,10 +22,8 @@
 //! then renames atomically so a reader never observes a partially written
 //! page.
 
-use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Mutex;
 
 use sha2::{Digest as _, Sha256};
 
@@ -69,33 +67,24 @@ pub trait IsrCoordinator: Send + Sync + 'static {
     ) -> IsrFuture<'a, ()>;
 }
 
-/// In-process ISR coordinator.
+/// In-process ISR coordinator — always grants the lock.
 ///
-/// This is the **default** coordinator. It is a pass-through: all local
-/// deduplication is already handled by the `AtomicBool` in-flight guard
-/// inside `StaticFileLayer`. This coordinator always grants the lock so
-/// that a single process never misses a revalidation cycle.
+/// This is the **default** coordinator and is a true no-op. Local
+/// deduplication is entirely handled by the per-route `AtomicBool` in
+/// `StaticFileLayer`: only one background task can be spawned per route at
+/// a time, so the coordinator will never see a concurrent call for the same
+/// (route, window) pair within a single process.
 ///
 /// For multi-replica deployments use [`PostgresIsrCoordinator`] (feature
 /// `db`) which enforces fleet-wide deduplication via `pg_try_advisory_lock`.
-pub struct LocalIsrCoordinator {
-    /// Tracks (`url_path`, `window_key`) pairs currently held by this process.
-    held: Mutex<HashSet<(String, String)>>,
-}
+#[derive(Debug, Default)]
+pub struct LocalIsrCoordinator;
 
 impl LocalIsrCoordinator {
     /// Create a new in-process coordinator.
     #[must_use]
-    pub fn new() -> Self {
-        Self {
-            held: Mutex::new(HashSet::new()),
-        }
-    }
-}
-
-impl Default for LocalIsrCoordinator {
-    fn default() -> Self {
-        Self::new()
+    pub const fn new() -> Self {
+        Self
     }
 }
 
@@ -106,24 +95,18 @@ impl IsrCoordinator for LocalIsrCoordinator {
 
     fn try_acquire<'a>(
         &'a self,
-        url_path: &'a str,
-        window_key: &'a str,
+        _url_path: &'a str,
+        _window_key: &'a str,
     ) -> IsrFuture<'a, bool> {
-        Box::pin(async move {
-            let key = (url_path.to_owned(), window_key.to_owned());
-            self.held.lock().unwrap().insert(key)
-        })
+        Box::pin(async move { true })
     }
 
     fn release<'a>(
         &'a self,
-        url_path: &'a str,
-        window_key: &'a str,
+        _url_path: &'a str,
+        _window_key: &'a str,
     ) -> IsrFuture<'a, ()> {
-        Box::pin(async move {
-            let key = (url_path.to_owned(), window_key.to_owned());
-            self.held.lock().unwrap().remove(&key);
-        })
+        Box::pin(async move {})
     }
 }
 
@@ -139,24 +122,40 @@ impl IsrCoordinator for LocalIsrCoordinator {
 ///
 /// ## Connection management
 ///
-/// A dedicated connection is checked out for the duration of the lock because
-/// Postgres session-level advisory locks are bound to the connection. The
-/// connection is returned to the pool when [`IsrCoordinator::release`] is
-/// called. Regeneration tasks that fail to acquire the Postgres lock return
-/// their pooled connection immediately.
+/// Postgres session-level advisory locks are bound to the database connection
+/// that acquired them. This coordinator therefore **holds the connection** that
+/// won the lock (stored in an internal map keyed by advisory lock key) and
+/// retrieves the same connection in [`IsrCoordinator::release`] to call
+/// `pg_advisory_unlock` before returning it to the pool.
+///
+/// Connections held during regeneration are not available to other tasks.
+/// Regeneration tasks that fail to acquire the Postgres lock return their
+/// pooled connection immediately.
 #[cfg(feature = "db")]
 pub struct PostgresIsrCoordinator {
     pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+    /// Connections holding active advisory locks, keyed by advisory lock key.
+    /// The connection must be reused for the unlock call because session-level
+    /// advisory locks are connection-scoped.
+    held: std::sync::Mutex<
+        std::collections::HashMap<
+            i64,
+            diesel_async::pooled_connection::deadpool::Object<diesel_async::AsyncPgConnection>,
+        >,
+    >,
 }
 
 #[cfg(feature = "db")]
 impl PostgresIsrCoordinator {
     /// Create a Postgres ISR coordinator backed by the given connection pool.
     #[must_use]
-    pub const fn new(
+    pub fn new(
         pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
     ) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            held: std::sync::Mutex::new(std::collections::HashMap::new()),
+        }
     }
 }
 
@@ -181,7 +180,12 @@ impl IsrCoordinator for PostgresIsrCoordinator {
                 }
             };
             match try_pg_advisory_lock(&mut conn, lock_key).await {
-                Ok(acquired) => acquired,
+                Ok(true) => {
+                    // Hold the connection so we can unlock on the same session.
+                    self.held.lock().unwrap().insert(lock_key, conn);
+                    true
+                }
+                Ok(false) => false,
                 Err(e) => {
                     tracing::warn!(error = %e, "ISR coordinator: pg_try_advisory_lock failed");
                     false
@@ -197,22 +201,29 @@ impl IsrCoordinator for PostgresIsrCoordinator {
     ) -> IsrFuture<'a, ()> {
         let lock_key = isr_advisory_lock_key(url_path, window_key);
         Box::pin(async move {
-            let mut conn = match self.pool.get().await {
-                Ok(c) => c,
-                Err(e) => {
-                    tracing::warn!(error = %e, "ISR coordinator: could not get Postgres connection for release");
-                    return;
-                }
+            // Retrieve the connection that holds the lock.
+            // Extract outside `let...else` so the mutex guard drops immediately.
+            let maybe_conn = self.held.lock().unwrap().remove(&lock_key);
+            let Some(mut conn) = maybe_conn else {
+                tracing::warn!(
+                    lock_key,
+                    "ISR coordinator: release called without a held connection"
+                );
+                return;
             };
             match unlock_pg_advisory_lock(&mut conn, lock_key).await {
                 Ok(false) => {
-                    tracing::warn!(lock_key, "ISR coordinator: pg_advisory_unlock returned false (lock already released)");
+                    tracing::warn!(
+                        lock_key,
+                        "ISR coordinator: pg_advisory_unlock returned false (lock already released)"
+                    );
                 }
                 Ok(true) => {}
                 Err(e) => {
                     tracing::warn!(error = %e, "ISR coordinator: pg_advisory_unlock failed");
                 }
             }
+            // conn is dropped here, returning the connection to the pool.
         })
     }
 }
@@ -371,22 +382,19 @@ mod tests {
     // --- LocalIsrCoordinator ---
 
     #[tokio::test]
-    async fn local_coordinator_first_acquire() {
+    async fn local_coordinator_always_grants() {
+        // LocalIsrCoordinator is a no-op: local dedup is handled by the
+        // AtomicBool in StaticFileLayer, not by this coordinator.
         let c = LocalIsrCoordinator::new();
+        assert!(c.try_acquire("/a", "w1").await);
+        // Even a second concurrent call returns true (no-op).
         assert!(c.try_acquire("/a", "w1").await);
     }
 
     #[tokio::test]
-    async fn local_coordinator_double_acquire_denied() {
+    async fn local_coordinator_release_is_noop() {
         let c = LocalIsrCoordinator::new();
-        assert!(c.try_acquire("/a", "w1").await);
-        assert!(!c.try_acquire("/a", "w1").await);
-    }
-
-    #[tokio::test]
-    async fn local_coordinator_release_allows_reacquire() {
-        let c = LocalIsrCoordinator::new();
-        assert!(c.try_acquire("/a", "w1").await);
+        // release should not panic and the coordinator continues to grant.
         c.release("/a", "w1").await;
         assert!(c.try_acquire("/a", "w1").await);
     }

--- a/autumn/src/static_gen/isr_coordinator.rs
+++ b/autumn/src/static_gen/isr_coordinator.rs
@@ -51,20 +51,12 @@ pub trait IsrCoordinator: Send + Sync + 'static {
     ///
     /// Returns `true` when this caller may proceed; `false` when another
     /// task or replica already holds the lock for this (route, window) pair.
-    fn try_acquire<'a>(
-        &'a self,
-        url_path: &'a str,
-        window_key: &'a str,
-    ) -> IsrFuture<'a, bool>;
+    fn try_acquire<'a>(&'a self, url_path: &'a str, window_key: &'a str) -> IsrFuture<'a, bool>;
 
     /// Release the lock after regeneration completes (success or failure).
     ///
     /// Must be called exactly once for every successful [`try_acquire`](Self::try_acquire).
-    fn release<'a>(
-        &'a self,
-        url_path: &'a str,
-        window_key: &'a str,
-    ) -> IsrFuture<'a, ()>;
+    fn release<'a>(&'a self, url_path: &'a str, window_key: &'a str) -> IsrFuture<'a, ()>;
 }
 
 /// In-process ISR coordinator — always grants the lock.
@@ -93,19 +85,11 @@ impl IsrCoordinator for LocalIsrCoordinator {
         "local"
     }
 
-    fn try_acquire<'a>(
-        &'a self,
-        _url_path: &'a str,
-        _window_key: &'a str,
-    ) -> IsrFuture<'a, bool> {
+    fn try_acquire<'a>(&'a self, _url_path: &'a str, _window_key: &'a str) -> IsrFuture<'a, bool> {
         Box::pin(async move { true })
     }
 
-    fn release<'a>(
-        &'a self,
-        _url_path: &'a str,
-        _window_key: &'a str,
-    ) -> IsrFuture<'a, ()> {
+    fn release<'a>(&'a self, _url_path: &'a str, _window_key: &'a str) -> IsrFuture<'a, ()> {
         Box::pin(async move {})
     }
 }
@@ -165,11 +149,7 @@ impl IsrCoordinator for PostgresIsrCoordinator {
         "postgres"
     }
 
-    fn try_acquire<'a>(
-        &'a self,
-        url_path: &'a str,
-        window_key: &'a str,
-    ) -> IsrFuture<'a, bool> {
+    fn try_acquire<'a>(&'a self, url_path: &'a str, window_key: &'a str) -> IsrFuture<'a, bool> {
         let lock_key = isr_advisory_lock_key(url_path, window_key);
         Box::pin(async move {
             let mut conn = match self.pool.get().await {
@@ -194,11 +174,7 @@ impl IsrCoordinator for PostgresIsrCoordinator {
         })
     }
 
-    fn release<'a>(
-        &'a self,
-        url_path: &'a str,
-        window_key: &'a str,
-    ) -> IsrFuture<'a, ()> {
+    fn release<'a>(&'a self, url_path: &'a str, window_key: &'a str) -> IsrFuture<'a, ()> {
         let lock_key = isr_advisory_lock_key(url_path, window_key);
         Box::pin(async move {
             // Retrieve the connection that holds the lock.
@@ -347,7 +323,10 @@ mod tests {
     #[test]
     fn window_key_route_prefix() {
         let key = isr_window_key("/about", 60, 1_700_000_000);
-        assert!(key.starts_with("/about:"), "key should start with route: {key}");
+        assert!(
+            key.starts_with("/about:"),
+            "key should start with route: {key}"
+        );
     }
 
     #[test]

--- a/autumn/src/static_gen/isr_coordinator.rs
+++ b/autumn/src/static_gen/isr_coordinator.rs
@@ -1,0 +1,399 @@
+//! ISR coordination backends.
+//!
+//! Controls which replica may regenerate a given route within a revalidation
+//! window. The [`LocalIsrCoordinator`] is an in-process no-op suitable for
+//! single-replica / development deployments -- all local deduplication is
+//! already handled by the per-route `AtomicBool` in `StaticFileLayer`.
+//! The [`PostgresIsrCoordinator`] uses `pg_try_advisory_lock` to ensure that
+//! at most one replica regenerates a given route per revalidation window
+//! across the entire fleet.
+//!
+//! ## Local vs multi-replica contract
+//!
+//! | Deployment | Recommended coordinator | Guarantee |
+//! |------------|-------------------------|-----------|
+//! | Single process / dev | `LocalIsrCoordinator` (default) | At most one in-flight task per route per process |
+//! | Multi-replica (shared `dist/`) | `PostgresIsrCoordinator` | At most one regeneration per route per revalidation window across the fleet |
+//! | Read-only `dist/` (build-time only) | Disable ISR (`revalidate` = None) | No runtime writes |
+//!
+//! ## Atomic writes
+//!
+//! Regardless of coordinator, regeneration always writes to a `.tmp` file
+//! then renames atomically so a reader never observes a partially written
+//! page.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Mutex;
+
+use sha2::{Digest as _, Sha256};
+
+/// Boxed async future returned by coordinator operations.
+pub type IsrFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Coordination backend for ISR background regeneration.
+///
+/// Implementations decide whether *this* replica may regenerate a given route
+/// for a given revalidation window. Returning `false` from
+/// [`try_acquire`](Self::try_acquire) means another task or replica has
+/// already claimed the work; the caller should skip regeneration.
+///
+/// Implementors must also call [`release`](Self::release) after the
+/// regeneration attempt so that subsequent windows can be acquired.
+pub trait IsrCoordinator: Send + Sync + 'static {
+    /// Short backend identifier used in log messages.
+    fn backend(&self) -> &'static str;
+
+    /// Try to acquire the right to regenerate `url_path` for `window_key`.
+    ///
+    /// `window_key` is derived from [`isr_window_key`] and encodes both the
+    /// route and the current revalidation bucket; two replicas that observe
+    /// the same stale file within the same window will produce the same key.
+    ///
+    /// Returns `true` when this caller may proceed; `false` when another
+    /// task or replica already holds the lock for this (route, window) pair.
+    fn try_acquire<'a>(
+        &'a self,
+        url_path: &'a str,
+        window_key: &'a str,
+    ) -> IsrFuture<'a, bool>;
+
+    /// Release the lock after regeneration completes (success or failure).
+    ///
+    /// Must be called exactly once for every successful [`try_acquire`](Self::try_acquire).
+    fn release<'a>(
+        &'a self,
+        url_path: &'a str,
+        window_key: &'a str,
+    ) -> IsrFuture<'a, ()>;
+}
+
+/// In-process ISR coordinator.
+///
+/// This is the **default** coordinator. It is a pass-through: all local
+/// deduplication is already handled by the `AtomicBool` in-flight guard
+/// inside `StaticFileLayer`. This coordinator always grants the lock so
+/// that a single process never misses a revalidation cycle.
+///
+/// For multi-replica deployments use [`PostgresIsrCoordinator`] (feature
+/// `db`) which enforces fleet-wide deduplication via `pg_try_advisory_lock`.
+pub struct LocalIsrCoordinator {
+    /// Tracks (url_path, window_key) pairs currently held by this process.
+    held: Mutex<HashMap<(String, String), ()>>,
+}
+
+impl LocalIsrCoordinator {
+    /// Create a new in-process coordinator.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            held: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl Default for LocalIsrCoordinator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IsrCoordinator for LocalIsrCoordinator {
+    fn backend(&self) -> &'static str {
+        "local"
+    }
+
+    fn try_acquire<'a>(
+        &'a self,
+        url_path: &'a str,
+        window_key: &'a str,
+    ) -> IsrFuture<'a, bool> {
+        Box::pin(async move {
+            let key = (url_path.to_owned(), window_key.to_owned());
+            let mut held = self.held.lock().unwrap();
+            if held.contains_key(&key) {
+                false
+            } else {
+                held.insert(key, ());
+                true
+            }
+        })
+    }
+
+    fn release<'a>(
+        &'a self,
+        url_path: &'a str,
+        window_key: &'a str,
+    ) -> IsrFuture<'a, ()> {
+        Box::pin(async move {
+            let key = (url_path.to_owned(), window_key.to_owned());
+            self.held.lock().unwrap().remove(&key);
+        })
+    }
+}
+
+/// Postgres advisory-lock ISR coordinator.
+///
+/// Uses `pg_try_advisory_lock` / `pg_advisory_unlock` to prevent duplicate
+/// regeneration across replicas. Requires the `db` feature.
+///
+/// The advisory lock is keyed on [`isr_advisory_lock_key`] which is derived
+/// from (route, window) -- two replicas that see the same stale page in the
+/// same revalidation window will attempt the same lock key, and only the
+/// first will succeed.
+///
+/// ## Connection management
+///
+/// A dedicated connection is checked out for the duration of the lock because
+/// Postgres session-level advisory locks are bound to the connection. The
+/// connection is returned to the pool when [`IsrCoordinator::release`] is
+/// called. Regeneration tasks that fail to acquire the Postgres lock return
+/// their pooled connection immediately.
+#[cfg(feature = "db")]
+pub struct PostgresIsrCoordinator {
+    pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+}
+
+#[cfg(feature = "db")]
+impl PostgresIsrCoordinator {
+    /// Create a Postgres ISR coordinator backed by the given connection pool.
+    #[must_use]
+    pub fn new(
+        pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+    ) -> Self {
+        Self { pool }
+    }
+}
+
+#[cfg(feature = "db")]
+impl IsrCoordinator for PostgresIsrCoordinator {
+    fn backend(&self) -> &'static str {
+        "postgres"
+    }
+
+    fn try_acquire<'a>(
+        &'a self,
+        url_path: &'a str,
+        window_key: &'a str,
+    ) -> IsrFuture<'a, bool> {
+        let lock_key = isr_advisory_lock_key(url_path, window_key);
+        Box::pin(async move {
+            let mut conn = match self.pool.get().await {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(error = %e, "ISR coordinator: could not get Postgres connection");
+                    return false;
+                }
+            };
+            match try_pg_advisory_lock(&mut conn, lock_key).await {
+                Ok(acquired) => acquired,
+                Err(e) => {
+                    tracing::warn!(error = %e, "ISR coordinator: pg_try_advisory_lock failed");
+                    false
+                }
+            }
+        })
+    }
+
+    fn release<'a>(
+        &'a self,
+        url_path: &'a str,
+        window_key: &'a str,
+    ) -> IsrFuture<'a, ()> {
+        let lock_key = isr_advisory_lock_key(url_path, window_key);
+        Box::pin(async move {
+            let mut conn = match self.pool.get().await {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(error = %e, "ISR coordinator: could not get Postgres connection for release");
+                    return;
+                }
+            };
+            match unlock_pg_advisory_lock(&mut conn, lock_key).await {
+                Ok(false) => {
+                    tracing::warn!(lock_key, "ISR coordinator: pg_advisory_unlock returned false (lock already released)");
+                }
+                Ok(true) => {}
+                Err(e) => {
+                    tracing::warn!(error = %e, "ISR coordinator: pg_advisory_unlock failed");
+                }
+            }
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Key derivation utilities (public -- useful in application code and tests)
+// ---------------------------------------------------------------------------
+
+/// Compute the revalidation window key for a route and the current time.
+///
+/// All replicas that evaluate a given route as stale within the same
+/// revalidation period will produce the same key, making it safe to use
+/// as a distributed lock discriminator.
+///
+/// # Arguments
+///
+/// * `url_path` -- The URL path of the route (e.g. `"/about"`).
+/// * `revalidate_secs` -- The ISR interval in seconds (0 is treated as 1).
+/// * `now_unix_secs` -- Current Unix timestamp in seconds.
+///
+/// # Returns
+///
+/// A string of the form `"{url_path}:{bucket}"` where `bucket = now / interval`.
+#[must_use]
+pub fn isr_window_key(url_path: &str, revalidate_secs: u64, now_unix_secs: u64) -> String {
+    let interval = revalidate_secs.max(1);
+    let bucket = now_unix_secs / interval;
+    format!("{url_path}:{bucket}")
+}
+
+/// Derive a stable signed 64-bit advisory lock key for a (route, window) pair.
+///
+/// Suitable for `pg_try_advisory_lock`. The result is a deterministic hash
+/// of the inputs; different routes or different windows produce different keys
+/// with overwhelming probability.
+#[must_use]
+pub fn isr_advisory_lock_key(url_path: &str, window_key: &str) -> i64 {
+    let mut hasher = Sha256::new();
+    hasher.update(b"isr\0");
+    hasher.update(url_path.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(window_key.as_bytes());
+    let digest = hasher.finalize();
+    let mut bytes = [0_u8; 8];
+    bytes.copy_from_slice(&digest[..8]);
+    i64::from_be_bytes(bytes)
+}
+
+// ---------------------------------------------------------------------------
+// Postgres helpers (feature = "db")
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "db")]
+#[derive(diesel::QueryableByName)]
+struct PgAdvisoryLockRow {
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    acquired: bool,
+}
+
+#[cfg(feature = "db")]
+async fn try_pg_advisory_lock(
+    conn: &mut diesel_async::pooled_connection::deadpool::Object<diesel_async::AsyncPgConnection>,
+    key: i64,
+) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+    use diesel_async::RunQueryDsl as _;
+
+    let row = diesel::sql_query("SELECT pg_try_advisory_lock($1) AS acquired")
+        .bind::<diesel::sql_types::BigInt, _>(key)
+        .get_result::<PgAdvisoryLockRow>(&mut **conn)
+        .await?;
+    Ok(row.acquired)
+}
+
+#[cfg(feature = "db")]
+#[derive(diesel::QueryableByName)]
+struct PgAdvisoryUnlockRow {
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    released: bool,
+}
+
+#[cfg(feature = "db")]
+async fn unlock_pg_advisory_lock(
+    conn: &mut diesel_async::pooled_connection::deadpool::Object<diesel_async::AsyncPgConnection>,
+    key: i64,
+) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+    use diesel_async::RunQueryDsl as _;
+
+    let row = diesel::sql_query("SELECT pg_advisory_unlock($1) AS released")
+        .bind::<diesel::sql_types::BigInt, _>(key)
+        .get_result::<PgAdvisoryUnlockRow>(&mut **conn)
+        .await?;
+    Ok(row.released)
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- isr_window_key ---
+
+    #[test]
+    fn window_key_stable_within_interval() {
+        // Bucket 28_333_333 covers [1_699_999_980, 1_700_000_039].
+        let a = isr_window_key("/about", 60, 1_700_000_000);
+        let b = isr_window_key("/about", 60, 1_700_000_039);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn window_key_changes_on_boundary() {
+        // 1_700_000_039 is bucket 28_333_333; 1_700_000_040 is bucket 28_333_334.
+        let a = isr_window_key("/about", 60, 1_700_000_039);
+        let b = isr_window_key("/about", 60, 1_700_000_040);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn window_key_route_prefix() {
+        let key = isr_window_key("/about", 60, 1_700_000_000);
+        assert!(key.starts_with("/about:"), "key should start with route: {key}");
+    }
+
+    #[test]
+    fn window_key_zero_revalidate_no_panic() {
+        let key = isr_window_key("/edge", 0, 42);
+        assert!(!key.is_empty());
+    }
+
+    // --- isr_advisory_lock_key ---
+
+    #[test]
+    fn advisory_key_deterministic() {
+        let a = isr_advisory_lock_key("/about", "/about:28333333");
+        let b = isr_advisory_lock_key("/about", "/about:28333333");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn advisory_key_differs_by_route() {
+        let a = isr_advisory_lock_key("/", "/about:28333333");
+        let b = isr_advisory_lock_key("/about", "/about:28333333");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn advisory_key_differs_by_window() {
+        let a = isr_advisory_lock_key("/about", "/about:1");
+        let b = isr_advisory_lock_key("/about", "/about:2");
+        assert_ne!(a, b);
+    }
+
+    // --- LocalIsrCoordinator ---
+
+    #[tokio::test]
+    async fn local_coordinator_first_acquire() {
+        let c = LocalIsrCoordinator::new();
+        assert!(c.try_acquire("/a", "w1").await);
+    }
+
+    #[tokio::test]
+    async fn local_coordinator_double_acquire_denied() {
+        let c = LocalIsrCoordinator::new();
+        assert!(c.try_acquire("/a", "w1").await);
+        assert!(!c.try_acquire("/a", "w1").await);
+    }
+
+    #[tokio::test]
+    async fn local_coordinator_release_allows_reacquire() {
+        let c = LocalIsrCoordinator::new();
+        assert!(c.try_acquire("/a", "w1").await);
+        c.release("/a", "w1").await;
+        assert!(c.try_acquire("/a", "w1").await);
+    }
+}

--- a/autumn/src/static_gen/isr_coordinator.rs
+++ b/autumn/src/static_gen/isr_coordinator.rs
@@ -22,7 +22,7 @@
 //! then renames atomically so a reader never observes a partially written
 //! page.
 
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Mutex;
@@ -79,8 +79,8 @@ pub trait IsrCoordinator: Send + Sync + 'static {
 /// For multi-replica deployments use [`PostgresIsrCoordinator`] (feature
 /// `db`) which enforces fleet-wide deduplication via `pg_try_advisory_lock`.
 pub struct LocalIsrCoordinator {
-    /// Tracks (url_path, window_key) pairs currently held by this process.
-    held: Mutex<HashMap<(String, String), ()>>,
+    /// Tracks (`url_path`, `window_key`) pairs currently held by this process.
+    held: Mutex<HashSet<(String, String)>>,
 }
 
 impl LocalIsrCoordinator {
@@ -88,7 +88,7 @@ impl LocalIsrCoordinator {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            held: Mutex::new(HashMap::new()),
+            held: Mutex::new(HashSet::new()),
         }
     }
 }
@@ -111,13 +111,7 @@ impl IsrCoordinator for LocalIsrCoordinator {
     ) -> IsrFuture<'a, bool> {
         Box::pin(async move {
             let key = (url_path.to_owned(), window_key.to_owned());
-            let mut held = self.held.lock().unwrap();
-            if held.contains_key(&key) {
-                false
-            } else {
-                held.insert(key, ());
-                true
-            }
+            self.held.lock().unwrap().insert(key)
         })
     }
 
@@ -159,7 +153,7 @@ pub struct PostgresIsrCoordinator {
 impl PostgresIsrCoordinator {
     /// Create a Postgres ISR coordinator backed by the given connection pool.
     #[must_use]
-    pub fn new(
+    pub const fn new(
         pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
     ) -> Self {
         Self { pool }

--- a/autumn/src/static_gen/middleware.rs
+++ b/autumn/src/static_gen/middleware.rs
@@ -685,4 +685,59 @@ mod tests {
         let content = std::fs::read_to_string(&dest).unwrap();
         assert_eq!(content, "old content");
     }
+
+    #[tokio::test]
+    async fn isr_coordinator_deny_clears_in_flight_and_skips_regen() {
+        use crate::static_gen::isr_coordinator::IsrFuture;
+
+        // A coordinator that always denies acquisition — exercises the
+        // `if !acquired { return; }` branch in the spawned ISR task.
+        struct DenyCoordinator;
+        impl IsrCoordinator for DenyCoordinator {
+            fn backend(&self) -> &'static str {
+                "deny"
+            }
+
+            fn try_acquire<'a>(&'a self, _: &'a str, _: &'a str) -> IsrFuture<'a, bool> {
+                Box::pin(async { false })
+            }
+
+            fn release<'a>(&'a self, _: &'a str, _: &'a str) -> IsrFuture<'a, ()> {
+                Box::pin(async {})
+            }
+        }
+
+        let tmp = create_isr_dist(1);
+        let dist = tmp.path().join("dist");
+        let file = dist.join("about/index.html");
+
+        let old_time = std::time::SystemTime::now() - std::time::Duration::from_secs(100);
+        let _ = filetime::set_file_mtime(&file, filetime::FileTime::from_system_time(old_time));
+
+        let router =
+            axum::Router::new().fallback(axum::routing::get(|| async { "should not appear" }));
+        let layer = StaticFileLayer::new(&dist)
+            .expect("layer")
+            .with_router(router)
+            .with_isr_coordinator(Arc::new(DenyCoordinator));
+
+        // Trigger the ISR background task.
+        let _ = layer.resolve("/about");
+
+        // Wait for the spawned task to run the deny branch and exit.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // InFlightReset guard must have cleared the flag despite early return.
+        let state = layer.isr_state.get("/about").unwrap();
+        assert!(
+            !state.in_flight.load(Ordering::Relaxed),
+            "in_flight must be cleared when coordinator denies acquisition"
+        );
+
+        // File must be unchanged — regeneration was skipped.
+        assert_eq!(
+            std::fs::read_to_string(&file).unwrap(),
+            "<h1>About (stale)</h1>"
+        );
+    }
 }

--- a/autumn/src/static_gen/middleware.rs
+++ b/autumn/src/static_gen/middleware.rs
@@ -207,6 +207,14 @@ impl StaticFileLayer {
         let coordinator = Arc::clone(&self.isr_coordinator);
 
         tokio::spawn(async move {
+            // RAII guard: clears the in_flight flag when this scope exits,
+            // including on panic, so ISR is never permanently disabled for
+            // a route after a handler crash.
+            let _guard = InFlightReset {
+                state: &in_flight,
+                url: &url,
+            };
+
             // Distributed coordination: prevents multiple replicas from
             // regenerating the same route in the same revalidation window.
             let acquired = coordinator.try_acquire(&url, &window_key).await;
@@ -216,21 +224,13 @@ impl StaticFileLayer {
                     backend = coordinator.backend(),
                     "ISR: another replica holds the lock for this window, skipping"
                 );
-                if let Some(state) = in_flight.get(&url) {
-                    state.in_flight.store(false, Ordering::Release);
-                }
-                return;
+                return; // _guard drops here, resetting in_flight
             }
 
             let result = regenerate_page(&router, &url, &dest).await;
 
-            // Release distributed lock
+            // Release distributed lock before the guard drops.
             coordinator.release(&url, &window_key).await;
-
-            // Clear the in-process in-flight flag
-            if let Some(state) = in_flight.get(&url) {
-                state.in_flight.store(false, Ordering::Release);
-            }
 
             match result {
                 Ok(()) => {
@@ -240,7 +240,25 @@ impl StaticFileLayer {
                     tracing::warn!(route = %url, error = %e, "ISR: regeneration failed");
                 }
             }
+            // _guard drops here, resetting in_flight
         });
+    }
+}
+
+/// RAII guard that resets the per-route `in_flight` flag when dropped.
+///
+/// Placed at the top of every ISR background task so the flag is always
+/// cleared on normal exit, early return, or panic.
+struct InFlightReset<'a> {
+    state: &'a HashMap<String, IsrRouteState>,
+    url: &'a str,
+}
+
+impl Drop for InFlightReset<'_> {
+    fn drop(&mut self) {
+        if let Some(s) = self.state.get(self.url) {
+            s.in_flight.store(false, Ordering::Release);
+        }
     }
 }
 

--- a/autumn/src/static_gen/middleware.rs
+++ b/autumn/src/static_gen/middleware.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::StaticManifest;
+use super::isr_coordinator::{IsrCoordinator, LocalIsrCoordinator, isr_window_key};
 
 /// Per-route ISR state, tracking whether a regeneration is in flight
 /// and when the last regeneration attempt occurred.
@@ -52,6 +53,12 @@ pub struct StaticFileLayer {
     /// The Axum router used for ISR regeneration. Cloned from the app
     /// router at construction time. `None` if ISR is not needed.
     isr_router: Option<Arc<axum::Router>>,
+    /// Coordination backend that prevents duplicate regeneration.
+    /// Defaults to [`LocalIsrCoordinator`] (in-process only).
+    /// Use [`with_isr_coordinator`](Self::with_isr_coordinator) to supply
+    /// a distributed backend such as `PostgresIsrCoordinator` for
+    /// multi-replica deployments.
+    isr_coordinator: Arc<dyn IsrCoordinator>,
 }
 
 impl StaticFileLayer {
@@ -75,6 +82,7 @@ impl StaticFileLayer {
             manifest: Arc::new(manifest),
             isr_state: Arc::new(isr_state),
             isr_router: None,
+            isr_coordinator: Arc::new(LocalIsrCoordinator::new()),
         })
     }
 
@@ -85,6 +93,31 @@ impl StaticFileLayer {
     #[must_use]
     pub fn with_router(mut self, router: axum::Router) -> Self {
         self.isr_router = Some(Arc::new(router));
+        self
+    }
+
+    /// Set the ISR coordination backend.
+    ///
+    /// The default is [`LocalIsrCoordinator`], which is suitable for
+    /// single-replica and development deployments. For multi-replica
+    /// deployments sharing a writable `dist/` volume, supply a distributed
+    /// backend such as `PostgresIsrCoordinator` (feature `db`) to prevent
+    /// stampede writes.
+    ///
+    /// # Example (production multi-replica)
+    ///
+    /// ```rust,ignore
+    /// use std::sync::Arc;
+    /// use autumn_web::static_gen::{StaticFileLayer, PostgresIsrCoordinator};
+    ///
+    /// let layer = StaticFileLayer::new("dist")
+    ///     .unwrap()
+    ///     .with_router(app_router)
+    ///     .with_isr_coordinator(Arc::new(PostgresIsrCoordinator::new(pool)));
+    /// ```
+    #[must_use]
+    pub fn with_isr_coordinator(mut self, coordinator: Arc<dyn IsrCoordinator>) -> Self {
+        self.isr_coordinator = coordinator;
         self
     }
 
@@ -149,29 +182,52 @@ impl StaticFileLayer {
             return;
         }
 
-        // Try to claim the in-flight flag (CAS: false -> true)
+        // Try to claim the in-flight flag (CAS: false -> true).
+        // This prevents this process from spawning more than one task per route.
         if route_state
             .in_flight
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
             .is_err()
         {
-            // Another task is already regenerating this route
+            // Another task is already regenerating this route in this process
             return;
         }
 
         // Record attempt time
         route_state.last_attempt.store(now, Ordering::Relaxed);
 
+        // Compute the revalidation window key for distributed coordination
+        let window_key = isr_window_key(url_path, revalidate_secs, now);
+
         // Spawn background regeneration
         let router = Arc::clone(router);
         let url = url_path.to_owned();
         let dest = file_path.to_owned();
         let in_flight = Arc::clone(&self.isr_state);
+        let coordinator = Arc::clone(&self.isr_coordinator);
 
         tokio::spawn(async move {
+            // Distributed coordination: prevents multiple replicas from
+            // regenerating the same route in the same revalidation window.
+            let acquired = coordinator.try_acquire(&url, &window_key).await;
+            if !acquired {
+                tracing::debug!(
+                    route = %url,
+                    backend = coordinator.backend(),
+                    "ISR: another replica holds the lock for this window, skipping"
+                );
+                if let Some(state) = in_flight.get(&url) {
+                    state.in_flight.store(false, Ordering::Release);
+                }
+                return;
+            }
+
             let result = regenerate_page(&router, &url, &dest).await;
 
-            // Clear the in-flight flag
+            // Release distributed lock
+            coordinator.release(&url, &window_key).await;
+
+            // Clear the in-process in-flight flag
             if let Some(state) = in_flight.get(&url) {
                 state.in_flight.store(false, Ordering::Release);
             }

--- a/autumn/src/static_gen/mod.rs
+++ b/autumn/src/static_gen/mod.rs
@@ -13,10 +13,14 @@
 //! 2. **Runtime phase:** The `StaticFileLayer` intercepts requests. If a pre-rendered file exists, it serves it directly!
 
 pub(crate) mod build;
+pub mod isr_coordinator;
 mod middleware;
 mod types;
 
 pub use build::{BuildError, render_static_routes};
+pub use isr_coordinator::{IsrCoordinator, LocalIsrCoordinator, isr_advisory_lock_key, isr_window_key};
+#[cfg(feature = "db")]
+pub use isr_coordinator::PostgresIsrCoordinator;
 pub use middleware::StaticFileLayer;
 pub use types::{
     ManifestEntry, ParamsFn, StaticManifest, StaticParams, StaticRouteMeta, url_to_file_path,

--- a/autumn/src/static_gen/mod.rs
+++ b/autumn/src/static_gen/mod.rs
@@ -11,6 +11,52 @@
 //!
 //! 1. **Build phase:** `autumn build` discovers your `#[static_get]` routes and runs them, saving the HTML to `dist/`.
 //! 2. **Runtime phase:** The `StaticFileLayer` intercepts requests. If a pre-rendered file exists, it serves it directly!
+//!
+//! ## Build-time-only vs runtime ISR: choosing the right model
+//!
+//! ### Build-time-only (`revalidate = None`)
+//!
+//! Pages are rendered once during `autumn build` and served read-only at
+//! runtime. `dist/` can be baked into a container image or uploaded to a
+//! CDN -- no process needs write access at runtime.
+//!
+//! **When to use:** marketing pages, blog posts, documentation -- any page
+//! where staleness of a full redeploy cycle is acceptable.
+//!
+//! ### Runtime ISR (`#[static_get(..., revalidate = N)]`)
+//!
+//! Pages are pre-rendered at build time **and** refreshed in the background
+//! when they become stale (stale-while-revalidate). The serving process
+//! needs write access to `dist/` at runtime.
+//!
+//! **When to use:** product listings, leaderboards, dashboards -- pages
+//! that should stay fresh without a full redeploy but don't need to be
+//! up-to-the-second accurate.
+//!
+//! #### Multi-replica ISR
+//!
+//! In single-replica / development deployments the default
+//! [`isr_coordinator::LocalIsrCoordinator`] is sufficient: an `AtomicBool`
+//! per route prevents duplicate background tasks within the same process.
+//!
+//! In **multi-replica** deployments sharing a writable `dist/` volume or
+//! object-backed storage, each replica independently detects staleness and
+//! can race to regenerate the same page. Supply a
+//! [`isr_coordinator::PostgresIsrCoordinator`] (feature `db`) via
+//! [`StaticFileLayer::with_isr_coordinator`] so that only one replica wins
+//! the lock per revalidation window:
+//!
+//! ```rust,ignore
+//! use std::sync::Arc;
+//! use autumn_web::static_gen::{StaticFileLayer, PostgresIsrCoordinator};
+//!
+//! let layer = StaticFileLayer::new("dist")
+//!     .unwrap()
+//!     .with_router(app_router.clone())
+//!     .with_isr_coordinator(Arc::new(PostgresIsrCoordinator::new(db_pool)));
+//! ```
+//!
+//! See [`isr_coordinator`] for the full deployment contract table.
 
 pub(crate) mod build;
 pub mod isr_coordinator;

--- a/autumn/src/static_gen/mod.rs
+++ b/autumn/src/static_gen/mod.rs
@@ -64,9 +64,11 @@ mod middleware;
 mod types;
 
 pub use build::{BuildError, render_static_routes};
-pub use isr_coordinator::{IsrCoordinator, LocalIsrCoordinator, isr_advisory_lock_key, isr_window_key};
 #[cfg(feature = "db")]
 pub use isr_coordinator::PostgresIsrCoordinator;
+pub use isr_coordinator::{
+    IsrCoordinator, LocalIsrCoordinator, isr_advisory_lock_key, isr_window_key,
+};
 pub use middleware::StaticFileLayer;
 pub use types::{
     ManifestEntry, ParamsFn, StaticManifest, StaticParams, StaticRouteMeta, url_to_file_path,

--- a/autumn/tests/db_hooks_lifecycle.rs
+++ b/autumn/tests/db_hooks_lifecycle.rs
@@ -345,3 +345,109 @@ async fn db_api_token_store_two_tokens_same_principal() {
     assert_eq!(store.verify(&t1).await.unwrap(), None);
     assert_eq!(store.verify(&t2).await.unwrap(), Some("user:1".to_owned()));
 }
+
+// ── PostgresIsrCoordinator tests ─────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn postgres_isr_coordinator_backend_name() {
+    use autumn_web::static_gen::PostgresIsrCoordinator;
+    use autumn_web::static_gen::isr_coordinator::IsrCoordinator as _;
+
+    let (pool, _container) = setup_pool().await;
+    let coord = PostgresIsrCoordinator::new(pool);
+    assert_eq!(coord.backend(), "postgres");
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn postgres_isr_coordinator_acquire_grants_and_release_unlocks() {
+    use autumn_web::static_gen::PostgresIsrCoordinator;
+    use autumn_web::static_gen::isr_coordinator::IsrCoordinator as _;
+
+    let (pool, _container) = setup_pool().await;
+    let coord = PostgresIsrCoordinator::new(pool);
+
+    assert!(
+        coord.try_acquire("/about", "window-1").await,
+        "first acquire must succeed"
+    );
+    // release must not panic
+    coord.release("/about", "window-1").await;
+
+    // after release, the same window is acquirable again
+    assert!(
+        coord.try_acquire("/about", "window-1").await,
+        "acquire after release must succeed"
+    );
+    coord.release("/about", "window-1").await;
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn postgres_isr_coordinator_blocks_duplicate_window() {
+    use autumn_web::static_gen::PostgresIsrCoordinator;
+    use autumn_web::static_gen::isr_coordinator::IsrCoordinator as _;
+
+    let (pool, _container) = setup_pool().await;
+    let coord = PostgresIsrCoordinator::new(pool);
+
+    // First acquisition holds the advisory lock on its connection.
+    assert!(
+        coord.try_acquire("/about", "window-1").await,
+        "first acquire must succeed"
+    );
+
+    // Second acquisition for the same (route, window) must fail: the advisory
+    // lock is session-scoped, and the first connection still holds it.
+    assert!(
+        !coord.try_acquire("/about", "window-1").await,
+        "duplicate acquire for the same window must fail"
+    );
+
+    coord.release("/about", "window-1").await;
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn postgres_isr_coordinator_release_without_acquire_is_noop() {
+    use autumn_web::static_gen::PostgresIsrCoordinator;
+    use autumn_web::static_gen::isr_coordinator::IsrCoordinator as _;
+
+    let (pool, _container) = setup_pool().await;
+    let coord = PostgresIsrCoordinator::new(pool);
+
+    // release without a preceding acquire must not panic (emits a warning).
+    coord.release("/about", "window-1").await;
+
+    // Subsequent acquire must still succeed.
+    assert!(
+        coord.try_acquire("/about", "window-1").await,
+        "acquire after orphaned release must succeed"
+    );
+    coord.release("/about", "window-1").await;
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn postgres_isr_coordinator_independent_routes_and_windows() {
+    use autumn_web::static_gen::PostgresIsrCoordinator;
+    use autumn_web::static_gen::isr_coordinator::IsrCoordinator as _;
+
+    let (pool, _container) = setup_pool().await;
+    let coord = PostgresIsrCoordinator::new(pool);
+
+    // Different routes in the same window get different lock keys.
+    assert!(coord.try_acquire("/", "window-1").await);
+    assert!(coord.try_acquire("/about", "window-1").await);
+
+    coord.release("/", "window-1").await;
+    coord.release("/about", "window-1").await;
+
+    // Same route in different windows also gets different lock keys.
+    assert!(coord.try_acquire("/about", "window-1").await);
+    assert!(coord.try_acquire("/about", "window-2").await);
+
+    coord.release("/about", "window-1").await;
+    coord.release("/about", "window-2").await;
+}

--- a/autumn/tests/isr_coordination.rs
+++ b/autumn/tests/isr_coordination.rs
@@ -1,0 +1,177 @@
+//! Tests for ISR coordination: lock-key derivation and coordinator behavior.
+//!
+//! These tests exercise the public API of `autumn_web::static_gen::isr_coordinator`
+//! without requiring a real database or network. The Postgres coordinator is
+//! covered by integration tests in the `bookmarks-distributed` example; here
+//! we focus on the local coordinator and the pure key-derivation functions.
+
+use std::sync::Arc;
+
+use autumn_web::static_gen::isr_coordinator::{
+    IsrCoordinator, LocalIsrCoordinator, isr_advisory_lock_key, isr_window_key,
+};
+
+// ---------------------------------------------------------------------------
+// isr_window_key: stability within a window, change across windows
+// ---------------------------------------------------------------------------
+
+#[test]
+fn isr_window_key_is_stable_within_interval() {
+    // Bucket 28_333_333 covers unix seconds [1_699_999_980, 1_700_000_039].
+    // Two timestamps within that range must produce the same key.
+    let key_a = isr_window_key("/about", 60, 1_700_000_000);
+    let key_b = isr_window_key("/about", 60, 1_700_000_039);
+    assert_eq!(key_a, key_b, "same revalidation window should yield the same key");
+}
+
+#[test]
+fn isr_window_key_changes_on_new_interval() {
+    // 1_700_000_039 is the last second of bucket 28_333_333.
+    // 1_700_000_040 is the first second of bucket 28_333_334.
+    let key_a = isr_window_key("/about", 60, 1_700_000_039);
+    let key_b = isr_window_key("/about", 60, 1_700_000_040);
+    assert_ne!(key_a, key_b, "adjacent revalidation windows should yield different keys");
+}
+
+#[test]
+fn isr_window_key_includes_route_path() {
+    // Different routes in the same time window must produce different keys so
+    // that their distributed locks are independent.
+    let home = isr_window_key("/", 60, 1_700_000_010);
+    let about = isr_window_key("/about", 60, 1_700_000_010);
+    assert_ne!(home, about, "different routes must produce different window keys");
+}
+
+#[test]
+fn isr_window_key_handles_sub_second_bucket_boundary() {
+    // The 1-second revalidate edge: timestamps 99 and 100 cross a bucket.
+    let key_a = isr_window_key("/live", 1, 99);
+    let key_b = isr_window_key("/live", 1, 100);
+    assert_ne!(key_a, key_b);
+}
+
+#[test]
+fn isr_window_key_revalidate_zero_treated_as_one() {
+    // A revalidate of 0 should not cause a division-by-zero panic.
+    let key = isr_window_key("/edge", 0, 1_700_000_000);
+    assert!(!key.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// isr_advisory_lock_key: deterministic, route- and window-sensitive i64
+// ---------------------------------------------------------------------------
+
+#[test]
+fn isr_advisory_lock_key_is_stable() {
+    let a = isr_advisory_lock_key("/about", "/about:28333333");
+    let b = isr_advisory_lock_key("/about", "/about:28333333");
+    assert_eq!(a, b, "advisory lock key must be deterministic");
+}
+
+#[test]
+fn isr_advisory_lock_key_differs_by_route() {
+    let home = isr_advisory_lock_key("/", "/about:28333333");
+    let about = isr_advisory_lock_key("/about", "/about:28333333");
+    assert_ne!(home, about);
+}
+
+#[test]
+fn isr_advisory_lock_key_differs_by_window() {
+    let window_a = isr_advisory_lock_key("/about", "/about:28333333");
+    let window_b = isr_advisory_lock_key("/about", "/about:28333334");
+    assert_ne!(window_a, window_b);
+}
+
+// ---------------------------------------------------------------------------
+// LocalIsrCoordinator: in-process acquisition / release
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn local_coordinator_try_acquire_returns_true_first() {
+    let coord = LocalIsrCoordinator::new();
+    let acquired = coord.try_acquire("/about", "window-1").await;
+    assert!(acquired, "first try_acquire should succeed");
+}
+
+#[tokio::test]
+async fn local_coordinator_second_acquire_denied_while_held() {
+    let coord = LocalIsrCoordinator::new();
+    let first = coord.try_acquire("/about", "window-1").await;
+    assert!(first);
+
+    let second = coord.try_acquire("/about", "window-1").await;
+    assert!(!second, "second try_acquire for the same key should fail while first is held");
+}
+
+#[tokio::test]
+async fn local_coordinator_can_reacquire_after_release() {
+    let coord = LocalIsrCoordinator::new();
+    let first = coord.try_acquire("/about", "window-1").await;
+    assert!(first);
+
+    coord.release("/about", "window-1").await;
+
+    let second = coord.try_acquire("/about", "window-1").await;
+    assert!(second, "should be able to reacquire after release");
+}
+
+#[tokio::test]
+async fn local_coordinator_different_routes_are_independent() {
+    let coord = LocalIsrCoordinator::new();
+    let home = coord.try_acquire("/", "window-1").await;
+    let about = coord.try_acquire("/about", "window-1").await;
+    assert!(home, "/ should be acquirable");
+    assert!(about, "/about should be acquirable independently of /");
+}
+
+#[tokio::test]
+async fn local_coordinator_different_windows_are_independent() {
+    let coord = LocalIsrCoordinator::new();
+    let w1 = coord.try_acquire("/about", "window-1").await;
+    let w2 = coord.try_acquire("/about", "window-2").await;
+    assert!(w1, "window-1 should be acquirable");
+    assert!(w2, "window-2 should be acquirable independently of window-1");
+}
+
+#[tokio::test]
+async fn local_coordinator_backend_name() {
+    let coord = LocalIsrCoordinator::new();
+    assert_eq!(coord.backend(), "local");
+}
+
+// ---------------------------------------------------------------------------
+// StaticFileLayer: accepts a custom coordinator via builder
+// ---------------------------------------------------------------------------
+
+#[test]
+fn static_file_layer_with_isr_coordinator_accepts_local() {
+    use autumn_web::static_gen::{ManifestEntry, StaticFileLayer, StaticManifest};
+    use std::collections::HashMap;
+
+    // Build a minimal dist dir
+    let tmp = tempfile::tempdir().unwrap();
+    let dist = tmp.path().join("dist");
+    std::fs::create_dir_all(&dist).unwrap();
+    std::fs::write(dist.join("index.html"), "<h1>Home</h1>").unwrap();
+
+    let mut routes = HashMap::new();
+    routes.insert(
+        "/".to_owned(),
+        ManifestEntry {
+            file: "index.html".to_owned(),
+            revalidate: None,
+        },
+    );
+    let manifest = StaticManifest {
+        generated_at: "2026-05-06T00:00:00Z".to_owned(),
+        autumn_version: "0.3.0".to_owned(),
+        routes,
+    };
+    let json = serde_json::to_string(&manifest).unwrap();
+    std::fs::write(dist.join("manifest.json"), json).unwrap();
+
+    // Should compile and not panic
+    let _layer = StaticFileLayer::new(&dist)
+        .expect("layer")
+        .with_isr_coordinator(Arc::new(LocalIsrCoordinator::new()));
+}

--- a/autumn/tests/isr_coordination.rs
+++ b/autumn/tests/isr_coordination.rs
@@ -21,7 +21,10 @@ fn isr_window_key_is_stable_within_interval() {
     // Two timestamps within that range must produce the same key.
     let key_a = isr_window_key("/about", 60, 1_700_000_000);
     let key_b = isr_window_key("/about", 60, 1_700_000_039);
-    assert_eq!(key_a, key_b, "same revalidation window should yield the same key");
+    assert_eq!(
+        key_a, key_b,
+        "same revalidation window should yield the same key"
+    );
 }
 
 #[test]
@@ -30,7 +33,10 @@ fn isr_window_key_changes_on_new_interval() {
     // 1_700_000_040 is the first second of bucket 28_333_334.
     let key_a = isr_window_key("/about", 60, 1_700_000_039);
     let key_b = isr_window_key("/about", 60, 1_700_000_040);
-    assert_ne!(key_a, key_b, "adjacent revalidation windows should yield different keys");
+    assert_ne!(
+        key_a, key_b,
+        "adjacent revalidation windows should yield different keys"
+    );
 }
 
 #[test]
@@ -39,7 +45,10 @@ fn isr_window_key_includes_route_path() {
     // that their distributed locks are independent.
     let home = isr_window_key("/", 60, 1_700_000_010);
     let about = isr_window_key("/about", 60, 1_700_000_010);
-    assert_ne!(home, about, "different routes must produce different window keys");
+    assert_ne!(
+        home, about,
+        "different routes must produce different window keys"
+    );
 }
 
 #[test]
@@ -91,7 +100,10 @@ async fn local_coordinator_always_grants_acquisition() {
     // LocalIsrCoordinator is a true no-op: local dedup is handled by the
     // AtomicBool in StaticFileLayer, not by this coordinator.
     let coord = LocalIsrCoordinator::new();
-    assert!(coord.try_acquire("/about", "window-1").await, "first call should succeed");
+    assert!(
+        coord.try_acquire("/about", "window-1").await,
+        "first call should succeed"
+    );
     // A second concurrent call also returns true — no HashMap tracking.
     assert!(
         coord.try_acquire("/about", "window-1").await,
@@ -123,7 +135,10 @@ async fn local_coordinator_different_windows_are_independent() {
     let w1 = coord.try_acquire("/about", "window-1").await;
     let w2 = coord.try_acquire("/about", "window-2").await;
     assert!(w1, "window-1 should be acquirable");
-    assert!(w2, "window-2 should be acquirable independently of window-1");
+    assert!(
+        w2,
+        "window-2 should be acquirable independently of window-1"
+    );
 }
 
 #[tokio::test]

--- a/autumn/tests/isr_coordination.rs
+++ b/autumn/tests/isr_coordination.rs
@@ -87,32 +87,25 @@ fn isr_advisory_lock_key_differs_by_window() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn local_coordinator_try_acquire_returns_true_first() {
+async fn local_coordinator_always_grants_acquisition() {
+    // LocalIsrCoordinator is a true no-op: local dedup is handled by the
+    // AtomicBool in StaticFileLayer, not by this coordinator.
     let coord = LocalIsrCoordinator::new();
-    let acquired = coord.try_acquire("/about", "window-1").await;
-    assert!(acquired, "first try_acquire should succeed");
+    assert!(coord.try_acquire("/about", "window-1").await, "first call should succeed");
+    // A second concurrent call also returns true — no HashMap tracking.
+    assert!(
+        coord.try_acquire("/about", "window-1").await,
+        "local coordinator always grants (no-op dedup)"
+    );
 }
 
 #[tokio::test]
-async fn local_coordinator_second_acquire_denied_while_held() {
+async fn local_coordinator_release_is_noop_and_does_not_panic() {
     let coord = LocalIsrCoordinator::new();
-    let first = coord.try_acquire("/about", "window-1").await;
-    assert!(first);
-
-    let second = coord.try_acquire("/about", "window-1").await;
-    assert!(!second, "second try_acquire for the same key should fail while first is held");
-}
-
-#[tokio::test]
-async fn local_coordinator_can_reacquire_after_release() {
-    let coord = LocalIsrCoordinator::new();
-    let first = coord.try_acquire("/about", "window-1").await;
-    assert!(first);
-
+    // release without a prior acquire must not panic.
     coord.release("/about", "window-1").await;
-
-    let second = coord.try_acquire("/about", "window-1").await;
-    assert!(second, "should be able to reacquire after release");
+    // Subsequent acquire still works.
+    assert!(coord.try_acquire("/about", "window-1").await);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Introduces a pluggable ISR (Incremental Static Regeneration) coordination system to prevent duplicate page regeneration across multiple replicas. The default `LocalIsrCoordinator` handles single-process deduplication, while the new `PostgresIsrCoordinator` uses Postgres advisory locks for fleet-wide coordination.

## Key Changes

- **New `isr_coordinator` module** with trait-based coordinator abstraction:
  - `IsrCoordinator` trait defining `try_acquire()` and `release()` operations
  - `LocalIsrCoordinator`: in-process HashMap-based locking (default, no-op for single replica)
  - `PostgresIsrCoordinator`: distributed locking via `pg_try_advisory_lock` (feature-gated on `db`)

- **Key derivation utilities**:
  - `isr_window_key()`: generates stable keys for (route, time-window) pairs so replicas in the same revalidation bucket coordinate on the same lock
  - `isr_advisory_lock_key()`: derives deterministic i64 lock keys from window keys using SHA256 hashing

- **StaticFileLayer integration**:
  - Added `isr_coordinator` field with `LocalIsrCoordinator` default
  - New `with_isr_coordinator()` builder method to supply custom backends
  - Background regeneration now calls `coordinator.try_acquire()` before work and `coordinator.release()` after completion
  - Skips regeneration if another replica holds the lock for the current window

- **Comprehensive test coverage**:
  - Unit tests in `isr_coordinator.rs` for key derivation and local coordinator behavior
  - Integration tests in `tests/isr_coordination.rs` validating window stability, lock independence, and coordinator API
  - Test verifying `StaticFileLayer` accepts custom coordinators

## Implementation Details

- Window keys encode both the route path and a time bucket (derived from `now / revalidate_secs`), ensuring all replicas observing the same stale page in the same period attempt the same distributed lock
- Postgres coordinator manages connection lifecycle: checks out a connection for the lock duration, returns it on release
- Graceful degradation: if Postgres lock acquisition fails, the replica skips regeneration rather than proceeding unsafely
- Documentation includes deployment contract table and multi-replica usage examples

https://claude.ai/code/session_011f1FvDznWtKEkU2RLz8B2Z