### PR TITLE
feat(webhook): add signed webhook intake with durable replay protection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["autumn", "autumn-macros", "autumn-cli", "autumn-admin-plugin", "autumn-storage-s3", "autumn-cache-redis", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/wiki", "examples/reddit-clone", "examples/custom_config_loader", "examples/ws-echo"]
+members = ["autumn", "autumn-macros", "autumn-cli", "autumn-admin-plugin", "autumn-storage-s3", "autumn-cache-redis", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/wiki", "examples/reddit-clone", "examples/custom_config_loader", "examples/ws-echo", "examples/signed-webhooks"]
 resolver = "3"
 
 [patch.crates-io]

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -157,6 +157,21 @@ blocks publishing `autumn-web` or `autumn-cli`.
 
 ---
 
+### `examples/signed-webhooks` - Signed Webhook Intake
+
+<!-- catalog:example name=signed-webhooks tier=supported -->
+
+| Field | Value |
+|-------|-------|
+| **Persona** | Developer integrating payment, Git, chat, or CMS callbacks |
+| **Journey** | Signed intake: configure a provider preset, verify raw-body HMAC, reject stale/tampered/replayed deliveries |
+| **Key capabilities** | `SignedWebhook`, Stripe-style signatures, raw-body verification, replay protection, Problem Details failures |
+| **Prerequisites** | Rust 1.88.0+ |
+| **Run command** | `cargo run -p signed-webhooks-example` |
+| **Success proof** | `cargo test -p signed-webhooks-example` passes valid, tampered-body, stale-timestamp, bad-signature, and duplicate-delivery fixtures |
+
+---
+
 ## Journey Map
 
 The table below maps each example to a distinct learning journey so evaluators
@@ -173,6 +188,7 @@ can pick the closest starting point without overlap.
 | Full-stack clone | `reddit-clone` | Auth, sessions, jobs, channels, email — the complete server-first stack |
 | Custom config loading | `custom_config_loader` | Replace the default config loader with a custom `ConfigLoader` |
 | WebSocket / SSE | `ws-echo` | Echo, fan-out channels, SSE, Redis multi-replica pub/sub |
+| Signed intake | `signed-webhooks` | Provider-shaped webhook HMAC verification and replay rejection |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -181,10 +181,12 @@ See [EXAMPLES.md](EXAMPLES.md) for the full catalog with personas, journeys, pre
 | [`examples/reddit-clone`](examples/reddit-clone) | Full-featured Reddit clone: auth, sessions, CSRF, `#[secured]`, transactional email, `#[job]`, `#[ws]` channels, Redis fan-out, htmx voting, and profiles |
 | [`examples/custom_config_loader`](examples/custom_config_loader) | Replace the default TOML + env config loader with a custom `ConfigLoader` (JSON file, Vault, Secrets Manager, etc.) |
 | [`examples/ws-echo`](examples/ws-echo) | WebSocket echo server, SSE fan-out, htmx live list, and Redis-backed multi-replica pub/sub |
+| [`examples/signed-webhooks`](examples/signed-webhooks) | Signed webhook intake with provider-shaped HMAC verification, replay protection, and fixture tests |
 
 ## Documentation
 
 - [Getting Started Guide](docs/guide/getting-started.md)
+- [Signed Webhook Intake](docs/guide/signed-webhooks.md)
 - [Docs Smoke Procedure](docs/guide/docs-smoke.md) - release gate for first-run docs
 - [Release Checklist](docs/release-checklist.md)
 - [Code Generators](docs/guide/generators.md) — `autumn generate model | migration | scaffold`

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1509,7 +1509,12 @@ impl AppBuilder {
         // entropy-meeting secret before the server binds. Dev/test are exempt.
         fail_fast_on_invalid_signing_secret(&config);
 
-        // 4e. Provision the configured BlobStore *before* `setup_database`.
+        // 4e. Signed webhook configs must resolve to usable key material
+        // before the app binds. Missing secrets should fail before a real
+        // provider retry loop starts hammering a broken endpoint.
+        fail_fast_on_invalid_webhook_config(&config);
+
+        // 4f. Provision the configured BlobStore *before* `setup_database`.
         // `LocalBlobStore::new` does real IO (creates + canonicalizes the
         // root) and the storage code may `process::exit(1)` on failure
         // (unwritable root, or `storage.backend = "s3"` with no plugin).
@@ -1619,6 +1624,7 @@ impl AppBuilder {
         // into the user's router below.
         #[cfg(feature = "storage")]
         let storage_router = storage_bootstrap.and_then(|b| b.install(&state));
+        install_webhook_registry(&state, &config);
 
         let env = crate::config::OsEnv;
         let dist_dir = project_dir("dist", &env);
@@ -2966,6 +2972,23 @@ fn fail_fast_on_invalid_signing_secret(config: &AutumnConfig) {
                 std::process::exit(1);
             }
         }
+    }
+}
+
+fn fail_fast_on_invalid_webhook_config(config: &AutumnConfig) {
+    let is_production = matches!(config.profile.as_deref(), Some("prod" | "production"));
+    if let Err(error) = config.security.webhooks.validate(is_production) {
+        eprintln!("Invalid signed webhook configuration: {error}");
+        std::process::exit(1);
+    }
+}
+
+pub(crate) fn install_webhook_registry(state: &AppState, config: &AutumnConfig) {
+    if let Err(error) =
+        crate::webhook::install_registry_from_config(state, &config.security.webhooks)
+    {
+        eprintln!("Invalid signed webhook configuration: {error}");
+        std::process::exit(1);
     }
 }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -110,6 +110,10 @@
 //! | `AUTUMN_SECURITY__FORBIDDEN_RESPONSE` | `security.forbidden_response` | `"403"` or `"404"` |
 //! | `AUTUMN_SECURITY__ALLOW_UNAUTHORIZED_REPOSITORY_API` | `security.allow_unauthorized_repository_api` | `bool` |
 //! | `AUTUMN_SECURITY__SIGNING_SECRET` | `security.signing_secret.secret` | `String` |
+//! | `AUTUMN_SECURITY__WEBHOOKS__REPLAY__BACKEND` | `security.webhooks.replay.backend` | `memory` / `redis` |
+//! | `AUTUMN_SECURITY__WEBHOOKS__REPLAY__REDIS__URL` | `security.webhooks.replay.redis.url` | `String` |
+//! | `AUTUMN_SECURITY__WEBHOOKS__REPLAY__REDIS__KEY_PREFIX` | `security.webhooks.replay.redis.key_prefix` | `String` |
+//! | `AUTUMN_SECURITY__WEBHOOKS__REPLAY__ALLOW_MEMORY_IN_PRODUCTION` | `security.webhooks.replay.allow_memory_in_production` | `bool` |
 
 use std::path::{Path, PathBuf};
 
@@ -1224,6 +1228,11 @@ impl AutumnConfig {
         self.database.validate()?;
         self.cors.validate()?;
         self.scheduler.validate()?;
+        let is_production = matches!(self.profile.as_deref(), Some("prod" | "production"));
+        self.security
+            .webhooks
+            .validate(is_production)
+            .map_err(|error| ConfigError::Validation(error.to_string()))?;
         #[cfg(feature = "mail")]
         self.mail.validate(self.profile.as_deref())?;
         // Session backend validation deliberately lives in
@@ -1288,6 +1297,12 @@ impl AutumnConfig {
     /// - `AUTUMN_JOBS__REDIS__URL` → `jobs.redis.url` (`String`)
     /// - `AUTUMN_JOBS__REDIS__KEY_PREFIX` → `jobs.redis.key_prefix` (`String`)
     /// - `AUTUMN_JOBS__REDIS__VISIBILITY_TIMEOUT_MS` → `jobs.redis.visibility_timeout_ms` (`u64`)
+    ///
+    /// # Signed webhooks
+    /// - `AUTUMN_SECURITY__WEBHOOKS__REPLAY__BACKEND` -> `security.webhooks.replay.backend` (`memory` / `redis`)
+    /// - `AUTUMN_SECURITY__WEBHOOKS__REPLAY__REDIS__URL` -> `security.webhooks.replay.redis.url` (`String`)
+    /// - `AUTUMN_SECURITY__WEBHOOKS__REPLAY__REDIS__KEY_PREFIX` -> `security.webhooks.replay.redis.key_prefix` (`String`)
+    /// - `AUTUMN_SECURITY__WEBHOOKS__REPLAY__ALLOW_MEMORY_IN_PRODUCTION` -> `security.webhooks.replay.allow_memory_in_production` (`bool`)
     pub fn apply_env_overrides(&mut self) {
         self.apply_env_overrides_with_env(&OsEnv);
     }
@@ -1721,6 +1736,8 @@ impl AutumnConfig {
             "AUTUMN_SECURITY__SIGNING_SECRET",
             &mut self.security.signing_secret.secret,
         );
+
+        self.security.webhooks.apply_env_overrides_with_env(env);
     }
 
     fn apply_rate_limit_env_overrides_with_env(&mut self, env: &dyn Env) {

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -164,6 +164,7 @@ pub use form::ChangesetForm;
 /// Trait implemented for all `validator::Validate` types to produce a [`Changeset`].
 pub use form::IntoChangeset;
 pub mod validation;
+pub mod webhook;
 #[cfg(feature = "ws")]
 pub mod ws;
 

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -142,6 +142,11 @@ pub use crate::authorization::{Policy, PolicyContext, Scope, ScopeQuery, Scoped}
 pub use crate::security::CsrfFormField;
 /// CSRF token extractor for embedding in forms.
 pub use crate::security::CsrfToken;
+/// Signed webhook extractor and configuration helpers.
+pub use crate::webhook::{
+    SignedWebhook, WebhookEndpointConfig, WebhookProvider, WebhookReplayBackend,
+    WebhookReplayConfig,
+};
 
 // ── Application state ────────────────────────────────────────────
 /// Shared application state (for custom extractors).

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -41,6 +41,11 @@
 //! | `AUTUMN_SECURITY__UPLOAD__MAX_REQUEST_SIZE_BYTES` | `security.upload.max_request_size_bytes` | `usize` |
 //! | `AUTUMN_SECURITY__UPLOAD__MAX_FILE_SIZE_BYTES` | `security.upload.max_file_size_bytes` | `usize` |
 //! | `AUTUMN_SECURITY__UPLOAD__ALLOWED_MIME_TYPES` | `security.upload.allowed_mime_types` | comma-separated `String` |
+//! | `AUTUMN_SECURITY__WEBHOOKS__REPLAY__BACKEND` | `security.webhooks.replay.backend` | `memory` / `redis` |
+//! | `AUTUMN_SECURITY__WEBHOOKS__REPLAY__REDIS__URL` | `security.webhooks.replay.redis.url` | `String` |
+//! | `AUTUMN_SECURITY__WEBHOOKS__REPLAY__REDIS__KEY_PREFIX` | `security.webhooks.replay.redis.key_prefix` | `String` |
+//! | `AUTUMN_SECURITY__WEBHOOKS__REPLAY__ALLOW_MEMORY_IN_PRODUCTION` | `security.webhooks.replay.allow_memory_in_production` | `bool` |
+//! | per-endpoint `secret_env` | `security.webhooks.endpoints[*].secret` | environment variable name |
 //!
 //! Setting any header value to an empty string disables it (the header is
 //! not emitted). This is the escape hatch for opting out of a default.
@@ -215,6 +220,12 @@ pub fn validate_signing_secret(
 // ── Resolved signing key material ─────────────────────────────────────────
 
 /// HMAC-SHA256 of `message` under `key`, returned as lowercase hex.
+///
+/// # Panics
+///
+/// This should not panic because HMAC accepts keys of any length. A panic would
+/// indicate a broken crypto crate invariant.
+#[must_use]
 pub fn hmac_sha256_hex(key: &[u8], message: &[u8]) -> String {
     use hmac::{Hmac, Mac};
     use sha2::Sha256;
@@ -345,6 +356,10 @@ pub struct SecurityConfig {
     /// Multipart upload safeguards and validation policy.
     #[serde(default)]
     pub upload: UploadConfig,
+
+    /// Signed webhook intake endpoints.
+    #[serde(default)]
+    pub webhooks: crate::webhook::WebhookConfig,
 
     /// HTTP status returned when a [`Policy`](crate::authorization::Policy)
     /// denies a record-level action. Defaults to `"404"` to mirror the

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -378,6 +378,7 @@ impl TestApp {
         for register in self.policy_registrations {
             register(state.policy_registry());
         }
+        crate::app::install_webhook_registry(&state, &self.config);
 
         let router = crate::router::try_build_router_inner(
             self.routes,

--- a/autumn/src/webhook.rs
+++ b/autumn/src/webhook.rs
@@ -701,12 +701,25 @@ pub struct WebhookReplayStoreError {
     message: String,
 }
 
+impl WebhookReplayStoreError {
+    /// Create a replay-store failure with a human-readable diagnostic.
+    ///
+    /// Custom [`WebhookReplayStore`] implementations should return this when
+    /// their durable backend is unavailable or cannot complete the atomic
+    /// delivery-ID claim. Autumn surfaces the failure as `503 Service
+    /// Unavailable` before the webhook handler runs.
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
 #[cfg(feature = "redis")]
 impl WebhookReplayStoreError {
     fn backend(operation: &'static str, error: impl std::fmt::Display) -> Self {
-        Self {
-            message: format!("webhook replay store {operation} failed: {error}"),
-        }
+        Self::new(format!("webhook replay store {operation} failed: {error}"))
     }
 }
 

--- a/autumn/src/webhook.rs
+++ b/autumn/src/webhook.rs
@@ -1,0 +1,1249 @@
+//! Signed webhook intake for third-party callbacks.
+//!
+//! The [`SignedWebhook`] extractor verifies provider signatures against the
+//! exact HTTP request bytes before handler code runs. Configure endpoints with
+//! [`WebhookEndpointConfig`] under `security.webhooks.endpoints`.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::extract::FromRequest;
+use bytes::Bytes;
+use http::{HeaderMap, StatusCode};
+use serde::Deserialize;
+use thiserror::Error;
+
+pub use crate::security::config::hmac_sha256_hex;
+
+const DEFAULT_TIMESTAMP_TOLERANCE_SECS: u64 = 300;
+const DEFAULT_REPLAY_WINDOW_SECS: u64 = 24 * 60 * 60;
+const DEFAULT_MAX_BODY_BYTES: usize = 1024 * 1024;
+
+/// Provider preset for signed webhook verification.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WebhookProvider {
+    /// Stripe-style `Stripe-Signature: t=...,v1=...`.
+    Stripe,
+    /// GitHub-style `X-Hub-Signature-256: sha256=...`.
+    Github,
+    /// Slack-style `X-Slack-Signature: v0=...`.
+    Slack,
+    /// Generic HMAC-SHA256 over the raw request body.
+    #[default]
+    Generic,
+}
+
+impl WebhookProvider {
+    /// Stable lower-case provider name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Stripe => "stripe",
+            Self::Github => "github",
+            Self::Slack => "slack",
+            Self::Generic => "generic",
+        }
+    }
+}
+
+impl std::fmt::Display for WebhookProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Signed webhook configuration section.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct WebhookConfig {
+    /// Replay protection backend used for all replay-protected endpoints.
+    #[serde(default)]
+    pub replay: WebhookReplayConfig,
+    /// Configured signed webhook endpoints.
+    #[serde(default)]
+    pub endpoints: Vec<WebhookEndpointConfig>,
+}
+
+impl WebhookConfig {
+    /// Apply environment-sourced webhook configuration.
+    pub(crate) fn apply_env_overrides_with_env(&mut self, env: &dyn crate::config::Env) {
+        self.replay.apply_env_overrides_with_env(env);
+        self.resolve_secret_envs_with_env(env);
+    }
+
+    /// Resolve `secret_env` and `previous_secret_envs` entries from the
+    /// configured environment.
+    fn resolve_secret_envs_with_env(&mut self, env: &dyn crate::config::Env) {
+        for endpoint in &mut self.endpoints {
+            if endpoint.secret.is_none()
+                && let Some(env_name) = endpoint.secret_env.as_deref()
+                && let Ok(secret) = env.var(env_name)
+            {
+                endpoint.secret = Some(secret);
+            }
+
+            for env_name in &endpoint.previous_secret_envs {
+                if let Ok(secret) = env.var(env_name)
+                    && !secret.is_empty()
+                {
+                    endpoint.previous_secrets.push(secret);
+                }
+            }
+        }
+    }
+
+    /// Validate configured signed webhook endpoints.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebhookConfigError`] when an endpoint has no usable secret,
+    /// an invalid path, or a weak production secret.
+    pub fn validate(&self, is_production: bool) -> Result<(), WebhookConfigError> {
+        for endpoint in &self.endpoints {
+            endpoint.validate(is_production)?;
+        }
+        if self
+            .endpoints
+            .iter()
+            .any(|endpoint| endpoint.replay_protection)
+        {
+            self.replay.validate(is_production)?;
+        }
+        Ok(())
+    }
+}
+
+/// Replay protection backend for signed webhooks.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WebhookReplayBackend {
+    /// Process-local memory store. Suitable for tests, development, and
+    /// explicitly acknowledged single-replica deployments.
+    #[serde(alias = "local", alias = "in_memory")]
+    #[default]
+    Memory,
+    /// Redis `SET NX EX` store shared by every application replica.
+    Redis,
+}
+
+impl WebhookReplayBackend {
+    fn from_env_value(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "memory" | "local" | "in_memory" | "in-memory" => Some(Self::Memory),
+            "redis" => Some(Self::Redis),
+            _ => None,
+        }
+    }
+}
+
+/// Replay protection storage configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WebhookReplayConfig {
+    /// Active replay backend.
+    #[serde(default)]
+    pub backend: WebhookReplayBackend,
+    /// Explicit production escape hatch for single-replica deployments.
+    #[serde(default)]
+    pub allow_memory_in_production: bool,
+    /// Redis backend options.
+    #[serde(default)]
+    pub redis: WebhookReplayRedisConfig,
+}
+
+impl Default for WebhookReplayConfig {
+    fn default() -> Self {
+        Self {
+            backend: WebhookReplayBackend::Memory,
+            allow_memory_in_production: false,
+            redis: WebhookReplayRedisConfig::default(),
+        }
+    }
+}
+
+impl WebhookReplayConfig {
+    fn apply_env_overrides_with_env(&mut self, env: &dyn crate::config::Env) {
+        if let Ok(value) = env.var("AUTUMN_SECURITY__WEBHOOKS__REPLAY__BACKEND") {
+            if let Some(backend) = WebhookReplayBackend::from_env_value(&value) {
+                self.backend = backend;
+            } else {
+                eprintln!(
+                    "Warning: AUTUMN_SECURITY__WEBHOOKS__REPLAY__BACKEND={value:?} is not valid \
+                     (expected memory or redis), ignoring"
+                );
+            }
+        }
+        if let Ok(value) = env.var("AUTUMN_SECURITY__WEBHOOKS__REPLAY__ALLOW_MEMORY_IN_PRODUCTION")
+        {
+            match value.trim().parse::<bool>() {
+                Ok(value) => self.allow_memory_in_production = value,
+                Err(error) => eprintln!(
+                    "Warning: AUTUMN_SECURITY__WEBHOOKS__REPLAY__ALLOW_MEMORY_IN_PRODUCTION \
+                     could not be parsed as bool: {error}"
+                ),
+            }
+        }
+        if let Ok(value) = env.var("AUTUMN_SECURITY__WEBHOOKS__REPLAY__REDIS__URL") {
+            let value = value.trim();
+            self.redis.url = if value.is_empty() {
+                None
+            } else {
+                Some(value.to_owned())
+            };
+        }
+        if let Ok(value) = env.var("AUTUMN_SECURITY__WEBHOOKS__REPLAY__REDIS__KEY_PREFIX")
+            && !value.trim().is_empty()
+        {
+            self.redis.key_prefix = value;
+        }
+    }
+
+    fn validate(&self, is_production: bool) -> Result<(), WebhookConfigError> {
+        match self.backend {
+            WebhookReplayBackend::Memory => {
+                if is_production && !self.allow_memory_in_production {
+                    return Err(WebhookConfigError::MemoryReplayInProduction);
+                }
+                Ok(())
+            }
+            WebhookReplayBackend::Redis => validate_redis_replay_config(&self.redis),
+        }
+    }
+}
+
+/// Redis replay protection backend configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WebhookReplayRedisConfig {
+    /// Redis connection URL.
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Prefix for all replay keys stored in Redis.
+    #[serde(default = "default_replay_redis_key_prefix")]
+    pub key_prefix: String,
+}
+
+impl Default for WebhookReplayRedisConfig {
+    fn default() -> Self {
+        Self {
+            url: None,
+            key_prefix: default_replay_redis_key_prefix(),
+        }
+    }
+}
+
+/// Configuration for one signed webhook endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WebhookEndpointConfig {
+    /// Unique endpoint name used in diagnostics and replay keys.
+    pub name: String,
+    /// Exact route path protected by this config.
+    pub path: String,
+    /// Provider verification preset.
+    #[serde(default)]
+    pub provider: WebhookProvider,
+    /// Current webhook signing secret.
+    #[serde(default)]
+    pub secret: Option<String>,
+    /// Environment variable that provides the current secret.
+    #[serde(default)]
+    pub secret_env: Option<String>,
+    /// Previous secrets accepted during a rotation grace window.
+    #[serde(default)]
+    pub previous_secrets: Vec<String>,
+    /// Environment variables that provide previous rotation secrets.
+    #[serde(default)]
+    pub previous_secret_envs: Vec<String>,
+    /// Maximum timestamp skew accepted for timestamped providers.
+    #[serde(default = "default_timestamp_tolerance_secs")]
+    pub timestamp_tolerance_secs: u64,
+    /// Replay rejection window for duplicate delivery IDs.
+    #[serde(default = "default_replay_window_secs")]
+    pub replay_window_secs: u64,
+    /// Whether duplicate delivery IDs are rejected.
+    #[serde(default = "default_true")]
+    pub replay_protection: bool,
+    /// Header carrying the signature. Provider defaults are applied by
+    /// constructors and by `Default`.
+    #[serde(default)]
+    pub signature_header: Option<String>,
+    /// Optional prefix stripped from header signatures before comparison.
+    #[serde(default)]
+    pub signature_prefix: Option<String>,
+    /// Optional header carrying a Unix timestamp.
+    #[serde(default)]
+    pub timestamp_header: Option<String>,
+    /// Optional header carrying provider delivery ID.
+    #[serde(default)]
+    pub delivery_id_header: Option<String>,
+    /// Optional header carrying provider event type.
+    #[serde(default)]
+    pub event_type_header: Option<String>,
+    /// Maximum raw body bytes read by the extractor.
+    #[serde(default = "default_max_body_bytes")]
+    pub max_body_bytes: usize,
+}
+
+impl Default for WebhookEndpointConfig {
+    fn default() -> Self {
+        Self::provider_defaults(WebhookProvider::Generic)
+    }
+}
+
+impl WebhookEndpointConfig {
+    /// Create a provider-shaped endpoint config with a current secret.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        path: impl Into<String>,
+        provider: WebhookProvider,
+        secret: impl Into<String>,
+    ) -> Self {
+        let mut config = Self::provider_defaults(provider);
+        config.name = name.into();
+        config.path = path.into();
+        config.secret = Some(secret.into());
+        config
+    }
+
+    /// Create a Stripe-style endpoint.
+    #[must_use]
+    pub fn stripe(
+        name: impl Into<String>,
+        path: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> Self {
+        Self::new(name, path, WebhookProvider::Stripe, secret)
+    }
+
+    /// Create a GitHub-style endpoint.
+    #[must_use]
+    pub fn github(
+        name: impl Into<String>,
+        path: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> Self {
+        Self::new(name, path, WebhookProvider::Github, secret)
+    }
+
+    /// Create a Slack-style endpoint.
+    #[must_use]
+    pub fn slack(
+        name: impl Into<String>,
+        path: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> Self {
+        Self::new(name, path, WebhookProvider::Slack, secret)
+    }
+
+    /// Create a generic HMAC-SHA256 endpoint.
+    #[must_use]
+    pub fn generic(
+        name: impl Into<String>,
+        path: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> Self {
+        Self::new(name, path, WebhookProvider::Generic, secret)
+    }
+
+    /// Accept one previous secret during rotation.
+    #[must_use]
+    pub fn with_previous_secret(mut self, secret: impl Into<String>) -> Self {
+        self.previous_secrets.push(secret.into());
+        self
+    }
+
+    /// Override timestamp tolerance.
+    #[must_use]
+    pub const fn with_timestamp_tolerance_secs(mut self, secs: u64) -> Self {
+        self.timestamp_tolerance_secs = secs;
+        self
+    }
+
+    /// Override replay rejection window.
+    #[must_use]
+    pub const fn with_replay_window_secs(mut self, secs: u64) -> Self {
+        self.replay_window_secs = secs;
+        self
+    }
+
+    /// Disable duplicate delivery rejection for this endpoint.
+    #[must_use]
+    pub const fn without_replay_protection(mut self) -> Self {
+        self.replay_protection = false;
+        self
+    }
+
+    fn provider_defaults(provider: WebhookProvider) -> Self {
+        let mut config = Self {
+            name: String::new(),
+            path: String::new(),
+            provider,
+            secret: None,
+            secret_env: None,
+            previous_secrets: Vec::new(),
+            previous_secret_envs: Vec::new(),
+            timestamp_tolerance_secs: DEFAULT_TIMESTAMP_TOLERANCE_SECS,
+            replay_window_secs: DEFAULT_REPLAY_WINDOW_SECS,
+            replay_protection: true,
+            signature_header: None,
+            signature_prefix: None,
+            timestamp_header: None,
+            delivery_id_header: None,
+            event_type_header: None,
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+        };
+
+        match provider {
+            WebhookProvider::Stripe => {
+                config.signature_header = Some("Stripe-Signature".to_owned());
+            }
+            WebhookProvider::Github => {
+                config.signature_header = Some("X-Hub-Signature-256".to_owned());
+                config.signature_prefix = Some("sha256=".to_owned());
+                config.delivery_id_header = Some("X-GitHub-Delivery".to_owned());
+                config.event_type_header = Some("X-GitHub-Event".to_owned());
+            }
+            WebhookProvider::Slack => {
+                config.signature_header = Some("X-Slack-Signature".to_owned());
+                config.signature_prefix = Some("v0=".to_owned());
+                config.timestamp_header = Some("X-Slack-Request-Timestamp".to_owned());
+                config.delivery_id_header = Some("X-Slack-Request-Id".to_owned());
+                config.event_type_header = Some("X-Slack-Event-Type".to_owned());
+            }
+            WebhookProvider::Generic => {
+                config.signature_header = Some("X-Webhook-Signature".to_owned());
+                config.signature_prefix = Some("sha256=".to_owned());
+                config.delivery_id_header = Some("X-Webhook-Delivery".to_owned());
+                config.event_type_header = Some("X-Webhook-Event".to_owned());
+            }
+        }
+
+        config
+    }
+
+    fn validate(&self, is_production: bool) -> Result<(), WebhookConfigError> {
+        if self.name.trim().is_empty() {
+            return Err(WebhookConfigError::InvalidEndpoint {
+                name: self.name.clone(),
+                message: "name must not be empty".to_owned(),
+            });
+        }
+        if !self.path.starts_with('/') || self.path.trim() == "/" || self.path.trim().is_empty() {
+            return Err(WebhookConfigError::InvalidEndpoint {
+                name: self.name.clone(),
+                message: format!("path {:?} must start with '/' and not be root", self.path),
+            });
+        }
+        let Some(secret) = self.secret.as_deref().filter(|value| !value.is_empty()) else {
+            return Err(WebhookConfigError::MissingSecret {
+                name: self.name.clone(),
+                path: self.path.clone(),
+            });
+        };
+
+        if is_production {
+            crate::security::config::validate_signing_secret(Some(secret), true).map_err(
+                |reason| WebhookConfigError::InvalidSecret {
+                    name: self.name.clone(),
+                    reason,
+                },
+            )?;
+            for (index, previous) in self.previous_secrets.iter().enumerate() {
+                crate::security::config::validate_signing_secret(Some(previous), true).map_err(
+                    |reason| WebhookConfigError::InvalidPreviousSecret {
+                        name: self.name.clone(),
+                        index,
+                        reason,
+                    },
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn apply_provider_defaults(&mut self) {
+        let defaults = Self::provider_defaults(self.provider);
+        if self.signature_header.is_none() {
+            self.signature_header = defaults.signature_header;
+        }
+        if self.signature_prefix.is_none() {
+            self.signature_prefix = defaults.signature_prefix;
+        }
+        if self.timestamp_header.is_none() {
+            self.timestamp_header = defaults.timestamp_header;
+        }
+        if self.delivery_id_header.is_none() {
+            self.delivery_id_header = defaults.delivery_id_header;
+        }
+        if self.event_type_header.is_none() {
+            self.event_type_header = defaults.event_type_header;
+        }
+    }
+}
+
+/// Webhook configuration validation failure.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum WebhookConfigError {
+    /// A configured endpoint has no current secret.
+    #[error("webhook endpoint {name:?} at {path:?} is missing a secret")]
+    MissingSecret {
+        /// Endpoint name.
+        name: String,
+        /// Endpoint path.
+        path: String,
+    },
+    /// A configured endpoint is invalid.
+    #[error("webhook endpoint {name:?} is invalid: {message}")]
+    InvalidEndpoint {
+        /// Endpoint name.
+        name: String,
+        /// Validation message.
+        message: String,
+    },
+    /// Current production secret is weak or malformed.
+    #[error("webhook endpoint {name:?} has invalid secret: {reason}")]
+    InvalidSecret {
+        /// Endpoint name.
+        name: String,
+        /// Signing secret validation error.
+        reason: crate::security::config::SigningSecretError,
+    },
+    /// Previous production secret is weak or malformed.
+    #[error("webhook endpoint {name:?} has invalid previous secret {index}: {reason}")]
+    InvalidPreviousSecret {
+        /// Endpoint name.
+        name: String,
+        /// Previous secret index.
+        index: usize,
+        /// Signing secret validation error.
+        reason: crate::security::config::SigningSecretError,
+    },
+    /// Process-local replay storage was selected for production webhooks.
+    #[error(
+        "webhook replay backend memory is not allowed in production; set \
+         security.webhooks.replay.backend = \"redis\" or explicitly set \
+         security.webhooks.replay.allow_memory_in_production = true"
+    )]
+    MemoryReplayInProduction,
+    /// Redis replay protection was selected without a URL.
+    #[error("webhook redis replay backend requires security.webhooks.replay.redis.url")]
+    RedisReplayMissingUrl,
+    /// Redis replay URL is malformed.
+    #[error("webhook redis replay backend URL is invalid: {0}")]
+    RedisReplayInvalidUrl(String),
+    /// Redis replay protection was selected without compiling the Redis feature.
+    #[error("webhook redis replay backend requires the autumn-web redis feature")]
+    RedisReplayFeatureDisabled,
+}
+
+#[derive(Debug)]
+struct ResolvedWebhookEndpoint {
+    config: WebhookEndpointConfig,
+    keys: crate::security::config::ResolvedSigningKeys,
+}
+
+/// Runtime registry for signed webhook endpoints.
+#[derive(Clone, Debug)]
+pub struct WebhookRegistry {
+    endpoints_by_path: Arc<HashMap<String, Arc<ResolvedWebhookEndpoint>>>,
+    replay_store: Arc<dyn WebhookReplayStore>,
+}
+
+impl WebhookRegistry {
+    /// Build a registry from config using the built-in in-memory replay store.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebhookConfigError`] when any endpoint is missing a secret.
+    pub fn from_config(config: &WebhookConfig) -> Result<Self, WebhookConfigError> {
+        let replay_store = if config
+            .endpoints
+            .iter()
+            .any(|endpoint| endpoint.replay_protection)
+        {
+            replay_store_from_config(&config.replay)?
+        } else {
+            Arc::new(InMemoryWebhookReplayStore::default())
+        };
+        Self::from_config_with_shared_replay_store(config, replay_store)
+    }
+
+    /// Build a registry from config with a custom replay store.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebhookConfigError`] when any endpoint is missing a secret.
+    pub fn from_config_with_replay_store(
+        config: &WebhookConfig,
+        replay_store: impl WebhookReplayStore + 'static,
+    ) -> Result<Self, WebhookConfigError> {
+        Self::from_config_with_shared_replay_store(config, Arc::new(replay_store))
+    }
+
+    /// Build a registry from config with a shared replay store.
+    ///
+    /// This is useful when multiple test app instances should share replay
+    /// state, or when an integration constructs its own durable backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebhookConfigError`] when any endpoint is missing a secret.
+    pub fn from_config_with_shared_replay_store(
+        config: &WebhookConfig,
+        replay_store: Arc<dyn WebhookReplayStore>,
+    ) -> Result<Self, WebhookConfigError> {
+        let mut endpoints_by_path = HashMap::new();
+        for endpoint in &config.endpoints {
+            let mut endpoint = endpoint.clone();
+            endpoint.apply_provider_defaults();
+            endpoint.validate(false)?;
+            let Some(secret) = endpoint.secret.as_ref() else {
+                return Err(WebhookConfigError::MissingSecret {
+                    name: endpoint.name.clone(),
+                    path: endpoint.path.clone(),
+                });
+            };
+            let current = secret.as_bytes().to_vec();
+            let previous = endpoint
+                .previous_secrets
+                .iter()
+                .map(|secret| secret.as_bytes().to_vec())
+                .collect();
+            endpoints_by_path.insert(
+                endpoint.path.clone(),
+                Arc::new(ResolvedWebhookEndpoint {
+                    config: endpoint,
+                    keys: crate::security::config::ResolvedSigningKeys::new(current, previous),
+                }),
+            );
+        }
+
+        Ok(Self {
+            endpoints_by_path: Arc::new(endpoints_by_path),
+            replay_store,
+        })
+    }
+
+    fn endpoint_for_path(&self, path: &str) -> Option<Arc<ResolvedWebhookEndpoint>> {
+        self.endpoints_by_path.get(path).cloned()
+    }
+}
+
+/// Boxed replay store operation future.
+pub type WebhookReplayFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<bool, WebhookReplayStoreError>> + Send + 'a>>;
+
+/// Replay store used to reject duplicate provider delivery IDs.
+pub trait WebhookReplayStore: Send + Sync + std::fmt::Debug {
+    /// Insert a delivery key and return `true`; return `false` if it already
+    /// exists inside the replay window.
+    fn check_and_insert<'a>(
+        &'a self,
+        key: &'a str,
+        received_at: SystemTime,
+        window: Duration,
+    ) -> WebhookReplayFuture<'a>;
+}
+
+impl<T> WebhookReplayStore for Arc<T>
+where
+    T: WebhookReplayStore + ?Sized,
+{
+    fn check_and_insert<'a>(
+        &'a self,
+        key: &'a str,
+        received_at: SystemTime,
+        window: Duration,
+    ) -> WebhookReplayFuture<'a> {
+        self.as_ref().check_and_insert(key, received_at, window)
+    }
+}
+
+/// Replay store operation failure.
+#[derive(Debug, Clone, Error)]
+#[error("{message}")]
+pub struct WebhookReplayStoreError {
+    message: String,
+}
+
+#[cfg(feature = "redis")]
+impl WebhookReplayStoreError {
+    fn backend(operation: &'static str, error: impl std::fmt::Display) -> Self {
+        Self {
+            message: format!("webhook replay store {operation} failed: {error}"),
+        }
+    }
+}
+
+/// In-memory replay protection store.
+///
+/// This is suitable for tests, development, and single-process deployments. A
+/// multi-replica production fleet should configure the Redis replay backend.
+#[derive(Debug, Default)]
+pub struct InMemoryWebhookReplayStore {
+    seen: Mutex<HashMap<String, SystemTime>>,
+}
+
+impl InMemoryWebhookReplayStore {
+    fn check_and_insert_sync(&self, key: &str, received_at: SystemTime, window: Duration) -> bool {
+        let mut seen = self
+            .seen
+            .lock()
+            .expect("webhook replay store lock poisoned");
+        seen.retain(|_, first_seen| {
+            received_at
+                .duration_since(*first_seen)
+                .map_or(true, |age| age <= window)
+        });
+        if seen.contains_key(key) {
+            return false;
+        }
+        seen.insert(key.to_owned(), received_at);
+        true
+    }
+}
+
+impl WebhookReplayStore for InMemoryWebhookReplayStore {
+    fn check_and_insert<'a>(
+        &'a self,
+        key: &'a str,
+        received_at: SystemTime,
+        window: Duration,
+    ) -> WebhookReplayFuture<'a> {
+        Box::pin(async move { Ok(self.check_and_insert_sync(key, received_at, window)) })
+    }
+}
+
+/// Redis replay protection store.
+#[cfg(feature = "redis")]
+#[derive(Clone, Debug)]
+pub struct RedisWebhookReplayStore {
+    connection: redis::aio::ConnectionManager,
+    key_prefix: String,
+}
+
+#[cfg(feature = "redis")]
+impl RedisWebhookReplayStore {
+    /// Build a Redis replay store from config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebhookConfigError`] when the URL is absent or malformed.
+    pub fn from_config(config: &WebhookReplayRedisConfig) -> Result<Self, WebhookConfigError> {
+        let url = config
+            .url
+            .as_deref()
+            .filter(|url| !url.trim().is_empty())
+            .ok_or(WebhookConfigError::RedisReplayMissingUrl)?;
+        let client = redis::Client::open(url)
+            .map_err(|error| WebhookConfigError::RedisReplayInvalidUrl(error.to_string()))?;
+        let connection = redis::aio::ConnectionManager::new_lazy_with_config(
+            client,
+            redis::aio::ConnectionManagerConfig::new(),
+        )
+        .map_err(|error| WebhookConfigError::RedisReplayInvalidUrl(error.to_string()))?;
+        Ok(Self {
+            connection,
+            key_prefix: config.key_prefix.clone(),
+        })
+    }
+
+    fn key_for(&self, replay_key: &str) -> String {
+        format!("{}:{replay_key}", self.key_prefix)
+    }
+}
+
+#[cfg(feature = "redis")]
+impl WebhookReplayStore for RedisWebhookReplayStore {
+    fn check_and_insert<'a>(
+        &'a self,
+        key: &'a str,
+        received_at: SystemTime,
+        window: Duration,
+    ) -> WebhookReplayFuture<'a> {
+        Box::pin(async move {
+            let mut connection = self.connection.clone();
+            let key = self.key_for(key);
+            let ttl_secs = window.as_secs().max(1);
+            let received_unix = received_at
+                .duration_since(UNIX_EPOCH)
+                .map_err(|error| WebhookReplayStoreError::backend("timestamp", error))?
+                .as_secs()
+                .to_string();
+            let inserted: Option<String> = redis::cmd("SET")
+                .arg(&key)
+                .arg(received_unix)
+                .arg("NX")
+                .arg("EX")
+                .arg(ttl_secs)
+                .query_async(&mut connection)
+                .await
+                .map_err(|error| WebhookReplayStoreError::backend("insert", error))?;
+            Ok(inserted.is_some())
+        })
+    }
+}
+
+/// A request that has passed signed webhook verification.
+#[derive(Debug, Clone)]
+pub struct SignedWebhook {
+    provider: WebhookProvider,
+    endpoint: String,
+    delivery_id: Option<String>,
+    event_type: Option<String>,
+    received_at: SystemTime,
+    raw_body: Bytes,
+}
+
+impl SignedWebhook {
+    /// Provider preset that verified this request.
+    #[must_use]
+    pub const fn provider(&self) -> &'static str {
+        self.provider.as_str()
+    }
+
+    /// Configured endpoint name.
+    #[must_use]
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Provider delivery ID, when present.
+    #[must_use]
+    pub fn delivery_id(&self) -> Option<&str> {
+        self.delivery_id.as_deref()
+    }
+
+    /// Provider event type, when present.
+    #[must_use]
+    pub fn event_type(&self) -> Option<&str> {
+        self.event_type.as_deref()
+    }
+
+    /// Request receive time used for timestamp and replay checks.
+    #[must_use]
+    pub const fn received_at(&self) -> SystemTime {
+        self.received_at
+    }
+
+    /// Exact verified request body bytes.
+    #[must_use]
+    pub fn raw_body(&self) -> &[u8] {
+        &self.raw_body
+    }
+
+    /// Decode the verified body as JSON.
+    ///
+    /// # Errors
+    ///
+    /// Returns `serde_json::Error` when the verified body is not valid JSON for
+    /// the requested type.
+    pub fn json<T: serde::de::DeserializeOwned>(&self) -> Result<T, serde_json::Error> {
+        serde_json::from_slice(&self.raw_body)
+    }
+}
+
+impl FromRequest<crate::AppState> for SignedWebhook {
+    type Rejection = crate::AutumnError;
+
+    async fn from_request(
+        req: axum::extract::Request,
+        state: &crate::AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let (parts, body) = req.into_parts();
+        let path = parts.uri.path().to_owned();
+        let registry = state
+            .extension::<WebhookRegistry>()
+            .ok_or_else(|| WebhookVerifyError::RegistryMissing.into_autumn_error())?;
+        let endpoint = registry
+            .endpoint_for_path(&path)
+            .ok_or_else(|| WebhookVerifyError::EndpointMissing(path.clone()).into_autumn_error())?;
+        let body = axum::body::to_bytes(body, endpoint.config.max_body_bytes)
+            .await
+            .map_err(|err| {
+                crate::AutumnError::bad_request_msg(format!(
+                    "webhook body could not be read: {err}"
+                ))
+            })?;
+        let received_at = SystemTime::now();
+        verify_request(&registry, &endpoint, &parts.headers, body, received_at)
+            .await
+            .map_err(WebhookVerifyError::into_autumn_error)
+    }
+}
+
+#[derive(Debug, Error)]
+enum WebhookVerifyError {
+    #[error("signed webhook registry is not installed")]
+    RegistryMissing,
+    #[error("no signed webhook endpoint is configured for path {0}")]
+    EndpointMissing(String),
+    #[error("missing required webhook header {0}")]
+    MissingHeader(String),
+    #[error("malformed webhook signature")]
+    MalformedSignature,
+    #[error("malformed webhook timestamp")]
+    MalformedTimestamp,
+    #[error("webhook timestamp is outside the accepted tolerance")]
+    StaleTimestamp,
+    #[error("webhook signature mismatch")]
+    SignatureMismatch,
+    #[error("missing webhook delivery ID")]
+    MissingDeliveryId,
+    #[error("duplicate webhook delivery")]
+    DuplicateDelivery,
+    #[error("webhook replay store unavailable: {0}")]
+    ReplayStoreUnavailable(String),
+}
+
+impl WebhookVerifyError {
+    const fn status(&self) -> StatusCode {
+        match self {
+            Self::RegistryMissing | Self::EndpointMissing(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::MissingHeader(_)
+            | Self::MalformedSignature
+            | Self::MalformedTimestamp
+            | Self::MissingDeliveryId => StatusCode::BAD_REQUEST,
+            Self::StaleTimestamp | Self::SignatureMismatch => StatusCode::UNAUTHORIZED,
+            Self::DuplicateDelivery => StatusCode::CONFLICT,
+            Self::ReplayStoreUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
+        }
+    }
+
+    fn into_autumn_error(self) -> crate::AutumnError {
+        crate::AutumnError::bad_request_msg(self.to_string()).with_status(self.status())
+    }
+}
+
+async fn verify_request(
+    registry: &WebhookRegistry,
+    endpoint: &ResolvedWebhookEndpoint,
+    headers: &HeaderMap,
+    body: Bytes,
+    received_at: SystemTime,
+) -> Result<SignedWebhook, WebhookVerifyError> {
+    match endpoint.config.provider {
+        WebhookProvider::Stripe => verify_stripe(endpoint, headers, &body, received_at)?,
+        WebhookProvider::Github | WebhookProvider::Generic => {
+            verify_body_hmac(endpoint, headers, &body, None, received_at)?;
+        }
+        WebhookProvider::Slack => verify_slack(endpoint, headers, &body, received_at)?,
+    }
+
+    let delivery_id = resolve_delivery_id(&endpoint.config, headers, &body);
+    if endpoint.config.replay_protection {
+        let delivery_id = delivery_id
+            .as_deref()
+            .ok_or(WebhookVerifyError::MissingDeliveryId)?;
+        let replay_key = format!(
+            "{}:{}:{delivery_id}",
+            endpoint.config.provider.as_str(),
+            endpoint.config.name
+        );
+        let window = Duration::from_secs(endpoint.config.replay_window_secs);
+        if !registry
+            .replay_store
+            .check_and_insert(&replay_key, received_at, window)
+            .await
+            .map_err(|error| WebhookVerifyError::ReplayStoreUnavailable(error.to_string()))?
+        {
+            return Err(WebhookVerifyError::DuplicateDelivery);
+        }
+    }
+
+    Ok(SignedWebhook {
+        provider: endpoint.config.provider,
+        endpoint: endpoint.config.name.clone(),
+        delivery_id,
+        event_type: resolve_event_type(&endpoint.config, headers, &body),
+        received_at,
+        raw_body: body,
+    })
+}
+
+fn verify_stripe(
+    endpoint: &ResolvedWebhookEndpoint,
+    headers: &HeaderMap,
+    body: &[u8],
+    received_at: SystemTime,
+) -> Result<(), WebhookVerifyError> {
+    let header = required_header(headers, signature_header(endpoint))?;
+    let (timestamp, signatures) = parse_stripe_signature(header)?;
+    verify_timestamp(
+        timestamp,
+        received_at,
+        endpoint.config.timestamp_tolerance_secs,
+    )?;
+
+    let mut signed_payload = timestamp.to_string().into_bytes();
+    signed_payload.push(b'.');
+    signed_payload.extend_from_slice(body);
+
+    if signatures
+        .iter()
+        .any(|signature| endpoint.keys.verify(&signed_payload, signature))
+    {
+        Ok(())
+    } else {
+        Err(WebhookVerifyError::SignatureMismatch)
+    }
+}
+
+fn verify_slack(
+    endpoint: &ResolvedWebhookEndpoint,
+    headers: &HeaderMap,
+    body: &[u8],
+    received_at: SystemTime,
+) -> Result<(), WebhookVerifyError> {
+    let timestamp_header = endpoint
+        .config
+        .timestamp_header
+        .as_deref()
+        .ok_or(WebhookVerifyError::MalformedTimestamp)?;
+    let timestamp = required_header(headers, timestamp_header)?
+        .parse::<i64>()
+        .map_err(|_| WebhookVerifyError::MalformedTimestamp)?;
+    verify_timestamp(
+        timestamp,
+        received_at,
+        endpoint.config.timestamp_tolerance_secs,
+    )?;
+
+    let mut signed_payload = format!("v0:{timestamp}:").into_bytes();
+    signed_payload.extend_from_slice(body);
+    verify_body_hmac(
+        endpoint,
+        headers,
+        &signed_payload,
+        endpoint.config.signature_prefix.as_deref(),
+        received_at,
+    )
+}
+
+fn verify_body_hmac(
+    endpoint: &ResolvedWebhookEndpoint,
+    headers: &HeaderMap,
+    body_or_base: &[u8],
+    explicit_prefix: Option<&str>,
+    received_at: SystemTime,
+) -> Result<(), WebhookVerifyError> {
+    if let Some(timestamp_header) = endpoint.config.timestamp_header.as_deref()
+        && endpoint.config.provider != WebhookProvider::Slack
+    {
+        let timestamp = required_header(headers, timestamp_header)?
+            .parse::<i64>()
+            .map_err(|_| WebhookVerifyError::MalformedTimestamp)?;
+        verify_timestamp(
+            timestamp,
+            received_at,
+            endpoint.config.timestamp_tolerance_secs,
+        )?;
+    }
+
+    let mut signature = required_header(headers, signature_header(endpoint))?;
+    let prefix = explicit_prefix.or(endpoint.config.signature_prefix.as_deref());
+    if let Some(prefix) = prefix {
+        signature = signature
+            .strip_prefix(prefix)
+            .ok_or(WebhookVerifyError::MalformedSignature)?;
+    }
+
+    if endpoint.keys.verify(body_or_base, signature) {
+        Ok(())
+    } else {
+        Err(WebhookVerifyError::SignatureMismatch)
+    }
+}
+
+fn signature_header(endpoint: &ResolvedWebhookEndpoint) -> &str {
+    endpoint
+        .config
+        .signature_header
+        .as_deref()
+        .unwrap_or("X-Webhook-Signature")
+}
+
+fn required_header<'a>(headers: &'a HeaderMap, name: &str) -> Result<&'a str, WebhookVerifyError> {
+    headers
+        .get(name)
+        .ok_or_else(|| WebhookVerifyError::MissingHeader(name.to_owned()))?
+        .to_str()
+        .map_err(|_| WebhookVerifyError::MalformedSignature)
+}
+
+fn parse_stripe_signature(header: &str) -> Result<(i64, Vec<&str>), WebhookVerifyError> {
+    let mut timestamp = None;
+    let mut signatures = Vec::new();
+
+    for part in header.split(',') {
+        let Some((key, value)) = part.split_once('=') else {
+            return Err(WebhookVerifyError::MalformedSignature);
+        };
+        match key.trim() {
+            "t" => {
+                timestamp = Some(
+                    value
+                        .trim()
+                        .parse::<i64>()
+                        .map_err(|_| WebhookVerifyError::MalformedTimestamp)?,
+                );
+            }
+            "v1" => signatures.push(value.trim()),
+            _ => {}
+        }
+    }
+
+    let timestamp = timestamp.ok_or(WebhookVerifyError::MalformedTimestamp)?;
+    if signatures.is_empty() {
+        return Err(WebhookVerifyError::MalformedSignature);
+    }
+    Ok((timestamp, signatures))
+}
+
+fn verify_timestamp(
+    timestamp: i64,
+    received_at: SystemTime,
+    tolerance_secs: u64,
+) -> Result<(), WebhookVerifyError> {
+    let now = i64::try_from(
+        received_at
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| WebhookVerifyError::MalformedTimestamp)?
+            .as_secs(),
+    )
+    .map_err(|_| WebhookVerifyError::MalformedTimestamp)?;
+    let skew = now.saturating_sub(timestamp).unsigned_abs();
+    if skew > tolerance_secs {
+        return Err(WebhookVerifyError::StaleTimestamp);
+    }
+    Ok(())
+}
+
+fn resolve_delivery_id(
+    config: &WebhookEndpointConfig,
+    headers: &HeaderMap,
+    body: &[u8],
+) -> Option<String> {
+    config
+        .delivery_id_header
+        .as_deref()
+        .and_then(|header| optional_header(headers, header))
+        .or_else(|| json_string_field(body, "id"))
+}
+
+fn resolve_event_type(
+    config: &WebhookEndpointConfig,
+    headers: &HeaderMap,
+    body: &[u8],
+) -> Option<String> {
+    config
+        .event_type_header
+        .as_deref()
+        .and_then(|header| optional_header(headers, header))
+        .or_else(|| json_string_field(body, "type"))
+        .or_else(|| nested_json_string_field(body, "event", "type"))
+}
+
+fn optional_header(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_owned)
+}
+
+fn json_string_field(body: &[u8], field: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_slice(body).ok()?;
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+}
+
+fn nested_json_string_field(body: &[u8], parent: &str, field: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_slice(body).ok()?;
+    value
+        .get(parent)
+        .and_then(|parent_value| parent_value.get(field))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+}
+
+const fn default_timestamp_tolerance_secs() -> u64 {
+    DEFAULT_TIMESTAMP_TOLERANCE_SECS
+}
+
+const fn default_replay_window_secs() -> u64 {
+    DEFAULT_REPLAY_WINDOW_SECS
+}
+
+const fn default_max_body_bytes() -> usize {
+    DEFAULT_MAX_BODY_BYTES
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+fn default_replay_redis_key_prefix() -> String {
+    "autumn:webhooks:replay".to_owned()
+}
+
+fn validate_redis_replay_config(
+    config: &WebhookReplayRedisConfig,
+) -> Result<(), WebhookConfigError> {
+    let url = config
+        .url
+        .as_deref()
+        .filter(|url| !url.trim().is_empty())
+        .ok_or(WebhookConfigError::RedisReplayMissingUrl)?;
+
+    #[cfg(feature = "redis")]
+    {
+        redis::Client::open(url)
+            .map_err(|error| WebhookConfigError::RedisReplayInvalidUrl(error.to_string()))?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "redis"))]
+    {
+        let _ = url;
+        Err(WebhookConfigError::RedisReplayFeatureDisabled)
+    }
+}
+
+fn replay_store_from_config(
+    config: &WebhookReplayConfig,
+) -> Result<Arc<dyn WebhookReplayStore>, WebhookConfigError> {
+    match config.backend {
+        WebhookReplayBackend::Memory => Ok(Arc::new(InMemoryWebhookReplayStore::default())),
+        WebhookReplayBackend::Redis => {
+            #[cfg(feature = "redis")]
+            {
+                Ok(Arc::new(RedisWebhookReplayStore::from_config(
+                    &config.redis,
+                )?))
+            }
+
+            #[cfg(not(feature = "redis"))]
+            {
+                Err(WebhookConfigError::RedisReplayFeatureDisabled)
+            }
+        }
+    }
+}
+
+pub(crate) fn install_registry_from_config(
+    state: &crate::AppState,
+    config: &WebhookConfig,
+) -> Result<(), WebhookConfigError> {
+    if config.endpoints.is_empty() {
+        return Ok(());
+    }
+    let registry = WebhookRegistry::from_config(config)?;
+    state.insert_extension(registry);
+    Ok(())
+}

--- a/autumn/src/webhook.rs
+++ b/autumn/src/webhook.rs
@@ -21,6 +21,8 @@ pub use crate::security::config::hmac_sha256_hex;
 const DEFAULT_TIMESTAMP_TOLERANCE_SECS: u64 = 300;
 const DEFAULT_REPLAY_WINDOW_SECS: u64 = 24 * 60 * 60;
 const DEFAULT_MAX_BODY_BYTES: usize = 1024 * 1024;
+const IN_MEMORY_REPLAY_CLEANUP_INTERVAL: usize = 128;
+const IN_MEMORY_REPLAY_CLEANUP_HIGH_WATER: usize = 16 * 1024;
 
 /// Provider preset for signed webhook verification.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Deserialize)]
@@ -409,8 +411,6 @@ impl WebhookEndpointConfig {
                 config.signature_header = Some("X-Slack-Signature".to_owned());
                 config.signature_prefix = Some("v0=".to_owned());
                 config.timestamp_header = Some("X-Slack-Request-Timestamp".to_owned());
-                config.delivery_id_header = Some("X-Slack-Request-Id".to_owned());
-                config.event_type_header = Some("X-Slack-Event-Type".to_owned());
             }
             WebhookProvider::Generic => {
                 config.signature_header = Some("X-Webhook-Signature".to_owned());
@@ -684,25 +684,52 @@ impl WebhookReplayStoreError {
 /// multi-replica production fleet should configure the Redis replay backend.
 #[derive(Debug, Default)]
 pub struct InMemoryWebhookReplayStore {
-    seen: Mutex<HashMap<String, SystemTime>>,
+    state: Mutex<InMemoryWebhookReplayState>,
+}
+
+#[derive(Debug, Default)]
+struct InMemoryWebhookReplayState {
+    seen: HashMap<String, SystemTime>,
+    checks_since_cleanup: usize,
 }
 
 impl InMemoryWebhookReplayStore {
     fn check_and_insert_sync(&self, key: &str, received_at: SystemTime, window: Duration) -> bool {
-        let mut seen = self
-            .seen
-            .lock()
-            .expect("webhook replay store lock poisoned");
-        seen.retain(|_, first_seen| {
-            received_at
-                .duration_since(*first_seen)
-                .map_or(true, |age| age <= window)
-        });
-        if seen.contains_key(key) {
-            return false;
+        {
+            let mut state = self
+                .state
+                .lock()
+                .expect("webhook replay store lock poisoned");
+            state.checks_since_cleanup = state.checks_since_cleanup.saturating_add(1);
+
+            if let Some(expires_at) = state.seen.get(key).copied() {
+                if expires_at.duration_since(received_at).is_ok() {
+                    Self::cleanup_if_due(&mut state, received_at);
+                    drop(state);
+                    return false;
+                }
+                state.seen.remove(key);
+            }
+
+            let expires_at = received_at.checked_add(window).unwrap_or(received_at);
+            state.seen.insert(key.to_owned(), expires_at);
+            Self::cleanup_if_due(&mut state, received_at);
+            drop(state);
         }
-        seen.insert(key.to_owned(), received_at);
         true
+    }
+
+    fn cleanup_if_due(state: &mut InMemoryWebhookReplayState, received_at: SystemTime) {
+        if state.checks_since_cleanup < IN_MEMORY_REPLAY_CLEANUP_INTERVAL
+            && state.seen.len() <= IN_MEMORY_REPLAY_CLEANUP_HIGH_WATER
+        {
+            return;
+        }
+
+        state.checks_since_cleanup = 0;
+        state
+            .seen
+            .retain(|_, expires_at| expires_at.duration_since(received_at).is_ok());
     }
 }
 
@@ -933,7 +960,8 @@ async fn verify_request(
         WebhookProvider::Slack => verify_slack(endpoint, headers, &body, received_at)?,
     }
 
-    let delivery_id = resolve_delivery_id(&endpoint.config, headers, &body);
+    let json_body = serde_json::from_slice::<serde_json::Value>(&body).ok();
+    let delivery_id = resolve_delivery_id(&endpoint.config, headers, json_body.as_ref());
     if endpoint.config.replay_protection {
         let delivery_id = delivery_id
             .as_deref()
@@ -958,7 +986,7 @@ async fn verify_request(
         provider: endpoint.config.provider,
         endpoint: endpoint.config.name.clone(),
         delivery_id,
-        event_type: resolve_event_type(&endpoint.config, headers, &body),
+        event_type: resolve_event_type(&endpoint.config, headers, json_body.as_ref()),
         received_at,
         raw_body: body,
     })
@@ -978,7 +1006,9 @@ fn verify_stripe(
         endpoint.config.timestamp_tolerance_secs,
     )?;
 
-    let mut signed_payload = timestamp.to_string().into_bytes();
+    let timestamp = timestamp.to_string();
+    let mut signed_payload = Vec::with_capacity(timestamp.len() + 1 + body.len());
+    signed_payload.extend_from_slice(timestamp.as_bytes());
     signed_payload.push(b'.');
     signed_payload.extend_from_slice(body);
 
@@ -1012,7 +1042,11 @@ fn verify_slack(
         endpoint.config.timestamp_tolerance_secs,
     )?;
 
-    let mut signed_payload = format!("v0:{timestamp}:").into_bytes();
+    let timestamp = timestamp.to_string();
+    let mut signed_payload = Vec::with_capacity(3 + timestamp.len() + 1 + body.len());
+    signed_payload.extend_from_slice(b"v0:");
+    signed_payload.extend_from_slice(timestamp.as_bytes());
+    signed_payload.push(b':');
     signed_payload.extend_from_slice(body);
     verify_body_hmac(
         endpoint,
@@ -1115,7 +1149,7 @@ fn verify_timestamp(
             .as_secs(),
     )
     .map_err(|_| WebhookVerifyError::MalformedTimestamp)?;
-    let skew = now.saturating_sub(timestamp).unsigned_abs();
+    let skew = now.abs_diff(timestamp);
     if skew > tolerance_secs {
         return Err(WebhookVerifyError::StaleTimestamp);
     }
@@ -1125,26 +1159,32 @@ fn verify_timestamp(
 fn resolve_delivery_id(
     config: &WebhookEndpointConfig,
     headers: &HeaderMap,
-    body: &[u8],
+    json_body: Option<&serde_json::Value>,
 ) -> Option<String> {
-    config
+    let header = config
         .delivery_id_header
         .as_deref()
-        .and_then(|header| optional_header(headers, header))
-        .or_else(|| json_string_field(body, "id"))
+        .and_then(|header| optional_header(headers, header));
+
+    match config.provider {
+        WebhookProvider::Slack => header
+            .or_else(|| slack_delivery_id(json_body))
+            .or_else(|| json_string_field(json_body, "id")),
+        _ => header.or_else(|| json_string_field(json_body, "id")),
+    }
 }
 
 fn resolve_event_type(
     config: &WebhookEndpointConfig,
     headers: &HeaderMap,
-    body: &[u8],
+    json_body: Option<&serde_json::Value>,
 ) -> Option<String> {
     config
         .event_type_header
         .as_deref()
         .and_then(|header| optional_header(headers, header))
-        .or_else(|| json_string_field(body, "type"))
-        .or_else(|| nested_json_string_field(body, "event", "type"))
+        .or_else(|| json_string_field(json_body, "type"))
+        .or_else(|| nested_json_string_field(json_body, "event", "type"))
 }
 
 fn optional_header(headers: &HeaderMap, name: &str) -> Option<String> {
@@ -1155,16 +1195,34 @@ fn optional_header(headers: &HeaderMap, name: &str) -> Option<String> {
         .map(str::to_owned)
 }
 
-fn json_string_field(body: &[u8], field: &str) -> Option<String> {
-    let value: serde_json::Value = serde_json::from_slice(body).ok()?;
+fn slack_delivery_id(json_body: Option<&serde_json::Value>) -> Option<String> {
+    json_string_field(json_body, "event_id").or_else(|| {
+        let value = json_body?;
+        if value.get("type").and_then(serde_json::Value::as_str) == Some("url_verification") {
+            value
+                .get("challenge")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        } else {
+            None
+        }
+    })
+}
+
+fn json_string_field(value: Option<&serde_json::Value>, field: &str) -> Option<String> {
+    let value = value?;
     value
         .get(field)
         .and_then(serde_json::Value::as_str)
         .map(str::to_owned)
 }
 
-fn nested_json_string_field(body: &[u8], parent: &str, field: &str) -> Option<String> {
-    let value: serde_json::Value = serde_json::from_slice(body).ok()?;
+fn nested_json_string_field(
+    value: Option<&serde_json::Value>,
+    parent: &str,
+    field: &str,
+) -> Option<String> {
+    let value = value?;
     value
         .get(parent)
         .and_then(|parent_value| parent_value.get(field))

--- a/autumn/src/webhook.rs
+++ b/autumn/src/webhook.rs
@@ -107,6 +107,7 @@ impl WebhookConfig {
         for endpoint in &self.endpoints {
             endpoint.validate(is_production)?;
         }
+        validate_unique_endpoint_paths(&self.endpoints)?;
         if self
             .endpoints
             .iter()
@@ -503,6 +504,19 @@ pub enum WebhookConfigError {
         /// Validation message.
         message: String,
     },
+    /// Two endpoints declare the same route path.
+    #[error(
+        "duplicate webhook endpoint path {path:?}: endpoints {first_name:?} and \
+         {duplicate_name:?} would shadow each other"
+    )]
+    DuplicatePath {
+        /// Shared endpoint path.
+        path: String,
+        /// Name of the first endpoint using the path.
+        first_name: String,
+        /// Name of the later endpoint using the same path.
+        duplicate_name: String,
+    },
     /// Current production secret is weak or malformed.
     #[error("webhook endpoint {name:?} has invalid secret: {reason}")]
     InvalidSecret {
@@ -595,6 +609,7 @@ impl WebhookRegistry {
         config: &WebhookConfig,
         replay_store: Arc<dyn WebhookReplayStore>,
     ) -> Result<Self, WebhookConfigError> {
+        validate_unique_endpoint_paths(&config.endpoints)?;
         let mut endpoints_by_path = HashMap::new();
         for endpoint in &config.endpoints {
             let mut endpoint = endpoint.clone();
@@ -630,6 +645,23 @@ impl WebhookRegistry {
     fn endpoint_for_path(&self, path: &str) -> Option<Arc<ResolvedWebhookEndpoint>> {
         self.endpoints_by_path.get(path).cloned()
     }
+}
+
+fn validate_unique_endpoint_paths(
+    endpoints: &[WebhookEndpointConfig],
+) -> Result<(), WebhookConfigError> {
+    let mut seen_paths = HashMap::new();
+    for endpoint in endpoints {
+        if let Some(first_name) = seen_paths.insert(endpoint.path.as_str(), endpoint.name.as_str())
+        {
+            return Err(WebhookConfigError::DuplicatePath {
+                path: endpoint.path.clone(),
+                first_name: first_name.to_owned(),
+                duplicate_name: endpoint.name.clone(),
+            });
+        }
+    }
+    Ok(())
 }
 
 /// Boxed replay store operation future.

--- a/autumn/tests/signed_webhooks.rs
+++ b/autumn/tests/signed_webhooks.rs
@@ -1,13 +1,13 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use autumn_web::config::{AutumnConfig, MockEnv};
 use autumn_web::prelude::*;
 use autumn_web::security::{CsrfConfig, SecurityConfig};
 use autumn_web::test::{TestApp, TestResponse};
 use autumn_web::webhook::{
-    SignedWebhook, WebhookEndpointConfig, WebhookProvider, WebhookRegistry, WebhookReplayBackend,
-    hmac_sha256_hex,
+    InMemoryWebhookReplayStore, SignedWebhook, WebhookEndpointConfig, WebhookProvider,
+    WebhookRegistry, WebhookReplayBackend, WebhookReplayStore, hmac_sha256_hex,
 };
 use serde_json::json;
 
@@ -120,7 +120,11 @@ fn github_signature(secret: &str, body: &[u8]) -> String {
 }
 
 fn slack_signature(secret: &str, timestamp: i64, body: &[u8]) -> String {
-    let mut signed_payload = format!("v0:{timestamp}:").into_bytes();
+    let timestamp = timestamp.to_string();
+    let mut signed_payload = Vec::with_capacity(3 + timestamp.len() + 1 + body.len());
+    signed_payload.extend_from_slice(b"v0:");
+    signed_payload.extend_from_slice(timestamp.as_bytes());
+    signed_payload.push(b':');
     signed_payload.extend_from_slice(body);
     format!("v0={}", hmac_sha256_hex(secret.as_bytes(), &signed_payload))
 }
@@ -137,10 +141,17 @@ fn problem_json(response: &TestResponse, status: u16) -> serde_json::Value {
     assert!(
         json["detail"]
             .as_str()
-            .is_some_and(|detail| !detail.is_empty())
+            .is_some_and(|detail| !detail.is_empty()),
+        "Problem+JSON response should include a detail message"
     );
-    assert!(json["instance"].as_str().is_some());
-    assert!(json["request_id"].as_str().is_some());
+    assert!(
+        json["instance"].as_str().is_some(),
+        "Problem+JSON response should include an instance path"
+    );
+    assert!(
+        json["request_id"].as_str().is_some(),
+        "Problem+JSON response should include a request_id"
+    );
     json
 }
 
@@ -192,24 +203,23 @@ async fn provider_presets_verify_valid_requests_and_expose_metadata() {
     assert_eq!(github["delivery_id"], "gh-delivery-1");
     assert_eq!(github["event_type"], "pull_request");
 
-    let slack_body = b"token=ignored&team_id=T123&api_app_id=A123";
+    let slack_body = br#"{"type":"event_callback","event":{"type":"message"},"event_id":"Ev-provider-preset","event_time":1234567890}"#;
     let response = client
         .post("/webhooks/slack")
+        .header("content-type", "application/json")
         .header("x-slack-request-timestamp", &now.to_string())
         .header(
             "x-slack-signature",
             &slack_signature(CURRENT_SECRET, now, slack_body),
         )
-        .header("x-slack-request-id", "slack-delivery-1")
-        .header("x-slack-event-type", "url_verification")
         .body(slack_body.as_slice())
         .send()
         .await;
     response.assert_ok();
     let slack: serde_json::Value = response.json();
     assert_eq!(slack["provider"], "slack");
-    assert_eq!(slack["delivery_id"], "slack-delivery-1");
-    assert_eq!(slack["event_type"], "url_verification");
+    assert_eq!(slack["delivery_id"], "Ev-provider-preset");
+    assert_eq!(slack["event_type"], "event_callback");
 
     let generic_body = br#"{"kind":"cms.updated"}"#;
     let response = client
@@ -230,6 +240,77 @@ async fn provider_presets_verify_valid_requests_and_expose_metadata() {
     assert_eq!(generic["event_type"], "cms.updated");
 
     assert_eq!(HANDLER_CALLS.load(Ordering::SeqCst), 4);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn slack_events_api_json_body_uses_event_id_for_replay_protection() {
+    let _guard = TEST_LOCK.lock().await;
+    HANDLER_CALLS.store(0, Ordering::SeqCst);
+    let client = client(vec![endpoint(
+        WebhookProvider::Slack,
+        "/webhooks/slack",
+        "slack",
+    )]);
+    let now = unix_now();
+    let body = br#"{"type":"event_callback","event":{"type":"app_mention"},"event_id":"Ev123ABC456","event_time":1234567890}"#;
+    let signature = slack_signature(CURRENT_SECRET, now, body);
+
+    let first = client
+        .post("/webhooks/slack")
+        .header("content-type", "application/json")
+        .header("x-slack-request-timestamp", &now.to_string())
+        .header("x-slack-signature", &signature)
+        .body(body.as_slice())
+        .send()
+        .await;
+    first.assert_ok();
+    let json: serde_json::Value = first.json();
+    assert_eq!(json["provider"], "slack");
+    assert_eq!(json["delivery_id"], "Ev123ABC456");
+    assert_eq!(json["event_type"], "event_callback");
+
+    let second = client
+        .post("/webhooks/slack")
+        .header("content-type", "application/json")
+        .header("x-slack-request-timestamp", &now.to_string())
+        .header("x-slack-signature", &signature)
+        .body(body.as_slice())
+        .send()
+        .await;
+    problem_json(&second, 409);
+    assert_eq!(HANDLER_CALLS.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn slack_url_verification_json_body_uses_challenge_as_replay_id() {
+    let _guard = TEST_LOCK.lock().await;
+    HANDLER_CALLS.store(0, Ordering::SeqCst);
+    let client = client(vec![endpoint(
+        WebhookProvider::Slack,
+        "/webhooks/slack",
+        "slack",
+    )]);
+    let now = unix_now();
+    let body =
+        br#"{"token":"deprecated-token","challenge":"challenge-123","type":"url_verification"}"#;
+
+    let response = client
+        .post("/webhooks/slack")
+        .header("content-type", "application/json")
+        .header("x-slack-request-timestamp", &now.to_string())
+        .header(
+            "x-slack-signature",
+            &slack_signature(CURRENT_SECRET, now, body),
+        )
+        .body(body.as_slice())
+        .send()
+        .await;
+    response.assert_ok();
+    let json: serde_json::Value = response.json();
+    assert_eq!(json["provider"], "slack");
+    assert_eq!(json["delivery_id"], "challenge-123");
+    assert_eq!(json["event_type"], "url_verification");
+    assert_eq!(HANDLER_CALLS.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -307,6 +388,19 @@ async fn rejects_missing_malformed_stale_and_bad_signatures_with_problem_details
         .await;
     problem_json(&stale, 401);
 
+    let future_timestamp = now + 301;
+    let future = client
+        .post("/webhooks/stripe")
+        .header("content-type", "application/json")
+        .header(
+            "stripe-signature",
+            &stripe_signature(CURRENT_SECRET, future_timestamp, body),
+        )
+        .body(body.as_slice())
+        .send()
+        .await;
+    problem_json(&future, 401);
+
     let bad = client
         .post("/webhooks/stripe")
         .header("content-type", "application/json")
@@ -359,6 +453,40 @@ async fn duplicate_delivery_ids_are_rejected_deterministically() {
             .is_some_and(|detail| detail.contains("duplicate"))
     );
     assert_eq!(HANDLER_CALLS.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn in_memory_replay_store_rejects_duplicates_until_window_expires() {
+    let store = InMemoryWebhookReplayStore::default();
+    let received_at = UNIX_EPOCH + Duration::from_secs(1_000);
+    let window = Duration::from_secs(300);
+
+    assert!(
+        store
+            .check_and_insert("stripe:stripe:evt_replay", received_at, window)
+            .await
+            .expect("in-memory replay store should not fail")
+    );
+    assert!(
+        !store
+            .check_and_insert(
+                "stripe:stripe:evt_replay",
+                received_at + Duration::from_secs(299),
+                window,
+            )
+            .await
+            .expect("in-memory replay store should not fail")
+    );
+    assert!(
+        store
+            .check_and_insert(
+                "stripe:stripe:evt_replay",
+                received_at + Duration::from_secs(301),
+                window,
+            )
+            .await
+            .expect("in-memory replay store should not fail")
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/autumn/tests/signed_webhooks.rs
+++ b/autumn/tests/signed_webhooks.rs
@@ -155,6 +155,17 @@ fn problem_json(response: &TestResponse, status: u16) -> serde_json::Value {
     json
 }
 
+fn assert_duplicate_path_error(error: impl std::fmt::Display) {
+    let message = error.to_string();
+    assert!(
+        message.contains("duplicate")
+            && message.contains("/webhooks/duplicate")
+            && message.contains("stripe")
+            && message.contains("github"),
+        "duplicate path error should identify both endpoints and the shared path, got: {message}"
+    );
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn provider_presets_verify_valid_requests_and_expose_metadata() {
     let _guard = TEST_LOCK.lock().await;
@@ -311,6 +322,23 @@ async fn slack_url_verification_json_body_uses_challenge_as_replay_id() {
     assert_eq!(json["delivery_id"], "challenge-123");
     assert_eq!(json["event_type"], "url_verification");
     assert_eq!(HANDLER_CALLS.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn duplicate_webhook_paths_are_rejected_before_registry_construction() {
+    let config = webhook_config(vec![
+        endpoint(WebhookProvider::Stripe, "/webhooks/duplicate", "stripe"),
+        endpoint(WebhookProvider::Github, "/webhooks/duplicate", "github"),
+    ]);
+
+    let error = config
+        .validate()
+        .expect_err("duplicate webhook paths must fail app config validation");
+    assert_duplicate_path_error(error);
+
+    let error = WebhookRegistry::from_config(&config.security.webhooks)
+        .expect_err("duplicate webhook paths must fail direct registry construction");
+    assert_duplicate_path_error(error);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/autumn/tests/signed_webhooks.rs
+++ b/autumn/tests/signed_webhooks.rs
@@ -7,7 +7,8 @@ use autumn_web::security::{CsrfConfig, SecurityConfig};
 use autumn_web::test::{TestApp, TestResponse};
 use autumn_web::webhook::{
     InMemoryWebhookReplayStore, SignedWebhook, WebhookEndpointConfig, WebhookProvider,
-    WebhookRegistry, WebhookReplayBackend, WebhookReplayStore, hmac_sha256_hex,
+    WebhookRegistry, WebhookReplayBackend, WebhookReplayFuture, WebhookReplayStore,
+    WebhookReplayStoreError, hmac_sha256_hex,
 };
 use serde_json::json;
 
@@ -16,6 +17,24 @@ static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 const CURRENT_SECRET: &str = "current-webhook-secret-32-bytes!!";
 const PREVIOUS_SECRET: &str = "previous-webhook-secret-32-bytes!";
+
+#[derive(Debug)]
+struct UnavailableReplayStore;
+
+impl WebhookReplayStore for UnavailableReplayStore {
+    fn check_and_insert<'a>(
+        &'a self,
+        _key: &'a str,
+        _received_at: SystemTime,
+        _window: Duration,
+    ) -> WebhookReplayFuture<'a> {
+        Box::pin(async {
+            Err(WebhookReplayStoreError::new(
+                "custom replay backend offline",
+            ))
+        })
+    }
+}
 
 #[post("/webhooks/stripe")]
 async fn stripe_webhook(webhook: SignedWebhook) -> Json<serde_json::Value> {
@@ -94,6 +113,16 @@ fn client(endpoints: Vec<WebhookEndpointConfig>) -> autumn_web::test::TestClient
             generic_webhook
         ])
         .build()
+}
+
+fn client_with_registry(registry: WebhookRegistry) -> autumn_web::test::TestClient {
+    let state = autumn_web::AppState::for_test().with_extension(registry);
+    let mut route_defs = routes![github_webhook];
+    let route = route_defs.remove(0);
+    let router = axum::Router::new()
+        .route(route.path, route.handler)
+        .with_state(state);
+    TestApp::from_router(router)
 }
 
 fn endpoint(
@@ -481,6 +510,46 @@ async fn duplicate_delivery_ids_are_rejected_deterministically() {
             .is_some_and(|detail| detail.contains("duplicate"))
     );
     assert_eq!(HANDLER_CALLS.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn custom_replay_store_failures_are_reported_as_service_unavailable() {
+    let _guard = TEST_LOCK.lock().await;
+    HANDLER_CALLS.store(0, Ordering::SeqCst);
+    let config = autumn_web::webhook::WebhookConfig {
+        endpoints: vec![endpoint(
+            WebhookProvider::Github,
+            "/webhooks/github",
+            "github",
+        )],
+        ..Default::default()
+    };
+    let registry = WebhookRegistry::from_config_with_replay_store(&config, UnavailableReplayStore)
+        .expect("custom replay store should be installable");
+    let client = client_with_registry(registry);
+    let body = br#"{"action":"opened"}"#;
+
+    let response = client
+        .post("/webhooks/github")
+        .header(
+            "x-hub-signature-256",
+            &github_signature(CURRENT_SECRET, body),
+        )
+        .header("x-github-delivery", "store-outage-delivery")
+        .header("x-github-event", "pull_request")
+        .body(body.as_slice())
+        .send()
+        .await;
+
+    response.assert_status(503);
+    let json: serde_json::Value = response.json();
+    assert_eq!(json["status"], 503);
+    assert!(
+        json["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("custom replay backend offline"))
+    );
+    assert_eq!(HANDLER_CALLS.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/autumn/tests/signed_webhooks.rs
+++ b/autumn/tests/signed_webhooks.rs
@@ -1,0 +1,651 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use autumn_web::config::{AutumnConfig, MockEnv};
+use autumn_web::prelude::*;
+use autumn_web::security::{CsrfConfig, SecurityConfig};
+use autumn_web::test::{TestApp, TestResponse};
+use autumn_web::webhook::{
+    SignedWebhook, WebhookEndpointConfig, WebhookProvider, WebhookRegistry, WebhookReplayBackend,
+    hmac_sha256_hex,
+};
+use serde_json::json;
+
+static HANDLER_CALLS: AtomicUsize = AtomicUsize::new(0);
+static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+const CURRENT_SECRET: &str = "current-webhook-secret-32-bytes!!";
+const PREVIOUS_SECRET: &str = "previous-webhook-secret-32-bytes!";
+
+#[post("/webhooks/stripe")]
+async fn stripe_webhook(webhook: SignedWebhook) -> Json<serde_json::Value> {
+    HANDLER_CALLS.fetch_add(1, Ordering::SeqCst);
+    Json(json!({
+        "provider": webhook.provider(),
+        "delivery_id": webhook.delivery_id(),
+        "event_type": webhook.event_type(),
+        "raw": String::from_utf8_lossy(webhook.raw_body()),
+    }))
+}
+
+#[post("/webhooks/github")]
+async fn github_webhook(webhook: SignedWebhook) -> Json<serde_json::Value> {
+    HANDLER_CALLS.fetch_add(1, Ordering::SeqCst);
+    Json(json!({
+        "provider": webhook.provider(),
+        "delivery_id": webhook.delivery_id(),
+        "event_type": webhook.event_type(),
+    }))
+}
+
+#[post("/webhooks/slack")]
+async fn slack_webhook(webhook: SignedWebhook) -> Json<serde_json::Value> {
+    HANDLER_CALLS.fetch_add(1, Ordering::SeqCst);
+    Json(json!({
+        "provider": webhook.provider(),
+        "delivery_id": webhook.delivery_id(),
+        "event_type": webhook.event_type(),
+    }))
+}
+
+#[post("/webhooks/generic")]
+async fn generic_webhook(webhook: SignedWebhook) -> Json<serde_json::Value> {
+    HANDLER_CALLS.fetch_add(1, Ordering::SeqCst);
+    Json(json!({
+        "provider": webhook.provider(),
+        "delivery_id": webhook.delivery_id(),
+        "event_type": webhook.event_type(),
+    }))
+}
+
+fn unix_now() -> i64 {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock must be after unix epoch")
+        .as_secs();
+    i64::try_from(secs).expect("current unix timestamp fits in i64")
+}
+
+fn webhook_config(endpoints: Vec<WebhookEndpointConfig>) -> AutumnConfig {
+    AutumnConfig {
+        profile: Some("test".to_owned()),
+        security: SecurityConfig {
+            csrf: CsrfConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            webhooks: autumn_web::webhook::WebhookConfig {
+                endpoints,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn client(endpoints: Vec<WebhookEndpointConfig>) -> autumn_web::test::TestClient {
+    TestApp::new()
+        .config(webhook_config(endpoints))
+        .routes(routes![
+            stripe_webhook,
+            github_webhook,
+            slack_webhook,
+            generic_webhook
+        ])
+        .build()
+}
+
+fn endpoint(
+    provider: WebhookProvider,
+    path: &'static str,
+    name: &'static str,
+) -> WebhookEndpointConfig {
+    WebhookEndpointConfig::new(name, path, provider, CURRENT_SECRET)
+        .with_previous_secret(PREVIOUS_SECRET)
+        .with_timestamp_tolerance_secs(300)
+        .with_replay_window_secs(300)
+}
+
+fn stripe_signature(secret: &str, timestamp: i64, body: &[u8]) -> String {
+    let mut signed_payload = timestamp.to_string().into_bytes();
+    signed_payload.push(b'.');
+    signed_payload.extend_from_slice(body);
+    let signature = hmac_sha256_hex(secret.as_bytes(), &signed_payload);
+    format!("t={timestamp},v1={signature}")
+}
+
+fn github_signature(secret: &str, body: &[u8]) -> String {
+    format!("sha256={}", hmac_sha256_hex(secret.as_bytes(), body))
+}
+
+fn slack_signature(secret: &str, timestamp: i64, body: &[u8]) -> String {
+    let mut signed_payload = format!("v0:{timestamp}:").into_bytes();
+    signed_payload.extend_from_slice(body);
+    format!("v0={}", hmac_sha256_hex(secret.as_bytes(), &signed_payload))
+}
+
+fn generic_signature(secret: &str, body: &[u8]) -> String {
+    format!("sha256={}", hmac_sha256_hex(secret.as_bytes(), body))
+}
+
+fn problem_json(response: &TestResponse, status: u16) -> serde_json::Value {
+    response.assert_status(status);
+    response.assert_header_contains("content-type", "application/problem+json");
+    let json: serde_json::Value = response.json();
+    assert_eq!(json["status"], status);
+    assert!(
+        json["detail"]
+            .as_str()
+            .is_some_and(|detail| !detail.is_empty())
+    );
+    assert!(json["instance"].as_str().is_some());
+    assert!(json["request_id"].as_str().is_some());
+    json
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn provider_presets_verify_valid_requests_and_expose_metadata() {
+    let _guard = TEST_LOCK.lock().await;
+    HANDLER_CALLS.store(0, Ordering::SeqCst);
+    let client = client(vec![
+        endpoint(WebhookProvider::Stripe, "/webhooks/stripe", "stripe"),
+        endpoint(WebhookProvider::Github, "/webhooks/github", "github"),
+        endpoint(WebhookProvider::Slack, "/webhooks/slack", "slack"),
+        endpoint(WebhookProvider::Generic, "/webhooks/generic", "generic"),
+    ]);
+    let now = unix_now();
+
+    let stripe_body = br#"{"id":"evt_123","type":"invoice.paid"}"#;
+    let response = client
+        .post("/webhooks/stripe")
+        .header("content-type", "application/json")
+        .header(
+            "stripe-signature",
+            &stripe_signature(CURRENT_SECRET, now, stripe_body),
+        )
+        .body(stripe_body.as_slice())
+        .send()
+        .await;
+    response.assert_ok();
+    let stripe: serde_json::Value = response.json();
+    assert_eq!(stripe["provider"], "stripe");
+    assert_eq!(stripe["delivery_id"], "evt_123");
+    assert_eq!(stripe["event_type"], "invoice.paid");
+    assert_eq!(stripe["raw"], r#"{"id":"evt_123","type":"invoice.paid"}"#);
+
+    let github_body = br#"{"action":"opened"}"#;
+    let response = client
+        .post("/webhooks/github")
+        .header(
+            "x-hub-signature-256",
+            &github_signature(CURRENT_SECRET, github_body),
+        )
+        .header("x-github-delivery", "gh-delivery-1")
+        .header("x-github-event", "pull_request")
+        .body(github_body.as_slice())
+        .send()
+        .await;
+    response.assert_ok();
+    let github: serde_json::Value = response.json();
+    assert_eq!(github["provider"], "github");
+    assert_eq!(github["delivery_id"], "gh-delivery-1");
+    assert_eq!(github["event_type"], "pull_request");
+
+    let slack_body = b"token=ignored&team_id=T123&api_app_id=A123";
+    let response = client
+        .post("/webhooks/slack")
+        .header("x-slack-request-timestamp", &now.to_string())
+        .header(
+            "x-slack-signature",
+            &slack_signature(CURRENT_SECRET, now, slack_body),
+        )
+        .header("x-slack-request-id", "slack-delivery-1")
+        .header("x-slack-event-type", "url_verification")
+        .body(slack_body.as_slice())
+        .send()
+        .await;
+    response.assert_ok();
+    let slack: serde_json::Value = response.json();
+    assert_eq!(slack["provider"], "slack");
+    assert_eq!(slack["delivery_id"], "slack-delivery-1");
+    assert_eq!(slack["event_type"], "url_verification");
+
+    let generic_body = br#"{"kind":"cms.updated"}"#;
+    let response = client
+        .post("/webhooks/generic")
+        .header(
+            "x-webhook-signature",
+            &generic_signature(CURRENT_SECRET, generic_body),
+        )
+        .header("x-webhook-delivery", "generic-delivery-1")
+        .header("x-webhook-event", "cms.updated")
+        .body(generic_body.as_slice())
+        .send()
+        .await;
+    response.assert_ok();
+    let generic: serde_json::Value = response.json();
+    assert_eq!(generic["provider"], "generic");
+    assert_eq!(generic["delivery_id"], "generic-delivery-1");
+    assert_eq!(generic["event_type"], "cms.updated");
+
+    assert_eq!(HANDLER_CALLS.load(Ordering::SeqCst), 4);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn byte_modified_payload_fails_before_handler_even_when_json_is_equivalent() {
+    let _guard = TEST_LOCK.lock().await;
+    HANDLER_CALLS.store(0, Ordering::SeqCst);
+    let client = client(vec![endpoint(
+        WebhookProvider::Stripe,
+        "/webhooks/stripe",
+        "stripe",
+    )]);
+    let now = unix_now();
+    let signed_body = br#"{"id":"evt_tamper","type":"invoice.paid"}"#;
+    let modified_body = br#"{"id": "evt_tamper", "type": "invoice.paid"}"#;
+
+    let response = client
+        .post("/webhooks/stripe")
+        .header("content-type", "application/json")
+        .header(
+            "stripe-signature",
+            &stripe_signature(CURRENT_SECRET, now, signed_body),
+        )
+        .body(modified_body.as_slice())
+        .send()
+        .await;
+
+    let json = problem_json(&response, 401);
+    assert!(
+        json["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("signature"))
+    );
+    assert_eq!(HANDLER_CALLS.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn rejects_missing_malformed_stale_and_bad_signatures_with_problem_details() {
+    let _guard = TEST_LOCK.lock().await;
+    HANDLER_CALLS.store(0, Ordering::SeqCst);
+    let client = client(vec![endpoint(
+        WebhookProvider::Stripe,
+        "/webhooks/stripe",
+        "stripe",
+    )]);
+    let body = br#"{"id":"evt_bad","type":"invoice.paid"}"#;
+    let now = unix_now();
+
+    let missing = client
+        .post("/webhooks/stripe")
+        .header("content-type", "application/json")
+        .body(body.as_slice())
+        .send()
+        .await;
+    problem_json(&missing, 400);
+
+    let malformed = client
+        .post("/webhooks/stripe")
+        .header("content-type", "application/json")
+        .header("stripe-signature", "not-a-stripe-signature")
+        .body(body.as_slice())
+        .send()
+        .await;
+    problem_json(&malformed, 400);
+
+    let stale_timestamp = now - 301;
+    let stale = client
+        .post("/webhooks/stripe")
+        .header("content-type", "application/json")
+        .header(
+            "stripe-signature",
+            &stripe_signature(CURRENT_SECRET, stale_timestamp, body),
+        )
+        .body(body.as_slice())
+        .send()
+        .await;
+    problem_json(&stale, 401);
+
+    let bad = client
+        .post("/webhooks/stripe")
+        .header("content-type", "application/json")
+        .header(
+            "stripe-signature",
+            &stripe_signature("wrong-webhook-secret-32-bytes!!", now, body),
+        )
+        .body(body.as_slice())
+        .send()
+        .await;
+    problem_json(&bad, 401);
+
+    assert_eq!(HANDLER_CALLS.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn duplicate_delivery_ids_are_rejected_deterministically() {
+    let _guard = TEST_LOCK.lock().await;
+    HANDLER_CALLS.store(0, Ordering::SeqCst);
+    let client = client(vec![endpoint(
+        WebhookProvider::Github,
+        "/webhooks/github",
+        "github",
+    )]);
+    let body = br#"{"action":"opened"}"#;
+    let signature = github_signature(CURRENT_SECRET, body);
+
+    let first = client
+        .post("/webhooks/github")
+        .header("x-hub-signature-256", &signature)
+        .header("x-github-delivery", "same-delivery")
+        .header("x-github-event", "pull_request")
+        .body(body.as_slice())
+        .send()
+        .await;
+    first.assert_ok();
+
+    let second = client
+        .post("/webhooks/github")
+        .header("x-hub-signature-256", &signature)
+        .header("x-github-delivery", "same-delivery")
+        .header("x-github-event", "pull_request")
+        .body(body.as_slice())
+        .send()
+        .await;
+    let json = problem_json(&second, 409);
+    assert!(
+        json["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("duplicate"))
+    );
+    assert_eq!(HANDLER_CALLS.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn previous_secret_is_accepted_during_rotation() {
+    let _guard = TEST_LOCK.lock().await;
+    HANDLER_CALLS.store(0, Ordering::SeqCst);
+    let client = client(vec![endpoint(
+        WebhookProvider::Github,
+        "/webhooks/github",
+        "github",
+    )]);
+    let body = br#"{"action":"closed"}"#;
+
+    let response = client
+        .post("/webhooks/github")
+        .header(
+            "x-hub-signature-256",
+            &github_signature(PREVIOUS_SECRET, body),
+        )
+        .header("x-github-delivery", "rotated-delivery")
+        .header("x-github-event", "pull_request")
+        .body(body.as_slice())
+        .send()
+        .await;
+
+    response.assert_ok();
+    assert_eq!(HANDLER_CALLS.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn production_config_rejects_missing_or_weak_webhook_secret() {
+    let mut missing = webhook_config(vec![WebhookEndpointConfig {
+        name: "stripe".to_owned(),
+        path: "/webhooks/stripe".to_owned(),
+        provider: WebhookProvider::Stripe,
+        secret: None,
+        previous_secrets: Vec::new(),
+        ..Default::default()
+    }]);
+    missing.profile = Some("prod".to_owned());
+    let error = missing
+        .validate()
+        .expect_err("prod webhook secret must be required");
+    assert!(
+        error.to_string().contains("webhook")
+            && error.to_string().contains("stripe")
+            && error.to_string().contains("secret")
+    );
+
+    let mut weak = webhook_config(vec![endpoint(
+        WebhookProvider::Github,
+        "/webhooks/github",
+        "github",
+    )]);
+    weak.profile = Some("prod".to_owned());
+    weak.security.webhooks.endpoints[0].secret = Some("secret".to_owned());
+    let error = weak
+        .validate()
+        .expect_err("weak prod webhook secret must fail");
+    assert!(
+        error.to_string().contains("webhook")
+            && error.to_string().contains("github")
+            && error.to_string().contains("template")
+    );
+}
+
+#[test]
+fn production_config_requires_shared_replay_backend_unless_explicitly_allowed() {
+    let mut config = webhook_config(vec![endpoint(
+        WebhookProvider::Github,
+        "/webhooks/github",
+        "github",
+    )]);
+    config.profile = Some("prod".to_owned());
+
+    let error = config
+        .validate()
+        .expect_err("prod webhook replay protection must reject memory backend");
+    assert!(
+        error.to_string().contains("replay")
+            && error.to_string().contains("memory")
+            && error.to_string().contains("production")
+    );
+
+    config.security.webhooks.replay.allow_memory_in_production = true;
+    config
+        .validate()
+        .expect("explicit memory replay opt-in should validate");
+}
+
+#[test]
+fn webhook_replay_backend_loads_from_toml_and_env() {
+    let config: AutumnConfig = toml::from_str(
+        r#"
+            [security.webhooks.replay]
+            backend = "redis"
+            allow_memory_in_production = false
+
+            [security.webhooks.replay.redis]
+            url = "redis://localhost:6379/3"
+            key_prefix = "myapp:webhooks:replay"
+        "#,
+    )
+    .expect("webhook replay config should parse");
+    assert_eq!(
+        config.security.webhooks.replay.backend,
+        WebhookReplayBackend::Redis
+    );
+    assert_eq!(
+        config.security.webhooks.replay.redis.url.as_deref(),
+        Some("redis://localhost:6379/3")
+    );
+    assert_eq!(
+        config.security.webhooks.replay.redis.key_prefix,
+        "myapp:webhooks:replay"
+    );
+
+    let env = MockEnv::new()
+        .with("AUTUMN_SECURITY__WEBHOOKS__REPLAY__BACKEND", "redis")
+        .with(
+            "AUTUMN_SECURITY__WEBHOOKS__REPLAY__REDIS__URL",
+            "redis://redis:6379/5",
+        )
+        .with(
+            "AUTUMN_SECURITY__WEBHOOKS__REPLAY__REDIS__KEY_PREFIX",
+            "env:webhooks:replay",
+        )
+        .with(
+            "AUTUMN_SECURITY__WEBHOOKS__REPLAY__ALLOW_MEMORY_IN_PRODUCTION",
+            "true",
+        );
+    let mut config = AutumnConfig::default();
+    config.apply_env_overrides_with_env(&env);
+    assert_eq!(
+        config.security.webhooks.replay.backend,
+        WebhookReplayBackend::Redis
+    );
+    assert_eq!(
+        config.security.webhooks.replay.redis.url.as_deref(),
+        Some("redis://redis:6379/5")
+    );
+    assert_eq!(
+        config.security.webhooks.replay.redis.key_prefix,
+        "env:webhooks:replay"
+    );
+    assert!(config.security.webhooks.replay.allow_memory_in_production);
+}
+
+#[cfg(not(feature = "redis"))]
+#[test]
+fn redis_replay_backend_requires_redis_feature() {
+    let mut config = webhook_config(vec![endpoint(
+        WebhookProvider::Github,
+        "/webhooks/github",
+        "github",
+    )]);
+    config.security.webhooks.replay.backend = WebhookReplayBackend::Redis;
+    config.security.webhooks.replay.redis.url = Some("redis://localhost:6379/0".to_owned());
+
+    let error = config
+        .validate()
+        .expect_err("redis replay backend must require redis feature");
+    assert!(
+        error.to_string().contains("redis") && error.to_string().contains("feature"),
+        "{error}"
+    );
+}
+
+#[cfg(feature = "redis")]
+#[test]
+fn redis_replay_backend_requires_url() {
+    let mut config = webhook_config(vec![endpoint(
+        WebhookProvider::Github,
+        "/webhooks/github",
+        "github",
+    )]);
+    config.security.webhooks.replay.backend = WebhookReplayBackend::Redis;
+
+    let error = config
+        .validate()
+        .expect_err("redis replay backend must require a url");
+    assert!(
+        error.to_string().contains("redis") && error.to_string().contains("url"),
+        "{error}"
+    );
+}
+
+#[test]
+fn disabled_replay_endpoint_does_not_require_replay_backend_configuration() {
+    let mut config = autumn_web::webhook::WebhookConfig {
+        replay: autumn_web::webhook::WebhookReplayConfig {
+            backend: WebhookReplayBackend::Redis,
+            ..Default::default()
+        },
+        endpoints: vec![
+            endpoint(WebhookProvider::Github, "/webhooks/github", "github")
+                .without_replay_protection(),
+        ],
+    };
+
+    config
+        .validate(false)
+        .expect("disabled replay should not validate the replay backend");
+    WebhookRegistry::from_config(&config)
+        .expect("disabled replay should not construct the unused replay backend");
+
+    config.endpoints[0].replay_protection = true;
+    let error = config
+        .validate(false)
+        .expect_err("enabled replay should validate the configured backend");
+    assert!(
+        error.to_string().contains("redis"),
+        "unexpected validation error: {error}"
+    );
+}
+
+#[test]
+fn webhook_secret_can_be_sourced_from_environment() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::write(
+        dir.path().join("autumn.toml"),
+        r#"
+            [security.webhooks]
+
+            [[security.webhooks.endpoints]]
+            name = "stripe"
+            path = "/webhooks/stripe"
+            provider = "stripe"
+            secret_env = "STRIPE_WEBHOOK_SECRET"
+            previous_secret_envs = ["STRIPE_WEBHOOK_SECRET_PREVIOUS"]
+        "#,
+    )
+    .expect("write config");
+
+    let env = MockEnv::new()
+        .with("AUTUMN_ENV", "test")
+        .with("AUTUMN_MANIFEST_DIR", dir.path().to_str().unwrap())
+        .with("STRIPE_WEBHOOK_SECRET", CURRENT_SECRET)
+        .with("STRIPE_WEBHOOK_SECRET_PREVIOUS", PREVIOUS_SECRET);
+
+    let config = AutumnConfig::load_with_env(&env).expect("config should load");
+    let endpoint = &config.security.webhooks.endpoints[0];
+    assert_eq!(endpoint.secret.as_deref(), Some(CURRENT_SECRET));
+    assert_eq!(endpoint.previous_secrets, vec![PREVIOUS_SECRET.to_owned()]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn toml_provider_preset_applies_signature_header_defaults() {
+    let _guard = TEST_LOCK.lock().await;
+    HANDLER_CALLS.store(0, Ordering::SeqCst);
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::write(
+        dir.path().join("autumn.toml"),
+        r#"
+            [security.webhooks]
+
+            [[security.webhooks.endpoints]]
+            name = "stripe"
+            path = "/webhooks/stripe"
+            provider = "stripe"
+            secret_env = "STRIPE_WEBHOOK_SECRET"
+        "#,
+    )
+    .expect("write config");
+    let env = MockEnv::new()
+        .with("AUTUMN_ENV", "test")
+        .with("AUTUMN_MANIFEST_DIR", dir.path().to_str().unwrap())
+        .with("STRIPE_WEBHOOK_SECRET", CURRENT_SECRET);
+    let config = AutumnConfig::load_with_env(&env).expect("config should load");
+    let client = TestApp::new()
+        .config(config)
+        .routes(routes![stripe_webhook])
+        .build();
+    let now = unix_now();
+    let body = br#"{"id":"evt_toml","type":"invoice.paid"}"#;
+
+    let response = client
+        .post("/webhooks/stripe")
+        .header("content-type", "application/json")
+        .header(
+            "stripe-signature",
+            &stripe_signature(CURRENT_SECRET, now, body),
+        )
+        .body(body.as_slice())
+        .send()
+        .await;
+
+    response.assert_ok();
+    assert_eq!(HANDLER_CALLS.load(Ordering::SeqCst), 1);
+}

--- a/docs/guide/signed-webhooks.md
+++ b/docs/guide/signed-webhooks.md
@@ -1,0 +1,155 @@
+# Signed Webhook Intake
+
+Autumn can verify third-party callbacks before your handler runs. The
+`SignedWebhook` extractor preserves the exact request bytes, checks the
+provider signature, applies timestamp tolerance, rejects replayed delivery IDs,
+and then hands the verified bytes and metadata to your route.
+
+## Configure endpoints
+
+Use provider presets under `security.webhooks.endpoints`.
+
+```toml
+[security.webhooks]
+
+[security.webhooks.replay]
+# Dev/test default is "memory". Production webhook endpoints should use Redis.
+backend = "redis"
+
+[security.webhooks.replay.redis]
+url = "redis://redis:6379/0"
+key_prefix = "myapp:webhooks:replay"
+
+[[security.webhooks.endpoints]]
+name = "stripe"
+path = "/webhooks/stripe"
+provider = "stripe"
+secret_env = "STRIPE_WEBHOOK_SECRET"
+previous_secret_envs = ["STRIPE_WEBHOOK_SECRET_PREVIOUS"]
+timestamp_tolerance_secs = 300
+replay_window_secs = 86400
+
+[[security.webhooks.endpoints]]
+name = "github"
+path = "/webhooks/github"
+provider = "github"
+secret_env = "GITHUB_WEBHOOK_SECRET"
+```
+
+Provider presets:
+
+| Provider | Signature input | Signature header | Timestamp | Delivery/event metadata |
+|----------|-----------------|------------------|-----------|-------------------------|
+| `stripe` | `{timestamp}.{raw_body}` | `Stripe-Signature: t=...,v1=...` | from signature header | JSON `id` and `type` |
+| `github` | raw body | `X-Hub-Signature-256: sha256=...` | none | `X-GitHub-Delivery`, `X-GitHub-Event` |
+| `slack` | `v0:{timestamp}:{raw_body}` | `X-Slack-Signature: v0=...` | `X-Slack-Request-Timestamp` | `X-Slack-Request-Id`, `X-Slack-Event-Type` |
+| `generic` | raw body | `X-Webhook-Signature: sha256=...` | optional | `X-Webhook-Delivery`, `X-Webhook-Event` |
+
+Secrets can be set directly with `secret = "..."` for local fixtures, but use
+`secret_env` in real deployments. During rotation, move the old value to
+`previous_secrets` or `previous_secret_envs`; new signatures use `secret`, while
+old signatures verify until you remove the previous value.
+
+Production config validation fails when a configured endpoint has no secret or
+uses a weak/template value. Apps with no configured signed webhooks are
+unchanged.
+
+## Write a handler
+
+```rust,ignore
+use autumn_web::prelude::*;
+
+#[post("/webhooks/stripe")]
+async fn stripe(webhook: SignedWebhook) -> AutumnResult<Json<serde_json::Value>> {
+    let event: serde_json::Value = webhook.json()?;
+
+    Ok(Json(serde_json::json!({
+        "received": true,
+        "provider": webhook.provider(),
+        "delivery_id": webhook.delivery_id(),
+        "event_type": webhook.event_type(),
+        "event": event,
+    })))
+}
+```
+
+`SignedWebhook` exposes:
+
+- `provider()` - `stripe`, `github`, `slack`, or `generic`
+- `endpoint()` - configured endpoint name
+- `delivery_id()` - provider delivery ID when present
+- `event_type()` - provider event type when present
+- `received_at()` - server receive time used for tolerance/replay checks
+- `raw_body()` - exact verified HTTP bytes
+- `json<T>()` - parse the verified payload after authentication
+
+## Error contract
+
+Failures happen before handler business logic:
+
+| Failure | Status | Problem Details code |
+|---------|--------|----------------------|
+| Missing signature, malformed signature, malformed timestamp, missing replay ID | `400 Bad Request` | `autumn.bad_request` |
+| Stale timestamp or mismatched signature | `401 Unauthorized` | `autumn.unauthorized` |
+| Duplicate delivery ID inside the replay window | `409 Conflict` | `autumn.conflict` |
+| Replay backend unavailable | `503 Service Unavailable` | `autumn.service_unavailable` |
+
+Responses use `application/problem+json` and include `type`, `title`, `status`,
+`detail`, `instance`, `code`, `request_id`, and `errors`.
+
+## Raw-body invariant
+
+Signatures are verified against the exact HTTP body bytes. Do not parse JSON or
+forms before verification. A payload like `{"id":"evt_1"}` and
+`{"id": "evt_1"}` can deserialize to the same value but must produce different
+HMAC inputs; Autumn rejects the byte-modified request before your handler runs.
+
+## Replay protection
+
+Replay protection is enabled by default. Autumn stores
+`provider:endpoint:delivery_id` and rejects a second delivery inside
+`replay_window_secs` with `409 Conflict`.
+
+The default replay backend is `memory`, which is process-local and suitable for
+tests, development, and explicitly single-replica deployments. Production
+validation refuses to start replay-protected webhook endpoints on `memory`
+unless you set:
+
+```toml
+[security.webhooks.replay]
+backend = "memory"
+allow_memory_in_production = true
+```
+
+Multi-replica production deployments should use Redis:
+
+```toml
+[security.webhooks.replay]
+backend = "redis"
+
+[security.webhooks.replay.redis]
+url = "redis://redis:6379/0"
+key_prefix = "myapp:webhooks:replay"
+```
+
+The Redis backend uses an atomic `SET NX EX` write, so every replica shares the
+same delivery-ID claim and Redis expires claims after the configured replay
+window. Compile `autumn-web` with the `redis` feature when selecting this
+backend.
+
+## Logging posture
+
+Do not log signing secrets or full raw payloads. Log the provider, endpoint,
+delivery ID, event type, status, and request ID. If you need payload diagnostics,
+log a bounded hash or a redacted subset after verification.
+
+## Synchronous versus background work
+
+Do only quick validation and idempotent acceptance in the webhook handler. For
+slow work such as sending mail, syncing a repository, or updating a billing
+projection, enqueue a `#[job]` after verification and return promptly. Jobs are
+recommended for follow-up processing, but they are not required to accept a
+signed webhook.
+
+See `examples/signed-webhooks/` for runnable fixture tests covering valid,
+tampered-body, stale-timestamp, bad-signature, and duplicate-delivery cases.

--- a/docs/guide/signed-webhooks.md
+++ b/docs/guide/signed-webhooks.md
@@ -42,13 +42,19 @@ Provider presets:
 |----------|-----------------|------------------|-----------|-------------------------|
 | `stripe` | `{timestamp}.{raw_body}` | `Stripe-Signature: t=...,v1=...` | from signature header | JSON `id` and `type` |
 | `github` | raw body | `X-Hub-Signature-256: sha256=...` | none | `X-GitHub-Delivery`, `X-GitHub-Event` |
-| `slack` | `v0:{timestamp}:{raw_body}` | `X-Slack-Signature: v0=...` | `X-Slack-Request-Timestamp` | `X-Slack-Request-Id`, `X-Slack-Event-Type` |
+| `slack` | `v0:{timestamp}:{raw_body}` | `X-Slack-Signature: v0=...` | `X-Slack-Request-Timestamp` | JSON `event_id` and `type`; URL verification falls back to JSON `challenge` |
 | `generic` | raw body | `X-Webhook-Signature: sha256=...` | optional | `X-Webhook-Delivery`, `X-Webhook-Event` |
 
 Secrets can be set directly with `secret = "..."` for local fixtures, but use
 `secret_env` in real deployments. During rotation, move the old value to
 `previous_secrets` or `previous_secret_envs`; new signatures use `secret`, while
 old signatures verify until you remove the previous value.
+
+For Slack Events API callbacks, replay protection uses the `event_id` field in
+the JSON callback body. URL verification requests do not include `event_id`, so
+Autumn uses their `challenge` value as the one-shot replay key. For Slack-style
+sources outside Events API, set `delivery_id_header` and `event_type_header`
+explicitly if those identifiers arrive in headers.
 
 Production config validation fails when a configured endpoint has no secret or
 uses a weak/template value. Apps with no configured signed webhooks are

--- a/docs/guide/tutorial/12-whats-next.md
+++ b/docs/guide/tutorial/12-whats-next.md
@@ -26,12 +26,14 @@ tutorial omitted. Then branch out into the newer example apps:
 - `examples/blog/` for hybrid rendering and a richer admin UI
 - `examples/bookmarks/` for repository macros, generated CRUD APIs, and scheduled tasks
 - `examples/wiki/` for mutation hooks and revision history
+- `examples/signed-webhooks/` for signed third-party callback intake and replay fixtures
 
 ### Ideas for Extending the App
 
 - **Authentication** -- add user accounts with session cookies
 - **Actuator hardening** -- tune which operational endpoints stay visible in prod
 - **Background work** -- add a `#[scheduled]` task for cleanup or polling
+- **Third-party callbacks** -- add signed Stripe/GitHub/Slack-style webhooks
 - **Categories** -- associate todos with categories (a second table, foreign keys)
 - **Search** -- add a search bar with `ILIKE` queries
 - **Pagination** -- limit the list with `.limit()` and `.offset()`
@@ -41,6 +43,7 @@ tutorial omitted. Then branch out into the newer example apps:
 
 - [API Reference](https://docs.rs/autumn-web) -- generated Rust docs for every public type
 - [Getting Started Guide](../getting-started.md) -- quick overview of all features
+- [Signed Webhook Intake](../signed-webhooks.md) -- raw-body HMAC verification and replay protection
 - [Example App](../../../examples/todo-app/) -- the reference implementation
 - [Autumn on crates.io](https://crates.io/crates/autumn-web) -- versioned releases
 

--- a/docs/guide/tutorial/index.md
+++ b/docs/guide/tutorial/index.md
@@ -35,6 +35,10 @@ stuck, compare your code against the example.
 > [i18n guide](../i18n.md) for the opt-in Project Fluent integration —
 > file convention, `Locale` extractor, and the `t!()` macro.
 
+> **Accepting third-party callbacks?** See the
+> [signed webhook guide](../signed-webhooks.md) for Stripe/GitHub/Slack-style
+> HMAC verification and replay protection.
+
 ## How to Use This Tutorial
 
 Each chapter builds on the previous one. Start from Chapter 1 and work

--- a/docs/plans/2026-05-11-signed-webhook-intake.md
+++ b/docs/plans/2026-05-11-signed-webhook-intake.md
@@ -1,0 +1,73 @@
+# Signed Webhook Intake Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add first-class signed webhook intake for Stripe, GitHub, Slack, and generic HMAC-SHA256 callbacks.
+
+**Architecture:** Add an additive `autumn_web::webhook` module with provider presets, raw-body verification, replay protection, and an Axum extractor. Configure endpoints under `security.webhooks.endpoints`, install a `WebhookRegistry` into `AppState`, and let handlers receive a `SignedWebhook` only after verification succeeds.
+
+**Tech Stack:** Rust 2024, Axum extractors, `hmac`/`sha2`, `subtle`, `serde`, Autumn Problem Details responses, in-memory replay store for the built-in default.
+
+---
+
+### Task 1: RED - Contract Tests
+
+**Files:**
+- Create: `autumn/tests/signed_webhooks.rs`
+- Modify later: `autumn/src/webhook.rs`, `autumn/src/lib.rs`, `autumn/src/prelude.rs`, `autumn/src/security/config.rs`, `autumn/src/config.rs`, `autumn/src/app.rs`, `autumn/src/test.rs`
+
+**Steps:**
+1. Add tests for valid Stripe/GitHub/Slack/generic HMAC requests.
+2. Add tests proving raw byte changes fail even when JSON is semantically equivalent.
+3. Add tests for missing, malformed, stale, bad-signature, duplicate-delivery, and previous-secret rotation cases.
+4. Add config tests for production rejecting missing/weak webhook secrets.
+5. Run `cargo test -p autumn-web --test signed_webhooks` and confirm RED from missing API.
+
+### Task 2: GREEN - Core Intake API
+
+**Files:**
+- Create: `autumn/src/webhook.rs`
+- Modify: `autumn/src/lib.rs`, `autumn/src/prelude.rs`
+
+**Steps:**
+1. Implement provider enum, endpoint config builders, runtime registry, in-memory replay store, verification error type, and `SignedWebhook`.
+2. Implement exact raw-body HMAC bases:
+   - Stripe: `timestamp.raw_body`, `Stripe-Signature: t=...,v1=...`
+   - GitHub: raw body, `X-Hub-Signature-256: sha256=...`
+   - Slack: `v0:timestamp:raw_body`, `X-Slack-Signature: v0=...`
+   - Generic: raw body, configurable header/prefix defaults
+3. Implement `FromRequest<AppState>` so handler logic runs only after verification.
+4. Return `AutumnError` values that render as Problem Details.
+
+### Task 3: GREEN - Config and Startup Wiring
+
+**Files:**
+- Modify: `autumn/src/security/config.rs`, `autumn/src/config.rs`, `autumn/src/app.rs`, `autumn/src/test.rs`
+
+**Steps:**
+1. Add `security.webhooks.endpoints` config and secret-env resolution.
+2. Validate configured endpoint secrets, including previous secrets during production rotation.
+3. Install `WebhookRegistry` into `AppState` in normal app startup and `TestApp`.
+4. Re-run focused tests and fix compile/test failures.
+
+### Task 4: REFACTOR - Docs and Example
+
+**Files:**
+- Create: `docs/guide/signed-webhooks.md`
+- Modify: `docs/guide/tutorial/12-whats-next.md`, `docs/guide/tutorial/index.md` if needed
+- Create: `examples/signed-webhooks/Cargo.toml`, `examples/signed-webhooks/src/main.rs`, `examples/signed-webhooks/tests/fixtures.rs`
+- Modify: root `Cargo.toml`
+
+**Steps:**
+1. Document raw-body preservation, provider headers, timestamp tolerance, replay protection, secret sourcing, rotation, error responses, and logging posture.
+2. Add a runnable example with fixture tests for valid, tampered-body, stale-timestamp, bad-signature, and duplicate-delivery cases.
+3. Run `cargo test -p signed-webhooks-example` plus focused Autumn tests.
+
+### Task 5: Final Verification
+
+**Steps:**
+1. Run `cargo fmt`.
+2. Run focused tests: `cargo test -p autumn-web --test signed_webhooks`.
+3. Run example tests: `cargo test -p signed-webhooks-example`.
+4. Scan affected areas for stubs: `rg "TODO|FIXME|Stub:" autumn/src/webhook.rs autumn/tests/signed_webhooks.rs docs/guide/signed-webhooks.md examples/signed-webhooks`.
+5. Review `git diff --check` and `git diff --stat`.

--- a/examples/signed-webhooks/Cargo.toml
+++ b/examples/signed-webhooks/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "signed-webhooks-example"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+autumn-web = { path = "../../autumn" }
+serde_json = "1"
+
+[dev-dependencies]
+tokio.workspace = true
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/examples/signed-webhooks/README.md
+++ b/examples/signed-webhooks/README.md
@@ -1,0 +1,25 @@
+# Signed Webhooks Example
+
+This example shows a Stripe-style signed webhook endpoint using Autumn's
+`SignedWebhook` extractor.
+
+## Prerequisites
+
+- Rust 1.88.0+
+
+## Quick start
+
+Run the app:
+
+```bash
+cargo run -p signed-webhooks-example
+```
+
+Run the fixture tests:
+
+```bash
+cargo test -p signed-webhooks-example
+```
+
+The tests cover valid, tampered-body, stale-timestamp, bad-signature, and
+duplicate-delivery webhook requests.

--- a/examples/signed-webhooks/autumn.toml
+++ b/examples/signed-webhooks/autumn.toml
@@ -1,0 +1,12 @@
+[server]
+port = 3010
+
+[security.webhooks]
+
+[[security.webhooks.endpoints]]
+name = "stripe"
+path = "/webhooks/stripe"
+provider = "stripe"
+secret = "dev-stripe-webhook-secret-32-bytes"
+timestamp_tolerance_secs = 300
+replay_window_secs = 86400

--- a/examples/signed-webhooks/src/lib.rs
+++ b/examples/signed-webhooks/src/lib.rs
@@ -1,0 +1,49 @@
+use autumn_web::prelude::*;
+use autumn_web::webhook::{WebhookConfig, WebhookEndpointConfig, WebhookProvider};
+
+pub const STRIPE_SECRET: &str = "dev-stripe-webhook-secret-32-bytes";
+
+#[post("/webhooks/stripe")]
+async fn stripe(webhook: SignedWebhook) -> Json<serde_json::Value> {
+    let payload = webhook
+        .json::<serde_json::Value>()
+        .unwrap_or(serde_json::Value::Null);
+    Json(serde_json::json!({
+        "accepted": true,
+        "provider": webhook.provider(),
+        "delivery_id": webhook.delivery_id(),
+        "event_type": webhook.event_type(),
+        "payload": payload,
+    }))
+}
+
+pub fn routes() -> Vec<autumn_web::Route> {
+    routes![stripe]
+}
+
+pub fn config() -> autumn_web::config::AutumnConfig {
+    autumn_web::config::AutumnConfig {
+        profile: Some("test".to_owned()),
+        security: autumn_web::security::SecurityConfig {
+            csrf: autumn_web::security::CsrfConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            webhooks: WebhookConfig {
+                endpoints: vec![
+                    WebhookEndpointConfig::new(
+                        "stripe",
+                        "/webhooks/stripe",
+                        WebhookProvider::Stripe,
+                        STRIPE_SECRET,
+                    )
+                    .with_timestamp_tolerance_secs(300)
+                    .with_replay_window_secs(86400),
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}

--- a/examples/signed-webhooks/src/lib.rs
+++ b/examples/signed-webhooks/src/lib.rs
@@ -4,17 +4,17 @@ use autumn_web::webhook::{WebhookConfig, WebhookEndpointConfig, WebhookProvider}
 pub const STRIPE_SECRET: &str = "dev-stripe-webhook-secret-32-bytes";
 
 #[post("/webhooks/stripe")]
-async fn stripe(webhook: SignedWebhook) -> Json<serde_json::Value> {
-    let payload = webhook
-        .json::<serde_json::Value>()
-        .unwrap_or(serde_json::Value::Null);
-    Json(serde_json::json!({
+async fn stripe(webhook: SignedWebhook) -> AutumnResult<Json<serde_json::Value>> {
+    let payload = webhook.json::<serde_json::Value>().map_err(|error| {
+        AutumnError::bad_request_msg(format!("invalid webhook JSON payload: {error}"))
+    })?;
+    Ok(Json(serde_json::json!({
         "accepted": true,
         "provider": webhook.provider(),
         "delivery_id": webhook.delivery_id(),
         "event_type": webhook.event_type(),
         "payload": payload,
-    }))
+    })))
 }
 
 pub fn routes() -> Vec<autumn_web::Route> {

--- a/examples/signed-webhooks/src/main.rs
+++ b/examples/signed-webhooks/src/main.rs
@@ -1,0 +1,7 @@
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .routes(signed_webhooks_example::routes())
+        .run()
+        .await;
+}

--- a/examples/signed-webhooks/tests/fixtures.rs
+++ b/examples/signed-webhooks/tests/fixtures.rs
@@ -13,7 +13,9 @@ fn unix_now() -> i64 {
 }
 
 fn stripe_signature(secret: &str, timestamp: i64, body: &[u8]) -> String {
-    let mut signed_payload = timestamp.to_string().into_bytes();
+    let timestamp = timestamp.to_string();
+    let mut signed_payload = Vec::with_capacity(timestamp.len() + 1 + body.len());
+    signed_payload.extend_from_slice(timestamp.as_bytes());
     signed_payload.push(b'.');
     signed_payload.extend_from_slice(body);
     let signature = hmac_sha256_hex(secret.as_bytes(), &signed_payload);
@@ -29,6 +31,20 @@ fn problem_json(response: &TestResponse, status: u16) -> serde_json::Value {
     response.assert_header_contains("content-type", "application/problem+json");
     let json: serde_json::Value = response.json();
     assert_eq!(json["status"], status);
+    assert!(
+        json["detail"]
+            .as_str()
+            .is_some_and(|detail| !detail.is_empty()),
+        "Problem+JSON response should include a detail message"
+    );
+    assert!(
+        json["instance"].as_str().is_some(),
+        "Problem+JSON response should include an instance path"
+    );
+    assert!(
+        json["request_id"].as_str().is_some(),
+        "Problem+JSON response should include a request_id"
+    );
     json
 }
 

--- a/examples/signed-webhooks/tests/fixtures.rs
+++ b/examples/signed-webhooks/tests/fixtures.rs
@@ -1,0 +1,141 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use autumn_web::test::{TestApp, TestResponse};
+use autumn_web::webhook::hmac_sha256_hex;
+use signed_webhooks_example::{STRIPE_SECRET, config, routes};
+
+fn unix_now() -> i64 {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock must be after unix epoch")
+        .as_secs();
+    i64::try_from(secs).expect("current unix timestamp fits in i64")
+}
+
+fn stripe_signature(secret: &str, timestamp: i64, body: &[u8]) -> String {
+    let mut signed_payload = timestamp.to_string().into_bytes();
+    signed_payload.push(b'.');
+    signed_payload.extend_from_slice(body);
+    let signature = hmac_sha256_hex(secret.as_bytes(), &signed_payload);
+    format!("t={timestamp},v1={signature}")
+}
+
+fn client() -> autumn_web::test::TestClient {
+    TestApp::new().config(config()).routes(routes()).build()
+}
+
+fn problem_json(response: &TestResponse, status: u16) -> serde_json::Value {
+    response.assert_status(status);
+    response.assert_header_contains("content-type", "application/problem+json");
+    let json: serde_json::Value = response.json();
+    assert_eq!(json["status"], status);
+    json
+}
+
+#[tokio::test]
+async fn accepts_valid_stripe_fixture() {
+    let now = unix_now();
+    let body = br#"{"id":"evt_valid","type":"invoice.paid"}"#;
+
+    let response = client()
+        .post("/webhooks/stripe")
+        .header("content-type", "application/json")
+        .header(
+            "stripe-signature",
+            &stripe_signature(STRIPE_SECRET, now, body),
+        )
+        .body(body.as_slice())
+        .send()
+        .await;
+
+    response.assert_ok();
+    let json: serde_json::Value = response.json();
+    assert_eq!(json["accepted"], true);
+    assert_eq!(json["delivery_id"], "evt_valid");
+    assert_eq!(json["event_type"], "invoice.paid");
+}
+
+#[tokio::test]
+async fn rejects_tampered_body_fixture() {
+    let now = unix_now();
+    let signed_body = br#"{"id":"evt_tampered","type":"invoice.paid"}"#;
+    let sent_body = br#"{"id": "evt_tampered", "type": "invoice.paid"}"#;
+
+    let response = client()
+        .post("/webhooks/stripe")
+        .header("content-type", "application/json")
+        .header(
+            "stripe-signature",
+            &stripe_signature(STRIPE_SECRET, now, signed_body),
+        )
+        .body(sent_body.as_slice())
+        .send()
+        .await;
+
+    problem_json(&response, 401);
+}
+
+#[tokio::test]
+async fn rejects_stale_timestamp_fixture() {
+    let stale = unix_now() - 301;
+    let body = br#"{"id":"evt_stale","type":"invoice.paid"}"#;
+
+    let response = client()
+        .post("/webhooks/stripe")
+        .header("content-type", "application/json")
+        .header(
+            "stripe-signature",
+            &stripe_signature(STRIPE_SECRET, stale, body),
+        )
+        .body(body.as_slice())
+        .send()
+        .await;
+
+    problem_json(&response, 401);
+}
+
+#[tokio::test]
+async fn rejects_bad_signature_fixture() {
+    let now = unix_now();
+    let body = br#"{"id":"evt_bad_sig","type":"invoice.paid"}"#;
+
+    let response = client()
+        .post("/webhooks/stripe")
+        .header("content-type", "application/json")
+        .header(
+            "stripe-signature",
+            &stripe_signature("wrong-dev-webhook-secret-32-bytes", now, body),
+        )
+        .body(body.as_slice())
+        .send()
+        .await;
+
+    problem_json(&response, 401);
+}
+
+#[tokio::test]
+async fn rejects_duplicate_delivery_fixture() {
+    let now = unix_now();
+    let body = br#"{"id":"evt_duplicate","type":"invoice.paid"}"#;
+    let signature = stripe_signature(STRIPE_SECRET, now, body);
+    let client = client();
+
+    client
+        .post("/webhooks/stripe")
+        .header("content-type", "application/json")
+        .header("stripe-signature", &signature)
+        .body(body.as_slice())
+        .send()
+        .await
+        .assert_ok();
+
+    let duplicate = client
+        .post("/webhooks/stripe")
+        .header("content-type", "application/json")
+        .header("stripe-signature", &signature)
+        .body(body.as_slice())
+        .send()
+        .await;
+
+    problem_json(&duplicate, 409);
+}


### PR DESCRIPTION
Implement signed webhook verification for Stripe, GitHub, Slack, and generic
  HMAC providers.

  Verify raw request bytes before handler execution, enforce timestamp tolerance,
  reject duplicate delivery IDs, support current/previous secrets for rotation,
  and validate production webhook secrets at startup.

  Add configurable replay storage with memory for dev/test and Redis SET NX EX
  for shared production replay protection. Production rejects memory replay unless
  explicitly opted in.

  Add docs, example fixtures, and TDD coverage for valid requests, tampering,
  stale timestamps, bad signatures, secret rotation, config validation, and replay.