### PR TITLE
Fix release gate changelog mutation

### DIFF
--- a/.github/workflows/publish-gate.yml
+++ b/.github/workflows/publish-gate.yml
@@ -209,31 +209,18 @@ jobs:
     # produced when every check passes.
     needs: [semver, release-notes, smoke]
     if: github.ref_type == 'tag'
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install git-cliff
         uses: taiki-e/install-action@git-cliff
-      - name: Generate release notes and update CHANGELOG
+      - name: Generate release notes artifact
         run: |
+          # CHANGELOG.md must be updated before tagging so the packaged crates
+          # include the release notes. Do not commit from this detached tag
+          # checkout; that races with trunk and can block the GitHub Release.
           git-cliff --config cliff.toml --latest --strip header > RELEASE_NOTES.md
-          git-cliff --config cliff.toml --output CHANGELOG.md
-      - name: Commit CHANGELOG.md to trunk
-        env:
-          RELEASE_TAG: ${{ github.ref_name }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          if ! git diff --staged --quiet; then
-            git commit -m "docs: update CHANGELOG.md for ${RELEASE_TAG}"
-            git push origin HEAD:trunk
-          else
-            echo "CHANGELOG.md already up to date — skipping commit"
-          fi
       - name: Record release tag
         env:
           RELEASE_TAG: ${{ github.ref_name }}

--- a/autumn-cli/tests/repo_hygiene.rs
+++ b/autumn-cli/tests/repo_hygiene.rs
@@ -341,6 +341,27 @@ fn publish_dry_run_script_uses_list_not_no_verify() {
 }
 
 #[test]
+fn publish_gate_prepare_release_does_not_mutate_changelog() {
+    let root = workspace_root();
+    let workflow_path = root.join(".github/workflows/publish-gate.yml");
+    let workflow = std::fs::read_to_string(&workflow_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", workflow_path.display()));
+
+    for forbidden in [
+        "git-cliff --config cliff.toml --output CHANGELOG.md",
+        "Commit CHANGELOG.md to trunk",
+        "git commit -m \"docs: update CHANGELOG.md",
+        "git push origin HEAD:trunk",
+        "contents: write",
+    ] {
+        assert!(
+            !workflow.contains(forbidden),
+            "publish-gate must not mutate CHANGELOG.md from a detached tag checkout; found `{forbidden}`",
+        );
+    }
+}
+
+#[test]
 fn release_notes_script_detects_breaking_section_with_long_changelog_entry() {
     let root = workspace_root();
     let tmp = tempfile::TempDir::new().expect("tempdir");


### PR DESCRIPTION
## Summary
- Stop `publish-gate` release prep from regenerating, committing, and pushing `CHANGELOG.md` from a detached tag checkout.
- Keep release prep artifact-only: generate `RELEASE_NOTES.md` for the GitHub Release and record the tag.
- Add a repo hygiene regression test so Publish Gate cannot regain `contents: write` or trunk-push behavior.

## Verification
- `cargo test -p autumn-cli --test repo_hygiene publish_gate_prepare_release_does_not_mutate_changelog -- --exact` (red before fix, green after)
- `cargo test -p autumn-cli --test repo_hygiene`
- `cargo fmt --all -- --check`
- `git diff --check`