### PR TITLE
 feat(mail): add dev mailer preview UI

### DIFF
--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -18,7 +18,9 @@ mod collect;
 mod i18n;
 mod job;
 mod jobs_macro;
+mod mail_previews_macro;
 mod mailer;
+mod mailer_preview;
 mod main_macro;
 mod model;
 mod oauth2_callback;
@@ -233,6 +235,18 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn mailer(attr: TokenStream, item: TokenStream) -> TokenStream {
     mailer::mailer_macro(attr.into(), item.into()).into()
+}
+
+/// Register zero-argument mail preview methods for the dev mail preview UI.
+#[proc_macro_attribute]
+pub fn mailer_preview(attr: TokenStream, item: TokenStream) -> TokenStream {
+    mailer_preview::mailer_preview_macro(attr.into(), item.into()).into()
+}
+
+/// Collect `#[mailer_preview]` impl blocks into runtime preview registrations.
+#[proc_macro]
+pub fn mail_previews(input: TokenStream) -> TokenStream {
+    mail_previews_macro::mail_previews_macro(input.into()).into()
 }
 
 /// Attribute macro for Autumn database models.

--- a/autumn-macros/src/mail_previews_macro.rs
+++ b/autumn-macros/src/mail_previews_macro.rs
@@ -1,0 +1,26 @@
+//! `mail_previews![]` proc macro implementation.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::parse::Parser;
+use syn::punctuated::Punctuated;
+use syn::{Token, Type};
+
+pub fn mail_previews_macro(input: TokenStream) -> TokenStream {
+    let types = match Punctuated::<Type, Token![,]>::parse_terminated.parse2(input) {
+        Ok(types) => types,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    let registrations = types.iter().map(|ty| {
+        quote! {
+            previews.extend(#ty::__autumn_mail_previews());
+        }
+    });
+
+    quote! {{
+        let mut previews = ::std::vec::Vec::new();
+        #( #registrations )*
+        previews
+    }}
+}

--- a/autumn-macros/src/mailer.rs
+++ b/autumn-macros/src/mailer.rs
@@ -14,7 +14,7 @@ struct MailMethod {
     args: Vec<(syn::Ident, Type)>,
 }
 
-fn returns_mail(method: &ImplItemFn) -> bool {
+pub fn returns_mail(method: &ImplItemFn) -> bool {
     let ReturnType::Type(_, ty) = &method.sig.output else {
         return false;
     };

--- a/autumn-macros/src/mailer_preview.rs
+++ b/autumn-macros/src/mailer_preview.rs
@@ -1,0 +1,155 @@
+//! `#[mailer_preview]` proc macro implementation.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{FnArg, ImplItem, ImplItemFn, ItemImpl, Type};
+
+struct PreviewMethod {
+    method: syn::Ident,
+    cfg_attrs: Vec<syn::Attribute>,
+}
+
+fn parse_preview_method(method: &ImplItemFn) -> syn::Result<Option<PreviewMethod>> {
+    if !crate::mailer::returns_mail(method) {
+        return Ok(None);
+    }
+    if method.sig.asyncness.is_some() {
+        return Err(syn::Error::new_spanned(
+            &method.sig.ident,
+            "#[mailer_preview] methods must be synchronous and return Mail",
+        ));
+    }
+    if !method.sig.generics.params.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &method.sig.generics,
+            "#[mailer_preview] methods must not have generics",
+        ));
+    }
+    if method.sig.inputs.iter().any(|arg| match arg {
+        FnArg::Receiver(_) | FnArg::Typed(_) => true,
+    }) {
+        return Err(syn::Error::new_spanned(
+            &method.sig.inputs,
+            "#[mailer_preview] methods must be zero-arg associated functions",
+        ));
+    }
+
+    Ok(Some(PreviewMethod {
+        method: method.sig.ident.clone(),
+        cfg_attrs: method
+            .attrs
+            .iter()
+            .filter(|attr| attr.path().is_ident("cfg") || attr.path().is_ident("cfg_attr"))
+            .cloned()
+            .collect(),
+    }))
+}
+
+fn mailer_name(self_ty: &Type) -> String {
+    if let Type::Path(type_path) = self_ty
+        && let Some(segment) = type_path.path.segments.last()
+    {
+        return segment.ident.to_string();
+    }
+    quote!(#self_ty).to_string().replace(' ', "")
+}
+
+pub fn mailer_preview_macro(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input_impl: ItemImpl = match syn::parse2(item) {
+        Ok(item) => item,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    let self_ty = input_impl.self_ty.clone();
+    let input_generics = input_impl.generics.clone();
+    let (impl_generics, _ty_generics, where_clause) = input_generics.split_for_impl();
+    let impl_cfg_attrs = input_impl
+        .attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("cfg") || attr.path().is_ident("cfg_attr"))
+        .cloned()
+        .collect::<Vec<_>>();
+    let mailer_name = mailer_name(&self_ty);
+
+    let mut methods = Vec::new();
+    for item in &input_impl.items {
+        if let ImplItem::Fn(method) = item {
+            match parse_preview_method(method) {
+                Ok(Some(method)) => methods.push(method),
+                Ok(None) => {}
+                Err(err) => return err.to_compile_error(),
+            }
+        }
+    }
+
+    let registrations = methods.iter().map(|method| {
+        let method_name = &method.method;
+        let method_label = method_name.to_string();
+        let cfg_attrs = &method.cfg_attrs;
+        quote! {
+            #( #cfg_attrs )*
+            previews.push(::autumn_web::mail::MailPreview::new(
+                #mailer_name,
+                #method_label,
+                Self::#method_name,
+            ));
+        }
+    });
+
+    quote! {
+        #input_impl
+
+        #( #impl_cfg_attrs )*
+        impl #impl_generics #self_ty #where_clause {
+            #[doc(hidden)]
+            pub fn __autumn_mail_previews() -> ::std::vec::Vec<::autumn_web::mail::MailPreview> {
+                let mut previews = ::std::vec::Vec::new();
+                #( #registrations )*
+                previews
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+
+    #[test]
+    fn generates_preview_registration_helper() {
+        let out = mailer_preview_macro(
+            TokenStream::new(),
+            quote! {
+                impl AccountMailer {
+                    fn reset_preview() -> Mail {
+                        panic!("template body is irrelevant to macro rendering test")
+                    }
+                }
+            },
+        );
+        let rendered = out.to_string();
+        assert!(rendered.contains("__autumn_mail_previews"));
+        assert!(rendered.contains("AccountMailer"));
+        assert!(rendered.contains("reset_preview"));
+    }
+
+    #[test]
+    fn rejects_preview_methods_with_arguments() {
+        let out = mailer_preview_macro(
+            TokenStream::new(),
+            quote! {
+                impl AccountMailer {
+                    fn reset_preview(to: String) -> Mail {
+                        let _ = to;
+                        panic!("template body is irrelevant to macro rendering test")
+                    }
+                }
+            },
+        );
+        assert!(
+            out.to_string()
+                .contains("methods must be zero-arg associated functions")
+        );
+    }
+}

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -107,6 +107,8 @@ pub fn app() -> AppBuilder {
         policy_registrations: Vec::new(),
         #[cfg(feature = "mail")]
         mail_delivery_queue_factory: None,
+        #[cfg(feature = "mail")]
+        mail_previews: Vec::new(),
     }
 }
 
@@ -266,6 +268,9 @@ pub struct AppBuilder {
     /// can capture framework-managed resources (DB pool, channels, etc.).
     #[cfg(feature = "mail")]
     mail_delivery_queue_factory: Option<MailDeliveryQueueFactory>,
+    /// Mail template previews registered for the dev preview UI.
+    #[cfg(feature = "mail")]
+    mail_previews: Vec<crate::mail::MailPreview>,
 }
 
 /// Boxed builder closure that constructs a durable
@@ -1183,6 +1188,19 @@ impl AppBuilder {
         self
     }
 
+    /// Register mail template previews for the dev mail preview UI.
+    ///
+    /// Pair this with `#[mailer_preview]` and `mail_previews![...]`.
+    #[cfg(feature = "mail")]
+    #[must_use]
+    pub fn mail_previews(
+        mut self,
+        previews: impl IntoIterator<Item = crate::mail::MailPreview>,
+    ) -> Self {
+        self.mail_previews.extend(previews);
+        self
+    }
+
     /// Register an additional audit sink for structured audit events.
     ///
     /// Multiple calls accumulate sinks. Logged events are fanned out to all
@@ -1421,6 +1439,8 @@ impl AppBuilder {
             policy_registrations,
             #[cfg(feature = "mail")]
             mail_delivery_queue_factory,
+            #[cfg(feature = "mail")]
+            mail_previews,
         } = self;
 
         let all_routes = routes;
@@ -1543,6 +1563,8 @@ impl AppBuilder {
             tracing::error!(error = %error, "Failed to configure mailer");
             std::process::exit(1);
         });
+        #[cfg(feature = "mail")]
+        state.insert_extension(crate::mail::MailPreviewRegistry::new(mail_previews));
         if let Some(logger) = audit_logger {
             state.insert_extension::<crate::audit::AuditLogger>((*logger).clone());
         }
@@ -1745,6 +1767,8 @@ impl AppBuilder {
             policy_registrations,
             #[cfg(feature = "mail")]
             mail_delivery_queue_factory,
+            #[cfg(feature = "mail")]
+            mail_previews,
         } = self;
 
         let all_routes = routes;
@@ -1854,6 +1878,8 @@ impl AppBuilder {
             eprintln!("Failed to configure mailer: {error}");
             std::process::exit(1);
         });
+        #[cfg(feature = "mail")]
+        state.insert_extension(crate::mail::MailPreviewRegistry::new(mail_previews));
         // run_build_mode used ProbeState::default(), which does not start as pending
         state.probes = crate::probe::ProbeState::default();
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1801,6 +1801,7 @@ impl AutumnConfig {
             "AUTUMN_MAIL__ALLOW_IN_PROCESS_DELIVER_LATER_IN_PRODUCTION",
             &mut self.mail.allow_in_process_deliver_later_in_production,
         );
+        parse_env_bool(env, "AUTUMN_MAIL__PREVIEW", &mut self.mail.preview);
         if let Ok(val) = env.var("AUTUMN_MAIL__FILE_DIR") {
             self.mail.file_dir = PathBuf::from(val);
         }

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -321,9 +321,15 @@ pub use autumn_macros::api_doc;
 /// }
 /// ```
 pub use autumn_macros::get;
+/// Collect mailer preview registrations into an `AppBuilder`.
+#[cfg(feature = "mail")]
+pub use autumn_macros::mail_previews;
 /// Generate ergonomic `send_*` and `deliver_later_*` helpers for mailer impls.
 #[cfg(feature = "mail")]
 pub use autumn_macros::mailer;
+/// Register zero-argument mail template previews for the dev mail UI.
+#[cfg(feature = "mail")]
+pub use autumn_macros::mailer_preview;
 /// Set up the Tokio async runtime for an Autumn application.
 ///
 /// A thin wrapper around `#[tokio::main]`. The real framework setup

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -9,8 +9,10 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::extract::FromRequestParts;
+use axum::response::{Html, IntoResponse, Response};
 use lettre::message::{Mailbox, MultiPart, SinglePart};
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
@@ -125,6 +127,12 @@ pub struct MailConfig {
     /// Directory for file transport.
     #[serde(default = "default_file_dir")]
     pub file_dir: PathBuf,
+    /// Force-enable the dev mail preview UI.
+    ///
+    /// The UI is auto-enabled in `dev` when `mail.transport = "file"`.
+    /// Setting this flag outside `dev` is rejected at startup.
+    #[serde(default)]
+    pub preview: bool,
     /// SMTP settings.
     #[serde(default)]
     pub smtp: SmtpConfig,
@@ -139,6 +147,7 @@ impl Default for MailConfig {
             allow_log_in_production: false,
             allow_in_process_deliver_later_in_production: false,
             file_dir: default_file_dir(),
+            preview: false,
             smtp: SmtpConfig::default(),
         }
     }
@@ -169,7 +178,18 @@ impl MailConfig {
             ));
         }
 
+        if self.preview && !matches!(profile, Some("dev" | "development")) {
+            return Err(crate::config::ConfigError::Validation(
+                "mail.preview = true is only allowed in dev; refusing to mount /_autumn/mail outside the dev profile".to_owned(),
+            ));
+        }
+
         Ok(())
+    }
+
+    pub(crate) fn preview_routes_enabled(&self, profile: Option<&str>) -> bool {
+        matches!(profile, Some("dev" | "development"))
+            && (self.preview || self.transport == Transport::File)
     }
 }
 
@@ -216,6 +236,119 @@ pub struct Mail {
     pub html: Option<String>,
     /// Plain-text body.
     pub text: Option<String>,
+}
+
+/// Stable root path for the dev mail preview UI.
+pub const MAIL_PREVIEW_PATH: &str = "/_autumn/mail";
+
+const MAIL_PREVIEW_MESSAGE_PATH: &str = "/_autumn/mail/messages/{message_id}";
+const MAIL_PREVIEW_TEMPLATE_PATH: &str = "/_autumn/mail/previews/{mailer}/{method}";
+
+/// A developer-authored, zero-argument mail template preview.
+#[derive(Clone)]
+pub struct MailPreview {
+    mailer: &'static str,
+    method: &'static str,
+    render: fn() -> Mail,
+}
+
+impl std::fmt::Debug for MailPreview {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MailPreview")
+            .field("mailer", &self.mailer)
+            .field("method", &self.method)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MailPreview {
+    /// Register a mail preview for the dev mail preview UI.
+    #[must_use]
+    pub const fn new(mailer: &'static str, method: &'static str, render: fn() -> Mail) -> Self {
+        Self {
+            mailer,
+            method,
+            render,
+        }
+    }
+
+    /// Mailer type label used in preview URLs.
+    #[must_use]
+    pub const fn mailer(&self) -> &'static str {
+        self.mailer
+    }
+
+    /// Preview method label used in preview URLs.
+    #[must_use]
+    pub const fn method(&self) -> &'static str {
+        self.method
+    }
+
+    /// Render the preview without invoking any configured transport.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MailPreviewError::PreviewPanicked`] if the preview function
+    /// panics while constructing sample data.
+    pub fn render(&self) -> Result<Mail, MailPreviewError> {
+        std::panic::catch_unwind(|| (self.render)()).map_err(|_| {
+            MailPreviewError::PreviewPanicked {
+                mailer: self.mailer,
+                method: self.method,
+            }
+        })
+    }
+}
+
+/// Collection of registered mail previews stored on [`AppState`].
+#[derive(Debug, Clone, Default)]
+pub struct MailPreviewRegistry {
+    previews: Arc<Vec<MailPreview>>,
+}
+
+impl MailPreviewRegistry {
+    /// Create a registry from preview registrations.
+    #[must_use]
+    pub fn new(previews: Vec<MailPreview>) -> Self {
+        Self {
+            previews: Arc::new(previews),
+        }
+    }
+
+    /// Registered previews.
+    #[must_use]
+    pub fn previews(&self) -> &[MailPreview] {
+        &self.previews
+    }
+
+    fn find(&self, mailer: &str, method: &str) -> Option<MailPreview> {
+        self.previews
+            .iter()
+            .find(|preview| preview.mailer == mailer && preview.method == method)
+            .cloned()
+    }
+}
+
+/// Dev mail preview UI errors.
+#[derive(Debug, Error)]
+pub enum MailPreviewError {
+    /// File transport preview IO failed.
+    #[error("mail preview file IO failed: {0}")]
+    Io(#[from] std::io::Error),
+    /// Requested captured message was not found.
+    #[error("captured mail message not found: {0}")]
+    NotFound(String),
+    /// Requested message id is not a single `.eml` filename.
+    #[error("invalid captured mail message id: {0}")]
+    InvalidMessageId(String),
+    /// Developer-authored preview panicked while rendering sample data.
+    #[error("mail preview {mailer}::{method} panicked while rendering")]
+    PreviewPanicked {
+        /// Mailer label.
+        mailer: &'static str,
+        /// Method label.
+        method: &'static str,
+    },
 }
 
 impl Mail {
@@ -828,6 +961,12 @@ fn render_eml(mail: &Mail) -> String {
         out.push_str(reply_to);
         out.push('\n');
     }
+    out.push_str("Date: ");
+    out.push_str(&chrono::Utc::now().to_rfc2822());
+    out.push('\n');
+    out.push_str("Message-Id: <");
+    out.push_str(&uuid::Uuid::new_v4().to_string());
+    out.push_str("@autumn.local>\n");
     out.push_str("Subject: ");
     out.push_str(&mail.subject);
     out.push_str("\nMIME-Version: 1.0\n");
@@ -854,6 +993,468 @@ fn render_eml(mail: &Mail) -> String {
         out.push('\n');
     }
     out
+}
+
+#[derive(Debug, Clone)]
+struct ParsedMail {
+    headers: Vec<(String, String)>,
+    to: Vec<String>,
+    subject: String,
+    date: Option<String>,
+    html: Option<String>,
+    text: Option<String>,
+    raw: String,
+}
+
+impl ParsedMail {
+    fn header_value(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(header, _)| header.eq_ignore_ascii_case(name))
+            .map(|(_, value)| value.as_str())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CapturedMailSummary {
+    id: String,
+    to: Vec<String>,
+    subject: String,
+    timestamp: String,
+    modified: SystemTime,
+}
+
+pub(crate) fn mail_preview_router(file_dir: PathBuf) -> axum::Router<AppState> {
+    let file_dir = Arc::new(file_dir);
+    axum::Router::new()
+        .route(
+            MAIL_PREVIEW_PATH,
+            axum::routing::get({
+                let file_dir = Arc::clone(&file_dir);
+                move |axum::extract::State(state): axum::extract::State<AppState>| {
+                    let file_dir = Arc::clone(&file_dir);
+                    async move { list_mail_preview(file_dir, state).await }
+                }
+            }),
+        )
+        .route(
+            MAIL_PREVIEW_MESSAGE_PATH,
+            axum::routing::get({
+                let file_dir = Arc::clone(&file_dir);
+                move |axum::extract::Path(message_id): axum::extract::Path<String>| {
+                    let file_dir = Arc::clone(&file_dir);
+                    async move { show_captured_mail(file_dir, message_id).await }
+                }
+            }),
+        )
+        .route(
+            MAIL_PREVIEW_TEMPLATE_PATH,
+            axum::routing::get(
+                |axum::extract::Path((mailer, method)): axum::extract::Path<(String, String)>,
+                 axum::extract::State(state): axum::extract::State<AppState>| async move {
+                    show_template_preview(&state, &mailer, &method)
+                },
+            ),
+        )
+}
+
+async fn list_mail_preview(file_dir: Arc<PathBuf>, state: AppState) -> Response {
+    match captured_messages(&file_dir).await {
+        Ok(messages) => {
+            let previews = state
+                .extension::<MailPreviewRegistry>()
+                .map(|registry| registry.previews().to_vec())
+                .unwrap_or_default();
+            html_response(render_mail_index(&messages, &previews, &file_dir))
+        }
+        Err(error) => preview_error_response(&error),
+    }
+}
+
+async fn show_captured_mail(file_dir: Arc<PathBuf>, message_id: String) -> Response {
+    match read_captured_message(&file_dir, &message_id).await {
+        Ok(parsed) => html_response(render_mail_detail(&parsed, "Captured message")),
+        Err(error) => preview_error_response(&error),
+    }
+}
+
+fn show_template_preview(state: &AppState, mailer: &str, method: &str) -> Response {
+    let preview = state
+        .extension::<MailPreviewRegistry>()
+        .and_then(|registry| registry.find(mailer, method));
+    let Some(preview) = preview else {
+        return preview_error_response(&MailPreviewError::NotFound(format!("{mailer}/{method}")));
+    };
+
+    match preview.render() {
+        Ok(mail) => {
+            let raw = render_eml(&mail);
+            let parsed = parse_eml(&raw);
+            html_response(render_mail_detail(&parsed, "Template preview"))
+        }
+        Err(error) => preview_error_response(&error),
+    }
+}
+
+async fn captured_messages(dir: &Path) -> Result<Vec<CapturedMailSummary>, MailPreviewError> {
+    let mut entries = match tokio::fs::read_dir(dir).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error.into()),
+    };
+
+    let mut messages = Vec::new();
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if !path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("eml"))
+        {
+            continue;
+        }
+        let Some(id) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        let metadata = entry.metadata().await?;
+        let modified = metadata.modified().unwrap_or(UNIX_EPOCH);
+        let raw = tokio::fs::read_to_string(&path).await?;
+        let parsed = parse_eml(&raw);
+        messages.push(CapturedMailSummary {
+            id: id.to_owned(),
+            to: parsed.to,
+            subject: parsed.subject,
+            timestamp: parsed.date.unwrap_or_else(|| format_system_time(modified)),
+            modified,
+        });
+    }
+
+    messages.sort_by(|left, right| {
+        right
+            .modified
+            .cmp(&left.modified)
+            .then_with(|| right.id.cmp(&left.id))
+    });
+    Ok(messages)
+}
+
+async fn read_captured_message(
+    dir: &Path,
+    message_id: &str,
+) -> Result<ParsedMail, MailPreviewError> {
+    if !valid_message_id(message_id) {
+        return Err(MailPreviewError::InvalidMessageId(message_id.to_owned()));
+    }
+    let path = dir.join(message_id);
+    let raw = match tokio::fs::read_to_string(&path).await {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(MailPreviewError::NotFound(message_id.to_owned()));
+        }
+        Err(error) => return Err(error.into()),
+    };
+    Ok(parse_eml(&raw))
+}
+
+fn valid_message_id(message_id: &str) -> bool {
+    !message_id.is_empty()
+        && Path::new(message_id)
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("eml"))
+        && !message_id.contains('/')
+        && !message_id.contains('\\')
+        && !message_id.contains("..")
+}
+
+fn parse_eml(raw: &str) -> ParsedMail {
+    let normalized = raw.replace("\r\n", "\n");
+    let (headers, body) = split_headers_body(&normalized);
+    let content_type = header_value(&headers, "Content-Type").unwrap_or_default();
+    let (html, text) = parse_mail_body(&content_type, body);
+    let to = header_values(&headers, "To");
+    let subject = header_value(&headers, "Subject").unwrap_or_else(|| "(no subject)".to_owned());
+    let date = header_value(&headers, "Date");
+
+    ParsedMail {
+        headers,
+        to,
+        subject,
+        date,
+        html,
+        text,
+        raw: raw.to_owned(),
+    }
+}
+
+fn split_headers_body(raw: &str) -> (Vec<(String, String)>, &str) {
+    let Some((header_block, body)) = raw.split_once("\n\n") else {
+        return (parse_header_block(raw), "");
+    };
+    (parse_header_block(header_block), body)
+}
+
+fn parse_header_block(header_block: &str) -> Vec<(String, String)> {
+    let mut headers = Vec::new();
+    let mut current: Option<(String, String)> = None;
+
+    for line in header_block.lines() {
+        if line.starts_with(' ') || line.starts_with('\t') {
+            if let Some((_, value)) = current.as_mut() {
+                value.push(' ');
+                value.push_str(line.trim());
+            }
+            continue;
+        }
+        if let Some(header) = current.take() {
+            headers.push(header);
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            current = Some((name.trim().to_owned(), value.trim().to_owned()));
+        }
+    }
+    if let Some(header) = current {
+        headers.push(header);
+    }
+    headers
+}
+
+fn header_value(headers: &[(String, String)], name: &str) -> Option<String> {
+    headers
+        .iter()
+        .find(|(header, _)| header.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.clone())
+}
+
+fn header_values(headers: &[(String, String)], name: &str) -> Vec<String> {
+    headers
+        .iter()
+        .filter(|(header, _)| header.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.clone())
+        .collect()
+}
+
+fn parse_mail_body(content_type: &str, body: &str) -> (Option<String>, Option<String>) {
+    if content_type
+        .to_ascii_lowercase()
+        .contains("multipart/alternative")
+        && let Some(boundary) = content_type_boundary(content_type)
+    {
+        return parse_multipart_alternative(body, &boundary);
+    }
+
+    if content_type.to_ascii_lowercase().contains("text/html") {
+        (Some(trim_body(body)), None)
+    } else {
+        (None, Some(trim_body(body)))
+    }
+}
+
+fn parse_multipart_alternative(body: &str, boundary: &str) -> (Option<String>, Option<String>) {
+    let marker = format!("--{boundary}");
+    let mut html = None;
+    let mut text = None;
+
+    for segment in body.split(&marker).skip(1) {
+        let segment = segment.trim_start_matches(['\n', '\r']);
+        if segment.starts_with("--") {
+            break;
+        }
+        let (headers, part_body) = split_headers_body(segment);
+        let content_type = header_value(&headers, "Content-Type").unwrap_or_default();
+        if content_type.to_ascii_lowercase().contains("text/html") {
+            html = Some(trim_body(part_body));
+        } else if content_type.to_ascii_lowercase().contains("text/plain") {
+            text = Some(trim_body(part_body));
+        }
+    }
+
+    (html, text)
+}
+
+fn content_type_boundary(content_type: &str) -> Option<String> {
+    content_type.split(';').find_map(|part| {
+        let part = part.trim();
+        let (name, value) = part.split_once('=')?;
+        if !name.trim().eq_ignore_ascii_case("boundary") {
+            return None;
+        }
+        Some(value.trim().trim_matches('"').to_owned())
+    })
+}
+
+fn trim_body(body: &str) -> String {
+    body.trim_matches(['\r', '\n']).to_owned()
+}
+
+fn format_system_time(time: SystemTime) -> String {
+    let datetime: chrono::DateTime<chrono::Utc> = time.into();
+    datetime.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn render_mail_index(
+    messages: &[CapturedMailSummary],
+    previews: &[MailPreview],
+    file_dir: &Path,
+) -> String {
+    let mut body = String::new();
+    body.push_str("<h1>Autumn Mail</h1>");
+    body.push_str("<section><h2>Captured messages</h2>");
+    if messages.is_empty() {
+        body.push_str("<p class=\"empty\">No captured emails yet. Set <code>mail.transport = &quot;file&quot;</code>, send an email, then refresh this page. Autumn reads <code>");
+        body.push_str(&escape_html(&file_dir.display().to_string()));
+        body.push_str("</code>.</p>");
+    } else {
+        body.push_str(
+            "<table><thead><tr><th>Timestamp</th><th>To</th><th>Subject</th></tr></thead><tbody>",
+        );
+        for message in messages {
+            body.push_str("<tr><td>");
+            body.push_str(&escape_html(&message.timestamp));
+            body.push_str("</td><td>");
+            body.push_str(&escape_html(&message.to.join(", ")));
+            body.push_str("</td><td><a href=\"");
+            body.push_str(MAIL_PREVIEW_PATH);
+            body.push_str("/messages/");
+            body.push_str(&escape_html(&message.id));
+            body.push_str("\">");
+            body.push_str(&escape_html(&message.subject));
+            body.push_str("</a></td></tr>");
+        }
+        body.push_str("</tbody></table>");
+    }
+    body.push_str("</section><section><h2>Template previews</h2>");
+    if previews.is_empty() {
+        body.push_str("<p class=\"empty\">No mailer previews registered.</p>");
+    } else {
+        body.push_str("<table><thead><tr><th>Mailer</th><th>Preview</th></tr></thead><tbody>");
+        for preview in previews {
+            body.push_str("<tr><td>");
+            body.push_str(&escape_html(preview.mailer()));
+            body.push_str("</td><td><a href=\"");
+            body.push_str(MAIL_PREVIEW_PATH);
+            body.push_str("/previews/");
+            body.push_str(&escape_html(preview.mailer()));
+            body.push('/');
+            body.push_str(&escape_html(preview.method()));
+            body.push_str("\">");
+            body.push_str(&escape_html(preview.method()));
+            body.push_str("</a></td></tr>");
+        }
+        body.push_str("</tbody></table>");
+    }
+    body.push_str("</section>");
+    render_mail_preview_layout("Autumn Mail", &body)
+}
+
+fn render_mail_detail(parsed: &ParsedMail, label: &str) -> String {
+    let mut body = String::new();
+    body.push_str("<p><a href=\"");
+    body.push_str(MAIL_PREVIEW_PATH);
+    body.push_str("\">Back to mail</a></p><h1>");
+    body.push_str(&escape_html(&parsed.subject));
+    body.push_str("</h1><p class=\"muted\">");
+    body.push_str(&escape_html(label));
+    body.push_str("</p>");
+
+    if let Some(html) = &parsed.html {
+        body.push_str("<iframe title=\"Rendered HTML email\" sandbox srcdoc=\"");
+        body.push_str(&escape_html(html));
+        body.push_str("\"></iframe>");
+    } else {
+        body.push_str("<p class=\"empty\">No HTML body was found for this email.</p>");
+    }
+
+    body.push_str("<details><summary>Plain text</summary><pre>");
+    body.push_str(&escape_html(parsed.text.as_deref().unwrap_or("")));
+    body.push_str("</pre></details>");
+
+    body.push_str("<details><summary>Headers</summary><dl>");
+    for header in ["From", "To", "Reply-To", "Subject", "Date", "Message-Id"] {
+        if let Some(value) = parsed.header_value(header) {
+            body.push_str("<dt>");
+            body.push_str(header);
+            body.push_str("</dt><dd>");
+            body.push_str(&escape_html(value));
+            body.push_str("</dd>");
+        }
+    }
+    body.push_str("</dl></details>");
+
+    body.push_str("<details><summary>Raw .eml</summary><pre>");
+    body.push_str(&escape_html(&parsed.raw));
+    body.push_str("</pre></details>");
+
+    render_mail_preview_layout(&parsed.subject, &body)
+}
+
+fn render_mail_preview_layout(title: &str, body: &str) -> String {
+    format!(
+        "<!doctype html><html><head><meta charset=\"utf-8\"><title>{}</title><style>{}</style></head><body>{}</body></html>",
+        escape_html(title),
+        MAIL_PREVIEW_CSS,
+        body
+    )
+}
+
+const MAIL_PREVIEW_CSS: &str = r#"
+body{margin:0;padding:24px;font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#1f2933;background:#f6f8fa}
+h1{margin:0 0 16px;font-size:28px}
+h2{margin:28px 0 12px;font-size:18px}
+table{width:100%;border-collapse:collapse;background:white;border:1px solid #d9e2ec}
+th,td{padding:10px 12px;border-bottom:1px solid #e5eaf0;text-align:left;font-size:14px;vertical-align:top}
+th{background:#edf2f7;color:#394b59;font-weight:650}
+a{color:#0b63ce;text-decoration:none}
+a:hover{text-decoration:underline}
+.empty,.muted{color:#52616f}
+code,pre{font-family:ui-monospace,SFMono-Regular,Consolas,monospace}
+pre{white-space:pre-wrap;background:#111827;color:#f8fafc;padding:12px;overflow:auto}
+iframe{width:100%;min-height:420px;border:1px solid #cbd5e1;background:white}
+details{margin-top:14px;background:white;border:1px solid #d9e2ec;padding:10px 12px}
+summary{cursor:pointer;font-weight:650}
+dt{font-weight:650;margin-top:8px}
+dd{margin:2px 0 8px}
+"#;
+
+fn html_response(html: String) -> Response {
+    Html(html).into_response()
+}
+
+fn preview_error_response(error: &MailPreviewError) -> Response {
+    let status = match error {
+        MailPreviewError::NotFound(_) | MailPreviewError::InvalidMessageId(_) => {
+            http::StatusCode::NOT_FOUND
+        }
+        MailPreviewError::Io(_) | MailPreviewError::PreviewPanicked { .. } => {
+            http::StatusCode::INTERNAL_SERVER_ERROR
+        }
+    };
+    (
+        status,
+        Html(render_mail_preview_layout(
+            "Mail preview error",
+            &format!(
+                "<h1>Mail preview error</h1><p>{}</p>",
+                escape_html(&error.to_string())
+            ),
+        )),
+    )
+        .into_response()
+}
+
+fn escape_html(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
 }
 
 fn parse_mailbox(address: &str) -> Result<Mailbox, MailError> {

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -26,8 +26,6 @@
 pub use crate::Redirect;
 /// Typed path helper extension trait (`.with_query()`).
 pub use crate::paths::PathExt;
-#[cfg(feature = "mail")]
-pub use autumn_macros::mailer;
 /// WebSocket route macro.
 #[cfg(feature = "ws")]
 pub use autumn_macros::ws;
@@ -37,6 +35,8 @@ pub use autumn_macros::{
     patch, paths, post, put, routes, scheduled, secured, service, static_get, static_routes, task,
     tasks,
 };
+#[cfg(feature = "mail")]
+pub use autumn_macros::{mail_previews, mailer, mailer_preview};
 
 // ── Rendering ────────────────────────────────────────────────────
 /// Resolve a logical static asset path to a fingerprinted URL in release builds.
@@ -72,8 +72,8 @@ pub use crate::htmx::{HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HxRequest};
 /// Transactional email types and extractor.
 #[cfg(feature = "mail")]
 pub use crate::mail::{
-    Mail, MailConfig, MailDeliveryQueue, MailDeliveryQueueHandle, MailError, MailTransport, Mailer,
-    SmtpConfig, TlsMode, Transport,
+    Mail, MailConfig, MailDeliveryQueue, MailDeliveryQueueHandle, MailError, MailPreview,
+    MailPreviewError, MailPreviewRegistry, MailTransport, Mailer, SmtpConfig, TlsMode, Transport,
 };
 /// Server-Sent Events (SSE) support.
 pub use crate::sse::{Event, Sse};

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -168,6 +168,32 @@ pub(crate) fn append_framework_routes(
         });
     }
 
+    #[cfg(feature = "mail")]
+    if config
+        .mail
+        .preview_routes_enabled(config.profile.as_deref())
+    {
+        for (path, handler) in [
+            (crate::mail::MAIL_PREVIEW_PATH, "mail_preview"),
+            (
+                "/_autumn/mail/messages/{message_id}",
+                "mail_preview_message",
+            ),
+            (
+                "/_autumn/mail/previews/{mailer}/{method}",
+                "mail_preview_template",
+            ),
+        ] {
+            infos.push(RouteInfo {
+                method: "GET".to_owned(),
+                path: path.to_owned(),
+                handler: handler.to_owned(),
+                source: RouteSource::Framework,
+                middleware: Vec::new(),
+            });
+        }
+    }
+
     // Static file serving is unconditionally mounted at /static.
     infos.push(RouteInfo {
         method: "GET".to_owned(),

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -255,7 +255,7 @@ pub fn try_build_router_inner(
 
     let dev_reload_enabled = dev::is_enabled_with_env(&crate::config::OsEnv);
 
-    router = mount_framework_routes(router, dev_reload_enabled);
+    router = mount_framework_routes(router, config, dev_reload_enabled);
 
     let (mounted_probe_paths, router_with_probes) = mount_probe_endpoints(router, config);
     router = router_with_probes;
@@ -661,6 +661,15 @@ fn reject_openapi_path_collisions(
         claimed.insert(dev::LIVE_RELOAD_PATH.to_owned());
         claimed.insert(dev::LIVE_RELOAD_SCRIPT_PATH.to_owned());
     }
+    #[cfg(feature = "mail")]
+    if config
+        .mail
+        .preview_routes_enabled(config.profile.as_deref())
+    {
+        claimed.insert(crate::mail::MAIL_PREVIEW_PATH.to_owned());
+        claimed.insert("/_autumn/mail/messages/{message_id}".to_owned());
+        claimed.insert("/_autumn/mail/previews/{mailer}/{method}".to_owned());
+    }
 
     check_openapi_path_against(
         "openapi_json_path",
@@ -766,6 +775,7 @@ fn group_and_mount_routes(route_list: Vec<Route>) -> axum::Router<AppState> {
 
 fn mount_framework_routes(
     mut router: axum::Router<AppState>,
+    config: &AutumnConfig,
     dev_reload_enabled: bool,
 ) -> axum::Router<AppState> {
     // Framework-provided routes
@@ -803,6 +813,20 @@ fn mount_framework_routes(
             state_path = dev::LIVE_RELOAD_PATH,
             script_path = dev::LIVE_RELOAD_SCRIPT_PATH,
             "Mounted dev live reload endpoints"
+        );
+    }
+
+    #[cfg(feature = "mail")]
+    if config
+        .mail
+        .preview_routes_enabled(config.profile.as_deref())
+    {
+        router = router.merge(crate::mail::mail_preview_router(
+            config.mail.file_dir.clone(),
+        ));
+        tracing::debug!(
+            path = crate::mail::MAIL_PREVIEW_PATH,
+            "Mounted dev mail preview endpoints"
         );
     }
 
@@ -1779,6 +1803,164 @@ mod tests {
             .unwrap();
         assert_eq!(blocked.status(), StatusCode::TOO_MANY_REQUESTS);
         assert!(blocked.headers().get("retry-after").is_some());
+    }
+
+    #[cfg(feature = "mail")]
+    fn dev_mail_preview_config(dir: &std::path::Path) -> AutumnConfig {
+        AutumnConfig {
+            profile: Some("dev".to_owned()),
+            mail: crate::mail::MailConfig {
+                transport: crate::mail::Transport::File,
+                file_dir: dir.to_path_buf(),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[cfg(feature = "mail")]
+    async fn response_text(response: axum::response::Response) -> String {
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should collect");
+        String::from_utf8(body.to_vec()).expect("body should be utf8")
+    }
+
+    #[cfg(feature = "mail")]
+    #[tokio::test]
+    async fn build_router_mounts_dev_mail_preview_empty_state_for_file_transport() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = dev_mail_preview_config(dir.path());
+        let router = build_router(Vec::new(), &config, test_state());
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/_autumn/mail")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_text(response).await;
+        assert!(
+            body.contains("No captured emails"),
+            "missing empty state: {body}"
+        );
+        assert!(
+            body.contains("mail.transport = &quot;file&quot;"),
+            "empty state should explain capture setup: {body}"
+        );
+    }
+
+    #[cfg(feature = "mail")]
+    #[tokio::test]
+    async fn build_router_lists_captured_mail_newest_first() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let older = dir.path().join("older.eml");
+        let newer = dir.path().join("newer.eml");
+        std::fs::write(
+            &older,
+            "To: first@example.com\nSubject: First\nDate: Tue, 05 May 2026 10:00:00 +0000\nMessage-Id: <first@example.com>\n\nfirst body\n",
+        )
+        .expect("write older eml");
+        std::fs::write(
+            &newer,
+            "To: second@example.com\nSubject: Second\nDate: Tue, 05 May 2026 10:01:00 +0000\nMessage-Id: <second@example.com>\n\nsecond body\n",
+        )
+        .expect("write newer eml");
+        filetime::set_file_mtime(&older, filetime::FileTime::from_unix_time(100, 0))
+            .expect("set older mtime");
+        filetime::set_file_mtime(&newer, filetime::FileTime::from_unix_time(200, 0))
+            .expect("set newer mtime");
+
+        let config = dev_mail_preview_config(dir.path());
+        let router = build_router(Vec::new(), &config, test_state());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/_autumn/mail")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_text(response).await;
+        let second = body.find("Second").expect("newer subject should render");
+        let first = body.find("First").expect("older subject should render");
+        assert!(second < first, "newest message should render first: {body}");
+        assert!(
+            body.contains("second@example.com"),
+            "missing To column: {body}"
+        );
+        assert!(
+            body.contains("Timestamp"),
+            "missing timestamp column: {body}"
+        );
+    }
+
+    #[cfg(feature = "mail")]
+    #[tokio::test]
+    async fn build_router_mail_preview_detail_renders_html_in_sandboxed_iframe() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("detail.eml"),
+            "From: Autumn <noreply@example.com>\nTo: ada@example.com\nReply-To: support@example.com\nSubject: Reset\nDate: Tue, 05 May 2026 10:00:00 +0000\nMessage-Id: <reset@example.com>\nMIME-Version: 1.0\nContent-Type: multipart/alternative; boundary=\"autumn-mail\"\n\n--autumn-mail\nContent-Type: text/plain; charset=utf-8\n\nPlain reset\n--autumn-mail\nContent-Type: text/html; charset=utf-8\n\n<h1>Hello iframe</h1>\n--autumn-mail--\n",
+        )
+        .expect("write detail eml");
+
+        let config = dev_mail_preview_config(dir.path());
+        let router = build_router(Vec::new(), &config, test_state());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/_autumn/mail/messages/detail.eml")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_text(response).await;
+        assert!(body.contains("<iframe"), "missing iframe: {body}");
+        assert!(body.contains("sandbox"), "iframe must be sandboxed: {body}");
+        assert!(body.contains("Hello iframe"), "missing html body: {body}");
+        assert!(body.contains("Plain text"), "missing text toggle: {body}");
+        assert!(body.contains("Headers"), "missing headers toggle: {body}");
+        assert!(
+            body.contains("Raw .eml"),
+            "missing raw source toggle: {body}"
+        );
+        assert!(
+            body.contains("Message-Id"),
+            "missing message id header: {body}"
+        );
+    }
+
+    #[cfg(feature = "mail")]
+    #[tokio::test]
+    async fn build_router_does_not_mount_mail_preview_outside_dev() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut config = dev_mail_preview_config(dir.path());
+        config.profile = Some("prod".to_owned());
+        let router = build_router(Vec::new(), &config, test_state());
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/_autumn/mail")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/autumn/tests/mail.rs
+++ b/autumn/tests/mail.rs
@@ -41,6 +41,30 @@ from = "noreply@example.com"
 }
 
 #[test]
+fn prod_profile_rejects_forced_mail_preview() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("autumn.toml"),
+        r#"
+[mail]
+transport = "file"
+preview = true
+"#,
+    )
+    .expect("write config");
+    let env = MockEnv::new()
+        .with("AUTUMN_MANIFEST_DIR", dir.path().to_str().unwrap())
+        .with("AUTUMN_PROFILE", "prod");
+
+    let error = AutumnConfig::load_with_env(&env).expect_err("prod preview must fail");
+
+    assert!(
+        error.to_string().contains("mail.preview"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
 fn dev_mail_table_without_transport_defaults_to_log() {
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::write(

--- a/autumn/tests/mail_macro.rs
+++ b/autumn/tests/mail_macro.rs
@@ -65,6 +65,19 @@ impl AccountMailer {
     }
 }
 
+#[mailer_preview]
+impl AccountMailer {
+    fn reset_password_preview() -> Mail {
+        Mail::builder()
+            .to("preview@example.com")
+            .subject("Preview reset")
+            .html(html! { p { "Preview token" } })
+            .text("Preview token")
+            .build()
+            .expect("valid preview mail")
+    }
+}
+
 struct GenericAccountMailer<T> {
     marker: std::marker::PhantomData<T>,
 }
@@ -111,6 +124,19 @@ fn mailer_macro_generates_send_helpers() {
             .count(),
         1
     );
+}
+
+#[test]
+fn mailer_preview_macro_registers_zero_arg_methods() {
+    let previews = mail_previews![AccountMailer];
+
+    assert_eq!(previews.len(), 1);
+    assert_eq!(previews[0].mailer(), "AccountMailer");
+    assert_eq!(previews[0].method(), "reset_password_preview");
+
+    let mail = previews[0].render().expect("preview should render");
+    assert_eq!(mail.subject, "Preview reset");
+    assert_eq!(mail.to, ["preview@example.com"]);
 }
 
 #[test]

--- a/docs/guide/mail.md
+++ b/docs/guide/mail.md
@@ -84,6 +84,54 @@ If the route also persists DB state (for example, writing an outbox row plus
 creating a user), wrap the DB side in [`Db::tx`](transactions.md) so your write
 sequence is atomic.
 
+## Previewing Emails In Dev
+
+When the active profile is `dev` and `[mail] transport = "file"`, Autumn mounts
+the mail preview UI at `/_autumn/mail`. The index shows recent `.eml` captures
+from `mail.file_dir` newest-first and links to a detail view with sandboxed HTML,
+plain text, selected headers, and raw source.
+
+Register sample-data previews with `#[mailer_preview]` and `mail_previews![...]`:
+
+```rust
+use autumn_web::prelude::*;
+
+struct AccountMailer;
+
+#[mailer]
+impl AccountMailer {
+    fn reset_password(&self, to: String, token: String) -> Mail {
+        Mail::builder()
+            .to(to)
+            .subject("Reset your password")
+            .html(html! { p { "Token: " (token) } })
+            .text(format!("Token: {token}"))
+            .build()
+            .expect("static template should be valid")
+    }
+}
+
+#[mailer_preview]
+impl AccountMailer {
+    fn reset_password_preview() -> Mail {
+        AccountMailer.reset_password("preview@example.com".into(), "abc123".into())
+    }
+}
+
+autumn_web::app()
+    .mail_previews(mail_previews![AccountMailer])
+    .run()
+    .await;
+```
+
+Preview methods are zero-argument associated functions returning `Mail`; they
+render through the UI without invoking any transport. Adding a new preview method
+and refreshing `/_autumn/mail` is enough after the normal `autumn dev` recompile.
+
+The preview UI is a dev-only surface. Setting `[mail] preview = true` outside the
+`dev` profile fails startup with a `mail.preview` validation error instead of
+silently exposing captured email in production.
+
 ## Deferred Delivery (`deliver_later`)
 
 `Mailer::deliver_later` and the generated `deliver_later_*` helpers do **not**

--- a/examples/reddit-clone/autumn-dev.toml
+++ b/examples/reddit-clone/autumn-dev.toml
@@ -3,3 +3,6 @@
 
 [database]
 url = "postgres://autumn:autumn@localhost:5432/reddit"
+
+[mail]
+transport = "file"

--- a/examples/reddit-clone/src/main.rs
+++ b/examples/reddit-clone/src/main.rs
@@ -8,6 +8,7 @@
 //   Mutation hooks      -> before_create / before_update lifecycle hooks
 //   Authentication      -> Session cookies, bcrypt hashing, session.rotate_id()
 //   Transactional Email -> Mailer extractor + #[mailer] welcome email template
+//   Mail previews       -> dev-only /_autumn/mail preview registration
 //   Authorization       -> #[secured] macro for route protection
 //   CSRF protection     -> CsrfToken extractor in forms
 //   Validation          -> #[validate(length(min, max))] on model fields
@@ -71,6 +72,7 @@ async fn main() {
             repositories::post_api_list,
             repositories::post_api_get,
         ])
+        .mail_previews(routes::auth::mail_previews())
         .policy::<Post, _>(PostPolicy)
         .static_routes(static_routes![routes::about::about])
         .tasks(tasks![

--- a/examples/reddit-clone/src/routes/auth.rs
+++ b/examples/reddit-clone/src/routes/auth.rs
@@ -37,6 +37,20 @@ impl AccountMailer {
     }
 }
 
+#[mailer_preview]
+impl AccountMailer {
+    fn welcome_preview() -> Mail {
+        AccountMailer.welcome(
+            "preview@example.com".to_owned(),
+            "cool_rustacean".to_owned(),
+        )
+    }
+}
+
+pub fn mail_previews() -> Vec<MailPreview> {
+    mail_previews![AccountMailer]
+}
+
 // ── Register ───────────────────────────────────────────────────
 
 #[get("/register")]


### PR DESCRIPTION
  Add dev-only /_autumn/mail routes for file transport captures, including
  newest-first listing, sandboxed HTML detail rendering, headers, text, and raw
  EML views.

  Add #[mailer_preview] and mail_previews![...] support for zero-arg Mail
  template previews, wire preview registration into AppBuilder, document the dev
  workflow, and add reddit-clone example wiring.