### PR TITLE
👾 Havoc: Fix Idempotency TTL Panic and X-Forwarded-Host Spoofing

### DIFF
--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -464,10 +464,14 @@ impl IdempotencyStore for MemoryIdempotencyStore {
     }
 
     fn set(&self, key: &str, record: IdempotencyRecord, body_hash: Vec<u8>, ttl: Duration) {
+        let expires_at = Instant::now().checked_add(ttl).unwrap_or_else(|| {
+            // If the duration is so large it overflows, cap it to the maximum possible Instant.
+            Instant::now() + Duration::from_secs(60 * 60 * 24 * 365 * 100) // approx 100 years
+        });
         let entry = IdempotencyEntry {
             record,
             body_hash,
-            expires_at: Instant::now() + ttl,
+            expires_at,
         };
         let mut entries = self.entries.write().unwrap();
         entries.insert(key.to_owned(), entry);
@@ -500,11 +504,14 @@ impl IdempotencyStore for MemoryIdempotencyStore {
         } else {
             lock_ttl
         };
+        let expires_at = now.checked_add(ttl).unwrap_or_else(|| {
+            now + Duration::from_secs(60 * 60 * 24 * 365 * 100)
+        });
         in_flight.insert(
             key.to_owned(),
             MemoryInFlightLock {
                 owner: owner.to_owned(),
-                expires_at: now + ttl,
+                expires_at,
             },
         );
         true

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -7318,7 +7318,7 @@ mod tests {
             map.insert("tracestate".to_owned(), "vendor=val".to_owned());
             let extractor = JobMapExtractor(&map);
             let mut keys = extractor.keys();
-            keys.sort();
+            keys.sort_unstable();
             assert_eq!(keys, vec!["traceparent", "tracestate"]);
         }
 

--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -396,29 +396,41 @@ fn origin_matches_request(origin: &str, headers: &http::HeaderMap) -> bool {
         return false;
     };
 
-    let expected_host = headers
-        .get("x-forwarded-host")
-        .and_then(|v| v.to_str().ok())
-        .or_else(|| {
-            headers
-                .get(http::header::HOST)
-                .and_then(|v| v.to_str().ok())
-        });
+    let x_forwarded_hosts = headers
+        .get_all("x-forwarded-host")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let expected_host = if x_forwarded_hosts.is_empty() {
+        headers
+            .get(http::header::HOST)
+            .and_then(|v| v.to_str().ok())
+            .map(ToOwned::to_owned)
+    } else {
+        x_forwarded_hosts.rsplit(',').next().map(str::trim).map(ToOwned::to_owned)
+    };
+
     let Some(expected_host) = expected_host else {
         return false;
     };
-    if !origin_authority.eq_ignore_ascii_case(expected_host) {
+    if !origin_authority.eq_ignore_ascii_case(&expected_host) {
         return false;
     }
 
-    if let Some(scheme) = headers
-        .get("x-forwarded-proto")
-        .and_then(|v| v.to_str().ok())
-    {
+    let x_forwarded_protos = headers
+        .get_all("x-forwarded-proto")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    if !x_forwarded_protos.is_empty() {
         // Multiple `X-Forwarded-Proto` values can be chained by
         // intermediaries; the leftmost (client-facing) is the one
         // that matters here.
-        let outermost = scheme.split(',').next().unwrap_or(scheme).trim();
+        let outermost = x_forwarded_protos.split(',').next().unwrap_or(x_forwarded_protos.as_str()).trim();
         return outermost.eq_ignore_ascii_case(origin_scheme);
     }
 

--- a/autumn/tests/chaos_idempotency_ttl_panic.rs
+++ b/autumn/tests/chaos_idempotency_ttl_panic.rs
@@ -1,0 +1,14 @@
+use autumn_web::idempotency::{MemoryIdempotencyStore, IdempotencyStore, IdempotencyRecord};
+use std::time::Duration;
+
+#[test]
+fn test_idempotency_ttl_panic() {
+    let store = MemoryIdempotencyStore::new(Duration::from_secs(60));
+    let record = IdempotencyRecord {
+        status: 200,
+        headers: vec![],
+        body: vec![],
+        metadata: vec![],
+    };
+    store.set("key", record, vec![], Duration::MAX);
+}

--- a/autumn/tests/chaos_origin_fuzz.rs
+++ b/autumn/tests/chaos_origin_fuzz.rs
@@ -1,0 +1,47 @@
+use autumn_web::middleware::MethodOverrideLayer;
+use axum::{body::Body, http::Request, routing::post, Router};
+use tower::{ServiceExt, Layer};
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn does_not_crash_on_any_header_combination(
+        ref origin in "\\PC*",
+        ref xfh in "\\PC*",
+        ref xfp in "\\PC*",
+        ref host in "\\PC*"
+    ) {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        let _guard = rt.enter();
+
+        let router = Router::new()
+            .route("/items/1", post(|| async { "post-ok" }))
+            .route("/items/1", axum::routing::delete(|| async { "deleted" }));
+
+        let app = MethodOverrideLayer::new().layer(router);
+
+        let mut builder = Request::builder()
+            .method("POST")
+            .uri("/items/1")
+            .header("content-type", "application/x-www-form-urlencoded")
+            .header("sec-fetch-site", "same-origin");
+
+        if let Ok(val) = axum::http::HeaderValue::from_str(origin) {
+            builder = builder.header("origin", val);
+        }
+        if let Ok(val) = axum::http::HeaderValue::from_str(xfh) {
+            builder = builder.header("x-forwarded-host", val.clone());
+            builder = builder.header("x-forwarded-host", val);
+        }
+        if let Ok(val) = axum::http::HeaderValue::from_str(xfp) {
+            builder = builder.header("x-forwarded-proto", val);
+        }
+        if let Ok(val) = axum::http::HeaderValue::from_str(host) {
+            builder = builder.header("host", val);
+        }
+
+        let request = builder.body(Body::from("_method=DELETE")).unwrap();
+
+        let _ = rt.block_on(app.oneshot(request));
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:**
Passing `Duration::MAX` or any unreasonably large value as a TTL to `MemoryIdempotencyStore::set` or `try_lock_owned` triggered an arithmetic overflow when added to `Instant::now()`. Separately, supplying a spoofed `X-Forwarded-Host` alongside a proxy-appended host caused `method_override` origin verification to incorrectly use the first value (spoofed) instead of the rightmost proxy-appended value.

📉 **The Stack Trace:**
```
thread 'test_idempotency_ttl_panic' panicked at library/std/src/time.rs:429:33:
overflow when adding duration to instant
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

🧪 **Reproduction:**
- For TTL: Invoke `MemoryIdempotencyStore::set` passing `Duration::MAX`.
- For XFH: Send `X-Forwarded-Host: attacker.example, real-proxy.internal` to trigger the origin bypass.

😈 **Comment:**
"You assumed `ttl` would fit in the monotonic clock, and that `headers.get` extracts the full comma-separated truth of `X-Forwarded-Host`. You were wrong."

---
*PR created automatically by Jules for task [14769302012697659990](https://jules.google.com/task/14769302012697659990) started by @madmax983*