### PR TITLE
Add trusted-hosts allow-list with middleware, config, doctor checks and docs

### DIFF
--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -167,6 +167,50 @@ pub fn check_signing_secret_impl(secret: Option<&str>, is_production: bool) -> C
     }
 }
 
+pub fn check_trusted_hosts_impl(hosts: &[String], is_production: bool) -> CheckResult {
+    if hosts.is_empty() {
+        return if is_production {
+            CheckResult {
+                name: "trusted_hosts",
+                status: CheckStatus::Fail,
+                detail: Some("trusted hosts list is empty in production".into()),
+                hint: Some(
+                    "Set [security.trusted_hosts] hosts = [\"example.com\"] or \
+                     AUTUMN_SECURITY__TRUSTED_HOSTS__HOSTS",
+                ),
+            }
+        } else {
+            CheckResult {
+                name: "trusted_hosts",
+                status: CheckStatus::Warn,
+                detail: Some("trusted hosts list is empty".into()),
+                hint: Some(
+                    "Set [security.trusted_hosts] hosts to prevent Host-header rebinding attacks",
+                ),
+            }
+        };
+    }
+
+    if hosts.len() == 1 && hosts[0] == "*" {
+        return CheckResult {
+            name: "trusted_hosts",
+            status: CheckStatus::Warn,
+            detail: Some("trusted hosts wildcard '*' disables host-header allow-listing".into()),
+            hint: Some("Prefer explicit hosts in production to fail closed"),
+        };
+    }
+
+    CheckResult {
+        name: "trusted_hosts",
+        status: CheckStatus::Pass,
+        detail: Some(format!(
+            "trusted hosts configured ({} entries)",
+            hosts.len()
+        )),
+        hint: None,
+    }
+}
+
 // ─── Pure helper functions (fully unit-testable) ──────────────────────────────
 
 pub const fn glyph(status: &CheckStatus) -> &'static str {
@@ -1117,6 +1161,38 @@ fn resolve_optional_signing_secret() -> Option<String> {
         })
 }
 
+fn resolve_trusted_hosts() -> Vec<String> {
+    if let Ok(val) = std::env::var("AUTUMN_SECURITY__TRUSTED_HOSTS__HOSTS") {
+        let parsed: Vec<String> = val
+            .split(',')
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(std::borrow::ToOwned::to_owned)
+            .collect();
+        if !parsed.is_empty() {
+            return parsed;
+        }
+    }
+    std::fs::read_to_string("autumn.toml")
+        .ok()
+        .and_then(|c| toml::from_str::<toml::Table>(&c).ok())
+        .and_then(|t| {
+            t.get("security")
+                .and_then(|s| s.get("trusted_hosts"))
+                .and_then(|th| th.get("hosts"))
+                .and_then(toml::Value::as_array)
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(toml::Value::as_str)
+                        .map(str::trim)
+                        .filter(|v| !v.is_empty())
+                        .map(std::borrow::ToOwned::to_owned)
+                        .collect::<Vec<_>>()
+                })
+        })
+        .unwrap_or_default()
+}
+
 /// Resolve whether the active profile is production from the environment or
 /// `autumn.toml`.
 fn resolve_is_production() -> bool {
@@ -1180,6 +1256,7 @@ pub fn run(opts: DoctorOptions) {
     let port = resolve_server_port();
     let tailwind = tailwind_enabled();
     let signing_secret = resolve_optional_signing_secret();
+    let trusted_hosts = resolve_trusted_hosts();
     let is_production = resolve_is_production();
 
     // ── Phase 2: build tasks in display order ────────────────────────────────
@@ -1246,6 +1323,9 @@ pub fn run(opts: DoctorOptions) {
     tasks.push(Box::new(move || {
         check_signing_secret_impl(signing_secret.as_deref(), is_production)
     }));
+    tasks.push(Box::new(move || {
+        check_trusted_hosts_impl(&trusted_hosts, is_production)
+    }));
 
     // 9. Stale artifacts (warn only, never fail)
     tasks.push(Box::new(check_stale_artifacts));
@@ -1304,6 +1384,20 @@ mod tests {
     #[test]
     fn glyph_fail() {
         assert_eq!(glyph(&CheckStatus::Fail), "❌");
+    }
+
+    #[test]
+    fn trusted_hosts_fail_in_production_when_empty() {
+        let result = check_trusted_hosts_impl(&[], true);
+        assert_eq!(result.name, "trusted_hosts");
+        assert!(matches!(result.status, CheckStatus::Fail));
+    }
+
+    #[test]
+    fn trusted_hosts_warn_on_wildcard() {
+        let result = check_trusted_hosts_impl(&["*".to_owned()], true);
+        assert_eq!(result.name, "trusted_hosts");
+        assert!(matches!(result.status, CheckStatus::Warn));
     }
 
     // ── compute_summary ──────────────────────────────────────────────────────

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -168,7 +168,12 @@ pub fn check_signing_secret_impl(secret: Option<&str>, is_production: bool) -> C
 }
 
 pub fn check_trusted_hosts_impl(hosts: &[String], is_production: bool) -> CheckResult {
-    if hosts.is_empty() {
+    let normalized: Vec<String> = hosts
+        .iter()
+        .map(|h| h.trim().to_owned())
+        .filter(|h| !h.is_empty())
+        .collect();
+    if normalized.is_empty() {
         return if is_production {
             CheckResult {
                 name: "trusted_hosts",
@@ -191,7 +196,7 @@ pub fn check_trusted_hosts_impl(hosts: &[String], is_production: bool) -> CheckR
         };
     }
 
-    if hosts.len() == 1 && hosts[0] == "*" {
+    if normalized.iter().any(|h| h == "*") {
         return CheckResult {
             name: "trusted_hosts",
             status: CheckStatus::Warn,
@@ -205,7 +210,7 @@ pub fn check_trusted_hosts_impl(hosts: &[String], is_production: bool) -> CheckR
         status: CheckStatus::Pass,
         detail: Some(format!(
             "trusted hosts configured ({} entries)",
-            hosts.len()
+            normalized.len()
         )),
         hint: None,
     }
@@ -1163,15 +1168,12 @@ fn resolve_optional_signing_secret() -> Option<String> {
 
 fn resolve_trusted_hosts() -> Vec<String> {
     if let Ok(val) = std::env::var("AUTUMN_SECURITY__TRUSTED_HOSTS__HOSTS") {
-        let parsed: Vec<String> = val
+        return val
             .split(',')
             .map(str::trim)
             .filter(|v| !v.is_empty())
             .map(std::borrow::ToOwned::to_owned)
             .collect();
-        if !parsed.is_empty() {
-            return parsed;
-        }
     }
     std::fs::read_to_string("autumn.toml")
         .ok()
@@ -1396,6 +1398,13 @@ mod tests {
     #[test]
     fn trusted_hosts_warn_on_wildcard() {
         let result = check_trusted_hosts_impl(&["*".to_owned()], true);
+        assert_eq!(result.name, "trusted_hosts");
+        assert!(matches!(result.status, CheckStatus::Warn));
+    }
+
+    #[test]
+    fn trusted_hosts_warn_on_wildcard_when_mixed_with_other_entries() {
+        let result = check_trusted_hosts_impl(&["example.com".to_owned(), "*".to_owned()], true);
         assert_eq!(result.name, "trusted_hosts");
         assert!(matches!(result.status, CheckStatus::Warn));
     }

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1175,24 +1175,43 @@ fn resolve_trusted_hosts() -> Vec<String> {
             .map(std::borrow::ToOwned::to_owned)
             .collect();
     }
-    std::fs::read_to_string("autumn.toml")
+    let table = read_autumn_toml_table().unwrap_or_default();
+    let profile = std::env::var("AUTUMN_ENV")
         .ok()
-        .and_then(|c| toml::from_str::<toml::Table>(&c).ok())
-        .and_then(|t| {
-            t.get("security")
-                .and_then(|s| s.get("trusted_hosts"))
-                .and_then(|th| th.get("hosts"))
-                .and_then(toml::Value::as_array)
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(toml::Value::as_str)
-                        .map(str::trim)
-                        .filter(|v| !v.is_empty())
-                        .map(std::borrow::ToOwned::to_owned)
-                        .collect::<Vec<_>>()
-                })
-        })
+        .or_else(|| std::env::var("AUTUMN_PROFILE").ok())
         .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+
+    let parse_hosts = |root: &toml::Table| {
+        root.get("security")
+            .and_then(|s| s.get("trusted_hosts"))
+            .and_then(|th| th.get("hosts"))
+            .and_then(toml::Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(toml::Value::as_str)
+                    .map(str::trim)
+                    .filter(|v| !v.is_empty())
+                    .map(std::borrow::ToOwned::to_owned)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+    };
+
+    if !profile.is_empty()
+        && let Some(profile_table) = table
+            .get("profile")
+            .and_then(|v| v.get(&profile))
+            .and_then(toml::Value::as_table)
+    {
+        let profile_hosts = parse_hosts(profile_table);
+        if !profile_hosts.is_empty() {
+            return profile_hosts;
+        }
+    }
+
+    parse_hosts(&table)
 }
 
 /// Resolve whether the active profile is production from the environment or

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -3436,14 +3436,21 @@ fn fail_fast_on_invalid_trusted_hosts(config: &AutumnConfig) {
     if !is_production {
         return;
     }
-    let hosts = &config.security.trusted_hosts.hosts;
+    let hosts: Vec<String> = config
+        .security
+        .trusted_hosts
+        .hosts
+        .iter()
+        .map(|h| h.trim().to_owned())
+        .filter(|h| !h.is_empty())
+        .collect();
     if hosts.is_empty() {
         eprintln!(
             "[security.trusted_hosts] is required in production; set hosts = [\"example.com\"] or explicit entries"
         );
         std::process::exit(1);
     }
-    if hosts.len() == 1 && hosts[0] == "*" {
+    if hosts.iter().any(|h| h == "*") {
         tracing::warn!("trusted host validation disabled via wildcard '*' in production");
     }
 }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1649,6 +1649,7 @@ impl AppBuilder {
         // 4d. Validate signing secret — production must have a stable, private,
         // entropy-meeting secret before the server binds. Dev/test are exempt.
         fail_fast_on_invalid_signing_secret(&config);
+        fail_fast_on_invalid_trusted_hosts(&config);
 
         // 4e. Signed webhook configs must resolve to usable key material
         // before the app binds. Missing secrets should fail before a real
@@ -2191,6 +2192,7 @@ impl AppBuilder {
         // builds don't run migrations against a doomed boot either.
         fail_fast_on_invalid_session_config(&config, session_store.is_some());
         fail_fast_on_invalid_signing_secret(&config);
+        fail_fast_on_invalid_trusted_hosts(&config);
 
         // Preflight the configured BlobStore the same way `run()` does.
         // Static routes can read presigned URLs out of `BlobStoreState`
@@ -2538,6 +2540,7 @@ impl AppBuilder {
 
         fail_fast_on_invalid_session_config(&config, session_store.is_some());
         fail_fast_on_invalid_signing_secret(&config);
+        fail_fast_on_invalid_trusted_hosts(&config);
 
         #[cfg(feature = "storage")]
         let storage_bootstrap = blob_store.map_or_else(
@@ -3425,6 +3428,23 @@ fn fail_fast_on_invalid_webhook_config(config: &AutumnConfig) {
     if let Err(error) = config.security.webhooks.validate(is_production) {
         eprintln!("Invalid signed webhook configuration: {error}");
         std::process::exit(1);
+    }
+}
+
+fn fail_fast_on_invalid_trusted_hosts(config: &AutumnConfig) {
+    let is_production = matches!(config.profile.as_deref(), Some("prod" | "production"));
+    if !is_production {
+        return;
+    }
+    let hosts = &config.security.trusted_hosts.hosts;
+    if hosts.is_empty() {
+        eprintln!(
+            "[security.trusted_hosts] is required in production; set hosts = [\"example.com\"] or explicit entries"
+        );
+        std::process::exit(1);
+    }
+    if hosts.len() == 1 && hosts[0] == "*" {
+        tracing::warn!("trusted host validation disabled via wildcard '*' in production");
     }
 }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2036,6 +2036,11 @@ impl AutumnConfig {
             "AUTUMN_SECURITY__SIGNING_SECRET",
             &mut self.security.signing_secret.secret,
         );
+        parse_env_csv(
+            env,
+            "AUTUMN_SECURITY__TRUSTED_HOSTS__HOSTS",
+            &mut self.security.trusted_hosts.hosts,
+        );
 
         self.security.webhooks.apply_env_overrides_with_env(env);
     }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -2339,6 +2339,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri("/_autumn/mail/messages/detail.eml")
+                    .header("host", "example.com")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -2374,6 +2375,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri("/_autumn/mail")
+                    .header("host", "example.com")
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1292,7 +1292,10 @@ async fn trusted_host_middleware(
         .and_then(|v| v.to_str().ok());
     let raw_host = authority.or(host_header);
     let parsed_host = raw_host.and_then(extract_host_without_port);
-    let host = parsed_host.map(str::to_ascii_lowercase);
+    let host = parsed_host
+        .map(str::to_ascii_lowercase)
+        .map(|h| h.trim_end_matches('.').to_owned())
+        .filter(|h| !h.is_empty());
     let host_source_present = raw_host.is_some();
     if host.is_none() && !host_source_present && policy.allow_missing_host {
         return next.run(req).await;
@@ -2298,6 +2301,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri("/_autumn/mail")
+                    .header("host", "example.com")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -3297,6 +3301,24 @@ mod trusted_host_tests {
             .await
             .expect("request should complete");
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn trusted_host_accepts_trailing_dot_fqdn() {
+        let mut cfg = AutumnConfig::default();
+        cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/nope")
+                    .header("host", "example.com.")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1287,8 +1287,9 @@ async fn trusted_host_middleware(
         .headers()
         .get(http::header::HOST)
         .and_then(|v| v.to_str().ok())
-        .and_then(extract_host_without_port);
-    if host.is_some_and(|host| policy.allows_host(host)) {
+        .and_then(extract_host_without_port)
+        .map(str::to_ascii_lowercase);
+    if host.as_deref().is_some_and(|host| policy.allows_host(host)) {
         next.run(req).await
     } else {
         tracing::warn!(host = ?host, "trusted host rejected request");
@@ -1319,13 +1320,18 @@ fn extract_host_without_port(header: &str) -> Option<&str> {
         let end = host.find(']')?;
         return host.get(1..end).filter(|v| !v.is_empty());
     }
-    let (candidate, _) = host.rsplit_once(':').unwrap_or((host, ""));
-    let normalized = if host.contains(':') && candidate.contains(':') {
-        host
-    } else {
-        candidate
+    let Some((candidate, maybe_port)) = host.rsplit_once(':') else {
+        return Some(host);
     };
-    (!normalized.is_empty()).then_some(normalized)
+    if candidate.contains(':') {
+        // unbracketed IPv6 literal; keep host verbatim
+        return Some(host);
+    }
+    if maybe_port.chars().all(|c| c.is_ascii_digit()) && !candidate.is_empty() {
+        Some(candidate)
+    } else {
+        None
+    }
 }
 
 /// Build the router with optional static-file-first serving.
@@ -3176,6 +3182,24 @@ mod trusted_host_tests {
     }
 
     #[tokio::test]
+    async fn trusted_host_bypasses_actuator_health_path() {
+        let mut cfg = AutumnConfig::default();
+        cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/health")
+                    .header("host", "evil.com")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
     async fn trusted_host_release_rejects_loopback_unless_listed() {
         let mut cfg = AutumnConfig::default();
         cfg.profile = Some("prod".into());
@@ -3209,6 +3233,42 @@ mod trusted_host_tests {
             .await
             .expect("request should complete");
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn trusted_host_matching_is_case_insensitive() {
+        let mut cfg = AutumnConfig::default();
+        cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/nope")
+                    .header("host", "EXAMPLE.COM")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn trusted_host_rejects_malformed_port() {
+        let mut cfg = AutumnConfig::default();
+        cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/nope")
+                    .header("host", "example.com:abc")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]
@@ -3264,7 +3324,7 @@ impl TrustedHostPolicy {
             .map(|h| h.trim().to_ascii_lowercase())
             .filter(|h| !h.is_empty())
             .collect();
-        if matches!(config.profile.as_deref(), Some("dev" | "development")) {
+        if !matches!(config.profile.as_deref(), Some("prod" | "production")) {
             rules.extend(
                 ["localhost", "127.0.0.1", "::1"]
                     .into_iter()
@@ -3277,6 +3337,7 @@ impl TrustedHostPolicy {
             config.health.live_path.clone(),
             config.health.ready_path.clone(),
             config.health.startup_path.clone(),
+            crate::actuator::actuator_route_path(&config.actuator.prefix, "/health"),
         ]);
         Self {
             rules: Arc::new(rules),

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1165,10 +1165,9 @@ fn apply_middleware(
         };
 
     router = apply_cors_middleware(router, config);
-    let trusted_hosts = config.security.trusted_hosts.hosts.clone();
-    let profile = config.profile.clone().unwrap_or_else(|| "dev".to_string());
+    let trusted_host_policy = TrustedHostPolicy::from_config(config);
     router = router.layer(axum::middleware::from_fn(move |req, next| {
-        trusted_host_middleware(req, next, trusted_hosts.clone(), profile.clone())
+        trusted_host_middleware(req, next, trusted_host_policy.clone())
     }));
     router = apply_csrf_middleware(router, config, signing_keys_opt.clone());
     // Method-override rejection filter. The outer `MethodOverrideLayer`
@@ -1278,57 +1277,21 @@ fn apply_middleware(
 async fn trusted_host_middleware(
     req: Request<axum::body::Body>,
     next: Next,
-    trusted_hosts: Vec<String>,
-    profile: String,
+    policy: TrustedHostPolicy,
 ) -> axum::response::Response {
     let path = req.uri().path();
-    if ["/actuator/health", "/live", "/ready", "/startup"].contains(&path) {
+    if policy.probe_bypass_paths.contains(path) {
         return next.run(req).await;
     }
     let host = req
         .headers()
         .get(http::header::HOST)
         .and_then(|v| v.to_str().ok())
-        .unwrap_or_default()
-        .split(':')
-        .next()
-        .unwrap_or_default()
-        .trim_matches('[')
-        .trim_matches(']')
-        .to_ascii_lowercase();
-    let mut allowed = trusted_hosts.clone();
-    if profile == "dev" || profile == "development" {
-        allowed.extend(
-            ["localhost", "127.0.0.1", "::1"]
-                .iter()
-                .map(|s| s.to_string()),
-        );
-    }
-    let wildcard = allowed.iter().any(|h| h == "*");
-    let listed = |candidate: &str| {
-        allowed.iter().any(|rule| {
-            let r = rule.to_ascii_lowercase();
-            if let Some(suffix) = r.strip_prefix('.') {
-                candidate == suffix || candidate.ends_with(&format!(".{suffix}"))
-            } else {
-                candidate == r
-            }
-        })
-    };
-    let is_release_profile = profile == "prod" || profile == "production";
-    let is_loopback = matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1");
-
-    let ok = if wildcard {
-        true
-    } else if is_release_profile && is_loopback {
-        listed(host.as_str())
-    } else {
-        listed(host.as_str())
-    };
-    if ok {
+        .and_then(extract_host_without_port);
+    if host.is_some_and(|host| policy.allows_host(host)) {
         next.run(req).await
     } else {
-        tracing::warn!(host = %host, "trusted host rejected request");
+        tracing::warn!(host = ?host, "trusted host rejected request");
         let body = crate::error::problem_details_json_string(
             StatusCode::BAD_REQUEST,
             "Invalid Host header",
@@ -1345,6 +1308,24 @@ async fn trusted_host_middleware(
         )
             .into_response()
     }
+}
+
+fn extract_host_without_port(header: &str) -> Option<&str> {
+    let host = header.trim();
+    if host.is_empty() {
+        return None;
+    }
+    if host.starts_with('[') {
+        let end = host.find(']')?;
+        return host.get(1..end).filter(|v| !v.is_empty());
+    }
+    let (candidate, _) = host.rsplit_once(':').unwrap_or((host, ""));
+    let normalized = if host.contains(':') && candidate.contains(':') {
+        host
+    } else {
+        candidate
+    };
+    (!normalized.is_empty()).then_some(normalized)
 }
 
 /// Build the router with optional static-file-first serving.
@@ -3211,5 +3192,112 @@ mod trusted_host_tests {
             .await
             .expect("request should complete");
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn trusted_host_accepts_bracketed_ipv6_loopback_in_dev() {
+        let cfg = AutumnConfig::default();
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/nope")
+                    .header("host", "[::1]:3000")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn trusted_host_bypasses_custom_probe_path_only() {
+        let mut cfg = AutumnConfig::default();
+        cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
+        cfg.health.path = "/healthz".into();
+        cfg.health.startup_path = "/startupz".into();
+        cfg.health.ready_path = "/readyz".into();
+        cfg.health.live_path = "/livez".into();
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+
+        let bypassed = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .header("host", "evil.com")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(bypassed.status(), StatusCode::OK);
+
+        let not_bypassed = router
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .header("host", "evil.com")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(not_bypassed.status(), StatusCode::BAD_REQUEST);
+    }
+}
+#[derive(Clone, Debug)]
+struct TrustedHostPolicy {
+    rules: Arc<Vec<String>>,
+    allow_any: bool,
+    probe_bypass_paths: Arc<std::collections::HashSet<String>>,
+}
+
+impl TrustedHostPolicy {
+    fn from_config(config: &AutumnConfig) -> Self {
+        let mut rules: Vec<String> = config
+            .security
+            .trusted_hosts
+            .hosts
+            .iter()
+            .map(|h| h.trim().to_ascii_lowercase())
+            .filter(|h| !h.is_empty())
+            .collect();
+        if matches!(config.profile.as_deref(), Some("dev" | "development")) {
+            rules.extend(
+                ["localhost", "127.0.0.1", "::1"]
+                    .into_iter()
+                    .map(std::borrow::ToOwned::to_owned),
+            );
+        }
+        let allow_any = rules.iter().any(|h| h == "*");
+        let probe_bypass_paths = std::collections::HashSet::from([
+            config.health.path.clone(),
+            config.health.live_path.clone(),
+            config.health.ready_path.clone(),
+            config.health.startup_path.clone(),
+        ]);
+        Self {
+            rules: Arc::new(rules),
+            allow_any,
+            probe_bypass_paths: Arc::new(probe_bypass_paths),
+        }
+    }
+
+    fn allows_host(&self, host: &str) -> bool {
+        if self.allow_any {
+            return true;
+        }
+        self.rules.iter().any(|rule| {
+            if let Some(suffix) = rule.strip_prefix('.') {
+                host == suffix
+                    || host
+                        .strip_suffix(suffix)
+                        .is_some_and(|prefix| prefix.ends_with('.'))
+            } else {
+                host == rule
+            }
+        })
     }
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -3116,7 +3116,7 @@ mod trusted_host_tests {
     async fn trusted_host_allows_matching_and_blocks_nonmatching() {
         let mut cfg = AutumnConfig::default();
         cfg.security.trusted_hosts.hosts = vec!["example.com".into(), ".example.com".into()];
-        let state = crate::state::AppState::for_tests();
+        let state = crate::state::AppState::for_test();
         let router = build_router(vec![], &cfg, state);
 
         let ok = router
@@ -3149,7 +3149,7 @@ mod trusted_host_tests {
     async fn trusted_host_wildcard_allows_any_host() {
         let mut cfg = AutumnConfig::default();
         cfg.security.trusted_hosts.hosts = vec!["*".into()];
-        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
         let response = router
             .oneshot(
                 Request::builder()
@@ -3167,7 +3167,7 @@ mod trusted_host_tests {
     async fn trusted_host_bypasses_probe_paths() {
         let mut cfg = AutumnConfig::default();
         cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
-        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
         let response = router
             .oneshot(
                 Request::builder()
@@ -3185,7 +3185,7 @@ mod trusted_host_tests {
     async fn trusted_host_bypasses_actuator_health_path() {
         let mut cfg = AutumnConfig::default();
         cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
-        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
         let response = router
             .oneshot(
                 Request::builder()
@@ -3204,7 +3204,7 @@ mod trusted_host_tests {
         let mut cfg = AutumnConfig::default();
         cfg.profile = Some("prod".into());
         cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
-        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
         let response = router
             .oneshot(
                 Request::builder()
@@ -3221,7 +3221,7 @@ mod trusted_host_tests {
     #[tokio::test]
     async fn trusted_host_accepts_bracketed_ipv6_loopback_in_dev() {
         let cfg = AutumnConfig::default();
-        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
         let response = router
             .oneshot(
                 Request::builder()
@@ -3239,7 +3239,7 @@ mod trusted_host_tests {
     async fn trusted_host_matching_is_case_insensitive() {
         let mut cfg = AutumnConfig::default();
         cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
-        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
         let response = router
             .oneshot(
                 Request::builder()
@@ -3257,7 +3257,7 @@ mod trusted_host_tests {
     async fn trusted_host_rejects_malformed_port() {
         let mut cfg = AutumnConfig::default();
         cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
-        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
         let response = router
             .oneshot(
                 Request::builder()
@@ -3279,7 +3279,7 @@ mod trusted_host_tests {
         cfg.health.startup_path = "/startupz".into();
         cfg.health.ready_path = "/readyz".into();
         cfg.health.live_path = "/livez".into();
-        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
 
         let bypassed = router
             .clone()
@@ -3351,14 +3351,15 @@ impl TrustedHostPolicy {
             return true;
         }
         self.rules.iter().any(|rule| {
-            if let Some(suffix) = rule.strip_prefix('.') {
-                host == suffix
-                    || host
-                        .strip_suffix(suffix)
-                        .is_some_and(|prefix| prefix.ends_with('.'))
-            } else {
-                host == rule
-            }
+            rule.strip_prefix('.').map_or_else(
+                || host == rule,
+                |suffix| {
+                    host == suffix
+                        || host
+                            .strip_suffix(suffix)
+                            .is_some_and(|prefix| prefix.ends_with('.'))
+                },
+            )
         })
     }
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1280,16 +1280,25 @@ async fn trusted_host_middleware(
     policy: TrustedHostPolicy,
 ) -> axum::response::Response {
     let path = req.uri().path();
-    if policy.probe_bypass_paths.contains(path) {
+    if (req.method() == http::Method::GET || req.method() == http::Method::HEAD)
+        && policy.probe_bypass_paths.contains(path)
+    {
         return next.run(req).await;
     }
     let host = req
-        .headers()
-        .get(http::header::HOST)
-        .and_then(|v| v.to_str().ok())
-        .or_else(|| req.uri().authority().map(http::uri::Authority::as_str))
+        .uri()
+        .authority()
+        .map(http::uri::Authority::as_str)
+        .or_else(|| {
+            req.headers()
+                .get(http::header::HOST)
+                .and_then(|v| v.to_str().ok())
+        })
         .and_then(extract_host_without_port)
         .map(str::to_ascii_lowercase);
+    if host.is_none() && policy.allow_missing_host {
+        return next.run(req).await;
+    }
     if host.as_deref().is_some_and(|host| policy.allows_host(host)) {
         next.run(req).await
     } else {
@@ -3326,11 +3335,31 @@ mod trusted_host_tests {
             .expect("request should complete");
         assert_eq!(not_bypassed.status(), StatusCode::BAD_REQUEST);
     }
+
+    #[tokio::test]
+    async fn trusted_host_does_not_bypass_non_get_probe_path_requests() {
+        let mut cfg = AutumnConfig::default();
+        cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/health")
+                    .header("host", "evil.com")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
 }
 #[derive(Clone, Debug)]
 struct TrustedHostPolicy {
     rules: Arc<Vec<String>>,
     allow_any: bool,
+    allow_missing_host: bool,
     probe_bypass_paths: Arc<std::collections::HashSet<String>>,
 }
 
@@ -3344,7 +3373,8 @@ impl TrustedHostPolicy {
             .map(|h| h.trim().to_ascii_lowercase())
             .filter(|h| !h.is_empty())
             .collect();
-        if !matches!(config.profile.as_deref(), Some("prod" | "production")) {
+        let is_production = matches!(config.profile.as_deref(), Some("prod" | "production"));
+        if !is_production {
             rules.extend(
                 ["localhost", "127.0.0.1", "::1"]
                     .into_iter()
@@ -3362,6 +3392,7 @@ impl TrustedHostPolicy {
         Self {
             rules: Arc::new(rules),
             allow_any,
+            allow_missing_host: !is_production,
             probe_bypass_paths: Arc::new(probe_bypass_paths),
         }
     }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -3361,6 +3361,24 @@ mod trusted_host_tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
     #[tokio::test]
+    async fn trusted_host_configured_trailing_dot_matches_normalized_host() {
+        let mut cfg = AutumnConfig::default();
+        cfg.security.trusted_hosts.hosts = vec!["example.com.".into()];
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/nope")
+                    .header("host", "example.com")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
     async fn trusted_host_accepts_trailing_dot_fqdn() {
         let mut cfg = AutumnConfig::default();
         cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
@@ -3449,6 +3467,7 @@ impl TrustedHostPolicy {
             .hosts
             .iter()
             .map(|h| h.trim().to_ascii_lowercase())
+            .map(|h| h.trim_end_matches('.').to_owned())
             .filter(|h| !h.is_empty())
             .collect();
         let is_production = matches!(config.profile.as_deref(), Some("prod" | "production"));

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1287,6 +1287,7 @@ async fn trusted_host_middleware(
         .headers()
         .get(http::header::HOST)
         .and_then(|v| v.to_str().ok())
+        .or_else(|| req.uri().authority().map(http::uri::Authority::as_str))
         .and_then(extract_host_without_port)
         .map(str::to_ascii_lowercase);
     if host.as_deref().is_some_and(|host| policy.allows_host(host)) {
@@ -3201,8 +3202,10 @@ mod trusted_host_tests {
 
     #[tokio::test]
     async fn trusted_host_release_rejects_loopback_unless_listed() {
-        let mut cfg = AutumnConfig::default();
-        cfg.profile = Some("prod".into());
+        let mut cfg = AutumnConfig {
+            profile: Some("prod".into()),
+            ..AutumnConfig::default()
+        };
         cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
         let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
         let response = router
@@ -3216,6 +3219,23 @@ mod trusted_host_tests {
             .await
             .expect("request should complete");
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn trusted_host_uses_uri_authority_when_host_header_missing() {
+        let mut cfg = AutumnConfig::default();
+        cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("http://EXAMPLE.COM/nope")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -22,7 +22,7 @@ use crate::route::Route;
 use crate::state::AppState;
 use axum::middleware::Next;
 use axum::response::IntoResponse;
-use http::StatusCode;
+use http::{Request, StatusCode};
 use thiserror::Error;
 
 pub const DEFAULT_FAVICON_PATH: &str = "/favicon.ico";
@@ -1165,6 +1165,11 @@ fn apply_middleware(
         };
 
     router = apply_cors_middleware(router, config);
+    let trusted_hosts = config.security.trusted_hosts.hosts.clone();
+    let profile = config.profile.clone().unwrap_or_else(|| "dev".to_string());
+    router = router.layer(axum::middleware::from_fn(move |req, next| {
+        trusted_host_middleware(req, next, trusted_hosts.clone(), profile.clone())
+    }));
     router = apply_csrf_middleware(router, config, signing_keys_opt.clone());
     // Method-override rejection filter. The outer `MethodOverrideLayer`
     // (applied at the `axum::serve` boundary so it can rewrite the
@@ -1268,6 +1273,78 @@ fn apply_middleware(
         .layer(crate::middleware::MetricsLayer::new(state.metrics.clone()));
 
     Ok(router)
+}
+
+async fn trusted_host_middleware(
+    req: Request<axum::body::Body>,
+    next: Next,
+    trusted_hosts: Vec<String>,
+    profile: String,
+) -> axum::response::Response {
+    let path = req.uri().path();
+    if ["/actuator/health", "/live", "/ready", "/startup"].contains(&path) {
+        return next.run(req).await;
+    }
+    let host = req
+        .headers()
+        .get(http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .split(':')
+        .next()
+        .unwrap_or_default()
+        .trim_matches('[')
+        .trim_matches(']')
+        .to_ascii_lowercase();
+    let mut allowed = trusted_hosts.clone();
+    if profile == "dev" || profile == "development" {
+        allowed.extend(
+            ["localhost", "127.0.0.1", "::1"]
+                .iter()
+                .map(|s| s.to_string()),
+        );
+    }
+    let wildcard = allowed.iter().any(|h| h == "*");
+    let listed = |candidate: &str| {
+        allowed.iter().any(|rule| {
+            let r = rule.to_ascii_lowercase();
+            if let Some(suffix) = r.strip_prefix('.') {
+                candidate == suffix || candidate.ends_with(&format!(".{suffix}"))
+            } else {
+                candidate == r
+            }
+        })
+    };
+    let is_release_profile = profile == "prod" || profile == "production";
+    let is_loopback = matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1");
+
+    let ok = if wildcard {
+        true
+    } else if is_release_profile && is_loopback {
+        listed(host.as_str())
+    } else {
+        listed(host.as_str())
+    };
+    if ok {
+        next.run(req).await
+    } else {
+        tracing::warn!(host = %host, "trusted host rejected request");
+        let body = crate::error::problem_details_json_string(
+            StatusCode::BAD_REQUEST,
+            "Invalid Host header",
+            None,
+            None,
+            None,
+            None,
+            true,
+        );
+        (
+            StatusCode::BAD_REQUEST,
+            [(http::header::CONTENT_TYPE, "application/problem+json")],
+            body,
+        )
+            .into_response()
+    }
 }
 
 /// Build the router with optional static-file-first serving.
@@ -3038,5 +3115,101 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+}
+
+#[cfg(test)]
+mod trusted_host_tests {
+    use super::*;
+    use axum::body::Body;
+    use http::Request;
+    use tower::util::ServiceExt;
+
+    #[tokio::test]
+    async fn trusted_host_allows_matching_and_blocks_nonmatching() {
+        let mut cfg = AutumnConfig::default();
+        cfg.security.trusted_hosts.hosts = vec!["example.com".into(), ".example.com".into()];
+        let state = crate::state::AppState::for_tests();
+        let router = build_router(vec![], &cfg, state);
+
+        let ok = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/nope")
+                    .header("host", "api.example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(ok.status(), StatusCode::NOT_FOUND);
+
+        let blocked = router
+            .oneshot(
+                Request::builder()
+                    .uri("/nope")
+                    .header("host", "evil.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(blocked.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn trusted_host_wildcard_allows_any_host() {
+        let mut cfg = AutumnConfig::default();
+        cfg.security.trusted_hosts.hosts = vec!["*".into()];
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/nope")
+                    .header("host", "anything.example")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn trusted_host_bypasses_probe_paths() {
+        let mut cfg = AutumnConfig::default();
+        cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/health")
+                    .header("host", "evil.com")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn trusted_host_release_rejects_loopback_unless_listed() {
+        let mut cfg = AutumnConfig::default();
+        cfg.profile = Some("prod".into());
+        cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_tests());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/nope")
+                    .header("host", "localhost")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1329,7 +1329,22 @@ fn extract_host_without_port(header: &str) -> Option<&str> {
     }
     if host.starts_with('[') {
         let end = host.find(']')?;
-        return host.get(1..end).filter(|v| !v.is_empty());
+        let literal = host.get(1..end)?;
+        if literal.is_empty() || literal.parse::<std::net::IpAddr>().is_err() {
+            return None;
+        }
+
+        let remainder = host.get(end + 1..)?;
+        if remainder.is_empty() {
+            return Some(literal);
+        }
+
+        let maybe_port = remainder.strip_prefix(':')?;
+        if !maybe_port.is_empty() && maybe_port.chars().all(|c| c.is_ascii_digit()) {
+            return Some(literal);
+        }
+
+        return None;
     }
     let Some((candidate, maybe_port)) = host.rsplit_once(':') else {
         return Some(host);
@@ -1338,7 +1353,10 @@ fn extract_host_without_port(header: &str) -> Option<&str> {
         // unbracketed IPv6 literal; keep host verbatim
         return Some(host);
     }
-    if maybe_port.chars().all(|c| c.is_ascii_digit()) && !candidate.is_empty() {
+    if !maybe_port.is_empty()
+        && maybe_port.chars().all(|c| c.is_ascii_digit())
+        && !candidate.is_empty()
+    {
         Some(candidate)
     } else {
         None
@@ -3307,6 +3325,41 @@ mod trusted_host_tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
+    #[tokio::test]
+    async fn trusted_host_rejects_empty_port_suffix() {
+        let mut cfg = AutumnConfig::default();
+        cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/nope")
+                    .header("host", "example.com:")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn trusted_host_rejects_bracketed_reg_name() {
+        let mut cfg = AutumnConfig::default();
+        cfg.security.trusted_hosts.hosts = vec!["example.com".into()];
+        let router = build_router(vec![], &cfg, crate::state::AppState::for_test());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/nope")
+                    .header("host", "[example.com]")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
     #[tokio::test]
     async fn trusted_host_accepts_trailing_dot_fqdn() {
         let mut cfg = AutumnConfig::default();

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -2225,7 +2225,7 @@ mod tests {
 
     #[cfg(feature = "mail")]
     fn dev_mail_preview_config(dir: &std::path::Path) -> AutumnConfig {
-        AutumnConfig {
+        let mut config = AutumnConfig {
             profile: Some("dev".to_owned()),
             mail: crate::mail::MailConfig {
                 transport: crate::mail::Transport::File,
@@ -2233,7 +2233,9 @@ mod tests {
                 ..Default::default()
             },
             ..Default::default()
-        }
+        };
+        config.security.trusted_hosts.hosts = vec!["example.com".to_owned()];
+        config
     }
 
     #[cfg(feature = "mail")]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1285,18 +1285,16 @@ async fn trusted_host_middleware(
     {
         return next.run(req).await;
     }
-    let host = req
-        .uri()
-        .authority()
-        .map(http::uri::Authority::as_str)
-        .or_else(|| {
-            req.headers()
-                .get(http::header::HOST)
-                .and_then(|v| v.to_str().ok())
-        })
-        .and_then(extract_host_without_port)
-        .map(str::to_ascii_lowercase);
-    if host.is_none() && policy.allow_missing_host {
+    let authority = req.uri().authority().map(http::uri::Authority::as_str);
+    let host_header = req
+        .headers()
+        .get(http::header::HOST)
+        .and_then(|v| v.to_str().ok());
+    let raw_host = authority.or(host_header);
+    let parsed_host = raw_host.and_then(extract_host_without_port);
+    let host = parsed_host.map(str::to_ascii_lowercase);
+    let host_source_present = raw_host.is_some();
+    if host.is_none() && !host_source_present && policy.allow_missing_host {
         return next.run(req).await;
     }
     if host.as_deref().is_some_and(|host| policy.allows_host(host)) {
@@ -2254,6 +2252,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri("/_autumn/mail")
+                    .header("host", "example.com")
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -392,6 +392,16 @@ pub struct SecurityConfig {
     /// secret via `AUTUMN_SECURITY__SIGNING_SECRET`.
     #[serde(default)]
     pub signing_secret: SigningSecretConfig,
+
+    /// Trusted Host header allow-list.
+    #[serde(default)]
+    pub trusted_hosts: TrustedHostsConfig,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct TrustedHostsConfig {
+    #[serde(default)]
+    pub hosts: Vec<String>,
 }
 
 /// Security response headers configuration.

--- a/autumn/tests/problem_details.rs
+++ b/autumn/tests/problem_details.rs
@@ -203,6 +203,7 @@ async fn validation_errors_keep_field_level_problem_details() {
 }
 
 #[tokio::test]
+#[allow(clippy::field_reassign_with_default)]
 async fn production_500_problem_details_do_not_leak_internal_detail() {
     let mut config = AutumnConfig::default();
     config.profile = Some("prod".to_owned());

--- a/autumn/tests/problem_details.rs
+++ b/autumn/tests/problem_details.rs
@@ -204,11 +204,16 @@ async fn validation_errors_keep_field_level_problem_details() {
 
 #[tokio::test]
 async fn production_500_problem_details_do_not_leak_internal_detail() {
-    let client = TestApp::new().profile("prod").routes(routes![boom]).build();
+    let mut config = AutumnConfig::default();
+    config.profile = Some("prod".to_owned());
+    config.security.trusted_hosts.hosts = vec!["example.com".to_owned()];
+
+    let client = TestApp::new().config(config).routes(routes![boom]).build();
 
     let response = client
         .get("/boom")
         .header("accept", "application/json")
+        .header("host", "example.com")
         .send()
         .await;
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -189,6 +189,32 @@ this file. Pass them as environment variables at runtime:
 priority layer — see the
 [config reference](getting-started.md#environment-variable-overrides).
 
+## Trusted hosts (Host-header allow-list)
+
+Autumn supports a host allow-list to prevent host-header rebinding and cache-poisoning style attacks.
+
+```toml
+[security.trusted_hosts]
+hosts = ["app.example.com", ".example.com"]
+```
+
+- `app.example.com` matches exactly that hostname.
+- `.example.com` matches both `example.com` and any subdomain like `api.example.com`.
+- `hosts = ["*"]` disables host filtering (escape hatch; not recommended for production).
+
+In `prod`/`production` profile, startup fails when `security.trusted_hosts.hosts` is empty.
+Health/probe routes (`/actuator/health`, `/live`, `/ready`, `/startup`) intentionally bypass host checks so orchestration probes remain reliable.
+
+### Runnable repro
+
+```bash
+# Expected: 400 + application/problem+json
+curl -i http://localhost:3000/ -H 'Host: evil.example'
+
+# Expected: normal route response
+curl -i http://localhost:3000/ -H 'Host: app.example.com'
+```
+
 ---
 
 ## Deploy to fly.io

--- a/examples/blog/autumn.toml
+++ b/examples/blog/autumn.toml
@@ -12,6 +12,9 @@ format = "Pretty"
 [health]
 path = "/health"
 
+[security.trusted_hosts]
+hosts = ["localhost", "127.0.0.1", "::1"]
+
 [i18n]
 default_locale = "en"
 supported_locales = ["en", "es"]


### PR DESCRIPTION
### Motivation

- Prevent Host-header rebinding and cache-poisoning attacks by providing an allow-list for accepted Host headers and failing early in production when misconfigured.

### Description

- Introduce `security.trusted_hosts.hosts` config and `AUTUMN_SECURITY__TRUSTED_HOSTS__HOSTS` env var parsing via a new `TrustedHostsConfig` and `parse_env_csv` integration. 
- Add a `trusted_host_middleware` that validates the `Host` header against the configured list, allows common dev loopback hosts in non-release profiles, treats `"*"` as a wildcard escape hatch, and bypasses health/probe endpoints. 
- Wire the middleware into router construction and add `fail_fast_on_invalid_trusted_hosts` to abort startup in `prod` when the hosts list is empty. 
- Add doctor checks and helpers: `resolve_trusted_hosts`, `check_trusted_hosts_impl`, and register the check in `autumn doctor` task list. 
- Update docs (`docs/guide/deployment.md`) and the example `autumn.toml` to document and demonstrate the new setting. 
- Add unit and integration tests covering the doctor check and router middleware behavior (including wildcard, probe bypass, and release-profile loopback handling).

### Testing

- Ran unit tests including new `trusted_hosts_fail_in_production_when_empty` and `trusted_hosts_warn_on_wildcard`, and all unit tests passed. 
- Ran asynchronous router integration tests in `trusted_host_tests` (probe bypass, wildcard, matching/blocking, release loopback behavior) under `cargo test -- --test-threads=1` and they passed. 
- Executed full test suite (`cargo test`) locally and observed all tests succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a108d1c6254832a96f4dfd9e6de8646)