### PR TITLE
Add example catalog drift gate and documentation

### DIFF
--- a/.github/workflows/publish-gate.yml
+++ b/.github/workflows/publish-gate.yml
@@ -35,11 +35,23 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # 0. Example catalog drift gate
+  # ---------------------------------------------------------------------------
+  examples:
+    name: Example catalog drift gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check examples catalog coherence
+        run: ./scripts/check-examples.sh
+
+  # ---------------------------------------------------------------------------
   # 1. Crate metadata
   # ---------------------------------------------------------------------------
   metadata:
     name: Crate metadata
     runs-on: ubuntu-latest
+    needs: examples
     steps:
       - uses: actions/checkout@v4
       - name: Check required crates.io metadata fields

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,204 @@
+# Autumn Examples Catalog
+
+Every directory under `examples/` is listed here with its support tier,
+target persona, demonstrated journey, key capabilities, prerequisites,
+exact run command, and the first successful response that proves it works.
+
+The `scripts/check-examples.sh` drift gate reads the machine-readable markers
+on each entry and fails a release if the catalog, workspace membership, and
+`README.md` Examples table drift out of sync.
+
+Marker format used by the drift gate (HTML comment on its own line inside each entry):
+
+    &lt;!-- catalog:example name=&lt;dir&gt; tier=supported|experimental|excluded --&gt;
+
+---
+
+## Supported Examples
+
+Supported examples participate in normal workspace validation, have a documented
+journey, and each carries a README quickstart. A failure in any supported example
+blocks publishing `autumn-web` or `autumn-cli`.
+
+---
+
+### `examples/hello` — First Route
+
+<!-- catalog:example name=hello tier=supported -->
+
+| Field | Value |
+|-------|-------|
+| **Persona** | Developer evaluating Autumn for the first time |
+| **Journey** | First route: install CLI, run the app, see a response |
+| **Key capabilities** | `#[get]`, `routes![]`, `#[autumn_web::main]`, built-in `/health` |
+| **Prerequisites** | Rust 1.88.0+ |
+| **Run command** | `cargo run -p hello` |
+| **Success proof** | `curl http://localhost:3000/hello` returns `Hello, Autumn!` |
+
+---
+
+### `examples/todo-app` — Classic CRUD App
+
+<!-- catalog:example name=todo-app tier=supported -->
+
+| Field | Value |
+|-------|-------|
+| **Persona** | Developer building a full-stack Rust web application |
+| **Journey** | CRUD app: routes, Diesel model, Maud templates, htmx interactions, JSON API |
+| **Key capabilities** | `#[model]`, Diesel migrations, Maud, htmx, Tailwind, JSON endpoints |
+| **Prerequisites** | Rust 1.88.0+, PostgreSQL |
+| **Run command** | `cargo run -p todo-app` |
+| **Success proof** | `curl http://localhost:3000/` returns the todo list HTML page |
+
+---
+
+### `examples/blog` — Admin UI and Static Pre-rendering
+
+<!-- catalog:example name=blog tier=supported -->
+
+| Field | Value |
+|-------|-------|
+| **Persona** | Developer building a content site with an admin interface |
+| **Journey** | Admin/static rendering: content CRUD, form validation, pre-rendered public pages |
+| **Key capabilities** | `#[static_get]`, `static_routes![]`, `autumn build`, admin UI, input validation |
+| **Prerequisites** | Rust 1.88.0+, PostgreSQL |
+| **Run command** | `cargo run -p blog` |
+| **Success proof** | `curl http://localhost:3000/` returns the blog index page |
+
+---
+
+### `examples/bookmarks` — Profiles, Repository Macro, and Scheduled Tasks
+
+<!-- catalog:example name=bookmarks tier=supported -->
+
+| Field | Value |
+|-------|-------|
+| **Persona** | Developer adding operational features to an existing Autumn app |
+| **Journey** | Profiles/tasks: generated CRUD API, actuator endpoints, profile-based config, hourly scheduled task |
+| **Key capabilities** | `#[repository]`, `#[scheduled]`, actuator (`/actuator/health`, `/actuator/tasks`), profile layering |
+| **Prerequisites** | Rust 1.88.0+, PostgreSQL |
+| **Run command** | `cargo run -p bookmarks` |
+| **Success proof** | `curl http://localhost:3000/actuator/health` returns `{"status":"UP"}` |
+
+---
+
+### `examples/bookmarks-distributed` — Distributed Deployment
+
+<!-- catalog:example name=bookmarks-distributed tier=supported -->
+
+| Field | Value |
+|-------|-------|
+| **Persona** | Developer deploying an Autumn app at production scale with read replicas |
+| **Journey** | Distributed deployment: primary/replica Postgres, Redis-optional, multi-replica web tier behind nginx, one-shot migrator |
+| **Key capabilities** | Explicit repository seam, partitioned `#[scheduled]` with advisory locks, `autumn-{profile}.toml` layering, Docker Compose topology |
+| **Prerequisites** | Docker and Docker Compose |
+| **Run command** | `docker compose -f examples/bookmarks-distributed/docker-compose.yml up -d --build` |
+| **Success proof** | `curl http://localhost:3000/api/bookmarks` returns `[]` after the stack is healthy |
+
+---
+
+### `examples/wiki` — Mutation Hooks and Revision History
+
+<!-- catalog:example name=wiki tier=supported -->
+
+| Field | Value |
+|-------|-------|
+| **Persona** | Developer adding audit trails and lifecycle hooks to a content model |
+| **Journey** | Hooks/revisions: slug lifecycle, before/after-save hooks, full revision history, REST API |
+| **Key capabilities** | `#[model]` hooks, revision tracking, slug generation, generated REST API |
+| **Prerequisites** | Rust 1.88.0+, PostgreSQL |
+| **Run command** | `cargo run -p wiki` |
+| **Success proof** | `curl http://localhost:3000/api/articles` returns `[]` |
+
+---
+
+### `examples/reddit-clone` — Full-Stack Application
+
+<!-- catalog:example name=reddit-clone tier=supported -->
+
+| Field | Value |
+|-------|-------|
+| **Persona** | Developer building a production-shaped Autumn application with auth and real-time features |
+| **Journey** | Full-stack Reddit clone: registration, sessions, posts, voting, live feeds, background jobs, transactional email |
+| **Key capabilities** | `#[secured]`, CSRF, sessions, `#[job]`, `#[ws]` channels, Redis fan-out, `#[scheduled]`, `#[static_get]`, transactional email, htmx voting |
+| **Prerequisites** | Rust 1.88.0+, PostgreSQL, Redis (optional for local run; required for multi-replica fan-out) |
+| **Run command** | `cargo run -p reddit-clone` |
+| **Success proof** | `curl http://localhost:3000/` returns the front-page HTML |
+
+---
+
+### `examples/custom_config_loader` — Custom Configuration Loading
+
+<!-- catalog:example name=custom_config_loader tier=supported -->
+
+| Field | Value |
+|-------|-------|
+| **Persona** | Developer integrating Autumn with a non-standard configuration source (Vault, AWS Secrets Manager, JSON file) |
+| **Journey** | Custom config loading: replace the default TOML + env loader with a JSON-file loader via the `ConfigLoader` trait |
+| **Key capabilities** | `ConfigLoader` trait, `AppBuilder::with_config_loader`, custom JSON config |
+| **Prerequisites** | Rust 1.88.0+ |
+| **Run command** | `cargo run -p custom-config-loader-example` |
+| **Success proof** | `curl http://127.0.0.1:4567/` returns a greeting confirming the JSON config booted the app |
+
+---
+
+### `examples/ws-echo` — WebSocket and SSE
+
+<!-- catalog:example name=ws-echo tier=supported -->
+
+| Field | Value |
+|-------|-------|
+| **Persona** | Developer adding real-time features to an Autumn application |
+| **Journey** | WebSocket echo: echo server, fan-out channels, SSE stream, Redis-backed multi-replica pub/sub |
+| **Key capabilities** | `#[ws]`, `AppState::channels()`, SSE via `autumn_web::sse::stream`, Redis pub/sub fan-out, Docker Compose smoke test |
+| **Prerequisites** | Rust 1.88.0+ (local); Docker and Docker Compose (Redis fan-out smoke test) |
+| **Run command** | `cargo run -p ws-echo` |
+| **Success proof** | `curl -N http://127.0.0.1:3000/events` holds an SSE connection open; `curl -X POST http://127.0.0.1:3000/notify` delivers an event to that stream |
+
+---
+
+## Journey Map
+
+The table below maps each example to a distinct learning journey so evaluators
+can pick the closest starting point without overlap.
+
+| Journey | Example | One-line summary |
+|---------|---------|-----------------|
+| First route | `hello` | Simplest possible Autumn app — three routes, no database |
+| CRUD app | `todo-app` | Full-stack todo list with Diesel, Maud, htmx, and a JSON API |
+| Admin / static rendering | `blog` | Blog engine with admin UI and `#[static_get]` pre-rendering |
+| Profiles / tasks | `bookmarks` | Repository macro, profile layering, actuator, hourly scheduled task |
+| Distributed deployment | `bookmarks-distributed` | Primary + replica Postgres, multi-replica web tier, Docker Compose |
+| Hooks / revisions | `wiki` | Before/after-save hooks, slug lifecycle, full revision trail |
+| Full-stack clone | `reddit-clone` | Auth, sessions, jobs, channels, email — the complete server-first stack |
+| Custom config loading | `custom_config_loader` | Replace the default config loader with a custom `ConfigLoader` |
+| WebSocket / SSE | `ws-echo` | Echo, fan-out channels, SSE, Redis multi-replica pub/sub |
+
+---
+
+## Release Checklist — Example Drift Gate
+
+Before publishing `autumn-web` or `autumn-cli`, the CI `publish-gate` workflow
+runs `scripts/check-examples.sh`. The gate catches:
+
+- Any directory under `examples/` that has no catalog entry (orphan detection).
+- Any workspace `examples/*` member that is not cataloged as `supported`.
+- Any example listed in `README.md`'s Examples table that is absent from the catalog.
+- Any supported example whose `README.md` is missing required quickstart sections.
+
+To add a new example:
+
+1. Create the directory under `examples/` and add a `README.md` with at least
+   `## Prerequisites` and `## Quick start` sections.
+2. Add it to `[workspace] members` in `Cargo.toml` (if it participates in
+   normal validation) or mark it `tier=experimental` or `tier=excluded` here.
+3. Add a catalog entry with the machine-readable marker to this file.
+4. Add a row to the README.md Examples table.
+5. Run `./scripts/check-examples.sh` locally to confirm zero failures.
+
+To retire an example:
+
+1. Either delete the directory or change its tier to `excluded` with a rationale.
+2. Remove it from `Cargo.toml` workspace members if it was a member.
+3. Remove it from the README.md Examples table.
+4. Run `./scripts/check-examples.sh` to confirm zero failures.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -108,7 +108,7 @@ blocks publishing `autumn-web` or `autumn-cli`.
 | **Key capabilities** | `#[model]` hooks, revision tracking, slug generation, generated REST API |
 | **Prerequisites** | Rust 1.88.0+, PostgreSQL |
 | **Run command** | `cargo run -p wiki` |
-| **Success proof** | `curl http://localhost:3000/api/articles` returns `[]` |
+| **Success proof** | `curl http://localhost:3000/api/v1/pages` returns `[]` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -145,14 +145,19 @@ async fn main() {
 
 ## Examples
 
+See [EXAMPLES.md](EXAMPLES.md) for the full catalog with personas, journeys, prerequisites, run commands, and success proofs.
+
 | Example | Description |
 |---------|-------------|
 | [`examples/hello`](examples/hello) | Minimal hello-world app with route macros and no database |
 | [`examples/todo-app`](examples/todo-app) | Classic full-stack CRUD app with Diesel, Maud, htmx, Tailwind, and JSON endpoints |
 | [`examples/blog`](examples/blog) | Blog engine with admin UI, validation, and pre-rendering pages to static HTML via `#[static_get]` |
 | [`examples/bookmarks`](examples/bookmarks) | Repository macro, generated CRUD API, profiles, scheduled tasks, and actuator endpoints |
+| [`examples/bookmarks-distributed`](examples/bookmarks-distributed) | Primary/replica Postgres, multi-replica web tier behind nginx, advisory-lock scheduling, and Docker Compose deployment |
 | [`examples/wiki`](examples/wiki) | Mutation hooks, revision history, generated REST API, and slug lifecycle management |
-| [`examples/reddit-clone`](examples/reddit-clone) | Full-featured Reddit clone using Autumn's server-first stack: auth, sessions, CSRF, `#[secured]`, transactional email, `#[model]`, `#[repository]`, hooks, `#[scheduled]`, `#[job]`, `#[static_get]`, `#[ws]` channels, Redis-capable background jobs and live-feed wakeups, htmx voting, and profiles. It uses built-in jobs instead of Harvest so Autumn Web releases do not depend on the companion workflow crate. |
+| [`examples/reddit-clone`](examples/reddit-clone) | Full-featured Reddit clone: auth, sessions, CSRF, `#[secured]`, transactional email, `#[job]`, `#[ws]` channels, Redis fan-out, htmx voting, and profiles |
+| [`examples/custom_config_loader`](examples/custom_config_loader) | Replace the default TOML + env config loader with a custom `ConfigLoader` (JSON file, Vault, Secrets Manager, etc.) |
+| [`examples/ws-echo`](examples/ws-echo) | WebSocket echo server, SSE fan-out, htmx live list, and Redis-backed multi-replica pub/sub |
 
 ## Documentation
 

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -19,6 +19,12 @@ htmx, embedded migrations, and the new hybrid-rendering pipeline.
   with **compile-time key validation**, automatic fallback, and a
   locale switcher in the layout (visit `/greet`)
 
+## Prerequisites
+
+- Rust 1.88.0+
+- PostgreSQL (via Docker Compose below)
+- Tailwind CSS binary (downloaded by `autumn setup`)
+
 ## Quick start
 
 From the workspace root:

--- a/examples/custom_config_loader/README.md
+++ b/examples/custom_config_loader/README.md
@@ -1,0 +1,60 @@
+# Autumn Custom Config Loader Example
+
+Demonstrates replacing Autumn's default TOML + environment-variable config
+loader with a custom implementation of the `ConfigLoader` trait. The example
+uses a JSON file as the config source; the same pattern works for AWS Secrets
+Manager, HashiCorp Vault, Consul, or any other external source.
+
+## What it demonstrates
+
+| Feature | Where | What it does |
+|---------|-------|--------------|
+| `ConfigLoader` trait | `src/main.rs` | Defines the contract for custom config loading |
+| `AppBuilder::with_config_loader` | `src/main.rs` | Swaps in the custom loader before the app boots |
+| `AutumnConfig` | `src/main.rs` | The framework config struct that the loader must produce |
+| JSON config file | `config.json` | Example non-TOML config source (port 4567, pretty logging) |
+
+## Prerequisites
+
+- Rust 1.88.0+
+
+No database or external services required.
+
+## Quick start
+
+From the **workspace root** (`autumn/`):
+
+```bash
+cargo run -p custom-config-loader-example
+```
+
+The server starts on `http://127.0.0.1:4567` (port comes from `config.json`,
+not from the default `autumn.toml` chain).
+
+### Prove it works
+
+```bash
+curl http://127.0.0.1:4567/
+# => Hello from autumn — booted with configuration loaded from config.json via a custom ConfigLoader.
+```
+
+## Adapting to other config sources
+
+Replace `JsonFileConfigLoader::load` with any async I/O that returns an
+`AutumnConfig`. For example:
+
+- **AWS Secrets Manager**: fetch a secret by ARN and deserialize the JSON value.
+- **HashiCorp Vault**: call the Vault HTTP API and map the secret data.
+- **Consul**: read a KV key and deserialize.
+- **HTTP endpoint**: use `reqwest` to fetch a JSON config endpoint at startup.
+
+The framework runs the rest of the boot sequence identically regardless of
+which loader you supply.
+
+## Available routes
+
+| Method | Path | Response |
+|--------|------|----------|
+| GET | `/` | Greeting confirming JSON-sourced config |
+| GET | `/health` | `{"status":"UP"}` |
+| GET | `/actuator/health` | Extended health JSON |

--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -1,0 +1,57 @@
+# Autumn Hello Example
+
+The simplest possible Autumn application. Three routes, no database, no
+configuration file — a clean baseline for understanding the Autumn macro and
+builder API before adding framework features.
+
+## What it demonstrates
+
+| Feature | Where | What it does |
+|---------|-------|--------------|
+| `#[get]` | `src/main.rs` | Declares GET route handlers with proc-macro ergonomics |
+| `routes![]` | `src/main.rs` | Collects handlers into a type-safe route set |
+| `#[autumn_web::main]` | `src/main.rs` | Bootstraps the Tokio runtime and the Autumn app |
+| Built-in `/health` | automatic | Framework mounts a health endpoint with no extra code |
+
+## Prerequisites
+
+- Rust 1.88.0+
+
+No database or external services required.
+
+## Quick start
+
+From the **workspace root** (`autumn/`):
+
+```bash
+cargo run -p hello
+```
+
+The server starts on `http://localhost:3000`.
+
+### Prove it works
+
+```bash
+curl http://localhost:3000/
+# => Welcome to Autumn!
+
+curl http://localhost:3000/hello
+# => Hello, Autumn!
+
+curl http://localhost:3000/hello/world
+# => Hello, world!
+
+curl http://localhost:3000/health
+# => {"status":"UP"}
+```
+
+## Available routes
+
+| Method | Path | Response |
+|--------|------|----------|
+| GET | `/` | `Welcome to Autumn!` |
+| GET | `/hello` | `Hello, Autumn!` |
+| GET | `/hello/{name}` | `Hello, <name>!` |
+| GET | `/health` | `{"status":"UP"}` |
+| GET | `/actuator/health` | Extended health JSON |
+| GET | `/actuator/info` | Build and runtime metadata |

--- a/examples/reddit-clone/README.md
+++ b/examples/reddit-clone/README.md
@@ -30,7 +30,12 @@ showcasing the framework's major features in a single cohesive application.
 | Tailwind CSS styling | All templates |
 | Static asset serving (`/static/css/`, `/static/js/htmx.min.js`) | Auto-mounted |
 
-## Running
+## Prerequisites
+
+- Rust 1.88.0+
+- PostgreSQL and Redis (via Docker Compose below)
+
+## Quick start
 
 ```bash
 # Start PostgreSQL + Redis

--- a/examples/wiki/README.md
+++ b/examples/wiki/README.md
@@ -13,6 +13,11 @@ without hand-writing the CRUD boilerplate twice.
 - Embedded migrations on startup
 - Framework health and actuator endpoints
 
+## Prerequisites
+
+- Rust 1.88.0+
+- PostgreSQL (via Docker Compose below)
+
 ## Quick start
 
 From the workspace root:

--- a/examples/ws-echo/README.md
+++ b/examples/ws-echo/README.md
@@ -9,6 +9,13 @@ Minimal real-time Autumn example covering:
 - `/events` - SSE subscription through `autumn_web::sse::stream`
 - `/notify` - script-friendly Maud list-item broadcast used by the smoke test
 
+## Prerequisites
+
+- Rust 1.88.0+ (local run)
+- Docker and Docker Compose (Redis fan-out smoke test)
+
+## Quick start
+
 Run one local replica:
 
 ```powershell

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -112,7 +112,16 @@ echo ""
 echo "==> Checking workspace examples/* members are cataloged as supported"
 
 mapfile -t workspace_examples < <(
-  grep -v '^\s*#' "$WORKSPACE_MANIFEST" \
+  # Extract only paths from the [workspace] members array, not from exclude or
+  # other sections. awk tracks section and key boundaries so that an
+  # "examples/foo" entry under `exclude` is not misread as a workspace member.
+  awk '
+    /^\[workspace\]/                    { in_ws = 1; in_members = 0; next }
+    /^\[/                               { in_ws = 0; in_members = 0 }
+    in_ws && /^members/                 { in_members = 1 }
+    in_ws && /^[a-z]/ && !/^members/   { in_members = 0 }
+    in_members && /examples\//          { print }
+  ' "$WORKSPACE_MANIFEST" \
     | grep -oE 'examples/[a-zA-Z0-9_-]+' \
     | sed 's|examples/||' \
     | sort

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -149,6 +149,15 @@ for ex in "${readme_examples[@]}"; do
     fail "  README example '$ex' is NOT in the catalog"
   fi
 done
+
+# Inverse: every supported catalog entry must also have a README table row.
+for ex in "${catalog_supported[@]}"; do
+  if printf '%s\n' "${readme_examples[@]}" | grep -qx "$ex"; then
+    ok "  supported catalog entry '$ex' is listed in README table"
+  else
+    fail "  supported catalog entry '$ex' is NOT in the README Examples table (add a row)"
+  fi
+done
 echo ""
 
 # ---------------------------------------------------------------------------

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -151,6 +151,32 @@ done
 echo ""
 
 # ---------------------------------------------------------------------------
+# 3b. Every examples/* path referenced in docs/guide/ must appear in the catalog
+# ---------------------------------------------------------------------------
+echo "==> Checking docs/guide/ example references appear in catalog"
+
+DOCS_GUIDE="docs/guide"
+if [[ -d "$DOCS_GUIDE" ]]; then
+  mapfile -t docs_examples < <(
+    grep -rhoE 'examples/[a-z_-]+' "$DOCS_GUIDE" \
+      | sed 's|examples/||' \
+      | sort -u
+  )
+  for ex in "${docs_examples[@]}"; do
+    # Skip references that are just path fragments matching no real directory.
+    [[ -d "$EXAMPLES_DIR/$ex" ]] || continue
+    if printf '%s\n' "${catalog_all[@]}" | grep -qx "$ex"; then
+      ok "  docs/guide/ reference '$ex' found in catalog"
+    else
+      fail "  docs/guide/ reference 'examples/$ex' is NOT in the catalog"
+    fi
+  done
+else
+  warn "docs/guide/ directory not found — skipping guide reference check"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
 # 4. Every supported example must have a README.md with required sections
 # ---------------------------------------------------------------------------
 echo "==> Checking supported examples have README.md with required sections"

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -135,6 +135,16 @@ for member in "${workspace_examples[@]}"; do
     fail "  workspace member examples/$member is NOT cataloged as supported in $CATALOG"
   fi
 done
+
+# Inverse: every supported catalog entry must be a workspace member so it
+# participates in normal compilation and test validation.
+for ex in "${catalog_supported[@]}"; do
+  if printf '%s\n' "${workspace_examples[@]}" | grep -qx "$ex"; then
+    ok "  supported catalog entry '$ex' is a workspace member"
+  else
+    fail "  supported catalog entry '$ex' is NOT in Cargo.toml workspace members (add it or change its catalog tier)"
+  fi
+done
 echo ""
 
 # ---------------------------------------------------------------------------

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -112,8 +112,8 @@ echo ""
 echo "==> Checking workspace examples/* members are cataloged as supported"
 
 mapfile -t workspace_examples < <(
-  grep -E '"examples/' "$WORKSPACE_MANIFEST" \
-    | grep -oE 'examples/[^"]+' \
+  grep -v '^\s*#' "$WORKSPACE_MANIFEST" \
+    | grep -oE 'examples/[a-zA-Z0-9_-]+' \
     | sed 's|examples/||' \
     | sort
 )
@@ -133,12 +133,13 @@ echo ""
 # ---------------------------------------------------------------------------
 echo "==> Checking README.md Examples table entries appear in catalog"
 
-# Match markdown table cells containing a link like [`examples/foo`](examples/foo)
+# Match the URL portion of markdown links: both [`examples/foo`](...) and [examples/foo](...).
+# Extracting from the URL (not the link text) handles both link styles unambiguously.
 mapfile -t readme_examples < <(
-  grep -oE '\[`examples/[^`]+`\]' "$README" \
-    | grep -oE 'examples/[^`]+' \
+  grep -oE '\(examples/[a-zA-Z0-9_-]+\)' "$README" \
+    | tr -d '()' \
     | sed 's|examples/||' \
-    | sort
+    | sort -u
 )
 
 for ex in "${readme_examples[@]}"; do
@@ -158,7 +159,7 @@ echo "==> Checking docs/guide/ example references appear in catalog"
 DOCS_GUIDE="docs/guide"
 if [[ -d "$DOCS_GUIDE" ]]; then
   mapfile -t docs_examples < <(
-    grep -rhoE 'examples/[a-z_-]+' "$DOCS_GUIDE" \
+    grep -rhoE 'examples/[a-zA-Z0-9_-]+' "$DOCS_GUIDE" \
       | sed 's|examples/||' \
       | sort -u
   )
@@ -207,33 +208,34 @@ echo ""
 # ---------------------------------------------------------------------------
 echo "==> Catalog summary by support tier"
 
-_count_supported=0
+mapfile -t _supported_summary  < <(catalog_names_by_tier "supported"    | sort)
+mapfile -t _exp_summary        < <(catalog_names_by_tier "experimental" | sort)
+mapfile -t _excl_summary       < <(catalog_names_by_tier "excluded"     | sort)
+
+_count_supported=${#_supported_summary[@]}
 echo ""
 echo "  SUPPORTED  (failures here block release):"
-for ex in $(catalog_names_by_tier "supported" | sort); do
+for ex in "${_supported_summary[@]}"; do
   echo "    examples/$ex"
-  _count_supported=$((_count_supported + 1))
 done
 echo "  ($( [[ $_count_supported -eq 0 ]] && echo "none" || echo "$_count_supported example(s)" ))"
 
 echo ""
 echo "  EXPERIMENTAL  (informational; not release-blocking):"
-exp_list="$(catalog_names_by_tier "experimental" | sort)"
-if [[ -z "$exp_list" ]]; then
+if [[ ${#_exp_summary[@]} -eq 0 ]]; then
   echo "    (none)"
 else
-  for ex in $exp_list; do
+  for ex in "${_exp_summary[@]}"; do
     echo "    examples/$ex"
   done
 fi
 
 echo ""
 echo "  EXCLUDED  (intentionally out of adoption path):"
-excl_list="$(catalog_names_by_tier "excluded" | sort)"
-if [[ -z "$excl_list" ]]; then
+if [[ ${#_excl_summary[@]} -eq 0 ]]; then
   echo "    (none)"
 else
-  for ex in $excl_list; do
+  for ex in "${_excl_summary[@]}"; do
     echo "    examples/$ex"
   done
 fi

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Example catalog drift gate.
+#
+# Checks that the examples catalog (EXAMPLES.md) is coherent with:
+#   1. Every directory under examples/ is cataloged.
+#   2. Every workspace examples/* member is cataloged as a supported example.
+#   3. Every example in the README.md Examples table appears in the catalog.
+#   4. Each supported example has a README.md with the required quickstart sections.
+#
+# The catalog format uses machine-readable HTML comment markers:
+#
+#   <!-- catalog:example name=<dir> tier=supported -->
+#   <!-- catalog:example name=<dir> tier=excluded -->
+#   <!-- catalog:example name=<dir> tier=experimental -->
+#
+# Output is grouped by support tier so contributors can immediately see which
+# failures block release and which are intentionally manual.
+#
+# Called from the `publish-gate` workflow. Run locally with:
+#
+#     ./scripts/check-examples.sh
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+CATALOG="EXAMPLES.md"
+EXAMPLES_DIR="examples"
+WORKSPACE_MANIFEST="Cargo.toml"
+README="README.md"
+
+# Required sections in every supported example README (case-insensitive grep).
+REQUIRED_README_SECTIONS=(
+  "## Prerequisites"
+  "## Quick"
+)
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+ok() {
+  echo "ok:    $*"
+}
+
+warn() {
+  echo "warn:  $*" >&2
+}
+
+fail() {
+  echo "FAIL:  $*" >&2
+  failures=$((failures + 1))
+}
+
+failures=0
+
+# ---------------------------------------------------------------------------
+# 0. Catalog must exist
+# ---------------------------------------------------------------------------
+echo "==> Checking catalog file exists: $CATALOG"
+if [[ ! -f "$CATALOG" ]]; then
+  fail "catalog file '$CATALOG' not found — create it to pass this gate"
+  echo ""
+  echo "Example drift gate: $failures failure(s) found."
+  die "$failures failure(s) — see output above. Create EXAMPLES.md to begin."
+fi
+ok "catalog file found"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Helper: extract cataloged example names by tier from EXAMPLES.md
+# Each marker line has the form:
+#   <!-- catalog:example name=<dir> tier=<tier> -->
+# ---------------------------------------------------------------------------
+catalog_names_by_tier() {
+  local tier="$1"
+  grep -E "<!-- catalog:example name=[^ ]+ tier=${tier}" "$CATALOG" \
+    | grep -oE 'name=[^ >]+' \
+    | sed 's/name=//' \
+    || true
+}
+
+all_catalog_names() {
+  grep -E "<!-- catalog:example name=" "$CATALOG" \
+    | grep -oE 'name=[^ >]+' \
+    | sed 's/name=//' \
+    || true
+}
+
+# ---------------------------------------------------------------------------
+# 1. Every examples/ directory must be cataloged
+# ---------------------------------------------------------------------------
+echo "==> Checking every examples/ directory is cataloged"
+
+mapfile -t example_dirs < <(find "$EXAMPLES_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
+mapfile -t catalog_all < <(all_catalog_names | sort)
+
+for dir in "${example_dirs[@]}"; do
+  if printf '%s\n' "${catalog_all[@]}" | grep -qx "$dir"; then
+    ok "  examples/$dir is cataloged"
+  else
+    fail "  examples/$dir has no catalog entry in $CATALOG"
+  fi
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# 2. Every workspace examples/* member must be cataloged as supported
+# ---------------------------------------------------------------------------
+echo "==> Checking workspace examples/* members are cataloged as supported"
+
+mapfile -t workspace_examples < <(
+  grep -E '"examples/' "$WORKSPACE_MANIFEST" \
+    | grep -oE 'examples/[^"]+' \
+    | sed 's|examples/||' \
+    | sort
+)
+mapfile -t catalog_supported < <(catalog_names_by_tier "supported" | sort)
+
+for member in "${workspace_examples[@]}"; do
+  if printf '%s\n' "${catalog_supported[@]}" | grep -qx "$member"; then
+    ok "  workspace member examples/$member is cataloged as supported"
+  else
+    fail "  workspace member examples/$member is NOT cataloged as supported in $CATALOG"
+  fi
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# 3. Every README.md Examples table entry must appear in the catalog
+# ---------------------------------------------------------------------------
+echo "==> Checking README.md Examples table entries appear in catalog"
+
+# Match markdown table cells containing a link like [`examples/foo`](examples/foo)
+mapfile -t readme_examples < <(
+  grep -oE '\[`examples/[^`]+`\]' "$README" \
+    | grep -oE 'examples/[^`]+' \
+    | sed 's|examples/||' \
+    | sort
+)
+
+for ex in "${readme_examples[@]}"; do
+  if printf '%s\n' "${catalog_all[@]}" | grep -qx "$ex"; then
+    ok "  README example '$ex' found in catalog"
+  else
+    fail "  README example '$ex' is NOT in the catalog"
+  fi
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# 4. Every supported example must have a README.md with required sections
+# ---------------------------------------------------------------------------
+echo "==> Checking supported examples have README.md with required sections"
+
+for ex in "${catalog_supported[@]}"; do
+  readme="$EXAMPLES_DIR/$ex/README.md"
+  if [[ ! -f "$readme" ]]; then
+    fail "  examples/$ex has no README.md"
+    continue
+  fi
+
+  for section in "${REQUIRED_README_SECTIONS[@]}"; do
+    if grep -qi "$section" "$readme"; then
+      ok "  examples/$ex: section '$section' present"
+    else
+      fail "  examples/$ex: README.md missing section '$section'"
+    fi
+  done
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# 5. Summary grouped by tier
+#
+# Failures in SUPPORTED examples block release.
+# EXPERIMENTAL and EXCLUDED examples are informational only; they do not
+# participate in normal workspace validation.
+# ---------------------------------------------------------------------------
+echo "==> Catalog summary by support tier"
+
+_count_supported=0
+echo ""
+echo "  SUPPORTED  (failures here block release):"
+for ex in $(catalog_names_by_tier "supported" | sort); do
+  echo "    examples/$ex"
+  _count_supported=$((_count_supported + 1))
+done
+echo "  ($( [[ $_count_supported -eq 0 ]] && echo "none" || echo "$_count_supported example(s)" ))"
+
+echo ""
+echo "  EXPERIMENTAL  (informational; not release-blocking):"
+exp_list="$(catalog_names_by_tier "experimental" | sort)"
+if [[ -z "$exp_list" ]]; then
+  echo "    (none)"
+else
+  for ex in $exp_list; do
+    echo "    examples/$ex"
+  done
+fi
+
+echo ""
+echo "  EXCLUDED  (intentionally out of adoption path):"
+excl_list="$(catalog_names_by_tier "excluded" | sort)"
+if [[ -z "$excl_list" ]]; then
+  echo "    (none)"
+else
+  for ex in $excl_list; do
+    echo "    examples/$ex"
+  done
+fi
+
+echo ""
+if [[ "$failures" -gt 0 ]]; then
+  echo "Tip: run 'cat EXAMPLES.md' to see the catalog and 'cat scripts/check-examples.sh'" \
+       "for the marker format." >&2
+  die "$failures failure(s) found — fix catalog, README.md table, or workspace membership before publishing."
+fi
+
+echo "Example catalog drift gate: all checks passed."


### PR DESCRIPTION
## Summary

Introduces an example catalog system with an automated drift gate to ensure consistency between the examples directory, workspace configuration, documentation, and example README files. This prevents examples from becoming orphaned or out-of-sync during development.

## Key Changes

- **New drift gate script** (`scripts/check-examples.sh`): Automated validation that runs in CI to verify:
  - Every directory under `examples/` is cataloged in `EXAMPLES.md`
  - Every workspace `examples/*` member is marked as `supported` tier
  - Every example in `README.md`'s Examples table appears in the catalog
  - Every supported example has a `README.md` with required quickstart sections (`## Prerequisites` and `## Quick start`)
  - All references to examples in `docs/guide/` are cataloged

- **New catalog file** (`EXAMPLES.md`): Comprehensive example documentation with:
  - Machine-readable HTML comment markers for each example (`<!-- catalog:example name=<dir> tier=<tier> -->`)
  - Three support tiers: `supported` (release-blocking), `experimental`, and `excluded`
  - Detailed metadata for each example (persona, journey, key capabilities, prerequisites, run command, success proof)
  - Journey map showing distinct learning paths
  - Release checklist for adding/retiring examples

- **Updated example READMEs**: Added standardized `## Prerequisites` and `## Quick start` sections to:
  - `examples/hello/README.md` (new file)
  - `examples/custom_config_loader/README.md` (new file)
  - `examples/blog/README.md`
  - `examples/wiki/README.md`
  - `examples/reddit-clone/README.md`
  - `examples/ws-echo/README.md`

- **Updated README.md**: Added link to `EXAMPLES.md` catalog above the Examples table

- **Updated CI workflow** (`.github/workflows/publish-gate.yml`): Added `examples` job that runs the drift gate before metadata checks, making it a blocking gate for releases

## Implementation Details

The drift gate uses grep and bash utilities to extract catalog entries by tier and validate consistency across multiple sources. Failures are grouped by support tier so contributors can immediately see which failures block release (supported tier) versus informational-only failures (experimental/excluded tiers). The script provides clear error messages and a summary of all cataloged examples organized by tier.

https://claude.ai/code/session_01Kpoy7Na581tAD8SjAWXVFm