### PR TITLE
Add migration safety preflight check with SQL pattern analysis

### DIFF
--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -177,10 +177,21 @@ fn split_on_keyword(s: &str, keyword: &str) -> Option<(String, String)> {
 }
 
 /// SQL for adding columns to a table.
+///
+/// Prepends an `autumn-safety` comment for `NOT NULL` columns that have no
+/// `DEFAULT` — those require a backfill or a default before the constraint can
+/// be added safely on a live table.
 #[must_use]
 pub fn add_columns_up_sql(table: &str, fields: &[Field]) -> String {
     let mut out = String::new();
     for f in fields {
+        if !f.nullable {
+            let _ = writeln!(
+                out,
+                "-- autumn-safety: potentially-blocking \
+                 -- add a DEFAULT or backfill existing rows before enforcing NOT NULL"
+            );
+        }
         let _ = writeln!(
             out,
             "ALTER TABLE {table} ADD COLUMN {} {} {};",
@@ -203,10 +214,20 @@ pub fn add_columns_down_sql(table: &str, fields: &[Field]) -> String {
 }
 
 /// SQL for removing columns from a table.
+///
+/// Prepends an `autumn-safety` comment for each `DROP COLUMN` to make the
+/// rolling-deploy risk visible at a glance and machine-parseable by
+/// `autumn migrate check`.
 #[must_use]
 pub fn remove_columns_up_sql(table: &str, fields: &[Field]) -> String {
     let mut out = String::new();
     for f in fields {
+        let _ = writeln!(
+            out,
+            "-- autumn-safety: destructive \
+             -- old replicas that reference this column will fail until restarted; \
+             use expand/contract"
+        );
         let _ = writeln!(out, "ALTER TABLE {table} DROP COLUMN {};", f.name);
     }
     out

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -565,6 +565,37 @@ mod tests {
     }
 
     #[test]
+    fn add_columns_up_sql_includes_safety_comment_for_not_null() {
+        let f = fields(&["title:String"]);
+        let sql = add_columns_up_sql("posts", &f);
+        assert!(
+            sql.contains("autumn-safety: potentially-blocking"),
+            "NOT NULL column must carry a safety comment; got:\n{sql}"
+        );
+    }
+
+    #[test]
+    fn add_columns_up_sql_no_safety_comment_for_nullable() {
+        let f = fields(&["subtitle:Option<String>"]);
+        let sql = add_columns_up_sql("posts", &f);
+        assert!(
+            !sql.contains("autumn-safety"),
+            "nullable column must NOT carry a safety comment; got:\n{sql}"
+        );
+    }
+
+    #[test]
+    fn remove_columns_up_sql_includes_safety_comment() {
+        let f = fields(&["body:String"]);
+        let sql = remove_columns_up_sql("posts", &f);
+        assert!(
+            sql.contains("autumn-safety: destructive"),
+            "DROP COLUMN must carry a safety comment; got:\n{sql}"
+        );
+        assert!(sql.contains("ALTER TABLE posts DROP COLUMN body;"));
+    }
+
+    #[test]
     fn add_columns_down_sql_drops_in_reverse() {
         let f = fields(&["title:String", "count:i32"]);
         let sql = add_columns_down_sql("posts", &f);

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -295,6 +295,23 @@ enum Commands {
 enum MigrateCommands {
     /// Show migration status (applied and pending)
     Status,
+    /// Run a production-safety preflight check on all migration SQL files.
+    ///
+    /// Classifies every `up.sql` in the migrations directory into one of:
+    /// safe, potentially-blocking, destructive, irreversible, data-backfill,
+    /// or manual-review-required.
+    ///
+    /// Exits with code 0 when all migrations are safe for a rolling deploy.
+    /// Exits with code 1 and prints a detailed report when any unsafe or
+    /// unclassified operations are detected.
+    ///
+    /// Does not require a database connection — safe to run in CI before deploy.
+    ///
+    /// # Example
+    ///
+    ///   autumn migrate check
+    #[command(verbatim_doc_comment)]
+    Check,
 }
 
 /// Subcommands for `autumn token`.
@@ -508,6 +525,7 @@ fn run_command(command: Commands) {
         Commands::Migrate { action } => {
             let action = match action {
                 Some(MigrateCommands::Status) => migrate::MigrateAction::Status,
+                Some(MigrateCommands::Check) => migrate::MigrateAction::Check,
                 None => migrate::MigrateAction::Run,
             };
             migrate::run(action);
@@ -969,6 +987,23 @@ mod tests {
                 action: Some(MigrateCommands::Status)
             }
         ));
+    }
+
+    #[test]
+    fn parse_migrate_check() {
+        let cli = Cli::try_parse_from(["autumn", "migrate", "check"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Migrate {
+                action: Some(MigrateCommands::Check)
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_migrate_no_subcommand_runs_migrations() {
+        let cli = Cli::try_parse_from(["autumn", "migrate"]).unwrap();
+        assert!(matches!(cli.command, Commands::Migrate { action: None }));
     }
 
     #[test]

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -183,11 +183,11 @@ fn check_concurrent_index_transaction_opt_out(
 
     if !opted_out {
         findings.push(safety::SafetyFinding {
-            operation: "CREATE INDEX CONCURRENTLY (missing transaction opt-out)".to_owned(),
+            operation: "CONCURRENTLY index operation (missing transaction opt-out)".to_owned(),
             risk: safety::RiskLevel::PotentiallyBlocking,
-            why: "PostgreSQL rejects CONCURRENTLY inside a transaction block. Diesel wraps \
-                  migrations in a transaction by default, so this migration will fail at \
-                  deploy time unless the transaction is disabled.",
+            why: "`PostgreSQL` rejects `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` \
+                  inside a transaction block. Diesel wraps migrations in a transaction by default, \
+                  so this migration will fail at deploy time unless the transaction is disabled.",
             next_action: "Add `run_in_transaction = false` to the migration's `metadata.toml` \
                           (create the file if absent). Example: \
                           echo 'run_in_transaction = false' > migrations/<name>/metadata.toml",
@@ -885,6 +885,24 @@ replica_url = "postgres://replica:5432/app"
                 .iter()
                 .any(|f| f.operation.contains("CONCURRENTLY")),
             "missing metadata.toml should produce a CONCURRENTLY finding"
+        );
+    }
+
+    #[test]
+    fn drop_index_concurrently_without_metadata_toml_is_flagged() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migration_dir = tmp.path().join("20260104000000_drop_index");
+        std::fs::create_dir_all(&migration_dir).unwrap();
+
+        let sql = "DROP INDEX CONCURRENTLY idx_posts_title;";
+        let mut findings = Vec::new();
+        check_concurrent_index_transaction_opt_out(sql, &migration_dir, &mut findings);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, safety::RiskLevel::PotentiallyBlocking);
+        assert!(
+            findings[0].operation.contains("CONCURRENTLY"),
+            "finding should mention CONCURRENTLY"
         );
     }
 

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -103,7 +103,9 @@ fn run_safety_check(migrations_dir: &str) {
         }
     }
 
-    let any_unsafe = reports.iter().any(|(_, findings)| safety::has_unsafe_findings(findings));
+    let any_unsafe = reports
+        .iter()
+        .any(|(_, findings)| safety::has_unsafe_findings(findings));
 
     eprintln!();
     if any_unsafe {
@@ -111,12 +113,8 @@ fn run_safety_check(migrations_dir: &str) {
             "\u{2717} One or more migrations contain operations that are unsafe for a live \
              rolling deploy."
         );
-        eprintln!(
-            "  Review the findings above, apply the expand/contract pattern where needed,"
-        );
-        eprintln!(
-            "  or coordinate a maintenance window before deploying these migrations."
-        );
+        eprintln!("  Review the findings above, apply the expand/contract pattern where needed,");
+        eprintln!("  or coordinate a maintenance window before deploying these migrations.");
         std::process::exit(1);
     } else {
         eprintln!("\u{2713} All {total} migration(s) are safe for a rolling deploy.");
@@ -423,7 +421,10 @@ mod tests {
         assert_eq!(results.len(), 1);
         let (name, findings) = &results[0];
         assert_eq!(name, "20260101000000_create_posts");
-        assert!(findings.is_empty(), "CREATE TABLE should produce no findings");
+        assert!(
+            findings.is_empty(),
+            "CREATE TABLE should produce no findings"
+        );
     }
 
     #[test]
@@ -453,7 +454,11 @@ mod tests {
         let names: Vec<_> = results.iter().map(|(n, _)| n.as_str()).collect();
         assert_eq!(
             names,
-            vec!["20260101000000_first", "20260102000000_second", "20260103000000_third"]
+            vec![
+                "20260101000000_first",
+                "20260102000000_second",
+                "20260103000000_third"
+            ]
         );
     }
 
@@ -485,7 +490,10 @@ mod tests {
         let results = check_migrations_in_dir(tmp.path()).unwrap();
         assert_eq!(results.len(), 2);
         assert!(results[0].1.is_empty(), "first migration should be safe");
-        assert!(!results[1].1.is_empty(), "second migration should have findings");
+        assert!(
+            !results[1].1.is_empty(),
+            "second migration should have findings"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -13,6 +13,8 @@
 //! migrations (via `.migrations()` on `AppBuilder`). This CLI command
 //! is a convenience wrapper for explicit migration management.
 
+pub mod safety;
+
 use std::path::Path;
 use std::process::Command;
 
@@ -29,11 +31,34 @@ pub enum MigrateAction {
     Run,
     /// Show migration status (pending / applied).
     Status,
+    /// Preflight safety check — classifies all migration SQL files and returns
+    /// a non-zero exit code if any unsafe or unclassified operations are found.
+    Check,
+}
+
+/// Read every migration directory in `dir`, classify its `up.sql`, and return
+/// a sorted list of `(migration_name, findings)` pairs.
+///
+/// Migration directories that have no `up.sql` are silently skipped.
+/// TODO(red): stub — always returns empty; implement in green phase
+pub fn check_migrations_in_dir(
+    _dir: &Path,
+) -> Result<Vec<(String, Vec<safety::SafetyFinding>)>, String> {
+    Ok(vec![])
 }
 
 /// Run the migrate command.
 pub fn run(action: MigrateAction) {
     eprintln!("\u{1F342} autumn migrate\n");
+
+    match action {
+        MigrateAction::Check => {
+            let migrations_dir = resolve_migrations_dir();
+            run_safety_check(&migrations_dir);
+            return;
+        }
+        _ => {}
+    }
 
     // 1. Resolve database URL from autumn.toml + env
     let database_url = resolve_database_url();
@@ -54,7 +79,12 @@ pub fn run(action: MigrateAction) {
             show_status(&database_url, &migrations_dir);
             show_framework_status(&database_url);
         }
+        MigrateAction::Check => unreachable!("handled above"),
     }
+}
+
+fn run_safety_check(_migrations_dir: &str) {
+    eprintln!("  TODO: implement safety check in green phase");
 }
 
 /// Resolve the primary/write database URL from autumn.toml and environment variables.
@@ -291,7 +321,118 @@ mod tests {
     fn migrate_action_eq() {
         assert_eq!(MigrateAction::Run, MigrateAction::Run);
         assert_eq!(MigrateAction::Status, MigrateAction::Status);
+        assert_eq!(MigrateAction::Check, MigrateAction::Check);
         assert_ne!(MigrateAction::Run, MigrateAction::Status);
+        assert_ne!(MigrateAction::Run, MigrateAction::Check);
+    }
+
+    // ── check_migrations_in_dir ────────────────────────────────────────────
+
+    fn write_migration(dir: &std::path::Path, name: &str, up_sql: &str) {
+        let migration_dir = dir.join(name);
+        std::fs::create_dir_all(&migration_dir).unwrap();
+        std::fs::write(migration_dir.join("up.sql"), up_sql).unwrap();
+        std::fs::write(migration_dir.join("down.sql"), "").unwrap();
+    }
+
+    #[test]
+    fn check_empty_migrations_dir_returns_empty() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let results = check_migrations_in_dir(tmp.path()).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn check_safe_migration_produces_no_findings() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        write_migration(
+            tmp.path(),
+            "20260101000000_create_posts",
+            "CREATE TABLE posts (id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL);",
+        );
+
+        let results = check_migrations_in_dir(tmp.path()).unwrap();
+        assert_eq!(results.len(), 1);
+        let (name, findings) = &results[0];
+        assert_eq!(name, "20260101000000_create_posts");
+        assert!(findings.is_empty(), "CREATE TABLE should produce no findings");
+    }
+
+    #[test]
+    fn check_destructive_migration_produces_findings() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        write_migration(
+            tmp.path(),
+            "20260102000000_remove_body_from_posts",
+            "ALTER TABLE posts DROP COLUMN body;",
+        );
+
+        let results = check_migrations_in_dir(tmp.path()).unwrap();
+        assert_eq!(results.len(), 1);
+        let (_, findings) = &results[0];
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, safety::RiskLevel::Destructive);
+    }
+
+    #[test]
+    fn check_results_are_sorted_by_migration_name() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        write_migration(tmp.path(), "20260103000000_third", "SELECT 1;");
+        write_migration(tmp.path(), "20260101000000_first", "SELECT 1;");
+        write_migration(tmp.path(), "20260102000000_second", "SELECT 1;");
+
+        let results = check_migrations_in_dir(tmp.path()).unwrap();
+        let names: Vec<_> = results.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["20260101000000_first", "20260102000000_second", "20260103000000_third"]
+        );
+    }
+
+    #[test]
+    fn check_directories_without_up_sql_are_skipped() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join("incomplete_migration")).unwrap();
+        write_migration(tmp.path(), "20260101000000_valid", "SELECT 1;");
+
+        let results = check_migrations_in_dir(tmp.path()).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "20260101000000_valid");
+    }
+
+    #[test]
+    fn check_multiple_migrations_reports_each() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        write_migration(
+            tmp.path(),
+            "20260101000000_create_posts",
+            "CREATE TABLE posts (id BIGSERIAL PRIMARY KEY);",
+        );
+        write_migration(
+            tmp.path(),
+            "20260102000000_remove_body",
+            "ALTER TABLE posts DROP COLUMN body;",
+        );
+
+        let results = check_migrations_in_dir(tmp.path()).unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(results[0].1.is_empty(), "first migration should be safe");
+        assert!(!results[1].1.is_empty(), "second migration should have findings");
+    }
+
+    #[test]
+    fn check_non_concurrent_index_is_flagged() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        write_migration(
+            tmp.path(),
+            "20260103000000_add_index",
+            "CREATE INDEX idx_posts_title ON posts (title);",
+        );
+
+        let results = check_migrations_in_dir(tmp.path()).unwrap();
+        let (_, findings) = &results[0];
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, safety::RiskLevel::PotentiallyBlocking);
     }
 
     #[test]

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -177,8 +177,14 @@ fn check_concurrent_index_transaction_opt_out(
 
     let metadata_path = migration_dir.join("metadata.toml");
     let opted_out = std::fs::read_to_string(&metadata_path)
-        .map(|content| content.contains("run_in_transaction = false"))
-        .unwrap_or(false);
+        .ok()
+        .and_then(|content| toml::from_str::<toml::Table>(&content).ok())
+        .and_then(|table| {
+            table
+                .get("run_in_transaction")
+                .and_then(toml::Value::as_bool)
+        })
+        .is_some_and(|v| !v);
 
     if !opted_out {
         findings.push(safety::SafetyFinding {
@@ -732,6 +738,50 @@ replica_url = "postgres://replica:5432/app"
             findings.is_empty(),
             "correctly opted-out CONCURRENTLY should produce no additional findings"
         );
+    }
+
+    #[test]
+    fn concurrent_index_with_run_in_transaction_false_no_spaces_is_not_flagged() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migration_dir = tmp.path().join("20260104000000_add_index");
+        std::fs::create_dir_all(&migration_dir).unwrap();
+        std::fs::write(
+            migration_dir.join("metadata.toml"),
+            "run_in_transaction=false\n",
+        )
+        .unwrap();
+
+        let sql = "CREATE INDEX CONCURRENTLY idx_posts_title ON posts (title);";
+        let mut findings = Vec::new();
+        check_concurrent_index_transaction_opt_out(sql, &migration_dir, &mut findings);
+
+        assert!(
+            findings.is_empty(),
+            "TOML `run_in_transaction=false` (no spaces) should also suppress the finding"
+        );
+    }
+
+    #[test]
+    fn concurrent_index_with_commented_out_flag_is_flagged() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migration_dir = tmp.path().join("20260104000000_add_index");
+        std::fs::create_dir_all(&migration_dir).unwrap();
+        std::fs::write(
+            migration_dir.join("metadata.toml"),
+            "# run_in_transaction = false\n",
+        )
+        .unwrap();
+
+        let sql = "CREATE INDEX CONCURRENTLY idx_posts_title ON posts (title);";
+        let mut findings = Vec::new();
+        check_concurrent_index_transaction_opt_out(sql, &migration_dir, &mut findings);
+
+        assert_eq!(
+            findings.len(),
+            1,
+            "a commented-out opt-out should NOT suppress the finding"
+        );
+        assert_eq!(findings[0].risk, safety::RiskLevel::PotentiallyBlocking);
     }
 
     #[test]

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -166,12 +166,7 @@ fn check_concurrent_index_transaction_opt_out(
     migration_dir: &Path,
     findings: &mut Vec<safety::SafetyFinding>,
 ) {
-    let lower = sql.to_lowercase();
-    // Collapse whitespace so multi-line statements like `CREATE INDEX\n  CONCURRENTLY` match.
-    let normalized = lower.split_whitespace().collect::<Vec<_>>().join(" ");
-    let uses_concurrently = normalized.contains("create index concurrently")
-        || normalized.contains("create unique index concurrently");
-    if !uses_concurrently {
+    if !safety::contains_concurrent_index(sql) {
         return;
     }
 
@@ -816,6 +811,25 @@ replica_url = "postgres://replica:5432/app"
         assert!(
             findings.is_empty(),
             "non-CONCURRENTLY index should not be flagged by opt-out check"
+        );
+    }
+
+    #[test]
+    fn concurrent_index_in_sql_comment_is_not_flagged() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migration_dir = tmp.path().join("20260104000000_add_index");
+        std::fs::create_dir_all(&migration_dir).unwrap();
+
+        // The concurrent index is only mentioned in a comment; the actual
+        // statement is a plain (non-concurrent) CREATE INDEX.
+        let sql = "-- TODO: switch to CREATE INDEX CONCURRENTLY once traffic drops\n\
+                   CREATE INDEX idx_posts_title ON posts (title);";
+        let mut findings = Vec::new();
+        check_concurrent_index_transaction_opt_out(sql, &migration_dir, &mut findings);
+
+        assert!(
+            findings.is_empty(),
+            "a CONCURRENTLY reference inside a SQL comment must not trigger the opt-out check"
         );
     }
 

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -146,11 +146,50 @@ pub fn check_migrations_in_dir(
         }
         let sql = std::fs::read_to_string(&up_sql_path)
             .map_err(|e| format!("cannot read {}: {e}", up_sql_path.display()))?;
-        let findings = safety::classify_sql(&sql);
+        let mut findings = safety::classify_sql(&sql);
+        check_concurrent_index_transaction_opt_out(&sql, &entry.path(), &mut findings);
         results.push((migration_name, findings));
     }
 
     Ok(results)
+}
+
+/// If the SQL uses `CREATE INDEX CONCURRENTLY` but the migration directory does not
+/// opt out of Diesel's default transaction wrapping via `metadata.toml`, add a
+/// `PotentiallyBlocking` finding.
+///
+/// `PostgreSQL` rejects `CREATE INDEX CONCURRENTLY` inside a transaction block.
+/// Without `run_in_transaction = false` in `metadata.toml`, Diesel wraps the
+/// migration in a transaction and the deployment job will fail.
+fn check_concurrent_index_transaction_opt_out(
+    sql: &str,
+    migration_dir: &Path,
+    findings: &mut Vec<safety::SafetyFinding>,
+) {
+    let lower = sql.to_lowercase();
+    let uses_concurrently = lower.contains("create index concurrently")
+        || lower.contains("create unique index concurrently");
+    if !uses_concurrently {
+        return;
+    }
+
+    let metadata_path = migration_dir.join("metadata.toml");
+    let opted_out = std::fs::read_to_string(&metadata_path)
+        .map(|content| content.contains("run_in_transaction = false"))
+        .unwrap_or(false);
+
+    if !opted_out {
+        findings.push(safety::SafetyFinding {
+            operation: "CREATE INDEX CONCURRENTLY (missing transaction opt-out)".to_owned(),
+            risk: safety::RiskLevel::PotentiallyBlocking,
+            why: "PostgreSQL rejects CONCURRENTLY inside a transaction block. Diesel wraps \
+                  migrations in a transaction by default, so this migration will fail at \
+                  deploy time unless the transaction is disabled.",
+            next_action: "Add `run_in_transaction = false` to the migration's `metadata.toml` \
+                          (create the file if absent). Example: \
+                          echo 'run_in_transaction = false' > migrations/<name>/metadata.toml",
+        });
+    }
 }
 
 /// Resolve the primary/write database URL from autumn.toml and environment variables.
@@ -644,5 +683,152 @@ replica_url = "postgres://replica:5432/app"
         let url = resolve_primary_database_url_from_sources(env_var, Some(&table)).unwrap();
 
         assert_eq!(url, "postgres://primary:5432/app");
+    }
+
+    // ── check_concurrent_index_transaction_opt_out ────────────────────────
+
+    #[test]
+    fn concurrent_index_without_metadata_toml_is_flagged() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migration_dir = tmp.path().join("20260104000000_add_index");
+        std::fs::create_dir_all(&migration_dir).unwrap();
+
+        let sql = "CREATE INDEX CONCURRENTLY idx_posts_title ON posts (title);";
+        let mut findings = Vec::new();
+        check_concurrent_index_transaction_opt_out(sql, &migration_dir, &mut findings);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, safety::RiskLevel::PotentiallyBlocking);
+        assert!(
+            findings[0].operation.contains("CONCURRENTLY"),
+            "finding should mention CONCURRENTLY"
+        );
+        assert!(
+            findings[0]
+                .next_action
+                .contains("run_in_transaction = false"),
+            "next_action should guide user to metadata.toml"
+        );
+    }
+
+    #[test]
+    fn concurrent_index_with_run_in_transaction_false_is_not_flagged() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migration_dir = tmp.path().join("20260104000000_add_index");
+        std::fs::create_dir_all(&migration_dir).unwrap();
+        std::fs::write(
+            migration_dir.join("metadata.toml"),
+            "run_in_transaction = false\n",
+        )
+        .unwrap();
+
+        let sql = "CREATE INDEX CONCURRENTLY idx_posts_title ON posts (title);";
+        let mut findings = Vec::new();
+        check_concurrent_index_transaction_opt_out(sql, &migration_dir, &mut findings);
+
+        assert!(
+            findings.is_empty(),
+            "correctly opted-out CONCURRENTLY should produce no additional findings"
+        );
+    }
+
+    #[test]
+    fn concurrent_index_with_metadata_toml_missing_flag_is_flagged() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migration_dir = tmp.path().join("20260104000000_add_index");
+        std::fs::create_dir_all(&migration_dir).unwrap();
+        std::fs::write(
+            migration_dir.join("metadata.toml"),
+            "# Diesel migration metadata\n",
+        )
+        .unwrap();
+
+        let sql = "CREATE INDEX CONCURRENTLY idx_posts_title ON posts (title);";
+        let mut findings = Vec::new();
+        check_concurrent_index_transaction_opt_out(sql, &migration_dir, &mut findings);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, safety::RiskLevel::PotentiallyBlocking);
+    }
+
+    #[test]
+    fn non_concurrent_index_is_not_flagged_by_opt_out_check() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migration_dir = tmp.path().join("20260104000000_add_index");
+        std::fs::create_dir_all(&migration_dir).unwrap();
+
+        let sql = "CREATE INDEX idx_posts_title ON posts (title);";
+        let mut findings = Vec::new();
+        check_concurrent_index_transaction_opt_out(sql, &migration_dir, &mut findings);
+
+        assert!(
+            findings.is_empty(),
+            "non-CONCURRENTLY index should not be flagged by opt-out check"
+        );
+    }
+
+    #[test]
+    fn concurrent_unique_index_without_metadata_toml_is_flagged() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migration_dir = tmp.path().join("20260104000000_add_unique_index");
+        std::fs::create_dir_all(&migration_dir).unwrap();
+
+        let sql = "CREATE UNIQUE INDEX CONCURRENTLY idx_posts_slug ON posts (slug);";
+        let mut findings = Vec::new();
+        check_concurrent_index_transaction_opt_out(sql, &migration_dir, &mut findings);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, safety::RiskLevel::PotentiallyBlocking);
+    }
+
+    #[test]
+    fn check_migrations_in_dir_flags_concurrent_index_without_metadata() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migration_dir = tmp.path().join("20260104000000_add_index");
+        std::fs::create_dir_all(&migration_dir).unwrap();
+        std::fs::write(
+            migration_dir.join("up.sql"),
+            "CREATE INDEX CONCURRENTLY idx_posts_title ON posts (title);",
+        )
+        .unwrap();
+        std::fs::write(migration_dir.join("down.sql"), "").unwrap();
+
+        let results = check_migrations_in_dir(tmp.path()).unwrap();
+        assert_eq!(results.len(), 1);
+        let (_, findings) = &results[0];
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.operation.contains("CONCURRENTLY")),
+            "missing metadata.toml should produce a CONCURRENTLY finding"
+        );
+    }
+
+    #[test]
+    fn check_migrations_in_dir_concurrent_index_with_metadata_is_safe() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migration_dir = tmp.path().join("20260104000000_add_index");
+        std::fs::create_dir_all(&migration_dir).unwrap();
+        std::fs::write(
+            migration_dir.join("up.sql"),
+            "CREATE INDEX CONCURRENTLY idx_posts_title ON posts (title);",
+        )
+        .unwrap();
+        std::fs::write(migration_dir.join("down.sql"), "").unwrap();
+        std::fs::write(
+            migration_dir.join("metadata.toml"),
+            "run_in_transaction = false\n",
+        )
+        .unwrap();
+
+        let results = check_migrations_in_dir(tmp.path()).unwrap();
+        assert_eq!(results.len(), 1);
+        let (_, findings) = &results[0];
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.operation.contains("CONCURRENTLY")),
+            "opted-out CONCURRENTLY should not produce a transaction opt-out finding"
+        );
     }
 }

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -36,17 +36,6 @@ pub enum MigrateAction {
     Check,
 }
 
-/// Read every migration directory in `dir`, classify its `up.sql`, and return
-/// a sorted list of `(migration_name, findings)` pairs.
-///
-/// Migration directories that have no `up.sql` are silently skipped.
-/// TODO(red): stub — always returns empty; implement in green phase
-pub fn check_migrations_in_dir(
-    _dir: &Path,
-) -> Result<Vec<(String, Vec<safety::SafetyFinding>)>, String> {
-    Ok(vec![])
-}
-
 /// Run the migrate command.
 pub fn run(action: MigrateAction) {
     eprintln!("\u{1F342} autumn migrate\n");
@@ -83,8 +72,90 @@ pub fn run(action: MigrateAction) {
     }
 }
 
-fn run_safety_check(_migrations_dir: &str) {
-    eprintln!("  TODO: implement safety check in green phase");
+/// Run the migration safety preflight check against all SQL files in `migrations_dir`.
+///
+/// Prints a human-readable report to stderr and exits with code 1 if any
+/// unsafe or potentially-blocking operations are detected.
+fn run_safety_check(migrations_dir: &str) {
+    let reports = match check_migrations_in_dir(Path::new(migrations_dir)) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("\u{2717} Migration safety check failed: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if reports.is_empty() {
+        eprintln!("\u{2713} No migrations found in {migrations_dir}/");
+        return;
+    }
+
+    let total = reports.len();
+    eprintln!("  Scanning {total} migration(s) in {migrations_dir}/...\n");
+
+    let mut any_unsafe = false;
+    for (name, findings) in &reports {
+        if findings.is_empty() {
+            eprintln!("  \u{2713} {name}  [safe]");
+        } else {
+            eprintln!("  \u{2717} {name}");
+            for f in findings {
+                eprintln!("      \u{2022} {} [{}]", f.operation, f.risk);
+                eprintln!("        Why:  {}", f.why);
+                eprintln!("        Next: {}", f.next_action);
+            }
+            any_unsafe = true;
+        }
+    }
+
+    eprintln!();
+    if any_unsafe {
+        eprintln!(
+            "\u{2717} One or more migrations contain operations that are unsafe for a live \
+             rolling deploy."
+        );
+        eprintln!(
+            "  Review the findings above, apply the expand/contract pattern where needed,"
+        );
+        eprintln!(
+            "  or coordinate a maintenance window before deploying these migrations."
+        );
+        std::process::exit(1);
+    } else {
+        eprintln!("\u{2713} All {total} migration(s) are safe for a rolling deploy.");
+    }
+}
+
+/// Read every migration directory in `dir`, classify its `up.sql`, and return
+/// a sorted list of `(migration_name, findings)` pairs.
+///
+/// Migration directories that have no `up.sql` are silently skipped.
+pub fn check_migrations_in_dir(
+    dir: &Path,
+) -> Result<Vec<(String, Vec<safety::SafetyFinding>)>, String> {
+    let mut entries: Vec<_> = std::fs::read_dir(dir)
+        .map_err(|e| format!("cannot read {}: {e}", dir.display()))?
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.path().is_dir())
+        .collect();
+
+    // Sort by directory name (which starts with a timestamp) for stable output.
+    entries.sort_by_key(|e| e.file_name());
+
+    let mut results = Vec::new();
+    for entry in entries {
+        let migration_name = entry.file_name().to_string_lossy().into_owned();
+        let up_sql_path = entry.path().join("up.sql");
+        if !up_sql_path.exists() {
+            continue;
+        }
+        let sql = std::fs::read_to_string(&up_sql_path)
+            .map_err(|e| format!("cannot read {}: {e}", up_sql_path.display()))?;
+        let findings = safety::classify_sql(&sql);
+        results.push((migration_name, findings));
+    }
+
+    Ok(results)
 }
 
 /// Resolve the primary/write database URL from autumn.toml and environment variables.

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -167,8 +167,10 @@ fn check_concurrent_index_transaction_opt_out(
     findings: &mut Vec<safety::SafetyFinding>,
 ) {
     let lower = sql.to_lowercase();
-    let uses_concurrently = lower.contains("create index concurrently")
-        || lower.contains("create unique index concurrently");
+    // Collapse whitespace so multi-line statements like `CREATE INDEX\n  CONCURRENTLY` match.
+    let normalized = lower.split_whitespace().collect::<Vec<_>>().join(" ");
+    let uses_concurrently = normalized.contains("create index concurrently")
+        || normalized.contains("create unique index concurrently");
     if !uses_concurrently {
         return;
     }
@@ -778,6 +780,24 @@ replica_url = "postgres://replica:5432/app"
         check_concurrent_index_transaction_opt_out(sql, &migration_dir, &mut findings);
 
         assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, safety::RiskLevel::PotentiallyBlocking);
+    }
+
+    #[test]
+    fn concurrent_index_multiline_without_metadata_toml_is_flagged() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migration_dir = tmp.path().join("20260104000000_add_index");
+        std::fs::create_dir_all(&migration_dir).unwrap();
+
+        let sql = "CREATE INDEX\n  CONCURRENTLY idx_posts_title ON posts (title);";
+        let mut findings = Vec::new();
+        check_concurrent_index_transaction_opt_out(sql, &migration_dir, &mut findings);
+
+        assert_eq!(
+            findings.len(),
+            1,
+            "multi-line CREATE INDEX CONCURRENTLY should be flagged when metadata.toml is absent"
+        );
         assert_eq!(findings[0].risk, safety::RiskLevel::PotentiallyBlocking);
     }
 

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -40,13 +40,10 @@ pub enum MigrateAction {
 pub fn run(action: MigrateAction) {
     eprintln!("\u{1F342} autumn migrate\n");
 
-    match action {
-        MigrateAction::Check => {
-            let migrations_dir = resolve_migrations_dir();
-            run_safety_check(&migrations_dir);
-            return;
-        }
-        _ => {}
+    if action == MigrateAction::Check {
+        let migrations_dir = resolve_migrations_dir();
+        run_safety_check(&migrations_dir);
+        return;
     }
 
     // 1. Resolve database URL from autumn.toml + env
@@ -93,9 +90,8 @@ fn run_safety_check(migrations_dir: &str) {
     let total = reports.len();
     eprintln!("  Scanning {total} migration(s) in {migrations_dir}/...\n");
 
-    let mut any_unsafe = false;
     for (name, findings) in &reports {
-        if findings.is_empty() {
+        if safety::is_safe(findings) {
             eprintln!("  \u{2713} {name}  [safe]");
         } else {
             eprintln!("  \u{2717} {name}");
@@ -104,9 +100,10 @@ fn run_safety_check(migrations_dir: &str) {
                 eprintln!("        Why:  {}", f.why);
                 eprintln!("        Next: {}", f.next_action);
             }
-            any_unsafe = true;
         }
     }
+
+    let any_unsafe = reports.iter().any(|(_, findings)| safety::has_unsafe_findings(findings));
 
     eprintln!();
     if any_unsafe {
@@ -135,12 +132,12 @@ pub fn check_migrations_in_dir(
 ) -> Result<Vec<(String, Vec<safety::SafetyFinding>)>, String> {
     let mut entries: Vec<_> = std::fs::read_dir(dir)
         .map_err(|e| format!("cannot read {}: {e}", dir.display()))?
-        .filter_map(|entry| entry.ok())
+        .filter_map(std::result::Result::ok)
         .filter(|entry| entry.path().is_dir())
         .collect();
 
     // Sort by directory name (which starts with a timestamp) for stable output.
-    entries.sort_by_key(|e| e.file_name());
+    entries.sort_by_key(std::fs::DirEntry::file_name);
 
     let mut results = Vec::new();
     for entry in entries {

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -7,11 +7,11 @@
 //! # Known limitations
 //!
 //! - Statement splitting uses `;` as the delimiter with awareness of
-//!   `PostgreSQL` dollar-quoted blocks (`$$…$$` and `$tag$…$tag$`).
-//!   Semicolons inside a dollar-quoted function body are kept intact so that
-//!   a `-- autumn-safety: reviewed` marker correctly suppresses the whole
-//!   statement. Semicolons inside single-quoted string literals are not
-//!   handled; that pattern is essentially absent from real migration files.
+//!   `PostgreSQL` dollar-quoted blocks (`$$…$$` and `$tag$…$tag$`) and
+//!   `--` line comments. Semicolons inside a dollar-quoted function body or
+//!   inside a `--` comment are kept intact so they do not produce spurious
+//!   statement fragments. Semicolons inside single-quoted string literals are
+//!   not handled; that pattern is essentially absent from real migration files.
 //! - Line comment stripping matches `--` by position on each line. A `--`
 //!   sequence inside a string literal would be incorrectly treated as a comment
 //!   start. Again, this pattern is essentially absent from real migration files.
@@ -141,7 +141,14 @@ fn split_statements(sql: &str) -> Vec<String> {
             }
         }
 
-        if rest.starts_with(';') {
+        // Line comment: consume to end-of-line without treating the semicolons
+        // inside the comment as statement separators.  The comment text is kept
+        // in `current` so that `has_review_suppression` can still see it.
+        if rest.starts_with("--") {
+            let end = rest.find('\n').unwrap_or(rest.len());
+            current.push_str(&rest[..end]);
+            i += end;
+        } else if rest.starts_with(';') {
             let trimmed = current.trim().to_owned();
             if !trimmed.is_empty() {
                 statements.push(trimmed);
@@ -267,14 +274,26 @@ const STABLE_FN_PREFIXES: &[&str] = &["now(", "current_timestamp(", "localtimest
 /// Returns `true` when `default_expr` is a volatile function call that `PostgreSQL`
 /// cannot optimise via the PG 11+ fast-constant-default path.
 ///
-/// STABLE/IMMUTABLE functions (e.g. `now()`) are evaluated once at statement time
-/// and stored as a constant, so they do not require a table rewrite.  Only truly
-/// VOLATILE functions (e.g. `random()`, `gen_random_uuid()`) must be flagged.
+/// Only VOLATILE function calls are flagged.  Grouped constant expressions such as
+/// `(0)` or `('draft')` have `(` as the first non-space character (no identifier
+/// before the parenthesis) and are treated as constants — they use the fast path.
+/// STABLE/IMMUTABLE functions (e.g. `now()`) are also exempt via `STABLE_FN_PREFIXES`.
 fn is_volatile_function_default(default_expr: &str) -> bool {
-    default_expr.contains('(')
-        && !STABLE_FN_PREFIXES
-            .iter()
-            .any(|p| default_expr.starts_with(p))
+    let Some(paren_pos) = default_expr.find('(') else {
+        return false; // no parentheses — constant literal
+    };
+    // A function call has an identifier character immediately before `(`.
+    // A grouped constant like `(0)` or `('x')` has nothing or whitespace before it.
+    let is_fn_call = default_expr[..paren_pos]
+        .chars()
+        .next_back()
+        .is_some_and(|c| c.is_alphanumeric() || c == '_');
+    if !is_fn_call {
+        return false; // parenthesized constant — uses the fast-default path
+    }
+    !STABLE_FN_PREFIXES
+        .iter()
+        .any(|p| default_expr.starts_with(p))
 }
 
 /// Apply all pattern checks to a single normalized (lowercase, single-spaced) statement.
@@ -796,6 +815,24 @@ mod tests {
     }
 
     #[test]
+    fn add_not_null_column_with_parenthesized_constant_default_is_safe() {
+        // `DEFAULT (0)` and `DEFAULT ('draft')` are parenthesized constants, not function
+        // calls.  They use the PG11+ fast-default path and must not be flagged as volatile.
+        let findings_int =
+            classify_sql("ALTER TABLE posts ADD COLUMN score INT NOT NULL DEFAULT (0);");
+        assert!(
+            findings_int.is_empty(),
+            "DEFAULT (0) must be safe: {findings_int:?}"
+        );
+        let findings_str =
+            classify_sql("ALTER TABLE posts ADD COLUMN status TEXT NOT NULL DEFAULT ('draft');");
+        assert!(
+            findings_str.is_empty(),
+            "DEFAULT ('draft') must be safe: {findings_str:?}"
+        );
+    }
+
+    #[test]
     fn add_not_null_column_with_constant_default_is_safe() {
         // Constant literals use the PG11+ fast path — no table rewrite.
         let findings =
@@ -865,6 +902,21 @@ mod tests {
         let sql = "-- Removing old column\nALTER TABLE posts DROP COLUMN body;";
         let findings = classify_sql(sql);
         assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
+    }
+
+    #[test]
+    fn line_comment_with_semicolon_does_not_hide_following_statement() {
+        // A `;` inside a `--` comment must not be treated as a statement separator.
+        // Before the fix, `-- rollout complete; safe\nDROP TABLE posts` would be split
+        // and the fragment `safe\nDROP TABLE posts` no longer starts with `drop table`.
+        let sql = "-- rollout complete; safe to proceed\nDROP TABLE posts;";
+        let findings = classify_sql(sql);
+        assert_eq!(
+            findings.len(),
+            1,
+            "DROP TABLE must be found after a line comment containing ';': {findings:?}"
+        );
         assert_eq!(findings[0].risk, RiskLevel::Destructive);
     }
 

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -75,10 +75,33 @@ pub fn classify_sql(sql: &str) -> Vec<SafetyFinding> {
     // semicolon inside a block comment (e.g. `/* note; end */`) does not produce
     // a spurious empty statement fragment.
     let without_block_comments = strip_block_comments(sql);
-    split_statements(&without_block_comments)
+    let stmts = split_statements(&without_block_comments);
+
+    // Tables created within this migration have no existing rows or live traffic,
+    // so a non-concurrent index build on them is safe.  Collect the names upfront
+    // so we can suppress the false-positive PotentiallyBlocking finding for those
+    // tables when we encounter their CREATE INDEX statements below.
+    let newly_created: Vec<String> = stmts
+        .iter()
+        .filter(|s| !has_review_suppression(s))
+        .filter_map(|s| extract_created_table_name(&normalize_statement(s)))
+        .collect();
+
+    stmts
         .iter()
         .filter(|stmt| !has_review_suppression(stmt))
-        .flat_map(|stmt| classify_statement(&normalize_statement(stmt)))
+        .flat_map(|stmt| {
+            let normalized = normalize_statement(stmt);
+            let mut findings = classify_statement(&normalized);
+            // Drop any non-concurrent-index finding whose table was created earlier
+            // in this same migration file.
+            findings.retain(|f| {
+                f.operation != "CREATE INDEX (non-concurrent)"
+                    || extract_index_table_name(&normalized)
+                        .is_none_or(|t| !newly_created.iter().any(|c| c == t))
+            });
+            findings
+        })
         .collect()
 }
 
@@ -105,6 +128,25 @@ pub fn has_unsafe_findings(findings: &[SafetyFinding]) -> bool {
 }
 
 // ── internals ────────────────────────────────────────────────────────────────
+
+/// Extract the table name from a normalized `CREATE TABLE [IF NOT EXISTS] name …` statement.
+fn extract_created_table_name(normalized: &str) -> Option<String> {
+    let rest = normalized.strip_prefix("create table ")?;
+    let rest = rest.strip_prefix("if not exists ").unwrap_or(rest);
+    let name = rest.split([' ', '(']).next()?;
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_owned())
+    }
+}
+
+/// Extract the target table name from a normalized `CREATE [UNIQUE] INDEX … ON name …` statement.
+fn extract_index_table_name(normalized: &str) -> Option<&str> {
+    let after_on = normalized.find(" on ").map(|i| &normalized[i + 4..])?;
+    let name = after_on.split([' ', '(']).next()?;
+    if name.is_empty() { None } else { Some(name) }
+}
 
 /// Split `sql` into individual statements, using `;` as the delimiter.
 ///
@@ -951,6 +993,45 @@ mod tests {
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
         assert_eq!(findings[0].operation, "CREATE INDEX (non-concurrent)");
+    }
+
+    #[test]
+    fn non_concurrent_index_on_newly_created_table_is_safe() {
+        // The table is created in the same migration — no existing rows to lock.
+        // This is the shape emitted by `autumn generate ... --index`.
+        let sql = "CREATE TABLE posts (id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL);\n\
+                   CREATE INDEX idx_posts_title ON posts (title);";
+        let findings = classify_sql(sql);
+        assert!(
+            findings.is_empty(),
+            "non-concurrent index on a table created in the same migration must be safe: \
+             {findings:?}"
+        );
+    }
+
+    #[test]
+    fn unique_non_concurrent_index_on_newly_created_table_is_safe() {
+        let sql = "CREATE TABLE posts (id BIGSERIAL PRIMARY KEY, slug TEXT NOT NULL);\n\
+                   CREATE UNIQUE INDEX idx_posts_slug ON posts (slug);";
+        let findings = classify_sql(sql);
+        assert!(
+            findings.is_empty(),
+            "non-concurrent unique index on a newly created table must be safe: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn non_concurrent_index_on_different_table_is_still_blocking() {
+        // CREATE TABLE `posts` does not exempt an index on a different table `comments`.
+        let sql = "CREATE TABLE posts (id BIGSERIAL PRIMARY KEY);\n\
+                   CREATE INDEX idx_comments_post_id ON comments (post_id);";
+        let findings = classify_sql(sql);
+        assert_eq!(
+            findings.len(),
+            1,
+            "non-concurrent index on a pre-existing table must still be flagged: {findings:?}"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
     }
 
     // ── multi-statement SQL ───────────────────────────────────────────────────

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -6,10 +6,12 @@
 //!
 //! # Known limitations
 //!
-//! - Statement splitting uses `;` as the delimiter. Semicolons inside string
-//!   literals or `PostgreSQL` dollar-quoted blocks (`$$…$$`) will produce
-//!   incorrect splits. Real migration files almost never embed semicolons in
-//!   strings, so this is an acceptable approximation.
+//! - Statement splitting uses `;` as the delimiter with awareness of
+//!   `PostgreSQL` dollar-quoted blocks (`$$…$$` and `$tag$…$tag$`).
+//!   Semicolons inside a dollar-quoted function body are kept intact so that
+//!   a `-- autumn-safety: reviewed` marker correctly suppresses the whole
+//!   statement. Semicolons inside single-quoted string literals are not
+//!   handled; that pattern is essentially absent from real migration files.
 //! - Line comment stripping matches `--` by position on each line. A `--`
 //!   sequence inside a string literal would be incorrectly treated as a comment
 //!   start. Again, this pattern is essentially absent from real migration files.
@@ -104,12 +106,60 @@ pub fn has_unsafe_findings(findings: &[SafetyFinding]) -> bool {
 
 // ── internals ────────────────────────────────────────────────────────────────
 
+/// Split `sql` into individual statements, using `;` as the delimiter.
+///
+/// Dollar-quoted blocks (`$$…$$`, `$tag$…$tag$`) are kept intact so that
+/// semicolons inside a function body do not produce spurious fragments.
 fn split_statements(sql: &str) -> Vec<String> {
-    sql.split(';')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned)
-        .collect()
+    let mut statements = Vec::new();
+    let mut current = String::new();
+    let mut i = 0;
+
+    while i < sql.len() {
+        let rest = &sql[i..];
+
+        // Detect a dollar-quote opening: $identifier$ (identifier may be empty → $$).
+        // When found, consume everything up to and including the matching closing tag
+        // so that semicolons inside the body are not treated as statement separators.
+        if let Some(after_dollar) = rest.strip_prefix('$')
+            && let Some(close_in_rest1) = after_dollar.find('$')
+        {
+            let tag_body = &after_dollar[..close_in_rest1];
+            if tag_body.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                let tag_len = 1 + close_in_rest1 + 1; // opening $ + body + closing $
+                let tag = &rest[..tag_len];
+                if let Some(close_pos) = rest[tag_len..].find(tag) {
+                    // Push opening tag + body + closing tag as one chunk.
+                    current.push_str(&rest[..tag_len + close_pos + tag_len]);
+                    i += tag_len + close_pos + tag_len;
+                } else {
+                    // Unclosed dollar-quote: consume to end of input.
+                    current.push_str(rest);
+                    i = sql.len();
+                }
+                continue;
+            }
+        }
+
+        if rest.starts_with(';') {
+            let trimmed = current.trim().to_owned();
+            if !trimmed.is_empty() {
+                statements.push(trimmed);
+            }
+            current.clear();
+            i += 1;
+        } else {
+            let c = rest.chars().next().unwrap();
+            current.push(c);
+            i += c.len_utf8();
+        }
+    }
+
+    let trimmed = current.trim().to_owned();
+    if !trimmed.is_empty() {
+        statements.push(trimmed);
+    }
+    statements
 }
 
 /// Split a normalized `ALTER TABLE` statement into individual subcommand strings.
@@ -1163,6 +1213,48 @@ mod tests {
             "DROP TABLE after a block comment containing ';' must still be classified"
         );
         assert_eq!(findings[0].risk, RiskLevel::Destructive);
+    }
+
+    // ── dollar-quoted function bodies ─────────────────────────────────────────
+
+    #[test]
+    fn dollar_quoted_function_with_semicolons_is_one_statement() {
+        // The semicolons inside $$ ... $$ must not produce extra statement fragments.
+        let sql = "CREATE FUNCTION bump() RETURNS void AS $$ BEGIN \
+                   UPDATE posts SET hits = hits + 1; RETURN; END; $$ LANGUAGE plpgsql;";
+        let findings = classify_sql(sql);
+        assert_eq!(
+            findings.len(),
+            1,
+            "dollar-quoted body with semicolons must produce exactly one finding: {findings:?}"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::ManualReview);
+    }
+
+    #[test]
+    fn autumn_safety_reviewed_suppresses_function_with_dml_in_body() {
+        // Without dollar-quote-aware splitting the DML fragment would escape suppression.
+        let sql = "-- autumn-safety: reviewed\n\
+                   CREATE FUNCTION migrate_posts() RETURNS void AS $$\n\
+                   BEGIN\n  UPDATE posts SET migrated = true;\n  RETURN;\nEND;\n\
+                   $$ LANGUAGE plpgsql;";
+        let findings = classify_sql(sql);
+        assert!(
+            findings.is_empty(),
+            "reviewed marker must suppress a dollar-quoted function containing DML: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn tagged_dollar_quote_with_semicolons_is_one_statement() {
+        let sql = "CREATE FUNCTION foo() RETURNS void AS $func$ \
+                   BEGIN UPDATE posts SET x = 1; END; $func$ LANGUAGE plpgsql;";
+        let findings = classify_sql(sql);
+        assert_eq!(
+            findings.len(),
+            1,
+            "tagged dollar-quote body with semicolons must not split: {findings:?}"
+        );
     }
 
     // ── DROP INDEX ────────────────────────────────────────────────────────────

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -202,9 +202,9 @@ fn normalize_statement(stmt: &str) -> String {
 pub fn contains_concurrent_index(sql: &str) -> bool {
     split_statements(sql).iter().any(|stmt| {
         let normalized = normalize_statement(stmt);
-        normalized.contains("create index concurrently")
-            || normalized.contains("create unique index concurrently")
-            || normalized.contains("drop index concurrently")
+        normalized.contains("create index concurrently ")
+            || normalized.contains("create unique index concurrently ")
+            || normalized.starts_with("drop index concurrently ")
     })
 }
 
@@ -424,7 +424,9 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
     }
 
     // DROP INDEX (non-concurrent) — holds an exclusive table lock
-    if normalized.starts_with("drop index") && !normalized.contains("concurrently") {
+    // Use token-aware check: `concurrently` must be the SQL option immediately after
+    // `drop index`, not a substring of the index name (e.g. idx_concurrently).
+    if normalized.starts_with("drop index") && !normalized.starts_with("drop index concurrently ") {
         findings.push(SafetyFinding {
             operation: "DROP INDEX (non-concurrent)".to_owned(),
             risk: RiskLevel::PotentiallyBlocking,
@@ -1135,6 +1137,18 @@ mod tests {
         let findings = classify_sql("DROP INDEX idx_posts_title;");
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
+        assert_eq!(findings[0].operation, "DROP INDEX (non-concurrent)");
+    }
+
+    #[test]
+    fn drop_index_with_concurrently_in_name_is_still_blocking() {
+        // "concurrently" appears in the index name, not as the SQL token.
+        let findings = classify_sql("DROP INDEX idx_concurrently;");
+        assert_eq!(
+            findings.len(),
+            1,
+            "index named idx_concurrently must still be flagged as non-concurrent: {findings:?}"
+        );
         assert_eq!(findings[0].operation, "DROP INDEX (non-concurrent)");
     }
 

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -106,6 +106,47 @@ fn split_statements(sql: &str) -> Vec<String> {
         .collect()
 }
 
+/// Split a normalized `ALTER TABLE` statement into individual subcommand strings.
+///
+/// Strips the `alter table <name>` prefix and splits the remaining text on
+/// commas that are not enclosed in parentheses, trimming each segment.
+fn alter_table_subcommands(normalized: &str) -> Vec<&str> {
+    let after_prefix = normalized.strip_prefix("alter table ").unwrap_or("");
+    let subcommands_start = after_prefix.find(' ').map_or(after_prefix.len(), |i| i + 1);
+    let subcommands = &after_prefix[subcommands_start..];
+
+    let mut result = Vec::new();
+    let mut depth: i32 = 0;
+    let mut start = 0;
+    for (i, c) in subcommands.char_indices() {
+        match c {
+            '(' => depth += 1,
+            ')' => depth -= 1,
+            ',' if depth == 0 => {
+                result.push(subcommands[start..i].trim());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    let last = subcommands[start..].trim();
+    if !last.is_empty() {
+        result.push(last);
+    }
+    result
+}
+
+/// True iff `subcommand` is an ALTER TABLE subcommand that Autumn fully classifies.
+///
+/// A subcommand is "known" when a specific safety rule covers all risk scenarios
+/// for it (including the case where it is safe and produces no finding).
+fn is_known_alter_subcommand(subcommand: &str) -> bool {
+    subcommand.starts_with("add column ")
+        || subcommand.starts_with("drop column ")
+        || subcommand.starts_with("rename ") // RENAME COLUMN or RENAME TO
+        || (subcommand.starts_with("alter column ") && subcommand.contains(" type "))
+}
+
 /// Strip line comments, collapse whitespace, and lowercase a single statement.
 fn normalize_statement(stmt: &str) -> String {
     stmt.lines()
@@ -204,31 +245,38 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
         });
     }
 
-    // ADD COLUMN NOT NULL without DEFAULT
-    // Use " default " (word-boundary) so column names like `defaulted_at` don't suppress the check.
-    if normalized.contains(" add column ")
-        && normalized.contains("not null")
-        && !normalized.contains(" default ")
-    {
-        findings.push(SafetyFinding {
-            operation: "ADD COLUMN NOT NULL (no default)".to_owned(),
-            risk: RiskLevel::PotentiallyBlocking,
-            why: "Adding a NOT NULL column without a DEFAULT forces Postgres to validate every \
-                  existing row under an exclusive lock. On a large table this may time out.",
-            next_action: "Provide a DEFAULT value, or add the column as nullable first, backfill \
-                          existing rows, then add the NOT NULL constraint in a later migration.",
-        });
+    // ADD COLUMN NOT NULL without DEFAULT — checked per subcommand so that a DEFAULT
+    // on one column in a multi-column ALTER TABLE does not suppress the check for other
+    // columns that lack a DEFAULT.
+    if normalized.starts_with("alter table") {
+        for subcommand in alter_table_subcommands(normalized) {
+            if subcommand.starts_with("add column ")
+                && subcommand.contains("not null")
+                && !subcommand.contains(" default ")
+            {
+                findings.push(SafetyFinding {
+                    operation: "ADD COLUMN NOT NULL (no default)".to_owned(),
+                    risk: RiskLevel::PotentiallyBlocking,
+                    why: "Adding a NOT NULL column without a DEFAULT forces Postgres to validate \
+                          every existing row under an exclusive lock. On a large table this may \
+                          time out.",
+                    next_action: "Provide a DEFAULT value, or add the column as nullable first, \
+                                  backfill existing rows, then add the NOT NULL constraint in a \
+                                  later migration.",
+                });
+                break; // one finding per statement is sufficient
+            }
+        }
     }
 
-    // Unclassified ALTER TABLE subcommand — catch operations like DROP CONSTRAINT,
-    // ADD CONSTRAINT, and ALTER COLUMN SET NOT NULL that aren't covered by the rules
-    // above. Only fires when none of the specific rules produced a finding.
-    if normalized.starts_with("alter table") && findings.is_empty() {
-        let known_subcommand = normalized.contains(" add column ")
-            || normalized.contains(" drop column ")
-            || normalized.contains(" rename ") // RENAME COLUMN or RENAME TO
-            || (normalized.contains(" alter column ") && normalized.contains(" type "));
-        if !known_subcommand {
+    // Unclassified ALTER TABLE subcommand — fires when any subcommand in the statement
+    // is not covered by the specific rules above. Checking all subcommands individually
+    // prevents a known-safe subcommand (e.g. ADD COLUMN) from hiding an unknown one
+    // (e.g. DROP CONSTRAINT) in the same multi-action ALTER TABLE.
+    if normalized.starts_with("alter table") {
+        let subcommands = alter_table_subcommands(normalized);
+        let all_known = subcommands.iter().all(|s| is_known_alter_subcommand(s));
+        if !all_known {
             findings.push(SafetyFinding {
                 operation: "Unclassified ALTER TABLE".to_owned(),
                 risk: RiskLevel::ManualReview,
@@ -506,6 +554,32 @@ mod tests {
     }
 
     // ── potentially blocking patterns ─────────────────────────────────────────
+
+    #[test]
+    fn multi_column_add_only_flags_clause_without_default() {
+        // ADD COLUMN score has DEFAULT — ADD COLUMN slug does NOT. Only slug should be flagged.
+        let sql = "ALTER TABLE posts \
+                   ADD COLUMN score INT NOT NULL DEFAULT 0, \
+                   ADD COLUMN slug TEXT NOT NULL;";
+        let findings = classify_sql(sql);
+        assert_eq!(
+            findings.len(),
+            1,
+            "only the column without a DEFAULT should be flagged"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
+    }
+
+    #[test]
+    fn mixed_known_and_unknown_alter_table_subcommands_flagged() {
+        // ADD COLUMN is safe, but DROP CONSTRAINT is unclassified — should get ManualReview.
+        let sql = "ALTER TABLE posts ADD COLUMN subtitle TEXT, DROP CONSTRAINT posts_title_key;";
+        let findings = classify_sql(sql);
+        assert!(
+            findings.iter().any(|f| f.risk == RiskLevel::ManualReview),
+            "unknown subcommand must produce ManualReview: {findings:?}"
+        );
+    }
 
     #[test]
     fn add_not_null_column_without_default_is_blocking() {

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -204,11 +204,23 @@ fn alter_table_subcommands(normalized: &str) -> Vec<&str> {
 /// A subcommand is "known" when a specific safety rule covers all risk scenarios
 /// for it (including the case where it is safe and produces no finding).
 fn is_known_alter_subcommand(subcommand: &str) -> bool {
-    subcommand.starts_with("add column ")
+    // `add column` is known unless it carries an inline PRIMARY KEY constraint,
+    // which Autumn does not specifically classify.  UNIQUE and REFERENCES are handled
+    // by dedicated rules; NOT NULL is handled by the NOT NULL rule.
+    let add_col_known =
+        subcommand.starts_with("add column ") && !subcommand.contains(" primary key");
+    add_col_known
         || subcommand.starts_with("drop column ")
         || subcommand.starts_with("rename column ") // RENAME COLUMN
         || subcommand.starts_with("rename to ") // RENAME TABLE (ALTER TABLE … RENAME TO …)
         || (subcommand.starts_with("alter column ") && subcommand.contains(" type "))
+}
+
+/// Returns `true` when the normalized `add column` subcommand carries an inline
+/// `UNIQUE` constraint keyword.  Trailing-space / end-of-string anchoring prevents
+/// matching a column or table name that contains `unique` as a substring.
+fn has_inline_unique_constraint(subcommand: &str) -> bool {
+    subcommand.contains(" unique ") || subcommand.ends_with(" unique")
 }
 
 /// Remove `/* ... */` block comments from `sql`.
@@ -431,6 +443,40 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
                     });
                     break; // one finding per statement is sufficient
                 }
+            }
+        }
+    }
+
+    // ADD COLUMN with inline UNIQUE — implicitly builds a non-concurrent unique index
+    // ADD COLUMN with inline REFERENCES — scans existing rows to validate the FK
+    if normalized.starts_with("alter table") {
+        for subcommand in alter_table_subcommands(normalized) {
+            if !subcommand.starts_with("add column ") {
+                continue;
+            }
+            if has_inline_unique_constraint(subcommand) {
+                findings.push(SafetyFinding {
+                    operation: "ADD COLUMN UNIQUE (inline constraint)".to_owned(),
+                    risk: RiskLevel::PotentiallyBlocking,
+                    why: "An inline UNIQUE constraint implicitly builds a non-concurrent unique \
+                          index under an exclusive table lock, blocking all reads and writes during \
+                          the build.",
+                    next_action: "Add the column without UNIQUE first, then create the unique \
+                                  index in a separate migration using \
+                                  `CREATE UNIQUE INDEX CONCURRENTLY`.",
+                });
+            }
+            if subcommand.contains(" references ") {
+                findings.push(SafetyFinding {
+                    operation: "ADD COLUMN REFERENCES (inline FK)".to_owned(),
+                    risk: RiskLevel::PotentiallyBlocking,
+                    why: "An inline REFERENCES constraint scans all existing rows to validate the \
+                          foreign key, acquiring locks that can block writes on the referenced \
+                          table.",
+                    next_action: "Add the column without the constraint first, then add the FK \
+                                  using `ADD CONSTRAINT ... FOREIGN KEY ... NOT VALID` and \
+                                  validate separately with `VALIDATE CONSTRAINT`.",
+                });
             }
         }
     }
@@ -840,6 +886,53 @@ mod tests {
         assert!(
             findings.is_empty(),
             "constant DEFAULT false must be safe: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn add_column_with_inline_unique_is_potentially_blocking() {
+        let findings = classify_sql("ALTER TABLE posts ADD COLUMN slug TEXT UNIQUE;");
+        assert_eq!(
+            findings.len(),
+            1,
+            "inline UNIQUE must be flagged: {findings:?}"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
+        assert_eq!(
+            findings[0].operation,
+            "ADD COLUMN UNIQUE (inline constraint)"
+        );
+    }
+
+    #[test]
+    fn add_column_with_inline_references_is_potentially_blocking() {
+        let findings =
+            classify_sql("ALTER TABLE posts ADD COLUMN user_id INT REFERENCES users(id);");
+        assert_eq!(
+            findings.len(),
+            1,
+            "inline REFERENCES must be flagged: {findings:?}"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
+        assert_eq!(findings[0].operation, "ADD COLUMN REFERENCES (inline FK)");
+    }
+
+    #[test]
+    fn add_column_with_primary_key_requires_manual_review() {
+        // PRIMARY KEY inline on ADD COLUMN is not specifically classified.
+        let findings = classify_sql("ALTER TABLE posts ADD COLUMN id BIGSERIAL PRIMARY KEY;");
+        assert!(
+            findings.iter().any(|f| f.risk == RiskLevel::ManualReview),
+            "inline PRIMARY KEY must require manual review: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn add_column_without_constraints_does_not_trigger_manual_review() {
+        let findings = classify_sql("ALTER TABLE posts ADD COLUMN subtitle TEXT;");
+        assert!(
+            findings.iter().all(|f| f.risk != RiskLevel::ManualReview),
+            "simple ADD COLUMN must not trigger ManualReview: {findings:?}"
         );
     }
 

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -238,6 +238,7 @@ fn strip_block_comments(sql: &str) -> String {
                 match chars.next() {
                     Some('*') if chars.peek() == Some(&'/') => {
                         chars.next(); // consume '/'
+                        result.push(' '); // preserve token boundary where the comment was
                         break;
                     }
                     None => break, // unclosed block comment
@@ -1356,6 +1357,19 @@ mod tests {
             findings.len(),
             1,
             "DROP TABLE after a block comment containing ';' must still be classified"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
+    }
+
+    #[test]
+    fn block_comment_between_keywords_preserves_token_boundary() {
+        // `DROP/* note */TABLE posts` must not concatenate to `DROPTABLE posts`,
+        // which would miss both the `drop table` rule and the `drop ` catch-all.
+        let findings = classify_sql("DROP/* note */TABLE posts;");
+        assert_eq!(
+            findings.len(),
+            1,
+            "block comment between keywords must not merge them: {findings:?}"
         );
         assert_eq!(findings[0].risk, RiskLevel::Destructive);
     }

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -1,0 +1,306 @@
+//! Migration safety classification — pure SQL pattern analysis.
+//!
+//! Inspects the contents of `up.sql` files and classifies each SQL statement
+//! into a risk tier. The result drives `autumn migrate check`'s exit code and
+//! human-readable safety report printed to stderr.
+
+use std::fmt;
+
+/// Risk level for a migration operation, ordered from least to most risky.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RiskLevel {
+    /// Additive, backward-compatible schema change. Safe for rolling deploys.
+    Safe,
+    /// May acquire a table-level lock on large datasets.
+    PotentiallyBlocking,
+    /// Removes data or structure; old replicas may fail until they restart.
+    Destructive,
+    /// Cannot be easily reversed without a multi-step expand/contract cycle.
+    Irreversible,
+    /// Schema change is safe but requires a separate data backfill job.
+    DataBackfill,
+    /// Autumn cannot auto-classify this statement. Operator review required.
+    ManualReview,
+}
+
+impl fmt::Display for RiskLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Safe => write!(f, "safe"),
+            Self::PotentiallyBlocking => write!(f, "potentially-blocking"),
+            Self::Destructive => write!(f, "destructive"),
+            Self::Irreversible => write!(f, "irreversible"),
+            Self::DataBackfill => write!(f, "data-backfill"),
+            Self::ManualReview => write!(f, "manual-review"),
+        }
+    }
+}
+
+/// A single safety finding for one SQL statement in a migration file.
+#[derive(Debug, Clone)]
+pub struct SafetyFinding {
+    /// Short description of the risky operation (e.g. `DROP COLUMN`).
+    pub operation: String,
+    /// Risk classification.
+    pub risk: RiskLevel,
+    /// Why this is dangerous for a rolling deploy.
+    pub why: &'static str,
+    /// Recommended next action for the operator.
+    pub next_action: &'static str,
+}
+
+/// Classify the SQL content of an `up.sql` file and return all safety findings.
+///
+/// Returns an empty `Vec` when the migration is fully additive and safe.
+/// TODO(red): stub — always returns empty; implement in green phase
+pub fn classify_sql(_sql: &str) -> Vec<SafetyFinding> {
+    vec![]
+}
+
+/// True iff there are no findings above `Safe` risk level.
+pub fn is_safe(findings: &[SafetyFinding]) -> bool {
+    findings.iter().all(|f| f.risk == RiskLevel::Safe)
+}
+
+/// True iff any finding exceeds the `Safe` risk level.
+pub fn has_unsafe_findings(findings: &[SafetyFinding]) -> bool {
+    findings.iter().any(|f| f.risk > RiskLevel::Safe)
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── RiskLevel ordering ────────────────────────────────────────────────────
+
+    #[test]
+    fn risk_level_ordering() {
+        assert!(RiskLevel::Safe < RiskLevel::PotentiallyBlocking);
+        assert!(RiskLevel::PotentiallyBlocking < RiskLevel::Destructive);
+        assert!(RiskLevel::Destructive < RiskLevel::Irreversible);
+        assert!(RiskLevel::Irreversible < RiskLevel::DataBackfill);
+        assert!(RiskLevel::DataBackfill < RiskLevel::ManualReview);
+    }
+
+    #[test]
+    fn risk_level_display() {
+        assert_eq!(RiskLevel::Safe.to_string(), "safe");
+        assert_eq!(RiskLevel::PotentiallyBlocking.to_string(), "potentially-blocking");
+        assert_eq!(RiskLevel::Destructive.to_string(), "destructive");
+        assert_eq!(RiskLevel::Irreversible.to_string(), "irreversible");
+        assert_eq!(RiskLevel::DataBackfill.to_string(), "data-backfill");
+        assert_eq!(RiskLevel::ManualReview.to_string(), "manual-review");
+    }
+
+    // ── safe migrations ───────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_sql_has_no_findings() {
+        assert!(classify_sql("").is_empty());
+    }
+
+    #[test]
+    fn create_table_is_safe() {
+        let sql = "CREATE TABLE posts (\n    id BIGSERIAL PRIMARY KEY,\n    title TEXT NOT NULL\n);";
+        let findings = classify_sql(sql);
+        assert!(findings.is_empty(), "CREATE TABLE should be safe: {findings:?}");
+    }
+
+    #[test]
+    fn add_nullable_column_is_safe() {
+        let sql = "ALTER TABLE posts ADD COLUMN subtitle TEXT NULL;";
+        let findings = classify_sql(sql);
+        assert!(findings.is_empty(), "ADD COLUMN NULL should be safe: {findings:?}");
+    }
+
+    #[test]
+    fn add_not_null_column_with_default_is_safe() {
+        let sql = "ALTER TABLE posts ADD COLUMN status TEXT NOT NULL DEFAULT 'draft';";
+        let findings = classify_sql(sql);
+        assert!(findings.is_empty(), "ADD COLUMN NOT NULL DEFAULT should be safe: {findings:?}");
+    }
+
+    #[test]
+    fn create_concurrent_index_is_safe() {
+        let sql = "CREATE INDEX CONCURRENTLY idx_posts_title ON posts (title);";
+        let findings = classify_sql(sql);
+        assert!(findings.is_empty(), "CREATE INDEX CONCURRENTLY should be safe: {findings:?}");
+    }
+
+    // ── destructive patterns ──────────────────────────────────────────────────
+
+    #[test]
+    fn drop_table_is_destructive() {
+        let findings = classify_sql("DROP TABLE posts;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
+        assert_eq!(findings[0].operation, "DROP TABLE");
+    }
+
+    #[test]
+    fn drop_column_is_destructive() {
+        let findings = classify_sql("ALTER TABLE posts DROP COLUMN title;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
+        assert_eq!(findings[0].operation, "DROP COLUMN");
+    }
+
+    #[test]
+    fn drop_column_case_insensitive() {
+        let findings = classify_sql("alter table posts drop column title;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
+    }
+
+    #[test]
+    fn alter_column_type_is_destructive() {
+        let findings = classify_sql("ALTER TABLE posts ALTER COLUMN score TYPE BIGINT;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
+        assert_eq!(findings[0].operation, "ALTER COLUMN TYPE");
+    }
+
+    // ── irreversible patterns ─────────────────────────────────────────────────
+
+    #[test]
+    fn rename_column_is_irreversible() {
+        let findings = classify_sql("ALTER TABLE posts RENAME COLUMN body TO content;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::Irreversible);
+        assert_eq!(findings[0].operation, "RENAME COLUMN");
+    }
+
+    #[test]
+    fn rename_table_is_irreversible() {
+        let findings = classify_sql("ALTER TABLE posts RENAME TO articles;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::Irreversible);
+        assert_eq!(findings[0].operation, "RENAME TABLE");
+    }
+
+    // ── potentially blocking patterns ─────────────────────────────────────────
+
+    #[test]
+    fn add_not_null_column_without_default_is_blocking() {
+        let findings = classify_sql("ALTER TABLE posts ADD COLUMN score INTEGER NOT NULL;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
+        assert_eq!(findings[0].operation, "ADD COLUMN NOT NULL (no default)");
+    }
+
+    #[test]
+    fn create_non_concurrent_index_is_blocking() {
+        let findings = classify_sql("CREATE INDEX idx_posts_title ON posts (title);");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
+        assert_eq!(findings[0].operation, "CREATE INDEX (non-concurrent)");
+    }
+
+    // ── multi-statement SQL ───────────────────────────────────────────────────
+
+    #[test]
+    fn multiple_safe_statements_produce_no_findings() {
+        let sql = "\
+            ALTER TABLE posts ADD COLUMN subtitle TEXT NULL;\n\
+            CREATE INDEX CONCURRENTLY idx_posts_subtitle ON posts (subtitle);";
+        let findings = classify_sql(sql);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn mixed_safe_and_unsafe_statements_produces_findings_for_unsafe() {
+        let sql = "\
+            ALTER TABLE posts ADD COLUMN subtitle TEXT NULL;\n\
+            ALTER TABLE posts DROP COLUMN body;";
+        let findings = classify_sql(sql);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
+    }
+
+    #[test]
+    fn multiple_unsafe_statements_produce_multiple_findings() {
+        let sql = "\
+            ALTER TABLE posts DROP COLUMN body;\n\
+            CREATE INDEX idx_posts_title ON posts (title);";
+        let findings = classify_sql(sql);
+        assert_eq!(findings.len(), 2);
+        assert!(findings.iter().any(|f| f.risk == RiskLevel::Destructive));
+        assert!(findings.iter().any(|f| f.risk == RiskLevel::PotentiallyBlocking));
+    }
+
+    // ── line comments are ignored ─────────────────────────────────────────────
+
+    #[test]
+    fn sql_with_line_comments_is_classified_correctly() {
+        let sql = "-- Removing old column\nALTER TABLE posts DROP COLUMN body;";
+        let findings = classify_sql(sql);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
+    }
+
+    #[test]
+    fn autumn_safety_comment_does_not_double_classify() {
+        // Autumn-generated SQL includes a leading safety comment; ensure the
+        // comment text itself doesn't trigger a second finding.
+        let sql = "-- autumn-safety: destructive\nALTER TABLE posts DROP COLUMN body;";
+        let findings = classify_sql(sql);
+        assert_eq!(findings.len(), 1);
+    }
+
+    // ── helper predicates ─────────────────────────────────────────────────────
+
+    #[test]
+    fn is_safe_returns_true_for_empty() {
+        assert!(is_safe(&[]));
+    }
+
+    #[test]
+    fn is_safe_returns_false_for_unsafe_findings() {
+        let f = SafetyFinding {
+            operation: "DROP COLUMN".to_owned(),
+            risk: RiskLevel::Destructive,
+            why: "",
+            next_action: "",
+        };
+        assert!(!is_safe(&[f]));
+    }
+
+    #[test]
+    fn has_unsafe_findings_returns_false_for_empty() {
+        assert!(!has_unsafe_findings(&[]));
+    }
+
+    #[test]
+    fn has_unsafe_findings_returns_true_for_blocking() {
+        let f = SafetyFinding {
+            operation: "CREATE INDEX (non-concurrent)".to_owned(),
+            risk: RiskLevel::PotentiallyBlocking,
+            why: "",
+            next_action: "",
+        };
+        assert!(has_unsafe_findings(&[f]));
+    }
+
+    // ── finding fields carry useful guidance ─────────────────────────────────
+
+    #[test]
+    fn drop_column_finding_names_the_risk_and_next_action() {
+        let findings = classify_sql("ALTER TABLE posts DROP COLUMN body;");
+        let f = &findings[0];
+        assert!(!f.why.is_empty(), "why must explain the rolling-deploy risk");
+        assert!(!f.next_action.is_empty(), "next_action must tell the operator what to do");
+    }
+
+    #[test]
+    fn non_concurrent_index_finding_mentions_concurrently() {
+        let findings = classify_sql("CREATE INDEX idx ON posts (title);");
+        let f = &findings[0];
+        assert!(
+            f.next_action.to_lowercase().contains("concurrently"),
+            "next_action should recommend CONCURRENTLY: {}",
+            f.next_action
+        );
+    }
+}

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -580,6 +580,7 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
     if normalized.starts_with("update ")
         || normalized.starts_with("insert into ")
         || normalized.starts_with("delete from ")
+        || normalized.starts_with("merge into ")
     {
         findings.push(SafetyFinding {
             operation: "Bulk DML (data backfill)".to_owned(),
@@ -630,6 +631,33 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
         });
     }
 
+    // ALTER TYPE RENAME VALUE — renaming an enum label breaks old replicas that
+    // still INSERT or compare against the old label during a rolling deploy.
+    if normalized.starts_with("alter type") && normalized.contains(" rename value ") {
+        findings.push(SafetyFinding {
+            operation: "ALTER TYPE RENAME VALUE".to_owned(),
+            risk: RiskLevel::Irreversible,
+            why: "Renaming an enum label breaks old replicas that still insert, compare, or \
+                  decode the old label. Errors will appear immediately during a rolling deploy.",
+            next_action: "Use expand/contract: add a new enum value, migrate all writes to use \
+                          it, then remove the old value in a subsequent release.",
+        });
+        return findings;
+    }
+
+    // ALTER TYPE RENAME TO — renaming the type itself breaks references in old replicas.
+    if normalized.starts_with("alter type") && normalized.contains(" rename to ") {
+        findings.push(SafetyFinding {
+            operation: "ALTER TYPE RENAME".to_owned(),
+            risk: RiskLevel::Irreversible,
+            why: "Renaming a type breaks all references to its old name in old replicas, \
+                  causing errors during a rolling deploy.",
+            next_action: "Coordinate a maintenance window or use expand/contract by creating \
+                          the new type, migrating columns/code, then dropping the old one.",
+        });
+        return findings;
+    }
+
     // Generic catch-all — DDL/DML not matched by any rule above
     let is_known_start = normalized.starts_with("drop table")
         || normalized.starts_with("drop index")
@@ -640,12 +668,13 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
         || normalized.starts_with("update ")
         || normalized.starts_with("insert into ")
         || normalized.starts_with("delete from ")
+        || normalized.starts_with("merge into ")
         || normalized.starts_with("comment on")
         || normalized.starts_with("create sequence")
         || normalized.starts_with("alter sequence")
         || normalized.starts_with("drop sequence")
         || normalized.starts_with("create type")
-        || normalized.starts_with("alter type")
+        // `alter type` is intentionally absent — unclassified forms fall through to ManualReview
         // `drop type` is intentionally absent — falls through to ManualReview
         || normalized.starts_with("create extension")
         || normalized.starts_with("create view")
@@ -854,6 +883,42 @@ mod tests {
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].risk, RiskLevel::Irreversible);
         assert_eq!(findings[0].operation, "RENAME TABLE");
+    }
+
+    #[test]
+    fn alter_type_rename_value_is_irreversible() {
+        let findings = classify_sql("ALTER TYPE status RENAME VALUE 'draft' TO 'pending';");
+        assert_eq!(
+            findings.len(),
+            1,
+            "ALTER TYPE RENAME VALUE must be flagged: {findings:?}"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::Irreversible);
+        assert_eq!(findings[0].operation, "ALTER TYPE RENAME VALUE");
+    }
+
+    #[test]
+    fn alter_type_rename_to_is_irreversible() {
+        let findings = classify_sql("ALTER TYPE order_status RENAME TO status;");
+        assert_eq!(
+            findings.len(),
+            1,
+            "ALTER TYPE RENAME TO must be flagged: {findings:?}"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::Irreversible);
+        assert_eq!(findings[0].operation, "ALTER TYPE RENAME");
+    }
+
+    #[test]
+    fn alter_type_add_value_requires_manual_review() {
+        // ADD VALUE is not specifically classified — operator must review.
+        let findings = classify_sql("ALTER TYPE status ADD VALUE 'archived';");
+        assert_eq!(
+            findings.len(),
+            1,
+            "unclassified ALTER TYPE must require manual review: {findings:?}"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::ManualReview);
     }
 
     #[test]
@@ -1228,6 +1293,22 @@ mod tests {
     }
 
     // ── data backfill patterns ────────────────────────────────────────────────
+
+    #[test]
+    fn merge_into_is_data_backfill() {
+        let sql = "MERGE INTO posts AS target \
+                   USING staging AS src ON target.id = src.id \
+                   WHEN MATCHED THEN UPDATE SET title = src.title \
+                   WHEN NOT MATCHED THEN INSERT (id, title) VALUES (src.id, src.title);";
+        let findings = classify_sql(sql);
+        assert_eq!(
+            findings.len(),
+            1,
+            "MERGE INTO must be classified as a data backfill: {findings:?}"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::DataBackfill);
+        assert_eq!(findings[0].operation, "Bulk DML (data backfill)");
+    }
 
     #[test]
     fn bulk_update_is_data_backfill() {

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -62,11 +62,28 @@ pub struct SafetyFinding {
 /// Classify the SQL content of an `up.sql` file and return all safety findings.
 ///
 /// Returns an empty `Vec` when the migration is fully additive and safe.
+///
+/// A statement annotated with `-- autumn-safety: reviewed` is skipped entirely,
+/// allowing operators to acknowledge and suppress findings they have manually
+/// reviewed and accepted.
 pub fn classify_sql(sql: &str) -> Vec<SafetyFinding> {
     split_statements(sql)
         .iter()
+        .filter(|stmt| !has_review_suppression(stmt))
         .flat_map(|stmt| classify_statement(&normalize_statement(stmt)))
         .collect()
+}
+
+/// Returns `true` if the raw (un-normalized) statement carries an operator
+/// acknowledgement marker (`-- autumn-safety: reviewed`).
+///
+/// The check is done on the raw text before comment-stripping so the marker
+/// is not accidentally erased.
+fn has_review_suppression(stmt: &str) -> bool {
+    stmt.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed.starts_with("--") && trimmed.contains("autumn-safety: reviewed")
+    })
 }
 
 /// True iff all findings are at the `Safe` risk level (or there are none).
@@ -175,9 +192,10 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
     }
 
     // ADD COLUMN NOT NULL without DEFAULT
+    // Use " default " (word-boundary) so column names like `defaulted_at` don't suppress the check.
     if normalized.contains(" add column ")
         && normalized.contains("not null")
-        && !normalized.contains("default")
+        && !normalized.contains(" default ")
     {
         findings.push(SafetyFinding {
             operation: "ADD COLUMN NOT NULL (no default)".to_owned(),
@@ -359,6 +377,19 @@ mod tests {
     }
 
     #[test]
+    fn add_not_null_column_name_containing_default_is_blocking() {
+        // Column named `defaulted_at` must not be mistaken for having a DEFAULT clause.
+        let sql = "ALTER TABLE posts ADD COLUMN defaulted_at TIMESTAMP NOT NULL;";
+        let findings = classify_sql(sql);
+        assert_eq!(
+            findings.len(),
+            1,
+            "column name containing 'default' must not suppress finding"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
+    }
+
+    #[test]
     fn create_concurrent_index_is_safe() {
         let sql = "CREATE INDEX CONCURRENTLY idx_posts_title ON posts (title);";
         let findings = classify_sql(sql);
@@ -508,6 +539,39 @@ mod tests {
         let sql = "-- autumn-safety: destructive\nALTER TABLE posts DROP COLUMN body;";
         let findings = classify_sql(sql);
         assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn autumn_safety_reviewed_suppresses_manual_review_finding() {
+        // Operator acknowledges a CREATE FUNCTION is safe for their deploy.
+        let sql = "-- autumn-safety: reviewed\nCREATE FUNCTION noop() RETURNS void LANGUAGE sql AS $$SELECT 1$$;";
+        let findings = classify_sql(sql);
+        assert!(
+            findings.is_empty(),
+            "reviewed marker must suppress ManualReview finding: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn autumn_safety_reviewed_suppresses_unclassified_alter_table() {
+        let sql = "-- autumn-safety: reviewed\nALTER TABLE users DROP CONSTRAINT users_email_key;";
+        let findings = classify_sql(sql);
+        assert!(
+            findings.is_empty(),
+            "reviewed marker must suppress finding: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn autumn_safety_destructive_does_not_suppress() {
+        // Only the `reviewed` marker suppresses; other autumn-safety values are informational.
+        let sql = "-- autumn-safety: destructive\nALTER TABLE posts DROP COLUMN body;";
+        let findings = classify_sql(sql);
+        assert_eq!(
+            findings.len(),
+            1,
+            "non-reviewed marker must not suppress findings"
+        );
     }
 
     // ── helper predicates ─────────────────────────────────────────────────────

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -149,7 +149,8 @@ fn alter_table_subcommands(normalized: &str) -> Vec<&str> {
 fn is_known_alter_subcommand(subcommand: &str) -> bool {
     subcommand.starts_with("add column ")
         || subcommand.starts_with("drop column ")
-        || subcommand.starts_with("rename ") // RENAME COLUMN or RENAME TO
+        || subcommand.starts_with("rename column ") // RENAME COLUMN
+        || subcommand.starts_with("rename to ") // RENAME TABLE (ALTER TABLE … RENAME TO …)
         || (subcommand.starts_with("alter column ") && subcommand.contains(" type "))
 }
 
@@ -206,6 +207,24 @@ pub fn contains_concurrent_index(sql: &str) -> bool {
             || normalized.contains("create unique index concurrently ")
             || normalized.starts_with("drop index concurrently ")
     })
+}
+
+/// `PostgreSQL` STABLE/IMMUTABLE function prefixes that are safe as NOT NULL column
+/// defaults: Postgres evaluates them once at statement time and stores the result as
+/// a constant, so the PG 11+ fast-default path applies — no table rewrite needed.
+const STABLE_FN_PREFIXES: &[&str] = &["now(", "current_timestamp(", "localtimestamp("];
+
+/// Returns `true` when `default_expr` is a volatile function call that `PostgreSQL`
+/// cannot optimise via the PG 11+ fast-constant-default path.
+///
+/// STABLE/IMMUTABLE functions (e.g. `now()`) are evaluated once at statement time
+/// and stored as a constant, so they do not require a table rewrite.  Only truly
+/// VOLATILE functions (e.g. `random()`, `gen_random_uuid()`) must be flagged.
+fn is_volatile_function_default(default_expr: &str) -> bool {
+    default_expr.contains('(')
+        && !STABLE_FN_PREFIXES
+            .iter()
+            .any(|p| default_expr.starts_with(p))
 }
 
 /// Apply all pattern checks to a single normalized (lowercase, single-spaced) statement.
@@ -308,13 +327,15 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
         for subcommand in alter_table_subcommands(normalized) {
             if subcommand.starts_with("add column ") && subcommand.contains("not null") {
                 let has_default = subcommand.contains(" default ");
-                // A DEFAULT is "volatile" when it contains a function call (has `(`
-                // anywhere after the `default` keyword).  Constant literals such as
-                // `DEFAULT 0` or `DEFAULT ''` do not contain `(`.
+                // A DEFAULT is "volatile" when it is a VOLATILE function call —
+                // i.e. one that Postgres must evaluate per-row, preventing the PG11+
+                // fast-constant-default path.  STABLE functions (e.g. `now()`) are
+                // evaluated once at statement time and do not require a table rewrite.
                 let has_volatile_default = has_default
-                    && subcommand
-                        .find(" default ")
-                        .is_some_and(|pos| subcommand[pos..].contains('('));
+                    && subcommand.find(" default ").is_some_and(|pos| {
+                        let default_expr = subcommand[pos + " default ".len()..].trim();
+                        is_volatile_function_default(default_expr)
+                    });
 
                 if !has_default {
                     findings.push(SafetyFinding {
@@ -332,9 +353,9 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
                     findings.push(SafetyFinding {
                         operation: "ADD COLUMN NOT NULL (volatile default)".to_owned(),
                         risk: RiskLevel::PotentiallyBlocking,
-                        why: "A function-call DEFAULT (e.g. random(), now(), gen_random_uuid()) \
-                              is volatile: Postgres must evaluate it for every existing row under \
-                              an exclusive lock, potentially rewriting the entire table.",
+                        why: "A volatile function-call DEFAULT (e.g. random(), gen_random_uuid()) \
+                              is evaluated per-row: Postgres cannot use the PG11+ fast-constant \
+                              path and must rewrite the entire table under an exclusive lock.",
                         next_action: "Use a constant literal DEFAULT instead (e.g. DEFAULT 0, \
                                       DEFAULT ''), or add the column nullable, backfill, then \
                                       add the NOT NULL constraint in a later migration.",
@@ -648,6 +669,20 @@ mod tests {
         assert_eq!(findings[0].operation, "RENAME TABLE");
     }
 
+    #[test]
+    fn rename_constraint_requires_manual_review() {
+        // RENAME CONSTRAINT is a schema change that Autumn cannot auto-classify —
+        // it must not silently pass as safe.
+        let findings = classify_sql("ALTER TABLE users RENAME CONSTRAINT old_name TO new_name;");
+        assert_eq!(
+            findings.len(),
+            1,
+            "RENAME CONSTRAINT must not silently pass: {findings:?}"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::ManualReview);
+        assert_eq!(findings[0].operation, "Unclassified ALTER TABLE");
+    }
+
     // ── potentially blocking patterns ─────────────────────────────────────────
 
     #[test]
@@ -698,15 +733,15 @@ mod tests {
     }
 
     #[test]
-    fn add_not_null_column_with_now_default_is_blocking() {
+    fn add_not_null_column_with_now_default_is_safe() {
+        // now() is STABLE: Postgres evaluates it once at statement time and stores the
+        // constant, so the PG11+ fast-default path applies — no table rewrite needed.
         let findings = classify_sql(
             "ALTER TABLE posts ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT now();",
         );
-        assert_eq!(findings.len(), 1);
-        assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
-        assert_eq!(
-            findings[0].operation,
-            "ADD COLUMN NOT NULL (volatile default)"
+        assert!(
+            findings.is_empty(),
+            "DEFAULT now() is stable and must not be flagged as volatile: {findings:?}"
         );
     }
 

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -157,6 +157,20 @@ fn normalize_statement(stmt: &str) -> String {
         .to_lowercase()
 }
 
+/// Returns `true` when `sql` contains an executable `CREATE INDEX CONCURRENTLY`
+/// or `CREATE UNIQUE INDEX CONCURRENTLY` statement.
+///
+/// Uses the same comment-stripping and whitespace-normalization pipeline as
+/// [`classify_sql`] so that a concurrent index mentioned only inside a SQL
+/// comment (e.g. `-- CREATE INDEX CONCURRENTLY ...`) is not counted.
+pub fn contains_concurrent_index(sql: &str) -> bool {
+    split_statements(sql).iter().any(|stmt| {
+        let normalized = normalize_statement(stmt);
+        normalized.contains("create index concurrently")
+            || normalized.contains("create unique index concurrently")
+    })
+}
+
 /// Apply all pattern checks to a single normalized (lowercase, single-spaced) statement.
 #[allow(clippy::too_many_lines)]
 fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
@@ -892,6 +906,44 @@ mod tests {
         assert!(
             findings.iter().all(|f| f.risk != RiskLevel::ManualReview),
             "safe ADD COLUMN should not produce ManualReview: {findings:?}"
+        );
+    }
+
+    // ── contains_concurrent_index ─────────────────────────────────────────────
+
+    #[test]
+    fn contains_concurrent_index_true_for_executable_statement() {
+        assert!(contains_concurrent_index(
+            "CREATE INDEX CONCURRENTLY idx ON posts (title);"
+        ));
+        assert!(contains_concurrent_index(
+            "CREATE UNIQUE INDEX CONCURRENTLY idx ON posts (slug);"
+        ));
+    }
+
+    #[test]
+    fn contains_concurrent_index_false_for_non_concurrent() {
+        assert!(!contains_concurrent_index(
+            "CREATE INDEX idx ON posts (title);"
+        ));
+    }
+
+    #[test]
+    fn contains_concurrent_index_false_for_comment_only_mention() {
+        let sql = "-- TODO: use CREATE INDEX CONCURRENTLY later\n\
+                   CREATE INDEX idx ON posts (title);";
+        assert!(
+            !contains_concurrent_index(sql),
+            "a CONCURRENTLY reference only in a comment must return false"
+        );
+    }
+
+    #[test]
+    fn contains_concurrent_index_true_for_multiline_statement() {
+        let sql = "CREATE INDEX\n  CONCURRENTLY idx_posts_title ON posts (title);";
+        assert!(
+            contains_concurrent_index(sql),
+            "multi-line CONCURRENTLY statement must be detected"
         );
     }
 }

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -69,7 +69,11 @@ pub struct SafetyFinding {
 /// allowing operators to acknowledge and suppress findings they have manually
 /// reviewed and accepted.
 pub fn classify_sql(sql: &str) -> Vec<SafetyFinding> {
-    split_statements(sql)
+    // Strip block comments at the whole-SQL level before splitting so that a
+    // semicolon inside a block comment (e.g. `/* note; end */`) does not produce
+    // a spurious empty statement fragment.
+    let without_block_comments = strip_block_comments(sql);
+    split_statements(&without_block_comments)
         .iter()
         .filter(|stmt| !has_review_suppression(stmt))
         .flat_map(|stmt| classify_statement(&normalize_statement(stmt)))
@@ -394,6 +398,18 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
         });
     }
 
+    // DROP INDEX (non-concurrent) — holds an exclusive table lock
+    if normalized.starts_with("drop index") && !normalized.contains("concurrently") {
+        findings.push(SafetyFinding {
+            operation: "DROP INDEX (non-concurrent)".to_owned(),
+            risk: RiskLevel::PotentiallyBlocking,
+            why: "Non-concurrent DROP INDEX acquires an AccessExclusiveLock on the table, \
+                  blocking all reads and writes for the duration of the drop.",
+            next_action: "Use DROP INDEX CONCURRENTLY to avoid the exclusive table lock. \
+                          Add `run_in_transaction = false` to the migration's `metadata.toml`.",
+        });
+    }
+
     // Generic catch-all — DDL/DML not matched by any rule above
     let is_known_start = normalized.starts_with("drop table")
         || normalized.starts_with("drop index")
@@ -410,7 +426,7 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
         || normalized.starts_with("drop sequence")
         || normalized.starts_with("create type")
         || normalized.starts_with("alter type")
-        || normalized.starts_with("drop type")
+        // `drop type` is intentionally absent — falls through to ManualReview
         || normalized.starts_with("create extension")
         || normalized.starts_with("create view")
         || normalized.starts_with("drop view")
@@ -1035,5 +1051,58 @@ mod tests {
             findings.iter().all(|f| f.risk != RiskLevel::Destructive),
             "Destructive keyword inside block comment must not produce a Destructive finding"
         );
+    }
+
+    #[test]
+    fn block_comment_with_semicolon_does_not_hide_following_statement() {
+        // The semicolon inside the block comment must not split the statement early.
+        let sql = "/* cleanup; safe to drop */ DROP TABLE posts;";
+        let findings = classify_sql(sql);
+        assert_eq!(
+            findings.len(),
+            1,
+            "DROP TABLE after a block comment containing ';' must still be classified"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
+    }
+
+    // ── DROP INDEX ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn drop_index_non_concurrent_is_potentially_blocking() {
+        let findings = classify_sql("DROP INDEX idx_posts_title;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
+        assert_eq!(findings[0].operation, "DROP INDEX (non-concurrent)");
+    }
+
+    #[test]
+    fn drop_index_concurrently_is_safe_from_classifier() {
+        // CONCURRENTLY avoids the table lock; the opt-out check in migrate.rs handles
+        // the metadata.toml requirement separately.
+        let findings = classify_sql("DROP INDEX CONCURRENTLY idx_posts_title;");
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.risk != RiskLevel::PotentiallyBlocking
+                    || f.operation.contains("CONCURRENTLY")),
+            "DROP INDEX CONCURRENTLY must not produce a non-concurrent finding"
+        );
+    }
+
+    // ── DROP TYPE ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn drop_type_requires_manual_review() {
+        let findings = classify_sql("DROP TYPE status;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::ManualReview);
+    }
+
+    #[test]
+    fn drop_type_cascade_requires_manual_review() {
+        let findings = classify_sql("DROP TYPE status CASCADE;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::ManualReview);
     }
 }

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -386,6 +386,20 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
         return findings;
     }
 
+    // DROP SEQUENCE
+    if normalized.starts_with("drop sequence") {
+        findings.push(SafetyFinding {
+            operation: "DROP SEQUENCE".to_owned(),
+            risk: RiskLevel::Destructive,
+            why: "Dropping a sequence breaks any column that uses it as a default \
+                  (`nextval(seq)`) and any application code that calls `nextval` directly. \
+                  Old replicas will error immediately on INSERT.",
+            next_action: "Use expand/contract: first deploy code that no longer relies on this \
+                          sequence, then drop it in a subsequent release.",
+        });
+        return findings;
+    }
+
     // DROP COLUMN
     if normalized.contains(" drop column ") {
         findings.push(SafetyFinding {
@@ -784,6 +798,21 @@ mod tests {
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].risk, RiskLevel::Destructive);
         assert_eq!(findings[0].operation, "DROP TABLE");
+    }
+
+    #[test]
+    fn drop_sequence_is_destructive() {
+        let findings = classify_sql("DROP SEQUENCE posts_id_seq;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
+        assert_eq!(findings[0].operation, "DROP SEQUENCE");
+    }
+
+    #[test]
+    fn drop_sequence_cascade_is_destructive() {
+        let findings = classify_sql("DROP SEQUENCE posts_id_seq CASCADE;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
     }
 
     #[test]

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -52,9 +52,11 @@ pub struct SafetyFinding {
 /// Classify the SQL content of an `up.sql` file and return all safety findings.
 ///
 /// Returns an empty `Vec` when the migration is fully additive and safe.
-/// TODO(red): stub — always returns empty; implement in green phase
-pub fn classify_sql(_sql: &str) -> Vec<SafetyFinding> {
-    vec![]
+pub fn classify_sql(sql: &str) -> Vec<SafetyFinding> {
+    split_statements(sql)
+        .iter()
+        .flat_map(|stmt| classify_statement(&normalize_statement(stmt)))
+        .collect()
 }
 
 /// True iff there are no findings above `Safe` risk level.
@@ -65,6 +67,150 @@ pub fn is_safe(findings: &[SafetyFinding]) -> bool {
 /// True iff any finding exceeds the `Safe` risk level.
 pub fn has_unsafe_findings(findings: &[SafetyFinding]) -> bool {
     findings.iter().any(|f| f.risk > RiskLevel::Safe)
+}
+
+// ── internals ────────────────────────────────────────────────────────────────
+
+fn split_statements(sql: &str) -> Vec<String> {
+    sql.split(';')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Strip line comments, collapse whitespace, and lowercase a single statement.
+fn normalize_statement(stmt: &str) -> String {
+    let stripped: String = stmt
+        .lines()
+        .map(|line| {
+            if let Some(idx) = line.find("--") {
+                &line[..idx]
+            } else {
+                line
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    stripped.split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase()
+}
+
+/// Apply all pattern checks to a single normalized (lowercase, single-spaced) statement.
+fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
+    if normalized.is_empty() {
+        return vec![];
+    }
+
+    let mut findings = Vec::new();
+
+    // DROP TABLE — check first; it subsumes DROP COLUMN detection
+    if normalized.starts_with("drop table") {
+        findings.push(SafetyFinding {
+            operation: "DROP TABLE".to_owned(),
+            risk: RiskLevel::Destructive,
+            why: "Drops the entire table and all its data. Old replicas that reference this \
+                  table will error immediately.",
+            next_action: "Use expand/contract: first deploy code that stops using the table, \
+                          then drop it in a subsequent release.",
+        });
+        return findings;
+    }
+
+    // DROP COLUMN
+    if normalized.contains(" drop column ") {
+        findings.push(SafetyFinding {
+            operation: "DROP COLUMN".to_owned(),
+            risk: RiskLevel::Destructive,
+            why: "Removes a column and its data. Old replicas that SELECT or INSERT this column \
+                  will error until they restart.",
+            next_action: "Use expand/contract: first deploy code that no longer reads or writes \
+                          this column, then drop it in the next release.",
+        });
+    }
+
+    // RENAME COLUMN
+    if normalized.contains(" rename column ") {
+        findings.push(SafetyFinding {
+            operation: "RENAME COLUMN".to_owned(),
+            risk: RiskLevel::Irreversible,
+            why: "Renaming a column breaks queries from old replicas that still reference the \
+                  old name, causing errors during a rolling deploy.",
+            next_action: "Use expand/contract: add the new column, dual-write, backfill existing \
+                          rows, update all code, then drop the old column.",
+        });
+    }
+
+    // RENAME TABLE
+    if normalized.contains("alter table") && normalized.contains(" rename to ")
+        && !normalized.contains(" rename column ")
+    {
+        findings.push(SafetyFinding {
+            operation: "RENAME TABLE".to_owned(),
+            risk: RiskLevel::Irreversible,
+            why: "Renaming a table breaks all queries from old replicas that reference the \
+                  original name.",
+            next_action: "Create a view under the old name while the new name rolls out, or \
+                          coordinate a maintenance window.",
+        });
+    }
+
+    // ALTER COLUMN TYPE
+    if normalized.contains("alter column") {
+        let after_alter = normalized
+            .find("alter column")
+            .map(|i| &normalized[i..])
+            .unwrap_or("");
+        if after_alter.contains(" type ") {
+            findings.push(SafetyFinding {
+                operation: "ALTER COLUMN TYPE".to_owned(),
+                risk: RiskLevel::Destructive,
+                why: "Changing a column's type rewrites the column data and may be incompatible \
+                      with values read by old replicas or application code.",
+                next_action: "Add a new column with the target type, migrate data, update code to \
+                              use the new column, then drop the old one.",
+            });
+        }
+    }
+
+    // ADD COLUMN NOT NULL without DEFAULT
+    if normalized.contains(" add column ") {
+        if let Some(finding) = check_add_column_not_null(normalized) {
+            findings.push(finding);
+        }
+    }
+
+    // CREATE INDEX without CONCURRENTLY
+    if normalized.starts_with("create index")
+        && !normalized.starts_with("create index concurrently")
+    {
+        findings.push(SafetyFinding {
+            operation: "CREATE INDEX (non-concurrent)".to_owned(),
+            risk: RiskLevel::PotentiallyBlocking,
+            why: "Non-concurrent index creation holds an exclusive table lock for the entire \
+                  build, blocking all reads and writes.",
+            next_action: "Use CREATE INDEX CONCURRENTLY instead. Note: concurrent index \
+                          creation cannot run inside a transaction block.",
+        });
+    }
+
+    findings
+}
+
+/// Inspect an ADD COLUMN statement: flag NOT NULL without a DEFAULT.
+fn check_add_column_not_null(normalized: &str) -> Option<SafetyFinding> {
+    if normalized.contains("not null") && !normalized.contains("default") {
+        Some(SafetyFinding {
+            operation: "ADD COLUMN NOT NULL (no default)".to_owned(),
+            risk: RiskLevel::PotentiallyBlocking,
+            why: "Adding a NOT NULL column without a DEFAULT forces Postgres to validate every \
+                  existing row under an exclusive lock. On a large table this may time out.",
+            next_action: "Provide a DEFAULT value, or add the column as nullable first, backfill \
+                          existing rows, then add the NOT NULL constraint in a later migration.",
+        })
+    } else {
+        None
+    }
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -327,10 +327,15 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
 
     // CTE-prefixed bulk DML — WITH … UPDATE / DELETE / INSERT
     // A CTE starts with `with` so the plain DML checks above don't fire.
+    // Check both the outer statement (`) update/delete/insert`) and CTE bodies
+    // (`(update/delete/insert`) to catch data-modifying CTEs followed by SELECT.
     if normalized.starts_with("with ")
         && (normalized.contains(") update ")
             || normalized.contains(") delete ")
-            || normalized.contains(") insert into "))
+            || normalized.contains(") insert into ")
+            || normalized.contains("(update ")
+            || normalized.contains("(delete ")
+            || normalized.contains("(insert into "))
     {
         findings.push(SafetyFinding {
             operation: "Bulk DML (data backfill via CTE)".to_owned(),
@@ -820,6 +825,19 @@ mod tests {
         assert!(
             findings.iter().all(|f| f.risk != RiskLevel::DataBackfill),
             "read-only CTE must not produce DataBackfill finding: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn cte_body_write_with_outer_select_is_data_backfill() {
+        // data-modifying CTE where the outer statement is SELECT, not UPDATE/DELETE.
+        let sql = "WITH touched AS \
+                   (UPDATE posts SET migrated = true WHERE migrated IS NULL RETURNING id) \
+                   SELECT count(*) FROM touched;";
+        let findings = classify_sql(sql);
+        assert!(
+            findings.iter().any(|f| f.risk == RiskLevel::DataBackfill),
+            "data-modifying CTE with outer SELECT must still be flagged: {findings:?}"
         );
     }
 

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -81,19 +81,12 @@ fn split_statements(sql: &str) -> Vec<String> {
 
 /// Strip line comments, collapse whitespace, and lowercase a single statement.
 fn normalize_statement(stmt: &str) -> String {
-    let stripped: String = stmt
-        .lines()
-        .map(|line| {
-            if let Some(idx) = line.find("--") {
-                &line[..idx]
-            } else {
-                line
-            }
-        })
+    stmt.lines()
+        .map(|line| line.find("--").map_or(line, |i| &line[..i]))
+        .flat_map(str::split_whitespace)
         .collect::<Vec<_>>()
-        .join(" ");
-
-    stripped.split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase()
+        .join(" ")
+        .to_lowercase()
 }
 
 /// Apply all pattern checks to a single normalized (lowercase, single-spaced) statement.
@@ -156,12 +149,8 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
     }
 
     // ALTER COLUMN TYPE
-    if normalized.contains("alter column") {
-        let after_alter = normalized
-            .find("alter column")
-            .map(|i| &normalized[i..])
-            .unwrap_or("");
-        if after_alter.contains(" type ") {
+    if let Some(i) = normalized.find("alter column") {
+        if normalized[i..].contains(" type ") {
             findings.push(SafetyFinding {
                 operation: "ALTER COLUMN TYPE".to_owned(),
                 risk: RiskLevel::Destructive,
@@ -174,10 +163,18 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
     }
 
     // ADD COLUMN NOT NULL without DEFAULT
-    if normalized.contains(" add column ") {
-        if let Some(finding) = check_add_column_not_null(normalized) {
-            findings.push(finding);
-        }
+    if normalized.contains(" add column ")
+        && normalized.contains("not null")
+        && !normalized.contains("default")
+    {
+        findings.push(SafetyFinding {
+            operation: "ADD COLUMN NOT NULL (no default)".to_owned(),
+            risk: RiskLevel::PotentiallyBlocking,
+            why: "Adding a NOT NULL column without a DEFAULT forces Postgres to validate every \
+                  existing row under an exclusive lock. On a large table this may time out.",
+            next_action: "Provide a DEFAULT value, or add the column as nullable first, backfill \
+                          existing rows, then add the NOT NULL constraint in a later migration.",
+        });
     }
 
     // CREATE INDEX without CONCURRENTLY
@@ -195,22 +192,6 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
     }
 
     findings
-}
-
-/// Inspect an ADD COLUMN statement: flag NOT NULL without a DEFAULT.
-fn check_add_column_not_null(normalized: &str) -> Option<SafetyFinding> {
-    if normalized.contains("not null") && !normalized.contains("default") {
-        Some(SafetyFinding {
-            operation: "ADD COLUMN NOT NULL (no default)".to_owned(),
-            risk: RiskLevel::PotentiallyBlocking,
-            why: "Adding a NOT NULL column without a DEFAULT forces Postgres to validate every \
-                  existing row under an exclusive lock. On a large table this may time out.",
-            next_action: "Provide a DEFAULT value, or add the column as nullable first, backfill \
-                          existing rows, then add the NOT NULL constraint in a later migration.",
-        })
-    } else {
-        None
-    }
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -191,6 +191,63 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
         });
     }
 
+    // Data backfill — bulk DML inside a migration requires a separate job
+    if normalized.starts_with("update ") || normalized.starts_with("insert into ") {
+        findings.push(SafetyFinding {
+            operation: "Bulk DML (data backfill)".to_owned(),
+            risk: RiskLevel::DataBackfill,
+            why: "Running bulk UPDATE or INSERT inside a migration locks rows for the duration \
+                  of the transaction. On large tables this can time out or block application \
+                  traffic for seconds to minutes.",
+            next_action: "Run the data backfill as a separate idempotent background job or \
+                          one-off task (`autumn task`) after the schema migration has deployed. \
+                          Add a NOT VALID constraint first if you need the constraint enforced \
+                          before the backfill completes.",
+        });
+    }
+
+    // Manual review catch-all — DDL or DML not covered by the rules above
+    // Unknown DDL/DML that Autumn has no rule for — require operator review.
+    // Check only statements that look like DDL but don't match any known starter.
+    let is_known_start = normalized.starts_with("drop table")
+        || normalized.starts_with("drop index")
+        || normalized.starts_with("alter table")
+        || normalized.starts_with("create table")
+        || normalized.starts_with("create index")
+        || normalized.starts_with("create unique index")
+        || normalized.starts_with("update ")
+        || normalized.starts_with("insert into ")
+        || normalized.starts_with("comment on")
+        || normalized.starts_with("create sequence")
+        || normalized.starts_with("alter sequence")
+        || normalized.starts_with("drop sequence")
+        || normalized.starts_with("create type")
+        || normalized.starts_with("alter type")
+        || normalized.starts_with("drop type")
+        || normalized.starts_with("create extension")
+        || normalized.starts_with("create view")
+        || normalized.starts_with("drop view")
+        || normalized.starts_with("select ");
+
+    let starts_with_ddl_keyword = normalized.starts_with("create ")
+        || normalized.starts_with("drop ")
+        || normalized.starts_with("alter ")
+        || normalized.starts_with("truncate ")
+        || normalized.starts_with("grant ")
+        || normalized.starts_with("revoke ");
+
+    if starts_with_ddl_keyword && !is_known_start {
+        findings.push(SafetyFinding {
+            operation: "Unclassified DDL".to_owned(),
+            risk: RiskLevel::ManualReview,
+            why: "Autumn cannot automatically assess the safety of this statement for a rolling \
+                  deploy. Operator review is required before applying this migration in \
+                  production.",
+            next_action: "Review the statement manually. If it is safe, you may suppress this \
+                          finding by adding `-- autumn-safety: reviewed` above the statement.",
+        });
+    }
+
     findings
 }
 
@@ -428,6 +485,66 @@ mod tests {
             f.next_action.to_lowercase().contains("concurrently"),
             "next_action should recommend CONCURRENTLY: {}",
             f.next_action
+        );
+    }
+
+    // ── data backfill patterns ────────────────────────────────────────────────
+
+    #[test]
+    fn bulk_update_is_data_backfill() {
+        let findings = classify_sql("UPDATE posts SET status = 'draft' WHERE status IS NULL;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::DataBackfill);
+        assert_eq!(findings[0].operation, "Bulk DML (data backfill)");
+    }
+
+    #[test]
+    fn insert_select_is_data_backfill() {
+        let findings = classify_sql(
+            "INSERT INTO post_tags (post_id, tag) SELECT id, 'untagged' FROM posts;",
+        );
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::DataBackfill);
+    }
+
+    #[test]
+    fn data_backfill_finding_recommends_separate_job() {
+        let findings = classify_sql("UPDATE posts SET slug = LOWER(title);");
+        let f = &findings[0];
+        assert!(!f.why.is_empty());
+        assert!(
+            f.next_action.to_lowercase().contains("background job")
+                || f.next_action.to_lowercase().contains("task"),
+            "next_action should recommend a separate job or task: {}",
+            f.next_action
+        );
+    }
+
+    // ── manual review patterns ────────────────────────────────────────────────
+
+    #[test]
+    fn create_function_requires_manual_review() {
+        let sql = "CREATE FUNCTION update_modified() RETURNS trigger AS $$ BEGIN NEW.updated_at = now(); RETURN NEW; END; $$ LANGUAGE plpgsql;";
+        let findings = classify_sql(sql);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::ManualReview);
+        assert_eq!(findings[0].operation, "Unclassified DDL");
+    }
+
+    #[test]
+    fn truncate_requires_manual_review() {
+        let findings = classify_sql("TRUNCATE TABLE staging_data;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::ManualReview);
+    }
+
+    #[test]
+    fn known_ddl_does_not_trigger_manual_review() {
+        // CREATE TABLE is safe — must not get a ManualReview finding on top
+        let findings = classify_sql("CREATE TABLE comments (id BIGSERIAL PRIMARY KEY);");
+        assert!(
+            findings.iter().all(|f| f.risk != RiskLevel::ManualReview),
+            "known DDL should not also produce ManualReview: {findings:?}"
         );
     }
 }

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -138,6 +138,19 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
         return findings;
     }
 
+    // DROP VIEW
+    if normalized.starts_with("drop view") {
+        findings.push(SafetyFinding {
+            operation: "DROP VIEW".to_owned(),
+            risk: RiskLevel::Destructive,
+            why: "Drops the view. Old replicas that query this view will error immediately \
+                  during a rolling deploy.",
+            next_action: "Use expand/contract: first deploy code that no longer references the \
+                          view, then drop it in a subsequent release.",
+        });
+        return findings;
+    }
+
     // DROP COLUMN
     if normalized.contains(" drop column ") {
         findings.push(SafetyFinding {
@@ -261,6 +274,23 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
                           one-off task (`autumn task`) after the schema migration has deployed. \
                           Add a NOT VALID constraint first if you need the constraint enforced \
                           before the backfill completes.",
+        });
+    }
+
+    // CTE-prefixed bulk DML — WITH … UPDATE / DELETE / INSERT
+    // A CTE starts with `with` so the plain DML checks above don't fire.
+    if normalized.starts_with("with ")
+        && (normalized.contains(") update ")
+            || normalized.contains(") delete ")
+            || normalized.contains(") insert into "))
+    {
+        findings.push(SafetyFinding {
+            operation: "Bulk DML (data backfill via CTE)".to_owned(),
+            risk: RiskLevel::DataBackfill,
+            why: "A CTE that writes (UPDATE, DELETE, INSERT) locks rows for the duration of the \
+                  transaction. On large tables this can time out or block application traffic.",
+            next_action: "Run the data backfill as a separate idempotent background job or \
+                          one-off task (`autumn task`) after the schema migration has deployed.",
         });
     }
 
@@ -410,6 +440,21 @@ mod tests {
     }
 
     // ── destructive patterns ──────────────────────────────────────────────────
+
+    #[test]
+    fn drop_view_is_destructive() {
+        let findings = classify_sql("DROP VIEW active_posts;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
+        assert_eq!(findings[0].operation, "DROP VIEW");
+    }
+
+    #[test]
+    fn drop_view_cascade_is_destructive() {
+        let findings = classify_sql("DROP VIEW active_posts CASCADE;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
+    }
 
     #[test]
     fn drop_table_is_destructive() {
@@ -671,6 +716,36 @@ mod tests {
                 || f.next_action.to_lowercase().contains("task"),
             "next_action should recommend a separate job or task: {}",
             f.next_action
+        );
+    }
+
+    #[test]
+    fn cte_update_is_data_backfill() {
+        let sql = "WITH batch AS (SELECT id FROM posts WHERE status IS NULL LIMIT 1000) \
+                   UPDATE posts SET status = 'draft' FROM batch WHERE posts.id = batch.id;";
+        let findings = classify_sql(sql);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::DataBackfill);
+        assert_eq!(findings[0].operation, "Bulk DML (data backfill via CTE)");
+    }
+
+    #[test]
+    fn cte_delete_is_data_backfill() {
+        let sql = "WITH doomed AS (SELECT id FROM posts WHERE archived = true) DELETE FROM posts USING doomed WHERE posts.id = doomed.id;";
+        let findings = classify_sql(sql);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::DataBackfill);
+    }
+
+    #[test]
+    fn cte_select_only_is_safe() {
+        // A read-only CTE should not produce a DataBackfill finding.
+        let sql = "WITH recent AS (SELECT id FROM posts ORDER BY created_at DESC LIMIT 10) \
+                   SELECT * FROM recent;";
+        let findings = classify_sql(sql);
+        assert!(
+            findings.iter().all(|f| f.risk != RiskLevel::DataBackfill),
+            "read-only CTE must not produce DataBackfill finding: {findings:?}"
         );
     }
 

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -296,26 +296,51 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
         });
     }
 
-    // ADD COLUMN NOT NULL without DEFAULT — checked per subcommand so that a DEFAULT
-    // on one column in a multi-column ALTER TABLE does not suppress the check for other
-    // columns that lack a DEFAULT.
+    // ADD COLUMN NOT NULL — checked per subcommand so that a DEFAULT on one column
+    // in a multi-column ALTER TABLE does not suppress the check for other columns.
+    //
+    // Two unsafe cases:
+    //  1. No DEFAULT at all — Postgres must validate every existing row under lock.
+    //  2. Volatile DEFAULT (contains a function call) — Postgres must evaluate the
+    //     function per-row and cannot use the fast constant-default path (PG 11+),
+    //     so the table is still rewritten under the exclusive lock.
     if normalized.starts_with("alter table") {
         for subcommand in alter_table_subcommands(normalized) {
-            if subcommand.starts_with("add column ")
-                && subcommand.contains("not null")
-                && !subcommand.contains(" default ")
-            {
-                findings.push(SafetyFinding {
-                    operation: "ADD COLUMN NOT NULL (no default)".to_owned(),
-                    risk: RiskLevel::PotentiallyBlocking,
-                    why: "Adding a NOT NULL column without a DEFAULT forces Postgres to validate \
-                          every existing row under an exclusive lock. On a large table this may \
-                          time out.",
-                    next_action: "Provide a DEFAULT value, or add the column as nullable first, \
-                                  backfill existing rows, then add the NOT NULL constraint in a \
-                                  later migration.",
-                });
-                break; // one finding per statement is sufficient
+            if subcommand.starts_with("add column ") && subcommand.contains("not null") {
+                let has_default = subcommand.contains(" default ");
+                // A DEFAULT is "volatile" when it contains a function call (has `(`
+                // anywhere after the `default` keyword).  Constant literals such as
+                // `DEFAULT 0` or `DEFAULT ''` do not contain `(`.
+                let has_volatile_default = has_default
+                    && subcommand
+                        .find(" default ")
+                        .is_some_and(|pos| subcommand[pos..].contains('('));
+
+                if !has_default {
+                    findings.push(SafetyFinding {
+                        operation: "ADD COLUMN NOT NULL (no default)".to_owned(),
+                        risk: RiskLevel::PotentiallyBlocking,
+                        why: "Adding a NOT NULL column without a DEFAULT forces Postgres to \
+                              validate every existing row under an exclusive lock. On a large \
+                              table this may time out.",
+                        next_action: "Provide a constant DEFAULT value, or add the column as \
+                                      nullable first, backfill existing rows, then add the NOT \
+                                      NULL constraint in a later migration.",
+                    });
+                    break; // one finding per statement is sufficient
+                } else if has_volatile_default {
+                    findings.push(SafetyFinding {
+                        operation: "ADD COLUMN NOT NULL (volatile default)".to_owned(),
+                        risk: RiskLevel::PotentiallyBlocking,
+                        why: "A function-call DEFAULT (e.g. random(), now(), gen_random_uuid()) \
+                              is volatile: Postgres must evaluate it for every existing row under \
+                              an exclusive lock, potentially rewriting the entire table.",
+                        next_action: "Use a constant literal DEFAULT instead (e.g. DEFAULT 0, \
+                                      DEFAULT ''), or add the column nullable, backfill, then \
+                                      add the NOT NULL constraint in a later migration.",
+                    });
+                    break; // one finding per statement is sufficient
+                }
             }
         }
     }
@@ -655,6 +680,43 @@ mod tests {
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
         assert_eq!(findings[0].operation, "ADD COLUMN NOT NULL (no default)");
+    }
+
+    #[test]
+    fn add_not_null_column_with_volatile_default_is_blocking() {
+        let findings = classify_sql(
+            "ALTER TABLE posts ADD COLUMN token UUID NOT NULL DEFAULT gen_random_uuid();",
+        );
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
+        assert_eq!(
+            findings[0].operation,
+            "ADD COLUMN NOT NULL (volatile default)"
+        );
+    }
+
+    #[test]
+    fn add_not_null_column_with_now_default_is_blocking() {
+        let findings = classify_sql(
+            "ALTER TABLE posts ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT now();",
+        );
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
+        assert_eq!(
+            findings[0].operation,
+            "ADD COLUMN NOT NULL (volatile default)"
+        );
+    }
+
+    #[test]
+    fn add_not_null_column_with_constant_default_is_safe() {
+        // Constant literals use the PG11+ fast path — no table rewrite.
+        let findings =
+            classify_sql("ALTER TABLE posts ADD COLUMN active BOOLEAN NOT NULL DEFAULT false;");
+        assert!(
+            findings.is_empty(),
+            "constant DEFAULT false must be safe: {findings:?}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -146,7 +146,8 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
     }
 
     // RENAME TABLE
-    if normalized.contains("alter table") && normalized.contains(" rename to ")
+    if normalized.contains("alter table")
+        && normalized.contains(" rename to ")
         && !normalized.contains(" rename column ")
     {
         findings.push(SafetyFinding {
@@ -212,8 +213,8 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
     }
 
     // CREATE INDEX / CREATE UNIQUE INDEX without CONCURRENTLY
-    let is_create_index = normalized.starts_with("create index")
-        || normalized.starts_with("create unique index");
+    let is_create_index =
+        normalized.starts_with("create index") || normalized.starts_with("create unique index");
     let is_concurrent = normalized.starts_with("create index concurrently")
         || normalized.starts_with("create unique index concurrently");
     if is_create_index && !is_concurrent {
@@ -309,7 +310,10 @@ mod tests {
     #[test]
     fn risk_level_display() {
         assert_eq!(RiskLevel::Safe.to_string(), "safe");
-        assert_eq!(RiskLevel::PotentiallyBlocking.to_string(), "potentially-blocking");
+        assert_eq!(
+            RiskLevel::PotentiallyBlocking.to_string(),
+            "potentially-blocking"
+        );
         assert_eq!(RiskLevel::Destructive.to_string(), "destructive");
         assert_eq!(RiskLevel::Irreversible.to_string(), "irreversible");
         assert_eq!(RiskLevel::DataBackfill.to_string(), "data-backfill");
@@ -325,30 +329,43 @@ mod tests {
 
     #[test]
     fn create_table_is_safe() {
-        let sql = "CREATE TABLE posts (\n    id BIGSERIAL PRIMARY KEY,\n    title TEXT NOT NULL\n);";
+        let sql =
+            "CREATE TABLE posts (\n    id BIGSERIAL PRIMARY KEY,\n    title TEXT NOT NULL\n);";
         let findings = classify_sql(sql);
-        assert!(findings.is_empty(), "CREATE TABLE should be safe: {findings:?}");
+        assert!(
+            findings.is_empty(),
+            "CREATE TABLE should be safe: {findings:?}"
+        );
     }
 
     #[test]
     fn add_nullable_column_is_safe() {
         let sql = "ALTER TABLE posts ADD COLUMN subtitle TEXT NULL;";
         let findings = classify_sql(sql);
-        assert!(findings.is_empty(), "ADD COLUMN NULL should be safe: {findings:?}");
+        assert!(
+            findings.is_empty(),
+            "ADD COLUMN NULL should be safe: {findings:?}"
+        );
     }
 
     #[test]
     fn add_not_null_column_with_default_is_safe() {
         let sql = "ALTER TABLE posts ADD COLUMN status TEXT NOT NULL DEFAULT 'draft';";
         let findings = classify_sql(sql);
-        assert!(findings.is_empty(), "ADD COLUMN NOT NULL DEFAULT should be safe: {findings:?}");
+        assert!(
+            findings.is_empty(),
+            "ADD COLUMN NOT NULL DEFAULT should be safe: {findings:?}"
+        );
     }
 
     #[test]
     fn create_concurrent_index_is_safe() {
         let sql = "CREATE INDEX CONCURRENTLY idx_posts_title ON posts (title);";
         let findings = classify_sql(sql);
-        assert!(findings.is_empty(), "CREATE INDEX CONCURRENTLY should be safe: {findings:?}");
+        assert!(
+            findings.is_empty(),
+            "CREATE INDEX CONCURRENTLY should be safe: {findings:?}"
+        );
     }
 
     #[test]
@@ -467,7 +484,11 @@ mod tests {
         let findings = classify_sql(sql);
         assert_eq!(findings.len(), 2);
         assert!(findings.iter().any(|f| f.risk == RiskLevel::Destructive));
-        assert!(findings.iter().any(|f| f.risk == RiskLevel::PotentiallyBlocking));
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.risk == RiskLevel::PotentiallyBlocking)
+        );
     }
 
     // ── line comments are ignored ─────────────────────────────────────────────
@@ -529,8 +550,14 @@ mod tests {
     fn drop_column_finding_names_the_risk_and_next_action() {
         let findings = classify_sql("ALTER TABLE posts DROP COLUMN body;");
         let f = &findings[0];
-        assert!(!f.why.is_empty(), "why must explain the rolling-deploy risk");
-        assert!(!f.next_action.is_empty(), "next_action must tell the operator what to do");
+        assert!(
+            !f.why.is_empty(),
+            "why must explain the rolling-deploy risk"
+        );
+        assert!(
+            !f.next_action.is_empty(),
+            "next_action must tell the operator what to do"
+        );
     }
 
     #[test]
@@ -556,9 +583,8 @@ mod tests {
 
     #[test]
     fn insert_select_is_data_backfill() {
-        let findings = classify_sql(
-            "INSERT INTO post_tags (post_id, tag) SELECT id, 'untagged' FROM posts;",
-        );
+        let findings =
+            classify_sql("INSERT INTO post_tags (post_id, tag) SELECT id, 'untagged' FROM posts;");
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].risk, RiskLevel::DataBackfill);
     }
@@ -604,8 +630,7 @@ mod tests {
 
     #[test]
     fn drop_constraint_requires_manual_review() {
-        let findings =
-            classify_sql("ALTER TABLE users DROP CONSTRAINT users_email_key;");
+        let findings = classify_sql("ALTER TABLE users DROP CONSTRAINT users_email_key;");
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].risk, RiskLevel::ManualReview);
         assert_eq!(findings[0].operation, "Unclassified ALTER TABLE");
@@ -613,8 +638,7 @@ mod tests {
 
     #[test]
     fn alter_column_set_not_null_requires_manual_review() {
-        let findings =
-            classify_sql("ALTER TABLE users ALTER COLUMN email SET NOT NULL;");
+        let findings = classify_sql("ALTER TABLE users ALTER COLUMN email SET NOT NULL;");
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].risk, RiskLevel::ManualReview);
         assert_eq!(findings[0].operation, "Unclassified ALTER TABLE");

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -10,9 +10,11 @@
 //!   literals or `PostgreSQL` dollar-quoted blocks (`$$…$$`) will produce
 //!   incorrect splits. Real migration files almost never embed semicolons in
 //!   strings, so this is an acceptable approximation.
-//! - Comment stripping matches `--` by position on each line. A `--` sequence
-//!   inside a string literal would be incorrectly treated as a comment start.
-//!   Again, this pattern is essentially absent from real migration files.
+//! - Line comment stripping matches `--` by position on each line. A `--`
+//!   sequence inside a string literal would be incorrectly treated as a comment
+//!   start. Again, this pattern is essentially absent from real migration files.
+//! - Block comment stripping (`/* … */`) similarly does not handle `/*` or `*/`
+//!   tokens that appear inside string literals.
 
 use std::fmt;
 
@@ -147,9 +149,39 @@ fn is_known_alter_subcommand(subcommand: &str) -> bool {
         || (subcommand.starts_with("alter column ") && subcommand.contains(" type "))
 }
 
+/// Remove `/* ... */` block comments from `sql`.
+///
+/// Handles single-line and multi-line block comments. Unclosed block comments
+/// are consumed to end-of-input. Block comments inside string literals are an
+/// edge case not handled here (same limitation as `--` in strings).
+fn strip_block_comments(sql: &str) -> String {
+    let mut result = String::with_capacity(sql.len());
+    let mut chars = sql.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '/' && chars.peek() == Some(&'*') {
+            chars.next(); // consume '*'
+            loop {
+                match chars.next() {
+                    Some('*') if chars.peek() == Some(&'/') => {
+                        chars.next(); // consume '/'
+                        break;
+                    }
+                    None => break, // unclosed block comment
+                    _ => {}
+                }
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
 /// Strip line comments, collapse whitespace, and lowercase a single statement.
 fn normalize_statement(stmt: &str) -> String {
-    stmt.lines()
+    let without_block_comments = strip_block_comments(stmt);
+    without_block_comments
+        .lines()
         .map(|line| line.find("--").map_or(line, |i| &line[..i]))
         .flat_map(str::split_whitespace)
         .collect::<Vec<_>>()
@@ -157,17 +189,18 @@ fn normalize_statement(stmt: &str) -> String {
         .to_lowercase()
 }
 
-/// Returns `true` when `sql` contains an executable `CREATE INDEX CONCURRENTLY`
-/// or `CREATE UNIQUE INDEX CONCURRENTLY` statement.
+/// Returns `true` when `sql` contains an executable concurrent index operation
+/// (`CREATE [UNIQUE] INDEX CONCURRENTLY` or `DROP INDEX CONCURRENTLY`).
 ///
 /// Uses the same comment-stripping and whitespace-normalization pipeline as
-/// [`classify_sql`] so that a concurrent index mentioned only inside a SQL
-/// comment (e.g. `-- CREATE INDEX CONCURRENTLY ...`) is not counted.
+/// [`classify_sql`] so that concurrent index keywords mentioned only inside a
+/// SQL comment (e.g. `-- CREATE INDEX CONCURRENTLY ...`) are not counted.
 pub fn contains_concurrent_index(sql: &str) -> bool {
     split_statements(sql).iter().any(|stmt| {
         let normalized = normalize_statement(stmt);
         normalized.contains("create index concurrently")
             || normalized.contains("create unique index concurrently")
+            || normalized.contains("drop index concurrently")
     })
 }
 
@@ -944,6 +977,63 @@ mod tests {
         assert!(
             contains_concurrent_index(sql),
             "multi-line CONCURRENTLY statement must be detected"
+        );
+    }
+
+    #[test]
+    fn contains_concurrent_index_true_for_drop_index_concurrently() {
+        assert!(
+            contains_concurrent_index("DROP INDEX CONCURRENTLY idx_posts_title;"),
+            "DROP INDEX CONCURRENTLY must be detected"
+        );
+    }
+
+    // ── block comment stripping ───────────────────────────────────────────────
+
+    #[test]
+    fn block_comment_before_drop_table_is_still_classified() {
+        let sql = "/* cleanup old table */ DROP TABLE posts;";
+        let findings = classify_sql(sql);
+        assert_eq!(
+            findings.len(),
+            1,
+            "DROP TABLE must be found after block comment"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
+    }
+
+    #[test]
+    fn block_comment_before_create_index_is_still_classified() {
+        let sql = "/* needs index */ CREATE INDEX idx ON posts (title);";
+        let findings = classify_sql(sql);
+        assert_eq!(
+            findings.len(),
+            1,
+            "CREATE INDEX must be found after block comment"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
+    }
+
+    #[test]
+    fn multiline_block_comment_is_stripped() {
+        let sql = "/*\n * Remove legacy column\n */\nALTER TABLE posts DROP COLUMN body;";
+        let findings = classify_sql(sql);
+        assert_eq!(
+            findings.len(),
+            1,
+            "DROP COLUMN must be found after multi-line block comment"
+        );
+        assert_eq!(findings[0].risk, RiskLevel::Destructive);
+    }
+
+    #[test]
+    fn block_comment_only_mention_of_keyword_is_not_classified() {
+        // Only mentions DROP TABLE inside a block comment; actual statement is safe.
+        let sql = "/* was: DROP TABLE posts; */ ALTER TABLE posts ADD COLUMN active BOOL;";
+        let findings = classify_sql(sql);
+        assert!(
+            findings.iter().all(|f| f.risk != RiskLevel::Destructive),
+            "Destructive keyword inside block comment must not produce a Destructive finding"
         );
     }
 }

--- a/autumn-cli/src/migrate/safety.rs
+++ b/autumn-cli/src/migrate/safety.rs
@@ -3,6 +3,16 @@
 //! Inspects the contents of `up.sql` files and classifies each SQL statement
 //! into a risk tier. The result drives `autumn migrate check`'s exit code and
 //! human-readable safety report printed to stderr.
+//!
+//! # Known limitations
+//!
+//! - Statement splitting uses `;` as the delimiter. Semicolons inside string
+//!   literals or `PostgreSQL` dollar-quoted blocks (`$$…$$`) will produce
+//!   incorrect splits. Real migration files almost never embed semicolons in
+//!   strings, so this is an acceptable approximation.
+//! - Comment stripping matches `--` by position on each line. A `--` sequence
+//!   inside a string literal would be incorrectly treated as a comment start.
+//!   Again, this pattern is essentially absent from real migration files.
 
 use std::fmt;
 
@@ -59,7 +69,7 @@ pub fn classify_sql(sql: &str) -> Vec<SafetyFinding> {
         .collect()
 }
 
-/// True iff there are no findings above `Safe` risk level.
+/// True iff all findings are at the `Safe` risk level (or there are none).
 pub fn is_safe(findings: &[SafetyFinding]) -> bool {
     findings.iter().all(|f| f.risk == RiskLevel::Safe)
 }
@@ -90,6 +100,7 @@ fn normalize_statement(stmt: &str) -> String {
 }
 
 /// Apply all pattern checks to a single normalized (lowercase, single-spaced) statement.
+#[allow(clippy::too_many_lines)]
 fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
     if normalized.is_empty() {
         return vec![];
@@ -149,17 +160,17 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
     }
 
     // ALTER COLUMN TYPE
-    if let Some(i) = normalized.find("alter column") {
-        if normalized[i..].contains(" type ") {
-            findings.push(SafetyFinding {
-                operation: "ALTER COLUMN TYPE".to_owned(),
-                risk: RiskLevel::Destructive,
-                why: "Changing a column's type rewrites the column data and may be incompatible \
-                      with values read by old replicas or application code.",
-                next_action: "Add a new column with the target type, migrate data, update code to \
-                              use the new column, then drop the old one.",
-            });
-        }
+    if let Some(i) = normalized.find("alter column")
+        && normalized[i..].contains(" type ")
+    {
+        findings.push(SafetyFinding {
+            operation: "ALTER COLUMN TYPE".to_owned(),
+            risk: RiskLevel::Destructive,
+            why: "Changing a column's type rewrites the column data and may be incompatible \
+                  with values read by old replicas or application code.",
+            next_action: "Add a new column with the target type, migrate data, update code to \
+                          use the new column, then drop the old one.",
+        });
     }
 
     // ADD COLUMN NOT NULL without DEFAULT
@@ -177,10 +188,35 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
         });
     }
 
-    // CREATE INDEX without CONCURRENTLY
-    if normalized.starts_with("create index")
-        && !normalized.starts_with("create index concurrently")
-    {
+    // Unclassified ALTER TABLE subcommand — catch operations like DROP CONSTRAINT,
+    // ADD CONSTRAINT, and ALTER COLUMN SET NOT NULL that aren't covered by the rules
+    // above. Only fires when none of the specific rules produced a finding.
+    if normalized.starts_with("alter table") && findings.is_empty() {
+        let known_subcommand = normalized.contains(" add column ")
+            || normalized.contains(" drop column ")
+            || normalized.contains(" rename ") // RENAME COLUMN or RENAME TO
+            || (normalized.contains(" alter column ") && normalized.contains(" type "));
+        if !known_subcommand {
+            findings.push(SafetyFinding {
+                operation: "Unclassified ALTER TABLE".to_owned(),
+                risk: RiskLevel::ManualReview,
+                why: "Autumn cannot automatically assess the safety of this ALTER TABLE \
+                      subcommand for a rolling deploy. Some operations (e.g. DROP CONSTRAINT, \
+                      ALTER COLUMN SET NOT NULL, ADD CONSTRAINT) acquire table locks or validate \
+                      existing rows.",
+                next_action: "Review the statement manually. If it is safe, you may suppress \
+                              this finding by adding `-- autumn-safety: reviewed` above the \
+                              statement.",
+            });
+        }
+    }
+
+    // CREATE INDEX / CREATE UNIQUE INDEX without CONCURRENTLY
+    let is_create_index = normalized.starts_with("create index")
+        || normalized.starts_with("create unique index");
+    let is_concurrent = normalized.starts_with("create index concurrently")
+        || normalized.starts_with("create unique index concurrently");
+    if is_create_index && !is_concurrent {
         findings.push(SafetyFinding {
             operation: "CREATE INDEX (non-concurrent)".to_owned(),
             risk: RiskLevel::PotentiallyBlocking,
@@ -192,7 +228,10 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
     }
 
     // Data backfill — bulk DML inside a migration requires a separate job
-    if normalized.starts_with("update ") || normalized.starts_with("insert into ") {
+    if normalized.starts_with("update ")
+        || normalized.starts_with("insert into ")
+        || normalized.starts_with("delete from ")
+    {
         findings.push(SafetyFinding {
             operation: "Bulk DML (data backfill)".to_owned(),
             risk: RiskLevel::DataBackfill,
@@ -206,17 +245,16 @@ fn classify_statement(normalized: &str) -> Vec<SafetyFinding> {
         });
     }
 
-    // Manual review catch-all — DDL or DML not covered by the rules above
-    // Unknown DDL/DML that Autumn has no rule for — require operator review.
-    // Check only statements that look like DDL but don't match any known starter.
+    // Generic catch-all — DDL/DML not matched by any rule above
     let is_known_start = normalized.starts_with("drop table")
         || normalized.starts_with("drop index")
-        || normalized.starts_with("alter table")
+        || normalized.starts_with("alter table") // unclassified subcommands handled above
         || normalized.starts_with("create table")
         || normalized.starts_with("create index")
         || normalized.starts_with("create unique index")
         || normalized.starts_with("update ")
         || normalized.starts_with("insert into ")
+        || normalized.starts_with("delete from ")
         || normalized.starts_with("comment on")
         || normalized.starts_with("create sequence")
         || normalized.starts_with("alter sequence")
@@ -313,6 +351,16 @@ mod tests {
         assert!(findings.is_empty(), "CREATE INDEX CONCURRENTLY should be safe: {findings:?}");
     }
 
+    #[test]
+    fn create_unique_index_concurrently_is_safe() {
+        let sql = "CREATE UNIQUE INDEX CONCURRENTLY idx_posts_slug ON posts (slug);";
+        let findings = classify_sql(sql);
+        assert!(
+            findings.is_empty(),
+            "CREATE UNIQUE INDEX CONCURRENTLY should be safe: {findings:?}"
+        );
+    }
+
     // ── destructive patterns ──────────────────────────────────────────────────
 
     #[test]
@@ -377,6 +425,14 @@ mod tests {
     #[test]
     fn create_non_concurrent_index_is_blocking() {
         let findings = classify_sql("CREATE INDEX idx_posts_title ON posts (title);");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
+        assert_eq!(findings[0].operation, "CREATE INDEX (non-concurrent)");
+    }
+
+    #[test]
+    fn create_unique_index_without_concurrently_is_blocking() {
+        let findings = classify_sql("CREATE UNIQUE INDEX idx_posts_slug ON posts (slug);");
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].risk, RiskLevel::PotentiallyBlocking);
         assert_eq!(findings[0].operation, "CREATE INDEX (non-concurrent)");
@@ -508,6 +564,14 @@ mod tests {
     }
 
     #[test]
+    fn bulk_delete_is_data_backfill() {
+        let findings = classify_sql("DELETE FROM posts WHERE created_at < '2020-01-01';");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::DataBackfill);
+        assert_eq!(findings[0].operation, "Bulk DML (data backfill)");
+    }
+
+    #[test]
     fn data_backfill_finding_recommends_separate_job() {
         let findings = classify_sql("UPDATE posts SET slug = LOWER(title);");
         let f = &findings[0];
@@ -539,12 +603,40 @@ mod tests {
     }
 
     #[test]
+    fn drop_constraint_requires_manual_review() {
+        let findings =
+            classify_sql("ALTER TABLE users DROP CONSTRAINT users_email_key;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::ManualReview);
+        assert_eq!(findings[0].operation, "Unclassified ALTER TABLE");
+    }
+
+    #[test]
+    fn alter_column_set_not_null_requires_manual_review() {
+        let findings =
+            classify_sql("ALTER TABLE users ALTER COLUMN email SET NOT NULL;");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].risk, RiskLevel::ManualReview);
+        assert_eq!(findings[0].operation, "Unclassified ALTER TABLE");
+    }
+
+    #[test]
     fn known_ddl_does_not_trigger_manual_review() {
         // CREATE TABLE is safe — must not get a ManualReview finding on top
         let findings = classify_sql("CREATE TABLE comments (id BIGSERIAL PRIMARY KEY);");
         assert!(
             findings.iter().all(|f| f.risk != RiskLevel::ManualReview),
             "known DDL should not also produce ManualReview: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn add_column_does_not_trigger_unclassified_alter_table() {
+        // A safe ADD COLUMN must not also generate a ManualReview finding.
+        let findings = classify_sql("ALTER TABLE posts ADD COLUMN subtitle TEXT NULL;");
+        assert!(
+            findings.iter().all(|f| f.risk != RiskLevel::ManualReview),
+            "safe ADD COLUMN should not produce ManualReview: {findings:?}"
         );
     }
 }

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -283,7 +283,11 @@ pub(crate) fn auto_migrate(
                 if is_prod {
                     tracing::warn!(
                         "Production profile detected: automatic migrations are disabled by default. \
-                         Set database.auto_migrate_in_production=true to opt in."
+                         Run `autumn migrate check` to review safety before applying, then \
+                         `autumn migrate` in your deployment job. \
+                         Set database.auto_migrate_in_production=true only for single-process \
+                         deployments after confirming all pending migrations are safe for a \
+                         rolling deploy (expand/contract pattern)."
                     );
                 }
                 tracing::warn!(

--- a/docs/guide/cloud-native.md
+++ b/docs/guide/cloud-native.md
@@ -192,6 +192,88 @@ AUTUMN_DATABASE__PRIMARY_URL="postgres://user:pass@primary:5432/app" autumn migr
 `auto_migrate_in_production = false` on web replicas unless you are deliberately
 running a single-process deployment.
 
+## Migration Safety Preflight
+
+Before applying migrations in production, run the safety check in CI or locally:
+
+```bash
+autumn migrate check
+```
+
+`autumn migrate check` reads every `migrations/*/up.sql` file from disk (no
+database connection required) and classifies each SQL statement by its risk for
+a rolling deploy. It exits **0** when all statements are fully safe and **1**
+when any finding is `potentially-blocking`, `destructive`, `irreversible`,
+`data-backfill`, or `manual-review`. Each finding includes a one-line reason and
+a concrete next action.
+
+Example output:
+
+```
+✓ 20240301_create_posts                 safe
+✗ 20240312_add_index_posts_title        potentially-blocking
+  └─ CREATE INDEX (non-concurrent): holds an exclusive table lock for the entire build
+     next: Use CREATE INDEX CONCURRENTLY instead.
+✗ 20240315_rename_body_to_content       irreversible
+  └─ RENAME COLUMN: breaks queries from old replicas still referencing the old name
+     next: Use expand/contract: add the new column, dual-write, backfill, update code, drop old.
+```
+
+### Risk levels
+
+| Level | Meaning |
+|---|---|
+| `safe` | Additive, backward-compatible. Safe for rolling deploys. |
+| `potentially-blocking` | May acquire a table-level lock on large datasets. |
+| `destructive` | Removes data or structure; old replicas may fail until restart. |
+| `irreversible` | Cannot be undone without a multi-step expand/contract cycle. |
+| `data-backfill` | Schema change is safe but requires a separate backfill job. |
+| `manual-review` | Autumn cannot auto-classify this statement; operator review required. |
+
+### Adding `autumn migrate check` to CI
+
+```yaml
+# GitHub Actions example
+- name: Check migration safety
+  run: autumn migrate check
+```
+
+Place this step after building the binary and before any deployment step that
+applies migrations. A non-zero exit code fails the pipeline, preventing unsafe
+migrations from reaching production unreviewed.
+
+### The expand/contract pattern
+
+Most "dangerous" schema changes can be made safe by splitting them into two
+separately deployed changes:
+
+1. **Expand** — add the new column or table alongside the old one; update code
+   to dual-write and read from either. This migration is `safe` and can be
+   applied with a rolling deploy.
+2. **Contract** — once all replicas run the new code, remove the old
+   column/table. This migration may be `destructive` but is now safe because no
+   running code references the old structure.
+
+Common patterns:
+
+| Goal | Naïve (unsafe) | Expand/contract (safe) |
+|---|---|---|
+| Rename a column | `RENAME COLUMN old TO new` | Add `new`, dual-write, backfill, drop `old` |
+| Change a column type | `ALTER COLUMN x TYPE bigint` | Add `x_new bigint`, migrate data, swap code, drop `x` |
+| Drop a column | `DROP COLUMN body` | First deploy: remove all reads/writes; second deploy: `DROP COLUMN` |
+| Add NOT NULL | `ADD COLUMN x INT NOT NULL` | Add nullable, backfill, add constraint `NOT VALID`, validate |
+
+### When a maintenance window is required
+
+Some operations cannot be made zero-downtime regardless of the pattern:
+
+- **Non-concurrent index creation** on very large tables (prefer
+  `CREATE INDEX CONCURRENTLY`).
+- **Adding a primary key** to a table with existing rows without `NOT VALID`.
+- **Enabling row-level security** on a table referenced by live queries.
+
+For these, schedule a maintenance window and communicate the outage to users.
+
 ## Database Topology
 
 Use the `[database]` section to declare the shape:
@@ -406,7 +488,9 @@ Before calling an Autumn app "cloud ready", verify:
 - cache uses the Redis backend if replicas > 1
 - file uploads use the `S3` blob store if replicas > 1
 - mail uses SMTP, not log/file transport
-- migrations run before web rollout
+- `autumn migrate check` passes in CI before the deploy job
+- migrations run before web rollout via a dedicated migration job
+- destructive/irreversible migrations follow the expand/contract pattern
 - background jobs use the right runtime model
 - multi-replica write paths use `#[lock_version]` (optimistic) or `with_lock` (pessimistic) to prevent lost updates
 - the generated container image builds without manual template surgery

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -127,6 +127,70 @@ The name detection is purely cosmetic — Autumn treats both `Post` and
 `Remove…From…`, the generator just emits empty `up.sql` and `down.sql`
 files for you to fill in.
 
+### Generated safety comments
+
+When `autumn generate migration` produces SQL that could be dangerous for a
+rolling deploy, it prepends an `-- autumn-safety:` comment to the statement:
+
+```sql
+-- autumn-safety: potentially-blocking
+ALTER TABLE posts ADD COLUMN score INTEGER NOT NULL;
+```
+
+```sql
+-- autumn-safety: destructive
+ALTER TABLE posts DROP COLUMN body;
+```
+
+These comments are purely informational; they do not change runtime behavior.
+`autumn migrate check` strips them before classifying statements so they do not
+produce duplicate findings.
+
+### Expand/contract: safe column rename or removal
+
+The naive approach — `autumn generate migration RenameBodyToContent` then hand-
+editing the SQL to `RENAME COLUMN body TO content` — produces an `irreversible`
+finding from `autumn migrate check` because old replicas still running the prior
+code will error on any query that references the old name.
+
+The expand/contract pattern splits the change into two consecutive deploys:
+
+**Step 1 — Expand** (add the new column alongside the old one):
+
+```bash
+autumn generate migration AddContentToPosts content:String
+```
+
+Edit the generated `up.sql` to copy existing data:
+
+```sql
+ALTER TABLE posts ADD COLUMN content TEXT;
+UPDATE posts SET content = body WHERE content IS NULL;
+```
+
+Deploy this. All replicas now see both `body` and `content`. Update application
+code to dual-write both columns and read from `content`.
+
+**Step 2 — Contract** (remove the old column once all replicas run the new code):
+
+```bash
+autumn generate migration RemoveBodyFromPosts body:String
+```
+
+The generated `up.sql` will contain:
+
+```sql
+-- autumn-safety: destructive
+ALTER TABLE posts DROP COLUMN body;
+```
+
+Run `autumn migrate check` — the finding will now be `destructive`, not
+`irreversible`, because the column rename is already complete. This migration is
+safe to apply because no running code references `body` any longer.
+
+The same two-step pattern applies to column type changes and to removing columns
+with foreign-key references.
+
 ## `autumn generate task`
 
 For operational scripts that should run through the full Autumn app context.


### PR DESCRIPTION
## Summary

Introduces `autumn migrate check`, a new CLI command that performs static analysis on migration SQL files to classify operations by their risk for rolling deploys. The command reads all `migrations/*/up.sql` files, categorizes each SQL statement into one of six risk levels, and exits with code 1 if any unsafe operations are detected.

## Key Changes

- **New `safety` module** (`autumn-cli/src/migrate/safety.rs`): Pure SQL pattern analyzer that classifies statements into risk tiers:
  - `Safe`: Additive, backward-compatible changes
  - `PotentiallyBlocking`: May acquire table-level locks (e.g., non-concurrent index creation)
  - `Destructive`: Removes data/structure (e.g., DROP COLUMN)
  - `Irreversible`: Cannot be undone without expand/contract (e.g., RENAME COLUMN)
  - `DataBackfill`: Safe schema change requiring separate backfill job (e.g., bulk UPDATE)
  - `ManualReview`: Unclassified DDL requiring operator review

- **New `MigrateAction::Check` variant** and `run_safety_check()` function in `autumn-cli/src/migrate.rs`:
  - Scans all migration directories, reads `up.sql` files, and generates a human-readable report
  - Prints findings with operation name, risk level, explanation, and recommended next action
  - Exits 0 for all-safe migrations, 1 for any unsafe findings

- **CLI integration** in `autumn-cli/src/main.rs`:
  - Added `Check` subcommand to `MigrateCommands` enum
  - Wired into command parsing and dispatch

- **Generator enhancements** in `autumn-cli/src/generate/schema_edit.rs`:
  - `add_columns_up_sql()` now prepends `-- autumn-safety: potentially-blocking` comment for NOT NULL columns without DEFAULT
  - `remove_columns_up_sql()` prepends `-- autumn-safety: destructive` comment for DROP COLUMN statements
  - Comments are informational and stripped during classification to avoid duplicate findings

- **Documentation** in `docs/guide/cloud-native.md` and `docs/guide/generators.md`:
  - Explains risk levels, CI integration, and the expand/contract pattern for safe schema changes
  - Provides examples of when maintenance windows are required

## Implementation Details

- **Pattern matching**: Uses normalized (lowercase, single-spaced, comment-stripped) SQL to detect operations via string prefix/substring checks
- **Multi-statement support**: Splits SQL on semicolons and classifies each statement independently
- **Sorted output**: Migration directories are sorted by name (timestamp-based) for stable, reproducible reports
- **No database required**: Operates entirely on disk; safe to run in CI before deployment
- **Comprehensive test coverage**: 50+ tests covering safe patterns, destructive operations, multi-statement files, comment handling, and helper predicates

The implementation prioritizes clarity and operator guidance—each finding includes a concrete reason why the operation is risky for rolling deploys and a recommended next action (e.g., "Use CREATE INDEX CONCURRENTLY" or "Use expand/contract pattern").

https://claude.ai/code/session_01Nc6xcBQiEhSKsMu4b5ZGfx