### PR TITLE
🔒 Fix cleartext SMTP password leak in error messages

### DIFF
--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -998,9 +998,7 @@ impl SmtpTransport {
                 )
             })?;
             let password = std::env::var(&password_env).map_err(|_| {
-                MailError::InvalidMessage(
-                    "mail.smtp.password_env could not be resolved".to_owned()
-                )
+                MailError::InvalidMessage("mail.smtp.password_env could not be resolved".to_owned())
             })?;
             builder = builder.credentials(Credentials::new(username, password));
         }

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -997,10 +997,10 @@ impl SmtpTransport {
                     "mail.smtp.password_env is required when mail.smtp.username is set".to_owned(),
                 )
             })?;
-            let password = std::env::var(&password_env).map_err(|error| {
-                MailError::InvalidMessage(format!(
-                    "mail.smtp.password_env={password_env:?} could not be resolved: {error}"
-                ))
+            let password = std::env::var(&password_env).map_err(|_| {
+                MailError::InvalidMessage(
+                    "mail.smtp.password_env could not be resolved".to_owned()
+                )
             })?;
             builder = builder.credentials(Credentials::new(username, password));
         }
@@ -1809,6 +1809,8 @@ mod tests {
 
     #[test]
     fn smtp_transport_rejects_missing_password_env_when_username_is_set() {
+        // Eris regression test: the original password environment variable name should not be logged.
+        // It's checked here as a proxy for the value, as the actual failure is when the env lookup fails.
         let missing_key = format!(
             "AUTUMN_TEST_MISSING_SMTP_PASSWORD_{}_{}",
             std::process::id(),
@@ -1824,7 +1826,9 @@ mod tests {
             panic!("missing password env should fail at startup");
         };
 
-        assert!(error.to_string().contains(&missing_key));
+        let err_string = error.to_string();
+        assert!(err_string.contains("mail.smtp.password_env could not be resolved"));
+        assert!(!err_string.contains(&missing_key));
     }
 
     #[test]

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,5 @@
+🎯 **What:** The application was leaking the raw SMTP password environment variable content when it failed to resolve properly by interpolating the error object into the InvalidMessage result.
+
+⚠️ **Risk:** If a malicious actor could force an environment resolution failure, or if logs containing these errors were exposed or ingested into a centralized logging platform, the raw SMTP credentials would be exposed in cleartext, leading to potential unauthorized access to the configured mail server.
+
+🛡️ **Solution:** Removed the {password_env:?} interpolation and the underlying `{error}` from the map_err closure in `SmtpTransport::new`, opting instead for a static, generic error message ("mail.smtp.password_env could not be resolved"). Also updated the corresponding integration test to assert against this secure static message instead of the raw variable name.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,5 +1,0 @@
-🎯 **What:** The application was leaking the raw SMTP password environment variable content when it failed to resolve properly by interpolating the error object into the InvalidMessage result.
-
-⚠️ **Risk:** If a malicious actor could force an environment resolution failure, or if logs containing these errors were exposed or ingested into a centralized logging platform, the raw SMTP credentials would be exposed in cleartext, leading to potential unauthorized access to the configured mail server.
-
-🛡️ **Solution:** Removed the {password_env:?} interpolation and the underlying `{error}` from the map_err closure in `SmtpTransport::new`, opting instead for a static, generic error message ("mail.smtp.password_env could not be resolved"). Also updated the corresponding integration test to assert against this secure static message instead of the raw variable name.


### PR DESCRIPTION
🎯 **What:** The application was leaking the raw SMTP password environment variable content when it failed to resolve properly by interpolating the error object into the InvalidMessage result.

⚠️ **Risk:** If a malicious actor could force an environment resolution failure, or if logs containing these errors were exposed or ingested into a centralized logging platform, the raw SMTP credentials would be exposed in cleartext, leading to potential unauthorized access to the configured mail server.

🛡️ **Solution:** Removed the {password_env:?} interpolation and the underlying `{error}` from the map_err closure in `SmtpTransport::new`, opting instead for a static, generic error message ("mail.smtp.password_env could not be resolved"). Also updated the corresponding integration test to assert against this secure static message instead of the raw variable name.

---
*PR created automatically by Jules for task [14706271287828905638](https://jules.google.com/task/14706271287828905638) started by @madmax983*