### PR TITLE
🍎 Eris: Fix method override origin bypass via X-Forwarded-Host injection

### DIFF
--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -397,8 +397,13 @@ fn origin_matches_request(origin: &str, headers: &http::HeaderMap) -> bool {
     };
 
     let expected_host = headers
-        .get("x-forwarded-host")
-        .and_then(|v| v.to_str().ok())
+        .get_all("x-forwarded-host")
+        .iter()
+        .rev()
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|s| s.rsplit(','))
+        .map(str::trim)
+        .find(|s| !s.is_empty())
         .or_else(|| {
             headers
                 .get(http::header::HOST)

--- a/autumn/tests/security/method_override_bypass.rs
+++ b/autumn/tests/security/method_override_bypass.rs
@@ -1,0 +1,43 @@
+use autumn_web::middleware::MethodOverrideLayer;
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+    routing::delete,
+};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn method_override_origin_bypass_poc() {
+    let app = Router::new()
+        .route("/items/1", delete(|| async { "deleted" }))
+        .layer(MethodOverrideLayer::new());
+
+    let mut req = Request::builder()
+        .method("POST")
+        .uri("/items/1")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .header("origin", "https://evil.com")
+        .header("host", "legitimate.com") // Original host header
+        .header("x-forwarded-proto", "https")
+        .body(Body::from("_method=DELETE"))
+        .unwrap();
+
+    // The attacker sets X-Forwarded-Host: evil.com
+    req.headers_mut()
+        .append("x-forwarded-host", "evil.com".parse().unwrap());
+
+    // The proxy appends X-Forwarded-Host: legitimate.com
+    req.headers_mut()
+        .append("x-forwarded-host", "legitimate.com".parse().unwrap());
+
+    let res = app.oneshot(req).await.unwrap();
+
+    // With the patch, the method override should be rejected and fall through to the POST handler
+    // Since there is no POST handler for /items/1, it returns 405 Method Not Allowed.
+    assert_eq!(
+        res.status(),
+        StatusCode::METHOD_NOT_ALLOWED,
+        "Origin bypass should be rejected"
+    );
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -10,6 +10,7 @@ pub mod csrf_path_traversal;
 pub mod csrf_timing;
 pub mod ctf;
 pub mod fallback_middleware_bypass;
+pub mod method_override_bypass;
 pub mod rate_limit_xff_bypass;
 pub mod session_exhaustion;
 pub mod session_fixation;


### PR DESCRIPTION
🍎 **Eris: Method Override Origin Bypass via X-Forwarded-Host Injection**

**Reconnaissance:**
During an audit of the `MethodOverrideLayer` which allows HTTP method overriding via a `_method` form field, I investigated the CSRF protection mechanism (`origin_matches_request`). The middleware attempts to validate the incoming `Origin` against the `X-Forwarded-Host` header to ensure it's not a cross-origin attack.

**Hypothesis:**
I hypothesized that the `origin_matches_request` function securely extracts the forwarded host header improperly. Since `headers.get()` in the `http` crate only evaluates the *first* header matching the key, an attacker could spoof the origin by sending their own `X-Forwarded-Host` header. When the reverse proxy appends the legitimate host, it is added to the end of the header list or comma-separated string, leaving the attacker's value as the first evaluated result.

**Exploit development:**
I developed a PoC that sends a `POST` request with `_method=DELETE` and a malicious `Origin: https://evil.com`. The attacker sends `X-Forwarded-Host: evil.com`. Assuming the proxy appends the legitimate host resulting in two headers or a comma-separated list like `X-Forwarded-Host: evil.com, legitimate.com`, the server evaluates `evil.com` and incorrectly grants the request as same-origin.

**Verification:**
The PoC successfully bypassed the `405 Method Not Allowed` fallback and executed the `DELETE` handler, returning a `200 OK`. 

**Severity assessment:**
**CVSS 3.1 Base Score: 6.5 (Medium)** (`CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N`). This allows a remote attacker to bypass CSRF protections specifically for routes relying on method overrides. It requires user interaction (the victim clicking a link or submitting a form) but can lead to severe state modifications (like unauthenticated `DELETE` or `PUT` actions on sensitive endpoints).

**Remediation recommendation:**
When relying on `X-Forwarded-*` headers, we must parse the *entire chain* and extract the most trusted value. In the case of `X-Forwarded-Host`, this is the *rightmost* value appended by the reverse proxy. I have replaced `headers.get()` with `headers.get_all()` mapping logic that joins all instances of the header, splits them by commas, and securely extracts the last non-empty element. A permanent regression test `method_override_origin_bypass_poc` has been added to `autumn/tests/security/method_override_bypass.rs`.

---
*PR created automatically by Jules for task [2770335937404019629](https://jules.google.com/task/2770335937404019629) started by @madmax983*