### PR TITLE
⚒️ Forge: Simplify Redis job handling flow

### DIFF
--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -2317,11 +2317,10 @@ return { id, updated }
         return Ok(None);
     };
 
-    match serde_json::from_str::<RedisJobRecord>(&body) {
-        Ok(record) => Ok(Some(record)),
+    let record = match serde_json::from_str::<RedisJobRecord>(&body) {
+        Ok(record) => record,
         Err(error) => {
             tracing::warn!(job_id = %id, error = %error, "invalid durable job record");
-            let malformed_id = id.clone();
             let malformed = serde_json::json!({
                 "id": id,
                 "error": error.to_string(),
@@ -2330,12 +2329,13 @@ return { id, updated }
             push_json_list_item(connection, &worker_config.dead_key, &malformed).await;
             let _ = redis::cmd("ZREM")
                 .arg(&worker_config.processing_key)
-                .arg(malformed_id)
+                .arg(id)
                 .query_async::<usize>(connection)
                 .await;
-            Ok(None)
+            return Ok(None);
         }
-    }
+    };
+    Ok(Some(record))
 }
 
 #[cfg(feature = "redis")]
@@ -2764,25 +2764,23 @@ fn spawn_redis_worker(
                 break;
             }
 
+            #[allow(clippy::collapsible_if)]
             if retry_promotion_throttle.take_due(std::time::Instant::now()) {
-                match promote_due_redis_retries(&mut connection, &worker_config, &state, &job_admin)
-                    .await
+                if let Err(error) =
+                    promote_due_redis_retries(&mut connection, &worker_config, &state, &job_admin)
+                        .await
                 {
-                    Ok(()) => {}
-                    Err(error) => {
-                        tracing::warn!(error = %error, "redis job worker retry promotion failed");
-                    }
+                    tracing::warn!(error = %error, "redis job worker retry promotion failed");
                 }
             }
 
+            #[allow(clippy::collapsible_if)]
             if stale_recovery_throttle.take_due(std::time::Instant::now()) {
-                match recover_stale_redis_jobs(&mut connection, &worker_config, &state, &job_admin)
-                    .await
+                if let Err(error) =
+                    recover_stale_redis_jobs(&mut connection, &worker_config, &state, &job_admin)
+                        .await
                 {
-                    Ok(()) => {}
-                    Err(error) => {
-                        tracing::warn!(error = %error, "redis job worker stale recovery failed");
-                    }
+                    tracing::warn!(error = %error, "redis job worker stale recovery failed");
                 }
             }
 


### PR DESCRIPTION
🚰 Smell
There were empty match arms `Ok(()) => {}` within the Redis job loops in `spawn_redis_worker`, leading to unnecessary nesting and "Pyramid of Doom" structures. The JSON extraction loop was matching an inner error only to build a return value rather than early returning.

✨ Solution
Refactored the empty matches using `if let Err(error) = ...` alongside `#[allow(clippy::collapsible_if)]` for compiler compatibility since `let_chains` isn't stable. Extracted the `serde_json::from_str` matching out into an early-returning guard clause to eliminate deeper nesting inside `claim_next_redis_job`.

🧼 Benefit
Reduces cognitive load by explicitly returning or handling only the `Err` states, flattening the code structure and adhering to more idiomatic Rust guard clauses while preserving the exact runtime logic.

🛡️ Verification
Ran all `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test -p autumn-web --lib job --features test-support,db,storage,maud`, and `cargo test -p autumn-web --lib job --features test-support,db,storage,maud --release`. All tests pass perfectly, verifying that no logic was changed.

---
*PR created automatically by Jules for task [923975523224560964](https://jules.google.com/task/923975523224560964) started by @madmax983*