### PR TITLE
Add TOML config file support for scaffold generator

### DIFF
--- a/autumn-cli/src/generate/config.rs
+++ b/autumn-cli/src/generate/config.rs
@@ -65,14 +65,10 @@ pub fn read_scaffold_config(
     config_path: &Path,
     resource_name: &str,
 ) -> Result<Option<ScaffoldConfigEntry>, GenerateError> {
-    let content = std::fs::read_to_string(config_path).map_err(|e| {
-        std::io::Error::new(e.kind(), format!("{}: {e}", config_path.display()))
-    })?;
+    let content = std::fs::read_to_string(config_path)
+        .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {e}", config_path.display())))?;
     let mut config: GeneratorConfig = toml::from_str(&content).map_err(|e| {
-        GenerateError::Config(format!(
-            "invalid TOML in {}: {e}",
-            config_path.display()
-        ))
+        GenerateError::Config(format!("invalid TOML in {}: {e}", config_path.display()))
     })?;
     Ok(config.scaffold.remove(resource_name))
 }
@@ -100,7 +96,11 @@ pub fn merge_config_with_cli(
     (
         fields,
         ScaffoldOptions {
-            model: ModelOptions { indexes, validations, defaults },
+            model: ModelOptions {
+                indexes,
+                validations,
+                defaults,
+            },
             queries,
         },
     )
@@ -144,9 +144,15 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             vec!["url:String", "title:String", "tag:String", "alive:bool"]
         );
         assert_eq!(entry.indexes, vec!["url", "tag"]);
-        assert_eq!(entry.validations, vec!["url=url", "title=length:min=1,max=200"]);
+        assert_eq!(
+            entry.validations,
+            vec!["url=url", "title=length:min=1,max=200"]
+        );
         assert_eq!(entry.defaults, vec!["alive=true"]);
-        assert_eq!(entry.queries, vec!["find_by_tag:tag", "find_by_alive:alive"]);
+        assert_eq!(
+            entry.queries,
+            vec!["find_by_tag:tag", "find_by_alive:alive"]
+        );
     }
 
     #[test]
@@ -232,27 +238,15 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
 
     #[test]
     fn merge_cli_indexes_override_toml_indexes() {
-        let (_, opts) = merge_config_with_cli(
-            bookmark_entry(),
-            &[],
-            &["tag".into()],
-            &[],
-            &[],
-            &[],
-        );
+        let (_, opts) =
+            merge_config_with_cli(bookmark_entry(), &[], &["tag".into()], &[], &[], &[]);
         assert_eq!(opts.model.indexes, vec!["tag"]);
     }
 
     #[test]
     fn merge_cli_validations_override_toml_validations() {
-        let (_, opts) = merge_config_with_cli(
-            bookmark_entry(),
-            &[],
-            &[],
-            &["url=email".into()],
-            &[],
-            &[],
-        );
+        let (_, opts) =
+            merge_config_with_cli(bookmark_entry(), &[], &[], &["url=email".into()], &[], &[]);
         assert_eq!(opts.model.validations, vec!["url=email"]);
     }
 

--- a/autumn-cli/src/generate/config.rs
+++ b/autumn-cli/src/generate/config.rs
@@ -34,6 +34,7 @@ use super::scaffold::ScaffoldOptions;
 
 /// One resource's scaffold metadata from a TOML config file.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct ScaffoldConfigEntry {
     #[serde(default)]
     pub fields: Vec<String>,
@@ -182,6 +183,27 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             .unwrap()
             .expect("snake_case name should resolve to PascalCase section");
         assert_eq!(entry.fields, vec!["url:String"]);
+    }
+
+    #[test]
+    fn unknown_key_returns_config_error() {
+        let tmp = TempDir::new().unwrap();
+        // `index` is the wrong key; the correct key is `indexes`.
+        let path = write_config(
+            &tmp,
+            "[scaffold.Post]\nfields = [\"title:String\"]\nindex = [\"title\"]\n",
+        );
+
+        let err = read_scaffold_config(&path, "Post").unwrap_err();
+        assert!(
+            matches!(err, GenerateError::Config(_)),
+            "misspelled key should return Config error, got: {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("index"),
+            "error should mention the unknown key; got: {msg}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/config.rs
+++ b/autumn-cli/src/generate/config.rs
@@ -29,6 +29,7 @@ use serde::Deserialize;
 
 use super::GenerateError;
 use super::model::ModelOptions;
+use super::naming::pascal;
 use super::scaffold::ScaffoldOptions;
 
 /// One resource's scaffold metadata from a TOML config file.
@@ -70,7 +71,10 @@ pub fn read_scaffold_config(
     let mut config: GeneratorConfig = toml::from_str(&content).map_err(|e| {
         GenerateError::Config(format!("invalid TOML in {}: {e}", config_path.display()))
     })?;
-    Ok(config.scaffold.remove(resource_name))
+    // Normalize to PascalCase so `bookmark` and `Bookmark` both match
+    // `[scaffold.Bookmark]`, consistent with how the generator itself handles
+    // resource names passed on the CLI.
+    Ok(config.scaffold.remove(pascal(resource_name).as_str()))
 }
 
 /// Merge a TOML config entry with CLI-supplied values.
@@ -166,6 +170,18 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
         assert!(entry.validations.is_empty());
         assert!(entry.defaults.is_empty());
         assert!(entry.queries.is_empty());
+    }
+
+    #[test]
+    fn snake_case_name_matches_pascal_case_toml_section() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_config(&tmp, "[scaffold.Bookmark]\nfields = [\"url:String\"]\n");
+
+        // CLI input `bookmark` (snake_case) must find `[scaffold.Bookmark]`.
+        let entry = read_scaffold_config(&path, "bookmark")
+            .unwrap()
+            .expect("snake_case name should resolve to PascalCase section");
+        assert_eq!(entry.fields, vec!["url:String"]);
     }
 
     #[test]

--- a/autumn-cli/src/generate/config.rs
+++ b/autumn-cli/src/generate/config.rs
@@ -1,0 +1,290 @@
+//! TOML-based generator configuration for `autumn generate scaffold`.
+//!
+//! Reads `[scaffold.ResourceName]` sections from a project-local TOML file
+//! so scaffold metadata can be checked in and reproduced without long CLI
+//! invocations.
+//!
+//! # File format
+//!
+//! ```toml
+//! [scaffold.Bookmark]
+//! fields      = ["url:String", "title:String", "tag:String", "alive:bool"]
+//! indexes     = ["url", "tag"]
+//! validations = ["url=url", "title=length:min=1,max=200"]
+//! defaults    = ["alive=true"]
+//! queries     = ["find_by_tag:tag", "find_by_alive:alive"]
+//! ```
+//!
+//! # Precedence
+//!
+//! CLI flags win. If the caller passes any values for a repeated flag (e.g.
+//! `--index`), those values completely replace the corresponding TOML list.
+//! Fields (positional arguments) follow the same rule: non-empty CLI fields
+//! shadow TOML fields.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use super::GenerateError;
+use super::model::ModelOptions;
+use super::scaffold::ScaffoldOptions;
+
+/// One resource's scaffold metadata from a TOML config file.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct ScaffoldConfigEntry {
+    #[serde(default)]
+    pub fields: Vec<String>,
+    #[serde(default)]
+    pub indexes: Vec<String>,
+    #[serde(default)]
+    pub validations: Vec<String>,
+    #[serde(default)]
+    pub defaults: Vec<String>,
+    #[serde(default)]
+    pub queries: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct GeneratorConfig {
+    #[serde(default)]
+    scaffold: HashMap<String, ScaffoldConfigEntry>,
+}
+
+/// Read the scaffold config entry for `resource_name` from `config_path`.
+///
+/// Returns `None` when the file is valid TOML but has no
+/// `[scaffold.ResourceName]` section for the requested name.
+///
+/// # Errors
+///
+/// - [`GenerateError::Io`] if the file cannot be read.
+/// - [`GenerateError::Config`] if the file is not valid TOML.
+pub fn read_scaffold_config(
+    config_path: &Path,
+    resource_name: &str,
+) -> Result<Option<ScaffoldConfigEntry>, GenerateError> {
+    let content = std::fs::read_to_string(config_path).map_err(|e| {
+        std::io::Error::new(e.kind(), format!("{}: {e}", config_path.display()))
+    })?;
+    let mut config: GeneratorConfig = toml::from_str(&content).map_err(|e| {
+        GenerateError::Config(format!(
+            "invalid TOML in {}: {e}",
+            config_path.display()
+        ))
+    })?;
+    Ok(config.scaffold.remove(resource_name))
+}
+
+/// Merge a TOML config entry with CLI-supplied values.
+///
+/// For each key, if the caller supplied a non-empty CLI slice that value set
+/// replaces the TOML list; otherwise the TOML list is kept.
+pub fn merge_config_with_cli(
+    config: ScaffoldConfigEntry,
+    cli_fields: &[String],
+    cli_indexes: &[String],
+    cli_validations: &[String],
+    cli_defaults: &[String],
+    cli_queries: &[String],
+) -> (Vec<String>, ScaffoldOptions) {
+    let pick = |cli: &[String], toml: Vec<String>| -> Vec<String> {
+        if cli.is_empty() { toml } else { cli.to_vec() }
+    };
+    let fields = pick(cli_fields, config.fields);
+    let indexes = pick(cli_indexes, config.indexes);
+    let validations = pick(cli_validations, config.validations);
+    let defaults = pick(cli_defaults, config.defaults);
+    let queries = pick(cli_queries, config.queries);
+    (
+        fields,
+        ScaffoldOptions {
+            model: ModelOptions { indexes, validations, defaults },
+            queries,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_config(tmp: &TempDir, content: &str) -> std::path::PathBuf {
+        let path = tmp.path().join("autumn.generate.toml");
+        fs::write(&path, content).unwrap();
+        path
+    }
+
+    // ── read_scaffold_config ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_valid_scaffold_config() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_config(
+            &tmp,
+            r#"
+[scaffold.Bookmark]
+fields      = ["url:String", "title:String", "tag:String", "alive:bool"]
+indexes     = ["url", "tag"]
+validations = ["url=url", "title=length:min=1,max=200"]
+defaults    = ["alive=true"]
+queries     = ["find_by_tag:tag", "find_by_alive:alive"]
+"#,
+        );
+
+        let entry = read_scaffold_config(&path, "Bookmark")
+            .unwrap()
+            .expect("Bookmark section must be present");
+
+        assert_eq!(
+            entry.fields,
+            vec!["url:String", "title:String", "tag:String", "alive:bool"]
+        );
+        assert_eq!(entry.indexes, vec!["url", "tag"]);
+        assert_eq!(entry.validations, vec!["url=url", "title=length:min=1,max=200"]);
+        assert_eq!(entry.defaults, vec!["alive=true"]);
+        assert_eq!(entry.queries, vec!["find_by_tag:tag", "find_by_alive:alive"]);
+    }
+
+    #[test]
+    fn parse_minimal_config_with_fields_only() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_config(&tmp, "[scaffold.Post]\nfields = [\"title:String\"]\n");
+
+        let entry = read_scaffold_config(&path, "Post").unwrap().unwrap();
+        assert_eq!(entry.fields, vec!["title:String"]);
+        assert!(entry.indexes.is_empty());
+        assert!(entry.validations.is_empty());
+        assert!(entry.defaults.is_empty());
+        assert!(entry.queries.is_empty());
+    }
+
+    #[test]
+    fn missing_section_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_config(&tmp, "[scaffold.Post]\nfields = [\"title:String\"]\n");
+
+        let result = read_scaffold_config(&path, "Bookmark").unwrap();
+        assert!(result.is_none(), "unknown resource should return None");
+    }
+
+    #[test]
+    fn invalid_toml_returns_config_error() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_config(&tmp, "not valid toml {{{{");
+
+        let err = read_scaffold_config(&path, "Bookmark").unwrap_err();
+        assert!(
+            matches!(err, GenerateError::Config(_)),
+            "expected Config error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn missing_file_returns_io_error() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("nonexistent.toml");
+
+        let err = read_scaffold_config(&path, "Bookmark").unwrap_err();
+        assert!(
+            matches!(err, GenerateError::Io(_)),
+            "expected Io error for missing file, got: {err:?}"
+        );
+    }
+
+    // ── merge_config_with_cli ─────────────────────────────────────────────
+
+    fn bookmark_entry() -> ScaffoldConfigEntry {
+        ScaffoldConfigEntry {
+            fields: vec!["url:String".into(), "tag:String".into()],
+            indexes: vec!["url".into()],
+            validations: vec!["url=url".into()],
+            defaults: vec![],
+            queries: vec!["find_by_url:url".into()],
+        }
+    }
+
+    #[test]
+    fn merge_uses_toml_when_all_cli_empty() {
+        let (fields, opts) = merge_config_with_cli(bookmark_entry(), &[], &[], &[], &[], &[]);
+        assert_eq!(fields, vec!["url:String", "tag:String"]);
+        assert_eq!(opts.model.indexes, vec!["url"]);
+        assert_eq!(opts.model.validations, vec!["url=url"]);
+        assert!(opts.model.defaults.is_empty());
+        assert_eq!(opts.queries, vec!["find_by_url:url"]);
+    }
+
+    #[test]
+    fn merge_cli_fields_override_toml_fields() {
+        let (fields, _) = merge_config_with_cli(
+            bookmark_entry(),
+            &["title:String".into(), "body:Text".into()],
+            &[],
+            &[],
+            &[],
+            &[],
+        );
+        assert_eq!(fields, vec!["title:String", "body:Text"]);
+    }
+
+    #[test]
+    fn merge_cli_indexes_override_toml_indexes() {
+        let (_, opts) = merge_config_with_cli(
+            bookmark_entry(),
+            &[],
+            &["tag".into()],
+            &[],
+            &[],
+            &[],
+        );
+        assert_eq!(opts.model.indexes, vec!["tag"]);
+    }
+
+    #[test]
+    fn merge_cli_validations_override_toml_validations() {
+        let (_, opts) = merge_config_with_cli(
+            bookmark_entry(),
+            &[],
+            &[],
+            &["url=email".into()],
+            &[],
+            &[],
+        );
+        assert_eq!(opts.model.validations, vec!["url=email"]);
+    }
+
+    #[test]
+    fn merge_cli_defaults_override_toml_defaults() {
+        let mut entry = bookmark_entry();
+        entry.defaults = vec!["url=example.com".into()];
+        let (_, opts) = merge_config_with_cli(entry, &[], &[], &[], &["tag=general".into()], &[]);
+        assert_eq!(opts.model.defaults, vec!["tag=general"]);
+    }
+
+    #[test]
+    fn merge_cli_queries_override_toml_queries() {
+        let (_, opts) = merge_config_with_cli(
+            bookmark_entry(),
+            &[],
+            &[],
+            &[],
+            &[],
+            &["find_by_tag:tag".into()],
+        );
+        assert_eq!(opts.queries, vec!["find_by_tag:tag"]);
+    }
+
+    #[test]
+    fn merge_empty_cli_keeps_empty_toml() {
+        let entry = ScaffoldConfigEntry::default();
+        let (fields, opts) = merge_config_with_cli(entry, &[], &[], &[], &[], &[]);
+        assert!(fields.is_empty());
+        assert!(opts.model.indexes.is_empty());
+        assert!(opts.model.validations.is_empty());
+        assert!(opts.model.defaults.is_empty());
+        assert!(opts.queries.is_empty());
+    }
+}

--- a/autumn-cli/src/generate/mod.rs
+++ b/autumn-cli/src/generate/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod admin;
 pub mod auth;
+pub mod config;
 pub mod dsl;
 pub mod emit;
 pub mod migration;
@@ -50,6 +51,10 @@ pub enum GenerateError {
     /// Filesystem error during code emission.
     #[error("{0}")]
     Io(#[from] std::io::Error),
+
+    /// Generator config file is invalid or missing a required section.
+    #[error("{0}")]
+    Config(String),
 }
 
 /// ⚡ Bolt optimization: Formats collision paths directly into a pre-allocated

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -827,25 +827,28 @@ fn run_generate_command(cmd: GenerateCommands) {
         } => {
             let config_entry = match config {
                 None => generate::config::ScaffoldConfigEntry::default(),
-                Some(ref path) => {
-                    match generate::config::read_scaffold_config(path, &name) {
-                        Ok(Some(e)) => e,
-                        Ok(None) => {
-                            eprintln!(
-                                "Error: no [scaffold.{name}] section found in {}",
-                                path.display()
-                            );
-                            std::process::exit(1);
-                        }
-                        Err(e) => {
-                            eprintln!("Error: {e}");
-                            std::process::exit(1);
-                        }
+                Some(ref path) => match generate::config::read_scaffold_config(path, &name) {
+                    Ok(Some(e)) => e,
+                    Ok(None) => {
+                        eprintln!(
+                            "Error: no [scaffold.{name}] section found in {}",
+                            path.display()
+                        );
+                        std::process::exit(1);
                     }
-                }
+                    Err(e) => {
+                        eprintln!("Error: {e}");
+                        std::process::exit(1);
+                    }
+                },
             };
             let (fields, options) = generate::config::merge_config_with_cli(
-                config_entry, &fields, &index, &validate, &default, &query,
+                config_entry,
+                &fields,
+                &index,
+                &validate,
+                &default,
+                &query,
             );
             generate::scaffold::run(&name, &fields, generate::Flags { dry_run, force }, &options);
         }

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -831,7 +831,8 @@ fn run_generate_command(cmd: GenerateCommands) {
                     Ok(Some(e)) => e,
                     Ok(None) => {
                         eprintln!(
-                            "Error: no [scaffold.{name}] section found in {}",
+                            "Error: no [scaffold.{}] section found in {}",
+                            generate::naming::pascal(&name),
                             path.display()
                         );
                         std::process::exit(1);

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -825,9 +825,9 @@ fn run_generate_command(cmd: GenerateCommands) {
             dry_run,
             force,
         } => {
-            let config_entry = match config {
-                None => generate::config::ScaffoldConfigEntry::default(),
-                Some(ref path) => match generate::config::read_scaffold_config(path, &name) {
+            let config_entry = config.as_ref().map_or_else(
+                generate::config::ScaffoldConfigEntry::default,
+                |path| match generate::config::read_scaffold_config(path, &name) {
                     Ok(Some(e)) => e,
                     Ok(None) => {
                         eprintln!(
@@ -842,7 +842,7 @@ fn run_generate_command(cmd: GenerateCommands) {
                         std::process::exit(1);
                     }
                 },
-            };
+            );
             let (fields, options) = generate::config::merge_config_with_cli(
                 config_entry,
                 &fields,

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -524,6 +524,10 @@ enum GenerateCommands {
         /// Add a derived repository query, e.g. `find_by_tag:tag`.
         #[arg(long, value_name = "METHOD:FIELD")]
         query: Vec<String>,
+        /// Load scaffold metadata from a TOML config file (e.g. `autumn.generate.toml`).
+        /// CLI flags take precedence over values in the config file.
+        #[arg(long, value_name = "PATH")]
+        config: Option<std::path::PathBuf>,
         /// Print the file plan and exit without writing anything.
         #[arg(long)]
         dry_run: bool,
@@ -817,17 +821,32 @@ fn run_generate_command(cmd: GenerateCommands) {
             validate,
             default,
             query,
+            config,
             dry_run,
             force,
         } => {
-            let options = generate::scaffold::ScaffoldOptions {
-                model: generate::model::ModelOptions {
-                    indexes: index,
-                    validations: validate,
-                    defaults: default,
-                },
-                queries: query,
+            let config_entry = match config {
+                None => generate::config::ScaffoldConfigEntry::default(),
+                Some(ref path) => {
+                    match generate::config::read_scaffold_config(path, &name) {
+                        Ok(Some(e)) => e,
+                        Ok(None) => {
+                            eprintln!(
+                                "Error: no [scaffold.{name}] section found in {}",
+                                path.display()
+                            );
+                            std::process::exit(1);
+                        }
+                        Err(e) => {
+                            eprintln!("Error: {e}");
+                            std::process::exit(1);
+                        }
+                    }
+                }
             };
+            let (fields, options) = generate::config::merge_config_with_cli(
+                config_entry, &fields, &index, &validate, &default, &query,
+            );
             generate::scaffold::run(&name, &fields, generate::Flags { dry_run, force }, &options);
         }
     }
@@ -1231,6 +1250,26 @@ mod tests {
         assert_eq!(validate, vec!["url=url"]);
         assert_eq!(default, vec!["alive=true"]);
         assert_eq!(query, vec!["find_by_alive:alive"]);
+    }
+
+    #[test]
+    fn parse_generate_scaffold_config_flag() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "generate",
+            "scaffold",
+            "Post",
+            "--config",
+            "autumn.generate.toml",
+        ])
+        .unwrap();
+        let Commands::Generate(GenerateCommands::Scaffold { config, .. }) = cli.command else {
+            panic!("expected generate scaffold");
+        };
+        assert_eq!(
+            config,
+            Some(std::path::PathBuf::from("autumn.generate.toml"))
+        );
     }
 
     #[test]

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -952,3 +952,173 @@ fn generate_auth_help_documents_command() {
     );
     assert!(stdout.contains("--force"), "help should mention --force");
 }
+
+// ── TOML config (issue #669) ──────────────────────────────────────────────────
+
+/// Scaffold a resource using only a `--config` file, no inline CLI metadata.
+#[test]
+fn generate_scaffold_from_config_file() {
+    let (_tmp, project) = fresh_project("scaffold-config-app");
+
+    fs::write(
+        project.join("autumn.generate.toml"),
+        "[scaffold.Bookmark]\n\
+         fields      = [\"url:String\", \"title:String\", \"tag:String\", \"alive:bool\"]\n\
+         indexes     = [\"url\", \"tag\"]\n\
+         validations = [\"url=url\", \"title=length:min=1,max=200\"]\n\
+         defaults    = [\"alive=true\"]\n\
+         queries     = [\"find_by_tag:tag\", \"find_by_alive:alive\"]\n",
+    )
+    .unwrap();
+
+    run_autumn(
+        &project,
+        &["generate", "scaffold", "Bookmark", "--config", "autumn.generate.toml"],
+    );
+
+    let model = fs::read_to_string(project.join("src/models/bookmark.rs")).unwrap();
+    assert!(
+        model.contains("#[indexed]\n    #[validate(url)]\n    pub url: String,"),
+        "model missing indexed+validated url field:\n{model}"
+    );
+    assert!(
+        model.contains("#[validate(length(min = 1, max = 200))]\n    pub title: String,"),
+        "model missing length-validated title field:\n{model}"
+    );
+    assert!(
+        model.contains("#[indexed]\n    pub tag: String,"),
+        "model missing indexed tag field:\n{model}"
+    );
+    assert!(
+        model.contains("#[default]\n    pub alive: bool,"),
+        "model missing defaulted alive field:\n{model}"
+    );
+
+    let repo = fs::read_to_string(project.join("src/repositories/bookmark.rs")).unwrap();
+    assert!(
+        repo.contains("fn find_by_tag(tag: String) -> Vec<Bookmark>;"),
+        "repo missing find_by_tag query:\n{repo}"
+    );
+    assert!(
+        repo.contains("fn find_by_alive(alive: bool) -> Vec<Bookmark>;"),
+        "repo missing find_by_alive query:\n{repo}"
+    );
+
+    let migration = fs::read_dir(project.join("migrations"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .find(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .ends_with("_create_bookmarks")
+        })
+        .expect("create_bookmarks migration must exist");
+    let up = fs::read_to_string(migration.path().join("up.sql")).unwrap();
+    assert!(up.contains("alive BOOLEAN NOT NULL DEFAULT TRUE"), "SQL missing default: {up}");
+    assert!(
+        up.contains("CREATE INDEX idx_bookmarks_url ON bookmarks (url);"),
+        "SQL missing url index: {up}"
+    );
+    assert!(
+        up.contains("CREATE INDEX idx_bookmarks_tag ON bookmarks (tag);"),
+        "SQL missing tag index: {up}"
+    );
+
+    let cargo_toml = fs::read_to_string(project.join("Cargo.toml")).unwrap();
+    assert!(
+        cargo_toml.contains("validator ="),
+        "Cargo.toml missing validator dep:\n{cargo_toml}"
+    );
+}
+
+/// CLI flags override the corresponding TOML values when both are present.
+#[test]
+fn generate_scaffold_cli_overrides_toml_config() {
+    let (_tmp, project) = fresh_project("scaffold-config-override-app");
+
+    fs::write(
+        project.join("autumn.generate.toml"),
+        "[scaffold.Post]\nfields  = [\"title:String\", \"body:Text\"]\nindexes = [\"title\"]\n",
+    )
+    .unwrap();
+
+    run_autumn(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Post",
+            "content:String",
+            "--index",
+            "content",
+            "--config",
+            "autumn.generate.toml",
+        ],
+    );
+
+    let model = fs::read_to_string(project.join("src/models/post.rs")).unwrap();
+    assert!(model.contains("pub content: String"), "model must have CLI field 'content': {model}");
+    assert!(!model.contains("pub title: String"), "model must not have TOML field 'title': {model}");
+    assert!(!model.contains("pub body:"), "model must not have TOML field 'body': {model}");
+
+    let migration = fs::read_dir(project.join("migrations"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .find(|e| e.file_name().to_string_lossy().ends_with("_create_posts"))
+        .expect("create_posts migration must exist");
+    let up = fs::read_to_string(migration.path().join("up.sql")).unwrap();
+    assert!(
+        up.contains("CREATE INDEX idx_posts_content ON posts (content);"),
+        "SQL must have CLI index on 'content': {up}"
+    );
+    assert!(
+        !up.contains("idx_posts_title"),
+        "SQL must not have TOML index on 'title': {up}"
+    );
+}
+
+/// A non-existent config file must cause a non-zero exit with the filename
+/// mentioned in the error output.
+#[test]
+fn generate_scaffold_rejects_missing_config_file() {
+    let (_tmp, project) = fresh_project("scaffold-missing-config-app");
+
+    let (_, stderr, code) = run_autumn_failing(
+        &project,
+        &["generate", "scaffold", "Post", "title:String", "--config", "nonexistent.toml"],
+    );
+
+    assert_eq!(code, Some(1), "expected exit code 1; got {code:?}");
+    assert!(
+        stderr.contains("nonexistent.toml"),
+        "error must mention the missing file name; got:\n{stderr}"
+    );
+}
+
+/// When the config file exists but has no entry for the requested resource,
+/// the command must fail with a helpful error message.
+#[test]
+fn generate_scaffold_rejects_config_missing_resource_section() {
+    let (_tmp, project) = fresh_project("scaffold-missing-section-app");
+
+    fs::write(
+        project.join("autumn.generate.toml"),
+        "[scaffold.OtherResource]\nfields = [\"name:String\"]\n",
+    )
+    .unwrap();
+
+    let (_, stderr, code) = run_autumn_failing(
+        &project,
+        &["generate", "scaffold", "Post", "--config", "autumn.generate.toml"],
+    );
+
+    assert_eq!(code, Some(1), "expected exit code 1; got {code:?}");
+    assert!(
+        stderr.contains("Post"),
+        "error must mention the resource name; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("autumn.generate.toml"),
+        "error must mention the config file name; got:\n{stderr}"
+    );
+}

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -1122,3 +1122,56 @@ fn generate_scaffold_rejects_config_missing_resource_section() {
         "error must mention the config file name; got:\n{stderr}"
     );
 }
+
+/// Slow compile-check: scaffold a fresh project from a TOML config file and
+/// verify that `cargo check --tests` succeeds against the local `autumn-web`
+/// crate.  Ensures that the config-driven generator adds every dependency its
+/// emitted code needs (validator, maud, etc.) and that all generated files
+/// type-check without manual edits.
+///
+/// Ignored by default; run with:
+/// `cargo test -p autumn-cli --test generate generated_scaffold_config_cargo_checks -- --ignored --exact`
+#[test]
+#[ignore = "slow: cargo-checks a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn generated_scaffold_config_cargo_checks() {
+    let (_tmp, project) = fresh_project("scaffold-config-build");
+
+    patch_generated_cargo_toml(&project);
+    let _ = fs::remove_file(project.join("build.rs"));
+
+    fs::write(
+        project.join("autumn.generate.toml"),
+        "[scaffold.Bookmark]\n\
+         fields      = [\"url:String\", \"title:String\", \"tag:String\", \"alive:bool\"]\n\
+         indexes     = [\"url\", \"tag\"]\n\
+         validations = [\"url=url\", \"title=length:min=1,max=200\"]\n\
+         defaults    = [\"alive=true\"]\n\
+         queries     = [\"find_by_tag:tag\", \"find_by_alive:alive\"]\n",
+    )
+    .unwrap();
+
+    run_autumn(
+        &project,
+        &["generate", "scaffold", "Bookmark", "--config", "autumn.generate.toml"],
+    );
+
+    let cargo_toml = fs::read_to_string(project.join("Cargo.toml")).unwrap();
+    for dep in ["chrono", "diesel", "diesel-async", "maud", "serde", "serde_urlencoded", "url", "validator"] {
+        assert!(
+            cargo_toml.contains(&format!("{dep} =")),
+            "Cargo.toml missing '{dep}' after config-driven scaffold"
+        );
+    }
+
+    let check = Command::new("cargo")
+        .args(["check", "--tests", "--offline"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "cargo check on config-driven scaffold failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -973,7 +973,13 @@ fn generate_scaffold_from_config_file() {
 
     run_autumn(
         &project,
-        &["generate", "scaffold", "Bookmark", "--config", "autumn.generate.toml"],
+        &[
+            "generate",
+            "scaffold",
+            "Bookmark",
+            "--config",
+            "autumn.generate.toml",
+        ],
     );
 
     let model = fs::read_to_string(project.join("src/models/bookmark.rs")).unwrap();
@@ -1014,7 +1020,10 @@ fn generate_scaffold_from_config_file() {
         })
         .expect("create_bookmarks migration must exist");
     let up = fs::read_to_string(migration.path().join("up.sql")).unwrap();
-    assert!(up.contains("alive BOOLEAN NOT NULL DEFAULT TRUE"), "SQL missing default: {up}");
+    assert!(
+        up.contains("alive BOOLEAN NOT NULL DEFAULT TRUE"),
+        "SQL missing default: {up}"
+    );
     assert!(
         up.contains("CREATE INDEX idx_bookmarks_url ON bookmarks (url);"),
         "SQL missing url index: {up}"
@@ -1057,9 +1066,18 @@ fn generate_scaffold_cli_overrides_toml_config() {
     );
 
     let model = fs::read_to_string(project.join("src/models/post.rs")).unwrap();
-    assert!(model.contains("pub content: String"), "model must have CLI field 'content': {model}");
-    assert!(!model.contains("pub title: String"), "model must not have TOML field 'title': {model}");
-    assert!(!model.contains("pub body:"), "model must not have TOML field 'body': {model}");
+    assert!(
+        model.contains("pub content: String"),
+        "model must have CLI field 'content': {model}"
+    );
+    assert!(
+        !model.contains("pub title: String"),
+        "model must not have TOML field 'title': {model}"
+    );
+    assert!(
+        !model.contains("pub body:"),
+        "model must not have TOML field 'body': {model}"
+    );
 
     let migration = fs::read_dir(project.join("migrations"))
         .unwrap()
@@ -1085,7 +1103,14 @@ fn generate_scaffold_rejects_missing_config_file() {
 
     let (_, stderr, code) = run_autumn_failing(
         &project,
-        &["generate", "scaffold", "Post", "title:String", "--config", "nonexistent.toml"],
+        &[
+            "generate",
+            "scaffold",
+            "Post",
+            "title:String",
+            "--config",
+            "nonexistent.toml",
+        ],
     );
 
     assert_eq!(code, Some(1), "expected exit code 1; got {code:?}");
@@ -1109,7 +1134,13 @@ fn generate_scaffold_rejects_config_missing_resource_section() {
 
     let (_, stderr, code) = run_autumn_failing(
         &project,
-        &["generate", "scaffold", "Post", "--config", "autumn.generate.toml"],
+        &[
+            "generate",
+            "scaffold",
+            "Post",
+            "--config",
+            "autumn.generate.toml",
+        ],
     );
 
     assert_eq!(code, Some(1), "expected exit code 1; got {code:?}");
@@ -1152,11 +1183,26 @@ fn generated_scaffold_config_cargo_checks() {
 
     run_autumn(
         &project,
-        &["generate", "scaffold", "Bookmark", "--config", "autumn.generate.toml"],
+        &[
+            "generate",
+            "scaffold",
+            "Bookmark",
+            "--config",
+            "autumn.generate.toml",
+        ],
     );
 
     let cargo_toml = fs::read_to_string(project.join("Cargo.toml")).unwrap();
-    for dep in ["chrono", "diesel", "diesel-async", "maud", "serde", "serde_urlencoded", "url", "validator"] {
+    for dep in [
+        "chrono",
+        "diesel",
+        "diesel-async",
+        "maud",
+        "serde",
+        "serde_urlencoded",
+        "url",
+        "validator",
+    ] {
         assert!(
             cargo_toml.contains(&format!("{dep} =")),
             "Cargo.toml missing '{dep}' after config-driven scaffold"

--- a/autumn/tests/security/rate_limit_xff_bypass.rs
+++ b/autumn/tests/security/rate_limit_xff_bypass.rs
@@ -13,6 +13,7 @@ async fn rate_limit_xff_bypass() {
         burst: 1,                      // only 1 request allowed
         trust_forwarded_headers: true, // typical for setups behind load balancers
         trusted_proxies: vec!["203.0.113.10".to_string()],
+        ..Default::default()
     };
 
     let app = Router::new()

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -341,13 +341,63 @@ intentionally small and documents which gaps are outside the generic generator:
 | Hourly `#[scheduled]` link checker | Operational workflow; generate or write a task separately. |
 | Mounting `POST`/`PUT`/`DELETE` JSON API routes | Application policy; scaffold keeps only read APIs registered by default. |
 
+### Reusable scaffold config (`autumn.generate.toml`)
+
+Long scaffolds with many metadata flags can be checked in as a TOML file
+so the intent is reviewable and reproducible without spelunking shell
+history. Create a file at any path — `autumn.generate.toml` is the
+conventional name — with one `[scaffold.<ResourceName>]` section per
+resource:
+
+```toml
+[scaffold.Bookmark]
+fields      = ["url:String", "title:String", "tag:String", "alive:bool"]
+indexes     = ["url", "tag"]
+validations = ["url=url", "title=length:min=1,max=200"]
+defaults    = ["alive=true"]
+queries     = ["find_by_tag:tag", "find_by_alive:alive"]
+```
+
+Pass the file with `--config`:
+
+```bash
+autumn generate scaffold Bookmark --config autumn.generate.toml
+```
+
+All the same keys are supported as their CLI counterparts — see the
+metadata flags table above for the accepted syntax of each.
+
+**Precedence rules (CLI wins):** if a CLI flag is supplied alongside
+`--config`, it completely replaces the corresponding TOML list for that
+key. An empty CLI slice (i.e. the flag was not passed) falls back to the
+TOML value. This matches normal CLI ergonomics where the explicit flag is
+always authoritative:
+
+| Scenario | Effective value |
+|---|---|
+| TOML only | TOML list |
+| CLI only (no `--config`) | CLI list |
+| Both, CLI non-empty | CLI list (TOML ignored for that key) |
+| Both, CLI empty / flag absent | TOML list |
+
+This applies independently to each key: you can keep `fields` and
+`validations` from TOML while overriding `indexes` on the CLI for a
+one-off variant.
+
+The config is additive, not a replacement — existing CLI flags always
+work without a config file, and the config never changes the output of
+any previously working invocation.
+
 ### Slow live scaffold verification
 
 The CLI test suite includes two ignored scaffold checks:
 
 ```bash
-# Compile-check the generated app and its generated smoke test.
+# Compile-check the generated app and its generated smoke test (CLI flags).
 cargo test -p autumn-cli --test generate generated_scaffold_cargo_checks -- --ignored --exact
+
+# Compile-check a config-file-driven scaffold (--config flag).
+cargo test -p autumn-cli --test generate generated_scaffold_config_cargo_checks -- --ignored --exact
 
 # Boot Postgres, run `autumn migrate`, start the generated server, and
 # verify GET /posts and GET /api/posts over real HTTP.


### PR DESCRIPTION
## Summary

Adds support for loading scaffold metadata from a reusable TOML configuration file (`autumn.generate.toml`), allowing complex scaffold invocations to be checked in and reproduced without long CLI commands.

## Key Changes

- **New `config` module** (`autumn-cli/src/generate/config.rs`): Implements TOML parsing and merging logic
  - `read_scaffold_config()`: Reads `[scaffold.ResourceName]` sections from TOML files
  - `merge_config_with_cli()`: Merges TOML values with CLI flags using CLI-wins precedence
  - `ScaffoldConfigEntry`: Deserializable struct for scaffold metadata (fields, indexes, validations, defaults, queries)
  - Comprehensive test coverage for parsing, merging, and error cases

- **CLI integration** (`autumn-cli/src/main.rs`):
  - Added `--config PATH` flag to `generate scaffold` command
  - Integrated config loading and merging into the scaffold command handler
  - Added CLI test for config flag parsing

- **Documentation** (`docs/guide/generators.md`):
  - Added "Reusable scaffold config" section with TOML format examples
  - Documented precedence rules (CLI flags override TOML values)
  - Added reference to new `generated_scaffold_config_cargo_checks` test

- **Integration tests** (`autumn-cli/tests/generate.rs`):
  - `generate_scaffold_from_config_file`: Full scaffold from TOML only
  - `generate_scaffold_cli_overrides_toml_config`: Verifies CLI precedence
  - `generate_scaffold_rejects_missing_config_file`: Error handling for missing files
  - `generate_scaffold_rejects_config_missing_resource_section`: Error handling for missing sections
  - `generated_scaffold_config_cargo_checks`: Slow compile-check test (ignored by default)

## Implementation Details

- **Precedence model**: CLI flags completely replace corresponding TOML lists when non-empty; empty CLI slices fall back to TOML values. This applies independently per key, allowing mixed overrides.
- **Error handling**: Distinguishes between IO errors (missing file) and config errors (invalid TOML or missing section) with helpful error messages including file paths and resource names.
- **Backward compatible**: Config is entirely optional; existing CLI-only invocations work unchanged.

https://claude.ai/code/session_01KNYQkWsKDL4e3zfmV3nqM3