### PR TITLE
⚡ Bolt: Optimize path normalization by removing Vec allocation

### DIFF
--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -350,17 +350,26 @@ pub fn check_route_prefix(
 /// Both named params (`{id}`) and catch-all params (`{*rest}`) normalize to
 /// `{}`. matchit (Axum's router) treats a named param and a catch-all at the
 /// same path position as a conflict, so they must map to the same key.
+///
+/// **Performance note**: This function avoids intermediate `Vec` allocations
+/// by writing directly to a pre-allocated `String`, as this path normalization
+/// runs across the entire route tree during plugin conformance checks.
 fn normalize_path_for_collision(path: &str) -> String {
-    path.split('/')
-        .map(|seg| {
-            if seg.starts_with('{') && seg.ends_with('}') {
-                "{}"
-            } else {
-                seg
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
+    let mut result = String::with_capacity(path.len());
+    let mut first = true;
+    for seg in path.split('/') {
+        if !first {
+            result.push('/');
+        }
+        first = false;
+
+        if seg.starts_with('{') && seg.ends_with('}') {
+            result.push_str("{}");
+        } else {
+            result.push_str(seg);
+        }
+    }
+    result
 }
 
 /// Detect route collisions: any two routes sharing the same (method, path) pair.


### PR DESCRIPTION
💡 **What:** Refactored `normalize_path_for_collision` in `autumn/src/plugin_conformance.rs` to replace the `.collect::<Vec<_>>().join("/")` chain with direct `String` mutation using `push_str()` and `push()`.

🎯 **Why:** The previous approach allocated an intermediate `Vec<&str>` for every route segment normalized during plugin conformance checks. This process is hot when starting the app or checking plugin conformance.

📊 **Impact:** Removes one heap allocation (`Vec`) per path normalized.

🔬 **Measurement:** Run `cargo test -p autumn-web --lib plugin_conformance` to verify correctness. Memory savings can be profiled via `cargo bench` if setup in the workspace.

---
*PR created automatically by Jules for task [4530215977438872531](https://jules.google.com/task/4530215977438872531) started by @madmax983*