### PR TITLE
👺 Havoc: Prevent Instant addition arithmetic overflow panic

### DIFF
--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -467,7 +467,9 @@ impl IdempotencyStore for MemoryIdempotencyStore {
         let entry = IdempotencyEntry {
             record,
             body_hash,
-            expires_at: Instant::now() + ttl,
+            expires_at: Instant::now()
+                .checked_add(ttl)
+                .unwrap_or_else(|| Instant::now() + Duration::from_secs(315_360_000)),
         };
         let mut entries = self.entries.write().unwrap();
         entries.insert(key.to_owned(), entry);
@@ -504,7 +506,9 @@ impl IdempotencyStore for MemoryIdempotencyStore {
             key.to_owned(),
             MemoryInFlightLock {
                 owner: owner.to_owned(),
-                expires_at: now + ttl,
+                expires_at: now
+                    .checked_add(ttl)
+                    .unwrap_or_else(|| now + Duration::from_secs(315_360_000)),
             },
         );
         true

--- a/autumn/tests/chaos_idempotency_fuzz.rs
+++ b/autumn/tests/chaos_idempotency_fuzz.rs
@@ -1,0 +1,22 @@
+use autumn_web::idempotency::IdempotencyRecord;
+use autumn_web::idempotency::IdempotencyStore;
+use autumn_web::idempotency::MemoryIdempotencyStore;
+use proptest::prelude::*;
+use std::time::Duration;
+
+proptest! {
+    #[test]
+    fn test_idempotency_ttl_fuzz(ttl in proptest::num::u64::ANY) {
+        let store = MemoryIdempotencyStore::new(Duration::from_secs(3600));
+        let record = IdempotencyRecord {
+            status: 200,
+            headers: vec![],
+            body: vec![],
+            metadata: vec![],
+        };
+
+        let d = Duration::from_secs(ttl);
+        store.set("key", record, vec![], d);
+        store.try_lock("key", d);
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:**
Passing a very large TTL (like `Duration::MAX`) to `IdempotencyStore::set` or `try_lock`.

📉 **The Stack Trace:**
```
thread 'test_idempotency_ttl_fuzz' panicked at library/std/src/time.rs:429:33:
overflow when adding duration to instant
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

🧪 **Reproduction:**
Run `cargo test -p autumn-web --test chaos_idempotency_fuzz` before the fix.

😈 **Comment:**
"You assumed the duration you added to Instant::now() would always fit in a 64-bit integer without checking. You were wrong."

---
*PR created automatically by Jules for task [6459333279756753207](https://jules.google.com/task/6459333279756753207) started by @madmax983*