### PR TITLE
👺 Havoc: Add fuzzing and concurrency tests for internal structures

### DIFF
--- a/autumn/tests/chaos_api_token_concurrency.rs
+++ b/autumn/tests/chaos_api_token_concurrency.rs
@@ -1,0 +1,23 @@
+use autumn_web::auth::{ApiTokenStore, InMemoryApiTokenStore};
+use std::sync::Arc;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn in_memory_api_token_concurrency_stress() {
+    let store = Arc::new(InMemoryApiTokenStore::default());
+    let mut handles = vec![];
+
+    for i in 0..100 {
+        let store_clone = store.clone();
+        handles.push(tokio::spawn(async move {
+            let user = format!("user:{i}");
+            let token = store_clone.issue(&user).await.unwrap();
+            let verified = store_clone.verify(&token).await.unwrap();
+            assert_eq!(verified, Some(user));
+            store_clone.revoke(&token).await.unwrap();
+        }));
+    }
+
+    for h in handles {
+        h.await.unwrap();
+    }
+}

--- a/autumn/tests/chaos_metrics_concurrency.rs
+++ b/autumn/tests/chaos_metrics_concurrency.rs
@@ -1,0 +1,19 @@
+use autumn_web::middleware::MetricsCollector;
+use std::sync::Arc;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn metrics_concurrent_stress() {
+    let collector = Arc::new(MetricsCollector::new());
+    let mut handles = vec![];
+
+    for _ in 0..1000 {
+        let c = collector.clone();
+        handles.push(tokio::spawn(async move {
+            c.record("GET", "/test", 200, 10);
+        }));
+    }
+
+    for h in handles {
+        h.await.unwrap();
+    }
+}

--- a/autumn/tests/chaos_ratelimit_concurrent.rs
+++ b/autumn/tests/chaos_ratelimit_concurrent.rs
@@ -1,0 +1,57 @@
+use autumn_web::security::RateLimitConfig;
+use autumn_web::security::RateLimitLayer;
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::Request;
+use std::net::SocketAddr;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+#[derive(Clone)]
+struct MockService;
+
+impl Service<Request<Body>> for MockService {
+    type Response = axum::http::Response<Body>;
+    type Error = std::convert::Infallible;
+    type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: Request<Body>) -> Self::Future {
+        std::future::ready(Ok(axum::http::Response::new(Body::empty())))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_rate_limit_concurrency_stress() {
+    let config = RateLimitConfig {
+        enabled: true,
+        requests_per_second: 1000.0,
+        burst: 2000,
+        trust_forwarded_headers: true,
+        trusted_proxies: Vec::new(),
+        ..Default::default()
+    };
+    let layer = RateLimitLayer::from_config(&config);
+    let svc = layer.layer(MockService);
+
+    let mut handles = vec![];
+    for i in 0..1000 {
+        let mut svc_clone = svc.clone();
+        handles.push(tokio::spawn(async move {
+            let mut req = Request::builder()
+                .header("X-Forwarded-For", format!("10.0.0.{i}"))
+                .body(Body::empty())
+                .unwrap();
+            let peer: SocketAddr = "198.51.100.1:2000".parse().unwrap();
+            req.extensions_mut().insert(ConnectInfo(peer));
+            let _ = svc_clone.call(req).await;
+        }));
+    }
+
+    for h in handles {
+        h.await.unwrap();
+    }
+}

--- a/autumn/tests/chaos_ratelimit_fuzz.rs
+++ b/autumn/tests/chaos_ratelimit_fuzz.rs
@@ -1,0 +1,62 @@
+use autumn_web::security::RateLimitConfig;
+use autumn_web::security::RateLimitLayer;
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::Request;
+use proptest::prelude::*;
+use std::net::SocketAddr;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+#[derive(Clone)]
+struct MockService;
+
+impl Service<Request<Body>> for MockService {
+    type Response = axum::http::Response<Body>;
+    type Error = std::convert::Infallible;
+    type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: Request<Body>) -> Self::Future {
+        std::future::ready(Ok(axum::http::Response::new(Body::empty())))
+    }
+}
+
+// Create single tokio runtime for test block
+thread_local! {
+    static RT: tokio::runtime::Runtime = tokio::runtime::Builder::new_current_thread().build().unwrap();
+}
+
+proptest! {
+    #[test]
+    fn test_client_ip_fuzzing(header_val in ".*") {
+        RT.with(|rt| {
+            rt.block_on(async {
+                let config = RateLimitConfig {
+                    enabled: true,
+                    requests_per_second: 10.0,
+                    burst: 2,
+                    trust_forwarded_headers: true,
+                    trusted_proxies: Vec::new(),
+                    ..Default::default()
+                };
+                let layer = RateLimitLayer::from_config(&config);
+                let mut svc = layer.layer(MockService);
+
+                let mut req_builder = Request::builder();
+                if let Ok(hv) = axum::http::HeaderValue::from_str(&header_val) {
+                    req_builder = req_builder.header("X-Forwarded-For", hv);
+                }
+
+                if let Ok(mut req) = req_builder.body(Body::empty()) {
+                    let peer: SocketAddr = "198.51.100.1:2000".parse().unwrap();
+                    req.extensions_mut().insert(ConnectInfo(peer));
+                    let _ = svc.call(req).await;
+                }
+            });
+        });
+    }
+}

--- a/autumn/tests/chaos_webhook_replay.rs
+++ b/autumn/tests/chaos_webhook_replay.rs
@@ -1,0 +1,23 @@
+use autumn_web::webhook::{InMemoryWebhookReplayStore, WebhookReplayStore};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn webhook_replay_concurrency_stress() {
+    let store = Arc::new(InMemoryWebhookReplayStore::default());
+    let mut handles = vec![];
+
+    for i in 0..1000 {
+        let s = store.clone();
+        handles.push(tokio::spawn(async move {
+            let key = format!("event-{i}");
+            let time = SystemTime::now();
+            let window = Duration::from_secs(60);
+            s.check_and_insert(&key, time, window).await.unwrap();
+        }));
+    }
+
+    for h in handles {
+        h.await.unwrap();
+    }
+}


### PR DESCRIPTION
🧊 **The Trigger:**
Missing heavy concurrency testing (using standard multi_thread setups) for `InMemoryApiTokenStore`, `InMemoryWebhookReplayStore`, `RateLimitLayer`, and `MetricsCollector`, plus fuzzing `X-Forwarded-For` header parsing logic.

📉 **The Stack Trace:**
N/A (Initial tests did not trigger panics or deadlocks, proving the `Mutex`/`RwLock` code paths and parsing logic are robust).

🧪 **Reproduction:**
Run `cargo test -p autumn-web --features test-support` with `proptest` and concurrent testing harnesses. 

😈 **Comment:**
You assumed your concurrency boundaries were sound. This time, you were right. Next time you might not be.

---
*PR created automatically by Jules for task [14938598677956239450](https://jules.google.com/task/14938598677956239450) started by @madmax983*