### PR TITLE
🌟 Nova: [CLI Monitor Replay]

### DIFF
--- a/autumn-cli/src/export.rs
+++ b/autumn-cli/src/export.rs
@@ -26,6 +26,7 @@ pub fn run_inner(url: &str, output: &str) -> Result<(), String> {
     let metrics = fetch_endpoint(&client, base_url, "/actuator/metrics");
     let tasks = fetch_endpoint(&client, base_url, "/actuator/tasks");
     let loggers = fetch_endpoint(&client, base_url, "/actuator/loggers");
+    let channels = fetch_endpoint(&client, base_url, "/actuator/channels");
 
     // If any endpoint returns an error, fail the export
     for (name, val) in [
@@ -33,6 +34,7 @@ pub fn run_inner(url: &str, output: &str) -> Result<(), String> {
         ("metrics", &metrics),
         ("tasks", &tasks),
         ("loggers", &loggers),
+        ("channels", &channels),
     ] {
         if let Some(err) = val.get("error") {
             return Err(format!(
@@ -56,6 +58,7 @@ pub fn run_inner(url: &str, output: &str) -> Result<(), String> {
         "metrics": metrics,
         "tasks": tasks,
         "loggers": loggers,
+        "channels": channels,
     });
 
     match File::create(output) {
@@ -173,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_run_inner_success() {
-        let url = spawn_mock_server("HTTP/1.1 200 OK", r#"{"status": "ok"}"#, 4);
+        let url = spawn_mock_server("HTTP/1.1 200 OK", r#"{"status": "ok"}"#, 5);
 
         let output_file = tempfile::NamedTempFile::new().unwrap();
         let output_path = output_file.path().to_str().unwrap();
@@ -189,6 +192,7 @@ mod tests {
         assert_eq!(json["metrics"]["status"], "ok");
         assert_eq!(json["tasks"]["status"], "ok");
         assert_eq!(json["loggers"]["status"], "ok");
+        assert_eq!(json["channels"]["status"], "ok");
     }
 
     #[test]
@@ -207,7 +211,7 @@ mod tests {
 
     #[test]
     fn test_run_inner_file_creation_error() {
-        let url = spawn_mock_server("HTTP/1.1 200 OK", r#"{"status": "ok"}"#, 4);
+        let url = spawn_mock_server("HTTP/1.1 200 OK", r#"{"status": "ok"}"#, 5);
 
         // Use an invalid path that cannot be created
         let result = run_inner(&url, "/invalid/path/that/does/not/exist/diag.json");

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -71,12 +71,15 @@ enum Commands {
     },
     /// Live monitoring dashboard for a running Autumn application
     Monitor {
-        /// URL of the running Autumn application
+        /// URL of the running Autumn application (or file path if --replay is set)
         #[arg(short, long, default_value = "http://localhost:3000")]
         url: String,
         /// Polling interval in seconds
         #[arg(short, long, default_value = "1")]
         interval: u64,
+        /// Start monitor from an exported diagnostics file
+        #[arg(long)]
+        replay: bool,
     },
     /// Export an offline diagnostic snapshot of the application
     Export {
@@ -511,7 +514,17 @@ fn run_command(command: Commands) {
             };
             migrate::run(action);
         }
-        Commands::Monitor { url, interval } => monitor::run(&url, interval),
+        Commands::Monitor {
+            url,
+            interval,
+            replay,
+        } => {
+            if replay {
+                monitor::run_replay(&url);
+            } else {
+                monitor::run(&url, interval);
+            }
+        }
         Commands::Export { url, output } => export::run(&url, &output),
         Commands::New {
             name,
@@ -974,9 +987,14 @@ mod tests {
     fn parse_monitor_defaults() {
         let cli = Cli::try_parse_from(["autumn", "monitor"]).unwrap();
         match cli.command {
-            Commands::Monitor { url, interval } => {
+            Commands::Monitor {
+                url,
+                interval,
+                replay,
+            } => {
                 assert_eq!(url, "http://localhost:3000");
                 assert_eq!(interval, 1);
+                assert!(!replay);
             }
             _ => panic!("expected Monitor command"),
         }
@@ -987,9 +1005,32 @@ mod tests {
         let cli = Cli::try_parse_from(["autumn", "monitor", "-u", "http://prod:8080", "-i", "5"])
             .unwrap();
         match cli.command {
-            Commands::Monitor { url, interval } => {
+            Commands::Monitor {
+                url,
+                interval,
+                replay,
+            } => {
                 assert_eq!(url, "http://prod:8080");
                 assert_eq!(interval, 5);
+                assert!(!replay);
+            }
+            _ => panic!("expected Monitor command"),
+        }
+    }
+
+    #[test]
+    fn parse_monitor_replay() {
+        let cli =
+            Cli::try_parse_from(["autumn", "monitor", "-u", "diag.json", "--replay"]).unwrap();
+        match cli.command {
+            Commands::Monitor {
+                url,
+                interval,
+                replay,
+            } => {
+                assert_eq!(url, "diag.json");
+                assert_eq!(interval, 1);
+                assert!(replay);
             }
             _ => panic!("expected Monitor command"),
         }

--- a/autumn-cli/src/monitor.rs
+++ b/autumn-cli/src/monitor.rs
@@ -166,6 +166,7 @@ const SPARKLINE_DEPTH: usize = 120;
 
 struct DashboardState {
     base_url: String,
+    is_replay: bool,
     health: HealthResponse,
     metrics: MetricsResponse,
     tasks: TasksResponse,
@@ -196,6 +197,7 @@ struct DashboardState {
 impl DashboardState {
     fn new(base_url: String) -> Self {
         Self {
+            is_replay: false,
             base_url,
             health: HealthResponse::default(),
             metrics: MetricsResponse::default(),
@@ -365,6 +367,45 @@ pub fn run(url: &str, poll_secs: u64) {
     }
 }
 
+pub fn run_replay(file_path: &str) {
+    let file = std::fs::File::open(file_path).unwrap_or_else(|e| {
+        eprintln!("Failed to open replay file '{file_path}': {e}");
+        std::process::exit(1);
+    });
+    let snapshot: serde_json::Value = serde_json::from_reader(file).unwrap_or_else(|e| {
+        eprintln!("Failed to parse replay file '{file_path}': {e}");
+        std::process::exit(1);
+    });
+
+    let mut state = DashboardState::new(snapshot["url"].as_str().unwrap_or("unknown").to_string());
+    state.is_replay = true;
+    state.health = serde_json::from_value(snapshot["health"].clone()).unwrap_or_default();
+    state.metrics = serde_json::from_value(snapshot["metrics"].clone()).unwrap_or_default();
+    state.tasks = serde_json::from_value(snapshot["tasks"].clone()).unwrap_or_default();
+    state.loggers = serde_json::from_value(snapshot["loggers"].clone()).unwrap_or_default();
+    state.channels = serde_json::from_value(snapshot["channels"].clone()).unwrap_or_default();
+    state.connected = true;
+
+    // Populate static charts if needed, or leave history empty for replay mode.
+    if state.metrics.http.requests_total > 0 {
+        state
+            .throughput_history
+            .push_back(state.metrics.http.requests_total);
+    }
+
+    terminal::enable_raw_mode().expect("failed to enable raw mode");
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, cursor::Hide).expect("failed to setup terminal");
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend).expect("failed to create terminal");
+
+    let _ = run_loop(&mut terminal, &mut state, Duration::from_secs(60));
+
+    terminal::disable_raw_mode().expect("failed to disable raw mode");
+    execute!(terminal.backend_mut(), LeaveAlternateScreen, cursor::Show)
+        .expect("failed to restore terminal");
+}
+
 fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     state: &mut DashboardState,
@@ -410,7 +451,10 @@ fn run_loop(
 
         // Poll actuator endpoints
         if state.last_poll.elapsed() >= poll_interval {
-            state.poll();
+            if !state.is_replay {
+                state.poll();
+            }
+            state.last_poll = Instant::now();
         }
     }
 }


### PR DESCRIPTION
💡 **The Spark:** The `autumn export` command is great for grabbing a snapshot of an application's state, but staring at raw JSON isn't nearly as pleasant as using `autumn monitor`. Can we connect them so the monitor can "replay" an exported file?

🚀 **The Feature:** Implemented `autumn monitor --replay <file>` that bypasses the network polling loop and populates the `DashboardState` entirely from the provided JSON snapshot. Updated `autumn export` to also capture the `/actuator/channels` endpoint to ensure the replay is feature-complete.

🔭 **The Potential:** Enables developers to share production failure snapshots via Slack and inspect them locally using the rich TUI tools they are already familiar with. Opens the door for future features like "time-traveling" through multiple sequential snapshots.

⚠️ **Risk:** Low. The `is_replay` flag cleanly isolates the new logic, preventing any interference with the normal live polling behavior. Reverted CLI flag renaming to preserve backward compatibility.

---
*PR created automatically by Jules for task [13709595559401064640](https://jules.google.com/task/13709595559401064640) started by @madmax983*