### PR TITLE
⚒️ Forge: Refactor manual URL form parsing into a HashMap collection

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -726,27 +726,18 @@ fn parse_oauth2_token_response(
         });
     }
 
-    let mut access_token = None;
-    let mut token_type = None;
-    let mut id_token = None;
+    let mut form: std::collections::HashMap<_, _> = url::form_urlencoded::parse(body.as_bytes())
+        .into_owned()
+        .collect();
 
-    for (k, v) in url::form_urlencoded::parse(body.as_bytes()) {
-        match k.as_ref() {
-            "access_token" => access_token = Some(v.into_owned()),
-            "token_type" => token_type = Some(v.into_owned()),
-            "id_token" => id_token = Some(v.into_owned()),
-            _ => {}
-        }
-    }
-
-    let access_token = access_token.ok_or_else(|| {
+    let access_token = form.remove("access_token").ok_or_else(|| {
         crate::AutumnError::bad_request_msg("token response missing access_token")
     })?;
 
     Ok(OAuth2TokenResponse {
         access_token,
-        token_type,
-        id_token,
+        token_type: form.remove("token_type"),
+        id_token: form.remove("id_token"),
     })
 }
 

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,35 @@
+--- autumn/src/auth.rs
++++ autumn/src/auth.rs
+@@ -733,26 +733,18 @@
+         });
+     }
+
+-    let mut access_token = None;
+-    let mut token_type = None;
+-    let mut id_token = None;
++    let mut form: std::collections::HashMap<_, _> = url::form_urlencoded::parse(body.as_bytes())
++        .into_owned()
++        .collect();
+
+-    for (k, v) in url::form_urlencoded::parse(body.as_bytes()) {
+-        match k.as_ref() {
+-            "access_token" => access_token = Some(v.into_owned()),
+-            "token_type" => token_type = Some(v.into_owned()),
+-            "id_token" => id_token = Some(v.into_owned()),
+-            _ => {}
+-        }
+-    }
+-
+-    let access_token = access_token.ok_or_else(|| {
++    let access_token = form.remove("access_token").ok_or_else(|| {
+         crate::AutumnError::bad_request_msg("token response missing access_token")
+     })?;
+
+     Ok(OAuth2TokenResponse {
+         access_token,
+-        token_type,
+-        id_token,
++        token_type: form.remove("token_type"),
++        id_token: form.remove("id_token"),
+     })
+ }


### PR DESCRIPTION
🚮 Smell: The `parse_oauth2_token_response` function manually iterated over url-encoded body properties in a loop with mutable variables for specific fields instead of using a standard collection pipeline.
✨ Solution: Extracted the url-encoded parameters directly into a HashMap via `.into_owned().collect()` and extracted the required fields using `.remove()`.
🧼 Benefit: Replaces imperative mutability with a concise, declarative pipeline, removing boilerplate variables and reducing cognitive load while staying idiomatic to Rust's collections.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [11849241047488616460](https://jules.google.com/task/11849241047488616460) started by @madmax983*