### PR TITLE
🛡️ Sentry: Add test coverage for is_query_canceled

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -1793,4 +1793,36 @@ mod tests {
         assert_eq!(super::scrub_sql("SELECT col_5_val"), "SELECT col_5_val");
         assert_eq!(super::scrub_sql("SELECT col_5"), "SELECT col_5");
     }
+
+    // ── is_query_canceled tests ───────────────────────────────────────────
+
+    #[test]
+    fn is_query_canceled_matches_57014() {
+        let inner_err: Box<dyn std::error::Error + Send + Sync> = "Custom 57014 error".into();
+        let err = diesel::result::Error::DeserializationError(inner_err);
+        assert!(super::is_query_canceled(&err));
+    }
+
+    #[test]
+    fn is_query_canceled_matches_query_canceled() {
+        let inner_err: Box<dyn std::error::Error + Send + Sync> =
+            "Some query canceled error".into();
+        let err = diesel::result::Error::DeserializationError(inner_err);
+        assert!(super::is_query_canceled(&err));
+    }
+
+    #[test]
+    fn is_query_canceled_matches_statement_timeout() {
+        let inner_err: Box<dyn std::error::Error + Send + Sync> =
+            "canceling statement due to statement timeout".into();
+        let err = diesel::result::Error::DeserializationError(inner_err);
+        assert!(super::is_query_canceled(&err));
+    }
+
+    #[test]
+    fn is_query_canceled_returns_false_for_unrelated_error() {
+        let inner_err: Box<dyn std::error::Error + Send + Sync> = "connection refused".into();
+        let err = diesel::result::Error::DeserializationError(inner_err);
+        assert!(!super::is_query_canceled(&err));
+    }
 }


### PR DESCRIPTION
🎯 Target: `autumn::db::is_query_canceled` helper function
💣 Risk: This function was previously untested. If the parsing logic fails to properly detect a postgres query cancellation or statement timeout (which it checks for by attempting to parse `diesel::result::Error`), we might wrongly interpret `57014` errors and inadvertently surface internal 500 server errors rather than the cleaner 503 gateway timeouts or properly mapped query timeouts.
🧪 Strategy: I used standard Rust unit tests inside the `tests` module for `db.rs`. I constructed mock `diesel::result::Error::DeserializationError` objects with inner string representations corresponding to the expected timeouts, as well as an unrelated string to act as the negative case. 
🔭 Verification: The tests were verified to run cleanly using `cargo test -p autumn-web --lib db` under both `debug` and `--release` mode.

---
*PR created automatically by Jules for task [6806581242887605423](https://jules.google.com/task/6806581242887605423) started by @madmax983*