### PR TITLE
🍎 Eris: Fix rate limit bypass via X-Forwarded-For manipulation

### DIFF
--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -250,11 +250,20 @@ impl Limiter {
         let peer_ip = Self::peer_ip(req);
 
         if self.trust_forwarded_headers && self.forwarded_headers_allowed(req) {
-            let xff_ip = req
+            let xff_headers: Vec<&str> = req
                 .headers()
-                .get("x-forwarded-for")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|s| self.client_ip_from_x_forwarded_for(s, peer_ip));
+                .get_all("x-forwarded-for")
+                .iter()
+                .filter_map(|v| v.to_str().ok())
+                .collect();
+
+            let joined = xff_headers.join(",");
+
+            let xff_ip = if joined.is_empty() {
+                None
+            } else {
+                self.client_ip_from_x_forwarded_for(&joined, peer_ip)
+            };
 
             if xff_ip.is_some() {
                 return xff_ip;

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -12,3 +12,4 @@ pub mod ctf;
 pub mod fallback_middleware_bypass;
 pub mod session_exhaustion;
 pub mod session_fixation;
+pub mod rate_limit_bypass;

--- a/autumn/tests/security/rate_limit_bypass.rs
+++ b/autumn/tests/security/rate_limit_bypass.rs
@@ -1,0 +1,51 @@
+use autumn_web::security::{RateLimitConfig, RateLimitLayer};
+use axum::{routing::get, Router, body::Body, extract::ConnectInfo};
+use http::Request;
+use std::net::SocketAddr;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn x_forwarded_for_multiple_headers_bypass() {
+    let config = RateLimitConfig {
+        enabled: true,
+        requests_per_second: 1.0,
+        burst: 1,
+        trust_forwarded_headers: true,
+        trusted_proxies: vec!["10.0.0.0/8".to_string()],
+    };
+
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(RateLimitLayer::from_config(&config));
+
+    // Request 1: Attacker sends an untrusted IP.
+    // The reverse proxy appends its own IP in a separate header.
+    let mut req1 = Request::builder()
+        .method("GET")
+        .uri("/")
+        .header("X-Forwarded-For", "attacker-ip-1")
+        .header("X-Forwarded-For", "192.168.1.1") // Proxy appends here (this is simulating another header line)
+        .body(Body::empty())
+        .unwrap();
+    req1.extensions_mut().insert(ConnectInfo("10.0.0.1:4000".parse::<SocketAddr>().unwrap()));
+
+    let res1 = app.clone().oneshot(req1).await.unwrap();
+    assert_eq!(res1.status(), http::StatusCode::OK);
+
+    // Request 2: Attacker sends another request but changes the *first* header.
+    let mut req2 = Request::builder()
+        .method("GET")
+        .uri("/")
+        .header("X-Forwarded-For", "attacker-ip-2")
+        .header("X-Forwarded-For", "192.168.1.1")
+        .body(Body::empty())
+        .unwrap();
+    req2.extensions_mut().insert(ConnectInfo("10.0.0.1:4000".parse::<SocketAddr>().unwrap()));
+
+    let res2 = app.clone().oneshot(req2).await.unwrap();
+
+    // With the fix, the joined header is "attacker-ip-2,192.168.1.1".
+    // "192.168.1.1" is untrusted, so the limiter correctly uses it, and sees the same client for both req1 and req2.
+    // Thus it blocks req2!
+    assert_eq!(res2.status(), http::StatusCode::TOO_MANY_REQUESTS);
+}


### PR DESCRIPTION
🍎 Eris: Fix rate limit bypass via X-Forwarded-For manipulation

Attack Surface Area: HTTP / Axum Foundation (Layer 1) & Rate Limiting

Reconnaissance:
The `RateLimitLayer` previously used `req.headers().get("x-forwarded-for")` to retrieve the client IP behind a reverse proxy. However, `get()` only retrieves the *first* header.

Hypothesis:
An attacker can bypass the rate limiter's trusted proxy checks by injecting a fake `X-Forwarded-For` header. The reverse proxy will append its own IP (or the real client IP) as a *second* `X-Forwarded-For` header. Because `get()` only reads the first header, the rate limiter never sees the proxy-appended IP, allowing the attacker to spoof a unique client IP on every request and exhaust the API rate limit or evade blocks.

Exploit development:
A regression test (`autumn/tests/security/rate_limit_bypass.rs`) was developed. It constructs requests simulating an attacker's fake header and the proxy's appended header. Before the fix, the rate limiter identified them as different clients, bypassing the limit.

Verification:
The test confirms that requests carrying the same proxy-appended chain are now correctly identified as the same client, yielding a `429 Too Many Requests`.

Severity assessment:
CVSS 3.1 Base Score: 5.3 (Medium)
Vector: AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L
Impacts availability by allowing unauthenticated actors to bypass rate limits.

Remediation recommendation:
Modified `autumn/src/security/rate_limit.rs` to use `req.headers().get_all("x-forwarded-for")`. The fix iterates over all values, drops invalid UTF-8 (preventing panics), and joins them with commas before extracting the client IP right-to-left.

---
*PR created automatically by Jules for task [10002795835993461099](https://jules.google.com/task/10002795835993461099) started by @madmax983*