### PR TITLE
👺 Havoc: Fix X-Forwarded-For Rate Limiting Bypass

### DIFF
--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -164,7 +164,7 @@ impl Limiter {
                 .headers()
                 .get("x-forwarded-for")
                 .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.split(',').next())
+                .and_then(|s| s.rsplit(',').next())
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
                 .map(ToOwned::to_owned);
@@ -440,12 +440,12 @@ mod tests {
     }
 
     #[test]
-    fn client_ip_prefers_x_forwarded_for_first_entry_when_trusted() {
+    fn client_ip_prefers_x_forwarded_for_rightmost_entry_when_trusted() {
         let req: Request<()> = Request::builder()
             .header("X-Forwarded-For", "1.2.3.4, 5.6.7.8")
             .body(())
             .expect("infallible response builder");
-        assert_eq!(limiter(true).client_ip(&req).as_deref(), Some("1.2.3.4"));
+        assert_eq!(limiter(true).client_ip(&req).as_deref(), Some("5.6.7.8"));
     }
 
     #[test]
@@ -498,8 +498,8 @@ mod tests {
             .header("X-Real-IP", "8.8.8.8")
             .body(())
             .expect("infallible response builder");
-        // First XFF entry is empty after trim, so we fall back to X-Real-IP.
-        assert_eq!(limiter(true).client_ip(&req).as_deref(), Some("8.8.8.8"));
+        // Rightmost XFF entry is valid, we don't fall back to X-Real-IP.
+        assert_eq!(limiter(true).client_ip(&req).as_deref(), Some("5.5.5.5"));
     }
 
     #[test]

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -10,5 +10,6 @@ pub mod csrf_path_traversal;
 pub mod csrf_timing;
 pub mod ctf;
 pub mod fallback_middleware_bypass;
+pub mod rate_limit_spoof;
 pub mod session_exhaustion;
 pub mod session_fixation;

--- a/autumn/tests/security/rate_limit_spoof.rs
+++ b/autumn/tests/security/rate_limit_spoof.rs
@@ -1,0 +1,54 @@
+use autumn_web::security::RateLimitConfig;
+use autumn_web::security::RateLimitLayer;
+use axum::body::Body;
+use axum::http::Request;
+use tower::ServiceExt;
+
+// 👺 Havoc: Rate limit bypass via X-Forwarded-For spoofing
+// 🌩️ **The Trigger:** An attacker appends a spoofed IP to the left of their real IP in the X-Forwarded-For header.
+// 📉 **The Stack Trace:** No stack trace, but the rate limiter fails to enforce limits because it parses the leftmost IP instead of the rightmost IP.
+// 🧪 **Reproduction:** See `test_rate_limit_spoofing` below.
+// 😈 **Comment:** You trusted the first IP the client gave you. Never trust the client.
+
+#[tokio::test]
+async fn test_rate_limit_spoofing() {
+    let config = RateLimitConfig {
+        enabled: true,
+        requests_per_second: 1.0,
+        burst: 1,
+        trust_forwarded_headers: true,
+    };
+
+    let app = axum::Router::new()
+        .route("/", axum::routing::get(|| async { "ok" }))
+        .layer(RateLimitLayer::from_config(&config));
+
+    // Send a request from "real-ip" but with a spoofed X-Forwarded-For header
+    let req1 = Request::builder()
+        .method("GET")
+        .uri("/")
+        .header("X-Forwarded-For", "spoofed-ip, real-ip")
+        .body(Body::empty())
+        .unwrap();
+
+    let res1 = app.clone().oneshot(req1).await.unwrap();
+    assert_eq!(res1.status(), axum::http::StatusCode::OK);
+
+    // Send another request with a DIFFERENT spoofed IP but same real IP
+    let req2 = Request::builder()
+        .method("GET")
+        .uri("/")
+        .header("X-Forwarded-For", "different-spoof, real-ip")
+        .body(Body::empty())
+        .unwrap();
+
+    let res2 = app.clone().oneshot(req2).await.unwrap();
+
+    // Now that the bug is fixed, the rate limiter uses the rightmost IP ("real-ip") for BOTH requests.
+    // The second request should be throttled.
+    assert_eq!(
+        res2.status(),
+        axum::http::StatusCode::TOO_MANY_REQUESTS,
+        "Spoofing failed: Rate limit enforced correctly!"
+    );
+}


### PR DESCRIPTION
🌩️ **The Trigger:**
An attacker appends a spoofed IP to the left of their real IP in the X-Forwarded-For header (e.g. `X-Forwarded-For: fake-ip, real-ip`).

📉 **The Stack Trace:**
No stack trace or panic, but the rate limiter fails to enforce limits because it parses the leftmost IP instead of the rightmost IP, creating an endless supply of fresh buckets.

🧪 **Reproduction:**
Run the new security test:
`cargo test -p autumn-web --test security_tests rate_limit_spoof`

😈 **Comment:**
You trusted the first IP the client gave you. Never trust the client. I changed it to `.rsplit(',').next()` to extract the rightmost IP, which was securely appended by the trusted proxy. Try harder next time.

---
*PR created automatically by Jules for task [12753085818838768347](https://jules.google.com/task/12753085818838768347) started by @madmax983*