### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn/src/static_gen/isr_coordinator.rs
+++ b/autumn/src/static_gen/isr_coordinator.rs
@@ -227,7 +227,7 @@ impl IsrCoordinator for PostgresIsrCoordinator {
 /// # Examples
 ///
 /// ```rust
-/// use autumn_web::static_gen::isr_coordinator::isr_window_key;
+/// use autumn_web::static_gen::isr_window_key;
 ///
 /// let url_path = "/about";
 /// let revalidate_secs = 60;
@@ -251,9 +251,10 @@ pub fn isr_window_key(url_path: &str, revalidate_secs: u64, now_unix_secs: u64) 
 /// # Examples
 ///
 /// ```rust
-/// use autumn_web::static_gen::isr_coordinator::isr_advisory_lock_key;
+/// use autumn_web::static_gen::{isr_window_key, isr_advisory_lock_key};
 ///
-/// let lock_key = isr_advisory_lock_key("/about", "/about:28333333");
+/// let window_key = isr_window_key("/about", 60, 1_700_000_000);
+/// let lock_key = isr_advisory_lock_key("/about", &window_key);
 /// // The value is a stable 64-bit integer
 /// assert_ne!(lock_key, 0);
 /// ```

--- a/autumn/src/static_gen/isr_coordinator.rs
+++ b/autumn/src/static_gen/isr_coordinator.rs
@@ -223,6 +223,18 @@ impl IsrCoordinator for PostgresIsrCoordinator {
 /// # Returns
 ///
 /// A string of the form `"{url_path}:{bucket}"` where `bucket = now / interval`.
+///
+/// # Examples
+///
+/// ```rust
+/// use autumn_web::static_gen::isr_coordinator::isr_window_key;
+///
+/// let url_path = "/about";
+/// let revalidate_secs = 60;
+/// let now_unix_secs = 1_700_000_000;
+/// let key = isr_window_key(url_path, revalidate_secs, now_unix_secs);
+/// assert_eq!(key, "/about:28333333");
+/// ```
 #[must_use]
 pub fn isr_window_key(url_path: &str, revalidate_secs: u64, now_unix_secs: u64) -> String {
     let interval = revalidate_secs.max(1);
@@ -235,6 +247,16 @@ pub fn isr_window_key(url_path: &str, revalidate_secs: u64, now_unix_secs: u64) 
 /// Suitable for `pg_try_advisory_lock`. The result is a deterministic hash
 /// of the inputs; different routes or different windows produce different keys
 /// with overwhelming probability.
+///
+/// # Examples
+///
+/// ```rust
+/// use autumn_web::static_gen::isr_coordinator::isr_advisory_lock_key;
+///
+/// let lock_key = isr_advisory_lock_key("/about", "/about:28333333");
+/// // The value is a stable 64-bit integer
+/// assert_ne!(lock_key, 0);
+/// ```
 #[must_use]
 pub fn isr_advisory_lock_key(url_path: &str, window_key: &str) -> i64 {
     let mut hasher = Sha256::new();

--- a/autumn/src/static_gen/mod.rs
+++ b/autumn/src/static_gen/mod.rs
@@ -36,14 +36,14 @@
 //! #### Multi-replica ISR
 //!
 //! In single-replica / development deployments the default
-//! [`isr_coordinator::LocalIsrCoordinator`] is sufficient: an `AtomicBool`
+//! [`crate::static_gen::isr_coordinator::LocalIsrCoordinator`] is sufficient: an `AtomicBool`
 //! per route prevents duplicate background tasks within the same process.
 //!
 //! In **multi-replica** deployments sharing a writable `dist/` volume or
 //! object-backed storage, each replica independently detects staleness and
 //! can race to regenerate the same page. Supply a
-//! [`isr_coordinator::PostgresIsrCoordinator`] (feature `db`) via
-//! [`StaticFileLayer::with_isr_coordinator`] so that only one replica wins
+//! [`crate::static_gen::isr_coordinator::PostgresIsrCoordinator`] (feature `db`) via
+//! [`crate::static_gen::StaticFileLayer::with_isr_coordinator`] so that only one replica wins
 //! the lock per revalidation window:
 //!
 //! ```rust,ignore
@@ -56,7 +56,7 @@
 //!     .with_isr_coordinator(Arc::new(PostgresIsrCoordinator::new(db_pool)));
 //! ```
 //!
-//! See [`isr_coordinator`] for the full deployment contract table.
+//! See [`crate::static_gen::isr_coordinator`] for the full deployment contract table.
 
 pub(crate) mod build;
 pub mod isr_coordinator;


### PR DESCRIPTION
📖 Chapter: The `static_gen` and `job` modules
🔦 Insight: Clarified and fixed broken intra-doc links and redundant links. Added executable doctests to public functions to demonstrate usage.
🧪 Example: Added `/// # Examples` doctests for `isr_window_key` and `isr_advisory_lock_key`. Verified with `cargo doc` and `cargo test --doc`.

---
*PR created automatically by Jules for task [3223701141307848675](https://jules.google.com/task/3223701141307848675) started by @madmax983*