### PR TITLE
🗣️ Echo: Fix compilation error for path-qualified primitive return types in routes

### DIFF
--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -326,11 +326,11 @@ fn should_stringify_primitive_output(output: &ReturnType) -> bool {
         return false;
     };
 
-    if path.qself.is_some() || path.path.segments.len() != 1 {
+    if path.qself.is_some() || path.path.segments.is_empty() {
         return false;
     }
 
-    let ident = path.path.segments[0].ident.to_string();
+    let ident = path.path.segments.last().unwrap().ident.to_string();
     matches!(
         ident.as_str(),
         "bool"


### PR DESCRIPTION
1. 🔎 EXPERIENCE
Following the normal user journey, I started scaffolding an application. When adding a route that returned a basic integer, I explicitly added the `std::primitive::i32` path type prefix out of habit. 

2. 🚧 STUMBLE
When using the path-qualified primitive type `std::primitive::i32` instead of just `i32` or returning a `String`, my program failed to compile with the error:

```
error[E0277]: the trait bound `fn() -> ... {primitive}: Handler<_, _>` is not satisfied
   --> my-dx-audit/src/main.rs:4:10
```

3. 📢 REPORT
The DX expects the `routes!` macro to handle primitives smoothly by stringifying them internally. However, if a user slightly qualifies the type, they get a giant Axum compilation failure wall of text. The `autumn-macros` route parsing only checks `path.segments.len() == 1`. 

4. 🧪 VERIFY
I've updated `should_stringify_primitive_output` in `autumn-macros/src/route.rs` to check the `.last()` segment of the path instead of strictly enforcing a single segment. Cargo test passes locally, and test apps can now return path-qualified primitives.

---
*PR created automatically by Jules for task [6044950738454399556](https://jules.google.com/task/6044950738454399556) started by @madmax983*