### PR TITLE
🍎 Eris: [X-Forwarded-For rate limit bypass]

### DIFF
--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -250,11 +250,21 @@ impl Limiter {
         let peer_ip = Self::peer_ip(req);
 
         if self.trust_forwarded_headers && self.forwarded_headers_allowed(req) {
-            let xff_ip = req
-                .headers()
-                .get("x-forwarded-for")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|s| self.client_ip_from_x_forwarded_for(s, peer_ip));
+            let xff_ip = {
+                let all_xff: Vec<&str> = req
+                    .headers()
+                    .get_all("x-forwarded-for")
+                    .iter()
+                    .filter_map(|v| v.to_str().ok())
+                    .collect();
+
+                if all_xff.is_empty() {
+                    None
+                } else {
+                    let joined = all_xff.join(", ");
+                    self.client_ip_from_x_forwarded_for(&joined, peer_ip)
+                }
+            };
 
             if xff_ip.is_some() {
                 return xff_ip;

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -10,5 +10,6 @@ pub mod csrf_path_traversal;
 pub mod csrf_timing;
 pub mod ctf;
 pub mod fallback_middleware_bypass;
+pub mod rate_limit_xff_bypass;
 pub mod session_exhaustion;
 pub mod session_fixation;

--- a/autumn/tests/security/rate_limit_xff_bypass.rs
+++ b/autumn/tests/security/rate_limit_xff_bypass.rs
@@ -1,0 +1,61 @@
+use autumn_web::security::{RateLimitConfig, RateLimitLayer};
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode};
+use axum::{Router, body::Body, routing::get};
+use std::net::SocketAddr;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn rate_limit_xff_bypass() {
+    let config = RateLimitConfig {
+        enabled: true,
+        requests_per_second: 0.1,      // very low limit
+        burst: 1,                      // only 1 request allowed
+        trust_forwarded_headers: true, // typical for setups behind load balancers
+        trusted_proxies: vec!["203.0.113.10".to_string()],
+    };
+
+    let app = Router::new()
+        .route("/", get(|| async { "Hello" }))
+        .layer(RateLimitLayer::from_config(&config));
+
+    let peer: SocketAddr = "203.0.113.10:4000".parse().unwrap();
+
+    let make_req = |attacker_ip: &str, real_ip: &str| {
+        let mut req = Request::builder()
+            .method("GET")
+            .uri("/")
+            // The attacker sends an XFF header
+            .header("X-Forwarded-For", attacker_ip)
+            // The proxy appends another XFF header (or appends to the same, but let's test separate headers)
+            .header("X-Forwarded-For", real_ip)
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(ConnectInfo(peer));
+        req
+    };
+
+    // First request from attacker
+    let first = app
+        .clone()
+        .oneshot(make_req("1.1.1.1", "198.51.100.1"))
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::OK);
+
+    // Second request from attacker, but they spoofed their XFF header. The proxy still appended the real IP.
+    let second = app
+        .clone()
+        .oneshot(make_req("2.2.2.2", "198.51.100.1"))
+        .await
+        .unwrap();
+
+    // If it's vulnerable, it will return OK because it keyed on the first XFF header (1.1.1.1 then 2.2.2.2)
+    // instead of the real one.
+    // If it's secure, it should return TOO_MANY_REQUESTS because it should see "198.51.100.1" (the last IP).
+    assert_eq!(
+        second.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "Vulnerable to XFF spoofing: attacker bypassed rate limit!"
+    );
+}


### PR DESCRIPTION
**Reconnaissance**: I reviewed `autumn/src/security/rate_limit.rs` and noticed that when processing the `X-Forwarded-For` header for identifying the client IP behind trusted proxies, the code used `req.headers().get("x-forwarded-for")`. The `.get()` method in `http::HeaderMap` only returns the *first* header of the given name. In standard load-balanced architectures, if a client submits an `X-Forwarded-For` header, proxies may *append* a new `X-Forwarded-For` header rather than modifying the existing string.

**Hypothesis**: I hypothesize that an attacker can bypass rate limiting by injecting their own spoofed `X-Forwarded-For` header with a unique IP per request. Because `.get()` only grabs the first header, the framework will parse the attacker-controlled header instead of the proxy-appended header containing the real client IP.

**Exploit development**: I created `autumn/tests/security/rate_limit_xff_bypass.rs`, establishing a scenario where a rate limiter is configured with `trust_forwarded_headers: true`. I simulated an attacker sending a spoofed XFF header and a trusted proxy appending a second XFF header containing the attacker's real IP. 

**Verification**: The PoC successfully bypassed the rate limit before the fix because it parsed `1.1.1.1` and `2.2.2.2` (the spoofed IPs) rather than `198.51.100.1` (the real IP). The fix changes `get()` to `get_all()`, gathering all XFF headers and joining them with commas, mirroring standard proxy behavior. The test now correctly returns `429 Too Many Requests` on the second attempt.

**Severity assessment (CVSS 3.1)**: Medium
CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L
This allows unauthenticated attackers to bypass application-layer rate limits, potentially leading to resource exhaustion (DoS), but does not directly expose data or lead to code execution.

**Remediation**: Replaced `req.headers().get("x-forwarded-for")` with a block that iterates over `req.headers().get_all("x-forwarded-for")`, filters valid strings, and joins them into a single string literal before attempting to extract the right-most trusted IP.

---
*PR created automatically by Jules for task [2721052933149318650](https://jules.google.com/task/2721052933149318650) started by @madmax983*