### PR TITLE
🗣️ Echo: Fix DX friction points around 404s and watcher directories

### DIFF
--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -40,7 +40,7 @@ const WATCH_FILES: &[&str] = &[
 ];
 
 /// Directories that are always watched recursively, regardless of config.
-const DEFAULT_WATCH_DIRS: &[&str] = &["src", "static", "templates", "migrations"];
+const DEFAULT_WATCH_DIRS: &[&str] = &["src", "static", "templates", "migrations", "views"];
 
 /// Path of the project config file relative to the dev server's working directory.
 const AUTUMN_TOML: &str = "autumn.toml";
@@ -1838,9 +1838,14 @@ watch_dirs = ["views", "locales"]
     #[test]
     fn sanitize_drops_default_dirs() {
         let dirs = sanitize_custom_watch_dirs(DevConfig {
-            watch_dirs: vec!["src".into(), "static".into(), "views".into()],
+            watch_dirs: vec![
+                "src".into(),
+                "static".into(),
+                "views".into(),
+                "locales".into(),
+            ],
         });
-        assert_eq!(dirs, vec!["views"]);
+        assert_eq!(dirs, vec!["locales"]);
     }
 
     #[test]
@@ -1848,13 +1853,13 @@ watch_dirs = ["views", "locales"]
         let dirs = sanitize_custom_watch_dirs(DevConfig {
             watch_dirs: vec![
                 "  ".into(),
-                "views".into(),
-                "views".into(),
-                "  locales  ".into(),
+                "locales".into(),
+                "locales".into(),
+                "  other  ".into(),
                 String::new(),
             ],
         });
-        assert_eq!(dirs, vec!["views", "locales"]);
+        assert_eq!(dirs, vec!["locales", "other"]);
     }
 
     // ── classify_change with custom dirs ───────────────────────────
@@ -2140,11 +2145,11 @@ watch_dirs = ["views", "locales"]
             watch_dirs: vec![
                 "../escape".into(),
                 "target".into(),
-                "views".into(),
+                "other".into(),
                 "./locales".into(),
             ],
         });
         let expected_locales = "locales".to_owned();
-        assert_eq!(dirs, vec!["views".to_owned(), expected_locales]);
+        assert_eq!(dirs, vec!["other".to_owned(), expected_locales]);
     }
 }

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -164,9 +164,9 @@ fn accepts_html<B>(req: &axum::http::Request<B>) -> bool {
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
 
-    // If no Accept header, default to JSON (API-first).
+    // If no Accept header, default to HTML to avoid empty responses on raw HTTP errors.
     if accept.is_empty() {
-        return false;
+        return true;
     }
 
     let mut html: Option<(f32, usize)> = None;
@@ -339,9 +339,9 @@ mod tests {
     }
 
     #[test]
-    fn rejects_html_for_empty_accept() {
+    fn accepts_html_for_empty_accept() {
         let req = Request::builder().body(Body::empty()).unwrap();
-        assert!(!accepts_html(&req));
+        assert!(accepts_html(&req));
     }
 
     #[test]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -953,6 +953,12 @@ fn mount_raw_routers(
     // Nest user-supplied raw Axum routers under path prefixes.
     for (prefix, raw_router) in nest_routers {
         tracing::debug!(prefix = %prefix, "Nested raw Axum router");
+        // Axum nested routers do NOT inherit the outer router's fallback handler.
+        // We must manually append it before nesting to ensure that missing routes
+        // inside the prefix hit the custom 404 handler rather than Axum's default
+        // empty 404 response.
+        let raw_router =
+            raw_router.fallback(crate::middleware::error_page_filter::fallback_404_handler);
         router = router.nest(&prefix, raw_router);
     }
     router


### PR DESCRIPTION
1. 🔎 EXPERIENCE: We went through the quickstart guide and ran `curl` on missing paths and expected a 404 error page. We also added template files to `src/views` expecting the dev server to watch it.

2. 🚧 STUMBLE: 
- Hitting a missing URL via `curl` with no `Accept` header returned a totally blank response body instead of a framework error payload.
- Unmatched paths under nested `.nest()` routes also returned empty bodies because Axum doesn't inherit fallback handlers.
- Adding a view to `views/` and running `autumn dev` failed to pick up the file changes since it wasn't watched.

3. 📢 REPORT: 
- "Why does a 404 give me an empty page? Simple is better than powerful, but empty is just confusing."
- "If I make a typo in the routes! macro, why do I get a weird error about __autumn_route_info_...? I am the dumbest person in the room, just tell me 'Route not found'." (Note: We must accept the second macro-level error as an unavoidable cost for ergonomic macros, per the verification step).
- "Why does the dev server ignore my views folder?"

4. 🧪 VERIFY:
- Modified `accepts_html` to default to `true` when the header is empty, tested via tests.
- Modified `mount_raw_routers` to explicitly attach the `fallback_404_handler`.
- Added `views` to `DEFAULT_WATCH_DIRS` and updated relevant tests.
- All unit and integration tests successfully pass with `cargo test -p autumn-web && cargo test -p autumn-cli && cargo test -p autumn-macros`.

---
*PR created automatically by Jules for task [7970630337724549854](https://jules.google.com/task/7970630337724549854) started by @madmax983*