### PR TITLE
🔒 Warden: [Fix X-Forwarded-For Rate Limiting Spoofing]

### DIFF
--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -246,11 +246,21 @@ impl Limiter {
     /// proxy overwrites the forwarding header.
     fn client_ip<B>(&self, req: &Request<B>) -> Option<String> {
         if self.trust_forwarded_headers && self.forwarded_headers_allowed(req) {
-            let xff_ip = req
-                .headers()
-                .get("x-forwarded-for")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|s| self.client_ip_from_x_forwarded_for(s));
+            // Combine all X-Forwarded-For headers into a single chain.
+            // When multiple headers exist, they are conceptually a single comma-separated list.
+            let xff_ip = {
+                let headers: Vec<&str> = req
+                    .headers()
+                    .get_all("x-forwarded-for")
+                    .iter()
+                    .filter_map(|v| v.to_str().ok())
+                    .collect();
+                if headers.is_empty() {
+                    None
+                } else {
+                    self.client_ip_from_x_forwarded_for(&headers.join(", "))
+                }
+            };
 
             if xff_ip.is_some() {
                 return xff_ip;

--- a/autumn/tests/security/eris_xff_spoofing.rs
+++ b/autumn/tests/security/eris_xff_spoofing.rs
@@ -1,0 +1,68 @@
+use autumn_web::security::RateLimitConfig;
+use autumn_web::security::RateLimitLayer;
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode};
+use std::net::SocketAddr;
+use tower::{Layer, Service};
+
+#[derive(Clone)]
+struct MockService;
+
+impl Service<Request<Body>> for MockService {
+    type Response = axum::http::Response<Body>;
+    type Error = std::convert::Infallible;
+    type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: Request<Body>) -> Self::Future {
+        std::future::ready(Ok(axum::http::Response::builder()
+            .status(StatusCode::OK)
+            .body(Body::empty())
+            .unwrap()))
+    }
+}
+
+#[tokio::test]
+async fn test_xff_spoofing() {
+    let config = RateLimitConfig {
+        enabled: true,
+        requests_per_second: 1.0,
+        burst: 1,
+        trust_forwarded_headers: true,
+        trusted_proxies: vec![],
+    };
+
+    let layer = RateLimitLayer::from_config(&config);
+    let mut app = layer.layer(MockService);
+
+    let peer: SocketAddr = "198.51.100.1:2000".parse().unwrap();
+
+    let make_req = |spoofed_ip: &str| {
+        let mut req = Request::builder()
+            .method("GET")
+            .uri("/")
+            .header("X-Forwarded-For", spoofed_ip)
+            .header("X-Forwarded-For", "1.2.3.4") // Proxy appends the real IP in a new header
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(ConnectInfo(peer));
+        req
+    };
+
+    let res1 = app.call(make_req("spoofed_1")).await.unwrap();
+    assert_eq!(res1.status(), StatusCode::OK);
+
+    let res2 = app.call(make_req("spoofed_2")).await.unwrap();
+    assert_eq!(
+        res2.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "Rate limit bypassed!"
+    );
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -10,5 +10,6 @@ pub mod csrf_path_traversal;
 pub mod csrf_timing;
 pub mod ctf;
 pub mod fallback_middleware_bypass;
+pub mod eris_xff_spoofing;
 pub mod session_exhaustion;
 pub mod session_fixation;

--- a/test_xff.rs
+++ b/test_xff.rs
@@ -1,0 +1,13 @@
+use http::{HeaderMap, HeaderValue};
+
+fn main() {
+    let mut headers = HeaderMap::new();
+    headers.append("X-Forwarded-For", HeaderValue::from_static("attacker_ip"));
+    headers.append("X-Forwarded-For", HeaderValue::from_static("real_ip"));
+
+    let first = headers.get("X-Forwarded-For").unwrap().to_str().unwrap();
+    println!("get(): {}", first);
+
+    let all: Vec<_> = headers.get_all("X-Forwarded-For").iter().map(|v| v.to_str().unwrap()).collect();
+    println!("get_all(): {:?}", all);
+}

--- a/test_xff_header.rs
+++ b/test_xff_header.rs
@@ -1,0 +1,11 @@
+use http::{HeaderMap, HeaderValue};
+
+fn main() {
+    let mut headers = HeaderMap::new();
+    headers.append("X-Forwarded-For", HeaderValue::from_static("attacker_ip"));
+    headers.append("X-Forwarded-For", HeaderValue::from_static("real_ip"));
+
+    // `.get()` only returns the FIRST header value!
+    let first = headers.get("x-forwarded-for").unwrap().to_str().unwrap();
+    println!("get() returns: {}", first);
+}


### PR DESCRIPTION
🦠 Threat: An attacker can spoof their client IP address for the rate limiter by sending multiple X-Forwarded-For headers. The rate limiter previously only extracted the first header via `req.headers().get("x-forwarded-for")`. If a reverse proxy appends its own IP in a separate `X-Forwarded-For` header instead of combining them into one, the malicious header dictates the client IP, completely bypassing the rate limit.

🛡️ Defense: Modify the rate limiter's extraction logic in `client_ip` to fetch *all* X-Forwarded-For header values using `req.headers().get_all`, join them securely into a single comma-separated list, and safely pass them to `client_ip_from_x_forwarded_for`. This properly accounts for reverse proxies that append IPs by inserting new headers instead of modifying existing ones.

💥 Severity: 5.3 (Medium) - Allows an attacker to reliably bypass rate limiting protections without authentication.

🧪 Verification: Added `eris_xff_spoofing.rs` to security tests which mimics the reverse proxy append logic. Verified fix locally with `cargo test -p autumn-web --lib security::rate_limit` and `cargo test -p autumn-web --test security_tests`.

---
*PR created automatically by Jules for task [12375526115377973258](https://jules.google.com/task/12375526115377973258) started by @madmax983*