### PR TITLE
🗺️ Atlas: Extract layer registration types

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -173,6 +173,8 @@ type PolicyRegistration = Box<dyn FnOnce(&crate::authorization::PolicyRegistry) 
 ///         .await;
 /// }
 /// ```
+use crate::layer_registration::{CustomLayerRegistration, ScopedGroup};
+
 pub struct AppBuilder {
     routes: Vec<Route>,
     /// Parallel to `routes`: registration origin for each route.
@@ -277,40 +279,6 @@ pub(crate) type MailDeliveryQueueFactory = Box<
     dyn FnOnce(&AppState) -> crate::AutumnResult<Arc<dyn crate::mail::MailDeliveryQueue>> + Send,
 >;
 
-/// A group of routes sharing a common path prefix and middleware layer.
-///
-/// Created by [`AppBuilder::scoped`]. The routes are mounted under the
-/// prefix with the middleware applied only to this group.
-pub(crate) struct ScopedGroup {
-    pub(crate) prefix: String,
-    pub(crate) routes: Vec<Route>,
-    /// Registration origin: user application or a named plugin.
-    pub(crate) source: crate::route_listing::RouteSource,
-    /// Closure that applies the layer to a sub-router.
-    pub(crate) apply_layer:
-        Box<dyn FnOnce(axum::Router<AppState>) -> axum::Router<AppState> + Send>,
-}
-
-/// A deferred router mutator that applies a user-registered
-/// [`tower::Layer`] to the app-wide router.
-///
-/// Stored on [`AppBuilder`] by [`AppBuilder::layer`] and drained inside
-/// `apply_middleware` where the final layer stack is assembled.
-pub(crate) type CustomLayerApplier =
-    Box<dyn FnOnce(axum::Router<AppState>) -> axum::Router<AppState> + Send>;
-
-/// Metadata and deferred application closure for a user-registered layer.
-pub(crate) struct CustomLayerRegistration {
-    /// Concrete type for the registered layer.
-    pub(crate) type_id: TypeId,
-    /// Deferred router mutation that applies the layer.
-    pub(crate) apply: CustomLayerApplier,
-}
-
-mod sealed {
-    pub trait Sealed {}
-}
-
 /// Marker trait for types that can be registered with
 /// [`AppBuilder::layer`] as an app-wide Tower middleware.
 ///
@@ -329,13 +297,13 @@ mod sealed {
     label = "this type does not implement `tower::Layer<axum::routing::Route>` with the required service bounds",
     note = "`AppBuilder::layer(..)` requires:\n    L: tower::Layer<axum::routing::Route> + Clone + Send + Sync + 'static,\n    L::Service: Service<axum::extract::Request, Response = axum::response::Response, Error = Infallible> + Clone + Send + Sync + 'static,\n    <L::Service as Service<axum::extract::Request>>::Future: Send + 'static\nSee docs/guide/middleware.md for common patterns and how to wrap raw-error layers (e.g. TimeoutLayer) with HandleErrorLayer."
 )]
-pub trait IntoAppLayer: sealed::Sealed + Send + Sync + 'static {
+pub trait IntoAppLayer: crate::layer_registration::sealed::Sealed + Send + Sync + 'static {
     /// Apply this layer to the given router. Not intended for direct use.
     #[doc(hidden)]
     fn apply_to(self, router: axum::Router<AppState>) -> axum::Router<AppState>;
 }
 
-impl<L> sealed::Sealed for L
+impl<L> crate::layer_registration::sealed::Sealed for L
 where
     L: tower::Layer<axum::routing::Route> + Clone + Send + Sync + 'static,
     L::Service: tower::Service<

--- a/autumn/src/layer_registration.rs
+++ b/autumn/src/layer_registration.rs
@@ -1,0 +1,36 @@
+use crate::route::Route;
+use crate::state::AppState;
+use std::any::TypeId;
+
+/// A group of routes sharing a common path prefix and middleware layer.
+///
+/// Created by [`AppBuilder::scoped`]. The routes are mounted under the
+/// prefix with the middleware applied only to this group.
+pub struct ScopedGroup {
+    pub prefix: String,
+    pub routes: Vec<Route>,
+    /// Registration origin: user application or a named plugin.
+    pub source: crate::route_listing::RouteSource,
+    /// Closure that applies the layer to a sub-router.
+    pub apply_layer: Box<dyn FnOnce(axum::Router<AppState>) -> axum::Router<AppState> + Send>,
+}
+
+/// A deferred router mutator that applies a user-registered
+/// [`tower::Layer`] to the app-wide router.
+///
+/// Stored on [`AppBuilder`] by [`AppBuilder::layer`] and drained inside
+/// `apply_middleware` where the final layer stack is assembled.
+pub type CustomLayerApplier =
+    Box<dyn FnOnce(axum::Router<AppState>) -> axum::Router<AppState> + Send>;
+
+/// Metadata and deferred application closure for a user-registered layer.
+pub struct CustomLayerRegistration {
+    /// Concrete type for the registered layer.
+    pub type_id: TypeId,
+    /// Deferred router mutation that applies the layer.
+    pub apply: CustomLayerApplier,
+}
+
+pub mod sealed {
+    pub trait Sealed {}
+}

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -120,6 +120,7 @@ pub use repository::RepositoryError;
 /// This module is responsible for taking the application's configuration,
 /// defined routes, middleware, and state, and building the final `axum::Router`
 /// that will handle incoming HTTP requests.
+pub(crate) mod layer_registration;
 pub(crate) mod router;
 
 #[cfg(feature = "db")]

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::app::ScopedGroup;
+use crate::layer_registration::ScopedGroup;
 use crate::route::Route;
 
 /// Where a route was registered: by the user application, by a named plugin,

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -7,10 +7,10 @@
 
 use std::sync::Arc;
 
-use crate::app::ScopedGroup;
 use crate::config::AutumnConfig;
 use crate::error_pages::{self, SharedRenderer};
 use crate::extract::State;
+use crate::layer_registration::ScopedGroup;
 use crate::middleware::RequestIdLayer;
 use crate::middleware::dev;
 use crate::middleware::exception_filter::{
@@ -115,7 +115,7 @@ pub struct RouterContext {
     /// [`AppBuilder::layer`](crate::app::AppBuilder::layer). Applied inside
     /// [`RequestIdLayer`] on the ingress
     /// path so user middleware observes the generated request ID.
-    pub custom_layers: Vec<crate::app::CustomLayerRegistration>,
+    pub custom_layers: Vec<crate::layer_registration::CustomLayerRegistration>,
     pub error_page_renderer: Option<SharedRenderer>,
     /// Custom session store installed via
     /// [`AppBuilder::with_session_store`](crate::app::AppBuilder::with_session_store).
@@ -1057,7 +1057,7 @@ fn apply_middleware(
     config: &AutumnConfig,
     state: &AppState,
     exception_filters: Vec<Arc<dyn ExceptionFilter>>,
-    custom_layers: Vec<crate::app::CustomLayerRegistration>,
+    custom_layers: Vec<crate::layer_registration::CustomLayerRegistration>,
     error_page_renderer: Option<SharedRenderer>,
     session_store: Option<Arc<dyn crate::session::BoxedSessionStore>>,
 ) -> Result<axum::Router<AppState>, RouterBuildError> {
@@ -2091,7 +2091,7 @@ mod tests {
         async fn child() -> &'static str {
             "inner"
         }
-        let group = crate::app::ScopedGroup {
+        let group = crate::layer_registration::ScopedGroup {
             prefix: "/api".to_owned(),
             routes: vec![Route {
                 method: http::Method::GET,
@@ -2175,7 +2175,7 @@ mod tests {
             },
             repository: None,
         };
-        let group = crate::app::ScopedGroup {
+        let group = crate::layer_registration::ScopedGroup {
             prefix: "/orgs/{org_id}".to_owned(),
             routes: vec![child],
             source: crate::route_listing::RouteSource::User,

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -161,7 +161,7 @@ pub struct TestApp {
     routes: Vec<Route>,
     merge_routers: Vec<axum::Router<crate::state::AppState>>,
     nest_routers: Vec<(String, axum::Router<crate::state::AppState>)>,
-    custom_layers: Vec<crate::app::CustomLayerRegistration>,
+    custom_layers: Vec<crate::layer_registration::CustomLayerRegistration>,
     config: AutumnConfig,
     #[cfg(feature = "openapi")]
     openapi: Option<crate::openapi::OpenApiConfig>,
@@ -287,7 +287,7 @@ impl TestApp {
     #[must_use]
     pub fn layer<L: crate::app::IntoAppLayer>(mut self, layer: L) -> Self {
         self.custom_layers
-            .push(crate::app::CustomLayerRegistration {
+            .push(crate::layer_registration::CustomLayerRegistration {
                 type_id: std::any::TypeId::of::<L>(),
                 apply: Box::new(move |router| layer.apply_to(router)),
             });


### PR DESCRIPTION
🕸️ Tangle: The `ScopedGroup`, `CustomLayerRegistration`, and `CustomLayerApplier` internal registration structs were declared as `pub(crate)` within the bloated 7,000 line `app.rs` file, but were leaked out across `router.rs` and `route_listing.rs`.

📐 Blueprint: Extracted these registration types into their own dedicated `layer_registration.rs` module, converting their fields from `pub(crate)` to `pub` so they can be securely exported via the `pub(crate) mod layer_registration` barrier in `lib.rs`, fixing the leaky abstraction and module bloat.

🧱 Stability: Improved high cohesion by isolating registration logic into its own domain module, maintaining correct internal privacy bounds, and reducing the footprint of the massive `AppBuilder` source file.

🔭 Verification: Compiled, linted, and fully tested successfully on both debug and release targets with `cargo test -p autumn-web --features test-support,db,storage,maud`.

---
*PR created automatically by Jules for task [7840886435954031981](https://jules.google.com/task/7840886435954031981) started by @madmax983*