### PR TITLE
⚡ Bolt: Remove intermediate Vec allocations in path normalization

### DIFF
--- a/autumn-cli/src/plugin_check.rs
+++ b/autumn-cli/src/plugin_check.rs
@@ -427,17 +427,23 @@ fn check_duplicate_registration(plugin_name: &str, routes: &[RouteInfo]) -> Chec
     }
 }
 
+/// ⚡ Bolt: Iterates and pushes directly to a pre-allocated `String` instead of
+/// chaining `.collect::<Vec<_>>().join("/")` to avoid intermediate heap allocations.
 fn normalize_path_for_collision(path: &str) -> String {
-    path.split('/')
-        .map(|seg| {
-            if seg.starts_with('{') && seg.ends_with('}') {
-                "{}"
-            } else {
-                seg
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
+    let mut out = String::with_capacity(path.len());
+    let mut first = true;
+    for seg in path.split('/') {
+        if !first {
+            out.push('/');
+        }
+        first = false;
+        if seg.starts_with('{') && seg.ends_with('}') {
+            out.push_str("{}");
+        } else {
+            out.push_str(seg);
+        }
+    }
+    out
 }
 
 fn check_collisions(routes: &[RouteInfo]) -> CheckResult {

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -350,17 +350,24 @@ pub fn check_route_prefix(
 /// Both named params (`{id}`) and catch-all params (`{*rest}`) normalize to
 /// `{}`. matchit (Axum's router) treats a named param and a catch-all at the
 /// same path position as a conflict, so they must map to the same key.
+///
+/// ⚡ Bolt: Iterates and pushes directly to a pre-allocated `String` instead of
+/// chaining `.collect::<Vec<_>>().join("/")` to avoid intermediate heap allocations.
 fn normalize_path_for_collision(path: &str) -> String {
-    path.split('/')
-        .map(|seg| {
-            if seg.starts_with('{') && seg.ends_with('}') {
-                "{}"
-            } else {
-                seg
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
+    let mut out = String::with_capacity(path.len());
+    let mut first = true;
+    for seg in path.split('/') {
+        if !first {
+            out.push('/');
+        }
+        first = false;
+        if seg.starts_with('{') && seg.ends_with('}') {
+            out.push_str("{}");
+        } else {
+            out.push_str(seg);
+        }
+    }
+    out
 }
 
 /// Detect route collisions: any two routes sharing the same (method, path) pair.


### PR DESCRIPTION
💡 What: Replaced a `split().map().collect::<Vec<_>>().join("/")` chain with an iterative approach that pushes to a pre-allocated `String::with_capacity()` inside `normalize_path_for_collision` in both `autumn/src/plugin_conformance.rs` and `autumn-cli/src/plugin_check.rs`.

🎯 Why: To avoid unnecessary heap allocations for an intermediate `Vec` during route validation and collision detection loops.

📊 Impact: Removes one vector heap allocation per route processed during plugin collision checks.

🔬 Measurement: Verified with `cargo test` that the string formatting behavior exactly mirrors the original semantics.

---
*PR created automatically by Jules for task [1862792926719681996](https://jules.google.com/task/1862792926719681996) started by @madmax983*