### PR TITLE
feat(plugins): add plugin conformance checks — autumn plugin-check CLI and library API

### DIFF
--- a/autumn-admin-plugin/src/lib.rs
+++ b/autumn-admin-plugin/src/lib.rs
@@ -228,7 +228,7 @@ pub(crate) fn admin_route_infos(prefix: &str) -> Vec<RouteInfo> {
 
 #[cfg(test)]
 mod conformance_tests {
-    use autumn_web::plugin_conformance::{run_conformance, ConformanceConfig};
+    use autumn_web::plugin_conformance::{ConformanceConfig, run_conformance};
     use autumn_web::route_listing::{RouteInfo, RouteSource};
 
     const PLUGIN_NAME: &str = "autumn-admin-plugin";
@@ -261,12 +261,8 @@ mod conformance_tests {
     #[test]
     fn admin_plugin_routes_live_under_admin_prefix() {
         let routes = admin_routes("/admin");
-        let result = autumn_web::plugin_conformance::check_route_prefix(
-            PLUGIN_NAME,
-            "/admin",
-            &[],
-            &routes,
-        );
+        let result =
+            autumn_web::plugin_conformance::check_route_prefix(PLUGIN_NAME, "/admin", &[], &routes);
         assert_eq!(
             result.status,
             autumn_web::plugin_conformance::CheckStatus::Pass,
@@ -360,7 +356,11 @@ mod conformance_tests {
         let diag = &diagnostics[0];
         assert_eq!(diag.method, "GET");
         assert_eq!(diag.path, "/admin");
-        let sources: Vec<&str> = diag.contributors.iter().map(|c| c.source.as_str()).collect();
+        let sources: Vec<&str> = diag
+            .contributors
+            .iter()
+            .map(|c| c.source.as_str())
+            .collect();
         assert!(
             sources.contains(&"user"),
             "missing user contributor: {sources:?}"

--- a/autumn-admin-plugin/src/lib.rs
+++ b/autumn-admin-plugin/src/lib.rs
@@ -57,6 +57,7 @@ use std::sync::Arc;
 
 use autumn_web::app::AppBuilder;
 use autumn_web::plugin::Plugin;
+use autumn_web::route_listing::RouteInfo;
 
 /// The admin panel plugin.
 ///
@@ -178,8 +179,41 @@ impl Plugin for AdminPlugin {
             "🍂 Autumn Admin mounted"
         );
 
-        app.nest(&prefix, router)
+        // Declare routes for `autumn routes` listing. The underlying Axum router
+        // is added via nest() which is opaque to route enumeration, so we
+        // explicitly register route metadata here.
+        let declared = admin_route_infos(&prefix);
+
+        app.nest(&prefix, router).declare_plugin_routes(declared)
     }
+}
+
+/// Generate the route metadata list for this plugin's mounted routes.
+///
+/// Kept in sync with `routes::admin_router` — update here when routes are
+/// added or removed from the admin router.
+pub(crate) fn admin_route_infos(prefix: &str) -> Vec<RouteInfo> {
+    [
+        ("GET", format!("{prefix}")),
+        ("GET", format!("{prefix}/{{slug}}")),
+        ("POST", format!("{prefix}/{{slug}}")),
+        ("GET", format!("{prefix}/{{slug}}/new")),
+        ("GET", format!("{prefix}/{{slug}}/{{id}}")),
+        ("POST", format!("{prefix}/{{slug}}/{{id}}")),
+        ("DELETE", format!("{prefix}/{{slug}}/{{id}}")),
+        ("GET", format!("{prefix}/{{slug}}/{{id}}/edit")),
+        ("POST", format!("{prefix}/{{slug}}/actions")),
+        ("GET", format!("{prefix}/static/admin.{{hash}}.js")),
+    ]
+    .into_iter()
+    .map(|(method, path)| RouteInfo {
+        method: method.to_owned(),
+        path,
+        handler: format!("admin::{}", method.to_lowercase()),
+        source: autumn_web::route_listing::RouteSource::User, // overwritten by declare_plugin_routes
+        middleware: vec![],
+    })
+    .collect()
 }
 
 // ── Conformance reference tests ────────────────────────────────────────────
@@ -199,32 +233,15 @@ mod conformance_tests {
 
     const PLUGIN_NAME: &str = "autumn-admin-plugin";
 
-    /// Build a representative slice of routes that `AdminPlugin` contributes
-    /// under the default `/admin` prefix.  These mirror the routes declared in
-    /// `routes::admin_router` — kept in sync manually; update here when routes
-    /// are added or removed.
+    /// Build the routes that `AdminPlugin` contributes under `prefix`,
+    /// attributed to the plugin. Reuses `admin_route_infos` from the outer
+    /// module and overrides the source to `Plugin(PLUGIN_NAME)`.
     fn admin_routes(prefix: &str) -> Vec<RouteInfo> {
-        let src = RouteSource::Plugin(PLUGIN_NAME.to_owned());
-        let routes_data = [
-            ("GET", format!("{prefix}")),
-            ("GET", format!("{prefix}/{{slug}}")),
-            ("POST", format!("{prefix}/{{slug}}")),
-            ("GET", format!("{prefix}/{{slug}}/new")),
-            ("GET", format!("{prefix}/{{slug}}/{{id}}")),
-            ("POST", format!("{prefix}/{{slug}}/{{id}}")),
-            ("DELETE", format!("{prefix}/{{slug}}/{{id}}")),
-            ("GET", format!("{prefix}/{{slug}}/{{id}}/edit")),
-            ("POST", format!("{prefix}/{{slug}}/actions")),
-            ("GET", format!("{prefix}/static/admin.{{hash}}.js")),
-        ];
-        routes_data
+        super::admin_route_infos(prefix)
             .into_iter()
-            .map(|(method, path)| RouteInfo {
-                method: method.to_owned(),
-                path,
-                handler: format!("admin::{}", method.to_lowercase()),
-                source: src.clone(),
-                middleware: vec![],
+            .map(|mut r| {
+                r.source = RouteSource::Plugin(PLUGIN_NAME.to_owned());
+                r
             })
             .collect()
     }
@@ -368,6 +385,33 @@ mod conformance_tests {
             report.passed(),
             "AdminPlugin with custom prefix failed conformance:\n{}",
             report.to_text_report()
+        );
+    }
+
+    #[test]
+    fn admin_plugin_double_registration_detected() {
+        // Simulate registering the admin plugin twice — its routes appear twice.
+        let mut routes = admin_routes("/admin");
+        routes.extend(admin_routes("/admin"));
+        let result =
+            autumn_web::plugin_conformance::check_duplicate_registration(PLUGIN_NAME, &routes);
+        assert_eq!(
+            result.status,
+            autumn_web::plugin_conformance::CheckStatus::Fail,
+            "expected duplicate-registration FAIL when plugin installed twice"
+        );
+    }
+
+    #[test]
+    fn admin_plugin_single_registration_passes_duplicate_check() {
+        let routes = admin_routes("/admin");
+        let result =
+            autumn_web::plugin_conformance::check_duplicate_registration(PLUGIN_NAME, &routes);
+        assert_eq!(
+            result.status,
+            autumn_web::plugin_conformance::CheckStatus::Pass,
+            "single registration should pass: {}",
+            result.message
         );
     }
 }

--- a/autumn-admin-plugin/src/lib.rs
+++ b/autumn-admin-plugin/src/lib.rs
@@ -203,7 +203,7 @@ pub(crate) fn admin_route_infos(prefix: &str) -> Vec<RouteInfo> {
         ("DELETE", format!("{prefix}/{{slug}}/{{id}}")),
         ("GET", format!("{prefix}/{{slug}}/{{id}}/edit")),
         ("POST", format!("{prefix}/{{slug}}/actions")),
-        ("GET", format!("{prefix}/static/admin.{{hash}}.js")),
+        ("GET", format!("{prefix}{}", &*routes::ADMIN_JS_PATH)),
     ]
     .into_iter()
     .map(|(method, path)| RouteInfo {

--- a/autumn-admin-plugin/src/lib.rs
+++ b/autumn-admin-plugin/src/lib.rs
@@ -181,3 +181,193 @@ impl Plugin for AdminPlugin {
         app.nest(&prefix, router)
     }
 }
+
+// ── Conformance reference tests ────────────────────────────────────────────
+//
+// These tests are the reference example for the Autumn plugin conformance
+// workflow documented in docs/plugins.md.  They use
+// `autumn_web::plugin_conformance` to verify that the admin plugin's declared
+// routes satisfy all conformance checks before publication.
+//
+// See docs/plugins.md § "Plugin conformance and publishing checklist" for the
+// equivalent `autumn plugin-check` CLI invocation.
+
+#[cfg(test)]
+mod conformance_tests {
+    use autumn_web::plugin_conformance::{run_conformance, ConformanceConfig};
+    use autumn_web::route_listing::{RouteInfo, RouteSource};
+
+    const PLUGIN_NAME: &str = "autumn-admin-plugin";
+
+    /// Build a representative slice of routes that `AdminPlugin` contributes
+    /// under the default `/admin` prefix.  These mirror the routes declared in
+    /// `routes::admin_router` — kept in sync manually; update here when routes
+    /// are added or removed.
+    fn admin_routes(prefix: &str) -> Vec<RouteInfo> {
+        let src = RouteSource::Plugin(PLUGIN_NAME.to_owned());
+        let routes_data = [
+            ("GET", format!("{prefix}")),
+            ("GET", format!("{prefix}/{{slug}}")),
+            ("POST", format!("{prefix}/{{slug}}")),
+            ("GET", format!("{prefix}/{{slug}}/new")),
+            ("GET", format!("{prefix}/{{slug}}/{{id}}")),
+            ("POST", format!("{prefix}/{{slug}}/{{id}}")),
+            ("DELETE", format!("{prefix}/{{slug}}/{{id}}")),
+            ("GET", format!("{prefix}/{{slug}}/{{id}}/edit")),
+            ("POST", format!("{prefix}/{{slug}}/actions")),
+            ("GET", format!("{prefix}/static/admin.{{hash}}.js")),
+        ];
+        routes_data
+            .into_iter()
+            .map(|(method, path)| RouteInfo {
+                method: method.to_owned(),
+                path,
+                handler: format!("admin::{}", method.to_lowercase()),
+                source: src.clone(),
+                middleware: vec![],
+            })
+            .collect()
+    }
+
+    #[test]
+    fn admin_plugin_routes_are_attributed_to_plugin_name() {
+        let routes = admin_routes("/admin");
+        let result = autumn_web::plugin_conformance::check_route_attribution(PLUGIN_NAME, &routes);
+        assert_eq!(
+            result.status,
+            autumn_web::plugin_conformance::CheckStatus::Pass,
+            "route attribution failed: {}",
+            result.message
+        );
+    }
+
+    #[test]
+    fn admin_plugin_routes_live_under_admin_prefix() {
+        let routes = admin_routes("/admin");
+        let result = autumn_web::plugin_conformance::check_route_prefix(
+            PLUGIN_NAME,
+            "/admin",
+            &[],
+            &routes,
+        );
+        assert_eq!(
+            result.status,
+            autumn_web::plugin_conformance::CheckStatus::Pass,
+            "prefix check failed: {}\n{:?}",
+            result.message,
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn admin_plugin_has_no_route_collisions_in_isolation() {
+        let routes = admin_routes("/admin");
+        let (result, _) = autumn_web::plugin_conformance::check_collisions(&routes);
+        assert_eq!(
+            result.status,
+            autumn_web::plugin_conformance::CheckStatus::Pass,
+            "unexpected collision: {}\n{:?}",
+            result.message,
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn admin_plugin_sensitive_surfaces_declared_with_role_requirement() {
+        let routes = admin_routes("/admin");
+        let declared = vec![autumn_web::plugin_conformance::SensitiveRoute {
+            path_pattern: "/admin".to_owned(),
+            auth_mechanism: "Role: admin required via AdminPlugin::require_role \
+                             (default) or AdminPlugin::require_role(None) to disable"
+                .to_owned(),
+        }];
+        let result = autumn_web::plugin_conformance::check_sensitive_surfaces(
+            PLUGIN_NAME,
+            &routes,
+            &declared,
+        );
+        assert_eq!(
+            result.status,
+            autumn_web::plugin_conformance::CheckStatus::Pass,
+            "sensitive-surfaces check failed: {}",
+            result.message
+        );
+    }
+
+    #[test]
+    fn admin_plugin_sensitive_surfaces_fail_without_declaration() {
+        let routes = admin_routes("/admin");
+        let result =
+            autumn_web::plugin_conformance::check_sensitive_surfaces(PLUGIN_NAME, &routes, &[]);
+        assert_eq!(
+            result.status,
+            autumn_web::plugin_conformance::CheckStatus::Fail,
+            "expected FAIL when sensitive routes are undeclared"
+        );
+    }
+
+    #[test]
+    fn admin_plugin_passes_full_conformance_with_config() {
+        let routes = admin_routes("/admin");
+        let config = ConformanceConfig::new(PLUGIN_NAME)
+            .prefix("/admin")
+            .sensitive_route(
+                "/admin",
+                "Role: admin required via AdminPlugin::require_role",
+            );
+        let report = run_conformance(&config, &routes);
+        assert!(
+            report.passed(),
+            "AdminPlugin conformance failed:\n{}",
+            report.to_text_report()
+        );
+    }
+
+    #[test]
+    fn admin_plugin_collision_with_host_route_detected() {
+        let mut routes = admin_routes("/admin");
+        // Simulate a host app that accidentally defines GET /admin
+        routes.push(RouteInfo {
+            method: "GET".to_owned(),
+            path: "/admin".to_owned(),
+            handler: "host::admin_redirect".to_owned(),
+            source: RouteSource::User,
+            middleware: vec![],
+        });
+        let (result, diagnostics) = autumn_web::plugin_conformance::check_collisions(&routes);
+        assert_eq!(
+            result.status,
+            autumn_web::plugin_conformance::CheckStatus::Fail,
+            "expected collision to be detected"
+        );
+        let diag = &diagnostics[0];
+        assert_eq!(diag.method, "GET");
+        assert_eq!(diag.path, "/admin");
+        let sources: Vec<&str> = diag.contributors.iter().map(|c| c.source.as_str()).collect();
+        assert!(
+            sources.contains(&"user"),
+            "missing user contributor: {sources:?}"
+        );
+        assert!(
+            sources.contains(&"plugin:autumn-admin-plugin"),
+            "missing plugin contributor: {sources:?}"
+        );
+    }
+
+    #[test]
+    fn admin_plugin_custom_prefix_passes_conformance() {
+        let routes = admin_routes("/backend");
+        let config = ConformanceConfig::new(PLUGIN_NAME)
+            .prefix("/backend")
+            .sensitive_route(
+                "/backend",
+                "Role: admin required via AdminPlugin::require_role",
+            );
+        let report = run_conformance(&config, &routes);
+        assert!(
+            report.passed(),
+            "AdminPlugin with custom prefix failed conformance:\n{}",
+            report.to_text_report()
+        );
+    }
+}

--- a/autumn-admin-plugin/src/lib.rs
+++ b/autumn-admin-plugin/src/lib.rs
@@ -194,7 +194,7 @@ impl Plugin for AdminPlugin {
 /// added or removed from the admin router.
 pub(crate) fn admin_route_infos(prefix: &str) -> Vec<RouteInfo> {
     [
-        ("GET", format!("{prefix}")),
+        ("GET", prefix.to_string()),
         ("GET", format!("{prefix}/{{slug}}")),
         ("POST", format!("{prefix}/{{slug}}")),
         ("GET", format!("{prefix}/{{slug}}/new")),

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -429,6 +429,7 @@ fn main() {
     run_command(cli.command);
 }
 
+#[allow(clippy::too_many_lines)]
 fn run_command(command: Commands) {
     match command {
         Commands::Build { debug, package } => build::run(debug, package.as_deref()),

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1572,9 +1572,13 @@ mod tests {
 
     #[test]
     fn parse_plugin_check_required_plugin_name() {
-        let cli =
-            Cli::try_parse_from(["autumn", "plugin-check", "--plugin-name", "autumn-admin-plugin"])
-                .unwrap();
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "plugin-check",
+            "--plugin-name",
+            "autumn-admin-plugin",
+        ])
+        .unwrap();
         match cli.command {
             Commands::PluginCheck { plugin_name, .. } => {
                 assert_eq!(plugin_name, "autumn-admin-plugin");
@@ -1669,7 +1673,9 @@ mod tests {
         ])
         .unwrap();
         match cli.command {
-            Commands::PluginCheck { sensitive_route, .. } => {
+            Commands::PluginCheck {
+                sensitive_route, ..
+            } => {
                 assert_eq!(sensitive_route, vec!["/admin:Role admin required"]);
             }
             _ => panic!("expected PluginCheck"),
@@ -1690,7 +1696,9 @@ mod tests {
         ])
         .unwrap();
         match cli.command {
-            Commands::PluginCheck { sensitive_route, .. } => {
+            Commands::PluginCheck {
+                sensitive_route, ..
+            } => {
                 assert_eq!(sensitive_route.len(), 2);
             }
             _ => panic!("expected PluginCheck"),

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -9,6 +9,7 @@ mod generate;
 mod migrate;
 mod monitor;
 mod new;
+mod plugin_check;
 mod release;
 mod routes;
 mod seed;
@@ -218,6 +219,41 @@ enum Commands {
         /// Treat warnings as failures (exit 1 on any ⚠️).
         #[arg(long)]
         strict: bool,
+    },
+
+    /// Run conformance checks against a plugin's route contributions.
+    ///
+    /// Compiles the application (debug profile), introspects its route table,
+    /// and verifies that the named plugin satisfies five checks: installability,
+    /// route attribution, route prefix, route collision, and sensitive-surface
+    /// gating.  Exits 0 on pass, 1 on failure.
+    ///
+    /// # Examples
+    ///
+    ///   autumn plugin-check --plugin-name autumn-admin-plugin --prefix /admin \
+    ///       --sensitive-route /admin:"Role: admin required"
+    #[command(verbatim_doc_comment)]
+    PluginCheck {
+        /// Package to build (for workspaces).
+        #[arg(short, long)]
+        package: Option<String>,
+        /// Binary target to build (for packages with multiple bin targets).
+        #[arg(long, value_name = "BIN")]
+        bin: Option<String>,
+        /// Documented plugin name to check (e.g. `autumn-admin-plugin`).
+        #[arg(long, value_name = "NAME")]
+        plugin_name: String,
+        /// Expected route prefix for all plugin routes (e.g. `/admin`).
+        #[arg(long, value_name = "PREFIX")]
+        prefix: Option<String>,
+        /// Declare a sensitive route with its auth/profile gating mechanism.
+        /// Format: `PATH_PREFIX:DESCRIPTION` (e.g. `/admin:Role admin required`).
+        /// Repeatable.
+        #[arg(long, value_name = "PATH:DESCRIPTION")]
+        sensitive_route: Vec<String>,
+        /// Output format: `text` (default) or `json`.
+        #[arg(long, default_value = "text", value_name = "FORMAT")]
+        format: String,
     },
 
     /// Print every mounted route — method, path, handler, source, middleware.
@@ -490,6 +526,23 @@ fn run_command(command: Commands) {
         Commands::Doctor { json, strict } => {
             doctor::run(doctor::DoctorOptions { json, strict });
         }
+        Commands::PluginCheck {
+            package,
+            bin,
+            plugin_name,
+            prefix,
+            sensitive_route,
+            format,
+        } => {
+            run_plugin_check_command(
+                package.as_deref(),
+                bin.as_deref(),
+                &plugin_name,
+                prefix.as_deref(),
+                &sensitive_route,
+                &format,
+            );
+        }
         Commands::Generate(cmd) => run_generate_command(cmd),
     }
 }
@@ -509,6 +562,44 @@ fn run_task_command(
         list,
         name,
         args,
+    });
+}
+
+fn run_plugin_check_command(
+    package: Option<&str>,
+    bin: Option<&str>,
+    plugin_name: &str,
+    prefix: Option<&str>,
+    sensitive_route_args: &[String],
+    format: &str,
+) {
+    let fmt = format.parse().unwrap_or_else(|e| {
+        eprintln!("autumn plugin-check: {e}");
+        std::process::exit(1);
+    });
+
+    let mut sensitive_routes: Vec<plugin_check::SensitiveRouteDecl> = Vec::new();
+    for arg in sensitive_route_args {
+        if let Some((path, desc)) = arg.split_once(':') {
+            sensitive_routes.push(plugin_check::SensitiveRouteDecl {
+                path_pattern: path.to_owned(),
+                auth_mechanism: desc.to_owned(),
+            });
+        } else {
+            eprintln!(
+                "autumn plugin-check: invalid --sensitive-route '{arg}'; expected PATH:DESCRIPTION"
+            );
+            std::process::exit(1);
+        }
+    }
+
+    plugin_check::run(&plugin_check::PluginCheckOptions {
+        package,
+        bin,
+        plugin_name,
+        expected_prefix: prefix,
+        sensitive_routes: &sensitive_routes,
+        format: fmt,
     });
 }
 
@@ -1474,5 +1565,192 @@ mod tests {
     #[test]
     fn parse_token_revoke_without_token_is_error() {
         assert!(Cli::try_parse_from(["autumn", "token", "revoke"]).is_err());
+    }
+
+    // ── autumn plugin-check tests ──────────────────────────────────────────
+
+    #[test]
+    fn parse_plugin_check_required_plugin_name() {
+        let cli =
+            Cli::try_parse_from(["autumn", "plugin-check", "--plugin-name", "autumn-admin-plugin"])
+                .unwrap();
+        match cli.command {
+            Commands::PluginCheck { plugin_name, .. } => {
+                assert_eq!(plugin_name, "autumn-admin-plugin");
+            }
+            _ => panic!("expected PluginCheck"),
+        }
+    }
+
+    #[test]
+    fn parse_plugin_check_missing_plugin_name_is_error() {
+        assert!(Cli::try_parse_from(["autumn", "plugin-check"]).is_err());
+    }
+
+    #[test]
+    fn parse_plugin_check_with_prefix() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "plugin-check",
+            "--plugin-name",
+            "autumn-admin-plugin",
+            "--prefix",
+            "/admin",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::PluginCheck { prefix, .. } => {
+                assert_eq!(prefix.as_deref(), Some("/admin"));
+            }
+            _ => panic!("expected PluginCheck"),
+        }
+    }
+
+    #[test]
+    fn parse_plugin_check_with_package() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "plugin-check",
+            "-p",
+            "my-app",
+            "--plugin-name",
+            "myplugin",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::PluginCheck { package, .. } => {
+                assert_eq!(package.as_deref(), Some("my-app"));
+            }
+            _ => panic!("expected PluginCheck"),
+        }
+    }
+
+    #[test]
+    fn parse_plugin_check_with_json_format() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "plugin-check",
+            "--plugin-name",
+            "myplugin",
+            "--format",
+            "json",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::PluginCheck { format, .. } => {
+                assert_eq!(format, "json");
+            }
+            _ => panic!("expected PluginCheck"),
+        }
+    }
+
+    #[test]
+    fn parse_plugin_check_default_format_is_text() {
+        let cli =
+            Cli::try_parse_from(["autumn", "plugin-check", "--plugin-name", "myplugin"]).unwrap();
+        match cli.command {
+            Commands::PluginCheck { format, .. } => {
+                assert_eq!(format, "text");
+            }
+            _ => panic!("expected PluginCheck"),
+        }
+    }
+
+    #[test]
+    fn parse_plugin_check_with_sensitive_route() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "plugin-check",
+            "--plugin-name",
+            "myplugin",
+            "--sensitive-route",
+            "/admin:Role admin required",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::PluginCheck { sensitive_route, .. } => {
+                assert_eq!(sensitive_route, vec!["/admin:Role admin required"]);
+            }
+            _ => panic!("expected PluginCheck"),
+        }
+    }
+
+    #[test]
+    fn parse_plugin_check_multiple_sensitive_routes() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "plugin-check",
+            "--plugin-name",
+            "myplugin",
+            "--sensitive-route",
+            "/admin:Role admin required",
+            "--sensitive-route",
+            "/debug:Internal use only",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::PluginCheck { sensitive_route, .. } => {
+                assert_eq!(sensitive_route.len(), 2);
+            }
+            _ => panic!("expected PluginCheck"),
+        }
+    }
+
+    #[test]
+    fn parse_plugin_check_with_bin() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "plugin-check",
+            "--plugin-name",
+            "myplugin",
+            "--bin",
+            "server",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::PluginCheck { bin, .. } => {
+                assert_eq!(bin.as_deref(), Some("server"));
+            }
+            _ => panic!("expected PluginCheck"),
+        }
+    }
+
+    #[test]
+    fn parse_plugin_check_all_options() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "plugin-check",
+            "-p",
+            "my-app",
+            "--bin",
+            "server",
+            "--plugin-name",
+            "autumn-admin-plugin",
+            "--prefix",
+            "/admin",
+            "--sensitive-route",
+            "/admin:Role: admin required",
+            "--format",
+            "json",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::PluginCheck {
+                package,
+                bin,
+                plugin_name,
+                prefix,
+                sensitive_route,
+                format,
+            } => {
+                assert_eq!(package.as_deref(), Some("my-app"));
+                assert_eq!(bin.as_deref(), Some("server"));
+                assert_eq!(plugin_name, "autumn-admin-plugin");
+                assert_eq!(prefix.as_deref(), Some("/admin"));
+                assert_eq!(sensitive_route, vec!["/admin:Role: admin required"]);
+                assert_eq!(format, "json");
+            }
+            _ => panic!("expected PluginCheck"),
+        }
     }
 }

--- a/autumn-cli/src/plugin_check.rs
+++ b/autumn-cli/src/plugin_check.rs
@@ -18,7 +18,7 @@ use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 
-use crate::routes::{compile_binary, find_binary, RouteInfo};
+use crate::routes::{RouteInfo, compile_binary, find_binary};
 
 // ── Report types ───────────────────────────────────────────────────────────
 
@@ -241,8 +241,7 @@ pub fn build_report(opts: &PluginCheckOptions<'_>, routes: &[RouteInfo]) -> Conf
 
 fn check_route_attribution(plugin_name: &str, routes: &[RouteInfo]) -> CheckResult {
     let expected = format!("plugin:{plugin_name}");
-    let plugin_routes: Vec<&RouteInfo> =
-        routes.iter().filter(|r| r.source == expected).collect();
+    let plugin_routes: Vec<&RouteInfo> = routes.iter().filter(|r| r.source == expected).collect();
 
     if plugin_routes.is_empty() {
         return CheckResult {
@@ -269,8 +268,7 @@ fn check_route_attribution(plugin_name: &str, routes: &[RouteInfo]) -> CheckResu
 
 fn check_route_prefix(plugin_name: &str, prefix: &str, routes: &[RouteInfo]) -> CheckResult {
     let expected = format!("plugin:{plugin_name}");
-    let plugin_routes: Vec<&RouteInfo> =
-        routes.iter().filter(|r| r.source == expected).collect();
+    let plugin_routes: Vec<&RouteInfo> = routes.iter().filter(|r| r.source == expected).collect();
 
     if plugin_routes.is_empty() {
         return CheckResult {
@@ -385,8 +383,7 @@ fn check_duplicate_registration(plugin_name: &str, routes: &[RouteInfo]) -> Chec
     use std::collections::HashMap;
 
     let expected = format!("plugin:{plugin_name}");
-    let plugin_routes: Vec<&RouteInfo> =
-        routes.iter().filter(|r| r.source == expected).collect();
+    let plugin_routes: Vec<&RouteInfo> = routes.iter().filter(|r| r.source == expected).collect();
 
     if plugin_routes.is_empty() {
         return CheckResult {
@@ -399,9 +396,7 @@ fn check_duplicate_registration(plugin_name: &str, routes: &[RouteInfo]) -> Chec
 
     let mut counts: HashMap<(&str, &str), usize> = HashMap::new();
     for route in &plugin_routes {
-        *counts
-            .entry((&route.method, &route.path))
-            .or_insert(0) += 1;
+        *counts.entry((&route.method, &route.path)).or_insert(0) += 1;
     }
 
     let mut duplicates: Vec<String> = counts
@@ -656,7 +651,11 @@ mod tests {
             auth_mechanism: String::new(),
         }];
         let result = check_sensitive_surfaces("myplugin", &routes, &declared);
-        assert_eq!(result.status, CheckStatus::Fail, "empty auth_mechanism must fail");
+        assert_eq!(
+            result.status,
+            CheckStatus::Fail,
+            "empty auth_mechanism must fail"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/plugin_check.rs
+++ b/autumn-cli/src/plugin_check.rs
@@ -427,13 +427,29 @@ fn check_duplicate_registration(plugin_name: &str, routes: &[RouteInfo]) -> Chec
     }
 }
 
+fn normalize_path_for_collision(path: &str) -> String {
+    path.split('/')
+        .map(|seg| {
+            if seg.starts_with('{') && seg.ends_with('}') {
+                if seg.starts_with("{*") { "{*}" } else { "{}" }
+            } else {
+                seg
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 fn check_collisions(routes: &[RouteInfo]) -> CheckResult {
     use std::collections::HashMap;
 
-    let mut by_key: HashMap<(&str, &str), Vec<&RouteInfo>> = HashMap::new();
+    let mut by_key: HashMap<(String, String), Vec<&RouteInfo>> = HashMap::new();
     for route in routes {
         by_key
-            .entry((&route.method, &route.path))
+            .entry((
+                route.method.clone(),
+                normalize_path_for_collision(&route.path),
+            ))
             .or_default()
             .push(route);
     }
@@ -611,6 +627,62 @@ mod tests {
         ];
         let result = check_collisions(&routes);
         assert_eq!(result.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn collisions_dynamic_segment_different_names_detected() {
+        let routes = vec![
+            make_route("GET", "/users/{user_id}", "user"),
+            make_route("GET", "/users/{id}", "plugin:auth"),
+        ];
+        let result = check_collisions(&routes);
+        assert_eq!(
+            result.status,
+            CheckStatus::Fail,
+            "different param names should collide: {}",
+            result.message
+        );
+    }
+
+    #[test]
+    fn collisions_catchall_different_names_detected() {
+        let routes = vec![
+            make_route("GET", "/files/{*path}", "user"),
+            make_route("GET", "/files/{*rest}", "plugin:storage"),
+        ];
+        let result = check_collisions(&routes);
+        assert_eq!(
+            result.status,
+            CheckStatus::Fail,
+            "different catch-all names should collide"
+        );
+    }
+
+    #[test]
+    fn collisions_catchall_vs_param_not_collapsed() {
+        let routes = vec![
+            make_route("GET", "/files/{id}", "user"),
+            make_route("GET", "/files/{*rest}", "plugin:storage"),
+        ];
+        let result = check_collisions(&routes);
+        assert_eq!(
+            result.status,
+            CheckStatus::Pass,
+            "catch-all and single-segment params are different shapes"
+        );
+    }
+
+    #[test]
+    fn normalize_path_replaces_param_names() {
+        assert_eq!(
+            normalize_path_for_collision("/users/{user_id}/posts/{post_id}"),
+            "/users/{}/posts/{}"
+        );
+        assert_eq!(normalize_path_for_collision("/files/{*rest}"), "/files/{*}");
+        assert_eq!(
+            normalize_path_for_collision("/static/app.js"),
+            "/static/app.js"
+        );
     }
 
     // ── check_sensitive_surfaces ───────────────────────────────────────────

--- a/autumn-cli/src/plugin_check.rs
+++ b/autumn-cli/src/plugin_check.rs
@@ -239,8 +239,11 @@ fn check_route_attribution(plugin_name: &str, routes: &[RouteInfo]) -> CheckResu
     if plugin_routes.is_empty() {
         return CheckResult {
             name: "route-attribution".to_owned(),
-            status: CheckStatus::Skip,
-            message: format!("No routes attributed to plugin:{plugin_name}"),
+            status: CheckStatus::Fail,
+            message: format!(
+                "No routes attributed to plugin:{plugin_name} — \
+                 check the plugin name or call AppBuilder::declare_plugin_routes"
+            ),
             diagnostics: vec![],
         };
     }
@@ -272,7 +275,10 @@ fn check_route_prefix(plugin_name: &str, prefix: &str, routes: &[RouteInfo]) -> 
 
     let off_prefix: Vec<String> = plugin_routes
         .iter()
-        .filter(|r| !r.path.starts_with(prefix))
+        .filter(|r| {
+            let p = &r.path;
+            p != prefix && !p.starts_with(&format!("{prefix}/"))
+        })
         .map(|r| format!("{} {}", r.method, r.path))
         .collect();
 
@@ -495,10 +501,15 @@ mod tests {
     }
 
     #[test]
-    fn attribution_no_plugin_routes_skips() {
+    fn attribution_no_plugin_routes_fails() {
         let routes = vec![make_route("GET", "/posts", "user")];
         let result = check_route_attribution("admin", &routes);
-        assert_eq!(result.status, CheckStatus::Skip);
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(
+            result.message.contains("plugin:admin"),
+            "message should name the plugin: {}",
+            result.message
+        );
     }
 
     #[test]

--- a/autumn-cli/src/plugin_check.rs
+++ b/autumn-cli/src/plugin_check.rs
@@ -527,7 +527,7 @@ mod tests {
             make_route("GET", "/admin/items", "plugin:admin"),
         ];
         let result = check_route_attribution("admin", &routes);
-        assert!(result.message.contains("2"), "{}", result.message);
+        assert!(result.message.contains('2'), "{}", result.message);
     }
 
     // ── check_route_prefix ─────────────────────────────────────────────────
@@ -653,7 +653,7 @@ mod tests {
         let routes = vec![make_route("GET", "/admin/users", "plugin:myplugin")];
         let declared = vec![SensitiveRouteDecl {
             path_pattern: "/admin".to_owned(),
-            auth_mechanism: "".to_owned(),
+            auth_mechanism: String::new(),
         }];
         let result = check_sensitive_surfaces("myplugin", &routes, &declared);
         assert_eq!(result.status, CheckStatus::Fail, "empty auth_mechanism must fail");

--- a/autumn-cli/src/plugin_check.rs
+++ b/autumn-cli/src/plugin_check.rs
@@ -1,0 +1,800 @@
+//! `autumn plugin-check` — run conformance checks against a plugin's routes.
+//!
+//! Compiles the target binary (debug profile), runs it with
+//! `AUTUMN_DUMP_ROUTES=1` to collect the route manifest, then applies
+//! five conformance checks and outputs a pass/fail report.
+//!
+//! # Checks
+//!
+//! | Check | Description |
+//! |-------|-------------|
+//! | `installability` | Binary compiled and route manifest collected |
+//! | `route-attribution` | Plugin routes carry `plugin:<name>` source |
+//! | `route-prefix` | Plugin routes live under the declared prefix |
+//! | `route-collision` | No two routes share (method, path) |
+//! | `sensitive-surfaces` | Sensitive-named routes declared with auth info |
+
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use crate::routes::{compile_binary, find_binary, RouteInfo};
+
+// ── Report types ───────────────────────────────────────────────────────────
+
+/// Status of a conformance check item.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckStatus {
+    Pass,
+    Fail,
+    Skip,
+}
+
+impl std::fmt::Display for CheckStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pass => write!(f, "PASS"),
+            Self::Fail => write!(f, "FAIL"),
+            Self::Skip => write!(f, "SKIP"),
+        }
+    }
+}
+
+/// Result of a single conformance check.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckResult {
+    pub name: String,
+    pub status: CheckStatus,
+    pub message: String,
+    pub diagnostics: Vec<String>,
+}
+
+/// Full conformance report for a plugin.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConformanceReport {
+    pub plugin_name: String,
+    pub checks: Vec<CheckResult>,
+}
+
+impl ConformanceReport {
+    /// Returns `true` when no check has `CheckStatus::Fail`.
+    pub fn passed(&self) -> bool {
+        self.checks.iter().all(|c| c.status != CheckStatus::Fail)
+    }
+
+    /// Render the report as human-readable text.
+    pub fn to_text_report(&self) -> String {
+        let mut out = String::new();
+        let overall = if self.passed() { "PASS" } else { "FAIL" };
+        out.push_str(&format!(
+            "Plugin conformance: {} \u{2014} {}\n",
+            self.plugin_name, overall
+        ));
+        out.push_str(&"\u{2500}".repeat(60));
+        out.push('\n');
+        for check in &self.checks {
+            let icon = match check.status {
+                CheckStatus::Pass => "\u{2713}",
+                CheckStatus::Fail => "\u{2717}",
+                CheckStatus::Skip => "\u{2212}",
+            };
+            out.push_str(&format!(
+                "{icon} [{}] {}: {}\n",
+                check.status, check.name, check.message
+            ));
+            for diag in &check.diagnostics {
+                out.push_str(&format!("  \u{2192} {diag}\n"));
+            }
+        }
+        out.push_str(&"\u{2500}".repeat(60));
+        out.push('\n');
+        if self.passed() {
+            out.push_str("All conformance checks passed.\n");
+        } else {
+            let fails = self
+                .checks
+                .iter()
+                .filter(|c| c.status == CheckStatus::Fail)
+                .count();
+            out.push_str(&format!("{fails} check(s) failed.\n"));
+        }
+        out
+    }
+}
+
+/// Output format for the report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReportFormat {
+    Text,
+    Json,
+}
+
+impl std::str::FromStr for ReportFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "text" | "table" => Ok(Self::Text),
+            "json" => Ok(Self::Json),
+            other => Err(format!(
+                "unknown format '{other}'; expected 'text' or 'json'"
+            )),
+        }
+    }
+}
+
+/// A declared sensitive route with its auth/profile gating description.
+#[derive(Debug, Clone)]
+pub struct SensitiveRouteDecl {
+    /// Path prefix (e.g. `"/admin"`).
+    pub path_pattern: String,
+    /// Human-readable auth description (e.g. `"Role: admin required"`).
+    pub auth_mechanism: String,
+}
+
+/// Options for `autumn plugin-check`.
+pub struct PluginCheckOptions<'a> {
+    /// Cargo package to build (workspace multi-package projects).
+    pub package: Option<&'a str>,
+    /// Binary target name (for packages with multiple `[[bin]]` targets).
+    pub bin: Option<&'a str>,
+    /// The documented plugin name to check (e.g. `"autumn-admin-plugin"`).
+    pub plugin_name: &'a str,
+    /// Expected URL prefix for plugin routes (e.g. `"/admin"`).
+    pub expected_prefix: Option<&'a str>,
+    /// Declared sensitive routes with their auth mechanisms.
+    pub sensitive_routes: &'a [SensitiveRouteDecl],
+    /// Output format.
+    pub format: ReportFormat,
+}
+
+/// Run `autumn plugin-check`.
+pub fn run(opts: &PluginCheckOptions<'_>) {
+    eprintln!("\u{1F342} autumn plugin-check\n");
+    compile_binary(opts.package);
+    let binary = find_binary(opts.package, opts.bin);
+
+    let output = Command::new(&binary)
+        .env("AUTUMN_DUMP_ROUTES", "1")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .unwrap_or_else(|e| {
+            eprintln!("\u{2717} Failed to run {}: {e}", binary.display());
+            std::process::exit(1);
+        });
+
+    if !output.status.success() {
+        eprintln!(
+            "\u{2717} Binary exited with status {} while dumping routes",
+            output.status
+        );
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let routes: Vec<RouteInfo> = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        eprintln!("\u{2717} Failed to parse route listing JSON: {e}");
+        eprintln!("Raw output: {stdout}");
+        std::process::exit(1);
+    });
+
+    let report = build_report(opts, &routes);
+
+    match opts.format {
+        ReportFormat::Text => print!("{}", report.to_text_report()),
+        ReportFormat::Json => {
+            let json = serde_json::to_string_pretty(&report)
+                .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"));
+            println!("{json}");
+        }
+    }
+
+    if !report.passed() {
+        std::process::exit(1);
+    }
+}
+
+/// Build the conformance report from a route listing and options.
+///
+/// Public so callers can unit-test the analysis without running a binary.
+pub fn build_report(opts: &PluginCheckOptions<'_>, routes: &[RouteInfo]) -> ConformanceReport {
+    let mut checks = Vec::new();
+
+    checks.push(CheckResult {
+        name: "installability".to_owned(),
+        status: CheckStatus::Pass,
+        message: format!("{} routes collected from binary", routes.len()),
+        diagnostics: vec![],
+    });
+
+    checks.push(check_route_attribution(opts.plugin_name, routes));
+
+    if let Some(prefix) = opts.expected_prefix {
+        checks.push(check_route_prefix(opts.plugin_name, prefix, routes));
+    }
+
+    checks.push(check_collisions(routes));
+    checks.push(check_sensitive_surfaces(
+        opts.plugin_name,
+        routes,
+        opts.sensitive_routes,
+    ));
+
+    ConformanceReport {
+        plugin_name: opts.plugin_name.to_owned(),
+        checks,
+    }
+}
+
+// ── Individual check helpers ───────────────────────────────────────────────
+
+fn check_route_attribution(plugin_name: &str, routes: &[RouteInfo]) -> CheckResult {
+    let expected = format!("plugin:{plugin_name}");
+    let plugin_routes: Vec<&RouteInfo> =
+        routes.iter().filter(|r| r.source == expected).collect();
+
+    if plugin_routes.is_empty() {
+        return CheckResult {
+            name: "route-attribution".to_owned(),
+            status: CheckStatus::Skip,
+            message: format!("No routes attributed to plugin:{plugin_name}"),
+            diagnostics: vec![],
+        };
+    }
+
+    CheckResult {
+        name: "route-attribution".to_owned(),
+        status: CheckStatus::Pass,
+        message: format!(
+            "{} route(s) correctly attributed to plugin:{plugin_name}",
+            plugin_routes.len()
+        ),
+        diagnostics: vec![],
+    }
+}
+
+fn check_route_prefix(plugin_name: &str, prefix: &str, routes: &[RouteInfo]) -> CheckResult {
+    let expected = format!("plugin:{plugin_name}");
+    let plugin_routes: Vec<&RouteInfo> =
+        routes.iter().filter(|r| r.source == expected).collect();
+
+    if plugin_routes.is_empty() {
+        return CheckResult {
+            name: "route-prefix".to_owned(),
+            status: CheckStatus::Skip,
+            message: format!("No routes attributed to plugin:{plugin_name}"),
+            diagnostics: vec![],
+        };
+    }
+
+    let off_prefix: Vec<String> = plugin_routes
+        .iter()
+        .filter(|r| !r.path.starts_with(prefix))
+        .map(|r| format!("{} {}", r.method, r.path))
+        .collect();
+
+    if off_prefix.is_empty() {
+        CheckResult {
+            name: "route-prefix".to_owned(),
+            status: CheckStatus::Pass,
+            message: format!("All plugin routes live under {prefix}"),
+            diagnostics: vec![],
+        }
+    } else {
+        CheckResult {
+            name: "route-prefix".to_owned(),
+            status: CheckStatus::Fail,
+            message: format!("{} route(s) not under prefix {prefix}", off_prefix.len()),
+            diagnostics: off_prefix,
+        }
+    }
+}
+
+const SENSITIVE_KEYWORDS: &[&str] = &[
+    "admin",
+    "debug",
+    "credential",
+    "operator",
+    "secret",
+    "metrics",
+];
+
+fn is_sensitive_path(path: &str) -> bool {
+    let lower = path.to_lowercase();
+    SENSITIVE_KEYWORDS.iter().any(|kw| {
+        lower
+            .split('/')
+            .any(|segment| segment == *kw || segment.starts_with(kw))
+    })
+}
+
+fn check_sensitive_surfaces(
+    plugin_name: &str,
+    routes: &[RouteInfo],
+    declared: &[SensitiveRouteDecl],
+) -> CheckResult {
+    let expected = format!("plugin:{plugin_name}");
+    let sensitive: Vec<&RouteInfo> = routes
+        .iter()
+        .filter(|r| r.source == expected && is_sensitive_path(&r.path))
+        .collect();
+
+    if sensitive.is_empty() {
+        return CheckResult {
+            name: "sensitive-surfaces".to_owned(),
+            status: CheckStatus::Pass,
+            message: "No sensitive-named routes detected".to_owned(),
+            diagnostics: vec![],
+        };
+    }
+
+    let mut undeclared: Vec<String> = Vec::new();
+    for route in &sensitive {
+        let is_ok = declared.iter().any(|d| {
+            route.path.starts_with(&d.path_pattern) && !d.auth_mechanism.trim().is_empty()
+        });
+        if !is_ok {
+            undeclared.push(format!(
+                "{} {} \u{2014} document auth/profile gating with --sensitive-route",
+                route.method, route.path
+            ));
+        }
+    }
+
+    if undeclared.is_empty() {
+        CheckResult {
+            name: "sensitive-surfaces".to_owned(),
+            status: CheckStatus::Pass,
+            message: format!(
+                "{} sensitive route(s) declared with auth/profile gating",
+                sensitive.len()
+            ),
+            diagnostics: vec![],
+        }
+    } else {
+        CheckResult {
+            name: "sensitive-surfaces".to_owned(),
+            status: CheckStatus::Fail,
+            message: format!(
+                "{} sensitive-named route(s) not declared with auth/profile gating",
+                undeclared.len()
+            ),
+            diagnostics: undeclared,
+        }
+    }
+}
+
+fn check_collisions(routes: &[RouteInfo]) -> CheckResult {
+    use std::collections::HashMap;
+
+    let mut by_key: HashMap<(&str, &str), Vec<&RouteInfo>> = HashMap::new();
+    for route in routes {
+        by_key
+            .entry((&route.method, &route.path))
+            .or_default()
+            .push(route);
+    }
+
+    let mut collisions: Vec<String> = by_key
+        .iter()
+        .filter(|(_, rs)| rs.len() > 1)
+        .map(|((method, path), rs)| {
+            let contributors: Vec<String> = rs
+                .iter()
+                .map(|r| format!("{} ({})", r.handler, r.source))
+                .collect();
+            format!(
+                "{method} {path} \u{2014} collides between: {}",
+                contributors.join(", ")
+            )
+        })
+        .collect();
+    collisions.sort();
+
+    if collisions.is_empty() {
+        CheckResult {
+            name: "route-collision".to_owned(),
+            status: CheckStatus::Pass,
+            message: "No route collisions detected".to_owned(),
+            diagnostics: vec![],
+        }
+    } else {
+        CheckResult {
+            name: "route-collision".to_owned(),
+            status: CheckStatus::Fail,
+            message: format!("{} route collision(s) detected", collisions.len()),
+            diagnostics: collisions,
+        }
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_route(method: &str, path: &str, source: &str) -> RouteInfo {
+        RouteInfo {
+            method: method.to_owned(),
+            path: path.to_owned(),
+            handler: format!("{}_handler", path.trim_start_matches('/').replace('/', "_")),
+            source: source.to_owned(),
+            middleware: vec![],
+        }
+    }
+
+    fn no_sensitive() -> Vec<SensitiveRouteDecl> {
+        vec![]
+    }
+
+    // ── check_route_attribution ────────────────────────────────────────────
+
+    #[test]
+    fn attribution_all_attributed_passes() {
+        let routes = vec![
+            make_route("GET", "/admin", "plugin:admin"),
+            make_route("POST", "/admin/items", "plugin:admin"),
+        ];
+        let result = check_route_attribution("admin", &routes);
+        assert_eq!(result.status, CheckStatus::Pass, "{}", result.message);
+    }
+
+    #[test]
+    fn attribution_no_plugin_routes_skips() {
+        let routes = vec![make_route("GET", "/posts", "user")];
+        let result = check_route_attribution("admin", &routes);
+        assert_eq!(result.status, CheckStatus::Skip);
+    }
+
+    #[test]
+    fn attribution_message_includes_count() {
+        let routes = vec![
+            make_route("GET", "/admin", "plugin:admin"),
+            make_route("GET", "/admin/items", "plugin:admin"),
+        ];
+        let result = check_route_attribution("admin", &routes);
+        assert!(result.message.contains("2"), "{}", result.message);
+    }
+
+    // ── check_route_prefix ─────────────────────────────────────────────────
+
+    #[test]
+    fn prefix_all_under_prefix_passes() {
+        let routes = vec![
+            make_route("GET", "/admin", "plugin:admin"),
+            make_route("POST", "/admin/items", "plugin:admin"),
+        ];
+        let result = check_route_prefix("admin", "/admin", &routes);
+        assert_eq!(result.status, CheckStatus::Pass, "{}", result.message);
+    }
+
+    #[test]
+    fn prefix_route_outside_fails_with_diagnostic() {
+        let routes = vec![
+            make_route("GET", "/admin", "plugin:admin"),
+            make_route("GET", "/webhook", "plugin:admin"),
+        ];
+        let result = check_route_prefix("admin", "/admin", &routes);
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(result.diagnostics.iter().any(|d| d.contains("/webhook")));
+    }
+
+    #[test]
+    fn prefix_no_plugin_routes_skips() {
+        let routes = vec![make_route("GET", "/posts", "user")];
+        let result = check_route_prefix("admin", "/admin", &routes);
+        assert_eq!(result.status, CheckStatus::Skip);
+    }
+
+    // ── check_collisions ───────────────────────────────────────────────────
+
+    #[test]
+    fn collisions_no_collisions_passes() {
+        let routes = vec![
+            make_route("GET", "/posts", "user"),
+            make_route("GET", "/admin", "plugin:admin"),
+        ];
+        let result = check_collisions(&routes);
+        assert_eq!(result.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn collisions_host_plugin_collision_fails() {
+        let routes = vec![
+            make_route("GET", "/posts", "user"),
+            make_route("GET", "/posts", "plugin:harvest"),
+        ];
+        let result = check_collisions(&routes);
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert_eq!(result.diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn collisions_plugin_plugin_collision_fails() {
+        let routes = vec![
+            make_route("GET", "/api/feed", "plugin:harvest"),
+            make_route("GET", "/api/feed", "plugin:feeds"),
+        ];
+        let result = check_collisions(&routes);
+        assert_eq!(result.status, CheckStatus::Fail);
+    }
+
+    #[test]
+    fn collisions_diagnostic_names_method_path_contributors() {
+        let routes = vec![
+            make_route("POST", "/items", "user"),
+            make_route("POST", "/items", "plugin:inventory"),
+        ];
+        let result = check_collisions(&routes);
+        assert_eq!(result.status, CheckStatus::Fail);
+        let diag = &result.diagnostics[0];
+        assert!(diag.contains("POST"), "missing method: {diag}");
+        assert!(diag.contains("/items"), "missing path: {diag}");
+        assert!(diag.contains("user"), "missing user: {diag}");
+        assert!(diag.contains("plugin:inventory"), "missing plugin: {diag}");
+    }
+
+    #[test]
+    fn collisions_different_methods_no_collision() {
+        let routes = vec![
+            make_route("GET", "/posts", "user"),
+            make_route("POST", "/posts", "plugin:blog"),
+        ];
+        let result = check_collisions(&routes);
+        assert_eq!(result.status, CheckStatus::Pass);
+    }
+
+    // ── check_sensitive_surfaces ───────────────────────────────────────────
+
+    #[test]
+    fn sensitive_no_sensitive_routes_passes() {
+        let routes = vec![
+            make_route("GET", "/posts", "plugin:blog"),
+            make_route("GET", "/api/users", "plugin:blog"),
+        ];
+        let result = check_sensitive_surfaces("blog", &routes, &no_sensitive());
+        assert_eq!(result.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn sensitive_admin_route_undeclared_fails() {
+        let routes = vec![make_route("GET", "/admin/dashboard", "plugin:myplugin")];
+        let result = check_sensitive_surfaces("myplugin", &routes, &no_sensitive());
+        assert_eq!(result.status, CheckStatus::Fail);
+    }
+
+    #[test]
+    fn sensitive_admin_route_declared_passes() {
+        let routes = vec![make_route("GET", "/admin/dashboard", "plugin:myplugin")];
+        let declared = vec![SensitiveRouteDecl {
+            path_pattern: "/admin".to_owned(),
+            auth_mechanism: "Role: admin required".to_owned(),
+        }];
+        let result = check_sensitive_surfaces("myplugin", &routes, &declared);
+        assert_eq!(result.status, CheckStatus::Pass, "{}", result.message);
+    }
+
+    #[test]
+    fn sensitive_empty_auth_mechanism_fails() {
+        let routes = vec![make_route("GET", "/admin/users", "plugin:myplugin")];
+        let declared = vec![SensitiveRouteDecl {
+            path_pattern: "/admin".to_owned(),
+            auth_mechanism: "".to_owned(),
+        }];
+        let result = check_sensitive_surfaces("myplugin", &routes, &declared);
+        assert_eq!(result.status, CheckStatus::Fail, "empty auth_mechanism must fail");
+    }
+
+    #[test]
+    fn sensitive_only_checks_plugin_routes() {
+        let routes = vec![
+            make_route("GET", "/admin/panel", "user"),
+            make_route("GET", "/posts", "plugin:blog"),
+        ];
+        let result = check_sensitive_surfaces("blog", &routes, &no_sensitive());
+        assert_eq!(result.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn sensitive_debug_route_fails() {
+        let routes = vec![make_route("GET", "/debug/state", "plugin:myplugin")];
+        let result = check_sensitive_surfaces("myplugin", &routes, &no_sensitive());
+        assert_eq!(result.status, CheckStatus::Fail);
+    }
+
+    // ── ConformanceReport ──────────────────────────────────────────────────
+
+    #[test]
+    fn report_passed_true_all_pass() {
+        let report = ConformanceReport {
+            plugin_name: "test".to_owned(),
+            checks: vec![
+                CheckResult {
+                    name: "c1".to_owned(),
+                    status: CheckStatus::Pass,
+                    message: "ok".to_owned(),
+                    diagnostics: vec![],
+                },
+                CheckResult {
+                    name: "c2".to_owned(),
+                    status: CheckStatus::Skip,
+                    message: "skipped".to_owned(),
+                    diagnostics: vec![],
+                },
+            ],
+        };
+        assert!(report.passed());
+    }
+
+    #[test]
+    fn report_passed_false_any_fail() {
+        let report = ConformanceReport {
+            plugin_name: "test".to_owned(),
+            checks: vec![CheckResult {
+                name: "c1".to_owned(),
+                status: CheckStatus::Fail,
+                message: "fail".to_owned(),
+                diagnostics: vec![],
+            }],
+        };
+        assert!(!report.passed());
+    }
+
+    #[test]
+    fn report_text_contains_plugin_name() {
+        let report = ConformanceReport {
+            plugin_name: "autumn-admin-plugin".to_owned(),
+            checks: vec![],
+        };
+        assert!(report.to_text_report().contains("autumn-admin-plugin"));
+    }
+
+    #[test]
+    fn report_text_shows_overall_pass() {
+        let report = ConformanceReport {
+            plugin_name: "test".to_owned(),
+            checks: vec![],
+        };
+        assert!(report.to_text_report().contains("PASS"));
+    }
+
+    #[test]
+    fn report_text_shows_overall_fail() {
+        let report = ConformanceReport {
+            plugin_name: "test".to_owned(),
+            checks: vec![CheckResult {
+                name: "c1".to_owned(),
+                status: CheckStatus::Fail,
+                message: "fail".to_owned(),
+                diagnostics: vec![],
+            }],
+        };
+        assert!(report.to_text_report().contains("FAIL"));
+    }
+
+    #[test]
+    fn report_serializes_to_json() {
+        let report = ConformanceReport {
+            plugin_name: "test-plugin".to_owned(),
+            checks: vec![CheckResult {
+                name: "route-attribution".to_owned(),
+                status: CheckStatus::Pass,
+                message: "ok".to_owned(),
+                diagnostics: vec![],
+            }],
+        };
+        let json = serde_json::to_string(&report).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["plugin_name"], "test-plugin");
+        assert_eq!(parsed["checks"][0]["status"], "pass");
+    }
+
+    // ── ReportFormat parsing ───────────────────────────────────────────────
+
+    #[test]
+    fn parse_format_text() {
+        let f: ReportFormat = "text".parse().unwrap();
+        assert_eq!(f, ReportFormat::Text);
+    }
+
+    #[test]
+    fn parse_format_table_alias() {
+        let f: ReportFormat = "table".parse().unwrap();
+        assert_eq!(f, ReportFormat::Text);
+    }
+
+    #[test]
+    fn parse_format_json() {
+        let f: ReportFormat = "json".parse().unwrap();
+        assert_eq!(f, ReportFormat::Json);
+    }
+
+    #[test]
+    fn parse_format_unknown_is_error() {
+        let r: Result<ReportFormat, _> = "xml".parse();
+        assert!(r.is_err());
+    }
+
+    // ── is_sensitive_path ──────────────────────────────────────────────────
+
+    #[test]
+    fn admin_path_is_sensitive() {
+        assert!(is_sensitive_path("/admin"));
+        assert!(is_sensitive_path("/admin/users"));
+    }
+
+    #[test]
+    fn debug_path_is_sensitive() {
+        assert!(is_sensitive_path("/debug"));
+        assert!(is_sensitive_path("/api/debug/state"));
+    }
+
+    #[test]
+    fn normal_paths_not_sensitive() {
+        assert!(!is_sensitive_path("/posts"));
+        assert!(!is_sensitive_path("/api/users"));
+    }
+
+    // ── build_report ───────────────────────────────────────────────────────
+
+    #[test]
+    fn build_report_includes_installability_check() {
+        let opts = PluginCheckOptions {
+            package: None,
+            bin: None,
+            plugin_name: "test",
+            expected_prefix: None,
+            sensitive_routes: &[],
+            format: ReportFormat::Text,
+        };
+        let routes = vec![make_route("GET", "/posts", "user")];
+        let report = build_report(&opts, &routes);
+        assert!(report.checks.iter().any(|c| c.name == "installability"));
+    }
+
+    #[test]
+    fn build_report_skips_prefix_check_when_none() {
+        let opts = PluginCheckOptions {
+            package: None,
+            bin: None,
+            plugin_name: "test",
+            expected_prefix: None,
+            sensitive_routes: &[],
+            format: ReportFormat::Text,
+        };
+        let report = build_report(&opts, &[]);
+        assert!(!report.checks.iter().any(|c| c.name == "route-prefix"));
+    }
+
+    #[test]
+    fn build_report_includes_prefix_check_when_set() {
+        let opts = PluginCheckOptions {
+            package: None,
+            bin: None,
+            plugin_name: "admin",
+            expected_prefix: Some("/admin"),
+            sensitive_routes: &[],
+            format: ReportFormat::Text,
+        };
+        let routes = vec![make_route("GET", "/admin", "plugin:admin")];
+        let report = build_report(&opts, &routes);
+        assert!(report.checks.iter().any(|c| c.name == "route-prefix"));
+    }
+
+    #[test]
+    fn build_report_plugin_name_in_report() {
+        let opts = PluginCheckOptions {
+            package: None,
+            bin: None,
+            plugin_name: "autumn-admin-plugin",
+            expected_prefix: None,
+            sensitive_routes: &[],
+            format: ReportFormat::Text,
+        };
+        let report = build_report(&opts, &[]);
+        assert_eq!(report.plugin_name, "autumn-admin-plugin");
+    }
+}

--- a/autumn-cli/src/plugin_check.rs
+++ b/autumn-cli/src/plugin_check.rs
@@ -67,10 +67,11 @@ impl ConformanceReport {
     pub fn to_text_report(&self) -> String {
         let mut out = String::new();
         let overall = if self.passed() { "PASS" } else { "FAIL" };
-        out.push_str(&format!(
-            "Plugin conformance: {} \u{2014} {}\n",
-            self.plugin_name, overall
-        ));
+        out.push_str("Plugin conformance: ");
+        out.push_str(&self.plugin_name);
+        out.push_str(" \u{2014} ");
+        out.push_str(overall);
+        out.push('\n');
         out.push_str(&"\u{2500}".repeat(60));
         out.push('\n');
         for check in &self.checks {
@@ -79,12 +80,18 @@ impl ConformanceReport {
                 CheckStatus::Fail => "\u{2717}",
                 CheckStatus::Skip => "\u{2212}",
             };
-            out.push_str(&format!(
-                "{icon} [{}] {}: {}\n",
-                check.status, check.name, check.message
-            ));
+            out.push_str(icon);
+            out.push_str(" [");
+            out.push_str(&check.status.to_string());
+            out.push_str("] ");
+            out.push_str(&check.name);
+            out.push_str(": ");
+            out.push_str(&check.message);
+            out.push('\n');
             for diag in &check.diagnostics {
-                out.push_str(&format!("  \u{2192} {diag}\n"));
+                out.push_str("  \u{2192} ");
+                out.push_str(diag);
+                out.push('\n');
             }
         }
         out.push_str(&"\u{2500}".repeat(60));
@@ -97,7 +104,8 @@ impl ConformanceReport {
                 .iter()
                 .filter(|c| c.status == CheckStatus::Fail)
                 .count();
-            out.push_str(&format!("{fails} check(s) failed.\n"));
+            out.push_str(&fails.to_string());
+            out.push_str(" check(s) failed.\n");
         }
         out
     }

--- a/autumn-cli/src/plugin_check.rs
+++ b/autumn-cli/src/plugin_check.rs
@@ -160,7 +160,7 @@ pub struct PluginCheckOptions<'a> {
 /// Run `autumn plugin-check`.
 pub fn run(opts: &PluginCheckOptions<'_>) {
     eprintln!("\u{1F342} autumn plugin-check\n");
-    compile_binary(opts.package);
+    compile_binary(opts.package, opts.bin);
     let binary = find_binary(opts.package, opts.bin);
 
     let output = Command::new(&binary)

--- a/autumn-cli/src/plugin_check.rs
+++ b/autumn-cli/src/plugin_check.rs
@@ -431,7 +431,7 @@ fn normalize_path_for_collision(path: &str) -> String {
     path.split('/')
         .map(|seg| {
             if seg.starts_with('{') && seg.ends_with('}') {
-                if seg.starts_with("{*") { "{*}" } else { "{}" }
+                "{}"
             } else {
                 seg
             }
@@ -659,7 +659,8 @@ mod tests {
     }
 
     #[test]
-    fn collisions_catchall_vs_param_not_collapsed() {
+    fn collisions_catchall_vs_named_param_detected() {
+        // matchit treats {id} and {*rest} at the same position as a conflict.
         let routes = vec![
             make_route("GET", "/files/{id}", "user"),
             make_route("GET", "/files/{*rest}", "plugin:storage"),
@@ -667,8 +668,8 @@ mod tests {
         let result = check_collisions(&routes);
         assert_eq!(
             result.status,
-            CheckStatus::Pass,
-            "catch-all and single-segment params are different shapes"
+            CheckStatus::Fail,
+            "catch-all and named param at same position conflict in matchit"
         );
     }
 
@@ -678,7 +679,7 @@ mod tests {
             normalize_path_for_collision("/users/{user_id}/posts/{post_id}"),
             "/users/{}/posts/{}"
         );
-        assert_eq!(normalize_path_for_collision("/files/{*rest}"), "/files/{*}");
+        assert_eq!(normalize_path_for_collision("/files/{*rest}"), "/files/{}");
         assert_eq!(
             normalize_path_for_collision("/static/app.js"),
             "/static/app.js"

--- a/autumn-cli/src/plugin_check.rs
+++ b/autumn-cli/src/plugin_check.rs
@@ -221,6 +221,7 @@ pub fn build_report(opts: &PluginCheckOptions<'_>, routes: &[RouteInfo]) -> Conf
         routes,
         opts.sensitive_routes,
     ));
+    checks.push(check_duplicate_registration(opts.plugin_name, routes));
 
     ConformanceReport {
         plugin_name: opts.plugin_name.to_owned(),
@@ -362,6 +363,57 @@ fn check_sensitive_surfaces(
                 undeclared.len()
             ),
             diagnostics: undeclared,
+        }
+    }
+}
+
+fn check_duplicate_registration(plugin_name: &str, routes: &[RouteInfo]) -> CheckResult {
+    use std::collections::HashMap;
+
+    let expected = format!("plugin:{plugin_name}");
+    let plugin_routes: Vec<&RouteInfo> =
+        routes.iter().filter(|r| r.source == expected).collect();
+
+    if plugin_routes.is_empty() {
+        return CheckResult {
+            name: "duplicate-registration".to_owned(),
+            status: CheckStatus::Skip,
+            message: format!("No routes attributed to plugin:{plugin_name}"),
+            diagnostics: vec![],
+        };
+    }
+
+    let mut counts: HashMap<(&str, &str), usize> = HashMap::new();
+    for route in &plugin_routes {
+        *counts
+            .entry((&route.method, &route.path))
+            .or_insert(0) += 1;
+    }
+
+    let mut duplicates: Vec<String> = counts
+        .into_iter()
+        .filter(|(_, count)| *count > 1)
+        .map(|((method, path), count)| format!("{method} {path} \u{2014} appears {count} times"))
+        .collect();
+    duplicates.sort();
+
+    if duplicates.is_empty() {
+        CheckResult {
+            name: "duplicate-registration".to_owned(),
+            status: CheckStatus::Pass,
+            message: format!("No duplicate route registrations for plugin:{plugin_name}"),
+            diagnostics: vec![],
+        }
+    } else {
+        CheckResult {
+            name: "duplicate-registration".to_owned(),
+            status: CheckStatus::Fail,
+            message: format!(
+                "{} route(s) registered more than once; plugin:{plugin_name} \
+                 may have been installed twice",
+                duplicates.len()
+            ),
+            diagnostics: duplicates,
         }
     }
 }
@@ -736,6 +788,49 @@ mod tests {
     fn normal_paths_not_sensitive() {
         assert!(!is_sensitive_path("/posts"));
         assert!(!is_sensitive_path("/api/users"));
+    }
+
+    // ── check_duplicate_registration ──────────────────────────────────────
+
+    #[test]
+    fn duplicate_no_duplicates_passes() {
+        let routes = vec![
+            make_route("GET", "/admin", "plugin:admin"),
+            make_route("POST", "/admin/items", "plugin:admin"),
+        ];
+        let result = check_duplicate_registration("admin", &routes);
+        assert_eq!(result.status, CheckStatus::Pass, "{}", result.message);
+    }
+
+    #[test]
+    fn duplicate_same_route_twice_fails() {
+        let routes = vec![
+            make_route("GET", "/admin", "plugin:admin"),
+            make_route("GET", "/admin", "plugin:admin"),
+        ];
+        let result = check_duplicate_registration("admin", &routes);
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert_eq!(result.diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn duplicate_diagnostic_names_route() {
+        let routes = vec![
+            make_route("POST", "/admin/items", "plugin:admin"),
+            make_route("POST", "/admin/items", "plugin:admin"),
+        ];
+        let result = check_duplicate_registration("admin", &routes);
+        assert_eq!(result.status, CheckStatus::Fail);
+        let diag = &result.diagnostics[0];
+        assert!(diag.contains("POST"), "missing method: {diag}");
+        assert!(diag.contains("/admin/items"), "missing path: {diag}");
+    }
+
+    #[test]
+    fn duplicate_no_plugin_routes_skips() {
+        let routes = vec![make_route("GET", "/posts", "user")];
+        let result = check_duplicate_registration("admin", &routes);
+        assert_eq!(result.status, CheckStatus::Skip);
     }
 
     // ── build_report ───────────────────────────────────────────────────────

--- a/autumn-cli/src/routes.rs
+++ b/autumn-cli/src/routes.rs
@@ -55,7 +55,7 @@ pub struct RoutesOptions<'a> {
 /// Run `autumn routes`.
 pub fn run(opts: &RoutesOptions<'_>) {
     eprintln!("\u{1F342} autumn routes\n");
-    compile_binary(opts.package);
+    compile_binary(opts.package, opts.bin);
     let binary = find_binary(opts.package, opts.bin);
 
     let output = Command::new(&binary)
@@ -370,11 +370,14 @@ fn resolve_binary_from_metadata(
 
 // ── Also compile the binary before running ─────────────────────────────────
 
-pub fn compile_binary(package: Option<&str>) {
+pub fn compile_binary(package: Option<&str>, bin: Option<&str>) {
     let mut cargo = Command::new("cargo");
     cargo.arg("build");
     if let Some(pkg) = package {
         cargo.args(["-p", pkg]);
+    }
+    if let Some(b) = bin {
+        cargo.args(["--bin", b]);
     }
 
     let status = cargo.status().expect("failed to run cargo build");

--- a/autumn-cli/src/task.rs
+++ b/autumn-cli/src/task.rs
@@ -24,7 +24,7 @@ pub struct TaskListing {
 /// Run `autumn task`.
 pub fn run(opts: &TaskOptions<'_>) {
     eprintln!("autumn task\n");
-    crate::routes::compile_binary(opts.package);
+    crate::routes::compile_binary(opts.package, opts.bin);
     let binary = crate::routes::find_binary(opts.package, opts.bin);
 
     if opts.list {

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2032,10 +2032,10 @@ impl AppBuilder {
         } = self;
 
         // Raw Axum routers registered via .merge()/.nest() are opaque: there is
-        // no public API to enumerate their routes. Warn only when no plugin has
-        // called declare_plugin_routes() to cover them.
+        // no public API to enumerate their routes. Always warn so callers know
+        // some routes may be missing even if declare_plugin_routes was used.
         let hidden = merge_routers.len() + nest_routers.len();
-        if hidden > 0 && declared_routes.is_empty() {
+        if hidden > 0 {
             eprintln!(
                 "[autumn routes] warning: {hidden} raw router(s) added via \
                  .merge()/.nest() are not enumerable and are omitted from this listing"

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -109,6 +109,7 @@ pub fn app() -> AppBuilder {
         mail_delivery_queue_factory: None,
         #[cfg(feature = "mail")]
         mail_previews: Vec::new(),
+        declared_routes: Vec::new(),
     }
 }
 
@@ -271,6 +272,10 @@ pub struct AppBuilder {
     /// Mail template previews registered for the dev preview UI.
     #[cfg(feature = "mail")]
     mail_previews: Vec<crate::mail::MailPreview>,
+    /// Routes explicitly declared by plugins for listing purposes, to complement
+    /// opaque `nest_routers`. Included in `autumn routes` output even though
+    /// the underlying Axum router is not enumerable.
+    declared_routes: Vec<crate::route_listing::RouteInfo>,
 }
 
 /// Boxed builder closure that constructs a durable
@@ -814,6 +819,33 @@ impl AppBuilder {
     #[must_use]
     pub fn nest(mut self, path: &str, router: axum::Router<AppState>) -> Self {
         self.nest_routers.push((path.to_owned(), router));
+        self
+    }
+
+    /// Explicitly register route metadata for listing via `autumn routes`.
+    ///
+    /// Plugins that mount routes via [`AppBuilder::nest`] (which is opaque to
+    /// the route listing) can call this method so that `autumn routes --format json`
+    /// shows their routes with the correct plugin attribution.
+    ///
+    /// Routes are automatically attributed to the current plugin when called from
+    /// within a plugin's `build()` method. The `source` field of each supplied
+    /// `RouteInfo` is overwritten with that attribution.
+    #[must_use]
+    pub fn declare_plugin_routes(
+        mut self,
+        routes: impl IntoIterator<Item = crate::route_listing::RouteInfo>,
+    ) -> Self {
+        let source = self
+            .current_plugin
+            .as_ref()
+            .cloned()
+            .map(crate::route_listing::RouteSource::Plugin)
+            .unwrap_or(crate::route_listing::RouteSource::User);
+        for mut route in routes {
+            route.source = source.clone();
+            self.declared_routes.push(route);
+        }
         self
     }
 
@@ -1441,6 +1473,7 @@ impl AppBuilder {
             mail_delivery_queue_factory,
             #[cfg(feature = "mail")]
             mail_previews,
+            declared_routes: _,
         } = self;
 
         let all_routes = routes;
@@ -1769,6 +1802,7 @@ impl AppBuilder {
             mail_delivery_queue_factory,
             #[cfg(feature = "mail")]
             mail_previews,
+            declared_routes: _,
         } = self;
 
         let all_routes = routes;
@@ -1989,6 +2023,7 @@ impl AppBuilder {
             scoped_groups,
             merge_routers,
             nest_routers,
+            declared_routes,
             config_loader_factory,
             telemetry_provider,
             #[cfg(feature = "openapi")]
@@ -1997,10 +2032,10 @@ impl AppBuilder {
         } = self;
 
         // Raw Axum routers registered via .merge()/.nest() are opaque: there is
-        // no public API to enumerate their routes. Warn so callers know the
-        // snapshot may be incomplete.
+        // no public API to enumerate their routes. Warn only when no plugin has
+        // called declare_plugin_routes() to cover them.
         let hidden = merge_routers.len() + nest_routers.len();
-        if hidden > 0 {
+        if hidden > 0 && declared_routes.is_empty() {
             eprintln!(
                 "[autumn routes] warning: {hidden} raw router(s) added via \
                  .merge()/.nest() are not enumerable and are omitted from this listing"
@@ -2012,6 +2047,7 @@ impl AppBuilder {
 
         let mut infos =
             crate::route_listing::collect_route_infos(&routes, &route_sources, &scoped_groups);
+        infos.extend(declared_routes);
         crate::route_listing::append_framework_routes(&mut infos, &config);
         #[cfg(feature = "openapi")]
         if let Some(ref oa) = openapi {

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -838,10 +838,10 @@ impl AppBuilder {
     ) -> Self {
         let source = self
             .current_plugin
-            .as_ref()
-            .cloned()
-            .map(crate::route_listing::RouteSource::Plugin)
-            .unwrap_or(crate::route_listing::RouteSource::User);
+            .as_deref()
+            .map_or(crate::route_listing::RouteSource::User, |name| {
+                crate::route_listing::RouteSource::Plugin(name.to_owned())
+            });
         for mut route in routes {
             route.source = source.clone();
             self.declared_routes.push(route);

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -102,6 +102,7 @@ pub mod mail;
 #[cfg(feature = "db")]
 pub mod migrate;
 pub mod plugin;
+pub mod plugin_conformance;
 pub mod probe;
 #[cfg(feature = "system-info")]
 pub mod system_info;

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -345,7 +345,28 @@ pub fn check_route_prefix(
     }
 }
 
+/// Canonicalize dynamic route segments so that `{user_id}` and `{id}` both
+/// become `{}`, and `{*rest}` becomes `{*}`. Axum matches routes by shape, not
+/// parameter name, so collision detection must do the same.
+fn normalize_path_for_collision(path: &str) -> String {
+    path.split('/')
+        .map(|seg| {
+            if seg.starts_with('{') && seg.ends_with('}') {
+                if seg.starts_with("{*") { "{*}" } else { "{}" }
+            } else {
+                seg
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 /// Detect route collisions: any two routes sharing the same (method, path) pair.
+///
+/// Dynamic segment names are normalized before comparison so that
+/// `GET /users/{user_id}` and `GET /users/{id}` are correctly detected as
+/// colliding. The `path` field in each `CollisionDiagnostic` reflects the
+/// normalized shape (e.g. `/users/{}`).
 ///
 /// Returns both a `CheckResult` and the full list of `CollisionDiagnostic` values
 /// so callers can serialize detailed collision info in JSON output.
@@ -355,7 +376,10 @@ pub fn check_collisions(routes: &[RouteInfo]) -> (CheckResult, Vec<CollisionDiag
     let mut by_key: HashMap<(String, String), Vec<&RouteInfo>> = HashMap::new();
     for route in routes {
         by_key
-            .entry((route.method.clone(), route.path.clone()))
+            .entry((
+                route.method.clone(),
+                normalize_path_for_collision(&route.path),
+            ))
             .or_default()
             .push(route);
     }
@@ -787,12 +811,14 @@ mod tests {
             make_route("DELETE", "/items/{id}", plugin("inventory")),
         ];
         let (result, _) = check_collisions(&routes);
+        // Path is shown in normalized form ({id} → {}) so the reader
+        // sees the structural shape that Axum matches on.
         assert!(
             result
                 .diagnostics
                 .iter()
-                .any(|d| d.contains("DELETE") && d.contains("/items/{id}")),
-            "diagnostic should mention method and path: {:?}",
+                .any(|d| d.contains("DELETE") && d.contains("/items/{}")),
+            "diagnostic should mention method and normalized path: {:?}",
             result.diagnostics
         );
     }
@@ -805,6 +831,67 @@ mod tests {
         ];
         let (result, _) = check_collisions(&routes);
         assert_eq!(result.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn collisions_dynamic_segment_different_names_detected() {
+        let routes = vec![
+            make_route("GET", "/users/{user_id}", RouteSource::User),
+            make_route("GET", "/users/{id}", plugin("auth")),
+        ];
+        let (result, diagnostics) = check_collisions(&routes);
+        assert_eq!(
+            result.status,
+            CheckStatus::Fail,
+            "different param names should collide: {}",
+            result.message
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].path, "/users/{}");
+    }
+
+    #[test]
+    fn collisions_catchall_different_names_detected() {
+        let routes = vec![
+            make_route("GET", "/files/{*path}", RouteSource::User),
+            make_route("GET", "/files/{*rest}", plugin("storage")),
+        ];
+        let (result, diagnostics) = check_collisions(&routes);
+        assert_eq!(
+            result.status,
+            CheckStatus::Fail,
+            "different catch-all names should collide"
+        );
+        assert_eq!(diagnostics[0].path, "/files/{*}");
+    }
+
+    #[test]
+    fn collisions_catchall_vs_param_not_collapsed() {
+        // {*rest} matches multiple segments; {id} matches one — different shapes.
+        let routes = vec![
+            make_route("GET", "/files/{id}", RouteSource::User),
+            make_route("GET", "/files/{*rest}", plugin("storage")),
+        ];
+        let (result, _) = check_collisions(&routes);
+        assert_eq!(
+            result.status,
+            CheckStatus::Pass,
+            "catch-all and single-segment params are different shapes"
+        );
+    }
+
+    #[test]
+    fn normalize_path_for_collision_replaces_param_names() {
+        assert_eq!(
+            normalize_path_for_collision("/users/{user_id}/posts/{post_id}"),
+            "/users/{}/posts/{}"
+        );
+        assert_eq!(normalize_path_for_collision("/files/{*rest}"), "/files/{*}");
+        assert_eq!(
+            normalize_path_for_collision("/static/app.js"),
+            "/static/app.js"
+        );
+        assert_eq!(normalize_path_for_collision("/"), "/");
     }
 
     // ── check_sensitive_surfaces ───────────────────────────────────────────

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -273,8 +273,11 @@ pub fn check_route_attribution(plugin_name: &str, routes: &[RouteInfo]) -> Check
     if plugin_routes.is_empty() {
         return CheckResult {
             name: "route-attribution".to_owned(),
-            status: CheckStatus::Skip,
-            message: format!("No routes attributed to plugin:{plugin_name}"),
+            status: CheckStatus::Fail,
+            message: format!(
+                "No routes attributed to plugin:{plugin_name} — \
+                 check the plugin name or call AppBuilder::declare_plugin_routes"
+            ),
             diagnostics: vec![],
         };
     }
@@ -315,9 +318,10 @@ pub fn check_route_prefix(
         };
     }
 
+    let under_prefix = |path: &str| path == prefix || path.starts_with(&format!("{prefix}/"));
     let off_prefix: Vec<String> = plugin_routes
         .iter()
-        .filter(|r| !r.path.starts_with(prefix) && !intentional_root.contains(&r.path))
+        .filter(|r| !under_prefix(&r.path) && !intentional_root.contains(&r.path))
         .map(|r| format!("{} {}", r.method, r.path))
         .collect();
 
@@ -610,10 +614,15 @@ mod tests {
     }
 
     #[test]
-    fn attribution_no_plugin_routes_skips() {
+    fn attribution_no_plugin_routes_fails() {
         let routes = vec![make_route("GET", "/posts", RouteSource::User)];
         let result = check_route_attribution("admin", &routes);
-        assert_eq!(result.status, CheckStatus::Skip);
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(
+            result.message.contains("plugin:admin"),
+            "message should name the plugin: {}",
+            result.message
+        );
     }
 
     #[test]
@@ -687,6 +696,24 @@ mod tests {
         ];
         let intentional = vec!["/webhook".to_owned()];
         let result = check_route_prefix("admin", "/admin", &intentional, &routes);
+        assert_eq!(result.status, CheckStatus::Pass, "{}", result.message);
+    }
+
+    #[test]
+    fn prefix_sibling_path_with_same_string_prefix_fails() {
+        let routes = vec![make_route("GET", "/administer/settings", plugin("admin"))];
+        let result = check_route_prefix("admin", "/admin", &[], &routes);
+        assert_eq!(
+            result.status,
+            CheckStatus::Fail,
+            "/administer/settings should not pass /admin prefix check"
+        );
+    }
+
+    #[test]
+    fn prefix_exact_match_passes() {
+        let routes = vec![make_route("GET", "/admin", plugin("admin"))];
+        let result = check_route_prefix("admin", "/admin", &[], &routes);
         assert_eq!(result.status, CheckStatus::Pass, "{}", result.message);
     }
 

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -181,18 +181,21 @@ pub struct ConformanceReport {
 impl ConformanceReport {
     /// Returns `true` when no check has `CheckStatus::Fail`.
     /// Skipped checks do not count as failures.
+    #[must_use]
     pub fn passed(&self) -> bool {
         self.checks.iter().all(|c| c.status != CheckStatus::Fail)
     }
 
     /// Render the report as a human-readable text string.
+    #[must_use]
     pub fn to_text_report(&self) -> String {
         let mut out = String::new();
         let overall = if self.passed() { "PASS" } else { "FAIL" };
-        out.push_str(&format!(
-            "Plugin conformance: {} — {}\n",
-            self.plugin_name, overall
-        ));
+        out.push_str("Plugin conformance: ");
+        out.push_str(&self.plugin_name);
+        out.push_str(" — ");
+        out.push_str(overall);
+        out.push('\n');
         out.push_str(&"─".repeat(60));
         out.push('\n');
         for check in &self.checks {
@@ -201,12 +204,18 @@ impl ConformanceReport {
                 CheckStatus::Fail => "✗",
                 CheckStatus::Skip => "−",
             };
-            out.push_str(&format!(
-                "{icon} [{}] {}: {}\n",
-                check.status, check.name, check.message
-            ));
+            out.push_str(icon);
+            out.push_str(" [");
+            out.push_str(&check.status.to_string());
+            out.push_str("] ");
+            out.push_str(&check.name);
+            out.push_str(": ");
+            out.push_str(&check.message);
+            out.push('\n');
             for diag in &check.diagnostics {
-                out.push_str(&format!("  → {diag}\n"));
+                out.push_str("  → ");
+                out.push_str(diag);
+                out.push('\n');
             }
         }
         out.push_str(&"─".repeat(60));
@@ -219,7 +228,8 @@ impl ConformanceReport {
                 .iter()
                 .filter(|c| c.status == CheckStatus::Fail)
                 .count();
-            out.push_str(&format!("{fails} check(s) failed.\n"));
+            out.push_str(&fails.to_string());
+            out.push_str(" check(s) failed.\n");
         }
         out
     }
@@ -253,6 +263,7 @@ fn is_sensitive_path(path: &str) -> bool {
 /// `Plugin("<plugin_name>")` source.
 ///
 /// Returns `Skip` when no routes at all are attributed to the plugin.
+#[must_use]
 pub fn check_route_attribution(plugin_name: &str, routes: &[RouteInfo]) -> CheckResult {
     let plugin_routes: Vec<&RouteInfo> = routes
         .iter()
@@ -283,6 +294,7 @@ pub fn check_route_attribution(plugin_name: &str, routes: &[RouteInfo]) -> Check
 ///
 /// Routes listed in `intentional_root` (exact path match) are exempt.
 /// Returns `Skip` when no routes are attributed to the plugin.
+#[must_use]
 pub fn check_route_prefix(
     plugin_name: &str,
     prefix: &str,
@@ -389,11 +401,14 @@ pub fn check_collisions(routes: &[RouteInfo]) -> (CheckResult, Vec<CollisionDiag
     }
 }
 
-/// Check that plugin routes with sensitive-sounding paths (containing `admin`,
-/// `debug`, `credential`, `operator`, `secret`, or `metrics`) are declared in
+/// Check that sensitive-sounding plugin routes are declared with an auth mechanism.
+///
+/// "Sensitive" paths contain segments matching `admin`, `debug`, `credential`,
+/// `operator`, `secret`, or `metrics`. Each must appear in
 /// `ConformanceConfig::sensitive_routes` with a non-empty `auth_mechanism`.
 ///
 /// Returns `Pass` when no sensitive-named plugin routes are found.
+#[must_use]
 pub fn check_sensitive_surfaces(
     plugin_name: &str,
     routes: &[RouteInfo],
@@ -463,6 +478,7 @@ pub fn check_sensitive_surfaces(
 /// Detects (method, path) pairs that appear more than once among routes
 /// attributed to the named plugin. Returns `Skip` when no routes are
 /// attributed to the plugin.
+#[must_use]
 pub fn check_duplicate_registration(plugin_name: &str, routes: &[RouteInfo]) -> CheckResult {
     use std::collections::HashMap;
 
@@ -529,6 +545,7 @@ pub fn check_duplicate_registration(plugin_name: &str, routes: &[RouteInfo]) -> 
 /// 3. `route-collision` — no two routes share (method, path)
 /// 4. `sensitive-surfaces` — sensitive-named plugin routes are declared with auth
 /// 5. `duplicate-registration` — plugin routes are not registered more than once
+#[must_use]
 pub fn run_conformance(config: &ConformanceConfig, routes: &[RouteInfo]) -> ConformanceReport {
     let mut checks = Vec::new();
 

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -1,0 +1,946 @@
+//! Plugin conformance checks for Autumn plugin authors.
+//!
+//! Provides types and functions to verify that a plugin's route contributions
+//! are safe, correctly attributed, and ready to publish. Plugin authors use
+//! this module in integration tests to get a pass/fail conformance report
+//! before publishing their crate.
+//!
+//! # Quick start
+//!
+//! ```rust,no_run
+//! use autumn_web::plugin_conformance::{ConformanceConfig, run_conformance};
+//!
+//! // Build a minimal host app that installs the plugin, then inspect its routes
+//! // via AppBuilder::plugin_route_infos() or via `autumn plugin-check` in CI.
+//! let config = ConformanceConfig::new("autumn-admin-plugin")
+//!     .prefix("/admin")
+//!     .sensitive_route("/admin", "Role: admin required via AdminPlugin::require_role");
+//! // Pass route_infos collected from AppBuilder to run_conformance(...)
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+use crate::route_listing::{RouteInfo, RouteSource};
+
+// ── Configuration ──────────────────────────────────────────────────────────
+
+/// Configuration for a conformance run against a specific plugin.
+#[derive(Debug, Clone)]
+pub struct ConformanceConfig {
+    /// The documented plugin name (e.g. `"autumn-admin-plugin"`).
+    pub plugin_name: String,
+    /// Expected URL prefix for all plugin routes (e.g. `"/admin"`).
+    /// If `None`, the route-prefix check is skipped.
+    pub expected_prefix: Option<String>,
+    /// Paths that are intentionally at the root level (not under `expected_prefix`).
+    /// Each entry must be the exact path as it appears in the route manifest.
+    pub intentional_root_routes: Vec<String>,
+    /// Sensitive surface declarations: routes whose path contains keywords like
+    /// `admin`, `debug`, `credential`, `operator`, `secret`, or `metrics` must
+    /// appear here with a non-empty `auth_mechanism`, or the check fails.
+    pub sensitive_routes: Vec<SensitiveRoute>,
+}
+
+impl ConformanceConfig {
+    /// Create a minimal config with only the plugin name.
+    pub fn new(plugin_name: impl Into<String>) -> Self {
+        Self {
+            plugin_name: plugin_name.into(),
+            expected_prefix: None,
+            intentional_root_routes: Vec::new(),
+            sensitive_routes: Vec::new(),
+        }
+    }
+
+    /// Declare the expected route prefix (e.g. `"/admin"`).
+    #[must_use]
+    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.expected_prefix = Some(prefix.into());
+        self
+    }
+
+    /// Declare a path as an intentional root-level route, exempting it from
+    /// the prefix check (e.g. `"/webhook"`).
+    #[must_use]
+    pub fn intentional_root_route(mut self, path: impl Into<String>) -> Self {
+        self.intentional_root_routes.push(path.into());
+        self
+    }
+
+    /// Declare a sensitive route with its auth/profile gating mechanism.
+    ///
+    /// `path_pattern` is a prefix that matches the route path (e.g. `"/admin"`).
+    /// `auth_mechanism` is a human-readable description (e.g. `"Role: admin required"`).
+    /// An empty `auth_mechanism` still fails the check — the string must be non-empty.
+    #[must_use]
+    pub fn sensitive_route(
+        mut self,
+        path_pattern: impl Into<String>,
+        auth_mechanism: impl Into<String>,
+    ) -> Self {
+        self.sensitive_routes.push(SensitiveRoute {
+            path_pattern: path_pattern.into(),
+            auth_mechanism: auth_mechanism.into(),
+        });
+        self
+    }
+}
+
+/// Declaration of a sensitive route and its auth/profile gating mechanism.
+#[derive(Debug, Clone)]
+pub struct SensitiveRoute {
+    /// Path prefix that matches sensitive routes (e.g. `"/admin"`).
+    pub path_pattern: String,
+    /// Human-readable description of the gating mechanism
+    /// (e.g. `"Role: admin required via AdminPlugin::require_role"`).
+    pub auth_mechanism: String,
+}
+
+// ── Report types ───────────────────────────────────────────────────────────
+
+/// Status of an individual conformance check.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckStatus {
+    /// The check passed.
+    Pass,
+    /// The check found a problem that must be resolved before publishing.
+    Fail,
+    /// The check was skipped (e.g. no routes attributed to the plugin).
+    Skip,
+}
+
+impl std::fmt::Display for CheckStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pass => write!(f, "PASS"),
+            Self::Fail => write!(f, "FAIL"),
+            Self::Skip => write!(f, "SKIP"),
+        }
+    }
+}
+
+/// Result of a single conformance check.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckResult {
+    /// Short check identifier (e.g. `"route-attribution"`).
+    pub name: String,
+    /// Pass, fail, or skip.
+    pub status: CheckStatus,
+    /// Human-readable description of the result.
+    pub message: String,
+    /// Additional diagnostic lines (e.g. collision details, off-prefix paths).
+    pub diagnostics: Vec<String>,
+}
+
+/// Information about two or more routes that collide on the same (method, path).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CollisionDiagnostic {
+    /// HTTP method of the collision.
+    pub method: String,
+    /// URL path of the collision.
+    pub path: String,
+    /// All routes that contribute to this collision.
+    pub contributors: Vec<RouteContributor>,
+}
+
+impl CollisionDiagnostic {
+    fn to_diagnostic_string(&self) -> String {
+        let contributors: Vec<String> = self
+            .contributors
+            .iter()
+            .map(|c| format!("{} (source: {})", c.handler, c.source))
+            .collect();
+        format!(
+            "{} {} — collides between: {}",
+            self.method,
+            self.path,
+            contributors.join(", ")
+        )
+    }
+}
+
+/// A single route that contributes to a collision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RouteContributor {
+    /// Registration source (e.g. `"user"`, `"plugin:admin"`, `"framework"`).
+    pub source: String,
+    /// Handler function name (e.g. `"posts::create"`).
+    pub handler: String,
+}
+
+/// The full conformance report for a plugin.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConformanceReport {
+    /// The plugin name this report covers.
+    pub plugin_name: String,
+    /// Results for each conformance check that was run.
+    pub checks: Vec<CheckResult>,
+}
+
+impl ConformanceReport {
+    /// Returns `true` when no check has `CheckStatus::Fail`.
+    /// Skipped checks do not count as failures.
+    pub fn passed(&self) -> bool {
+        self.checks.iter().all(|c| c.status != CheckStatus::Fail)
+    }
+
+    /// Render the report as a human-readable text string.
+    pub fn to_text_report(&self) -> String {
+        let mut out = String::new();
+        let overall = if self.passed() { "PASS" } else { "FAIL" };
+        out.push_str(&format!(
+            "Plugin conformance: {} — {}\n",
+            self.plugin_name, overall
+        ));
+        out.push_str(&"─".repeat(60));
+        out.push('\n');
+        for check in &self.checks {
+            let icon = match check.status {
+                CheckStatus::Pass => "✓",
+                CheckStatus::Fail => "✗",
+                CheckStatus::Skip => "−",
+            };
+            out.push_str(&format!(
+                "{icon} [{}] {}: {}\n",
+                check.status, check.name, check.message
+            ));
+            for diag in &check.diagnostics {
+                out.push_str(&format!("  → {diag}\n"));
+            }
+        }
+        out.push_str(&"─".repeat(60));
+        out.push('\n');
+        if self.passed() {
+            out.push_str("All conformance checks passed.\n");
+        } else {
+            let fails = self
+                .checks
+                .iter()
+                .filter(|c| c.status == CheckStatus::Fail)
+                .count();
+            out.push_str(&format!("{fails} check(s) failed.\n"));
+        }
+        out
+    }
+}
+
+// ── Sensitive path classification ──────────────────────────────────────────
+
+const SENSITIVE_KEYWORDS: &[&str] = &[
+    "admin",
+    "debug",
+    "credential",
+    "operator",
+    "secret",
+    "metrics",
+];
+
+/// Returns `true` when `path` contains a segment that is or starts with a
+/// sensitive keyword (case-insensitive).
+fn is_sensitive_path(path: &str) -> bool {
+    let lower = path.to_lowercase();
+    SENSITIVE_KEYWORDS.iter().any(|kw| {
+        lower
+            .split('/')
+            .any(|segment| segment == *kw || segment.starts_with(kw))
+    })
+}
+
+// ── Individual check functions ─────────────────────────────────────────────
+
+/// Check that all routes attributed to the plugin carry the expected
+/// `Plugin("<plugin_name>")` source.
+///
+/// Returns `Skip` when no routes at all are attributed to the plugin.
+pub fn check_route_attribution(plugin_name: &str, routes: &[RouteInfo]) -> CheckResult {
+    let plugin_routes: Vec<&RouteInfo> = routes
+        .iter()
+        .filter(|r| matches!(&r.source, RouteSource::Plugin(n) if n == plugin_name))
+        .collect();
+
+    if plugin_routes.is_empty() {
+        return CheckResult {
+            name: "route-attribution".to_owned(),
+            status: CheckStatus::Skip,
+            message: format!("No routes attributed to plugin:{plugin_name}"),
+            diagnostics: vec![],
+        };
+    }
+
+    CheckResult {
+        name: "route-attribution".to_owned(),
+        status: CheckStatus::Pass,
+        message: format!(
+            "{} route(s) correctly attributed to plugin:{plugin_name}",
+            plugin_routes.len()
+        ),
+        diagnostics: vec![],
+    }
+}
+
+/// Check that all plugin routes live under `prefix`.
+///
+/// Routes listed in `intentional_root` (exact path match) are exempt.
+/// Returns `Skip` when no routes are attributed to the plugin.
+pub fn check_route_prefix(
+    plugin_name: &str,
+    prefix: &str,
+    intentional_root: &[String],
+    routes: &[RouteInfo],
+) -> CheckResult {
+    let plugin_routes: Vec<&RouteInfo> = routes
+        .iter()
+        .filter(|r| matches!(&r.source, RouteSource::Plugin(n) if n == plugin_name))
+        .collect();
+
+    if plugin_routes.is_empty() {
+        return CheckResult {
+            name: "route-prefix".to_owned(),
+            status: CheckStatus::Skip,
+            message: format!("No routes attributed to plugin:{plugin_name}"),
+            diagnostics: vec![],
+        };
+    }
+
+    let off_prefix: Vec<String> = plugin_routes
+        .iter()
+        .filter(|r| !r.path.starts_with(prefix) && !intentional_root.contains(&r.path))
+        .map(|r| format!("{} {}", r.method, r.path))
+        .collect();
+
+    if off_prefix.is_empty() {
+        CheckResult {
+            name: "route-prefix".to_owned(),
+            status: CheckStatus::Pass,
+            message: format!("All plugin routes live under {prefix}"),
+            diagnostics: vec![],
+        }
+    } else {
+        CheckResult {
+            name: "route-prefix".to_owned(),
+            status: CheckStatus::Fail,
+            message: format!(
+                "{} route(s) not under prefix {prefix} and not declared as intentional root routes",
+                off_prefix.len()
+            ),
+            diagnostics: off_prefix,
+        }
+    }
+}
+
+/// Detect route collisions: any two routes sharing the same (method, path) pair.
+///
+/// Returns both a `CheckResult` and the full list of `CollisionDiagnostic` values
+/// so callers can serialize detailed collision info in JSON output.
+pub fn check_collisions(routes: &[RouteInfo]) -> (CheckResult, Vec<CollisionDiagnostic>) {
+    use std::collections::HashMap;
+
+    let mut by_key: HashMap<(String, String), Vec<&RouteInfo>> = HashMap::new();
+    for route in routes {
+        by_key
+            .entry((route.method.clone(), route.path.clone()))
+            .or_default()
+            .push(route);
+    }
+
+    let mut diagnostics: Vec<CollisionDiagnostic> = by_key
+        .into_iter()
+        .filter(|(_, rs)| rs.len() > 1)
+        .map(|((method, path), rs)| CollisionDiagnostic {
+            method,
+            path,
+            contributors: rs
+                .iter()
+                .map(|r| RouteContributor {
+                    source: r.source.to_string(),
+                    handler: r.handler.clone(),
+                })
+                .collect(),
+        })
+        .collect();
+
+    diagnostics.sort_by(|a, b| a.path.cmp(&b.path).then_with(|| a.method.cmp(&b.method)));
+
+    if diagnostics.is_empty() {
+        (
+            CheckResult {
+                name: "route-collision".to_owned(),
+                status: CheckStatus::Pass,
+                message: "No route collisions detected".to_owned(),
+                diagnostics: vec![],
+            },
+            diagnostics,
+        )
+    } else {
+        let diag_strings: Vec<String> = diagnostics
+            .iter()
+            .map(CollisionDiagnostic::to_diagnostic_string)
+            .collect();
+        (
+            CheckResult {
+                name: "route-collision".to_owned(),
+                status: CheckStatus::Fail,
+                message: format!("{} route collision(s) detected", diagnostics.len()),
+                diagnostics: diag_strings,
+            },
+            diagnostics,
+        )
+    }
+}
+
+/// Check that plugin routes with sensitive-sounding paths (containing `admin`,
+/// `debug`, `credential`, `operator`, `secret`, or `metrics`) are declared in
+/// `ConformanceConfig::sensitive_routes` with a non-empty `auth_mechanism`.
+///
+/// Returns `Pass` when no sensitive-named plugin routes are found.
+pub fn check_sensitive_surfaces(
+    plugin_name: &str,
+    routes: &[RouteInfo],
+    declared: &[SensitiveRoute],
+) -> CheckResult {
+    let sensitive_plugin_routes: Vec<&RouteInfo> = routes
+        .iter()
+        .filter(|r| {
+            matches!(&r.source, RouteSource::Plugin(n) if n == plugin_name)
+                && is_sensitive_path(&r.path)
+        })
+        .collect();
+
+    if sensitive_plugin_routes.is_empty() {
+        return CheckResult {
+            name: "sensitive-surfaces".to_owned(),
+            status: CheckStatus::Pass,
+            message: "No sensitive-named routes detected".to_owned(),
+            diagnostics: vec![],
+        };
+    }
+
+    let mut undeclared: Vec<String> = Vec::new();
+    for route in &sensitive_plugin_routes {
+        let is_declared = declared.iter().any(|d| {
+            route.path.starts_with(&d.path_pattern) && !d.auth_mechanism.trim().is_empty()
+        });
+        if !is_declared {
+            undeclared.push(format!(
+                "{} {} — undeclared sensitive surface",
+                route.method, route.path
+            ));
+        }
+    }
+
+    if undeclared.is_empty() {
+        CheckResult {
+            name: "sensitive-surfaces".to_owned(),
+            status: CheckStatus::Pass,
+            message: format!(
+                "{} sensitive route(s) declared with auth/profile gating mechanisms",
+                sensitive_plugin_routes.len()
+            ),
+            diagnostics: vec![],
+        }
+    } else {
+        let mut diagnostics = undeclared;
+        diagnostics.push(
+            "Add .sensitive_route(path_prefix, auth_mechanism) to ConformanceConfig".to_owned(),
+        );
+        CheckResult {
+            name: "sensitive-surfaces".to_owned(),
+            status: CheckStatus::Fail,
+            message: format!(
+                "{} sensitive-named route(s) not declared with auth/profile gating",
+                diagnostics.len() - 1
+            ),
+            diagnostics,
+        }
+    }
+}
+
+// ── Main entry point ───────────────────────────────────────────────────────
+
+/// Run all conformance checks and return a `ConformanceReport`.
+///
+/// Checks run:
+/// 1. `route-attribution` — plugin routes carry `plugin:<name>` source
+/// 2. `route-prefix` — plugin routes live under `config.expected_prefix` (if set)
+/// 3. `route-collision` — no two routes share (method, path)
+/// 4. `sensitive-surfaces` — sensitive-named plugin routes are declared with auth
+pub fn run_conformance(config: &ConformanceConfig, routes: &[RouteInfo]) -> ConformanceReport {
+    let mut checks = Vec::new();
+
+    checks.push(check_route_attribution(&config.plugin_name, routes));
+
+    if let Some(ref prefix) = config.expected_prefix {
+        checks.push(check_route_prefix(
+            &config.plugin_name,
+            prefix,
+            &config.intentional_root_routes,
+            routes,
+        ));
+    }
+
+    let (collision_check, _) = check_collisions(routes);
+    checks.push(collision_check);
+
+    checks.push(check_sensitive_surfaces(
+        &config.plugin_name,
+        routes,
+        &config.sensitive_routes,
+    ));
+
+    ConformanceReport {
+        plugin_name: config.plugin_name.clone(),
+        checks,
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_route(method: &str, path: &str, source: RouteSource) -> RouteInfo {
+        RouteInfo {
+            method: method.to_owned(),
+            path: path.to_owned(),
+            handler: format!("{}_handler", path.trim_start_matches('/').replace('/', "_")),
+            source,
+            middleware: vec![],
+        }
+    }
+
+    fn plugin(name: &str) -> RouteSource {
+        RouteSource::Plugin(name.to_owned())
+    }
+
+    // ── check_route_attribution ────────────────────────────────────────────
+
+    #[test]
+    fn attribution_all_attributed_passes() {
+        let routes = vec![
+            make_route("GET", "/admin", plugin("admin")),
+            make_route("POST", "/admin/items", plugin("admin")),
+        ];
+        let result = check_route_attribution("admin", &routes);
+        assert_eq!(result.status, CheckStatus::Pass, "{}", result.message);
+    }
+
+    #[test]
+    fn attribution_no_plugin_routes_skips() {
+        let routes = vec![make_route("GET", "/posts", RouteSource::User)];
+        let result = check_route_attribution("admin", &routes);
+        assert_eq!(result.status, CheckStatus::Skip);
+    }
+
+    #[test]
+    fn attribution_pass_message_includes_count() {
+        let routes = vec![
+            make_route("GET", "/admin", plugin("admin")),
+            make_route("GET", "/admin/items", plugin("admin")),
+        ];
+        let result = check_route_attribution("admin", &routes);
+        assert!(
+            result.message.contains("2"),
+            "expected count in message: {}",
+            result.message
+        );
+    }
+
+    #[test]
+    fn attribution_other_plugin_routes_not_counted() {
+        let routes = vec![
+            make_route("GET", "/harvest/feeds", plugin("harvest")),
+            make_route("GET", "/admin", plugin("admin")),
+        ];
+        let result = check_route_attribution("admin", &routes);
+        assert_eq!(result.status, CheckStatus::Pass);
+        assert!(
+            result.message.contains("1"),
+            "only 1 admin route: {}",
+            result.message
+        );
+    }
+
+    // ── check_route_prefix ─────────────────────────────────────────────────
+
+    #[test]
+    fn prefix_all_under_prefix_passes() {
+        let routes = vec![
+            make_route("GET", "/admin", plugin("admin")),
+            make_route("POST", "/admin/items", plugin("admin")),
+        ];
+        let result = check_route_prefix("admin", "/admin", &[], &routes);
+        assert_eq!(result.status, CheckStatus::Pass, "{}", result.message);
+    }
+
+    #[test]
+    fn prefix_route_outside_prefix_fails() {
+        let routes = vec![
+            make_route("GET", "/admin", plugin("admin")),
+            make_route("GET", "/webhook", plugin("admin")),
+        ];
+        let result = check_route_prefix("admin", "/admin", &[], &routes);
+        assert_eq!(result.status, CheckStatus::Fail, "{}", result.message);
+    }
+
+    #[test]
+    fn prefix_off_prefix_diagnostic_names_the_route() {
+        let routes = vec![make_route("GET", "/webhook", plugin("admin"))];
+        let result = check_route_prefix("admin", "/admin", &[], &routes);
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(
+            result.diagnostics.iter().any(|d| d.contains("/webhook")),
+            "expected /webhook in diagnostics: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn prefix_intentional_root_exempted() {
+        let routes = vec![
+            make_route("GET", "/admin", plugin("admin")),
+            make_route("GET", "/webhook", plugin("admin")),
+        ];
+        let intentional = vec!["/webhook".to_owned()];
+        let result = check_route_prefix("admin", "/admin", &intentional, &routes);
+        assert_eq!(result.status, CheckStatus::Pass, "{}", result.message);
+    }
+
+    #[test]
+    fn prefix_no_plugin_routes_skips() {
+        let routes = vec![make_route("GET", "/posts", RouteSource::User)];
+        let result = check_route_prefix("admin", "/admin", &[], &routes);
+        assert_eq!(result.status, CheckStatus::Skip);
+    }
+
+    // ── check_collisions ───────────────────────────────────────────────────
+
+    #[test]
+    fn collisions_no_collisions_passes() {
+        let routes = vec![
+            make_route("GET", "/posts", RouteSource::User),
+            make_route("GET", "/admin", plugin("admin")),
+            make_route("POST", "/posts", RouteSource::User),
+        ];
+        let (result, diagnostics) = check_collisions(&routes);
+        assert_eq!(result.status, CheckStatus::Pass, "{}", result.message);
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn collisions_host_plugin_collision_fails() {
+        let routes = vec![
+            make_route("GET", "/posts", RouteSource::User),
+            make_route("GET", "/posts", plugin("harvest")),
+        ];
+        let (result, diagnostics) = check_collisions(&routes);
+        assert_eq!(result.status, CheckStatus::Fail, "{}", result.message);
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn collisions_plugin_plugin_collision_fails() {
+        let routes = vec![
+            make_route("GET", "/api/feed", plugin("harvest")),
+            make_route("GET", "/api/feed", plugin("feeds")),
+        ];
+        let (result, diagnostics) = check_collisions(&routes);
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn collisions_diagnostic_has_method_path_contributors() {
+        let routes = vec![
+            make_route("POST", "/items", RouteSource::User),
+            make_route("POST", "/items", plugin("inventory")),
+        ];
+        let (_, diagnostics) = check_collisions(&routes);
+        assert_eq!(diagnostics.len(), 1);
+        let diag = &diagnostics[0];
+        assert_eq!(diag.method, "POST");
+        assert_eq!(diag.path, "/items");
+        assert_eq!(diag.contributors.len(), 2);
+        let sources: Vec<&str> = diag.contributors.iter().map(|c| c.source.as_str()).collect();
+        assert!(sources.contains(&"user"), "missing user: {sources:?}");
+        assert!(
+            sources.contains(&"plugin:inventory"),
+            "missing plugin:inventory: {sources:?}"
+        );
+    }
+
+    #[test]
+    fn collisions_diagnostic_string_names_method_and_path() {
+        let routes = vec![
+            make_route("DELETE", "/items/{id}", RouteSource::User),
+            make_route("DELETE", "/items/{id}", plugin("inventory")),
+        ];
+        let (result, _) = check_collisions(&routes);
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|d| d.contains("DELETE") && d.contains("/items/{id}")),
+            "diagnostic should mention method and path: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn collisions_different_methods_same_path_no_collision() {
+        let routes = vec![
+            make_route("GET", "/posts", RouteSource::User),
+            make_route("POST", "/posts", plugin("blog")),
+        ];
+        let (result, _) = check_collisions(&routes);
+        assert_eq!(result.status, CheckStatus::Pass);
+    }
+
+    // ── check_sensitive_surfaces ───────────────────────────────────────────
+
+    #[test]
+    fn sensitive_no_sensitive_routes_passes() {
+        let routes = vec![
+            make_route("GET", "/posts", plugin("blog")),
+            make_route("GET", "/api/users", plugin("blog")),
+        ];
+        let result = check_sensitive_surfaces("blog", &routes, &[]);
+        assert_eq!(result.status, CheckStatus::Pass, "{}", result.message);
+    }
+
+    #[test]
+    fn sensitive_admin_route_undeclared_fails() {
+        let routes = vec![make_route("GET", "/admin/dashboard", plugin("myplugin"))];
+        let result = check_sensitive_surfaces("myplugin", &routes, &[]);
+        assert_eq!(result.status, CheckStatus::Fail, "{}", result.message);
+    }
+
+    #[test]
+    fn sensitive_admin_route_declared_passes() {
+        let routes = vec![make_route("GET", "/admin/dashboard", plugin("myplugin"))];
+        let declared = vec![SensitiveRoute {
+            path_pattern: "/admin".to_owned(),
+            auth_mechanism: "Role: admin required".to_owned(),
+        }];
+        let result = check_sensitive_surfaces("myplugin", &routes, &declared);
+        assert_eq!(result.status, CheckStatus::Pass, "{}", result.message);
+    }
+
+    #[test]
+    fn sensitive_debug_route_undeclared_fails() {
+        let routes = vec![make_route("GET", "/debug/state", plugin("myplugin"))];
+        let result = check_sensitive_surfaces("myplugin", &routes, &[]);
+        assert_eq!(result.status, CheckStatus::Fail);
+    }
+
+    #[test]
+    fn sensitive_empty_auth_mechanism_fails() {
+        let routes = vec![make_route("GET", "/admin/users", plugin("myplugin"))];
+        let declared = vec![SensitiveRoute {
+            path_pattern: "/admin".to_owned(),
+            auth_mechanism: "".to_owned(),
+        }];
+        let result = check_sensitive_surfaces("myplugin", &routes, &declared);
+        assert_eq!(
+            result.status,
+            CheckStatus::Fail,
+            "empty auth_mechanism must fail"
+        );
+    }
+
+    #[test]
+    fn sensitive_only_checks_own_plugin_routes() {
+        let routes = vec![
+            make_route("GET", "/admin/panel", RouteSource::User),
+            make_route("GET", "/posts", plugin("blog")),
+        ];
+        let result = check_sensitive_surfaces("blog", &routes, &[]);
+        assert_eq!(result.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn sensitive_credentials_keyword_detected() {
+        let routes = vec![make_route("GET", "/credential/rotate", plugin("auth"))];
+        let result = check_sensitive_surfaces("auth", &routes, &[]);
+        assert_eq!(result.status, CheckStatus::Fail);
+    }
+
+    #[test]
+    fn sensitive_metrics_keyword_detected() {
+        let routes = vec![make_route("GET", "/metrics", plugin("prom"))];
+        let result = check_sensitive_surfaces("prom", &routes, &[]);
+        assert_eq!(result.status, CheckStatus::Fail);
+    }
+
+    // ── run_conformance ────────────────────────────────────────────────────
+
+    #[test]
+    fn run_conformance_all_pass_when_clean() {
+        let routes = vec![
+            make_route("GET", "/admin", plugin("admin")),
+            make_route("POST", "/admin/items", plugin("admin")),
+        ];
+        let config = ConformanceConfig::new("admin")
+            .prefix("/admin")
+            .sensitive_route("/admin", "Role: admin required");
+        let report = run_conformance(&config, &routes);
+        assert!(
+            report.passed(),
+            "expected pass:\n{}",
+            report.to_text_report()
+        );
+    }
+
+    #[test]
+    fn run_conformance_fails_on_collision() {
+        let routes = vec![
+            make_route("GET", "/posts", RouteSource::User),
+            make_route("GET", "/posts", plugin("harvest")),
+        ];
+        let config = ConformanceConfig::new("harvest");
+        let report = run_conformance(&config, &routes);
+        assert!(!report.passed());
+    }
+
+    #[test]
+    fn run_conformance_report_has_plugin_name() {
+        let config = ConformanceConfig::new("my-plugin");
+        let report = run_conformance(&config, &[]);
+        assert_eq!(report.plugin_name, "my-plugin");
+    }
+
+    #[test]
+    fn run_conformance_skips_prefix_check_when_none() {
+        let routes = vec![make_route("GET", "/anywhere", plugin("myplugin"))];
+        let config = ConformanceConfig::new("myplugin");
+        let report = run_conformance(&config, &routes);
+        let has_prefix_check = report.checks.iter().any(|c| c.name == "route-prefix");
+        assert!(
+            !has_prefix_check,
+            "prefix check should not run when expected_prefix is None"
+        );
+    }
+
+    // ── ConformanceReport ──────────────────────────────────────────────────
+
+    #[test]
+    fn report_passed_false_when_any_fail() {
+        let report = ConformanceReport {
+            plugin_name: "test".to_owned(),
+            checks: vec![
+                CheckResult {
+                    name: "check-1".to_owned(),
+                    status: CheckStatus::Pass,
+                    message: "ok".to_owned(),
+                    diagnostics: vec![],
+                },
+                CheckResult {
+                    name: "check-2".to_owned(),
+                    status: CheckStatus::Fail,
+                    message: "fail".to_owned(),
+                    diagnostics: vec![],
+                },
+            ],
+        };
+        assert!(!report.passed());
+    }
+
+    #[test]
+    fn report_passed_true_with_skip() {
+        let report = ConformanceReport {
+            plugin_name: "test".to_owned(),
+            checks: vec![CheckResult {
+                name: "route-prefix".to_owned(),
+                status: CheckStatus::Skip,
+                message: "no routes".to_owned(),
+                diagnostics: vec![],
+            }],
+        };
+        assert!(report.passed(), "Skip should not fail the report");
+    }
+
+    #[test]
+    fn report_text_contains_plugin_name() {
+        let report = ConformanceReport {
+            plugin_name: "autumn-admin-plugin".to_owned(),
+            checks: vec![],
+        };
+        assert!(report.to_text_report().contains("autumn-admin-plugin"));
+    }
+
+    #[test]
+    fn report_text_shows_fail_when_failed() {
+        let report = ConformanceReport {
+            plugin_name: "test".to_owned(),
+            checks: vec![CheckResult {
+                name: "route-collision".to_owned(),
+                status: CheckStatus::Fail,
+                message: "1 collision".to_owned(),
+                diagnostics: vec![],
+            }],
+        };
+        assert!(report.to_text_report().contains("FAIL"));
+    }
+
+    #[test]
+    fn report_text_shows_pass_when_all_pass() {
+        let report = ConformanceReport {
+            plugin_name: "test".to_owned(),
+            checks: vec![],
+        };
+        assert!(report.to_text_report().contains("PASS"));
+    }
+
+    #[test]
+    fn report_serializes_to_json() {
+        let report = ConformanceReport {
+            plugin_name: "test-plugin".to_owned(),
+            checks: vec![CheckResult {
+                name: "route-attribution".to_owned(),
+                status: CheckStatus::Pass,
+                message: "ok".to_owned(),
+                diagnostics: vec![],
+            }],
+        };
+        let json = serde_json::to_string(&report).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["plugin_name"], "test-plugin");
+        assert_eq!(parsed["checks"][0]["status"], "pass");
+    }
+
+    #[test]
+    fn report_deserializes_from_json() {
+        let json = r#"{"plugin_name":"test","checks":[{"name":"route-attribution","status":"pass","message":"ok","diagnostics":[]}]}"#;
+        let report: ConformanceReport = serde_json::from_str(json).unwrap();
+        assert_eq!(report.plugin_name, "test");
+        assert_eq!(report.checks[0].status, CheckStatus::Pass);
+    }
+
+    // ── is_sensitive_path ──────────────────────────────────────────────────
+
+    #[test]
+    fn admin_path_is_sensitive() {
+        assert!(is_sensitive_path("/admin"));
+        assert!(is_sensitive_path("/admin/users"));
+    }
+
+    #[test]
+    fn debug_path_is_sensitive() {
+        assert!(is_sensitive_path("/debug"));
+        assert!(is_sensitive_path("/api/debug/state"));
+    }
+
+    #[test]
+    fn posts_path_is_not_sensitive() {
+        assert!(!is_sensitive_path("/posts"));
+        assert!(!is_sensitive_path("/api/users"));
+    }
+
+    #[test]
+    fn path_with_admin_as_substring_of_longer_segment_not_sensitive() {
+        // "administrator" as a whole segment IS caught (starts_with("admin"))
+        // but this is intentional per the spec: admin-prefixed segments are sensitive
+        assert!(!is_sensitive_path("/products/admiration"));
+    }
+}

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -456,6 +456,69 @@ pub fn check_sensitive_surfaces(
     }
 }
 
+/// Check that the plugin's routes are not duplicated, which would indicate the
+/// plugin was registered more than once and the framework's dedup logic was
+/// bypassed.
+///
+/// Detects (method, path) pairs that appear more than once among routes
+/// attributed to the named plugin. Returns `Skip` when no routes are
+/// attributed to the plugin.
+pub fn check_duplicate_registration(plugin_name: &str, routes: &[RouteInfo]) -> CheckResult {
+    use std::collections::HashMap;
+
+    let plugin_routes: Vec<&RouteInfo> = routes
+        .iter()
+        .filter(|r| matches!(&r.source, RouteSource::Plugin(n) if n == plugin_name))
+        .collect();
+
+    if plugin_routes.is_empty() {
+        return CheckResult {
+            name: "duplicate-registration".to_owned(),
+            status: CheckStatus::Skip,
+            message: format!("No routes attributed to plugin:{plugin_name}"),
+            diagnostics: vec![],
+        };
+    }
+
+    let mut counts: HashMap<(String, String), usize> = HashMap::new();
+    for route in &plugin_routes {
+        *counts
+            .entry((route.method.clone(), route.path.clone()))
+            .or_insert(0) += 1;
+    }
+
+    let mut duplicates: Vec<String> = counts
+        .into_iter()
+        .filter(|(_, count)| *count > 1)
+        .map(|((method, path), count)| {
+            format!("{method} {path} — appears {count} times")
+        })
+        .collect();
+    duplicates.sort();
+
+    if duplicates.is_empty() {
+        CheckResult {
+            name: "duplicate-registration".to_owned(),
+            status: CheckStatus::Pass,
+            message: format!(
+                "No duplicate route registrations for plugin:{plugin_name}"
+            ),
+            diagnostics: vec![],
+        }
+    } else {
+        CheckResult {
+            name: "duplicate-registration".to_owned(),
+            status: CheckStatus::Fail,
+            message: format!(
+                "{} route(s) registered more than once; plugin:{plugin_name} \
+                 may have been installed twice",
+                duplicates.len()
+            ),
+            diagnostics: duplicates,
+        }
+    }
+}
+
 // ── Main entry point ───────────────────────────────────────────────────────
 
 /// Run all conformance checks and return a `ConformanceReport`.
@@ -465,6 +528,7 @@ pub fn check_sensitive_surfaces(
 /// 2. `route-prefix` — plugin routes live under `config.expected_prefix` (if set)
 /// 3. `route-collision` — no two routes share (method, path)
 /// 4. `sensitive-surfaces` — sensitive-named plugin routes are declared with auth
+/// 5. `duplicate-registration` — plugin routes are not registered more than once
 pub fn run_conformance(config: &ConformanceConfig, routes: &[RouteInfo]) -> ConformanceReport {
     let mut checks = Vec::new();
 
@@ -487,6 +551,8 @@ pub fn run_conformance(config: &ConformanceConfig, routes: &[RouteInfo]) -> Conf
         routes,
         &config.sensitive_routes,
     ));
+
+    checks.push(check_duplicate_registration(&config.plugin_name, routes));
 
     ConformanceReport {
         plugin_name: config.plugin_name.clone(),
@@ -771,6 +837,68 @@ mod tests {
         let routes = vec![make_route("GET", "/metrics", plugin("prom"))];
         let result = check_sensitive_surfaces("prom", &routes, &[]);
         assert_eq!(result.status, CheckStatus::Fail);
+    }
+
+    // ── check_duplicate_registration ──────────────────────────────────────
+
+    #[test]
+    fn duplicate_registration_no_duplicates_passes() {
+        let routes = vec![
+            make_route("GET", "/admin", plugin("admin")),
+            make_route("POST", "/admin/items", plugin("admin")),
+        ];
+        let result = check_duplicate_registration("admin", &routes);
+        assert_eq!(result.status, CheckStatus::Pass, "{}", result.message);
+    }
+
+    #[test]
+    fn duplicate_registration_same_route_twice_fails() {
+        let routes = vec![
+            make_route("GET", "/admin", plugin("admin")),
+            make_route("GET", "/admin", plugin("admin")),
+        ];
+        let result = check_duplicate_registration("admin", &routes);
+        assert_eq!(result.status, CheckStatus::Fail, "{}", result.message);
+        assert_eq!(result.diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn duplicate_registration_diagnostic_names_method_path_count() {
+        let routes = vec![
+            make_route("POST", "/admin/items", plugin("admin")),
+            make_route("POST", "/admin/items", plugin("admin")),
+            make_route("POST", "/admin/items", plugin("admin")),
+        ];
+        let result = check_duplicate_registration("admin", &routes);
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(
+            result.diagnostics[0].contains("POST") && result.diagnostics[0].contains("/admin/items"),
+            "diagnostic should name route: {:?}",
+            result.diagnostics
+        );
+        assert!(
+            result.diagnostics[0].contains("3"),
+            "diagnostic should include count: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn duplicate_registration_no_plugin_routes_skips() {
+        let routes = vec![make_route("GET", "/posts", RouteSource::User)];
+        let result = check_duplicate_registration("admin", &routes);
+        assert_eq!(result.status, CheckStatus::Skip);
+    }
+
+    #[test]
+    fn duplicate_registration_only_checks_own_plugin() {
+        let routes = vec![
+            make_route("GET", "/harvest/feed", plugin("harvest")),
+            make_route("GET", "/harvest/feed", plugin("harvest")),
+            make_route("GET", "/admin", plugin("admin")),
+        ];
+        let result = check_duplicate_registration("admin", &routes);
+        assert_eq!(result.status, CheckStatus::Pass);
     }
 
     // ── run_conformance ────────────────────────────────────────────────────

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -345,14 +345,16 @@ pub fn check_route_prefix(
     }
 }
 
-/// Canonicalize dynamic route segments so that `{user_id}` and `{id}` both
-/// become `{}`, and `{*rest}` becomes `{*}`. Axum matches routes by shape, not
-/// parameter name, so collision detection must do the same.
+/// Canonicalize dynamic route segments before collision detection.
+///
+/// Both named params (`{id}`) and catch-all params (`{*rest}`) normalize to
+/// `{}`. matchit (Axum's router) treats a named param and a catch-all at the
+/// same path position as a conflict, so they must map to the same key.
 fn normalize_path_for_collision(path: &str) -> String {
     path.split('/')
         .map(|seg| {
             if seg.starts_with('{') && seg.ends_with('}') {
-                if seg.starts_with("{*") { "{*}" } else { "{}" }
+                "{}"
             } else {
                 seg
             }
@@ -862,12 +864,13 @@ mod tests {
             CheckStatus::Fail,
             "different catch-all names should collide"
         );
-        assert_eq!(diagnostics[0].path, "/files/{*}");
+        assert_eq!(diagnostics[0].path, "/files/{}");
     }
 
     #[test]
-    fn collisions_catchall_vs_param_not_collapsed() {
-        // {*rest} matches multiple segments; {id} matches one — different shapes.
+    fn collisions_catchall_vs_named_param_detected() {
+        // matchit treats {id} and {*rest} at the same position as a conflict:
+        // inserting /src/{file} after /src/{*filepath} returns InsertError::Conflict.
         let routes = vec![
             make_route("GET", "/files/{id}", RouteSource::User),
             make_route("GET", "/files/{*rest}", plugin("storage")),
@@ -875,8 +878,8 @@ mod tests {
         let (result, _) = check_collisions(&routes);
         assert_eq!(
             result.status,
-            CheckStatus::Pass,
-            "catch-all and single-segment params are different shapes"
+            CheckStatus::Fail,
+            "catch-all and named param at same position conflict in matchit"
         );
     }
 
@@ -886,7 +889,7 @@ mod tests {
             normalize_path_for_collision("/users/{user_id}/posts/{post_id}"),
             "/users/{}/posts/{}"
         );
-        assert_eq!(normalize_path_for_collision("/files/{*rest}"), "/files/{*}");
+        assert_eq!(normalize_path_for_collision("/files/{*rest}"), "/files/{}");
         assert_eq!(
             normalize_path_for_collision("/static/app.js"),
             "/static/app.js"

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -510,9 +510,7 @@ pub fn check_duplicate_registration(plugin_name: &str, routes: &[RouteInfo]) -> 
     let mut duplicates: Vec<String> = counts
         .into_iter()
         .filter(|(_, count)| *count > 1)
-        .map(|((method, path), count)| {
-            format!("{method} {path} — appears {count} times")
-        })
+        .map(|((method, path), count)| format!("{method} {path} — appears {count} times"))
         .collect();
     duplicates.sort();
 
@@ -520,9 +518,7 @@ pub fn check_duplicate_registration(plugin_name: &str, routes: &[RouteInfo]) -> 
         CheckResult {
             name: "duplicate-registration".to_owned(),
             status: CheckStatus::Pass,
-            message: format!(
-                "No duplicate route registrations for plugin:{plugin_name}"
-            ),
+            message: format!("No duplicate route registrations for plugin:{plugin_name}"),
             diagnostics: vec![],
         }
     } else {
@@ -772,7 +768,11 @@ mod tests {
         assert_eq!(diag.method, "POST");
         assert_eq!(diag.path, "/items");
         assert_eq!(diag.contributors.len(), 2);
-        let sources: Vec<&str> = diag.contributors.iter().map(|c| c.source.as_str()).collect();
+        let sources: Vec<&str> = diag
+            .contributors
+            .iter()
+            .map(|c| c.source.as_str())
+            .collect();
         assert!(sources.contains(&"user"), "missing user: {sources:?}");
         assert!(
             sources.contains(&"plugin:inventory"),
@@ -916,7 +916,8 @@ mod tests {
         let result = check_duplicate_registration("admin", &routes);
         assert_eq!(result.status, CheckStatus::Fail);
         assert!(
-            result.diagnostics[0].contains("POST") && result.diagnostics[0].contains("/admin/items"),
+            result.diagnostics[0].contains("POST")
+                && result.diagnostics[0].contains("/admin/items"),
             "diagnostic should name route: {:?}",
             result.diagnostics
         );

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -633,7 +633,7 @@ mod tests {
         ];
         let result = check_route_attribution("admin", &routes);
         assert!(
-            result.message.contains("2"),
+            result.message.contains('2'),
             "expected count in message: {}",
             result.message
         );
@@ -648,7 +648,7 @@ mod tests {
         let result = check_route_attribution("admin", &routes);
         assert_eq!(result.status, CheckStatus::Pass);
         assert!(
-            result.message.contains("1"),
+            result.message.contains('1'),
             "only 1 admin route: {}",
             result.message
         );
@@ -849,7 +849,7 @@ mod tests {
         let routes = vec![make_route("GET", "/admin/users", plugin("myplugin"))];
         let declared = vec![SensitiveRoute {
             path_pattern: "/admin".to_owned(),
-            auth_mechanism: "".to_owned(),
+            auth_mechanism: String::new(),
         }];
         let result = check_sensitive_surfaces("myplugin", &routes, &declared);
         assert_eq!(
@@ -921,7 +921,7 @@ mod tests {
             result.diagnostics
         );
         assert!(
-            result.diagnostics[0].contains("3"),
+            result.diagnostics[0].contains('3'),
             "diagnostic should include count: {:?}",
             result.diagnostics
         );

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -773,6 +773,7 @@ fn group_and_mount_routes(route_list: Vec<Route>) -> axum::Router<AppState> {
     router
 }
 
+#[cfg_attr(not(feature = "mail"), allow(unused_variables))]
 fn mount_framework_routes(
     mut router: axum::Router<AppState>,
     config: &AutumnConfig,

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -152,3 +152,117 @@ impl Plugin for MyTelemetryPlugin {
 [`autumn_web::Plugin`]: https://docs.rs/autumn-web/latest/autumn_web/plugin/trait.Plugin.html
 [`Plugin::name`]: https://docs.rs/autumn-web/latest/autumn_web/plugin/trait.Plugin.html#method.name
 [`AppBuilder::has_plugin`]: https://docs.rs/autumn-web/latest/autumn_web/app/struct.AppBuilder.html#method.has_plugin
+
+---
+
+## Plugin conformance and publishing checklist
+
+Before publishing a plugin crate to crates.io, run the Autumn conformance
+flow to prove your plugin is safe to install in a real host app.
+
+### 1. Run conformance against a minimal host app
+
+Create a small example or test binary that installs your plugin, then run:
+
+```bash
+autumn plugin-check \
+  --plugin-name autumn-myplugin-plugin \
+  --prefix /my-prefix \
+  --sensitive-route /my-prefix:"Role: myadmin required" \
+  -p my-conformance-app
+```
+
+This checks:
+
+| Check | What it verifies |
+|-------|-----------------|
+| `installability` | Binary compiles and route manifest is produced |
+| `route-attribution` | Every plugin route carries `plugin:<your-name>` source |
+| `route-prefix` | Every plugin route lives under the declared prefix |
+| `route-collision` | No two routes share (method, path); names the conflicting handlers and sources |
+| `sensitive-surfaces` | Routes with admin/debug/credential/operator/secret/metrics paths are declared with auth mechanisms |
+
+Add `--format json` to produce a machine-readable report suitable for CI:
+
+```bash
+autumn plugin-check --plugin-name autumn-myplugin-plugin --prefix /my-prefix \
+  --sensitive-route /my-prefix:"Role: myadmin required" \
+  --format json | tee conformance-report.json
+```
+
+### 2. Write library-level conformance tests
+
+For tighter integration, use `autumn_web::plugin_conformance` in your
+test suite to verify conformance at `cargo test` time without a separate
+binary step:
+
+```rust
+#[cfg(test)]
+mod conformance_tests {
+    use autumn_web::plugin_conformance::{ConformanceConfig, run_conformance};
+    use autumn_web::route_listing::{RouteInfo, RouteSource};
+
+    #[test]
+    fn plugin_passes_conformance() {
+        // Simulate the routes your plugin contributes
+        let routes = vec![
+            RouteInfo {
+                method: "GET".to_owned(),
+                path: "/my-prefix".to_owned(),
+                handler: "myplugin::index".to_owned(),
+                source: RouteSource::Plugin("autumn-myplugin-plugin".to_owned()),
+                middleware: vec![],
+            },
+        ];
+
+        let config = ConformanceConfig::new("autumn-myplugin-plugin")
+            .prefix("/my-prefix")
+            .sensitive_route("/my-prefix", "Role: myadmin required");
+
+        let report = run_conformance(&config, &routes);
+        assert!(report.passed(), "conformance failed:\n{}", report.to_text_report());
+    }
+}
+```
+
+### 3. Publishing checklist
+
+Work through this list before `cargo publish`:
+
+- [ ] **Crate name** — follows the `autumn-<name>-plugin` (first-party) or
+  `autumn-plugin-<name>` (third-party) convention
+- [ ] **Install snippet** — README includes a one-line `.plugin(MyPlugin::new())`
+  install example with the correct import path
+- [ ] **Route prefix** — all plugin routes live under a documented prefix,
+  or any root-level routes are explicitly explained in the README
+- [ ] **Route manifest** — `autumn routes --format json` on a host app shows
+  every plugin route with `"source": "plugin:<your-name>"`
+- [ ] **Production exposure gates** — if the plugin mounts admin, debug,
+  credential, operator, secret, or metrics surfaces, the README documents
+  the auth/profile gating mechanism and conformance passes with
+  `--sensitive-route PATH:DESCRIPTION`
+- [ ] **SemVer expectations** — breaking changes to the `Plugin::build`
+  signature or to any mounted route path bump the major version
+- [ ] **Conformance report** — `autumn plugin-check` exits 0 and the
+  CI log shows "All conformance checks passed"
+- [ ] **Duplicate-registration contract** — installing the plugin twice
+  is a no-op (second registration is skipped with a warning); document
+  whether your plugin is designed to be registered more than once
+- [ ] **Existing app compatibility** — downstream apps that only consume
+  the plugin continue to compile and run unchanged after each release
+
+### Reference example: `autumn-admin-plugin`
+
+`autumn-admin-plugin` is the first-party reference for the conformance
+workflow.  See `autumn-admin-plugin/src/lib.rs` for the library-level
+conformance test that runs as part of `cargo test`.
+
+To run the CLI conformance check against the admin plugin's example app:
+
+```bash
+autumn plugin-check \
+  -p bookmarks \
+  --plugin-name autumn-admin-plugin \
+  --prefix /admin \
+  --sensitive-route /admin:"Role: admin required via AdminPlugin::require_role"
+```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -181,6 +181,7 @@ This checks:
 | `route-prefix` | Every plugin route lives under the declared prefix |
 | `route-collision` | No two routes share (method, path); names the conflicting handlers and sources |
 | `sensitive-surfaces` | Routes with admin/debug/credential/operator/secret/metrics paths are declared with auth mechanisms |
+| `duplicate-registration` | No plugin route appears more than once, which would indicate the plugin was installed twice |
 
 Add `--format json` to produce a machine-readable report suitable for CI:
 
@@ -236,7 +237,10 @@ Work through this list before `cargo publish`:
 - [ ] **Route prefix** — all plugin routes live under a documented prefix,
   or any root-level routes are explicitly explained in the README
 - [ ] **Route manifest** — `autumn routes --format json` on a host app shows
-  every plugin route with `"source": "plugin:<your-name>"`
+  every plugin route with `"source": "plugin:<your-name>"`. If your plugin
+  uses `AppBuilder::nest()` (whose routes are opaque to the listing), call
+  `AppBuilder::declare_plugin_routes(routes)` alongside `nest()` to make
+  those routes visible.
 - [ ] **Production exposure gates** — if the plugin mounts admin, debug,
   credential, operator, secret, or metrics surfaces, the README documents
   the auth/profile gating mechanism and conformance passes with


### PR DESCRIPTION
Implements #591 via red/green/refactor TDD.

RED: wrote 90+ failing tests covering route attribution, route prefix
enforcement, collision detection with actionable diagnostics, sensitive-
surface gating, report serialisation, and CLI argument parsing.

GREEN: implemented all check functions and CLI command to make tests pass.

REFACTOR: updated docs/plugins.md with the publishing checklist and added
autumn-admin-plugin as the reference conformance example.

Changes:
- autumn/src/plugin_conformance.rs (new): ConformanceConfig, SensitiveRoute,
  ConformanceReport, CheckResult, CheckStatus, CollisionDiagnostic,
  RouteContributor, run_conformance(), check_route_attribution(),
  check_route_prefix(), check_collisions(), check_sensitive_surfaces()
- autumn/src/lib.rs: export pub mod plugin_conformance
- autumn-cli/src/plugin_check.rs (new): autumn plugin-check command —
  builds the binary, dumps routes via AUTUMN_DUMP_ROUTES=1, applies all
  five checks, and outputs text or JSON report
- autumn-cli/src/main.rs: add PluginCheck subcommand with --plugin-name,
  --prefix, --sensitive-route, --format, -p, --bin flags; parsing tests
- docs/plugins.md: add conformance and publishing checklist section
- autumn-admin-plugin/src/lib.rs: 8 conformance_tests::{} as reference
  example showing route attribution, prefix, collision and sensitive-
  surface checks using autumn_web::plugin_conformance

Test counts: autumn-web +38 (971 total), autumn-cli +44 (644 total),
autumn-admin-plugin +8 (85 total); all pass.

https://claude.ai/code/session_019rNMfS11sz8LsUKavpqoZ5