### PR TITLE
Harden Claude GitHub workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,6 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -33,7 +32,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@d2f5cd942af4451d6bb357bf705afe8cbf50ec59 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,16 +13,31 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+        contains(github.event.comment.body, '@claude')
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+        contains(github.event.comment.body, '@claude')
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association) &&
+        contains(github.event.review.body, '@claude')
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association) &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
@@ -32,7 +47,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@d2f5cd942af4451d6bb357bf705afe8cbf50ec59 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
### Motivation
- The Claude workflow could be triggered by untrusted issue/review comments containing `@claude`, which allowed attacker-controlled text to run an action with repository secrets and OIDC privileges.

### Description
- Require the comment/review/issue `author_association` to be one of `OWNER`, `MEMBER`, or `COLLABORATOR` before honoring `@claude` in `.github/workflows/claude.yml`.
- Remove unnecessary `id-token: write` permission from both `.github/workflows/claude.yml` and `.github/workflows/claude-code-review.yml`.
- Pin `anthropics/claude-code-action` to the `v1` tag commit SHA (`d2f5cd942af4451d6bb357bf705afe8cbf50ec59`) in both workflows to reduce third-party action drift.

### Testing
- Parsed both workflow files with Ruby YAML to validate syntax using `ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f); puts \"parsed #{f}\" }" .github/workflows/claude.yml .github/workflows/claude-code-review.yml` and it succeeded.
- Ran Python assertions to verify the trusted-author gates are present, `id-token: write` is removed, and the action is pinned, and the checks passed.
- Ran `actionlint` via `GOBIN=/tmp/actionlint-bin go install github.com/rhysd/actionlint/cmd/actionlint@latest && /tmp/actionlint-bin/actionlint .github/workflows/claude.yml .github/workflows/claude-code-review.yml` to lint the workflows and it reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05cc1bd114832ab0fffeacd321b2ba)