### PR TITLE
🔒 Warden: [security fix] Rate Limit X-Forwarded-For Spoofing Bypass

### DIFF
--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -96,6 +96,7 @@
 //! | `AUTUMN_SECURITY__RATE_LIMIT__REQUESTS_PER_SECOND` | `security.rate_limit.requests_per_second` | `f64` |
 //! | `AUTUMN_SECURITY__RATE_LIMIT__BURST` | `security.rate_limit.burst` | `u32` |
 //! | `AUTUMN_SECURITY__RATE_LIMIT__TRUST_FORWARDED_HEADERS` | `security.rate_limit.trust_forwarded_headers` | `bool` |
+//! | `AUTUMN_SECURITY__RATE_LIMIT__TRUSTED_PROXIES` | `security.rate_limit.trusted_proxies` | comma-separated `String` |
 //! | `AUTUMN_ENV` | active profile | `String` |
 //! | `AUTUMN_PROFILE` | active profile (legacy alias) | `String` |
 //! | `AUTUMN_SECURITY__UPLOAD__MAX_REQUEST_SIZE_BYTES` | `security.upload.max_request_size_bytes` | `usize` |
@@ -1642,27 +1643,7 @@ impl AutumnConfig {
             &mut self.security.csrf.cookie_name,
         );
 
-        // Rate limiting
-        parse_env_bool(
-            env,
-            "AUTUMN_SECURITY__RATE_LIMIT__ENABLED",
-            &mut self.security.rate_limit.enabled,
-        );
-        parse_env(
-            env,
-            "AUTUMN_SECURITY__RATE_LIMIT__REQUESTS_PER_SECOND",
-            &mut self.security.rate_limit.requests_per_second,
-        );
-        parse_env(
-            env,
-            "AUTUMN_SECURITY__RATE_LIMIT__BURST",
-            &mut self.security.rate_limit.burst,
-        );
-        parse_env_bool(
-            env,
-            "AUTUMN_SECURITY__RATE_LIMIT__TRUST_FORWARDED_HEADERS",
-            &mut self.security.rate_limit.trust_forwarded_headers,
-        );
+        self.apply_rate_limit_env_overrides_with_env(env);
 
         // Multipart uploads
         parse_env(
@@ -1694,6 +1675,34 @@ impl AutumnConfig {
             env,
             "AUTUMN_SECURITY__ALLOW_UNAUTHORIZED_REPOSITORY_API",
             &mut self.security.allow_unauthorized_repository_api,
+        );
+    }
+
+    fn apply_rate_limit_env_overrides_with_env(&mut self, env: &dyn Env) {
+        parse_env_bool(
+            env,
+            "AUTUMN_SECURITY__RATE_LIMIT__ENABLED",
+            &mut self.security.rate_limit.enabled,
+        );
+        parse_env(
+            env,
+            "AUTUMN_SECURITY__RATE_LIMIT__REQUESTS_PER_SECOND",
+            &mut self.security.rate_limit.requests_per_second,
+        );
+        parse_env(
+            env,
+            "AUTUMN_SECURITY__RATE_LIMIT__BURST",
+            &mut self.security.rate_limit.burst,
+        );
+        parse_env_bool(
+            env,
+            "AUTUMN_SECURITY__RATE_LIMIT__TRUST_FORWARDED_HEADERS",
+            &mut self.security.rate_limit.trust_forwarded_headers,
+        );
+        parse_env_csv(
+            env,
+            "AUTUMN_SECURITY__RATE_LIMIT__TRUSTED_PROXIES",
+            &mut self.security.rate_limit.trusted_proxies,
         );
     }
 
@@ -3165,6 +3174,21 @@ path = "/healthz"
         parse_env_csv(&env, "SOME_CSV", &mut target);
         assert_eq!(target, vec!["a", "b", "c"]);
     }
+
+    #[test]
+    fn env_override_rate_limit_trusted_proxies() {
+        let env = MockEnv::new().with(
+            "AUTUMN_SECURITY__RATE_LIMIT__TRUSTED_PROXIES",
+            "10.0.0.10, 203.0.113.0/24",
+        );
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(
+            config.security.rate_limit.trusted_proxies,
+            vec!["10.0.0.10", "203.0.113.0/24"]
+        );
+    }
+
     #[test]
     fn env_override_server_host() {
         let env = MockEnv::new().with("AUTUMN_SERVER__HOST", "0.0.0.0");

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -37,6 +37,7 @@
 //! | `AUTUMN_SECURITY__RATE_LIMIT__REQUESTS_PER_SECOND` | `security.rate_limit.requests_per_second` | `f64` |
 //! | `AUTUMN_SECURITY__RATE_LIMIT__BURST` | `security.rate_limit.burst` | `u32` |
 //! | `AUTUMN_SECURITY__RATE_LIMIT__TRUST_FORWARDED_HEADERS` | `security.rate_limit.trust_forwarded_headers` | `bool` |
+//! | `AUTUMN_SECURITY__RATE_LIMIT__TRUSTED_PROXIES` | `security.rate_limit.trusted_proxies` | comma-separated `String` |
 //! | `AUTUMN_SECURITY__UPLOAD__MAX_REQUEST_SIZE_BYTES` | `security.upload.max_request_size_bytes` | `usize` |
 //! | `AUTUMN_SECURITY__UPLOAD__MAX_FILE_SIZE_BYTES` | `security.upload.max_file_size_bytes` | `usize` |
 //! | `AUTUMN_SECURITY__UPLOAD__ALLOWED_MIME_TYPES` | `security.upload.allowed_mime_types` | comma-separated `String` |
@@ -301,6 +302,7 @@ impl Default for CsrfConfig {
 /// | `requests_per_second` | `10.0` |
 /// | `burst` | `20` |
 /// | `trust_forwarded_headers` | `false` |
+/// | `trusted_proxies` | `[]` |
 ///
 /// # Client IP resolution
 ///
@@ -310,6 +312,11 @@ impl Default for CsrfConfig {
 /// sits behind a trusted reverse proxy that strips and rewrites
 /// forwarding headers on every request.
 ///
+/// If trusted upstream proxies append to `X-Forwarded-For`, configure
+/// `trusted_proxies` with the trusted proxy IPs or CIDR ranges. Autumn
+/// then walks the header from right to left, skips those trusted proxy
+/// hops, and keys the bucket on the nearest untrusted client IP.
+///
 /// # Examples
 ///
 /// ```toml
@@ -318,6 +325,7 @@ impl Default for CsrfConfig {
 /// requests_per_second = 5.0
 /// burst = 10
 /// trust_forwarded_headers = false
+/// trusted_proxies = ["10.0.0.10", "203.0.113.0/24"]
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 pub struct RateLimitConfig {
@@ -342,6 +350,15 @@ pub struct RateLimitConfig {
     /// can rotate header values to bypass throttling.
     #[serde(default)]
     pub trust_forwarded_headers: bool,
+
+    /// Trusted proxy IP addresses or CIDR ranges to skip at the right
+    /// side of an appended `X-Forwarded-For` chain.
+    ///
+    /// This is only used when `trust_forwarded_headers = true`. Include
+    /// the immediate peer proxy when `ConnectInfo` is available; forwarded
+    /// headers from non-trusted peers are ignored.
+    #[serde(default)]
+    pub trusted_proxies: Vec<String>,
 }
 
 impl Default for RateLimitConfig {
@@ -351,6 +368,7 @@ impl Default for RateLimitConfig {
             requests_per_second: default_rps(),
             burst: default_burst(),
             trust_forwarded_headers: false,
+            trusted_proxies: Vec::new(),
         }
     }
 }
@@ -581,21 +599,24 @@ mod tests {
         assert!((config.requests_per_second - 10.0).abs() < f64::EPSILON);
         assert_eq!(config.burst, 20);
         assert!(!config.trust_forwarded_headers);
+        assert!(config.trusted_proxies.is_empty());
     }
 
     #[test]
     fn rate_limit_config_deserialize() {
-        let toml_str = r"
+        let toml_str = r#"
             enabled = true
             requests_per_second = 5.0
             burst = 100
             trust_forwarded_headers = true
-        ";
+            trusted_proxies = ["10.0.0.10", "203.0.113.0/24"]
+        "#;
         let config: RateLimitConfig = toml::from_str(toml_str).unwrap();
         assert!(config.enabled);
         assert!((config.requests_per_second - 5.0).abs() < f64::EPSILON);
         assert_eq!(config.burst, 100);
         assert!(config.trust_forwarded_headers);
+        assert_eq!(config.trusted_proxies, vec!["10.0.0.10", "203.0.113.0/24"]);
     }
 
     #[test]
@@ -606,6 +627,7 @@ mod tests {
         assert!((config.requests_per_second - 10.0).abs() < f64::EPSILON);
         assert_eq!(config.burst, 20);
         assert!(!config.trust_forwarded_headers);
+        assert!(config.trusted_proxies.is_empty());
     }
 
     #[test]

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -357,7 +357,8 @@ pub struct RateLimitConfig {
     /// This is only used when `trust_forwarded_headers = true`. Include
     /// the immediate peer proxy when `ConnectInfo` is available; forwarded
     /// headers from non-trusted peers, or requests without peer metadata,
-    /// are ignored.
+    /// are ignored. Invalid entries are ignored; if every configured
+    /// entry is invalid, forwarded headers are ignored rather than trusted.
     #[serde(default)]
     pub trusted_proxies: Vec<String>,
 }

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -356,7 +356,8 @@ pub struct RateLimitConfig {
     ///
     /// This is only used when `trust_forwarded_headers = true`. Include
     /// the immediate peer proxy when `ConnectInfo` is available; forwarded
-    /// headers from non-trusted peers are ignored.
+    /// headers from non-trusted peers, or requests without peer metadata,
+    /// are ignored.
     #[serde(default)]
     pub trusted_proxies: Vec<String>,
 }

--- a/autumn/src/security/mod.rs
+++ b/autumn/src/security/mod.rs
@@ -50,6 +50,8 @@
 //! enabled = true                       # per-IP token bucket
 //! requests_per_second = 10.0
 //! burst = 20
+//! trust_forwarded_headers = true       # only behind trusted proxies
+//! trusted_proxies = ["10.0.0.10", "203.0.113.0/24"]
 //! ```
 //!
 //! ## Quick start

--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -15,7 +15,7 @@
 //! ([`ConnectInfo<SocketAddr>`]) by default. When
 //! [`RateLimitConfig::trust_forwarded_headers`] is `true` — which should
 //! only be set behind a reverse proxy that strips and rewrites these
-//! headers — the limiter consults `X-Forwarded-For` (first entry) and
+//! headers — the limiter consults `X-Forwarded-For` (last entry) and
 //! `X-Real-IP` first, falling back to the peer address.
 //!
 //! Requests with no identifiable client (no trusted forwarding header
@@ -154,7 +154,7 @@ impl Limiter {
     /// the static site generator and `Router::oneshot`-style test
     /// harnesses fall into this path.
     ///
-    /// When `trust_forwarded_headers` is `true`, the first entry of
+    /// When `trust_forwarded_headers` is `true`, the last entry of
     /// `X-Forwarded-For` and then `X-Real-IP` are consulted before
     /// [`ConnectInfo<SocketAddr>`]. Otherwise only the peer address is
     /// used.
@@ -164,7 +164,7 @@ impl Limiter {
                 .headers()
                 .get("x-forwarded-for")
                 .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.split(',').next())
+                .and_then(|s| s.rsplit(',').next())
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
                 .map(ToOwned::to_owned);
@@ -440,12 +440,24 @@ mod tests {
     }
 
     #[test]
-    fn client_ip_prefers_x_forwarded_for_first_entry_when_trusted() {
+    fn client_ip_prevents_spoofing() {
+        let req: Request<()> = Request::builder()
+            .header("X-Forwarded-For", "attacker_spoofed_ip, real_client_ip")
+            .body(())
+            .expect("infallible response builder");
+        assert_eq!(
+            limiter(true).client_ip(&req).as_deref(),
+            Some("real_client_ip")
+        );
+    }
+
+    #[test]
+    fn client_ip_prefers_x_forwarded_for_last_entry_when_trusted() {
         let req: Request<()> = Request::builder()
             .header("X-Forwarded-For", "1.2.3.4, 5.6.7.8")
             .body(())
             .expect("infallible response builder");
-        assert_eq!(limiter(true).client_ip(&req).as_deref(), Some("1.2.3.4"));
+        assert_eq!(limiter(true).client_ip(&req).as_deref(), Some("5.6.7.8"));
     }
 
     #[test]
@@ -494,11 +506,11 @@ mod tests {
     #[test]
     fn client_ip_empty_xff_falls_through_to_x_real_ip_when_trusted() {
         let req: Request<()> = Request::builder()
-            .header("X-Forwarded-For", " , 5.5.5.5")
+            .header("X-Forwarded-For", "5.5.5.5,  ")
             .header("X-Real-IP", "8.8.8.8")
             .body(())
             .expect("infallible response builder");
-        // First XFF entry is empty after trim, so we fall back to X-Real-IP.
+        // Last XFF entry is empty after trim, so we fall back to X-Real-IP.
         assert_eq!(limiter(true).client_ip(&req).as_deref(), Some("8.8.8.8"));
     }
 

--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -15,8 +15,11 @@
 //! ([`ConnectInfo<SocketAddr>`]) by default. When
 //! [`RateLimitConfig::trust_forwarded_headers`] is `true` — which should
 //! only be set behind a reverse proxy that strips and rewrites these
-//! headers — the limiter consults `X-Forwarded-For` (last entry) and
-//! `X-Real-IP` first, falling back to the peer address.
+//! headers — the limiter consults `X-Forwarded-For` and `X-Real-IP` first,
+//! falling back to the peer address. If
+//! [`RateLimitConfig::trusted_proxies`] is configured, trusted proxy
+//! addresses at the right side of the `X-Forwarded-For` chain are skipped
+//! so appended proxy chains still key on the nearest untrusted client.
 //!
 //! Requests with no identifiable client (no trusted forwarding header
 //! AND no `ConnectInfo`) bypass rate limiting entirely. In-process
@@ -37,7 +40,7 @@
 
 use lru::LruCache;
 use std::future::Future;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::num::NonZeroUsize;
 use std::pin::Pin;
 
@@ -62,6 +65,7 @@ struct Limiter {
     burst: f64,
     burst_header: HeaderValue,
     trust_forwarded_headers: bool,
+    trusted_proxies: Vec<TrustedProxy>,
     buckets: Mutex<LruCache<String, Bucket>>,
 }
 
@@ -69,6 +73,65 @@ struct Limiter {
 struct Bucket {
     tokens: f64,
     last_refill: Instant,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TrustedProxy {
+    network: IpAddr,
+    prefix_len: u8,
+}
+
+impl TrustedProxy {
+    fn parse(value: &str) -> Option<Self> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        let (addr, prefix_len) = if let Some((addr, prefix)) = trimmed.split_once('/') {
+            let addr = addr.trim().parse::<IpAddr>().ok()?;
+            let prefix_len = prefix.trim().parse::<u8>().ok()?;
+            (addr, prefix_len)
+        } else {
+            let addr = trimmed.parse::<IpAddr>().ok()?;
+            let prefix_len = match addr {
+                IpAddr::V4(_) => 32,
+                IpAddr::V6(_) => 128,
+            };
+            (addr, prefix_len)
+        };
+
+        let max_prefix = match addr {
+            IpAddr::V4(_) => 32,
+            IpAddr::V6(_) => 128,
+        };
+
+        (prefix_len <= max_prefix).then_some(Self {
+            network: addr,
+            prefix_len,
+        })
+    }
+
+    fn contains(&self, ip: IpAddr) -> bool {
+        if self.prefix_len == 0 {
+            return matches!(
+                (self.network, ip),
+                (IpAddr::V4(_), IpAddr::V4(_)) | (IpAddr::V6(_), IpAddr::V6(_))
+            );
+        }
+
+        match (self.network, ip) {
+            (IpAddr::V4(network), IpAddr::V4(candidate)) => {
+                let shift = 32_u8.saturating_sub(self.prefix_len);
+                (u32::from(network) >> shift) == (u32::from(candidate) >> shift)
+            }
+            (IpAddr::V6(network), IpAddr::V6(candidate)) => {
+                let shift = 128_u8.saturating_sub(self.prefix_len);
+                (u128::from(network) >> shift) == (u128::from(candidate) >> shift)
+            }
+            (IpAddr::V4(_), IpAddr::V6(_)) | (IpAddr::V6(_), IpAddr::V4(_)) => false,
+        }
+    }
 }
 
 /// Outcome of consuming one token from a bucket.
@@ -83,11 +146,25 @@ impl Limiter {
         let burst = f64::from(config.burst.max(1));
         let refill_per_sec = config.requests_per_second.max(f64::MIN_POSITIVE);
         let burst_header = HeaderValue::from(config.burst.max(1));
+        let trusted_proxies = config
+            .trusted_proxies
+            .iter()
+            .filter_map(|proxy| {
+                TrustedProxy::parse(proxy).or_else(|| {
+                    tracing::warn!(
+                        trusted_proxy = %proxy,
+                        "ignoring invalid rate limit trusted proxy"
+                    );
+                    None
+                })
+            })
+            .collect();
         Self {
             refill_per_sec,
             burst,
             burst_header,
             trust_forwarded_headers: config.trust_forwarded_headers,
+            trusted_proxies,
             buckets: Mutex::new(LruCache::new(
                 NonZeroUsize::new(10_000).expect("10_000 is non-zero"),
             )),
@@ -154,20 +231,20 @@ impl Limiter {
     /// the static site generator and `Router::oneshot`-style test
     /// harnesses fall into this path.
     ///
-    /// When `trust_forwarded_headers` is `true`, the last entry of
-    /// `X-Forwarded-For` and then `X-Real-IP` are consulted before
-    /// [`ConnectInfo<SocketAddr>`]. Otherwise only the peer address is
-    /// used.
+    /// When `trust_forwarded_headers` is `true`, `X-Forwarded-For` and
+    /// then `X-Real-IP` are consulted before [`ConnectInfo<SocketAddr>`].
+    /// If trusted proxies are configured, the `X-Forwarded-For` chain is
+    /// walked from right to left and configured proxy IPs/CIDRs are
+    /// skipped. Without a trusted proxy list, the last non-empty XFF
+    /// entry is used for backward compatibility with single-proxy setups
+    /// where the final proxy overwrites the forwarding header.
     fn client_ip<B>(&self, req: &Request<B>) -> Option<String> {
-        if self.trust_forwarded_headers {
+        if self.trust_forwarded_headers && self.forwarded_headers_allowed(req) {
             let xff_ip = req
                 .headers()
                 .get("x-forwarded-for")
                 .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.rsplit(',').next())
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(ToOwned::to_owned);
+                .and_then(|s| self.client_ip_from_x_forwarded_for(s));
 
             if xff_ip.is_some() {
                 return xff_ip;
@@ -186,9 +263,50 @@ impl Limiter {
             }
         }
 
+        Self::peer_ip(req).map(|ip| ip.to_string())
+    }
+
+    fn peer_ip<B>(req: &Request<B>) -> Option<IpAddr> {
         req.extensions()
             .get::<ConnectInfo<SocketAddr>>()
-            .map(|ConnectInfo(addr)| addr.ip().to_string())
+            .map(|ConnectInfo(addr)| addr.ip())
+    }
+
+    fn forwarded_headers_allowed<B>(&self, req: &Request<B>) -> bool {
+        if self.trusted_proxies.is_empty() {
+            return true;
+        }
+
+        Self::peer_ip(req).is_none_or(|peer_ip| self.is_trusted_proxy(peer_ip))
+    }
+
+    fn client_ip_from_x_forwarded_for(&self, header: &str) -> Option<String> {
+        if self.trusted_proxies.is_empty() {
+            return header
+                .rsplit(',')
+                .next()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned);
+        }
+
+        for entry in header.rsplit(',').map(str::trim).filter(|s| !s.is_empty()) {
+            let Ok(ip) = entry.parse::<IpAddr>() else {
+                continue;
+            };
+
+            if !self.is_trusted_proxy(ip) {
+                return Some(ip.to_string());
+            }
+        }
+
+        None
+    }
+
+    fn is_trusted_proxy(&self, ip: IpAddr) -> bool {
+        self.trusted_proxies
+            .iter()
+            .any(|trusted_proxy| trusted_proxy.contains(ip))
     }
 }
 
@@ -301,6 +419,7 @@ mod tests {
             // Tests exercise the key-by-IP path via X-Forwarded-For so
             // they don't need a real TCP listener.
             trust_forwarded_headers: true,
+            trusted_proxies: Vec::new(),
         }
     }
 
@@ -325,7 +444,28 @@ mod tests {
             requests_per_second: 10.0,
             burst: 5,
             trust_forwarded_headers: trust,
+            trusted_proxies: Vec::new(),
         })
+    }
+
+    fn limiter_with_trusted_proxies(proxies: &[&str]) -> Limiter {
+        Limiter::from_config(&RateLimitConfig {
+            enabled: true,
+            requests_per_second: 10.0,
+            burst: 5,
+            trust_forwarded_headers: true,
+            trusted_proxies: proxies.iter().map(|proxy| (*proxy).to_owned()).collect(),
+        })
+    }
+
+    fn req_with_connect_info(xff: &str, peer: &str) -> Request<()> {
+        let mut req: Request<()> = Request::builder()
+            .header("X-Forwarded-For", xff)
+            .body(())
+            .expect("infallible response builder");
+        let addr: SocketAddr = peer.parse().expect("test peer socket address parses");
+        req.extensions_mut().insert(ConnectInfo(addr));
+        req
     }
 
     #[tokio::test]
@@ -461,6 +601,58 @@ mod tests {
     }
 
     #[test]
+    fn client_ip_skips_configured_trusted_proxy_chain_entries() {
+        let req: Request<()> = Request::builder()
+            .header("X-Forwarded-For", "198.51.100.77, 203.0.113.10")
+            .body(())
+            .expect("infallible response builder");
+        assert_eq!(
+            limiter_with_trusted_proxies(&["203.0.113.10"])
+                .client_ip(&req)
+                .as_deref(),
+            Some("198.51.100.77")
+        );
+    }
+
+    #[test]
+    fn client_ip_skips_configured_trusted_proxy_cidr_entries() {
+        let req: Request<()> = Request::builder()
+            .header("X-Forwarded-For", "198.51.100.77, 203.0.113.10, 10.0.0.5")
+            .body(())
+            .expect("infallible response builder");
+        assert_eq!(
+            limiter_with_trusted_proxies(&["203.0.113.0/24", "10.0.0.5"])
+                .client_ip(&req)
+                .as_deref(),
+            Some("198.51.100.77")
+        );
+    }
+
+    #[test]
+    fn client_ip_accepts_forwarded_chain_from_configured_trusted_peer() {
+        let req = req_with_connect_info("198.51.100.77, 203.0.113.10", "10.0.0.5:4000");
+
+        assert_eq!(
+            limiter_with_trusted_proxies(&["10.0.0.5", "203.0.113.10"])
+                .client_ip(&req)
+                .as_deref(),
+            Some("198.51.100.77")
+        );
+    }
+
+    #[test]
+    fn client_ip_ignores_forwarded_chain_from_untrusted_peer() {
+        let req = req_with_connect_info("198.51.100.77, 203.0.113.10", "192.0.2.44:4000");
+
+        assert_eq!(
+            limiter_with_trusted_proxies(&["203.0.113.10"])
+                .client_ip(&req)
+                .as_deref(),
+            Some("192.0.2.44")
+        );
+    }
+
+    #[test]
     fn client_ip_trims_whitespace_when_trusted() {
         let req: Request<()> = Request::builder()
             .header("X-Forwarded-For", "  9.9.9.9  ")
@@ -542,6 +734,7 @@ mod tests {
             requests_per_second: 0.1,
             burst: 1,
             trust_forwarded_headers: false,
+            trusted_proxies: Vec::new(),
         };
         let app = app(&config);
         let peer: SocketAddr = "198.51.100.1:2000"
@@ -575,6 +768,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn forwarded_header_chains_keep_independent_client_buckets() {
+        let config = RateLimitConfig {
+            enabled: true,
+            requests_per_second: 0.1,
+            burst: 1,
+            trust_forwarded_headers: true,
+            trusted_proxies: vec!["203.0.113.10".to_owned()],
+        };
+        let app = app(&config);
+
+        let req_with_chain = |client_ip: &str| {
+            Request::builder()
+                .method("GET")
+                .uri("/")
+                .header("X-Forwarded-For", format!("{client_ip}, 203.0.113.10"))
+                .body(Body::empty())
+                .expect("infallible response builder")
+        };
+
+        let first_a = app
+            .clone()
+            .oneshot(req_with_chain("198.51.100.77"))
+            .await
+            .expect("infallible response builder");
+        assert_eq!(first_a.status(), StatusCode::OK);
+
+        let blocked_a = app
+            .clone()
+            .oneshot(req_with_chain("198.51.100.77"))
+            .await
+            .expect("infallible response builder");
+        assert_eq!(blocked_a.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        let first_b = app
+            .clone()
+            .oneshot(req_with_chain("198.51.100.88"))
+            .await
+            .expect("infallible response builder");
+        assert_eq!(first_b.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
     async fn requests_without_connect_info_bypass_rate_limit() {
         // Static site generation and `Router::oneshot`-style callers
         // don't set ConnectInfo. The limiter must pass them through so
@@ -584,6 +819,7 @@ mod tests {
             requests_per_second: 0.001,
             burst: 1,
             trust_forwarded_headers: false,
+            trusted_proxies: Vec::new(),
         };
         let app = app(&config);
 

--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -67,6 +67,7 @@ struct Limiter {
     burst: f64,
     burst_header: HeaderValue,
     trust_forwarded_headers: bool,
+    trusted_proxies_configured: bool,
     trusted_proxies: Vec<TrustedProxy>,
     buckets: Mutex<LruCache<String, Bucket>>,
 }
@@ -148,6 +149,7 @@ impl Limiter {
         let burst = f64::from(config.burst.max(1));
         let refill_per_sec = config.requests_per_second.max(f64::MIN_POSITIVE);
         let burst_header = HeaderValue::from(config.burst.max(1));
+        let trusted_proxies_configured = !config.trusted_proxies.is_empty();
         let trusted_proxies = config
             .trusted_proxies
             .iter()
@@ -166,6 +168,7 @@ impl Limiter {
             burst,
             burst_header,
             trust_forwarded_headers: config.trust_forwarded_headers,
+            trusted_proxies_configured,
             trusted_proxies,
             buckets: Mutex::new(LruCache::new(
                 NonZeroUsize::new(10_000).expect("10_000 is non-zero"),
@@ -276,7 +279,7 @@ impl Limiter {
     }
 
     fn forwarded_headers_allowed<B>(&self, req: &Request<B>) -> bool {
-        if self.trusted_proxies.is_empty() {
+        if !self.trusted_proxies_configured {
             return true;
         }
 
@@ -284,7 +287,7 @@ impl Limiter {
     }
 
     fn client_ip_from_x_forwarded_for(&self, header: &str) -> Option<String> {
-        if self.trusted_proxies.is_empty() {
+        if !self.trusted_proxies_configured {
             return header
                 .rsplit(',')
                 .next()
@@ -665,6 +668,18 @@ mod tests {
     }
 
     #[test]
+    fn client_ip_falls_back_to_peer_when_all_trusted_proxies_are_invalid() {
+        let req = req_with_connect_info("198.51.100.77, 203.0.113.10", "192.0.2.44:4000");
+
+        assert_eq!(
+            limiter_with_trusted_proxies(&["203.0.113.10:443", "198.51.100.0/999"])
+                .client_ip(&req)
+                .as_deref(),
+            Some("192.0.2.44")
+        );
+    }
+
+    #[test]
     fn client_ip_trims_whitespace_when_trusted() {
         let req: Request<()> = Request::builder()
             .header("X-Forwarded-For", "  9.9.9.9  ")
@@ -891,5 +906,45 @@ mod tests {
                 "requests with configured trusted proxies but no peer must not trust forwarded headers"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn invalid_trusted_proxies_do_not_reopen_forwarded_header_trust() {
+        let config = RateLimitConfig {
+            enabled: true,
+            requests_per_second: 0.001,
+            burst: 1,
+            trust_forwarded_headers: true,
+            trusted_proxies: vec!["203.0.113.10:443".to_owned(), "198.51.100.0/999".to_owned()],
+        };
+        let app = app(&config);
+        let peer: SocketAddr = "192.0.2.44:4000"
+            .parse()
+            .expect("test peer socket address parses");
+
+        let make_req = |xff: &str| {
+            let mut req = Request::builder()
+                .method("GET")
+                .uri("/")
+                .header("X-Forwarded-For", xff)
+                .body(Body::empty())
+                .expect("infallible response builder");
+            req.extensions_mut().insert(ConnectInfo(peer));
+            req
+        };
+
+        let first = app
+            .clone()
+            .oneshot(make_req("198.51.100.77"))
+            .await
+            .expect("infallible response builder");
+        assert_eq!(first.status(), StatusCode::OK);
+
+        let blocked = app
+            .clone()
+            .oneshot(make_req("198.51.100.88"))
+            .await
+            .expect("infallible response builder");
+        assert_eq!(blocked.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 }

--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -18,8 +18,10 @@
 //! headers — the limiter consults `X-Forwarded-For` and `X-Real-IP` first,
 //! falling back to the peer address. If
 //! [`RateLimitConfig::trusted_proxies`] is configured, trusted proxy
-//! addresses at the right side of the `X-Forwarded-For` chain are skipped
-//! so appended proxy chains still key on the nearest untrusted client.
+//! addresses at the right side of the `X-Forwarded-For` chain are skipped,
+//! but only when the request peer address is present and trusted, so
+//! appended proxy chains still key on the nearest untrusted client without
+//! trusting spoofable headers from direct callers.
 //!
 //! Requests with no identifiable client (no trusted forwarding header
 //! AND no `ConnectInfo`) bypass rate limiting entirely. In-process
@@ -235,9 +237,10 @@ impl Limiter {
     /// then `X-Real-IP` are consulted before [`ConnectInfo<SocketAddr>`].
     /// If trusted proxies are configured, the `X-Forwarded-For` chain is
     /// walked from right to left and configured proxy IPs/CIDRs are
-    /// skipped. Without a trusted proxy list, the last non-empty XFF
-    /// entry is used for backward compatibility with single-proxy setups
-    /// where the final proxy overwrites the forwarding header.
+    /// skipped, but only when the request peer is present and trusted.
+    /// Without a trusted proxy list, the last non-empty XFF entry is used
+    /// for backward compatibility with single-proxy setups where the final
+    /// proxy overwrites the forwarding header.
     fn client_ip<B>(&self, req: &Request<B>) -> Option<String> {
         if self.trust_forwarded_headers && self.forwarded_headers_allowed(req) {
             let xff_ip = req
@@ -277,7 +280,7 @@ impl Limiter {
             return true;
         }
 
-        Self::peer_ip(req).is_none_or(|peer_ip| self.is_trusted_proxy(peer_ip))
+        Self::peer_ip(req).is_some_and(|peer_ip| self.is_trusted_proxy(peer_ip))
     }
 
     fn client_ip_from_x_forwarded_for(&self, header: &str) -> Option<String> {
@@ -602,10 +605,7 @@ mod tests {
 
     #[test]
     fn client_ip_skips_configured_trusted_proxy_chain_entries() {
-        let req: Request<()> = Request::builder()
-            .header("X-Forwarded-For", "198.51.100.77, 203.0.113.10")
-            .body(())
-            .expect("infallible response builder");
+        let req = req_with_connect_info("198.51.100.77, 203.0.113.10", "203.0.113.10:4000");
         assert_eq!(
             limiter_with_trusted_proxies(&["203.0.113.10"])
                 .client_ip(&req)
@@ -616,10 +616,7 @@ mod tests {
 
     #[test]
     fn client_ip_skips_configured_trusted_proxy_cidr_entries() {
-        let req: Request<()> = Request::builder()
-            .header("X-Forwarded-For", "198.51.100.77, 203.0.113.10, 10.0.0.5")
-            .body(())
-            .expect("infallible response builder");
+        let req = req_with_connect_info("198.51.100.77, 203.0.113.10, 10.0.0.5", "10.0.0.5:4000");
         assert_eq!(
             limiter_with_trusted_proxies(&["203.0.113.0/24", "10.0.0.5"])
                 .client_ip(&req)
@@ -649,6 +646,21 @@ mod tests {
                 .client_ip(&req)
                 .as_deref(),
             Some("192.0.2.44")
+        );
+    }
+
+    #[test]
+    fn client_ip_ignores_forwarded_headers_without_peer_when_trusted_proxies_configured() {
+        let req: Request<()> = Request::builder()
+            .header("X-Forwarded-For", "198.51.100.77, 203.0.113.10")
+            .header("X-Real-IP", "198.51.100.88")
+            .body(())
+            .expect("infallible response builder");
+
+        assert!(
+            limiter_with_trusted_proxies(&["203.0.113.10"])
+                .client_ip(&req)
+                .is_none()
         );
     }
 
@@ -779,12 +791,17 @@ mod tests {
         let app = app(&config);
 
         let req_with_chain = |client_ip: &str| {
-            Request::builder()
+            let mut req = Request::builder()
                 .method("GET")
                 .uri("/")
                 .header("X-Forwarded-For", format!("{client_ip}, 203.0.113.10"))
                 .body(Body::empty())
-                .expect("infallible response builder")
+                .expect("infallible response builder");
+            let peer: SocketAddr = "203.0.113.10:4000"
+                .parse()
+                .expect("test peer socket address parses");
+            req.extensions_mut().insert(ConnectInfo(peer));
+            req
         };
 
         let first_a = app
@@ -839,6 +856,39 @@ mod tests {
             assert!(
                 response.headers().get("x-ratelimit-limit").is_none(),
                 "bypassed requests should not carry rate-limit headers"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn requests_without_connect_info_bypass_when_trusted_proxies_configured() {
+        let config = RateLimitConfig {
+            enabled: true,
+            requests_per_second: 0.001,
+            burst: 1,
+            trust_forwarded_headers: true,
+            trusted_proxies: vec!["203.0.113.10".to_owned()],
+        };
+        let app = app(&config);
+
+        for _ in 0..3 {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri("/")
+                        .header("X-Forwarded-For", "198.51.100.77, 203.0.113.10")
+                        .header("X-Real-IP", "198.51.100.88")
+                        .body(Body::empty())
+                        .expect("infallible response builder"),
+                )
+                .await
+                .expect("infallible response builder");
+            assert_eq!(response.status(), StatusCode::OK);
+            assert!(
+                response.headers().get("x-ratelimit-limit").is_none(),
+                "requests with configured trusted proxies but no peer must not trust forwarded headers"
             );
         }
     }

--- a/autumn/tests/chaos_rate_limit_fuzz.rs
+++ b/autumn/tests/chaos_rate_limit_fuzz.rs
@@ -37,6 +37,7 @@ proptest! {
                     requests_per_second: 10.0,
                     burst: 2,
                     trust_forwarded_headers: true,
+                    trusted_proxies: Vec::new(),
                 };
                 let layer = RateLimitLayer::from_config(&config);
                 let mut svc = layer.layer(MockService);

--- a/autumn/tests/chaos_rate_limit_loom.rs
+++ b/autumn/tests/chaos_rate_limit_loom.rs
@@ -33,6 +33,7 @@ fn rate_limit_concurrent_requests() {
         requests_per_second: 10.0,
         burst: 2,
         trust_forwarded_headers: true,
+        trusted_proxies: Vec::new(),
     };
     let layer = RateLimitLayer::from_config(&config);
     let svc = layer.layer(MockService);

--- a/examples/bookmarks-distributed/docker/nginx/nginx.conf
+++ b/examples/bookmarks-distributed/docker/nginx/nginx.conf
@@ -14,6 +14,9 @@ http {
       proxy_pass http://bookmarks_cluster;
       proxy_http_version 1.1;
       proxy_set_header Host $host;
+      # This appends the upstream address. If Autumn rate limiting trusts
+      # forwarded headers and this nginx sits behind another trusted proxy/CDN,
+      # include those proxy IPs/CIDRs in security.rate_limit.trusted_proxies.
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header Connection "";


### PR DESCRIPTION
🦠 Threat: Rate limit bypass by IP spoofing in `X-Forwarded-For` leftmost position.

🛡️ Defense: Extract the rightmost IP in `X-Forwarded-For` added by the last trusted proxy.

💥 Severity: High - could allow attackers to bypass throttling limits.

🧪 Verification: Added `client_ip_prevents_spoofing` test to verify resistance against forged leftmost IP values.

---
*PR created automatically by Jules for task [1308175279289508915](https://jules.google.com/task/1308175279289508915) started by @madmax983*