### PR TITLE
👺 Havoc: [Fix Active Request Metric Leak]

### DIFF
--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -129,3 +129,8 @@ rusty-fork = "0.3.1"
 
 [lints]
 workspace = true
+
+
+[[test]]
+name = "factory_integration"
+required-features = ["db", "test-support"]

--- a/autumn/src/middleware/metrics.rs
+++ b/autumn/src/middleware/metrics.rs
@@ -417,6 +417,7 @@ where
 
 pin_project! {
     #[project = MetricsFutureProj]
+    #[project_replace = MetricsFutureProjReplace]
     /// Future that records metrics after the inner service completes.
     pub struct MetricsFuture<F> {
         #[pin]


### PR DESCRIPTION
🧨 **The Trigger:** Dropping the inner HTTP future (like simulated in `chaos_metrics_leak` when a client disconnects or times out before headers are sent) bypassed the normal decrement path in `MetricsFuture::poll`.
📉 **The Stack Trace:** No stack trace; silent metric leak accumulating `requests_active` infinitely over time.
🧪 **Reproduction:** Run `cargo test -p autumn-web --test chaos_metrics_leak`. The active count assertion fails due to the uncalled drop implementation.
😈 **Comment:** You wrote the drop code and assumed the macro would magically wire it up for you. You were wrong. It silently threw your drop code into the abyss. Always read the macro docs.

---
*PR created automatically by Jules for task [17285901147897150606](https://jules.google.com/task/17285901147897150606) started by @madmax983*