### PR TITLE
⚡ Bolt: Remove intermediate Vec allocation in normalize_path_for_collision

### DIFF
--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -350,17 +350,25 @@ pub fn check_route_prefix(
 /// Both named params (`{id}`) and catch-all params (`{*rest}`) normalize to
 /// `{}`. matchit (Axum's router) treats a named param and a catch-all at the
 /// same path position as a conflict, so they must map to the same key.
+///
+/// ⚡ Bolt Optimization: Uses a single pre-allocated String instead of collecting
+/// segments into an intermediate Vec. This avoids heap allocations during route evaluation.
 fn normalize_path_for_collision(path: &str) -> String {
-    path.split('/')
-        .map(|seg| {
-            if seg.starts_with('{') && seg.ends_with('}') {
-                "{}"
-            } else {
-                seg
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
+    let mut normalized = String::with_capacity(path.len());
+    let mut first = true;
+    for seg in path.split('/') {
+        if !first {
+            normalized.push('/');
+        }
+        first = false;
+
+        if seg.starts_with('{') && seg.ends_with('}') {
+            normalized.push_str("{}");
+        } else {
+            normalized.push_str(seg);
+        }
+    }
+    normalized
 }
 
 /// Detect route collisions: any two routes sharing the same (method, path) pair.


### PR DESCRIPTION
💡 What: Replaced the chained iterator collection `collect::<Vec<_>>().join("/")` with a single, pre-allocated `String` and manual in-place concatenation in the `normalize_path_for_collision` function.
🎯 Why: `normalize_path_for_collision` is heavily used when determining route uniqueness and plugin conformance. The original implementation allocated an intermediate heap `Vec` to store string slices before joining them, wasting memory and CPU cycles.
📊 Impact: Completely eliminates the intermediate heap allocation (`Vec`) and multiple reallocation overheads by using exactly one correctly-sized string buffer.
🔬 Measurement: Run `cargo check` and `cargo test -p autumn-web --lib plugin_conformance` in both debug and release mode to verify functional equivalence.

---
*PR created automatically by Jules for task [14511935522481849734](https://jules.google.com/task/14511935522481849734) started by @madmax983*