### PR TITLE
⚒️ Forge: [Refactor Error Pages and Filters]

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2848,7 +2848,7 @@ impl StorageBootstrap {
 #[cfg(feature = "storage")]
 #[allow(clippy::too_many_lines)] // Single switch over backend variants reads as one unit.
 fn preflight_storage(config: &AutumnConfig) -> Option<StorageBootstrap> {
-    use crate::storage::{LocalBlobStore, SharedBlobStore, StorageBackendPlan, local::SigningKey};
+    use crate::storage::StorageBackendPlan;
 
     let plan = config
         .storage
@@ -2871,69 +2871,14 @@ fn preflight_storage(config: &AutumnConfig) -> Option<StorageBootstrap> {
             mount_path,
             default_url_expiry_secs,
             warn_in_production,
-        } => {
-            if warn_in_production {
-                tracing::warn!(
-                    "prod profile is using the local-disk blob store; \
-                     bytes won't survive replica turnover. Set \
-                     storage.backend=s3 or storage.allow_local_in_production=true \
-                     to acknowledge"
-                );
-            }
-            let signing_key = config
-                .storage
-                .local
-                .signing_key
-                .as_deref()
-                .filter(|s| !s.is_empty())
-                .map_or_else(
-                    || {
-                        if matches!(config.profile.as_deref(), Some("prod" | "production")) {
-                            tracing::warn!(
-                                "no storage.local.signing_key configured in prod; \
-                                 generated URLs won't survive a process restart. \
-                                 Set [storage.local].signing_key or \
-                                 AUTUMN_STORAGE__LOCAL__SIGNING_KEY"
-                            );
-                        }
-                        SigningKey::random()
-                    },
-                    |s| SigningKey::new(s.as_bytes().to_vec()),
-                );
-            let store = match LocalBlobStore::new(
-                provider_id.clone(),
-                root.clone(),
-                mount_path.clone(),
-                std::time::Duration::from_secs(default_url_expiry_secs),
-                signing_key,
-            ) {
-                Ok(store) => store,
-                Err(err) => {
-                    // The operator explicitly chose `storage.backend = "local"`
-                    // — a non-writable root means uploads can't possibly
-                    // work, so abort the boot rather than letting upload
-                    // handlers serve 500s after deploy.
-                    tracing::error!(
-                        error = %err,
-                        root = %root.display(),
-                        "failed to initialize local blob store; aborting startup"
-                    );
-                    std::process::exit(1);
-                }
-            };
-            let serving = crate::storage::local::serve_router(&store);
-            let arc: SharedBlobStore = std::sync::Arc::new(store);
-            tracing::info!(
-                provider = %provider_id,
-                root = %root.display(),
-                mount = %mount_path,
-                "Local blob store mounted"
-            );
-            Some(StorageBootstrap {
-                store: arc,
-                serving: Some(serving),
-            })
-        }
+        } => Some(bootstrap_local_storage(
+            config,
+            &provider_id,
+            &root,
+            &mount_path,
+            default_url_expiry_secs,
+            warn_in_production,
+        )),
         StorageBackendPlan::S3 { .. } => {
             // `storage.backend = "s3"` requires the `autumn-storage-s3` plugin.
             // Construct an `S3BlobStore` and register it with `.with_blob_store()`
@@ -2950,6 +2895,84 @@ fn preflight_storage(config: &AutumnConfig) -> Option<StorageBootstrap> {
     }
 }
 
+#[cfg(feature = "storage")]
+fn bootstrap_local_storage(
+    config: &AutumnConfig,
+    provider_id: &str,
+    root: &std::path::Path,
+    mount_path: &str,
+    default_url_expiry_secs: u64,
+    warn_in_production: bool,
+) -> StorageBootstrap {
+    use crate::storage::{LocalBlobStore, SharedBlobStore, local::SigningKey};
+
+    if warn_in_production {
+        tracing::warn!(
+            "prod profile is using the local-disk blob store; \
+             bytes won't survive replica turnover. Set \
+             storage.backend=s3 or storage.allow_local_in_production=true \
+             to acknowledge"
+        );
+    }
+
+    let signing_key = config
+        .storage
+        .local
+        .signing_key
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .map_or_else(
+            || {
+                if matches!(config.profile.as_deref(), Some("prod" | "production")) {
+                    tracing::warn!(
+                        "no storage.local.signing_key configured in prod; \
+                         generated URLs won't survive a process restart. \
+                         Set [storage.local].signing_key or \
+                         AUTUMN_STORAGE__LOCAL__SIGNING_KEY"
+                    );
+                }
+                SigningKey::random()
+            },
+            |s| SigningKey::new(s.as_bytes().to_vec()),
+        );
+
+    let store = match LocalBlobStore::new(
+        provider_id.to_string(),
+        root.to_path_buf(),
+        mount_path.to_string(),
+        std::time::Duration::from_secs(default_url_expiry_secs),
+        signing_key,
+    ) {
+        Ok(store) => store,
+        Err(err) => {
+            // The operator explicitly chose `storage.backend = "local"`
+            // — a non-writable root means uploads can't possibly
+            // work, so abort the boot rather than letting upload
+            // handlers serve 500s after deploy.
+            tracing::error!(
+                error = %err,
+                root = %root.display(),
+                "failed to initialize local blob store; aborting startup"
+            );
+            std::process::exit(1);
+        }
+    };
+
+    let serving = crate::storage::local::serve_router(&store);
+    let arc: SharedBlobStore = std::sync::Arc::new(store);
+
+    tracing::info!(
+        provider = %provider_id,
+        root = %root.display(),
+        mount = %mount_path,
+        "Local blob store mounted"
+    );
+
+    StorageBootstrap {
+        store: arc,
+        serving: Some(serving),
+    }
+}
 async fn load_config_and_telemetry(
     config_loader: Option<ConfigLoaderFactory>,
     telemetry_provider: Option<Box<dyn crate::telemetry::TelemetryProvider>>,

--- a/autumn/src/error_pages/defaults.rs
+++ b/autumn/src/error_pages/defaults.rs
@@ -31,12 +31,7 @@ impl ErrorPageRenderer for DefaultErrorPages {
                         }
                         " could not be found."
                     }
-                    div class="mt-8" {
-                        a href="/"
-                          class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
-                            "Go to homepage"
-                        }
-                    }
+                    (home_link())
                 }
             },
         )
@@ -61,12 +56,7 @@ impl ErrorPageRenderer for DefaultErrorPages {
                             "Request ID: " (req_id)
                         }
                     }
-                    div class="mt-8" {
-                        a href="/"
-                          class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
-                            "Go to homepage"
-                        }
-                    }
+                    (home_link())
                 }
             },
         )
@@ -102,12 +92,7 @@ impl ErrorPageRenderer for DefaultErrorPages {
                             }
                         }
                     }
-                    div class="mt-8" {
-                        a href="/"
-                          class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
-                            "Go to homepage"
-                        }
-                    }
+                    (home_link())
                 }
             },
         )
@@ -135,12 +120,7 @@ impl ErrorPageRenderer for DefaultErrorPages {
                             "Request ID: " (req_id)
                         }
                     }
-                    div class="mt-8" {
-                        a href="/"
-                          class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
-                            "Go to homepage"
-                        }
-                    }
+                    (home_link())
                 }
             },
         )
@@ -148,6 +128,18 @@ impl ErrorPageRenderer for DefaultErrorPages {
 }
 
 /// Shared HTML layout wrapper for all error pages.
+/// Reusable "Go to homepage" button for error pages
+fn home_link() -> Markup {
+    html! {
+        div class="mt-8" {
+            a href="/"
+              class="inline-block px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-md hover:bg-gray-700 dark:hover:bg-gray-300 transition-colors" {
+                "Go to homepage"
+            }
+        }
+    }
+}
+
 fn error_page_layout(ctx: &ErrorContext, content: &Markup) -> Markup {
     let status_code = ctx.status.as_u16();
     let reason = ctx.status.canonical_reason().unwrap_or("Error");

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -29,8 +29,6 @@ pub struct ErrorPageFilter {
 
 impl ExceptionFilter for ErrorPageFilter {
     fn filter(&self, error: &AutumnErrorInfo, response: Response) -> Response {
-        // Check if the original request wanted HTML (stored in extensions
-        // by the error page middleware layer).
         let wants_html = response
             .extensions()
             .get::<WantsHtml>()
@@ -40,76 +38,16 @@ impl ExceptionFilter for ErrorPageFilter {
             return response;
         }
 
-        let request_id = response
-            .extensions()
-            .get::<ErrorPageRequestContext>()
-            .and_then(|ctx| {
-                ctx.request_id
-                    .as_ref()
-                    .map(std::string::ToString::to_string)
-            });
-
-        let path = response
-            .extensions()
-            .get::<ErrorPageRequestContext>()
-            .map(|ctx| ctx.uri.path().to_string())
-            .unwrap_or_default();
-
-        let ctx = ErrorContext {
-            status: error.status,
-            message: error.message.clone(),
-            path,
-            request_id: request_id.clone(),
-            details: error.details.clone(),
-            is_dev: self.is_dev,
-        };
-
+        let ctx = Self::build_error_context(error, &response, self.is_dev);
         let mut html_body =
             error_pages::render_error_page(self.renderer.as_ref(), error.status, &ctx)
                 .into_string();
 
-        // In dev mode, inject the error badge before </body>
         if self.is_dev {
-            let badge_ctx = DevBadgeContext {
-                status_code: error.status.as_u16(),
-                status_reason: error
-                    .status
-                    .canonical_reason()
-                    .unwrap_or("Error")
-                    .to_string(),
-                message: error.message.clone(),
-                path: ctx.path,
-                request_id,
-                source_location: None,
-            };
-            let badge = dev_badge::dev_error_badge_html(&badge_ctx).into_string();
-            if let Some(pos) = html_body.rfind("</body>") {
-                html_body.insert_str(pos, &badge);
-            } else {
-                html_body.push_str(&badge);
-            }
+            Self::inject_dev_badge(&mut html_body, error, &ctx);
         }
 
-        let content_length = html_body.len();
-
-        let mut resp = (
-            error.status,
-            [(axum::http::header::CONTENT_TYPE, "text/html; charset=utf-8")],
-            html_body,
-        )
-            .into_response();
-
-        // Re-attach error info so downstream filters still see it
-        resp.extensions_mut().insert(error.clone());
-
-        // Ensure content-length is set correctly, as middleware might otherwise
-        // drop it in some environments like fallback routes.
-        resp.headers_mut().insert(
-            axum::http::header::CONTENT_LENGTH,
-            axum::http::HeaderValue::from(content_length),
-        );
-
-        resp
+        Self::build_html_response(error, html_body)
     }
 }
 
@@ -298,6 +236,82 @@ pub async fn fallback_404_handler(method: axum::http::Method, uri: axum::http::U
 
     crate::error::AutumnError::not_found_msg(format!("No route matches {}", uri.path()))
         .into_response()
+}
+
+impl ErrorPageFilter {
+    fn build_error_context(
+        error: &AutumnErrorInfo,
+        response: &Response,
+        is_dev: bool,
+    ) -> ErrorContext {
+        let request_id = response
+            .extensions()
+            .get::<ErrorPageRequestContext>()
+            .and_then(|ctx| {
+                ctx.request_id
+                    .as_ref()
+                    .map(std::string::ToString::to_string)
+            });
+
+        let path = response
+            .extensions()
+            .get::<ErrorPageRequestContext>()
+            .map(|ctx| ctx.uri.path().to_string())
+            .unwrap_or_default();
+
+        ErrorContext {
+            status: error.status,
+            message: error.message.clone(),
+            path,
+            request_id,
+            details: error.details.clone(),
+            is_dev,
+        }
+    }
+
+    fn inject_dev_badge(html_body: &mut String, error: &AutumnErrorInfo, ctx: &ErrorContext) {
+        let badge_ctx = DevBadgeContext {
+            status_code: error.status.as_u16(),
+            status_reason: error
+                .status
+                .canonical_reason()
+                .unwrap_or("Error")
+                .to_string(),
+            message: error.message.clone(),
+            path: ctx.path.clone(),
+            request_id: ctx.request_id.clone(),
+            source_location: None,
+        };
+        let badge = dev_badge::dev_error_badge_html(&badge_ctx).into_string();
+        if let Some(pos) = html_body.rfind("</body>") {
+            html_body.insert_str(pos, &badge);
+        } else {
+            html_body.push_str(&badge);
+        }
+    }
+
+    fn build_html_response(error: &AutumnErrorInfo, html_body: String) -> Response {
+        let content_length = html_body.len();
+
+        let mut resp = (
+            error.status,
+            [(axum::http::header::CONTENT_TYPE, "text/html; charset=utf-8")],
+            html_body,
+        )
+            .into_response();
+
+        // Re-attach error info so downstream filters still see it
+        resp.extensions_mut().insert(error.clone());
+
+        // Ensure content-length is set correctly, as middleware might otherwise
+        // drop it in some environments like fallback routes.
+        resp.headers_mut().insert(
+            axum::http::header::CONTENT_LENGTH,
+            axum::http::HeaderValue::from(content_length),
+        );
+
+        resp
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🚮 Smell: 
- "Pyramid of Doom" and "God Function" smells were detected across multiple files. Specifically, `error_page_filter.rs` contained deeply nested HTML logic within the Axum filter method. `defaults.rs` repeated the same "Go to homepage" Tailwind anchor block four times. `app.rs` featured a deeply nested storage matching arm that reduced readability.

✨ Solution: 
- Extracted `home_link()` from duplicate declarations in `defaults.rs` to reuse the HTML block.
- Extracted context building and response creation into `build_error_context`, `inject_dev_badge`, and `build_html_response` in `error_page_filter.rs` to flatten the logic of the `filter` method.
- Extracted local storage bootstrapping into a well-named helper function `bootstrap_local_storage` to simplify `preflight_storage` in `app.rs`.

🧼 Benefit: 
- Reduces cognitive load and adheres to DRY principles. Flattening functions like the exception filter and preflight storage ensures logic remains highly legible.

🛡️ Verification: 
- Tests passed. No logic changed. Verified thoroughly with `cargo test -p autumn-web` and `cargo clippy --all-targets --all-features -- -D warnings`. Code reviewer marked as correct.

---
*PR created automatically by Jules for task [8039666547283570136](https://jules.google.com/task/8039666547283570136) started by @madmax983*