### PR TITLE
fix(csrf): remove misplaced duplicate CsrfToken doc block above CsrfFormField

### DIFF
--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -59,28 +59,6 @@ use super::config::CsrfConfig;
 /// Error body returned with a `403 Forbidden` when CSRF validation fails.
 const CSRF_FORBIDDEN_MESSAGE: &str = "CSRF token missing or invalid";
 
-/// A CSRF token extracted from the request.
-///
-/// Use this as a handler parameter to access the CSRF token for embedding
-/// in HTML forms. The token is generated per-request and stored in
-/// request extensions by the [`CsrfLayer`].
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// use autumn_web::prelude::*;
-/// use autumn_web::security::CsrfToken;
-///
-/// #[get("/edit")]
-/// async fn edit_form(csrf: CsrfToken) -> Markup {
-///     html! {
-///         form method="POST" {
-///             input type="hidden" name="_csrf" value=(csrf.token());
-///             // ...
-///         }
-///     }
-/// }
-/// ```
 /// The configured CSRF form field name, placed in request extensions by [`CsrfLayer`].
 ///
 /// [`ChangesetForm`](crate::form::ChangesetForm) reads this so `form_tag` emits the


### PR DESCRIPTION
## Summary

Removes a misplaced, duplicate `CsrfToken` documentation block that was incorrectly attached to `CsrfFormField`, based on code review feedback.

## Changes

- Deleted the duplicate `CsrfToken` doc comment (22 lines) that was placed above `CsrfFormField` instead of `CsrfToken`
- The correct `CsrfToken` documentation and usage example remain intact at the proper location directly above the `CsrfToken` struct
- `CsrfFormField` is now correctly documented by its own concise doc comment

## Notes

This is purely a documentation cleanup — no behaviour changes. The misplaced block shadowed `CsrfFormField`'s own doc comment and duplicated the `CsrfToken` docs unnecessarily.

https://claude.ai/code/session_01N33PozVQd5zGWdb6dn79xS