### PR TITLE
🌟 Nova: Actuator Monitor Plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["autumn", "autumn-macros", "autumn-cli", "autumn-admin-plugin", "autumn-storage-s3", "autumn-cache-redis", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/wiki", "examples/reddit-clone", "examples/custom_config_loader", "examples/ws-echo", "examples/signed-webhooks"]
+members = ["autumn", "autumn-macros", "autumn-cli", "autumn-admin-plugin", "autumn-storage-s3", "autumn-cache-redis", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/wiki", "examples/reddit-clone", "examples/custom_config_loader", "examples/ws-echo", "examples/signed-webhooks", "autumn-monitor-plugin"]
 resolver = "3"
 
 [patch.crates-io]

--- a/autumn-monitor-plugin/Cargo.toml
+++ b/autumn-monitor-plugin/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "autumn-monitor-plugin"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+autumn-web = { path = "../autumn", default-features = false, features = ["htmx", "maud"] }
+maud = { version = "0.27", features = ["axum"] }
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/autumn-monitor-plugin/src/lib.rs
+++ b/autumn-monitor-plugin/src/lib.rs
@@ -1,0 +1,122 @@
+use autumn_web::app::AppBuilder;
+use autumn_web::plugin::Plugin;
+use autumn_web::reexports::axum::{Router, response::IntoResponse, routing};
+use maud::{DOCTYPE, html};
+use std::borrow::Cow;
+
+/// A plugin that adds an interactive HTML dashboard at `/actuator/monitor`
+/// to view metrics from the existing `/actuator/metrics` JSON endpoint via HTMX.
+pub struct MonitorPlugin {
+    prefix: String,
+}
+
+impl MonitorPlugin {
+    /// Create a new monitor plugin.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            prefix: "/actuator".to_owned(),
+        }
+    }
+
+    /// Set a custom prefix instead of `/actuator`.
+    #[must_use]
+    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = prefix.into();
+        self
+    }
+}
+
+impl Default for MonitorPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for MonitorPlugin {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("autumn_monitor_plugin::MonitorPlugin")
+    }
+
+    fn build(self, app: AppBuilder) -> AppBuilder {
+        let monitor_route = format!("{}/monitor", self.prefix.trim_end_matches('/'));
+
+        let router = Router::new().route("/", routing::get(monitor_dashboard));
+
+        app.nest(&monitor_route, router)
+    }
+}
+
+async fn monitor_dashboard() -> impl IntoResponse {
+    let markup = html! {
+        (DOCTYPE)
+        html lang="en" {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                title { "Autumn Monitor" }
+                // Fallback basic styling
+                style {
+                    "body { font-family: system-ui, sans-serif; background: #f9fafb; color: #111827; margin: 0; padding: 2rem; }"
+                    "h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 1.5rem; }"
+                    ".grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem; }"
+                    ".card { background: white; padding: 1.5rem; border-radius: 0.5rem; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }"
+                    ".card h2 { font-size: 1.125rem; font-weight: 500; margin-top: 0; margin-bottom: 1rem; border-bottom: 1px solid #e5e7eb; padding-bottom: 0.5rem; }"
+                    "pre { white-space: pre-wrap; font-size: 0.875rem; background: #f3f4f6; padding: 1rem; border-radius: 0.25rem; }"
+                }
+                script src="/static/js/htmx.min.js" {}
+            }
+            body {
+                h1 { "🍂 Autumn Monitor" }
+                div class="grid" {
+                    div class="card" {
+                        h2 { "Live Metrics" }
+                        // Fetch the JSON from /actuator/metrics and just dump it for now.
+                        // Real implementation would parse it and show pretty charts.
+                        div hx-get="/actuator/metrics" hx-trigger="load, every 2s" {
+                            "Loading metrics..."
+                        }
+                    }
+                    div class="card" {
+                        h2 { "Tasks" }
+                        div hx-get="/actuator/tasks" hx-trigger="load, every 5s" {
+                            "Loading tasks..."
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    (
+        [(
+            autumn_web::reexports::http::header::CONTENT_TYPE,
+            "text/html; charset=utf-8",
+        )],
+        markup.into_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use autumn_web::reexports::axum::{Router, routing};
+    use autumn_web::test::TestApp;
+
+    // Use a direct router approach because plugins directly integrate into the `AppBuilder` lifecycle
+    // during boot rather than simple route mounts that TestApp handles via `routes()`.
+    // In actual framework usages, one might boot a real app.
+
+    #[tokio::test]
+    async fn ui_renders_html() {
+        let router = Router::new().route("/monitor", routing::get(monitor_dashboard));
+        let test_app = TestApp::new().merge(router).build();
+
+        let response = test_app.get("/monitor").send().await;
+        response.assert_status(200);
+
+        let html = response.text();
+        assert!(html.contains("Autumn Monitor"));
+        assert!(html.contains("hx-get=\"/actuator/metrics\""));
+    }
+}

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 autumn-web = { path = "../../autumn" }
+autumn-monitor-plugin = { path = "../../autumn-monitor-plugin" }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -18,6 +18,7 @@ async fn hello_name(name: Path<String>) -> String {
 #[autumn_web::main]
 async fn main() {
     autumn_web::app()
+        .plugin(autumn_monitor_plugin::MonitorPlugin::new())
         .routes(routes![index, hello, hello_name])
         .run()
         .await;


### PR DESCRIPTION
💡 **The Spark:** I noticed we have `/actuator/metrics` JSON endpoints, but we don't have an easily readable interactive dashboard UI as a plugin.
🚀 **The Feature:** Implemented `MonitorPlugin` which mounts an interactive HTML dashboard at `/actuator/monitor`.
🔮 **The Potential:** Could be expanded to show live charts or let developers manage background tasks visually.
⚠️ **Risk:** Low. Isolated in `autumn-monitor-plugin` crate and mounted only when registered.

---
*PR created automatically by Jules for task [974538215219172429](https://jules.google.com/task/974538215219172429) started by @madmax983*