### PR TITLE
🗣️ Echo: Fix empty responses for 404s and 405s in nested routers

### DIFF
--- a/autumn/src/middleware/exception_filter.rs
+++ b/autumn/src/middleware/exception_filter.rs
@@ -188,8 +188,29 @@ where
         let this = self.project();
         match this.inner.poll(cx) {
             Poll::Ready(Ok(response)) => {
+                let status = response.status();
+                let is_empty = axum::body::HttpBody::size_hint(response.body()).exact() == Some(0);
+
+                let error_info = if let Some(info) = response.extensions().get::<AutumnErrorInfo>().cloned() {
+                    Some(info)
+                } else if is_empty && (status == axum::http::StatusCode::NOT_FOUND || status == axum::http::StatusCode::METHOD_NOT_ALLOWED) {
+                    // This handles empty 404s/405s returned by axum nested routers or method router fallbacks
+                    let message = if status == axum::http::StatusCode::METHOD_NOT_ALLOWED {
+                        "Method not allowed"
+                    } else {
+                        "Page not found"
+                    };
+                    Some(AutumnErrorInfo {
+                        status,
+                        message: message.to_string(),
+                        details: None,
+                    })
+                } else {
+                    None
+                };
+
                 // Check if this response came from AutumnError and clone the info out
-                if let Some(error_info) = response.extensions().get::<AutumnErrorInfo>().cloned() {
+                if let Some(error_info) = error_info {
                     let mut response = response;
                     let filters = this.filters;
                     for filter in filters.iter() {

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -948,7 +948,7 @@ fn mount_raw_routers(
     // Nest user-supplied raw Axum routers under path prefixes.
     for (prefix, raw_router) in nest_routers {
         tracing::debug!(prefix = %prefix, "Nested raw Axum router");
-        router = router.nest(&prefix, raw_router);
+        router = router.nest(&prefix, raw_router.fallback(crate::middleware::error_page_filter::fallback_404_handler));
     }
     router
 }


### PR DESCRIPTION
1. 🔎 EXPERIENCE: Built a modular API using `.merge()` and `.nest()`.
2. 🚧 STUMBLE: Requesting missing paths returned `content-length: 0` instead of a helpful error.
3. 📢 REPORT: Unmatched paths inside nested routers and Method Mismatches bypass the custom error rendering.
4. 🧪 VERIFY: Empty 404/405 responses are intercepted by ExceptionFilter and replaced with standard `AutumnErrorInfo` payloads.

---
*PR created automatically by Jules for task [4824395643177752635](https://jules.google.com/task/4824395643177752635) started by @madmax983*