### PR TITLE
🌟 Nova: Export OpenAPI specification

### DIFF
--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -9,6 +9,7 @@ mod generate;
 mod migrate;
 mod monitor;
 mod new;
+mod openapi;
 mod plugin_check;
 mod release;
 mod routes;
@@ -287,6 +288,21 @@ enum Commands {
         #[arg(long)]
         user_only: bool,
     },
+    /// Export the application's `OpenAPI` specification.
+    ///
+    /// Compiles the application (debug profile) and extracts its `OpenAPI`
+    /// specification without starting the HTTP server or connecting to a database.
+    Openapi {
+        /// Package to inspect (for workspaces).
+        #[arg(short, long)]
+        package: Option<String>,
+        /// Binary target to inspect (for packages with multiple bin targets).
+        #[arg(long, value_name = "BIN")]
+        bin: Option<String>,
+        /// Output format: `json` or `yaml`.
+        #[arg(long, default_value = "json", value_name = "FORMAT")]
+        format: String,
+    },
 }
 
 /// Subcommands for `autumn migrate`.
@@ -558,6 +574,11 @@ fn run_command(command: Commands) {
             &method,
             user_only,
         ),
+        Commands::Openapi {
+            package,
+            bin,
+            format,
+        } => run_openapi_command(package.as_deref(), bin.as_deref(), &format),
         Commands::Release(cmd) => run_release_command(cmd),
         Commands::Token(cmd) => match cmd {
             TokenCommands::Issue { principal_id } => token::run_issue(&principal_id),
@@ -693,6 +714,18 @@ fn run_routes_command(
         filter: effective_filter,
         methods: method,
         user_only,
+    });
+}
+
+fn run_openapi_command(package: Option<&str>, bin: Option<&str>, format: &str) {
+    let fmt = format.parse().unwrap_or_else(|e| {
+        eprintln!("autumn openapi: {e}");
+        std::process::exit(1);
+    });
+    openapi::run(&openapi::OpenApiOptions {
+        package,
+        bin,
+        format: fmt,
     });
 }
 
@@ -1522,6 +1555,34 @@ mod tests {
                 assert_eq!(prefix.as_deref(), Some("/api"));
             }
             _ => panic!("expected Routes command"),
+        }
+    }
+
+    #[test]
+    fn parse_openapi_defaults() {
+        let cli = Cli::try_parse_from(["autumn", "openapi"]).unwrap();
+        match cli.command {
+            Commands::Openapi {
+                format,
+                package,
+                bin,
+            } => {
+                assert_eq!(format, "json");
+                assert!(package.is_none());
+                assert!(bin.is_none());
+            }
+            _ => panic!("expected Openapi command"),
+        }
+    }
+
+    #[test]
+    fn parse_openapi_yaml() {
+        let cli = Cli::try_parse_from(["autumn", "openapi", "--format", "yaml"]).unwrap();
+        match cli.command {
+            Commands::Openapi { format, .. } => {
+                assert_eq!(format, "yaml");
+            }
+            _ => panic!("expected Openapi command"),
         }
     }
 

--- a/autumn-cli/src/openapi.rs
+++ b/autumn-cli/src/openapi.rs
@@ -1,0 +1,61 @@
+use std::process::Command;
+
+/// Options controlling `autumn openapi` behaviour.
+pub struct OpenApiOptions<'a> {
+    pub package: Option<&'a str>,
+    pub bin: Option<&'a str>,
+    pub format: OutputFormat,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OutputFormat {
+    Json,
+    Yaml,
+}
+
+impl std::str::FromStr for OutputFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "json" => Ok(Self::Json),
+            "yaml" => Ok(Self::Yaml),
+            other => Err(format!(
+                "unknown format '{other}'; expected 'json' or 'yaml'"
+            )),
+        }
+    }
+}
+
+/// Run `autumn openapi`.
+pub fn run(opts: &OpenApiOptions<'_>) {
+    eprintln!("\u{1F342} autumn openapi\n");
+    crate::routes::compile_binary(opts.package, opts.bin);
+    let binary = crate::routes::find_binary(opts.package, opts.bin);
+
+    let format_env = match opts.format {
+        OutputFormat::Json => "json",
+        OutputFormat::Yaml => "yaml",
+    };
+
+    let output = Command::new(&binary)
+        .env("AUTUMN_DUMP_OPENAPI", "1")
+        .env("AUTUMN_OPENAPI_FORMAT", format_env)
+        .output()
+        .unwrap_or_else(|e| {
+            eprintln!("\u{2717} Failed to run {}: {e}", binary.display());
+            std::process::exit(1);
+        });
+
+    if !output.status.success() {
+        eprintln!("\u{2717} Extraction failed");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.trim().is_empty() {
+            eprintln!("{stderr}");
+        }
+        std::process::exit(1);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    print!("{stdout}");
+}

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1421,6 +1421,14 @@ impl AppBuilder {
             return;
         }
 
+        // ── OpenAPI dump mode ──────────────────────────────────────────
+        // When AUTUMN_DUMP_OPENAPI=1, print the OpenAPI spec and exit.
+        // This is triggered by `autumn openapi` to extract the spec offline.
+        if is_dump_openapi_mode() {
+            self.run_dump_openapi_mode().await;
+            return;
+        }
+
         if is_list_one_off_tasks_mode() {
             self.run_list_one_off_tasks_mode();
             return;
@@ -2011,6 +2019,61 @@ impl AppBuilder {
         }
     }
 
+    /// Dump the application's `OpenAPI` spec and exit.
+    ///
+    /// Triggered when `AUTUMN_DUMP_OPENAPI=1` is set (by `autumn openapi`).
+    async fn run_dump_openapi_mode(self) {
+        #[cfg(not(feature = "openapi"))]
+        {
+            eprintln!("Error: The 'openapi' feature is not enabled in autumn-web.");
+            std::process::exit(1);
+        }
+
+        #[cfg(feature = "openapi")]
+        {
+            let Self {
+                config_loader_factory,
+                telemetry_provider,
+                openapi,
+                routes,
+                ..
+            } = self;
+
+            let (_config, _telemetry_guard) =
+                load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
+
+            let Some(oa_config) = openapi else {
+                eprintln!(
+                    "Error: OpenAPI is not configured. Did you forget to call `.with_openapi(...)`?"
+                );
+                std::process::exit(1);
+            };
+
+            let mut docs = vec![];
+            for r in &routes {
+                docs.push(&r.api_doc);
+            }
+            let spec = crate::openapi::generate_spec(&oa_config, &docs);
+
+            let format =
+                std::env::var("AUTUMN_OPENAPI_FORMAT").unwrap_or_else(|_| "json".to_string());
+            let output = if format == "yaml" {
+                serde_yaml::to_string(&spec).unwrap_or_else(|e| {
+                    eprintln!("Failed to serialize OpenAPI spec to YAML: {e}");
+                    std::process::exit(1);
+                })
+            } else {
+                serde_json::to_string_pretty(&spec).unwrap_or_else(|e| {
+                    eprintln!("Failed to serialize OpenAPI spec to JSON: {e}");
+                    std::process::exit(1);
+                })
+            };
+
+            println!("{output}");
+            std::process::exit(0);
+        }
+    }
+
     /// Dump the application's route listing as JSON and exit.
     ///
     /// Triggered when `AUTUMN_DUMP_ROUTES=1` is set (by `autumn routes`).
@@ -2252,6 +2315,10 @@ pub(crate) fn is_static_build_mode() -> bool {
 
 pub(crate) fn is_dump_routes_mode() -> bool {
     std::env::var("AUTUMN_DUMP_ROUTES").as_deref() == Ok("1")
+}
+
+pub(crate) fn is_dump_openapi_mode() -> bool {
+    std::env::var("AUTUMN_DUMP_OPENAPI").as_deref() == Ok("1")
 }
 
 pub(crate) fn is_list_one_off_tasks_mode() -> bool {


### PR DESCRIPTION
💡 **The Spark:** We have a powerful `openapi` module generating specs at runtime, and a CLI tool that can introspect routes (`autumn routes`), but no way to export the OpenAPI spec to a file without booting the server or running a full static build.

🚀 **The Feature:** Implemented `autumn openapi` CLI command that compiles the app, extracts the OpenAPI specification using `AUTUMN_DUMP_OPENAPI=1`, and prints it.

🔭 **The Potential:** Enables generating OpenAPI specs in CI/CD pipelines for client generation (e.g. `openapi-generator`) without running the app.

⚠️ **Risk:** Low. Isolated in `autumn-cli` and `autumn/src/app.rs`. Fails gracefully if openapi feature is not enabled.

---
*PR created automatically by Jules for task [5365247905263199989](https://jules.google.com/task/5365247905263199989) started by @madmax983*