### PR TITLE
🔒 Eris: Fix X-Forwarded-Host spoofing vulnerability in Method Override Layer

### DIFF
--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -397,8 +397,13 @@ fn origin_matches_request(origin: &str, headers: &http::HeaderMap) -> bool {
     };
 
     let expected_host = headers
-        .get("x-forwarded-host")
-        .and_then(|v| v.to_str().ok())
+        .get_all("x-forwarded-host")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|s| s.split(','))
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .last()
         .or_else(|| {
             headers
                 .get(http::header::HOST)

--- a/autumn/tests/security/method_override_xff_bypass.rs
+++ b/autumn/tests/security/method_override_xff_bypass.rs
@@ -1,0 +1,60 @@
+use autumn_web::middleware::MethodOverrideLayer;
+use axum::{Router, routing::delete};
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+use axum::body::Body;
+
+#[tokio::test]
+async fn eris_xff_host_bypass_poc() {
+    let app = Router::new()
+        .route("/delete", delete(|| async { "deleted" }))
+        .layer(MethodOverrideLayer::new());
+
+    let mut req = Request::builder()
+        .method("POST")
+        .uri("/delete")
+        // No sec-fetch-site, meaning it falls back to origin matching.
+        .header("Origin", "https://attacker.com")
+        .header("X-Forwarded-Proto", "https")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(Body::from("_method=DELETE"))
+        .unwrap();
+    // Attacker sets: X-Forwarded-Host: attacker.com
+    req.headers_mut().append("x-forwarded-host", "attacker.com".parse().unwrap());
+    // Proxy adds: X-Forwarded-Host: app.example
+    req.headers_mut().append("x-forwarded-host", "app.example".parse().unwrap());
+
+    let response = app.oneshot(req).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::METHOD_NOT_ALLOWED,
+        "VULNERABLE! Server trusted the attacker's first X-Forwarded-Host header value!"
+    );
+}
+
+#[tokio::test]
+async fn eris_xff_host_bypass_comma_poc() {
+    let app = Router::new()
+        .route("/delete", delete(|| async { "deleted" }))
+        .layer(MethodOverrideLayer::new());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/delete")
+        .header("Origin", "https://attacker.com")
+        .header("X-Forwarded-Proto", "https")
+        // A single header containing comma-separated values, which is the standard way proxies append
+        .header("X-Forwarded-Host", "attacker.com, app.example")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(Body::from("_method=DELETE"))
+        .unwrap();
+
+    let response = app.clone().oneshot(req).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::METHOD_NOT_ALLOWED,
+        "VULNERABLE! Server trusted the attacker's first X-Forwarded-Host header value!"
+    );
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -13,3 +13,5 @@ pub mod fallback_middleware_bypass;
 pub mod rate_limit_xff_bypass;
 pub mod session_exhaustion;
 pub mod session_fixation;
+
+pub mod method_override_xff_bypass;


### PR DESCRIPTION
🎯 **What:** The `MethodOverrideLayer`'s `is_same_origin_form` check incorrectly parsed the `X-Forwarded-Host` header. By using `headers.get("x-forwarded-host")`, the framework only extracted the *first* header value. If an attacker provided their own `X-Forwarded-Host` header, the proxy would append its value (either via a second header or a comma-separated list). This allowed the attacker's value to take precedence and bypass the origin verification checks.
    
⚠️ **Risk:** **High.** This allowed an attacker to completely bypass the `MethodOverrideLayer`'s same-origin protections. By spoofing the `X-Forwarded-Host` to match their own malicious domain, an attacker could force the server to accept a cross-origin form POST request and execute state-changing actions (like `DELETE` or `PUT`) on behalf of a victim, essentially resulting in a CSRF bypass.

🛡️ **Solution:** Updated `origin_matches_request` to safely collect all `X-Forwarded-Host` values (`headers.get_all("x-forwarded-host")`), flat map them by commas to handle appended values, trim whitespace, filter empty strings, and explicitly extract the `.last()` element. The last element correctly represents the value appended by the closest trusted proxy. Added PoC tests for multiple headers and comma-separated header injection to `tests/security/method_override_xff_bypass.rs`.

---
*PR created automatically by Jules for task [9592529689190301039](https://jules.google.com/task/9592529689190301039) started by @madmax983*