### PR TITLE
feat(tenancy): implement first-class opt-in row-level multi-tenancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 To opt out of the generated `page` method: implement your own list handler using `repo.find_all()` or a custom Diesel query.  The `find_all` method is unchanged.
 
+### Fixed
+
+- **tenancy:** Normalize hostnames to lowercase in subdomain mode for DNS case-insensitivity
+- **tenancy:** Add `jwt_audience` config field; enable audience validation when configured
+
+
 ## [0.4.0] - 2026-05-12
 
 ### Added

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -611,6 +611,36 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Build Diesel-compatible changeset bridge (private struct with Option<T> fields)
     let changeset_name = format_ident!("__{}Changeset", name);
 
+    let tenant_id_field = fields_for_new
+        .iter()
+        .find(|f| f.ident.as_ref().is_some_and(|id| id == "tenant_id"));
+
+    #[allow(clippy::option_if_let_else)]
+    let can_set_tenant_id_impl = match tenant_id_field {
+        Some(f) => {
+            let is_option = is_option_type(&f.ty);
+            let val = if is_option {
+                quote! { ::core::option::Option::Some(::core::option::Option::Some(t)) }
+            } else {
+                quote! { ::core::option::Option::Some(t) }
+            };
+            quote! {
+                impl ::autumn_web::repository::CanSetTenantId for #changeset_name {
+                    fn set_tenant_id(&mut self, t: ::std::string::String) {
+                        self.tenant_id = #val;
+                    }
+                }
+            }
+        }
+        None => {
+            quote! {
+                impl ::autumn_web::repository::CanSetTenantId for #changeset_name {
+                    fn set_tenant_id(&mut self, _t: ::std::string::String) {}
+                }
+            }
+        }
+    };
+
     let mut changeset_fields: Vec<TokenStream> = fields_for_new
         .iter()
         .map(|f| {
@@ -1198,6 +1228,8 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
             }
         }
+
+        #can_set_tenant_id_impl
 
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #vis enum #field_enum_name {

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -641,6 +641,33 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
+    let model_tenant_id_meta_impl = tenant_id_field.as_ref().map_or_else(
+        || {
+            quote! {
+                impl ::autumn_web::tenancy::ModelTenantIdMeta for #new_name {
+                    const HAS_MANUAL_TENANT_ID: bool = false;
+                    fn try_set_tenant_id(&mut self, _tenant_id: &str) {}
+                }
+            }
+        },
+        |f| {
+            let is_option = is_option_type(&f.ty);
+            let set_field = if is_option {
+                quote! { self.tenant_id = ::core::option::Option::Some(tenant_id.to_string()); }
+            } else {
+                quote! { self.tenant_id = tenant_id.to_string(); }
+            };
+            quote! {
+                impl ::autumn_web::tenancy::ModelTenantIdMeta for #new_name {
+                    const HAS_MANUAL_TENANT_ID: bool = true;
+                    fn try_set_tenant_id(&mut self, tenant_id: &str) {
+                        #set_field
+                    }
+                }
+            }
+        },
+    );
+
     let mut changeset_fields: Vec<TokenStream> = fields_for_new
         .iter()
         .map(|f| {
@@ -1230,6 +1257,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         #can_set_tenant_id_impl
+        #model_tenant_id_meta_impl
 
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #vis enum #field_enum_name {

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -742,7 +742,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                                 let record = if let ::core::option::Option::Some(ref t) = tenant_id {
                                     ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                                        .values((&input, #table_ident::tenant_id.eq(t)))
+                                        .values(::autumn_web::tenancy::TenantInsertable::tenant_values(input.clone(), t))
                                         .get_result::<#model_name>(conn)
                                         .await
                                 } else {
@@ -869,7 +869,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                                 let record = if let ::core::option::Option::Some(ref t) = tenant_id {
                                     ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                                        .values((&input, #table_ident::tenant_id.eq(t)))
+                                        .values(::autumn_web::tenancy::TenantInsertable::tenant_values(input.clone(), t))
                                         .get_result::<#model_name>(conn)
                                         .await
                                 } else {
@@ -1976,7 +1976,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 let mut conn = self.__autumn_acquire_conn().await?;
                 if let ::core::option::Option::Some(ref t) = tenant_id {
                     ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                        .values((new, #table_ident::tenant_id.eq(t)))
+                        .values(::autumn_web::tenancy::TenantInsertable::tenant_values(new.clone(), t))
                         .get_result::<#model_name>(&mut conn)
                         .await
                 } else {
@@ -2505,6 +2505,31 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         (trait_method, impl_method)
     } else {
         (quote! {}, quote! {})
+    };
+
+    let tenant_scoped_traits = if config.tenant_scoped {
+        quote! {
+            impl ::autumn_web::tenancy::HasTenantIdColumn for #table_ident::table {
+                type Column = #table_ident::tenant_id;
+                fn column() -> Self::Column {
+                    #table_ident::tenant_id
+                }
+            }
+
+            impl<'a> ::autumn_web::tenancy::TenantInsertable<'a, #table_ident::table> for #new_name {
+                type Values = <::autumn_web::tenancy::TenantInsertableValuesSelector<'a, Self, #table_ident::table, { <Self as ::autumn_web::tenancy::ModelTenantIdMeta>::HAS_MANUAL_TENANT_ID }> as ::autumn_web::tenancy::GetInsertableValues>::Values;
+
+                fn tenant_values(self, tenant_id: &'a str) -> Self::Values {
+                    ::autumn_web::tenancy::GetInsertableValues::get_values(::autumn_web::tenancy::TenantInsertableValuesSelector::<'a, Self, #table_ident::table, { <Self as ::autumn_web::tenancy::ModelTenantIdMeta>::HAS_MANUAL_TENANT_ID }> {
+                        inner: self,
+                        tenant_id,
+                        _marker: ::core::marker::PhantomData,
+                    })
+                }
+            }
+        }
+    } else {
+        quote! {}
     };
 
     // ΓöÇΓöÇ Build API handlers (when `api = "/path"` is present) ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
@@ -3871,6 +3896,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         #hook_inventory_registration
 
         #api_handlers
+
+        #tenant_scoped_traits
     }
 }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1,12 +1,12 @@
-﻿//! `#[repository(Model)]` proc macro implementation.
+//! `#[repository(Model)]` proc macro implementation.
 //!
 //! Generates a concrete `PgXxxRepository` struct with:
 //! - Auto-generated CRUD (`find_by_id`, `find_all`, save, update, `delete_by_id`, count, `exists_by_id`)
 //! - Derived queries parsed from trait method names (`find_by_field`, `count_by_field`, etc.)
 //! - `FromRequestParts` extractor impl
 //!
-//! Uses native async fn in traits (Rust 1.75+) ΓÇö no `async_trait` crate needed.
-//! Uses `diesel-async` `RunQueryDsl` for async queries ΓÇö no sync `interact()`.
+//! Uses native async fn in traits (Rust 1.75+) - no `async_trait` crate needed.
+//! Uses `diesel-async` `RunQueryDsl` for async queries - no sync `interact()`.
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -330,7 +330,11 @@ fn generate_derived_query(
     }
 }
 
-#[allow(clippy::too_many_lines, clippy::option_if_let_else, clippy::large_stack_frames)]
+#[allow(
+    clippy::too_many_lines,
+    clippy::option_if_let_else,
+    clippy::large_stack_frames
+)]
 #[allow(clippy::cognitive_complexity)]
 pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let config = match parse_repo_args(attr) {
@@ -1109,7 +1113,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     }
 
                                     let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        draft.after.tenant_id = t.clone();
+                                    }
                                     self.hooks.before_update(&mut ctx, &mut draft).await?;
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        draft.after.tenant_id = t.clone();
+                                    }
 
                                     let proposed = draft.into_after();
                                     let update_target = #table_ident::table.find(id);
@@ -1139,7 +1149,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     ))?;
 
                                     let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        draft.after.tenant_id = t.clone();
+                                    }
                                     self.hooks.before_update(&mut ctx, &mut draft).await?;
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        draft.after.tenant_id = t.clone();
+                                    }
 
                                     let proposed = draft.into_after();
                                     let update_target = #table_ident::table.find(id);
@@ -1299,7 +1315,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     }
 
                                     let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        draft.after.tenant_id = t.clone();
+                                    }
                                     self.hooks.before_update(&mut ctx, &mut draft).await?;
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        draft.after.tenant_id = t.clone();
+                                    }
 
                                     let proposed = draft.into_after();
                                     let update_target = #table_ident::table.find(id);
@@ -1329,7 +1351,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     ))?;
 
                                     let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        draft.after.tenant_id = t.clone();
+                                    }
                                     self.hooks.before_update(&mut ctx, &mut draft).await?;
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        draft.after.tenant_id = t.clone();
+                                    }
 
                                     let proposed = draft.into_after();
                                     let update_target = #table_ident::table.find(id);
@@ -2023,7 +2051,11 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 }
                             }
 
-                            let diesel_changeset = changes.__to_changeset();
+                            let mut diesel_changeset = changes.__to_changeset();
+                            if let ::core::option::Option::Some(ref t) = tenant_id {
+                                use ::autumn_web::repository::CanSetTenantId as _;
+                                diesel_changeset.set_tenant_id(t.clone());
+                            }
                             let update_target = #table_ident::table.find(id);
                             if let ::core::option::Option::Some(ref t) = tenant_id {
                                 ::autumn_web::reexports::diesel::update(update_target.filter(#table_ident::tenant_id.eq(t)))
@@ -2042,7 +2074,11 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     })
                     .await
                 } else {
-                    let diesel_changeset = changes.__to_changeset();
+                    let mut diesel_changeset = changes.__to_changeset();
+                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                        use ::autumn_web::repository::CanSetTenantId as _;
+                        diesel_changeset.set_tenant_id(t.clone());
+                    }
                     let update_target = #table_ident::table.find(id);
                     if let ::core::option::Option::Some(ref t) = tenant_id {
                         ::autumn_web::reexports::diesel::update(update_target.filter(#table_ident::tenant_id.eq(t)))

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -48,6 +48,9 @@ struct RepoConfig {
     /// of issuing `DELETE FROM`, and all default finders filter out soft-deleted
     /// rows. Requires the model table to have a `deleted_at TIMESTAMP NULL` column.
     soft_delete: bool,
+    /// Enable row-level multi-tenancy: automatically scopes all queries to the
+    /// active tenant context.
+    tenant_scoped: bool,
 }
 
 fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
@@ -61,6 +64,7 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
     let mut cursor_key: Option<String> = None;
     let mut cursor_key_type: Option<syn::Path> = None;
     let mut soft_delete = false;
+    let mut tenant_scoped = false;
 
     syn::meta::parser(|meta| {
         // `hooks = Ident` must be checked before the catch-all model_name case,
@@ -100,12 +104,15 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
         } else if meta.path.is_ident("soft_delete") {
             soft_delete = true;
             Ok(())
+        } else if meta.path.is_ident("tenant_scoped") {
+            tenant_scoped = true;
+            Ok(())
         } else if meta.path.get_ident().is_some() && model_name.is_none() {
             model_name = Some(meta.path.get_ident().unwrap().clone());
             Ok(())
         } else {
             Err(meta.error(
-                "expected model name, table = \"...\", hooks = Type, commit_hooks = true, api = \"/path\", policy = Type, scope = Type, cursor_key = field, cursor_key_type = Type, or soft_delete",
+                "expected model name, table = \"...\", hooks = Type, commit_hooks = true, api = \"/path\", policy = Type, scope = Type, cursor_key = field, cursor_key_type = Type, soft_delete, or tenant_scoped",
             ))
         }
     })
@@ -136,6 +143,7 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
         cursor_key,
         cursor_key_type,
         soft_delete,
+        tenant_scoped,
     })
 }
 
@@ -176,11 +184,12 @@ fn parse_query_name(name: &str) -> Option<DerivedQuery> {
 }
 
 #[allow(clippy::too_many_lines)]
-fn generate_derived_query(
+fn generate_derived_query_for_source(
     query: &DerivedQuery,
     table_ident: &Ident,
     model_name: &Ident,
     soft_delete: bool,
+    query_source: &TokenStream,
 ) -> TokenStream {
     let field_idents: Vec<Ident> = query.fields.iter().map(|f| format_ident!("{f}")).collect();
     let param_names: Vec<Ident> = query.fields.iter().map(|f| format_ident!("{f}")).collect();
@@ -205,7 +214,7 @@ fn generate_derived_query(
         "find" => {
             quote! {
                 let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                #table_ident::table
+                #query_source
                     #(#filters)*
                     #soft_delete_filter
                     .load::<#model_name>(&mut conn)
@@ -216,7 +225,7 @@ fn generate_derived_query(
         "count" => {
             quote! {
                 let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                #table_ident::table
+                #query_source
                     #(#filters)*
                     #soft_delete_filter
                     .count()
@@ -231,7 +240,7 @@ fn generate_derived_query(
                     let __now = ::autumn_web::reexports::chrono::Utc::now().naive_utc();
                     let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
                     ::autumn_web::reexports::diesel::update(
-                        #table_ident::table #(#filters)* .filter(#table_ident::deleted_at.is_null())
+                        #query_source #(#filters)* .filter(#table_ident::deleted_at.is_null())
                     )
                     .set(#table_ident::deleted_at.eq(::core::option::Option::Some(__now)))
                     .execute(&mut conn)
@@ -242,7 +251,7 @@ fn generate_derived_query(
             } else {
                 quote! {
                     let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                    ::autumn_web::reexports::diesel::delete(#table_ident::table #(#filters)*)
+                    ::autumn_web::reexports::diesel::delete(#query_source #(#filters)*)
                         .execute(&mut conn)
                         .await
                         .map_err(::autumn_web::AutumnError::from)?;
@@ -255,7 +264,7 @@ fn generate_derived_query(
                 let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
                 ::autumn_web::reexports::diesel::select(
                     ::autumn_web::reexports::diesel::dsl::exists(
-                        #table_ident::table #(#filters)* #soft_delete_filter
+                        #query_source #(#filters)* #soft_delete_filter
                     )
                 )
                 .get_result::<bool>(&mut conn)
@@ -273,7 +282,55 @@ fn generate_derived_query(
     }
 }
 
-#[allow(clippy::too_many_lines, clippy::option_if_let_else)]
+fn generate_derived_query(
+    query: &DerivedQuery,
+    table_ident: &Ident,
+    model_name: &Ident,
+    soft_delete: bool,
+    tenant_scoped: bool,
+) -> TokenStream {
+    if tenant_scoped {
+        let across_tenants_query = generate_derived_query_for_source(
+            query,
+            table_ident,
+            model_name,
+            soft_delete,
+            &quote! { #table_ident::table },
+        );
+        let scoped_query = generate_derived_query_for_source(
+            query,
+            table_ident,
+            model_name,
+            soft_delete,
+            &quote! { #table_ident::table.filter(#table_ident::tenant_id.eq(tenant_id)) },
+        );
+        quote! {
+            if self.across_tenants {
+                #across_tenants_query
+            } else {
+                let tenant_id = match ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten() {
+                    ::core::option::Option::Some(t) => t,
+                    ::core::option::Option::None => {
+                        return ::core::result::Result::Err(::autumn_web::AutumnError::internal_server_error_msg(
+                            "no tenant context was established"
+                        ));
+                    }
+                };
+                #scoped_query
+            }
+        }
+    } else {
+        generate_derived_query_for_source(
+            query,
+            table_ident,
+            model_name,
+            soft_delete,
+            &quote! { #table_ident::table },
+        )
+    }
+}
+
+#[allow(clippy::too_many_lines, clippy::option_if_let_else, clippy::large_stack_frames)]
 #[allow(clippy::cognitive_complexity)]
 pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let config = match parse_repo_args(attr) {
@@ -341,8 +398,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                 let params = &user_params;
 
-                let body =
-                    generate_derived_query(&query, &table_ident, model_name, config.soft_delete);
+                let body = generate_derived_query(
+                    &query,
+                    &table_ident,
+                    model_name,
+                    config.soft_delete,
+                    config.tenant_scoped,
+                );
 
                 derived_trait_methods.push(quote! {
                     fn #fn_ident(&self, #(#params),*) -> impl ::std::future::Future<Output = ::autumn_web::AutumnResult<#return_type>> + Send;
@@ -368,6 +430,63 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     //
     // When absent, the generated code is identical to the pre-hooks version
     // (zero-cost path).
+
+    let tenant_struct_field = if config.tenant_scoped {
+        quote! { across_tenants: bool, }
+    } else {
+        quote! {}
+    };
+
+    let tenant_clone_field = if config.tenant_scoped {
+        quote! { across_tenants: self.across_tenants, }
+    } else {
+        quote! {}
+    };
+
+    let tenant_init_field = if config.tenant_scoped {
+        quote! { across_tenants: false, }
+    } else {
+        quote! {}
+    };
+
+    let across_tenants_method = if config.tenant_scoped {
+        if let Some(hooks_ident) = &config.hooks_type {
+            let idempotency_clone_field = if commit_hooks_enabled {
+                quote! {
+                    idempotency: self.idempotency.clone(),
+                }
+            } else {
+                quote! {}
+            };
+            quote! {
+                pub fn across_tenants(&self) -> Self {
+                    if ::core::cfg!(debug_assertions) {
+                        ::autumn_web::reexports::tracing::warn!("across_tenants() called on tenant_scoped repository");
+                    }
+                    Self {
+                        pool: self.pool.clone(),
+                        hooks: <#hooks_ident as ::autumn_web::hooks::RepositoryHooksClone>::autumn_clone(&self.hooks),
+                        #idempotency_clone_field
+                        across_tenants: true,
+                    }
+                }
+            }
+        } else {
+            quote! {
+                pub fn across_tenants(&self) -> Self {
+                    if ::core::cfg!(debug_assertions) {
+                        ::autumn_web::reexports::tracing::warn!("across_tenants() called on tenant_scoped repository");
+                    }
+                    Self {
+                        pool: self.pool.clone(),
+                        across_tenants: true,
+                    }
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
 
     let (
         struct_fields,
@@ -401,6 +520,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             >,
             hooks: #hooks_ident,
             #idempotency_struct_field
+            #tenant_struct_field
         };
 
         let clone_impl = quote! {
@@ -410,6 +530,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         pool: self.pool.clone(),
                         hooks: <#hooks_ident as ::autumn_web::hooks::RepositoryHooksClone>::autumn_clone(&self.hooks),
                         #idempotency_clone_field
+                        #tenant_clone_field
                     }
                 }
             }
@@ -425,6 +546,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         .extensions
                         .get::<::autumn_web::idempotency::IdempotencyContext>()
                         .cloned(),
+                    #tenant_init_field
                 })
             }
         } else {
@@ -432,6 +554,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 Ok(#pg_name {
                     pool,
                     hooks: <#hooks_ident as ::autumn_web::hooks::RepositoryHooksDefault>::autumn_default(),
+                    #tenant_init_field
                 })
             }
         };
@@ -537,422 +660,922 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         };
 
         // ── save (hooked) ─────────────────────────────────
-        let save_body = if commit_hooks_enabled {
-            quote! {
-                use ::autumn_web::reexports::diesel::prelude::*;
-                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                use ::autumn_web::reexports::diesel_async::AsyncConnection;
-                use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
-                use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
+        // ── save (hooked) ─────────────────────────────────
+        let save_body = if config.tenant_scoped {
+            if commit_hooks_enabled {
+                quote! {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                    use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+                    use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
 
-            Self::__autumn_register_repository_commit_hooks();
-            let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-            let (record, mut ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record) = conn
-                .transaction::<(#model_name, MutationContext, ::std::string::String, ::std::string::String, ::autumn_web::reexports::serde_json::Value), ::autumn_web::AutumnError, _>(|conn| {
-                    async move {
-                        let mut input = new.clone();
-                        let mut ctx = MutationContext::new(MutationOp::Create);
-                        let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
-                            ::core::option::Option::None;
-                        if let ::core::option::Option::Some(__autumn_idempotency) = &self.idempotency {
-                            ctx.set_idempotency_key(__autumn_idempotency.scoped_key());
-                            __autumn_commit_hook_discriminator =
-                                ::core::option::Option::Some(__autumn_idempotency.next_mutation_discriminator());
-                        }
+                    let tenant_id = if self.across_tenants {
+                        ::core::option::Option::None
+                    } else {
+                        let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                            .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                        ::core::option::Option::Some(t)
+                    };
+                    Self::__autumn_register_repository_commit_hooks();
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let (record, mut ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record) = conn
+                        .transaction::<(#model_name, MutationContext, ::std::string::String, ::std::string::String, ::autumn_web::reexports::serde_json::Value), ::autumn_web::AutumnError, _>(|conn| {
+                            async move {
+                                let mut input = new.clone();
+                                let mut ctx = MutationContext::new(MutationOp::Create);
+                                let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
+                                    ::core::option::Option::None;
+                                if let ::core::option::Option::Some(__autumn_idempotency) = &self.idempotency {
+                                    ctx.set_idempotency_key(__autumn_idempotency.scoped_key());
+                                    __autumn_commit_hook_discriminator =
+                                        ::core::option::Option::Some(__autumn_idempotency.next_mutation_discriminator());
+                                }
 
-                        // before_create can validate/reject/rewrite
-                        self.hooks.before_create(&mut ctx, &mut input).await?;
+                                // before_create can validate/reject/rewrite
+                                self.hooks.before_create(&mut ctx, &mut input).await?;
 
-                        let record = ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                            .values(&input)
-                            .get_result::<#model_name>(conn)
-                            .await
-                            .map_err(::autumn_web::AutumnError::from)?;
-
-                        let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
-                        let (__autumn_commit_hook_id, __autumn_commit_hook_owner) = ::autumn_web::__private::enqueue_repository_commit_hook_pending_on_conn(
-                            conn,
-                            Self::__autumn_repository_commit_hook_key(),
-                            "create",
-                            ctx.idempotency_key.as_deref(),
-                            __autumn_commit_hook_discriminator.as_deref(),
-                            &ctx,
-                            &__autumn_commit_hook_record,
-                        )
-                        .await?;
-
-                        Ok((record, ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record))
-                    }
-                    .scope_boxed()
-                })
-                .await?;
-            ::core::mem::drop(conn);
-            let __autumn_pending_heartbeat =
-                ::autumn_web::__private::start_repository_commit_hook_pending_finalizer_heartbeat(
-                    self.pool.clone(),
-                    __autumn_commit_hook_id.clone(),
-                    __autumn_commit_hook_owner.clone(),
-                );
-            let __autumn_after_create = ::autumn_web::__private::catch_repository_after_hook_unwind(
-                self.hooks.after_create(&mut ctx, &record)
-            )
-            .await;
-            match __autumn_after_create {
-                ::core::result::Result::Ok(::core::result::Result::Ok(())) => {}
-                ::core::result::Result::Ok(::core::result::Result::Err(__autumn_error)) => {
-                    let __autumn_error_message = ::std::format!("{__autumn_error}");
-                    ::autumn_web::__private::mark_repository_commit_hook_after_hook_failed(
-                        &self.pool,
-                        &__autumn_commit_hook_id,
-                        &__autumn_commit_hook_owner,
-                        __autumn_error_message,
-                    )
-                    .await;
-                    __autumn_pending_heartbeat.cancel();
-                    return ::core::result::Result::Err(
-                        ::autumn_web::idempotency::__cache_committed_error_response(__autumn_error)
-                    );
-                }
-                ::core::result::Result::Err(__autumn_panic) => {
-                    ::autumn_web::__private::mark_repository_commit_hook_after_hook_failed(
-                        &self.pool,
-                        &__autumn_commit_hook_id,
-                        &__autumn_commit_hook_owner,
-                        "after_create panicked",
-                    )
-                    .await;
-                    __autumn_pending_heartbeat.cancel();
-                    if self.idempotency.is_some() {
-                        return ::core::result::Result::Err(
-                            ::autumn_web::idempotency::__cache_committed_error_response(
-                                ::autumn_web::AutumnError::internal_server_error_msg("after_create panicked")
-                            )
-                        );
-                    }
-                    ::std::panic::resume_unwind(__autumn_panic);
-                }
-            }
-            let __autumn_finalize_result = ::autumn_web::__private::finalize_repository_commit_hook_after_hook(
-                &self.pool,
-                &__autumn_commit_hook_id,
-                &__autumn_commit_hook_owner,
-                &ctx,
-                &__autumn_commit_hook_record,
-            )
-            .await;
-            __autumn_pending_heartbeat.cancel();
-            match __autumn_finalize_result {
-                ::core::result::Result::Ok(()) => {
-                    ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
-                }
-                ::core::result::Result::Err(__autumn_error) => {
-                    ::autumn_web::reexports::tracing::warn!(
-                        hook_id = %__autumn_commit_hook_id,
-                        error = %__autumn_error,
-                        "failed to finalize repository create commit hook after mutation commit; failing request closed"
-                    );
-                    return ::core::result::Result::Err(
-                        ::autumn_web::idempotency::__cache_committed_error_response(__autumn_error)
-                    );
-                }
-            }
-
-                Ok(record)
-            }
-        } else {
-            quote! {
-                use ::autumn_web::reexports::diesel::prelude::*;
-                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                use ::autumn_web::reexports::diesel_async::AsyncConnection;
-                use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
-                use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
-
-                let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                let (record, mut ctx) = conn
-                    .transaction::<(#model_name, MutationContext), ::autumn_web::AutumnError, _>(|conn| {
-                        async move {
-                            let mut input = new.clone();
-                            let mut ctx = MutationContext::new(MutationOp::Create);
-
-                            self.hooks.before_create(&mut ctx, &mut input).await?;
-
-                            let record = ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                                .values(&input)
-                                .get_result::<#model_name>(conn)
-                                .await
+                                let record = if let ::core::option::Option::Some(ref t) = tenant_id {
+                                    ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                        .values((&input, #table_ident::tenant_id.eq(t)))
+                                        .get_result::<#model_name>(conn)
+                                        .await
+                                } else {
+                                    ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                        .values(&input)
+                                        .get_result::<#model_name>(conn)
+                                        .await
+                                }
                                 .map_err(::autumn_web::AutumnError::from)?;
 
-                            Ok((record, ctx))
-                        }
-                        .scope_boxed()
-                    })
-                    .await?;
-                ::core::mem::drop(conn);
-                self.hooks.after_create(&mut ctx, &record).await?;
+                                let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
+                                let (__autumn_commit_hook_id, __autumn_commit_hook_owner) = ::autumn_web::__private::enqueue_repository_commit_hook_pending_on_conn(
+                                    conn,
+                                    Self::__autumn_repository_commit_hook_key(),
+                                    "create",
+                                    ctx.idempotency_key.as_deref(),
+                                    __autumn_commit_hook_discriminator.as_deref(),
+                                    &ctx,
+                                    &__autumn_commit_hook_record,
+                                )
+                                .await?;
 
-                Ok(record)
+                                Ok((record, ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record))
+                            }
+                            .scope_boxed()
+                        })
+                        .await?;
+                    ::core::mem::drop(conn);
+                    let __autumn_pending_heartbeat =
+                        ::autumn_web::__private::start_repository_commit_hook_pending_finalizer_heartbeat(
+                            self.pool.clone(),
+                            __autumn_commit_hook_id.clone(),
+                            __autumn_commit_hook_owner.clone(),
+                        );
+                    let __autumn_after_create = ::autumn_web::__private::catch_repository_after_hook_unwind(
+                        self.hooks.after_create(&mut ctx, &record)
+                    )
+                    .await;
+                    match __autumn_after_create {
+                        ::core::result::Result::Ok(::core::result::Result::Ok(())) => {}
+                        ::core::result::Result::Ok(::core::result::Result::Err(__autumn_error)) => {
+                            let __autumn_error_message = ::std::format!("{__autumn_error}");
+                            ::autumn_web::__private::mark_repository_commit_hook_after_hook_failed(
+                                &self.pool,
+                                &__autumn_commit_hook_id,
+                                &__autumn_commit_hook_owner,
+                                __autumn_error_message,
+                            )
+                            .await;
+                            __autumn_pending_heartbeat.cancel();
+                            return ::core::result::Result::Err(
+                                ::autumn_web::idempotency::__cache_committed_error_response(__autumn_error)
+                            );
+                        }
+                        ::core::result::Result::Err(__autumn_panic) => {
+                            ::autumn_web::__private::mark_repository_commit_hook_after_hook_failed(
+                                &self.pool,
+                                &__autumn_commit_hook_id,
+                                &__autumn_commit_hook_owner,
+                                "after_create panicked",
+                            )
+                            .await;
+                            __autumn_pending_heartbeat.cancel();
+                            if self.idempotency.is_some() {
+                                return ::core::result::Result::Err(
+                                    ::autumn_web::idempotency::__cache_committed_error_response(
+                                        ::autumn_web::AutumnError::internal_server_error_msg("after_create panicked")
+                                    )
+                                );
+                            }
+                            ::std::panic::resume_unwind(__autumn_panic);
+                        }
+                    }
+                    let __autumn_finalize_result = ::autumn_web::__private::finalize_repository_commit_hook_after_hook(
+                        &self.pool,
+                        &__autumn_commit_hook_id,
+                        &__autumn_commit_hook_owner,
+                        &ctx,
+                        &__autumn_commit_hook_record,
+                    )
+                    .await;
+                    __autumn_pending_heartbeat.cancel();
+                    match __autumn_finalize_result {
+                        ::core::result::Result::Ok(()) => {
+                            ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
+                        }
+                        ::core::result::Result::Err(__autumn_error) => {
+                            ::autumn_web::reexports::tracing::warn!(
+                                hook_id = %__autumn_commit_hook_id,
+                                error = %__autumn_error,
+                                "failed to finalize repository create commit hook after mutation commit; failing request closed"
+                            );
+                            return ::core::result::Result::Err(
+                                ::autumn_web::idempotency::__cache_committed_error_response(__autumn_error)
+                            );
+                        }
+                    }
+
+                    Ok(record)
+                }
+            } else {
+                quote! {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                    use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+                    use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
+
+                    let tenant_id = if self.across_tenants {
+                        ::core::option::Option::None
+                    } else {
+                        let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                            .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                        ::core::option::Option::Some(t)
+                    };
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let (record, mut ctx) = conn
+                        .transaction::<(#model_name, MutationContext), ::autumn_web::AutumnError, _>(|conn| {
+                            async move {
+                                let mut input = new.clone();
+                                let mut ctx = MutationContext::new(MutationOp::Create);
+
+                                self.hooks.before_create(&mut ctx, &mut input).await?;
+
+                                let record = if let ::core::option::Option::Some(ref t) = tenant_id {
+                                    ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                        .values((&input, #table_ident::tenant_id.eq(t)))
+                                        .get_result::<#model_name>(conn)
+                                        .await
+                                } else {
+                                    ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                        .values(&input)
+                                        .get_result::<#model_name>(conn)
+                                        .await
+                                }
+                                .map_err(::autumn_web::AutumnError::from)?;
+
+                                Ok((record, ctx))
+                            }
+                            .scope_boxed()
+                        })
+                        .await?;
+                    ::core::mem::drop(conn);
+                    self.hooks.after_create(&mut ctx, &record).await?;
+
+                    Ok(record)
+                }
+            }
+        } else {
+            if commit_hooks_enabled {
+                quote! {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                    use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+                    use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
+
+                    Self::__autumn_register_repository_commit_hooks();
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let (record, mut ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record) = conn
+                        .transaction::<(#model_name, MutationContext, ::std::string::String, ::std::string::String, ::autumn_web::reexports::serde_json::Value), ::autumn_web::AutumnError, _>(|conn| {
+                            async move {
+                                let mut input = new.clone();
+                                let mut ctx = MutationContext::new(MutationOp::Create);
+                                let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
+                                    ::core::option::Option::None;
+                                if let ::core::option::Option::Some(__autumn_idempotency) = &self.idempotency {
+                                    ctx.set_idempotency_key(__autumn_idempotency.scoped_key());
+                                    __autumn_commit_hook_discriminator =
+                                        ::core::option::Option::Some(__autumn_idempotency.next_mutation_discriminator());
+                                }
+
+                                // before_create can validate/reject/rewrite
+                                self.hooks.before_create(&mut ctx, &mut input).await?;
+
+                                let record = ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(&input)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                                    .map_err(::autumn_web::AutumnError::from)?;
+
+                                let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
+                                let (__autumn_commit_hook_id, __autumn_commit_hook_owner) = ::autumn_web::__private::enqueue_repository_commit_hook_pending_on_conn(
+                                    conn,
+                                    Self::__autumn_repository_commit_hook_key(),
+                                    "create",
+                                    ctx.idempotency_key.as_deref(),
+                                    __autumn_commit_hook_discriminator.as_deref(),
+                                    &ctx,
+                                    &__autumn_commit_hook_record,
+                                )
+                                .await?;
+
+                                Ok((record, ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record))
+                            }
+                            .scope_boxed()
+                        })
+                        .await?;
+                    ::core::mem::drop(conn);
+                    let __autumn_pending_heartbeat =
+                        ::autumn_web::__private::start_repository_commit_hook_pending_finalizer_heartbeat(
+                            self.pool.clone(),
+                            __autumn_commit_hook_id.clone(),
+                            __autumn_commit_hook_owner.clone(),
+                        );
+                    let __autumn_after_create = ::autumn_web::__private::catch_repository_after_hook_unwind(
+                        self.hooks.after_create(&mut ctx, &record)
+                    )
+                    .await;
+                    match __autumn_after_create {
+                        ::core::result::Result::Ok(::core::result::Result::Ok(())) => {}
+                        ::core::result::Result::Ok(::core::result::Result::Err(__autumn_error)) => {
+                            let __autumn_error_message = ::std::format!("{__autumn_error}");
+                            ::autumn_web::__private::mark_repository_commit_hook_after_hook_failed(
+                                &self.pool,
+                                &__autumn_commit_hook_id,
+                                &__autumn_commit_hook_owner,
+                                __autumn_error_message,
+                            )
+                            .await;
+                            __autumn_pending_heartbeat.cancel();
+                            return ::core::result::Result::Err(
+                                ::autumn_web::idempotency::__cache_committed_error_response(__autumn_error)
+                            );
+                        }
+                        ::core::result::Result::Err(__autumn_panic) => {
+                            ::autumn_web::__private::mark_repository_commit_hook_after_hook_failed(
+                                &self.pool,
+                                &__autumn_commit_hook_id,
+                                &__autumn_commit_hook_owner,
+                                "after_create panicked",
+                            )
+                            .await;
+                            __autumn_pending_heartbeat.cancel();
+                            if self.idempotency.is_some() {
+                                return ::core::result::Result::Err(
+                                    ::autumn_web::idempotency::__cache_committed_error_response(
+                                        ::autumn_web::AutumnError::internal_server_error_msg("after_create panicked")
+                                    )
+                                );
+                            }
+                            ::std::panic::resume_unwind(__autumn_panic);
+                        }
+                    }
+                    let __autumn_finalize_result = ::autumn_web::__private::finalize_repository_commit_hook_after_hook(
+                        &self.pool,
+                        &__autumn_commit_hook_id,
+                        &__autumn_commit_hook_owner,
+                        &ctx,
+                        &__autumn_commit_hook_record,
+                    )
+                    .await;
+                    __autumn_pending_heartbeat.cancel();
+                    match __autumn_finalize_result {
+                        ::core::result::Result::Ok(()) => {
+                            ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
+                        }
+                        ::core::result::Result::Err(__autumn_error) => {
+                            ::autumn_web::reexports::tracing::warn!(
+                                hook_id = %__autumn_commit_hook_id,
+                                error = %__autumn_error,
+                                "failed to finalize repository create commit hook after mutation commit; failing request closed"
+                            );
+                            return ::core::result::Result::Err(
+                                ::autumn_web::idempotency::__cache_committed_error_response(__autumn_error)
+                            );
+                        }
+                    }
+
+                    Ok(record)
+                }
+            } else {
+                quote! {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                    use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+                    use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
+
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let (record, mut ctx) = conn
+                        .transaction::<(#model_name, MutationContext), ::autumn_web::AutumnError, _>(|conn| {
+                            async move {
+                                let mut input = new.clone();
+                                let mut ctx = MutationContext::new(MutationOp::Create);
+
+                                self.hooks.before_create(&mut ctx, &mut input).await?;
+
+                                let record = ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(&input)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                                    .map_err(::autumn_web::AutumnError::from)?;
+
+                                Ok((record, ctx))
+                            }
+                            .scope_boxed()
+                        })
+                        .await?;
+                    ::core::mem::drop(conn);
+                    self.hooks.after_create(&mut ctx, &record).await?;
+
+                    Ok(record)
+                }
             }
         };
 
         // ── update (hooked) ───────────────────────────────
         let draft_ext_trait = format_ident!("{}DraftExt", model_name);
-        let update_body = if commit_hooks_enabled {
-            quote! {
-            use ::autumn_web::reexports::diesel::prelude::*;
-            use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-            use ::autumn_web::reexports::diesel_async::AsyncConnection;
-            use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
-            use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks, UpdateDraft};
-            use ::autumn_web::repository::{AutumnLockVersionModelExt as _, AutumnLockVersionUpdateExt as _};
+        let update_body = if config.tenant_scoped {
+            if commit_hooks_enabled {
+                quote! {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                    use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+                    use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks, UpdateDraft};
+                    use ::autumn_web::repository::{AutumnLockVersionModelExt as _, AutumnLockVersionUpdateExt as _};
 
-            Self::__autumn_register_repository_commit_hooks();
-            let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-            let (record, mut ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record) = conn
-                .transaction::<(#model_name, MutationContext, ::std::string::String, ::std::string::String, ::autumn_web::reexports::serde_json::Value), ::autumn_web::AutumnError, _>(|conn| {
-                    async move {
-                        let mut ctx = MutationContext::new(MutationOp::Update);
-                        let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
-                            ::core::option::Option::None;
-                        if let ::core::option::Option::Some(__autumn_idempotency) = &self.idempotency {
-                            ctx.set_idempotency_key(__autumn_idempotency.scoped_key());
-                            __autumn_commit_hook_discriminator =
-                                ::core::option::Option::Some(__autumn_idempotency.next_mutation_discriminator());
-                        }
-                        let record: #model_name = if let ::core::option::Option::Some(expected_version) =
-                            changes.__autumn_lock_version_expected()
-                        {
-                            // SELECT FOR UPDATE grabs an exclusive row lock so
-                            // no concurrent writer can commit between our
-                            // version check and the UPDATE below.
-                            let current = #table_ident::table
-                                .find(id)
-                                .for_update()
-                                .first::<#model_name>(conn)
-                                .await
-                                .optional()
-                                .map_err(::autumn_web::AutumnError::from)?
-                                .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
-                                    format!("{} with id {} not found", stringify!(#model_name), id)
-                                ))?;
+                    let tenant_id = if self.across_tenants {
+                        ::core::option::Option::None
+                    } else {
+                        let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                            .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                        ::core::option::Option::Some(t)
+                    };
 
-                            if let ::core::option::Option::Some(actual_version) =
-                                current.__autumn_lock_version_actual()
-                            {
-                                if actual_version != expected_version {
-                                    return Err(::autumn_web::AutumnError::conflict(
-                                        ::autumn_web::RepositoryError::Conflict {
-                                            id,
-                                            expected_version,
-                                            actual_version: ::core::option::Option::Some(actual_version),
-                                        },
-                                    ));
+                    Self::__autumn_register_repository_commit_hooks();
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let (record, mut ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record) = conn
+                        .transaction::<(#model_name, MutationContext, ::std::string::String, ::std::string::String, ::autumn_web::reexports::serde_json::Value), ::autumn_web::AutumnError, _>(|conn| {
+                            async move {
+                                let mut ctx = MutationContext::new(MutationOp::Update);
+                                let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
+                                    ::core::option::Option::None;
+                                if let ::core::option::Option::Some(__autumn_idempotency) = &self.idempotency {
+                                    ctx.set_idempotency_key(__autumn_idempotency.scoped_key());
+                                    __autumn_commit_hook_discriminator =
+                                        ::core::option::Option::Some(__autumn_idempotency.next_mutation_discriminator());
                                 }
+                                let record: #model_name = if let ::core::option::Option::Some(expected_version) =
+                                    changes.__autumn_lock_version_expected()
+                                {
+                                    let load_query = #table_ident::table.find(id);
+                                    let current = if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                                    } else {
+                                        load_query.for_update().first::<#model_name>(conn).await
+                                    }
+                                    .optional()
+                                    .map_err(::autumn_web::AutumnError::from)?
+                                    .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                                        format!("{} with id {} not found", stringify!(#model_name), id)
+                                    ))?;
+
+                                    if let ::core::option::Option::Some(actual_version) =
+                                        current.__autumn_lock_version_actual()
+                                    {
+                                        if actual_version != expected_version {
+                                            return Err(::autumn_web::AutumnError::conflict(
+                                                ::autumn_web::RepositoryError::Conflict {
+                                                    id,
+                                                    expected_version,
+                                                    actual_version: ::core::option::Option::Some(actual_version),
+                                                },
+                                            ));
+                                        }
+                                    }
+
+                                    let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
+                                    self.hooks.before_update(&mut ctx, &mut draft).await?;
+
+                                    let proposed = draft.into_after();
+                                    let update_target = #table_ident::table.find(id);
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        ::autumn_web::reexports::diesel::update(update_target.filter(#table_ident::tenant_id.eq(t)))
+                                            .set(&proposed)
+                                            .get_result::<#model_name>(conn)
+                                            .await
+                                    } else {
+                                        ::autumn_web::reexports::diesel::update(update_target)
+                                            .set(&proposed)
+                                            .get_result::<#model_name>(conn)
+                                            .await
+                                    }
+                                    .map_err(::autumn_web::AutumnError::from)?
+                                } else {
+                                    let load_query = #table_ident::table.find(id);
+                                    let current = if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        load_query.filter(#table_ident::tenant_id.eq(t)).first::<#model_name>(conn).await
+                                    } else {
+                                        load_query.first::<#model_name>(conn).await
+                                    }
+                                    .optional()
+                                    .map_err(::autumn_web::AutumnError::from)?
+                                    .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                                        format!("{} with id {} not found", stringify!(#model_name), id)
+                                    ))?;
+
+                                    let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
+                                    self.hooks.before_update(&mut ctx, &mut draft).await?;
+
+                                    let proposed = draft.into_after();
+                                    let update_target = #table_ident::table.find(id);
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        ::autumn_web::reexports::diesel::update(update_target.filter(#table_ident::tenant_id.eq(t)))
+                                            .set(&proposed)
+                                            .get_result::<#model_name>(conn)
+                                            .await
+                                    } else {
+                                        ::autumn_web::reexports::diesel::update(update_target)
+                                            .set(&proposed)
+                                            .get_result::<#model_name>(conn)
+                                            .await
+                                    }
+                                    .map_err(::autumn_web::AutumnError::from)?
+                                };
+
+                                let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
+                                let (__autumn_commit_hook_id, __autumn_commit_hook_owner) = ::autumn_web::__private::enqueue_repository_commit_hook_pending_on_conn(
+                                    conn,
+                                    Self::__autumn_repository_commit_hook_key(),
+                                    "update",
+                                    ctx.idempotency_key.as_deref(),
+                                    __autumn_commit_hook_discriminator.as_deref(),
+                                    &ctx,
+                                    &__autumn_commit_hook_record,
+                                )
+                                .await?;
+
+                                Ok((record, ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record))
                             }
-
-                            let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
-                            self.hooks.before_update(&mut ctx, &mut draft).await?;
-
-                            let proposed = draft.into_after();
-                            ::autumn_web::reexports::diesel::update(#table_ident::table.find(id))
-                                .set(&proposed)
-                                .get_result::<#model_name>(conn)
-                                .await
-                                .map_err(::autumn_web::AutumnError::from)?
-                        } else {
-                            // Load current record
-                            let current = #table_ident::table
-                                .find(id)
-                                .first::<#model_name>(conn)
-                                .await
-                                .optional()
-                                .map_err(::autumn_web::AutumnError::from)?
-                                .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
-                                    format!("{} with id {} not found", stringify!(#model_name), id)
-                                ))?;
-
-                            let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
-                            self.hooks.before_update(&mut ctx, &mut draft).await?;
-
-                            let proposed = draft.into_after();
-                            ::autumn_web::reexports::diesel::update(#table_ident::table.find(id))
-                                .set(&proposed)
-                            .get_result::<#model_name>(conn)
-                            .await
-                            .map_err(::autumn_web::AutumnError::from)?
-                        };
-
-                        let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
-                        let (__autumn_commit_hook_id, __autumn_commit_hook_owner) = ::autumn_web::__private::enqueue_repository_commit_hook_pending_on_conn(
-                            conn,
-                            Self::__autumn_repository_commit_hook_key(),
-                            "update",
-                            ctx.idempotency_key.as_deref(),
-                            __autumn_commit_hook_discriminator.as_deref(),
-                            &ctx,
-                            &__autumn_commit_hook_record,
-                        )
+                            .scope_boxed()
+                        })
                         .await?;
-
-                        Ok((record, ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record))
-                    }
-                    .scope_boxed()
-                })
-                .await?;
-            ::core::mem::drop(conn);
-            let __autumn_pending_heartbeat =
-                ::autumn_web::__private::start_repository_commit_hook_pending_finalizer_heartbeat(
-                    self.pool.clone(),
-                    __autumn_commit_hook_id.clone(),
-                    __autumn_commit_hook_owner.clone(),
-                );
-            let __autumn_after_update = ::autumn_web::__private::catch_repository_after_hook_unwind(
-                self.hooks.after_update(&mut ctx, &record)
-            )
-            .await;
-            match __autumn_after_update {
-                ::core::result::Result::Ok(::core::result::Result::Ok(())) => {}
-                ::core::result::Result::Ok(::core::result::Result::Err(__autumn_error)) => {
-                    let __autumn_error_message = ::std::format!("{__autumn_error}");
-                    ::autumn_web::__private::mark_repository_commit_hook_after_hook_failed(
-                        &self.pool,
-                        &__autumn_commit_hook_id,
-                        &__autumn_commit_hook_owner,
-                        __autumn_error_message,
-                    )
-                    .await;
-                    __autumn_pending_heartbeat.cancel();
-                    return ::core::result::Result::Err(
-                        ::autumn_web::idempotency::__cache_committed_error_response(__autumn_error)
-                    );
-                }
-                ::core::result::Result::Err(__autumn_panic) => {
-                    ::autumn_web::__private::mark_repository_commit_hook_after_hook_failed(
-                        &self.pool,
-                        &__autumn_commit_hook_id,
-                        &__autumn_commit_hook_owner,
-                        "after_update panicked",
-                    )
-                    .await;
-                    __autumn_pending_heartbeat.cancel();
-                    if self.idempotency.is_some() {
-                        return ::core::result::Result::Err(
-                            ::autumn_web::idempotency::__cache_committed_error_response(
-                                ::autumn_web::AutumnError::internal_server_error_msg("after_update panicked")
-                            )
+                    ::core::mem::drop(conn);
+                    let __autumn_pending_heartbeat =
+                        ::autumn_web::__private::start_repository_commit_hook_pending_finalizer_heartbeat(
+                            self.pool.clone(),
+                            __autumn_commit_hook_id.clone(),
+                            __autumn_commit_hook_owner.clone(),
                         );
+                    let __autumn_after_update = ::autumn_web::__private::catch_repository_after_hook_unwind(
+                        self.hooks.after_update(&mut ctx, &record)
+                    )
+                    .await;
+                    match __autumn_after_update {
+                        ::core::result::Result::Ok(::core::result::Result::Ok(())) => {}
+                        ::core::result::Result::Ok(::core::result::Result::Err(__autumn_error)) => {
+                            let __autumn_error_message = ::std::format!("{__autumn_error}");
+                            ::autumn_web::__private::mark_repository_commit_hook_after_hook_failed(
+                                &self.pool,
+                                &__autumn_commit_hook_id,
+                                &__autumn_commit_hook_owner,
+                                __autumn_error_message,
+                            )
+                            .await;
+                            __autumn_pending_heartbeat.cancel();
+                            return ::core::result::Result::Err(
+                                ::autumn_web::idempotency::__cache_committed_error_response(__autumn_error)
+                            );
+                        }
+                        ::core::result::Result::Err(__autumn_panic) => {
+                            ::autumn_web::__private::mark_repository_commit_hook_after_hook_failed(
+                                &self.pool,
+                                &__autumn_commit_hook_id,
+                                &__autumn_commit_hook_owner,
+                                "after_update panicked",
+                            )
+                            .await;
+                            __autumn_pending_heartbeat.cancel();
+                            if self.idempotency.is_some() {
+                                return ::core::result::Result::Err(
+                                    ::autumn_web::idempotency::__cache_committed_error_response(
+                                        ::autumn_web::AutumnError::internal_server_error_msg("after_update panicked")
+                                    )
+                                );
+                            }
+                            ::std::panic::resume_unwind(__autumn_panic);
+                        }
                     }
-                    ::std::panic::resume_unwind(__autumn_panic);
-                }
-            }
-            let __autumn_finalize_result = ::autumn_web::__private::finalize_repository_commit_hook_after_hook(
-                &self.pool,
-                &__autumn_commit_hook_id,
-                &__autumn_commit_hook_owner,
-                &ctx,
-                &__autumn_commit_hook_record,
-            )
-            .await;
-            __autumn_pending_heartbeat.cancel();
-            match __autumn_finalize_result {
-                ::core::result::Result::Ok(()) => {
-                    ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
-                }
-                ::core::result::Result::Err(__autumn_error) => {
-                    ::autumn_web::reexports::tracing::warn!(
-                        hook_id = %__autumn_commit_hook_id,
-                        error = %__autumn_error,
-                        "failed to finalize repository update commit hook after mutation commit; failing request closed"
-                    );
-                    return ::core::result::Result::Err(
-                        ::autumn_web::idempotency::__cache_committed_error_response(__autumn_error)
-                    );
-                }
-            }
+                    let __autumn_finalize_result = ::autumn_web::__private::finalize_repository_commit_hook_after_hook(
+                        &self.pool,
+                        &__autumn_commit_hook_id,
+                        &__autumn_commit_hook_owner,
+                        &ctx,
+                        &__autumn_commit_hook_record,
+                    )
+                    .await;
+                    __autumn_pending_heartbeat.cancel();
+                    match __autumn_finalize_result {
+                        ::core::result::Result::Ok(()) => {
+                            ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
+                        }
+                        ::core::result::Result::Err(__autumn_error) => {
+                            ::autumn_web::reexports::tracing::warn!(
+                                hook_id = %__autumn_commit_hook_id,
+                                error = %__autumn_error,
+                                "failed to finalize repository update commit hook after mutation commit; failing request closed"
+                            );
+                            return ::core::result::Result::Err(
+                                ::autumn_web::idempotency::__cache_committed_error_response(__autumn_error)
+                            );
+                        }
+                    }
 
-                Ok(record)
+                    Ok(record)
+                }
+            } else {
+                quote! {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                    use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+                    use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks, UpdateDraft};
+                    use ::autumn_web::repository::{AutumnLockVersionModelExt as _, AutumnLockVersionUpdateExt as _};
+
+                    let tenant_id = if self.across_tenants {
+                        ::core::option::Option::None
+                    } else {
+                        let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                            .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                        ::core::option::Option::Some(t)
+                    };
+
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let (record, mut ctx) = conn
+                        .transaction::<(#model_name, MutationContext), ::autumn_web::AutumnError, _>(|conn| {
+                            async move {
+                                let mut ctx = MutationContext::new(MutationOp::Update);
+                                let record: #model_name = if let ::core::option::Option::Some(expected_version) =
+                                    changes.__autumn_lock_version_expected()
+                                {
+                                    let load_query = #table_ident::table.find(id);
+                                    let current = if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                                    } else {
+                                        load_query.for_update().first::<#model_name>(conn).await
+                                    }
+                                    .optional()
+                                    .map_err(::autumn_web::AutumnError::from)?
+                                    .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                                        format!("{} with id {} not found", stringify!(#model_name), id)
+                                    ))?;
+
+                                    if let ::core::option::Option::Some(actual_version) =
+                                        current.__autumn_lock_version_actual()
+                                    {
+                                        if actual_version != expected_version {
+                                            return Err(::autumn_web::AutumnError::conflict(
+                                                ::autumn_web::RepositoryError::Conflict {
+                                                    id,
+                                                    expected_version,
+                                                    actual_version: ::core::option::Option::Some(actual_version),
+                                                },
+                                            ));
+                                        }
+                                    }
+
+                                    let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
+                                    self.hooks.before_update(&mut ctx, &mut draft).await?;
+
+                                    let proposed = draft.into_after();
+                                    let update_target = #table_ident::table.find(id);
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        ::autumn_web::reexports::diesel::update(update_target.filter(#table_ident::tenant_id.eq(t)))
+                                            .set(&proposed)
+                                            .get_result::<#model_name>(conn)
+                                            .await
+                                    } else {
+                                        ::autumn_web::reexports::diesel::update(update_target)
+                                            .set(&proposed)
+                                            .get_result::<#model_name>(conn)
+                                            .await
+                                    }
+                                    .map_err(::autumn_web::AutumnError::from)?
+                                } else {
+                                    let load_query = #table_ident::table.find(id);
+                                    let current = if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        load_query.filter(#table_ident::tenant_id.eq(t)).first::<#model_name>(conn).await
+                                    } else {
+                                        load_query.first::<#model_name>(conn).await
+                                    }
+                                    .optional()
+                                    .map_err(::autumn_web::AutumnError::from)?
+                                    .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                                        format!("{} with id {} not found", stringify!(#model_name), id)
+                                    ))?;
+
+                                    let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
+                                    self.hooks.before_update(&mut ctx, &mut draft).await?;
+
+                                    let proposed = draft.into_after();
+                                    let update_target = #table_ident::table.find(id);
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        ::autumn_web::reexports::diesel::update(update_target.filter(#table_ident::tenant_id.eq(t)))
+                                            .set(&proposed)
+                                            .get_result::<#model_name>(conn)
+                                            .await
+                                    } else {
+                                        ::autumn_web::reexports::diesel::update(update_target)
+                                            .set(&proposed)
+                                            .get_result::<#model_name>(conn)
+                                            .await
+                                    }
+                                    .map_err(::autumn_web::AutumnError::from)?
+                                };
+
+                                Ok((record, ctx))
+                            }
+                            .scope_boxed()
+                        })
+                        .await?;
+                    ::core::mem::drop(conn);
+                    self.hooks.after_update(&mut ctx, &record).await?;
+
+                    Ok(record)
+                }
             }
         } else {
-            quote! {
-                use ::autumn_web::reexports::diesel::prelude::*;
-                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                use ::autumn_web::reexports::diesel_async::AsyncConnection;
-                use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
-                use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks, UpdateDraft};
-                use ::autumn_web::repository::{AutumnLockVersionModelExt as _, AutumnLockVersionUpdateExt as _};
+            if commit_hooks_enabled {
+                quote! {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                    use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+                    use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks, UpdateDraft};
+                    use ::autumn_web::repository::{AutumnLockVersionModelExt as _, AutumnLockVersionUpdateExt as _};
 
-                let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                let (record, mut ctx) = conn
-                    .transaction::<(#model_name, MutationContext), ::autumn_web::AutumnError, _>(|conn| {
-                        async move {
-                            let mut ctx = MutationContext::new(MutationOp::Update);
-                            let record: #model_name = if let ::core::option::Option::Some(expected_version) =
-                                changes.__autumn_lock_version_expected()
-                            {
-                                let current = #table_ident::table
-                                    .find(id)
-                                    .for_update()
-                                    .first::<#model_name>(conn)
-                                    .await
-                                    .optional()
-                                    .map_err(::autumn_web::AutumnError::from)?
-                                    .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
-                                        format!("{} with id {} not found", stringify!(#model_name), id)
-                                    ))?;
-
-                                if let ::core::option::Option::Some(actual_version) =
-                                    current.__autumn_lock_version_actual()
-                                {
-                                    if actual_version != expected_version {
-                                        return Err(::autumn_web::AutumnError::conflict(
-                                            ::autumn_web::RepositoryError::Conflict {
-                                                id,
-                                                expected_version,
-                                                actual_version: ::core::option::Option::Some(actual_version),
-                                            },
-                                        ));
-                                    }
+                    Self::__autumn_register_repository_commit_hooks();
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let (record, mut ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record) = conn
+                        .transaction::<(#model_name, MutationContext, ::std::string::String, ::std::string::String, ::autumn_web::reexports::serde_json::Value), ::autumn_web::AutumnError, _>(|conn| {
+                            async move {
+                                let mut ctx = MutationContext::new(MutationOp::Update);
+                                let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
+                                    ::core::option::Option::None;
+                                if let ::core::option::Option::Some(__autumn_idempotency) = &self.idempotency {
+                                    ctx.set_idempotency_key(__autumn_idempotency.scoped_key());
+                                    __autumn_commit_hook_discriminator =
+                                        ::core::option::Option::Some(__autumn_idempotency.next_mutation_discriminator());
                                 }
+                                let record: #model_name = if let ::core::option::Option::Some(expected_version) =
+                                    changes.__autumn_lock_version_expected()
+                                {
+                                    // SELECT FOR UPDATE grabs an exclusive row lock so
+                                    // no concurrent writer can commit between our
+                                    // version check and the UPDATE below.
+                                    let current = #table_ident::table
+                                        .find(id)
+                                        .for_update()
+                                        .first::<#model_name>(conn)
+                                        .await
+                                        .optional()
+                                        .map_err(::autumn_web::AutumnError::from)?
+                                        .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                                            format!("{} with id {} not found", stringify!(#model_name), id)
+                                        ))?;
 
-                                let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
-                                self.hooks.before_update(&mut ctx, &mut draft).await?;
+                                    if let ::core::option::Option::Some(actual_version) =
+                                        current.__autumn_lock_version_actual()
+                                    {
+                                        if actual_version != expected_version {
+                                            return Err(::autumn_web::AutumnError::conflict(
+                                                ::autumn_web::RepositoryError::Conflict {
+                                                    id,
+                                                    expected_version,
+                                                    actual_version: ::core::option::Option::Some(actual_version),
+                                                },
+                                            ));
+                                        }
+                                    }
 
-                                let proposed = draft.into_after();
-                                ::autumn_web::reexports::diesel::update(#table_ident::table.find(id))
-                                    .set(&proposed)
+                                    let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
+                                    self.hooks.before_update(&mut ctx, &mut draft).await?;
+
+                                    let proposed = draft.into_after();
+                                    ::autumn_web::reexports::diesel::update(#table_ident::table.find(id))
+                                        .set(&proposed)
+                                        .get_result::<#model_name>(conn)
+                                        .await
+                                        .map_err(::autumn_web::AutumnError::from)?
+                                } else {
+                                    // Load current record
+                                    let current = #table_ident::table
+                                        .find(id)
+                                        .first::<#model_name>(conn)
+                                        .await
+                                        .optional()
+                                        .map_err(::autumn_web::AutumnError::from)?
+                                        .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                                            format!("{} with id {} not found", stringify!(#model_name), id)
+                                        ))?;
+
+                                    let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
+                                    self.hooks.before_update(&mut ctx, &mut draft).await?;
+
+                                    let proposed = draft.into_after();
+                                    ::autumn_web::reexports::diesel::update(#table_ident::table.find(id))
+                                        .set(&proposed)
                                     .get_result::<#model_name>(conn)
                                     .await
                                     .map_err(::autumn_web::AutumnError::from)?
-                            } else {
-                                let current = #table_ident::table
-                                    .find(id)
-                                    .first::<#model_name>(conn)
-                                    .await
-                                    .optional()
-                                    .map_err(::autumn_web::AutumnError::from)?
-                                    .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
-                                        format!("{} with id {} not found", stringify!(#model_name), id)
-                                    ))?;
+                                };
 
-                                let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
-                                self.hooks.before_update(&mut ctx, &mut draft).await?;
+                                let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
+                                let (__autumn_commit_hook_id, __autumn_commit_hook_owner) = ::autumn_web::__private::enqueue_repository_commit_hook_pending_on_conn(
+                                    conn,
+                                    Self::__autumn_repository_commit_hook_key(),
+                                    "update",
+                                    ctx.idempotency_key.as_deref(),
+                                    __autumn_commit_hook_discriminator.as_deref(),
+                                    &ctx,
+                                    &__autumn_commit_hook_record,
+                                )
+                                .await?;
 
-                                let proposed = draft.into_after();
-                                ::autumn_web::reexports::diesel::update(#table_ident::table.find(id))
-                                    .set(&proposed)
-                                    .get_result::<#model_name>(conn)
-                                    .await
-                                    .map_err(::autumn_web::AutumnError::from)?
-                            };
-
-                            Ok((record, ctx))
+                                Ok((record, ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record))
+                            }
+                            .scope_boxed()
+                        })
+                        .await?;
+                    ::core::mem::drop(conn);
+                    let __autumn_pending_heartbeat =
+                        ::autumn_web::__private::start_repository_commit_hook_pending_finalizer_heartbeat(
+                            self.pool.clone(),
+                            __autumn_commit_hook_id.clone(),
+                            __autumn_commit_hook_owner.clone(),
+                        );
+                    let __autumn_after_update = ::autumn_web::__private::catch_repository_after_hook_unwind(
+                        self.hooks.after_update(&mut ctx, &record)
+                    )
+                    .await;
+                    match __autumn_after_update {
+                        ::core::result::Result::Ok(::core::result::Result::Ok(())) => {}
+                        ::core::result::Result::Ok(::core::result::Result::Err(__autumn_error)) => {
+                            let __autumn_error_message = ::std::format!("{__autumn_error}");
+                            ::autumn_web::__private::mark_repository_commit_hook_after_hook_failed(
+                                &self.pool,
+                                &__autumn_commit_hook_id,
+                                &__autumn_commit_hook_owner,
+                                __autumn_error_message,
+                            )
+                            .await;
+                            __autumn_pending_heartbeat.cancel();
+                            return ::core::result::Result::Err(
+                                ::autumn_web::idempotency::__cache_committed_error_response(__autumn_error)
+                            );
                         }
-                        .scope_boxed()
-                    })
-                    .await?;
-                ::core::mem::drop(conn);
-                self.hooks.after_update(&mut ctx, &record).await?;
+                        ::core::result::Result::Err(__autumn_panic) => {
+                            ::autumn_web::__private::mark_repository_commit_hook_after_hook_failed(
+                                &self.pool,
+                                &__autumn_commit_hook_id,
+                                &__autumn_commit_hook_owner,
+                                "after_update panicked",
+                            )
+                            .await;
+                            __autumn_pending_heartbeat.cancel();
+                            if self.idempotency.is_some() {
+                                return ::core::result::Result::Err(
+                                    ::autumn_web::idempotency::__cache_committed_error_response(
+                                        ::autumn_web::AutumnError::internal_server_error_msg("after_update panicked")
+                                    )
+                                );
+                            }
+                            ::std::panic::resume_unwind(__autumn_panic);
+                        }
+                    }
+                    let __autumn_finalize_result = ::autumn_web::__private::finalize_repository_commit_hook_after_hook(
+                        &self.pool,
+                        &__autumn_commit_hook_id,
+                        &__autumn_commit_hook_owner,
+                        &ctx,
+                        &__autumn_commit_hook_record,
+                    )
+                    .await;
+                    __autumn_pending_heartbeat.cancel();
+                    match __autumn_finalize_result {
+                        ::core::result::Result::Ok(()) => {
+                            ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
+                        }
+                        ::core::result::Result::Err(__autumn_error) => {
+                            ::autumn_web::reexports::tracing::warn!(
+                                hook_id = %__autumn_commit_hook_id,
+                                error = %__autumn_error,
+                                "failed to finalize repository update commit hook after mutation commit; failing request closed"
+                            );
+                            return ::core::result::Result::Err(
+                                ::autumn_web::idempotency::__cache_committed_error_response(__autumn_error)
+                            );
+                        }
+                    }
 
-                Ok(record)
+                    Ok(record)
+                }
+            } else {
+                quote! {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                    use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+                    use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks, UpdateDraft};
+                    use ::autumn_web::repository::{AutumnLockVersionModelExt as _, AutumnLockVersionUpdateExt as _};
+
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let (record, mut ctx) = conn
+                        .transaction::<(#model_name, MutationContext), ::autumn_web::AutumnError, _>(|conn| {
+                            async move {
+                                let mut ctx = MutationContext::new(MutationOp::Update);
+                                let record: #model_name = if let ::core::option::Option::Some(expected_version) =
+                                    changes.__autumn_lock_version_expected()
+                                {
+                                    let current = #table_ident::table
+                                        .find(id)
+                                        .for_update()
+                                        .first::<#model_name>(conn)
+                                        .await
+                                        .optional()
+                                        .map_err(::autumn_web::AutumnError::from)?
+                                        .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                                            format!("{} with id {} not found", stringify!(#model_name), id)
+                                        ))?;
+
+                                    if let ::core::option::Option::Some(actual_version) =
+                                        current.__autumn_lock_version_actual()
+                                    {
+                                        if actual_version != expected_version {
+                                            return Err(::autumn_web::AutumnError::conflict(
+                                                ::autumn_web::RepositoryError::Conflict {
+                                                    id,
+                                                    expected_version,
+                                                    actual_version: ::core::option::Option::Some(actual_version),
+                                                },
+                                            ));
+                                        }
+                                    }
+
+                                    let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
+                                    self.hooks.before_update(&mut ctx, &mut draft).await?;
+
+                                    let proposed = draft.into_after();
+                                    ::autumn_web::reexports::diesel::update(#table_ident::table.find(id))
+                                        .set(&proposed)
+                                        .get_result::<#model_name>(conn)
+                                        .await
+                                        .map_err(::autumn_web::AutumnError::from)?
+                                } else {
+                                    let current = #table_ident::table
+                                        .find(id)
+                                        .first::<#model_name>(conn)
+                                        .await
+                                        .optional()
+                                        .map_err(::autumn_web::AutumnError::from)?
+                                        .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                                            format!("{} with id {} not found", stringify!(#model_name), id)
+                                        ))?;
+
+                                    let mut draft = <UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?;
+                                    self.hooks.before_update(&mut ctx, &mut draft).await?;
+
+                                    let proposed = draft.into_after();
+                                    ::autumn_web::reexports::diesel::update(#table_ident::table.find(id))
+                                        .set(&proposed)
+                                        .get_result::<#model_name>(conn)
+                                        .await
+                                        .map_err(::autumn_web::AutumnError::from)?
+                                };
+
+                                Ok((record, ctx))
+                            }
+                            .scope_boxed()
+                        })
+                        .await?;
+                    ::core::mem::drop(conn);
+                    self.hooks.after_update(&mut ctx, &record).await?;
+
+                    Ok(record)
+                }
             }
         };
 
@@ -992,7 +1615,122 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         };
 
-        let delete_body = if commit_hooks_enabled {
+        let delete_body = if config.tenant_scoped {
+            let tenant_id_setup = quote! {
+                let tenant_id = if self.across_tenants {
+                    ::core::option::Option::None
+                } else {
+                    let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                        .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                    ::core::option::Option::Some(t)
+                };
+            };
+            if commit_hooks_enabled {
+                quote! {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                    use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+                    use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
+
+                    #tenant_id_setup
+                    Self::__autumn_register_repository_commit_hooks();
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    conn
+                        .transaction::<(), ::autumn_web::AutumnError, _>(|conn| {
+                            async move {
+                                let mut ctx = MutationContext::new(MutationOp::Delete);
+                                let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
+                                    ::core::option::Option::None;
+                                if let ::core::option::Option::Some(__autumn_idempotency) = &self.idempotency {
+                                    ctx.set_idempotency_key(__autumn_idempotency.scoped_key());
+                                    __autumn_commit_hook_discriminator =
+                                        ::core::option::Option::Some(__autumn_idempotency.next_mutation_discriminator());
+                                }
+
+                                // Load current record for before_delete context.
+                                // Apply the same soft-delete predicate as the mutation so
+                                // hooks only run when the row is actually deletable.
+                                let load_query = #table_ident::table.find(id) #sd_filter;
+                                let record = if let ::core::option::Option::Some(ref t) = tenant_id {
+                                    load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                                } else {
+                                    load_query.for_update().first::<#model_name>(conn).await
+                                }
+                                .optional()
+                                .map_err(::autumn_web::AutumnError::from)?
+                                .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                                    format!("{} with id {} not found", stringify!(#model_name), id)
+                                ))?;
+
+                                self.hooks.before_delete(&mut ctx, &record).await?;
+
+                                #hooked_delete_mutation_stmt
+
+                                let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
+                                ::autumn_web::__private::enqueue_repository_commit_hook_on_conn(
+                                    conn,
+                                    Self::__autumn_repository_commit_hook_key(),
+                                    "delete",
+                                    ctx.idempotency_key.as_deref(),
+                                    __autumn_commit_hook_discriminator.as_deref(),
+                                    &ctx,
+                                    &__autumn_commit_hook_record,
+                                )
+                                .await?;
+
+                                Ok(())
+                            }
+                            .scope_boxed()
+                        })
+                        .await?;
+                    ::core::mem::drop(conn);
+                    ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
+
+                    Ok(())
+                }
+            } else {
+                quote! {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                    use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+                    use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
+
+                    #tenant_id_setup
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    conn
+                        .transaction::<(), ::autumn_web::AutumnError, _>(|conn| {
+                            async move {
+                                let mut ctx = MutationContext::new(MutationOp::Delete);
+
+                                let load_query = #table_ident::table.find(id);
+                                let record = if let ::core::option::Option::Some(ref t) = tenant_id {
+                                    load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                                } else {
+                                    load_query.for_update().first::<#model_name>(conn).await
+                                }
+                                .optional()
+                                .map_err(::autumn_web::AutumnError::from)?
+                                .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                                    format!("{} with id {} not found", stringify!(#model_name), id)
+                                ))?;
+
+                                self.hooks.before_delete(&mut ctx, &record).await?;
+
+                                #hooked_delete_mutation_stmt
+
+                                Ok(())
+                            }
+                            .scope_boxed()
+                        })
+                        .await?;
+                    ::core::mem::drop(conn);
+
+                    Ok(())
+                }
+            }
+        } else if commit_hooks_enabled {
             quote! {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
@@ -1000,58 +1738,52 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
                 use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
 
-            Self::__autumn_register_repository_commit_hooks();
-            let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-            conn
-                .transaction::<(), ::autumn_web::AutumnError, _>(|conn| {
-                    async move {
-                        let mut ctx = MutationContext::new(MutationOp::Delete);
-                        let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
-                            ::core::option::Option::None;
-                        if let ::core::option::Option::Some(__autumn_idempotency) = &self.idempotency {
-                            ctx.set_idempotency_key(__autumn_idempotency.scoped_key());
-                            __autumn_commit_hook_discriminator =
-                                ::core::option::Option::Some(__autumn_idempotency.next_mutation_discriminator());
-                        }
+                Self::__autumn_register_repository_commit_hooks();
+                let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                conn
+                    .transaction::<(), ::autumn_web::AutumnError, _>(|conn| {
+                        async move {
+                            let mut ctx = MutationContext::new(MutationOp::Delete);
+                            let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
+                                ::core::option::Option::None;
+                            if let ::core::option::Option::Some(__autumn_idempotency) = &self.idempotency {
+                                ctx.set_idempotency_key(__autumn_idempotency.scoped_key());
+                                __autumn_commit_hook_discriminator =
+                                    ::core::option::Option::Some(__autumn_idempotency.next_mutation_discriminator());
+                            }
 
-                        // Load current record for before_delete context.
-                        // Apply the same soft-delete predicate as the mutation so
-                        // hooks only run when the row is actually deletable.
-                        let record = #table_ident::table
-                            .find(id)
-                            #sd_filter
-                            .for_update()
-                            .first::<#model_name>(conn)
-                            .await
+                            // Load current record for before_delete context.
+                            let load_query = #table_ident::table.find(id) #sd_filter;
+                            let record = load_query.for_update().first::<#model_name>(conn).await
                             .optional()
                             .map_err(::autumn_web::AutumnError::from)?
                             .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
                                 format!("{} with id {} not found", stringify!(#model_name), id)
                             ))?;
 
-                        self.hooks.before_delete(&mut ctx, &record).await?;
+                            self.hooks.before_delete(&mut ctx, &record).await?;
 
-                        #hooked_delete_mutation_stmt
+                            #hooked_delete_mutation_stmt
 
-                        let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
-                        ::autumn_web::__private::enqueue_repository_commit_hook_on_conn(
-                            conn,
-                            Self::__autumn_repository_commit_hook_key(),
-                            "delete",
-                            ctx.idempotency_key.as_deref(),
-                            __autumn_commit_hook_discriminator.as_deref(),
-                            &ctx,
-                            &__autumn_commit_hook_record,
-                        )
-                        .await?;
+                            let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
+                            ::autumn_web::__private::enqueue_repository_commit_hook_on_conn(
+                                conn,
+                                Self::__autumn_repository_commit_hook_key(),
+                                "delete",
+                                ctx.idempotency_key.as_deref(),
+                                __autumn_commit_hook_discriminator.as_deref(),
+                                &ctx,
+                                &__autumn_commit_hook_record,
+                            )
+                            .await?;
 
-                        Ok(())
-                    }
-                    .scope_boxed()
-                })
-                .await?;
-            ::core::mem::drop(conn);
-            ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
+                            Ok(())
+                        }
+                        .scope_boxed()
+                    })
+                    .await?;
+                ::core::mem::drop(conn);
+                ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
 
                 Ok(())
             }
@@ -1069,16 +1801,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         async move {
                             let mut ctx = MutationContext::new(MutationOp::Delete);
 
-                            let record = #table_ident::table
-                                .find(id)
-                                .for_update()
-                                .first::<#model_name>(conn)
-                                .await
-                                .optional()
-                                .map_err(::autumn_web::AutumnError::from)?
-                                .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
-                                    format!("{} with id {} not found", stringify!(#model_name), id)
-                                ))?;
+                            let load_query = #table_ident::table.find(id);
+                            let record = load_query.for_update().first::<#model_name>(conn).await
+                            .optional()
+                            .map_err(::autumn_web::AutumnError::from)?
+                            .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                                format!("{} with id {} not found", stringify!(#model_name), id)
+                            ))?;
 
                             self.hooks.before_delete(&mut ctx, &record).await?;
 
@@ -1112,6 +1841,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             pool: ::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
                 ::autumn_web::reexports::diesel_async::AsyncPgConnection,
             >,
+            #tenant_struct_field
         };
 
         let clone_impl = quote! {
@@ -1119,97 +1849,273 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 fn clone(&self) -> Self {
                     Self {
                         pool: self.pool.clone(),
+                        #tenant_clone_field
                     }
                 }
             }
         };
 
         let extractor_init = quote! {
-            Ok(#pg_name { pool })
+            Ok(#pg_name {
+                pool,
+                #tenant_init_field
+            })
         };
 
-        let save_body = quote! {
-            use ::autumn_web::reexports::diesel::prelude::*;
-            use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-            let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-            ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                .values(new)
-                .get_result::<#model_name>(&mut conn)
-                .await
+        let save_body = if config.tenant_scoped {
+            quote! {
+                use ::autumn_web::reexports::diesel::prelude::*;
+                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                let tenant_id = if self.across_tenants {
+                    ::core::option::Option::None
+                } else {
+                    let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                        .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                    ::core::option::Option::Some(t)
+                };
+                let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                if let ::core::option::Option::Some(ref t) = tenant_id {
+                    ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                        .values((new, #table_ident::tenant_id.eq(t)))
+                        .get_result::<#model_name>(&mut conn)
+                        .await
+                } else {
+                    ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                        .values(new)
+                        .get_result::<#model_name>(&mut conn)
+                        .await
+                }
                 .map_err(::autumn_web::AutumnError::from)
-        };
-
-        let update_body = quote! {
-            use ::autumn_web::reexports::diesel::prelude::*;
-            use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-            use ::autumn_web::repository::{AutumnLockVersionModelExt as _, AutumnLockVersionUpdateExt as _};
-            let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-
-            if let ::core::option::Option::Some(expected_version) =
-                changes.__autumn_lock_version_expected()
-            {
-                use ::autumn_web::reexports::diesel_async::AsyncConnection;
-                use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
-
-                conn.transaction::<_, ::autumn_web::AutumnError, _>(|conn| {
-                    async move {
-                        // SELECT FOR UPDATE grabs an exclusive row lock so
-                        // no concurrent writer can commit between our
-                        // version check and the UPDATE below.
-                        let current = #table_ident::table
-                            .find(id)
-                            .for_update()
-                            .first::<#model_name>(conn)
-                            .await
-                            .optional()
-                            .map_err(::autumn_web::AutumnError::from)?
-                            .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
-                                format!("{} with id {} not found", stringify!(#model_name), id)
-                            ))?;
-
-                        if let ::core::option::Option::Some(actual_version) =
-                            current.__autumn_lock_version_actual()
-                        {
-                            if actual_version != expected_version {
-                                return Err(::autumn_web::AutumnError::conflict(
-                                    ::autumn_web::RepositoryError::Conflict {
-                                        id,
-                                        expected_version,
-                                        actual_version: ::core::option::Option::Some(actual_version),
-                                    },
-                                ));
-                            }
-                        }
-
-                        let diesel_changeset = changes.__to_changeset();
-                        ::autumn_web::reexports::diesel::update(#table_ident::table.find(id))
-                            .set(&diesel_changeset)
-                            .get_result::<#model_name>(conn)
-                            .await
-                            .map_err(::autumn_web::AutumnError::from)
-                    }
-                    .scope_boxed()
-                })
-                .await
-            } else {
-                let diesel_changeset = changes.__to_changeset();
-                ::autumn_web::reexports::diesel::update(#table_ident::table.find(id))
-                    .set(&diesel_changeset)
+            }
+        } else {
+            quote! {
+                use ::autumn_web::reexports::diesel::prelude::*;
+                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                    .values(new)
                     .get_result::<#model_name>(&mut conn)
                     .await
                     .map_err(::autumn_web::AutumnError::from)
             }
         };
 
-        let delete_body = if config.soft_delete {
+        let update_body = if config.tenant_scoped {
+            quote! {
+                use ::autumn_web::reexports::diesel::prelude::*;
+                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                use ::autumn_web::repository::{AutumnLockVersionModelExt as _, AutumnLockVersionUpdateExt as _};
+                let tenant_id = if self.across_tenants {
+                    ::core::option::Option::None
+                } else {
+                    let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                        .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                    ::core::option::Option::Some(t)
+                };
+                let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+
+                if let ::core::option::Option::Some(expected_version) =
+                    changes.__autumn_lock_version_expected()
+                {
+                    use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                    use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+
+                    conn.transaction::<_, ::autumn_web::AutumnError, _>(|conn| {
+                        async move {
+                            // SELECT FOR UPDATE grabs an exclusive row lock so
+                            // no concurrent writer can commit between our
+                            // version check and the UPDATE below.
+                            let load_query = #table_ident::table.find(id);
+                            let current = if let ::core::option::Option::Some(ref t) = tenant_id {
+                                load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                            } else {
+                                load_query.for_update().first::<#model_name>(conn).await
+                            }
+                            .optional()
+                            .map_err(::autumn_web::AutumnError::from)?
+                            .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                                format!("{} with id {} not found", stringify!(#model_name), id)
+                            ))?;
+
+                            if let ::core::option::Option::Some(actual_version) =
+                                current.__autumn_lock_version_actual()
+                            {
+                                if actual_version != expected_version {
+                                    return Err(::autumn_web::AutumnError::conflict(
+                                        ::autumn_web::RepositoryError::Conflict {
+                                            id,
+                                            expected_version,
+                                            actual_version: ::core::option::Option::Some(actual_version),
+                                        },
+                                    ));
+                                }
+                            }
+
+                            let diesel_changeset = changes.__to_changeset();
+                            let update_target = #table_ident::table.find(id);
+                            if let ::core::option::Option::Some(ref t) = tenant_id {
+                                ::autumn_web::reexports::diesel::update(update_target.filter(#table_ident::tenant_id.eq(t)))
+                                    .set(&diesel_changeset)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                            } else {
+                                ::autumn_web::reexports::diesel::update(update_target)
+                                    .set(&diesel_changeset)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                            }
+                            .map_err(::autumn_web::AutumnError::from)
+                        }
+                        .scope_boxed()
+                    })
+                    .await
+                } else {
+                    let diesel_changeset = changes.__to_changeset();
+                    let update_target = #table_ident::table.find(id);
+                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                        ::autumn_web::reexports::diesel::update(update_target.filter(#table_ident::tenant_id.eq(t)))
+                            .set(&diesel_changeset)
+                            .get_result::<#model_name>(&mut conn)
+                            .await
+                    } else {
+                        ::autumn_web::reexports::diesel::update(update_target)
+                            .set(&diesel_changeset)
+                            .get_result::<#model_name>(&mut conn)
+                            .await
+                    }
+                    .map_err(::autumn_web::AutumnError::from)
+                }
+            }
+        } else {
+            quote! {
+                use ::autumn_web::reexports::diesel::prelude::*;
+                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                use ::autumn_web::repository::{AutumnLockVersionModelExt as _, AutumnLockVersionUpdateExt as _};
+                let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+
+                if let ::core::option::Option::Some(expected_version) =
+                    changes.__autumn_lock_version_expected()
+                {
+                    use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                    use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+
+                    conn.transaction::<_, ::autumn_web::AutumnError, _>(|conn| {
+                        async move {
+                            let load_query = #table_ident::table.find(id);
+                            let current = load_query.for_update().first::<#model_name>(conn).await
+                            .optional()
+                            .map_err(::autumn_web::AutumnError::from)?
+                            .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                                format!("{} with id {} not found", stringify!(#model_name), id)
+                            ))?;
+
+                            if let ::core::option::Option::Some(actual_version) =
+                                current.__autumn_lock_version_actual()
+                            {
+                                if actual_version != expected_version {
+                                    return Err(::autumn_web::AutumnError::conflict(
+                                        ::autumn_web::RepositoryError::Conflict {
+                                            id,
+                                            expected_version,
+                                            actual_version: ::core::option::Option::Some(actual_version),
+                                        },
+                                    ));
+                                }
+                            }
+
+                            let diesel_changeset = changes.__to_changeset();
+                            let update_target = #table_ident::table.find(id);
+                            ::autumn_web::reexports::diesel::update(update_target)
+                                .set(&diesel_changeset)
+                                .get_result::<#model_name>(conn)
+                                .await
+                                .map_err(::autumn_web::AutumnError::from)
+                        }
+                        .scope_boxed()
+                    })
+                    .await
+                } else {
+                    let diesel_changeset = changes.__to_changeset();
+                    let update_target = #table_ident::table.find(id);
+                    ::autumn_web::reexports::diesel::update(update_target)
+                        .set(&diesel_changeset)
+                        .get_result::<#model_name>(&mut conn)
+                        .await
+                        .map_err(::autumn_web::AutumnError::from)
+                }
+            }
+        };
+
+        let delete_body = if config.tenant_scoped {
+            let tenant_id_setup = quote! {
+                let tenant_id = if self.across_tenants {
+                    ::core::option::Option::None
+                } else {
+                    let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                        .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                    ::core::option::Option::Some(t)
+                };
+            };
+            if config.soft_delete {
+                quote! {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    #tenant_id_setup
+                    let __now = ::autumn_web::reexports::chrono::Utc::now().naive_utc();
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let delete_query = #table_ident::table.find(id).filter(#table_ident::deleted_at.is_null());
+                    let __count = if let ::core::option::Option::Some(ref t) = tenant_id {
+                        ::autumn_web::reexports::diesel::update(delete_query.filter(#table_ident::tenant_id.eq(t)))
+                            .set(#table_ident::deleted_at.eq(::core::option::Option::Some(__now)))
+                            .execute(&mut conn)
+                            .await
+                    } else {
+                        ::autumn_web::reexports::diesel::update(delete_query)
+                            .set(#table_ident::deleted_at.eq(::core::option::Option::Some(__now)))
+                            .execute(&mut conn)
+                            .await
+                    }
+                    .map_err(::autumn_web::AutumnError::from)?;
+                    if __count == 0 {
+                        return Err(::autumn_web::AutumnError::not_found_msg(
+                            format!("{} with id {} not found", stringify!(#model_name), id)
+                        ));
+                    }
+                    Ok(())
+                }
+            } else {
+                quote! {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    #tenant_id_setup
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let delete_query = #table_ident::table.find(id);
+                    let __count = if let ::core::option::Option::Some(ref t) = tenant_id {
+                        ::autumn_web::reexports::diesel::delete(delete_query.filter(#table_ident::tenant_id.eq(t)))
+                            .execute(&mut conn)
+                            .await
+                    } else {
+                        ::autumn_web::reexports::diesel::delete(delete_query)
+                            .execute(&mut conn)
+                            .await
+                    }
+                    .map_err(::autumn_web::AutumnError::from)?;
+                    if __count == 0 {
+                        return Err(::autumn_web::AutumnError::not_found_msg(
+                            format!("{} with id {} not found", stringify!(#model_name), id)
+                        ));
+                    }
+                    Ok(())
+                }
+            }
+        } else if config.soft_delete {
             quote! {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                 let __now = ::autumn_web::reexports::chrono::Utc::now().naive_utc();
                 let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                let __count = ::autumn_web::reexports::diesel::update(
-                    #table_ident::table.find(id).filter(#table_ident::deleted_at.is_null())
-                )
+                let delete_query = #table_ident::table.find(id).filter(#table_ident::deleted_at.is_null());
+                let __count = ::autumn_web::reexports::diesel::update(delete_query)
                     .set(#table_ident::deleted_at.eq(::core::option::Option::Some(__now)))
                     .execute(&mut conn)
                     .await
@@ -1226,10 +2132,16 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                 let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                ::autumn_web::reexports::diesel::delete(#table_ident::table.find(id))
+                let delete_query = #table_ident::table.find(id);
+                let __count = ::autumn_web::reexports::diesel::delete(delete_query)
                     .execute(&mut conn)
                     .await
                     .map_err(::autumn_web::AutumnError::from)?;
+                if __count == 0 {
+                    return Err(::autumn_web::AutumnError::not_found_msg(
+                        format!("{} with id {} not found", stringify!(#model_name), id)
+                    ));
+                }
                 Ok(())
             }
         };
@@ -1271,30 +2183,89 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             -> impl ::std::future::Future<Output = ::autumn_web::AutumnResult<::autumn_web::pagination::Page<#model_name>>> + Send;
     };
 
-    let pagination_impl_method = quote! {
-        async fn page(
-            &self,
-            req: &::autumn_web::pagination::PageRequest,
-        ) -> ::autumn_web::AutumnResult<::autumn_web::pagination::Page<#model_name>> {
-            use ::autumn_web::reexports::diesel::prelude::*;
-            use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-            let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-            let total: i64 = #table_ident::table
-                #sd_filter
-                .count()
-                .get_result::<i64>(&mut conn)
-                .await
-                .map_err(::autumn_web::AutumnError::from)?;
-            let items: ::std::vec::Vec<#model_name> = #table_ident::table
-                #sd_filter
-                .order(#table_ident::id.desc())
-                .limit(req.limit())
-                .offset(req.offset())
-                .select(#model_name::as_select())
-                .load::<#model_name>(&mut conn)
-                .await
-                .map_err(::autumn_web::AutumnError::from)?;
-            ::core::result::Result::Ok(::autumn_web::pagination::Page::new(items, total, req))
+    let pagination_impl_method = if config.tenant_scoped {
+        quote! {
+            async fn page(
+                &self,
+                req: &::autumn_web::pagination::PageRequest,
+            ) -> ::autumn_web::AutumnResult<::autumn_web::pagination::Page<#model_name>> {
+                use ::autumn_web::reexports::diesel::prelude::*;
+                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                let tenant_id = if self.across_tenants {
+                    ::core::option::Option::None
+                } else {
+                    let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                        .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                    ::core::option::Option::Some(t)
+                };
+                let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+
+                let query = #table_ident::table;
+                if let ::core::option::Option::Some(ref t) = tenant_id {
+                    let total: i64 = query
+                        .filter(#table_ident::tenant_id.eq(t))
+                        #sd_filter
+                        .count()
+                        .get_result::<i64>(&mut conn)
+                        .await
+                        .map_err(::autumn_web::AutumnError::from)?;
+                    let items: ::std::vec::Vec<#model_name> = query
+                        .filter(#table_ident::tenant_id.eq(t))
+                        #sd_filter
+                        .order(#table_ident::id.desc())
+                        .limit(req.limit())
+                        .offset(req.offset())
+                        .select(#model_name::as_select())
+                        .load::<#model_name>(&mut conn)
+                        .await
+                        .map_err(::autumn_web::AutumnError::from)?;
+                    ::core::result::Result::Ok(::autumn_web::pagination::Page::new(items, total, req))
+                } else {
+                    let total: i64 = query
+                        #sd_filter
+                        .count()
+                        .get_result::<i64>(&mut conn)
+                        .await
+                        .map_err(::autumn_web::AutumnError::from)?;
+                    let items: ::std::vec::Vec<#model_name> = query
+                        #sd_filter
+                        .order(#table_ident::id.desc())
+                        .limit(req.limit())
+                        .offset(req.offset())
+                        .select(#model_name::as_select())
+                        .load::<#model_name>(&mut conn)
+                        .await
+                        .map_err(::autumn_web::AutumnError::from)?;
+                    ::core::result::Result::Ok(::autumn_web::pagination::Page::new(items, total, req))
+                }
+            }
+        }
+    } else {
+        quote! {
+            async fn page(
+                &self,
+                req: &::autumn_web::pagination::PageRequest,
+            ) -> ::autumn_web::AutumnResult<::autumn_web::pagination::Page<#model_name>> {
+                use ::autumn_web::reexports::diesel::prelude::*;
+                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                let total: i64 = #table_ident::table
+                    #sd_filter
+                    .count()
+                    .get_result::<i64>(&mut conn)
+                    .await
+                    .map_err(::autumn_web::AutumnError::from)?;
+                let items: ::std::vec::Vec<#model_name> = #table_ident::table
+                    #sd_filter
+                    .order(#table_ident::id.desc())
+                    .limit(req.limit())
+                    .offset(req.offset())
+                    .select(#model_name::as_select())
+                    .load::<#model_name>(&mut conn)
+                    .await
+                    .map_err(::autumn_web::AutumnError::from)?;
+                ::core::result::Result::Ok(::autumn_web::pagination::Page::new(items, total, req))
+            }
         }
     };
 
@@ -1312,6 +2283,24 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     //   This is correct when cursor_key values are monotonically correlated
     //   with id (e.g. `created_at` on an auto-increment table).  For
     //   non-monotonic data (backfills, imports) implement cursor_page manually.
+    let tenant_query_filter = if config.tenant_scoped {
+        quote! {
+            if !self.across_tenants {
+                let tenant_id = match ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten() {
+                    ::core::option::Option::Some(t) => t,
+                    ::core::option::Option::None => {
+                        return ::core::result::Result::Err(::autumn_web::AutumnError::internal_server_error_msg(
+                            "no tenant context was established"
+                        ));
+                    }
+                };
+                query = query.filter(#table_ident::tenant_id.eq(tenant_id));
+            }
+        }
+    } else {
+        quote! {}
+    };
+
     let (cursor_page_trait_method, cursor_page_impl_method) = if let Some(ref ck) =
         config.cursor_key
     {
@@ -1338,6 +2327,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                     let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
                     let mut query = #table_ident::table.into_boxed();
+                    #tenant_query_filter
                     if let ::core::option::Option::Some((after_k, after_id)) =
                         req.decode::<(#key_type, i64)>()
                     {
@@ -1380,6 +2370,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                     let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
                     let mut query = #table_ident::table.into_boxed();
+                    #tenant_query_filter
                     if let ::core::option::Option::Some(after_id) = req.decode::<i64>() {
                         query = query.filter(#table_ident::id.lt(after_id));
                     }
@@ -2203,88 +3194,386 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let soft_delete_impl_methods = if config.soft_delete {
-        quote! {
-            async fn restore(&self, id: i64) -> ::autumn_web::AutumnResult<()> {
-                use ::autumn_web::reexports::diesel::prelude::*;
-                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                let __count = ::autumn_web::reexports::diesel::update(#table_ident::table.find(id))
-                    .set(#table_ident::deleted_at.eq(::core::option::Option::None::<::autumn_web::reexports::chrono::NaiveDateTime>))
-                    .execute(&mut conn)
-                    .await
+        if config.tenant_scoped {
+            let tenant_id_setup = quote! {
+                let tenant_id = if self.across_tenants {
+                    ::core::option::Option::None
+                } else {
+                    let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                        .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                    ::core::option::Option::Some(t)
+                };
+            };
+
+            quote! {
+                async fn restore(&self, id: i64) -> ::autumn_web::AutumnResult<()> {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    #tenant_id_setup
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let query = #table_ident::table.find(id);
+                    let __count = if let ::core::option::Option::Some(ref t) = tenant_id {
+                        ::autumn_web::reexports::diesel::update(query.filter(#table_ident::tenant_id.eq(t)))
+                            .set(#table_ident::deleted_at.eq(::core::option::Option::None::<::autumn_web::reexports::chrono::NaiveDateTime>))
+                            .execute(&mut conn)
+                            .await
+                    } else {
+                        ::autumn_web::reexports::diesel::update(query)
+                            .set(#table_ident::deleted_at.eq(::core::option::Option::None::<::autumn_web::reexports::chrono::NaiveDateTime>))
+                            .execute(&mut conn)
+                            .await
+                    }
                     .map_err(::autumn_web::AutumnError::from)?;
-                if __count == 0 {
-                    return Err(::autumn_web::AutumnError::not_found_msg(
-                        format!("{} with id {} not found", stringify!(#model_name), id)
-                    ));
+                    if __count == 0 {
+                        return Err(::autumn_web::AutumnError::not_found_msg(
+                            format!("{} with id {} not found", stringify!(#model_name), id)
+                        ));
+                    }
+                    Ok(())
                 }
-                Ok(())
-            }
 
-            async fn purge(&self, id: i64) -> ::autumn_web::AutumnResult<()> {
-                use ::autumn_web::reexports::diesel::prelude::*;
-                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                let __count = ::autumn_web::reexports::diesel::delete(#table_ident::table.find(id))
-                    .execute(&mut conn)
-                    .await
+                async fn purge(&self, id: i64) -> ::autumn_web::AutumnResult<()> {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    #tenant_id_setup
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let query = #table_ident::table.find(id);
+                    let __count = if let ::core::option::Option::Some(ref t) = tenant_id {
+                        ::autumn_web::reexports::diesel::delete(query.filter(#table_ident::tenant_id.eq(t)))
+                            .execute(&mut conn)
+                            .await
+                    } else {
+                        ::autumn_web::reexports::diesel::delete(query)
+                            .execute(&mut conn)
+                            .await
+                    }
                     .map_err(::autumn_web::AutumnError::from)?;
-                if __count == 0 {
-                    return Err(::autumn_web::AutumnError::not_found_msg(
-                        format!("{} with id {} not found", stringify!(#model_name), id)
-                    ));
+                    if __count == 0 {
+                        return Err(::autumn_web::AutumnError::not_found_msg(
+                            format!("{} with id {} not found", stringify!(#model_name), id)
+                        ));
+                    }
+                    Ok(())
                 }
-                Ok(())
-            }
 
-            async fn with_deleted(&self) -> ::autumn_web::AutumnResult<Vec<#model_name>> {
-                use ::autumn_web::reexports::diesel::prelude::*;
-                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                #table_ident::table
-                    .load::<#model_name>(&mut conn)
-                    .await
+                async fn with_deleted(&self) -> ::autumn_web::AutumnResult<Vec<#model_name>> {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    #tenant_id_setup
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let query = #table_ident::table;
+                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                        query.filter(#table_ident::tenant_id.eq(t))
+                            .load::<#model_name>(&mut conn)
+                            .await
+                    } else {
+                        query
+                            .load::<#model_name>(&mut conn)
+                            .await
+                    }
                     .map_err(::autumn_web::AutumnError::from)
-            }
+                }
 
-            async fn only_deleted(&self) -> ::autumn_web::AutumnResult<Vec<#model_name>> {
-                use ::autumn_web::reexports::diesel::prelude::*;
-                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                #table_ident::table
-                    .filter(#table_ident::deleted_at.is_not_null())
-                    .load::<#model_name>(&mut conn)
-                    .await
+                async fn only_deleted(&self) -> ::autumn_web::AutumnResult<Vec<#model_name>> {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    #tenant_id_setup
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let query = #table_ident::table.filter(#table_ident::deleted_at.is_not_null());
+                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                        query.filter(#table_ident::tenant_id.eq(t))
+                            .load::<#model_name>(&mut conn)
+                            .await
+                    } else {
+                        query
+                            .load::<#model_name>(&mut conn)
+                            .await
+                    }
                     .map_err(::autumn_web::AutumnError::from)
-            }
+                }
 
-            async fn page_only_deleted(
-                &self,
-                req: &::autumn_web::pagination::PageRequest,
-            ) -> ::autumn_web::AutumnResult<::autumn_web::pagination::Page<#model_name>> {
-                use ::autumn_web::reexports::diesel::prelude::*;
-                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                let total: i64 = #table_ident::table
-                    .filter(#table_ident::deleted_at.is_not_null())
-                    .count()
-                    .get_result::<i64>(&mut conn)
-                    .await
-                    .map_err(::autumn_web::AutumnError::from)?;
-                let items: ::std::vec::Vec<#model_name> = #table_ident::table
-                    .filter(#table_ident::deleted_at.is_not_null())
-                    .order(#table_ident::id.desc())
-                    .limit(req.limit())
-                    .offset(req.offset())
-                    .select(#model_name::as_select())
-                    .load::<#model_name>(&mut conn)
-                    .await
-                    .map_err(::autumn_web::AutumnError::from)?;
-                ::core::result::Result::Ok(::autumn_web::pagination::Page::new(items, total, req))
+                async fn page_only_deleted(
+                    &self,
+                    req: &::autumn_web::pagination::PageRequest,
+                ) -> ::autumn_web::AutumnResult<::autumn_web::pagination::Page<#model_name>> {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    #tenant_id_setup
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let query = #table_ident::table.filter(#table_ident::deleted_at.is_not_null());
+                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                        let total: i64 = query
+                            .filter(#table_ident::tenant_id.eq(t))
+                            .count()
+                            .get_result::<i64>(&mut conn)
+                            .await
+                            .map_err(::autumn_web::AutumnError::from)?;
+                        let items: ::std::vec::Vec<#model_name> = query
+                            .filter(#table_ident::tenant_id.eq(t))
+                            .order(#table_ident::id.desc())
+                            .limit(req.limit())
+                            .offset(req.offset())
+                            .select(#model_name::as_select())
+                            .load::<#model_name>(&mut conn)
+                            .await
+                            .map_err(::autumn_web::AutumnError::from)?;
+                        ::core::result::Result::Ok(::autumn_web::pagination::Page::new(items, total, req))
+                    } else {
+                        let total: i64 = query
+                            .count()
+                            .get_result::<i64>(&mut conn)
+                            .await
+                            .map_err(::autumn_web::AutumnError::from)?;
+                        let items: ::std::vec::Vec<#model_name> = query
+                            .order(#table_ident::id.desc())
+                            .limit(req.limit())
+                            .offset(req.offset())
+                            .select(#model_name::as_select())
+                            .load::<#model_name>(&mut conn)
+                            .await
+                            .map_err(::autumn_web::AutumnError::from)?;
+                        ::core::result::Result::Ok(::autumn_web::pagination::Page::new(items, total, req))
+                    }
+                }
+            }
+        } else {
+            quote! {
+                async fn restore(&self, id: i64) -> ::autumn_web::AutumnResult<()> {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let query = #table_ident::table.find(id);
+                    let __count = ::autumn_web::reexports::diesel::update(query)
+                        .set(#table_ident::deleted_at.eq(::core::option::Option::None::<::autumn_web::reexports::chrono::NaiveDateTime>))
+                        .execute(&mut conn)
+                        .await
+                        .map_err(::autumn_web::AutumnError::from)?;
+                    if __count == 0 {
+                        return Err(::autumn_web::AutumnError::not_found_msg(
+                            format!("{} with id {} not found", stringify!(#model_name), id)
+                        ));
+                    }
+                    Ok(())
+                }
+
+                async fn purge(&self, id: i64) -> ::autumn_web::AutumnResult<()> {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let query = #table_ident::table.find(id);
+                    let __count = ::autumn_web::reexports::diesel::delete(query)
+                        .execute(&mut conn)
+                        .await
+                        .map_err(::autumn_web::AutumnError::from)?;
+                    if __count == 0 {
+                        return Err(::autumn_web::AutumnError::not_found_msg(
+                            format!("{} with id {} not found", stringify!(#model_name), id)
+                        ));
+                    }
+                    Ok(())
+                }
+
+                async fn with_deleted(&self) -> ::autumn_web::AutumnResult<Vec<#model_name>> {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let query = #table_ident::table;
+                    query
+                        .load::<#model_name>(&mut conn)
+                        .await
+                        .map_err(::autumn_web::AutumnError::from)
+                }
+
+                async fn only_deleted(&self) -> ::autumn_web::AutumnResult<Vec<#model_name>> {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let query = #table_ident::table.filter(#table_ident::deleted_at.is_not_null());
+                    query
+                        .load::<#model_name>(&mut conn)
+                        .await
+                        .map_err(::autumn_web::AutumnError::from)
+                }
+
+                async fn page_only_deleted(
+                    &self,
+                    req: &::autumn_web::pagination::PageRequest,
+                ) -> ::autumn_web::AutumnResult<::autumn_web::pagination::Page<#model_name>> {
+                    use ::autumn_web::reexports::diesel::prelude::*;
+                    use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                    let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
+                    let query = #table_ident::table.filter(#table_ident::deleted_at.is_not_null());
+                    let total: i64 = query
+                        .count()
+                        .get_result::<i64>(&mut conn)
+                        .await
+                        .map_err(::autumn_web::AutumnError::from)?;
+                    let items: ::std::vec::Vec<#model_name> = query
+                        .order(#table_ident::id.desc())
+                        .limit(req.limit())
+                        .offset(req.offset())
+                        .select(#model_name::as_select())
+                        .load::<#model_name>(&mut conn)
+                        .await
+                        .map_err(::autumn_web::AutumnError::from)?;
+                    ::core::result::Result::Ok(::autumn_web::pagination::Page::new(items, total, req))
+                }
             }
         }
     } else {
         quote! {}
+    };
+
+    let find_by_id_impl = if config.tenant_scoped {
+        quote! {
+            let tenant_id = if self.across_tenants {
+                ::core::option::Option::None
+            } else {
+                let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                    .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                ::core::option::Option::Some(t)
+            };
+            let query = #table_ident::table.find(id);
+            if let ::core::option::Option::Some(ref t) = tenant_id {
+                query.filter(#table_ident::tenant_id.eq(t))
+                    #sd_filter
+                    .first::<#model_name>(&mut conn)
+                    .await
+                    .optional()
+                    .map_err(::autumn_web::AutumnError::from)
+            } else {
+                query
+                    #sd_filter
+                    .first::<#model_name>(&mut conn)
+                    .await
+                    .optional()
+                    .map_err(::autumn_web::AutumnError::from)
+            }
+        }
+    } else {
+        quote! {
+            #table_ident::table
+                .find(id)
+                #sd_filter
+                .first::<#model_name>(&mut conn)
+                .await
+                .optional()
+                .map_err(::autumn_web::AutumnError::from)
+        }
+    };
+
+    let find_all_impl = if config.tenant_scoped {
+        quote! {
+            let tenant_id = if self.across_tenants {
+                ::core::option::Option::None
+            } else {
+                let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                    .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                ::core::option::Option::Some(t)
+            };
+            let query = #table_ident::table;
+            if let ::core::option::Option::Some(ref t) = tenant_id {
+                query.filter(#table_ident::tenant_id.eq(t))
+                    #sd_filter
+                    .load::<#model_name>(&mut conn)
+                    .await
+                    .map_err(::autumn_web::AutumnError::from)
+            } else {
+                query
+                    #sd_filter
+                    .load::<#model_name>(&mut conn)
+                    .await
+                    .map_err(::autumn_web::AutumnError::from)
+            }
+        }
+    } else {
+        quote! {
+            #table_ident::table
+                #sd_filter
+                .load::<#model_name>(&mut conn)
+                .await
+                .map_err(::autumn_web::AutumnError::from)
+        }
+    };
+
+    let count_impl = if config.tenant_scoped {
+        quote! {
+            let tenant_id = if self.across_tenants {
+                ::core::option::Option::None
+            } else {
+                let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                    .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                ::core::option::Option::Some(t)
+            };
+            let query = #table_ident::table;
+            if let ::core::option::Option::Some(ref t) = tenant_id {
+                query.filter(#table_ident::tenant_id.eq(t))
+                    #sd_filter
+                    .count()
+                    .get_result::<i64>(&mut conn)
+                    .await
+                    .map_err(::autumn_web::AutumnError::from)
+            } else {
+                query
+                    #sd_filter
+                    .count()
+                    .get_result::<i64>(&mut conn)
+                    .await
+                    .map_err(::autumn_web::AutumnError::from)
+            }
+        }
+    } else {
+        quote! {
+            #table_ident::table
+                #sd_filter
+                .count()
+                .get_result::<i64>(&mut conn)
+                .await
+                .map_err(::autumn_web::AutumnError::from)
+        }
+    };
+
+    let exists_by_id_impl = if config.tenant_scoped {
+        quote! {
+            let tenant_id = if self.across_tenants {
+                ::core::option::Option::None
+            } else {
+                let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                    .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                ::core::option::Option::Some(t)
+            };
+            let query = #table_ident::table.find(id);
+            if let ::core::option::Option::Some(ref t) = tenant_id {
+                ::autumn_web::reexports::diesel::select(
+                    ::autumn_web::reexports::diesel::dsl::exists(
+                        query.filter(#table_ident::tenant_id.eq(t)) #sd_filter
+                    )
+                )
+                .get_result::<bool>(&mut conn)
+                .await
+                .map_err(::autumn_web::AutumnError::from)
+            } else {
+                ::autumn_web::reexports::diesel::select(
+                    ::autumn_web::reexports::diesel::dsl::exists(
+                        query #sd_filter
+                    )
+                )
+                .get_result::<bool>(&mut conn)
+                .await
+                .map_err(::autumn_web::AutumnError::from)
+            }
+        }
+    } else {
+        quote! {
+            ::autumn_web::reexports::diesel::select(
+                ::autumn_web::reexports::diesel::dsl::exists(
+                    #table_ident::table.find(id) #sd_filter
+                )
+            )
+            .get_result::<bool>(&mut conn)
+            .await
+            .map_err(::autumn_web::AutumnError::from)
+        }
     };
 
     // Generate the trait, impl, and extractor.
@@ -2338,24 +3627,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                 let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                #table_ident::table
-                    .find(id)
-                    #sd_filter
-                    .first::<#model_name>(&mut conn)
-                    .await
-                    .optional()
-                    .map_err(::autumn_web::AutumnError::from)
+                #find_by_id_impl
             }
 
             async fn find_all(&self) -> ::autumn_web::AutumnResult<Vec<#model_name>> {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                 let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                #table_ident::table
-                    #sd_filter
-                    .load::<#model_name>(&mut conn)
-                    .await
-                    .map_err(::autumn_web::AutumnError::from)
+                #find_all_impl
             }
 
             async fn save(&self, new: &#new_name) -> ::autumn_web::AutumnResult<#model_name> {
@@ -2374,26 +3653,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                 let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                #table_ident::table
-                    #sd_filter
-                    .count()
-                    .get_result::<i64>(&mut conn)
-                    .await
-                    .map_err(::autumn_web::AutumnError::from)
+                #count_impl
             }
 
             async fn exists_by_id(&self, id: i64) -> ::autumn_web::AutumnResult<bool> {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                 let mut conn = self.pool.get().await.map_err(::autumn_web::AutumnError::from)?;
-                ::autumn_web::reexports::diesel::select(
-                    ::autumn_web::reexports::diesel::dsl::exists(
-                        #table_ident::table.find(id) #sd_filter
-                    )
-                )
-                .get_result::<bool>(&mut conn)
-                .await
-                .map_err(::autumn_web::AutumnError::from)
+                #exists_by_id_impl
             }
 
             #pagination_impl_method
@@ -2403,6 +3670,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         impl #pg_name {
+            #across_tenants_method
             #hook_support_methods
 
             /// Acquire a database connection from the repository's
@@ -3344,6 +4612,43 @@ mod tests {
         assert!(
             generated.contains("page_only_deleted"),
             "soft_delete must generate a page_only_deleted() method: {generated}"
+        );
+    }
+
+    // ── Tenant Scoped generation (issue #695) ───────────────────
+
+    #[test]
+    fn parse_repo_args_recognizes_tenant_scoped_flag() {
+        let tokens: proc_macro2::TokenStream = "Post, tenant_scoped".parse().unwrap();
+        let config = parse_repo_args(tokens).unwrap();
+        assert_eq!(config.model_name.to_string(), "Post");
+        assert!(
+            config.tenant_scoped,
+            "tenant_scoped flag must be stored on RepoConfig"
+        );
+    }
+
+    #[test]
+    fn tenant_scoped_config_is_false_by_default() {
+        let tokens: proc_macro2::TokenStream = "Post".parse().unwrap();
+        let config = parse_repo_args(tokens).unwrap();
+        assert!(
+            !config.tenant_scoped,
+            "tenant_scoped must default to false when not specified"
+        );
+    }
+
+    #[test]
+    fn repository_macro_tenant_scoped_generates_across_tenants() {
+        let generated = repository_macro(
+            quote! { Post, tenant_scoped },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("across_tenants"),
+            "tenant_scoped must generate an across_tenants() method on the struct: {generated}"
         );
     }
 }

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -716,7 +716,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
 
                     let tenant_id = if self.across_tenants {
-                        ::core::option::Option::None
+                        ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
                     } else {
                         let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
                             .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
@@ -852,7 +852,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
 
                     let tenant_id = if self.across_tenants {
-                        ::core::option::Option::None
+                        ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
                     } else {
                         let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
                             .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
@@ -1967,7 +1967,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                 let tenant_id = if self.across_tenants {
-                    ::core::option::Option::None
+                    ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
                 } else {
                     let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
                         .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -21,7 +21,7 @@ htmx = []
 multipart = ["axum/multipart"]
 tailwind = []
 http-client = ["dep:reqwest"]
-oauth2 = ["http-client", "dep:jsonwebtoken"]
+oauth2 = ["http-client"]
 openapi = ["dep:serde_yaml"]
 db = [
     "dep:deadpool",
@@ -109,7 +109,7 @@ subtle = "2.6.1"
 url = "2.5.8"
 percent-encoding = "2"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
-jsonwebtoken = { version = "10.1.0", optional = true }
+jsonwebtoken = { version = "10.1.0", default-features = false, features = ["rust_crypto"] }
 lru = "0.18.0"
 hmac = "0.12"
 sha2 = "0.10"

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -3185,6 +3185,12 @@ pub struct TenancyConfig {
     #[serde(default)]
     pub jwt_issuer: Option<String>,
 
+    /// Expected JWT audience (`aud` claim) to validate.
+    /// When set, audience checking is enabled; when `None`, audience checking
+    /// is skipped for backward compatibility.
+    #[serde(default)]
+    pub jwt_audience: Option<String>,
+
     /// Optional base domain for subdomain tenancy.
     #[serde(default)]
     pub base_domain: Option<String>,
@@ -3216,6 +3222,7 @@ impl Default for TenancyConfig {
             jwt_claim: default_tenancy_jwt_claim(),
             jwt_secret: None,
             jwt_issuer: None,
+            jwt_audience: None,
             base_domain: None,
         }
     }

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -3169,13 +3169,25 @@ pub struct TenancyConfig {
     #[serde(default = "default_tenancy_header_name")]
     pub header_name: String,
 
-    /// Session key to lookup if source is "session". Default: "tenant_id".
+    /// Session key to lookup if source is "session". Default: "`tenant_id`".
     #[serde(default = "default_tenancy_session_key")]
     pub session_key: String,
 
-    /// JWT claim to lookup if source is "jwt". Default: "tenant_id".
+    /// JWT claim to lookup if source is "jwt". Default: "`tenant_id`".
     #[serde(default = "default_tenancy_jwt_claim")]
     pub jwt_claim: String,
+
+    /// JWT secret key used to verify the JWT signature.
+    #[serde(default)]
+    pub jwt_secret: Option<String>,
+
+    /// Expected JWT issuer to validate.
+    #[serde(default)]
+    pub jwt_issuer: Option<String>,
+
+    /// Optional base domain for subdomain tenancy.
+    #[serde(default)]
+    pub base_domain: Option<String>,
 }
 
 fn default_tenancy_source() -> String {
@@ -3202,6 +3214,9 @@ impl Default for TenancyConfig {
             header_name: default_tenancy_header_name(),
             session_key: default_tenancy_session_key(),
             jwt_claim: default_tenancy_jwt_claim(),
+            jwt_secret: None,
+            jwt_issuer: None,
+            base_domain: None,
         }
     }
 }

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -669,6 +669,10 @@ pub struct AutumnConfig {
     #[serde(default)]
     pub cache: CacheConfig,
 
+    /// Row-level multi-tenancy settings.
+    #[serde(default)]
+    pub tenancy: TenancyConfig,
+
     /// HTTP idempotency-key middleware settings.
     #[serde(default)]
     pub idempotency: IdempotencyConfig,
@@ -3028,6 +3032,59 @@ impl TomlEnvConfigLoader {
 impl ConfigLoader for TomlEnvConfigLoader {
     async fn load(&self) -> Result<AutumnConfig, ConfigError> {
         AutumnConfig::load_with_env(&OsEnv)
+    }
+}
+
+/// Row-level multi-tenancy configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TenancyConfig {
+    /// Whether row-level multi-tenancy is enabled.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Source configuration from which the tenant ID is extracted.
+    /// Values can be "header" (default), "subdomain", "session", "jwt".
+    #[serde(default = "default_tenancy_source")]
+    pub source: String,
+
+    /// Header name to lookup if source is "header". Default: "x-tenant-id".
+    #[serde(default = "default_tenancy_header_name")]
+    pub header_name: String,
+
+    /// Session key to lookup if source is "session". Default: "`tenant_id`".
+    #[serde(default = "default_tenancy_session_key")]
+    pub session_key: String,
+
+    /// JWT claim to lookup if source is "jwt". Default: "`tenant_id`".
+    #[serde(default = "default_tenancy_jwt_claim")]
+    pub jwt_claim: String,
+}
+
+fn default_tenancy_source() -> String {
+    "header".to_string()
+}
+
+fn default_tenancy_header_name() -> String {
+    "x-tenant-id".to_string()
+}
+
+fn default_tenancy_session_key() -> String {
+    "tenant_id".to_string()
+}
+
+fn default_tenancy_jwt_claim() -> String {
+    "tenant_id".to_string()
+}
+
+impl Default for TenancyConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            source: default_tenancy_source(),
+            header_name: default_tenancy_header_name(),
+            session_key: default_tenancy_session_key(),
+            jwt_claim: default_tenancy_jwt_claim(),
+        }
     }
 }
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -163,6 +163,7 @@ pub mod sse;
 pub mod static_gen;
 #[cfg(feature = "storage")]
 pub mod storage;
+pub mod tenancy;
 
 pub mod form;
 pub mod job;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -144,6 +144,8 @@ pub use crate::auth::Auth;
 pub use crate::auth::RequireApiToken;
 /// Session extractor for accessing per-user session data.
 pub use crate::session::Session;
+/// Tenant extractor and context helpers.
+pub use crate::tenancy::{Tenant, with_tenant};
 
 // ── Authorization ────────────────────────────────────────────────
 /// Record-level authorization primitives. See

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -69,6 +69,11 @@ pub trait AutumnLockVersionUpdateExt {
 impl<T: ?Sized> AutumnLockVersionModelExt for T {}
 impl<T: ?Sized> AutumnLockVersionUpdateExt for T {}
 
+/// Extension trait to override `tenant_id` on changesets in tenant-scoped updates.
+pub trait CanSetTenantId {
+    fn set_tenant_id(&mut self, tenant_id: String);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1206,9 +1206,7 @@ fn apply_middleware(
         tracing::debug!(count = custom_layer_count, "Custom Tower layers applied");
     }
 
-    // Apply framework middleware. Exception filters wrap outermost so they
-    // see all error responses regardless of scoping or interceptors.
-    let mut router = router.layer(RequestIdLayer).layer(security_headers);
+    let mut router = router;
 
     if config.tenancy.enabled {
         router = router.layer(axum::middleware::from_fn_with_state(
@@ -1217,6 +1215,8 @@ fn apply_middleware(
         ));
         tracing::debug!("Multi-tenancy middleware enabled");
     }
+
+    let router = router.layer(RequestIdLayer).layer(security_headers);
 
     let router = crate::session::apply_session_layer(
         router,

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1208,7 +1208,16 @@ fn apply_middleware(
 
     // Apply framework middleware. Exception filters wrap outermost so they
     // see all error responses regardless of scoping or interceptors.
-    let router = router.layer(RequestIdLayer).layer(security_headers);
+    let mut router = router.layer(RequestIdLayer).layer(security_headers);
+
+    if config.tenancy.enabled {
+        router = router.layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            crate::tenancy::tenancy_middleware,
+        ));
+        tracing::debug!("Multi-tenancy middleware enabled");
+    }
+
     let router = crate::session::apply_session_layer(
         router,
         &config.session,

--- a/autumn/src/tenancy.rs
+++ b/autumn/src/tenancy.rs
@@ -222,6 +222,29 @@ pub async fn extract_tenant_from_parts(
                 crate::AutumnError::unauthorized_msg(format!("JWT validation failed: {e}"))
             })?;
 
+            // `jsonwebtoken`'s `set_audience` validates the `aud` value when
+            // the claim is *present*, but silently accepts tokens that omit the
+            // `aud` field entirely. Explicitly reject those when audience
+            // validation is enabled so legacy tokens without an `aud` claim
+            // cannot bypass the check.
+            if let Some(ref expected_aud) = config.tenancy.jwt_audience {
+                let aud_ok = token_data
+                    .claims
+                    .get("aud")
+                    .is_some_and(|v| match v {
+                        serde_json::Value::String(s) => s == expected_aud,
+                        serde_json::Value::Array(arr) => arr
+                            .iter()
+                            .any(|e| e.as_str() == Some(expected_aud.as_str())),
+                        _ => false,
+                    });
+                if !aud_ok {
+                    return Err(crate::AutumnError::unauthorized_msg(
+                        "JWT audience validation failed: missing or invalid aud claim",
+                    ));
+                }
+            }
+
             let tenant = token_data
                 .claims
                 .get(&config.tenancy.jwt_claim)

--- a/autumn/src/tenancy.rs
+++ b/autumn/src/tenancy.rs
@@ -1,0 +1,250 @@
+use axum::{
+    extract::State,
+    http::Request,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use std::future::Future;
+
+// 1. Task-local storage for CURRENT_TENANT
+tokio::task_local! {
+    pub static CURRENT_TENANT: Option<String>;
+}
+
+// 2. Extractor structure
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tenant(pub String);
+
+impl axum::extract::FromRequestParts<crate::AppState> for Tenant {
+    type Rejection = crate::AutumnError;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &crate::AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let config = state
+            .extension::<crate::config::AutumnConfig>()
+            .ok_or_else(|| {
+                crate::AutumnError::service_unavailable_msg("Config is not available")
+            })?;
+        let tenant_id = extract_tenant_from_parts(parts, &config).await?;
+        Ok(Self(tenant_id))
+    }
+}
+
+// Helper to run in-test tenancy contexts
+pub async fn with_tenant<F, R>(tenant_id: String, future: F) -> R
+where
+    F: Future<Output = R>,
+{
+    CURRENT_TENANT.scope(Some(tenant_id), future).await
+}
+
+// Internal base64url decoder without external dependencies
+fn base64url_decode(input: &str) -> Option<Vec<u8>> {
+    let mut s = input.replace('-', "+").replace('_', "/");
+    while !s.len().is_multiple_of(4) {
+        s.push('=');
+    }
+    let mut bytes = Vec::new();
+    let chars: Vec<char> = s.chars().collect();
+    let lookup = |c: char| -> Option<u8> {
+        match c {
+            'A'..='Z' => Some(c as u8 - b'A'),
+            'a'..='z' => Some(c as u8 - b'a' + 26),
+            '0'..='9' => Some(c as u8 - b'0' + 52),
+            '+' => Some(62),
+            '/' => Some(63),
+            '=' => Some(0),
+            _ => None,
+        }
+    };
+
+    let mut i = 0;
+    while i < chars.len() {
+        if i + 3 >= chars.len() {
+            break;
+        }
+        let c1 = lookup(chars[i])?;
+        let c2 = lookup(chars[i + 1])?;
+        let c3 = lookup(chars[i + 2])?;
+        let c4 = lookup(chars[i + 3])?;
+
+        let b1 = (c1 << 2) | (c2 >> 4);
+        let b2 = ((c2 & 0x0f) << 4) | (c3 >> 2);
+        let b3 = ((c3 & 0x03) << 6) | c4;
+
+        bytes.push(b1);
+        if chars[i + 2] != '=' {
+            bytes.push(b2);
+        }
+        if chars[i + 3] != '=' {
+            bytes.push(b3);
+        }
+        i += 4;
+    }
+    Some(bytes)
+}
+
+// Tenant extraction logic based on configuration
+#[allow(clippy::missing_errors_doc, clippy::too_many_lines)]
+pub async fn extract_tenant_from_parts(
+    parts: &mut axum::http::request::Parts,
+    config: &crate::config::AutumnConfig,
+) -> Result<String, crate::AutumnError> {
+    if !config.tenancy.enabled {
+        return Err(crate::AutumnError::bad_request_msg("Tenancy is disabled"));
+    }
+
+    match config.tenancy.source.as_str() {
+        "header" => {
+            let header_value = parts
+                .headers
+                .get(&config.tenancy.header_name)
+                .ok_or_else(|| {
+                    crate::AutumnError::bad_request_msg(format!(
+                        "Missing required tenant header: {}",
+                        config.tenancy.header_name
+                    ))
+                })?;
+            let val = header_value
+                .to_str()
+                .map_err(|_| {
+                    crate::AutumnError::bad_request_msg(format!(
+                        "Invalid UTF-8 in tenant header: {}",
+                        config.tenancy.header_name
+                    ))
+                })?
+                .to_string();
+            if val.trim().is_empty() {
+                return Err(crate::AutumnError::bad_request_msg(format!(
+                    "Tenant header {} is empty",
+                    config.tenancy.header_name
+                )));
+            }
+            Ok(val)
+        }
+        "subdomain" => {
+            let host_header = parts.headers.get(axum::http::header::HOST).ok_or_else(|| {
+                crate::AutumnError::bad_request_msg("Missing Host header for subdomain tenancy")
+            })?;
+            let host = host_header
+                .to_str()
+                .map_err(|_| crate::AutumnError::bad_request_msg("Invalid UTF-8 in Host header"))?;
+            let subdomain = host.split('.').next().ok_or_else(|| {
+                crate::AutumnError::bad_request_msg("Unable to extract subdomain from Host header")
+            })?;
+            let tenant = subdomain.split(':').next().unwrap_or(subdomain).to_string();
+            if tenant.trim().is_empty() {
+                return Err(crate::AutumnError::bad_request_msg(
+                    "Extracted subdomain tenant is empty",
+                ));
+            }
+            Ok(tenant)
+        }
+        "session" => {
+            let session = parts
+                .extensions
+                .get::<crate::session::Session>()
+                .ok_or_else(|| {
+                    crate::AutumnError::internal_server_error_msg(
+                        "SessionLayer not installed but session tenancy source is configured",
+                    )
+                })?;
+            let tenant = session
+                .get(&config.tenancy.session_key)
+                .await
+                .ok_or_else(|| {
+                    crate::AutumnError::unauthorized_msg(format!(
+                        "Tenant ID missing from session key: {}",
+                        config.tenancy.session_key
+                    ))
+                })?;
+            if tenant.trim().is_empty() {
+                return Err(crate::AutumnError::unauthorized_msg(format!(
+                    "Tenant ID in session key {} is empty",
+                    config.tenancy.session_key
+                )));
+            }
+            Ok(tenant)
+        }
+        "jwt" => {
+            let auth_header = parts
+                .headers
+                .get(axum::http::header::AUTHORIZATION)
+                .ok_or_else(|| {
+                    crate::AutumnError::unauthorized_msg(
+                        "Missing Authorization header for JWT tenancy",
+                    )
+                })?;
+            let auth_str = auth_header.to_str().map_err(|_| {
+                crate::AutumnError::unauthorized_msg("Invalid UTF-8 in Authorization header")
+            })?;
+            if !auth_str.starts_with("Bearer ") {
+                return Err(crate::AutumnError::unauthorized_msg(
+                    "Invalid Authorization header format. Expected Bearer <token>",
+                ));
+            }
+            let token = &auth_str[7..];
+            let payload = token
+                .split('.')
+                .nth(1)
+                .ok_or_else(|| crate::AutumnError::unauthorized_msg("Invalid JWT token format"))?;
+            let decoded_bytes = base64url_decode(payload).ok_or_else(|| {
+                crate::AutumnError::unauthorized_msg("Failed to decode JWT payload base64url")
+            })?;
+            let json: serde_json::Value = serde_json::from_slice(&decoded_bytes).map_err(|_| {
+                crate::AutumnError::unauthorized_msg("Failed to parse JWT payload as JSON")
+            })?;
+            let tenant = json
+                .get(&config.tenancy.jwt_claim)
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    crate::AutumnError::unauthorized_msg(format!(
+                        "Tenant claim '{}' missing from JWT payload",
+                        config.tenancy.jwt_claim
+                    ))
+                })?
+                .to_string();
+            if tenant.trim().is_empty() {
+                return Err(crate::AutumnError::unauthorized_msg(format!(
+                    "Tenant claim '{}' in JWT payload is empty",
+                    config.tenancy.jwt_claim
+                )));
+            }
+            Ok(tenant)
+        }
+        other => Err(crate::AutumnError::internal_server_error_msg(format!(
+            "Unsupported tenancy source: {other}"
+        ))),
+    }
+}
+
+// Tenancy middleware for Axum requests
+pub async fn tenancy_middleware(
+    State(state): State<crate::AppState>,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    let Some(config) = state.extension::<crate::config::AutumnConfig>() else {
+        return crate::AutumnError::internal_server_error_msg(
+            "AutumnConfig not found in AppState",
+        )
+        .into_response();
+    };
+
+    if !config.tenancy.enabled {
+        return next.run(request).await;
+    }
+
+    let (mut parts, body) = request.into_parts();
+    let tenant_id = match extract_tenant_from_parts(&mut parts, &config).await {
+        Ok(t) => t,
+        Err(e) => return e.into_response(),
+    };
+
+    let request = Request::from_parts(parts, body);
+    CURRENT_TENANT
+        .scope(Some(tenant_id), next.run(request))
+        .await
+}

--- a/autumn/src/tenancy.rs
+++ b/autumn/src/tenancy.rs
@@ -196,7 +196,10 @@ pub async fn extract_tenant_from_parts(
                 crate::AutumnError::unauthorized_msg("Invalid UTF-8 in Authorization header")
             })?;
 
-            if auth_str.len() < 7 || !auth_str[..7].eq_ignore_ascii_case("bearer ") {
+            if auth_str.len() < 7
+                || !auth_str.is_char_boundary(7)
+                || !auth_str[..7].eq_ignore_ascii_case("bearer ")
+            {
                 return Err(crate::AutumnError::unauthorized_msg(
                     "Invalid Authorization header format. Expected Bearer <token>",
                 ));

--- a/autumn/src/tenancy.rs
+++ b/autumn/src/tenancy.rs
@@ -4,7 +4,11 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
+use http_body::Body as HttpBody;
+use pin_project_lite::pin_project;
 use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 // 1. Task-local storage for CURRENT_TENANT
 tokio::task_local! {
@@ -228,16 +232,13 @@ pub async fn extract_tenant_from_parts(
             // validation is enabled so legacy tokens without an `aud` claim
             // cannot bypass the check.
             if let Some(ref expected_aud) = config.tenancy.jwt_audience {
-                let aud_ok = token_data
-                    .claims
-                    .get("aud")
-                    .is_some_and(|v| match v {
-                        serde_json::Value::String(s) => s == expected_aud,
-                        serde_json::Value::Array(arr) => arr
-                            .iter()
-                            .any(|e| e.as_str() == Some(expected_aud.as_str())),
-                        _ => false,
-                    });
+                let aud_ok = token_data.claims.get("aud").is_some_and(|v| match v {
+                    serde_json::Value::String(s) => s == expected_aud,
+                    serde_json::Value::Array(arr) => arr
+                        .iter()
+                        .any(|e| e.as_str() == Some(expected_aud.as_str())),
+                    _ => false,
+                });
                 if !aud_ok {
                     return Err(crate::AutumnError::unauthorized_msg(
                         "JWT audience validation failed: missing or invalid aud claim",
@@ -293,7 +294,117 @@ pub async fn tenancy_middleware(
     };
 
     let request = Request::from_parts(parts, body);
-    CURRENT_TENANT
+    let tenant_id_clone = tenant_id.clone();
+    let response = CURRENT_TENANT
         .scope(Some(tenant_id), next.run(request))
-        .await
+        .await;
+
+    let (parts, body) = response.into_parts();
+    let wrapped = TenantPropagatingBody {
+        inner: body,
+        tenant_id: tenant_id_clone,
+    };
+    Response::from_parts(parts, axum::body::Body::new(wrapped))
+}
+
+pin_project! {
+    /// A response body wrapper that re-establishes the tenant context
+    /// for each poll of the inner body, so lazy/streaming bodies can
+    /// access tenant-scoped repositories during their polling phase.
+    pub struct TenantPropagatingBody<B> {
+        #[pin]
+        pub inner: B,
+        pub tenant_id: String,
+    }
+}
+
+impl<B> HttpBody for TenantPropagatingBody<B>
+where
+    B: HttpBody,
+{
+    type Data = B::Data;
+    type Error = B::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.project();
+        let tenant_id = this.tenant_id.clone();
+        CURRENT_TENANT.sync_scope(Some(tenant_id), || this.inner.poll_frame(cx))
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+/// A trait implemented by model insertable helper types to dynamically set tenant ID.
+///
+/// This sets or appends the tenant ID before database insertion. This avoids SQL duplicate
+/// column errors when a model already has a manual (non-default) `tenant_id` field.
+#[cfg(feature = "db")]
+pub trait TenantInsertable<'a, Table> {
+    type Values;
+    fn tenant_values(self, tenant_id: &'a str) -> Self::Values;
+}
+
+/// Metadata about a model's `tenant_id` struct field.
+#[cfg(feature = "db")]
+pub trait ModelTenantIdMeta {
+    /// True if the struct has a manual `tenant_id` field.
+    const HAS_MANUAL_TENANT_ID: bool;
+    /// Sets the tenant ID field on the struct if it has one.
+    fn try_set_tenant_id(&mut self, tenant_id: &str);
+}
+
+/// A trait that bridges a Diesel table to its `tenant_id` column.
+#[cfg(feature = "db")]
+pub trait HasTenantIdColumn {
+    type Column: ::diesel::Expression<SqlType = ::diesel::sql_types::Text>;
+    fn column() -> Self::Column;
+}
+
+/// A selector helper to choose between different insertable values.
+#[cfg(feature = "db")]
+pub struct TenantInsertableValuesSelector<'a, T, Table, const HAS_MANUAL: bool> {
+    pub inner: T,
+    pub tenant_id: &'a str,
+    pub _marker: std::marker::PhantomData<Table>,
+}
+
+/// A trait implemented by selector variants to get the actual insertable values.
+#[cfg(feature = "db")]
+pub trait GetInsertableValues {
+    type Values;
+    fn get_values(self) -> Self::Values;
+}
+
+#[cfg(feature = "db")]
+impl<T, Table> GetInsertableValues for TenantInsertableValuesSelector<'_, T, Table, true>
+where
+    T: ModelTenantIdMeta,
+{
+    type Values = T;
+    fn get_values(mut self) -> Self::Values {
+        self.inner.try_set_tenant_id(self.tenant_id);
+        self.inner
+    }
+}
+
+#[cfg(feature = "db")]
+impl<'a, T, Table> GetInsertableValues for TenantInsertableValuesSelector<'a, T, Table, false>
+where
+    Table: HasTenantIdColumn,
+    Table::Column: ::diesel::ExpressionMethods,
+{
+    type Values = (T, ::diesel::dsl::Eq<Table::Column, &'a str>);
+    fn get_values(self) -> Self::Values {
+        use ::diesel::ExpressionMethods;
+        (self.inner, Table::column().eq(self.tenant_id))
+    }
 }

--- a/autumn/src/tenancy.rs
+++ b/autumn/src/tenancy.rs
@@ -94,25 +94,29 @@ pub async fn extract_tenant_from_parts(
                 ));
             }
 
+            // DNS hostnames are case-insensitive; normalise to lowercase
+            // before any matching so that e.g. `Tenant1.Example.COM` works.
+            let host_lower = host_only.to_lowercase();
+
             if let Some(ref base_domain) = config.tenancy.base_domain {
-                let base_domain_clean = base_domain.trim();
-                if !host_only.ends_with(base_domain_clean) {
+                let base_domain_clean = base_domain.trim().to_lowercase();
+                if !host_lower.ends_with(base_domain_clean.as_str()) {
                     return Err(crate::AutumnError::bad_request_msg(format!(
                         "Host does not match base domain: {base_domain_clean}"
                     )));
                 }
-                if host_only.len() <= base_domain_clean.len() {
+                if host_lower.len() <= base_domain_clean.len() {
                     return Err(crate::AutumnError::bad_request_msg(
                         "Apex domain not allowed in subdomain mode",
                     ));
                 }
-                let prefix_len = host_only.len() - base_domain_clean.len();
-                if !host_only[..prefix_len].ends_with('.') {
+                let prefix_len = host_lower.len() - base_domain_clean.len();
+                if !host_lower[..prefix_len].ends_with('.') {
                     return Err(crate::AutumnError::bad_request_msg(
                         "Invalid subdomain format",
                     ));
                 }
-                let subdomain_part = &host_only[..prefix_len - 1];
+                let subdomain_part = &host_lower[..prefix_len - 1];
                 let tenant = subdomain_part.split('.').next().ok_or_else(|| {
                     crate::AutumnError::bad_request_msg("Unable to extract subdomain tenant")
                 })?;
@@ -123,7 +127,7 @@ pub async fn extract_tenant_from_parts(
                 }
                 Ok(tenant.to_string())
             } else {
-                let labels: Vec<&str> = host_only.split('.').filter(|s| !s.is_empty()).collect();
+                let labels: Vec<&str> = host_lower.split('.').filter(|s| !s.is_empty()).collect();
                 if labels.is_empty() {
                     return Err(crate::AutumnError::bad_request_msg("Empty host header"));
                 }
@@ -203,7 +207,11 @@ pub async fn extract_tenant_from_parts(
             if let Some(ref iss) = config.tenancy.jwt_issuer {
                 validation.set_issuer(::std::slice::from_ref(iss));
             }
-            validation.validate_aud = false;
+            if let Some(ref aud) = config.tenancy.jwt_audience {
+                validation.set_audience(&[aud.as_str()]);
+            } else {
+                validation.validate_aud = false;
+            }
 
             let token_data = ::jsonwebtoken::decode::<serde_json::Value>(
                 token,

--- a/autumn/src/tenancy.rs
+++ b/autumn/src/tenancy.rs
@@ -40,52 +40,6 @@ where
     CURRENT_TENANT.scope(Some(tenant_id), future).await
 }
 
-// Internal base64url decoder without external dependencies
-fn base64url_decode(input: &str) -> Option<Vec<u8>> {
-    let mut s = input.replace('-', "+").replace('_', "/");
-    while !s.len().is_multiple_of(4) {
-        s.push('=');
-    }
-    let mut bytes = Vec::new();
-    let chars: Vec<char> = s.chars().collect();
-    let lookup = |c: char| -> Option<u8> {
-        match c {
-            'A'..='Z' => Some(c as u8 - b'A'),
-            'a'..='z' => Some(c as u8 - b'a' + 26),
-            '0'..='9' => Some(c as u8 - b'0' + 52),
-            '+' => Some(62),
-            '/' => Some(63),
-            '=' => Some(0),
-            _ => None,
-        }
-    };
-
-    let mut i = 0;
-    while i < chars.len() {
-        if i + 3 >= chars.len() {
-            break;
-        }
-        let c1 = lookup(chars[i])?;
-        let c2 = lookup(chars[i + 1])?;
-        let c3 = lookup(chars[i + 2])?;
-        let c4 = lookup(chars[i + 3])?;
-
-        let b1 = (c1 << 2) | (c2 >> 4);
-        let b2 = ((c2 & 0x0f) << 4) | (c3 >> 2);
-        let b3 = ((c3 & 0x03) << 6) | c4;
-
-        bytes.push(b1);
-        if chars[i + 2] != '=' {
-            bytes.push(b2);
-        }
-        if chars[i + 3] != '=' {
-            bytes.push(b3);
-        }
-        i += 4;
-    }
-    Some(bytes)
-}
-
 // Tenant extraction logic based on configuration
 #[allow(clippy::missing_errors_doc, clippy::too_many_lines)]
 pub async fn extract_tenant_from_parts(
@@ -131,16 +85,69 @@ pub async fn extract_tenant_from_parts(
             let host = host_header
                 .to_str()
                 .map_err(|_| crate::AutumnError::bad_request_msg("Invalid UTF-8 in Host header"))?;
-            let subdomain = host.split('.').next().ok_or_else(|| {
-                crate::AutumnError::bad_request_msg("Unable to extract subdomain from Host header")
-            })?;
-            let tenant = subdomain.split(':').next().unwrap_or(subdomain).to_string();
-            if tenant.trim().is_empty() {
+
+            let host_only = host.split(':').next().unwrap_or(host).trim();
+
+            if host_only.parse::<std::net::IpAddr>().is_ok() {
                 return Err(crate::AutumnError::bad_request_msg(
-                    "Extracted subdomain tenant is empty",
+                    "IP address host not allowed in subdomain mode",
                 ));
             }
-            Ok(tenant)
+
+            if let Some(ref base_domain) = config.tenancy.base_domain {
+                let base_domain_clean = base_domain.trim();
+                if !host_only.ends_with(base_domain_clean) {
+                    return Err(crate::AutumnError::bad_request_msg(format!(
+                        "Host does not match base domain: {base_domain_clean}"
+                    )));
+                }
+                if host_only.len() <= base_domain_clean.len() {
+                    return Err(crate::AutumnError::bad_request_msg(
+                        "Apex domain not allowed in subdomain mode",
+                    ));
+                }
+                let prefix_len = host_only.len() - base_domain_clean.len();
+                if !host_only[..prefix_len].ends_with('.') {
+                    return Err(crate::AutumnError::bad_request_msg(
+                        "Invalid subdomain format",
+                    ));
+                }
+                let subdomain_part = &host_only[..prefix_len - 1];
+                let tenant = subdomain_part.split('.').next().ok_or_else(|| {
+                    crate::AutumnError::bad_request_msg("Unable to extract subdomain tenant")
+                })?;
+                if tenant.trim().is_empty() {
+                    return Err(crate::AutumnError::bad_request_msg(
+                        "Extracted subdomain tenant is empty",
+                    ));
+                }
+                Ok(tenant.to_string())
+            } else {
+                let labels: Vec<&str> = host_only.split('.').filter(|s| !s.is_empty()).collect();
+                if labels.is_empty() {
+                    return Err(crate::AutumnError::bad_request_msg("Empty host header"));
+                }
+
+                if labels.len() < 2 {
+                    return Err(crate::AutumnError::bad_request_msg(
+                        "Apex or local host without subdomain not allowed",
+                    ));
+                }
+
+                if labels.len() == 2 && labels[1] != "localhost" {
+                    return Err(crate::AutumnError::bad_request_msg(
+                        "Apex domain not allowed in subdomain mode",
+                    ));
+                }
+
+                let tenant = labels[0].to_string();
+                if tenant.trim().is_empty() {
+                    return Err(crate::AutumnError::bad_request_msg(
+                        "Extracted subdomain tenant is empty",
+                    ));
+                }
+                Ok(tenant)
+            }
         }
         "session" => {
             let session = parts
@@ -180,23 +187,35 @@ pub async fn extract_tenant_from_parts(
             let auth_str = auth_header.to_str().map_err(|_| {
                 crate::AutumnError::unauthorized_msg("Invalid UTF-8 in Authorization header")
             })?;
-            if !auth_str.starts_with("Bearer ") {
+
+            if auth_str.len() < 7 || !auth_str[..7].eq_ignore_ascii_case("bearer ") {
                 return Err(crate::AutumnError::unauthorized_msg(
                     "Invalid Authorization header format. Expected Bearer <token>",
                 ));
             }
             let token = &auth_str[7..];
-            let payload = token
-                .split('.')
-                .nth(1)
-                .ok_or_else(|| crate::AutumnError::unauthorized_msg("Invalid JWT token format"))?;
-            let decoded_bytes = base64url_decode(payload).ok_or_else(|| {
-                crate::AutumnError::unauthorized_msg("Failed to decode JWT payload base64url")
+
+            let secret = config.tenancy.jwt_secret.as_ref().ok_or_else(|| {
+                crate::AutumnError::unauthorized_msg("JWT secret is not configured")
             })?;
-            let json: serde_json::Value = serde_json::from_slice(&decoded_bytes).map_err(|_| {
-                crate::AutumnError::unauthorized_msg("Failed to parse JWT payload as JSON")
+
+            let mut validation = ::jsonwebtoken::Validation::default();
+            if let Some(ref iss) = config.tenancy.jwt_issuer {
+                validation.set_issuer(::std::slice::from_ref(iss));
+            }
+            validation.validate_aud = false;
+
+            let token_data = ::jsonwebtoken::decode::<serde_json::Value>(
+                token,
+                &::jsonwebtoken::DecodingKey::from_secret(secret.as_bytes()),
+                &validation,
+            )
+            .map_err(|e| {
+                crate::AutumnError::unauthorized_msg(format!("JWT validation failed: {e}"))
             })?;
-            let tenant = json
+
+            let tenant = token_data
+                .claims
                 .get(&config.tenancy.jwt_claim)
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| {
@@ -206,6 +225,7 @@ pub async fn extract_tenant_from_parts(
                     ))
                 })?
                 .to_string();
+
             if tenant.trim().is_empty() {
                 return Err(crate::AutumnError::unauthorized_msg(format!(
                     "Tenant claim '{}' in JWT payload is empty",
@@ -227,10 +247,8 @@ pub async fn tenancy_middleware(
     next: Next,
 ) -> Response {
     let Some(config) = state.extension::<crate::config::AutumnConfig>() else {
-        return crate::AutumnError::internal_server_error_msg(
-            "AutumnConfig not found in AppState",
-        )
-        .into_response();
+        return crate::AutumnError::internal_server_error_msg("AutumnConfig not found in AppState")
+            .into_response();
     };
 
     if !config.tenancy.enabled {

--- a/autumn/tests/tenancy.rs
+++ b/autumn/tests/tenancy.rs
@@ -217,3 +217,72 @@ async fn test_escape_hatch_across_tenants() {
     let all = repo.across_tenants().find_all().await.unwrap();
     assert_eq!(all.len(), 2);
 }
+
+// 4. Test that client attempts to update tenant_id in scoped updates are overridden/blocked
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn test_immutable_tenant_id_on_update() {
+    let container = testcontainers_modules::postgres::Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let manager = diesel_async::pooled_connection::AsyncDieselConnectionManager::<
+        diesel_async::AsyncPgConnection,
+    >::new(&url);
+    let pool = diesel_async::pooled_connection::deadpool::Pool::builder(manager)
+        .max_size(5)
+        .build()
+        .unwrap();
+
+    setup_db(&pool).await;
+
+    let repo = PgTenantPostRepository {
+        pool,
+        across_tenants: false,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: ::std::time::Duration::from_millis(100),
+        __autumn_route: ::core::option::Option::None,
+    };
+
+    // Save record for tenant A
+    let post_a = with_tenant("tenant-a".to_string(), async {
+        repo.save(&NewTenantPost {
+            title: "Post A".to_string(),
+        })
+        .await
+        .unwrap()
+    })
+    .await;
+    assert_eq!(post_a.tenant_id, "tenant-a");
+
+    // Try to update post_a's title
+    let updated = with_tenant("tenant-a".to_string(), async {
+        let changes = UpdateTenantPost {
+            title: ::autumn_web::hooks::Patch::Set("Post A Updated".to_string()),
+        };
+        repo.update(post_a.id, &changes).await.unwrap()
+    })
+    .await;
+
+    // The returned record should still have tenant_id "tenant-a", not "tenant-b"
+    assert_eq!(updated.tenant_id, "tenant-a");
+    assert_eq!(updated.title, "Post A Updated");
+
+    // Assert that the record still belongs to tenant-a, not tenant-b
+    with_tenant("tenant-b".to_string(), async {
+        let not_found = repo.find_by_id(post_a.id).await.unwrap();
+        assert!(not_found.is_none());
+    })
+    .await;
+
+    with_tenant("tenant-a".to_string(), async {
+        let found = repo.find_by_id(post_a.id).await.unwrap().unwrap();
+        assert_eq!(found.tenant_id, "tenant-a");
+        assert_eq!(found.title, "Post A Updated");
+    })
+    .await;
+}

--- a/autumn/tests/tenancy.rs
+++ b/autumn/tests/tenancy.rs
@@ -320,3 +320,50 @@ async fn test_immutable_tenant_id_on_update() {
     })
     .await;
 }
+
+// 5. Test that across_tenants().save(...) works with a framework-managed tenant_id (omitted from New*)
+// when a CURRENT_TENANT is established, resolving and inserting the correct tenant_id.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn test_across_tenants_save_without_tenant_id_on_new_struct_works() {
+    let container = testcontainers_modules::postgres::Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let manager = diesel_async::pooled_connection::AsyncDieselConnectionManager::<
+        diesel_async::AsyncPgConnection,
+    >::new(&url);
+    let pool = diesel_async::pooled_connection::deadpool::Pool::builder(manager)
+        .max_size(5)
+        .build()
+        .unwrap();
+
+    setup_db(&pool).await;
+
+    let repo = PgTenantPostRepository {
+        pool,
+        across_tenants: false,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: ::std::time::Duration::from_millis(100),
+        __autumn_route: ::core::option::Option::None,
+    };
+
+    // Under `across_tenants()`, we can save a `NewTenantPost` (which does NOT have a tenant_id field)
+    // if a CURRENT_TENANT is established, it should correctly resolve and use that tenant_id.
+    let saved = with_tenant("tenant-c".to_string(), async {
+        repo.across_tenants()
+            .save(&NewTenantPost {
+                title: "Across Tenant Save".to_string(),
+            })
+            .await
+            .unwrap()
+    })
+    .await;
+
+    assert_eq!(saved.title, "Across Tenant Save");
+    assert_eq!(saved.tenant_id, "tenant-c");
+}

--- a/autumn/tests/tenancy.rs
+++ b/autumn/tests/tenancy.rs
@@ -30,6 +30,40 @@ pub trait TenantPostRepository {
     fn find_by_title(title: String) -> Vec<TenantPost>;
 }
 
+mod manual_schema {
+    ::autumn_web::reexports::diesel::table! {
+        manual_tenant_posts (id) {
+            id -> Int8,
+            title -> Text,
+            tenant_id -> Text,
+        }
+    }
+}
+
+use manual_schema::manual_tenant_posts;
+
+#[autumn_web::model(table = "manual_tenant_posts")]
+pub struct ManualTenantPost {
+    #[id]
+    pub id: i64,
+    pub title: String,
+    pub tenant_id: String,
+}
+
+#[autumn_web::repository(ManualTenantPost, table = "manual_tenant_posts", tenant_scoped)]
+pub trait ManualTenantPostRepository {}
+
+#[test]
+fn test_manual_tenant_id_insertable() {
+    use autumn_web::tenancy::TenantInsertable;
+    let post = NewManualTenantPost {
+        title: "Hello".to_string(),
+        tenant_id: String::new(),
+    };
+    let with_tenant = post.tenant_values("my-tenant");
+    assert_eq!(with_tenant.tenant_id, "my-tenant");
+}
+
 // Helper to set up the DB table.
 async fn setup_db(
     pool: &autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<

--- a/autumn/tests/tenancy.rs
+++ b/autumn/tests/tenancy.rs
@@ -1,0 +1,210 @@
+#![cfg(feature = "db")]
+
+use autumn_web::tenancy::with_tenant;
+use diesel_async::RunQueryDsl;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        tenant_posts (id) {
+            id -> Int8,
+            title -> Text,
+            tenant_id -> Text,
+        }
+    }
+}
+
+use schema::tenant_posts;
+
+#[autumn_web::model(table = "tenant_posts")]
+pub struct TenantPost {
+    #[id]
+    pub id: i64,
+    pub title: String,
+    #[default]
+    pub tenant_id: String,
+}
+
+#[autumn_web::repository(TenantPost, table = "tenant_posts", tenant_scoped)]
+pub trait TenantPostRepository {
+    fn find_by_title(title: String) -> Vec<TenantPost>;
+}
+
+// Helper to set up the DB table.
+async fn setup_db(
+    pool: &autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
+        autumn_web::reexports::diesel_async::AsyncPgConnection,
+    >,
+) {
+    let mut conn = pool.get().await.unwrap();
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS tenant_posts (
+            id BIGSERIAL PRIMARY KEY,
+            title TEXT NOT NULL,
+            tenant_id TEXT NOT NULL
+        )",
+    )
+    .execute(&mut *conn)
+    .await
+    .unwrap();
+    diesel::sql_query("TRUNCATE tenant_posts RESTART IDENTITY")
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+}
+
+// 1. Test standard/derived CRUD operations under a specific tenant context
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn test_tenant_scoping_isolation() {
+    let container = testcontainers_modules::postgres::Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let manager = diesel_async::pooled_connection::AsyncDieselConnectionManager::<
+        diesel_async::AsyncPgConnection,
+    >::new(&url);
+    let pool = diesel_async::pooled_connection::deadpool::Pool::builder(manager)
+        .max_size(5)
+        .build()
+        .unwrap();
+
+    setup_db(&pool).await;
+
+    let repo = PgTenantPostRepository {
+        pool,
+        across_tenants: false,
+    };
+
+    // Save record for tenant A
+    let post_a = with_tenant("tenant-a".to_string(), async {
+        repo.save(&NewTenantPost {
+            title: "Post A".to_string(),
+        })
+        .await
+        .unwrap()
+    })
+    .await;
+    assert_eq!(post_a.tenant_id, "tenant-a");
+
+    // Save record for tenant B
+    let post_b = with_tenant("tenant-b".to_string(), async {
+        repo.save(&NewTenantPost {
+            title: "Post B".to_string(),
+        })
+        .await
+        .unwrap()
+    })
+    .await;
+    assert_eq!(post_b.tenant_id, "tenant-b");
+
+    // Assert tenant A can only read tenant A's post
+    with_tenant("tenant-a".to_string(), async {
+        let all = repo.find_all().await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].title, "Post A");
+
+        let found = repo.find_by_id(post_a.id).await.unwrap().unwrap();
+        assert_eq!(found.title, "Post A");
+
+        let found_by_title = repo.find_by_title("Post A".to_string()).await.unwrap();
+        assert_eq!(found_by_title.len(), 1);
+
+        let not_found = repo.find_by_id(post_b.id).await.unwrap();
+        assert!(not_found.is_none());
+
+        let exists = repo.exists_by_id(post_a.id).await.unwrap();
+        assert!(exists);
+        let exists_b = repo.exists_by_id(post_b.id).await.unwrap();
+        assert!(!exists_b);
+    })
+    .await;
+}
+
+// 2. Test that calling repository methods without a tenant context throws an error
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn test_unscoped_query_without_context_fails() {
+    let container = testcontainers_modules::postgres::Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let manager = diesel_async::pooled_connection::AsyncDieselConnectionManager::<
+        diesel_async::AsyncPgConnection,
+    >::new(&url);
+    let pool = diesel_async::pooled_connection::deadpool::Pool::builder(manager)
+        .max_size(5)
+        .build()
+        .unwrap();
+
+    setup_db(&pool).await;
+    let repo = PgTenantPostRepository {
+        pool,
+        across_tenants: false,
+    };
+
+    // Scoped methods should fail when run unscoped without context
+    let result = repo.find_all().await;
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("no tenant context was established"),
+        "Expected tenant context error, got: {err}"
+    );
+}
+
+// 3. Test that the across_tenants() escape hatch works and bypasses scoping
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn test_escape_hatch_across_tenants() {
+    let container = testcontainers_modules::postgres::Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let manager = diesel_async::pooled_connection::AsyncDieselConnectionManager::<
+        diesel_async::AsyncPgConnection,
+    >::new(&url);
+    let pool = diesel_async::pooled_connection::deadpool::Pool::builder(manager)
+        .max_size(5)
+        .build()
+        .unwrap();
+
+    setup_db(&pool).await;
+    let repo = PgTenantPostRepository {
+        pool,
+        across_tenants: false,
+    };
+
+    with_tenant("tenant-a".to_string(), async {
+        repo.save(&NewTenantPost {
+            title: "Post A".to_string(),
+        })
+        .await
+        .unwrap();
+    })
+    .await;
+    with_tenant("tenant-b".to_string(), async {
+        repo.save(&NewTenantPost {
+            title: "Post B".to_string(),
+        })
+        .await
+        .unwrap();
+    })
+    .await;
+
+    // Now read across all tenants
+    let all = repo.across_tenants().find_all().await.unwrap();
+    assert_eq!(all.len(), 2);
+}

--- a/autumn/tests/tenancy_unit.rs
+++ b/autumn/tests/tenancy_unit.rs
@@ -10,6 +10,8 @@ struct Claims {
     company: String,
     exp: usize,
     iss: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    aud: Option<String>,
 }
 
 // Helper to generate a signed JWT
@@ -19,6 +21,25 @@ fn generate_jwt(tenant: &str, secret: &str, expired: bool, issuer: Option<&str>)
         company: tenant.to_owned(),
         exp: if expired { 1 } else { 10_000_000_000 },
         iss: issuer.map(std::borrow::ToOwned::to_owned),
+        aud: None,
+    };
+    let header = Header::new(Algorithm::HS256);
+    encode(
+        &header,
+        &my_claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .unwrap()
+}
+
+// Helper to generate a JWT with an audience claim
+fn generate_jwt_with_audience(tenant: &str, secret: &str, audience: Option<&str>) -> String {
+    let my_claims = Claims {
+        sub: "1234567890".to_owned(),
+        company: tenant.to_owned(),
+        exp: 10_000_000_000,
+        iss: None,
+        aud: audience.map(std::borrow::ToOwned::to_owned),
     };
     let header = Header::new(Algorithm::HS256);
     encode(
@@ -228,4 +249,100 @@ async fn test_subdomain_mode_custom_base_domain() {
         .await
         .unwrap_err();
     assert!(err3.to_string().contains("domain") || err3.to_string().contains("subdomain"));
+}
+
+// ── New TDD tests for issue #695 ──────────────────────────────────────────
+
+/// A mixed-case host like `Tenant1.Example.COM` should match `base_domain`
+/// `"example.com"` and return tenant `"tenant1"` (lowercased).
+#[tokio::test]
+async fn mixed_case_host_matches_base_domain() {
+    let mut config = AutumnConfig::default();
+    config.tenancy.enabled = true;
+    config.tenancy.source = "subdomain".to_string();
+    config.tenancy.base_domain = Some("example.com".to_string());
+
+    let req = Request::builder()
+        .header("Host", "Tenant1.Example.COM")
+        .body(())
+        .unwrap();
+    let (mut parts, ()) = req.into_parts();
+    let tenant = extract_tenant_from_parts(&mut parts, &config)
+        .await
+        .expect("mixed-case host should match case-insensitively");
+    assert_eq!(tenant, "tenant1");
+}
+
+/// The apex domain `EXAMPLE.COM` with `base_domain` `"example.com"` should be
+/// rejected (apex not allowed), not succeed.
+#[tokio::test]
+async fn apex_mixed_case_rejected() {
+    let mut config = AutumnConfig::default();
+    config.tenancy.enabled = true;
+    config.tenancy.source = "subdomain".to_string();
+    config.tenancy.base_domain = Some("example.com".to_string());
+
+    let req = Request::builder()
+        .header("Host", "EXAMPLE.COM")
+        .body(())
+        .unwrap();
+    let (mut parts, ()) = req.into_parts();
+    let err = extract_tenant_from_parts(&mut parts, &config)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("apex") || err.to_string().contains("subdomain"),
+        "Expected apex rejection, got: {err}"
+    );
+}
+
+/// When `jwt_audience` is configured and the JWT carries a matching `aud`
+/// claim, extraction should succeed.
+#[tokio::test]
+async fn jwt_audience_valid_passes() {
+    let mut config = AutumnConfig::default();
+    config.tenancy.enabled = true;
+    config.tenancy.source = "jwt".to_string();
+    config.tenancy.jwt_claim = "company".to_string();
+    config.tenancy.jwt_secret = Some("secret".to_string());
+    config.tenancy.jwt_audience = Some("my-api".to_string());
+
+    let token = generate_jwt_with_audience("acme", "secret", Some("my-api"));
+    let req = Request::builder()
+        .header("Authorization", format!("Bearer {token}"))
+        .body(())
+        .unwrap();
+    let (mut parts, ()) = req.into_parts();
+    let tenant = extract_tenant_from_parts(&mut parts, &config)
+        .await
+        .expect("JWT with matching audience should succeed");
+    assert_eq!(tenant, "acme");
+}
+
+/// When `jwt_audience` is configured and the JWT carries a *different* `aud`
+/// claim, extraction must fail with a 401-style error.
+#[tokio::test]
+async fn jwt_audience_mismatch_fails() {
+    let mut config = AutumnConfig::default();
+    config.tenancy.enabled = true;
+    config.tenancy.source = "jwt".to_string();
+    config.tenancy.jwt_claim = "company".to_string();
+    config.tenancy.jwt_secret = Some("secret".to_string());
+    config.tenancy.jwt_audience = Some("my-api".to_string());
+
+    // Token carries audience "wrong-api" — should be rejected
+    let token = generate_jwt_with_audience("acme", "secret", Some("wrong-api"));
+    let req = Request::builder()
+        .header("Authorization", format!("Bearer {token}"))
+        .body(())
+        .unwrap();
+    let (mut parts, ()) = req.into_parts();
+    let err = extract_tenant_from_parts(&mut parts, &config)
+        .await
+        .unwrap_err();
+    let err_str = err.to_string().to_lowercase();
+    assert!(
+        err_str.contains("audience") || err_str.contains("unauthorized"),
+        "Expected audience rejection, got: {err}"
+    );
 }

--- a/autumn/tests/tenancy_unit.rs
+++ b/autumn/tests/tenancy_unit.rs
@@ -376,3 +376,51 @@ async fn jwt_audience_missing_claim_fails() {
         "Expected audience rejection for missing aud claim, got: {err}"
     );
 }
+
+/// When polling a response body wrapped in `TenantPropagatingBody`, the
+/// `CURRENT_TENANT` task-local context must be re-established for the duration
+/// of the poll.
+#[tokio::test]
+async fn tenant_propagating_body_sets_context_during_poll() {
+    use autumn_web::tenancy::{CURRENT_TENANT, TenantPropagatingBody};
+    use bytes::Bytes;
+    use http_body::{Body as HttpBody, Frame};
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    // A body that checks CURRENT_TENANT inside poll_frame
+    struct ContextCheckBody {
+        done: bool,
+    }
+    impl HttpBody for ContextCheckBody {
+        type Data = Bytes;
+        type Error = std::convert::Infallible;
+        fn poll_frame(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+            if self.done {
+                return Poll::Ready(None);
+            }
+            self.done = true;
+            let tenant = CURRENT_TENANT.try_with(Clone::clone).ok().flatten();
+            assert_eq!(
+                tenant.as_deref(),
+                Some("acme"),
+                "tenant must be visible during poll_frame"
+            );
+            Poll::Ready(Some(Ok(Frame::data(Bytes::from("data")))))
+        }
+    }
+
+    let body = ContextCheckBody { done: false };
+    let mut wrapped = TenantPropagatingBody {
+        inner: body,
+        tenant_id: "acme".to_string(),
+    };
+    // Poll it outside any CURRENT_TENANT scope (which would fail without the wrapper)
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let res = Pin::new(&mut wrapped).poll_frame(&mut cx);
+    assert!(res.is_ready());
+}

--- a/autumn/tests/tenancy_unit.rs
+++ b/autumn/tests/tenancy_unit.rs
@@ -346,3 +346,33 @@ async fn jwt_audience_mismatch_fails() {
         "Expected audience rejection, got: {err}"
     );
 }
+
+/// When `jwt_audience` is configured but the JWT has **no** `aud` claim at all
+/// (e.g. a legacy token issuer), extraction must fail. This covers the case
+/// where the token simply omits the audience field rather than providing the
+/// wrong value.
+#[tokio::test]
+async fn jwt_audience_missing_claim_fails() {
+    let mut config = AutumnConfig::default();
+    config.tenancy.enabled = true;
+    config.tenancy.source = "jwt".to_string();
+    config.tenancy.jwt_claim = "company".to_string();
+    config.tenancy.jwt_secret = Some("secret".to_string());
+    config.tenancy.jwt_audience = Some("my-api".to_string());
+
+    // Token has aud: None — skip_serializing_if means the field is absent
+    let token = generate_jwt_with_audience("acme", "secret", None);
+    let req = Request::builder()
+        .header("Authorization", format!("Bearer {token}"))
+        .body(())
+        .unwrap();
+    let (mut parts, ()) = req.into_parts();
+    let err = extract_tenant_from_parts(&mut parts, &config)
+        .await
+        .unwrap_err();
+    let err_str = err.to_string().to_lowercase();
+    assert!(
+        err_str.contains("audience") || err_str.contains("unauthorized"),
+        "Expected audience rejection for missing aud claim, got: {err}"
+    );
+}

--- a/autumn/tests/tenancy_unit.rs
+++ b/autumn/tests/tenancy_unit.rs
@@ -1,0 +1,231 @@
+use autumn_web::config::AutumnConfig;
+use autumn_web::tenancy::extract_tenant_from_parts;
+use axum::http::Request;
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Claims {
+    sub: String,
+    company: String,
+    exp: usize,
+    iss: Option<String>,
+}
+
+// Helper to generate a signed JWT
+fn generate_jwt(tenant: &str, secret: &str, expired: bool, issuer: Option<&str>) -> String {
+    let my_claims = Claims {
+        sub: "1234567890".to_owned(),
+        company: tenant.to_owned(),
+        exp: if expired { 1 } else { 10_000_000_000 },
+        iss: issuer.map(std::borrow::ToOwned::to_owned),
+    };
+    let header = Header::new(Algorithm::HS256);
+    encode(
+        &header,
+        &my_claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .unwrap()
+}
+
+// Test case-insensitive Bearer check
+#[tokio::test]
+async fn test_case_insensitive_bearer_and_valid_jwt() {
+    let mut config = AutumnConfig::default();
+    config.tenancy.enabled = true;
+    config.tenancy.source = "jwt".to_string();
+    config.tenancy.jwt_claim = "company".to_string();
+    config.tenancy.jwt_secret = Some("my-secret".to_string());
+    config.tenancy.jwt_issuer = Some("my-issuer".to_string());
+
+    let token = generate_jwt("tenant123", "my-secret", false, Some("my-issuer"));
+
+    // Case 1: Standard "Bearer "
+    let req1 = Request::builder()
+        .header("Authorization", format!("Bearer {token}"))
+        .body(())
+        .unwrap();
+    let (mut parts1, ()) = req1.into_parts();
+    let tenant1 = extract_tenant_from_parts(&mut parts1, &config)
+        .await
+        .expect("Should extract tenant with valid Bearer prefix");
+    assert_eq!(tenant1, "tenant123");
+
+    // Case 2: lowercase "bearer "
+    let req2 = Request::builder()
+        .header("Authorization", format!("bearer {token}"))
+        .body(())
+        .unwrap();
+    let (mut parts2, ()) = req2.into_parts();
+    let tenant2 = extract_tenant_from_parts(&mut parts2, &config)
+        .await
+        .expect("Should extract tenant with lowercase bearer prefix");
+    assert_eq!(tenant2, "tenant123");
+
+    // Case 3: mixed case "bEaReR "
+    let req3 = Request::builder()
+        .header("Authorization", format!("bEaReR {token}"))
+        .body(())
+        .unwrap();
+    let (mut parts3, ()) = req3.into_parts();
+    let tenant3 = extract_tenant_from_parts(&mut parts3, &config)
+        .await
+        .expect("Should extract tenant with mixed-case bearer prefix");
+    assert_eq!(tenant3, "tenant123");
+}
+
+// Test JWT validation and signature verification
+#[tokio::test]
+async fn test_jwt_verification_signature_and_expiration() {
+    let mut config = AutumnConfig::default();
+    config.tenancy.enabled = true;
+    config.tenancy.source = "jwt".to_string();
+    config.tenancy.jwt_claim = "company".to_string();
+    config.tenancy.jwt_secret = Some("my-secret".to_string());
+    config.tenancy.jwt_issuer = Some("my-issuer".to_string());
+
+    // 1. Untrusted signature (forged payload)
+    let forged_token = generate_jwt("tenant123", "wrong-secret", false, Some("my-issuer"));
+    let req1 = Request::builder()
+        .header("Authorization", format!("Bearer {forged_token}"))
+        .body(())
+        .unwrap();
+    let (mut parts1, ()) = req1.into_parts();
+    let err1 = extract_tenant_from_parts(&mut parts1, &config)
+        .await
+        .unwrap_err();
+    let err1_str = err1.to_string().to_lowercase();
+    assert!(err1_str.contains("signature") || err1_str.contains("unauthorized"));
+
+    // 2. Expired JWT
+    let expired_token = generate_jwt("tenant123", "my-secret", true, Some("my-issuer"));
+    let req2 = Request::builder()
+        .header("Authorization", format!("Bearer {expired_token}"))
+        .body(())
+        .unwrap();
+    let (mut parts2, ()) = req2.into_parts();
+    let err2 = extract_tenant_from_parts(&mut parts2, &config)
+        .await
+        .unwrap_err();
+    let err2_str = err2.to_string().to_lowercase();
+    assert!(err2_str.contains("expired") || err2_str.contains("unauthorized"));
+
+    // 3. Incorrect issuer
+    let bad_iss_token = generate_jwt("tenant123", "my-secret", false, Some("wrong-issuer"));
+    let req3 = Request::builder()
+        .header("Authorization", format!("Bearer {bad_iss_token}"))
+        .body(())
+        .unwrap();
+    let (mut parts3, ()) = req3.into_parts();
+    let err3 = extract_tenant_from_parts(&mut parts3, &config)
+        .await
+        .unwrap_err();
+    let err3_str = err3.to_string().to_lowercase();
+    assert!(err3_str.contains("issuer") || err3_str.contains("unauthorized"));
+}
+
+// Test rejection of non-subdomain hosts in subdomain mode
+#[tokio::test]
+async fn test_subdomain_mode_apex_and_ip_rejection() {
+    let mut config = AutumnConfig::default();
+    config.tenancy.enabled = true;
+    config.tenancy.source = "subdomain".to_string();
+
+    // 1. Valid subdomain
+    let req1 = Request::builder()
+        .header("Host", "tenant1.example.com")
+        .body(())
+        .unwrap();
+    let (mut parts1, ()) = req1.into_parts();
+    let tenant1 = extract_tenant_from_parts(&mut parts1, &config)
+        .await
+        .expect("Valid subdomain should succeed");
+    assert_eq!(tenant1, "tenant1");
+
+    // 2. Apex domain (e.g. example.com)
+    let req2 = Request::builder()
+        .header("Host", "example.com")
+        .body(())
+        .unwrap();
+    let (mut parts2, ()) = req2.into_parts();
+    let err2 = extract_tenant_from_parts(&mut parts2, &config)
+        .await
+        .unwrap_err();
+    assert!(err2.to_string().contains("apex") || err2.to_string().contains("subdomain"));
+
+    // 3. IP address host
+    let req3 = Request::builder()
+        .header("Host", "127.0.0.1:3000")
+        .body(())
+        .unwrap();
+    let (mut parts3, ()) = req3.into_parts();
+    let err3 = extract_tenant_from_parts(&mut parts3, &config)
+        .await
+        .unwrap_err();
+    assert!(err3.to_string().contains("IP") || err3.to_string().contains("subdomain"));
+
+    // 4. Local host (localhost:3000) - apex, rejected as it lacks subdomain
+    let req4 = Request::builder()
+        .header("Host", "localhost:3000")
+        .body(())
+        .unwrap();
+    let (mut parts4, ()) = req4.into_parts();
+    let err4 = extract_tenant_from_parts(&mut parts4, &config)
+        .await
+        .unwrap_err();
+    assert!(err4.to_string().contains("local") || err4.to_string().contains("subdomain"));
+
+    // 5. Local subdomain (tenant1.localhost) - valid
+    let req5 = Request::builder()
+        .header("Host", "tenant1.localhost")
+        .body(())
+        .unwrap();
+    let (mut parts5, ()) = req5.into_parts();
+    let tenant5 = extract_tenant_from_parts(&mut parts5, &config)
+        .await
+        .expect("subdomain of localhost is valid");
+    assert_eq!(tenant5, "tenant1");
+}
+
+// Test rejection of non-subdomain hosts with custom base_domain configured
+#[tokio::test]
+async fn test_subdomain_mode_custom_base_domain() {
+    let mut config = AutumnConfig::default();
+    config.tenancy.enabled = true;
+    config.tenancy.source = "subdomain".to_string();
+    config.tenancy.base_domain = Some("mycompany.co.uk".to_string());
+
+    // 1. Valid subdomain matching base domain
+    let req1 = Request::builder()
+        .header("Host", "tenant1.mycompany.co.uk")
+        .body(())
+        .unwrap();
+    let (mut parts1, ()) = req1.into_parts();
+    let tenant1 = extract_tenant_from_parts(&mut parts1, &config)
+        .await
+        .expect("Valid matching subdomain should succeed");
+    assert_eq!(tenant1, "tenant1");
+
+    // 2. Base domain itself (apex)
+    let req2 = Request::builder()
+        .header("Host", "mycompany.co.uk")
+        .body(())
+        .unwrap();
+    let (mut parts2, ()) = req2.into_parts();
+    let err2 = extract_tenant_from_parts(&mut parts2, &config)
+        .await
+        .unwrap_err();
+    assert!(err2.to_string().contains("apex") || err2.to_string().contains("subdomain"));
+
+    // 3. Different domain entirely
+    let req3 = Request::builder()
+        .header("Host", "tenant1.otherdomain.com")
+        .body(())
+        .unwrap();
+    let (mut parts3, ()) = req3.into_parts();
+    let err3 = extract_tenant_from_parts(&mut parts3, &config)
+        .await
+        .unwrap_err();
+    assert!(err3.to_string().contains("domain") || err3.to_string().contains("subdomain"));
+}

--- a/autumn/tests/tenancy_unit.rs
+++ b/autumn/tests/tenancy_unit.rs
@@ -377,6 +377,32 @@ async fn jwt_audience_missing_claim_fails() {
     );
 }
 
+/// Slicing Authorization at index 7 when index 7 is inside a multi-byte UTF-8 char
+/// (like `é`) must not panic, but must return a clean unauthorized error.
+#[tokio::test]
+async fn jwt_malformed_bearer_boundary_handling_does_not_panic() {
+    let mut config = AutumnConfig::default();
+    config.tenancy.enabled = true;
+    config.tenancy.source = "jwt".to_string();
+    config.tenancy.jwt_claim = "company".to_string();
+    config.tenancy.jwt_secret = Some("secret".to_string());
+
+    let req = Request::builder()
+        .header("Authorization", "aaaaaaé...")
+        .body(())
+        .unwrap();
+    let (mut parts, ()) = req.into_parts();
+    let err = extract_tenant_from_parts(&mut parts, &config)
+        .await
+        .unwrap_err();
+    let err_str = err.to_string();
+    assert!(
+        err_str.contains("Invalid Authorization header format")
+            || err_str.contains("Invalid UTF-8"),
+        "Expected clean unauthorized error, got: {err_str}"
+    );
+}
+
 /// When polling a response body wrapped in `TenantPropagatingBody`, the
 /// `CURRENT_TENANT` task-local context must be re-established for the duration
 /// of the poll.


### PR DESCRIPTION
Adds opt-in 'tenant_scoped' attribute to repositories, dynamically injects tenant checks and filters on all CRUD/derived queries via CURRENT_TENANT task-local context, implements multi-strategy Axum extractors/middleware (header, subdomain, session, JWT), exposes the 'across_tenants()' escape hatch with warning checks, and validates the full design via extensive integration tests and macro unit tests.