### PR TITLE
🗣️ Echo: Fix compilation error when returning fully qualified primitives from route handlers

### DIFF
--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -326,11 +326,11 @@ fn should_stringify_primitive_output(output: &ReturnType) -> bool {
         return false;
     };
 
-    if path.qself.is_some() || path.path.segments.len() != 1 {
+    if path.qself.is_some() || path.path.segments.is_empty() {
         return false;
     }
 
-    let ident = path.path.segments[0].ident.to_string();
+    let ident = path.path.segments.last().unwrap().ident.to_string();
     matches!(
         ident.as_str(),
         "bool"

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -326,11 +326,15 @@ fn should_stringify_primitive_output(output: &ReturnType) -> bool {
         return false;
     };
 
-    if path.qself.is_some() || path.path.segments.is_empty() {
+    let Some(last_segment) = path.path.segments.last() else {
+        return false;
+    };
+
+    if path.qself.is_some() || !last_segment.arguments.is_empty() {
         return false;
     }
 
-    let ident = path.path.segments.last().unwrap().ident.to_string();
+    let ident = last_segment.ident.to_string();
     matches!(
         ident.as_str(),
         "bool"

--- a/autumn/tests/route_macro.rs
+++ b/autumn/tests/route_macro.rs
@@ -253,9 +253,13 @@ fn multi_path_params_route_preserves_pattern() {
 #[test]
 fn fully_qualified_primitive_return_type_compiles_with_route_macro() {
     #[autumn_web::get("/foo")]
+    #[allow(clippy::unused_async)]
     async fn fully_qualified_int_route() -> std::primitive::i32 {
         42
     }
 
-    assert_eq!(__autumn_route_info_fully_qualified_int_route().name, "fully_qualified_int_route");
+    assert_eq!(
+        __autumn_route_info_fully_qualified_int_route().name,
+        "fully_qualified_int_route"
+    );
 }

--- a/autumn/tests/route_macro.rs
+++ b/autumn/tests/route_macro.rs
@@ -249,3 +249,13 @@ fn multi_path_params_route_preserves_pattern() {
     assert_eq!(route.path, "/posts/{year}/{slug}");
     assert_eq!(route.method, http::Method::GET);
 }
+
+#[test]
+fn fully_qualified_primitive_return_type_compiles_with_route_macro() {
+    #[autumn_web::get("/foo")]
+    async fn fully_qualified_int_route() -> std::primitive::i32 {
+        42
+    }
+
+    assert_eq!(__autumn_route_info_fully_qualified_int_route().name, "fully_qualified_int_route");
+}


### PR DESCRIPTION
1. 🔍 EXPERIENCE - The Walkthrough
- Did the "README Run" and tested writing a simpler custom route returning `std::primitive::i32`.

2. 🚧 STUMBLE - The Friction Points
- The route handler failed to compile with an unintelligible error about `Handler<_, _>` trait bounds not satisfied.
- Axum's `IntoResponse` trait isn't implemented for plain numbers out-of-the-box. The Autumn route macro handles primitive stringification, but failed when the return type was a path-qualified primitive like `std::primitive::i32` instead of just `i32`.

3. 📢 REPORT - The Complaint
- "Why can I return a String but not an integer? If I return a number, the compiler dumps 20 lines of trait bound errors about Axum internals. Simple is better than powerful, and right now simple numbers crash the compiler!"

4. 🧪 VERIFY - The "idiot proofing"
- Modified `should_stringify_primitive_output` in `autumn-macros/src/route.rs` to extract and match the last segment's identifier (e.g. `i32` in `std::primitive::i32`), enabling stringification of path-qualified primitives.
- Verified the fix by successfully returning a `std::primitive::i32` from an `autumn-web` route handler and passing all tests across debug and release profiles.

---
*PR created automatically by Jules for task [14754734987352446286](https://jules.google.com/task/14754734987352446286) started by @madmax983*