### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -649,7 +649,7 @@ fn validation_errors(
     errors
 }
 
-fn problem_type_for(status: StatusCode, has_validation_errors: bool) -> &'static str {
+const fn problem_type_for(status: StatusCode, has_validation_errors: bool) -> &'static str {
     if has_validation_errors {
         return "https://autumn.dev/problems/validation-failed";
     }

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -350,17 +350,25 @@ pub fn check_route_prefix(
 /// Both named params (`{id}`) and catch-all params (`{*rest}`) normalize to
 /// `{}`. matchit (Axum's router) treats a named param and a catch-all at the
 /// same path position as a conflict, so they must map to the same key.
+/// Normalizes a route path for collision detection by replacing dynamic segment names with `{}`.
+///
+/// ⚡ **Bolt**: This optimization eliminates an intermediate `Vec` allocation
+/// and joins the segments directly into a pre-allocated `String`, reducing memory overhead.
 fn normalize_path_for_collision(path: &str) -> String {
-    path.split('/')
-        .map(|seg| {
-            if seg.starts_with('{') && seg.ends_with('}') {
-                "{}"
-            } else {
-                seg
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
+    let mut out = String::with_capacity(path.len());
+    let mut first = true;
+    for seg in path.split('/') {
+        if !first {
+            out.push('/');
+        }
+        first = false;
+        if seg.starts_with('{') && seg.ends_with('}') {
+            out.push_str("{}");
+        } else {
+            out.push_str(seg);
+        }
+    }
+    out
 }
 
 /// Detect route collisions: any two routes sharing the same (method, path) pair.
@@ -881,6 +889,11 @@ mod tests {
             CheckStatus::Fail,
             "catch-all and named param at same position conflict in matchit"
         );
+    }
+
+    #[test]
+    fn normalize_path_for_collision_missing_leading_slash() {
+        assert_eq!(normalize_path_for_collision("api/{user}/{id}"), "api/{}/{}");
     }
 
     #[test]


### PR DESCRIPTION
💡 What: Eliminate intermediate `Vec` allocation in `normalize_path_for_collision`.
🎯 Why: Using `.collect::<Vec<_>>().join("/")` creates an unnecessary heap allocation. We can avoid this by pre-allocating a `String` and pushing to it directly.
📊 Impact: Reduces heap allocs by 1 per function call on a potentially hot startup/validation path.
🔬 Measurement: Run `cargo test -p autumn-web --lib plugin_conformance`.

---
*PR created automatically by Jules for task [11977606855771888574](https://jules.google.com/task/11977606855771888574) started by @madmax983*