### PR TITLE
🍏 Eris: Prevent X-Forwarded-Host injection bypass in Method Override CSRF protection

### DIFF
--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -396,18 +396,35 @@ fn origin_matches_request(origin: &str, headers: &http::HeaderMap) -> bool {
         return false;
     };
 
-    let expected_host = headers
-        .get("x-forwarded-host")
-        .and_then(|v| v.to_str().ok())
-        .or_else(|| {
-            headers
-                .get(http::header::HOST)
-                .and_then(|v| v.to_str().ok())
-        });
+    let x_forwarded_host = {
+        let all_xfh: Vec<&str> = headers
+            .get_all("x-forwarded-host")
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect();
+
+        if all_xfh.is_empty() {
+            None
+        } else {
+            let joined = all_xfh.join(", ");
+            joined
+                .rsplit(',')
+                .next()
+                .map(str::trim)
+                .map(ToOwned::to_owned)
+        }
+    };
+
+    let expected_host = x_forwarded_host.or_else(|| {
+        headers
+            .get(http::header::HOST)
+            .and_then(|v| v.to_str().ok())
+            .map(ToOwned::to_owned)
+    });
     let Some(expected_host) = expected_host else {
         return false;
     };
-    if !origin_authority.eq_ignore_ascii_case(expected_host) {
+    if !origin_authority.eq_ignore_ascii_case(&expected_host) {
         return false;
     }
 

--- a/autumn/tests/security/method_override_bypass.rs
+++ b/autumn/tests/security/method_override_bypass.rs
@@ -1,0 +1,33 @@
+use axum::{body::Body, http::Request, routing::delete};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn x_forwarded_host_injection_is_rejected() {
+    // Instead of TestApp::new().routes, we can use TestApp::from_app if it exists, or just build an axum Router.
+    // The previous tests used Router directly for the middleware unit tests.
+    // Let's just use `axum::Router` directly here.
+    let app = axum::Router::new()
+        .route("/items/1", delete(|| async { "deleted" }))
+        .layer(autumn_web::middleware::MethodOverrideLayer::new());
+
+    let mut req = Request::builder()
+        .method("POST")
+        .uri("/items/1")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .header("origin", "https://attacker.com")
+        .header("x-forwarded-host", "attacker.com")
+        .body(Body::from("_method=DELETE"))
+        .unwrap();
+
+    req.headers_mut()
+        .append("x-forwarded-host", "legitimate.com".parse().unwrap());
+
+    let res = app.oneshot(req).await.unwrap();
+
+    let status = res.status();
+    assert!(
+        status == axum::http::StatusCode::BAD_REQUEST
+            || status == axum::http::StatusCode::METHOD_NOT_ALLOWED,
+        "Method override should have been rejected! Status: {status}"
+    );
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -13,3 +13,5 @@ pub mod fallback_middleware_bypass;
 pub mod rate_limit_xff_bypass;
 pub mod session_exhaustion;
 pub mod session_fixation;
+
+pub mod method_override_bypass;


### PR DESCRIPTION
Reconnaissance
The `origin_matches_request` function in `MethodOverrideLayer` protects against cross-origin forged requests overriding the method (`POST` to `DELETE`/`PUT`/`PATCH`). It verifies the `Origin` header matches the expected `Host` or `X-Forwarded-Host`. The code was reading the `X-Forwarded-Host` header via `headers.get()`, which in `axum` only yields the first header.

Hypothesis
Because standard HTTP semantics allow multiple headers to be coalesced into a comma-separated list, or to be appended as separate headers, an attacker could spoof the expected host by injecting a malicious `X-Forwarded-Host` header. A trusted proxy would typically append its value at the end of the chain. By only reading the first header, `origin_matches_request` inadvertently trusts the attacker-controlled value over the proxy-appended value, bypassing the CSRF protection.

Exploit development
An attacker constructs a cross-origin form POST with a forged `X-Forwarded-Host` matching their `Origin` (e.g. `https://attacker.com`). A legitimate reverse proxy or load balancer appends the real expected host (`legitimate.com`). The application evaluates `headers.get("x-forwarded-host")`, reads `attacker.com`, matches it with the `Origin`, and successfully executes the method override (e.g., executing a `DELETE` request for an authenticated user).

Verification
A regression PoC test `x_forwarded_host_injection_is_rejected` has been added to `autumn/tests/security/method_override_bypass.rs`. Prior to the fix, this test failed as the attacker was able to spoof the host and bypass the override check, receiving a `200 OK` from the underlying target handler. After the patch, it correctly rejects the override, exposing the request to the `POST` route block and resulting in `405 Method Not Allowed` / `400 Bad Request`.

Severity assessment
CVSS 3.1 Base Score: 5.4 (Medium)
Vector: AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:L
The vulnerability allows for Cross-Site Request Forgery (CSRF) via Method Override, potentially resulting in unauthorized state changes (like DELETE requests) affecting the victim. Requires user interaction (visiting an attacker-controlled page) and depends on specific proxy append configurations.

Remediation
Modify `origin_matches_request` to extract all `X-Forwarded-Host` headers using `headers.get_all("x-forwarded-host")`. Join all values into a single string, split by commas, and extract the rightmost valid value (`.rsplit(',').next()`) to ensure the trusted proxy's appended value is evaluated instead of the attacker's leading value.

---
*PR created automatically by Jules for task [1814344328002026063](https://jules.google.com/task/1814344328002026063) started by @madmax983*