### PR TITLE
fix(db): enforce replica_fallback in readiness and read routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ for that same "ship the app, not the plumbing" shape in Rust.
 - **Pre-rendering pages to static HTML** - `#[static_get]` + `static_routes![]` with `autumn build` pre-rendering to `dist/`
 - **Application builder** - `.routes()`, `.tasks()`, `.static_routes()`, `.scoped()`, `.merge()`, and `.nest()`
 - **Configuration and profiles** - defaults, `autumn.toml`, `autumn-{profile}.toml`, and `AUTUMN_*` overrides
-- **Database ergonomics** - async Postgres pool, `Db` extractor, `#[model]`, `#[repository]`, hooks, and embedded migrations
+- **Database ergonomics** - async Postgres primary/replica pools, `Db` extractor for the primary/write role, `#[model]`, `#[repository]`, hooks, and embedded migrations
 - **HTML stack** - Maud templating, bundled htmx, Tailwind build pipeline, and static asset serving
 - **Operations** - `/health`, `/actuator/*`, structured logging, metrics, and graceful shutdown
 - **Background work** - `#[scheduled]` tasks, `#[job]` handlers, one-off `#[task]` scripts via `autumn task`, and runtime task visibility at `/actuator/tasks`
@@ -94,6 +94,26 @@ multi-replica deployment":
 If you are deploying beyond a single process, read the
 [Cloud-Native Guide](docs/guide/cloud-native.md) before treating the defaults as
 done.
+
+## Database Topologies
+
+Autumn supports three explicit database shapes:
+
+- **Single primary**: set `database.url` or `database.primary_url`. Writes,
+  transactions, advisory locks, and `autumn migrate` use that primary role.
+- **Primary plus read replica**: set `database.primary_url` and
+  `database.replica_url`, with optional `primary_pool_size`,
+  `replica_pool_size`, and `replica_fallback = "fail_readiness"` or
+  `"primary"`.
+- **One-shot migrator path**: run `autumn migrate` once against the primary
+  before rolling web replicas. Production web replicas should keep
+  `auto_migrate_in_production = false`.
+
+`database.url` and `DATABASE_URL` remain valid for existing single-URL apps.
+For new production config, prefer `AUTUMN_DATABASE__PRIMARY_URL` so the write
+role is named plainly. `autumn doctor --strict` reports missing primaries,
+unsafe production startup migrations, role connectivity failures, and stale
+replica migrations without printing credentials.
 
 ## Autumn Harvest
 

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -715,8 +715,9 @@ fn tcp_reachable(host: &str, port: u16) -> bool {
         .any(|addr| std::net::TcpStream::connect_timeout(addr, Duration::from_secs(1)).is_ok())
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum DoctorReplicaFallback {
+    #[default]
     FailReadiness,
     Primary,
 }
@@ -736,12 +737,6 @@ pub struct DoctorDatabaseTopology {
     pub replica_url: Option<String>,
     pub auto_migrate_in_production: bool,
     pub replica_fallback: DoctorReplicaFallback,
-}
-
-impl Default for DoctorReplicaFallback {
-    fn default() -> Self {
-        Self::FailReadiness
-    }
 }
 
 fn check_database_topology_contract(
@@ -1774,11 +1769,11 @@ foo = "bar"
 
     #[test]
     fn database_topology_parses_latest_applied_migration_version() {
-        let output = r#"
+        let output = r"
             [X] 20260509000000_create_widgets
             [ ] 20260510000000_add_widget_index
             [X] 20260508000000_create_users
-        "#;
+        ";
 
         assert_eq!(
             parse_latest_applied_migration_version(output).as_deref(),

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -715,39 +715,167 @@ fn tcp_reachable(host: &str, port: u16) -> bool {
         .any(|addr| std::net::TcpStream::connect_timeout(addr, Duration::from_secs(1)).is_ok())
 }
 
-fn check_db_connectivity(database_url: &str) -> CheckResult {
-    // Parse host and port from a Postgres URL: postgres://user:pass@host:port/db
-    let parsed = parse_db_host_port(database_url);
-    match parsed {
-        None => CheckResult {
-            name: "db_connectivity",
-            status: CheckStatus::Warn,
-            detail: Some("cannot parse database URL to extract host:port".into()),
-            hint: Some("Ensure database.url in autumn.toml is a valid PostgreSQL URL"),
-        },
-        Some((host, port)) => {
-            if tcp_reachable(&host, port) {
-                CheckResult {
-                    name: "db_connectivity",
-                    status: CheckStatus::Pass,
-                    detail: Some(format!("Postgres reachable at {host}:{port}")),
-                    hint: None,
-                }
-            } else {
-                CheckResult {
-                    name: "db_connectivity",
-                    status: CheckStatus::Fail,
-                    detail: Some(format!("cannot connect to Postgres at {host}:{port}")),
-                    hint: Some("Start Postgres and verify database.url in autumn.toml"),
-                }
-            }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DoctorReplicaFallback {
+    FailReadiness,
+    Primary,
+}
+
+impl DoctorReplicaFallback {
+    fn from_config_value(value: Option<&str>) -> Self {
+        match value.unwrap_or("fail_readiness") {
+            "primary" | "fallback_to_primary" | "fallback-to-primary" => Self::Primary,
+            _ => Self::FailReadiness,
         }
     }
 }
 
-fn check_pending_migrations() -> CheckResult {
+#[derive(Debug, Clone, Default)]
+pub struct DoctorDatabaseTopology {
+    pub primary_url: Option<String>,
+    pub replica_url: Option<String>,
+    pub auto_migrate_in_production: bool,
+    pub replica_fallback: DoctorReplicaFallback,
+}
+
+impl Default for DoctorReplicaFallback {
+    fn default() -> Self {
+        Self::FailReadiness
+    }
+}
+
+fn check_database_topology_contract(
+    topology: &DoctorDatabaseTopology,
+    is_production: bool,
+) -> CheckResult {
+    if topology.replica_url.is_some() && topology.primary_url.is_none() {
+        return CheckResult {
+            name: "database_topology",
+            status: CheckStatus::Fail,
+            detail: Some("replica role configured without a primary/write role".into()),
+            hint: Some("Set database.primary_url or remove database.replica_url"),
+        };
+    }
+
+    if is_production && topology.replica_url.is_some() && topology.auto_migrate_in_production {
+        return CheckResult {
+            name: "database_topology",
+            status: CheckStatus::Fail,
+            detail: Some(
+                "unsafe migration ownership: production primary/replica topology cannot run migrations from every web replica"
+                    .into(),
+            ),
+            hint: Some("Run `autumn migrate` as one primary-role job before starting web replicas"),
+        };
+    }
+
+    if topology.primary_url.is_some() && topology.replica_url.is_some() {
+        CheckResult {
+            name: "database_topology",
+            status: CheckStatus::Pass,
+            detail: Some("primary and replica database roles configured".into()),
+            hint: None,
+        }
+    } else if topology.primary_url.is_some() {
+        CheckResult {
+            name: "database_topology",
+            status: CheckStatus::Pass,
+            detail: Some("single primary database role configured".into()),
+            hint: None,
+        }
+    } else {
+        CheckResult {
+            name: "database_topology",
+            status: CheckStatus::Pass,
+            detail: Some("database not configured".into()),
+            hint: None,
+        }
+    }
+}
+
+fn check_replica_migration_versions(
+    primary_latest: Option<&str>,
+    replica_latest: Option<&str>,
+    fallback: DoctorReplicaFallback,
+) -> CheckResult {
+    match (primary_latest, replica_latest) {
+        (Some(primary), Some(replica)) if primary == replica => CheckResult {
+            name: "replica_migrations",
+            status: CheckStatus::Pass,
+            detail: Some(format!("replica replayed latest migration {primary}")),
+            hint: None,
+        },
+        (Some(primary), Some(replica)) => {
+            let detail = format!(
+                "replica migration version {replica} is behind primary migration version {primary}"
+            );
+            match fallback {
+                DoctorReplicaFallback::FailReadiness => CheckResult {
+                    name: "replica_migrations",
+                    status: CheckStatus::Fail,
+                    detail: Some(detail),
+                    hint: Some(
+                        "Wait for the replica to replay the latest migration before admitting traffic",
+                    ),
+                },
+                DoctorReplicaFallback::Primary => CheckResult {
+                    name: "replica_migrations",
+                    status: CheckStatus::Warn,
+                    detail: Some(format!("{detail}; reads may fall back to primary")),
+                    hint: Some(
+                        "Restore replica replay or set replica_fallback = \"fail_readiness\" for stricter rollout gates",
+                    ),
+                },
+            }
+        }
+        _ => CheckResult {
+            name: "replica_migrations",
+            status: CheckStatus::Warn,
+            detail: Some("could not determine primary and replica migration versions".into()),
+            hint: Some("Ensure both roles expose __diesel_schema_migrations"),
+        },
+    }
+}
+
+fn check_db_role_connectivity(
+    role: &'static str,
+    database_url: &str,
+    reachable: impl Fn(&str, u16) -> bool,
+) -> CheckResult {
+    match parse_db_host_port(database_url) {
+        None => CheckResult {
+            name: "db_connectivity",
+            status: CheckStatus::Warn,
+            detail: Some(format!(
+                "cannot parse {role} database URL to extract host:port"
+            )),
+            hint: Some("Ensure database URLs in autumn.toml use postgres:// or postgresql://"),
+        },
+        Some((host, port)) if reachable(&host, port) => CheckResult {
+            name: "db_connectivity",
+            status: CheckStatus::Pass,
+            detail: Some(format!("{role} database reachable at {host}:{port}")),
+            hint: None,
+        },
+        Some((host, port)) => CheckResult {
+            name: "db_connectivity",
+            status: CheckStatus::Fail,
+            detail: Some(format!(
+                "cannot connect to {role} database at {host}:{port}"
+            )),
+            hint: Some("Start Postgres and verify the configured database role URL"),
+        },
+    }
+}
+
+fn check_db_connectivity(database_url: &str) -> CheckResult {
+    check_db_role_connectivity("primary", database_url, tcp_reachable)
+}
+
+fn check_pending_migrations(database_url: &str) -> CheckResult {
     match std::process::Command::new("diesel")
         .args(["migration", "pending"])
+        .env("DATABASE_URL", database_url)
         .output()
     {
         Err(_) => CheckResult {
@@ -784,6 +912,49 @@ fn check_pending_migrations() -> CheckResult {
             hint: Some("Run `autumn migrate` to apply pending migrations"),
         },
     }
+}
+
+fn check_replica_migrations(
+    primary_url: &str,
+    replica_url: &str,
+    fallback: DoctorReplicaFallback,
+) -> CheckResult {
+    let primary_latest = latest_applied_migration_version(primary_url);
+    let replica_latest = latest_applied_migration_version(replica_url);
+    check_replica_migration_versions(
+        primary_latest.as_deref(),
+        replica_latest.as_deref(),
+        fallback,
+    )
+}
+
+fn latest_applied_migration_version(database_url: &str) -> Option<String> {
+    let output = std::process::Command::new("diesel")
+        .args(["migration", "list"])
+        .env("DATABASE_URL", database_url)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    parse_latest_applied_migration_version(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_latest_applied_migration_version(output: &str) -> Option<String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            let version = trimmed
+                .strip_prefix("[X]")
+                .or_else(|| trimmed.strip_prefix("[x]"))?
+                .split_whitespace()
+                .next()?;
+            Some(version.to_owned())
+        })
+        .max()
 }
 
 /// Parse (host, port) from a Postgres connection URL.
@@ -825,26 +996,93 @@ fn resolve_server_port() -> u16 {
         .unwrap_or(3000)
 }
 
-/// Resolve the optional database URL from env and `autumn.toml`.
-fn resolve_optional_db_url() -> Option<String> {
-    for var in ["AUTUMN_DATABASE__URL", "DATABASE_URL"] {
-        if let Ok(url) = std::env::var(var)
-            && !url.is_empty()
-        {
-            return Some(url);
-        }
-    }
-
+fn read_autumn_toml_table() -> Option<toml::Table> {
     std::fs::read_to_string("autumn.toml")
         .ok()
-        .and_then(|c| toml::from_str::<toml::Table>(&c).ok())
-        .and_then(|t| {
-            t.get("database")
-                .and_then(|db| db.get("url"))
-                .and_then(toml::Value::as_str)
-                .filter(|u| !u.is_empty())
-                .map(std::borrow::ToOwned::to_owned)
-        })
+        .and_then(|contents| toml::from_str::<toml::Table>(&contents).ok())
+}
+
+fn resolve_database_topology(table: Option<&toml::Table>) -> DoctorDatabaseTopology {
+    resolve_database_topology_from_sources(
+        |key| std::env::var(key).ok().filter(|value| !value.is_empty()),
+        table,
+    )
+}
+
+fn resolve_database_topology_from_sources<F>(
+    env_var: F,
+    table: Option<&toml::Table>,
+) -> DoctorDatabaseTopology
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let database = table
+        .and_then(|t| t.get("database"))
+        .and_then(toml::Value::as_table);
+
+    let primary_url = first_env(
+        &env_var,
+        &[
+            "AUTUMN_DATABASE__PRIMARY_URL",
+            "AUTUMN_DATABASE__URL",
+            "DATABASE_URL",
+        ],
+    )
+    .or_else(|| first_toml_string(database, &["primary_url", "url"]));
+
+    let replica_url = first_env(&env_var, &["AUTUMN_DATABASE__REPLICA_URL"])
+        .or_else(|| first_toml_string(database, &["replica_url"]));
+
+    let auto_migrate_in_production =
+        first_env(&env_var, &["AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION"])
+            .as_deref()
+            .and_then(parse_config_bool)
+            .or_else(|| database?.get("auto_migrate_in_production")?.as_bool())
+            .unwrap_or(false);
+
+    let replica_fallback = DoctorReplicaFallback::from_config_value(
+        first_env(&env_var, &["AUTUMN_DATABASE__REPLICA_FALLBACK"])
+            .or_else(|| first_toml_string(database, &["replica_fallback"]))
+            .as_deref(),
+    );
+
+    DoctorDatabaseTopology {
+        primary_url,
+        replica_url,
+        auto_migrate_in_production,
+        replica_fallback,
+    }
+}
+
+fn first_env<F>(env_var: &F, keys: &[&str]) -> Option<String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    keys.iter().find_map(|key| {
+        env_var(key)
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+    })
+}
+
+fn first_toml_string(database: Option<&toml::Table>, keys: &[&str]) -> Option<String> {
+    let database = database?;
+    keys.iter().find_map(|key| {
+        database
+            .get(*key)
+            .and_then(toml::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(std::borrow::ToOwned::to_owned)
+    })
+}
+
+fn parse_config_bool(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
 }
 
 /// Resolve the signing secret from the environment or `autumn.toml`.
@@ -925,7 +1163,12 @@ pub fn run(opts: DoctorOptions) {
     let msrv = read_msrv().unwrap_or_else(|| "1.88.0".to_owned());
     let web_ver = read_autumn_web_version();
     let toml_result = std::fs::read_to_string("autumn.toml");
-    let db_url = resolve_optional_db_url();
+    let toml_table = toml_result
+        .as_deref()
+        .ok()
+        .and_then(|content| toml::from_str::<toml::Table>(content).ok())
+        .or_else(read_autumn_toml_table);
+    let db_topology = resolve_database_topology(toml_table.as_ref());
     let port = resolve_server_port();
     let tailwind = tailwind_enabled();
     let signing_secret = resolve_optional_signing_secret();
@@ -953,10 +1196,34 @@ pub fn run(opts: DoctorOptions) {
         })),
     }
 
-    // 4 & 5. Database (only when configured)
-    if let Some(url) = db_url {
+    // 4+. Database topology and role-specific checks.
+    let topology_for_check = db_topology.clone();
+    tasks.push(Box::new(move || {
+        check_database_topology_contract(&topology_for_check, is_production)
+    }));
+
+    if let Some(url) = db_topology.primary_url.clone() {
+        let primary_for_pending = url.clone();
         tasks.push(Box::new(move || check_db_connectivity(&url)));
-        tasks.push(Box::new(check_pending_migrations));
+        tasks.push(Box::new(move || {
+            check_pending_migrations(&primary_for_pending)
+        }));
+    }
+
+    if let Some(url) = db_topology.replica_url.clone() {
+        tasks.push(Box::new(move || {
+            check_db_role_connectivity("replica", &url, tcp_reachable)
+        }));
+    }
+
+    if let (Some(primary_url), Some(replica_url)) = (
+        db_topology.primary_url.clone(),
+        db_topology.replica_url.clone(),
+    ) {
+        let fallback = db_topology.replica_fallback;
+        tasks.push(Box::new(move || {
+            check_replica_migrations(&primary_url, &replica_url, fallback)
+        }));
     }
 
     // 6. Port bindable
@@ -1446,6 +1713,98 @@ foo = "bar"
     }
 
     // ── check_tailwind_binary_at ─────────────────────────────────────────────
+
+    #[test]
+    fn database_topology_doctor_fails_replica_without_primary() {
+        let topology = DoctorDatabaseTopology {
+            primary_url: None,
+            replica_url: Some("postgres://user:secret@replica:5432/app".to_owned()),
+            auto_migrate_in_production: false,
+            replica_fallback: DoctorReplicaFallback::FailReadiness,
+        };
+
+        let result = check_database_topology_contract(&topology, true);
+
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(result.detail.unwrap_or_default().contains("replica"));
+        assert!(result.hint.unwrap_or_default().contains("primary"));
+    }
+
+    #[test]
+    fn database_topology_doctor_fails_prod_replica_with_startup_migrations() {
+        let topology = DoctorDatabaseTopology {
+            primary_url: Some("postgres://user:secret@primary:5432/app".to_owned()),
+            replica_url: Some("postgres://user:secret@replica:5432/app".to_owned()),
+            auto_migrate_in_production: true,
+            replica_fallback: DoctorReplicaFallback::FailReadiness,
+        };
+
+        let result = check_database_topology_contract(&topology, true);
+
+        assert_eq!(result.status, CheckStatus::Fail);
+        let detail = result.detail.unwrap_or_default();
+        assert!(detail.contains("migration"));
+        assert!(!detail.contains("secret"));
+    }
+
+    #[test]
+    fn database_topology_doctor_fails_stale_replica_when_readiness_must_fail() {
+        let result = check_replica_migration_versions(
+            Some("20260510000000"),
+            Some("20260509000000"),
+            DoctorReplicaFallback::FailReadiness,
+        );
+
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(result.detail.unwrap_or_default().contains("replica"));
+        assert!(result.hint.unwrap_or_default().contains("replay"));
+    }
+
+    #[test]
+    fn database_topology_doctor_warns_stale_replica_when_falling_back_to_primary() {
+        let result = check_replica_migration_versions(
+            Some("20260510000000"),
+            Some("20260509000000"),
+            DoctorReplicaFallback::Primary,
+        );
+
+        assert_eq!(result.status, CheckStatus::Warn);
+        assert!(result.detail.unwrap_or_default().contains("primary"));
+    }
+
+    #[test]
+    fn database_topology_parses_latest_applied_migration_version() {
+        let output = r#"
+            [X] 20260509000000_create_widgets
+            [ ] 20260510000000_add_widget_index
+            [X] 20260508000000_create_users
+        "#;
+
+        assert_eq!(
+            parse_latest_applied_migration_version(output).as_deref(),
+            Some("20260509000000_create_widgets")
+        );
+    }
+
+    #[test]
+    fn database_topology_connectivity_names_role_without_credentials() {
+        let result = check_db_role_connectivity(
+            "primary",
+            "postgres://user:secret@db:5432/app",
+            |host, port| {
+                assert_eq!(host, "db");
+                assert_eq!(port, 5432);
+                false
+            },
+        );
+
+        assert_eq!(result.status, CheckStatus::Fail);
+        let detail = result.detail.unwrap_or_default();
+        assert!(detail.contains("primary"));
+        assert!(detail.contains("db:5432"));
+        assert!(!detail.contains("user"));
+        assert!(!detail.contains("secret"));
+    }
 
     fn temp_tailwind_path(temp: &tempfile::TempDir) -> std::path::PathBuf {
         let tailwind_name = if cfg!(windows) {

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -2,8 +2,8 @@
 //!
 //! Because the CLI cannot embed the user's application-specific migrations
 //! (they live in the user's crate via `embed_migrations!`), this module
-//! delegates to the `diesel` CLI tool. It reads the database URL from
-//! `autumn.toml` + environment variables, then shells out to
+//! delegates to the `diesel` CLI tool. It reads the primary/write database URL
+//! from `autumn.toml` + environment variables, then shells out to
 //! `diesel migration run` or `diesel migration pending`.
 //!
 //! The user's application binary is the canonical way to run embedded
@@ -45,12 +45,14 @@ pub fn run(action: MigrateAction) {
     }
 }
 
-/// Resolve the database URL from autumn.toml and environment variables.
+/// Resolve the primary/write database URL from autumn.toml and environment variables.
 ///
 /// Precedence (highest to lowest):
-/// 1. `AUTUMN_DATABASE__URL` environment variable
-/// 2. `DATABASE_URL` environment variable
-/// 3. `database.url` from `autumn.toml`
+/// 1. `AUTUMN_DATABASE__PRIMARY_URL` environment variable
+/// 2. `AUTUMN_DATABASE__URL` environment variable
+/// 3. `DATABASE_URL` environment variable
+/// 4. `database.primary_url` from `autumn.toml`
+/// 5. `database.url` from `autumn.toml`
 fn resolve_database_url() -> String {
     resolve_database_url_with_env(|key| std::env::var(key))
 }
@@ -59,38 +61,58 @@ fn resolve_database_url_with_env<F>(env_var: F) -> String
 where
     F: Fn(&str) -> Result<String, std::env::VarError>,
 {
-    // Check env overrides first
-    if let Ok(url) = env_var("AUTUMN_DATABASE__URL")
-        && !url.is_empty()
-    {
+    let config_table = read_autumn_toml_table();
+    if let Some(url) = resolve_primary_database_url_from_sources(env_var, config_table.as_ref()) {
         return url;
-    }
-    if let Ok(url) = env_var("DATABASE_URL")
-        && !url.is_empty()
-    {
-        return url;
-    }
-
-    // Try loading from autumn.toml
-    let config_path = Path::new("autumn.toml");
-    if config_path.exists()
-        && let Ok(contents) = std::fs::read_to_string(config_path)
-        && let Ok(table) = toml::from_str::<toml::Table>(&contents)
-    {
-        let value = toml::Value::Table(table);
-        if let Some(url) = value
-            .get("database")
-            .and_then(|db: &toml::Value| db.get("url"))
-            .and_then(|u: &toml::Value| u.as_str())
-            && !url.is_empty()
-        {
-            return url.to_string();
-        }
     }
 
     eprintln!("\u{2717} No database URL found.");
-    eprintln!("  Set database.url in autumn.toml, or set AUTUMN_DATABASE__URL / DATABASE_URL.");
+    eprintln!(
+        "  Set database.primary_url (or database.url) in autumn.toml, or set AUTUMN_DATABASE__PRIMARY_URL / AUTUMN_DATABASE__URL / DATABASE_URL."
+    );
     std::process::exit(1);
+}
+
+fn read_autumn_toml_table() -> Option<toml::Table> {
+    let config_path = Path::new("autumn.toml");
+    if !config_path.exists() {
+        return None;
+    }
+    std::fs::read_to_string(config_path)
+        .ok()
+        .and_then(|contents| toml::from_str::<toml::Table>(&contents).ok())
+}
+
+fn resolve_primary_database_url_from_sources<F>(
+    env_var: F,
+    table: Option<&toml::Table>,
+) -> Option<String>
+where
+    F: Fn(&str) -> Result<String, std::env::VarError>,
+{
+    for var in [
+        "AUTUMN_DATABASE__PRIMARY_URL",
+        "AUTUMN_DATABASE__URL",
+        "DATABASE_URL",
+    ] {
+        if let Ok(url) = env_var(var)
+            && !url.is_empty()
+        {
+            return Some(url);
+        }
+    }
+
+    let database = table?.get("database").and_then(toml::Value::as_table)?;
+    for key in ["primary_url", "url"] {
+        if let Some(url) = database
+            .get(key)
+            .and_then(toml::Value::as_str)
+            .filter(|url| !url.is_empty())
+        {
+            return Some(url.to_owned());
+        }
+    }
+    None
 }
 
 /// Resolve the migrations directory (default: `./migrations/`).
@@ -212,5 +234,41 @@ mod tests {
         };
         let url = resolve_database_url_with_env(env_var);
         assert_eq!(url, "postgres://fallback:5432/db");
+    }
+
+    #[test]
+    fn database_topology_primary_env_wins_for_migrations() {
+        let env_var = |key: &str| -> Result<String, std::env::VarError> {
+            match key {
+                "AUTUMN_DATABASE__PRIMARY_URL" => Ok("postgres://primary:5432/app".to_string()),
+                "AUTUMN_DATABASE__URL" => Ok("postgres://legacy:5432/app".to_string()),
+                "DATABASE_URL" => Ok("postgres://database-url:5432/app".to_string()),
+                _ => Err(std::env::VarError::NotPresent),
+            }
+        };
+
+        let url = resolve_primary_database_url_from_sources(env_var, None).unwrap();
+
+        assert_eq!(url, "postgres://primary:5432/app");
+    }
+
+    #[test]
+    fn database_topology_toml_primary_wins_over_legacy_url() {
+        let table = toml::from_str::<toml::Table>(
+            r#"
+[database]
+url = "postgres://legacy:5432/app"
+primary_url = "postgres://primary:5432/app"
+replica_url = "postgres://replica:5432/app"
+"#,
+        )
+        .unwrap();
+        let env_var = |_key: &str| -> Result<String, std::env::VarError> {
+            Err(std::env::VarError::NotPresent)
+        };
+
+        let url = resolve_primary_database_url_from_sources(env_var, Some(&table)).unwrap();
+
+        assert_eq!(url, "postgres://primary:5432/app");
     }
 }

--- a/autumn-cli/src/release.rs
+++ b/autumn-cli/src/release.rs
@@ -92,19 +92,22 @@ pub fn run(action: ReleaseAction) {
                     );
                     println!("     Smoke-gate check — the app must refuse to start without it:");
                     println!("       AUTUMN_ENV=prod docker run --rm \\");
-                    println!("         -e DATABASE_URL=... \\");
+                    println!("         -e AUTUMN_DATABASE__PRIMARY_URL=... \\");
                     println!("         {project_name} 2>&1 | grep -i 'signing secret'");
                     println!("     And must start with it:");
                     println!("       AUTUMN_ENV=prod docker run --rm \\");
-                    println!("         -e DATABASE_URL=... \\");
+                    println!("         -e AUTUMN_DATABASE__PRIMARY_URL=... \\");
                     println!(
                         "         -e AUTUMN_SECURITY__SIGNING_SECRET=\"$AUTUMN_SECURITY__SIGNING_SECRET\" \\"
                     );
                     println!("         {project_name}");
                     println!();
-                    println!("  2. Build and run:");
+                    println!("  2. Build, migrate the primary once, then run web replicas:");
                     println!("       docker build -t {project_name} .");
-                    println!("       docker run --rm -p 3000:3000 -e DATABASE_URL=... \\");
+                    println!("       AUTUMN_DATABASE__PRIMARY_URL=... autumn migrate");
+                    println!(
+                        "       docker run --rm -p 3000:3000 -e AUTUMN_DATABASE__PRIMARY_URL=... \\"
+                    );
                     println!(
                         "         -e AUTUMN_SECURITY__SIGNING_SECRET=\"$AUTUMN_SECURITY__SIGNING_SECRET\" \\"
                     );
@@ -401,21 +404,18 @@ mod tests {
     }
 
     #[test]
-    fn dockerfile_runs_migrations_before_serving() {
+    fn dockerfile_defers_migrations_to_one_shot_primary_job() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
         init(&dir, "my-app", false, Target::Default).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
-            content.contains("migrate"),
-            "Dockerfile CMD must run migrations before serving"
+            !content.contains("auto_migrate_in_production = true"),
+            "Dockerfile must not enable startup migrations for every web replica"
         );
-        // The migration step must come before exec in the CMD
-        let migrate_pos = content.find("migrate").unwrap();
-        let exec_pos = content.find("exec").unwrap_or(content.len());
         assert!(
-            migrate_pos < exec_pos,
-            "migration must run before exec in the CMD"
+            content.contains("autumn migrate"),
+            "Dockerfile must document the explicit primary-role migration job"
         );
     }
 
@@ -844,15 +844,22 @@ previous_secrets = []
     // ── auto-migration config ─────────────────────────────────────────────────
 
     #[test]
-    fn production_config_enables_auto_migrate_in_production() {
+    fn production_config_disables_startup_migrations_by_default() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
         init(&dir, "my-app", false, Target::Default).unwrap();
         let content = fs::read_to_string(dir.join("autumn.production.toml.example")).unwrap();
         assert!(
-            content.contains("auto_migrate_in_production = true"),
-            "production config must set auto_migrate_in_production = true so the \
-             framework runs migrations at startup and calls exit(1) on failure"
+            content.contains("auto_migrate_in_production = false"),
+            "production config must leave web replicas out of migration ownership"
+        );
+        assert!(
+            content.contains("primary_url"),
+            "production config must name the primary/write database role"
+        );
+        assert!(
+            content.contains("autumn migrate"),
+            "production config must point operators at the one-shot migration command"
         );
     }
 

--- a/autumn-cli/src/release.rs
+++ b/autumn-cli/src/release.rs
@@ -223,6 +223,7 @@ fn render(template: &str, project_name: &str) -> String {
     template
         .replace("{{project_name}}", project_name)
         .replace("{{autumn_cli_version}}", env!("CARGO_PKG_VERSION"))
+        .replace("{{diesel_cli_version}}", "2.3.8")
 }
 
 fn planned_files(target: Target) -> Vec<(&'static str, &'static str)> {
@@ -436,6 +437,22 @@ mod tests {
     }
 
     #[test]
+    fn dockerfile_installs_diesel_cli_for_migration_jobs() {
+        let tmp = TempDir::new().unwrap();
+        let dir = make_project(&tmp, "my-app");
+        init(&dir, "my-app", false, Target::Default).unwrap();
+        let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
+        assert!(
+            content.contains("cargo install")
+                && content.contains("diesel_cli")
+                && content.contains("libpq-dev")
+                && content.contains("--features postgres")
+                && content.contains("/usr/local/bin/diesel"),
+            "Dockerfile must include the diesel CLI used by autumn migrate"
+        );
+    }
+
+    #[test]
     fn dockerfile_has_healthcheck() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
@@ -476,6 +493,10 @@ mod tests {
         assert!(
             !content.contains("{{project_name}}"),
             "Dockerfile must not contain unsubstituted {{{{project_name}}}}"
+        );
+        assert!(
+            !content.contains("{{"),
+            "Dockerfile must not contain any unsubstituted template placeholders"
         );
     }
 

--- a/autumn-cli/src/release.rs
+++ b/autumn-cli/src/release.rs
@@ -220,7 +220,9 @@ pub fn init(
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 fn render(template: &str, project_name: &str) -> String {
-    template.replace("{{project_name}}", project_name)
+    template
+        .replace("{{project_name}}", project_name)
+        .replace("{{autumn_cli_version}}", env!("CARGO_PKG_VERSION"))
 }
 
 fn planned_files(target: Target) -> Vec<(&'static str, &'static str)> {
@@ -416,6 +418,20 @@ mod tests {
         assert!(
             content.contains("autumn migrate"),
             "Dockerfile must document the explicit primary-role migration job"
+        );
+    }
+
+    #[test]
+    fn dockerfile_installs_autumn_cli_for_migration_jobs() {
+        let tmp = TempDir::new().unwrap();
+        let dir = make_project(&tmp, "my-app");
+        init(&dir, "my-app", false, Target::Default).unwrap();
+        let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
+        assert!(
+            content.contains("cargo install")
+                && content.contains("autumn-cli")
+                && content.contains("/usr/local/bin/autumn"),
+            "Dockerfile must include the autumn CLI used by one-shot migration jobs"
         );
     }
 
@@ -788,6 +804,27 @@ previous_secrets = []
         assert!(
             content.contains("depends_on"),
             "docker-compose.yml app service must depend_on the db"
+        );
+    }
+
+    #[test]
+    fn docker_compose_runs_one_shot_migration_before_app() {
+        let tmp = TempDir::new().unwrap();
+        let dir = make_project(&tmp, "my-app");
+        init(&dir, "my-app", false, Target::DockerCompose).unwrap();
+        let content = fs::read_to_string(dir.join("docker-compose.yml")).unwrap();
+
+        assert!(
+            content.contains("migrate:"),
+            "docker-compose.yml must include a one-shot migration service"
+        );
+        assert!(
+            content.contains("autumn migrate"),
+            "migration service must run autumn migrate"
+        );
+        assert!(
+            content.contains("condition: service_completed_successfully"),
+            "app service must wait for the migration job to complete successfully"
         );
     }
 

--- a/autumn-cli/src/seed.rs
+++ b/autumn-cli/src/seed.rs
@@ -57,10 +57,13 @@ fn find_package_dir(package: &str) -> Option<PathBuf> {
 /// the process working directory so that workspace invocations are correct.
 ///
 /// Precedence (highest to lowest):
-/// 1. `AUTUMN_DATABASE__URL` env var
-/// 2. `DATABASE_URL` env var
-/// 3. `[profile.<profile>.database.url]` in `<base_dir>/autumn.toml`
-/// 4. `[database.url]` in `<base_dir>/autumn.toml`
+/// 1. `AUTUMN_DATABASE__PRIMARY_URL` env var
+/// 2. `AUTUMN_DATABASE__URL` env var
+/// 3. `DATABASE_URL` env var
+/// 4. `[profile.<profile>.database.primary_url]` in `<base_dir>/autumn.toml`
+/// 5. `[profile.<profile>.database.url]` in `<base_dir>/autumn.toml`
+/// 6. `[database.primary_url]` in `<base_dir>/autumn.toml`
+/// 7. `[database.url]` in `<base_dir>/autumn.toml`
 fn resolve_database_url_with_env<F>(
     env_var: F,
     base_dir: &Path,
@@ -69,15 +72,16 @@ fn resolve_database_url_with_env<F>(
 where
     F: Fn(&str) -> Result<String, std::env::VarError>,
 {
-    if let Ok(url) = env_var("AUTUMN_DATABASE__URL")
-        && !url.is_empty()
-    {
-        return Ok(url);
-    }
-    if let Ok(url) = env_var("DATABASE_URL")
-        && !url.is_empty()
-    {
-        return Ok(url);
+    for var in [
+        "AUTUMN_DATABASE__PRIMARY_URL",
+        "AUTUMN_DATABASE__URL",
+        "DATABASE_URL",
+    ] {
+        if let Ok(url) = env_var(var)
+            && !url.is_empty()
+        {
+            return Ok(url);
+        }
     }
 
     let config_path = base_dir.join("autumn.toml");
@@ -87,30 +91,39 @@ where
     {
         let value = toml::Value::Table(table);
 
-        // Profile-specific override: [profile.<name>.database.url]
-        if let Some(url) = value
+        // Profile-specific override: [profile.<name>.database]
+        let profile_database = value
             .get("profile")
             .and_then(|p| p.get(profile))
             .and_then(|p| p.get("database"))
-            .and_then(|db| db.get("url"))
-            .and_then(|u| u.as_str())
-            .filter(|u| !u.is_empty())
-        {
-            return Ok(url.to_string());
+            .and_then(toml::Value::as_table);
+        if let Some(url) = first_database_url(profile_database) {
+            return Ok(url);
         }
 
-        // Top-level fallback: [database.url]
-        if let Some(url) = value
-            .get("database")
-            .and_then(|db: &toml::Value| db.get("url"))
-            .and_then(|u: &toml::Value| u.as_str())
-            .filter(|u| !u.is_empty())
-        {
-            return Ok(url.to_string());
+        // Top-level fallback: [database]
+        let database = value.get("database").and_then(toml::Value::as_table);
+        if let Some(url) = first_database_url(database) {
+            return Ok(url);
         }
     }
 
     Err(SeedError::MissingSeedBinary)
+}
+
+fn first_database_url(database: Option<&toml::Table>) -> Option<String> {
+    let database = database?;
+    for key in ["primary_url", "url"] {
+        if let Some(url) = database
+            .get(key)
+            .and_then(toml::Value::as_str)
+            .filter(|url| !url.is_empty())
+        {
+            return Some(url.to_owned());
+        }
+    }
+
+    None
 }
 
 /// Resolve the database URL using the real environment, a given base dir, and profile.
@@ -287,6 +300,18 @@ mod tests {
     }
 
     #[test]
+    fn resolve_db_url_prefers_primary_database_url_env() {
+        let env = |key: &str| match key {
+            "AUTUMN_DATABASE__PRIMARY_URL" => Ok("postgres://primary:5432/db".to_string()),
+            "AUTUMN_DATABASE__URL" => Ok("postgres://legacy:5432/db".to_string()),
+            "DATABASE_URL" => Ok("postgres://plain:5432/db".to_string()),
+            _ => Err(std::env::VarError::NotPresent),
+        };
+        let url = resolve_database_url_with_env(env, Path::new("."), "dev").unwrap();
+        assert_eq!(url, "postgres://primary:5432/db");
+    }
+
+    #[test]
     fn resolve_db_url_falls_back_to_database_url() {
         let env = |key: &str| match key {
             "DATABASE_URL" => Ok("postgres://fallback:5432/db".to_string()),
@@ -330,6 +355,21 @@ mod tests {
     }
 
     #[test]
+    fn resolve_db_url_reads_primary_url_from_base_dir_toml() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("autumn.toml"),
+            "[database]\nprimary_url = \"postgres://primary-toml:5432/db\"\n\
+             url = \"postgres://legacy-toml:5432/db\"\n",
+        )
+        .unwrap();
+        let env =
+            |_: &str| -> Result<String, std::env::VarError> { Err(std::env::VarError::NotPresent) };
+        let url = resolve_database_url_with_env(env, tmp.path(), "dev").unwrap();
+        assert_eq!(url, "postgres://primary-toml:5432/db");
+    }
+
+    #[test]
     fn resolve_db_url_ignores_toml_in_wrong_base_dir() {
         // autumn.toml exists only in a different directory; base_dir has none.
         let tmp_with_toml = TempDir::new().unwrap();
@@ -352,6 +392,21 @@ mod tests {
             tmp.path().join("autumn.toml"),
             "[database]\nurl = \"postgres://default:5432/db\"\n\
              [profile.demo.database]\nurl = \"postgres://demo:5432/demo_db\"\n",
+        )
+        .unwrap();
+        let env =
+            |_: &str| -> Result<String, std::env::VarError> { Err(std::env::VarError::NotPresent) };
+        let url = resolve_database_url_with_env(env, tmp.path(), "demo").unwrap();
+        assert_eq!(url, "postgres://demo:5432/demo_db");
+    }
+
+    #[test]
+    fn resolve_db_url_uses_profile_specific_primary_url_from_toml() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("autumn.toml"),
+            "[database]\nprimary_url = \"postgres://default:5432/db\"\n\
+             [profile.demo.database]\nprimary_url = \"postgres://demo:5432/demo_db\"\n",
         )
         .unwrap();
         let env =

--- a/autumn-cli/src/templates/autumn.toml.tmpl
+++ b/autumn-cli/src/templates/autumn.toml.tmpl
@@ -26,10 +26,19 @@ path = "/health"
 # protocol = "Grpc"  # Grpc | HttpProtobuf
 
 # Uncomment to configure database:
+# Single-primary apps can use url. Multi-role deployments should use
+# primary_url for writes/migrations and optional replica_url for reads.
 # [database]
 # url = "postgres://user:pass@localhost:5432/{{crate_name}}"
+# primary_url = "postgres://user:pass@localhost:5432/{{crate_name}}"
+# replica_url = "postgres://user:pass@localhost:5433/{{crate_name}}"
 # pool_size = 10
+# primary_pool_size = 10
+# replica_pool_size = 5
+# replica_fallback = "fail_readiness"  # fail_readiness | primary
 # connect_timeout_secs = 5  # pool wait/create timeout in seconds
+# Production web replicas should not run migrations. Use a one-shot
+# primary-role `autumn migrate` job before rolling the web tier.
 # auto_migrate_in_production = false
 
 # Uncomment to send transactional email in production:

--- a/autumn-cli/src/templates/release/Dockerfile.tmpl
+++ b/autumn-cli/src/templates/release/Dockerfile.tmpl
@@ -10,6 +10,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 
 ARG TAILWIND_VERSION=v4.1.4
+ARG AUTUMN_CLI_VERSION={{autumn_cli_version}}
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl \
@@ -32,6 +33,7 @@ RUN mkdir -p target/autumn \
 
 COPY . .
 RUN cargo build --release
+RUN cargo install --locked autumn-cli --version "${AUTUMN_CLI_VERSION}"
 
 # ── Stage 3: runtime ──────────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -49,6 +51,7 @@ RUN apt-get update \
 WORKDIR /app
 
 COPY --chown=autumn:autumn --from=builder /app/target/release/{{project_name}} /usr/local/bin/{{project_name}}
+COPY --chown=autumn:autumn --from=builder /usr/local/cargo/bin/autumn /usr/local/bin/autumn
 COPY --chown=autumn:autumn --from=builder /app/static /app/static
 COPY --chown=autumn:autumn --from=builder /app/migrations /app/migrations
 # Use the production config example as the runtime autumn.toml.

--- a/autumn-cli/src/templates/release/Dockerfile.tmpl
+++ b/autumn-cli/src/templates/release/Dockerfile.tmpl
@@ -52,7 +52,8 @@ COPY --chown=autumn:autumn --from=builder /app/target/release/{{project_name}} /
 COPY --chown=autumn:autumn --from=builder /app/static /app/static
 COPY --chown=autumn:autumn --from=builder /app/migrations /app/migrations
 # Use the production config example as the runtime autumn.toml.
-# It sets host = "0.0.0.0" and auto_migrate_in_production = true.
+# It sets host = "0.0.0.0" and leaves migration ownership to an explicit
+# one-shot primary-role job.
 COPY --chown=autumn:autumn --from=builder /app/autumn.production.toml.example /app/autumn.toml
 
 ENV AUTUMN_PROFILE=prod
@@ -63,8 +64,9 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 
 USER autumn
 
-# Migrations run automatically at startup via auto_migrate_in_production = true
-# in autumn.toml (or AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION=true env var).
-# On migration failure the framework calls exit(1), stopping the container.
+# Run migrations once before rolling web replicas, targeting only the primary:
+#   AUTUMN_DATABASE__PRIMARY_URL=... autumn migrate
+# Then start this image as the web process. Replica lag should fail readiness
+# or fall back to primary according to database.replica_fallback.
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/usr/local/bin/{{project_name}}"]

--- a/autumn-cli/src/templates/release/Dockerfile.tmpl
+++ b/autumn-cli/src/templates/release/Dockerfile.tmpl
@@ -11,9 +11,10 @@ FROM chef AS builder
 
 ARG TAILWIND_VERSION=v4.1.4
 ARG AUTUMN_CLI_VERSION={{autumn_cli_version}}
+ARG DIESEL_CLI_VERSION={{diesel_cli_version}}
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && apt-get install -y --no-install-recommends ca-certificates curl libpq-dev pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 # Pre-build dependencies — this layer is cached unless Cargo.lock changes.
@@ -34,6 +35,10 @@ RUN mkdir -p target/autumn \
 COPY . .
 RUN cargo build --release
 RUN cargo install --locked autumn-cli --version "${AUTUMN_CLI_VERSION}"
+RUN cargo install diesel_cli \
+    --version "${DIESEL_CLI_VERSION}" \
+    --no-default-features \
+    --features postgres
 
 # ── Stage 3: runtime ──────────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -52,6 +57,7 @@ WORKDIR /app
 
 COPY --chown=autumn:autumn --from=builder /app/target/release/{{project_name}} /usr/local/bin/{{project_name}}
 COPY --chown=autumn:autumn --from=builder /usr/local/cargo/bin/autumn /usr/local/bin/autumn
+COPY --chown=autumn:autumn --from=builder /usr/local/cargo/bin/diesel /usr/local/bin/diesel
 COPY --chown=autumn:autumn --from=builder /app/static /app/static
 COPY --chown=autumn:autumn --from=builder /app/migrations /app/migrations
 # Use the production config example as the runtime autumn.toml.

--- a/autumn-cli/src/templates/release/autumn.production.toml.example.tmpl
+++ b/autumn-cli/src/templates/release/autumn.production.toml.example.tmpl
@@ -16,14 +16,23 @@ path = "/health"
 # live_path = "/live"
 # ready_path = "/ready"
 
-# Database: prefer DATABASE_URL environment variable in production.
+# Database topology:
+# - primary_url is the write role used by Db, transactions, advisory locks, and migrations.
+# - replica_url is optional; use it only for read replicas that have replayed migrations.
+# - database.url and DATABASE_URL remain valid single-primary compatibility paths.
+# Prefer AUTUMN_DATABASE__PRIMARY_URL for real production secrets.
 [database]
-url = "postgres://user:CHANGE_ME@localhost:5432/{{project_name}}_prod"
+primary_url = "postgres://user:CHANGE_ME@localhost:5432/{{project_name}}_prod"
+# replica_url = "postgres://user:CHANGE_ME@replica:5432/{{project_name}}_prod"
 pool_size = 10
+# primary_pool_size = 10
+# replica_pool_size = 5
+replica_fallback = "fail_readiness" # fail_readiness | primary
 connect_timeout_secs = 5
-# Run pending migrations at startup; exit(1) on failure stops the container.
-# Requires .migrations(MIGRATIONS) to be registered in main.rs.
-auto_migrate_in_production = true
+# Production migrations belong to one explicit primary-role job:
+#   AUTUMN_DATABASE__PRIMARY_URL=... autumn migrate
+# Keep web replicas out of migration ownership.
+auto_migrate_in_production = false
 
 # ── Signing secret (REQUIRED in production) ─────────────────────────────────
 #

--- a/autumn-cli/src/templates/release/docker-compose.yml.tmpl
+++ b/autumn-cli/src/templates/release/docker-compose.yml.tmpl
@@ -12,7 +12,20 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     restart: unless-stopped
+
+  migrate:
+    build: .
+    command: ["sh", "-lc", "autumn migrate"]
+    environment:
+      AUTUMN_PROFILE: prod
+      AUTUMN_DATABASE__PRIMARY_URL: postgres://autumn:autumn@db:5432/{{project_name}}_prod
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: "no"
 
   db:
     image: postgres:16-alpine

--- a/autumn-cli/src/templates/release/docker-compose.yml.tmpl
+++ b/autumn-cli/src/templates/release/docker-compose.yml.tmpl
@@ -8,7 +8,7 @@ services:
       - "3000:3000"
     environment:
       AUTUMN_PROFILE: prod
-      DATABASE_URL: postgres://autumn:autumn@db:5432/{{project_name}}_prod
+      AUTUMN_DATABASE__PRIMARY_URL: postgres://autumn:autumn@db:5432/{{project_name}}_prod
     depends_on:
       db:
         condition: service_healthy

--- a/autumn-cli/src/token.rs
+++ b/autumn-cli/src/token.rs
@@ -67,38 +67,68 @@ fn os_random_bytes() -> [u8; 32] {
 /// Resolve the database URL from autumn.toml and environment variables.
 ///
 /// Precedence (highest to lowest):
-/// 1. `AUTUMN_DATABASE__URL` environment variable
-/// 2. `DATABASE_URL` environment variable
-/// 3. `database.url` from `autumn.toml`
+/// 1. `AUTUMN_DATABASE__PRIMARY_URL` environment variable
+/// 2. `AUTUMN_DATABASE__URL` environment variable
+/// 3. `DATABASE_URL` environment variable
+/// 4. `database.primary_url` from `autumn.toml`
+/// 5. `database.url` from `autumn.toml`
 fn resolve_database_url() -> String {
-    if let Ok(url) = std::env::var("AUTUMN_DATABASE__URL")
-        && !url.is_empty()
+    let config_table = read_autumn_toml_table();
+    if let Some(url) =
+        resolve_primary_database_url_from_sources(|key| std::env::var(key), config_table.as_ref())
     {
         return url;
     }
-    if let Ok(url) = std::env::var("DATABASE_URL")
-        && !url.is_empty()
-    {
-        return url;
-    }
+
+    eprintln!("\u{2717} No database URL found.");
+    eprintln!(
+        "  Set database.primary_url (or database.url) in autumn.toml, or set AUTUMN_DATABASE__PRIMARY_URL / AUTUMN_DATABASE__URL / DATABASE_URL."
+    );
+    std::process::exit(1);
+}
+
+fn read_autumn_toml_table() -> Option<toml::Table> {
     let config_path = Path::new("autumn.toml");
-    if config_path.exists()
-        && let Ok(contents) = std::fs::read_to_string(config_path)
-        && let Ok(table) = toml::from_str::<toml::Table>(&contents)
-    {
-        let value = toml::Value::Table(table);
-        if let Some(url) = value
-            .get("database")
-            .and_then(|db| db.get("url"))
-            .and_then(|u| u.as_str())
+    if !config_path.exists() {
+        return None;
+    }
+
+    std::fs::read_to_string(config_path)
+        .ok()
+        .and_then(|contents| toml::from_str::<toml::Table>(&contents).ok())
+}
+
+fn resolve_primary_database_url_from_sources<F>(
+    env_var: F,
+    table: Option<&toml::Table>,
+) -> Option<String>
+where
+    F: Fn(&str) -> Result<String, std::env::VarError>,
+{
+    for var in [
+        "AUTUMN_DATABASE__PRIMARY_URL",
+        "AUTUMN_DATABASE__URL",
+        "DATABASE_URL",
+    ] {
+        if let Ok(url) = env_var(var)
             && !url.is_empty()
         {
-            return url.to_string();
+            return Some(url);
         }
     }
-    eprintln!("\u{2717} No database URL found.");
-    eprintln!("  Set database.url in autumn.toml, or set AUTUMN_DATABASE__URL / DATABASE_URL.");
-    std::process::exit(1);
+
+    let database = table?.get("database").and_then(toml::Value::as_table)?;
+    for key in ["primary_url", "url"] {
+        if let Some(url) = database
+            .get(key)
+            .and_then(toml::Value::as_str)
+            .filter(|url| !url.is_empty())
+        {
+            return Some(url.to_owned());
+        }
+    }
+
+    None
 }
 
 fn check_psql() {
@@ -178,6 +208,7 @@ mod tests {
     fn resolve_prefers_autumn_database_url_over_database_url() {
         let url = temp_env::with_vars(
             [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
                 ("AUTUMN_DATABASE__URL", Some("postgres://autumn-primary")),
                 ("DATABASE_URL", Some("postgres://fallback")),
             ],
@@ -190,12 +221,43 @@ mod tests {
     fn resolve_falls_back_to_database_url_when_autumn_unset() {
         let url = temp_env::with_vars(
             [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
                 ("AUTUMN_DATABASE__URL", None::<&str>),
                 ("DATABASE_URL", Some("postgres://fallback")),
             ],
             resolve_database_url,
         );
         assert_eq!(url, "postgres://fallback");
+    }
+
+    #[test]
+    fn resolve_prefers_primary_database_url_env() {
+        let env = |key: &str| match key {
+            "AUTUMN_DATABASE__PRIMARY_URL" => Ok("postgres://primary-env".to_owned()),
+            "AUTUMN_DATABASE__URL" => Ok("postgres://legacy-env".to_owned()),
+            "DATABASE_URL" => Ok("postgres://fallback-env".to_owned()),
+            _ => Err(std::env::VarError::NotPresent),
+        };
+        let url = resolve_primary_database_url_from_sources(env, None).unwrap();
+        assert_eq!(url, "postgres://primary-env");
+    }
+
+    #[test]
+    fn resolve_reads_primary_database_url_from_toml() {
+        let table = toml::from_str::<toml::Table>(
+            r#"
+            [database]
+            primary_url = "postgres://primary-toml"
+            url = "postgres://legacy-toml"
+            "#,
+        )
+        .unwrap();
+        let env =
+            |_: &str| -> Result<String, std::env::VarError> { Err(std::env::VarError::NotPresent) };
+
+        let url = resolve_primary_database_url_from_sources(env, Some(&table)).unwrap();
+
+        assert_eq!(url, "postgres://primary-toml");
     }
 
     #[test]

--- a/autumn-storage-s3/src/lib.rs
+++ b/autumn-storage-s3/src/lib.rs
@@ -1,4 +1,4 @@
-//! S3-compatible [`BlobStore`](autumn_web::storage::BlobStore) plugin for autumn-web.
+//! S3-compatible [`BlobStore`] plugin for autumn-web.
 //!
 //! # Quick start
 //!
@@ -80,7 +80,7 @@ struct S3Options {
     public_base_url: Option<String>,
 }
 
-/// S3-compatible [`BlobStore`](autumn_web::storage::BlobStore) backed by
+/// S3-compatible [`BlobStore`] backed by
 /// `aws-sdk-s3`.
 ///
 /// Supports AWS S3, Cloudflare R2, `MinIO`, `DigitalOcean` Spaces, and Wasabi.

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -585,12 +585,47 @@ impl ConfigProperties {
         profile_str: &str,
     ) {
         let db_url = config.database.url.as_deref().unwrap_or("").to_string();
+        let primary_url = config
+            .database
+            .primary_url
+            .as_deref()
+            .unwrap_or("")
+            .to_string();
+        let replica_url = config
+            .database
+            .replica_url
+            .as_deref()
+            .unwrap_or("")
+            .to_string();
         Self::track_property(props, "database.url", &db_url, "", profile_str);
+        Self::track_property(props, "database.primary_url", &primary_url, "", profile_str);
+        Self::track_property(props, "database.replica_url", &replica_url, "", profile_str);
         Self::track_property(
             props,
             "database.pool_size",
             &config.database.pool_size.to_string(),
             &defaults.database.pool_size.to_string(),
+            profile_str,
+        );
+        Self::track_property(
+            props,
+            "database.primary_pool_size",
+            &config.database.effective_primary_pool_size().to_string(),
+            &defaults.database.effective_primary_pool_size().to_string(),
+            profile_str,
+        );
+        Self::track_property(
+            props,
+            "database.replica_pool_size",
+            &config.database.effective_replica_pool_size().to_string(),
+            &defaults.database.effective_replica_pool_size().to_string(),
+            profile_str,
+        );
+        Self::track_property(
+            props,
+            "database.replica_fallback",
+            &format!("{:?}", config.database.replica_fallback),
+            &format!("{:?}", defaults.database.replica_fallback),
             profile_str,
         );
     }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -3272,7 +3272,7 @@ async fn setup_database(
             config.database.replica_url.as_deref(),
         ) {
             (Some(primary_url), Some(replica_url)) => Some(
-                check_replica_migration_readiness_blocking(
+                crate::migrate::check_replica_migration_readiness_blocking(
                     primary_url.to_owned(),
                     replica_url.to_owned(),
                 )
@@ -3291,22 +3291,6 @@ async fn setup_database(
 }
 
 #[cfg(feature = "db")]
-async fn check_replica_migration_readiness_blocking(
-    primary_url: String,
-    replica_url: String,
-) -> crate::migrate::ReplicaMigrationReadiness {
-    tokio::task::spawn_blocking(move || {
-        crate::migrate::check_replica_migration_readiness(&primary_url, &replica_url)
-    })
-    .await
-    .unwrap_or_else(|error| {
-        crate::migrate::ReplicaMigrationReadiness::Unknown(format!(
-            "replica migration readiness task failed: {error}"
-        ))
-    })
-}
-
-#[cfg(feature = "db")]
 fn apply_replica_migration_readiness(
     state: &AppState,
     readiness: Option<crate::migrate::ReplicaMigrationReadiness>,
@@ -3318,7 +3302,7 @@ fn apply_replica_migration_readiness(
     if readiness.is_ready() {
         state.probes().mark_replica_migrations_ready();
     } else if let Some(detail) = readiness.detail() {
-        state.probes().mark_replica_unready(detail);
+        state.probes().mark_replica_migrations_unready(detail);
     }
 }
 
@@ -4019,6 +4003,14 @@ fn build_state(
         state
             .probes()
             .configure_replica_dependency(config.database.replica_fallback);
+        if let (Some(primary_url), Some(replica_url)) = (
+            config.database.effective_primary_url(),
+            config.database.replica_url.as_deref(),
+        ) {
+            state
+                .probes()
+                .configure_replica_migration_check(primary_url, replica_url);
+        }
     }
     state.insert_extension(config.clone());
     state
@@ -4305,6 +4297,32 @@ mod tests {
     }
 
     #[cfg(feature = "db")]
+    #[test]
+    fn build_state_configures_replica_migration_recheck_urls() {
+        let mut config = AutumnConfig::default();
+        config.database.primary_url = Some("postgres://localhost/primary".to_owned());
+        config.database.replica_url = Some("postgres://localhost/replica".to_owned());
+        let topology = crate::db::create_topology(&config.database)
+            .expect("topology should build")
+            .expect("database should be configured");
+
+        let state = build_state(
+            &config,
+            Some(topology),
+            #[cfg(feature = "ws")]
+            None,
+        );
+
+        let check = state
+            .probes()
+            .replica_migration_check()
+            .expect("replica migration check should be configured");
+
+        assert_eq!(check.primary_url, "postgres://localhost/primary");
+        assert_eq!(check.replica_url, "postgres://localhost/replica");
+    }
+
+    #[cfg(feature = "db")]
     #[tokio::test]
     async fn replica_migration_readiness_marks_ready_endpoint_degraded() {
         let mut config = AutumnConfig::default();
@@ -4339,7 +4357,7 @@ mod tests {
     #[cfg(feature = "db")]
     #[tokio::test]
     async fn blocking_replica_migration_readiness_reports_unknown_connection_errors() {
-        let readiness = check_replica_migration_readiness_blocking(
+        let readiness = crate::migrate::check_replica_migration_readiness_blocking(
             "not-a-primary-url".to_owned(),
             "not-a-replica-url".to_owned(),
         )

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1014,7 +1014,7 @@ impl AppBuilder {
         self
     }
 
-    /// Install a custom [`DatabasePoolProvider`],
+    /// Install a custom [`crate::db::DatabasePoolProvider`],
     /// replacing the default `deadpool + diesel-async` pool factory.
     ///
     /// Useful for adding metrics/circuit-breaker wrappers, switching to a

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1547,6 +1547,8 @@ impl AppBuilder {
         let pool = database.topology;
         #[cfg(feature = "db")]
         let replica_readiness = database.replica_readiness;
+        #[cfg(feature = "db")]
+        let replica_migration_check = database.replica_migration_check;
 
         #[cfg(feature = "db")]
         if pool.is_some() {
@@ -1577,6 +1579,8 @@ impl AppBuilder {
             #[cfg(feature = "ws")]
             channels_backend,
         );
+        #[cfg(feature = "db")]
+        configure_replica_migration_check(&state, replica_migration_check);
         #[cfg(feature = "db")]
         apply_replica_migration_readiness(&state, replica_readiness);
         if let Some(cache) = cache_backend {
@@ -1899,6 +1903,8 @@ impl AppBuilder {
         let pool = database.topology;
         #[cfg(feature = "db")]
         let replica_readiness = database.replica_readiness;
+        #[cfg(feature = "db")]
+        let replica_migration_check = database.replica_migration_check;
 
         let mut state = build_state(
             &config,
@@ -1907,6 +1913,8 @@ impl AppBuilder {
             #[cfg(feature = "ws")]
             channels_backend,
         );
+        #[cfg(feature = "db")]
+        configure_replica_migration_check(&state, replica_migration_check);
         #[cfg(feature = "db")]
         apply_replica_migration_readiness(&state, replica_readiness);
         if let Some(cache) = cache_backend {
@@ -2194,6 +2202,8 @@ impl AppBuilder {
         let pool = database.topology;
         #[cfg(feature = "db")]
         let replica_readiness = database.replica_readiness;
+        #[cfg(feature = "db")]
+        let replica_migration_check = database.replica_migration_check;
 
         let mut state = build_state(
             &config,
@@ -2202,6 +2212,8 @@ impl AppBuilder {
             #[cfg(feature = "ws")]
             channels_backend,
         );
+        #[cfg(feature = "db")]
+        configure_replica_migration_check(&state, replica_migration_check);
         #[cfg(feature = "db")]
         apply_replica_migration_readiness(&state, replica_readiness);
         if let Some(cache) = cache_backend {
@@ -3229,6 +3241,7 @@ fn install_i18n_bundle_layer(
 struct DatabaseBootstrap {
     topology: Option<crate::db::DatabaseTopology>,
     replica_readiness: Option<crate::migrate::ReplicaMigrationReadiness>,
+    replica_migration_check: Option<(String, String)>,
 }
 
 #[cfg(feature = "db")]
@@ -3263,7 +3276,7 @@ async fn setup_database(
         }
     }
 
-    let replica_readiness = if topology
+    let (replica_readiness, replica_migration_check) = if topology
         .as_ref()
         .is_some_and(|topology| check_replica_migrations && topology.replica().is_some())
     {
@@ -3271,22 +3284,26 @@ async fn setup_database(
             config.database.effective_primary_url(),
             config.database.replica_url.as_deref(),
         ) {
-            (Some(primary_url), Some(replica_url)) => Some(
-                crate::migrate::check_replica_migration_readiness_blocking(
-                    primary_url.to_owned(),
-                    replica_url.to_owned(),
+            (Some(primary_url), Some(replica_url)) => {
+                let primary_url = primary_url.to_owned();
+                let replica_url = replica_url.to_owned();
+                let readiness = crate::migrate::check_replica_migration_readiness_blocking(
+                    primary_url.clone(),
+                    replica_url.clone(),
                 )
-                .await,
-            ),
-            _ => None,
+                .await;
+                (Some(readiness), Some((primary_url, replica_url)))
+            }
+            _ => (None, None),
         }
     } else {
-        None
+        (None, None)
     };
 
     Ok(DatabaseBootstrap {
         topology,
         replica_readiness,
+        replica_migration_check,
     })
 }
 
@@ -3304,6 +3321,17 @@ fn apply_replica_migration_readiness(
     } else if let Some(detail) = readiness.detail() {
         state.probes().mark_replica_migrations_unready(detail);
     }
+}
+
+#[cfg(feature = "db")]
+fn configure_replica_migration_check(state: &AppState, check: Option<(String, String)>) {
+    let Some((primary_url, replica_url)) = check else {
+        return;
+    };
+
+    state
+        .probes()
+        .configure_replica_migration_check(primary_url, replica_url);
 }
 
 /// Refuse to start when a `#[repository(api = ...)]`-mounted route
@@ -3999,14 +4027,6 @@ fn build_state(
         state
             .probes()
             .configure_replica_dependency(config.database.replica_fallback);
-        if let (Some(primary_url), Some(replica_url)) = (
-            config.database.effective_primary_url(),
-            config.database.replica_url.as_deref(),
-        ) {
-            state
-                .probes()
-                .configure_replica_migration_check(primary_url, replica_url);
-        }
     }
     state.insert_extension(config.clone());
     state
@@ -4294,7 +4314,7 @@ mod tests {
 
     #[cfg(feature = "db")]
     #[test]
-    fn build_state_configures_replica_migration_recheck_urls() {
+    fn configure_replica_migration_check_stores_recheck_urls() {
         let mut config = AutumnConfig::default();
         config.database.primary_url = Some("postgres://localhost/primary".to_owned());
         config.database.replica_url = Some("postgres://localhost/replica".to_owned());
@@ -4307,6 +4327,19 @@ mod tests {
             Some(&topology),
             #[cfg(feature = "ws")]
             None,
+        );
+
+        assert!(
+            state.probes().replica_migration_check().is_none(),
+            "build_state should not enable migration checks without registered migrations"
+        );
+
+        configure_replica_migration_check(
+            &state,
+            Some((
+                "postgres://localhost/primary".to_owned(),
+                "postgres://localhost/replica".to_owned(),
+            )),
         );
 
         let check = state

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -34,8 +34,6 @@ use futures::FutureExt as _;
 use tracing::Instrument as _;
 
 use crate::config::{AutumnConfig, ConfigLoader};
-#[cfg(feature = "db")]
-use crate::db::DatabasePoolProvider;
 use crate::error_pages::{ErrorPageRenderer, SharedRenderer};
 use crate::middleware::exception_filter::ExceptionFilter;
 #[cfg(feature = "db")]
@@ -1355,9 +1353,12 @@ impl AppBuilder {
     /// Register embedded Diesel migrations with the application.
     ///
     /// When migrations are registered:
+    /// - They always target the primary/write database role
+    ///   (`database.primary_url`, falling back to legacy `database.url`).
     /// - In **dev** mode, pending migrations run automatically on startup.
     /// - In **prod** mode, pending migrations are logged as warnings but
-    ///   not applied -- use `autumn migrate` to apply them explicitly.
+    ///   not applied -- use a one-shot `autumn migrate` job before rolling web
+    ///   replicas.
     ///
     /// # Examples
     ///
@@ -1536,18 +1537,24 @@ impl AppBuilder {
 
         // 5. Create database pool and run migrations (if configured)
         #[cfg(feature = "db")]
-        let pool = setup_database(&config, migrations, pool_provider_factory)
+        let database = setup_database(&config, migrations, pool_provider_factory)
             .await
             .unwrap_or_else(|e| {
                 tracing::error!("{e}");
                 std::process::exit(1);
             });
+        #[cfg(feature = "db")]
+        let pool = database.topology;
+        #[cfg(feature = "db")]
+        let replica_readiness = database.replica_readiness;
 
         #[cfg(feature = "db")]
         if pool.is_some() {
             tracing::info!(
-                max_connections = config.database.pool_size,
-                "Database pool configured"
+                primary_max_connections = config.database.effective_primary_pool_size(),
+                replica_configured = config.database.replica_url.is_some(),
+                replica_max_connections = config.database.effective_replica_pool_size(),
+                "Database topology configured"
             );
         } else {
             tracing::info!("Database not configured");
@@ -1570,6 +1577,8 @@ impl AppBuilder {
             #[cfg(feature = "ws")]
             channels_backend,
         );
+        #[cfg(feature = "db")]
+        apply_replica_migration_readiness(&state, replica_readiness);
         if let Some(cache) = cache_backend {
             crate::cache::set_global_cache(cache.clone());
             state.shared_cache = Some(cache);
@@ -1880,12 +1889,16 @@ impl AppBuilder {
 
         // Build state (with DB if configured)
         #[cfg(feature = "db")]
-        let pool = setup_database(&config, vec![], pool_provider_factory)
+        let database = setup_database(&config, vec![], pool_provider_factory)
             .await
             .unwrap_or_else(|e| {
                 eprintln!("{e}");
                 std::process::exit(1);
             });
+        #[cfg(feature = "db")]
+        let pool = database.topology;
+        #[cfg(feature = "db")]
+        let replica_readiness = database.replica_readiness;
 
         let mut state = build_state(
             &config,
@@ -1894,6 +1907,8 @@ impl AppBuilder {
             #[cfg(feature = "ws")]
             channels_backend,
         );
+        #[cfg(feature = "db")]
+        apply_replica_migration_readiness(&state, replica_readiness);
         if let Some(cache) = cache_backend {
             crate::cache::set_global_cache(cache.clone());
             state.shared_cache = Some(cache);
@@ -2169,12 +2184,16 @@ impl AppBuilder {
         );
 
         #[cfg(feature = "db")]
-        let pool = setup_database(&config, migrations, pool_provider_factory)
+        let database = setup_database(&config, migrations, pool_provider_factory)
             .await
             .unwrap_or_else(|error| {
                 eprintln!("{error}");
                 std::process::exit(1);
             });
+        #[cfg(feature = "db")]
+        let pool = database.topology;
+        #[cfg(feature = "db")]
+        let replica_readiness = database.replica_readiness;
 
         let mut state = build_state(
             &config,
@@ -2183,6 +2202,8 @@ impl AppBuilder {
             #[cfg(feature = "ws")]
             channels_backend,
         );
+        #[cfg(feature = "db")]
+        apply_replica_migration_readiness(&state, replica_readiness);
         if let Some(cache) = cache_backend {
             crate::cache::set_global_cache(cache.clone());
             state.shared_cache = Some(cache);
@@ -3205,21 +3226,23 @@ fn install_i18n_bundle_layer(
 }
 
 #[cfg(feature = "db")]
+struct DatabaseBootstrap {
+    topology: Option<crate::db::DatabaseTopology>,
+    replica_readiness: Option<crate::migrate::ReplicaMigrationReadiness>,
+}
+
+#[cfg(feature = "db")]
 async fn setup_database(
     config: &AutumnConfig,
     migrations: Vec<crate::migrate::EmbeddedMigrations>,
     pool_provider: Option<PoolProviderFactory>,
-) -> Result<
-    Option<diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>,
-    String,
-> {
-    let pool = match pool_provider {
-        Some(factory) => factory(config.database.clone()).await,
-        None => {
-            crate::db::DieselDeadpoolPoolProvider::new()
-                .create_pool(&config.database)
-                .await
-        }
+) -> Result<DatabaseBootstrap, String> {
+    let check_replica_migrations = !migrations.is_empty();
+    let topology = match pool_provider {
+        Some(factory) => factory(config.database.clone())
+            .await
+            .map(|pool| pool.map(crate::db::DatabaseTopology::primary_only)),
+        None => crate::db::create_topology(&config.database),
     }
     .map_err(|e| format!("Failed to create database pool: {e}"))?;
 
@@ -3227,8 +3250,8 @@ async fn setup_database(
     // `Ok(None)`) — even if `database.url` is configured. Custom providers
     // signal "this app runs without a DB" by returning None; running
     // migrations against the URL anyway would defeat the opt-out.
-    if pool.is_some()
-        && let Some(url) = &config.database.url
+    if topology.is_some()
+        && let Some(url) = config.database.effective_primary_url()
     {
         for mig in migrations {
             crate::migrate::auto_migrate(
@@ -3240,7 +3263,38 @@ async fn setup_database(
         }
     }
 
-    Ok(pool)
+    let replica_readiness = topology.as_ref().and_then(|topology| {
+        if !check_replica_migrations || topology.replica().is_none() {
+            return None;
+        }
+        let primary_url = config.database.effective_primary_url()?;
+        let replica_url = config.database.replica_url.as_deref()?;
+        Some(crate::migrate::check_replica_migration_readiness(
+            primary_url,
+            replica_url,
+        ))
+    });
+
+    Ok(DatabaseBootstrap {
+        topology,
+        replica_readiness,
+    })
+}
+
+#[cfg(feature = "db")]
+fn apply_replica_migration_readiness(
+    state: &AppState,
+    readiness: Option<crate::migrate::ReplicaMigrationReadiness>,
+) {
+    let Some(readiness) = readiness else {
+        return;
+    };
+
+    if readiness.is_ready() {
+        state.probes().mark_replica_ready();
+    } else if let Some(detail) = readiness.detail() {
+        state.probes().mark_replica_unready(detail);
+    }
 }
 
 /// Refuse to start when a `#[repository(api = ...)]`-mounted route
@@ -3890,9 +3944,7 @@ mod validate_repository_api_policies_tests {
 
 fn build_state(
     config: &AutumnConfig,
-    #[cfg(feature = "db")] pool: Option<
-        diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
-    >,
+    #[cfg(feature = "db")] database_topology: Option<crate::db::DatabaseTopology>,
     #[cfg(feature = "ws")] channels_backend: Option<Arc<dyn crate::channels::ChannelsBackend>>,
 ) -> AppState {
     #[cfg(feature = "ws")]
@@ -3912,7 +3964,13 @@ fn build_state(
     let state = AppState {
         extensions: std::sync::Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
         #[cfg(feature = "db")]
-        pool,
+        pool: database_topology
+            .as_ref()
+            .map(|topology| topology.primary().clone()),
+        #[cfg(feature = "db")]
+        replica_pool: database_topology
+            .as_ref()
+            .and_then(|topology| topology.replica().cloned()),
         profile: config.profile.clone(),
         started_at: std::time::Instant::now(),
         health_detailed: config.health.detailed,
@@ -3931,6 +3989,12 @@ fn build_state(
         auth_session_key: config.auth.session_key.clone(),
         shared_cache: None,
     };
+    #[cfg(feature = "db")]
+    if state.replica_pool.is_some() {
+        state
+            .probes()
+            .configure_replica_dependency(config.database.replica_fallback);
+    }
     state.insert_extension(config.clone());
     state
 }
@@ -4037,9 +4101,19 @@ fn mask_database_url(url: &str, pool_size: usize) -> String {
 /// Build the configuration summary string.
 fn format_config_summary(config: &AutumnConfig) -> String {
     let profile = config.profile.as_deref().unwrap_or("none");
-    let db_status = config.database.url.as_deref().map_or_else(
+    let db_status = config.database.effective_primary_url().map_or_else(
         || "not configured".to_owned(),
-        |url| mask_database_url(url, config.database.pool_size),
+        |url| {
+            let primary = mask_database_url(url, config.database.effective_primary_pool_size());
+            if config.database.replica_url.is_some() {
+                format!(
+                    "primary={primary}, replica=configured (pool_size={})",
+                    config.database.effective_replica_pool_size()
+                )
+            } else {
+                primary
+            }
+        },
     );
     let telemetry_status = if config.telemetry.enabled {
         let endpoint = config
@@ -4156,6 +4230,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
@@ -4175,6 +4251,64 @@ mod tests {
             shared_cache: None,
         };
         crate::router::build_router(routes, &config, state)
+    }
+
+    #[cfg(feature = "db")]
+    #[test]
+    fn build_state_applies_replica_fallback_policy_to_read_routing() {
+        let mut config = AutumnConfig::default();
+        config.database.primary_url = Some("postgres://localhost/primary".to_owned());
+        config.database.primary_pool_size = Some(5);
+        config.database.replica_url = Some("postgres://localhost/replica".to_owned());
+        config.database.replica_pool_size = Some(2);
+        config.database.replica_fallback = crate::config::ReplicaFallback::Primary;
+        let topology = crate::db::create_topology(&config.database)
+            .expect("topology should build")
+            .expect("database should be configured");
+
+        let state = build_state(
+            &config,
+            Some(topology),
+            #[cfg(feature = "ws")]
+            None,
+        );
+        state
+            .probes()
+            .mark_replica_unready("replica migrations lag primary");
+
+        assert_eq!(state.read_pool().expect("read pool").status().max_size, 5);
+    }
+
+    #[cfg(feature = "db")]
+    #[test]
+    fn replica_migration_readiness_marks_ready_endpoint_degraded() {
+        let mut config = AutumnConfig::default();
+        config.database.primary_url = Some("postgres://localhost/primary".to_owned());
+        config.database.primary_pool_size = Some(5);
+        config.database.replica_url = Some("postgres://localhost/replica".to_owned());
+        config.database.replica_pool_size = Some(2);
+        config.database.replica_fallback = crate::config::ReplicaFallback::FailReadiness;
+        let topology = crate::db::create_topology(&config.database)
+            .expect("topology should build")
+            .expect("database should be configured");
+        let state = build_state(
+            &config,
+            Some(topology),
+            #[cfg(feature = "ws")]
+            None,
+        );
+
+        apply_replica_migration_readiness(
+            &state,
+            Some(crate::migrate::ReplicaMigrationReadiness::Stale {
+                primary_latest: Some("00000000000002".to_owned()),
+                replica_latest: Some("00000000000001".to_owned()),
+            }),
+        );
+
+        let (status, _) = crate::probe::readiness_response(&state);
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[cfg(feature = "ws")]
@@ -4671,6 +4805,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
@@ -4770,6 +4906,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
@@ -4843,6 +4981,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
@@ -5129,6 +5269,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
@@ -5429,6 +5571,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
@@ -5573,6 +5717,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
@@ -5615,6 +5761,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
@@ -5867,6 +6015,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
@@ -5933,6 +6083,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -3263,21 +3263,46 @@ async fn setup_database(
         }
     }
 
-    let replica_readiness = topology.as_ref().and_then(|topology| {
-        if !check_replica_migrations || topology.replica().is_none() {
-            return None;
+    let replica_readiness = if topology
+        .as_ref()
+        .is_some_and(|topology| check_replica_migrations && topology.replica().is_some())
+    {
+        match (
+            config.database.effective_primary_url(),
+            config.database.replica_url.as_deref(),
+        ) {
+            (Some(primary_url), Some(replica_url)) => Some(
+                check_replica_migration_readiness_blocking(
+                    primary_url.to_owned(),
+                    replica_url.to_owned(),
+                )
+                .await,
+            ),
+            _ => None,
         }
-        let primary_url = config.database.effective_primary_url()?;
-        let replica_url = config.database.replica_url.as_deref()?;
-        Some(crate::migrate::check_replica_migration_readiness(
-            primary_url,
-            replica_url,
-        ))
-    });
+    } else {
+        None
+    };
 
     Ok(DatabaseBootstrap {
         topology,
         replica_readiness,
+    })
+}
+
+#[cfg(feature = "db")]
+async fn check_replica_migration_readiness_blocking(
+    primary_url: String,
+    replica_url: String,
+) -> crate::migrate::ReplicaMigrationReadiness {
+    tokio::task::spawn_blocking(move || {
+        crate::migrate::check_replica_migration_readiness(&primary_url, &replica_url)
+    })
+    .await
+    .unwrap_or_else(|error| {
+        crate::migrate::ReplicaMigrationReadiness::Unknown(format!(
+            "replica migration readiness task failed: {error}"
+        ))
     })
 }
 
@@ -3291,7 +3316,7 @@ fn apply_replica_migration_readiness(
     };
 
     if readiness.is_ready() {
-        state.probes().mark_replica_ready();
+        state.probes().mark_replica_migrations_ready();
     } else if let Some(detail) = readiness.detail() {
         state.probes().mark_replica_unready(detail);
     }
@@ -4280,8 +4305,8 @@ mod tests {
     }
 
     #[cfg(feature = "db")]
-    #[test]
-    fn replica_migration_readiness_marks_ready_endpoint_degraded() {
+    #[tokio::test]
+    async fn replica_migration_readiness_marks_ready_endpoint_degraded() {
         let mut config = AutumnConfig::default();
         config.database.primary_url = Some("postgres://localhost/primary".to_owned());
         config.database.primary_pool_size = Some(5);
@@ -4306,9 +4331,24 @@ mod tests {
             }),
         );
 
-        let (status, _) = crate::probe::readiness_response(&state);
+        let (status, _) = crate::probe::readiness_response(&state).await;
 
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[cfg(feature = "db")]
+    #[tokio::test]
+    async fn blocking_replica_migration_readiness_reports_unknown_connection_errors() {
+        let readiness = check_replica_migration_readiness_blocking(
+            "not-a-primary-url".to_owned(),
+            "not-a-replica-url".to_owned(),
+        )
+        .await;
+
+        assert!(matches!(
+            readiness,
+            crate::migrate::ReplicaMigrationReadiness::Unknown(_)
+        ));
     }
 
     #[cfg(feature = "ws")]

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -135,14 +135,7 @@ type PoolProviderFactory = Box<
         ) -> Pin<
             Box<
                 dyn Future<
-                        Output = Result<
-                            Option<
-                                diesel_async::pooled_connection::deadpool::Pool<
-                                    diesel_async::AsyncPgConnection,
-                                >,
-                            >,
-                            crate::db::PoolError,
-                        >,
+                        Output = Result<Option<crate::db::DatabaseTopology>, crate::db::PoolError>,
                     > + Send,
             >,
         > + Send,
@@ -1034,7 +1027,7 @@ impl AppBuilder {
         }
         self.pool_provider_factory =
             Some(Box::new(move |config: crate::config::DatabaseConfig| {
-                Box::pin(async move { provider.create_pool(&config).await })
+                Box::pin(async move { provider.create_topology(&config).await })
             }));
         self
     }
@@ -3252,9 +3245,7 @@ async fn setup_database(
 ) -> Result<DatabaseBootstrap, String> {
     let check_replica_migrations = !migrations.is_empty();
     let topology = match pool_provider {
-        Some(factory) => factory(config.database.clone())
-            .await
-            .map(|pool| pool.map(crate::db::DatabaseTopology::primary_only)),
+        Some(factory) => factory(config.database.clone()).await,
         None => crate::db::create_topology(&config.database),
     }
     .map_err(|e| format!("Failed to create database pool: {e}"))?;
@@ -4310,6 +4301,68 @@ mod tests {
             .mark_replica_unready("replica migrations lag primary");
 
         assert_eq!(state.read_pool().expect("read pool").status().max_size, 5);
+    }
+
+    #[cfg(feature = "db")]
+    #[tokio::test]
+    async fn custom_pool_provider_preserves_configured_replica_topology() {
+        struct PassthroughPoolProvider;
+
+        impl crate::db::DatabasePoolProvider for PassthroughPoolProvider {
+            async fn create_pool(
+                &self,
+                config: &crate::config::DatabaseConfig,
+            ) -> Result<
+                Option<
+                    diesel_async::pooled_connection::deadpool::Pool<
+                        diesel_async::AsyncPgConnection,
+                    >,
+                >,
+                crate::db::PoolError,
+            > {
+                crate::db::create_pool(config)
+            }
+        }
+
+        let mut config = AutumnConfig::default();
+        config.database.primary_url = Some("postgres://localhost/primary".to_owned());
+        config.database.primary_pool_size = Some(5);
+        config.database.replica_url = Some("postgres://localhost/replica".to_owned());
+        config.database.replica_pool_size = Some(2);
+        config.database.replica_fallback = crate::config::ReplicaFallback::FailReadiness;
+        let AppBuilder {
+            pool_provider_factory,
+            ..
+        } = app().with_pool_provider(PassthroughPoolProvider);
+
+        let database = setup_database(&config, Vec::new(), pool_provider_factory)
+            .await
+            .expect("custom provider should build database topology");
+        let topology = database.topology.expect("database should be configured");
+
+        assert_eq!(topology.primary().status().max_size, 5);
+        assert_eq!(
+            topology
+                .replica()
+                .expect("custom provider should create replica pool")
+                .status()
+                .max_size,
+            2
+        );
+
+        let state = build_state(
+            &config,
+            Some(&topology),
+            #[cfg(feature = "ws")]
+            None,
+        );
+        state
+            .probes()
+            .mark_replica_connection_unready("replica connection failed");
+
+        assert!(state.read_pool().is_none());
+        let (status, _) = crate::probe::readiness_response(&state).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[cfg(feature = "db")]

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1573,7 +1573,7 @@ impl AppBuilder {
         let mut state = build_state(
             &config,
             #[cfg(feature = "db")]
-            pool,
+            pool.as_ref(),
             #[cfg(feature = "ws")]
             channels_backend,
         );
@@ -1903,7 +1903,7 @@ impl AppBuilder {
         let mut state = build_state(
             &config,
             #[cfg(feature = "db")]
-            pool,
+            pool.as_ref(),
             #[cfg(feature = "ws")]
             channels_backend,
         );
@@ -2198,7 +2198,7 @@ impl AppBuilder {
         let mut state = build_state(
             &config,
             #[cfg(feature = "db")]
-            pool,
+            pool.as_ref(),
             #[cfg(feature = "ws")]
             channels_backend,
         );
@@ -3953,7 +3953,7 @@ mod validate_repository_api_policies_tests {
 
 fn build_state(
     config: &AutumnConfig,
-    #[cfg(feature = "db")] database_topology: Option<crate::db::DatabaseTopology>,
+    #[cfg(feature = "db")] database_topology: Option<&crate::db::DatabaseTopology>,
     #[cfg(feature = "ws")] channels_backend: Option<Arc<dyn crate::channels::ChannelsBackend>>,
 ) -> AppState {
     #[cfg(feature = "ws")]
@@ -3973,13 +3973,9 @@ fn build_state(
     let state = AppState {
         extensions: std::sync::Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
         #[cfg(feature = "db")]
-        pool: database_topology
-            .as_ref()
-            .map(|topology| topology.primary().clone()),
+        pool: database_topology.map(|topology| topology.primary().clone()),
         #[cfg(feature = "db")]
-        replica_pool: database_topology
-            .as_ref()
-            .and_then(|topology| topology.replica().cloned()),
+        replica_pool: database_topology.and_then(|topology| topology.replica().cloned()),
         profile: config.profile.clone(),
         started_at: std::time::Instant::now(),
         health_detailed: config.health.detailed,
@@ -4285,7 +4281,7 @@ mod tests {
 
         let state = build_state(
             &config,
-            Some(topology),
+            Some(&topology),
             #[cfg(feature = "ws")]
             None,
         );
@@ -4308,7 +4304,7 @@ mod tests {
 
         let state = build_state(
             &config,
-            Some(topology),
+            Some(&topology),
             #[cfg(feature = "ws")]
             None,
         );
@@ -4336,7 +4332,7 @@ mod tests {
             .expect("database should be configured");
         let state = build_state(
             &config,
-            Some(topology),
+            Some(&topology),
             #[cfg(feature = "ws")]
             None,
         );

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -1623,6 +1623,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
@@ -1680,6 +1682,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
@@ -1745,6 +1749,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
@@ -1866,6 +1872,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
@@ -1937,6 +1945,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
@@ -2013,6 +2023,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
@@ -2085,6 +2097,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
@@ -2150,6 +2164,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -41,7 +41,12 @@
 //! | `AUTUMN_SERVER__HOST` | `server.host` | `String` |
 //! | `AUTUMN_SERVER__SHUTDOWN_TIMEOUT_SECS` | `server.shutdown_timeout_secs` | `u64` |
 //! | `AUTUMN_DATABASE__URL` | `database.url` | `String` |
+//! | `AUTUMN_DATABASE__PRIMARY_URL` | `database.primary_url` | `String` |
+//! | `AUTUMN_DATABASE__REPLICA_URL` | `database.replica_url` | `String` |
 //! | `AUTUMN_DATABASE__POOL_SIZE` | `database.pool_size` | `usize` |
+//! | `AUTUMN_DATABASE__PRIMARY_POOL_SIZE` | `database.primary_pool_size` | `usize` |
+//! | `AUTUMN_DATABASE__REPLICA_POOL_SIZE` | `database.replica_pool_size` | `usize` |
+//! | `AUTUMN_DATABASE__REPLICA_FALLBACK` | `database.replica_fallback` | `fail_readiness` / `primary` |
 //! | `AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS` | `database.connect_timeout_secs` | `u64` |
 //! | `AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION` | `database.auto_migrate_in_production` | `bool` |
 //! | `AUTUMN_LOG__LEVEL` | `log.level` | tracing filter directive |
@@ -1243,6 +1248,11 @@ impl AutumnConfig {
     /// - `AUTUMN_SERVER__SHUTDOWN_TIMEOUT_SECS` → `server.shutdown_timeout_secs` (u64)
     ///
     /// # Database
+    /// - `AUTUMN_DATABASE__PRIMARY_URL` -> `database.primary_url` (String)
+    /// - `AUTUMN_DATABASE__REPLICA_URL` -> `database.replica_url` (String)
+    /// - `AUTUMN_DATABASE__PRIMARY_POOL_SIZE` -> `database.primary_pool_size` (usize)
+    /// - `AUTUMN_DATABASE__REPLICA_POOL_SIZE` -> `database.replica_pool_size` (usize)
+    /// - `AUTUMN_DATABASE__REPLICA_FALLBACK` -> `database.replica_fallback` (`fail_readiness` | `primary`)
     /// - `AUTUMN_DATABASE__URL` → `database.url` (String)
     /// - `AUTUMN_DATABASE__POOL_SIZE` → `database.pool_size` (usize)
     /// - `AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS` → `database.connect_timeout_secs` (u64)
@@ -1316,10 +1326,35 @@ impl AutumnConfig {
         if let Ok(val) = env.var("AUTUMN_DATABASE__URL") {
             self.database.url = Some(val);
         }
+        parse_env_option_string(
+            env,
+            "AUTUMN_DATABASE__PRIMARY_URL",
+            &mut self.database.primary_url,
+        );
+        parse_env_option_string(
+            env,
+            "AUTUMN_DATABASE__REPLICA_URL",
+            &mut self.database.replica_url,
+        );
         parse_env(
             env,
             "AUTUMN_DATABASE__POOL_SIZE",
             &mut self.database.pool_size,
+        );
+        parse_env_option(
+            env,
+            "AUTUMN_DATABASE__PRIMARY_POOL_SIZE",
+            &mut self.database.primary_pool_size,
+        );
+        parse_env_option(
+            env,
+            "AUTUMN_DATABASE__REPLICA_POOL_SIZE",
+            &mut self.database.replica_pool_size,
+        );
+        parse_env(
+            env,
+            "AUTUMN_DATABASE__REPLICA_FALLBACK",
+            &mut self.database.replica_fallback,
         );
         parse_env(
             env,
@@ -1896,6 +1931,30 @@ pub struct ServerConfig {
     pub shutdown_timeout_secs: u64,
 }
 
+/// Behavior when a configured read replica is unavailable or stale.
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ReplicaFallback {
+    /// Readiness should fail when the configured replica cannot safely serve reads.
+    #[default]
+    FailReadiness,
+    /// Read paths may use the primary when the replica is unavailable or stale.
+    Primary,
+}
+
+impl std::str::FromStr for ReplicaFallback {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "fail_readiness" | "fail-readiness" | "fail" => Ok(Self::FailReadiness),
+            "primary" | "fallback_to_primary" | "fallback-to-primary" => Ok(Self::Primary),
+            _ => Err(()),
+        }
+    }
+}
+
 /// Database connection configuration.
 ///
 /// When `url` is `None` (the default), the application runs without a
@@ -1908,7 +1967,12 @@ pub struct ServerConfig {
 /// | Field | Default |
 /// |-------|---------|
 /// | `url` | `None` |
+/// | `primary_url` | `None` |
+/// | `replica_url` | `None` |
 /// | `pool_size` | `10` |
+/// | `primary_pool_size` | `None` |
+/// | `replica_pool_size` | `None` |
+/// | `replica_fallback` | `fail_readiness` |
 /// | `connect_timeout_secs` | `5` |
 /// | `auto_migrate_in_production` | `false` |
 ///
@@ -1925,13 +1989,46 @@ pub struct ServerConfig {
 pub struct DatabaseConfig {
     /// Postgres connection URL. `None` means no database is configured.
     ///
+    /// Compatibility alias for the primary/write role. New multi-role
+    /// deployments should prefer [`primary_url`](Self::primary_url).
+    ///
     /// Must start with `postgres://` or `postgresql://` when present.
     #[serde(default)]
     pub url: Option<String>,
 
+    /// Postgres URL for the primary/write role.
+    ///
+    /// All writes, transactions, advisory locks, and migrations use this role.
+    /// When unset, [`url`](Self::url) remains the single-primary fallback.
+    #[serde(default)]
+    pub primary_url: Option<String>,
+
+    /// Optional Postgres URL for the read/replica role.
+    ///
+    /// Read-only paths may use this pool when configured. If omitted, read
+    /// paths use the primary role.
+    #[serde(default)]
+    pub replica_url: Option<String>,
+
     /// Maximum number of connections in the pool. Default: `10`.
+    ///
+    /// Compatibility/default pool size used for both roles unless a
+    /// role-specific size is set.
     #[serde(default = "default_pool_size")]
     pub pool_size: usize,
+
+    /// Optional primary/write role pool size.
+    #[serde(default)]
+    pub primary_pool_size: Option<usize>,
+
+    /// Optional read/replica role pool size.
+    #[serde(default)]
+    pub replica_pool_size: Option<usize>,
+
+    /// Deterministic behavior for configured replicas that cannot safely serve
+    /// reads. Default: fail readiness.
+    #[serde(default)]
+    pub replica_fallback: ReplicaFallback,
 
     /// Seconds to wait while acquiring a pooled connection, including
     /// creating a new connection when the pool grows.
@@ -1949,19 +2046,54 @@ pub struct DatabaseConfig {
 }
 
 impl DatabaseConfig {
+    /// Resolved primary/write database URL.
+    #[must_use]
+    pub fn effective_primary_url(&self) -> Option<&str> {
+        self.primary_url.as_deref().or(self.url.as_deref())
+    }
+
+    /// Resolved primary/write role pool size.
+    #[must_use]
+    pub fn effective_primary_pool_size(&self) -> usize {
+        self.primary_pool_size.unwrap_or(self.pool_size)
+    }
+
+    /// Resolved read/replica role pool size.
+    #[must_use]
+    pub fn effective_replica_pool_size(&self) -> usize {
+        self.replica_pool_size.unwrap_or(self.pool_size)
+    }
+
     /// Validate database configuration.
     ///
     /// # Errors
     ///
     /// Returns a validation error if the URL has an invalid scheme.
     pub fn validate(&self) -> Result<(), ConfigError> {
-        if let Some(ref url) = self.url
-            && !url.starts_with("postgres://")
-            && !url.starts_with("postgresql://")
-        {
-            return Err(ConfigError::Validation(format!(
-                "Invalid database URL: must start with postgres:// or postgresql://, got {url:?}"
-            )));
+        for (field, url) in [
+            ("database.url", self.url.as_deref()),
+            ("database.primary_url", self.primary_url.as_deref()),
+            ("database.replica_url", self.replica_url.as_deref()),
+        ] {
+            if let Some(url) = url
+                && !url.starts_with("postgres://")
+                && !url.starts_with("postgresql://")
+            {
+                let label = if field == "database.url" {
+                    "database URL"
+                } else {
+                    field
+                };
+                return Err(ConfigError::Validation(format!(
+                    "Invalid {label}: must start with postgres:// or postgresql://, got {url:?}"
+                )));
+            }
+        }
+
+        if self.replica_url.is_some() && self.effective_primary_url().is_none() {
+            return Err(ConfigError::Validation(
+                "database.replica_url requires database.primary_url or database.url".to_owned(),
+            ));
         }
         Ok(())
     }
@@ -2300,6 +2432,19 @@ fn parse_env_option_string(env: &dyn Env, key: &str, target: &mut Option<String>
     }
 }
 
+fn parse_env_option<T: std::str::FromStr>(env: &dyn Env, key: &str, target: &mut Option<T>) {
+    if let Ok(val) = env.var(key) {
+        if val.is_empty() {
+            *target = None;
+        } else {
+            match val.parse::<T>() {
+                Ok(v) => *target = Some(v),
+                Err(_) => eprintln!("Warning: {key}={val:?} is not valid, ignoring"),
+            }
+        }
+    }
+}
+
 fn parse_env_string(env: &dyn Env, key: &str, target: &mut String) {
     if let Ok(val) = env.var(key) {
         *target = val;
@@ -2392,7 +2537,12 @@ impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
             url: None,
+            primary_url: None,
+            replica_url: None,
             pool_size: default_pool_size(),
+            primary_pool_size: None,
+            replica_pool_size: None,
+            replica_fallback: ReplicaFallback::default(),
             connect_timeout_secs: default_connect_timeout(),
             auto_migrate_in_production: false,
         }
@@ -2660,6 +2810,101 @@ mod tests {
         } else {
             panic!("Expected ConfigError::Validation");
         }
+    }
+
+    #[test]
+    fn database_topology_deserializes_primary_and_replica_urls() {
+        let config: AutumnConfig = toml::from_str(
+            r#"
+[database]
+primary_url = "postgres://primary.example/app"
+replica_url = "postgres://replica.example/app"
+primary_pool_size = 12
+replica_pool_size = 4
+replica_fallback = "primary"
+"#,
+        )
+        .expect("database topology config should parse");
+
+        assert_eq!(
+            config.database.primary_url.as_deref(),
+            Some("postgres://primary.example/app")
+        );
+        assert_eq!(
+            config.database.replica_url.as_deref(),
+            Some("postgres://replica.example/app")
+        );
+        assert_eq!(config.database.primary_pool_size, Some(12));
+        assert_eq!(config.database.replica_pool_size, Some(4));
+        assert_eq!(config.database.replica_fallback, ReplicaFallback::Primary);
+        assert_eq!(
+            config.database.effective_primary_url(),
+            Some("postgres://primary.example/app")
+        );
+        assert_eq!(config.database.effective_primary_pool_size(), 12);
+        assert_eq!(config.database.effective_replica_pool_size(), 4);
+    }
+
+    #[test]
+    fn database_topology_keeps_url_as_single_primary_compatibility_path() {
+        let config: AutumnConfig = toml::from_str(
+            r#"
+[database]
+url = "postgres://single.example/app"
+pool_size = 7
+"#,
+        )
+        .expect("legacy database.url config should parse");
+
+        assert_eq!(
+            config.database.effective_primary_url(),
+            Some("postgres://single.example/app")
+        );
+        assert_eq!(config.database.effective_primary_pool_size(), 7);
+        assert_eq!(config.database.effective_replica_pool_size(), 7);
+        assert!(config.database.replica_url.is_none());
+    }
+
+    #[test]
+    fn database_topology_rejects_replica_without_primary() {
+        let config = DatabaseConfig {
+            replica_url: Some("postgres://replica.example/app".to_owned()),
+            ..Default::default()
+        };
+
+        let result = config.validate();
+
+        assert!(result.is_err());
+        let Err(ConfigError::Validation(message)) = result else {
+            panic!("expected database topology validation error");
+        };
+        assert!(message.contains("database.replica_url"));
+        assert!(message.contains("database.primary_url"));
+    }
+
+    #[test]
+    fn database_topology_env_overrides_role_fields() {
+        let env = MockEnv::new()
+            .with("AUTUMN_DATABASE__PRIMARY_URL", "postgres://primary.env/app")
+            .with("AUTUMN_DATABASE__REPLICA_URL", "postgres://replica.env/app")
+            .with("AUTUMN_DATABASE__PRIMARY_POOL_SIZE", "9")
+            .with("AUTUMN_DATABASE__REPLICA_POOL_SIZE", "3")
+            .with("AUTUMN_DATABASE__REPLICA_FALLBACK", "primary");
+        let mut config = AutumnConfig::default();
+
+        config.apply_env_overrides_with_env(&env);
+
+        assert_eq!(
+            config.database.primary_url.as_deref(),
+            Some("postgres://primary.env/app")
+        );
+        assert_eq!(
+            config.database.replica_url.as_deref(),
+            Some("postgres://replica.env/app")
+        );
+        assert_eq!(config.database.primary_pool_size, Some(9));
+        assert_eq!(config.database.replica_pool_size, Some(3));
+        assert_eq!(config.database.replica_fallback, ReplicaFallback::Primary);
     }
 
     #[test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1325,6 +1325,7 @@ impl AutumnConfig {
     fn apply_database_env_overrides_with_env(&mut self, env: &dyn Env) {
         if let Ok(val) = env.var("AUTUMN_DATABASE__URL") {
             self.database.url = Some(val);
+            self.database.primary_url = None;
         }
         parse_env_option_string(
             env,
@@ -3135,6 +3136,41 @@ path = "/healthz"
         assert_eq!(
             config.database.url.as_deref(),
             Some("postgres://override:5432/test")
+        );
+    }
+
+    #[test]
+    fn env_override_database_url_wins_over_file_primary_url() {
+        let env = MockEnv::new().with("AUTUMN_DATABASE__URL", "postgres://env.example/app");
+        let mut config = AutumnConfig::default();
+        config.database.primary_url = Some("postgres://file.example/app".to_owned());
+
+        config.apply_env_overrides_with_env(&env);
+
+        assert_eq!(
+            config.database.effective_primary_url(),
+            Some("postgres://env.example/app")
+        );
+        assert!(config.database.primary_url.is_none());
+    }
+
+    #[test]
+    fn env_override_database_primary_url_wins_over_legacy_database_url() {
+        let env = MockEnv::new()
+            .with("AUTUMN_DATABASE__URL", "postgres://legacy.env/app")
+            .with("AUTUMN_DATABASE__PRIMARY_URL", "postgres://primary.env/app");
+        let mut config = AutumnConfig::default();
+        config.database.primary_url = Some("postgres://file.example/app".to_owned());
+
+        config.apply_env_overrides_with_env(&env);
+
+        assert_eq!(
+            config.database.effective_primary_url(),
+            Some("postgres://primary.env/app")
+        );
+        assert_eq!(
+            config.database.url.as_deref(),
+            Some("postgres://legacy.env/app")
         );
     }
 

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -69,6 +69,18 @@ pub struct DatabaseTopology {
 }
 
 impl DatabaseTopology {
+    /// Build a topology from explicit primary and optional replica pools.
+    ///
+    /// This is useful for custom [`DatabasePoolProvider`] implementations that
+    /// need to create or decorate both roles themselves.
+    #[must_use]
+    pub const fn from_pools(
+        primary: Pool<AsyncPgConnection>,
+        replica: Option<Pool<AsyncPgConnection>>,
+    ) -> Self {
+        Self { primary, replica }
+    }
+
     /// Build a topology from a primary pool only.
     #[must_use]
     pub const fn primary_only(primary: Pool<AsyncPgConnection>) -> Self {
@@ -388,6 +400,12 @@ where
 /// (e.g. `MySQL`, `SQLite`) would require generic `Pool<C>` propagation through
 /// `Db` / `DbState` / `AppState` and is intentionally out of scope.
 ///
+/// Providers that only implement [`DatabasePoolProvider::create_pool`] still
+/// participate in primary/replica topology: the default
+/// [`DatabasePoolProvider::create_topology`] uses the custom primary pool and
+/// builds the configured replica role with Autumn's deadpool factory. Override
+/// `create_topology` when both roles need custom construction.
+///
 /// # Example
 ///
 /// ```rust,no_run
@@ -418,6 +436,39 @@ pub trait DatabasePoolProvider: Send + Sync + 'static {
         &self,
         config: &DatabaseConfig,
     ) -> impl std::future::Future<Output = Result<Option<Pool<AsyncPgConnection>>, PoolError>> + Send;
+
+    /// Create primary and optional replica pools from the resolved
+    /// [`DatabaseConfig`].
+    ///
+    /// The default implementation preserves the provider's custom primary pool
+    /// and builds a replica pool when `database.replica_url` is configured.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PoolError`] if either configured role cannot be built.
+    fn create_topology(
+        &self,
+        config: &DatabaseConfig,
+    ) -> impl std::future::Future<Output = Result<Option<DatabaseTopology>, PoolError>> + Send {
+        async move {
+            let Some(primary) = self.create_pool(config).await? else {
+                return Ok(None);
+            };
+            let replica = config
+                .replica_url
+                .as_deref()
+                .map(|url| {
+                    build_pool(
+                        url,
+                        config.effective_replica_pool_size(),
+                        config.connect_timeout_secs,
+                    )
+                })
+                .transpose()?;
+
+            Ok(Some(DatabaseTopology::from_pools(primary, replica)))
+        }
+    }
 }
 
 /// Default [`DatabasePoolProvider`] — the `deadpool + diesel-async` factory.

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -5,9 +5,9 @@
 //! [`AppBuilder::run`](crate::app::AppBuilder::run) and stored in
 //! [`crate::state::AppState`].
 //!
-//! When no `database.url` is configured, [`create_pool`] returns `Ok(None)`
-//! and the application runs without a database -- useful for static-site or
-//! API-gateway use cases.
+//! When no `database.primary_url` or legacy `database.url` is configured,
+//! [`create_pool`] returns `Ok(None)` and the application runs without a
+//! database -- useful for static-site or API-gateway use cases.
 //!
 //! # The [`Db`] extractor
 //!
@@ -41,6 +41,18 @@ use crate::error::AutumnError;
 pub trait DbState {
     /// Returns the database connection pool, if configured.
     fn pool(&self) -> Option<&Pool<AsyncPgConnection>>;
+
+    /// Returns the read/replica connection pool, if configured.
+    fn replica_pool(&self) -> Option<&Pool<AsyncPgConnection>> {
+        None
+    }
+
+    /// Returns the pool used for read-only work.
+    ///
+    /// Defaults to the replica role when present, otherwise the primary role.
+    fn read_pool(&self) -> Option<&Pool<AsyncPgConnection>> {
+        self.replica_pool().or_else(|| self.pool())
+    }
 }
 
 /// Error type for pool creation failures.
@@ -49,30 +61,112 @@ pub trait DbState {
 /// the pool cannot be constructed (e.g., invalid max-size configuration).
 pub type PoolError = diesel_async::pooled_connection::deadpool::BuildError;
 
+/// Primary plus optional read-replica database pools.
+#[derive(Clone)]
+pub struct DatabaseTopology {
+    primary: Pool<AsyncPgConnection>,
+    replica: Option<Pool<AsyncPgConnection>>,
+}
+
+impl DatabaseTopology {
+    /// Build a topology from a primary pool only.
+    #[must_use]
+    pub const fn primary_only(primary: Pool<AsyncPgConnection>) -> Self {
+        Self {
+            primary,
+            replica: None,
+        }
+    }
+
+    /// Primary/write role pool.
+    #[must_use]
+    pub const fn primary(&self) -> &Pool<AsyncPgConnection> {
+        &self.primary
+    }
+
+    /// Optional read/replica role pool.
+    #[must_use]
+    pub const fn replica(&self) -> Option<&Pool<AsyncPgConnection>> {
+        self.replica.as_ref()
+    }
+
+    /// Pool used for read-only work.
+    #[must_use]
+    pub fn read(&self) -> &Pool<AsyncPgConnection> {
+        self.replica.as_ref().unwrap_or(&self.primary)
+    }
+}
+
+fn build_pool(
+    url: &str,
+    pool_size: usize,
+    connect_timeout_secs: u64,
+) -> Result<Pool<AsyncPgConnection>, PoolError> {
+    let timeout = Duration::from_secs(connect_timeout_secs);
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
+    Pool::builder(manager)
+        .max_size(pool_size.max(1))
+        .wait_timeout(Some(timeout))
+        .create_timeout(Some(timeout))
+        .runtime(deadpool::Runtime::Tokio1)
+        .build()
+}
+
 /// Create a connection pool from the database configuration.
 ///
-/// Returns `Ok(None)` if no database URL is configured (`database.url` is
-/// absent or `null` in `autumn.toml`).
+/// Returns `Ok(None)` if no primary database URL is configured
+/// (`database.primary_url` and the legacy `database.url` are absent or `null`
+/// in `autumn.toml`).
 ///
 /// # Errors
 ///
 /// Returns [`PoolError`] if the pool cannot be built (e.g., invalid
 /// max-size configuration).
 pub fn create_pool(config: &DatabaseConfig) -> Result<Option<Pool<AsyncPgConnection>>, PoolError> {
-    let Some(url) = &config.url else {
+    let Some(url) = config.effective_primary_url() else {
         return Ok(None);
     };
 
-    let timeout = Duration::from_secs(config.connect_timeout_secs);
-    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
-    let pool = Pool::builder(manager)
-        .max_size(config.pool_size.max(1))
-        .wait_timeout(Some(timeout))
-        .create_timeout(Some(timeout))
-        .runtime(deadpool::Runtime::Tokio1)
-        .build()?;
+    let pool = build_pool(
+        url,
+        config.effective_primary_pool_size(),
+        config.connect_timeout_secs,
+    )?;
 
     Ok(Some(pool))
+}
+
+/// Create primary and optional replica pools from the database configuration.
+///
+/// Returns `Ok(None)` when neither `database.primary_url` nor the legacy
+/// `database.url` compatibility field is configured.
+///
+/// # Errors
+///
+/// Returns [`PoolError`] if either configured role cannot be built.
+pub fn create_topology(config: &DatabaseConfig) -> Result<Option<DatabaseTopology>, PoolError> {
+    let Some(primary_url) = config.effective_primary_url() else {
+        return Ok(None);
+    };
+
+    let primary = build_pool(
+        primary_url,
+        config.effective_primary_pool_size(),
+        config.connect_timeout_secs,
+    )?;
+    let replica = config
+        .replica_url
+        .as_deref()
+        .map(|url| {
+            build_pool(
+                url,
+                config.effective_replica_pool_size(),
+                config.connect_timeout_secs,
+            )
+        })
+        .transpose()?;
+
+    Ok(Some(DatabaseTopology { primary, replica }))
 }
 
 // ── Db extractor ─────────────────────────────────────────────
@@ -106,7 +200,8 @@ impl Drop for TxDepthGuard<'_> {
 /// `diesel_async::AsyncPgConnection`, so you can use it directly with
 /// Diesel query methods.
 ///
-/// If no database is configured (i.e., `database.url` is absent),
+/// If no database is configured (i.e., `database.primary_url` and legacy
+/// `database.url` are absent),
 /// requests that use `Db` will receive a `503 Service Unavailable`
 /// response.
 ///
@@ -471,6 +566,45 @@ mod tests {
     // ── Db extractor tests ───────────────────────────────────────
 
     #[test]
+    fn database_topology_builds_primary_and_replica_pools() {
+        let config = DatabaseConfig {
+            primary_url: Some("postgres://localhost/primary".into()),
+            replica_url: Some("postgres://localhost/replica".into()),
+            primary_pool_size: Some(6),
+            replica_pool_size: Some(2),
+            ..Default::default()
+        };
+
+        let topology = create_topology(&config)
+            .expect("topology should build")
+            .expect("topology should be configured");
+
+        assert_eq!(topology.primary().status().max_size, 6);
+        assert_eq!(
+            topology.replica().expect("replica pool").status().max_size,
+            2
+        );
+        assert_eq!(topology.read().status().max_size, 2);
+    }
+
+    #[test]
+    fn database_topology_single_url_builds_only_primary_pool() {
+        let config = DatabaseConfig {
+            url: Some("postgres://localhost/single".into()),
+            pool_size: 5,
+            ..Default::default()
+        };
+
+        let topology = create_topology(&config)
+            .expect("topology should build")
+            .expect("topology should be configured");
+
+        assert_eq!(topology.primary().status().max_size, 5);
+        assert!(topology.replica().is_none());
+        assert_eq!(topology.read().status().max_size, 5);
+    }
+
+    #[test]
     fn config_runtime_drift_pool_applies_connect_timeout_to_wait_and_create() {
         let config = DatabaseConfig {
             url: Some("postgres://localhost/test".into()),
@@ -493,6 +627,30 @@ mod tests {
         fn pool(&self) -> Option<&Pool<AsyncPgConnection>> {
             None
         }
+    }
+
+    #[derive(Clone)]
+    struct TestReadState {
+        primary: Pool<AsyncPgConnection>,
+    }
+
+    impl DbState for TestReadState {
+        fn pool(&self) -> Option<&Pool<AsyncPgConnection>> {
+            Some(&self.primary)
+        }
+    }
+
+    #[test]
+    fn database_topology_read_pool_falls_back_to_primary() {
+        let config = DatabaseConfig {
+            url: Some("postgres://localhost/read-fallback".into()),
+            pool_size: 3,
+            ..Default::default()
+        };
+        let primary = create_pool(&config).unwrap().unwrap();
+        let state = TestReadState { primary };
+
+        assert_eq!(state.read_pool().expect("read pool").status().max_size, 3);
     }
 
     #[tokio::test]

--- a/autumn/src/health.rs
+++ b/autumn/src/health.rs
@@ -45,7 +45,7 @@ use axum::response::IntoResponse;
 pub async fn handler<S: ProvideProbeState + Send + Sync + 'static>(
     State(state): State<S>,
 ) -> impl IntoResponse {
-    crate::probe::readiness_response(&state)
+    crate::probe::readiness_response(&state).await
 }
 
 #[cfg(test)]

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -523,7 +523,7 @@ pub trait MailDeliveryQueue: Send + Sync {
 
 /// Cloneable handle to a [`MailDeliveryQueue`].
 ///
-/// Designed for storage on [`AppState`](crate::AppState) extensions. Plugins
+/// Designed for storage on [`AppState`] extensions. Plugins
 /// (Harvest, custom Redis, etc.) install this before `install_mailer` runs and
 /// the mailer picks it up.
 #[derive(Clone)]

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -25,8 +25,8 @@
 //! }
 //! ```
 
-use diesel::Connection;
 use diesel::migration::Migration;
+use diesel::{Connection, RunQueryDsl};
 use diesel_migrations::{HarnessWithOutput, MigrationHarness};
 
 /// Re-export `EmbeddedMigrations` so users can reference it without adding
@@ -54,6 +54,51 @@ pub enum MigrationError {
     /// A migration failed to apply.
     #[error("migration failed: {0}")]
     Migration(String),
+}
+
+#[derive(diesel::QueryableByName)]
+struct AppliedMigrationVersion {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    version: String,
+}
+
+/// Runtime readiness state for a configured read replica's schema version.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ReplicaMigrationReadiness {
+    /// Primary and replica report the same applied migration versions.
+    Ready,
+    /// The replica is reachable but has not applied the same migrations.
+    Stale {
+        primary_latest: Option<String>,
+        replica_latest: Option<String>,
+    },
+    /// The framework could not determine replica migration state.
+    Unknown(String),
+}
+
+impl ReplicaMigrationReadiness {
+    /// Returns whether the replica can safely receive read traffic.
+    #[must_use]
+    pub(crate) const fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready)
+    }
+
+    /// Human-readable reason used in runtime readiness state.
+    #[must_use]
+    pub(crate) fn detail(&self) -> Option<String> {
+        match self {
+            Self::Ready => None,
+            Self::Stale {
+                primary_latest,
+                replica_latest,
+            } => Some(format!(
+                "replica migrations lag primary (primary_latest={}, replica_latest={})",
+                primary_latest.as_deref().unwrap_or("<none>"),
+                replica_latest.as_deref().unwrap_or("<none>")
+            )),
+            Self::Unknown(error) => Some(format!("replica migration readiness unknown: {error}")),
+        }
+    }
 }
 
 /// Run all pending migrations against the given database URL.
@@ -107,6 +152,56 @@ pub fn pending_migrations(
         .iter()
         .map(|m| m.name().version().to_string())
         .collect())
+}
+
+pub(crate) fn compare_replica_migration_versions(
+    primary: &[String],
+    replica: &[String],
+) -> ReplicaMigrationReadiness {
+    let primary_versions: std::collections::BTreeSet<_> = primary.iter().collect();
+    let replica_versions: std::collections::BTreeSet<_> = replica.iter().collect();
+
+    if primary_versions == replica_versions {
+        ReplicaMigrationReadiness::Ready
+    } else {
+        ReplicaMigrationReadiness::Stale {
+            primary_latest: primary_versions
+                .iter()
+                .next_back()
+                .map(|version| (*version).clone()),
+            replica_latest: replica_versions
+                .iter()
+                .next_back()
+                .map(|version| (*version).clone()),
+        }
+    }
+}
+
+fn applied_migration_versions(database_url: &str) -> Result<Vec<String>, MigrationError> {
+    let mut conn = diesel::PgConnection::establish(database_url)
+        .map_err(|e| MigrationError::Connection(e.to_string()))?;
+
+    let rows = diesel::sql_query("SELECT version FROM __diesel_schema_migrations ORDER BY version")
+        .load::<AppliedMigrationVersion>(&mut conn)
+        .map_err(|e| MigrationError::Migration(e.to_string()))?;
+
+    Ok(rows.into_iter().map(|row| row.version).collect())
+}
+
+pub(crate) fn check_replica_migration_readiness(
+    primary_url: &str,
+    replica_url: &str,
+) -> ReplicaMigrationReadiness {
+    let primary = match applied_migration_versions(primary_url) {
+        Ok(versions) => versions,
+        Err(error) => return ReplicaMigrationReadiness::Unknown(error.to_string()),
+    };
+    let replica = match applied_migration_versions(replica_url) {
+        Ok(versions) => versions,
+        Err(error) => return ReplicaMigrationReadiness::Unknown(error.to_string()),
+    };
+
+    compare_replica_migration_versions(&primary, &replica)
 }
 
 fn should_auto_apply(profile: Option<&str>, allow_auto_migrate_in_production: bool) -> bool {
@@ -218,6 +313,22 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("migration failed"));
         assert!(msg.contains("syntax error"));
+    }
+
+    #[test]
+    fn replica_migration_comparison_detects_stale_replica() {
+        let primary = vec!["00000000000001".to_owned(), "00000000000002".to_owned()];
+        let replica = vec!["00000000000001".to_owned()];
+
+        let readiness = compare_replica_migration_versions(&primary, &replica);
+
+        assert!(!readiness.is_ready());
+        assert!(
+            readiness
+                .detail()
+                .expect("stale detail")
+                .contains("00000000000002")
+        );
     }
 
     #[test]

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -204,6 +204,21 @@ pub(crate) fn check_replica_migration_readiness(
     compare_replica_migration_versions(&primary, &replica)
 }
 
+pub(crate) async fn check_replica_migration_readiness_blocking(
+    primary_url: String,
+    replica_url: String,
+) -> ReplicaMigrationReadiness {
+    tokio::task::spawn_blocking(move || {
+        check_replica_migration_readiness(&primary_url, &replica_url)
+    })
+    .await
+    .unwrap_or_else(|error| {
+        ReplicaMigrationReadiness::Unknown(format!(
+            "replica migration readiness task failed: {error}"
+        ))
+    })
+}
+
 fn should_auto_apply(profile: Option<&str>, allow_auto_migrate_in_production: bool) -> bool {
     let profile_name = profile.unwrap_or("none");
     matches!(profile_name, "dev" | "development")

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -169,6 +169,7 @@ mod tests {
                 std::collections::HashMap::new(),
             )),
             pool: None,
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,

--- a/autumn/src/probe.rs
+++ b/autumn/src/probe.rs
@@ -44,6 +44,15 @@ pub trait ProvideProbeState {
         &self,
     ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>;
 
+    /// Returns an optional read-replica pool for readiness checks.
+    #[cfg(feature = "db")]
+    fn replica_pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
+        None
+    }
+
     /// Helper method to mark the application startup as complete.
     ///
     /// Delegates to [`ProbeState::mark_startup_complete`].
@@ -87,7 +96,8 @@ pub struct ProbeState {
 struct ReplicaDependency {
     configured: bool,
     fallback: crate::config::ReplicaFallback,
-    ready: bool,
+    connection_ready: bool,
+    migrations_ready: bool,
     detail: Option<String>,
 }
 
@@ -97,7 +107,8 @@ impl Default for ReplicaDependency {
         Self {
             configured: false,
             fallback: crate::config::ReplicaFallback::default(),
-            ready: true,
+            connection_ready: true,
+            migrations_ready: true,
             detail: None,
         }
     }
@@ -159,9 +170,47 @@ impl ProbeState {
         *dependency = ReplicaDependency {
             configured: true,
             fallback,
-            ready: true,
-            detail: None,
+            connection_ready: false,
+            migrations_ready: true,
+            detail: Some("replica has not passed a readiness check".to_owned()),
         };
+    }
+
+    /// Mark the configured read replica as reachable.
+    #[cfg(feature = "db")]
+    pub fn mark_replica_connection_ready(&self) {
+        let mut dependency = self
+            .replica_dependency
+            .write()
+            .expect("replica dependency lock poisoned");
+        dependency.connection_ready = true;
+        if dependency.migrations_ready {
+            dependency.detail = None;
+        }
+    }
+
+    /// Mark the configured read replica as unreachable.
+    #[cfg(feature = "db")]
+    pub fn mark_replica_connection_unready(&self, detail: impl Into<String>) {
+        let mut dependency = self
+            .replica_dependency
+            .write()
+            .expect("replica dependency lock poisoned");
+        dependency.connection_ready = false;
+        dependency.detail = Some(detail.into());
+    }
+
+    /// Mark the configured read replica's migration state as current.
+    #[cfg(feature = "db")]
+    pub fn mark_replica_migrations_ready(&self) {
+        let mut dependency = self
+            .replica_dependency
+            .write()
+            .expect("replica dependency lock poisoned");
+        dependency.migrations_ready = true;
+        if dependency.connection_ready {
+            dependency.detail = None;
+        }
     }
 
     /// Mark the configured read replica as ready.
@@ -171,7 +220,8 @@ impl ProbeState {
             .replica_dependency
             .write()
             .expect("replica dependency lock poisoned");
-        dependency.ready = true;
+        dependency.connection_ready = true;
+        dependency.migrations_ready = true;
         dependency.detail = None;
     }
 
@@ -182,7 +232,8 @@ impl ProbeState {
             .replica_dependency
             .write()
             .expect("replica dependency lock poisoned");
-        dependency.ready = false;
+        dependency.connection_ready = false;
+        dependency.migrations_ready = false;
         dependency.detail = Some(detail.into());
     }
 
@@ -210,8 +261,9 @@ impl ProbeState {
             .replica_dependency
             .read()
             .expect("replica dependency lock poisoned");
+        let ready = dependency.connection_ready && dependency.migrations_ready;
         !dependency.configured
-            || dependency.ready
+            || ready
             || matches!(dependency.fallback, crate::config::ReplicaFallback::Primary)
     }
 
@@ -221,12 +273,26 @@ impl ProbeState {
             .replica_dependency
             .read()
             .expect("replica dependency lock poisoned");
-        !dependency.configured
-            || dependency.ready
-            || matches!(
-                dependency.fallback,
-                crate::config::ReplicaFallback::FailReadiness
-            )
+        !dependency.configured || (dependency.connection_ready && dependency.migrations_ready)
+    }
+
+    #[cfg(feature = "db")]
+    pub(crate) fn should_fallback_reads_to_primary(&self) -> bool {
+        let dependency = self
+            .replica_dependency
+            .read()
+            .expect("replica dependency lock poisoned");
+        dependency.configured
+            && !(dependency.connection_ready && dependency.migrations_ready)
+            && matches!(dependency.fallback, crate::config::ReplicaFallback::Primary)
+    }
+
+    #[cfg(feature = "db")]
+    pub(crate) fn replica_configured(&self) -> bool {
+        self.replica_dependency
+            .read()
+            .expect("replica dependency lock poisoned")
+            .configured
     }
 }
 
@@ -289,6 +355,27 @@ fn dependency_readiness<S: ProvideProbeState>(state: &S) -> (bool, Option<PoolSt
     }
 }
 
+#[cfg(feature = "db")]
+async fn refresh_replica_readiness<S: ProvideProbeState>(state: &S) {
+    if !state.probes().replica_configured() {
+        return;
+    }
+
+    let Some(replica_pool) = state.replica_pool() else {
+        state
+            .probes()
+            .mark_replica_connection_unready("replica pool is not available");
+        return;
+    };
+
+    match replica_pool.get().await {
+        Ok(_conn) => state.probes().mark_replica_connection_ready(),
+        Err(error) => state
+            .probes()
+            .mark_replica_connection_unready(format!("replica connection failed: {error}")),
+    }
+}
+
 fn probe_response<S: ProvideProbeState>(
     state: &S,
     kind: ProbeKind,
@@ -342,6 +429,8 @@ pub async fn live_handler<S: ProvideProbeState + Send + Sync + 'static>(
 pub async fn ready_handler<S: ProvideProbeState + Send + Sync + 'static>(
     State(state): State<S>,
 ) -> impl IntoResponse {
+    #[cfg(feature = "db")]
+    refresh_replica_readiness(&state).await;
     probe_response(&state, ProbeKind::Ready)
 }
 
@@ -353,9 +442,11 @@ pub async fn startup_handler<S: ProvideProbeState + Send + Sync + 'static>(
 }
 
 /// Compatibility alias for the legacy `/health` endpoint.
-pub(crate) fn readiness_response<S: ProvideProbeState>(
+pub(crate) async fn readiness_response<S: ProvideProbeState>(
     state: &S,
 ) -> (StatusCode, Json<ProbeResponse>) {
+    #[cfg(feature = "db")]
+    refresh_replica_readiness(state).await;
     probe_response(state, ProbeKind::Ready)
 }
 
@@ -470,6 +561,21 @@ mod tests {
             .mark_replica_unready("replica migrations lag primary");
 
         let (status, Json(response)) = probe_response(&state, ProbeKind::Ready);
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.status, "degraded");
+    }
+
+    #[cfg(feature = "db")]
+    #[tokio::test]
+    async fn ready_fails_when_replica_is_configured_but_not_checked() {
+        let state = TestProbeState::new();
+        state.mark_startup_complete();
+        state
+            .probes()
+            .configure_replica_dependency(crate::config::ReplicaFallback::FailReadiness);
+
+        let (status, Json(response)) = readiness_response(&state).await;
 
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(response.status, "degraded");

--- a/autumn/src/probe.rs
+++ b/autumn/src/probe.rs
@@ -170,6 +170,10 @@ impl ProbeState {
     }
 
     /// Configure runtime readiness behavior for a read replica.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the replica dependency lock is poisoned.
     #[cfg(feature = "db")]
     pub fn configure_replica_dependency(&self, fallback: crate::config::ReplicaFallback) {
         let mut dependency = self
@@ -204,6 +208,10 @@ impl ProbeState {
     }
 
     /// Mark the configured read replica as reachable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the replica dependency lock is poisoned.
     #[cfg(feature = "db")]
     pub fn mark_replica_connection_ready(&self) {
         let mut dependency = self
@@ -217,6 +225,10 @@ impl ProbeState {
     }
 
     /// Mark the configured read replica as unreachable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the replica dependency lock is poisoned.
     #[cfg(feature = "db")]
     pub fn mark_replica_connection_unready(&self, detail: impl Into<String>) {
         let mut dependency = self
@@ -228,6 +240,10 @@ impl ProbeState {
     }
 
     /// Mark the configured read replica's migration state as current.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the replica dependency lock is poisoned.
     #[cfg(feature = "db")]
     pub fn mark_replica_migrations_ready(&self) {
         let mut dependency = self
@@ -252,6 +268,10 @@ impl ProbeState {
     }
 
     /// Mark the configured read replica as ready.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the replica dependency lock is poisoned.
     #[cfg(feature = "db")]
     pub fn mark_replica_ready(&self) {
         let mut dependency = self
@@ -264,6 +284,10 @@ impl ProbeState {
     }
 
     /// Mark the configured read replica as unavailable or stale.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the replica dependency lock is poisoned.
     #[cfg(feature = "db")]
     pub fn mark_replica_unready(&self, detail: impl Into<String>) {
         let mut dependency = self

--- a/autumn/src/probe.rs
+++ b/autumn/src/probe.rs
@@ -6,6 +6,8 @@
 //! - startup stays unavailable until startup hooks complete
 
 use std::sync::Arc;
+#[cfg(feature = "db")]
+use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::extract::State;
@@ -76,6 +78,29 @@ pub trait ProvideProbeState {
 pub struct ProbeState {
     startup_complete: Arc<AtomicBool>,
     shutting_down: Arc<AtomicBool>,
+    #[cfg(feature = "db")]
+    replica_dependency: Arc<RwLock<ReplicaDependency>>,
+}
+
+#[cfg(feature = "db")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ReplicaDependency {
+    configured: bool,
+    fallback: crate::config::ReplicaFallback,
+    ready: bool,
+    detail: Option<String>,
+}
+
+#[cfg(feature = "db")]
+impl Default for ReplicaDependency {
+    fn default() -> Self {
+        Self {
+            configured: false,
+            fallback: crate::config::ReplicaFallback::default(),
+            ready: true,
+            detail: None,
+        }
+    }
 }
 
 impl ProbeState {
@@ -124,6 +149,43 @@ impl ProbeState {
         self.shutting_down.store(draining, Ordering::Relaxed);
     }
 
+    /// Configure runtime readiness behavior for a read replica.
+    #[cfg(feature = "db")]
+    pub fn configure_replica_dependency(&self, fallback: crate::config::ReplicaFallback) {
+        let mut dependency = self
+            .replica_dependency
+            .write()
+            .expect("replica dependency lock poisoned");
+        *dependency = ReplicaDependency {
+            configured: true,
+            fallback,
+            ready: true,
+            detail: None,
+        };
+    }
+
+    /// Mark the configured read replica as ready.
+    #[cfg(feature = "db")]
+    pub fn mark_replica_ready(&self) {
+        let mut dependency = self
+            .replica_dependency
+            .write()
+            .expect("replica dependency lock poisoned");
+        dependency.ready = true;
+        dependency.detail = None;
+    }
+
+    /// Mark the configured read replica as unavailable or stale.
+    #[cfg(feature = "db")]
+    pub fn mark_replica_unready(&self, detail: impl Into<String>) {
+        let mut dependency = self
+            .replica_dependency
+            .write()
+            .expect("replica dependency lock poisoned");
+        dependency.ready = false;
+        dependency.detail = Some(detail.into());
+    }
+
     /// Returns whether startup completed successfully.
     #[must_use]
     pub fn is_startup_complete(&self) -> bool {
@@ -140,6 +202,31 @@ impl ProbeState {
     #[must_use]
     pub fn draining(&self) -> bool {
         self.is_shutting_down()
+    }
+
+    #[cfg(feature = "db")]
+    pub(crate) fn replica_allows_readiness(&self) -> bool {
+        let dependency = self
+            .replica_dependency
+            .read()
+            .expect("replica dependency lock poisoned");
+        !dependency.configured
+            || dependency.ready
+            || matches!(dependency.fallback, crate::config::ReplicaFallback::Primary)
+    }
+
+    #[cfg(feature = "db")]
+    pub(crate) fn should_route_reads_to_replica(&self) -> bool {
+        let dependency = self
+            .replica_dependency
+            .read()
+            .expect("replica dependency lock poisoned");
+        !dependency.configured
+            || dependency.ready
+            || matches!(
+                dependency.fallback,
+                crate::config::ReplicaFallback::FailReadiness
+            )
     }
 }
 
@@ -174,24 +261,32 @@ pub(crate) struct PoolStatus {
 fn dependency_readiness<S: ProvideProbeState>(state: &S) -> (bool, Option<PoolStatus>) {
     #[cfg(feature = "db")]
     {
-        if let Some(pool) = state.pool() {
+        let replica_ready_for_policy = state.probes().replica_allows_readiness();
+        let (pool_ready, pool_status) = if let Some(pool) = state.pool() {
             let status = pool.status();
             let available = status.available as u64;
             let size = status.max_size as u64;
             let waiting = status.waiting as u64;
 
-            return (
+            (
                 available > 0 || waiting == 0,
                 Some(PoolStatus {
                     size,
                     available,
                     waiting,
                 }),
-            );
-        }
+            )
+        } else {
+            (true, None)
+        };
+
+        return (pool_ready && replica_ready_for_policy, pool_status);
     }
 
-    (true, None)
+    #[cfg(not(feature = "db"))]
+    {
+        (true, None)
+    }
 }
 
 fn probe_response<S: ProvideProbeState>(
@@ -360,6 +455,42 @@ mod tests {
         let (status, Json(response)) = probe_response(&state, ProbeKind::Ready);
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(response.status, "degraded");
+    }
+
+    #[cfg(feature = "db")]
+    #[tokio::test]
+    async fn ready_fails_when_replica_is_unready_and_policy_is_fail_readiness() {
+        let state = TestProbeState::new();
+        state.mark_startup_complete();
+        state
+            .probes()
+            .configure_replica_dependency(crate::config::ReplicaFallback::FailReadiness);
+        state
+            .probes()
+            .mark_replica_unready("replica migrations lag primary");
+
+        let (status, Json(response)) = probe_response(&state, ProbeKind::Ready);
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.status, "degraded");
+    }
+
+    #[cfg(feature = "db")]
+    #[tokio::test]
+    async fn ready_allows_primary_fallback_when_replica_is_unready() {
+        let state = TestProbeState::new();
+        state.mark_startup_complete();
+        state
+            .probes()
+            .configure_replica_dependency(crate::config::ReplicaFallback::Primary);
+        state
+            .probes()
+            .mark_replica_unready("replica migrations lag primary");
+
+        let (status, Json(response)) = probe_response(&state, ProbeKind::Ready);
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(response.status, "ok");
     }
 
     #[tokio::test]

--- a/autumn/src/probe.rs
+++ b/autumn/src/probe.rs
@@ -358,14 +358,6 @@ impl ProbeState {
     }
 
     #[cfg(feature = "db")]
-    pub(crate) fn replica_migrations_ready(&self) -> bool {
-        self.replica_dependency
-            .read()
-            .expect("replica dependency lock poisoned")
-            .migrations_ready
-    }
-
-    #[cfg(feature = "db")]
     pub(crate) fn replica_migration_check(&self) -> Option<ReplicaMigrationCheck> {
         self.replica_dependency
             .read()
@@ -459,19 +451,27 @@ async fn refresh_replica_readiness<S: ProvideProbeState + Sync>(state: &S) {
 
 #[cfg(feature = "db")]
 async fn refresh_replica_migration_readiness<S: ProvideProbeState + Sync>(state: &S) {
-    if state.probes().replica_migrations_ready() {
-        return;
-    }
+    refresh_replica_migration_readiness_with(state, |check| {
+        crate::migrate::check_replica_migration_readiness_blocking(
+            check.primary_url,
+            check.replica_url,
+        )
+    })
+    .await;
+}
 
+#[cfg(feature = "db")]
+async fn refresh_replica_migration_readiness_with<S, F, Fut>(state: &S, check_readiness: F)
+where
+    S: ProvideProbeState + Sync,
+    F: FnOnce(ReplicaMigrationCheck) -> Fut,
+    Fut: std::future::Future<Output = crate::migrate::ReplicaMigrationReadiness>,
+{
     let Some(check) = state.probes().replica_migration_check() else {
         return;
     };
 
-    let readiness = crate::migrate::check_replica_migration_readiness_blocking(
-        check.primary_url,
-        check.replica_url,
-    )
-    .await;
+    let readiness = check_readiness(check).await;
 
     if readiness.is_ready() {
         state.probes().mark_replica_migrations_ready();
@@ -721,6 +721,38 @@ mod tests {
 
         assert_eq!(check.primary_url, "postgres://localhost/primary");
         assert_eq!(check.replica_url, "postgres://localhost/replica");
+    }
+
+    #[cfg(feature = "db")]
+    #[tokio::test]
+    async fn replica_migration_readiness_rechecks_after_initial_ready_state() {
+        let state = TestProbeState::new();
+        state.mark_startup_complete();
+        state
+            .probes()
+            .configure_replica_dependency(crate::config::ReplicaFallback::FailReadiness);
+        state.probes().configure_replica_migration_check(
+            "postgres://localhost/primary",
+            "postgres://localhost/replica",
+        );
+        state.probes().mark_replica_connection_ready();
+        state.probes().mark_replica_migrations_ready();
+
+        let checks = std::sync::atomic::AtomicUsize::new(0);
+        refresh_replica_migration_readiness_with(&state, |check| {
+            checks.fetch_add(1, Ordering::Relaxed);
+            assert_eq!(check.primary_url, "postgres://localhost/primary");
+            assert_eq!(check.replica_url, "postgres://localhost/replica");
+            std::future::ready(crate::migrate::ReplicaMigrationReadiness::Stale {
+                primary_latest: Some("20260511000000".to_owned()),
+                replica_latest: Some("20260510000000".to_owned()),
+            })
+        })
+        .await;
+
+        assert_eq!(checks.load(Ordering::Relaxed), 1);
+        assert!(!state.probes().replica_allows_readiness());
+        assert!(!state.probes().should_route_reads_to_replica());
     }
 
     #[cfg(feature = "db")]

--- a/autumn/src/probe.rs
+++ b/autumn/src/probe.rs
@@ -93,11 +93,19 @@ pub struct ProbeState {
 
 #[cfg(feature = "db")]
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ReplicaMigrationCheck {
+    pub(crate) primary_url: String,
+    pub(crate) replica_url: String,
+}
+
+#[cfg(feature = "db")]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct ReplicaDependency {
     configured: bool,
     fallback: crate::config::ReplicaFallback,
     connection_ready: bool,
     migrations_ready: bool,
+    migration_check: Option<ReplicaMigrationCheck>,
     detail: Option<String>,
 }
 
@@ -109,6 +117,7 @@ impl Default for ReplicaDependency {
             fallback: crate::config::ReplicaFallback::default(),
             connection_ready: true,
             migrations_ready: true,
+            migration_check: None,
             detail: None,
         }
     }
@@ -172,8 +181,26 @@ impl ProbeState {
             fallback,
             connection_ready: false,
             migrations_ready: true,
+            migration_check: None,
             detail: Some("replica has not passed a readiness check".to_owned()),
         };
+    }
+
+    /// Store URLs needed to retry replica migration readiness checks.
+    #[cfg(feature = "db")]
+    pub(crate) fn configure_replica_migration_check(
+        &self,
+        primary_url: impl Into<String>,
+        replica_url: impl Into<String>,
+    ) {
+        let mut dependency = self
+            .replica_dependency
+            .write()
+            .expect("replica dependency lock poisoned");
+        dependency.migration_check = Some(ReplicaMigrationCheck {
+            primary_url: primary_url.into(),
+            replica_url: replica_url.into(),
+        });
     }
 
     /// Mark the configured read replica as reachable.
@@ -211,6 +238,17 @@ impl ProbeState {
         if dependency.connection_ready {
             dependency.detail = None;
         }
+    }
+
+    /// Mark the configured read replica's migration state as stale.
+    #[cfg(feature = "db")]
+    pub(crate) fn mark_replica_migrations_unready(&self, detail: impl Into<String>) {
+        let mut dependency = self
+            .replica_dependency
+            .write()
+            .expect("replica dependency lock poisoned");
+        dependency.migrations_ready = false;
+        dependency.detail = Some(detail.into());
     }
 
     /// Mark the configured read replica as ready.
@@ -294,6 +332,23 @@ impl ProbeState {
             .expect("replica dependency lock poisoned")
             .configured
     }
+
+    #[cfg(feature = "db")]
+    pub(crate) fn replica_migrations_ready(&self) -> bool {
+        self.replica_dependency
+            .read()
+            .expect("replica dependency lock poisoned")
+            .migrations_ready
+    }
+
+    #[cfg(feature = "db")]
+    pub(crate) fn replica_migration_check(&self) -> Option<ReplicaMigrationCheck> {
+        self.replica_dependency
+            .read()
+            .expect("replica dependency lock poisoned")
+            .migration_check
+            .clone()
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -328,7 +383,7 @@ fn dependency_readiness<S: ProvideProbeState>(state: &S) -> (bool, Option<PoolSt
     #[cfg(feature = "db")]
     {
         let replica_ready_for_policy = state.probes().replica_allows_readiness();
-        let (pool_ready, pool_status) = if let Some(pool) = state.pool() {
+        let (pool_ready, pool_status) = state.pool().map_or((true, None), |pool| {
             let status = pool.status();
             let available = status.available as u64;
             let size = status.max_size as u64;
@@ -342,11 +397,9 @@ fn dependency_readiness<S: ProvideProbeState>(state: &S) -> (bool, Option<PoolSt
                     waiting,
                 }),
             )
-        } else {
-            (true, None)
-        };
+        });
 
-        return (pool_ready && replica_ready_for_policy, pool_status);
+        (pool_ready && replica_ready_for_policy, pool_status)
     }
 
     #[cfg(not(feature = "db"))]
@@ -356,7 +409,7 @@ fn dependency_readiness<S: ProvideProbeState>(state: &S) -> (bool, Option<PoolSt
 }
 
 #[cfg(feature = "db")]
-async fn refresh_replica_readiness<S: ProvideProbeState>(state: &S) {
+async fn refresh_replica_readiness<S: ProvideProbeState + Sync>(state: &S) {
     if !state.probes().replica_configured() {
         return;
     }
@@ -369,10 +422,37 @@ async fn refresh_replica_readiness<S: ProvideProbeState>(state: &S) {
     };
 
     match replica_pool.get().await {
-        Ok(_conn) => state.probes().mark_replica_connection_ready(),
+        Ok(conn) => {
+            drop(conn);
+            state.probes().mark_replica_connection_ready();
+            refresh_replica_migration_readiness(state).await;
+        }
         Err(error) => state
             .probes()
             .mark_replica_connection_unready(format!("replica connection failed: {error}")),
+    }
+}
+
+#[cfg(feature = "db")]
+async fn refresh_replica_migration_readiness<S: ProvideProbeState + Sync>(state: &S) {
+    if state.probes().replica_migrations_ready() {
+        return;
+    }
+
+    let Some(check) = state.probes().replica_migration_check() else {
+        return;
+    };
+
+    let readiness = crate::migrate::check_replica_migration_readiness_blocking(
+        check.primary_url,
+        check.replica_url,
+    )
+    .await;
+
+    if readiness.is_ready() {
+        state.probes().mark_replica_migrations_ready();
+    } else if let Some(detail) = readiness.detail() {
+        state.probes().mark_replica_migrations_unready(detail);
     }
 }
 
@@ -442,7 +522,7 @@ pub async fn startup_handler<S: ProvideProbeState + Send + Sync + 'static>(
 }
 
 /// Compatibility alias for the legacy `/health` endpoint.
-pub(crate) async fn readiness_response<S: ProvideProbeState>(
+pub(crate) async fn readiness_response<S: ProvideProbeState + Sync>(
     state: &S,
 ) -> (StatusCode, Json<ProbeResponse>) {
     #[cfg(feature = "db")]
@@ -579,6 +659,44 @@ mod tests {
 
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(response.status, "degraded");
+    }
+
+    #[cfg(feature = "db")]
+    #[test]
+    fn replica_migration_lag_can_recover_without_resetting_connection_readiness() {
+        let probes = ProbeState::ready_for_test();
+        probes.configure_replica_dependency(crate::config::ReplicaFallback::FailReadiness);
+        probes.mark_replica_connection_ready();
+        probes.mark_replica_migrations_unready("replica migrations lag primary");
+
+        assert!(!probes.replica_allows_readiness());
+        assert!(!probes.should_route_reads_to_replica());
+
+        probes.mark_replica_connection_ready();
+        assert!(!probes.replica_allows_readiness());
+        assert!(!probes.should_route_reads_to_replica());
+
+        probes.mark_replica_migrations_ready();
+        assert!(probes.replica_allows_readiness());
+        assert!(probes.should_route_reads_to_replica());
+    }
+
+    #[cfg(feature = "db")]
+    #[test]
+    fn replica_migration_retry_urls_are_stored_for_readiness_rechecks() {
+        let probes = ProbeState::ready_for_test();
+        probes.configure_replica_dependency(crate::config::ReplicaFallback::FailReadiness);
+        probes.configure_replica_migration_check(
+            "postgres://localhost/primary",
+            "postgres://localhost/replica",
+        );
+
+        let check = probes
+            .replica_migration_check()
+            .expect("migration check should be configured");
+
+        assert_eq!(check.primary_url, "postgres://localhost/primary");
+        assert_eq!(check.replica_url, "postgres://localhost/replica");
     }
 
     #[cfg(feature = "db")]

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -1,5 +1,11 @@
 //! Repository error types for framework-generated CRUD operations.
 //!
+//! Framework-generated repositories use the [`Db`](crate::Db) extractor, which
+//! is bound to the primary/write database role. If an application wants a
+//! primary/replica read split, use an explicit repository seam and route reads
+//! through [`crate::AppState::read_pool`] while keeping writes on
+//! [`crate::AppState::pool`].
+//!
 //! [`RepositoryError`] surfaces typed errors that arise during repository
 //! operations — most notably optimistic-lock conflicts when two replicas
 //! write the same row concurrently.

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1559,6 +1559,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: Some("test".to_owned()),
             started_at: std::time::Instant::now(),
             health_detailed: false,

--- a/autumn/src/seed.rs
+++ b/autumn/src/seed.rs
@@ -1,4 +1,4 @@
-﻿//! Seed context for populating databases with representative data.
+//! Seed context for populating databases with representative data.
 //!
 //! Enabled with the `seed` cargo feature (off by default). Include in your
 //! project's `Cargo.toml` to use it in a seed binary:
@@ -49,7 +49,7 @@ pub enum SeedContextError {
 /// Context provided to a seed binary.
 ///
 /// Holds the database connection pool and the active profile, both resolved
-/// from the project's `autumn.toml` and environment variables â€” the same
+/// from the project's `autumn.toml` and environment variables — the same
 /// sources the main application uses.
 ///
 /// # Usage
@@ -209,7 +209,7 @@ fn first_database_url(database: Option<&toml::Value>) -> Option<String> {
 mod tests {
     use super::*;
 
-    // â”€â”€ resolve_profile â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── resolve_profile ────────────────────────────────────────────────────
 
     #[test]
     fn resolve_profile_defaults_to_dev() {
@@ -251,7 +251,7 @@ mod tests {
         );
     }
 
-    // â”€â”€ resolve_database_url â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── resolve_database_url ───────────────────────────────────────────────
 
     #[test]
     fn resolve_database_url_prefers_autumn_database_primary_url() {
@@ -375,7 +375,7 @@ primary_url = "postgres://default:5432/db"
         assert_eq!(result.as_deref(), Some("postgres://default:5432/db"));
     }
 
-    // â”€â”€ SeedContextError messages â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── SeedContextError messages ──────────────────────────────────────────
 
     #[test]
     fn no_database_url_error_message_is_actionable() {

--- a/autumn/src/seed.rs
+++ b/autumn/src/seed.rs
@@ -1,4 +1,4 @@
-//! Seed context for populating databases with representative data.
+﻿//! Seed context for populating databases with representative data.
 //!
 //! Enabled with the `seed` cargo feature (off by default). Include in your
 //! project's `Cargo.toml` to use it in a seed binary:
@@ -33,7 +33,7 @@ use diesel_async::pooled_connection::deadpool::{Object, Pool};
 pub enum SeedContextError {
     /// No database URL was found in the environment or `autumn.toml`.
     #[error(
-        "no database URL configured; set AUTUMN_DATABASE__URL or `database.url` in autumn.toml"
+        "no primary database URL configured; set AUTUMN_DATABASE__PRIMARY_URL, AUTUMN_DATABASE__URL, or `database.primary_url` in autumn.toml"
     )]
     NoDatabaseUrl,
 
@@ -49,7 +49,7 @@ pub enum SeedContextError {
 /// Context provided to a seed binary.
 ///
 /// Holds the database connection pool and the active profile, both resolved
-/// from the project's `autumn.toml` and environment variables — the same
+/// from the project's `autumn.toml` and environment variables â€” the same
 /// sources the main application uses.
 ///
 /// # Usage
@@ -79,9 +79,11 @@ impl SeedContext {
     /// 3. Defaults to `"dev"`
     ///
     /// Database URL resolution order (first wins):
-    /// 1. `AUTUMN_DATABASE__URL` env var
-    /// 2. `DATABASE_URL` env var
-    /// 3. `database.url` in `autumn.toml`
+    /// 1. `AUTUMN_DATABASE__PRIMARY_URL` env var
+    /// 2. `AUTUMN_DATABASE__URL` env var
+    /// 3. `DATABASE_URL` env var
+    /// 4. `database.primary_url` in `autumn.toml`
+    /// 5. `database.url` in `autumn.toml`
     ///
     /// # Errors
     ///
@@ -93,7 +95,7 @@ impl SeedContext {
         let db_url = resolve_database_url(&profile).ok_or(SeedContextError::NoDatabaseUrl)?;
 
         let config = DatabaseConfig {
-            url: Some(db_url),
+            primary_url: Some(db_url),
             ..DatabaseConfig::default()
         };
 
@@ -136,11 +138,19 @@ fn resolve_profile() -> String {
 /// Resolve the database URL from environment variables and `autumn.toml`.
 ///
 /// Resolution order (first non-empty value wins):
-/// 1. `AUTUMN_DATABASE__URL` env var
-/// 2. `DATABASE_URL` env var
-/// 3. `[profile.<profile>.database.url]` in `autumn.toml`
-/// 4. `[database.url]` in `autumn.toml`
+/// 1. `AUTUMN_DATABASE__PRIMARY_URL` env var
+/// 2. `AUTUMN_DATABASE__URL` env var
+/// 3. `DATABASE_URL` env var
+/// 4. `[profile.<profile>.database.primary_url]` in `autumn.toml`
+/// 5. `[profile.<profile>.database.url]` in `autumn.toml`
+/// 6. `[database.primary_url]` in `autumn.toml`
+/// 7. `[database.url]` in `autumn.toml`
 fn resolve_database_url(profile: &str) -> Option<String> {
+    if let Ok(url) = std::env::var("AUTUMN_DATABASE__PRIMARY_URL")
+        && !url.is_empty()
+    {
+        return Some(url);
+    }
     if let Ok(url) = std::env::var("AUTUMN_DATABASE__URL")
         && !url.is_empty()
     {
@@ -162,29 +172,36 @@ fn resolve_database_url_from_toml(profile: &str, config_path: &Path) -> Option<S
     {
         let value = toml::Value::Table(table);
 
-        // Profile-specific override: [profile.<name>.database.url]
-        if let Some(url) = value
-            .get("profile")
-            .and_then(|p| p.get(profile))
-            .and_then(|p| p.get("database"))
-            .and_then(|db| db.get("url"))
-            .and_then(|u| u.as_str())
-            .filter(|u| !u.is_empty())
-        {
-            return Some(url.to_string());
+        // Profile-specific override: [profile.<name>.database.primary_url/url]
+        if let Some(url) = first_database_url(
+            value
+                .get("profile")
+                .and_then(|p| p.get(profile))
+                .and_then(|p| p.get("database")),
+        ) {
+            return Some(url);
         }
 
-        // Top-level fallback: [database.url]
-        if let Some(url) = value
-            .get("database")
-            .and_then(|db: &toml::Value| db.get("url"))
-            .and_then(|u: &toml::Value| u.as_str())
+        // Top-level fallback: [database.primary_url/url]
+        if let Some(url) = first_database_url(value.get("database")) {
+            return Some(url);
+        }
+    }
+
+    None
+}
+
+fn first_database_url(database: Option<&toml::Value>) -> Option<String> {
+    let database = database?;
+    for key in ["primary_url", "url"] {
+        if let Some(url) = database
+            .get(key)
+            .and_then(toml::Value::as_str)
             .filter(|u| !u.is_empty())
         {
             return Some(url.to_string());
         }
     }
-
     None
 }
 
@@ -192,7 +209,7 @@ fn resolve_database_url_from_toml(profile: &str, config_path: &Path) -> Option<S
 mod tests {
     use super::*;
 
-    // ── resolve_profile ────────────────────────────────────────────────────
+    // â”€â”€ resolve_profile â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn resolve_profile_defaults_to_dev() {
@@ -234,14 +251,18 @@ mod tests {
         );
     }
 
-    // ── resolve_database_url ───────────────────────────────────────────────
+    // â”€â”€ resolve_database_url â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
-    fn resolve_database_url_prefers_autumn_database_url() {
+    fn resolve_database_url_prefers_autumn_database_primary_url() {
         temp_env::with_vars(
             [
-                ("AUTUMN_DATABASE__URL", Some("postgres://primary:5432/db")),
-                ("DATABASE_URL", Some("postgres://secondary:5432/db")),
+                (
+                    "AUTUMN_DATABASE__PRIMARY_URL",
+                    Some("postgres://primary:5432/db"),
+                ),
+                ("AUTUMN_DATABASE__URL", Some("postgres://legacy:5432/db")),
+                ("DATABASE_URL", Some("postgres://fallback:5432/db")),
             ],
             || {
                 assert_eq!(
@@ -256,6 +277,7 @@ mod tests {
     fn resolve_database_url_falls_back_to_database_url() {
         temp_env::with_vars(
             [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
                 ("AUTUMN_DATABASE__URL", None::<&str>),
                 ("DATABASE_URL", Some("postgres://fallback:5432/db")),
             ],
@@ -272,6 +294,7 @@ mod tests {
     fn resolve_database_url_returns_none_when_nothing_configured() {
         temp_env::with_vars(
             [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
                 ("AUTUMN_DATABASE__URL", None::<&str>),
                 ("DATABASE_URL", None::<&str>),
             ],
@@ -292,6 +315,7 @@ mod tests {
     fn resolve_database_url_ignores_empty_autumn_database_url() {
         temp_env::with_vars(
             [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
                 ("AUTUMN_DATABASE__URL", Some("")),
                 ("DATABASE_URL", Some("postgres://real:5432/db")),
             ],
@@ -313,12 +337,13 @@ mod tests {
 url = "postgres://default:5432/db"
 
 [profile.demo.database]
-url = "postgres://demo:5432/demo_db"
+primary_url = "postgres://demo:5432/demo_db"
 "#;
         std::fs::write(tmp.path().join("autumn.toml"), toml_content).unwrap();
 
         let result = temp_env::with_vars(
             [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
                 ("AUTUMN_DATABASE__URL", None::<&str>),
                 ("DATABASE_URL", None::<&str>),
             ],
@@ -334,12 +359,13 @@ url = "postgres://demo:5432/demo_db"
         let tmp = TempDir::new().unwrap();
         let toml_content = r#"
 [database]
-url = "postgres://default:5432/db"
+primary_url = "postgres://default:5432/db"
 "#;
         std::fs::write(tmp.path().join("autumn.toml"), toml_content).unwrap();
 
         let result = temp_env::with_vars(
             [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
                 ("AUTUMN_DATABASE__URL", None::<&str>),
                 ("DATABASE_URL", None::<&str>),
             ],
@@ -349,13 +375,13 @@ url = "postgres://default:5432/db"
         assert_eq!(result.as_deref(), Some("postgres://default:5432/db"));
     }
 
-    // ── SeedContextError messages ──────────────────────────────────────────
+    // â”€â”€ SeedContextError messages â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn no_database_url_error_message_is_actionable() {
         let msg = SeedContextError::NoDatabaseUrl.to_string();
         assert!(
-            msg.contains("AUTUMN_DATABASE__URL") || msg.contains("autumn.toml"),
+            msg.contains("AUTUMN_DATABASE__PRIMARY_URL") || msg.contains("autumn.toml"),
             "error should be actionable, got: {msg}"
         );
     }

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -1136,6 +1136,8 @@ mod tests {
             )),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,
@@ -1182,6 +1184,8 @@ mod tests {
             extensions: Arc::new(std::sync::RwLock::new(HashMap::new())),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: false,

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -197,6 +197,10 @@ impl AppState {
     {
         if self.replica_pool.is_some() && self.probes.should_route_reads_to_replica() {
             self.replica_pool.as_ref()
+        } else if self.replica_pool.is_some() && self.probes.should_fallback_reads_to_primary() {
+            self.pool.as_ref()
+        } else if self.replica_pool.is_some() {
+            None
         } else {
             self.pool.as_ref()
         }
@@ -550,6 +554,14 @@ impl crate::probe::ProvideProbeState for AppState {
     {
         self.pool.as_ref()
     }
+
+    #[cfg(feature = "db")]
+    fn replica_pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
+        self.replica_pool.as_ref()
+    }
 }
 
 impl crate::actuator::ProvideActuatorState for AppState {
@@ -734,7 +746,36 @@ mod tests {
 
     #[cfg(feature = "db")]
     #[test]
-    fn readiness_fails_when_app_state_replica_is_unready_and_policy_is_fail_readiness() {
+    fn read_pool_does_not_route_to_unready_replica_when_policy_fails_readiness() {
+        let primary_config = config::DatabaseConfig {
+            url: Some("postgres://localhost/primary".into()),
+            pool_size: 5,
+            ..Default::default()
+        };
+        let replica_config = config::DatabaseConfig {
+            url: Some("postgres://localhost/replica".into()),
+            pool_size: 2,
+            ..Default::default()
+        };
+        let primary = db::create_pool(&primary_config).unwrap().unwrap();
+        let replica = db::create_pool(&replica_config).unwrap().unwrap();
+
+        let state = AppState::for_test()
+            .with_pool(primary)
+            .with_replica_pool(replica);
+        state
+            .probes()
+            .configure_replica_dependency(config::ReplicaFallback::FailReadiness);
+        state
+            .probes()
+            .mark_replica_unready("replica connection failed");
+
+        assert!(state.read_pool().is_none());
+    }
+
+    #[cfg(feature = "db")]
+    #[tokio::test]
+    async fn readiness_fails_when_app_state_replica_is_unready_and_policy_is_fail_readiness() {
         let primary_config = config::DatabaseConfig {
             url: Some("postgres://localhost/primary".into()),
             pool_size: 5,
@@ -758,7 +799,7 @@ mod tests {
             .probes()
             .mark_replica_unready("replica migrations lag primary");
 
-        let (status, _) = crate::probe::readiness_response(&state);
+        let (status, _) = crate::probe::readiness_response(&state).await;
 
         assert_eq!(status, http::StatusCode::SERVICE_UNAVAILABLE);
     }

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -57,9 +57,15 @@ pub struct AppState {
     /// state has been constructed.
     pub(crate) extensions: Arc<std::sync::RwLock<HashMap<TypeId, Arc<dyn Any + Send + Sync>>>>,
 
-    /// Database connection pool, or `None` when no `database.url` is configured.
+    /// Primary/write database connection pool, or `None` when no
+    /// `database.primary_url` or legacy `database.url` is configured.
     #[cfg(feature = "db")]
     pub(crate) pool:
+        Option<diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>,
+
+    /// Read-replica connection pool, or `None` when no replica role is configured.
+    #[cfg(feature = "db")]
+    pub(crate) replica_pool:
         Option<diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>,
 
     /// Active profile name (e.g., "dev", "prod", "staging").
@@ -172,6 +178,30 @@ impl AppState {
         self.pool.as_ref()
     }
 
+    /// Returns the read-replica database connection pool, if configured.
+    #[cfg(feature = "db")]
+    #[must_use]
+    pub const fn replica_pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
+        self.replica_pool.as_ref()
+    }
+
+    /// Returns the pool used for read-only work.
+    #[cfg(feature = "db")]
+    #[must_use]
+    pub fn read_pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
+        if self.replica_pool.is_some() && self.probes.should_route_reads_to_replica() {
+            self.replica_pool.as_ref()
+        } else {
+            self.pool.as_ref()
+        }
+    }
+
     /// Returns the metrics collector.
     #[must_use]
     pub const fn metrics(&self) -> &middleware::MetricsCollector {
@@ -226,6 +256,17 @@ impl AppState {
         pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
     ) -> Self {
         self.pool = Some(pool);
+        self
+    }
+
+    /// Sets the read-replica database pool.
+    #[cfg(feature = "db")]
+    #[must_use]
+    pub fn with_replica_pool(
+        mut self,
+        pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+    ) -> Self {
+        self.replica_pool = Some(pool);
         self
     }
 
@@ -430,6 +471,8 @@ impl AppState {
             extensions: Arc::new(std::sync::RwLock::new(HashMap::new())),
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             profile: None,
             started_at: std::time::Instant::now(),
             health_detailed: true,
@@ -466,6 +509,20 @@ impl DbState for AppState {
     ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
     {
         self.pool.as_ref()
+    }
+
+    fn replica_pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
+        self.replica_pool.as_ref()
+    }
+
+    fn read_pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
+        AppState::read_pool(self)
     }
 }
 
@@ -605,6 +662,105 @@ mod tests {
         let state = AppState::for_test().with_pool(pool);
         let debug = format!("{state:?}");
         assert!(debug.contains("Pool(max=5)"));
+    }
+
+    #[cfg(feature = "db")]
+    #[test]
+    fn database_topology_state_exposes_replica_as_read_pool() {
+        let primary_config = config::DatabaseConfig {
+            url: Some("postgres://localhost/primary".into()),
+            pool_size: 5,
+            ..Default::default()
+        };
+        let replica_config = config::DatabaseConfig {
+            url: Some("postgres://localhost/replica".into()),
+            pool_size: 2,
+            ..Default::default()
+        };
+        let primary = db::create_pool(&primary_config).unwrap().unwrap();
+        let replica = db::create_pool(&replica_config).unwrap().unwrap();
+
+        let state = AppState::for_test()
+            .with_pool(primary)
+            .with_replica_pool(replica);
+
+        assert_eq!(state.pool().expect("primary pool").status().max_size, 5);
+        assert_eq!(
+            state
+                .replica_pool()
+                .expect("replica pool")
+                .status()
+                .max_size,
+            2
+        );
+        assert_eq!(state.read_pool().expect("read pool").status().max_size, 2);
+    }
+
+    #[cfg(feature = "db")]
+    #[test]
+    fn read_pool_uses_primary_when_replica_is_unready_and_policy_allows_fallback() {
+        let primary_config = config::DatabaseConfig {
+            url: Some("postgres://localhost/primary".into()),
+            pool_size: 5,
+            ..Default::default()
+        };
+        let replica_config = config::DatabaseConfig {
+            url: Some("postgres://localhost/replica".into()),
+            pool_size: 2,
+            ..Default::default()
+        };
+        let primary = db::create_pool(&primary_config).unwrap().unwrap();
+        let replica = db::create_pool(&replica_config).unwrap().unwrap();
+
+        let state = AppState::for_test()
+            .with_pool(primary)
+            .with_replica_pool(replica);
+        state
+            .probes()
+            .configure_replica_dependency(config::ReplicaFallback::Primary);
+        state
+            .probes()
+            .mark_replica_unready("replica migrations lag primary");
+
+        assert_eq!(state.read_pool().expect("read pool").status().max_size, 5);
+        assert_eq!(
+            db::DbState::read_pool(&state)
+                .expect("trait read pool")
+                .status()
+                .max_size,
+            5
+        );
+    }
+
+    #[cfg(feature = "db")]
+    #[test]
+    fn readiness_fails_when_app_state_replica_is_unready_and_policy_is_fail_readiness() {
+        let primary_config = config::DatabaseConfig {
+            url: Some("postgres://localhost/primary".into()),
+            pool_size: 5,
+            ..Default::default()
+        };
+        let replica_config = config::DatabaseConfig {
+            url: Some("postgres://localhost/replica".into()),
+            pool_size: 2,
+            ..Default::default()
+        };
+        let primary = db::create_pool(&primary_config).unwrap().unwrap();
+        let replica = db::create_pool(&replica_config).unwrap().unwrap();
+
+        let state = AppState::for_test()
+            .with_pool(primary)
+            .with_replica_pool(replica);
+        state
+            .probes()
+            .configure_replica_dependency(config::ReplicaFallback::FailReadiness);
+        state
+            .probes()
+            .mark_replica_unready("replica migrations lag primary");
+
+        let (status, _) = crate::probe::readiness_response(&state);
+
+        assert_eq!(status, http::StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[test]

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -526,7 +526,7 @@ impl DbState for AppState {
         &self,
     ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
     {
-        AppState::read_pool(self)
+        Self::read_pool(self)
     }
 }
 

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -167,6 +167,8 @@ pub struct TestApp {
     openapi: Option<crate::openapi::OpenApiConfig>,
     #[cfg(feature = "db")]
     pool: Option<Pool<AsyncPgConnection>>,
+    #[cfg(feature = "db")]
+    replica_pool: Option<Pool<AsyncPgConnection>>,
     /// Deferred policy / scope registrations applied during
     /// [`TestApp::build`].
     policy_registrations: Vec<TestPolicyRegistration>,
@@ -197,6 +199,8 @@ impl TestApp {
             openapi: None,
             #[cfg(feature = "db")]
             pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
             policy_registrations: Vec::new(),
             forbidden_response_override: None,
         }
@@ -348,6 +352,8 @@ impl TestApp {
             )),
             #[cfg(feature = "db")]
             pool: self.pool,
+            #[cfg(feature = "db")]
+            replica_pool: self.replica_pool,
             profile: self.config.profile.clone(),
             started_at: std::time::Instant::now(),
             health_detailed: self.config.health.detailed,

--- a/docs/guide/cloud-native.md
+++ b/docs/guide/cloud-native.md
@@ -181,7 +181,45 @@ For multi-replica deployments, do not rely on each web process racing to apply
 migrations. Run migrations once as a dedicated job, then start the web
 deployment after it succeeds.
 
-The distributed bookmarks example uses this shape explicitly.
+The migration job must target the primary/write role:
+
+```bash
+AUTUMN_DATABASE__PRIMARY_URL="postgres://user:pass@primary:5432/app" autumn migrate
+```
+
+`DATABASE_URL` still works for single-primary apps, but naming
+`AUTUMN_DATABASE__PRIMARY_URL` keeps the deployment contract explicit. Keep
+`auto_migrate_in_production = false` on web replicas unless you are deliberately
+running a single-process deployment.
+
+## Database Topology
+
+Use the `[database]` section to declare the shape:
+
+```toml
+[database]
+primary_url = "postgres://user:pass@primary:5432/app"
+replica_url = "postgres://user:pass@replica:5432/app" # optional
+primary_pool_size = 10
+replica_pool_size = 5
+replica_fallback = "fail_readiness" # or "primary"
+auto_migrate_in_production = false
+```
+
+`Db`, transactions, advisory locks, scheduled-task coordination, and migrations
+use the primary role. Read-oriented code may use the replica pool when one is
+configured; if the replica is missing or stale, choose one deterministic
+behavior: fail readiness (`fail_readiness`) or explicitly fall back to the
+primary (`primary`).
+
+`autumn doctor --strict` checks the topology contract: missing primary role,
+unreachable primary/replica endpoints, unsafe production migration ownership,
+and stale replica migration versions. Diagnostics name the failing role and
+redact credentials.
+
+The distributed bookmarks example uses this shape explicitly with a primary,
+streaming replica, one migration job, two web replicas, and a readiness gate
+that fails while the replica has not replayed the latest Diesel migration.
 
 ## Shared Cache
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -1,4 +1,4 @@
-# Deploying an Autumn App
+﻿# Deploying an Autumn App
 
 This guide walks you from a fresh `autumn new` project to a production-shaped
 container running against a real Postgres database. Every command is verbatim;
@@ -12,13 +12,13 @@ internet connection.
 ## Prerequisites
 
 - **Rust 1.88.0+** with `cargo`
-- **Docker** (or Docker Desktop) — `docker --version`
+- **Docker** (or Docker Desktop) â€” `docker --version`
 - **PostgreSQL** accessible at a connection string you control (local or remote)
 - The `autumn` CLI - `cargo install autumn-cli --version 0.3.0`
 
 ---
 
-## Step 1 — Create the project
+## Step 1 â€” Create the project
 
 ```bash
 autumn new myapp
@@ -29,7 +29,7 @@ This scaffolds a working Autumn application with a dev-oriented `Dockerfile`.
 
 ---
 
-## Step 2 — Generate production deployment files
+## Step 2 â€” Generate production deployment files
 
 ```bash
 autumn release init --force
@@ -43,20 +43,20 @@ The command emits three files at the project root:
 
 | File | Purpose |
 |---|---|
-| `Dockerfile` | Multi-stage image: cargo-chef dep cache → release binary → debian-slim runtime |
+| `Dockerfile` | Multi-stage image: cargo-chef dep cache â†’ release binary â†’ debian-slim runtime |
 | `.dockerignore` | Keeps `target/`, `.git/`, `node_modules/`, `dist/` out of the build context |
-| `autumn.production.toml.example` | Production config template with placeholder values — no real secrets |
+| `autumn.production.toml.example` | Production config template with placeholder values â€” no real secrets |
 
 > **What changed in the Dockerfile?**
 > The production Dockerfile adds cargo-chef dependency caching (so rebuilds only
 > recompile what changed), installs `libpq`, `tini`, and `ca-certificates` in the
-> slim runtime, copies compiled Tailwind assets from `static/`, runs migrations
-> before the server starts, and wires the `/health` endpoint as the container
+> slim runtime, copies compiled Tailwind assets from `static/`, leaves
+> migrations to an explicit primary-role job, and wires the `/health` endpoint as the container
 > `HEALTHCHECK`.
 
 ---
 
-## Step 3 — Build the image
+## Step 3 â€” Build the image
 
 ```bash
 docker build -t myapp .
@@ -79,37 +79,41 @@ Successfully tagged myapp:latest
 
 ---
 
-## Step 4 — Run the container
+## Step 4 â€” Migrate, Then Run the Container
 
-Provide your Postgres connection string as the `DATABASE_URL` environment
-variable. The container will run pending migrations and then start the server:
+Provide your primary/write Postgres connection string as
+`AUTUMN_DATABASE__PRIMARY_URL`. Run migrations once against that primary role
+before starting web replicas:
+
+```bash
+AUTUMN_DATABASE__PRIMARY_URL="postgres://user:pass@host:5432/myapp_prod" autumn migrate
+```
+
+Then start the web container:
 
 ```bash
 docker run --rm \
   -p 3000:3000 \
-  -e DATABASE_URL="postgres://user:pass@host:5432/myapp_prod" \
+  -e AUTUMN_DATABASE__PRIMARY_URL="postgres://user:pass@host:5432/myapp_prod" \
   myapp
 ```
 
 You should see something like:
 
 ```
-Running migrations...
-  Applying 20240101000000_create_users ... OK
 INFO autumn: Listening addr=0.0.0.0:3000
 ```
 
-Visit [http://localhost:3000/health](http://localhost:3000/health) — a healthy
+Visit [http://localhost:3000/health](http://localhost:3000/health) â€” a healthy
 response looks like:
 
 ```json
 { "status": "ok", "version": "0.3.0" }
 ```
 
-> **Migration failure stops the container.** If `DATABASE_URL` is wrong or the
-> database is unreachable, the migration step exits non-zero and the container
-> stops immediately — nothing silently degrades. Fix the connection string and
-> rerun.
+> **Migration failure stops the rollout.** If the primary URL is wrong or the
+> database is unreachable, `autumn migrate` exits non-zero and you do not roll
+> the web tier. Fix the connection string and rerun the one-shot job.
 
 ---
 
@@ -117,18 +121,18 @@ response looks like:
 
 ```
 rust:1.88-bookworm (chef stage)
-  └─ cargo chef prepare          # snapshot dependency graph
-       └─ cargo chef cook        # build all dependencies (cached layer)
-            └─ cargo build --release
-                 └─ debian:bookworm-slim (runtime stage)
+  â””â”€ cargo chef prepare          # snapshot dependency graph
+       â””â”€ cargo chef cook        # build all dependencies (cached layer)
+            â””â”€ cargo build --release
+                 â””â”€ debian:bookworm-slim (runtime stage)
                        libpq5, tini, ca-certificates, curl
-                       /usr/local/bin/myapp     ← your binary
-                       /app/static/             ← compiled Tailwind + assets
-                       /app/migrations/         ← SQL migration files
-                       /app/autumn.toml         ← production config (host=0.0.0.0)
+                       /usr/local/bin/myapp     â† your binary
+                       /app/static/             â† compiled Tailwind + assets
+                       /app/migrations/         â† SQL migration files
+                       /app/autumn.toml         â† production config (host=0.0.0.0)
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["/bin/sh", "-c", "myapp migrate run && exec myapp"]
+CMD ["/usr/local/bin/myapp"]
 ```
 
 Key design decisions:
@@ -137,9 +141,9 @@ Key design decisions:
   handler reuses cached dependencies; only your crate recompiles.
 - **tini** is the PID 1 init process. It reaps zombie processes and forwards
   signals (SIGTERM, SIGINT) so the server shuts down gracefully.
-- **`migrate run && exec`** — migrations run first; `&&` means any migration
-  failure aborts the start. `exec` replaces the shell with the server process so
-  signals reach the binary directly.
+- **Explicit migration ownership** -- migrations run once through
+  `AUTUMN_DATABASE__PRIMARY_URL=... autumn migrate` before web replicas roll.
+  The web image starts only the server, so replicas do not race schema changes.
 - **`autumn.production.toml.example` is copied as `/app/autumn.toml`** so the
   binary binds to `0.0.0.0` (all interfaces) instead of the dev default
   `127.0.0.1`. Override any value at runtime via `AUTUMN_*` environment
@@ -166,20 +170,23 @@ level = "info"
 format = "Json"        # structured JSON for log aggregators
 
 [database]
-url = "postgres://user:CHANGE_ME@localhost:5432/myapp_prod"
+primary_url = "postgres://user:CHANGE_ME@localhost:5432/myapp_prod"
+# replica_url = "postgres://user:CHANGE_ME@replica:5432/myapp_prod"
 pool_size = 10
+replica_fallback = "fail_readiness"
+auto_migrate_in_production = false
 ```
 
 Sensitive values (database password, SMTP credentials) should **never** be in
 this file. Pass them as environment variables at runtime:
 
 ```bash
--e DATABASE_URL="postgres://user:realpass@host:5432/myapp_prod"
+-e AUTUMN_DATABASE__PRIMARY_URL="postgres://user:realpass@host:5432/myapp_prod"
 -e AUTUMN_LOG__LEVEL=debug
 ```
 
 `AUTUMN_*` environment variables override `autumn.toml` at the highest
-priority layer — see the
+priority layer â€” see the
 [config reference](getting-started.md#environment-variable-overrides).
 
 ---
@@ -198,12 +205,14 @@ Deploy:
 
 ```bash
 fly launch --no-deploy          # creates the app on fly.io
-fly secrets set DATABASE_URL="postgres://user:pass@host:5432/myapp_prod"
+fly secrets set AUTUMN_DATABASE__PRIMARY_URL="postgres://user:pass@host:5432/myapp_prod"
+AUTUMN_DATABASE__PRIMARY_URL="postgres://user:pass@host:5432/myapp_prod" autumn migrate
 fly deploy
 ```
 
-The container entrypoint runs migrations on every deploy before traffic is
-forwarded to the new instance, so your schema is always up to date.
+Run the migration step once before `fly deploy`. If you add a read replica,
+configure `AUTUMN_DATABASE__REPLICA_URL` separately and gate readiness until the
+replica has replayed the latest Diesel migration.
 
 ---
 
@@ -221,9 +230,9 @@ Start both services:
 docker compose up --build
 ```
 
-The `docker-compose.yml` sets `DATABASE_URL` pointing at the `db` service and
-waits for Postgres to pass its healthcheck before starting the app. No manual
-Postgres setup is needed.
+The `docker-compose.yml` sets `AUTUMN_DATABASE__PRIMARY_URL` pointing at the
+`db` service and waits for Postgres to pass its healthcheck before starting the
+app. No manual Postgres setup is needed.
 
 To reset the database:
 
@@ -239,7 +248,7 @@ docker compose up --build
 By default `autumn release init` refuses to overwrite existing files:
 
 ```
-Error: 'Dockerfile' already exists — run with --force to overwrite
+Error: 'Dockerfile' already exists â€” run with --force to overwrite
 ```
 
 Use `--force` to regenerate everything, or delete individual files first if you
@@ -253,16 +262,16 @@ Before the server will bind in the `prod` profile, you must set a stable signing
 secret. It protects sessions, CSRF tokens, and signed storage URLs:
 
 ```bash
-# Generate once, store securely (e.g. Fly secrets, AWS Secrets Manager, …)
+# Generate once, store securely (e.g. Fly secrets, AWS Secrets Manager, â€¦)
 export AUTUMN_SECURITY__SIGNING_SECRET="$(openssl rand -hex 32)"
 ```
 
-**Smoke-gate check** — the app must refuse to boot _without_ the secret:
+**Smoke-gate check** â€” the app must refuse to boot _without_ the secret:
 
 ```bash
 docker run --rm \
   -e AUTUMN_ENV=prod \
-  -e DATABASE_URL=... \
+  -e AUTUMN_DATABASE__PRIMARY_URL=... \
   myapp 2>&1 | grep -i "signing secret"
 # Expected: "Invalid signing secret configuration: signing secret is required in production"
 ```
@@ -272,7 +281,7 @@ And must start successfully _with_ a valid secret:
 ```bash
 docker run --rm -p 3000:3000 \
   -e AUTUMN_ENV=prod \
-  -e DATABASE_URL=... \
+  -e AUTUMN_DATABASE__PRIMARY_URL=... \
   -e AUTUMN_SECURITY__SIGNING_SECRET="$AUTUMN_SECURITY__SIGNING_SECRET" \
   myapp
 ```
@@ -294,16 +303,16 @@ SECRET=$(openssl rand -hex 32)
 # Replica 1
 docker run --rm -p 3000:3000 \
   -e AUTUMN_ENV=prod \
-  -e DATABASE_URL=postgres://... \
+  -e AUTUMN_DATABASE__PRIMARY_URL=postgres://... \
   -e AUTUMN_SECURITY__SIGNING_SECRET="$SECRET" \
   -e AUTUMN_SESSION__BACKEND=redis \
   -e AUTUMN_SESSION__REDIS__URL=redis://redis:6379 \
   myapp &
 
-# Replica 2 — identical secret and Redis URL
+# Replica 2 â€” identical secret, primary URL, and Redis URL
 docker run --rm -p 3001:3000 \
   -e AUTUMN_ENV=prod \
-  -e DATABASE_URL=postgres://... \
+  -e AUTUMN_DATABASE__PRIMARY_URL=postgres://... \
   -e AUTUMN_SECURITY__SIGNING_SECRET="$SECRET" \
   -e AUTUMN_SESSION__BACKEND=redis \
   -e AUTUMN_SESSION__REDIS__URL=redis://redis:6379 \

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -1,4 +1,4 @@
-﻿# Deploying an Autumn App
+# Deploying an Autumn App
 
 This guide walks you from a fresh `autumn new` project to a production-shaped
 container running against a real Postgres database. Every command is verbatim;
@@ -12,13 +12,13 @@ internet connection.
 ## Prerequisites
 
 - **Rust 1.88.0+** with `cargo`
-- **Docker** (or Docker Desktop) â€” `docker --version`
+- **Docker** (or Docker Desktop) — `docker --version`
 - **PostgreSQL** accessible at a connection string you control (local or remote)
 - The `autumn` CLI - `cargo install autumn-cli --version 0.3.0`
 
 ---
 
-## Step 1 â€” Create the project
+## Step 1 — Create the project
 
 ```bash
 autumn new myapp
@@ -29,7 +29,7 @@ This scaffolds a working Autumn application with a dev-oriented `Dockerfile`.
 
 ---
 
-## Step 2 â€” Generate production deployment files
+## Step 2 — Generate production deployment files
 
 ```bash
 autumn release init --force
@@ -43,9 +43,9 @@ The command emits three files at the project root:
 
 | File | Purpose |
 |---|---|
-| `Dockerfile` | Multi-stage image: cargo-chef dep cache â†’ release binary â†’ debian-slim runtime |
+| `Dockerfile` | Multi-stage image: cargo-chef dep cache → release binary → debian-slim runtime |
 | `.dockerignore` | Keeps `target/`, `.git/`, `node_modules/`, `dist/` out of the build context |
-| `autumn.production.toml.example` | Production config template with placeholder values â€” no real secrets |
+| `autumn.production.toml.example` | Production config template with placeholder values — no real secrets |
 
 > **What changed in the Dockerfile?**
 > The production Dockerfile adds cargo-chef dependency caching (so rebuilds only
@@ -56,7 +56,7 @@ The command emits three files at the project root:
 
 ---
 
-## Step 3 â€” Build the image
+## Step 3 — Build the image
 
 ```bash
 docker build -t myapp .
@@ -79,7 +79,7 @@ Successfully tagged myapp:latest
 
 ---
 
-## Step 4 â€” Migrate, Then Run the Container
+## Step 4 — Migrate, Then Run the Container
 
 Provide your primary/write Postgres connection string as
 `AUTUMN_DATABASE__PRIMARY_URL`. Run migrations once against that primary role
@@ -104,7 +104,7 @@ You should see something like:
 INFO autumn: Listening addr=0.0.0.0:3000
 ```
 
-Visit [http://localhost:3000/health](http://localhost:3000/health) â€” a healthy
+Visit [http://localhost:3000/health](http://localhost:3000/health) — a healthy
 response looks like:
 
 ```json
@@ -121,15 +121,15 @@ response looks like:
 
 ```
 rust:1.88-bookworm (chef stage)
-  â””â”€ cargo chef prepare          # snapshot dependency graph
-       â””â”€ cargo chef cook        # build all dependencies (cached layer)
-            â””â”€ cargo build --release
-                 â””â”€ debian:bookworm-slim (runtime stage)
+  └─ cargo chef prepare          # snapshot dependency graph
+       └─ cargo chef cook        # build all dependencies (cached layer)
+            └─ cargo build --release
+                 └─ debian:bookworm-slim (runtime stage)
                        libpq5, tini, ca-certificates, curl
-                       /usr/local/bin/myapp     â† your binary
-                       /app/static/             â† compiled Tailwind + assets
-                       /app/migrations/         â† SQL migration files
-                       /app/autumn.toml         â† production config (host=0.0.0.0)
+                       /usr/local/bin/myapp     ← your binary
+                       /app/static/             ← compiled Tailwind + assets
+                       /app/migrations/         ← SQL migration files
+                       /app/autumn.toml         ← production config (host=0.0.0.0)
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/usr/local/bin/myapp"]
@@ -186,7 +186,7 @@ this file. Pass them as environment variables at runtime:
 ```
 
 `AUTUMN_*` environment variables override `autumn.toml` at the highest
-priority layer â€” see the
+priority layer — see the
 [config reference](getting-started.md#environment-variable-overrides).
 
 ---
@@ -218,7 +218,8 @@ replica has replayed the latest Diesel migration.
 
 ## Run locally with Docker Compose (app + Postgres)
 
-Scaffold a `docker-compose.yml` with an app service and a managed Postgres:
+Scaffold a `docker-compose.yml` with an app service, a one-shot migration job,
+and a managed Postgres:
 
 ```bash
 autumn release init --force --target docker-compose
@@ -231,8 +232,9 @@ docker compose up --build
 ```
 
 The `docker-compose.yml` sets `AUTUMN_DATABASE__PRIMARY_URL` pointing at the
-`db` service and waits for Postgres to pass its healthcheck before starting the
-app. No manual Postgres setup is needed.
+`db` service, waits for Postgres to pass its healthcheck, runs `autumn migrate`
+once, and starts the app only after that job exits successfully. No manual
+Postgres setup is needed.
 
 To reset the database:
 
@@ -248,7 +250,7 @@ docker compose up --build
 By default `autumn release init` refuses to overwrite existing files:
 
 ```
-Error: 'Dockerfile' already exists â€” run with --force to overwrite
+Error: 'Dockerfile' already exists — run with --force to overwrite
 ```
 
 Use `--force` to regenerate everything, or delete individual files first if you
@@ -262,11 +264,11 @@ Before the server will bind in the `prod` profile, you must set a stable signing
 secret. It protects sessions, CSRF tokens, and signed storage URLs:
 
 ```bash
-# Generate once, store securely (e.g. Fly secrets, AWS Secrets Manager, â€¦)
+# Generate once, store securely (e.g. Fly secrets, AWS Secrets Manager, …)
 export AUTUMN_SECURITY__SIGNING_SECRET="$(openssl rand -hex 32)"
 ```
 
-**Smoke-gate check** â€” the app must refuse to boot _without_ the secret:
+**Smoke-gate check** — the app must refuse to boot _without_ the secret:
 
 ```bash
 docker run --rm \
@@ -309,7 +311,7 @@ docker run --rm -p 3000:3000 \
   -e AUTUMN_SESSION__REDIS__URL=redis://redis:6379 \
   myapp &
 
-# Replica 2 â€” identical secret, primary URL, and Redis URL
+# Replica 2 — identical secret, primary URL, and Redis URL
 docker run --rm -p 3001:3000 \
   -e AUTUMN_ENV=prod \
   -e AUTUMN_DATABASE__PRIMARY_URL=postgres://... \

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -344,11 +344,28 @@ pool_size = 10
 connect_timeout_secs = 5
 ```
 
-You can also set the URL via environment variable, which takes precedence over
-the TOML file:
+`url` is the single-primary compatibility field. For production-shaped config,
+name the write role explicitly:
+
+```toml
+[database]
+primary_url = "postgres://localhost/my_app"
+# replica_url = "postgres://localhost:5433/my_app"
+primary_pool_size = 10
+replica_pool_size = 5
+replica_fallback = "fail_readiness"
+auto_migrate_in_production = false
+```
+
+`Db`, transactions, advisory locks, and `autumn migrate` use the primary role.
+The optional replica role is for read paths that can tolerate replica replay
+lag according to `replica_fallback`.
+
+You can also set the primary URL via environment variable, which takes
+precedence over the TOML file:
 
 ```bash
-export AUTUMN_DATABASE__URL="postgres://localhost/my_app"
+export AUTUMN_DATABASE__PRIMARY_URL="postgres://localhost/my_app"
 ```
 
 (Note the double underscore `__` separating section from field.)
@@ -837,9 +854,15 @@ port = 3000                  # default
 shutdown_timeout_secs = 30   # default, seconds to drain in-flight requests
 
 [database]
-url = "postgres://user:pass@localhost:5432/my_app"
-pool_size = 10               # default, max connections
+primary_url = "postgres://user:pass@localhost:5432/my_app"
+# url = "postgres://user:pass@localhost:5432/my_app" # legacy single-primary alias
+# replica_url = "postgres://user:pass@localhost:5433/my_app"
+pool_size = 10               # default, max connections per role
+# primary_pool_size = 10
+# replica_pool_size = 5
+replica_fallback = "fail_readiness" # or "primary"
 connect_timeout_secs = 5     # default
+auto_migrate_in_production = false
 
 [log]
 level = "info"               # default, supports tracing filter syntax
@@ -863,7 +886,12 @@ Every config field can be overridden via environment variables. The pattern is
 | `AUTUMN_SERVER__HOST`                | `server.host`          |
 | `AUTUMN_SERVER__SHUTDOWN_TIMEOUT_SECS` | `server.shutdown_timeout_secs` |
 | `AUTUMN_DATABASE__URL`               | `database.url`         |
+| `AUTUMN_DATABASE__PRIMARY_URL`       | `database.primary_url` |
+| `AUTUMN_DATABASE__REPLICA_URL`       | `database.replica_url` |
 | `AUTUMN_DATABASE__POOL_SIZE`         | `database.pool_size`   |
+| `AUTUMN_DATABASE__PRIMARY_POOL_SIZE` | `database.primary_pool_size` |
+| `AUTUMN_DATABASE__REPLICA_POOL_SIZE` | `database.replica_pool_size` |
+| `AUTUMN_DATABASE__REPLICA_FALLBACK`  | `database.replica_fallback` |
 | `AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS` | `database.connect_timeout_secs` |
 | `AUTUMN_LOG__LEVEL`                  | `log.level`            |
 | `AUTUMN_LOG__FORMAT`                 | `log.format`           |
@@ -890,8 +918,8 @@ deployment with env vars.
 
 ### Running without a database
 
-If you omit the `[database]` section (or leave `url` unset), Autumn starts
-without a database pool. Handlers that use `Db` will return 503 Service
+If you omit the `[database]` section (or leave both `primary_url` and `url`
+unset), Autumn starts without a database pool. Handlers that use `Db` will return 503 Service
 Unavailable. This is useful for static sites, APIs that do not need a
 database, or during early development.
 

--- a/docs/guide/scheduled-multi-replica.md
+++ b/docs/guide/scheduled-multi-replica.md
@@ -70,7 +70,7 @@ async fn warm_local_cache(_state: AppState) -> AutumnResult<()> {
 ## Verify With Three Replicas
 
 With a Docker Compose file that has a `db` service and a `web` service using
-the same `DATABASE_URL`, run three web replicas:
+the same `AUTUMN_DATABASE__PRIMARY_URL`, run three web replicas:
 
 ```bash
 docker compose up --build --scale web=3

--- a/docs/guide/tutorial/01-project-setup.md
+++ b/docs/guide/tutorial/01-project-setup.md
@@ -169,8 +169,12 @@ path = "/health"
 # Uncomment to configure database:
 # [database]
 # url = "postgres://user:pass@localhost:5432/todo_app"
+# primary_url = "postgres://user:pass@localhost:5432/todo_app"
+# replica_url = "postgres://user:pass@localhost:5433/todo_app"
 # pool_size = 10
+# replica_fallback = "fail_readiness"
 # connect_timeout_secs = 5
+# auto_migrate_in_production = false
 ```
 
 Autumn uses a five-layer configuration system:

--- a/docs/guide/tutorial/03-database.md
+++ b/docs/guide/tutorial/03-database.md
@@ -21,7 +21,8 @@ verifying the installation.
 ### Configuring the Database Connection
 
 Uncommenting the `[database]` section in `autumn.toml` and setting the
-connection URL. How Autumn's config system loads the database URL.
+primary/write connection URL. How Autumn's config system keeps legacy
+single-URL apps valid while also supporting explicit primary/replica topology.
 
 ### Creating Your First Migration
 

--- a/docs/guide/tutorial/10-configuration.md
+++ b/docs/guide/tutorial/10-configuration.md
@@ -53,7 +53,8 @@ understanding are:
 - `[health]` for `/health`, `/live`, `/ready`, and `/startup`
 - `[telemetry]` for OTLP export and service metadata
 - `[session]` and `[session.redis]` when you move beyond a single process
-- `[database]` for connection URL, pool size, and connect timeout
+- `[database]` for primary/write URL, optional replica/read URL, pool sizes,
+  replica fallback behavior, and connect timeout
 - `[actuator]` for prefix and sensitive endpoint exposure
 
 ## Environment Variable Overrides

--- a/docs/guide/tutorial/10-configuration.md
+++ b/docs/guide/tutorial/10-configuration.md
@@ -1,4 +1,4 @@
-﻿# Chapter 10: Configuration and Production Defaults
+# Chapter 10: Configuration and Production Defaults
 
 **Goal:** By the end of this chapter, you will understand Autumn's profile-aware
 configuration system, know how to override settings with environment variables,

--- a/docs/guide/what-happens-when.md
+++ b/docs/guide/what-happens-when.md
@@ -90,9 +90,9 @@ Not an error. Autumn uses its compiled-in defaults:
 | `server.host` | 127.0.0.1         |
 | `log.level`   | info              |
 | `log.format`  | Auto              |
-| `database.url`| (none -- no DB)   |
+| `database.primary_url` / `database.url` | (none -- no DB) |
 
-### No `[database]` section (or no `url`)
+### No `[database]` section (or no primary URL)
 
 Autumn starts without a database pool. Handlers that inject `Db` return 503:
 
@@ -132,12 +132,12 @@ matching) and falls back to defaults:
 WARN autumn: Unknown profile "dvv", did you mean "dev"?
 ```
 
-### Invalid `database.url` scheme
+### Invalid database URL scheme
 
 Configuration validation catches it immediately:
 
 ```
-Failed to load configuration: database.url must start with postgres:// or postgresql://
+Failed to load configuration: database.primary_url must start with postgres:// or postgresql://
 ```
 
 ### Environment variable overrides
@@ -379,8 +379,8 @@ health check will report the database as unhealthy.
 
 ## What Happens When You Use `Db` Without a Database?
 
-If no `database.url` is configured, the pool is `None`. The `Db` extractor
-returns 503 immediately:
+If neither `database.primary_url` nor the legacy `database.url` is configured,
+the primary/write pool is `None`. The `Db` extractor returns 503 immediately:
 
 ```json
 {

--- a/docs/plans/2026-05-10-database-topology-contracts.md
+++ b/docs/plans/2026-05-10-database-topology-contracts.md
@@ -1,0 +1,144 @@
+# Database Topology Contracts Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make primary/replica database topology a first-class Autumn contract instead of example-local glue.
+
+**Architecture:** Extend the core `[database]` config with canonical primary and replica roles while keeping `database.url` as the single-primary compatibility path. Build a primary pool plus optional replica pool in framework state, keep `Db` on the primary role, add a read-role extractor, and teach CLI/docs/templates that migrations target only the primary role.
+
+**Tech Stack:** Rust 2024, Autumn Web, diesel-async/deadpool, autumn-cli, TOML config, Markdown docs.
+
+---
+
+### Task 1: Core Config Contract
+
+**Files:**
+- Modify: `autumn/src/config.rs`
+- Test: `autumn/src/config.rs`
+
+**Step 1: Write failing tests**
+
+Add tests for:
+- `database.primary_url` and `database.replica_url` deserialize from TOML.
+- `database.url` remains a valid single-primary compatibility path.
+- `database.replica_url` without `url` or `primary_url` fails validation.
+- env vars `AUTUMN_DATABASE__PRIMARY_URL`, `AUTUMN_DATABASE__REPLICA_URL`, and replica fallback override config.
+
+**Step 2: Run tests to verify RED**
+
+Run: `cargo test -p autumn-web database_topology --features db`
+
+Expected: compile/test failure because fields and helpers do not exist.
+
+**Step 3: Implement minimal config**
+
+Add role fields, a `ReplicaFallback` enum, URL/pool helper methods, validation, defaults, and env overrides.
+
+**Step 4: Run tests to verify GREEN**
+
+Run: `cargo test -p autumn-web database_topology --features db`
+
+Expected: PASS.
+
+### Task 2: Runtime Pool Contract
+
+**Files:**
+- Modify: `autumn/src/db.rs`
+- Modify: `autumn/src/state.rs`
+- Modify: `autumn/src/app.rs`
+- Test: `autumn/src/db.rs`, `autumn/src/state.rs`
+
+**Step 1: Write failing tests**
+
+Add tests for:
+- topology creation builds primary and replica pools with role-specific pool sizes.
+- single-url apps still create only a primary pool.
+- `ReadDb` falls back to primary when no replica exists.
+
+**Step 2: Run tests to verify RED**
+
+Run: `cargo test -p autumn-web database_topology --features db`
+
+Expected: failure because topology/replica APIs do not exist.
+
+**Step 3: Implement minimal runtime**
+
+Add primary/replica pool creation, AppState storage/accessors, `DbState::read_pool`, and a `ReadDb` extractor.
+
+**Step 4: Run tests to verify GREEN**
+
+Run: `cargo test -p autumn-web database_topology --features db`
+
+Expected: PASS.
+
+### Task 3: CLI Primary-Role Migrations and Doctor Checks
+
+**Files:**
+- Modify: `autumn-cli/src/migrate.rs`
+- Modify: `autumn-cli/src/doctor.rs`
+- Test: `autumn-cli/src/migrate.rs`, `autumn-cli/src/doctor.rs`
+
+**Step 1: Write failing tests**
+
+Add tests proving:
+- `autumn migrate` resolves `AUTUMN_DATABASE__PRIMARY_URL` before legacy URLs and never chooses replica.
+- doctor topology checks fail replica-without-primary and prod replica plus startup migrations.
+- stale replica migration versions fail when fallback is `fail_readiness`.
+- diagnostics include role names and omit credentials.
+
+**Step 2: Run tests to verify RED**
+
+Run: `cargo test -p autumn-cli database_topology`
+
+Expected: failure because topology parsing/checking does not exist.
+
+**Step 3: Implement minimal CLI behavior**
+
+Resolve primary role in migrate, add pure doctor topology helpers, add role-aware connectivity checks, and wire checks into `run`.
+
+**Step 4: Run tests to verify GREEN**
+
+Run: `cargo test -p autumn-cli database_topology`
+
+Expected: PASS.
+
+### Task 4: Docs, Templates, and Certified Example
+
+**Files:**
+- Modify: `autumn-cli/src/templates/autumn.toml.tmpl`
+- Modify: `autumn-cli/src/templates/release/*.tmpl`
+- Modify: `autumn-cli/src/release.rs`
+- Modify: `examples/bookmarks-distributed/*`
+- Modify: `README.md`, `docs/guide/cloud-native.md`, `docs/guide/deployment.md`, `docs/guide/tutorial/03-database.md`, `docs/guide/tutorial/10-configuration.md`, `docs/guide/what-happens-when.md`
+
+**Step 1: Write failing tests**
+
+Add/adjust release template tests that reject production auto-migrate defaults and require primary-role comments.
+
+**Step 2: Run tests to verify RED**
+
+Run: `cargo test -p autumn-cli release`
+
+Expected: failure before template edits.
+
+**Step 3: Implement docs/templates**
+
+Replace startup migration guidance with one-shot migrator guidance, document supported topologies, and migrate the distributed example to canonical `[database]` fields.
+
+**Step 4: Run tests to verify GREEN**
+
+Run: `cargo test -p autumn-cli release`
+
+Expected: PASS.
+
+### Task 5: Verification
+
+Run:
+- `cargo fmt`
+- `cargo test -p autumn-web --features db database_topology`
+- `cargo test -p autumn-cli database_topology`
+- `cargo test -p autumn-cli release`
+- affected docs/template grep for stale `auto_migrate_in_production = true`
+- affected-area TODO/FIXME scan
+
+Expected: all targeted tests pass; any remaining failures are reported with exact scope.

--- a/examples/bookmarks-distributed/README.md
+++ b/examples/bookmarks-distributed/README.md
@@ -1,4 +1,4 @@
-# Autumn Bookmarks Distributed Example
+﻿# Autumn Bookmarks Distributed Example
 
 A bookmark manager copied from `bookmarks` as a clean baseline for the future
 distributed retrofit. It keeps the same bookmark domain and user-facing surface
@@ -12,12 +12,12 @@ runtime seams pulled into the open instead of hidden behind happy-path defaults.
 
 | Feature | Where | What it does |
 |---------|-------|--------------|
-| **Profiles** | `autumn.toml` + `autumn-dev.toml` + `autumn-docker.toml` | Local dev and Docker deployment use different runtime wiring without touching framework internals |
+| **Profiles** | `autumn.toml` + `autumn-dev.toml` + `autumn-docker.toml` | Local dev and Docker deployment use canonical `[database]` primary/replica wiring without touching framework internals |
 | **`#[model]`** | `models.rs` | Generates `Bookmark`, `NewBookmark`, `UpdateBookmark` from one struct |
 | **Explicit repository** | `repositories.rs` | Routes reads to replica, writes to primary, and defines `/api/bookmarks` handlers by hand |
 | **Partitioned scheduled task** | `tasks.rs` | `#[scheduled(every = "1h")]` link checker partitions work into fixed shards and uses Postgres advisory locks for ownership |
 | **Explicit migrator** | `src/bin/migrate.rs` | Runs embedded migrations once against the primary before web replicas start |
-| **Compose deployment** | `docker-compose.yml` + `docker/` | Primary + streaming replica + one-shot migrator + 3 web replicas + nginx |
+| **Compose deployment** | `docker-compose.yml` + `docker/` | Primary + streaming replica + one-shot migrator + 2 web replicas + nginx |
 | **Shared signing secret** | `docker-compose.yml` + `autumn-docker.toml` | All replicas share `AUTUMN_SECURITY__SIGNING_SECRET` so sessions and CSRF tokens survive load-balanced requests |
 | **Redis session backend** | `autumn-docker.toml` | Sessions stored in Redis so any replica can read a session established by another |
 | **Actuator** | Nav bar links | `/actuator/health`, `/actuator/info` auto-mounted |
@@ -34,7 +34,7 @@ runtime seams pulled into the open instead of hidden behind happy-path defaults.
 From the **workspace root** (`autumn/`):
 
 ```bash
-# 1. Generate a stable signing secret shared by all three web replicas.
+# 1. Generate a stable signing secret shared by both web replicas.
 #    All replicas must use the same value or session cookies signed by one
 #    replica will be rejected by the others.
 export AUTUMN_SECURITY__SIGNING_SECRET="$(openssl rand -hex 32)"
@@ -45,14 +45,17 @@ docker compose -f examples/bookmarks-distributed/docker-compose.yml up -d --buil
 
 `docker-compose.yml` passes `AUTUMN_SECURITY__SIGNING_SECRET` from your shell
 into every web replica via the `x-bookmarks-base` anchor. Compose will refuse
-to start if the variable is unset — that mirrors the hard startup failure you
+to start if the variable is unset â€” that mirrors the hard startup failure you
 would see in a production Autumn app.
 
-`autumn-docker.toml` wires two additional things:
-- `[session] backend = "redis"` — sessions are stored in the shared Redis
+`autumn-docker.toml` wires three additional things:
+- `[database] primary_url` / `replica_url` -- the same first-class topology
+  contract used by Autumn itself. The old `[distributed.database]` shape is
+  still accepted by the example loader only as a migration bridge.
+- `[session] backend = "redis"` â€” sessions are stored in the shared Redis
   instance so a session established by `bookmarks-1` is readable by
-  `bookmarks-2` and `bookmarks-3`.
-- `[security.signing_secret]` — the runtime secret comes from the env var
+  `bookmarks-2`.
+- `[security.signing_secret]` â€” the runtime secret comes from the env var
   above; the comment reminds you not to hardcode a value in the TOML file.
 
 That stack brings up:
@@ -60,7 +63,7 @@ That stack brings up:
 - `postgres-primary` on `localhost:5432`
 - `postgres-replica` on `localhost:5433`
 - `bookmarks-migrate` as a one-shot embedded-migration runner
-- `bookmarks-1`, `bookmarks-2`, `bookmarks-3`
+- `bookmarks-1`, `bookmarks-2`
 - `load-balancer` on <http://localhost:3000>
 
 Generated `static/css/autumn.css` is intentionally ignored. You do not need to
@@ -68,7 +71,8 @@ run `autumn setup` just to compile or test the example; the build skips CSS
 regeneration when Tailwind is unavailable. Set `AUTUMN_REQUIRE_TAILWIND=true`
 when you explicitly want missing or broken Tailwind to fail the build.
 The web replicas wait until the standby has replayed the latest Diesel migration
-version before they start serving traffic.
+version before they start serving traffic. If the replica is stale, the replica
+healthcheck fails and Compose never admits the web tier.
 
 Useful follow-ups:
 
@@ -156,20 +160,20 @@ curl -X PUT http://localhost:3000/api/bookmarks/1 \
 ## Verifying cross-replica session consistency
 
 Once the stack is up, you can confirm that a session established on one replica
-is honoured by the others — which is the practical test of a shared signing
+is honoured by the others â€” which is the practical test of a shared signing
 secret plus a shared session store:
 
 ```bash
 # 1. Open a session on whichever replica nginx selects first
 SESSION=$(curl -s -c /tmp/bm-cookies.txt http://localhost:3000/ > /dev/null && cat /tmp/bm-cookies.txt | grep session | awk '{print $NF}')
 
-# 2. Hit the load balancer several times — nginx round-robins across the three
+# 2. Hit the load balancer several times: nginx round-robins across the two
 #    replicas, so at least one request will land on a different process.
 for i in 1 2 3 4 5; do curl -s -b /tmp/bm-cookies.txt http://localhost:3000/ | grep -c "bookmarks" ; done
 ```
 
 Each request should return bookmark data (rather than a redirect to a sign-in
-page), regardless of which of the three replicas handles it.
+page), regardless of which replica handles it.
 
 ## Pain points surfaced on purpose
 
@@ -188,6 +192,6 @@ page), regardless of which of the three replicas handles it.
   might reduce ceremony without hiding the runtime truth.
 - Signing secrets must be provisioned before `docker compose up`. The compose
   file uses `${AUTUMN_SECURITY__SIGNING_SECRET:?...}` syntax so that Compose
-  itself fails loudly if the variable is missing — rather than silently starting
+  itself fails loudly if the variable is missing â€” rather than silently starting
   replicas with per-process ephemeral keys that would cause every session cookie
   to be invalid on any replica other than the one that set it.

--- a/examples/bookmarks-distributed/README.md
+++ b/examples/bookmarks-distributed/README.md
@@ -1,4 +1,4 @@
-﻿# Autumn Bookmarks Distributed Example
+# Autumn Bookmarks Distributed Example
 
 A bookmark manager copied from `bookmarks` as a clean baseline for the future
 distributed retrofit. It keeps the same bookmark domain and user-facing surface
@@ -45,17 +45,17 @@ docker compose -f examples/bookmarks-distributed/docker-compose.yml up -d --buil
 
 `docker-compose.yml` passes `AUTUMN_SECURITY__SIGNING_SECRET` from your shell
 into every web replica via the `x-bookmarks-base` anchor. Compose will refuse
-to start if the variable is unset â€” that mirrors the hard startup failure you
+to start if the variable is unset — that mirrors the hard startup failure you
 would see in a production Autumn app.
 
 `autumn-docker.toml` wires three additional things:
 - `[database] primary_url` / `replica_url` -- the same first-class topology
   contract used by Autumn itself. The old `[distributed.database]` shape is
   still accepted by the example loader only as a migration bridge.
-- `[session] backend = "redis"` â€” sessions are stored in the shared Redis
+- `[session] backend = "redis"` — sessions are stored in the shared Redis
   instance so a session established by `bookmarks-1` is readable by
   `bookmarks-2`.
-- `[security.signing_secret]` â€” the runtime secret comes from the env var
+- `[security.signing_secret]` — the runtime secret comes from the env var
   above; the comment reminds you not to hardcode a value in the TOML file.
 
 That stack brings up:
@@ -160,7 +160,7 @@ curl -X PUT http://localhost:3000/api/bookmarks/1 \
 ## Verifying cross-replica session consistency
 
 Once the stack is up, you can confirm that a session established on one replica
-is honoured by the others â€” which is the practical test of a shared signing
+is honoured by the others — which is the practical test of a shared signing
 secret plus a shared session store:
 
 ```bash
@@ -192,6 +192,6 @@ page), regardless of which replica handles it.
   might reduce ceremony without hiding the runtime truth.
 - Signing secrets must be provisioned before `docker compose up`. The compose
   file uses `${AUTUMN_SECURITY__SIGNING_SECRET:?...}` syntax so that Compose
-  itself fails loudly if the variable is missing â€” rather than silently starting
+  itself fails loudly if the variable is missing — rather than silently starting
   replicas with per-process ephemeral keys that would cause every session cookie
   to be invalid on any replica other than the one that set it.

--- a/examples/bookmarks-distributed/autumn-dev.toml
+++ b/examples/bookmarks-distributed/autumn-dev.toml
@@ -3,11 +3,8 @@
 #
 # Smart defaults already set: log.level=debug, log.format=Pretty,
 # health.detailed=true, actuator.sensitive=true.
-# We only need the database URL here.
-
+# The base [database] section names primary_url and replica_url. Dev only
+# changes pool sizing.
 [database]
-url = "postgres://autumn:autumn@localhost:5432/bookmarks_distributed"
-
-[distributed.database]
 primary_pool_size = 7
 replica_pool_size = 3

--- a/examples/bookmarks-distributed/autumn-docker.toml
+++ b/examples/bookmarks-distributed/autumn-docker.toml
@@ -3,14 +3,12 @@ host = "0.0.0.0"
 port = 3000
 
 [database]
-url = "postgres://autumn:autumn@postgres-primary:5432/bookmarks_distributed"
-pool_size = 8
-
-[distributed.database]
 primary_url = "postgres://autumn:autumn@postgres-primary:5432/bookmarks_distributed"
 replica_url = "postgres://autumn:autumn@postgres-replica:5432/bookmarks_distributed"
 primary_pool_size = 8
 replica_pool_size = 8
+replica_fallback = "fail_readiness"
+auto_migrate_in_production = false
 
 [cache]
 backend = "redis"
@@ -19,7 +17,7 @@ backend = "redis"
 url = "redis://redis:6379"
 key_prefix = "bookmarks:cache"
 
-# Sessions must be stored in Redis so they survive across all three replicas.
+# Sessions must be stored in Redis so they survive across all web replicas.
 # The signing secret is read from AUTUMN_SECURITY__SIGNING_SECRET at startup;
 # every replica must receive the same value or cookies signed by replica A will
 # be rejected by replica B.

--- a/examples/bookmarks-distributed/autumn.toml
+++ b/examples/bookmarks-distributed/autumn.toml
@@ -7,8 +7,10 @@ level = "info"
 [health]
 path = "/health"
 
-[distributed.database]
+[database]
 primary_url = "postgres://autumn:autumn@localhost:5432/bookmarks_distributed"
 replica_url = "postgres://autumn:autumn@localhost:5433/bookmarks_distributed"
 primary_pool_size = 4
 replica_pool_size = 2
+replica_fallback = "fail_readiness"
+auto_migrate_in_production = false

--- a/examples/bookmarks-distributed/docker-compose.yml
+++ b/examples/bookmarks-distributed/docker-compose.yml
@@ -119,24 +119,11 @@ services:
       redis:
         condition: service_healthy
 
-  bookmarks-3:
-    <<: *bookmarks-base
-    depends_on:
-      bookmarks-migrate:
-        condition: service_completed_successfully
-      postgres-primary:
-        condition: service_healthy
-      postgres-replica:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-
   load-balancer:
     image: nginx:1.27-alpine
     depends_on:
       - bookmarks-1
       - bookmarks-2
-      - bookmarks-3
     ports:
       - "3000:3000"
     volumes:

--- a/examples/bookmarks-distributed/docker/nginx/nginx.conf
+++ b/examples/bookmarks-distributed/docker/nginx/nginx.conf
@@ -4,7 +4,6 @@ http {
   upstream bookmarks_cluster {
     server bookmarks-1:3000;
     server bookmarks-2:3000;
-    server bookmarks-3:3000;
   }
 
   server {

--- a/examples/bookmarks-distributed/src/config.rs
+++ b/examples/bookmarks-distributed/src/config.rs
@@ -209,7 +209,11 @@ impl fmt::Display for DistributedConfigLoadError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MissingSection { path } => {
-                write!(f, "missing [distributed] section in {}", path.display())
+                write!(
+                    f,
+                    "missing [database] primary/replica topology section in {}",
+                    path.display()
+                )
             }
             Self::Io { path, source } => {
                 write!(
@@ -249,6 +253,14 @@ fn load_distributed_section(
                     path: path.to_path_buf(),
                     source: Box::new(source),
                 })?;
+            if let Some(database) = table.get("database").and_then(toml::Value::as_table)
+                && canonical_database_table_has_topology(database)
+            {
+                let mut section = toml::map::Map::new();
+                section.insert("database".to_owned(), toml::Value::Table(database.clone()));
+                return Ok(Some(toml::Value::Table(section)));
+            }
+
             Ok(toml::Value::Table(table).get("distributed").cloned())
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
@@ -257,6 +269,17 @@ fn load_distributed_section(
             source,
         }),
     }
+}
+
+fn canonical_database_table_has_topology(database: &toml::Table) -> bool {
+    [
+        "primary_url",
+        "replica_url",
+        "primary_pool_size",
+        "replica_pool_size",
+    ]
+    .iter()
+    .any(|key| database.contains_key(*key))
 }
 
 fn deep_merge(base: &mut toml::Value, overlay: toml::Value) {
@@ -291,7 +314,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_primary_and_replica_urls_from_toml() {
+    fn parses_primary_and_replica_urls_from_canonical_database_toml() {
         let temp_dir = unique_temp_dir("autumn-bookmarks-distributed-parse");
         let _ = fs::remove_dir_all(&temp_dir);
         fs::create_dir_all(&temp_dir).expect("temp dir should be created");
@@ -299,7 +322,7 @@ mod tests {
         fs::write(
             temp_dir.join("autumn.toml"),
             r#"
-                [distributed.database]
+                [database]
                 primary_url = "postgres://autumn:autumn@localhost:5432/bookmarks_distributed_primary"
                 replica_url = "postgres://autumn:autumn@localhost:5432/bookmarks_distributed_replica"
                 primary_pool_size = 7
@@ -360,7 +383,7 @@ mod tests {
     }
 
     #[test]
-    fn loads_layered_distributed_section_from_example_files() {
+    fn loads_layered_canonical_database_section_from_example_files() {
         let temp_dir = unique_temp_dir("autumn-bookmarks-distributed-config");
         let _ = fs::remove_dir_all(&temp_dir);
         fs::create_dir_all(&temp_dir).expect("temp dir should be created");
@@ -368,7 +391,7 @@ mod tests {
         fs::write(
             temp_dir.join("autumn.toml"),
             r#"
-                [distributed.database]
+                [database]
                 primary_url = "postgres://autumn:autumn@localhost:5432/bookmarks_distributed_primary"
                 replica_url = "postgres://autumn:autumn@localhost:5432/bookmarks_distributed_replica"
                 primary_pool_size = 4
@@ -379,7 +402,7 @@ mod tests {
         fs::write(
             temp_dir.join("autumn-staging.toml"),
             r#"
-                [distributed.database]
+                [database]
                 primary_pool_size = 7
                 replica_pool_size = 3
             "#,
@@ -404,7 +427,38 @@ mod tests {
     }
 
     #[test]
-    fn missing_distributed_section_is_an_error() {
+    fn legacy_distributed_database_section_still_loads() {
+        let temp_dir = unique_temp_dir("autumn-bookmarks-distributed-legacy-config");
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).expect("temp dir should be created");
+
+        fs::write(
+            temp_dir.join("autumn.toml"),
+            r#"
+                [distributed.database]
+                primary_url = "postgres://autumn:autumn@localhost:5432/bookmarks_distributed_primary"
+                replica_url = "postgres://autumn:autumn@localhost:5432/bookmarks_distributed_replica"
+            "#,
+        )
+        .expect("base config should be written");
+
+        let config = DistributedConfig::load_from_dir(Path::new(&temp_dir), None)
+            .expect("legacy distributed config should still load");
+
+        assert_eq!(
+            config.database.primary_url.as_deref(),
+            Some("postgres://autumn:autumn@localhost:5432/bookmarks_distributed_primary")
+        );
+        assert_eq!(
+            config.database.replica_url.as_deref(),
+            Some("postgres://autumn:autumn@localhost:5432/bookmarks_distributed_replica")
+        );
+
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn missing_database_topology_section_is_an_error() {
         let temp_dir = unique_temp_dir("autumn-bookmarks-distributed-config-missing");
         let _ = fs::remove_dir_all(&temp_dir);
         fs::create_dir_all(&temp_dir).expect("temp dir should be created");
@@ -413,9 +467,9 @@ mod tests {
             .expect("base config should be written");
 
         let error = DistributedConfig::load_from_dir(Path::new(&temp_dir), None)
-            .expect_err("missing distributed section should fail");
+            .expect_err("missing database topology section should fail");
 
-        assert!(error.to_string().contains("distributed"));
+        assert!(error.to_string().contains("database"));
 
         let _ = fs::remove_dir_all(&temp_dir);
     }

--- a/examples/bookmarks-distributed/tests/cache_cross_replica.rs
+++ b/examples/bookmarks-distributed/tests/cache_cross_replica.rs
@@ -1,7 +1,7 @@
 //! Integration test: two replicas sharing a Redis backend see the same cached
 //! data and invalidations within one round-trip.
 //!
-//! Mirrors the production topology: three `bookmarks-distributed` replicas
+//! Mirrors the production topology: two `bookmarks-distributed` replicas
 //! share a single Redis instance (see `docker-compose.yml`). Any write to the
 //! cache on replica A must be readable by replica B, and any invalidation from
 //! replica A must immediately remove the entry on replica B.
@@ -18,7 +18,7 @@ async fn cross_replica_cached_count_consistency() {
     let port = container.get_host_port_ipv4(6379).await.unwrap();
     let url = format!("redis://127.0.0.1:{port}");
 
-    // Two "replicas" that share the same Redis namespace, just like the three
+    // Two "replicas" that share the same Redis namespace, just like the two
     // bookmarks-distributed replicas behind the nginx load-balancer.
     let replica_a = RedisCache::connect(&url, "bookmarks:cache").await.unwrap();
     let replica_b = RedisCache::connect(&url, "bookmarks:cache").await.unwrap();


### PR DESCRIPTION
Wire replica runtime state into /ready and read_pool().
  Fail readiness for stale replicas under fail_readiness, and route reads
  to primary when replica_fallback = primary. Add migration-version
  readiness checks and regression coverage.