### PR TITLE
feat(admin): add jobs dashboard for background work

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ async fn main() {
 - [Code Generators](docs/guide/generators.md) — `autumn generate model | migration | scaffold`
 - [One-Off Tasks](docs/guide/tasks.md) - `#[task]`, `one_off_tasks![]`, and `autumn task`
 - [Multi-Replica Scheduled Tasks](docs/guide/scheduled-multi-replica.md) - `#[scheduled]` with Postgres advisory-lock coordination
+- [Operating Background Jobs](docs/guide/operating-background-jobs.md) - admin dashboard and recovery actions for `#[job]`
 - [Mail Guide](docs/guide/mail.md)
 - [Cloud-Native Guide](docs/guide/cloud-native.md)
 - [Todo Tutorial](docs/guide/tutorial/index.md)

--- a/autumn-admin-plugin/README.md
+++ b/autumn-admin-plugin/README.md
@@ -9,6 +9,7 @@
 
 - Mounts an admin UI under `/admin` by default
 - Generates list, create, detail, edit, delete, and bulk-action flows
+- Includes a built-in jobs dashboard for queued, running, completed, and failed work
 - Uses Maud + HTMX and works under Autumn's default `Content-Security-Policy`
 - Reads and writes model data through a small `AdminModel` trait
 - Requires an authenticated session with the `"admin"` role by default
@@ -23,8 +24,10 @@ autumn-web = { version = "0.3", features = ["db", "flash", "htmx", "maud"] }
 autumn-admin-plugin = "0.3"
 ```
 
-`autumn-admin-plugin` expects a configured Autumn database pool because all
- admin model operations receive the app's Postgres pool.
+`autumn-admin-plugin` expects a configured Autumn database pool for registered
+admin models because model operations receive the app's Postgres pool. The
+built-in jobs dashboard can render without a database pool when no model route
+is accessed.
 
 ## Quick Start
 
@@ -49,6 +52,11 @@ async fn main() {
 When mounted at the default `/admin` prefix, the plugin serves:
 
 - `GET /admin/` — dashboard
+- `GET /admin/jobs` — background jobs dashboard
+- `GET /admin/jobs/counters` — HTMX counter fragment, refreshed at most every 2s
+- `POST /admin/jobs/{id}/retry` — retry a failed job
+- `POST /admin/jobs/{id}/discard` — discard a failed job
+- `POST /admin/jobs/{id}/cancel` — cancel an enqueued job
 - `GET /admin/{slug}` — paginated list view
 - `POST /admin/{slug}` — create record
 - `GET /admin/{slug}/new` — new-record form

--- a/autumn-admin-plugin/src/registry.rs
+++ b/autumn-admin-plugin/src/registry.rs
@@ -8,6 +8,8 @@ use std::collections::btree_map::{BTreeMap, Entry};
 
 use crate::traits::AdminModel;
 
+const RESERVED_MODEL_SLUGS: &[&str] = &["jobs"];
+
 /// Holds all registered admin models, keyed by their URL slug.
 ///
 /// Stored as an `Arc<AdminRegistry>` in `AppState` extensions so route
@@ -29,6 +31,10 @@ impl AdminRegistry {
     /// at startup rather than silently shadowing).
     pub(crate) fn register<M: AdminModel>(&mut self, model: M) {
         let slug = model.slug();
+        assert!(
+            !RESERVED_MODEL_SLUGS.contains(&slug),
+            "autumn-admin: reserved model slug '{slug}' conflicts with built-in admin routes",
+        );
         let name = model.display_name();
         match self.models.entry(slug) {
             Entry::Occupied(_) => panic!(
@@ -184,6 +190,16 @@ mod tests {
         registry.register(DummyModel {
             slug: "projects",
             name: "Project 2",
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "reserved model slug 'jobs'")]
+    fn reserved_jobs_slug_panics() {
+        let mut registry = AdminRegistry::new();
+        registry.register(DummyModel {
+            slug: "jobs",
+            name: "Jobs",
         });
     }
 }

--- a/autumn-admin-plugin/src/routes.rs
+++ b/autumn-admin-plugin/src/routes.rs
@@ -361,6 +361,7 @@ async fn jobs_dashboard(
 /// `GET /admin/jobs/counters` -- HTMX counter refresh fragment.
 async fn jobs_counters(
     State(state): State<AppState>,
+    axum::Extension(AdminPrefix(prefix)): axum::Extension<AdminPrefix>,
     Query(query): Query<JobsQuery>,
 ) -> AutumnResult<Response> {
     let mut snapshot = match job_admin_backend(&state) {
@@ -368,7 +369,7 @@ async fn jobs_counters(
         None => JobAdminSnapshot::empty(),
     };
     snapshot.schedules = scheduled_job_summaries(&state);
-    Ok(render(templates::jobs_counters(&snapshot)))
+    Ok(render(templates::jobs_counters(&snapshot, &prefix)))
 }
 
 /// `POST /admin/jobs/{id}/retry` -- retry a failed job.

--- a/autumn-admin-plugin/src/routes.rs
+++ b/autumn-admin-plugin/src/routes.rs
@@ -11,6 +11,7 @@ use std::convert::Infallible;
 use std::sync::LazyLock;
 
 use autumn_web::flash::Flash;
+use autumn_web::job::{JobAdminQuery, JobAdminSnapshot, JobScheduleSummary, job_admin_backend};
 use autumn_web::prelude::HxResponseExt;
 use autumn_web::security::CsrfToken;
 use autumn_web::{AppState, AutumnError, AutumnResult};
@@ -104,6 +105,11 @@ pub fn admin_router(
     let router = axum::Router::new()
         // Dashboard
         .route("/", routing::get(dashboard))
+        .route("/jobs", routing::get(jobs_dashboard))
+        .route("/jobs/counters", routing::get(jobs_counters))
+        .route("/jobs/{id}/retry", routing::post(job_retry))
+        .route("/jobs/{id}/discard", routing::post(job_discard))
+        .route("/jobs/{id}/cancel", routing::post(job_cancel))
         // Model routes (dynamic dispatch via slug)
         .route("/{slug}", routing::get(model_list).post(model_create))
         .route("/{slug}/new", routing::get(model_new_form))
@@ -166,8 +172,38 @@ struct ListQuery {
     dir: SortDirection,
 }
 
+#[derive(Debug, Deserialize)]
+struct JobsQuery {
+    #[serde(default = "default_page", rename = "enqueued_page")]
+    enqueued: u64,
+    #[serde(default = "default_page", rename = "running_page")]
+    running: u64,
+    #[serde(default = "default_page", rename = "completed_page")]
+    completed: u64,
+    #[serde(default = "default_page", rename = "failed_page")]
+    failed: u64,
+    #[serde(default = "default_jobs_per_page", rename = "per_page")]
+    per: u64,
+}
+
+impl From<JobsQuery> for JobAdminQuery {
+    fn from(query: JobsQuery) -> Self {
+        Self {
+            enqueued_page: query.enqueued.max(1),
+            running_page: query.running.max(1),
+            completed_page: query.completed.max(1),
+            failed_page: query.failed.max(1),
+            per_page: query.per.clamp(1, 100),
+        }
+    }
+}
+
 const fn default_page() -> u64 {
     1
+}
+
+const fn default_jobs_per_page() -> u64 {
+    25
 }
 
 // ── Shared resolution ───────────────────────────────────────────────
@@ -295,7 +331,112 @@ async fn dashboard(
     )))
 }
 
-/// `GET /admin/{slug}` — Model list view.
+/// `GET /admin/jobs` -- built-in background jobs dashboard.
+async fn jobs_dashboard(
+    State(state): State<AppState>,
+    axum::Extension(registry): axum::Extension<Arc<AdminRegistry>>,
+    axum::Extension(AdminPrefix(prefix)): axum::Extension<AdminPrefix>,
+    axum::Extension(ActuatorPrefix(actuator_prefix)): axum::Extension<ActuatorPrefix>,
+    Query(query): Query<JobsQuery>,
+    csrf: AdminCsrf,
+    flash: Flash,
+) -> AutumnResult<Response> {
+    let mut snapshot = match job_admin_backend(&state) {
+        Some(backend) => backend.snapshot(query.into()).await?,
+        None => JobAdminSnapshot::empty(),
+    };
+    snapshot.schedules = scheduled_job_summaries(&state);
+    let messages = flash.consume().await;
+
+    Ok(render(templates::jobs_page(
+        &registry,
+        &snapshot,
+        &messages,
+        csrf.token(),
+        &prefix,
+        &actuator_prefix,
+    )))
+}
+
+/// `GET /admin/jobs/counters` -- HTMX counter refresh fragment.
+async fn jobs_counters(
+    State(state): State<AppState>,
+    Query(query): Query<JobsQuery>,
+) -> AutumnResult<Response> {
+    let mut snapshot = match job_admin_backend(&state) {
+        Some(backend) => backend.snapshot(query.into()).await?,
+        None => JobAdminSnapshot::empty(),
+    };
+    snapshot.schedules = scheduled_job_summaries(&state);
+    Ok(render(templates::jobs_counters(&snapshot)))
+}
+
+/// `POST /admin/jobs/{id}/retry` -- retry a failed job.
+async fn job_retry(
+    State(state): State<AppState>,
+    axum::Extension(AdminPrefix(prefix)): axum::Extension<AdminPrefix>,
+    Path(id): Path<String>,
+    flash: Flash,
+) -> AutumnResult<Response> {
+    let backend = job_admin_backend(&state)
+        .ok_or_else(|| AutumnError::service_unavailable_msg("job runtime is not initialized"))?;
+    backend.retry(&id).await?;
+    flash.success(format!("Retried job {id}.")).await;
+    Ok(Redirect::to(&format!("{prefix}/jobs")).into_response())
+}
+
+/// `POST /admin/jobs/{id}/discard` -- discard a failed job.
+async fn job_discard(
+    State(state): State<AppState>,
+    axum::Extension(AdminPrefix(prefix)): axum::Extension<AdminPrefix>,
+    Path(id): Path<String>,
+    flash: Flash,
+) -> AutumnResult<Response> {
+    let backend = job_admin_backend(&state)
+        .ok_or_else(|| AutumnError::service_unavailable_msg("job runtime is not initialized"))?;
+    backend.discard(&id).await?;
+    flash.success(format!("Discarded job {id}.")).await;
+    Ok(Redirect::to(&format!("{prefix}/jobs")).into_response())
+}
+
+/// `POST /admin/jobs/{id}/cancel` -- cancel a job that has not started.
+async fn job_cancel(
+    State(state): State<AppState>,
+    axum::Extension(AdminPrefix(prefix)): axum::Extension<AdminPrefix>,
+    Path(id): Path<String>,
+    flash: Flash,
+) -> AutumnResult<Response> {
+    let backend = job_admin_backend(&state)
+        .ok_or_else(|| AutumnError::service_unavailable_msg("job runtime is not initialized"))?;
+    backend.cancel(&id).await?;
+    flash.success(format!("Canceled job {id}.")).await;
+    Ok(Redirect::to(&format!("{prefix}/jobs")).into_response())
+}
+
+fn scheduled_job_summaries(state: &AppState) -> Vec<JobScheduleSummary> {
+    let mut schedules: Vec<_> = state
+        .task_registry()
+        .snapshot()
+        .into_iter()
+        .map(|(name, status)| {
+            let last_run_status = status
+                .last_error
+                .as_ref()
+                .map(|error| format!("failed: {error}"))
+                .or(status.last_result);
+            JobScheduleSummary {
+                name,
+                schedule: status.schedule,
+                next_run_at: status.next_run_at,
+                last_run_status,
+            }
+        })
+        .collect();
+    schedules.sort_by(|a, b| a.name.cmp(&b.name));
+    schedules
+}
+
+/// `GET /admin/{slug}` -- Model list view.
 #[allow(clippy::too_many_arguments)]
 async fn model_list(
     State(state): State<AppState>,
@@ -721,7 +862,12 @@ fn parse_form_bool(raw: &str) -> Option<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use autumn_web::job::{JobAdminBackendEntry, JobAdminMemoryBackend};
+    use autumn_web::session::Session;
+    use axum::body::Body;
     use serde_json::json;
+    use std::collections::HashMap;
+    use tower::ServiceExt;
 
     fn fields(specs: &[(&'static str, AdminFieldKind)]) -> Vec<AdminField> {
         specs
@@ -729,6 +875,56 @@ mod tests {
             .cloned()
             .map(|(name, kind)| AdminField::new(name, kind))
             .collect()
+    }
+
+    #[tokio::test]
+    async fn jobs_route_renders_without_database_pool() {
+        let backend = JobAdminMemoryBackend::new();
+        let state =
+            AppState::for_test().with_extension(JobAdminBackendEntry(std::sync::Arc::new(backend)));
+        state.task_registry().register_scheduled(
+            "cleanup",
+            "every 60s",
+            autumn_web::task::TaskCoordination::Fleet,
+            "local",
+            "replica-a",
+        );
+        state
+            .task_registry()
+            .record_next_run_at("cleanup", "2026-05-08T12:00:00Z");
+        let session = Session::new_for_test("sid".to_owned(), HashMap::new());
+        let app = admin_router(
+            std::sync::Arc::new(AdminRegistry::new()),
+            "/admin",
+            "/actuator".to_owned(),
+            "user_id".to_owned(),
+            None,
+        )
+        .layer(axum::Extension(session))
+        .with_state(state);
+
+        let response = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/jobs")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let html = String::from_utf8(body.to_vec()).expect("utf8");
+        assert!(html.contains("Jobs"), "html: {html}");
+        assert!(html.contains("Enqueued"), "html: {html}");
+        assert!(
+            html.contains(r#"hx-get="/admin/jobs/counters""#),
+            "html: {html}"
+        );
+        assert!(html.contains("cleanup"), "html: {html}");
+        assert!(html.contains("2026-05-08T12:00:00Z"), "html: {html}");
     }
 
     #[test]

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -496,12 +496,7 @@ pub fn jobs_page(
             "Jobs"
         }
 
-        div id="jobs-counters"
-            hx-get={ (prefix) "/jobs/counters" }
-            hx-trigger="load, every 2s"
-            hx-swap="outerHTML" {
-            (jobs_counters(snapshot))
-        }
+        (jobs_counters(snapshot, prefix))
 
         (job_list_card(
             "Enqueued",
@@ -556,9 +551,13 @@ pub fn jobs_page(
 }
 
 /// Render the HTMX-refreshable job counter fragment.
-pub fn jobs_counters(snapshot: &JobAdminSnapshot) -> Markup {
+pub fn jobs_counters(snapshot: &JobAdminSnapshot, prefix: &str) -> Markup {
     html! {
-        div id="jobs-counters" class="jobs-counter-grid" {
+        div id="jobs-counters"
+            class="jobs-counter-grid"
+            hx-get={ (prefix) "/jobs/counters" }
+            hx-trigger="load, every 2s"
+            hx-swap="outerHTML" {
             (job_counter("Enqueued", snapshot.enqueued.total))
             (job_counter("Running", snapshot.running.total))
             (job_counter("Completed 24h", snapshot.completed.total))
@@ -1795,6 +1794,17 @@ mod tests {
         assert!(html.contains(r#"hx-get="/admin/jobs/counters""#));
         assert!(html.contains(r#"hx-trigger="load, every 2s""#));
         assert!(html.contains("send-digest"));
+    }
+
+    #[test]
+    fn jobs_counters_fragment_preserves_polling_after_outer_swap() {
+        use autumn_web::job::JobAdminSnapshot;
+
+        let html = jobs_counters(&JobAdminSnapshot::empty(), "/admin").into_string();
+        assert!(html.contains(r#"id="jobs-counters""#));
+        assert!(html.contains(r#"hx-get="/admin/jobs/counters""#));
+        assert!(html.contains(r#"hx-trigger="load, every 2s""#));
+        assert!(html.contains(r#"hx-swap="outerHTML""#));
     }
 
     #[test]

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -5,6 +5,9 @@
 //! color palette, clean cards with subtle shadows.
 
 use autumn_web::flash::FlashMessage;
+use autumn_web::job::{
+    JobAdminPage, JobAdminRecord, JobAdminSnapshot, JobAdminStatus, JobScheduleSummary,
+};
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 use serde_json::Value;
 
@@ -17,6 +20,7 @@ use crate::traits::{
 const HTMX_JS_PATH: &str = "/static/js/htmx.min.js";
 const HTMX_CSRF_JS_PATH: &str = "/static/js/autumn-htmx-csrf.js";
 const TOKENS_CSS: &str = include_str!("tokens.css");
+const JOBS_NAV_SLUG: &str = "__admin_jobs";
 const FLASH_CSS: &str = "\
 .flash {
     padding: 0.75rem 1rem;
@@ -307,6 +311,43 @@ const ADMIN_CSS: &str = "
     .stat-label { font-size: 0.8125rem; color: var(--text-muted); font-weight: 500; }
     .stat-value { font-size: 1.75rem; font-weight: 700; margin-top: 0.25rem; }
     .stat-link { font-size: 0.8125rem; margin-top: 0.375rem; }
+    .jobs-counter-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 0.75rem;
+        margin-bottom: 1rem;
+    }
+    .jobs-counter {
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        padding: 0.875rem;
+        background: var(--bg);
+    }
+    .jobs-counter strong {
+        display: block;
+        font-size: 1.35rem;
+        line-height: 1.1;
+        margin-top: 0.2rem;
+    }
+    .job-error summary {
+        cursor: pointer;
+        color: var(--danger);
+    }
+    .job-error pre {
+        margin-top: 0.5rem;
+        white-space: pre-wrap;
+        word-break: break-word;
+        background: var(--danger-light);
+        border-radius: 0.375rem;
+        padding: 0.5rem;
+        max-width: 32rem;
+    }
+    .job-actions {
+        display: flex;
+        gap: 0.375rem;
+        flex-wrap: wrap;
+    }
+    .job-actions form { display: inline; }
 
     /* Breadcrumbs */
     .breadcrumbs {
@@ -408,6 +449,12 @@ pub fn admin_layout(
                                     }
                                 }
                                 li { div class="admin-nav-section" { "System" } }
+                                li {
+                                    a href={ (prefix) "/jobs" }
+                                      class=[(active_slug == Some(JOBS_NAV_SLUG)).then_some("active")] {
+                                        "Jobs"
+                                    }
+                                }
                                 li { a href={ (actuator_prefix) "/ui" } { "Actuator" } }
                             }
                         }
@@ -425,6 +472,301 @@ pub fn admin_layout(
             }
         }
     }
+}
+
+// ── Jobs dashboard ──────────────────────────────────────────────────
+
+/// Render the built-in jobs admin dashboard.
+pub fn jobs_page(
+    registry: &AdminRegistry,
+    snapshot: &JobAdminSnapshot,
+    messages: &[FlashMessage],
+    csrf_token: &str,
+    prefix: &str,
+    actuator_prefix: &str,
+) -> Markup {
+    let content = html! {
+        div class="breadcrumbs" {
+            a href=(prefix) { "Admin" }
+            span class="sep" { "›" }
+            span { "Jobs" }
+        }
+
+        h1 style="font-size: 1.5rem; font-weight: 700; margin-bottom: 1rem;" {
+            "Jobs"
+        }
+
+        div id="jobs-counters"
+            hx-get={ (prefix) "/jobs/counters" }
+            hx-trigger="load, every 2s"
+            hx-swap="outerHTML" {
+            (jobs_counters(snapshot))
+        }
+
+        (job_list_card(
+            "Enqueued",
+            "Work waiting for a worker.",
+            &snapshot.enqueued,
+            "enqueued_page",
+            csrf_token,
+            prefix,
+        ))
+        (job_list_card(
+            "Running",
+            "Work currently executing in this runtime.",
+            &snapshot.running,
+            "running_page",
+            csrf_token,
+            prefix,
+        ))
+        (job_list_card(
+            "Completed (last 24h)",
+            "Recently completed work retained by the bounded dashboard history.",
+            &snapshot.completed,
+            "completed_page",
+            csrf_token,
+            prefix,
+        ))
+        (job_list_card(
+            "Failed (last 7d)",
+            "Terminal failures available for retry or discard.",
+            &snapshot.failed,
+            "failed_page",
+            csrf_token,
+            prefix,
+        ))
+        (job_schedules_card(&snapshot.schedules))
+
+        p style="font-size: 0.8125rem; color: var(--text-muted); margin-top: 1rem;" {
+            "Default backend history is bounded to " (snapshot.bounded_history_limit)
+            " lifecycle entries; counter refreshes use bounded in-memory reads."
+        }
+    };
+
+    admin_layout(
+        registry,
+        Some(JOBS_NAV_SLUG),
+        "Jobs",
+        prefix,
+        actuator_prefix,
+        csrf_token,
+        messages,
+        &content,
+    )
+}
+
+/// Render the HTMX-refreshable job counter fragment.
+pub fn jobs_counters(snapshot: &JobAdminSnapshot) -> Markup {
+    html! {
+        div id="jobs-counters" class="jobs-counter-grid" {
+            (job_counter("Enqueued", snapshot.enqueued.total))
+            (job_counter("Running", snapshot.running.total))
+            (job_counter("Completed 24h", snapshot.completed.total))
+            (job_counter("Failed 7d", snapshot.failed.total))
+        }
+    }
+}
+
+fn job_counter(label: &str, value: u64) -> Markup {
+    html! {
+        div class="jobs-counter" {
+            span class="stat-label" { (label) }
+            strong { (value) }
+        }
+    }
+}
+
+fn job_list_card(
+    title: &str,
+    description: &str,
+    page: &JobAdminPage,
+    page_param: &str,
+    csrf_token: &str,
+    prefix: &str,
+) -> Markup {
+    html! {
+        div class="card" {
+            div class="card-header" {
+                div {
+                    span class="card-title" { (title) }
+                    div style="font-size: 0.8125rem; color: var(--text-muted); margin-top: 0.25rem;" {
+                        (description)
+                    }
+                }
+                span style="font-size: 0.875rem; color: var(--text-muted);" {
+                    (page.total) " total"
+                }
+            }
+            div class="table-wrap" {
+                table {
+                    thead {
+                        tr {
+                            th { "Job" }
+                            th { "Enqueued At" }
+                            th { "Started At" }
+                            th { "Finished At" }
+                            th { "Attempts" }
+                            th { "Principal" }
+                            th { "Correlation" }
+                            th { "Last Error" }
+                            th { "Actions" }
+                        }
+                    }
+                    tbody {
+                        @if page.records.is_empty() {
+                            tr {
+                                td colspan="9" style="text-align: center; padding: 1.5rem; color: var(--text-muted);" {
+                                    "No jobs."
+                                }
+                            }
+                        }
+                        @for record in &page.records {
+                            (job_row(record, csrf_token, prefix))
+                        }
+                    }
+                }
+            }
+            (jobs_pagination(page, page_param, prefix))
+        }
+    }
+}
+
+fn job_row(record: &JobAdminRecord, csrf_token: &str, prefix: &str) -> Markup {
+    html! {
+        tr {
+            td {
+                strong { (record.name) }
+                div style="font-size: 0.75rem; color: var(--text-muted);" {
+                    (record.status.label()) " · " (record.id)
+                }
+            }
+            td { (optional_text(record.enqueued_at.as_deref())) }
+            td { (optional_text(record.started_at.as_deref())) }
+            td { (optional_text(record.finished_at.as_deref())) }
+            td { (record.attempt) "/" (record.max_attempts) }
+            td { (optional_text(record.principal_id.as_deref())) }
+            td { (optional_text(record.correlation_id.as_deref())) }
+            td { (job_error(record)) }
+            td { (job_actions(record, csrf_token, prefix)) }
+        }
+    }
+}
+
+fn job_error(record: &JobAdminRecord) -> Markup {
+    let Some(error) = record.last_error.as_deref() else {
+        return html! { span style="color: var(--text-muted);" { "—" } };
+    };
+    if record.status == JobAdminStatus::Failed {
+        html! {
+            details class="job-error" {
+                summary { (truncate_display(error, 80)) }
+                pre { (error) }
+            }
+        }
+    } else {
+        html! { (truncate_display(error, 80)) }
+    }
+}
+
+fn job_actions(record: &JobAdminRecord, csrf_token: &str, prefix: &str) -> Markup {
+    html! {
+        div class="job-actions" {
+            @if record.status == JobAdminStatus::Failed {
+                (job_action_form(prefix, &record.id, "retry", "Retry", "btn btn-sm btn-primary", csrf_token))
+                (job_action_form(prefix, &record.id, "discard", "Discard", "btn btn-sm btn-danger", csrf_token))
+            } @else if record.status == JobAdminStatus::Enqueued {
+                (job_action_form(prefix, &record.id, "cancel", "Cancel", "btn btn-sm btn-danger", csrf_token))
+            } @else {
+                span style="color: var(--text-muted);" { "—" }
+            }
+        }
+    }
+}
+
+fn job_action_form(
+    prefix: &str,
+    id: &str,
+    action: &str,
+    label: &str,
+    class_name: &str,
+    csrf_token: &str,
+) -> Markup {
+    html! {
+        form method="post" action={ (prefix) "/jobs/" (id) "/" (action) } {
+            input type="hidden" name="_csrf" value=(csrf_token);
+            button type="submit" class=(class_name) {
+                (label)
+            }
+        }
+    }
+}
+
+fn jobs_pagination(page: &JobAdminPage, page_param: &str, prefix: &str) -> Markup {
+    if page.total_pages() <= 1 {
+        return html! {};
+    }
+    html! {
+        div class="pagination" {
+            div {
+                "Page " (page.page) " of " (page.total_pages())
+            }
+            div class="pagination-links" {
+                @if page.page > 1 {
+                    a href={ (prefix) "/jobs?" (page_param) "=" (page.page - 1) } { "Previous" }
+                }
+                span class="active" { (page.page) }
+                @if page.page < page.total_pages() {
+                    a href={ (prefix) "/jobs?" (page_param) "=" (page.page + 1) } { "Next" }
+                }
+            }
+        }
+    }
+}
+
+fn job_schedules_card(schedules: &[JobScheduleSummary]) -> Markup {
+    html! {
+        div class="card" {
+            div class="card-header" {
+                span class="card-title" { "Recurring Schedules" }
+            }
+            div class="table-wrap" {
+                table {
+                    thead {
+                        tr {
+                            th { "Name" }
+                            th { "Schedule" }
+                            th { "Next Run At" }
+                            th { "Last Run Status" }
+                        }
+                    }
+                    tbody {
+                        @if schedules.is_empty() {
+                            tr {
+                                td colspan="4" style="text-align: center; padding: 1.5rem; color: var(--text-muted);" {
+                                    "No scheduled tasks registered."
+                                }
+                            }
+                        }
+                        @for schedule in schedules {
+                            tr {
+                                td { (schedule.name) }
+                                td { (schedule.schedule) }
+                                td { (optional_text(schedule.next_run_at.as_deref())) }
+                                td { (optional_text(schedule.last_run_status.as_deref())) }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn optional_text(value: Option<&str>) -> Markup {
+    value.filter(|value| !value.is_empty()).map_or_else(
+        || html! { span style="color: var(--text-muted);" { "—" } },
+        |value| html! { (value) },
+    )
 }
 
 // ── Dashboard ───────────────────────────────────────────────────────
@@ -1347,6 +1689,112 @@ mod tests {
             !html.contains("/actuator/"),
             "must not hardcode /actuator when prefix is /ops: {html}"
         );
+    }
+
+    #[test]
+    fn jobs_page_renders_lists_actions_polling_and_csrf() {
+        use autumn_web::job::{
+            JobAdminPage, JobAdminRecord, JobAdminSnapshot, JobAdminStatus, JobScheduleSummary,
+        };
+
+        let r = dummy_registry();
+        let snapshot = JobAdminSnapshot {
+            enqueued: JobAdminPage::new(
+                vec![JobAdminRecord {
+                    id: "job-enqueued".to_owned(),
+                    name: "send_email".to_owned(),
+                    status: JobAdminStatus::Enqueued,
+                    enqueued_at: Some("2026-05-07T10:00:00Z".to_owned()),
+                    started_at: None,
+                    finished_at: None,
+                    attempt: 1,
+                    max_attempts: 5,
+                    last_error: None,
+                    principal_id: Some("42".to_owned()),
+                    correlation_id: Some("req-123".to_owned()),
+                }],
+                1,
+                1,
+                25,
+            ),
+            running: JobAdminPage::new(
+                vec![JobAdminRecord {
+                    id: "job-running".to_owned(),
+                    name: "reindex".to_owned(),
+                    status: JobAdminStatus::Running,
+                    enqueued_at: Some("2026-05-07T10:01:00Z".to_owned()),
+                    started_at: Some("2026-05-07T10:02:00Z".to_owned()),
+                    finished_at: None,
+                    attempt: 1,
+                    max_attempts: 3,
+                    last_error: None,
+                    principal_id: None,
+                    correlation_id: None,
+                }],
+                1,
+                1,
+                25,
+            ),
+            completed: JobAdminPage::new(
+                vec![JobAdminRecord {
+                    id: "job-complete".to_owned(),
+                    name: "digest".to_owned(),
+                    status: JobAdminStatus::Completed,
+                    enqueued_at: Some("2026-05-07T09:00:00Z".to_owned()),
+                    started_at: Some("2026-05-07T09:01:00Z".to_owned()),
+                    finished_at: Some("2026-05-07T09:02:00Z".to_owned()),
+                    attempt: 1,
+                    max_attempts: 3,
+                    last_error: None,
+                    principal_id: None,
+                    correlation_id: None,
+                }],
+                1,
+                1,
+                25,
+            ),
+            failed: JobAdminPage::new(
+                vec![JobAdminRecord {
+                    id: "job-failed".to_owned(),
+                    name: "send_email".to_owned(),
+                    status: JobAdminStatus::Failed,
+                    enqueued_at: Some("2026-05-07T08:00:00Z".to_owned()),
+                    started_at: Some("2026-05-07T08:01:00Z".to_owned()),
+                    finished_at: Some("2026-05-07T08:02:00Z".to_owned()),
+                    attempt: 5,
+                    max_attempts: 5,
+                    last_error: Some("smtp refused recipient".repeat(6)),
+                    principal_id: Some("7".to_owned()),
+                    correlation_id: None,
+                }],
+                1,
+                1,
+                25,
+            ),
+            schedules: vec![JobScheduleSummary {
+                name: "send-digest".to_owned(),
+                schedule: "every 1h".to_owned(),
+                next_run_at: None,
+                last_run_status: Some("ok".to_owned()),
+            }],
+            bounded_history_limit: 1_000,
+        };
+
+        let html = jobs_page(&r, &snapshot, &[], "tok-job", "/admin", "/actuator").into_string();
+        assert!(html.contains("Jobs"));
+        assert!(html.contains("Enqueued"));
+        assert!(html.contains("Running"));
+        assert!(html.contains("Completed (last 24h)"));
+        assert!(html.contains("Failed (last 7d)"));
+        assert!(html.contains("send_email"));
+        assert!(html.contains("req-123"));
+        assert!(html.contains(r#"action="/admin/jobs/job-failed/retry""#));
+        assert!(html.contains(r#"action="/admin/jobs/job-failed/discard""#));
+        assert!(html.contains(r#"action="/admin/jobs/job-enqueued/cancel""#));
+        assert!(html.contains(r#"name="_csrf" value="tok-job""#));
+        assert!(html.contains(r#"hx-get="/admin/jobs/counters""#));
+        assert!(html.contains(r#"hx-trigger="load, every 2s""#));
+        assert!(html.contains("send-digest"));
     }
 
     #[test]

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -200,6 +200,9 @@ pub struct TaskStatus {
     /// Last time this task fired (ISO 8601), if ever.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_fired_at: Option<String>,
+    /// Next scheduled run time (ISO 8601), if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_run_at: Option<String>,
     /// Current task state.
     pub status: String,
     /// Last time the task ran (ISO 8601), if ever.
@@ -298,6 +301,15 @@ impl JobRegistry {
         }
     }
 
+    /// Record that a queued job was canceled before execution.
+    pub fn record_cancel(&self, name: &str) {
+        if let Ok(mut guard) = self.inner.write()
+            && let Some(status) = guard.get_mut(name)
+        {
+            status.queued = status.queued.saturating_sub(1);
+        }
+    }
+
     /// Record a successful execution.
     pub fn record_success(&self, name: &str) {
         if let Ok(mut guard) = self.inner.write()
@@ -388,6 +400,7 @@ impl TaskRegistry {
                 current_leader: None,
                 last_tick: None,
                 last_fired_at: None,
+                next_run_at: None,
                 status: "idle".to_string(),
                 last_run: None,
                 last_duration_ms: None,
@@ -420,6 +433,18 @@ impl TaskRegistry {
             return;
         };
         task.status = "running".to_string();
+        task.next_run_at = None;
+    }
+
+    /// Record the next scheduled run time for an idle task.
+    pub fn record_next_run_at(&self, name: &str, next_run_at: &str) {
+        let Ok(mut guard) = self.inner.write() else {
+            return;
+        };
+        let Some(task) = guard.get_mut(name) else {
+            return;
+        };
+        task.next_run_at = Some(next_run_at.to_string());
     }
 
     /// Record that a task completed successfully.

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2323,6 +2323,9 @@ fn start_task_scheduler_with_config(
                 let shutdown = shutdown.child_token();
                 tokio::spawn(async move {
                     loop {
+                        state
+                            .task_registry
+                            .record_next_run_at(&name, &format_next_task_run_after(delay));
                         tokio::select! {
                             () = shutdown.cancelled() => break,
                             () = tokio::time::sleep(delay) => {
@@ -2698,6 +2701,10 @@ async fn run_cron_task_loop(
                 return;
             }
         };
+        state.task_registry.record_next_run_at(
+            &name,
+            &scheduled_at.with_timezone(&chrono::Utc).to_rfc3339(),
+        );
         let sleep_for = cron_sleep_duration_until(&scheduled_at);
         tokio::select! {
             () = shutdown.cancelled() => break,
@@ -2734,6 +2741,14 @@ async fn run_cron_task_loop(
             }
         }
     }
+}
+
+fn format_next_task_run_after(delay: std::time::Duration) -> String {
+    let now = chrono::Utc::now();
+    let Ok(delay) = chrono::TimeDelta::from_std(delay) else {
+        return now.to_rfc3339();
+    };
+    (now + delay).to_rfc3339()
 }
 
 fn next_cron_occurrence_after<Tz: chrono::TimeZone>(

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -485,6 +485,16 @@ impl JobAdminMemoryBackend {
         Ok(retry)
     }
 
+    fn restore_failed_retry(&self, id: &str) {
+        if let Ok(mut inner) = self.inner.write()
+            && let Some(record) = inner.records.get_mut(id)
+            && record.status == JobAdminStatus::Retried
+        {
+            record.status = JobAdminStatus::Failed;
+            record.finished_at = Some(chrono::Utc::now());
+        }
+    }
+
     fn ensure_retryable(&self, id: &str) -> AutumnResult<()> {
         let inner = self
             .inner
@@ -637,8 +647,13 @@ impl JobAdminBackend for JobAdminMemoryBackend {
                 AutumnError::service_unavailable_msg("job runtime is not initialized")
             })?;
             let (name, payload) = self.retry_payload(&id)?;
-            client.enqueue(&name, payload).await?;
-            Ok(())
+            match client.enqueue(&name, payload).await {
+                Ok(()) => Ok(()),
+                Err(error) => {
+                    self.restore_failed_retry(&id);
+                    Err(error)
+                }
+            }
         })
     }
 
@@ -974,10 +989,10 @@ impl JobClient {
         self.job_admin
             .record_enqueue(id.clone(), name, payload.clone(), 1, job_max_attempts);
 
-        if let Some(sender) = &self.local_sender {
+        let result = if let Some(sender) = &self.local_sender {
             sender
                 .send(QueuedJob {
-                    id,
+                    id: id.clone(),
                     name: name.to_string(),
                     payload,
                     attempt: 1,
@@ -994,15 +1009,28 @@ impl JobClient {
             #[cfg(feature = "redis")]
             {
                 if let Some(redis) = &self.redis {
-                    return redis
-                        .enqueue(id, name, payload, job_max_attempts, job_backoff_ms)
-                        .await;
+                    redis
+                        .enqueue(id.clone(), name, payload, job_max_attempts, job_backoff_ms)
+                        .await
+                } else {
+                    Err(AutumnError::internal_server_error(std::io::Error::other(
+                        "job runtime backend is unavailable",
+                    )))
                 }
             }
-            Err(AutumnError::internal_server_error(std::io::Error::other(
-                "job runtime backend is unavailable",
-            )))
+            #[cfg(not(feature = "redis"))]
+            {
+                let _ = payload;
+                Err(AutumnError::internal_server_error(std::io::Error::other(
+                    "job runtime backend is unavailable",
+                )))
+            }
+        };
+        if result.is_err() {
+            self.registry.record_cancel(name);
+            self.job_admin.record_cancelled(&id);
         }
+        result
     }
 }
 
@@ -2884,6 +2912,58 @@ mod tests {
             .expect("snapshot after retry");
         assert!(snapshot.failed.records.is_empty());
         assert_eq!(snapshot.enqueued.total, 1);
+
+        clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn job_admin_retry_restores_failed_record_when_enqueue_fails() {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let backend = JobAdminMemoryBackend::new_for_test(32);
+        let registry = crate::actuator::JobRegistry::new();
+        registry.register("send_email");
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+        init_global_job_client(JobClient {
+            local_sender: Some(tx),
+            #[cfg(feature = "redis")]
+            redis: None,
+            registry: registry.clone(),
+            job_admin: backend.clone(),
+            default_max_attempts: 5,
+            default_initial_backoff_ms: 250,
+            per_job_defaults: HashMap::from([("send_email".to_string(), (5, 250))]),
+        });
+
+        let failed_id =
+            backend.record_enqueue_for_test("send_email", serde_json::json!({"user_id": 7}), 2, 5);
+        backend.record_start_for_test(&failed_id, 2);
+        backend.record_failure_for_test(&failed_id, "smtp refused recipient");
+
+        let error = backend
+            .retry(&failed_id)
+            .await
+            .expect_err("closed worker channel should make retry enqueue fail");
+        assert!(
+            error.to_string().contains("failed to enqueue job"),
+            "unexpected retry error: {error}"
+        );
+
+        let snapshot = backend
+            .snapshot(JobAdminQuery::default())
+            .await
+            .expect("snapshot after failed retry enqueue");
+        assert_eq!(snapshot.failed.total, 1);
+        assert_eq!(snapshot.failed.records[0].id, failed_id);
+        assert_eq!(
+            snapshot.failed.records[0].last_error.as_deref(),
+            Some("smtp refused recipient")
+        );
+        assert_eq!(snapshot.enqueued.total, 0);
+        let status = registry.snapshot()["send_email"].clone();
+        assert_eq!(status.queued, 0);
 
         clear_global_job_client();
     }

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -3,14 +3,15 @@
 //! Provides [`JobInfo`] metadata used by `#[job]` and `jobs![]`, plus local
 //! and Redis-backed queue backends.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock, RwLock};
 
 use futures::FutureExt as _;
 #[cfg(feature = "redis")]
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use serde_json::Value;
 
 use crate::{AppState, AutumnError, AutumnResult};
@@ -20,6 +21,9 @@ use crate::{AppState, AutumnError, AutumnResult};
 /// Handlers receive the full `AppState` and a JSON `Value` representing the job's payload.
 pub type JobHandler =
     fn(AppState, Value) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>>;
+
+const DEFAULT_JOB_ADMIN_HISTORY_LIMIT: usize = 1_000;
+const DEFAULT_JOB_ADMIN_PER_PAGE: u64 = 25;
 
 /// Metadata describing a registered background job.
 #[derive(Clone)]
@@ -43,6 +47,7 @@ pub struct JobClient {
     #[cfg(feature = "redis")]
     redis: Option<RedisClient>,
     registry: crate::actuator::JobRegistry,
+    job_admin: JobAdminMemoryBackend,
     default_max_attempts: u32,
     default_initial_backoff_ms: u64,
     per_job_defaults: HashMap<String, (u32, u64)>,
@@ -50,6 +55,7 @@ pub struct JobClient {
 
 #[derive(Debug)]
 struct QueuedJob {
+    id: String,
     name: String,
     payload: Value,
     attempt: u32,
@@ -64,6 +70,670 @@ enum JobExecutionOutcome {
     Panicked(String),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JobAdminStartDecision {
+    Started,
+    Canceled,
+    Missing,
+    AlreadyTransitioned,
+}
+
+/// Boxed future returned by job-admin backends.
+pub type JobAdminFuture<'a, T> = Pin<Box<dyn Future<Output = AutumnResult<T>> + Send + 'a>>;
+
+/// Human-facing lifecycle status for a background job entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JobAdminStatus {
+    /// Waiting to be picked up by a worker.
+    Enqueued,
+    /// Currently executing in a worker.
+    Running,
+    /// Finished successfully.
+    Completed,
+    /// Finished with a terminal error.
+    Failed,
+    /// Removed from the failed set by an operator.
+    Discarded,
+    /// Canceled before it started.
+    Canceled,
+    /// Re-enqueued by an operator from a failed entry.
+    Retried,
+}
+
+impl JobAdminStatus {
+    /// Stable display string used by the admin UI.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Enqueued => "enqueued",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Discarded => "discarded",
+            Self::Canceled => "canceled",
+            Self::Retried => "retried",
+        }
+    }
+}
+
+/// A job row exposed to the admin dashboard.
+#[derive(Debug, Clone, Serialize)]
+pub struct JobAdminRecord {
+    /// Stable runtime id for this job attempt.
+    pub id: String,
+    /// Job kind/name from `#[job(name = "...")]`.
+    pub name: String,
+    /// Current lifecycle status.
+    pub status: JobAdminStatus,
+    /// Time the job entered the queue.
+    pub enqueued_at: Option<String>,
+    /// Time the job started running.
+    pub started_at: Option<String>,
+    /// Time the job finished, failed, or was operated on.
+    pub finished_at: Option<String>,
+    /// Current attempt number.
+    pub attempt: u32,
+    /// Maximum attempts configured for this job.
+    pub max_attempts: u32,
+    /// Last observed error, if any.
+    pub last_error: Option<String>,
+    /// Principal/user id extracted from common payload fields, if present.
+    pub principal_id: Option<String>,
+    /// Correlation/request id extracted from common payload fields, if present.
+    pub correlation_id: Option<String>,
+}
+
+/// Paginated records for one job status group.
+#[derive(Debug, Clone, Serialize)]
+pub struct JobAdminPage {
+    /// Records for the requested page, sorted newest-first.
+    pub records: Vec<JobAdminRecord>,
+    /// Total records matching this status/time window.
+    pub total: u64,
+    /// Current page number, 1-indexed.
+    pub page: u64,
+    /// Records per page.
+    pub per_page: u64,
+}
+
+impl JobAdminPage {
+    /// Construct a page from preselected records.
+    #[must_use]
+    pub const fn new(records: Vec<JobAdminRecord>, total: u64, page: u64, per_page: u64) -> Self {
+        Self {
+            records,
+            total,
+            page,
+            per_page,
+        }
+    }
+
+    /// Total page count for this status group.
+    #[must_use]
+    pub const fn total_pages(&self) -> u64 {
+        if self.per_page == 0 {
+            return 0;
+        }
+        self.total.div_ceil(self.per_page)
+    }
+}
+
+/// Scheduled task summary shown alongside ad-hoc jobs.
+#[derive(Debug, Clone, Serialize)]
+pub struct JobScheduleSummary {
+    /// Registered scheduled task name.
+    pub name: String,
+    /// Human-readable schedule expression.
+    pub schedule: String,
+    /// Next scheduled run time, if the scheduler backend can report it.
+    pub next_run_at: Option<String>,
+    /// Last run result/status, if any.
+    pub last_run_status: Option<String>,
+}
+
+/// Complete dashboard snapshot for `/admin/jobs`.
+#[derive(Debug, Clone, Serialize)]
+pub struct JobAdminSnapshot {
+    /// Enqueued jobs, newest-first.
+    pub enqueued: JobAdminPage,
+    /// Running jobs, newest-first.
+    pub running: JobAdminPage,
+    /// Completed jobs from the last 24 hours, newest-first.
+    pub completed: JobAdminPage,
+    /// Failed jobs from the last 7 days, newest-first.
+    pub failed: JobAdminPage,
+    /// Scheduled task summaries.
+    pub schedules: Vec<JobScheduleSummary>,
+    /// Maximum number of lifecycle entries retained by the default backend.
+    pub bounded_history_limit: usize,
+}
+
+impl JobAdminSnapshot {
+    /// Empty snapshot for apps that have not initialized a jobs runtime.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            enqueued: JobAdminPage::new(Vec::new(), 0, 1, DEFAULT_JOB_ADMIN_PER_PAGE),
+            running: JobAdminPage::new(Vec::new(), 0, 1, DEFAULT_JOB_ADMIN_PER_PAGE),
+            completed: JobAdminPage::new(Vec::new(), 0, 1, DEFAULT_JOB_ADMIN_PER_PAGE),
+            failed: JobAdminPage::new(Vec::new(), 0, 1, DEFAULT_JOB_ADMIN_PER_PAGE),
+            schedules: Vec::new(),
+            bounded_history_limit: DEFAULT_JOB_ADMIN_HISTORY_LIMIT,
+        }
+    }
+}
+
+/// Per-list pagination for the job dashboard.
+#[derive(Debug, Clone)]
+pub struct JobAdminQuery {
+    /// Page number for enqueued jobs.
+    pub enqueued_page: u64,
+    /// Page number for running jobs.
+    pub running_page: u64,
+    /// Page number for completed jobs.
+    pub completed_page: u64,
+    /// Page number for failed jobs.
+    pub failed_page: u64,
+    /// Shared page size for all lists.
+    pub per_page: u64,
+}
+
+impl Default for JobAdminQuery {
+    fn default() -> Self {
+        Self {
+            enqueued_page: 1,
+            running_page: 1,
+            completed_page: 1,
+            failed_page: 1,
+            per_page: DEFAULT_JOB_ADMIN_PER_PAGE,
+        }
+    }
+}
+
+/// Read/operate surface consumed by first-party and custom job dashboards.
+///
+/// The default implementation is process-local and bounded. Durable external
+/// queues can install their own backend in [`AppState`] by inserting
+/// [`JobAdminBackendEntry`].
+pub trait JobAdminBackend: Send + Sync + 'static {
+    /// Return the dashboard snapshot for the supplied pagination.
+    fn snapshot(&self, query: JobAdminQuery) -> JobAdminFuture<'_, JobAdminSnapshot>;
+
+    /// Retry a failed job using its original payload.
+    fn retry(&self, id: &str) -> JobAdminFuture<'_, ()>;
+
+    /// Discard a failed job so it no longer appears in the failed list.
+    fn discard(&self, id: &str) -> JobAdminFuture<'_, ()>;
+
+    /// Cancel an enqueued job that has not started.
+    fn cancel(&self, id: &str) -> JobAdminFuture<'_, ()>;
+}
+
+/// Typed [`AppState`](crate::AppState) extension carrying a job-admin backend.
+#[derive(Clone)]
+pub struct JobAdminBackendEntry(pub Arc<dyn JobAdminBackend>);
+
+/// Resolve the active job-admin backend from application state.
+#[must_use]
+pub fn job_admin_backend(state: &AppState) -> Option<Arc<dyn JobAdminBackend>> {
+    state
+        .extension::<JobAdminBackendEntry>()
+        .map(|entry| Arc::clone(&entry.0))
+}
+
+#[derive(Debug, Clone)]
+struct JobAdminStoredRecord {
+    id: String,
+    name: String,
+    payload: Value,
+    status: JobAdminStatus,
+    enqueued_at: Option<chrono::DateTime<chrono::Utc>>,
+    started_at: Option<chrono::DateTime<chrono::Utc>>,
+    finished_at: Option<chrono::DateTime<chrono::Utc>>,
+    attempt: u32,
+    max_attempts: u32,
+    last_error: Option<String>,
+    principal_id: Option<String>,
+    correlation_id: Option<String>,
+}
+
+impl JobAdminStoredRecord {
+    fn sort_time(&self) -> chrono::DateTime<chrono::Utc> {
+        self.finished_at
+            .or(self.started_at)
+            .or(self.enqueued_at)
+            .unwrap_or_else(chrono::Utc::now)
+    }
+
+    fn to_public(&self) -> JobAdminRecord {
+        JobAdminRecord {
+            id: self.id.clone(),
+            name: self.name.clone(),
+            status: self.status,
+            enqueued_at: self.enqueued_at.map(format_job_admin_time),
+            started_at: self.started_at.map(format_job_admin_time),
+            finished_at: self.finished_at.map(format_job_admin_time),
+            attempt: self.attempt,
+            max_attempts: self.max_attempts,
+            last_error: self.last_error.clone(),
+            principal_id: self.principal_id.clone(),
+            correlation_id: self.correlation_id.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct JobAdminMemoryInner {
+    records: HashMap<String, JobAdminStoredRecord>,
+    order: VecDeque<String>,
+    history_limit: usize,
+}
+
+/// Bounded process-local job dashboard backend used by the built-in runtime.
+#[derive(Clone)]
+pub struct JobAdminMemoryBackend {
+    inner: Arc<RwLock<JobAdminMemoryInner>>,
+}
+
+impl JobAdminMemoryBackend {
+    /// Create a backend retaining the default number of lifecycle entries.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_history_limit(DEFAULT_JOB_ADMIN_HISTORY_LIMIT)
+    }
+
+    /// Create a backend retaining at most `history_limit` finished entries.
+    #[must_use]
+    pub fn with_history_limit(history_limit: usize) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(JobAdminMemoryInner {
+                records: HashMap::new(),
+                order: VecDeque::new(),
+                history_limit: history_limit.max(1),
+            })),
+        }
+    }
+
+    fn record_enqueue(
+        &self,
+        id: String,
+        name: &str,
+        payload: Value,
+        attempt: u32,
+        max_attempts: u32,
+    ) {
+        let now = chrono::Utc::now();
+        let (principal_id, correlation_id) = job_payload_identity(&payload);
+        if let Ok(mut inner) = self.inner.write() {
+            inner.order.push_back(id.clone());
+            inner.records.insert(
+                id.clone(),
+                JobAdminStoredRecord {
+                    id,
+                    name: name.to_owned(),
+                    payload,
+                    status: JobAdminStatus::Enqueued,
+                    enqueued_at: Some(now),
+                    started_at: None,
+                    finished_at: None,
+                    attempt,
+                    max_attempts,
+                    last_error: None,
+                    principal_id,
+                    correlation_id,
+                },
+            );
+            prune_job_admin_history(&mut inner);
+        }
+    }
+
+    fn record_requeued(&self, id: &str, attempt: u32) {
+        if let Ok(mut inner) = self.inner.write()
+            && let Some(record) = inner.records.get_mut(id)
+        {
+            record.status = JobAdminStatus::Enqueued;
+            record.enqueued_at = Some(chrono::Utc::now());
+            record.started_at = None;
+            record.finished_at = None;
+            record.attempt = attempt;
+        }
+    }
+
+    fn try_record_start(&self, id: &str, attempt: u32) -> JobAdminStartDecision {
+        let Ok(mut inner) = self.inner.write() else {
+            return JobAdminStartDecision::Missing;
+        };
+        let Some(record) = inner.records.get_mut(id) else {
+            return JobAdminStartDecision::Missing;
+        };
+        match record.status {
+            JobAdminStatus::Enqueued => {
+                record.status = JobAdminStatus::Running;
+                record.started_at = Some(chrono::Utc::now());
+                record.finished_at = None;
+                record.attempt = attempt;
+                JobAdminStartDecision::Started
+            }
+            JobAdminStatus::Canceled => JobAdminStartDecision::Canceled,
+            _ => JobAdminStartDecision::AlreadyTransitioned,
+        }
+    }
+
+    fn record_success(&self, id: &str) {
+        if let Ok(mut inner) = self.inner.write()
+            && let Some(record) = inner.records.get_mut(id)
+        {
+            record.status = JobAdminStatus::Completed;
+            record.finished_at = Some(chrono::Utc::now());
+            record.last_error = None;
+            prune_job_admin_history(&mut inner);
+        }
+    }
+
+    fn record_retrying(&self, id: &str, error: &str) {
+        if let Ok(mut inner) = self.inner.write()
+            && let Some(record) = inner.records.get_mut(id)
+        {
+            record.status = JobAdminStatus::Failed;
+            record.finished_at = Some(chrono::Utc::now());
+            record.last_error = Some(error.to_owned());
+        }
+    }
+
+    fn record_failure(&self, id: &str, error: String) {
+        if let Ok(mut inner) = self.inner.write()
+            && let Some(record) = inner.records.get_mut(id)
+        {
+            record.status = JobAdminStatus::Failed;
+            record.finished_at = Some(chrono::Utc::now());
+            record.last_error = Some(error);
+            prune_job_admin_history(&mut inner);
+        }
+    }
+
+    fn record_cancelled(&self, id: &str) {
+        if let Ok(mut inner) = self.inner.write()
+            && let Some(record) = inner.records.get_mut(id)
+        {
+            record.status = JobAdminStatus::Canceled;
+            record.finished_at = Some(chrono::Utc::now());
+        }
+    }
+
+    fn mark_retried(&self, id: &str) {
+        if let Ok(mut inner) = self.inner.write()
+            && let Some(record) = inner.records.get_mut(id)
+        {
+            record.status = JobAdminStatus::Retried;
+            record.finished_at = Some(chrono::Utc::now());
+        }
+    }
+
+    fn retry_payload(&self, id: &str) -> AutumnResult<(String, Value)> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|_| AutumnError::internal_server_error_msg("job admin store lock poisoned"))?;
+        let record = inner
+            .records
+            .get(id)
+            .ok_or_else(|| AutumnError::not_found_msg(format!("job '{id}' not found")))?;
+        if record.status != JobAdminStatus::Failed {
+            return Err(AutumnError::bad_request_msg(
+                "only failed jobs can be retried",
+            ));
+        }
+        let retry = (record.name.clone(), record.payload.clone());
+        drop(inner);
+        Ok(retry)
+    }
+
+    fn discard_failed(&self, id: &str) -> AutumnResult<()> {
+        let mut inner = self
+            .inner
+            .write()
+            .map_err(|_| AutumnError::internal_server_error_msg("job admin store lock poisoned"))?;
+        let record = inner
+            .records
+            .get_mut(id)
+            .ok_or_else(|| AutumnError::not_found_msg(format!("job '{id}' not found")))?;
+        if record.status != JobAdminStatus::Failed {
+            return Err(AutumnError::bad_request_msg(
+                "only failed jobs can be discarded",
+            ));
+        }
+        record.status = JobAdminStatus::Discarded;
+        record.finished_at = Some(chrono::Utc::now());
+        drop(inner);
+        Ok(())
+    }
+
+    fn cancel_enqueued(&self, id: &str) -> AutumnResult<()> {
+        let mut inner = self
+            .inner
+            .write()
+            .map_err(|_| AutumnError::internal_server_error_msg("job admin store lock poisoned"))?;
+        let record = inner
+            .records
+            .get_mut(id)
+            .ok_or_else(|| AutumnError::not_found_msg(format!("job '{id}' not found")))?;
+        if record.status != JobAdminStatus::Enqueued {
+            return Err(AutumnError::bad_request_msg(
+                "only enqueued jobs can be canceled",
+            ));
+        }
+        record.status = JobAdminStatus::Canceled;
+        record.finished_at = Some(chrono::Utc::now());
+        drop(inner);
+        Ok(())
+    }
+
+    fn snapshot_sync(&self, query: &JobAdminQuery) -> JobAdminSnapshot {
+        let Ok(inner) = self.inner.read() else {
+            return JobAdminSnapshot::empty();
+        };
+        let now = chrono::Utc::now();
+        let per_page = query.per_page.clamp(1, 100);
+        JobAdminSnapshot {
+            enqueued: paginate_job_admin_records(
+                &inner,
+                JobAdminStatus::Enqueued,
+                None,
+                query.enqueued_page,
+                per_page,
+            ),
+            running: paginate_job_admin_records(
+                &inner,
+                JobAdminStatus::Running,
+                None,
+                query.running_page,
+                per_page,
+            ),
+            completed: paginate_job_admin_records(
+                &inner,
+                JobAdminStatus::Completed,
+                Some(now - chrono::TimeDelta::hours(24)),
+                query.completed_page,
+                per_page,
+            ),
+            failed: paginate_job_admin_records(
+                &inner,
+                JobAdminStatus::Failed,
+                Some(now - chrono::TimeDelta::days(7)),
+                query.failed_page,
+                per_page,
+            ),
+            schedules: Vec::new(),
+            bounded_history_limit: inner.history_limit,
+        }
+    }
+
+    #[cfg(test)]
+    fn new_for_test(history_limit: usize) -> Self {
+        Self::with_history_limit(history_limit)
+    }
+
+    #[cfg(test)]
+    fn record_enqueue_for_test(
+        &self,
+        name: &str,
+        payload: Value,
+        attempt: u32,
+        max_attempts: u32,
+    ) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        self.record_enqueue(id.clone(), name, payload, attempt, max_attempts);
+        id
+    }
+
+    #[cfg(test)]
+    fn record_start_for_test(&self, id: &str, attempt: u32) {
+        let _ = self.try_record_start(id, attempt);
+    }
+
+    #[cfg(test)]
+    fn record_success_for_test(&self, id: &str) {
+        self.record_success(id);
+    }
+
+    #[cfg(test)]
+    fn record_failure_for_test(&self, id: &str, error: &str) {
+        self.record_failure(id, error.to_owned());
+    }
+}
+
+impl Default for JobAdminMemoryBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl JobAdminBackend for JobAdminMemoryBackend {
+    fn snapshot(&self, query: JobAdminQuery) -> JobAdminFuture<'_, JobAdminSnapshot> {
+        Box::pin(async move { Ok(self.snapshot_sync(&query)) })
+    }
+
+    fn retry(&self, id: &str) -> JobAdminFuture<'_, ()> {
+        let id = id.to_owned();
+        Box::pin(async move {
+            let (name, payload) = self.retry_payload(&id)?;
+            let client = global_job_client().ok_or_else(|| {
+                AutumnError::service_unavailable_msg("job runtime is not initialized")
+            })?;
+            client.enqueue(&name, payload).await?;
+            self.mark_retried(&id);
+            Ok(())
+        })
+    }
+
+    fn discard(&self, id: &str) -> JobAdminFuture<'_, ()> {
+        let id = id.to_owned();
+        Box::pin(async move { self.discard_failed(&id) })
+    }
+
+    fn cancel(&self, id: &str) -> JobAdminFuture<'_, ()> {
+        let id = id.to_owned();
+        Box::pin(async move { self.cancel_enqueued(&id) })
+    }
+}
+
+fn format_job_admin_time(time: chrono::DateTime<chrono::Utc>) -> String {
+    time.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn prune_job_admin_history(inner: &mut JobAdminMemoryInner) {
+    let mut scanned = 0;
+    while inner.order.len() > inner.history_limit && scanned < inner.order.len() {
+        let Some(id) = inner.order.pop_front() else {
+            break;
+        };
+        let is_active = inner.records.get(&id).is_some_and(|record| {
+            matches!(
+                record.status,
+                JobAdminStatus::Enqueued | JobAdminStatus::Running
+            )
+        });
+        if is_active {
+            inner.order.push_back(id);
+            scanned += 1;
+        } else {
+            inner.records.remove(&id);
+        }
+    }
+}
+
+fn paginate_job_admin_records(
+    inner: &JobAdminMemoryInner,
+    status: JobAdminStatus,
+    since: Option<chrono::DateTime<chrono::Utc>>,
+    page: u64,
+    per_page: u64,
+) -> JobAdminPage {
+    let page = page.max(1);
+    let mut records: Vec<_> = inner
+        .records
+        .values()
+        .filter(|record| {
+            record.status == status
+                && since.is_none_or(|cutoff| {
+                    record
+                        .finished_at
+                        .or(record.started_at)
+                        .or(record.enqueued_at)
+                        .is_some_and(|time| time >= cutoff)
+                })
+        })
+        .cloned()
+        .collect();
+    records.sort_by_key(JobAdminStoredRecord::sort_time);
+    records.reverse();
+
+    let total = records.len() as u64;
+    let start =
+        usize::try_from(page.saturating_sub(1).saturating_mul(per_page)).unwrap_or(usize::MAX);
+    let take = usize::try_from(per_page).unwrap_or(usize::MAX);
+    let page_records = records
+        .into_iter()
+        .skip(start)
+        .take(take)
+        .map(|record| record.to_public())
+        .collect();
+
+    JobAdminPage::new(page_records, total, page, per_page)
+}
+
+fn job_payload_identity(payload: &Value) -> (Option<String>, Option<String>) {
+    let principal = first_payload_string(payload, &["principal_id", "principal", "user_id"]);
+    let correlation = first_payload_string(payload, &["correlation_id", "request_id"]);
+    (principal, correlation)
+}
+
+fn first_payload_string(payload: &Value, keys: &[&str]) -> Option<String> {
+    let object = payload.as_object()?;
+    for key in keys {
+        let Some(value) = object.get(*key) else {
+            continue;
+        };
+        if let Some(raw) = value.as_str() {
+            if !raw.is_empty() {
+                return Some(raw.to_owned());
+            }
+        } else if value.is_number() || value.is_boolean() {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn default_job_admin_backend_for_state(state: &AppState) -> JobAdminMemoryBackend {
+    let backend = JobAdminMemoryBackend::new();
+    if job_admin_backend(state).is_none() {
+        state.insert_extension(JobAdminBackendEntry(Arc::new(backend.clone())));
+    }
+    backend
+}
+
 #[cfg(feature = "redis")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct RedisJobRecord {
@@ -73,6 +743,12 @@ struct RedisJobRecord {
     attempt: u32,
     max_attempts: u32,
     initial_backoff_ms: u64,
+    #[serde(default)]
+    enqueued_at_ms: Option<u64>,
+    #[serde(default)]
+    started_at_ms: Option<u64>,
+    #[serde(default)]
+    finished_at_ms: Option<u64>,
     #[serde(default)]
     claimed_by: Option<String>,
     #[serde(default)]
@@ -162,7 +838,9 @@ struct RedisWorkerConfig {
     processing_key: String,
     delayed_key: String,
     dead_key: String,
+    completed_key: String,
     record_prefix: String,
+    dead_record_prefix: String,
     worker_id: String,
     visibility_timeout_ms: u64,
     default_attempts: u32,
@@ -276,11 +954,15 @@ impl JobClient {
         } else {
             self.default_initial_backoff_ms
         };
+        let id = uuid::Uuid::new_v4().to_string();
         self.registry.record_enqueue(name);
+        self.job_admin
+            .record_enqueue(id.clone(), name, payload.clone(), 1, job_max_attempts);
 
         if let Some(sender) = &self.local_sender {
             sender
                 .send(QueuedJob {
+                    id,
                     name: name.to_string(),
                     payload,
                     attempt: 1,
@@ -298,7 +980,7 @@ impl JobClient {
             {
                 if let Some(redis) = &self.redis {
                     return redis
-                        .enqueue(name, payload, job_max_attempts, job_backoff_ms)
+                        .enqueue(id, name, payload, job_max_attempts, job_backoff_ms)
                         .await;
                 }
             }
@@ -372,6 +1054,7 @@ pub(crate) fn start_local_runtime(
     default_max_attempts: u32,
     default_initial_backoff_ms: u64,
 ) {
+    let job_admin = default_job_admin_backend_for_state(state);
     let per_job_defaults = build_per_job_defaults(&jobs);
     let jobs_by_name: Arc<RwLock<HashMap<String, JobInfo>>> = Arc::new(RwLock::new(
         jobs.into_iter().map(|j| (j.name.clone(), j)).collect(),
@@ -393,6 +1076,7 @@ pub(crate) fn start_local_runtime(
         #[cfg(feature = "redis")]
         redis: None,
         registry: state.job_registry.clone(),
+        job_admin: job_admin.clone(),
         default_max_attempts,
         default_initial_backoff_ms,
         per_job_defaults,
@@ -402,6 +1086,7 @@ pub(crate) fn start_local_runtime(
     for _ in 0..worker_count {
         let state = state.clone();
         let tx = tx.clone();
+        let job_admin = job_admin.clone();
         let jobs_by_name = Arc::clone(&jobs_by_name);
         let shared_rx = Arc::clone(&shared_rx);
         let shutdown = shutdown.clone();
@@ -415,7 +1100,7 @@ pub(crate) fn start_local_runtime(
                         guard.recv().await
                     } => {
                         let Some(job) = maybe else { break; };
-                        execute_local_job(job, &jobs_by_name, &tx, &state).await;
+                        execute_local_job(job, &jobs_by_name, &tx, &state, &job_admin).await;
                     }
                 }
             }
@@ -428,7 +1113,13 @@ async fn execute_local_job(
     jobs_by_name: &Arc<RwLock<HashMap<String, JobInfo>>>,
     tx: &tokio::sync::mpsc::Sender<QueuedJob>,
     state: &AppState,
+    job_admin: &JobAdminMemoryBackend,
 ) {
+    if job_admin.try_record_start(&job.id, job.attempt) == JobAdminStartDecision::Canceled {
+        state.job_registry.record_cancel(&job.name);
+        job_admin.record_cancelled(&job.id);
+        return;
+    }
     state.job_registry.record_start(&job.name);
 
     let Some((handler, info_max_attempts, info_backoff_ms)) = jobs_by_name
@@ -440,6 +1131,7 @@ async fn execute_local_job(
         state
             .job_registry
             .record_failure(&job.name, format!("unknown job '{}'", job.name), true);
+        job_admin.record_failure(&job.id, format!("unknown job '{}'", job.name));
         return;
     };
     let max_attempts = if job.max_attempts != 0 {
@@ -458,22 +1150,30 @@ async fn execute_local_job(
     };
 
     match run_job_handler(handler, state.clone(), job.payload.clone()).await {
-        JobExecutionOutcome::Succeeded => state.job_registry.record_success(&job.name),
+        JobExecutionOutcome::Succeeded => {
+            state.job_registry.record_success(&job.name);
+            job_admin.record_success(&job.id);
+        }
         JobExecutionOutcome::Failed(error) => {
             if job.attempt < max_attempts {
                 state
                     .job_registry
                     .record_retry(&job.name, &error, job.attempt);
+                job_admin.record_retrying(&job.id, &error);
                 let sender = tx.clone();
                 let registry = state.job_registry.clone();
+                let job_admin = job_admin.clone();
+                let id = job.id.clone();
                 let name = job.name.clone();
                 let payload = job.payload;
                 let delay = backoff_ms.saturating_mul(2_u64.saturating_pow(job.attempt - 1));
                 tokio::spawn(async move {
                     tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
                     registry.record_enqueue(&name);
+                    job_admin.record_requeued(&id, job.attempt + 1);
                     let _ = sender
                         .send(QueuedJob {
+                            id,
                             name,
                             payload,
                             attempt: job.attempt + 1,
@@ -483,12 +1183,18 @@ async fn execute_local_job(
                         .await;
                 });
             } else {
-                state.job_registry.record_failure(&job.name, error, true);
+                state
+                    .job_registry
+                    .record_failure(&job.name, error.clone(), true);
+                job_admin.record_failure(&job.id, error);
             }
         }
         JobExecutionOutcome::Panicked(error) => {
             tracing::error!(job = %job.name, error = %error, "local job handler panicked");
-            state.job_registry.record_failure(&job.name, error, true);
+            state
+                .job_registry
+                .record_failure(&job.name, error.clone(), true);
+            job_admin.record_failure(&job.id, error);
         }
     }
 }
@@ -549,6 +1255,7 @@ fn prepare_redis_failure_action(
 ) -> RedisFailureAction {
     clear_redis_claim(&mut record);
     record.last_error = Some(error);
+    record.finished_at_ms = Some(now_ms);
 
     if record.attempt < record.max_attempts {
         let due_at_ms = now_ms.saturating_add(redis_retry_delay_ms(
@@ -563,9 +1270,14 @@ fn prepare_redis_failure_action(
 }
 
 #[cfg(feature = "redis")]
-fn prepare_redis_panic_dead_letter(mut record: RedisJobRecord, error: String) -> RedisJobRecord {
+fn prepare_redis_panic_dead_letter(
+    mut record: RedisJobRecord,
+    error: String,
+    now_ms: u64,
+) -> RedisJobRecord {
     clear_redis_claim(&mut record);
     record.last_error = Some(error);
+    record.finished_at_ms = Some(now_ms);
     record
 }
 
@@ -587,6 +1299,7 @@ fn recover_stale_redis_record(
     record.last_error = Some(format!(
         "visibility timeout expired for claim by {claimed_by} at {claimed_at_ms}"
     ));
+    record.finished_at_ms = Some(now_ms);
     clear_redis_claim(&mut record);
 
     if record.attempt < record.max_attempts {
@@ -610,13 +1323,13 @@ fn encode_redis_record(record: &RedisJobRecord) -> AutumnResult<String> {
 impl RedisClient {
     async fn enqueue(
         &self,
+        id: String,
         name: &str,
         payload: Value,
         default_max_attempts: u32,
         default_initial_backoff_ms: u64,
     ) -> AutumnResult<()> {
         let mut connection = self.connection.clone();
-        let id = uuid::Uuid::new_v4().to_string();
         let msg = RedisJobRecord {
             id: id.clone(),
             name: name.to_string(),
@@ -624,6 +1337,9 @@ impl RedisClient {
             attempt: 1,
             max_attempts: default_max_attempts,
             initial_backoff_ms: default_initial_backoff_ms,
+            enqueued_at_ms: Some(now_unix_ms()),
+            started_at_ms: None,
+            finished_at_ms: None,
             claimed_by: None,
             claimed_at_ms: None,
             last_error: None,
@@ -649,6 +1365,400 @@ impl RedisClient {
                 )))
             })
     }
+}
+
+#[cfg(feature = "redis")]
+#[derive(Clone)]
+struct RedisJobAdminBackend {
+    connection: redis::aio::ConnectionManager,
+    queue_key: String,
+    processing_key: String,
+    dead_key: String,
+    completed_key: String,
+    record_prefix: String,
+    dead_record_prefix: String,
+    history_limit: usize,
+}
+
+#[cfg(feature = "redis")]
+impl RedisJobAdminBackend {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        connection: redis::aio::ConnectionManager,
+        queue_key: String,
+        processing_key: String,
+        dead_key: String,
+        completed_key: String,
+        record_prefix: String,
+        dead_record_prefix: String,
+        history_limit: usize,
+    ) -> Self {
+        Self {
+            connection,
+            queue_key,
+            processing_key,
+            dead_key,
+            completed_key,
+            record_prefix,
+            dead_record_prefix,
+            history_limit: history_limit.max(1),
+        }
+    }
+
+    async fn snapshot_redis(&self, query: &JobAdminQuery) -> AutumnResult<JobAdminSnapshot> {
+        let mut connection = self.connection.clone();
+        let per_page = query.per_page.clamp(1, 100);
+        let now_ms = now_unix_ms();
+        let completed_since = now_ms.saturating_sub(86_400_000);
+        let failed_since = now_ms.saturating_sub(604_800_000);
+
+        let enqueued = redis_admin_active_list_page(
+            &mut connection,
+            &self.queue_key,
+            &self.record_prefix,
+            JobAdminStatus::Enqueued,
+            query.enqueued_page,
+            per_page,
+        )
+        .await?;
+        let running = redis_admin_running_page(
+            &mut connection,
+            &self.processing_key,
+            &self.record_prefix,
+            query.running_page,
+            per_page,
+        )
+        .await?;
+        let completed = redis_admin_encoded_list_page(
+            &mut connection,
+            &self.completed_key,
+            JobAdminStatus::Completed,
+            Some(completed_since),
+            query.completed_page,
+            per_page,
+            self.history_limit,
+        )
+        .await?;
+        let failed = redis_admin_encoded_list_page(
+            &mut connection,
+            &self.dead_key,
+            JobAdminStatus::Failed,
+            Some(failed_since),
+            query.failed_page,
+            per_page,
+            self.history_limit,
+        )
+        .await?;
+
+        Ok(JobAdminSnapshot {
+            enqueued,
+            running,
+            completed,
+            failed,
+            schedules: Vec::new(),
+            bounded_history_limit: self.history_limit,
+        })
+    }
+
+    async fn retry_failed_redis(&self, id: &str) -> AutumnResult<()> {
+        let mut connection = self.connection.clone();
+        let new_id = uuid::Uuid::new_v4().to_string();
+        let dead_record_key = format!("{}{id}", self.dead_record_prefix);
+        let result: i64 = redis::cmd("EVAL")
+            .arg(
+                r"
+local failed = redis.call('GET', KEYS[1])
+if not failed then
+  return 0
+end
+if redis.call('LREM', KEYS[2], 0, failed) == 0 then
+  return -1
+end
+local ok, record = pcall(cjson.decode, failed)
+if not ok then
+  return -2
+end
+redis.call('DEL', KEYS[1])
+record['id'] = ARGV[1]
+record['attempt'] = 1
+record['enqueued_at_ms'] = tonumber(ARGV[2])
+record['started_at_ms'] = nil
+record['finished_at_ms'] = nil
+record['claimed_by'] = nil
+record['claimed_at_ms'] = nil
+record['last_error'] = nil
+local active = cjson.encode(record)
+redis.call('SET', KEYS[3] .. ARGV[1], active)
+redis.call('LPUSH', KEYS[4], ARGV[1])
+return 1
+",
+            )
+            .arg(4)
+            .arg(dead_record_key)
+            .arg(&self.dead_key)
+            .arg(&self.record_prefix)
+            .arg(&self.queue_key)
+            .arg(new_id)
+            .arg(now_unix_ms())
+            .query_async(&mut connection)
+            .await
+            .map_err(|error| redis_admin_error("retry failed job", &error))?;
+        redis_admin_operation_result(result, id, "retry failed job")
+    }
+
+    async fn discard_failed_redis(&self, id: &str) -> AutumnResult<()> {
+        let mut connection = self.connection.clone();
+        let dead_record_key = format!("{}{id}", self.dead_record_prefix);
+        let result: i64 = redis::cmd("EVAL")
+            .arg(
+                r"
+local failed = redis.call('GET', KEYS[1])
+if not failed then
+  return 0
+end
+if redis.call('LREM', KEYS[2], 0, failed) == 0 then
+  return -1
+end
+redis.call('DEL', KEYS[1])
+return 1
+",
+            )
+            .arg(2)
+            .arg(dead_record_key)
+            .arg(&self.dead_key)
+            .query_async(&mut connection)
+            .await
+            .map_err(|error| redis_admin_error("discard failed job", &error))?;
+        redis_admin_operation_result(result, id, "discard failed job")
+    }
+
+    async fn cancel_enqueued_redis(&self, id: &str) -> AutumnResult<()> {
+        let mut connection = self.connection.clone();
+        let active_record_key = redis_record_key(&self.record_prefix, id);
+        let result: i64 = redis::cmd("EVAL")
+            .arg(
+                r"
+if not redis.call('GET', KEYS[1]) then
+  return 0
+end
+if redis.call('LREM', KEYS[2], 0, ARGV[1]) == 0 then
+  return -1
+end
+redis.call('DEL', KEYS[1])
+return 1
+",
+            )
+            .arg(2)
+            .arg(active_record_key)
+            .arg(&self.queue_key)
+            .arg(id)
+            .query_async(&mut connection)
+            .await
+            .map_err(|error| redis_admin_error("cancel enqueued job", &error))?;
+        redis_admin_operation_result(result, id, "cancel enqueued job")
+    }
+}
+
+#[cfg(feature = "redis")]
+impl JobAdminBackend for RedisJobAdminBackend {
+    fn snapshot(&self, query: JobAdminQuery) -> JobAdminFuture<'_, JobAdminSnapshot> {
+        Box::pin(async move { self.snapshot_redis(&query).await })
+    }
+
+    fn retry(&self, id: &str) -> JobAdminFuture<'_, ()> {
+        let id = id.to_owned();
+        Box::pin(async move { self.retry_failed_redis(&id).await })
+    }
+
+    fn discard(&self, id: &str) -> JobAdminFuture<'_, ()> {
+        let id = id.to_owned();
+        Box::pin(async move { self.discard_failed_redis(&id).await })
+    }
+
+    fn cancel(&self, id: &str) -> JobAdminFuture<'_, ()> {
+        let id = id.to_owned();
+        Box::pin(async move { self.cancel_enqueued_redis(&id).await })
+    }
+}
+
+#[cfg(feature = "redis")]
+fn redis_admin_error(operation: &str, error: &redis::RedisError) -> AutumnError {
+    AutumnError::internal_server_error(std::io::Error::other(format!(
+        "redis job admin {operation} failed: {error}"
+    )))
+}
+
+#[cfg(feature = "redis")]
+fn redis_admin_operation_result(result: i64, id: &str, operation: &str) -> AutumnResult<()> {
+    match result {
+        1 => Ok(()),
+        0 => Err(AutumnError::not_found_msg(format!("job '{id}' not found"))),
+        -1 => Err(AutumnError::bad_request_msg(format!(
+            "job '{id}' is not in the expected state for {operation}"
+        ))),
+        -2 => Err(AutumnError::internal_server_error_msg(format!(
+            "job '{id}' has an invalid stored payload"
+        ))),
+        _ => Err(AutumnError::internal_server_error_msg(format!(
+            "redis job admin {operation} returned unexpected code {result}"
+        ))),
+    }
+}
+
+#[cfg(feature = "redis")]
+fn redis_admin_time(ms: Option<u64>) -> Option<String> {
+    let ms = i64::try_from(ms?).ok()?;
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms).map(format_job_admin_time)
+}
+
+#[cfg(feature = "redis")]
+fn redis_record_sort_time(record: &RedisJobRecord) -> u64 {
+    record
+        .finished_at_ms
+        .or(record.started_at_ms)
+        .or(record.enqueued_at_ms)
+        .unwrap_or_default()
+}
+
+#[cfg(feature = "redis")]
+fn redis_record_to_admin_record(record: &RedisJobRecord, status: JobAdminStatus) -> JobAdminRecord {
+    let (principal_id, correlation_id) = job_payload_identity(&record.payload);
+    JobAdminRecord {
+        id: record.id.clone(),
+        name: record.name.clone(),
+        status,
+        enqueued_at: redis_admin_time(record.enqueued_at_ms),
+        started_at: redis_admin_time(record.started_at_ms),
+        finished_at: redis_admin_time(record.finished_at_ms),
+        attempt: record.attempt,
+        max_attempts: record.max_attempts,
+        last_error: record.last_error.clone(),
+        principal_id,
+        correlation_id,
+    }
+}
+
+#[cfg(feature = "redis")]
+async fn redis_records_for_ids(
+    connection: &mut redis::aio::ConnectionManager,
+    record_prefix: &str,
+    ids: &[String],
+) -> Result<Vec<RedisJobRecord>, redis::RedisError> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let keys: Vec<String> = ids
+        .iter()
+        .map(|id| redis_record_key(record_prefix, id))
+        .collect();
+    let bodies: Vec<Option<String>> = redis::cmd("MGET").arg(keys).query_async(connection).await?;
+    Ok(bodies
+        .into_iter()
+        .flatten()
+        .filter_map(|body| serde_json::from_str::<RedisJobRecord>(&body).ok())
+        .collect())
+}
+
+#[cfg(feature = "redis")]
+async fn redis_admin_active_list_page(
+    connection: &mut redis::aio::ConnectionManager,
+    queue_key: &str,
+    record_prefix: &str,
+    status: JobAdminStatus,
+    page: u64,
+    per_page: u64,
+) -> AutumnResult<JobAdminPage> {
+    let page = page.max(1);
+    let start = page.saturating_sub(1).saturating_mul(per_page);
+    let stop = start.saturating_add(per_page).saturating_sub(1);
+    let (ids, total): (Vec<String>, u64) = redis::pipe()
+        .cmd("LRANGE")
+        .arg(queue_key)
+        .arg(start)
+        .arg(stop)
+        .cmd("LLEN")
+        .arg(queue_key)
+        .query_async(connection)
+        .await
+        .map_err(|error| redis_admin_error("read enqueued page", &error))?;
+    let records = redis_records_for_ids(connection, record_prefix, &ids)
+        .await
+        .map_err(|error| redis_admin_error("read enqueued records", &error))?
+        .into_iter()
+        .map(|record| redis_record_to_admin_record(&record, status))
+        .collect();
+    Ok(JobAdminPage::new(records, total, page, per_page))
+}
+
+#[cfg(feature = "redis")]
+async fn redis_admin_running_page(
+    connection: &mut redis::aio::ConnectionManager,
+    processing_key: &str,
+    record_prefix: &str,
+    page: u64,
+    per_page: u64,
+) -> AutumnResult<JobAdminPage> {
+    let page = page.max(1);
+    let start = page.saturating_sub(1).saturating_mul(per_page);
+    let stop = start.saturating_add(per_page).saturating_sub(1);
+    let (ids, total): (Vec<String>, u64) = redis::pipe()
+        .cmd("ZREVRANGE")
+        .arg(processing_key)
+        .arg(start)
+        .arg(stop)
+        .cmd("ZCARD")
+        .arg(processing_key)
+        .query_async(connection)
+        .await
+        .map_err(|error| redis_admin_error("read running page", &error))?;
+    let mut records: Vec<_> = redis_records_for_ids(connection, record_prefix, &ids)
+        .await
+        .map_err(|error| redis_admin_error("read running records", &error))?
+        .into_iter()
+        .map(|record| redis_record_to_admin_record(&record, JobAdminStatus::Running))
+        .collect();
+    records.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+    Ok(JobAdminPage::new(records, total, page, per_page))
+}
+
+#[cfg(feature = "redis")]
+async fn redis_admin_encoded_list_page(
+    connection: &mut redis::aio::ConnectionManager,
+    list_key: &str,
+    status: JobAdminStatus,
+    since_ms: Option<u64>,
+    page: u64,
+    per_page: u64,
+    history_limit: usize,
+) -> AutumnResult<JobAdminPage> {
+    let page = page.max(1);
+    let stop = isize::try_from(history_limit.saturating_sub(1)).unwrap_or(isize::MAX);
+    let bodies: Vec<String> = redis::cmd("LRANGE")
+        .arg(list_key)
+        .arg(0)
+        .arg(stop)
+        .query_async(connection)
+        .await
+        .map_err(|error| redis_admin_error("read completed/failed list", &error))?;
+    let mut records: Vec<_> = bodies
+        .into_iter()
+        .filter_map(|body| serde_json::from_str::<RedisJobRecord>(&body).ok())
+        .filter(|record| since_ms.is_none_or(|since| redis_record_sort_time(record) >= since))
+        .collect();
+    records.sort_by_key(redis_record_sort_time);
+    records.reverse();
+
+    let total = records.len() as u64;
+    let start =
+        usize::try_from(page.saturating_sub(1).saturating_mul(per_page)).unwrap_or(usize::MAX);
+    let take = usize::try_from(per_page).unwrap_or(usize::MAX);
+    let page_records = records
+        .into_iter()
+        .skip(start)
+        .take(take)
+        .map(|record| redis_record_to_admin_record(&record, status))
+        .collect();
+    Ok(JobAdminPage::new(page_records, total, page, per_page))
 }
 
 #[cfg(feature = "redis")]
@@ -704,6 +1814,8 @@ if not ok then
 end
 record['claimed_by'] = ARGV[1]
 record['claimed_at_ms'] = tonumber(ARGV[2])
+record['started_at_ms'] = tonumber(ARGV[2])
+record['finished_at_ms'] = nil
 local updated = cjson.encode(record)
 redis.call('SET', key, updated)
 redis.call('ZADD', KEYS[2], ARGV[3], id)
@@ -754,6 +1866,7 @@ async fn record_enqueues_for_redis_ids(
     connection: &mut redis::aio::ConnectionManager,
     worker_config: &RedisWorkerConfig,
     state: &AppState,
+    job_admin: &JobAdminMemoryBackend,
     ids: &[String],
 ) -> Result<(), redis::RedisError> {
     if ids.is_empty() {
@@ -770,8 +1883,21 @@ async fn record_enqueues_for_redis_ids(
         .await?;
 
     for body in bodies.into_iter().flatten() {
-        if let Ok(record) = serde_json::from_str::<RedisJobRecord>(&body) {
+        if let Ok(mut record) = serde_json::from_str::<RedisJobRecord>(&body) {
+            record.enqueued_at_ms = Some(now_unix_ms());
+            record.started_at_ms = None;
+            record.finished_at_ms = None;
+            clear_redis_claim(&mut record);
+            if let Ok(encoded) = encode_redis_record(&record) {
+                let key = redis_record_key(&worker_config.record_prefix, &record.id);
+                let _ = redis::cmd("SET")
+                    .arg(key)
+                    .arg(encoded)
+                    .query_async::<()>(&mut *connection)
+                    .await;
+            }
             state.job_registry.record_enqueue(&record.name);
+            job_admin.record_requeued(&record.id, record.attempt);
         }
     }
 
@@ -783,6 +1909,7 @@ async fn promote_due_redis_retries(
     connection: &mut redis::aio::ConnectionManager,
     worker_config: &RedisWorkerConfig,
     state: &AppState,
+    job_admin: &JobAdminMemoryBackend,
 ) -> Result<(), redis::RedisError> {
     const PROMOTE_SCRIPT: &str = r"
 local ids = redis.call('ZRANGEBYSCORE', KEYS[1], '-inf', ARGV[1], 'LIMIT', 0, ARGV[2])
@@ -806,7 +1933,7 @@ return promoted
         .query_async(connection)
         .await?;
 
-    record_enqueues_for_redis_ids(connection, worker_config, state, &promoted).await?;
+    record_enqueues_for_redis_ids(connection, worker_config, state, job_admin, &promoted).await?;
     Ok(())
 }
 
@@ -842,12 +1969,16 @@ if record['claimed_at_ms'] ~= tonumber(ARGV[3]) then
 end
 redis.call('ZREM', KEYS[1], ARGV[1])
 if ARGV[4] == 'success' then
+  redis.call('LPUSH', KEYS[5], ARGV[5])
+  redis.call('LTRIM', KEYS[5], 0, tonumber(ARGV[7]) - 1)
   redis.call('DEL', key)
 elseif ARGV[4] == 'retry' then
   redis.call('SET', key, ARGV[5])
   redis.call('ZADD', KEYS[3], ARGV[6], ARGV[1])
 elseif ARGV[4] == 'dead' then
   redis.call('LPUSH', KEYS[4], ARGV[5])
+  redis.call('SET', KEYS[6] .. ARGV[1], ARGV[5])
+  redis.call('LTRIM', KEYS[4], 0, tonumber(ARGV[7]) - 1)
   redis.call('DEL', key)
 else
   return 0
@@ -861,17 +1992,20 @@ return 1
 
     let applied: usize = redis::cmd("EVAL")
         .arg(TRANSITION_SCRIPT)
-        .arg(4)
+        .arg(6)
         .arg(&worker_config.processing_key)
         .arg(&worker_config.record_prefix)
         .arg(&worker_config.delayed_key)
         .arg(&worker_config.dead_key)
+        .arg(&worker_config.completed_key)
+        .arg(&worker_config.dead_record_prefix)
         .arg(&expected.id)
         .arg(claimed_by)
         .arg(claimed_at_ms)
         .arg(mode)
         .arg(encoded_record.unwrap_or_default())
         .arg(due_at_ms.unwrap_or_default())
+        .arg(DEFAULT_JOB_ADMIN_HISTORY_LIMIT)
         .query_async(connection)
         .await?;
 
@@ -884,7 +2018,23 @@ async fn ack_redis_success(
     worker_config: &RedisWorkerConfig,
     record: &RedisJobRecord,
 ) -> Result<bool, redis::RedisError> {
-    apply_claimed_redis_transition(connection, worker_config, record, "success", None, None).await
+    let mut completed = record.clone();
+    clear_redis_claim(&mut completed);
+    completed.finished_at_ms = Some(now_unix_ms());
+    completed.last_error = None;
+    let Ok(encoded) = encode_redis_record(&completed) else {
+        tracing::warn!(job_id = %record.id, "failed to serialize redis completed record");
+        return Ok(false);
+    };
+    apply_claimed_redis_transition(
+        connection,
+        worker_config,
+        record,
+        "success",
+        Some(encoded),
+        None,
+    )
+    .await
 }
 
 #[cfg(feature = "redis")]
@@ -1004,6 +2154,7 @@ async fn recover_stale_redis_jobs(
     connection: &mut redis::aio::ConnectionManager,
     worker_config: &RedisWorkerConfig,
     state: &AppState,
+    job_admin: &JobAdminMemoryBackend,
 ) -> Result<(), redis::RedisError> {
     let stale_ids: Vec<String> = redis::cmd("ZRANGEBYSCORE")
         .arg(&worker_config.processing_key)
@@ -1060,17 +2211,20 @@ async fn recover_stale_redis_jobs(
                         state
                             .job_registry
                             .record_retry(&requeued.name, error, record.attempt);
+                        job_admin.record_retrying(&requeued.id, error);
                     }
                     state.job_registry.record_enqueue(&requeued.name);
+                    job_admin.record_requeued(&requeued.id, requeued.attempt);
                 }
                 RedisStaleRecovery::DeadLetter(dead) => {
-                    state.job_registry.record_failure(
-                        &dead.name,
-                        dead.last_error
-                            .clone()
-                            .unwrap_or_else(|| "visibility timeout expired".to_string()),
-                        true,
-                    );
+                    let error = dead
+                        .last_error
+                        .clone()
+                        .unwrap_or_else(|| "visibility timeout expired".to_string());
+                    state
+                        .job_registry
+                        .record_failure(&dead.name, error.clone(), true);
+                    job_admin.record_failure(&dead.id, error);
                 }
             }
         }
@@ -1084,6 +2238,7 @@ fn spawn_redis_worker(
     client: &redis::Client,
     jobs_by_name: Arc<RwLock<HashMap<String, JobInfo>>>,
     state: AppState,
+    job_admin: JobAdminMemoryBackend,
     shutdown: tokio_util::sync::CancellationToken,
     worker_config: RedisWorkerConfig,
 ) -> Result<(), AutumnError> {
@@ -1107,7 +2262,9 @@ fn spawn_redis_worker(
             }
 
             if retry_promotion_throttle.take_due(std::time::Instant::now()) {
-                match promote_due_redis_retries(&mut connection, &worker_config, &state).await {
+                match promote_due_redis_retries(&mut connection, &worker_config, &state, &job_admin)
+                    .await
+                {
                     Ok(()) => {}
                     Err(error) => {
                         tracing::warn!(error = %error, "redis job worker retry promotion failed");
@@ -1116,7 +2273,9 @@ fn spawn_redis_worker(
             }
 
             if stale_recovery_throttle.take_due(std::time::Instant::now()) {
-                match recover_stale_redis_jobs(&mut connection, &worker_config, &state).await {
+                match recover_stale_redis_jobs(&mut connection, &worker_config, &state, &job_admin)
+                    .await
+                {
                     Ok(()) => {}
                     Err(error) => {
                         tracing::warn!(error = %error, "redis job worker stale recovery failed");
@@ -1141,6 +2300,7 @@ fn spawn_redis_worker(
                 record,
                 &jobs_by_name,
                 &state,
+                &job_admin,
                 &worker_config,
             )
             .await;
@@ -1158,6 +2318,7 @@ async fn settle_failed_redis_job(
     record: &RedisJobRecord,
     error: String,
     outcome: &str,
+    job_admin: &JobAdminMemoryBackend,
 ) {
     let action = prepare_redis_failure_action(record.clone(), error.clone(), now_unix_ms());
     match action {
@@ -1167,6 +2328,7 @@ async fn settle_failed_redis_job(
                     state
                         .job_registry
                         .record_retry(&schedule.record.name, &error, record.attempt);
+                    job_admin.record_retrying(&schedule.record.id, &error);
                 }
                 Ok(false) => tracing::warn!(
                     job = %record.name,
@@ -1185,7 +2347,12 @@ async fn settle_failed_redis_job(
         }
         RedisFailureAction::DeadLetter(dead) => {
             match dead_letter_redis_job(connection, worker_config, record, &dead).await {
-                Ok(true) => state.job_registry.record_failure(&dead.name, error, true),
+                Ok(true) => {
+                    state
+                        .job_registry
+                        .record_failure(&dead.name, error.clone(), true);
+                    job_admin.record_failure(&dead.id, error);
+                }
                 Ok(false) => tracing::warn!(
                     job = %record.name,
                     job_id = %record.id,
@@ -1211,10 +2378,16 @@ async fn dead_letter_panicked_redis_job(
     state: &AppState,
     record: &RedisJobRecord,
     error: String,
+    job_admin: &JobAdminMemoryBackend,
 ) {
-    let dead = prepare_redis_panic_dead_letter(record.clone(), error.clone());
+    let dead = prepare_redis_panic_dead_letter(record.clone(), error.clone(), now_unix_ms());
     match dead_letter_redis_job(connection, worker_config, record, &dead).await {
-        Ok(true) => state.job_registry.record_failure(&dead.name, error, true),
+        Ok(true) => {
+            state
+                .job_registry
+                .record_failure(&dead.name, error.clone(), true);
+            job_admin.record_failure(&dead.id, error);
+        }
         Ok(false) => tracing::warn!(
             job = %record.name,
             job_id = %record.id,
@@ -1230,13 +2403,39 @@ async fn dead_letter_panicked_redis_job(
 }
 
 #[cfg(feature = "redis")]
+async fn dead_letter_invalid_redis_job(
+    connection: &mut redis::aio::ConnectionManager,
+    worker_config: &RedisWorkerConfig,
+    state: &AppState,
+    record: &RedisJobRecord,
+    error: &str,
+    job_admin: &JobAdminMemoryBackend,
+) {
+    state
+        .job_registry
+        .record_failure(&record.name, error.to_owned(), true);
+    job_admin.record_failure(&record.id, error.to_owned());
+    let mut dead = record.clone();
+    clear_redis_claim(&mut dead);
+    dead.last_error = Some(error.to_owned());
+    let _ = dead_letter_redis_job(connection, worker_config, record, &dead).await;
+}
+
+#[cfg(feature = "redis")]
 async fn process_redis_job_record(
     connection: &mut redis::aio::ConnectionManager,
     mut record: RedisJobRecord,
     jobs_by_name: &Arc<RwLock<HashMap<String, JobInfo>>>,
     state: &AppState,
+    job_admin: &JobAdminMemoryBackend,
     worker_config: &RedisWorkerConfig,
 ) {
+    if job_admin.try_record_start(&record.id, record.attempt) == JobAdminStartDecision::Canceled {
+        state.job_registry.record_cancel(&record.name);
+        job_admin.record_cancelled(&record.id);
+        let _ = ack_redis_success(connection, worker_config, &record).await;
+        return;
+    }
     state.job_registry.record_start(&record.name);
 
     let maybe_info = {
@@ -1246,13 +2445,15 @@ async fn process_redis_job_record(
             .map(|info| (info.handler, info.max_attempts, info.initial_backoff_ms))
     };
     let Some((handler, info_max_attempts, info_backoff_ms)) = maybe_info else {
-        state
-            .job_registry
-            .record_failure(&record.name, "unknown job type".to_owned(), true);
-        let mut dead = record.clone();
-        clear_redis_claim(&mut dead);
-        dead.last_error = Some("unknown job type".to_string());
-        let _ = dead_letter_redis_job(connection, worker_config, &record, &dead).await;
+        dead_letter_invalid_redis_job(
+            connection,
+            worker_config,
+            state,
+            &record,
+            "unknown job type",
+            job_admin,
+        )
+        .await;
         return;
     };
 
@@ -1274,22 +2475,25 @@ async fn process_redis_job_record(
     record.initial_backoff_ms = backoff_ms;
 
     if record.attempt == 0 {
-        state.job_registry.record_failure(
-            &record.name,
-            "invalid job payload: attempt must be >= 1".to_owned(),
-            true,
-        );
-        let mut dead = record.clone();
-        clear_redis_claim(&mut dead);
-        dead.last_error = Some("invalid job payload: attempt must be >= 1".to_string());
-        let _ = dead_letter_redis_job(connection, worker_config, &record, &dead).await;
+        dead_letter_invalid_redis_job(
+            connection,
+            worker_config,
+            state,
+            &record,
+            "invalid job payload: attempt must be >= 1",
+            job_admin,
+        )
+        .await;
         return;
     }
 
     match run_job_handler(handler, state.clone(), record.payload.clone()).await {
         JobExecutionOutcome::Succeeded => {
             match ack_redis_success(connection, worker_config, &record).await {
-                Ok(true) => state.job_registry.record_success(&record.name),
+                Ok(true) => {
+                    state.job_registry.record_success(&record.name);
+                    job_admin.record_success(&record.id);
+                }
                 Ok(false) => tracing::warn!(
                     job = %record.name,
                     job_id = %record.id,
@@ -1304,12 +2508,28 @@ async fn process_redis_job_record(
             }
         }
         JobExecutionOutcome::Failed(error) => {
-            settle_failed_redis_job(connection, worker_config, state, &record, error, "failed")
-                .await;
+            settle_failed_redis_job(
+                connection,
+                worker_config,
+                state,
+                &record,
+                error,
+                "failed",
+                job_admin,
+            )
+            .await;
         }
         JobExecutionOutcome::Panicked(error) => {
             tracing::error!(job = %record.name, error = %error, "redis job handler panicked");
-            dead_letter_panicked_redis_job(connection, worker_config, state, &record, error).await;
+            dead_letter_panicked_redis_job(
+                connection,
+                worker_config,
+                state,
+                &record,
+                error,
+                job_admin,
+            )
+            .await;
         }
     }
 }
@@ -1321,6 +2541,7 @@ fn start_redis_runtime(
     shutdown: &tokio_util::sync::CancellationToken,
     config: &crate::config::JobConfig,
 ) -> Result<(), AutumnError> {
+    let job_admin = JobAdminMemoryBackend::new();
     let url = config
         .redis
         .url
@@ -1339,12 +2560,29 @@ fn start_redis_runtime(
     })?;
     let producer_connection =
         new_redis_connection_manager(&client, "jobs redis connection manager")?;
+    let admin_connection =
+        new_redis_connection_manager(&client, "jobs redis admin connection manager")?;
 
     let queue_key = format!("{}:queue", config.redis.key_prefix);
     let processing_key = format!("{}:processing", config.redis.key_prefix);
     let delayed_key = format!("{}:delayed", config.redis.key_prefix);
     let dead_key = format!("{}:dead", config.redis.key_prefix);
+    let completed_key = format!("{}:completed", config.redis.key_prefix);
     let record_prefix = format!("{}:record:", config.redis.key_prefix);
+    let dead_record_prefix = format!("{}:dead-record:", config.redis.key_prefix);
+
+    if job_admin_backend(state).is_none() {
+        state.insert_extension(JobAdminBackendEntry(Arc::new(RedisJobAdminBackend::new(
+            admin_connection,
+            queue_key.clone(),
+            processing_key.clone(),
+            dead_key.clone(),
+            completed_key.clone(),
+            record_prefix.clone(),
+            dead_record_prefix.clone(),
+            DEFAULT_JOB_ADMIN_HISTORY_LIMIT,
+        ))));
+    }
 
     let per_job_defaults = build_per_job_defaults(&jobs);
     let retry_promotion_interval = std::time::Duration::from_millis(
@@ -1369,6 +2607,7 @@ fn start_redis_runtime(
             record_prefix: record_prefix.clone(),
         }),
         registry: state.job_registry.clone(),
+        job_admin: job_admin.clone(),
         default_max_attempts: config.max_attempts,
         default_initial_backoff_ms: config.initial_backoff_ms,
         per_job_defaults,
@@ -1380,13 +2619,16 @@ fn start_redis_runtime(
             &client,
             Arc::clone(&jobs_by_name),
             state.clone(),
+            job_admin.clone(),
             shutdown.clone(),
             RedisWorkerConfig {
                 queue_key: queue_key.clone(),
                 processing_key: processing_key.clone(),
                 delayed_key: delayed_key.clone(),
                 dead_key: dead_key.clone(),
+                completed_key: completed_key.clone(),
                 record_prefix: record_prefix.clone(),
+                dead_record_prefix: dead_record_prefix.clone(),
                 worker_id: format!("{}:{}", std::process::id(), uuid::Uuid::new_v4()),
                 visibility_timeout_ms: config.redis.visibility_timeout_ms,
                 default_attempts: config.max_attempts,
@@ -1418,10 +2660,12 @@ fn validate_unique_job_names(jobs: &[JobInfo]) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "redis")]
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::sync::mpsc;
     use tokio::time::{Duration, timeout};
 
+    #[cfg(feature = "redis")]
     static REDIS_HANDLER_CALLS: AtomicUsize = AtomicUsize::new(0);
 
     fn always_fail_handler(
@@ -1435,6 +2679,7 @@ mod tests {
         })
     }
 
+    #[cfg(feature = "redis")]
     fn redis_counting_success_handler(
         _state: AppState,
         _payload: Value,
@@ -1445,6 +2690,7 @@ mod tests {
         })
     }
 
+    #[cfg(feature = "redis")]
     fn redis_counting_failure_handler(
         _state: AppState,
         _payload: Value,
@@ -1471,6 +2717,134 @@ mod tests {
         _payload: Value,
     ) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>> {
         panic!("panic before future")
+    }
+
+    #[tokio::test]
+    async fn job_admin_backend_lists_and_operates_failed_jobs() {
+        let backend = JobAdminMemoryBackend::new_for_test(32);
+        let enqueued_id = backend.record_enqueue_for_test(
+            "send_email",
+            serde_json::json!({
+                "user_id": 42,
+                "correlation_id": "req-123",
+                "subject": "Welcome"
+            }),
+            1,
+            5,
+        );
+        let running_id = backend.record_enqueue_for_test("reindex", serde_json::json!({}), 1, 3);
+        backend.record_start_for_test(&running_id, 1);
+        let completed_id = backend.record_enqueue_for_test("digest", serde_json::json!({}), 1, 3);
+        backend.record_start_for_test(&completed_id, 1);
+        backend.record_success_for_test(&completed_id);
+        let failed_id =
+            backend.record_enqueue_for_test("send_email", serde_json::json!({"user_id": 7}), 2, 5);
+        backend.record_start_for_test(&failed_id, 2);
+        backend.record_failure_for_test(&failed_id, "smtp refused recipient");
+
+        let snapshot = backend
+            .snapshot(JobAdminQuery {
+                enqueued_page: 1,
+                running_page: 1,
+                completed_page: 1,
+                failed_page: 1,
+                per_page: 10,
+            })
+            .await
+            .expect("snapshot should render");
+
+        assert_eq!(snapshot.enqueued.records[0].id, enqueued_id);
+        assert_eq!(
+            snapshot.enqueued.records[0].principal_id.as_deref(),
+            Some("42")
+        );
+        assert_eq!(
+            snapshot.enqueued.records[0].correlation_id.as_deref(),
+            Some("req-123")
+        );
+        assert_eq!(snapshot.running.records[0].id, running_id);
+        assert_eq!(snapshot.completed.records[0].id, completed_id);
+        assert_eq!(snapshot.failed.records[0].id, failed_id);
+        assert_eq!(
+            snapshot.failed.records[0].last_error.as_deref(),
+            Some("smtp refused recipient")
+        );
+
+        backend
+            .discard(&failed_id)
+            .await
+            .expect("failed job should be discardable");
+        backend
+            .cancel(&enqueued_id)
+            .await
+            .expect("enqueued job should be cancelable");
+        assert_eq!(
+            backend.try_record_start(&enqueued_id, 1),
+            JobAdminStartDecision::Canceled,
+            "canceled jobs must not race into running"
+        );
+
+        let snapshot = backend
+            .snapshot(JobAdminQuery::default())
+            .await
+            .expect("snapshot after operations");
+        assert!(snapshot.failed.records.is_empty());
+        assert!(snapshot.enqueued.records.is_empty());
+    }
+
+    #[tokio::test]
+    async fn job_admin_retry_reenqueues_failed_payload() {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let backend = JobAdminMemoryBackend::new_for_test(32);
+        let (tx, mut rx) = mpsc::channel(1);
+        init_global_job_client(JobClient {
+            local_sender: Some(tx),
+            #[cfg(feature = "redis")]
+            redis: None,
+            registry: crate::actuator::JobRegistry::new(),
+            job_admin: backend.clone(),
+            default_max_attempts: 5,
+            default_initial_backoff_ms: 250,
+            per_job_defaults: HashMap::from([("send_email".to_string(), (5, 250))]),
+        });
+
+        let failed_id = backend.record_enqueue_for_test(
+            "send_email",
+            serde_json::json!({
+                "user_id": 7,
+                "correlation_id": "req-retry"
+            }),
+            2,
+            5,
+        );
+        backend.record_start_for_test(&failed_id, 2);
+        backend.record_failure_for_test(&failed_id, "smtp refused recipient");
+
+        backend
+            .retry(&failed_id)
+            .await
+            .expect("failed job should be retried");
+        let queued = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("retry should enqueue promptly")
+            .expect("retry should enqueue a job");
+
+        assert_eq!(queued.name, "send_email");
+        assert_eq!(queued.attempt, 1);
+        assert_eq!(queued.max_attempts, 5);
+        assert_eq!(queued.payload["user_id"], 7);
+        assert_eq!(queued.payload["correlation_id"], "req-retry");
+
+        let snapshot = backend
+            .snapshot(JobAdminQuery::default())
+            .await
+            .expect("snapshot after retry");
+        assert!(snapshot.failed.records.is_empty());
+        assert_eq!(snapshot.enqueued.total, 1);
+
+        clear_global_job_client();
     }
 
     #[tokio::test]
@@ -1541,8 +2915,11 @@ mod tests {
         let jobs_by_name = Arc::new(RwLock::new(jobs));
 
         let (tx, mut rx) = mpsc::channel(1);
+        let job_admin = JobAdminMemoryBackend::new_for_test(32);
+        let job_id = job_admin.record_enqueue_for_test("panic", serde_json::json!({}), 1, 3);
         execute_local_job(
             QueuedJob {
+                id: job_id,
                 name: "panic".to_string(),
                 payload: serde_json::json!({}),
                 attempt: 1,
@@ -1552,6 +2929,7 @@ mod tests {
             &jobs_by_name,
             &tx,
             &state,
+            &job_admin,
         )
         .await;
 
@@ -1588,8 +2966,11 @@ mod tests {
         let jobs_by_name = Arc::new(RwLock::new(jobs));
 
         let (tx, mut rx) = mpsc::channel(1);
+        let job_admin = JobAdminMemoryBackend::new_for_test(32);
+        let job_id = job_admin.record_enqueue_for_test("flaky", serde_json::json!({}), 1, 2);
         execute_local_job(
             QueuedJob {
+                id: job_id.clone(),
                 name: "flaky".to_string(),
                 payload: serde_json::json!({}),
                 attempt: 1,
@@ -1599,6 +2980,7 @@ mod tests {
             &jobs_by_name,
             &tx,
             &state,
+            &job_admin,
         )
         .await;
 
@@ -1606,6 +2988,7 @@ mod tests {
             .await
             .expect("retry should be scheduled")
             .expect("retry payload should be sent");
+        assert_eq!(retried.id, job_id);
         assert_eq!(retried.name, "flaky");
         assert_eq!(retried.attempt, 2);
 
@@ -1636,8 +3019,11 @@ mod tests {
         let jobs_by_name = Arc::new(RwLock::new(jobs));
 
         let (tx, mut rx) = mpsc::channel(1);
+        let job_admin = JobAdminMemoryBackend::new_for_test(32);
+        let job_id = job_admin.record_enqueue_for_test("flaky", serde_json::json!({}), 1, 1);
         execute_local_job(
             QueuedJob {
+                id: job_id,
                 name: "flaky".to_string(),
                 payload: serde_json::json!({}),
                 attempt: 1,
@@ -1647,6 +3033,7 @@ mod tests {
             &jobs_by_name,
             &tx,
             &state,
+            &job_admin,
         )
         .await;
 
@@ -1670,6 +3057,9 @@ mod tests {
             attempt,
             max_attempts,
             initial_backoff_ms: 250,
+            enqueued_at_ms: Some(1_000),
+            started_at_ms: None,
+            finished_at_ms: None,
             claimed_by: None,
             claimed_at_ms: None,
             last_error: None,
@@ -1780,12 +3170,14 @@ mod tests {
         record.claimed_by = Some("worker-a".to_string());
         record.claimed_at_ms = Some(20_000);
 
-        let dead = prepare_redis_panic_dead_letter(record, "job handler panicked".to_string());
+        let dead =
+            prepare_redis_panic_dead_letter(record, "job handler panicked".to_string(), 50_000);
 
         assert_eq!(dead.attempt, 1);
         assert_eq!(dead.max_attempts, 3);
         assert_eq!(dead.claimed_by, None);
         assert_eq!(dead.claimed_at_ms, None);
+        assert_eq!(dead.finished_at_ms, Some(50_000));
         assert_eq!(dead.last_error.as_deref(), Some("job handler panicked"));
     }
 
@@ -1850,7 +3242,9 @@ mod tests {
             processing_key: format!("{prefix}:processing"),
             delayed_key: format!("{prefix}:delayed"),
             dead_key: format!("{prefix}:dead"),
+            completed_key: format!("{prefix}:completed"),
             record_prefix: format!("{prefix}:record:"),
+            dead_record_prefix: format!("{prefix}:dead-record:"),
             worker_id: worker_id.to_string(),
             visibility_timeout_ms,
             default_attempts: 3,
@@ -1903,6 +3297,7 @@ mod tests {
         };
         producer
             .enqueue(
+                uuid::Uuid::new_v4().to_string(),
                 "send_email",
                 serde_json::json!({ "user_id": 42 }),
                 max_attempts,
@@ -1910,6 +3305,188 @@ mod tests {
             )
             .await
             .unwrap();
+    }
+
+    #[cfg(feature = "redis")]
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn redis_job_admin_dashboard_reads_cluster_storage_and_operates() {
+        use redis::AsyncCommands as _;
+
+        let (_container, client) = redis_test_client().await;
+        let worker_config = redis_test_worker_config("autumn:test:admin", "worker-a", 30_000);
+        let admin_connection = new_redis_connection_manager(&client, "test redis admin").unwrap();
+        let backend = RedisJobAdminBackend::new(
+            admin_connection,
+            worker_config.queue_key.clone(),
+            worker_config.processing_key.clone(),
+            worker_config.dead_key.clone(),
+            worker_config.completed_key.clone(),
+            worker_config.record_prefix.clone(),
+            worker_config.dead_record_prefix.clone(),
+            128,
+        );
+        let mut connection = new_redis_connection_manager(&client, "test redis setup").unwrap();
+        let now = now_unix_ms();
+
+        let enqueued = RedisJobRecord {
+            id: "job-enqueued".to_string(),
+            name: "send_email".to_string(),
+            payload: serde_json::json!({
+                "user_id": 42,
+                "correlation_id": "req-redis"
+            }),
+            attempt: 1,
+            max_attempts: 5,
+            initial_backoff_ms: 250,
+            enqueued_at_ms: Some(now.saturating_sub(4_000)),
+            started_at_ms: None,
+            finished_at_ms: None,
+            claimed_by: None,
+            claimed_at_ms: None,
+            last_error: None,
+        };
+        let running = RedisJobRecord {
+            id: "job-running".to_string(),
+            name: "reindex".to_string(),
+            payload: serde_json::json!({}),
+            attempt: 1,
+            max_attempts: 3,
+            initial_backoff_ms: 250,
+            enqueued_at_ms: Some(now.saturating_sub(3_000)),
+            started_at_ms: Some(now.saturating_sub(2_000)),
+            finished_at_ms: None,
+            claimed_by: Some("worker-a".to_string()),
+            claimed_at_ms: Some(now.saturating_sub(2_000)),
+            last_error: None,
+        };
+        let completed = RedisJobRecord {
+            id: "job-completed".to_string(),
+            name: "digest".to_string(),
+            payload: serde_json::json!({}),
+            attempt: 1,
+            max_attempts: 3,
+            initial_backoff_ms: 250,
+            enqueued_at_ms: Some(now.saturating_sub(3_000)),
+            started_at_ms: Some(now.saturating_sub(2_000)),
+            finished_at_ms: Some(now.saturating_sub(1_000)),
+            claimed_by: None,
+            claimed_at_ms: None,
+            last_error: None,
+        };
+        let failed_retry = RedisJobRecord {
+            id: "job-failed-retry".to_string(),
+            name: "send_email".to_string(),
+            payload: serde_json::json!({ "user_id": 7 }),
+            attempt: 5,
+            max_attempts: 5,
+            initial_backoff_ms: 250,
+            enqueued_at_ms: Some(now.saturating_sub(4_000)),
+            started_at_ms: Some(now.saturating_sub(3_000)),
+            finished_at_ms: Some(now.saturating_sub(500)),
+            claimed_by: None,
+            claimed_at_ms: None,
+            last_error: Some("smtp refused recipient".to_string()),
+        };
+        let failed_discard = RedisJobRecord {
+            id: "job-failed-discard".to_string(),
+            name: "webhook".to_string(),
+            payload: serde_json::json!({}),
+            attempt: 2,
+            max_attempts: 2,
+            initial_backoff_ms: 250,
+            enqueued_at_ms: Some(now.saturating_sub(4_000)),
+            started_at_ms: Some(now.saturating_sub(3_000)),
+            finished_at_ms: Some(now.saturating_sub(250)),
+            claimed_by: None,
+            claimed_at_ms: None,
+            last_error: Some("endpoint returned 410".to_string()),
+        };
+
+        connection
+            .set::<_, _, ()>(
+                redis_record_key(&worker_config.record_prefix, &enqueued.id),
+                encode_redis_record(&enqueued).unwrap(),
+            )
+            .await
+            .unwrap();
+        connection
+            .lpush::<_, _, ()>(&worker_config.queue_key, &enqueued.id)
+            .await
+            .unwrap();
+        connection
+            .set::<_, _, ()>(
+                redis_record_key(&worker_config.record_prefix, &running.id),
+                encode_redis_record(&running).unwrap(),
+            )
+            .await
+            .unwrap();
+        connection
+            .zadd::<_, _, _, ()>(
+                &worker_config.processing_key,
+                &running.id,
+                now.saturating_add(30_000),
+            )
+            .await
+            .unwrap();
+        connection
+            .lpush::<_, _, ()>(
+                &worker_config.completed_key,
+                encode_redis_record(&completed).unwrap(),
+            )
+            .await
+            .unwrap();
+        for failed in [&failed_retry, &failed_discard] {
+            let encoded = encode_redis_record(failed).unwrap();
+            connection
+                .lpush::<_, _, ()>(&worker_config.dead_key, &encoded)
+                .await
+                .unwrap();
+            connection
+                .set::<_, _, ()>(
+                    format!("{}{}", worker_config.dead_record_prefix, failed.id),
+                    encoded,
+                )
+                .await
+                .unwrap();
+        }
+
+        let snapshot = backend
+            .snapshot(JobAdminQuery {
+                enqueued_page: 1,
+                running_page: 1,
+                completed_page: 1,
+                failed_page: 1,
+                per_page: 10,
+            })
+            .await
+            .expect("redis dashboard snapshot");
+        assert_eq!(snapshot.enqueued.records[0].id, enqueued.id);
+        assert_eq!(
+            snapshot.enqueued.records[0].correlation_id.as_deref(),
+            Some("req-redis")
+        );
+        assert_eq!(snapshot.running.records[0].id, running.id);
+        assert_eq!(snapshot.completed.records[0].id, completed.id);
+        assert_eq!(snapshot.failed.total, 2);
+
+        backend
+            .cancel(&enqueued.id)
+            .await
+            .expect("enqueued redis job should be cancelable");
+        backend
+            .retry(&failed_retry.id)
+            .await
+            .expect("failed redis job should be retryable");
+        backend
+            .discard(&failed_discard.id)
+            .await
+            .expect("failed redis job should be discardable");
+
+        let queue_len: usize = connection.llen(&worker_config.queue_key).await.unwrap();
+        let dead_len: usize = connection.llen(&worker_config.dead_key).await.unwrap();
+        assert_eq!(queue_len, 1, "retry should enqueue a replacement job");
+        assert_eq!(dead_len, 0, "retry and discard should clear failed jobs");
     }
 
     #[cfg(feature = "redis")]
@@ -1936,6 +3513,7 @@ mod tests {
         assert_eq!(processing_count, 1);
 
         let state = AppState::for_test().with_profile("dev");
+        let job_admin = JobAdminMemoryBackend::new_for_test(32);
         state.job_registry().register("send_email");
         state.job_registry().record_enqueue("send_email");
         process_redis_job_record(
@@ -1943,6 +3521,7 @@ mod tests {
             record,
             &redis_jobs_by_name(redis_counting_success_handler, 2),
             &state,
+            &job_admin,
             &worker_config,
         )
         .await;
@@ -1976,6 +3555,7 @@ mod tests {
 
         let mut connection = new_redis_connection_manager(&client, "test redis worker").unwrap();
         let state = AppState::for_test().with_profile("dev");
+        let job_admin = JobAdminMemoryBackend::new_for_test(32);
         state.job_registry().register("send_email");
         state.job_registry().record_enqueue("send_email");
         let jobs = redis_jobs_by_name(redis_counting_failure_handler, 2);
@@ -1984,7 +3564,15 @@ mod tests {
             .await
             .unwrap()
             .expect("first attempt should be claimed");
-        process_redis_job_record(&mut connection, first, &jobs, &state, &worker_config).await;
+        process_redis_job_record(
+            &mut connection,
+            first,
+            &jobs,
+            &state,
+            &job_admin,
+            &worker_config,
+        )
+        .await;
         let delayed_count: usize = connection.zcard(&worker_config.delayed_key).await.unwrap();
         let processing_count: usize = connection
             .zcard(&worker_config.processing_key)
@@ -1994,7 +3582,7 @@ mod tests {
         assert_eq!(processing_count, 0);
 
         tokio::time::sleep(Duration::from_millis(5)).await;
-        promote_due_redis_retries(&mut connection, &worker_config, &state)
+        promote_due_redis_retries(&mut connection, &worker_config, &state, &job_admin)
             .await
             .unwrap();
         let queued_count: usize = connection.llen(&worker_config.queue_key).await.unwrap();
@@ -2005,7 +3593,15 @@ mod tests {
             .unwrap()
             .expect("retry attempt should be claimed");
         assert_eq!(second.attempt, 2);
-        process_redis_job_record(&mut connection, second, &jobs, &state, &worker_config).await;
+        process_redis_job_record(
+            &mut connection,
+            second,
+            &jobs,
+            &state,
+            &job_admin,
+            &worker_config,
+        )
+        .await;
 
         let dead_count: usize = connection.llen(&worker_config.dead_key).await.unwrap();
         let delayed_count: usize = connection.zcard(&worker_config.delayed_key).await.unwrap();
@@ -2030,6 +3626,7 @@ mod tests {
 
         let mut connection = new_redis_connection_manager(&client, "test redis worker").unwrap();
         let state = AppState::for_test().with_profile("dev");
+        let job_admin = JobAdminMemoryBackend::new_for_test(32);
         state.job_registry().register("send_email");
         state.job_registry().record_enqueue("send_email");
 
@@ -2042,6 +3639,7 @@ mod tests {
             record,
             &redis_jobs_by_name(panicking_handler, 3),
             &state,
+            &job_admin,
             &worker_config,
         )
         .await;
@@ -2085,8 +3683,9 @@ mod tests {
 
         tokio::time::sleep(Duration::from_millis(5)).await;
         let state = AppState::for_test().with_profile("dev");
+        let job_admin = JobAdminMemoryBackend::new_for_test(32);
         state.job_registry().register("send_email");
-        recover_stale_redis_jobs(&mut connection, &worker_b, &state)
+        recover_stale_redis_jobs(&mut connection, &worker_b, &state, &job_admin)
             .await
             .unwrap();
 
@@ -2274,6 +3873,7 @@ mod tests {
             #[cfg(feature = "redis")]
             redis: None,
             registry: crate::actuator::JobRegistry::new(),
+            job_admin: JobAdminMemoryBackend::new_for_test(32),
             default_max_attempts: 3,
             default_initial_backoff_ms: 250,
             per_job_defaults: HashMap::new(),

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -464,23 +464,14 @@ impl JobAdminMemoryBackend {
         }
     }
 
-    fn mark_retried(&self, id: &str) {
-        if let Ok(mut inner) = self.inner.write()
-            && let Some(record) = inner.records.get_mut(id)
-        {
-            record.status = JobAdminStatus::Retried;
-            record.finished_at = Some(chrono::Utc::now());
-        }
-    }
-
     fn retry_payload(&self, id: &str) -> AutumnResult<(String, Value)> {
-        let inner = self
+        let mut inner = self
             .inner
-            .read()
+            .write()
             .map_err(|_| AutumnError::internal_server_error_msg("job admin store lock poisoned"))?;
         let record = inner
             .records
-            .get(id)
+            .get_mut(id)
             .ok_or_else(|| AutumnError::not_found_msg(format!("job '{id}' not found")))?;
         if record.status != JobAdminStatus::Failed {
             return Err(AutumnError::bad_request_msg(
@@ -488,6 +479,8 @@ impl JobAdminMemoryBackend {
             ));
         }
         let retry = (record.name.clone(), record.payload.clone());
+        record.status = JobAdminStatus::Retried;
+        record.finished_at = Some(chrono::Utc::now());
         drop(inner);
         Ok(retry)
     }
@@ -620,12 +613,11 @@ impl JobAdminBackend for JobAdminMemoryBackend {
     fn retry(&self, id: &str) -> JobAdminFuture<'_, ()> {
         let id = id.to_owned();
         Box::pin(async move {
-            let (name, payload) = self.retry_payload(&id)?;
             let client = global_job_client().ok_or_else(|| {
                 AutumnError::service_unavailable_msg("job runtime is not initialized")
             })?;
+            let (name, payload) = self.retry_payload(&id)?;
             client.enqueue(&name, payload).await?;
-            self.mark_retried(&id);
             Ok(())
         })
     }
@@ -2115,6 +2107,8 @@ if ARGV[4] == 'requeue' then
   redis.call('LPUSH', KEYS[3], ARGV[1])
 elseif ARGV[4] == 'dead' then
   redis.call('LPUSH', KEYS[4], ARGV[5])
+  redis.call('SET', KEYS[5] .. ARGV[1], ARGV[5])
+  redis.call('LTRIM', KEYS[4], 0, tonumber(ARGV[6]) - 1)
   redis.call('DEL', key)
 else
   return 0
@@ -2136,16 +2130,18 @@ return 1
 
     let applied: usize = redis::cmd("EVAL")
         .arg(STALE_SCRIPT)
-        .arg(4)
+        .arg(5)
         .arg(&worker_config.processing_key)
         .arg(&worker_config.record_prefix)
         .arg(&worker_config.queue_key)
         .arg(&worker_config.dead_key)
+        .arg(&worker_config.dead_record_prefix)
         .arg(&expected.id)
         .arg(claimed_by)
         .arg(claimed_at_ms)
         .arg(mode)
         .arg(encoded)
+        .arg(DEFAULT_JOB_ADMIN_HISTORY_LIMIT)
         .query_async(connection)
         .await?;
 
@@ -2848,6 +2844,67 @@ mod tests {
         assert_eq!(snapshot.enqueued.total, 1);
 
         clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn job_admin_retry_claims_failed_record_before_enqueueing() {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let backend = JobAdminMemoryBackend::new_for_test(32);
+        let (tx, mut rx) = mpsc::channel(2);
+        init_global_job_client(JobClient {
+            local_sender: Some(tx),
+            #[cfg(feature = "redis")]
+            redis: None,
+            registry: crate::actuator::JobRegistry::new(),
+            job_admin: backend.clone(),
+            default_max_attempts: 5,
+            default_initial_backoff_ms: 250,
+            per_job_defaults: HashMap::from([("send_email".to_string(), (5, 250))]),
+        });
+
+        let failed_id =
+            backend.record_enqueue_for_test("send_email", serde_json::json!({"user_id": 7}), 2, 5);
+        backend.record_start_for_test(&failed_id, 2);
+        backend.record_failure_for_test(&failed_id, "smtp refused recipient");
+
+        let (first, second) = tokio::join!(backend.retry(&failed_id), backend.retry(&failed_id));
+        assert!(
+            first.is_ok() ^ second.is_ok(),
+            "exactly one concurrent retry should claim the failed job"
+        );
+        let queued = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("one retry should enqueue promptly")
+            .expect("one retry should enqueue a job");
+        assert_eq!(queued.name, "send_email");
+        assert!(timeout(Duration::from_millis(25), rx.recv()).await.is_err());
+
+        clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn job_admin_retry_payload_claim_is_single_use() {
+        let backend = JobAdminMemoryBackend::new_for_test(32);
+        let failed_id =
+            backend.record_enqueue_for_test("send_email", serde_json::json!({"user_id": 7}), 2, 5);
+        backend.record_start_for_test(&failed_id, 2);
+        backend.record_failure_for_test(&failed_id, "smtp refused recipient");
+
+        let first = backend
+            .retry_payload(&failed_id)
+            .expect("first retry claim should return the payload");
+        assert_eq!(first.0, "send_email");
+        let second = backend
+            .retry_payload(&failed_id)
+            .expect_err("second retry claim must be rejected before enqueue");
+        assert!(
+            second
+                .to_string()
+                .contains("only failed jobs can be retried"),
+            "unexpected second retry error: {second}"
+        );
     }
 
     #[tokio::test]
@@ -3820,6 +3877,57 @@ mod tests {
                 .as_deref()
                 .is_some_and(|error| error.contains("visibility timeout expired"))
         );
+    }
+
+    #[cfg(feature = "redis")]
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn redis_stale_terminal_failure_keeps_retry_discard_metadata() {
+        use redis::AsyncCommands as _;
+
+        let (_container, client) = redis_test_client().await;
+        let worker_a = redis_test_worker_config("autumn:test:stale-dead", "worker-a", 1);
+        let worker_b = redis_test_worker_config("autumn:test:stale-dead", "worker-b", 30_000);
+        redis_enqueue_test_job(&client, &worker_a, 1).await;
+
+        let mut connection = new_redis_connection_manager(&client, "test redis worker").unwrap();
+        let claimed = claim_next_redis_job(&mut connection, &worker_a)
+            .await
+            .unwrap()
+            .expect("first worker should claim the final attempt");
+        assert_eq!(claimed.claimed_by.as_deref(), Some("worker-a"));
+        assert_eq!(claimed.attempt, 1);
+        let failed_id = claimed.id.clone();
+
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        let state = AppState::for_test().with_profile("dev");
+        let job_admin = JobAdminMemoryBackend::new_for_test(32);
+        state.job_registry().register("send_email");
+        recover_stale_redis_jobs(&mut connection, &worker_b, &state, &job_admin)
+            .await
+            .unwrap();
+
+        let dead_record_key = format!("{}{}", worker_b.dead_record_prefix, failed_id);
+        let dead_record: Option<String> = connection.get(&dead_record_key).await.unwrap();
+        assert!(
+            dead_record.is_some(),
+            "stale terminal failures need per-id metadata for admin actions"
+        );
+        let dead_count: usize = connection.llen(&worker_b.dead_key).await.unwrap();
+        assert_eq!(dead_count, 1);
+
+        let backend = redis_admin_test_backend(&client, &worker_b);
+        backend
+            .retry(&failed_id)
+            .await
+            .expect("stale terminal failure should be retryable from the dashboard");
+
+        let queued_count: usize = connection.llen(&worker_b.queue_key).await.unwrap();
+        let dead_count: usize = connection.llen(&worker_b.dead_key).await.unwrap();
+        let dead_record_exists: bool = connection.exists(&dead_record_key).await.unwrap();
+        assert_eq!(queued_count, 1);
+        assert_eq!(dead_count, 0);
+        assert!(!dead_record_exists);
     }
 
     #[tokio::test]

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -485,6 +485,25 @@ impl JobAdminMemoryBackend {
         Ok(retry)
     }
 
+    fn ensure_retryable(&self, id: &str) -> AutumnResult<()> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|_| AutumnError::internal_server_error_msg("job admin store lock poisoned"))?;
+        let record = inner
+            .records
+            .get(id)
+            .ok_or_else(|| AutumnError::not_found_msg(format!("job '{id}' not found")))?;
+        let status = record.status;
+        drop(inner);
+        if status != JobAdminStatus::Failed {
+            return Err(AutumnError::bad_request_msg(
+                "only failed jobs can be retried",
+            ));
+        }
+        Ok(())
+    }
+
     fn discard_failed(&self, id: &str) -> AutumnResult<()> {
         let mut inner = self
             .inner
@@ -613,6 +632,7 @@ impl JobAdminBackend for JobAdminMemoryBackend {
     fn retry(&self, id: &str) -> JobAdminFuture<'_, ()> {
         let id = id.to_owned();
         Box::pin(async move {
+            self.ensure_retryable(&id)?;
             let client = global_job_client().ok_or_else(|| {
                 AutumnError::service_unavailable_msg("job runtime is not initialized")
             })?;
@@ -1938,15 +1958,17 @@ fn expected_claim_args(record: &RedisJobRecord) -> Option<(&str, u64)> {
 }
 
 #[cfg(feature = "redis")]
-async fn apply_claimed_redis_transition(
-    connection: &mut redis::aio::ConnectionManager,
-    worker_config: &RedisWorkerConfig,
-    expected: &RedisJobRecord,
-    mode: &str,
-    encoded_record: Option<String>,
-    due_at_ms: Option<u64>,
-) -> Result<bool, redis::RedisError> {
-    const TRANSITION_SCRIPT: &str = r"
+const CLAIMED_REDIS_TRANSITION_SCRIPT: &str = r"
+local function trim_dead_history(dead_key, dead_record_prefix, limit)
+  local trimmed_records = redis.call('LRANGE', dead_key, limit, -1)
+  for _, encoded in ipairs(trimmed_records) do
+    local trimmed_ok, trimmed = pcall(cjson.decode, encoded)
+    if trimmed_ok and trimmed['id'] then
+      redis.call('DEL', dead_record_prefix .. trimmed['id'])
+    end
+  end
+  redis.call('LTRIM', dead_key, 0, limit - 1)
+end
 local key = KEYS[2] .. ARGV[1]
 local body = redis.call('GET', key)
 if not body then
@@ -1973,7 +1995,7 @@ elseif ARGV[4] == 'retry' then
 elseif ARGV[4] == 'dead' then
   redis.call('LPUSH', KEYS[4], ARGV[5])
   redis.call('SET', KEYS[6] .. ARGV[1], ARGV[5])
-  redis.call('LTRIM', KEYS[4], 0, tonumber(ARGV[7]) - 1)
+  trim_dead_history(KEYS[4], KEYS[6], tonumber(ARGV[7]))
   redis.call('DEL', key)
 else
   return 0
@@ -1981,12 +2003,21 @@ end
 return 1
 ";
 
+#[cfg(feature = "redis")]
+async fn apply_claimed_redis_transition(
+    connection: &mut redis::aio::ConnectionManager,
+    worker_config: &RedisWorkerConfig,
+    expected: &RedisJobRecord,
+    mode: &str,
+    encoded_record: Option<String>,
+    due_at_ms: Option<u64>,
+) -> Result<bool, redis::RedisError> {
     let Some((claimed_by, claimed_at_ms)) = expected_claim_args(expected) else {
         return Ok(false);
     };
 
     let applied: usize = redis::cmd("EVAL")
-        .arg(TRANSITION_SCRIPT)
+        .arg(CLAIMED_REDIS_TRANSITION_SCRIPT)
         .arg(6)
         .arg(&worker_config.processing_key)
         .arg(&worker_config.record_prefix)
@@ -2077,13 +2108,17 @@ async fn dead_letter_redis_job(
 }
 
 #[cfg(feature = "redis")]
-async fn apply_stale_redis_recovery(
-    connection: &mut redis::aio::ConnectionManager,
-    worker_config: &RedisWorkerConfig,
-    expected: &RedisJobRecord,
-    action: &RedisStaleRecovery,
-) -> Result<bool, redis::RedisError> {
-    const STALE_SCRIPT: &str = r"
+const STALE_REDIS_RECOVERY_SCRIPT: &str = r"
+local function trim_dead_history(dead_key, dead_record_prefix, limit)
+  local trimmed_records = redis.call('LRANGE', dead_key, limit, -1)
+  for _, encoded in ipairs(trimmed_records) do
+    local trimmed_ok, trimmed = pcall(cjson.decode, encoded)
+    if trimmed_ok and trimmed['id'] then
+      redis.call('DEL', dead_record_prefix .. trimmed['id'])
+    end
+  end
+  redis.call('LTRIM', dead_key, 0, limit - 1)
+end
 local key = KEYS[2] .. ARGV[1]
 local body = redis.call('GET', key)
 if not body then
@@ -2108,7 +2143,7 @@ if ARGV[4] == 'requeue' then
 elseif ARGV[4] == 'dead' then
   redis.call('LPUSH', KEYS[4], ARGV[5])
   redis.call('SET', KEYS[5] .. ARGV[1], ARGV[5])
-  redis.call('LTRIM', KEYS[4], 0, tonumber(ARGV[6]) - 1)
+  trim_dead_history(KEYS[4], KEYS[5], tonumber(ARGV[6]))
   redis.call('DEL', key)
 else
   return 0
@@ -2116,6 +2151,13 @@ end
 return 1
 ";
 
+#[cfg(feature = "redis")]
+async fn apply_stale_redis_recovery(
+    connection: &mut redis::aio::ConnectionManager,
+    worker_config: &RedisWorkerConfig,
+    expected: &RedisJobRecord,
+    action: &RedisStaleRecovery,
+) -> Result<bool, redis::RedisError> {
     let Some((claimed_by, claimed_at_ms)) = expected_claim_args(expected) else {
         return Ok(false);
     };
@@ -2129,7 +2171,7 @@ return 1
     };
 
     let applied: usize = redis::cmd("EVAL")
-        .arg(STALE_SCRIPT)
+        .arg(STALE_REDIS_RECOVERY_SCRIPT)
         .arg(5)
         .arg(&worker_config.processing_key)
         .arg(&worker_config.record_prefix)
@@ -3346,6 +3388,35 @@ mod tests {
                 .as_deref()
                 .is_some_and(|error| error.contains("visibility timeout expired")),
             "dead-lettered stale claims should retain the recovery reason"
+        );
+    }
+
+    #[cfg(feature = "redis")]
+    #[test]
+    fn redis_dead_letter_scripts_delete_trimmed_dead_record_metadata() {
+        assert!(
+            CLAIMED_REDIS_TRANSITION_SCRIPT
+                .contains("trim_dead_history(KEYS[4], KEYS[6], tonumber(ARGV[7]))"),
+            "claimed-job dead-letter trim should delete metadata for records beyond the history limit"
+        );
+        assert!(
+            STALE_REDIS_RECOVERY_SCRIPT
+                .contains("trim_dead_history(KEYS[4], KEYS[5], tonumber(ARGV[6]))"),
+            "stale-recovery dead-letter trim should delete metadata for records beyond the history limit"
+        );
+        assert!(
+            CLAIMED_REDIS_TRANSITION_SCRIPT
+                .matches("redis.call('DEL', dead_record_prefix .. trimmed['id'])")
+                .count()
+                >= 1,
+            "claimed-job dead-letter script should remove trimmed per-id metadata"
+        );
+        assert!(
+            STALE_REDIS_RECOVERY_SCRIPT
+                .matches("redis.call('DEL', dead_record_prefix .. trimmed['id'])")
+                .count()
+                >= 1,
+            "stale-recovery dead-letter script should remove trimmed per-id metadata"
         );
     }
 

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -89,6 +89,8 @@ pub enum JobAdminStatus {
     Enqueued,
     /// Currently executing in a worker.
     Running,
+    /// Failed but already scheduled for an automatic retry.
+    Retrying,
     /// Finished successfully.
     Completed,
     /// Finished with a terminal error.
@@ -108,6 +110,7 @@ impl JobAdminStatus {
         match self {
             Self::Enqueued => "enqueued",
             Self::Running => "running",
+            Self::Retrying => "retrying",
             Self::Completed => "completed",
             Self::Failed => "failed",
             Self::Discarded => "discarded",
@@ -435,7 +438,7 @@ impl JobAdminMemoryBackend {
         if let Ok(mut inner) = self.inner.write()
             && let Some(record) = inner.records.get_mut(id)
         {
-            record.status = JobAdminStatus::Failed;
+            record.status = JobAdminStatus::Retrying;
             record.finished_at = Some(chrono::Utc::now());
             record.last_error = Some(error.to_owned());
         }
@@ -651,7 +654,7 @@ fn prune_job_admin_history(inner: &mut JobAdminMemoryInner) {
         let is_active = inner.records.get(&id).is_some_and(|record| {
             matches!(
                 record.status,
-                JobAdminStatus::Enqueued | JobAdminStatus::Running
+                JobAdminStatus::Enqueued | JobAdminStatus::Running | JobAdminStatus::Retrying
             )
         });
         if is_active {
@@ -3048,6 +3051,64 @@ mod tests {
         assert!(status.last_error.is_some());
     }
 
+    #[tokio::test]
+    async fn job_admin_local_retriable_failure_is_not_operator_retryable_failed_work() {
+        let state = AppState::for_test().with_profile("dev");
+        state.job_registry().register("flaky");
+        state.job_registry().record_enqueue("flaky");
+
+        let mut jobs = HashMap::new();
+        jobs.insert(
+            "flaky".to_string(),
+            JobInfo {
+                name: "flaky".to_string(),
+                max_attempts: 2,
+                initial_backoff_ms: 60_000,
+                handler: always_fail_handler,
+            },
+        );
+        let jobs_by_name = Arc::new(RwLock::new(jobs));
+
+        let (tx, mut rx) = mpsc::channel(1);
+        let job_admin = JobAdminMemoryBackend::new_for_test(32);
+        let job_id = job_admin.record_enqueue_for_test("flaky", serde_json::json!({}), 1, 2);
+        execute_local_job(
+            QueuedJob {
+                id: job_id.clone(),
+                name: "flaky".to_string(),
+                payload: serde_json::json!({}),
+                attempt: 1,
+                max_attempts: 2,
+                initial_backoff_ms: 60_000,
+            },
+            &jobs_by_name,
+            &tx,
+            &state,
+            &job_admin,
+        )
+        .await;
+
+        let snapshot = job_admin
+            .snapshot(JobAdminQuery::default())
+            .await
+            .expect("job admin snapshot");
+        assert!(
+            snapshot.failed.records.is_empty(),
+            "automatic retries must stay out of terminal failed work"
+        );
+        let retry_error = job_admin
+            .retry(&job_id)
+            .await
+            .expect_err("operator retry must reject sleeping automatic retries");
+        assert!(
+            retry_error
+                .to_string()
+                .contains("only failed jobs can be retried"),
+            "unexpected retry error: {retry_error}"
+        );
+        assert!(timeout(Duration::from_millis(25), rx.recv()).await.is_err());
+    }
+
     #[cfg(feature = "redis")]
     fn redis_test_record(attempt: u32, max_attempts: u32) -> RedisJobRecord {
         RedisJobRecord {
@@ -3308,15 +3369,21 @@ mod tests {
     }
 
     #[cfg(feature = "redis")]
-    #[tokio::test(flavor = "multi_thread")]
-    #[ignore = "requires Docker (testcontainers)"]
-    async fn redis_job_admin_dashboard_reads_cluster_storage_and_operates() {
-        use redis::AsyncCommands as _;
+    struct RedisAdminSeedRecords {
+        enqueued: RedisJobRecord,
+        running: RedisJobRecord,
+        completed: RedisJobRecord,
+        failed_retry: RedisJobRecord,
+        failed_discard: RedisJobRecord,
+    }
 
-        let (_container, client) = redis_test_client().await;
-        let worker_config = redis_test_worker_config("autumn:test:admin", "worker-a", 30_000);
-        let admin_connection = new_redis_connection_manager(&client, "test redis admin").unwrap();
-        let backend = RedisJobAdminBackend::new(
+    #[cfg(feature = "redis")]
+    fn redis_admin_test_backend(
+        client: &redis::Client,
+        worker_config: &RedisWorkerConfig,
+    ) -> RedisJobAdminBackend {
+        let admin_connection = new_redis_connection_manager(client, "test redis admin").unwrap();
+        RedisJobAdminBackend::new(
             admin_connection,
             worker_config.queue_key.clone(),
             worker_config.processing_key.clone(),
@@ -3325,131 +3392,181 @@ mod tests {
             worker_config.record_prefix.clone(),
             worker_config.dead_record_prefix.clone(),
             128,
-        );
-        let mut connection = new_redis_connection_manager(&client, "test redis setup").unwrap();
-        let now = now_unix_ms();
+        )
+    }
 
-        let enqueued = RedisJobRecord {
-            id: "job-enqueued".to_string(),
-            name: "send_email".to_string(),
-            payload: serde_json::json!({
-                "user_id": 42,
-                "correlation_id": "req-redis"
-            }),
-            attempt: 1,
-            max_attempts: 5,
-            initial_backoff_ms: 250,
-            enqueued_at_ms: Some(now.saturating_sub(4_000)),
-            started_at_ms: None,
-            finished_at_ms: None,
-            claimed_by: None,
-            claimed_at_ms: None,
-            last_error: None,
-        };
-        let running = RedisJobRecord {
-            id: "job-running".to_string(),
-            name: "reindex".to_string(),
-            payload: serde_json::json!({}),
-            attempt: 1,
-            max_attempts: 3,
-            initial_backoff_ms: 250,
-            enqueued_at_ms: Some(now.saturating_sub(3_000)),
-            started_at_ms: Some(now.saturating_sub(2_000)),
-            finished_at_ms: None,
-            claimed_by: Some("worker-a".to_string()),
-            claimed_at_ms: Some(now.saturating_sub(2_000)),
-            last_error: None,
-        };
-        let completed = RedisJobRecord {
-            id: "job-completed".to_string(),
-            name: "digest".to_string(),
-            payload: serde_json::json!({}),
-            attempt: 1,
-            max_attempts: 3,
-            initial_backoff_ms: 250,
-            enqueued_at_ms: Some(now.saturating_sub(3_000)),
-            started_at_ms: Some(now.saturating_sub(2_000)),
-            finished_at_ms: Some(now.saturating_sub(1_000)),
-            claimed_by: None,
-            claimed_at_ms: None,
-            last_error: None,
-        };
-        let failed_retry = RedisJobRecord {
-            id: "job-failed-retry".to_string(),
-            name: "send_email".to_string(),
-            payload: serde_json::json!({ "user_id": 7 }),
-            attempt: 5,
-            max_attempts: 5,
-            initial_backoff_ms: 250,
-            enqueued_at_ms: Some(now.saturating_sub(4_000)),
-            started_at_ms: Some(now.saturating_sub(3_000)),
-            finished_at_ms: Some(now.saturating_sub(500)),
-            claimed_by: None,
-            claimed_at_ms: None,
-            last_error: Some("smtp refused recipient".to_string()),
-        };
-        let failed_discard = RedisJobRecord {
-            id: "job-failed-discard".to_string(),
-            name: "webhook".to_string(),
-            payload: serde_json::json!({}),
-            attempt: 2,
-            max_attempts: 2,
-            initial_backoff_ms: 250,
-            enqueued_at_ms: Some(now.saturating_sub(4_000)),
-            started_at_ms: Some(now.saturating_sub(3_000)),
-            finished_at_ms: Some(now.saturating_sub(250)),
-            claimed_by: None,
-            claimed_at_ms: None,
-            last_error: Some("endpoint returned 410".to_string()),
-        };
+    #[cfg(feature = "redis")]
+    fn redis_admin_seed_records(now: u64) -> RedisAdminSeedRecords {
+        RedisAdminSeedRecords {
+            enqueued: RedisJobRecord {
+                id: "job-enqueued".to_string(),
+                name: "send_email".to_string(),
+                payload: serde_json::json!({"user_id": 42, "correlation_id": "req-redis"}),
+                attempt: 1,
+                max_attempts: 5,
+                initial_backoff_ms: 250,
+                enqueued_at_ms: Some(now.saturating_sub(4_000)),
+                started_at_ms: None,
+                finished_at_ms: None,
+                claimed_by: None,
+                claimed_at_ms: None,
+                last_error: None,
+            },
+            running: RedisJobRecord {
+                id: "job-running".to_string(),
+                name: "reindex".to_string(),
+                payload: serde_json::json!({}),
+                attempt: 1,
+                max_attempts: 3,
+                initial_backoff_ms: 250,
+                enqueued_at_ms: Some(now.saturating_sub(3_000)),
+                started_at_ms: Some(now.saturating_sub(2_000)),
+                finished_at_ms: None,
+                claimed_by: Some("worker-a".to_string()),
+                claimed_at_ms: Some(now.saturating_sub(2_000)),
+                last_error: None,
+            },
+            completed: RedisJobRecord {
+                id: "job-completed".to_string(),
+                name: "digest".to_string(),
+                payload: serde_json::json!({}),
+                attempt: 1,
+                max_attempts: 3,
+                initial_backoff_ms: 250,
+                enqueued_at_ms: Some(now.saturating_sub(3_000)),
+                started_at_ms: Some(now.saturating_sub(2_000)),
+                finished_at_ms: Some(now.saturating_sub(1_000)),
+                claimed_by: None,
+                claimed_at_ms: None,
+                last_error: None,
+            },
+            failed_retry: RedisJobRecord {
+                id: "job-failed-retry".to_string(),
+                name: "send_email".to_string(),
+                payload: serde_json::json!({ "user_id": 7 }),
+                attempt: 5,
+                max_attempts: 5,
+                initial_backoff_ms: 250,
+                enqueued_at_ms: Some(now.saturating_sub(4_000)),
+                started_at_ms: Some(now.saturating_sub(3_000)),
+                finished_at_ms: Some(now.saturating_sub(500)),
+                claimed_by: None,
+                claimed_at_ms: None,
+                last_error: Some("smtp refused recipient".to_string()),
+            },
+            failed_discard: RedisJobRecord {
+                id: "job-failed-discard".to_string(),
+                name: "webhook".to_string(),
+                payload: serde_json::json!({}),
+                attempt: 2,
+                max_attempts: 2,
+                initial_backoff_ms: 250,
+                enqueued_at_ms: Some(now.saturating_sub(4_000)),
+                started_at_ms: Some(now.saturating_sub(3_000)),
+                finished_at_ms: Some(now.saturating_sub(250)),
+                claimed_by: None,
+                claimed_at_ms: None,
+                last_error: Some("endpoint returned 410".to_string()),
+            },
+        }
+    }
+
+    #[cfg(feature = "redis")]
+    async fn redis_store_active_admin_record(
+        connection: &mut redis::aio::ConnectionManager,
+        worker_config: &RedisWorkerConfig,
+        record: &RedisJobRecord,
+        now: u64,
+    ) {
+        use redis::AsyncCommands as _;
 
         connection
             .set::<_, _, ()>(
-                redis_record_key(&worker_config.record_prefix, &enqueued.id),
-                encode_redis_record(&enqueued).unwrap(),
+                redis_record_key(&worker_config.record_prefix, &record.id),
+                encode_redis_record(record).unwrap(),
             )
             .await
             .unwrap();
-        connection
-            .lpush::<_, _, ()>(&worker_config.queue_key, &enqueued.id)
-            .await
-            .unwrap();
-        connection
-            .set::<_, _, ()>(
-                redis_record_key(&worker_config.record_prefix, &running.id),
-                encode_redis_record(&running).unwrap(),
-            )
-            .await
-            .unwrap();
-        connection
-            .zadd::<_, _, _, ()>(
-                &worker_config.processing_key,
-                &running.id,
-                now.saturating_add(30_000),
-            )
-            .await
-            .unwrap();
-        connection
-            .lpush::<_, _, ()>(
-                &worker_config.completed_key,
-                encode_redis_record(&completed).unwrap(),
-            )
-            .await
-            .unwrap();
-        for failed in [&failed_retry, &failed_discard] {
-            let encoded = encode_redis_record(failed).unwrap();
+        match record.started_at_ms {
+            Some(_) => {
+                connection
+                    .zadd::<_, _, _, ()>(
+                        &worker_config.processing_key,
+                        &record.id,
+                        now.saturating_add(30_000),
+                    )
+                    .await
+                    .unwrap();
+            }
+            None => {
+                connection
+                    .lpush::<_, _, ()>(&worker_config.queue_key, &record.id)
+                    .await
+                    .unwrap();
+            }
+        }
+    }
+
+    #[cfg(feature = "redis")]
+    async fn redis_store_history_admin_record(
+        connection: &mut redis::aio::ConnectionManager,
+        worker_config: &RedisWorkerConfig,
+        record: &RedisJobRecord,
+        failed: bool,
+    ) {
+        use redis::AsyncCommands as _;
+
+        let encoded = encode_redis_record(record).unwrap();
+        if failed {
             connection
                 .lpush::<_, _, ()>(&worker_config.dead_key, &encoded)
                 .await
                 .unwrap();
             connection
                 .set::<_, _, ()>(
-                    format!("{}{}", worker_config.dead_record_prefix, failed.id),
+                    format!("{}{}", worker_config.dead_record_prefix, record.id),
                     encoded,
                 )
                 .await
                 .unwrap();
+        } else {
+            connection
+                .lpush::<_, _, ()>(&worker_config.completed_key, encoded)
+                .await
+                .unwrap();
         }
+    }
+
+    #[cfg(feature = "redis")]
+    async fn seed_redis_admin_storage(
+        connection: &mut redis::aio::ConnectionManager,
+        worker_config: &RedisWorkerConfig,
+        now: u64,
+    ) -> RedisAdminSeedRecords {
+        let records = redis_admin_seed_records(now);
+        redis_store_active_admin_record(connection, worker_config, &records.enqueued, now).await;
+        redis_store_active_admin_record(connection, worker_config, &records.running, now).await;
+        redis_store_history_admin_record(connection, worker_config, &records.completed, false)
+            .await;
+        redis_store_history_admin_record(connection, worker_config, &records.failed_retry, true)
+            .await;
+        redis_store_history_admin_record(connection, worker_config, &records.failed_discard, true)
+            .await;
+        records
+    }
+
+    #[cfg(feature = "redis")]
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn redis_job_admin_dashboard_reads_cluster_storage_and_operates() {
+        use redis::AsyncCommands as _;
+
+        let (_container, client) = redis_test_client().await;
+        let worker_config = redis_test_worker_config("autumn:test:admin", "worker-a", 30_000);
+        let backend = redis_admin_test_backend(&client, &worker_config);
+        let mut connection = new_redis_connection_manager(&client, "test redis setup").unwrap();
+        let records =
+            seed_redis_admin_storage(&mut connection, &worker_config, now_unix_ms()).await;
 
         let snapshot = backend
             .snapshot(JobAdminQuery {
@@ -3461,25 +3578,25 @@ mod tests {
             })
             .await
             .expect("redis dashboard snapshot");
-        assert_eq!(snapshot.enqueued.records[0].id, enqueued.id);
+        assert_eq!(snapshot.enqueued.records[0].id, records.enqueued.id);
         assert_eq!(
             snapshot.enqueued.records[0].correlation_id.as_deref(),
             Some("req-redis")
         );
-        assert_eq!(snapshot.running.records[0].id, running.id);
-        assert_eq!(snapshot.completed.records[0].id, completed.id);
+        assert_eq!(snapshot.running.records[0].id, records.running.id);
+        assert_eq!(snapshot.completed.records[0].id, records.completed.id);
         assert_eq!(snapshot.failed.total, 2);
 
         backend
-            .cancel(&enqueued.id)
+            .cancel(&records.enqueued.id)
             .await
             .expect("enqueued redis job should be cancelable");
         backend
-            .retry(&failed_retry.id)
+            .retry(&records.failed_retry.id)
             .await
             .expect("failed redis job should be retryable");
         backend
-            .discard(&failed_discard.id)
+            .discard(&records.failed_discard.id)
             .await
             .expect("failed redis job should be discardable");
 

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -778,6 +778,9 @@ fn mount_framework_routes(
     config: &AutumnConfig,
     dev_reload_enabled: bool,
 ) -> axum::Router<AppState> {
+    #[cfg(not(feature = "mail"))]
+    let _ = config;
+
     // Framework-provided routes
     #[cfg(feature = "htmx")]
     {

--- a/docs/guide/jobs.md
+++ b/docs/guide/jobs.md
@@ -81,6 +81,12 @@ domain aggregate id, or provider idempotency token.
 
 ## Observability
 
+Mount `autumn-admin-plugin` to get the built-in operator dashboard at
+`GET /admin/jobs` (or the plugin prefix you choose). It lists enqueued, running,
+recently completed, and failed jobs with retry/discard/cancel actions. See the
+[Operating Background Jobs](operating-background-jobs.md) guide for dashboard
+setup, action semantics, and bounded refresh behavior.
+
 `GET /actuator/jobs` returns per-job:
 
 - `queued`

--- a/docs/guide/operating-background-jobs.md
+++ b/docs/guide/operating-background-jobs.md
@@ -34,7 +34,7 @@ The dashboard renders four paginated lists, newest-first:
 - Enqueued jobs waiting for a worker.
 - Running jobs currently executing in this runtime.
 - Completed jobs from the last 24 hours.
-- Failed jobs from the last 7 days.
+- Terminally failed jobs from the last 7 days.
 
 Each row includes the job name, lifecycle timestamps, attempt count, principal
 id, correlation id, and last error. The default backend extracts principal and
@@ -49,9 +49,13 @@ next run time when available, and last run status.
 
 ## Operator actions
 
-Failed jobs can be retried or discarded. Retrying keeps the old failed row as a
-retried lifecycle entry and enqueues a new job with the original payload.
-Discarding removes the job from the active failed list.
+Failed jobs can be retried or discarded only after automatic attempts are
+exhausted. A job attempt that fails with attempts remaining is tracked as
+retrying/delayed work and stays out of the terminal failed list, so operators do
+not accidentally enqueue a duplicate while the framework retry is already
+sleeping. Retrying keeps the old failed row as a retried lifecycle entry and
+enqueues a new job with the original payload. Discarding removes the job from
+the active failed list.
 
 Enqueued jobs can be canceled before a worker starts them. The default local
 runtime checks the cancel marker during its atomic start transition, so a cancel

--- a/docs/guide/operating-background-jobs.md
+++ b/docs/guide/operating-background-jobs.md
@@ -1,0 +1,105 @@
+# Operating Background Jobs
+
+Autumn ships a built-in jobs dashboard in `autumn-admin-plugin` for operators
+who need to inspect and recover request-triggered `#[job]` work without adding a
+separate queue UI.
+
+## Enable the dashboard
+
+Register jobs normally and mount the admin plugin:
+
+```rust,ignore
+use autumn_admin_plugin::AdminPlugin;
+use autumn_web::prelude::*;
+
+#[autumn_web::main]
+async fn main() -> AutumnResult<()> {
+    autumn_web::app()
+        .jobs(jobs![send_welcome_email])
+        .plugin(AdminPlugin::new())
+        .run()
+        .await
+}
+```
+
+The dashboard is available at `GET /admin/jobs` by default. If the plugin is
+mounted with another prefix, use that prefix, for example `/backoffice/jobs`.
+It uses the same session role check as the rest of the admin panel and renders
+CSRF tokens for every mutating action.
+
+## What it shows
+
+The dashboard renders four paginated lists, newest-first:
+
+- Enqueued jobs waiting for a worker.
+- Running jobs currently executing in this runtime.
+- Completed jobs from the last 24 hours.
+- Failed jobs from the last 7 days.
+
+Each row includes the job name, lifecycle timestamps, attempt count, principal
+id, correlation id, and last error. The default backend extracts principal and
+correlation values from common JSON payload fields:
+
+- Principal: `principal_id`, `principal`, or `user_id`.
+- Correlation: `correlation_id` or `request_id`.
+
+Failed errors are truncated in the table and expandable in place. Registered
+scheduled tasks are listed below ad-hoc jobs with their schedule expression,
+next run time when available, and last run status.
+
+## Operator actions
+
+Failed jobs can be retried or discarded. Retrying keeps the old failed row as a
+retried lifecycle entry and enqueues a new job with the original payload.
+Discarding removes the job from the active failed list.
+
+Enqueued jobs can be canceled before a worker starts them. The default local
+runtime checks the cancel marker during its atomic start transition, so a cancel
+either wins cleanly or the job is already running and the action is rejected.
+
+## Runtime backends
+
+The built-in local job runtime installs a bounded, process-local
+`JobAdminMemoryBackend` automatically. It is designed for the default admin UI:
+reads are in-memory, status lists are bounded, and completed/failed windows are
+filtered at snapshot time.
+
+When `jobs.backend = "redis"` is enabled, Autumn installs a Redis-backed
+dashboard backend automatically. It reads the framework queue, processing,
+completed, and dead-letter keys directly, so `/admin/jobs` reflects cluster
+state instead of only the process serving the admin request. Retry, discard, and
+cancel actions mutate the same Redis storage used by workers.
+
+For cluster-wide durable queues or external job storage, install a custom
+backend by inserting `JobAdminBackendEntry` into `AppState`:
+
+```rust,ignore
+use std::sync::Arc;
+use autumn_web::job::{JobAdminBackend, JobAdminBackendEntry};
+
+let backend: Arc<dyn JobAdminBackend> = Arc::new(MyDurableJobAdminBackend::new());
+state.insert_extension(JobAdminBackendEntry(backend));
+```
+
+Custom backends provide the same read and operate surface:
+
+- `snapshot(query)` returns paginated enqueued, running, completed, and failed
+  pages plus schedule summaries.
+- `retry(id)` retries a failed job.
+- `discard(id)` removes a failed job from active operator attention.
+- `cancel(id)` cancels an enqueued job that has not started.
+
+## Refresh cost
+
+The counter fragment at `/admin/jobs/counters` refreshes with htmx at most every
+2 seconds. The local backend clamps page size to 100 rows and keeps at most
+1,000 lifecycle entries, so each refresh is a bounded in-memory scan rather than
+an unbounded queue traversal.
+
+The Redis backend uses `LLEN`/`ZCARD` for active queue counters and reads only
+the bounded completed/dead-letter history window for recent completed and failed
+counts. Durable custom backends should preserve that property with indexed
+status/time-window queries or similarly bounded history reads.
+
+For low-level counters, `GET /actuator/jobs` remains available and reports
+per-job queued, in-flight, success, failure, dead-letter, and last-error data.

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -8,6 +8,7 @@ htmx, embedded migrations, and the new hybrid-rendering pipeline.
 - Public blog listing and slug-based post pages
 - Admin UI for create, edit, publish, and delete
 - First-party `autumn-admin-plugin` mounted at `/backoffice`
+- Built-in jobs dashboard for the demo `publish_webhook` job
 - JSON endpoints alongside server-rendered HTML
 - Validation before insert/update
 - `#[static_get]` + `static_routes![]` for build-time rendering
@@ -34,6 +35,20 @@ cargo run -p blog
 ```
 
 Open <http://localhost:3000>.
+
+## Try the jobs dashboard
+
+The blog registers a demo `publish_webhook` background job and mounts the
+first-party admin plugin at `/backoffice` with role checks disabled for the
+example. Queue a job, then inspect the dashboard:
+
+```bash
+curl -X POST http://localhost:3000/api/posts/1/enqueue-publish-webhook
+curl http://localhost:3000/backoffice/jobs
+```
+
+The jobs page shows enqueued, running, completed, and failed work, plus the
+registered scheduled cleanup task.
 
 ## Try the hybrid-rendering flow
 
@@ -188,6 +203,7 @@ git diff routes.txt
 | GET | `/admin/{id}/edit` | Edit post form |
 | POST | `/admin/{id}` | Update a post |
 | DELETE | `/admin/{id}` | Delete a post with htmx |
+| GET | `/backoffice/jobs` | Admin plugin jobs dashboard |
 | GET | `/backoffice/posts` | Admin plugin list view for posts |
 
 ### JSON API


### PR DESCRIPTION
  Add a built-in /admin/jobs dashboard for queued, running, completed, and failed jobs, with retry, discard, and cancel actions protected by the
  existing admin CSRF/auth flow.

  Wire the default local backend and Redis-backed jobs storage into the shared JobAdminBackend surface, including bounded completed/dead-letter
  history for Redis cluster visibility.

  Document operating background jobs and point the blog example at the dashboard.

  Closes #585