### PR TITLE
feat: expose plugin hooks at framework-owned dependency boundaries (#690)

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2497,6 +2497,15 @@ impl AppBuilder {
             cache_backend,
             #[cfg(feature = "mail")]
             mail_delivery_queue_factory,
+            #[cfg(feature = "mail")]
+            mail_interceptor,
+            job_interceptor,
+            #[cfg(feature = "db")]
+            db_interceptor,
+            #[cfg(feature = "ws")]
+            channels_interceptor,
+            #[cfg(feature = "oauth2")]
+            http_interceptor,
             ..
         } = self;
 
@@ -2567,6 +2576,31 @@ impl AppBuilder {
             #[cfg(feature = "ws")]
             channels_backend,
         );
+        #[cfg(feature = "mail")]
+        if let Some(interceptor) = mail_interceptor {
+            state.insert_extension(interceptor);
+        }
+        if let Some(interceptor) = job_interceptor {
+            state.insert_extension(interceptor);
+        }
+        #[cfg(feature = "db")]
+        if let Some(interceptor) = db_interceptor {
+            state.insert_extension(interceptor);
+        }
+        #[cfg(feature = "ws")]
+        if let Some(interceptor) = channels_interceptor {
+            state.insert_extension(interceptor.clone());
+            state.channels = crate::channels::Channels::with_shared_backend(std::sync::Arc::new(
+                crate::channels::InterceptedChannelsBackend::new(
+                    state.channels.backend().clone(),
+                    vec![interceptor],
+                ),
+            ));
+        }
+        #[cfg(feature = "oauth2")]
+        if let Some(interceptor) = http_interceptor {
+            state.insert_extension(interceptor);
+        }
         #[cfg(feature = "db")]
         configure_replica_migration_check(&state, replica_migration_check);
         #[cfg(feature = "db")]

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -109,6 +109,15 @@ pub fn app() -> AppBuilder {
         mail_previews: Vec::new(),
         declared_routes: Vec::new(),
         idempotency_enabled: false,
+        #[cfg(feature = "mail")]
+        mail_interceptor: None,
+        job_interceptor: None,
+        #[cfg(feature = "db")]
+        db_interceptor: None,
+        #[cfg(feature = "ws")]
+        channels_interceptor: None,
+        #[cfg(feature = "oauth2")]
+        http_interceptor: None,
     }
 }
 
@@ -272,6 +281,15 @@ pub struct AppBuilder {
     /// loaded `AutumnConfig` before router assembly so that startup validation
     /// and `apply_middleware` both see `config.idempotency.enabled = true`.
     idempotency_enabled: bool,
+    #[cfg(feature = "mail")]
+    mail_interceptor: Option<Arc<dyn crate::interceptor::MailInterceptor>>,
+    job_interceptor: Option<Arc<dyn crate::interceptor::JobInterceptor>>,
+    #[cfg(feature = "db")]
+    db_interceptor: Option<Arc<dyn crate::interceptor::DbConnectionInterceptor>>,
+    #[cfg(feature = "ws")]
+    channels_interceptor: Option<Arc<dyn crate::interceptor::ChannelsInterceptor>>,
+    #[cfg(feature = "oauth2")]
+    http_interceptor: Option<Arc<dyn crate::interceptor::HttpInterceptor>>,
 }
 
 /// Boxed builder closure that constructs a durable
@@ -967,6 +985,55 @@ impl AppBuilder {
         self.extensions.get(&TypeId::of::<T>())?.downcast_ref::<T>()
     }
 
+    #[cfg(feature = "mail")]
+    #[must_use]
+    pub fn with_mail_interceptor(
+        mut self,
+        interceptor: impl crate::interceptor::MailInterceptor,
+    ) -> Self {
+        self.mail_interceptor = Some(Arc::new(interceptor));
+        self
+    }
+
+    #[must_use]
+    pub fn with_job_interceptor(
+        mut self,
+        interceptor: impl crate::interceptor::JobInterceptor,
+    ) -> Self {
+        self.job_interceptor = Some(Arc::new(interceptor));
+        self
+    }
+
+    #[cfg(feature = "db")]
+    #[must_use]
+    pub fn with_db_interceptor(
+        mut self,
+        interceptor: impl crate::interceptor::DbConnectionInterceptor,
+    ) -> Self {
+        self.db_interceptor = Some(Arc::new(interceptor));
+        self
+    }
+
+    #[cfg(feature = "ws")]
+    #[must_use]
+    pub fn with_channels_interceptor(
+        mut self,
+        interceptor: impl crate::interceptor::ChannelsInterceptor,
+    ) -> Self {
+        self.channels_interceptor = Some(Arc::new(interceptor));
+        self
+    }
+
+    #[cfg(feature = "oauth2")]
+    #[must_use]
+    pub fn with_http_interceptor(
+        mut self,
+        interceptor: impl crate::interceptor::HttpInterceptor,
+    ) -> Self {
+        self.http_interceptor = Some(Arc::new(interceptor));
+        self
+    }
+
     /// Register a pre-loaded i18n translation bundle.
     ///
     /// Most apps prefer [`Self::i18n_auto`] which loads from the
@@ -1518,6 +1585,15 @@ impl AppBuilder {
             mail_previews,
             declared_routes: _,
             idempotency_enabled,
+            #[cfg(feature = "mail")]
+            mail_interceptor,
+            job_interceptor,
+            #[cfg(feature = "db")]
+            db_interceptor,
+            #[cfg(feature = "ws")]
+            channels_interceptor,
+            #[cfg(feature = "oauth2")]
+            http_interceptor,
         } = self;
 
         let all_routes = routes;
@@ -1650,6 +1726,31 @@ impl AppBuilder {
             #[cfg(feature = "ws")]
             channels_backend,
         );
+        #[cfg(feature = "mail")]
+        if let Some(interceptor) = mail_interceptor {
+            state.insert_extension(interceptor);
+        }
+        if let Some(interceptor) = job_interceptor {
+            state.insert_extension(interceptor);
+        }
+        #[cfg(feature = "db")]
+        if let Some(interceptor) = db_interceptor {
+            state.insert_extension(interceptor);
+        }
+        #[cfg(feature = "ws")]
+        if let Some(interceptor) = channels_interceptor {
+            state.insert_extension(interceptor.clone());
+            state.channels = crate::channels::Channels::with_shared_backend(std::sync::Arc::new(
+                crate::channels::InterceptedChannelsBackend::new(
+                    state.channels.backend().clone(),
+                    vec![interceptor],
+                ),
+            ));
+        }
+        #[cfg(feature = "oauth2")]
+        if let Some(interceptor) = http_interceptor {
+            state.insert_extension(interceptor);
+        }
         #[cfg(feature = "db")]
         configure_replica_migration_check(&state, replica_migration_check);
         #[cfg(feature = "db")]
@@ -2019,6 +2120,15 @@ impl AppBuilder {
             mail_previews,
             declared_routes: _,
             idempotency_enabled,
+            #[cfg(feature = "mail")]
+                mail_interceptor: _,
+            job_interceptor: _,
+            #[cfg(feature = "db")]
+                db_interceptor: _,
+            #[cfg(feature = "ws")]
+                channels_interceptor: _,
+            #[cfg(feature = "oauth2")]
+                http_interceptor: _,
         } = self;
 
         let all_routes = routes;

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2661,6 +2661,21 @@ impl AppBuilder {
 
         tracing::info!(task = %task_name, "Running one-off task");
         let span = tracing::info_span!("one_off_task", task = %task_name);
+        #[cfg(feature = "oauth2")]
+        let result = {
+            use crate::interceptor::{ACTIVE_HTTP_INTERCEPTORS, HttpInterceptor};
+            let interceptors: Vec<std::sync::Arc<dyn HttpInterceptor>> = state
+                .extension::<std::sync::Arc<dyn HttpInterceptor>>()
+                .map(|interceptor_arc| vec![(*interceptor_arc).clone()])
+                .unwrap_or_default();
+            ACTIVE_HTTP_INTERCEPTORS
+                .scope(
+                    interceptors,
+                    (task_handler)(state.clone(), args).instrument(span),
+                )
+                .await
+        };
+        #[cfg(not(feature = "oauth2"))]
         let result = (task_handler)(state.clone(), args).instrument(span).await;
 
         task_shutdown.cancel();

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -848,15 +848,113 @@ async fn validate_and_decode_id_token(
 }
 
 #[cfg(feature = "oauth2")]
-fn oauth_http_client() -> crate::AutumnResult<reqwest::Client> {
-    reqwest::Client::builder()
+#[derive(Clone)]
+pub struct HttpClient {
+    inner: reqwest::Client,
+}
+
+#[cfg(feature = "oauth2")]
+pub struct HttpRequestBuilder {
+    client: reqwest::Client,
+    builder: reqwest::RequestBuilder,
+}
+
+#[cfg(feature = "oauth2")]
+impl HttpClient {
+    pub fn new(inner: reqwest::Client) -> Self {
+        Self { inner }
+    }
+
+    pub fn post(&self, url: &str) -> HttpRequestBuilder {
+        HttpRequestBuilder {
+            client: self.inner.clone(),
+            builder: self.inner.post(url),
+        }
+    }
+
+    pub fn get(&self, url: &str) -> HttpRequestBuilder {
+        HttpRequestBuilder {
+            client: self.inner.clone(),
+            builder: self.inner.get(url),
+        }
+    }
+}
+
+#[cfg(feature = "oauth2")]
+impl HttpRequestBuilder {
+    pub fn header<K, V>(mut self, key: K, value: V) -> Self
+    where
+        reqwest::header::HeaderName: TryFrom<K>,
+        <reqwest::header::HeaderName as TryFrom<K>>::Error: Into<http::Error>,
+        reqwest::header::HeaderValue: TryFrom<V>,
+        <reqwest::header::HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
+    {
+        self.builder = self.builder.header(key, value);
+        self
+    }
+
+    pub fn bearer_auth<T>(mut self, token: T) -> Self
+    where
+        T: std::fmt::Display,
+    {
+        self.builder = self.builder.bearer_auth(token);
+        self
+    }
+
+    pub fn form<T: serde::Serialize + ?Sized>(mut self, form: &T) -> Self {
+        self.builder = self.builder.form(form);
+        self
+    }
+
+    pub async fn send(self) -> Result<reqwest::Response, reqwest::Error> {
+        let req = self.builder.build()?;
+        let interceptors = crate::interceptor::ACTIVE_HTTP_INTERCEPTORS
+            .try_with(|i| i.clone())
+            .unwrap_or_default();
+        run_http_chain(req, interceptors, self.client.clone(), 0).await
+    }
+}
+
+#[cfg(feature = "oauth2")]
+fn run_http_chain(
+    req: reqwest::Request,
+    interceptors: Vec<Arc<dyn crate::interceptor::HttpInterceptor>>,
+    client: reqwest::Client,
+    idx: usize,
+) -> std::pin::Pin<
+    Box<
+        dyn std::future::Future<Output = Result<reqwest::Response, reqwest::Error>>
+            + Send
+            + 'static,
+    >,
+> {
+    Box::pin(async move {
+        if idx < interceptors.len() {
+            let interceptor = interceptors[idx].clone();
+            let next_interceptors = interceptors.clone();
+            let next_client = client.clone();
+            let next_fn = move |r: reqwest::Request| {
+                run_http_chain(r, next_interceptors.clone(), next_client.clone(), idx + 1)
+            };
+            let fut = interceptor.intercept(req, &next_fn);
+            fut.await
+        } else {
+            client.execute(req).await
+        }
+    })
+}
+
+#[cfg(feature = "oauth2")]
+fn oauth_http_client() -> crate::AutumnResult<HttpClient> {
+    let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(OAUTH_HTTP_TIMEOUT_SECS))
         .build()
         .map_err(|e| {
             crate::AutumnError::service_unavailable_msg(format!(
                 "failed to build oauth http client: {e}"
             ))
-        })
+        })?;
+    Ok(HttpClient::new(client))
 }
 
 impl Default for AuthConfig {

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -2621,7 +2621,87 @@ mod tests {
     }
 }
 
-// ── API token tests ───────────────────────────────────────────────────────────
+// ── HttpRequestBuilder interceptor task-local scope tests ────────────────────
+
+#[cfg(feature = "oauth2")]
+#[cfg(test)]
+mod http_interceptor_task_local_tests {
+    use crate::interceptor::{ACTIVE_HTTP_INTERCEPTORS, HttpInterceptor, HttpInterceptorFuture};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    struct FlagInterceptor {
+        fired: Arc<AtomicBool>,
+    }
+
+    impl HttpInterceptor for FlagInterceptor {
+        fn intercept<'a>(
+            &'a self,
+            req: reqwest::Request,
+            next: &'a dyn Fn(reqwest::Request) -> HttpInterceptorFuture<'a>,
+        ) -> HttpInterceptorFuture<'a> {
+            self.fired.store(true, Ordering::SeqCst);
+            // Delegate to next so the caller gets a real (likely connection-refused)
+            // error back — we discard it in the test with `let _ = ...`.
+            next(req)
+        }
+    }
+
+    /// Proves the task-local scope contract: when `ACTIVE_HTTP_INTERCEPTORS` is
+    /// set via `.scope()` (as `run_one_off_task_mode` must do), the interceptor
+    /// fires on every `HttpRequestBuilder::send` call within that scope.
+    #[tokio::test]
+    async fn http_request_builder_send_fires_interceptor_inside_scope() {
+        let fired = Arc::new(AtomicBool::new(false));
+        let interceptor: Arc<dyn HttpInterceptor> = Arc::new(FlagInterceptor {
+            fired: Arc::clone(&fired),
+        });
+
+        let client = reqwest::Client::new();
+        let http_client = super::HttpClient::new(client);
+
+        ACTIVE_HTTP_INTERCEPTORS
+            .scope(vec![interceptor], async {
+                let _ = http_client
+                    .get("http://127.0.0.1:54321/noreply")
+                    .send()
+                    .await;
+            })
+            .await;
+
+        assert!(
+            fired.load(Ordering::SeqCst),
+            "interceptor must fire when ACTIVE_HTTP_INTERCEPTORS scope is established"
+        );
+    }
+
+    /// Proves the regression: without a scope, the interceptor is silently
+    /// skipped. The fix in `run_one_off_task_mode` wraps the task handler in
+    /// `ACTIVE_HTTP_INTERCEPTORS.scope(...)` so that registered interceptors are
+    /// always active during task execution.
+    #[tokio::test]
+    async fn http_request_builder_send_skips_interceptor_outside_scope() {
+        let fired = Arc::new(AtomicBool::new(false));
+        let _interceptor: Arc<dyn HttpInterceptor> = Arc::new(FlagInterceptor {
+            fired: Arc::clone(&fired),
+        });
+
+        // Intentionally do NOT establish a scope — simulating pre-fix task mode.
+        let client = reqwest::Client::new();
+        let http_client = super::HttpClient::new(client);
+        let _ = http_client
+            .get("http://127.0.0.1:54321/noreply")
+            .send()
+            .await;
+
+        assert!(
+            !fired.load(Ordering::SeqCst),
+            "interceptor must NOT fire when ACTIVE_HTTP_INTERCEPTORS scope is absent"
+        );
+    }
+}
 
 #[cfg(test)]
 mod api_token_tests {

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -861,10 +861,12 @@ pub struct HttpRequestBuilder {
 
 #[cfg(feature = "oauth2")]
 impl HttpClient {
-    pub fn new(inner: reqwest::Client) -> Self {
+    #[must_use]
+    pub const fn new(inner: reqwest::Client) -> Self {
         Self { inner }
     }
 
+    #[must_use]
     pub fn post(&self, url: &str) -> HttpRequestBuilder {
         HttpRequestBuilder {
             client: self.inner.clone(),
@@ -872,6 +874,7 @@ impl HttpClient {
         }
     }
 
+    #[must_use]
     pub fn get(&self, url: &str) -> HttpRequestBuilder {
         HttpRequestBuilder {
             client: self.inner.clone(),
@@ -882,6 +885,7 @@ impl HttpClient {
 
 #[cfg(feature = "oauth2")]
 impl HttpRequestBuilder {
+    #[must_use]
     pub fn header<K, V>(mut self, key: K, value: V) -> Self
     where
         reqwest::header::HeaderName: TryFrom<K>,
@@ -893,6 +897,7 @@ impl HttpRequestBuilder {
         self
     }
 
+    #[must_use]
     pub fn bearer_auth<T>(mut self, token: T) -> Self
     where
         T: std::fmt::Display,
@@ -901,15 +906,22 @@ impl HttpRequestBuilder {
         self
     }
 
+    #[must_use]
     pub fn form<T: serde::Serialize + ?Sized>(mut self, form: &T) -> Self {
         self.builder = self.builder.form(form);
         self
     }
 
+    /// Sends the request through the interceptor chain.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `reqwest::Error` if building the request, sending the request, or
+    /// intercepting the call fails.
     pub async fn send(self) -> Result<reqwest::Response, reqwest::Error> {
         let req = self.builder.build()?;
         let interceptors = crate::interceptor::ACTIVE_HTTP_INTERCEPTORS
-            .try_with(|i| i.clone())
+            .try_with(Clone::clone)
             .unwrap_or_default();
         run_http_chain(req, interceptors, self.client.clone(), 0).await
     }

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -824,27 +824,28 @@ impl InterceptedChannelsBackend {
 }
 
 #[cfg(feature = "ws")]
+fn run_chain(
+    topic: &str,
+    msg: &ChannelMessage,
+    interceptors: &[Arc<dyn crate::interceptor::ChannelsInterceptor>],
+    inner: &dyn ChannelsBackend,
+    idx: usize,
+) -> Result<usize, ChannelPublishError> {
+    if idx < interceptors.len() {
+        let interceptor = &interceptors[idx];
+        let next =
+            |t: &str, m: &ChannelMessage| run_chain(t, m, interceptors, inner, idx + 1);
+        interceptor.intercept_publish(topic, msg, &next)
+    } else {
+        inner.publish(topic, msg.clone())
+    }
+}
+
+#[cfg(feature = "ws")]
 impl ChannelsBackend for InterceptedChannelsBackend {
     fn publish(&self, topic: &str, msg: ChannelMessage) -> Result<usize, ChannelPublishError> {
         let inner = &self.inner;
         let interceptors = &self.interceptors;
-
-        fn run_chain(
-            topic: &str,
-            msg: &ChannelMessage,
-            interceptors: &[Arc<dyn crate::interceptor::ChannelsInterceptor>],
-            inner: &dyn ChannelsBackend,
-            idx: usize,
-        ) -> Result<usize, ChannelPublishError> {
-            if idx < interceptors.len() {
-                let interceptor = &interceptors[idx];
-                let next =
-                    |t: &str, m: &ChannelMessage| run_chain(t, m, interceptors, inner, idx + 1);
-                interceptor.intercept_publish(topic, msg, &next)
-            } else {
-                inner.publish(topic, msg.clone())
-            }
-        }
 
         run_chain(topic, &msg, interceptors, &**inner, 0)
     }

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -802,7 +802,81 @@ impl ChannelsBackend for RedisChannelsBackend {
     }
 }
 
+#[cfg(feature = "ws")]
+#[derive(Clone)]
+pub struct InterceptedChannelsBackend {
+    inner: Arc<dyn ChannelsBackend>,
+    interceptors: Vec<Arc<dyn crate::interceptor::ChannelsInterceptor>>,
+}
+
+#[cfg(feature = "ws")]
+impl InterceptedChannelsBackend {
+    #[must_use]
+    pub fn new(
+        inner: Arc<dyn ChannelsBackend>,
+        interceptors: Vec<Arc<dyn crate::interceptor::ChannelsInterceptor>>,
+    ) -> Self {
+        Self {
+            inner,
+            interceptors,
+        }
+    }
+}
+
+#[cfg(feature = "ws")]
+impl ChannelsBackend for InterceptedChannelsBackend {
+    fn publish(&self, topic: &str, msg: ChannelMessage) -> Result<usize, ChannelPublishError> {
+        let inner = &self.inner;
+        let interceptors = &self.interceptors;
+
+        fn run_chain(
+            topic: &str,
+            msg: &ChannelMessage,
+            interceptors: &[Arc<dyn crate::interceptor::ChannelsInterceptor>],
+            inner: &dyn ChannelsBackend,
+            idx: usize,
+        ) -> Result<usize, ChannelPublishError> {
+            if idx < interceptors.len() {
+                let interceptor = &interceptors[idx];
+                let next =
+                    |t: &str, m: &ChannelMessage| run_chain(t, m, interceptors, inner, idx + 1);
+                interceptor.intercept_publish(topic, msg, &next)
+            } else {
+                inner.publish(topic, msg.clone())
+            }
+        }
+
+        run_chain(topic, &msg, interceptors, &**inner, 0)
+    }
+
+    fn ensure_topic(&self, topic: &str) -> Arc<broadcast::Sender<ChannelMessage>> {
+        self.inner.ensure_topic(topic)
+    }
+
+    fn subscribe(&self, topic: &str) -> Subscriber {
+        self.inner.subscribe(topic)
+    }
+
+    fn channel_count(&self) -> usize {
+        self.inner.channel_count()
+    }
+
+    fn gc(&self) {
+        self.inner.gc();
+    }
+
+    fn snapshot(&self) -> HashMap<String, ChannelStats> {
+        self.inner.snapshot()
+    }
+}
+
 impl Channels {
+    /// Return the underlying backend.
+    #[must_use]
+    pub fn backend(&self) -> &Arc<dyn ChannelsBackend> {
+        &self.backend
+    }
+
     /// Create a new local channel registry with the given buffer capacity.
     #[must_use]
     pub fn new(capacity: usize) -> Self {

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -833,8 +833,7 @@ fn run_chain(
 ) -> Result<usize, ChannelPublishError> {
     if idx < interceptors.len() {
         let interceptor = &interceptors[idx];
-        let next =
-            |t: &str, m: &ChannelMessage| run_chain(t, m, interceptors, inner, idx + 1);
+        let next = |t: &str, m: &ChannelMessage| run_chain(t, m, interceptors, inner, idx + 1);
         interceptor.intercept_publish(topic, msg, &next)
     } else {
         inner.publish(topic, msg.clone())

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -213,6 +213,13 @@ pub trait DbState {
     fn read_pool(&self) -> Option<&Pool<AsyncPgConnection>> {
         self.replica_pool().or_else(|| self.pool())
     }
+
+    /// Returns any registered database connection checkout interceptors.
+    fn db_interceptors(
+        &self,
+    ) -> Vec<std::sync::Arc<dyn crate::interceptor::DbConnectionInterceptor>> {
+        Vec::new()
+    }
 }
 
 /// Error type for pool creation failures.
@@ -344,7 +351,7 @@ pub fn create_topology(config: &DatabaseConfig) -> Result<Option<DatabaseTopolog
 // ── Db extractor ─────────────────────────────────────────────
 
 /// Connection type managed by the deadpool pool.
-type PooledConnection = diesel_async::pooled_connection::deadpool::Object<AsyncPgConnection>;
+pub type PooledConnection = diesel_async::pooled_connection::deadpool::Object<AsyncPgConnection>;
 
 struct TxDepthGuard<'a> {
     depth: &'a mut usize,
@@ -550,14 +557,26 @@ where
             otel.kind = "client",
             db.system = "postgresql",
         );
-        let conn = async {
+        let interceptors = state.db_interceptors();
+
+        let mut checkout_future: std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<PooledConnection, AutumnError>> + Send + '_,
+            >,
+        > = Box::pin(async {
             pool.get().await.map_err(|e| {
                 tracing::error!("Failed to acquire database connection: {e}");
                 AutumnError::service_unavailable_msg(e.to_string())
             })
+        });
+        for interceptor in &interceptors {
+            let ctx = crate::interceptor::DbCheckoutContext {
+                pool_name: "primary".to_string(),
+            };
+            checkout_future = interceptor.intercept_checkout(ctx, checkout_future);
         }
-        .instrument(span.clone())
-        .await?;
+
+        let conn = checkout_future.instrument(span.clone()).await?;
 
         Ok(Self {
             conn,

--- a/autumn/src/interceptor.rs
+++ b/autumn/src/interceptor.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+#[cfg(feature = "mail")]
+pub trait MailInterceptor: Send + Sync + 'static {
+    fn intercept<'a>(
+        &'a self,
+        mail: &'a crate::mail::Mail,
+        next: std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<(), crate::mail::MailError>> + Send + 'a>,
+        >,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<(), crate::mail::MailError>> + Send + 'a>,
+    >;
+}
+
+pub trait JobInterceptor: Send + Sync + 'static {
+    fn intercept_enqueue<'a>(
+        &'a self,
+        name: &'a str,
+        payload: &'a serde_json::Value,
+        next: std::pin::Pin<
+            Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+        >,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>>;
+
+    fn intercept_execute<'a>(
+        &'a self,
+        name: &'a str,
+        payload: &'a serde_json::Value,
+        next: std::pin::Pin<
+            Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+        >,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>>;
+}
+
+#[derive(Debug, Clone)]
+pub struct DbCheckoutContext {
+    pub pool_name: String,
+}
+
+#[cfg(feature = "db")]
+pub trait DbConnectionInterceptor: Send + Sync + 'static {
+    fn intercept_checkout<'a>(
+        &'a self,
+        ctx: DbCheckoutContext,
+        next: std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = Result<crate::db::PooledConnection, crate::AutumnError>,
+                    > + Send
+                    + 'a,
+            >,
+        >,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<crate::db::PooledConnection, crate::AutumnError>,
+                > + Send
+                + 'a,
+        >,
+    >;
+}
+
+#[cfg(feature = "ws")]
+pub trait ChannelsInterceptor: Send + Sync + 'static {
+    fn intercept_publish(
+        &self,
+        topic: &str,
+        msg: &crate::channels::ChannelMessage,
+        next: &dyn Fn(
+            &str,
+            &crate::channels::ChannelMessage,
+        ) -> Result<usize, crate::channels::ChannelPublishError>,
+    ) -> Result<usize, crate::channels::ChannelPublishError>;
+}
+
+#[cfg(feature = "oauth2")]
+pub trait HttpInterceptor: Send + Sync + 'static {
+    fn intercept<'a>(
+        &'a self,
+        req: reqwest::Request,
+        next: &'a dyn Fn(
+            reqwest::Request,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<reqwest::Response, reqwest::Error>>
+                    + Send
+                    + 'a,
+            >,
+        >,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<reqwest::Response, reqwest::Error>> + Send + 'a,
+        >,
+    >;
+}
+
+#[cfg(feature = "oauth2")]
+tokio::task_local! {
+    pub static ACTIVE_HTTP_INTERCEPTORS: Vec<Arc<dyn HttpInterceptor>>;
+}

--- a/autumn/src/interceptor.rs
+++ b/autumn/src/interceptor.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "oauth2")]
 use std::sync::Arc;
 
 #[cfg(feature = "mail")]
@@ -63,6 +64,11 @@ pub trait DbConnectionInterceptor: Send + Sync + 'static {
 
 #[cfg(feature = "ws")]
 pub trait ChannelsInterceptor: Send + Sync + 'static {
+    /// Intercepts a channel message publication.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ChannelPublishError`](crate::channels::ChannelPublishError) if publication fails.
     fn intercept_publish(
         &self,
         topic: &str,

--- a/autumn/src/interceptor.rs
+++ b/autumn/src/interceptor.rs
@@ -81,24 +81,17 @@ pub trait ChannelsInterceptor: Send + Sync + 'static {
 }
 
 #[cfg(feature = "oauth2")]
+pub type HttpInterceptorFuture<'a> = std::pin::Pin<
+    Box<dyn std::future::Future<Output = Result<reqwest::Response, reqwest::Error>> + Send + 'a>,
+>;
+
+#[cfg(feature = "oauth2")]
 pub trait HttpInterceptor: Send + Sync + 'static {
     fn intercept<'a>(
         &'a self,
         req: reqwest::Request,
-        next: &'a dyn Fn(
-            reqwest::Request,
-        ) -> std::pin::Pin<
-            Box<
-                dyn std::future::Future<Output = Result<reqwest::Response, reqwest::Error>>
-                    + Send
-                    + 'a,
-            >,
-        >,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<reqwest::Response, reqwest::Error>> + Send + 'a,
-        >,
-    >;
+        next: &'a dyn Fn(reqwest::Request) -> HttpInterceptorFuture<'a>,
+    ) -> HttpInterceptorFuture<'a>;
 }
 
 #[cfg(feature = "oauth2")]

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -998,10 +998,17 @@ async fn run_job_handler(
         Err(panic) => return JobExecutionOutcome::Panicked(format_job_panic(panic.as_ref())),
     };
 
-    let future = if let Some(interceptor) = &interceptor {
-        interceptor.intercept_execute(name, &payload, next)
-    } else {
-        next
+    let interceptor_res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if let Some(interceptor) = &interceptor {
+            interceptor.intercept_execute(name, &payload, next)
+        } else {
+            next
+        }
+    }));
+
+    let future = match interceptor_res {
+        Ok(future) => future,
+        Err(panic) => return JobExecutionOutcome::Panicked(format_job_panic(panic.as_ref())),
     };
 
     match std::panic::AssertUnwindSafe(future).catch_unwind().await {
@@ -4624,6 +4631,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_job_handler_catches_interceptor_setup_panics() {
+        struct PanickingJobInterceptor;
+        impl crate::interceptor::JobInterceptor for PanickingJobInterceptor {
+            fn intercept_enqueue<'a>(
+                &'a self,
+                _name: &'a str,
+                _payload: &'a serde_json::Value,
+                next: std::pin::Pin<
+                    Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+                >,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+            > {
+                next
+            }
+
+            fn intercept_execute<'a>(
+                &'a self,
+                _name: &'a str,
+                _payload: &'a serde_json::Value,
+                _next: std::pin::Pin<
+                    Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+                >,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+            > {
+                panic!("interceptor execution setup panicked")
+            }
+        }
+
+        fn success_handler(
+            _state: AppState,
+            _payload: Value,
+        ) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>> {
+            Box::pin(async move { Ok(()) })
+        }
+
+        let state = AppState::for_test().with_profile("dev");
+        state.insert_extension(
+            Arc::new(PanickingJobInterceptor) as Arc<dyn crate::interceptor::JobInterceptor>
+        );
+
+        let outcome =
+            run_job_handler("test_job", success_handler, state, serde_json::json!({})).await;
+
+        assert_eq!(
+            outcome,
+            JobExecutionOutcome::Panicked(
+                "job handler panicked: interceptor execution setup panicked".to_string()
+            )
+        );
+    }
+
+    #[tokio::test]
     async fn local_enqueue_p99_is_under_5ms() {
         let _guard = global_job_runtime_test_lock().lock().await;
         clear_global_job_client();
@@ -7473,6 +7534,7 @@ mod tests {
                 default_max_attempts: 3,
                 default_initial_backoff_ms: 100,
                 per_job_defaults: HashMap::from([("test_job".to_string(), (3_u32, 100_u64))]),
+                interceptor: None,
             };
             rt.block_on(async {
                 client

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -989,14 +989,22 @@ async fn run_job_handler(
         .extension::<Arc<dyn crate::interceptor::JobInterceptor>>()
         .map(|arc| (*arc).clone());
 
-    let future_res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        (handler)(state.clone(), payload.clone())
-    }));
+    let payload_for_handler = payload.clone();
+    // Defer the handler invocation into a lazy Pin<Box<dyn Future>>
+    let next = Box::pin(async move {
+        let future_res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            (handler)(state, payload_for_handler)
+        }));
 
-    let next = match future_res {
-        Ok(future) => future,
-        Err(panic) => return JobExecutionOutcome::Panicked(format_job_panic(panic.as_ref())),
-    };
+        let future = match future_res {
+            Ok(f) => f,
+            Err(panic) => {
+                std::panic::resume_unwind(panic);
+            }
+        };
+
+        future.await
+    });
 
     let interceptor_res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         if let Some(interceptor) = &interceptor {
@@ -4682,6 +4690,74 @@ mod tests {
                 "job handler panicked: interceptor execution setup panicked".to_string()
             )
         );
+    }
+
+    #[tokio::test]
+    async fn run_job_handler_interceptor_short_circuit_prevents_sync_execution() {
+        struct ShortCircuitInterceptor;
+        impl crate::interceptor::JobInterceptor for ShortCircuitInterceptor {
+            fn intercept_enqueue<'a>(
+                &'a self,
+                _name: &'a str,
+                _payload: &'a serde_json::Value,
+                next: std::pin::Pin<
+                    Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+                >,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+            > {
+                next
+            }
+
+            fn intercept_execute<'a>(
+                &'a self,
+                _name: &'a str,
+                _payload: &'a serde_json::Value,
+                _next: std::pin::Pin<
+                    Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+                >,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+            > {
+                Box::pin(async move {
+                    Err(crate::AutumnError::bad_request_msg(
+                        "blocked by interceptor",
+                    ))
+                })
+            }
+        }
+
+        static SYNC_CALLS: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+        fn side_effect_handler(
+            _state: AppState,
+            _payload: Value,
+        ) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>> {
+            SYNC_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Box::pin(async move { Ok(()) })
+        }
+
+        let state = AppState::for_test().with_profile("dev");
+        state.insert_extension(
+            Arc::new(ShortCircuitInterceptor) as Arc<dyn crate::interceptor::JobInterceptor>
+        );
+
+        SYNC_CALLS.store(0, std::sync::atomic::Ordering::SeqCst);
+
+        let outcome = run_job_handler(
+            "test_job",
+            side_effect_handler,
+            state,
+            serde_json::json!({}),
+        )
+        .await;
+
+        assert_eq!(
+            outcome,
+            JobExecutionOutcome::Failed("blocked by interceptor".to_string())
+        );
+
+        assert_eq!(SYNC_CALLS.load(std::sync::atomic::Ordering::SeqCst), 0);
     }
 
     #[tokio::test]

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -1035,6 +1035,38 @@ fn format_job_panic(panic: &(dyn std::any::Any + Send)) -> String {
     format!("job handler panicked: {detail}")
 }
 
+fn format_enqueue_panic(panic: &(dyn std::any::Any + Send)) -> AutumnError {
+    let detail = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&'static str>().copied())
+        .unwrap_or("non-string panic payload");
+    AutumnError::internal_server_error(std::io::Error::other(format!(
+        "job enqueue panicked: {detail}"
+    )))
+}
+
+async fn run_enqueue_interceptor(
+    interceptor: Arc<dyn crate::interceptor::JobInterceptor>,
+    name: &str,
+    payload: &Value,
+    actual_enqueue: std::pin::Pin<
+        Box<dyn std::future::Future<Output = AutumnResult<()>> + Send + '_>,
+    >,
+) -> AutumnResult<()> {
+    let setup_res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        interceptor.intercept_enqueue(name, payload, actual_enqueue)
+    }));
+    let fut = match setup_res {
+        Ok(f) => f,
+        Err(panic) => return Err(format_enqueue_panic(panic.as_ref())),
+    };
+    match std::panic::AssertUnwindSafe(fut).catch_unwind().await {
+        Ok(res) => res,
+        Err(panic) => Err(format_enqueue_panic(panic.as_ref())),
+    }
+}
+
 /// Retrieves the global initialized job client.
 ///
 /// Returns `None` if the job runtime hasn't been started yet.
@@ -1265,9 +1297,7 @@ impl JobClient {
 
         if let Some(interceptor) = &self.interceptor {
             let interceptor = (*interceptor).clone();
-            interceptor
-                .intercept_enqueue(name, &payload, Box::pin(actual_enqueue))
-                .await
+            run_enqueue_interceptor(interceptor, name, &payload, Box::pin(actual_enqueue)).await
         } else {
             actual_enqueue.await
         }
@@ -1443,9 +1473,7 @@ impl JobClient {
             );
             return if let Some(interceptor) = &self.interceptor {
                 let interceptor = (*interceptor).clone();
-                interceptor
-                    .intercept_enqueue(name, &payload, Box::pin(actual_enqueue))
-                    .await
+                run_enqueue_interceptor(interceptor, name, &payload, Box::pin(actual_enqueue)).await
             } else {
                 actual_enqueue.await
             };
@@ -1499,9 +1527,7 @@ impl JobClient {
 
         if let Some(interceptor) = &self.interceptor {
             let interceptor = (*interceptor).clone();
-            interceptor
-                .intercept_enqueue(name, &payload, Box::pin(actual_enqueue))
-                .await
+            run_enqueue_interceptor(interceptor, name, &payload, Box::pin(actual_enqueue)).await
         } else {
             actual_enqueue.await
         }
@@ -4758,6 +4784,122 @@ mod tests {
         );
 
         assert_eq!(SYNC_CALLS.load(std::sync::atomic::Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn job_client_enqueue_catches_interceptor_setup_panic() {
+        struct PanickingEnqueueInterceptor;
+        impl crate::interceptor::JobInterceptor for PanickingEnqueueInterceptor {
+            fn intercept_enqueue<'a>(
+                &'a self,
+                _name: &'a str,
+                _payload: &'a serde_json::Value,
+                _next: std::pin::Pin<
+                    Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+                >,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+            > {
+                panic!("interceptor enqueue setup panicked")
+            }
+
+            fn intercept_execute<'a>(
+                &'a self,
+                _name: &'a str,
+                _payload: &'a serde_json::Value,
+                next: std::pin::Pin<
+                    Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+                >,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+            > {
+                next
+            }
+        }
+
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let client = JobClient {
+            local_sender: Some(tx),
+            #[cfg(feature = "redis")]
+            redis: None,
+            #[cfg(feature = "db")]
+            pg_pool: None,
+            registry: crate::actuator::JobRegistry::new(),
+            job_admin: JobAdminMemoryBackend::new_for_test(32),
+            default_max_attempts: 3,
+            default_initial_backoff_ms: 100,
+            per_job_defaults: std::collections::HashMap::from([(
+                "test_job".to_string(),
+                (3_u32, 100_u64),
+            )]),
+            interceptor: Some(Arc::new(PanickingEnqueueInterceptor)),
+        };
+
+        let res = client.enqueue("test_job", serde_json::json!({})).await;
+        assert!(res.is_err());
+        let err_msg = res.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("job enqueue panicked: interceptor enqueue setup panicked"),
+            "expected panic error message, got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn job_client_enqueue_catches_interceptor_async_panic() {
+        struct AsyncPanickingEnqueueInterceptor;
+        impl crate::interceptor::JobInterceptor for AsyncPanickingEnqueueInterceptor {
+            fn intercept_enqueue<'a>(
+                &'a self,
+                _name: &'a str,
+                _payload: &'a serde_json::Value,
+                _next: std::pin::Pin<
+                    Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+                >,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+            > {
+                Box::pin(async move { panic!("interceptor enqueue async panicked") })
+            }
+
+            fn intercept_execute<'a>(
+                &'a self,
+                _name: &'a str,
+                _payload: &'a serde_json::Value,
+                next: std::pin::Pin<
+                    Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+                >,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+            > {
+                next
+            }
+        }
+
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let client = JobClient {
+            local_sender: Some(tx),
+            #[cfg(feature = "redis")]
+            redis: None,
+            #[cfg(feature = "db")]
+            pg_pool: None,
+            registry: crate::actuator::JobRegistry::new(),
+            job_admin: JobAdminMemoryBackend::new_for_test(32),
+            default_max_attempts: 3,
+            default_initial_backoff_ms: 100,
+            per_job_defaults: std::collections::HashMap::from([(
+                "test_job".to_string(),
+                (3_u32, 100_u64),
+            )]),
+            interceptor: Some(Arc::new(AsyncPanickingEnqueueInterceptor)),
+        };
+
+        let res = client.enqueue("test_job", serde_json::json!({})).await;
+        assert!(res.is_err());
+        let err_msg = res.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("job enqueue panicked: interceptor enqueue async panicked"),
+            "expected panic error message, got: {err_msg}"
+        );
     }
 
     #[tokio::test]

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -53,6 +53,7 @@ pub struct JobClient {
     default_max_attempts: u32,
     default_initial_backoff_ms: u64,
     per_job_defaults: HashMap<String, (u32, u64)>,
+    pub interceptor: Option<Arc<dyn crate::interceptor::JobInterceptor>>,
 }
 
 #[derive(Debug)]
@@ -897,8 +898,7 @@ struct RedisWorkerConfig {
 
 static GLOBAL_JOB_CLIENT: OnceLock<RwLock<Option<Arc<JobClient>>>> = OnceLock::new();
 
-#[cfg(test)]
-pub(crate) fn global_job_runtime_test_lock() -> &'static tokio::sync::Mutex<()> {
+pub fn global_job_runtime_test_lock() -> &'static tokio::sync::Mutex<()> {
     static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }
@@ -980,15 +980,28 @@ fn build_job_consumer_span(name: &str, attempt: u32) -> tracing::Span {
 }
 
 async fn run_job_handler(
+    name: &str,
     handler: JobHandler,
     state: AppState,
     payload: Value,
 ) -> JobExecutionOutcome {
-    let future = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        (handler)(state, payload)
-    })) {
+    let interceptor = state
+        .extension::<Arc<dyn crate::interceptor::JobInterceptor>>()
+        .map(|arc| (*arc).clone());
+
+    let future_res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        (handler)(state.clone(), payload.clone())
+    }));
+
+    let next = match future_res {
         Ok(future) => future,
         Err(panic) => return JobExecutionOutcome::Panicked(format_job_panic(panic.as_ref())),
+    };
+
+    let future = if let Some(interceptor) = &interceptor {
+        interceptor.intercept_execute(name, &payload, next)
+    } else {
+        next
     };
 
     match std::panic::AssertUnwindSafe(future).catch_unwind().await {
@@ -1027,7 +1040,7 @@ pub(crate) fn init_global_job_client(client: JobClient) {
     let _ = GLOBAL_JOB_CLIENT.set(RwLock::new(Some(Arc::new(client))));
 }
 
-pub(crate) fn clear_global_job_client() {
+pub fn clear_global_job_client() {
     if let Some(lock) = GLOBAL_JOB_CLIENT.get() {
         if let Ok(mut guard) = lock.write() {
             *guard = None;
@@ -1194,37 +1207,55 @@ impl JobClient {
         self.job_admin
             .record_enqueue(id.clone(), name, payload.clone(), 1, job_max_attempts);
 
-        let result = if let Some(sender) = &self.local_sender {
-            #[cfg(feature = "telemetry-otlp")]
-            let (traceparent, tracestate) = capture_job_trace_context();
-            sender
-                .send(QueuedJob {
-                    id: id.clone(),
-                    name: name.to_string(),
-                    payload,
-                    attempt: 1,
-                    max_attempts: job_max_attempts,
-                    initial_backoff_ms: job_backoff_ms,
-                    #[cfg(feature = "telemetry-otlp")]
-                    traceparent,
-                    #[cfg(feature = "telemetry-otlp")]
-                    tracestate,
-                })
+        let payload_clone = payload.clone();
+        let actual_enqueue = async move {
+            let result = if let Some(sender) = &self.local_sender {
+                #[cfg(feature = "telemetry-otlp")]
+                let (traceparent, tracestate) = capture_job_trace_context();
+                sender
+                    .send(QueuedJob {
+                        id: id.clone(),
+                        name: name.to_string(),
+                        payload: payload_clone.clone(),
+                        attempt: 1,
+                        max_attempts: job_max_attempts,
+                        initial_backoff_ms: job_backoff_ms,
+                        #[cfg(feature = "telemetry-otlp")]
+                        traceparent,
+                        #[cfg(feature = "telemetry-otlp")]
+                        tracestate,
+                    })
+                    .await
+                    .map_err(|e| {
+                        AutumnError::internal_server_error(std::io::Error::other(format!(
+                            "failed to enqueue job: {e}"
+                        )))
+                    })
+            } else {
+                self.enqueue_durable(
+                    id.clone(),
+                    name,
+                    payload_clone.clone(),
+                    job_max_attempts,
+                    job_backoff_ms,
+                )
                 .await
-                .map_err(|e| {
-                    AutumnError::internal_server_error(std::io::Error::other(format!(
-                        "failed to enqueue job: {e}"
-                    )))
-                })
-        } else {
-            self.enqueue_durable(id.clone(), name, payload, job_max_attempts, job_backoff_ms)
-                .await
+            };
+            if result.is_err() {
+                self.registry.record_cancel(name);
+                self.job_admin.record_cancelled(&id);
+            }
+            result
         };
-        if result.is_err() {
-            self.registry.record_cancel(name);
-            self.job_admin.record_cancelled(&id);
+
+        if let Some(interceptor) = &self.interceptor {
+            let interceptor = (*interceptor).clone();
+            interceptor
+                .intercept_enqueue(name, &payload, Box::pin(actual_enqueue))
+                .await
+        } else {
+            actual_enqueue.await
         }
-        result
     }
 
     /// Enqueue a job that fires **only after the surrounding transaction commits**.
@@ -1387,49 +1418,82 @@ impl JobClient {
         // transaction commits, so we cannot safely update process-local counters
         // here — the row may disappear on rollback while the counter persists.
         if self.pg_pool.is_some() {
-            return pg_enqueue_on_conn(conn, id, name, payload, job_max_attempts, job_backoff_ms)
-                .await;
+            let actual_enqueue = pg_enqueue_on_conn(
+                conn,
+                id,
+                name,
+                payload.clone(),
+                job_max_attempts,
+                job_backoff_ms,
+            );
+            return if let Some(interceptor) = &self.interceptor {
+                let interceptor = (*interceptor).clone();
+                interceptor
+                    .intercept_enqueue(name, &payload, Box::pin(actual_enqueue))
+                    .await
+            } else {
+                actual_enqueue.await
+            };
         }
 
         self.registry.record_enqueue(name);
         self.job_admin
             .record_enqueue(id.clone(), name, payload.clone(), 1, job_max_attempts);
 
-        let result = if let Some(sender) = &self.local_sender {
-            #[cfg(feature = "telemetry-otlp")]
-            let (traceparent, tracestate) = capture_job_trace_context();
-            sender
-                .send(QueuedJob {
-                    id: id.clone(),
-                    name: name.to_string(),
-                    payload,
-                    attempt: 1,
-                    max_attempts: job_max_attempts,
-                    initial_backoff_ms: job_backoff_ms,
-                    #[cfg(feature = "telemetry-otlp")]
-                    traceparent,
-                    #[cfg(feature = "telemetry-otlp")]
-                    tracestate,
-                })
+        #[cfg(feature = "telemetry-otlp")]
+        let (traceparent, tracestate) = capture_job_trace_context();
+
+        let payload_clone = payload.clone();
+        let actual_enqueue = async move {
+            let result = if let Some(sender) = &self.local_sender {
+                sender
+                    .send(QueuedJob {
+                        id: id.clone(),
+                        name: name.to_string(),
+                        payload: payload_clone.clone(),
+                        attempt: 1,
+                        max_attempts: job_max_attempts,
+                        initial_backoff_ms: job_backoff_ms,
+                        #[cfg(feature = "telemetry-otlp")]
+                        traceparent,
+                        #[cfg(feature = "telemetry-otlp")]
+                        tracestate,
+                    })
+                    .await
+                    .map_err(|e| {
+                        AutumnError::internal_server_error(std::io::Error::other(format!(
+                            "failed to enqueue job: {e}"
+                        )))
+                    })
+            } else {
+                self.enqueue_durable(
+                    id.clone(),
+                    name,
+                    payload_clone.clone(),
+                    job_max_attempts,
+                    job_backoff_ms,
+                )
                 .await
-                .map_err(|e| {
-                    AutumnError::internal_server_error(std::io::Error::other(format!(
-                        "failed to enqueue job: {e}"
-                    )))
-                })
-        } else {
-            self.enqueue_durable(id.clone(), name, payload, job_max_attempts, job_backoff_ms)
-                .await
+            };
+            if result.is_err() {
+                self.registry.record_cancel(name);
+                self.job_admin.record_cancelled(&id);
+            }
+            result
         };
-        if result.is_err() {
-            self.registry.record_cancel(name);
-            self.job_admin.record_cancelled(&id);
+
+        if let Some(interceptor) = &self.interceptor {
+            let interceptor = (*interceptor).clone();
+            interceptor
+                .intercept_enqueue(name, &payload, Box::pin(actual_enqueue))
+                .await
+        } else {
+            actual_enqueue.await
         }
-        result
     }
 }
 
-pub(crate) fn start_runtime(
+pub fn start_runtime(
     jobs: Vec<JobInfo>,
     state: &AppState,
     shutdown: &tokio_util::sync::CancellationToken,
@@ -1533,6 +1597,9 @@ pub(crate) fn start_local_runtime(
         default_max_attempts,
         default_initial_backoff_ms,
         per_job_defaults,
+        interceptor: state
+            .extension::<Arc<dyn crate::interceptor::JobInterceptor>>()
+            .map(|arc| (*arc).clone()),
     };
     init_global_job_client(client);
 
@@ -1610,7 +1677,7 @@ async fn execute_local_job(
         use tracing_opentelemetry::OpenTelemetrySpanExt as _;
         let _ = job_span.set_parent(cx);
     }
-    let f = run_job_handler(handler, state.clone(), job.payload.clone());
+    let f = run_job_handler(&job.name, handler, state.clone(), job.payload.clone());
     let outcome = tracing::Instrument::instrument(f, job_span).await;
     match outcome {
         JobExecutionOutcome::Succeeded => {
@@ -3000,7 +3067,7 @@ async fn process_redis_job_record(
         use tracing_opentelemetry::OpenTelemetrySpanExt as _;
         let _ = job_span.set_parent(cx);
     }
-    let f = run_job_handler(handler, state.clone(), record.payload.clone());
+    let f = run_job_handler(&record.name, handler, state.clone(), record.payload.clone());
     match tracing::Instrument::instrument(f, job_span).await {
         JobExecutionOutcome::Succeeded => {
             match ack_redis_success(connection, worker_config, &record).await {
@@ -3127,6 +3194,9 @@ fn start_redis_runtime(
         default_max_attempts: config.max_attempts,
         default_initial_backoff_ms: config.initial_backoff_ms,
         per_job_defaults,
+        interceptor: state
+            .extension::<Arc<dyn crate::interceptor::JobInterceptor>>()
+            .map(|arc| (*arc).clone()),
     });
 
     let worker_count = config.workers.max(1);
@@ -3784,7 +3854,7 @@ async fn pg_execute_job(
         use tracing_opentelemetry::OpenTelemetrySpanExt as _;
         let _ = job_span.set_parent(cx);
     }
-    let f = run_job_handler(handler, state.clone(), payload);
+    let f = run_job_handler(&row.name, handler, state.clone(), payload);
     match tracing::Instrument::instrument(f, job_span).await {
         JobExecutionOutcome::Succeeded => {
             let ack = pg_ack_success(pool, &row.id, worker_id).await;
@@ -4167,6 +4237,9 @@ fn start_postgres_runtime(
         default_max_attempts: config.max_attempts,
         default_initial_backoff_ms: config.initial_backoff_ms,
         per_job_defaults,
+        interceptor: state
+            .extension::<Arc<dyn crate::interceptor::JobInterceptor>>()
+            .map(|arc| (*arc).clone()),
     });
 
     let visibility_timeout_ms = config.postgres.visibility_timeout_ms;
@@ -4365,6 +4438,7 @@ mod tests {
             default_max_attempts: 5,
             default_initial_backoff_ms: 250,
             per_job_defaults: HashMap::from([("send_email".to_string(), (5, 250))]),
+            interceptor: None,
         });
 
         let failed_id = backend.record_enqueue_for_test(
@@ -4425,6 +4499,7 @@ mod tests {
             default_max_attempts: 5,
             default_initial_backoff_ms: 250,
             per_job_defaults: HashMap::from([("send_email".to_string(), (5, 250))]),
+            interceptor: None,
         });
 
         let failed_id =
@@ -4476,6 +4551,7 @@ mod tests {
             default_max_attempts: 5,
             default_initial_backoff_ms: 250,
             per_job_defaults: HashMap::from([("send_email".to_string(), (5, 250))]),
+            interceptor: None,
         });
 
         let failed_id =
@@ -4524,8 +4600,13 @@ mod tests {
     #[tokio::test]
     async fn run_job_handler_reports_immediate_panics() {
         let state = AppState::for_test().with_profile("dev");
-        let outcome =
-            run_job_handler(instantly_panicking_handler, state, serde_json::json!({})).await;
+        let outcome = run_job_handler(
+            "test_job",
+            instantly_panicking_handler,
+            state,
+            serde_json::json!({}),
+        )
+        .await;
         assert_eq!(
             outcome,
             JobExecutionOutcome::Panicked("job handler panicked: panic before future".to_string())
@@ -5787,6 +5868,7 @@ mod tests {
             default_max_attempts: 3,
             default_initial_backoff_ms: 250,
             per_job_defaults: HashMap::new(),
+            interceptor: None,
         });
         assert!(global_job_client().is_some());
 
@@ -6093,7 +6175,8 @@ mod tests {
     #[tokio::test]
     async fn run_job_handler_reports_async_panics() {
         let state = AppState::for_test().with_profile("dev");
-        let outcome = run_job_handler(panicking_handler, state, serde_json::json!({})).await;
+        let outcome =
+            run_job_handler("test_job", panicking_handler, state, serde_json::json!({})).await;
         assert_eq!(
             outcome,
             JobExecutionOutcome::Panicked("job handler panicked: forced panic".to_string())
@@ -7014,6 +7097,7 @@ mod tests {
             default_max_attempts: 3,
             default_initial_backoff_ms: 100,
             per_job_defaults: HashMap::from([("test_job".to_string(), (3_u32, 100_u64))]),
+            interceptor: None,
         };
         (client, rx)
     }

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -1493,6 +1493,16 @@ impl JobClient {
     }
 }
 
+/// Starts the background job execution runtime.
+///
+/// This initializes the configured job worker backend (local, redis, or postgres)
+/// and launches background worker tasks that run until the shutdown cancellation token is triggered.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - There are duplicate job names registered in the workspace
+/// - Redis or Postgres connection/initialization fails (if those backends are selected)
 pub fn start_runtime(
     jobs: Vec<JobInfo>,
     state: &AppState,

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -7549,7 +7549,7 @@ mod tests {
             map.insert("tracestate".to_owned(), "vendor=val".to_owned());
             let extractor = JobMapExtractor(&map);
             let mut keys = extractor.keys();
-            keys.sort();
+            keys.sort_unstable();
             assert_eq!(keys, vec!["traceparent", "tracestate"]);
         }
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -99,6 +99,7 @@ pub mod idempotency;
 /// `autumn_web::t!(locale, "key")` usage.
 #[cfg(feature = "i18n")]
 pub use crate::i18n::t;
+pub mod interceptor;
 #[cfg(feature = "mail")]
 pub mod mail;
 #[cfg(feature = "db")]

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -1599,6 +1599,27 @@ fn lettre_message(mail: &Mail) -> Result<Message, MailError> {
     }
 }
 
+struct InterceptedMailTransport {
+    inner: Arc<dyn MailTransport>,
+    interceptor: Arc<dyn crate::interceptor::MailInterceptor>,
+}
+
+impl MailTransport for InterceptedMailTransport {
+    fn send<'a>(
+        &'a self,
+        mail: Mail,
+    ) -> Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>> {
+        Box::pin(async move {
+            let next = self.inner.send(mail.clone());
+            self.interceptor.intercept(&mail, next).await
+        })
+    }
+
+    fn is_disabled(&self) -> bool {
+        self.inner.is_disabled()
+    }
+}
+
 /// Install the configured mailer into app state.
 ///
 /// Picks up a runtime-installed [`MailDeliveryQueueHandle`] from
@@ -1619,6 +1640,13 @@ pub(crate) fn install_mailer(
     enforce_durable_guard: bool,
 ) -> AutumnResult<()> {
     let mut mailer = Mailer::from_config(config).map_err(AutumnError::service_unavailable)?;
+
+    if let Some(interceptor) = state.extension::<Arc<dyn crate::interceptor::MailInterceptor>>() {
+        mailer.transport = Arc::new(InterceptedMailTransport {
+            inner: Arc::clone(&mailer.transport),
+            interceptor: (*interceptor).clone(),
+        });
+    }
 
     let in_production = matches!(state.profile(), "prod" | "production");
     let transport_sends_mail = config.transport != Transport::Disabled;

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -1610,7 +1610,9 @@ impl MailTransport for InterceptedMailTransport {
         mail: Mail,
     ) -> Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>> {
         Box::pin(async move {
-            let next = self.inner.send(mail.clone());
+            let inner = Arc::clone(&self.inner);
+            let mail_for_next = mail.clone();
+            let next = Box::pin(async move { inner.send(mail_for_next).await });
             self.interceptor.intercept(&mail, next).await
         })
     }
@@ -2598,5 +2600,64 @@ mod tests {
             !installed.has_durable_delivery_queue(),
             "disabled transport must suppress queue attachment so deliver_later is a no-op"
         );
+    }
+
+    #[tokio::test]
+    async fn intercepted_mail_transport_short_circuit_prevents_sync_execution() {
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        static TRANSPORT_CALLS: AtomicU32 = AtomicU32::new(0);
+
+        struct CountingTransport;
+        impl MailTransport for CountingTransport {
+            fn send<'a>(
+                &'a self,
+                _mail: Mail,
+            ) -> Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>> {
+                TRANSPORT_CALLS.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async move { Ok(()) })
+            }
+
+            fn is_disabled(&self) -> bool {
+                false
+            }
+        }
+
+        struct ShortCircuitMailInterceptor;
+        impl crate::interceptor::MailInterceptor for ShortCircuitMailInterceptor {
+            fn intercept<'a>(
+                &'a self,
+                _mail: &'a Mail,
+                _next: Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>>,
+            ) -> Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>> {
+                Box::pin(async move {
+                    Err(MailError::RuntimeUnavailable(
+                        "blocked by interceptor".to_owned(),
+                    ))
+                })
+            }
+        }
+
+        let transport = Arc::new(CountingTransport);
+        let interceptor = Arc::new(ShortCircuitMailInterceptor);
+        let intercepted = InterceptedMailTransport {
+            inner: transport,
+            interceptor,
+        };
+
+        let mail = Mail::builder()
+            .to("test@example.com")
+            .subject("test")
+            .text("body")
+            .build()
+            .unwrap();
+
+        TRANSPORT_CALLS.store(0, Ordering::SeqCst);
+
+        let res = intercepted.send(mail).await;
+        assert!(res.is_err());
+        assert_eq!(TRANSPORT_CALLS.load(Ordering::SeqCst), 0);
     }
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -346,6 +346,12 @@ fn build_router_pre_state(
             .layer(axum::middleware::from_fn(dev::inject_live_reload));
     }
 
+    #[cfg(feature = "oauth2")]
+    let router = router.layer(axum::middleware::from_fn_with_state(
+        state.clone(),
+        http_interceptor_middleware,
+    ));
+
     Ok(router)
 }
 
@@ -1809,6 +1815,24 @@ fn mount_swagger_ui_routes(
         }),
     );
     router
+}
+
+#[cfg(feature = "oauth2")]
+async fn http_interceptor_middleware(
+    state: axum::extract::State<AppState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use crate::interceptor::{ACTIVE_HTTP_INTERCEPTORS, HttpInterceptor};
+    if let Some(interceptor_arc) = state.extension::<Arc<dyn HttpInterceptor>>() {
+        let interceptor = (*interceptor_arc).clone();
+        let interceptors = vec![interceptor];
+        ACTIVE_HTTP_INTERCEPTORS
+            .scope(interceptors, async move { next.run(req).await })
+            .await
+    } else {
+        next.run(req).await
+    }
 }
 
 #[cfg(test)]

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -528,6 +528,14 @@ impl DbState for AppState {
     {
         Self::read_pool(self)
     }
+
+    fn db_interceptors(
+        &self,
+    ) -> Vec<std::sync::Arc<dyn crate::interceptor::DbConnectionInterceptor>> {
+        self.extension::<Arc<dyn crate::interceptor::DbConnectionInterceptor>>()
+            .map(|arc| vec![(*arc).clone()])
+            .unwrap_or_default()
+    }
 }
 
 impl crate::probe::ProvideProbeState for AppState {

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -513,6 +513,7 @@ impl TestApp {
         crate::cache::clear_global_cache();
 
         let probes = crate::probe::ProbeState::ready_for_test();
+        #[cfg_attr(not(feature = "ws"), allow(unused_mut))]
         let mut state = AppState {
             extensions: std::sync::Arc::new(std::sync::RwLock::new(
                 std::collections::HashMap::new(),

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -177,6 +177,15 @@ pub struct TestApp {
     /// the value derived from
     /// [`SecurityConfig::forbidden_response`](crate::security::SecurityConfig::forbidden_response).
     forbidden_response_override: Option<crate::authorization::ForbiddenResponse>,
+    #[cfg(feature = "mail")]
+    mail_interceptor: Option<std::sync::Arc<dyn crate::interceptor::MailInterceptor>>,
+    job_interceptor: Option<std::sync::Arc<dyn crate::interceptor::JobInterceptor>>,
+    #[cfg(feature = "db")]
+    db_interceptor: Option<std::sync::Arc<dyn crate::interceptor::DbConnectionInterceptor>>,
+    #[cfg(feature = "ws")]
+    channels_interceptor: Option<std::sync::Arc<dyn crate::interceptor::ChannelsInterceptor>>,
+    #[cfg(feature = "oauth2")]
+    http_interceptor: Option<std::sync::Arc<dyn crate::interceptor::HttpInterceptor>>,
 }
 
 type TestPolicyRegistration = Box<dyn FnOnce(&crate::authorization::PolicyRegistry) + Send>;
@@ -205,6 +214,15 @@ impl TestApp {
             replica_pool: None,
             policy_registrations: Vec::new(),
             forbidden_response_override: None,
+            #[cfg(feature = "mail")]
+            mail_interceptor: None,
+            job_interceptor: None,
+            #[cfg(feature = "db")]
+            db_interceptor: None,
+            #[cfg(feature = "ws")]
+            channels_interceptor: None,
+            #[cfg(feature = "oauth2")]
+            http_interceptor: None,
         }
     }
 
@@ -355,6 +373,55 @@ impl TestApp {
         self
     }
 
+    #[cfg(feature = "mail")]
+    #[must_use]
+    pub fn with_mail_interceptor(
+        mut self,
+        interceptor: impl crate::interceptor::MailInterceptor,
+    ) -> Self {
+        self.mail_interceptor = Some(std::sync::Arc::new(interceptor));
+        self
+    }
+
+    #[must_use]
+    pub fn with_job_interceptor(
+        mut self,
+        interceptor: impl crate::interceptor::JobInterceptor,
+    ) -> Self {
+        self.job_interceptor = Some(std::sync::Arc::new(interceptor));
+        self
+    }
+
+    #[cfg(feature = "db")]
+    #[must_use]
+    pub fn with_db_interceptor(
+        mut self,
+        interceptor: impl crate::interceptor::DbConnectionInterceptor,
+    ) -> Self {
+        self.db_interceptor = Some(std::sync::Arc::new(interceptor));
+        self
+    }
+
+    #[cfg(feature = "ws")]
+    #[must_use]
+    pub fn with_channels_interceptor(
+        mut self,
+        interceptor: impl crate::interceptor::ChannelsInterceptor,
+    ) -> Self {
+        self.channels_interceptor = Some(std::sync::Arc::new(interceptor));
+        self
+    }
+
+    #[cfg(feature = "oauth2")]
+    #[must_use]
+    pub fn with_http_interceptor(
+        mut self,
+        interceptor: impl crate::interceptor::HttpInterceptor,
+    ) -> Self {
+        self.http_interceptor = Some(std::sync::Arc::new(interceptor));
+        self
+    }
+
     /// Override the default test configuration.
     #[must_use]
     pub fn config(mut self, config: AutumnConfig) -> Self {
@@ -391,8 +458,9 @@ impl TestApp {
     pub fn build(self) -> TestClient {
         // Reset the global cache to prevent cross-test contamination.
         crate::cache::clear_global_cache();
+
         let probes = crate::probe::ProbeState::ready_for_test();
-        let state = AppState {
+        let mut state = AppState {
             extensions: std::sync::Arc::new(std::sync::RwLock::new(
                 std::collections::HashMap::new(),
             )),
@@ -425,6 +493,38 @@ impl TestApp {
             register(state.policy_registry());
         }
         crate::app::install_webhook_registry(&state, &self.config);
+
+        #[cfg(feature = "mail")]
+        if let Some(interceptor) = self.mail_interceptor {
+            state.insert_extension(interceptor);
+        }
+        if let Some(interceptor) = self.job_interceptor {
+            state.insert_extension(interceptor);
+        }
+        #[cfg(feature = "db")]
+        if let Some(interceptor) = self.db_interceptor {
+            state.insert_extension(interceptor);
+        }
+        #[cfg(feature = "ws")]
+        if let Some(interceptor) = self.channels_interceptor {
+            state.insert_extension(interceptor.clone());
+            state.channels = crate::channels::Channels::with_shared_backend(std::sync::Arc::new(
+                crate::channels::InterceptedChannelsBackend::new(
+                    state.channels.backend().clone(),
+                    vec![interceptor],
+                ),
+            ));
+        }
+        #[cfg(feature = "oauth2")]
+        if let Some(interceptor) = self.http_interceptor {
+            state.insert_extension(interceptor);
+        }
+
+        #[cfg(feature = "mail")]
+        {
+            crate::mail::install_mailer(&state, &self.config.mail, false)
+                .expect("Failed to configure test mailer");
+        }
 
         let router = crate::router::try_build_router_inner(
             self.routes,

--- a/autumn/tests/boundary_hooks_integration.rs
+++ b/autumn/tests/boundary_hooks_integration.rs
@@ -2,11 +2,23 @@ use autumn_web::app::app;
 use std::sync::Arc;
 
 // We expect these traits to be exposed under autumn_web::interceptor
-use autumn_web::interceptor::{
-    ChannelsInterceptor, DbConnectionInterceptor, HttpInterceptor, JobInterceptor, MailInterceptor,
-};
+use autumn_web::interceptor::JobInterceptor;
 
+#[cfg(feature = "mail")]
+use autumn_web::interceptor::MailInterceptor;
+
+#[cfg(feature = "db")]
+use autumn_web::interceptor::DbConnectionInterceptor;
+
+#[cfg(feature = "ws")]
+use autumn_web::interceptor::ChannelsInterceptor;
+
+#[cfg(feature = "oauth2")]
+use autumn_web::interceptor::HttpInterceptor;
+
+#[cfg(feature = "mail")]
 struct DummyMailInterceptor;
+#[cfg(feature = "mail")]
 impl MailInterceptor for DummyMailInterceptor {
     fn intercept<'a>(
         &'a self,
@@ -54,7 +66,9 @@ impl JobInterceptor for DummyJobInterceptor {
     }
 }
 
+#[cfg(feature = "db")]
 struct DummyDbInterceptor;
+#[cfg(feature = "db")]
 impl DbConnectionInterceptor for DummyDbInterceptor {
     fn intercept_checkout<'a>(
         &'a self,
@@ -79,22 +93,26 @@ impl DbConnectionInterceptor for DummyDbInterceptor {
     }
 }
 
+#[cfg(feature = "ws")]
 struct DummyChannelsInterceptor;
+#[cfg(feature = "ws")]
 impl ChannelsInterceptor for DummyChannelsInterceptor {
     fn intercept_publish(
         &self,
-        _topic: &str,
-        _msg: &autumn_web::channels::ChannelMessage,
+        topic: &str,
+        msg: &autumn_web::channels::ChannelMessage,
         next: &dyn Fn(
             &str,
             &autumn_web::channels::ChannelMessage,
         ) -> Result<usize, autumn_web::channels::ChannelPublishError>,
     ) -> Result<usize, autumn_web::channels::ChannelPublishError> {
-        next(_topic, _msg)
+        next(topic, msg)
     }
 }
 
+#[cfg(feature = "oauth2")]
 struct DummyHttpInterceptor;
+#[cfg(feature = "oauth2")]
 impl HttpInterceptor for DummyHttpInterceptor {
     fn intercept<'a>(
         &'a self,
@@ -119,12 +137,29 @@ impl HttpInterceptor for DummyHttpInterceptor {
 
 #[test]
 fn app_builder_registers_interceptors() {
-    let builder = app()
-        .with_mail_interceptor(DummyMailInterceptor)
-        .with_job_interceptor(DummyJobInterceptor)
-        .with_db_interceptor(DummyDbInterceptor)
-        .with_channels_interceptor(DummyChannelsInterceptor)
-        .with_http_interceptor(DummyHttpInterceptor);
+    let mut builder = app();
+
+    #[cfg(feature = "mail")]
+    {
+        builder = builder.with_mail_interceptor(DummyMailInterceptor);
+    }
+
+    builder = builder.with_job_interceptor(DummyJobInterceptor);
+
+    #[cfg(feature = "db")]
+    {
+        builder = builder.with_db_interceptor(DummyDbInterceptor);
+    }
+
+    #[cfg(feature = "ws")]
+    {
+        builder = builder.with_channels_interceptor(DummyChannelsInterceptor);
+    }
+
+    #[cfg(feature = "oauth2")]
+    {
+        builder = builder.with_http_interceptor(DummyHttpInterceptor);
+    }
 
     let _ = builder;
 }
@@ -200,9 +235,6 @@ async fn job_interceptor_intercepts_enqueue_and_execute() {
     use serde_json::json;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    let _guard = global_job_runtime_test_lock().lock().await;
-    clear_global_job_client();
-
     static ENQUEUES: AtomicUsize = AtomicUsize::new(0);
     static EXECUTES: AtomicUsize = AtomicUsize::new(0);
 
@@ -253,6 +285,9 @@ async fn job_interceptor_intercepts_enqueue_and_execute() {
     > {
         Box::pin(async move { Ok(()) })
     }
+
+    let _guard = global_job_runtime_test_lock().lock().await;
+    clear_global_job_client();
 
     let state = AppState::for_test();
     state.insert_extension(Arc::new(RecordingJobInterceptor) as Arc<dyn JobInterceptor>);

--- a/autumn/tests/boundary_hooks_integration.rs
+++ b/autumn/tests/boundary_hooks_integration.rs
@@ -1,0 +1,483 @@
+use autumn_web::app::app;
+use std::sync::Arc;
+
+// We expect these traits to be exposed under autumn_web::interceptor
+use autumn_web::interceptor::{
+    ChannelsInterceptor, DbConnectionInterceptor, HttpInterceptor, JobInterceptor, MailInterceptor,
+};
+
+struct DummyMailInterceptor;
+impl MailInterceptor for DummyMailInterceptor {
+    fn intercept<'a>(
+        &'a self,
+        _mail: &'a autumn_web::mail::Mail,
+        next: std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<(), autumn_web::mail::MailError>>
+                    + Send
+                    + 'a,
+            >,
+        >,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<(), autumn_web::mail::MailError>> + Send + 'a>,
+    > {
+        next
+    }
+}
+
+struct DummyJobInterceptor;
+impl JobInterceptor for DummyJobInterceptor {
+    fn intercept_enqueue<'a>(
+        &'a self,
+        _name: &'a str,
+        _payload: &'a serde_json::Value,
+        next: std::pin::Pin<
+            Box<dyn std::future::Future<Output = autumn_web::AutumnResult<()>> + Send + 'a>,
+        >,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = autumn_web::AutumnResult<()>> + Send + 'a>,
+    > {
+        next
+    }
+
+    fn intercept_execute<'a>(
+        &'a self,
+        _name: &'a str,
+        _payload: &'a serde_json::Value,
+        next: std::pin::Pin<
+            Box<dyn std::future::Future<Output = autumn_web::AutumnResult<()>> + Send + 'a>,
+        >,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = autumn_web::AutumnResult<()>> + Send + 'a>,
+    > {
+        next
+    }
+}
+
+struct DummyDbInterceptor;
+impl DbConnectionInterceptor for DummyDbInterceptor {
+    fn intercept_checkout<'a>(
+        &'a self,
+        _ctx: autumn_web::interceptor::DbCheckoutContext,
+        next: std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = Result<autumn_web::db::PooledConnection, autumn_web::AutumnError>,
+                    > + Send
+                    + 'a,
+            >,
+        >,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<autumn_web::db::PooledConnection, autumn_web::AutumnError>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        next
+    }
+}
+
+struct DummyChannelsInterceptor;
+impl ChannelsInterceptor for DummyChannelsInterceptor {
+    fn intercept_publish(
+        &self,
+        _topic: &str,
+        _msg: &autumn_web::channels::ChannelMessage,
+        next: &dyn Fn(
+            &str,
+            &autumn_web::channels::ChannelMessage,
+        ) -> Result<usize, autumn_web::channels::ChannelPublishError>,
+    ) -> Result<usize, autumn_web::channels::ChannelPublishError> {
+        next(_topic, _msg)
+    }
+}
+
+struct DummyHttpInterceptor;
+impl HttpInterceptor for DummyHttpInterceptor {
+    fn intercept<'a>(
+        &'a self,
+        req: reqwest::Request,
+        next: &'a dyn Fn(
+            reqwest::Request,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<reqwest::Response, reqwest::Error>>
+                    + Send
+                    + 'a,
+            >,
+        >,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<reqwest::Response, reqwest::Error>> + Send + 'a,
+        >,
+    > {
+        next(req)
+    }
+}
+
+#[test]
+fn app_builder_registers_interceptors() {
+    let builder = app()
+        .with_mail_interceptor(DummyMailInterceptor)
+        .with_job_interceptor(DummyJobInterceptor)
+        .with_db_interceptor(DummyDbInterceptor)
+        .with_channels_interceptor(DummyChannelsInterceptor)
+        .with_http_interceptor(DummyHttpInterceptor);
+
+    let _ = builder;
+}
+
+#[cfg(feature = "mail")]
+#[tokio::test]
+async fn mail_interceptor_intercepts_sends() {
+    use autumn_web::get;
+    use autumn_web::mail::{Mail, Mailer, Transport};
+    use autumn_web::test::TestApp;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    struct RecordingMailInterceptor;
+    impl MailInterceptor for RecordingMailInterceptor {
+        fn intercept<'a>(
+            &'a self,
+            _mail: &'a Mail,
+            next: std::pin::Pin<
+                Box<
+                    dyn std::future::Future<Output = Result<(), autumn_web::mail::MailError>>
+                        + Send
+                        + 'a,
+                >,
+            >,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<(), autumn_web::mail::MailError>>
+                    + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async move {
+                CALLS.fetch_add(1, Ordering::SeqCst);
+                next.await
+            })
+        }
+    }
+
+    #[get("/send-test-mail")]
+    async fn send_test_mail(mailer: Mailer) -> &'static str {
+        let mail = Mail::builder()
+            .to("test@example.com")
+            .subject("Interception Test")
+            .text("This should be intercepted")
+            .build()
+            .unwrap();
+        mailer.send(mail).await.unwrap();
+        "sent"
+    }
+
+    let mut config = autumn_web::config::AutumnConfig::default();
+    config.mail.transport = Transport::Log;
+    config.mail.from = Some("noreply@example.com".to_string());
+
+    let client = TestApp::new()
+        .config(config)
+        .with_mail_interceptor(RecordingMailInterceptor)
+        .routes(autumn_web::routes![send_test_mail])
+        .build();
+
+    let response = client.get("/send-test-mail").send().await;
+    response.assert_ok();
+
+    assert_eq!(CALLS.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn job_interceptor_intercepts_enqueue_and_execute() {
+    use autumn_web::AppState;
+    use autumn_web::job::{self, JobInfo, clear_global_job_client, global_job_runtime_test_lock};
+    use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let _guard = global_job_runtime_test_lock().lock().await;
+    clear_global_job_client();
+
+    static ENQUEUES: AtomicUsize = AtomicUsize::new(0);
+    static EXECUTES: AtomicUsize = AtomicUsize::new(0);
+
+    struct RecordingJobInterceptor;
+    impl JobInterceptor for RecordingJobInterceptor {
+        fn intercept_enqueue<'a>(
+            &'a self,
+            name: &'a str,
+            payload: &'a serde_json::Value,
+            next: std::pin::Pin<
+                Box<dyn std::future::Future<Output = autumn_web::AutumnResult<()>> + Send + 'a>,
+            >,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = autumn_web::AutumnResult<()>> + Send + 'a>,
+        > {
+            Box::pin(async move {
+                assert_eq!(name, "test-job");
+                assert_eq!(payload["data"], "hello");
+                ENQUEUES.fetch_add(1, Ordering::SeqCst);
+                next.await
+            })
+        }
+
+        fn intercept_execute<'a>(
+            &'a self,
+            name: &'a str,
+            payload: &'a serde_json::Value,
+            next: std::pin::Pin<
+                Box<dyn std::future::Future<Output = autumn_web::AutumnResult<()>> + Send + 'a>,
+            >,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = autumn_web::AutumnResult<()>> + Send + 'a>,
+        > {
+            Box::pin(async move {
+                assert_eq!(name, "test-job");
+                assert_eq!(payload["data"], "hello");
+                EXECUTES.fetch_add(1, Ordering::SeqCst);
+                next.await
+            })
+        }
+    }
+
+    fn test_job_handler(
+        _state: AppState,
+        _payload: serde_json::Value,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = autumn_web::AutumnResult<()>> + Send + 'static>,
+    > {
+        Box::pin(async move { Ok(()) })
+    }
+
+    let state = AppState::for_test();
+    state.insert_extension(Arc::new(RecordingJobInterceptor) as Arc<dyn JobInterceptor>);
+
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let config = autumn_web::config::JobConfig::default();
+
+    let job_info = JobInfo {
+        name: "test-job".to_string(),
+        max_attempts: 1,
+        initial_backoff_ms: 1,
+        handler: test_job_handler,
+    };
+
+    job::start_runtime(vec![job_info], &state, &shutdown, &config).unwrap();
+
+    job::enqueue("test-job", json!({ "data": "hello" }))
+        .await
+        .unwrap();
+
+    // Sleep briefly to let the local worker process the job
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    shutdown.cancel();
+
+    assert_eq!(ENQUEUES.load(Ordering::SeqCst), 1);
+    assert_eq!(EXECUTES.load(Ordering::SeqCst), 1);
+
+    clear_global_job_client();
+}
+
+#[cfg(feature = "db")]
+#[tokio::test]
+async fn db_connection_interceptor_intercepts_checkout() {
+    use autumn_web::db::Db;
+    use autumn_web::get;
+    use autumn_web::interceptor::DbCheckoutContext;
+    use autumn_web::test::TestApp;
+    use diesel_async::AsyncPgConnection;
+    use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+    use diesel_async::pooled_connection::deadpool::Pool;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static CHECKOUTS: AtomicUsize = AtomicUsize::new(0);
+
+    struct RecordingDbInterceptor;
+    impl DbConnectionInterceptor for RecordingDbInterceptor {
+        fn intercept_checkout<'a>(
+            &'a self,
+            ctx: DbCheckoutContext,
+            next: std::pin::Pin<
+                Box<
+                    dyn std::future::Future<
+                            Output = Result<
+                                autumn_web::db::PooledConnection,
+                                autumn_web::AutumnError,
+                            >,
+                        > + Send
+                        + 'a,
+                >,
+            >,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = Result<autumn_web::db::PooledConnection, autumn_web::AutumnError>,
+                    > + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async move {
+                assert_eq!(ctx.pool_name, "primary");
+                CHECKOUTS.fetch_add(1, Ordering::SeqCst);
+                next.await
+            })
+        }
+    }
+
+    #[get("/db-test")]
+    async fn db_test(_db: Db) -> &'static str {
+        "ok"
+    }
+
+    let manager =
+        AsyncDieselConnectionManager::<AsyncPgConnection>::new("postgres://127.0.0.1:54321/dummy");
+    let pool = Pool::builder(manager).build().unwrap();
+
+    let client = TestApp::new()
+        .routes(autumn_web::routes![db_test])
+        .with_db(pool)
+        .with_db_interceptor(RecordingDbInterceptor)
+        .build();
+
+    let response = client.get("/db-test").send().await;
+    assert_eq!(response.status, axum::http::StatusCode::SERVICE_UNAVAILABLE);
+
+    assert_eq!(CHECKOUTS.load(Ordering::SeqCst), 1);
+}
+
+#[cfg(feature = "ws")]
+#[tokio::test]
+async fn channels_interceptor_intercepts_publish() {
+    use autumn_web::channels::{ChannelMessage, ChannelPublishError};
+    use autumn_web::get;
+    use autumn_web::test::TestApp;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static PUBLISH_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    struct RecordingChannelsInterceptor;
+    impl ChannelsInterceptor for RecordingChannelsInterceptor {
+        fn intercept_publish(
+            &self,
+            topic: &str,
+            msg: &ChannelMessage,
+            next: &dyn Fn(&str, &ChannelMessage) -> Result<usize, ChannelPublishError>,
+        ) -> Result<usize, ChannelPublishError> {
+            assert_eq!(topic, "test-topic");
+            assert_eq!(msg.as_str(), "test-message");
+            PUBLISH_CALLS.fetch_add(1, Ordering::SeqCst);
+            next(topic, msg)
+        }
+    }
+
+    #[get("/publish-test")]
+    async fn publish_test(
+        autumn_web::prelude::State(state): autumn_web::prelude::State<autumn_web::AppState>,
+    ) -> &'static str {
+        state
+            .channels()
+            .publish("test-topic", "test-message")
+            .unwrap();
+        "ok"
+    }
+
+    let client = TestApp::new()
+        .routes(autumn_web::routes![publish_test])
+        .with_channels_interceptor(RecordingChannelsInterceptor)
+        .build();
+
+    let response = client.get("/publish-test").send().await;
+    response.assert_ok();
+
+    assert_eq!(PUBLISH_CALLS.load(Ordering::SeqCst), 1);
+}
+
+#[cfg(feature = "oauth2")]
+static HTTP_CALLS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(feature = "oauth2")]
+struct RecordingHttpInterceptor;
+
+#[cfg(feature = "oauth2")]
+#[cfg(feature = "oauth2")]
+impl HttpInterceptor for RecordingHttpInterceptor {
+    fn intercept<'a>(
+        &'a self,
+        req: reqwest::Request,
+        next: &'a dyn Fn(
+            reqwest::Request,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<reqwest::Response, reqwest::Error>>
+                    + Send
+                    + 'a,
+            >,
+        >,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<reqwest::Response, reqwest::Error>> + Send + 'a,
+        >,
+    > {
+        assert_eq!(req.url().as_str(), "http://127.0.0.1:54321/token");
+        HTTP_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let fut = next(req);
+        Box::pin(async move { fut.await })
+    }
+}
+
+#[cfg(feature = "oauth2")]
+#[autumn_web::get("/test-oauth-client")]
+async fn test_oauth_client(session: autumn_web::session::Session) -> &'static str {
+    use autumn_web::auth::{OAuth2Callback, OAuth2ProviderConfig, oauth2_finish_login};
+
+    let state_val = "test-state-val";
+    session
+        .insert("oauth2:github:state", state_val.to_string())
+        .await;
+
+    let provider = OAuth2ProviderConfig {
+        client_id: "client-id".to_string(),
+        client_secret: "client-secret".to_string(),
+        authorize_url: "https://example.com/auth".to_string(),
+        token_url: "http://127.0.0.1:54321/token".to_string(),
+        userinfo_url: None,
+        redirect_uri: "http://127.0.0.1/callback".to_string(),
+        scope: "user".to_string(),
+        issuer: None,
+        jwks_url: None,
+    };
+
+    let callback = OAuth2Callback {
+        code: "code".to_string(),
+        state: state_val.to_string(),
+    };
+
+    let _ = oauth2_finish_login(&session, "user_id", "github", &provider, &callback).await;
+
+    "ok"
+}
+
+#[cfg(feature = "oauth2")]
+#[tokio::test]
+async fn http_interceptor_intercepts_calls() {
+    use autumn_web::test::TestApp;
+    use std::sync::atomic::Ordering;
+
+    HTTP_CALLS.store(0, Ordering::SeqCst);
+
+    let client = TestApp::new()
+        .routes(autumn_web::routes![test_oauth_client])
+        .with_http_interceptor(RecordingHttpInterceptor)
+        .build();
+
+    let response = client.get("/test-oauth-client").send().await;
+    response.assert_ok();
+
+    assert_eq!(HTTP_CALLS.load(Ordering::SeqCst), 1);
+}

--- a/autumn/tests/boundary_hooks_integration.rs
+++ b/autumn/tests/boundary_hooks_integration.rs
@@ -445,24 +445,11 @@ impl HttpInterceptor for RecordingHttpInterceptor {
     fn intercept<'a>(
         &'a self,
         req: reqwest::Request,
-        next: &'a dyn Fn(
-            reqwest::Request,
-        ) -> std::pin::Pin<
-            Box<
-                dyn std::future::Future<Output = Result<reqwest::Response, reqwest::Error>>
-                    + Send
-                    + 'a,
-            >,
-        >,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<reqwest::Response, reqwest::Error>> + Send + 'a,
-        >,
-    > {
+        next: &'a dyn Fn(reqwest::Request) -> autumn_web::interceptor::HttpInterceptorFuture<'a>,
+    ) -> autumn_web::interceptor::HttpInterceptorFuture<'a> {
         assert_eq!(req.url().as_str(), "http://127.0.0.1:54321/token");
         HTTP_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        let fut = next(req);
-        Box::pin(async move { fut.await })
+        next(req)
     }
 }
 


### PR DESCRIPTION
Exposes plugin hooks (composition wrappers/decorators) at the 5 framework-owned dependency boundaries as requested in Issue #690:
1. **Mailer Transport**: `MailInterceptor` wraps outbound and deferred emails.
2. **Job Runner/Dispatcher**: `JobInterceptor` wraps enqueuing (`JobClient::enqueue`) and worker executions (combines seamlessly with upstream OpenTelemetry span context propagation).
3. **Database Connection Checkout**: `DbConnectionInterceptor` wraps the Deadpool connection checkout window in the `Db` axum extractor.
4. **Channels Backend Publishing**: `ChannelsInterceptor` wraps synchronous broadcasting.
5. **Outbound HTTP Client Calls**: `HttpInterceptor` wraps outbound OAuth client requests using thin wrappers around `reqwest::Client` and `reqwest::RequestBuilder`.

### Verification & Testing
Implemented under a strict Test-Driven Development (TDD) cycle. All 6 new integration tests in `tests/boundary_hooks_integration.rs` pass:
- `app_builder_registers_interceptors`
- `channels_interceptor_intercepts_publish`
- `mail_interceptor_intercepts_sends`
- `job_interceptor_intercepts_enqueue_and_execute`
- `db_connection_interceptor_intercepts_checkout`
- `http_interceptor_intercepts_calls`