### PR TITLE
🤖 Sentinel: [Test coverage improvement for pagination boundaries]

### DIFF
--- a/autumn/src/pagination.rs
+++ b/autumn/src/pagination.rs
@@ -878,6 +878,15 @@ mod tests {
     }
 
     #[test]
+    fn size_clamping_boundary_check() {
+        let r = PageRequest::new(1, MAX_PAGE_SIZE);
+        assert_eq!(r.size(), MAX_PAGE_SIZE);
+
+        let over = PageRequest::new(1, MAX_PAGE_SIZE + 1);
+        assert_eq!(over.size(), MAX_PAGE_SIZE);
+    }
+
+    #[test]
     fn size_zero_falls_back_to_default() {
         let r = PageRequest::new(3, 0);
         assert_eq!(r.size(), DEFAULT_PAGE_SIZE);
@@ -1185,6 +1194,15 @@ mod tests {
 
         let under = CursorRequest::new(None, MAX_PAGE_SIZE - 1);
         assert_eq!(under.size(), MAX_PAGE_SIZE - 1);
+    }
+
+    #[test]
+    fn cursor_size_clamping_boundary_check() {
+        let r = CursorRequest::new(None, MAX_PAGE_SIZE);
+        assert_eq!(r.size(), MAX_PAGE_SIZE);
+
+        let over = CursorRequest::new(None, MAX_PAGE_SIZE + 1);
+        assert_eq!(over.size(), MAX_PAGE_SIZE);
     }
 
     #[test]


### PR DESCRIPTION
🧬 **Mutants Found:**
2 surviving mutants in `pagination.rs`.
- `Some(s) if s > MAX_PAGE_SIZE` replaced with `s >= MAX_PAGE_SIZE` in `PageRequest::size`.
- `Some(s) if s > MAX_PAGE_SIZE` replaced with `s >= MAX_PAGE_SIZE` in `CursorRequest::size`.

🎯 **Tests Added/Strengthened:**
Added explicitly named boundary tests:
- `size_clamping_boundary_check` for `PageRequest`
- `cursor_size_clamping_boundary_check` for `CursorRequest`
These tests explicitly test exact clamping when `size` is equal to `MAX_PAGE_SIZE` and `MAX_PAGE_SIZE + 1`.

⚠️ **Suspected Bugs:**
None. The surviving mutants `s >= MAX_PAGE_SIZE` replacing `s > MAX_PAGE_SIZE` are mathematically equivalent to the original logic since for `s == MAX_PAGE_SIZE`, the next match arm `Some(s) => s` would return the exact same value. Since there is no behavioral change, the mutant is equivalent.

📊 **Kill Rate:**
No behavior-changing mutants are surviving in `pagination.rs`.

🔗 **Havoc Interaction:**
None.

---
*PR created automatically by Jules for task [15872581527873271975](https://jules.google.com/task/15872581527873271975) started by @madmax983*