### PR TITLE
🤖 Sentinel: [Closed test gaps in db.rs and htmx.rs]

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -519,6 +519,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn default_pool_provider_create_pool_succeeds_on_config() {
+        // create_pool simply parses the configuration without actively
+        // establishing a connection.
+        let provider = DieselDeadpoolPoolProvider;
+        let config = DatabaseConfig {
+            url: Some("invalid_url_format".into()),
+            ..Default::default()
+        };
+        let pool = provider.create_pool(&config).await.unwrap();
+        assert!(pool.is_some());
+    }
+
+    #[tokio::test]
+    async fn free_function_create_pool_succeeds_on_config() {
+        // create_pool simply parses the configuration without actively
+        // establishing a connection.
+        let config = DatabaseConfig {
+            url: Some("invalid_url_format".into()),
+            ..Default::default()
+        };
+        let pool = create_pool(&config).unwrap();
+        assert!(pool.is_some());
+    }
+    #[tokio::test]
     async fn pool_provider_trait_returns_supplied_pool() {
         // Even with a configured URL, the no-op provider returns None — proving
         // the trait can replace the default factory's behaviour.
@@ -704,6 +728,34 @@ mod tests {
         assert_eq!(state.read_pool().expect("read pool").status().max_size, 3);
     }
 
+    struct DummyState2(Pool<AsyncPgConnection>);
+    impl DbState for DummyState2 {
+        fn pool(&self) -> Option<&Pool<AsyncPgConnection>> {
+            Some(&self.0)
+        }
+    }
+
+    #[tokio::test]
+    async fn db_extractor_extracts_pool_from_state() {
+        let mut parts = axum::http::Request::builder()
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+
+        let config = DatabaseConfig {
+            url: Some("postgres://test".into()),
+            ..Default::default()
+        };
+        let pool = create_pool(&config).unwrap().unwrap();
+
+        let state2 = DummyState2(pool);
+        let err = Db::from_request_parts(&mut parts, &state2)
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), axum::http::StatusCode::SERVICE_UNAVAILABLE);
+    }
     #[tokio::test]
     async fn db_extractor_rejects_when_no_pool() {
         use axum::Router;

--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -294,6 +294,14 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn hx_response_ext_empty_values_are_valid() {
+        use axum::response::IntoResponse;
+
+        let response = "hello".hx_location("").into_response();
+        let headers = response.headers();
+        assert_eq!(headers.get("hx-location").unwrap(), "");
+    }
+    #[tokio::test]
     async fn hx_response_ext_ignores_invalid_header_values() {
         use axum::response::IntoResponse;
 
@@ -328,6 +336,24 @@ mod tests {
         assert!(headers.get("hx-trigger-after-swap").is_none());
     }
 
+    #[tokio::test]
+    async fn hx_request_extractor_handles_false_headers() -> Result<(), axum::http::Error> {
+        let req = Request::builder()
+            .header("hx-request", "false")
+            .header("hx-history-restore-request", "false")
+            .header("hx-boosted", "false")
+            .body(())?;
+        let (mut parts, ()) = req.into_parts();
+
+        let hx = HxRequest::from_request_parts(&mut parts, &())
+            .await
+            .expect("infallible");
+
+        assert!(!hx.is_htmx);
+        assert!(!hx.history_restore_request);
+        assert!(!hx.boosted);
+        Ok(())
+    }
     #[tokio::test]
     async fn hx_request_extractor_handles_missing_headers() -> Result<(), axum::http::Error> {
         let req = Request::builder().body(())?;


### PR DESCRIPTION
🦠 **Mutants Found:**
Surviving mutants were found in `htmx.rs` related to boolean header parsing (`hx-request`, etc) and empty string header insertion.
Surviving mutants were also found in `db.rs` related to the `Db::from_request_parts` extraction process and `create_pool` behaviors.

🎯 **Tests Added/Strengthened:**
- Added `hx_request_extractor_handles_false_headers` to verify `htmx` boolean header extractors appropriately handle literal `"false"` strings by turning the struct fields false.
- Added `hx_response_ext_empty_values_are_valid` to ensure empty strings are correctly set as headers and not stripped by `append_hx_header`.
- Added `db_extractor_extracts_pool_from_state` in `db.rs` to verify that `Db::from_request_parts` extracts the database pool from the active `DbState` instead of using `Default::default()`. We verify this by ensuring it returns a connection acquisition error, proving it retrieved the configured pool properly.
- Added `default_pool_provider_create_pool_succeeds_on_config` to verify that `DieselDeadpoolPoolProvider::create_pool` succeeds in instantiating deadpool connection managers even with invalid URLs since we don't connect immediately.
- Added `free_function_create_pool_succeeds_on_config` to verify `create_pool` error behavior matching that.

⚠️ **Suspected Bugs:**
None.

📊 **Kill Rate:**
The added tests eliminate mutants in `Db::from_request_parts` in `db.rs` and HTMX extension methods.

🔗 **Havoc Interaction:**
None.

---
*PR created automatically by Jules for task [13765657583083440458](https://jules.google.com/task/13765657583083440458) started by @madmax983*