### PR TITLE
🗣️ Echo: Fix scoped 404s, primitive returns, and tailwind warnings

### DIFF
--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -791,9 +791,7 @@ fn restart_server(
 
 fn tailwind_build() -> bool {
     let Some(mut cmd) = build_tailwind_command() else {
-        eprintln!(
-            "  \u{2717} Tailwind CSS CLI not found. Run `autumn setup` or install `tailwindcss`."
-        );
+        eprintln!("  \u{2139} Tailwind CSS CLI not found, skipping styled build.");
         return false;
     };
 

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -295,11 +295,11 @@ fn should_stringify_primitive_output(output: &ReturnType) -> bool {
         return false;
     };
 
-    if path.qself.is_some() || path.path.segments.len() != 1 {
+    if path.qself.is_some() || path.path.segments.is_empty() {
         return false;
     }
 
-    let ident = path.path.segments[0].ident.to_string();
+    let ident = path.path.segments.last().unwrap().ident.to_string();
     matches!(
         ident.as_str(),
         "bool"

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -942,6 +942,8 @@ fn mount_scoped_groups(
             sub_router = sub_router.route(route.path, route.handler);
         }
         sub_router = (group.apply_layer)(sub_router);
+        sub_router =
+            sub_router.fallback(crate::middleware::error_page_filter::fallback_404_handler);
         router = router.nest(&group.prefix, sub_router);
     }
     router


### PR DESCRIPTION
1. 🔎 EXPERIENCE
During a DX audit of the initial Quickstart and routing ergonomics, I discovered several rough edges. The goal is to make sure basic routing works smoothly (like returning simple ints) and error pages correctly inform the user of what went wrong, rather than providing empty pages or confusing compiler messages.

2. 🚧 STUMBLE
- Error Check 1: Requesting a missing path inside a nested scope (e.g. `/api/missing`) returns a completely blank response (`content-length: 0`) instead of the rich 404 HTML/JSON fallback page.
- Error Check 2: Route handlers attempting to return primitive integers like `i32` failed to compile with a massive `Handler<_, _> is not satisfied` Axum trait error because the macro couldn't parse the primitive correctly.
- The "README Run": `autumn dev` constantly yells `Tailwind CSS CLI not found` as a severe error despite the README calling the setup optional.

3. 📢 REPORT
- "Why does a 404 inside a scope give me an empty page? Simple is better than powerful, but empty is just confusing."
- "Why can I return a String but not an integer? If I return `42`, the compiler dumps 20 lines of trait bound errors about Axum internals."
- "Why does the CLI yell at me about Tailwind CSS every time I run the app if the README says it's optional?"

4. 🧪 VERIFY
- Fixed `mount_scoped_groups` to append the `fallback_404_handler` to the sub_router before it gets nested, ensuring scoped 404s are properly formatted.
- Fixed `should_stringify_primitive_output` to check the `last()` segment of the path, correctly identifying types like `std::primitive::i32` and generating the proper `to_string()` wrapper.
- Downgraded the missing Tailwind CLI warning to a simple info log (`ℹ Tailwind CSS CLI not found, skipping styled build.`) so users aren't bothered when choosing to skip Tailwind setup.

---
*PR created automatically by Jules for task [2888204864215017355](https://jules.google.com/task/2888204864215017355) started by @madmax983*