### PR TITLE
🍎 Eris: Fix Rate Limit Bypass via X-Forwarded-For spoofing

### DIFF
--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -164,7 +164,7 @@ impl Limiter {
                 .headers()
                 .get("x-forwarded-for")
                 .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.split(',').next())
+                .and_then(|s| s.rsplit(',').next())
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
                 .map(ToOwned::to_owned);

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -10,5 +10,6 @@ pub mod csrf_path_traversal;
 pub mod csrf_timing;
 pub mod ctf;
 pub mod fallback_middleware_bypass;
+pub mod rate_limit_bypass;
 pub mod session_exhaustion;
 pub mod session_fixation;

--- a/autumn/tests/security/rate_limit_bypass.rs
+++ b/autumn/tests/security/rate_limit_bypass.rs
@@ -1,0 +1,44 @@
+use autumn_web::config::AutumnConfig;
+use autumn_web::test::TestApp;
+use autumn_web::{get, routes};
+
+#[get("/test")]
+async fn test_handler() -> &'static str {
+    "test"
+}
+
+#[tokio::test]
+async fn eris_rate_limit_bypass_poc() {
+    let mut config = AutumnConfig::default();
+    config.security.rate_limit.enabled = true;
+    config.security.rate_limit.requests_per_second = 1.0;
+    config.security.rate_limit.burst = 1;
+    config.security.rate_limit.trust_forwarded_headers = true;
+
+    let client = TestApp::new()
+        .config(config)
+        .routes(routes![test_handler])
+        .build();
+
+    // First request, consumes burst
+    client
+        .get("/test")
+        .header("X-Forwarded-For", "fake_ip_1, real_ip")
+        .send()
+        .await
+        .assert_status(200);
+
+    // Second request, should be rate limited if using real_ip.
+    // If it uses fake_ip_2, it gets a fresh bucket and bypasses the limit!
+    let throttled = client
+        .get("/test")
+        .header("X-Forwarded-For", "fake_ip_2, real_ip")
+        .send()
+        .await;
+
+    // We expect 429 TOO MANY REQUESTS if fixed.
+    assert_eq!(
+        throttled.status, 429,
+        "VULNERABILITY: Rate limit bypassed via X-Forwarded-For spoofing!"
+    );
+}


### PR DESCRIPTION
**🍎 Eris: Fix Rate Limit Bypass via X-Forwarded-For spoofing**

**Threat**:
The rate limiting middleware's `client_ip` extraction relies on the `X-Forwarded-For` header when `trust_forwarded_headers` is true. It used `split(',').next()` to grab the *first* IP in the list. Because a malicious client can send a spoofed `X-Forwarded-For` header containing any fake IP, and a standard reverse proxy will simply append the real client IP to the end of this list (e.g., `X-Forwarded-For: <spoofed-ip>, <real-ip>`), the application would trust the spoofed IP. This allowed attackers to bypass the rate limit completely by generating a fresh token bucket on every request.

**Defense**:
Modified the IP extraction logic in `autumn/src/security/rate_limit.rs` to use `rsplit(',').next()` instead of `split(',').next()`. This ensures the rate limiter trusts the *last* IP in the `X-Forwarded-For` list, which corresponds to the IP injected by the immediate upstream trusted reverse proxy, preventing client spoofing.

**Severity**:
High (CVSS 7.5). Rate limit bypass allows DoS, brute forcing, and resource exhaustion against the application, directly undermining the security feature meant to prevent such attacks.

**Verification**:
Added a new PoC regression test, `eris_rate_limit_bypass_poc`, in `autumn/tests/security/rate_limit_bypass.rs`. The test sends requests with a spoofed `X-Forwarded-For` header followed by the real IP. Without the fix, the rate limiter would incorrectly bucket the requests by the spoofed IP and allow the request through. With the fix, the rate limiter correctly identifies the real IP and returns a `429 Too Many Requests` on the second request. All tests under `cargo test -p autumn-web --test security_tests` are green.

---
*PR created automatically by Jules for task [14304065913793794678](https://jules.google.com/task/14304065913793794678) started by @madmax983*