### PR TITLE
⚡ Bolt: Remove intermediate Vec allocation in path normalization

### DIFF
--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -351,16 +351,22 @@ pub fn check_route_prefix(
 /// `{}`. matchit (Axum's router) treats a named param and a catch-all at the
 /// same path position as a conflict, so they must map to the same key.
 fn normalize_path_for_collision(path: &str) -> String {
-    path.split('/')
-        .map(|seg| {
-            if seg.starts_with('{') && seg.ends_with('}') {
-                "{}"
-            } else {
-                seg
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
+    // ⚡ Bolt: Pre-allocate string capacity to avoid intermediate Vec allocation
+    // and multiple string re-allocations during path normalization.
+    let mut normalized = String::with_capacity(path.len());
+    let mut first = true;
+    for seg in path.split('/') {
+        if !first {
+            normalized.push('/');
+        }
+        first = false;
+        if seg.starts_with('{') && seg.ends_with('}') {
+            normalized.push_str("{}");
+        } else {
+            normalized.push_str(seg);
+        }
+    }
+    normalized
 }
 
 /// Detect route collisions: any two routes sharing the same (method, path) pair.


### PR DESCRIPTION
💡 What:
Refactored `normalize_path_for_collision` in `autumn/src/plugin_conformance.rs` to use a pre-allocated `String` and manually push segments, replacing the chained `.split()`, `.map()`, `.collect::<Vec<_>>()`, and `.join("/")` iterator pipeline.

🎯 Why:
The original approach caused an unnecessary intermediate heap allocation for the `Vec`, as well as a potential secondary allocation when joining the final string. This occurs during route path canonicalization, which can be called multiple times during plugin registration.

📊 Impact:
Removes 1 intermediate heap allocation per route path processed during collision detection, replacing it with a single, precisely sized string allocation and direct string pushing.

🔬 Measurement:
Run `cargo test -p autumn-web --lib plugin_conformance` and `cargo test -p autumn-web --lib plugin_conformance --release` to verify functionality is identical. Run `cargo bench` if available on canonicalization.

---
*PR created automatically by Jules for task [10425085849188530326](https://jules.google.com/task/10425085849188530326) started by @madmax983*