### PR TITLE
👺 Havoc: Fix Instant overflow panic in MemoryIdempotencyStore

### DIFF
--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -467,7 +467,9 @@ impl IdempotencyStore for MemoryIdempotencyStore {
         let entry = IdempotencyEntry {
             record,
             body_hash,
-            expires_at: Instant::now() + ttl,
+            expires_at: Instant::now()
+                .checked_add(ttl)
+                .unwrap_or_else(|| Instant::now() + Duration::from_secs(86_400 * 365)),
         };
         let mut entries = self.entries.write().unwrap();
         entries.insert(key.to_owned(), entry);
@@ -504,7 +506,9 @@ impl IdempotencyStore for MemoryIdempotencyStore {
             key.to_owned(),
             MemoryInFlightLock {
                 owner: owner.to_owned(),
-                expires_at: now + ttl,
+                expires_at: now
+                    .checked_add(ttl)
+                    .unwrap_or_else(|| now + Duration::from_secs(86_400 * 365)),
             },
         );
         true

--- a/autumn/tests/chaos_idempotency_proptest.proptest-regressions
+++ b/autumn/tests/chaos_idempotency_proptest.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc ef63b7c109cb7e2baad6a4f0f5196bdb60fd4179732f87a4e2e14cb580e9bc88 # shrinks to ttl_secs = 9223372036854775589

--- a/autumn/tests/chaos_idempotency_proptest.rs
+++ b/autumn/tests/chaos_idempotency_proptest.rs
@@ -1,0 +1,17 @@
+use autumn_web::idempotency::{IdempotencyRecord, IdempotencyStore, MemoryIdempotencyStore};
+use proptest::prelude::*;
+use std::time::Duration;
+
+proptest! {
+    #[test]
+    fn test_memory_idempotency_store_set_ttl_panic(ttl_secs in any::<u64>()) {
+        let store = MemoryIdempotencyStore::new(Duration::from_secs(60));
+        let record = IdempotencyRecord {
+            status: 200,
+            headers: vec![],
+            body: vec![],
+            metadata: vec![],
+        };
+        store.set("key", record, vec![], Duration::from_secs(ttl_secs));
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** Passing an extremely large `Duration` (e.g. `Duration::MAX` or large `u64` seconds) to `MemoryIdempotencyStore::set` or `try_lock_owned` caused an arithmetic overflow panic when added to `Instant::now()`.
📉 **The Stack Trace:**
```
thread 'test_memory_idempotency_store_set_ttl_panic' (8625) panicked at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/time.rs:429:33:
overflow when adding duration to instant
```
🧪 **Reproduction:** Run `cargo test -p autumn-web --test chaos_idempotency_proptest` (which blasts large `ttl_secs` into `set()`).
😈 **Comment:** "You assumed time wouldn't overflow just because TTL is small in production. You were wrong. If an attacker controls the TTL, they control the availability."

---
*PR created automatically by Jules for task [3493762482970059789](https://jules.google.com/task/3493762482970059789) started by @madmax983*