### PR TITLE
⚡ Bolt: Avoid unnecessary allocations in collect_openapi_docs

### DIFF
--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1713,7 +1713,7 @@ fn collect_openapi_docs(
     // effective path is `prefix + route.path`; we materialize these into
     // fresh `ApiDoc`s so the rendered spec reflects the actual URL the
     // user will call.
-    let mut docs: Vec<crate::openapi::ApiDoc> = Vec::new();
+    let mut docs: Vec<crate::openapi::ApiDoc> = Vec::with_capacity(route_list.len() + scoped_groups.iter().map(|g| g.routes.len()).sum::<usize>());
     for route in route_list {
         docs.push(route.api_doc.clone());
     }


### PR DESCRIPTION
- 💡 What: Pre-allocate the `docs` Vec using `Vec::with_capacity` in `collect_openapi_docs` in `autumn/src/router.rs`.
- 🎯 Why: Vectors created with `Vec::new()` start with zero capacity. Pushing items into them causes repeated memory allocations. Pre-calculating the capacity using the exact number of top-level routes and scoped group routes ensures no reallocation occurs.
- 📊 Impact: Eliminates multiple heap allocations during the startup routing phase when gathering OpenAPI docs.
- 🔬 Measurement: Run `cargo test -p autumn-web --lib router`

---
*PR created automatically by Jules for task [13951825759650658761](https://jules.google.com/task/13951825759650658761) started by @madmax983*