### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/autumn/src/i18n.rs
+++ b/autumn/src/i18n.rs
@@ -309,9 +309,10 @@ pub struct Bundle {
 }
 
 impl fmt::Debug for Bundle {
+    /// Eliminates heap allocation during debug formatting by passing the natively debuggable Keys iterator.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Bundle")
-            .field("locales", &self.messages.keys().collect::<Vec<_>>())
+            .field("locales", &self.messages.keys())
             .field("default_locale", &self.default_locale)
             .field("supported_locales", &self.supported_locales)
             .field("miss_count", &self.miss_count.load(Ordering::Relaxed))


### PR DESCRIPTION
💡 What: Switched from `.collect::<Vec<_>>()` to passing the `Keys` iterator directly in `Bundle`'s `Debug` format implementation.
🎯 Why: An intermediate Vec collection was unnecessarily being used just to print debug formatting.
📊 Impact: Removes an unnecessary heap allocation during `Bundle` debug formatting.
🔬 Measurement: Run `cargo test -p autumn-web --lib i18n`.

---
*PR created automatically by Jules for task [2817361991937252452](https://jules.google.com/task/2817361991937252452) started by @madmax983*