### PR TITLE
👺 Havoc: Prevent Instant panic on large TTL overflow

### DIFF
--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -467,7 +467,9 @@ impl IdempotencyStore for MemoryIdempotencyStore {
         let entry = IdempotencyEntry {
             record,
             body_hash,
-            expires_at: Instant::now() + ttl,
+            expires_at: Instant::now()
+                .checked_add(ttl)
+                .unwrap_or_else(|| Instant::now() + Duration::from_secs(31_536_000)), // cap to 1 year on overflow
         };
         let mut entries = self.entries.write().unwrap();
         entries.insert(key.to_owned(), entry);
@@ -504,7 +506,9 @@ impl IdempotencyStore for MemoryIdempotencyStore {
             key.to_owned(),
             MemoryInFlightLock {
                 owner: owner.to_owned(),
-                expires_at: now + ttl,
+                expires_at: now
+                    .checked_add(ttl)
+                    .unwrap_or_else(|| now + Duration::from_secs(31_536_000)),
             },
         );
         true

--- a/autumn/tests/chaos_idempotency_fuzz.proptest-regressions
+++ b/autumn/tests/chaos_idempotency_fuzz.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc ea0deee6d9b7feff8eb9d404e705a2aa2f079e4cd6dc4142ac7d173277ba4f07 # shrinks to ttl_secs = 9223372036854775482, ttl_nanos = 1050847893

--- a/autumn/tests/chaos_idempotency_fuzz.rs
+++ b/autumn/tests/chaos_idempotency_fuzz.rs
@@ -1,0 +1,27 @@
+use autumn_web::idempotency::{IdempotencyRecord, IdempotencyStore, MemoryIdempotencyStore};
+use proptest::prelude::*;
+use std::time::Duration;
+
+proptest! {
+    #[test]
+    fn test_memory_idempotency_ttl_fuzzing(ttl_secs in 0..=(u64::MAX - 4), ttl_nanos in any::<u32>()) {
+        let store = MemoryIdempotencyStore::new(Duration::from_secs(60));
+        let record = IdempotencyRecord {
+            status: 200,
+            headers: vec![],
+            body: vec![],
+            metadata: Vec::default(),
+        };
+        let ttl = Duration::new(ttl_secs, ttl_nanos);
+        store.set("test_key", record, vec![], ttl);
+    }
+}
+
+proptest! {
+    #[test]
+    fn test_memory_idempotency_try_lock_ttl_fuzzing(ttl_secs in 0..=(u64::MAX - 4), ttl_nanos in any::<u32>()) {
+        let store = MemoryIdempotencyStore::new(Duration::from_secs(60));
+        let ttl = Duration::new(ttl_secs, ttl_nanos);
+        store.try_lock("test_key", ttl);
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** Passing a very large `Duration` (e.g. `Duration::MAX`) to `MemoryIdempotencyStore::set` or `try_lock` caused an arithmetic overflow panic when added to `Instant::now()`.

📉 **The Stack Trace:**
```
thread 'test_memory_idempotency_ttl_fuzzing' panicked at /rustc/.../library/std/src/time.rs:429:33:
overflow when adding duration to instant
```

🧪 **Reproduction:** Run `cargo test --manifest-path ./autumn/Cargo.toml --test chaos_idempotency_fuzz`.

😈 **Comment:** You assumed the TTL would always safely fit within the limits of `Instant` addition. You were wrong. A maliciously large TTL could trivially crash the application. Fixed by using `checked_add` and safely capping the maximum expiration to 1 year on overflow.

---
*PR created automatically by Jules for task [6201587156424365104](https://jules.google.com/task/6201587156424365104) started by @madmax983*