### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -1114,6 +1114,31 @@ impl DatabasePoolProvider for DieselDeadpoolPoolProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_query_canceled_detects_string_matches() {
+        let errs = vec![
+            diesel::result::Error::DeserializationError("Error 57014: connection closed".into()),
+            diesel::result::Error::DeserializationError("query_canceled".into()),
+            diesel::result::Error::DeserializationError(
+                "canceling statement due to statement timeout".into(),
+            ),
+            diesel::result::Error::DeserializationError("statement timeout occurred".into()),
+            diesel::result::Error::DeserializationError("the query canceled".into()),
+        ];
+
+        for err in errs {
+            assert!(
+                is_query_canceled(&err),
+                "expected '{err}' to be detected as canceled",
+            );
+        }
+
+        let not_canceled =
+            diesel::result::Error::DeserializationError("just a normal error".into());
+        assert!(!is_query_canceled(&not_canceled));
+    }
+
     use crate::config::DatabaseConfig;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};


### PR DESCRIPTION
🎯 Target: `is_query_canceled` utility function in `autumn/src/db.rs`.
💣 Risk: Ensures we do not incorrectly classify non-canceled queries as canceled or miss string permutations of cancellation errors. 
🧪 Strategy: Added a table-driven test using mocked `diesel::result::Error::DeserializationError` to comprehensively cover the fallback string-matching logic without relying on uninstantiable `tokio_postgres` error types.
🔭 Verification: `cargo test -p autumn-web --lib db --features test-support,db,storage,maud`

---
*PR created automatically by Jules for task [15143046017536453311](https://jules.google.com/task/15143046017536453311) started by @madmax983*