### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -70,6 +70,26 @@ pub const HTMX_VERSION: &str = "2.0.4";
 /// Extracts the standard `hx-*` headers sent by htmx requests, enabling
 /// conditional rendering (e.g. sending back partials instead of full pages).
 ///
+/// ## Examples
+///
+/// Using [`HxRequest`] in an Axum handler to serve partials:
+///
+/// ```rust
+/// use axum::routing::get;
+/// use axum::Router;
+/// use autumn_web::prelude::HxRequest;
+///
+/// async fn dashboard(hx: HxRequest) -> &'static str {
+///     if hx.is_htmx {
+///         "<div>Partial Dashboard</div>"
+///     } else {
+///         "<html><body><div>Full Dashboard</div></body></html>"
+///     }
+/// }
+///
+/// let app = Router::<()>::new().route("/", get(dashboard));
+/// ```
+///
 /// See <https://htmx.org/reference/#request_headers> for more details.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Default)]
@@ -126,6 +146,21 @@ where
 ///
 /// This trait provides a fluent API for controlling htmx behavior from the server.
 /// If an invalid header value is provided, it is gracefully ignored.
+///
+/// ## Examples
+///
+/// Triggering client-side events after a successful operation:
+///
+/// ```rust
+/// use axum::response::IntoResponse;
+/// use autumn_web::prelude::HxResponseExt;
+///
+/// async fn update_item() -> impl IntoResponse {
+///     "Item updated successfully"
+///         .hx_trigger("item-updated")
+///         .hx_push_url("/items/1")
+/// }
+/// ```
 ///
 /// See <https://htmx.org/reference/#response_headers> for more details.
 pub trait HxResponseExt: IntoResponse + Sized {

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -273,7 +273,7 @@ pub trait JobAdminBackend: Send + Sync + 'static {
     fn cancel(&self, id: &str) -> JobAdminFuture<'_, ()>;
 }
 
-/// Typed [`AppState`](crate::AppState) extension carrying a job-admin backend.
+/// Typed [`AppState`] extension carrying a job-admin backend.
 #[derive(Clone)]
 pub struct JobAdminBackendEntry(pub Arc<dyn JobAdminBackend>);
 


### PR DESCRIPTION
📖 Chapter: The HTMX Extractors and Job Backend

🔦 Insight: The HTMX extractor `HxRequest` and extension trait `HxResponseExt` lacked context on how to use them effectively in handlers. I also fixed a redundant intra-doc link target warning that appeared during `cargo doc`.

🧪 Example: Added 2 executable doctests (one for `HxRequest` serving partials, and another for `HxResponseExt` triggering client-side events).

🖼️ Preview: Documentation is now richer with copy-pasteable examples for tired developers.

---
*PR created automatically by Jules for task [14410362558406676208](https://jules.google.com/task/14410362558406676208) started by @madmax983*