### PR TITLE
🗺️ Atlas: Make router-constructing functions generic over state

### DIFF
--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -1034,7 +1034,11 @@ struct CapturedMailSummary {
     modified: SystemTime,
 }
 
-pub(crate) fn mail_preview_router(file_dir: PathBuf) -> axum::Router<AppState> {
+pub(crate) fn mail_preview_router<S>(file_dir: PathBuf) -> axum::Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+    AppState: axum::extract::FromRef<S>,
+{
     let file_dir = Arc::new(file_dir);
     axum::Router::new()
         .route(

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -837,10 +837,14 @@ fn mount_framework_routes(
     router
 }
 
-fn mount_probe_endpoints(
-    mut router: axum::Router<AppState>,
+fn mount_probe_endpoints<S>(
+    mut router: axum::Router<S>,
     config: &AutumnConfig,
-) -> (std::collections::HashSet<String>, axum::Router<AppState>) {
+) -> (std::collections::HashSet<String>, axum::Router<S>)
+where
+    S: Clone + Send + Sync + 'static,
+    AppState: axum::extract::FromRef<S>,
+{
     // Probe endpoints (auto-mounted)
     let mut mounted_probe_paths = std::collections::HashSet::new();
 
@@ -953,10 +957,10 @@ fn mount_raw_routers(
     router
 }
 
-fn apply_cors_middleware(
-    mut router: axum::Router<AppState>,
-    config: &AutumnConfig,
-) -> axum::Router<AppState> {
+fn apply_cors_middleware<S>(mut router: axum::Router<S>, config: &AutumnConfig) -> axum::Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
     // CORS middleware (only applied when allowed_origins is non-empty)
     if !config.cors.allowed_origins.is_empty() {
         let cors = build_cors_layer(&config.cors);
@@ -970,10 +974,10 @@ fn apply_cors_middleware(
     router
 }
 
-fn apply_csrf_middleware(
-    mut router: axum::Router<AppState>,
-    config: &AutumnConfig,
-) -> axum::Router<AppState> {
+fn apply_csrf_middleware<S>(mut router: axum::Router<S>, config: &AutumnConfig) -> axum::Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
     // CSRF middleware (only applied when enabled)
     if config.security.csrf.enabled {
         let csrf_layer = crate::security::CsrfLayer::from_config(&config.security.csrf);
@@ -983,10 +987,13 @@ fn apply_csrf_middleware(
     router
 }
 
-fn apply_rate_limit_middleware(
-    mut router: axum::Router<AppState>,
+fn apply_rate_limit_middleware<S>(
+    mut router: axum::Router<S>,
     config: &AutumnConfig,
-) -> axum::Router<AppState> {
+) -> axum::Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
     // Rate limiting middleware (only applied when enabled)
     if config.security.rate_limit.enabled {
         let layer = crate::security::RateLimitLayer::from_config(&config.security.rate_limit);
@@ -1000,10 +1007,10 @@ fn apply_rate_limit_middleware(
     router
 }
 
-fn apply_upload_middleware(
-    router: axum::Router<AppState>,
-    config: &AutumnConfig,
-) -> axum::Router<AppState> {
+fn apply_upload_middleware<S>(router: axum::Router<S>, config: &AutumnConfig) -> axum::Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
     let upload_config = config.security.upload.clone();
     tracing::info!(
         max_request_size_bytes = upload_config.max_request_size_bytes,

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -740,12 +740,12 @@ fn session_store_unavailable_response(error: &SessionStoreError) -> Response {
     (StatusCode::SERVICE_UNAVAILABLE, "Session store unavailable").into_response()
 }
 
-pub(crate) fn apply_session_layer(
-    router: axum::Router<crate::state::AppState>,
+pub(crate) fn apply_session_layer<S: Clone + Send + Sync + 'static>(
+    router: axum::Router<S>,
     config: &SessionConfig,
     profile: Option<&str>,
     custom_store: Option<Arc<dyn BoxedSessionStore>>,
-) -> Result<axum::Router<crate::state::AppState>, SessionBackendConfigError> {
+) -> Result<axum::Router<S>, SessionBackendConfigError> {
     if let Some(store) = custom_store {
         tracing::debug!(
             "Custom session store installed via with_session_store(); skipping config-driven backend selection"


### PR DESCRIPTION
🕸️ Tangle: The codebase was hardcoding the concrete `Router<AppState>` state type in various router-constructing and middleware functions (e.g. `session.rs`, `router.rs`, `mail.rs`). This tight coupling creates potential circular dependencies in the routing and middleware layers.
📐 Blueprint: Refactored these functions to be generic over the Axum state type (`Router<S>`). Applied standard Axum bounds (`S: Clone + Send + Sync + 'static`) and explicitly preserved extractor functionality by requiring `AppState: axum::extract::FromRef<S>`.
🧱 Stability: Reduced coupling between core domain state logic and external router modules, improving architectural separation without affecting existing endpoint extractors.
🔭 Verification: Builds successfully, strict separation enforced. Tested `autumn-web` library modules `router`, `session`, and `mail` with `cargo test` passing smoothly. Code formatted and reviewed.

---
*PR created automatically by Jules for task [1293721424112025611](https://jules.google.com/task/1293721424112025611) started by @madmax983*