### PR TITLE
🤖 Sentinel: Strengthen rate limiter timeout calculation assertions

### DIFF
--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -1293,3 +1293,65 @@ mod tests {
         assert!(matches!(limiter.backend, BucketBackend::Memory(_)));
     }
 }
+
+#[cfg(test)]
+mod sentinel_tests_more {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn memory_store_retry_after_calculation() {
+        let store = MemoryStore::new();
+        let now = Instant::now();
+
+        assert!(matches!(
+            store.decide("test", now, 1.0, 0.1),
+            Decision::Allowed { .. }
+        ));
+
+        let decision = store.decide("test", now, 1.0, 0.1);
+        match decision {
+            Decision::Denied { retry_after_secs } => {
+                assert_eq!(retry_after_secs, 10);
+            }
+            Decision::Allowed { .. } => panic!("Expected Denied"),
+        }
+
+        let now5 = now + Duration::from_secs(5);
+        let decision5 = store.decide("test", now5, 1.0, 0.1);
+        match decision5 {
+            Decision::Denied { retry_after_secs } => {
+                assert_eq!(retry_after_secs, 5);
+            }
+            Decision::Allowed { .. } => panic!("Expected Denied, got {decision5:?}"),
+        }
+    }
+
+    #[test]
+    fn memory_store_retry_after_calculation_with_partial_tokens() {
+        let store = MemoryStore::new();
+        let now = Instant::now();
+
+        assert!(matches!(
+            store.decide("test_partial", now, 1.0, 0.1),
+            Decision::Allowed { .. }
+        ));
+
+        let decision = store.decide("test_partial", now, 1.0, 0.1);
+        match decision {
+            Decision::Denied { retry_after_secs } => {
+                assert_eq!(retry_after_secs, 10);
+            }
+            Decision::Allowed { .. } => panic!("Expected Denied"),
+        }
+
+        let now3 = now + Duration::from_secs(3);
+        let decision3 = store.decide("test_partial", now3, 1.0, 0.1);
+        match decision3 {
+            Decision::Denied { retry_after_secs } => {
+                assert_eq!(retry_after_secs, 7);
+            }
+            Decision::Allowed { .. } => panic!("Expected Denied"),
+        }
+    }
+}


### PR DESCRIPTION
🧬 **Mutants Found:** 2 timeouts in `MemoryStore::decide` related to timeout calculation (`let deficit = 1.0 - current_tokens;` replaced with `+` or `/`).
🎯 **Tests Added/Strengthened:** Added `memory_store_retry_after_calculation` and `memory_store_retry_after_calculation_with_partial_tokens` to `autumn/src/security/rate_limit.rs`. These tests strictly assert the `retry_after_secs` value based on known token limits and refilling times, ensuring that invalid math operations immediately trigger an assertion failure rather than falling into unhandled state or test timeouts.
⚠️ **Suspected Bugs:** None. The timeout was a testing gap due to loose assertions, not an implementation bug.
📊 **Kill Rate:** The `rate_limit.rs` file now properly fails when `MemoryStore::decide` deficit calculations are mutated.
🔗 **Havoc Interaction:** None.

---
*PR created automatically by Jules for task [4016291575350361042](https://jules.google.com/task/4016291575350361042) started by @madmax983*