### PR TITLE
⚡ Bolt: [Remove unnecessary Vec allocations in path normalization and debug formatting]

### DIFF
--- a/autumn/src/i18n.rs
+++ b/autumn/src/i18n.rs
@@ -310,8 +310,10 @@ pub struct Bundle {
 
 impl fmt::Debug for Bundle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // PERF: Pass `Keys` iterator directly since it natively implements `Debug`.
+        // This avoids creating an intermediate `Vec` and removes a heap allocation.
         f.debug_struct("Bundle")
-            .field("locales", &self.messages.keys().collect::<Vec<_>>())
+            .field("locales", &self.messages.keys())
             .field("default_locale", &self.default_locale)
             .field("supported_locales", &self.supported_locales)
             .field("miss_count", &self.miss_count.load(Ordering::Relaxed))

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -350,17 +350,22 @@ pub fn check_route_prefix(
 /// Both named params (`{id}`) and catch-all params (`{*rest}`) normalize to
 /// `{}`. matchit (Axum's router) treats a named param and a catch-all at the
 /// same path position as a conflict, so they must map to the same key.
+///
+/// **Performance:** Pre-allocates a `String` and pushes directly to it, which
+/// avoids intermediate `.collect::<Vec<_>>()` heap allocations.
 fn normalize_path_for_collision(path: &str) -> String {
-    path.split('/')
-        .map(|seg| {
-            if seg.starts_with('{') && seg.ends_with('}') {
-                "{}"
-            } else {
-                seg
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
+    let mut out = String::with_capacity(path.len());
+    for (i, seg) in path.split('/').enumerate() {
+        if i > 0 {
+            out.push('/');
+        }
+        if seg.starts_with('{') && seg.ends_with('}') {
+            out.push_str("{}");
+        } else {
+            out.push_str(seg);
+        }
+    }
+    out
 }
 
 /// Detect route collisions: any two routes sharing the same (method, path) pair.


### PR DESCRIPTION
💡 What: 
- Removed `.collect::<Vec<_>>()` chaining in `Bundle::fmt` in `i18n.rs`, passing the `.keys()` iterator directly to the debug struct formatter.
- Rewrote `normalize_path_for_collision` in `plugin_conformance.rs` to iterate over segments and push directly to a pre-allocated `String::with_capacity(path.len())`, replacing the previous `split().map().collect::<Vec<_>>().join("/")` chain.

🎯 Why: 
- In `Bundle::fmt`, creating an intermediate vector just for debugging purposes incurs a useless heap allocation. Iterators over HashMaps natively implement `Debug`.
- In `normalize_path_for_collision`, the intermediate collection step into a `Vec` for `join("/")` causes unnecessary heap allocations on a relatively hot path utilized during route collision checks.

📊 Impact: 
- Eliminates 1 heap allocation every time an `i18n::Bundle` is formatted.
- Eliminates 1 intermediate heap allocation per route normalized during application boot / plugin registration.

🔬 Measurement: 
- Verified logic stability by running unit tests (`cargo test -p autumn-web --lib plugin_conformance` and `cargo test -p autumn-web --lib i18n`). All tests pass, proving the optimizations preserve behavior exactly.

---
*PR created automatically by Jules for task [8784091158077298316](https://jules.google.com/task/8784091158077298316) started by @madmax983*