### PR TITLE
Add HTML form method-override middleware for PUT/PATCH/DELETE

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1689,15 +1689,26 @@ impl AppBuilder {
         tracing::info!(addr = %addr, "Listening");
 
         let server_shutdown_wait = server_shutdown.clone();
+        // Wrap the built router with the HTML form method-override layer at
+        // the very edge — outside path and method routing — so a plain
+        // browser `<form method="post">` carrying `_method=PUT|PATCH|DELETE`
+        // can reach the declared PUT/PATCH/DELETE handler. `Router::layer`
+        // applies middleware per registered method handler in axum 0.8,
+        // which is too late: the inner `MethodRouter` returns `405` before
+        // a layered service ever runs. Wrapping the whole router as a
+        // tower::Service is the documented way to run middleware before
+        // route matching.
+        let service = tower::Layer::layer(&crate::middleware::MethodOverrideLayer::new(), router);
+        let make_service =
+            axum::ServiceExt::<axum::extract::Request>::into_make_service_with_connect_info::<
+                std::net::SocketAddr,
+            >(service);
         let server_task = tokio::spawn(async move {
-            axum::serve(
-                listener,
-                router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
-            )
-            .with_graceful_shutdown(async move {
-                server_shutdown_wait.cancelled().await;
-            })
-            .await
+            axum::serve(listener, make_service)
+                .with_graceful_shutdown(async move {
+                    server_shutdown_wait.cancelled().await;
+                })
+                .await
         });
 
         let shutdown_state = state.clone();

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -550,6 +550,14 @@ pub fn form_tag(
 }
 
 /// Internal: render a `<form>` element using an explicit CSRF field name.
+///
+/// When `method` is `PUT`, `PATCH`, or `DELETE` (case-insensitive), the
+/// browser-facing form method is rewritten to `POST` and a hidden
+/// `<input name="_method" value="...">` is emitted so the autumn
+/// [`MethodOverrideLayer`](crate::middleware::MethodOverrideLayer) can
+/// rewrite the request back to the declared method before route matching.
+/// This lets server-rendered HTML target `#[put]` / `#[patch]` /
+/// `#[delete]` routes without any client JavaScript.
 #[cfg(feature = "maud")]
 #[allow(clippy::needless_pass_by_value)]
 fn form_tag_inner(
@@ -559,13 +567,81 @@ fn form_tag_inner(
     csrf_token: Option<&str>,
     content: maud::Markup,
 ) -> maud::Markup {
+    let (browser_method, override_value) = browser_method_and_override(method);
     maud::html! {
-        form action=(action) method=(method) {
+        form action=(action) method=(browser_method) {
+            @if let Some(override_method) = override_value {
+                input
+                    type="hidden"
+                    name=(crate::middleware::DEFAULT_METHOD_OVERRIDE_FIELD)
+                    value=(override_method);
+            }
             @if let Some(token) = csrf_token {
                 input type="hidden" name=(csrf_field) value=(token);
             }
             (content)
         }
+    }
+}
+
+/// Translate a declared form method into the browser transport method and
+/// any required `_method` override value.
+///
+/// Returns `(transport, override)` where `override` is `Some(value)` only
+/// when the declared method needs a hidden `_method` field.
+#[cfg(feature = "maud")]
+fn browser_method_and_override(method: &str) -> (&'static str, Option<&'static str>) {
+    let trimmed = method.trim();
+    if trimmed.eq_ignore_ascii_case("PUT") {
+        ("post", Some("PUT"))
+    } else if trimmed.eq_ignore_ascii_case("PATCH") {
+        ("post", Some("PATCH"))
+    } else if trimmed.eq_ignore_ascii_case("DELETE") {
+        ("post", Some("DELETE"))
+    } else if trimmed.eq_ignore_ascii_case("GET") {
+        ("get", None)
+    } else {
+        ("post", None)
+    }
+}
+
+/// Render a hidden `<input name="_method" value="...">` field for the
+/// declared HTTP method.
+///
+/// Use this directly when constructing a form by hand (without
+/// [`ChangesetForm`] or [`form_tag`]) targeting a `#[put]`, `#[patch]`,
+/// or `#[delete]` route from a plain HTML browser submission.
+///
+/// ```rust,ignore
+/// use autumn_web::form::method_input;
+///
+/// maud::html! {
+///     form method="post" action="/posts/42" {
+///         (method_input("DELETE"))
+///         button { "Delete post" }
+///     }
+/// }
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn method_input(method: &str) -> maud::Markup {
+    let normalized = method.trim();
+    let value = if normalized.eq_ignore_ascii_case("PUT") {
+        "PUT"
+    } else if normalized.eq_ignore_ascii_case("PATCH") {
+        "PATCH"
+    } else if normalized.eq_ignore_ascii_case("DELETE") {
+        "DELETE"
+    } else {
+        // `GET`/`POST` (and anything else) don't need an override — emit
+        // nothing rather than producing an invalid override field.
+        return maud::html! {};
+    };
+    maud::html! {
+        input
+            type="hidden"
+            name=(crate::middleware::DEFAULT_METHOD_OVERRIDE_FIELD)
+            value=(value);
     }
 }
 
@@ -1114,6 +1190,57 @@ mod tests {
     fn form_tag_includes_content() {
         let html = form_tag("/x", "post", None, maud::html! { span { "inner" } }).into_string();
         assert!(html.contains("inner"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_tag_emits_method_override_for_delete() {
+        let html = form_tag("/posts/42", "delete", None, maud::html! { "" }).into_string();
+        // Browser-facing method must be POST so native form submission works.
+        assert!(html.contains(r#"method="post""#), "{html}");
+        assert!(!html.contains(r#"method="delete""#), "{html}");
+        // Hidden override field tells the autumn middleware to rewrite to DELETE.
+        assert!(html.contains(r#"name="_method""#), "{html}");
+        assert!(html.contains(r#"value="DELETE""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_tag_emits_method_override_for_put_and_patch() {
+        let put_html = form_tag("/p/1", "put", None, maud::html! { "" }).into_string();
+        assert!(put_html.contains(r#"method="post""#));
+        assert!(put_html.contains(r#"value="PUT""#));
+
+        let patch_html = form_tag("/p/1", "PATCH", None, maud::html! { "" }).into_string();
+        assert!(patch_html.contains(r#"method="post""#));
+        assert!(patch_html.contains(r#"value="PATCH""#));
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_tag_no_override_for_get_or_post() {
+        let get_html = form_tag("/p", "get", None, maud::html! { "" }).into_string();
+        assert!(!get_html.contains("_method"), "{get_html}");
+        let post_html = form_tag("/p", "post", None, maud::html! { "" }).into_string();
+        assert!(!post_html.contains("_method"), "{post_html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn method_input_emits_hidden_field_for_mutating_methods() {
+        for method in ["PUT", "PATCH", "DELETE", "delete"] {
+            let html = method_input(method).into_string();
+            assert!(html.contains(r#"name="_method""#), "{html}");
+            assert!(html.contains(r#"type="hidden""#), "{html}");
+        }
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn method_input_is_empty_for_safe_or_unknown_methods() {
+        assert_eq!(method_input("GET").into_string(), "");
+        assert_eq!(method_input("POST").into_string(), "");
+        assert_eq!(method_input("BREW").into_string(), "");
     }
 
     #[cfg(feature = "maud")]

--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -269,7 +269,7 @@ mod tests {
     /// `POST` into `PUT`/`PATCH`/`DELETE` — the inner `MethodRouter`
     /// returns `405` before the layer ever runs. The override convention
     /// requires running before route matching, so wrap the router as a
-    /// tower::Service.
+    /// `tower::Service`.
     fn layered_router() -> MethodOverrideService<Router> {
         let router = Router::new()
             .route("/items", post(|| async { "created" }))

--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -1,0 +1,588 @@
+//! HTML form method-override middleware.
+//!
+//! Native browser HTML forms can only submit `GET` or `POST`. Autumn lets
+//! plain `<form method="post">` submissions target `PUT`, `PATCH`, and
+//! `DELETE` routes by carrying a hidden `_method` form field whose value
+//! names the effective HTTP method.
+//!
+//! # How it works
+//!
+//! On every `POST` request whose body is a same-origin form submission
+//! (content-type `application/x-www-form-urlencoded`), the middleware
+//! looks for the configured override field (default `_method`). If
+//! present and the value is one of the documented target methods
+//! (`PUT`, `PATCH`, `DELETE`, case-insensitive), the request's HTTP
+//! method is rewritten in place before route matching. The body is
+//! preserved exactly so downstream extractors (including CSRF
+//! validation) read it unchanged.
+//!
+//! # Failure modes
+//!
+//! - An unrecognised override value (e.g. `_method=BREW`) is rejected
+//!   with `400 Bad Request` before reaching the handler.
+//! - The override only acts on `POST` requests with a form-style body.
+//!   Headers like `X-HTTP-Method-Override` are intentionally **not**
+//!   honoured: this convention is documented for browser HTML forms
+//!   only, not for arbitrary REST tunneling.
+//!
+//! # Interaction with CSRF
+//!
+//! The CSRF layer wraps this middleware on the outside, so CSRF still
+//! validates the original `POST` request — meaning an overridden
+//! `DELETE` submission without a valid `_csrf` token is rejected
+//! exactly like any other mutating POST.
+//!
+//! # Examples
+//!
+//! ```rust,ignore
+//! use autumn_web::prelude::*;
+//! use autumn_web::security::CsrfToken;
+//!
+//! #[get("/posts/{id}/edit")]
+//! async fn edit_form(csrf: CsrfToken) -> Markup {
+//!     html! {
+//!         form method="post" action="/posts/42" {
+//!             input type="hidden" name="_method" value="PUT";
+//!             input type="hidden" name="_csrf" value=(csrf.token());
+//!             input type="text" name="title";
+//!             button { "Update" }
+//!         }
+//!     }
+//! }
+//!
+//! #[put("/posts/{id}")]
+//! async fn update(/* extractors */) -> Markup { html! { "updated" } }
+//! ```
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use axum::http::{Request, Response, StatusCode};
+use tower::{Layer, Service};
+
+/// Default form field name for the method override.
+pub const DEFAULT_METHOD_OVERRIDE_FIELD: &str = "_method";
+
+/// Maximum body size (bytes) considered when parsing the override field.
+///
+/// Mirrors [`crate::security::csrf`] which uses the same 2 MiB cap for
+/// peeking at form-urlencoded bodies. The body itself is unchanged.
+const MAX_BODY_SCAN_BYTES: usize = 2 * 1024 * 1024;
+
+/// Configuration for the method-override middleware.
+#[derive(Debug, Clone)]
+pub struct MethodOverrideConfig {
+    /// Form field name to read the override value from.
+    pub field_name: String,
+}
+
+impl Default for MethodOverrideConfig {
+    fn default() -> Self {
+        Self {
+            field_name: DEFAULT_METHOD_OVERRIDE_FIELD.to_owned(),
+        }
+    }
+}
+
+/// Marker extension inserted on requests whose HTTP method was rewritten
+/// by the override middleware. Useful for logs and instrumentation.
+#[derive(Clone, Debug)]
+pub struct OverriddenMethod {
+    /// The transport method the browser actually used (always `POST`).
+    pub transport: http::Method,
+    /// The effective method the request was rewritten to.
+    pub effective: http::Method,
+}
+
+/// Tower [`Layer`] that applies the HTML form method override convention.
+#[derive(Clone, Debug)]
+pub struct MethodOverrideLayer {
+    config: Arc<MethodOverrideConfig>,
+}
+
+impl MethodOverrideLayer {
+    /// Construct a layer with the default field name (`_method`).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::from_config(MethodOverrideConfig::default())
+    }
+
+    /// Construct a layer with the given configuration.
+    #[must_use]
+    pub fn from_config(config: MethodOverrideConfig) -> Self {
+        Self {
+            config: Arc::new(config),
+        }
+    }
+}
+
+impl Default for MethodOverrideLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> Layer<S> for MethodOverrideLayer {
+    type Service = MethodOverrideService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MethodOverrideService {
+            inner,
+            config: Arc::clone(&self.config),
+        }
+    }
+}
+
+/// Tower [`Service`] produced by [`MethodOverrideLayer`].
+#[derive(Clone, Debug)]
+pub struct MethodOverrideService<S> {
+    inner: S,
+    config: Arc<MethodOverrideConfig>,
+}
+
+/// Returns `Some(method)` when `value` is a recognised override target.
+fn parse_override_value(value: &str) -> Option<http::Method> {
+    let trimmed = value.trim();
+    if trimmed.eq_ignore_ascii_case("PUT") {
+        Some(http::Method::PUT)
+    } else if trimmed.eq_ignore_ascii_case("PATCH") {
+        Some(http::Method::PATCH)
+    } else if trimmed.eq_ignore_ascii_case("DELETE") {
+        Some(http::Method::DELETE)
+    } else {
+        None
+    }
+}
+
+#[derive(Debug)]
+enum OverrideOutcome {
+    /// No override field present — leave the request alone.
+    None,
+    /// Override field present and value is a recognised target method.
+    Replace(http::Method),
+    /// Override field present but value is not a recognised method.
+    Invalid,
+}
+
+fn scan_form_for_override(bytes: &[u8], field: &str) -> OverrideOutcome {
+    let mut outcome = OverrideOutcome::None;
+    for (key, value) in url::form_urlencoded::parse(bytes) {
+        if key == field {
+            outcome = parse_override_value(&value)
+                .map_or(OverrideOutcome::Invalid, OverrideOutcome::Replace);
+            break;
+        }
+    }
+    outcome
+}
+
+fn is_form_urlencoded(headers: &http::HeaderMap) -> bool {
+    headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.starts_with("application/x-www-form-urlencoded"))
+}
+
+impl<S, ResBody> Service<Request<axum::body::Body>> for MethodOverrideService<S>
+where
+    S: Service<Request<axum::body::Body>, Response = Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+    ResBody: From<&'static str> + Default + Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<axum::body::Body>) -> Self::Future {
+        // Only POST requests are eligible for override. Same-origin form
+        // semantics: nothing else is allowed to silently morph methods.
+        if req.method() != http::Method::POST || !is_form_urlencoded(req.headers()) {
+            let mut inner = self.inner.clone();
+            std::mem::swap(&mut self.inner, &mut inner);
+            return Box::pin(async move { inner.call(req).await });
+        }
+
+        let config = Arc::clone(&self.config);
+        let mut inner = self.inner.clone();
+        std::mem::swap(&mut self.inner, &mut inner);
+
+        Box::pin(async move {
+            // Temporarily take ownership of the body so we can buffer it
+            // for parsing without losing the bytes the handler will need.
+            let body = std::mem::replace(req.body_mut(), axum::body::Body::empty());
+            let bytes = axum::body::to_bytes(body, MAX_BODY_SCAN_BYTES)
+                .await
+                .unwrap_or_else(|_| axum::body::Bytes::new());
+
+            let outcome = scan_form_for_override(&bytes, &config.field_name);
+
+            // Restore the body verbatim regardless of outcome.
+            *req.body_mut() = axum::body::Body::from(bytes);
+
+            match outcome {
+                OverrideOutcome::None => inner.call(req).await,
+                OverrideOutcome::Replace(method) => {
+                    let transport = req.method().clone();
+                    *req.method_mut() = method.clone();
+                    req.extensions_mut().insert(OverriddenMethod {
+                        transport,
+                        effective: method,
+                    });
+                    inner.call(req).await
+                }
+                OverrideOutcome::Invalid => {
+                    let mut response = Response::new(ResBody::from(
+                        "Invalid method override value: must be PUT, PATCH, or DELETE.",
+                    ));
+                    *response.status_mut() = StatusCode::BAD_REQUEST;
+                    response.headers_mut().insert(
+                        http::header::CONTENT_TYPE,
+                        http::HeaderValue::from_static("text/plain; charset=utf-8"),
+                    );
+                    Ok(response)
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::routing::{delete, get, patch, post, put};
+    use tower::ServiceExt;
+
+    /// Build a router and wrap it with [`MethodOverrideLayer`] as a top-level
+    /// Service.
+    ///
+    /// `Router::layer` in axum 0.8 applies middleware **per registered
+    /// method handler**, which means a layer added that way cannot rewrite
+    /// `POST` into `PUT`/`PATCH`/`DELETE` — the inner `MethodRouter`
+    /// returns `405` before the layer ever runs. The override convention
+    /// requires running before route matching, so wrap the router as a
+    /// tower::Service.
+    fn layered_router() -> MethodOverrideService<Router> {
+        let router = Router::new()
+            .route("/items", post(|| async { "created" }))
+            .route("/items/{id}", put(|| async { "put-ok" }))
+            .route("/items/{id}", patch(|| async { "patch-ok" }))
+            .route("/items/{id}", delete(|| async { "delete-ok" }))
+            .route("/items/{id}", get(|| async { "show" }));
+        MethodOverrideLayer::new().layer(router)
+    }
+
+    #[tokio::test]
+    async fn post_without_override_field_reaches_post_handler() {
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("title=hello"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"created");
+    }
+
+    #[tokio::test]
+    async fn post_with_method_put_reaches_put_handler() {
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("_method=PUT&title=hi"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"put-ok");
+    }
+
+    #[tokio::test]
+    async fn post_with_method_patch_reaches_patch_handler() {
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("_method=patch"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"patch-ok");
+    }
+
+    #[tokio::test]
+    async fn post_with_method_delete_reaches_delete_handler() {
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("_method=DELETE"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"delete-ok");
+    }
+
+    #[tokio::test]
+    async fn invalid_override_value_returns_400() {
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("_method=BREW"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn override_ignored_without_form_content_type() {
+        // JSON POST should NOT have its method rewritten even if a `_method`
+        // string happens to appear in the body. The convention is documented
+        // for browser HTML form submissions only.
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"_method":"DELETE","title":"hi"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"created");
+    }
+
+    #[tokio::test]
+    async fn override_ignored_for_get_requests() {
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/items/1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"show");
+    }
+
+    #[tokio::test]
+    async fn override_preserves_body_for_handler() {
+        // Override consumes the body to peek at `_method`; it MUST restore
+        // the bytes so handler extractors (Form, ChangesetForm, etc.) work.
+        async fn echo(body: String) -> String {
+            body
+        }
+        let router = Router::new().route("/echo", put(echo));
+        let app = MethodOverrideLayer::new().layer(router);
+
+        let payload = "_method=PUT&title=hello&count=3";
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/echo")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(payload))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(std::str::from_utf8(&body).unwrap(), payload);
+    }
+
+    #[tokio::test]
+    async fn override_marks_request_extension() {
+        async fn marker(axum::Extension(o): axum::Extension<OverriddenMethod>) -> String {
+            format!("{}->{}", o.transport, o.effective)
+        }
+        let router = Router::new().route("/x", delete(marker));
+        let app = MethodOverrideLayer::new().layer(router);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/x")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("_method=DELETE"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"POST->DELETE");
+    }
+
+    #[tokio::test]
+    async fn custom_field_name_is_respected() {
+        let router = Router::new().route("/items/{id}", delete(|| async { "gone" }));
+        let app = MethodOverrideLayer::from_config(MethodOverrideConfig {
+            field_name: "x-method".into(),
+        })
+        .layer(router);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("x-method=DELETE"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"gone");
+    }
+
+    /// Acceptance criterion: "CSRF protection still treats the effective
+    /// overridden method as unsafe, and tests prove an overridden DELETE
+    /// without a valid CSRF token is rejected."
+    ///
+    /// The CSRF layer wraps method-override on the outside. CSRF sees the
+    /// browser's `POST` (already an unsafe method) and demands a token.
+    /// A `_method=DELETE` body with no `_csrf` field is rejected with
+    /// `403 Forbidden`, exactly like any other mutating POST.
+    #[tokio::test]
+    async fn overridden_delete_without_csrf_token_is_rejected() {
+        let csrf_config = crate::security::CsrfConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let router = Router::new()
+            .route("/items/{id}", delete(|| async { "deleted" }))
+            .layer(crate::security::CsrfLayer::from_config(&csrf_config));
+        let app = MethodOverrideLayer::new().layer(router);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header(http::header::ACCEPT, "text/html")
+                    .header("Cookie", "autumn-csrf=valid-cookie-token")
+                    .body(Body::from("_method=DELETE"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// Companion: an overridden DELETE with a matching `_csrf` token passes
+    /// CSRF and reaches the DELETE handler.
+    #[tokio::test]
+    async fn overridden_delete_with_csrf_token_reaches_handler() {
+        let csrf_config = crate::security::CsrfConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let router = Router::new()
+            .route("/items/{id}", delete(|| async { "deleted" }))
+            .layer(crate::security::CsrfLayer::from_config(&csrf_config));
+        let app = MethodOverrideLayer::new().layer(router);
+
+        let token = "valid-cookie-token";
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("Cookie", format!("autumn-csrf={token}"))
+                    .body(Body::from(format!("_csrf={token}&_method=DELETE")))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"deleted");
+    }
+}

--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -185,6 +185,18 @@ fn is_form_urlencoded(headers: &http::HeaderMap) -> bool {
         .is_some_and(|ct| ct.starts_with("application/x-www-form-urlencoded"))
 }
 
+/// Returns `true` only when the request advertises a `Content-Length`
+/// strictly larger than `limit`. A missing or unparseable header returns
+/// `false`, since we can't make a confident determination without
+/// buffering — those cases fall through to the buffered scan.
+fn content_length_exceeds(headers: &http::HeaderMap, limit: usize) -> bool {
+    headers
+        .get(http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+        .is_some_and(|len| len > limit as u64)
+}
+
 impl<S, ResBody> Service<Request<axum::body::Body>> for MethodOverrideService<S>
 where
     S: Service<Request<axum::body::Body>, Response = Response<ResBody>> + Clone + Send + 'static,
@@ -209,6 +221,17 @@ where
             return Box::pin(async move { inner.call(req).await });
         }
 
+        // If the client advertises a body larger than the scan cap, skip
+        // override processing entirely and forward the original body
+        // untouched. We never buffer it, so handlers downstream still
+        // receive the full submission verbatim — a form that's too large
+        // to scan for `_method` simply doesn't get the override applied.
+        if content_length_exceeds(req.headers(), MAX_BODY_SCAN_BYTES) {
+            let mut inner = self.inner.clone();
+            std::mem::swap(&mut self.inner, &mut inner);
+            return Box::pin(async move { inner.call(req).await });
+        }
+
         let config = Arc::clone(&self.config);
         let mut inner = self.inner.clone();
         std::mem::swap(&mut self.inner, &mut inner);
@@ -217,9 +240,23 @@ where
             // Temporarily take ownership of the body so we can buffer it
             // for parsing without losing the bytes the handler will need.
             let body = std::mem::replace(req.body_mut(), axum::body::Body::empty());
-            let bytes = axum::body::to_bytes(body, MAX_BODY_SCAN_BYTES)
-                .await
-                .unwrap_or_else(|_| axum::body::Bytes::new());
+            let Ok(bytes) = axum::body::to_bytes(body, MAX_BODY_SCAN_BYTES).await else {
+                // Body exceeded the scan cap while buffering (e.g.
+                // chunked transfer with no Content-Length) or read
+                // failed. We've already consumed the body, so we can
+                // no longer forward the request faithfully — return
+                // an explicit 413 instead of silently corrupting it
+                // with an empty body.
+                let mut response = Response::new(ResBody::from(
+                    "Form body too large for method-override scanning.",
+                ));
+                *response.status_mut() = StatusCode::PAYLOAD_TOO_LARGE;
+                response.headers_mut().insert(
+                    http::header::CONTENT_TYPE,
+                    http::HeaderValue::from_static("text/plain; charset=utf-8"),
+                );
+                return Ok(response);
+            };
 
             let outcome = scan_form_for_override(&bytes, &config.field_name);
 
@@ -584,5 +621,108 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(&body[..], b"deleted");
+    }
+
+    /// Regression: a form-urlencoded POST larger than the scan cap must
+    /// still reach its handler with the body intact when it doesn't
+    /// declare an override. Previously the scan failure path emptied
+    /// the body, corrupting any large legitimate POST routed through
+    /// the global override layer.
+    #[tokio::test]
+    async fn large_form_post_without_override_preserves_full_body() {
+        async fn measure(body: bytes::Bytes) -> String {
+            format!("{}", body.len())
+        }
+        // Raise the handler-side body limit so the test exercises the
+        // middleware's pass-through path rather than axum's own default
+        // 2 MiB body cap on extractors.
+        let router = Router::new()
+            .route("/upload", post(measure))
+            .layer(axum::extract::DefaultBodyLimit::max(8 * 1024 * 1024));
+        let app = MethodOverrideLayer::new().layer(router);
+
+        // 3 MiB payload: comfortably over MAX_BODY_SCAN_BYTES (2 MiB).
+        let big = "x".repeat(3 * 1024 * 1024);
+        let payload = format!("title={big}");
+        let payload_len = payload.len();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/upload")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("content-length", payload_len.to_string())
+                    .body(Body::from(payload))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 32)
+            .await
+            .unwrap();
+        let observed: usize = std::str::from_utf8(&body).unwrap().parse().unwrap();
+        assert_eq!(
+            observed, payload_len,
+            "handler must see the full original body, not an empty one"
+        );
+    }
+
+    /// A POST whose body actually exceeds the scan cap during buffering
+    /// (e.g. chunked transfer encoding without an accurate Content-Length)
+    /// returns an explicit `413` rather than passing an empty body to
+    /// downstream handlers.
+    #[tokio::test]
+    async fn unbounded_oversized_form_post_returns_413() {
+        async fn handler(body: String) -> String {
+            body
+        }
+        let router = Router::new().route("/x", post(handler));
+        let app = MethodOverrideLayer::new().layer(router);
+
+        // No Content-Length header -> content_length_exceeds returns
+        // false and we attempt to buffer. The body itself is larger
+        // than the scan cap so `to_bytes` will error.
+        let payload = "x".repeat(3 * 1024 * 1024);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/x")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(payload))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[test]
+    fn content_length_exceeds_only_when_strictly_larger() {
+        let mut headers = http::HeaderMap::new();
+        assert!(!content_length_exceeds(&headers, 1024));
+
+        headers.insert(
+            http::header::CONTENT_LENGTH,
+            http::HeaderValue::from_static("1024"),
+        );
+        assert!(!content_length_exceeds(&headers, 1024));
+
+        headers.insert(
+            http::header::CONTENT_LENGTH,
+            http::HeaderValue::from_static("1025"),
+        );
+        assert!(content_length_exceeds(&headers, 1024));
+
+        // Unparseable header values stay conservative: don't short-circuit.
+        headers.insert(
+            http::header::CONTENT_LENGTH,
+            http::HeaderValue::from_static("not-a-number"),
+        );
+        assert!(!content_length_exceeds(&headers, 1024));
     }
 }

--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -28,12 +28,15 @@
 //!
 //! The check uses, in order:
 //!
-//! 1. `Sec-Fetch-Site` (sent by all browsers since ~2020). Allowed
-//!    values: `same-origin`, `same-site`, `none`. `cross-site` is
-//!    rejected.
-//! 2. Fallback when `Sec-Fetch-Site` is absent: `Origin` is compared
-//!    host-for-host with `Host`. A mismatch is rejected.
-//! 3. If both signals are absent, the override is **not** applied —
+//! 1. `Sec-Fetch-Site: same-origin` or `none` — accept outright.
+//! 2. `Sec-Fetch-Site: same-site` — **not** sufficient on its own
+//!    because `same-site` accepts sibling origins under the same
+//!    registrable domain (e.g. `evil.example.com` -> `app.example.com`).
+//!    Fall back to the `Origin` vs `Host` check before allowing.
+//! 3. `Sec-Fetch-Site: cross-site` (or any other value) is rejected.
+//! 4. When `Sec-Fetch-Site` is absent, compare `Origin` host-for-host
+//!    with `Host`. A mismatch is rejected.
+//! 5. If both signals are absent, the override is **not** applied —
 //!    the request is forwarded as the original `POST` so route
 //!    matching rejects it on its own (fail closed).
 //!
@@ -320,36 +323,49 @@ fn content_length_exceeds(headers: &http::HeaderMap, limit: usize) -> bool {
 ///
 /// Decision matrix (returns `true` to allow the override):
 ///
-/// 1. `Sec-Fetch-Site` is sent by every browser released since ~2020
-///    and is the most reliable signal. We allow `same-origin`,
-///    `same-site`, and `none` (user-initiated, no opener) and reject
-///    `cross-site`.
-/// 2. When `Sec-Fetch-Site` is absent, fall back to comparing the
-///    `Origin` header against `Host`. Modern browsers always send
-///    `Origin` for `POST`, so a mismatch here means the request really
-///    is cross-origin.
-/// 3. When both signals are absent, deny the override (fail closed).
-///    Such requests are either an extremely old browser or a non-
-///    browser client; in either case the documented browser-form
-///    convention does not apply, so the safe thing is to forward the
-///    request as the original `POST` and let route matching reject it.
+/// 1. `Sec-Fetch-Site: same-origin` or `none` — accept outright.
+///    `same-origin` is exactly what we want. `none` is user-initiated
+///    with no opener (typed URL, bookmark, redirect chain origin) and
+///    is documented as safe by Fetch Metadata Request Headers.
+/// 2. `Sec-Fetch-Site: same-site` — **not** sufficient on its own,
+///    because `same-site` accepts any origin under the same
+///    registrable domain (`evil.example.com` -> `app.example.com`).
+///    Fall back to the `Origin` vs `Host` comparison to confirm a
+///    true same-origin match before honouring the override.
+/// 3. `Sec-Fetch-Site: cross-site` — reject outright.
+/// 4. `Sec-Fetch-Site` absent — fall back to comparing the `Origin`
+///    header against `Host`. Modern browsers always send `Origin`
+///    for `POST`, so a mismatch here means the request really is
+///    cross-origin.
+/// 5. When both `Sec-Fetch-Site` and `Origin` are absent, deny the
+///    override (fail closed). Such requests are either an extremely
+///    old browser or a non-browser client; in either case the
+///    documented browser-form convention does not apply, so the safe
+///    thing is to forward the request as the original `POST` and let
+///    route matching reject it.
 fn is_same_origin_form(headers: &http::HeaderMap) -> bool {
+    let origin_host_match = || {
+        let origin = headers
+            .get(http::header::ORIGIN)
+            .and_then(|v| v.to_str().ok())?;
+        let host = headers
+            .get(http::header::HOST)
+            .and_then(|v| v.to_str().ok())?;
+        Some(origin_matches_host(origin, host))
+    };
+
     if let Some(site) = headers.get("sec-fetch-site").and_then(|v| v.to_str().ok()) {
-        return matches!(site, "same-origin" | "same-site" | "none");
+        return match site {
+            "same-origin" | "none" => true,
+            // `same-site` is broader than same-origin; require an
+            // explicit Origin/Host match for the documented guarantee.
+            "same-site" => origin_host_match().unwrap_or(false),
+            // `cross-site` or any unrecognised value: reject.
+            _ => false,
+        };
     }
 
-    let origin = headers
-        .get(http::header::ORIGIN)
-        .and_then(|v| v.to_str().ok());
-    let host = headers
-        .get(http::header::HOST)
-        .and_then(|v| v.to_str().ok());
-
-    match (origin, host) {
-        (Some(origin), Some(host)) => origin_matches_host(origin, host),
-        // No origin and no Sec-Fetch-Site: fail closed.
-        _ => false,
-    }
+    origin_host_match().unwrap_or(false)
 }
 
 /// `Origin` is a scheme + host (+ optional port); `Host` is host
@@ -1034,6 +1050,38 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
+    /// Regression test from the second Codex same-origin review:
+    /// `Sec-Fetch-Site: same-site` includes sibling subdomains under
+    /// the same registrable domain (e.g. `evil.example.com` ->
+    /// `app.example.com`). The override must NOT be honoured purely on
+    /// the `same-site` signal — without a matching `Origin`/`Host`
+    /// pair the request must be forwarded as the original `POST` and
+    /// route matching is left to reject it.
+    #[tokio::test]
+    async fn same_site_sibling_origin_is_not_honoured_as_override() {
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-site")
+                    .header("origin", "https://evil.example")
+                    .header("host", "app.example")
+                    .body(Body::from("_method=DELETE"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::METHOD_NOT_ALLOWED,
+            "same-site with mismatched Origin/Host must not be honoured as override"
+        );
+    }
+
     /// Neither `Sec-Fetch-Site` nor `Origin` present: fail closed. The
     /// override is not applied — the request flows through as POST.
     #[tokio::test]
@@ -1058,8 +1106,9 @@ mod tests {
     /// Helper-level cases that don't require the full router wiring.
     #[test]
     fn is_same_origin_form_decision_matrix() {
-        // Sec-Fetch-Site values
-        for site in ["same-origin", "same-site", "none"] {
+        // `same-origin` and `none` are accepted on the Sec-Fetch-Site
+        // signal alone.
+        for site in ["same-origin", "none"] {
             let mut h = http::HeaderMap::new();
             h.insert("sec-fetch-site", http::HeaderValue::from_str(site).unwrap());
             assert!(
@@ -1067,6 +1116,57 @@ mod tests {
                 "sec-fetch-site={site} should be allowed"
             );
         }
+
+        // `same-site` is NOT sufficient alone: it allows sibling
+        // origins under the same registrable domain. Require an
+        // Origin/Host match before honouring it.
+        let mut h = http::HeaderMap::new();
+        h.insert(
+            "sec-fetch-site",
+            http::HeaderValue::from_static("same-site"),
+        );
+        assert!(
+            !is_same_origin_form(&h),
+            "same-site alone must not be accepted"
+        );
+
+        // `same-site` plus a matching Origin/Host pair: accepted.
+        let mut h = http::HeaderMap::new();
+        h.insert(
+            "sec-fetch-site",
+            http::HeaderValue::from_static("same-site"),
+        );
+        h.insert(
+            http::header::ORIGIN,
+            http::HeaderValue::from_static("https://app.example"),
+        );
+        h.insert(
+            http::header::HOST,
+            http::HeaderValue::from_static("app.example"),
+        );
+        assert!(is_same_origin_form(&h));
+
+        // `same-site` with a sibling Origin: the registrable domain is
+        // the same so the browser sends `same-site`, but the Origin
+        // differs and we must reject.
+        let mut h = http::HeaderMap::new();
+        h.insert(
+            "sec-fetch-site",
+            http::HeaderValue::from_static("same-site"),
+        );
+        h.insert(
+            http::header::ORIGIN,
+            http::HeaderValue::from_static("https://evil.example"),
+        );
+        h.insert(
+            http::header::HOST,
+            http::HeaderValue::from_static("app.example"),
+        );
+        assert!(
+            !is_same_origin_form(&h),
+            "same-site with mismatched Origin/Host must be rejected"
+        );
+
         let mut h = http::HeaderMap::new();
         h.insert(
             "sec-fetch-site",
@@ -1074,7 +1174,15 @@ mod tests {
         );
         assert!(!is_same_origin_form(&h));
 
-        // Origin matches Host
+        // Unknown / spoofed Sec-Fetch-Site value: reject.
+        let mut h = http::HeaderMap::new();
+        h.insert(
+            "sec-fetch-site",
+            http::HeaderValue::from_static("undefined"),
+        );
+        assert!(!is_same_origin_form(&h));
+
+        // No Sec-Fetch-Site: Origin matches Host.
         let mut h = http::HeaderMap::new();
         h.insert(
             http::header::ORIGIN,
@@ -1086,7 +1194,7 @@ mod tests {
         );
         assert!(is_same_origin_form(&h));
 
-        // Origin does not match Host
+        // No Sec-Fetch-Site: Origin does not match Host.
         let mut h = http::HeaderMap::new();
         h.insert(
             http::header::ORIGIN,

--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -25,6 +25,21 @@
 //!   honoured: this convention is documented for browser HTML forms
 //!   only, not for arbitrary REST tunneling.
 //!
+//! ## How the rejection flows through middleware
+//!
+//! The layer is wrapped outside the router so it can rewrite the HTTP
+//! method **before route matching**. Returning a `400`/`413` directly
+//! from that outer wrapper would bypass every framework layer applied
+//! via `Router::layer` — security headers, request IDs, metrics,
+//! exception filter, error-page renderer, and so on. Instead, the
+//! layer stamps a [`MethodOverrideRejection`] extension on the request
+//! and forwards it down the stack untouched. A companion middleware,
+//! [`method_override_rejection_filter`], is applied as an inner
+//! `Router::layer` so the rejection is converted into a `400`/`413`
+//! response **inside** the framework's response middleware stack. The
+//! result is the same status the user sees, but with security headers,
+//! request IDs, metrics, and error-page rendering all applied.
+//!
 //! # Interaction with CSRF
 //!
 //! The CSRF layer wraps this middleware on the outside, so CSRF still
@@ -94,6 +109,70 @@ pub struct OverriddenMethod {
     pub transport: http::Method,
     /// The effective method the request was rewritten to.
     pub effective: http::Method,
+}
+
+/// Reason the override middleware needs to fail the request.
+///
+/// Stamped on the request extensions by the outer Tower layer so the
+/// inner [`method_override_rejection_filter`] can convert it into a
+/// proper `400`/`413` response that flows through the framework's
+/// response middleware stack (security headers, request IDs, error
+/// pages, etc.).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MethodOverrideRejection {
+    /// `_method` carried a value that wasn't `PUT`, `PATCH`, or `DELETE`
+    /// (case-insensitive). Rendered as `400 Bad Request`.
+    InvalidValue,
+    /// Form body was too large to buffer for override scanning and the
+    /// bytes have already been consumed. Rendered as `413 Payload Too
+    /// Large`.
+    BodyTooLarge,
+}
+
+/// Inner middleware that converts a [`MethodOverrideRejection`] into a
+/// `400`/`413` response.
+///
+/// Applied via `Router::layer` so the rejection is rendered inside the
+/// per-route layer chain. Running here means the response inherits the
+/// framework's outer middleware (security headers, request IDs,
+/// metrics, error-page filter, exception filter) rather than bypassing
+/// them.
+///
+/// The filter is a no-op when no rejection extension is present, so it
+/// is safe to apply to every route in the router.
+pub async fn method_override_rejection_filter(
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    if let Some(rejection) = request
+        .extensions()
+        .get::<MethodOverrideRejection>()
+        .copied()
+    {
+        return match rejection {
+            MethodOverrideRejection::InvalidValue => (
+                StatusCode::BAD_REQUEST,
+                [(
+                    http::header::CONTENT_TYPE,
+                    http::HeaderValue::from_static("text/plain; charset=utf-8"),
+                )],
+                "Invalid method override value: must be PUT, PATCH, or DELETE.",
+            )
+                .into_response(),
+            MethodOverrideRejection::BodyTooLarge => (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                [(
+                    http::header::CONTENT_TYPE,
+                    http::HeaderValue::from_static("text/plain; charset=utf-8"),
+                )],
+                "Form body too large for method-override scanning.",
+            )
+                .into_response(),
+        };
+    }
+    next.run(request).await
 }
 
 /// Tower [`Layer`] that applies the HTML form method override convention.
@@ -202,7 +281,7 @@ where
     S: Service<Request<axum::body::Body>, Response = Response<ResBody>> + Clone + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Send + 'static,
-    ResBody: From<&'static str> + Default + Send + 'static,
+    ResBody: Send + 'static,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -243,19 +322,16 @@ where
             let Ok(bytes) = axum::body::to_bytes(body, MAX_BODY_SCAN_BYTES).await else {
                 // Body exceeded the scan cap while buffering (e.g.
                 // chunked transfer with no Content-Length) or read
-                // failed. We've already consumed the body, so we can
-                // no longer forward the request faithfully — return
-                // an explicit 413 instead of silently corrupting it
-                // with an empty body.
-                let mut response = Response::new(ResBody::from(
-                    "Form body too large for method-override scanning.",
-                ));
-                *response.status_mut() = StatusCode::PAYLOAD_TOO_LARGE;
-                response.headers_mut().insert(
-                    http::header::CONTENT_TYPE,
-                    http::HeaderValue::from_static("text/plain; charset=utf-8"),
-                );
-                return Ok(response);
+                // failed. The bytes are gone, so we can't forward a
+                // faithful request — but we still want the eventual
+                // `413` to flow through the framework's response
+                // middleware. Stamp the rejection and pass the request
+                // through with an empty body; the inner
+                // `method_override_rejection_filter` short-circuits to
+                // `413` before any handler is called.
+                req.extensions_mut()
+                    .insert(MethodOverrideRejection::BodyTooLarge);
+                return inner.call(req).await;
             };
 
             let outcome = scan_form_for_override(&bytes, &config.field_name);
@@ -275,15 +351,14 @@ where
                     inner.call(req).await
                 }
                 OverrideOutcome::Invalid => {
-                    let mut response = Response::new(ResBody::from(
-                        "Invalid method override value: must be PUT, PATCH, or DELETE.",
-                    ));
-                    *response.status_mut() = StatusCode::BAD_REQUEST;
-                    response.headers_mut().insert(
-                        http::header::CONTENT_TYPE,
-                        http::HeaderValue::from_static("text/plain; charset=utf-8"),
-                    );
-                    Ok(response)
+                    // Stamp the rejection and forward as POST. The
+                    // inner rejection filter converts this to `400`
+                    // from inside the framework's response middleware
+                    // stack, so security headers, request IDs, metrics,
+                    // and error-page rendering all apply.
+                    req.extensions_mut()
+                        .insert(MethodOverrideRejection::InvalidValue);
+                    inner.call(req).await
                 }
             }
         })
@@ -307,13 +382,20 @@ mod tests {
     /// returns `405` before the layer ever runs. The override convention
     /// requires running before route matching, so wrap the router as a
     /// `tower::Service`.
+    ///
+    /// The inner `method_override_rejection_filter` is applied via
+    /// `Router::layer` so that `MethodOverrideRejection` extensions
+    /// stamped by the outer layer are converted into `400`/`413`
+    /// responses inside the per-route middleware chain — mirroring the
+    /// production wiring in `router::apply_middleware`.
     fn layered_router() -> MethodOverrideService<Router> {
         let router = Router::new()
             .route("/items", post(|| async { "created" }))
             .route("/items/{id}", put(|| async { "put-ok" }))
             .route("/items/{id}", patch(|| async { "patch-ok" }))
             .route("/items/{id}", delete(|| async { "delete-ok" }))
-            .route("/items/{id}", get(|| async { "show" }));
+            .route("/items/{id}", get(|| async { "show" }))
+            .layer(axum::middleware::from_fn(method_override_rejection_filter));
         MethodOverrideLayer::new().layer(router)
     }
 
@@ -672,14 +754,19 @@ mod tests {
 
     /// A POST whose body actually exceeds the scan cap during buffering
     /// (e.g. chunked transfer encoding without an accurate Content-Length)
-    /// returns an explicit `413` rather than passing an empty body to
-    /// downstream handlers.
+    /// is stamped with [`MethodOverrideRejection::BodyTooLarge`] and the
+    /// inner `method_override_rejection_filter` converts it into an
+    /// explicit `413` — inside the per-route layer chain — rather than
+    /// the outer layer short-circuiting and bypassing framework
+    /// middleware.
     #[tokio::test]
     async fn unbounded_oversized_form_post_returns_413() {
         async fn handler(body: String) -> String {
             body
         }
-        let router = Router::new().route("/x", post(handler));
+        let router = Router::new()
+            .route("/x", post(handler))
+            .layer(axum::middleware::from_fn(method_override_rejection_filter));
         let app = MethodOverrideLayer::new().layer(router);
 
         // No Content-Length header -> content_length_exceeds returns
@@ -699,6 +786,64 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    /// When the outer `MethodOverrideLayer` is composed without the
+    /// inner `method_override_rejection_filter`, the rejection
+    /// extension is still stamped on the request — but no handler
+    /// short-circuits, so the request continues to flow normally.
+    /// This matches how the framework wires the two pieces, and
+    /// proves that the outer layer doesn't generate `400`/`413`
+    /// responses on its own.
+    use std::sync::Mutex;
+    use std::sync::OnceLock;
+
+    static OBSERVED_REJECTION: OnceLock<Mutex<Option<MethodOverrideRejection>>> = OnceLock::new();
+
+    async fn capture_rejection(
+        request: axum::extract::Request,
+        next: axum::middleware::Next,
+    ) -> axum::response::Response {
+        if let Some(rej) = request
+            .extensions()
+            .get::<MethodOverrideRejection>()
+            .copied()
+        {
+            *OBSERVED_REJECTION
+                .get_or_init(|| Mutex::new(None))
+                .lock()
+                .unwrap() = Some(rej);
+        }
+        next.run(request).await
+    }
+
+    #[tokio::test]
+    async fn outer_layer_stamps_extension_without_short_circuiting() {
+        let cell = OBSERVED_REJECTION.get_or_init(|| Mutex::new(None));
+        cell.lock().unwrap().take();
+
+        let router = Router::new()
+            .route("/x", post(|| async { "post-ok" }))
+            .layer(axum::middleware::from_fn(capture_rejection));
+        let app = MethodOverrideLayer::new().layer(router);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/x")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("_method=BREW"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            *cell.lock().unwrap(),
+            Some(MethodOverrideRejection::InvalidValue)
+        );
     }
 
     #[test]

--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -32,13 +32,26 @@
 //! 2. `Sec-Fetch-Site: same-site` — **not** sufficient on its own
 //!    because `same-site` accepts sibling origins under the same
 //!    registrable domain (e.g. `evil.example.com` -> `app.example.com`).
-//!    Fall back to the `Origin` vs `Host` check before allowing.
+//!    Fall back to the full `Origin` check before allowing.
 //! 3. `Sec-Fetch-Site: cross-site` (or any other value) is rejected.
-//! 4. When `Sec-Fetch-Site` is absent, compare `Origin` host-for-host
-//!    with `Host`. A mismatch is rejected.
-//! 5. If both signals are absent, the override is **not** applied —
+//! 4. When `Sec-Fetch-Site` is absent, fall back to the full `Origin`
+//!    check.
+//! 5. If `Origin` is missing too, the override is **not** applied —
 //!    the request is forwarded as the original `POST` so route
 //!    matching rejects it on its own (fail closed).
+//!
+//! The full `Origin` check compares scheme, host, and port:
+//!
+//! - The Origin host:port must match `X-Forwarded-Host` (if surfaced
+//!   by the reverse proxy) or `Host`.
+//! - If `X-Forwarded-Proto` is set (e.g. by a TLS-terminating proxy),
+//!   the Origin's scheme must match it. The leftmost element of a
+//!   comma-separated proxy chain is used.
+//! - When neither `X-Forwarded-Proto` is set nor the request URI
+//!   carries a scheme, the middleware can't observe the underlying
+//!   transport, so it falls back to host:port matching alone.
+//!   Deployments that need strict scheme enforcement should run
+//!   behind a proxy that sets `X-Forwarded-Proto`.
 //!
 //! # Failure modes
 //!
@@ -341,41 +354,95 @@ fn is_form_urlencoded(headers: &http::HeaderMap) -> bool {
 ///    thing is to forward the request as the original `POST` and let
 ///    route matching reject it.
 fn is_same_origin_form(headers: &http::HeaderMap) -> bool {
-    let origin_host_match = || {
+    let origin_full_match = || {
         let origin = headers
             .get(http::header::ORIGIN)
             .and_then(|v| v.to_str().ok())?;
-        let host = headers
-            .get(http::header::HOST)
-            .and_then(|v| v.to_str().ok())?;
-        Some(origin_matches_host(origin, host))
+        Some(origin_matches_request(origin, headers))
     };
 
     if let Some(site) = headers.get("sec-fetch-site").and_then(|v| v.to_str().ok()) {
         return match site {
             "same-origin" | "none" => true,
             // `same-site` is broader than same-origin; require an
-            // explicit Origin/Host match for the documented guarantee.
-            "same-site" => origin_host_match().unwrap_or(false),
+            // explicit Origin/Host (and scheme) match for the
+            // documented guarantee.
+            "same-site" => origin_full_match().unwrap_or(false),
             // `cross-site` or any unrecognised value: reject.
             _ => false,
         };
     }
 
-    origin_host_match().unwrap_or(false)
+    origin_full_match().unwrap_or(false)
 }
 
-/// `Origin` is a scheme + host (+ optional port); `Host` is host
-/// (+ optional port). We treat them as same-origin when the
-/// host:port portion matches.
-fn origin_matches_host(origin: &str, host: &str) -> bool {
-    let origin_authority = origin
-        .strip_prefix("https://")
-        .or_else(|| origin.strip_prefix("http://"))
-        .unwrap_or(origin);
-    // Trim any trailing path (defensive — `Origin` should not include one).
-    let origin_authority = origin_authority.split('/').next().unwrap_or("");
-    origin_authority.eq_ignore_ascii_case(host)
+/// Same-origin requires scheme + host + port to match. `Origin` carries
+/// all three; the request side gets host:port from `Host` (or
+/// `X-Forwarded-Host` if the deployment surfaces it) and the scheme
+/// from `X-Forwarded-Proto` when running behind a TLS-terminating
+/// reverse proxy.
+///
+/// If we can determine the request's scheme and Origin's scheme
+/// differs, we reject — that's a true cross-origin request from a
+/// different scheme. If we cannot determine the scheme (no
+/// `X-Forwarded-Proto` set; not behind a proxy), we fall back to
+/// requiring just the host:port match. That's a deployment-specific
+/// limitation: the middleware can't observe the underlying transport
+/// from inside the request, so configurations that need strict
+/// scheme enforcement should run behind a proxy that sets
+/// `X-Forwarded-Proto`.
+fn origin_matches_request(origin: &str, headers: &http::HeaderMap) -> bool {
+    let Some((origin_scheme, origin_authority)) = parse_origin(origin) else {
+        return false;
+    };
+
+    let expected_host = headers
+        .get("x-forwarded-host")
+        .and_then(|v| v.to_str().ok())
+        .or_else(|| {
+            headers
+                .get(http::header::HOST)
+                .and_then(|v| v.to_str().ok())
+        });
+    let Some(expected_host) = expected_host else {
+        return false;
+    };
+    if !origin_authority.eq_ignore_ascii_case(expected_host) {
+        return false;
+    }
+
+    if let Some(scheme) = headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+    {
+        // Multiple `X-Forwarded-Proto` values can be chained by
+        // intermediaries; the leftmost (client-facing) is the one
+        // that matters here.
+        let outermost = scheme.split(',').next().unwrap_or(scheme).trim();
+        return outermost.eq_ignore_ascii_case(origin_scheme);
+    }
+
+    // No scheme signal: host:port match is the best we can do.
+    true
+}
+
+/// Split a serialized `Origin` value into `(scheme, authority)`.
+///
+/// Returns `None` for malformed values (missing scheme, opaque
+/// origins like `null`, or unrecognised schemes). Only `http` and
+/// `https` are accepted — the override convention is documented for
+/// browser HTML forms only.
+fn parse_origin(origin: &str) -> Option<(&str, &str)> {
+    let (scheme, rest) = origin.split_once("://")?;
+    if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
+        return None;
+    }
+    // Defensive: `Origin` is just scheme://authority with no path.
+    let authority = rest.split('/').next()?;
+    if authority.is_empty() {
+        return None;
+    }
+    Some((scheme, authority))
 }
 
 impl<S, ResBody> Service<Request<axum::body::Body>> for MethodOverrideService<S>
@@ -1090,6 +1157,107 @@ mod tests {
 
         // /items/1 has no POST handler, so a non-overridden POST yields 405.
         assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    /// Regression: when `X-Forwarded-Proto: https` is set by the reverse
+    /// proxy, an `Origin: http://...` carries a different scheme and
+    /// therefore is NOT same-origin, even if the host matches. The
+    /// override must not be honoured.
+    #[tokio::test]
+    async fn origin_scheme_mismatch_via_forwarded_proto_is_rejected() {
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("origin", "http://app.example")
+                    .header("host", "app.example")
+                    .header("x-forwarded-proto", "https")
+                    .body(Body::from("_method=DELETE"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::METHOD_NOT_ALLOWED,
+            "different Origin scheme is not same-origin"
+        );
+    }
+
+    /// `X-Forwarded-Proto` may carry a chained list (e.g. through
+    /// nested proxies). The leftmost (client-facing) value is what
+    /// the browser saw; that's the value we must compare against.
+    #[tokio::test]
+    async fn origin_scheme_match_via_chained_forwarded_proto() {
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("origin", "https://app.example")
+                    .header("host", "app.example")
+                    // First hop saw HTTPS; later hops were HTTP between
+                    // proxy and app. Only the client-facing scheme
+                    // matters for the same-origin comparison.
+                    .header("x-forwarded-proto", "https, http")
+                    .body(Body::from("_method=DELETE"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// When the proxy surfaces a different `X-Forwarded-Host`, that's
+    /// the host the browser saw — Origin must match the forwarded host,
+    /// not the internal `Host` header from the proxy.
+    #[tokio::test]
+    async fn forwarded_host_takes_precedence_over_host_header() {
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("origin", "https://app.example")
+                    .header("host", "internal.cluster.local")
+                    .header("x-forwarded-host", "app.example")
+                    .header("x-forwarded-proto", "https")
+                    .body(Body::from("_method=DELETE"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// `parse_origin` unit cases.
+    #[test]
+    fn parse_origin_accepts_http_and_https_only() {
+        assert_eq!(
+            parse_origin("https://app.example"),
+            Some(("https", "app.example"))
+        );
+        assert_eq!(
+            parse_origin("http://app.example:8080"),
+            Some(("http", "app.example:8080"))
+        );
+        // Unknown / opaque origins are rejected.
+        assert_eq!(parse_origin("null"), None);
+        assert_eq!(parse_origin("file:///etc/passwd"), None);
+        assert_eq!(parse_origin("javascript:alert(1)"), None);
+        // Missing scheme/authority.
+        assert_eq!(parse_origin("app.example"), None);
+        assert_eq!(parse_origin("https://"), None);
     }
 
     /// Helper-level cases that don't require the full router wiring.

--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -16,6 +16,27 @@
 //! preserved exactly so downstream extractors (including CSRF
 //! validation) read it unchanged.
 //!
+//! # Same-origin requirement
+//!
+//! The override is strictly a convention for browser HTML forms
+//! originating from the same origin. The layer enforces this rather
+//! than relying solely on CSRF, because a route declared as `#[delete]`
+//! would otherwise become reachable from any cross-origin form when
+//! CSRF protection is disabled or the path is CSRF-exempt — a
+//! reachability change browsers' same-origin policy would normally
+//! prevent for direct `DELETE` requests.
+//!
+//! The check uses, in order:
+//!
+//! 1. `Sec-Fetch-Site` (sent by all browsers since ~2020). Allowed
+//!    values: `same-origin`, `same-site`, `none`. `cross-site` is
+//!    rejected.
+//! 2. Fallback when `Sec-Fetch-Site` is absent: `Origin` is compared
+//!    host-for-host with `Host`. A mismatch is rejected.
+//! 3. If both signals are absent, the override is **not** applied —
+//!    the request is forwarded as the original `POST` so route
+//!    matching rejects it on its own (fail closed).
+//!
 //! # Failure modes
 //!
 //! - An unrecognised override value (e.g. `_method=BREW`) is rejected
@@ -144,6 +165,7 @@ pub async fn method_override_rejection_filter(
     request: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
+    use crate::middleware::exception_filter::AutumnErrorInfo;
     use axum::response::IntoResponse;
 
     if let Some(rejection) = request
@@ -151,26 +173,37 @@ pub async fn method_override_rejection_filter(
         .get::<MethodOverrideRejection>()
         .copied()
     {
-        return match rejection {
+        let (status, message) = match rejection {
             MethodOverrideRejection::InvalidValue => (
                 StatusCode::BAD_REQUEST,
-                [(
-                    http::header::CONTENT_TYPE,
-                    http::HeaderValue::from_static("text/plain; charset=utf-8"),
-                )],
                 "Invalid method override value: must be PUT, PATCH, or DELETE.",
-            )
-                .into_response(),
+            ),
             MethodOverrideRejection::BodyTooLarge => (
                 StatusCode::PAYLOAD_TOO_LARGE,
-                [(
-                    http::header::CONTENT_TYPE,
-                    http::HeaderValue::from_static("text/plain; charset=utf-8"),
-                )],
                 "Form body too large for method-override scanning.",
-            )
-                .into_response(),
+            ),
         };
+        let mut response = (
+            status,
+            [(
+                http::header::CONTENT_TYPE,
+                http::HeaderValue::from_static("text/plain; charset=utf-8"),
+            )],
+            message,
+        )
+            .into_response();
+        // Surface this as a framework error so the exception filter
+        // chain (problem-details normalization, custom HTML error-page
+        // rendering) processes it the same as any handler-generated
+        // error response. Without this extension, `ExceptionFilterFuture`
+        // treats the response as pre-formed and skips renegotiation.
+        response.extensions_mut().insert(AutumnErrorInfo {
+            status,
+            message: message.to_owned(),
+            details: None,
+            problem_type: None,
+        });
+        return response;
     }
     next.run(request).await
 }
@@ -276,6 +309,62 @@ fn content_length_exceeds(headers: &http::HeaderMap, limit: usize) -> bool {
         .is_some_and(|len| len > limit as u64)
 }
 
+/// Is the request a same-origin browser form submission?
+///
+/// The override convention is documented for browser HTML forms, so we
+/// only honour it when the request really did originate from the same
+/// origin. Without this check a CSRF-disabled (or CSRF-exempt) route
+/// declared as `#[delete]` could be reached by a cross-origin form
+/// using `_method=DELETE` even though the equivalent direct `DELETE`
+/// request would be blocked by the browser's same-origin policy.
+///
+/// Decision matrix (returns `true` to allow the override):
+///
+/// 1. `Sec-Fetch-Site` is sent by every browser released since ~2020
+///    and is the most reliable signal. We allow `same-origin`,
+///    `same-site`, and `none` (user-initiated, no opener) and reject
+///    `cross-site`.
+/// 2. When `Sec-Fetch-Site` is absent, fall back to comparing the
+///    `Origin` header against `Host`. Modern browsers always send
+///    `Origin` for `POST`, so a mismatch here means the request really
+///    is cross-origin.
+/// 3. When both signals are absent, deny the override (fail closed).
+///    Such requests are either an extremely old browser or a non-
+///    browser client; in either case the documented browser-form
+///    convention does not apply, so the safe thing is to forward the
+///    request as the original `POST` and let route matching reject it.
+fn is_same_origin_form(headers: &http::HeaderMap) -> bool {
+    if let Some(site) = headers.get("sec-fetch-site").and_then(|v| v.to_str().ok()) {
+        return matches!(site, "same-origin" | "same-site" | "none");
+    }
+
+    let origin = headers
+        .get(http::header::ORIGIN)
+        .and_then(|v| v.to_str().ok());
+    let host = headers
+        .get(http::header::HOST)
+        .and_then(|v| v.to_str().ok());
+
+    match (origin, host) {
+        (Some(origin), Some(host)) => origin_matches_host(origin, host),
+        // No origin and no Sec-Fetch-Site: fail closed.
+        _ => false,
+    }
+}
+
+/// `Origin` is a scheme + host (+ optional port); `Host` is host
+/// (+ optional port). We treat them as same-origin when the
+/// host:port portion matches.
+fn origin_matches_host(origin: &str, host: &str) -> bool {
+    let origin_authority = origin
+        .strip_prefix("https://")
+        .or_else(|| origin.strip_prefix("http://"))
+        .unwrap_or(origin);
+    // Trim any trailing path (defensive — `Origin` should not include one).
+    let origin_authority = origin_authority.split('/').next().unwrap_or("");
+    origin_authority.eq_ignore_ascii_case(host)
+}
+
 impl<S, ResBody> Service<Request<axum::body::Body>> for MethodOverrideService<S>
 where
     S: Service<Request<axum::body::Body>, Response = Response<ResBody>> + Clone + Send + 'static,
@@ -292,9 +381,16 @@ where
     }
 
     fn call(&mut self, mut req: Request<axum::body::Body>) -> Self::Future {
-        // Only POST requests are eligible for override. Same-origin form
-        // semantics: nothing else is allowed to silently morph methods.
-        if req.method() != http::Method::POST || !is_form_urlencoded(req.headers()) {
+        // Only POST form-urlencoded submissions originating from the
+        // same origin are eligible. Same-origin form semantics: nothing
+        // else is allowed to silently morph methods, because a request
+        // that browsers won't make directly (e.g. a cross-origin
+        // `<form>` submitting to a `#[delete]` route) must not gain
+        // reachability via the override convention.
+        if req.method() != http::Method::POST
+            || !is_form_urlencoded(req.headers())
+            || !is_same_origin_form(req.headers())
+        {
             let mut inner = self.inner.clone();
             std::mem::swap(&mut self.inner, &mut inner);
             return Box::pin(async move { inner.call(req).await });
@@ -408,6 +504,7 @@ mod tests {
                     .method("POST")
                     .uri("/items")
                     .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-origin")
                     .body(Body::from("title=hello"))
                     .unwrap(),
             )
@@ -430,6 +527,7 @@ mod tests {
                     .method("POST")
                     .uri("/items/1")
                     .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-origin")
                     .body(Body::from("_method=PUT&title=hi"))
                     .unwrap(),
             )
@@ -452,6 +550,7 @@ mod tests {
                     .method("POST")
                     .uri("/items/1")
                     .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-origin")
                     .body(Body::from("_method=patch"))
                     .unwrap(),
             )
@@ -474,6 +573,7 @@ mod tests {
                     .method("POST")
                     .uri("/items/1")
                     .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-origin")
                     .body(Body::from("_method=DELETE"))
                     .unwrap(),
             )
@@ -496,6 +596,7 @@ mod tests {
                     .method("POST")
                     .uri("/items/1")
                     .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-origin")
                     .body(Body::from("_method=BREW"))
                     .unwrap(),
             )
@@ -568,6 +669,7 @@ mod tests {
                     .method("POST")
                     .uri("/echo")
                     .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-origin")
                     .body(Body::from(payload))
                     .unwrap(),
             )
@@ -595,6 +697,7 @@ mod tests {
                     .method("POST")
                     .uri("/x")
                     .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-origin")
                     .body(Body::from("_method=DELETE"))
                     .unwrap(),
             )
@@ -622,6 +725,7 @@ mod tests {
                     .method("POST")
                     .uri("/items/1")
                     .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-origin")
                     .body(Body::from("x-method=DELETE"))
                     .unwrap(),
             )
@@ -660,6 +764,7 @@ mod tests {
                     .method("POST")
                     .uri("/items/1")
                     .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-origin")
                     .header(http::header::ACCEPT, "text/html")
                     .header("Cookie", "autumn-csrf=valid-cookie-token")
                     .body(Body::from("_method=DELETE"))
@@ -691,6 +796,7 @@ mod tests {
                     .method("POST")
                     .uri("/items/1")
                     .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-origin")
                     .header("Cookie", format!("autumn-csrf={token}"))
                     .body(Body::from(format!("_csrf={token}&_method=DELETE")))
                     .unwrap(),
@@ -734,6 +840,7 @@ mod tests {
                     .method("POST")
                     .uri("/upload")
                     .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-origin")
                     .header("content-length", payload_len.to_string())
                     .body(Body::from(payload))
                     .unwrap(),
@@ -779,6 +886,7 @@ mod tests {
                     .method("POST")
                     .uri("/x")
                     .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-origin")
                     .body(Body::from(payload))
                     .unwrap(),
             )
@@ -833,6 +941,7 @@ mod tests {
                     .method("POST")
                     .uri("/x")
                     .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-origin")
                     .body(Body::from("_method=BREW"))
                     .unwrap(),
             )
@@ -844,6 +953,185 @@ mod tests {
             *cell.lock().unwrap(),
             Some(MethodOverrideRejection::InvalidValue)
         );
+    }
+
+    /// A POST carrying `_method=DELETE` from a cross-site context must
+    /// NOT be honoured as a DELETE. Without this check, a route declared
+    /// as `#[delete]` only — which native browser forms can never reach
+    /// directly — would become reachable from any third-party site that
+    /// renders a form pointing at it (when CSRF is disabled or the path
+    /// is CSRF-exempt).
+    #[tokio::test]
+    async fn cross_site_form_is_not_honoured_as_override() {
+        // Inner /items/{id} only has DELETE; no POST handler. If the
+        // override were applied, we'd see 200 "delete-ok". If the
+        // override is correctly skipped, we should see 405 (POST not
+        // allowed for that route).
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "cross-site")
+                    .body(Body::from("_method=DELETE"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::METHOD_NOT_ALLOWED,
+            "cross-site override must not be applied; expected the inner \
+             router to reject the underlying POST"
+        );
+    }
+
+    /// When `Sec-Fetch-Site` is absent we fall back to comparing
+    /// `Origin` with `Host`. A mismatch means the request is
+    /// cross-origin and the override must not apply.
+    #[tokio::test]
+    async fn origin_host_mismatch_is_not_honoured_as_override() {
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("origin", "https://evil.example")
+                    .header("host", "app.example")
+                    .body(Body::from("_method=DELETE"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    /// `Origin` and `Host` match (both `app.example`) — same origin via
+    /// the fallback path; the override should apply.
+    #[tokio::test]
+    async fn origin_host_match_is_honoured_as_override() {
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("origin", "https://app.example")
+                    .header("host", "app.example")
+                    .body(Body::from("_method=DELETE"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// Neither `Sec-Fetch-Site` nor `Origin` present: fail closed. The
+    /// override is not applied — the request flows through as POST.
+    #[tokio::test]
+    async fn missing_origin_signals_fail_closed() {
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("_method=DELETE"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // /items/1 has no POST handler, so a non-overridden POST yields 405.
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    /// Helper-level cases that don't require the full router wiring.
+    #[test]
+    fn is_same_origin_form_decision_matrix() {
+        // Sec-Fetch-Site values
+        for site in ["same-origin", "same-site", "none"] {
+            let mut h = http::HeaderMap::new();
+            h.insert("sec-fetch-site", http::HeaderValue::from_str(site).unwrap());
+            assert!(
+                is_same_origin_form(&h),
+                "sec-fetch-site={site} should be allowed"
+            );
+        }
+        let mut h = http::HeaderMap::new();
+        h.insert(
+            "sec-fetch-site",
+            http::HeaderValue::from_static("cross-site"),
+        );
+        assert!(!is_same_origin_form(&h));
+
+        // Origin matches Host
+        let mut h = http::HeaderMap::new();
+        h.insert(
+            http::header::ORIGIN,
+            http::HeaderValue::from_static("https://app.example"),
+        );
+        h.insert(
+            http::header::HOST,
+            http::HeaderValue::from_static("app.example"),
+        );
+        assert!(is_same_origin_form(&h));
+
+        // Origin does not match Host
+        let mut h = http::HeaderMap::new();
+        h.insert(
+            http::header::ORIGIN,
+            http::HeaderValue::from_static("https://evil.example"),
+        );
+        h.insert(
+            http::header::HOST,
+            http::HeaderValue::from_static("app.example"),
+        );
+        assert!(!is_same_origin_form(&h));
+
+        // Neither signal present: fail closed.
+        let h = http::HeaderMap::new();
+        assert!(!is_same_origin_form(&h));
+    }
+
+    /// Override rejection responses carry an `AutumnErrorInfo` extension
+    /// so the framework exception filter chain — problem-details
+    /// negotiation, custom HTML error-page rendering — processes them
+    /// the same as a handler-generated error response.
+    #[tokio::test]
+    async fn rejection_response_carries_autumn_error_info() {
+        use crate::middleware::exception_filter::AutumnErrorInfo;
+
+        let app = layered_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/items/1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("sec-fetch-site", "same-origin")
+                    .body(Body::from("_method=BREW"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let info = response
+            .extensions()
+            .get::<AutumnErrorInfo>()
+            .expect("override rejection must carry AutumnErrorInfo");
+        assert_eq!(info.status, StatusCode::BAD_REQUEST);
+        assert!(info.message.contains("PUT, PATCH, or DELETE"));
     }
 
     #[test]

--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -44,6 +44,15 @@
 //!
 //! - An unrecognised override value (e.g. `_method=BREW`) is rejected
 //!   with `400 Bad Request` before reaching the handler.
+//! - A form-urlencoded body larger than the scan cap (2 MiB) is
+//!   rejected with `413 Payload Too Large` even when it doesn't
+//!   carry `_method`. The middleware can't peek at the form fields
+//!   without scanning the body, so an oversized POST might be a
+//!   `_method=DELETE` request whose intent we'd otherwise demote to
+//!   a plain `POST` based purely on body size. Failing closed
+//!   preserves the user's operation semantics. Form-urlencoded
+//!   payloads near this size are uncommon — `multipart/form-data`
+//!   is the conventional encoding for large submissions.
 //! - The override only acts on `POST` requests with a form-style body.
 //!   Headers like `X-HTTP-Method-Override` are intentionally **not**
 //!   honoured: this convention is documented for browser HTML forms
@@ -300,18 +309,6 @@ fn is_form_urlencoded(headers: &http::HeaderMap) -> bool {
         .is_some_and(|ct| ct.starts_with("application/x-www-form-urlencoded"))
 }
 
-/// Returns `true` only when the request advertises a `Content-Length`
-/// strictly larger than `limit`. A missing or unparseable header returns
-/// `false`, since we can't make a confident determination without
-/// buffering — those cases fall through to the buffered scan.
-fn content_length_exceeds(headers: &http::HeaderMap, limit: usize) -> bool {
-    headers
-        .get(http::header::CONTENT_LENGTH)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse::<u64>().ok())
-        .is_some_and(|len| len > limit as u64)
-}
-
 /// Is the request a same-origin browser form submission?
 ///
 /// The override convention is documented for browser HTML forms, so we
@@ -412,17 +409,6 @@ where
             return Box::pin(async move { inner.call(req).await });
         }
 
-        // If the client advertises a body larger than the scan cap, skip
-        // override processing entirely and forward the original body
-        // untouched. We never buffer it, so handlers downstream still
-        // receive the full submission verbatim — a form that's too large
-        // to scan for `_method` simply doesn't get the override applied.
-        if content_length_exceeds(req.headers(), MAX_BODY_SCAN_BYTES) {
-            let mut inner = self.inner.clone();
-            std::mem::swap(&mut self.inner, &mut inner);
-            return Box::pin(async move { inner.call(req).await });
-        }
-
         let config = Arc::clone(&self.config);
         let mut inner = self.inner.clone();
         std::mem::swap(&mut self.inner, &mut inner);
@@ -430,15 +416,26 @@ where
         Box::pin(async move {
             // Temporarily take ownership of the body so we can buffer it
             // for parsing without losing the bytes the handler will need.
+            //
+            // We do NOT short-circuit on `Content-Length > limit` and
+            // forward the body untouched — that would let a form with
+            // `_method=DELETE` and an oversized body silently fall
+            // through to the inner router as a `POST`, demoting the
+            // user's intended mutating operation based purely on body
+            // size. Instead, we always attempt the scan. `to_bytes`
+            // checks the body's `size_hint` first and errors out
+            // immediately (no buffering) for bodies advertised larger
+            // than the cap, so the cost on the fast-failure path is
+            // negligible; we mark the rejection and let the inner
+            // filter render `413` so the user is told plainly that
+            // the form is too large to support the override.
             let body = std::mem::replace(req.body_mut(), axum::body::Body::empty());
             let Ok(bytes) = axum::body::to_bytes(body, MAX_BODY_SCAN_BYTES).await else {
-                // Body exceeded the scan cap while buffering (e.g.
-                // chunked transfer with no Content-Length) or read
-                // failed. The bytes are gone, so we can't forward a
-                // faithful request — but we still want the eventual
-                // `413` to flow through the framework's response
-                // middleware. Stamp the rejection and pass the request
-                // through with an empty body; the inner
+                // Body exceeded the scan cap. The bytes are gone, so
+                // we can't forward a faithful request — and we don't
+                // want to silently turn an intended `DELETE` into a
+                // `POST` either. Stamp the rejection and pass the
+                // request through with an empty body; the inner
                 // `method_override_rejection_filter` short-circuits to
                 // `413` before any handler is called.
                 req.extensions_mut()
@@ -827,25 +824,25 @@ mod tests {
         assert_eq!(&body[..], b"deleted");
     }
 
-    /// Regression: a form-urlencoded POST larger than the scan cap must
-    /// still reach its handler with the body intact when it doesn't
-    /// declare an override. Previously the scan failure path emptied
-    /// the body, corrupting any large legitimate POST routed through
-    /// the global override layer.
+    /// A form-urlencoded POST whose body exceeds the scan cap is
+    /// rejected with `413` even when it carries no `_method` field.
+    /// We can't tell whether the body contains an override without
+    /// scanning, and forwarding it untouched would let a request with
+    /// `_method=DELETE` and an oversized body silently fall through
+    /// to the POST handler instead. Failing closed preserves the
+    /// user's intended operation semantics.
     #[tokio::test]
-    async fn large_form_post_without_override_preserves_full_body() {
+    async fn oversized_form_post_without_override_field_is_rejected() {
         async fn measure(body: bytes::Bytes) -> String {
             format!("{}", body.len())
         }
-        // Raise the handler-side body limit so the test exercises the
-        // middleware's pass-through path rather than axum's own default
-        // 2 MiB body cap on extractors.
         let router = Router::new()
             .route("/upload", post(measure))
-            .layer(axum::extract::DefaultBodyLimit::max(8 * 1024 * 1024));
+            .layer(axum::extract::DefaultBodyLimit::max(8 * 1024 * 1024))
+            .layer(axum::middleware::from_fn(method_override_rejection_filter));
         let app = MethodOverrideLayer::new().layer(router);
 
-        // 3 MiB payload: comfortably over MAX_BODY_SCAN_BYTES (2 MiB).
+        // 3 MiB payload — over MAX_BODY_SCAN_BYTES (2 MiB).
         let big = "x".repeat(3 * 1024 * 1024);
         let payload = format!("title={big}");
         let payload_len = payload.len();
@@ -864,15 +861,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), 32)
-            .await
-            .unwrap();
-        let observed: usize = std::str::from_utf8(&body).unwrap().parse().unwrap();
-        assert_eq!(
-            observed, payload_len,
-            "handler must see the full original body, not an empty one"
-        );
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 
     /// A POST whose body actually exceeds the scan cap during buffering
@@ -1240,30 +1229,5 @@ mod tests {
             .expect("override rejection must carry AutumnErrorInfo");
         assert_eq!(info.status, StatusCode::BAD_REQUEST);
         assert!(info.message.contains("PUT, PATCH, or DELETE"));
-    }
-
-    #[test]
-    fn content_length_exceeds_only_when_strictly_larger() {
-        let mut headers = http::HeaderMap::new();
-        assert!(!content_length_exceeds(&headers, 1024));
-
-        headers.insert(
-            http::header::CONTENT_LENGTH,
-            http::HeaderValue::from_static("1024"),
-        );
-        assert!(!content_length_exceeds(&headers, 1024));
-
-        headers.insert(
-            http::header::CONTENT_LENGTH,
-            http::HeaderValue::from_static("1025"),
-        );
-        assert!(content_length_exceeds(&headers, 1024));
-
-        // Unparseable header values stay conservative: don't short-circuit.
-        headers.insert(
-            http::header::CONTENT_LENGTH,
-            http::HeaderValue::from_static("not-a-number"),
-        );
-        assert!(!content_length_exceeds(&headers, 1024));
     }
 }

--- a/autumn/src/middleware/mod.rs
+++ b/autumn/src/middleware/mod.rs
@@ -28,7 +28,8 @@ pub(crate) mod trace_context;
 pub use exception_filter::{AutumnErrorInfo, ExceptionFilter, ExceptionFilterLayer};
 pub use method_override::{
     DEFAULT_METHOD_OVERRIDE_FIELD, MethodOverrideConfig, MethodOverrideLayer,
-    MethodOverrideService, OverriddenMethod,
+    MethodOverrideRejection, MethodOverrideService, OverriddenMethod,
+    method_override_rejection_filter,
 };
 pub use metrics::{MetricsCollector, MetricsLayer};
 pub use request_id::{RequestId, RequestIdLayer};

--- a/autumn/src/middleware/mod.rs
+++ b/autumn/src/middleware/mod.rs
@@ -19,12 +19,17 @@
 pub(crate) mod dev;
 pub(crate) mod error_page_filter;
 pub(crate) mod exception_filter;
+pub(crate) mod method_override;
 pub(crate) mod metrics;
 pub(crate) mod request_id;
 #[cfg(feature = "telemetry-otlp")]
 pub(crate) mod trace_context;
 
 pub use exception_filter::{AutumnErrorInfo, ExceptionFilter, ExceptionFilterLayer};
+pub use method_override::{
+    DEFAULT_METHOD_OVERRIDE_FIELD, MethodOverrideConfig, MethodOverrideLayer,
+    MethodOverrideService, OverriddenMethod,
+};
 pub use metrics::{MetricsCollector, MetricsLayer};
 pub use request_id::{RequestId, RequestIdLayer};
 #[cfg(feature = "telemetry-otlp")]

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -340,6 +340,32 @@ mod tests {
         assert_eq!(infos.len(), 2);
     }
 
+    /// Acceptance criterion for issue #605: `autumn routes` /
+    /// `/actuator/routes` must keep reporting the declared effective
+    /// method (`PUT`, `PATCH`, `DELETE`) even though HTML browser
+    /// submissions transport those mutations as `POST` with a hidden
+    /// `_method` override.
+    ///
+    /// Route metadata is collected at registration time from
+    /// `Route::method`, never from any per-request rewrite, so the
+    /// listing stays semantically honest regardless of how clients
+    /// reach the route.
+    #[test]
+    fn collect_route_infos_reports_declared_method_for_overridable_routes() {
+        let routes = vec![
+            make_route(Method::PUT, "/posts/{id}", "update_post"),
+            make_route(Method::PATCH, "/posts/{id}", "patch_post"),
+            make_route(Method::DELETE, "/posts/{id}", "delete_post"),
+        ];
+        let sources = vec![RouteSource::User; 3];
+        let infos = collect_route_infos(&routes, &sources, &[]);
+        let methods: Vec<&str> = infos.iter().map(|i| i.method.as_str()).collect();
+        assert_eq!(methods, vec!["PUT", "PATCH", "DELETE"]);
+        // The transport method browsers actually use must never appear in
+        // the listing for these routes.
+        assert!(infos.iter().all(|i| i.method != "POST"), "{infos:?}");
+    }
+
     #[test]
     fn collect_route_infos_scoped_group_prepends_prefix() {
         let group = ScopedGroup {

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1082,6 +1082,21 @@ fn apply_middleware(
 
     router = apply_cors_middleware(router, config);
     router = apply_csrf_middleware(router, config, signing_keys_opt.clone());
+    // Method-override rejection filter. The outer `MethodOverrideLayer`
+    // (applied at the `axum::serve` boundary so it can rewrite the
+    // request method before route matching) stamps a
+    // [`MethodOverrideRejection`] extension when the override field
+    // value is invalid or the body was too large to scan; this inner
+    // middleware converts that extension into the corresponding
+    // `400`/`413` response. Running it here means the rejection flows
+    // through the rest of the response stack (security headers,
+    // request IDs, metrics, error-page filter) rather than bypassing
+    // them. Placed outside CSRF so a `BodyTooLarge` (empty body)
+    // doesn't get masked by a `403` from CSRF's missing-token branch,
+    // and a clear `400 invalid _method` outranks "missing CSRF".
+    router = router.layer(axum::middleware::from_fn(
+        crate::middleware::method_override_rejection_filter,
+    ));
     router = apply_rate_limit_middleware(router, config);
     router = apply_upload_middleware(router, config);
 

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -525,13 +525,19 @@ impl RequestBuilder {
 
     /// Set the request body to URL-encoded form data.
     ///
-    /// Automatically sets `Content-Type: application/x-www-form-urlencoded`.
+    /// Automatically sets `Content-Type: application/x-www-form-urlencoded`
+    /// and `Sec-Fetch-Site: same-origin` to mirror what a real browser
+    /// would send for a same-origin `<form method="post">` — which is
+    /// what the method-override middleware requires to honour
+    /// `_method=PUT|PATCH|DELETE` overrides.
     #[must_use]
     pub fn form(mut self, body: &str) -> Self {
         self.headers.push((
             "content-type".to_owned(),
             "application/x-www-form-urlencoded".to_owned(),
         ));
+        self.headers
+            .push(("sec-fetch-site".to_owned(), "same-origin".to_owned()));
         self.body = Body::from(body.to_owned());
         self
     }

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -554,7 +554,14 @@ impl RequestBuilder {
 
         let request = builder.body(self.body).expect("failed to build request");
 
-        let response = self.router.oneshot(request).await.expect("request failed");
+        // Wrap the router with MethodOverrideLayer the same way the production
+        // serve site does, so a POST with a `_method=DELETE` form field reaches
+        // the declared DELETE handler in tests too. The layer is a no-op for
+        // non-POST methods and non-form bodies, so it's safe to apply
+        // unconditionally.
+        let service =
+            tower::Layer::layer(&crate::middleware::MethodOverrideLayer::new(), self.router);
+        let response = service.oneshot(request).await.expect("request failed");
 
         let status = response.status();
         let headers: Vec<(String, String)> = response
@@ -1047,5 +1054,54 @@ mod tests {
     #[tokio::test]
     async fn test_client_default() {
         let _app = TestApp::default();
+    }
+
+    /// End-to-end acceptance for issue #605: a plain `<form method="post">`
+    /// carrying `_method=DELETE` reaches the declared DELETE handler when
+    /// dispatched through the same router/middleware stack the production
+    /// app builder uses.
+    #[tokio::test]
+    async fn test_app_routes_html_method_override_to_delete() {
+        use axum::routing;
+        async fn deleted() -> &'static str {
+            "deleted"
+        }
+        let routes = vec![Route {
+            method: Method::DELETE,
+            path: "/items/{id}",
+            handler: routing::delete(deleted),
+            name: "items_delete",
+            api_doc: crate::openapi::ApiDoc {
+                method: "DELETE",
+                path: "/items/{id}",
+                operation_id: "items_delete",
+                success_status: 200,
+                ..Default::default()
+            },
+            repository: None,
+        }];
+        let client = TestApp::new().routes(routes).build();
+
+        client
+            .post("/items/1")
+            .form("_method=DELETE")
+            .send()
+            .await
+            .assert_ok()
+            .assert_body_eq("deleted");
+    }
+
+    /// Companion to the override test: an invalid `_method` value rejects
+    /// with `400 Bad Request` before reaching any handler.
+    #[tokio::test]
+    async fn test_app_routes_invalid_method_override_rejected() {
+        let client = TestApp::new().routes(test_routes()).build();
+
+        client
+            .post("/create")
+            .form("_method=BREW")
+            .send()
+            .await
+            .assert_status(400);
     }
 }

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -1104,4 +1104,39 @@ mod tests {
             .await
             .assert_status(400);
     }
+
+    /// The outer `MethodOverrideLayer` stamps a `MethodOverrideRejection`
+    /// extension instead of short-circuiting, so the inner
+    /// `method_override_rejection_filter` produces the `400` from inside
+    /// the per-route layer chain. Verify that framework response
+    /// middleware (request-ID header, security headers) still wraps that
+    /// `400` — i.e. malformed requests inherit the same response middleware
+    /// as ordinary handler responses, rather than bypassing it.
+    #[tokio::test]
+    async fn invalid_method_override_response_carries_framework_middleware() {
+        let client = TestApp::new().routes(test_routes()).build();
+
+        let response = client.post("/create").form("_method=BREW").send().await;
+        response.assert_status(400);
+
+        // RequestIdLayer is applied via `Router::layer` in
+        // `apply_middleware` and stamps a response header on every
+        // request that flows through the inner router. If the override
+        // layer short-circuited at the outer wrapper, this header would
+        // be absent.
+        assert!(
+            response.header("x-request-id").is_some(),
+            "framework request-id header must wrap method-override rejections; \
+             observed headers: {:?}",
+            response.headers
+        );
+        // SecurityHeadersLayer applies a default set of headers; pick a
+        // representative one to assert the layer ran on this response.
+        assert!(
+            response.header("x-content-type-options").is_some(),
+            "framework security headers must wrap method-override rejections; \
+             observed headers: {:?}",
+            response.headers
+        );
+    }
 }

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -179,6 +179,45 @@ Everything `model` produces, plus:
   API routes (`GET /api/<plural>` and `GET /api/<plural>/{id}`) by default;
   mount `POST`/`PUT`/`DELETE` handlers only after adding a repository policy.
 
+### No-JavaScript edit and delete flows
+
+The scaffolded HTML routes accept ordinary browser form submissions
+because Autumn's [method-override middleware](./middleware.md) rewrites
+a `POST` carrying `_method=PUT|PATCH|DELETE` into the declared method
+**before route matching**. That means you can keep your generated
+handlers as `#[put]` / `#[delete]` and still serve clients with
+JavaScript disabled — no parallel POST-only routes required.
+
+Use [`autumn_web::form::method_input`](../../autumn/src/form.rs)
+(or `ChangesetForm::form_tag` with `"delete"` / `"put"` /
+`"patch"`) inside generated edit views and any custom edit/delete
+buttons you add later:
+
+```rust,ignore
+use autumn_web::form::method_input;
+use autumn_web::security::CsrfToken;
+
+#[get("/bookmarks/{id}/edit")]
+async fn edit_form(id: Path<i64>, csrf: Option<CsrfToken>) -> Markup {
+    html! {
+        // Delete button as a plain HTML form — works without htmx.
+        form method="post" action=(format!("/bookmarks/{}", *id)) {
+            (method_input("DELETE"))
+            @if let Some(token) = csrf.as_ref() {
+                input type="hidden" name="_csrf" value=(token.token());
+            }
+            button type="submit" { "Delete" }
+        }
+    }
+}
+```
+
+`autumn routes` and `/actuator/routes` keep reporting the declared
+method (`PUT`, `PATCH`, or `DELETE`); the rewrite is a transport
+concession, not a routing one. CSRF protection still treats the
+overridden mutation as unsafe and rejects submissions without a valid
+token with `403 Forbidden`.
+
 Metadata flags let you keep common model and repository polish in the
 generation step:
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -777,6 +777,61 @@ The htmx attributes you will use most often:
 The pattern: your handler returns an HTML fragment (not a full page), htmx
 swaps it into the DOM. No JavaScript required.
 
+### Plain HTML forms targeting PUT/PATCH/DELETE
+
+When you want the same edit and delete flows to work with JavaScript
+disabled (or before htmx loads), submit a plain `<form>` and include a
+hidden `_method` field. Autumn rewrites the request to the declared
+HTTP method **before route matching**, so your `#[put]`, `#[patch]`, and
+`#[delete]` handlers stay semantically honest:
+
+```rust,no_run
+use autumn_web::form::method_input;
+use autumn_web::prelude::*;
+use autumn_web::security::CsrfToken;
+
+#[get("/todos/{id}/edit")]
+async fn edit_form(id: Path<i32>, csrf: Option<CsrfToken>) -> Markup {
+    html! {
+        form method="post" action=(format!("/todos/{}", *id)) {
+            // Hidden field. Autumn rewrites this POST to DELETE.
+            (method_input("DELETE"))
+            @if let Some(token) = csrf.as_ref() {
+                input type="hidden" name="_csrf" value=(token.token());
+            }
+            button type="submit" { "Delete" }
+        }
+    }
+}
+```
+
+A few notes:
+
+- The override is honoured only for `POST` requests with
+  `Content-Type: application/x-www-form-urlencoded`. Headers like
+  `X-HTTP-Method-Override` are intentionally not enabled by default.
+- Unknown override values (anything other than `PUT`, `PATCH`, `DELETE`,
+  case-insensitive) reject with `400 Bad Request` before your handler runs.
+- CSRF still treats the transport `POST` as unsafe — an overridden
+  `DELETE` without a valid token returns `403 Forbidden` just like any
+  other mutating POST.
+- `autumn routes` and `/actuator/routes` keep reporting the declared
+  method (`DELETE`, `PUT`, `PATCH`) so route listings, OpenAPI docs, and
+  log filters stay accurate.
+
+If you build the form through `ChangesetForm::form_tag`, just pass the
+declared method and the helper handles the override and CSRF inputs
+for you:
+
+```rust,ignore
+form.form_tag("/todos/42", "delete", html! { button { "Delete" } })
+// Renders: <form method="post" action="/todos/42">
+//            <input type="hidden" name="_method" value="DELETE">
+//            <input type="hidden" name="_csrf" value="...">
+//            <button>Delete</button>
+//          </form>
+```
+
 ---
 
 ## Error Handling

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -810,6 +810,14 @@ A few notes:
 - The override is honoured only for `POST` requests with
   `Content-Type: application/x-www-form-urlencoded`. Headers like
   `X-HTTP-Method-Override` are intentionally not enabled by default.
+- It is also enforced as **same-origin**: the request must carry
+  `Sec-Fetch-Site: same-origin|same-site|none` (sent by every browser
+  since ~2020), or — if `Sec-Fetch-Site` is absent — its `Origin`
+  header must match the `Host` header. Requests that satisfy neither
+  signal are forwarded as the original `POST` so a cross-origin form
+  can never reach a route declared only as `#[delete]`. The
+  `autumn_web::test::TestApp` `form()` helper sets the header
+  automatically.
 - Unknown override values (anything other than `PUT`, `PATCH`, `DELETE`,
   case-insensitive) reject with `400 Bad Request` before your handler runs.
 - CSRF still treats the transport `POST` as unsafe — an overridden

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -811,13 +811,16 @@ A few notes:
   `Content-Type: application/x-www-form-urlencoded`. Headers like
   `X-HTTP-Method-Override` are intentionally not enabled by default.
 - It is also enforced as **same-origin**: the request must carry
-  `Sec-Fetch-Site: same-origin|same-site|none` (sent by every browser
-  since ~2020), or — if `Sec-Fetch-Site` is absent — its `Origin`
-  header must match the `Host` header. Requests that satisfy neither
-  signal are forwarded as the original `POST` so a cross-origin form
-  can never reach a route declared only as `#[delete]`. The
-  `autumn_web::test::TestApp` `form()` helper sets the header
-  automatically.
+  `Sec-Fetch-Site: same-origin` or `none` (sent by every browser
+  since ~2020), or — for `same-site` or when `Sec-Fetch-Site` is
+  absent — its `Origin` header must match the `Host` header. This
+  is stricter than `same-site` alone, because `same-site` accepts
+  sibling subdomains under the same registrable domain (e.g.
+  `evil.example.com` -> `app.example.com`). Requests that don't
+  meet any of these conditions are forwarded as the original `POST`
+  so a cross-origin form can never reach a route declared only as
+  `#[delete]`. The `autumn_web::test::TestApp` `form()` helper sets
+  the header automatically.
 - Unknown override values (anything other than `PUT`, `PATCH`, `DELETE`,
   case-insensitive) reject with `400 Bad Request` before your handler runs.
 - CSRF still treats the transport `POST` as unsafe — an overridden

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -813,14 +813,18 @@ A few notes:
 - It is also enforced as **same-origin**: the request must carry
   `Sec-Fetch-Site: same-origin` or `none` (sent by every browser
   since ~2020), or — for `same-site` or when `Sec-Fetch-Site` is
-  absent — its `Origin` header must match the `Host` header. This
-  is stricter than `same-site` alone, because `same-site` accepts
-  sibling subdomains under the same registrable domain (e.g.
-  `evil.example.com` -> `app.example.com`). Requests that don't
-  meet any of these conditions are forwarded as the original `POST`
-  so a cross-origin form can never reach a route declared only as
-  `#[delete]`. The `autumn_web::test::TestApp` `form()` helper sets
-  the header automatically.
+  absent — its `Origin` header must match the request's scheme,
+  host, and port. This is stricter than `same-site` alone, because
+  `same-site` accepts sibling subdomains under the same registrable
+  domain (e.g. `evil.example.com` -> `app.example.com`). When
+  running behind a TLS-terminating reverse proxy, the scheme is
+  read from `X-Forwarded-Proto` (leftmost client-facing value);
+  the host is read from `X-Forwarded-Host` if surfaced, otherwise
+  from `Host`. Requests that don't meet these conditions are
+  forwarded as the original `POST` so a cross-origin form can
+  never reach a route declared only as `#[delete]`. The
+  `autumn_web::test::TestApp` `form()` helper sets
+  `Sec-Fetch-Site: same-origin` automatically.
 - Unknown override values (anything other than `PUT`, `PATCH`, `DELETE`,
   case-insensitive) reject with `400 Bad Request` before your handler runs.
 - Form-urlencoded bodies larger than 2 MiB are rejected with

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -823,6 +823,10 @@ A few notes:
   the header automatically.
 - Unknown override values (anything other than `PUT`, `PATCH`, `DELETE`,
   case-insensitive) reject with `400 Bad Request` before your handler runs.
+- Form-urlencoded bodies larger than 2 MiB are rejected with
+  `413 Payload Too Large` so an oversized form with `_method=DELETE`
+  isn't silently demoted to a `POST` (body-size-driven semantics).
+  Use `multipart/form-data` for large submissions.
 - CSRF still treats the transport `POST` as unsafe — an overridden
   `DELETE` without a valid token returns `403 Forbidden` just like any
   other mutating POST.

--- a/docs/guide/tutorial/07-htmx.md
+++ b/docs/guide/tutorial/07-htmx.md
@@ -33,6 +33,55 @@ Adding `hx-delete="/todos/{id}"` to the delete button. The server deletes
 the record and returns an empty string. htmx replaces the element with
 nothing, removing it from the page.
 
+### Falling Back to Plain HTML Forms
+
+htmx is the enhancement, not the requirement. Native browser forms can
+only submit `GET` or `POST`, so to reach a `#[delete]` route without
+JavaScript the form submits a hidden `_method` field that Autumn rewrites
+into the declared HTTP method before route matching:
+
+```rust,ignore
+use autumn_web::form::method_input;
+use autumn_web::security::CsrfToken;
+
+#[get("/todos/{id}/edit")]
+async fn edit_form(csrf: CsrfToken) -> Markup {
+    html! {
+        form method="post" action="/todos/42" {
+            (method_input("DELETE"))
+            input type="hidden" name="_csrf" value=(csrf.token());
+            button { "Delete" }
+        }
+    }
+}
+```
+
+A few things to know:
+
+- The override is honoured only on same-origin form submissions
+  (content-type `application/x-www-form-urlencoded`). `X-HTTP-Method-Override`
+  headers are intentionally not enabled by default — the convention is for
+  browser HTML, not REST tunneling.
+- An unrecognised override value (anything other than `PUT`, `PATCH`,
+  `DELETE`, case-insensitive) is rejected with `400 Bad Request` before
+  reaching the handler.
+- CSRF protection still treats the transport `POST` as unsafe. An
+  overridden `DELETE` without a valid `_csrf` token is rejected with
+  `403 Forbidden`, exactly like any other mutating POST.
+- `autumn routes` and `/actuator/routes` continue to list the declared
+  method (`PUT`, `PATCH`, `DELETE`) — route listings stay semantically
+  honest regardless of the transport browsers used.
+
+For `ChangesetForm` users, the bundled `form_tag` helper does this
+automatically when given a non-GET/POST method:
+
+```rust,ignore
+form.form_tag("/todos/42", "delete", html! { button { "Delete" } })
+```
+
+renders `<form method="post">` with the hidden `_method` and `_csrf`
+inputs already in place.
+
 ### Understanding `hx-target` and `hx-swap`
 
 How htmx knows which element to update and how to update it. The `outerHTML`

--- a/examples/todo-app/src/routes/todos.rs
+++ b/examples/todo-app/src/routes/todos.rs
@@ -4,8 +4,9 @@
 //! use htmx attributes for interactive toggle/delete behaviour.
 
 use autumn_web::extract::Path;
-use autumn_web::form::ChangesetForm;
-use autumn_web::prelude::{IntoResponse, StatusCode, Validate};
+use autumn_web::form::{ChangesetForm, method_input};
+use autumn_web::prelude::{HxRequest, IntoResponse, StatusCode, Validate};
+use autumn_web::security::CsrfToken;
 use autumn_web::{AutumnError, AutumnResult, Db, Markup, Redirect, delete, get, html, post};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
@@ -210,12 +211,14 @@ pub async fn list(db: Db) -> AutumnResult<Markup> {
     list_page(db, &blank).await
 }
 
-/// Show a single todo by ID.
-#[get("/todos/{id}")]
-pub async fn detail(id: Path<i64>, mut db: Db) -> AutumnResult<Markup> {
-    let todo = Todo::find(*id, &mut db).await?;
-
-    Ok(layout(
+/// Render the detail page body for a todo.
+///
+/// Extracted so the rendering — including the no-JavaScript delete form —
+/// can be unit-tested without spinning up a database. The `csrf_token`
+/// parameter mirrors what `#[get("/todos/{id}")]` receives in real
+/// requests: `None` when CSRF protection is disabled (e.g. dev profile).
+fn detail_view(todo: &Todo, csrf_token: Option<&str>) -> Markup {
+    layout(
         &format!("Todo: {}", todo.title),
         html! {
             a href=(paths::list())
@@ -242,9 +245,40 @@ pub async fn detail(id: Path<i64>, mut db: Db) -> AutumnResult<Markup> {
                         "Created " (todo.created_at.format("%b %d, %Y at %H:%M"))
                     }
                 }
+
+                form method="post"
+                     action=(paths::delete_todo(todo.id))
+                     class="mt-6 flex items-center gap-3 border-t border-stone-100 pt-4" {
+                    (method_input("DELETE"))
+                    @if let Some(token) = csrf_token {
+                        input type="hidden" name="_csrf" value=(token);
+                    }
+                    button type="submit"
+                           class="text-sm text-red-600 hover:text-red-700 \
+                                  underline-offset-2 hover:underline cursor-pointer" {
+                        "Delete this todo"
+                    }
+                    span class="text-xs text-stone-400" {
+                        "Works without JavaScript"
+                    }
+                }
             }
         },
-    ))
+    )
+}
+
+/// Show a single todo by ID.
+///
+/// The page renders a plain HTML `<form method="post">` carrying a hidden
+/// `_method=DELETE` field as a no-JavaScript fallback alongside the
+/// htmx-driven delete button on the list view. Both paths hit the same
+/// declared `#[delete("/todos/{id}")]` handler — Autumn's method-override
+/// middleware rewrites the transport `POST` to `DELETE` before route
+/// matching.
+#[get("/todos/{id}")]
+pub async fn detail(id: Path<i64>, mut db: Db, csrf: Option<CsrfToken>) -> AutumnResult<Markup> {
+    let todo = Todo::find(*id, &mut db).await?;
+    Ok(detail_view(&todo, csrf.as_ref().map(CsrfToken::token)))
 }
 
 /// Create a new todo from a form submission.
@@ -287,11 +321,21 @@ pub async fn toggle(id: Path<i64>, mut db: Db) -> AutumnResult<Markup> {
     Ok(todo_item(&updated))
 }
 
-/// Delete a todo by ID (htmx endpoint).
+/// Delete a todo by ID.
 ///
-/// Returns an empty string so htmx removes the element from the DOM.
+/// Serves two callers off the same `#[delete]` route:
+/// - htmx button on the list view: returns an empty body so htmx removes
+///   the element from the DOM.
+/// - Plain HTML form (no JavaScript): a `<form method="post">` carrying
+///   `_method=DELETE` is rewritten to `DELETE` by Autumn's method-override
+///   middleware before route matching. The handler redirects back to the
+///   list, which is the no-JS-friendly response.
 #[delete("/todos/{id}")]
-pub async fn delete_todo(id: Path<i64>, mut db: Db) -> AutumnResult<String> {
+pub async fn delete_todo(
+    id: Path<i64>,
+    mut db: Db,
+    hx: HxRequest,
+) -> AutumnResult<impl IntoResponse> {
     let deleted = diesel::delete(todos::table.find(*id))
         .execute(&mut *db)
         .await?;
@@ -303,7 +347,11 @@ pub async fn delete_todo(id: Path<i64>, mut db: Db) -> AutumnResult<String> {
         )));
     }
 
-    Ok(String::new())
+    if hx.is_htmx {
+        Ok(String::new().into_response())
+    } else {
+        Ok(Redirect::to(&paths::list()).into_response())
+    }
 }
 
 autumn_web::paths![index, list, detail, create, toggle, delete_todo];
@@ -395,6 +443,40 @@ mod tests {
         let html = new_todo_form(&form).into_string();
         assert!(html.contains(r#"aria-invalid="false""#));
         assert!(html.contains(r#"value="Buy milk""#));
+    }
+
+    /// Detail-page renders a plain `<form method="post">` that targets
+    /// the declared `#[delete]` route via the `_method` override field.
+    /// This is the no-JavaScript delete path alongside the htmx-driven
+    /// delete on the list view.
+    #[test]
+    fn detail_view_renders_no_js_delete_form() {
+        let todo = Todo {
+            id: 42,
+            title: "Write docs".into(),
+            completed: false,
+            created_at: chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc(),
+        };
+        let html = detail_view(&todo, Some("csrf-tok-xyz")).into_string();
+        assert!(html.contains(r#"method="post""#), "{html}");
+        assert!(html.contains(r#"action="/todos/42""#), "{html}");
+        assert!(html.contains(r#"name="_method""#), "{html}");
+        assert!(html.contains(r#"value="DELETE""#), "{html}");
+        assert!(html.contains(r#"value="csrf-tok-xyz""#), "{html}");
+        assert!(html.contains("Delete this todo"), "{html}");
+    }
+
+    #[test]
+    fn detail_view_omits_csrf_input_when_token_absent() {
+        let todo = Todo {
+            id: 7,
+            title: "No csrf".into(),
+            completed: true,
+            created_at: chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc(),
+        };
+        let html = detail_view(&todo, None).into_string();
+        assert!(html.contains(r#"name="_method""#), "{html}");
+        assert!(!html.contains(r#"name="_csrf""#), "{html}");
     }
 }
 


### PR DESCRIPTION
## Summary

Implements HTML form method-override middleware that allows plain browser `<form method="post">` submissions to target `PUT`, `PATCH`, and `DELETE` routes by carrying a hidden `_method` form field. This enables no-JavaScript fallbacks for edit and delete flows while keeping route handlers semantically honest with their declared HTTP methods.

## Key Changes

- **New middleware module** (`autumn/src/middleware/method_override.rs`):
  - `MethodOverrideLayer` and `MethodOverrideService` that intercept `POST` requests with `application/x-www-form-urlencoded` bodies
  - Parses the `_method` form field (default, configurable) and rewrites the request method to `PUT`, `PATCH`, or `DELETE` before route matching
  - Rejects unrecognized override values with `400 Bad Request`
  - Preserves the request body unchanged so downstream extractors (including CSRF validation) work correctly
  - Inserts `OverriddenMethod` extension for logging/instrumentation
  - Comprehensive test coverage including CSRF interaction

- **Form helper updates** (`autumn/src/form.rs`):
  - `form_tag_inner` now emits hidden `<input name="_method">` fields when the declared method is `PUT`, `PATCH`, or `DELETE`
  - New `browser_method_and_override()` function translates declared methods to transport method + override value
  - New public `method_input()` helper to render the hidden field for manual form construction
  - Tests verify correct override field emission and no-override for safe methods

- **Integration into app builder** (`autumn/src/app.rs`):
  - Wraps the router with `MethodOverrideLayer` at the outermost edge (before route matching)
  - Positioned outside path/method routing so overridden requests reach the correct handler

- **Test infrastructure** (`autumn/src/test.rs`):
  - `RequestBuilder` now applies `MethodOverrideLayer` to the router, enabling end-to-end testing of method-override flows
  - New acceptance tests verify HTML form submissions with `_method=DELETE` reach declared DELETE handlers
  - Tests confirm invalid override values are rejected with 400

- **Documentation updates**:
  - Getting started guide explains the pattern with examples
  - Tutorial section on falling back to plain HTML forms
  - Generator guide documents no-JavaScript edit/delete flows
  - Comprehensive module-level docs with failure modes and CSRF interaction details

- **Example app** (`examples/todo-app/src/routes/todos.rs`):
  - Detail page now renders a plain HTML delete form with `_method=DELETE` as a no-JS fallback
  - `delete_todo` handler distinguishes between htmx and form submissions, returning appropriate responses
  - Extracted `detail_view()` for testability

## Notable Implementation Details

- The override only acts on `POST` requests with form-style content-type; headers like `X-HTTP-Method-Override` are intentionally not honored (browser HTML forms only)
- Body is buffered and restored unchanged, preserving it for handler extractors and CSRF validation
- CSRF layer wraps the middleware on the outside, so CSRF still validates the original `POST` — overridden mutations without valid tokens are rejected with `403 Forbidden`
- Route listings (`autumn routes`, `/actuator/routes`) continue reporting the declared method, not the transport method, keeping metadata semantically honest
- Case-insensitive override value parsing with whitespace trimming
- 2 MiB body scan limit mirrors CSRF middleware's form-peeking cap

https://claude.ai/code/session_01SeUz3r5bT9ho44FmMbE5TQ