### PR TITLE
⚒️ Forge: [Resolve Boolean Blindness]

### DIFF
--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -649,7 +649,7 @@ fn validation_errors(
     errors
 }
 
-fn problem_type_for(status: StatusCode, has_validation_errors: bool) -> &'static str {
+const fn problem_type_for(status: StatusCode, has_validation_errors: bool) -> &'static str {
     if has_validation_errors {
         return "https://autumn.dev/problems/validation-failed";
     }
@@ -689,7 +689,7 @@ fn problem_title_for(status: StatusCode, has_validation_errors: bool) -> &'stati
     }
 }
 
-fn problem_code_for(status: StatusCode, has_validation_errors: bool) -> &'static str {
+const fn problem_code_for(status: StatusCode, has_validation_errors: bool) -> &'static str {
     if has_validation_errors {
         return "autumn.validation_failed";
     }
@@ -705,9 +705,11 @@ fn problem_code_for(status: StatusCode, has_validation_errors: bool) -> &'static
         StatusCode::INTERNAL_SERVER_ERROR => "autumn.internal_server_error",
         StatusCode::NOT_IMPLEMENTED => "autumn.not_implemented",
         StatusCode::SERVICE_UNAVAILABLE => "autumn.service_unavailable",
-        _ if status.is_client_error() => "autumn.client_error",
-        _ if status.is_server_error() => "autumn.server_error",
-        _ => "autumn.error",
+        status => match status.as_u16() {
+            400..=499 => "autumn.client_error",
+            500..=599 => "autumn.server_error",
+            _ => "autumn.error",
+        }
     }
 }
 

--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -709,7 +709,7 @@ const fn problem_code_for(status: StatusCode, has_validation_errors: bool) -> &'
             400..=499 => "autumn.client_error",
             500..=599 => "autumn.server_error",
             _ => "autumn.error",
-        }
+        },
     }
 }
 

--- a/autumn/src/static_gen/middleware.rs
+++ b/autumn/src/static_gen/middleware.rs
@@ -186,8 +186,7 @@ impl StaticFileLayer {
         // This prevents this process from spawning more than one task per route.
         if route_state
             .in_flight
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
-            .is_err()
+            .swap(true, Ordering::AcqRel)
         {
             // Another task is already regenerating this route in this process
             return;

--- a/autumn/src/static_gen/middleware.rs
+++ b/autumn/src/static_gen/middleware.rs
@@ -184,10 +184,7 @@ impl StaticFileLayer {
 
         // Try to claim the in-flight flag (CAS: false -> true).
         // This prevents this process from spawning more than one task per route.
-        if route_state
-            .in_flight
-            .swap(true, Ordering::AcqRel)
-        {
+        if route_state.in_flight.swap(true, Ordering::AcqRel) {
             // Another task is already regenerating this route in this process
             return;
         }

--- a/examples/bookmarks-distributed/src/config.rs
+++ b/examples/bookmarks-distributed/src/config.rs
@@ -52,7 +52,9 @@ impl MissingDistributedDatabaseUrls {
 impl fmt::Display for MissingDistributedDatabaseUrls {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::PrimaryAndReplica => f.write_str("primary and replica database URLs are required"),
+            Self::PrimaryAndReplica => {
+                f.write_str("primary and replica database URLs are required")
+            }
             Self::Primary => f.write_str("primary database URL is required"),
             Self::Replica => f.write_str("replica database URL is required"),
         }

--- a/examples/bookmarks-distributed/src/config.rs
+++ b/examples/bookmarks-distributed/src/config.rs
@@ -26,44 +26,35 @@ pub struct DistributedDatabaseConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MissingDistributedDatabaseUrls {
-    missing_primary: bool,
-    missing_replica: bool,
+pub enum MissingDistributedDatabaseUrls {
+    PrimaryAndReplica,
+    Primary,
+    Replica,
 }
 
 impl MissingDistributedDatabaseUrls {
     #[must_use]
     pub fn primary_and_replica() -> Self {
-        Self {
-            missing_primary: true,
-            missing_replica: true,
-        }
+        Self::PrimaryAndReplica
     }
 
     #[must_use]
     pub fn primary() -> Self {
-        Self {
-            missing_primary: true,
-            missing_replica: false,
-        }
+        Self::Primary
     }
 
     #[must_use]
     pub fn replica() -> Self {
-        Self {
-            missing_primary: false,
-            missing_replica: true,
-        }
+        Self::Replica
     }
 }
 
 impl fmt::Display for MissingDistributedDatabaseUrls {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match (self.missing_primary, self.missing_replica) {
-            (true, true) => f.write_str("primary and replica database URLs are required"),
-            (true, false) => f.write_str("primary database URL is required"),
-            (false, true) => f.write_str("replica database URL is required"),
-            (false, false) => f.write_str("database URLs are required"),
+        match self {
+            Self::PrimaryAndReplica => f.write_str("primary and replica database URLs are required"),
+            Self::Primary => f.write_str("primary database URL is required"),
+            Self::Replica => f.write_str("replica database URL is required"),
         }
     }
 }

--- a/examples/reddit-clone/src/live_events.rs
+++ b/examples/reddit-clone/src/live_events.rs
@@ -346,11 +346,11 @@ impl LiveEventBusListener {
         if redis.is_none() && postgres.is_none() {
             None
         } else {
-            let label = match (redis.is_some(), postgres.is_some()) {
-                (true, true) => "redis+postgres",
-                (true, false) => "redis",
-                (false, true) => "postgres",
-                (false, false) => "polling",
+            let label = match (&redis, &postgres) {
+                (Some(_), Some(_)) => "redis+postgres",
+                (Some(_), None) => "redis",
+                (None, Some(_)) => "postgres",
+                (None, None) => "polling",
             };
             Some(Self {
                 label: label.to_owned(),


### PR DESCRIPTION
* 🚮 Smell: "Boolean blindness and unnecessary intermediate representations when checking booleans, options and atomics."
* ✨ Solution: "Introduced enum `MissingDistributedDatabaseUrls` to avoid boolean tuples. Avoided mapping to `(bool, bool)` and instead matched against `(&Option, &Option)`. Used `swap` for atomic variable update. Replaced `Option_if_let_else`."
* 🧼 Benefit: "Removes unnecessary boolean evaluations and makes the code strictly typed."
* 🛡️ Verification: "Tests passed. No logic changed."

---
*PR created automatically by Jules for task [11927964467757050323](https://jules.google.com/task/11927964467757050323) started by @madmax983*