### PR TITLE
🔓 Eris: [X-Forwarded-Host Spoofing in Method Override Middleware]

### DIFF
--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -396,9 +396,14 @@ fn origin_matches_request(origin: &str, headers: &http::HeaderMap) -> bool {
         return false;
     };
 
+    #[allow(clippy::double_ended_iterator_last)]
     let expected_host = headers
-        .get("x-forwarded-host")
-        .and_then(|v| v.to_str().ok())
+        .get_all("x-forwarded-host")
+        .into_iter()
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|s| s.split(','))
+        .map(str::trim)
+        .last()
         .or_else(|| {
             headers
                 .get(http::header::HOST)
@@ -412,14 +417,17 @@ fn origin_matches_request(origin: &str, headers: &http::HeaderMap) -> bool {
     }
 
     if let Some(scheme) = headers
-        .get("x-forwarded-proto")
-        .and_then(|v| v.to_str().ok())
+        .get_all("x-forwarded-proto")
+        .into_iter()
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|s| s.split(','))
+        .map(str::trim)
+        .next()
     {
         // Multiple `X-Forwarded-Proto` values can be chained by
         // intermediaries; the leftmost (client-facing) is the one
         // that matters here.
-        let outermost = scheme.split(',').next().unwrap_or(scheme).trim();
-        return outermost.eq_ignore_ascii_case(origin_scheme);
+        return scheme.eq_ignore_ascii_case(origin_scheme);
     }
 
     // No scheme signal: host:port match is the best we can do.

--- a/autumn/tests/security/method_override_xfh_bypass.rs
+++ b/autumn/tests/security/method_override_xfh_bypass.rs
@@ -1,0 +1,71 @@
+use autumn_web::middleware::MethodOverrideLayer;
+use axum::{Router, body::Body, http::Request, routing::post};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+async fn get_body(res: axum::http::Response<axum::body::Body>) -> String {
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn method_override_xfh_bypass() {
+    let app = Router::new()
+        .route(
+            "/test",
+            post(|| async { "POST" }).delete(|| async { "DELETE" }),
+        )
+        .layer(MethodOverrideLayer::new());
+
+    // Attacker spoofs x-forwarded-host.
+    let bypass_req = Request::builder()
+        .method("POST")
+        .uri("/test")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .header("origin", "https://evil.example")
+        .header("host", "internal.local")
+        .header("x-forwarded-host", "evil.example")
+        .header("x-forwarded-host", "app.example")
+        .header("x-forwarded-proto", "https")
+        .body(Body::from("_method=DELETE"))
+        .unwrap();
+
+    let res = app.clone().oneshot(bypass_req).await.unwrap();
+    let body = get_body(res).await;
+
+    assert_ne!(
+        body, "DELETE",
+        "Vulnerable to X-Forwarded-Host spoofing bypass"
+    );
+}
+
+#[tokio::test]
+async fn method_override_xfh_comma_separated() {
+    let app = Router::new()
+        .route(
+            "/test",
+            post(|| async { "POST" }).delete(|| async { "DELETE" }),
+        )
+        .layer(MethodOverrideLayer::new());
+
+    // Single header, comma separated
+    let bypass_req = Request::builder()
+        .method("POST")
+        .uri("/test")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .header("origin", "https://evil.example")
+        .header("host", "internal.local")
+        .header("x-forwarded-host", "evil.example, app.example")
+        .header("x-forwarded-proto", "https")
+        .body(Body::from("_method=DELETE"))
+        .unwrap();
+
+    let res = app.clone().oneshot(bypass_req).await.unwrap();
+    let _status = res.status();
+    let body = get_body(res).await;
+
+    assert_ne!(
+        body, "DELETE",
+        "Vulnerable to X-Forwarded-Host spoofing bypass via commas"
+    );
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -10,6 +10,7 @@ pub mod csrf_path_traversal;
 pub mod csrf_timing;
 pub mod ctf;
 pub mod fallback_middleware_bypass;
+pub mod method_override_xfh_bypass;
 pub mod rate_limit_xff_bypass;
 pub mod session_exhaustion;
 pub mod session_fixation;


### PR DESCRIPTION
🎯 **What:** The method override middleware (`MethodOverrideLayer`) trusted the first (leftmost) `X-Forwarded-Host` header when comparing `Origin` against the expected `Host` to prevent cross-site request forgery via method override forms.
⚠️ **Risk:** An attacker could craft a malicious page on `evil.example` that submitted a POST request containing `_method=DELETE` to the target application. By spoofing `X-Forwarded-Host: evil.example`, the attacker bypassed the same-origin validation because the middleware checked the leftmost header rather than the proxy-appended rightmost header. This resulted in an unauthenticated CSRF bypass for any endpoint leveraging method override logic.
🛡️ **Solution:** Updated `origin_matches_request` to gather all `X-Forwarded-Host` and `X-Forwarded-Proto` headers, split them by commas, and securely extract the correct value. `X-Forwarded-Host` now extracts the `.last()` element (the closest trusted proxy), and `X-Forwarded-Proto` safely extracts the `.next()` (original client-facing scheme). Added rigorous integration tests in `tests/security/` to prevent future regressions.

---
*PR created automatically by Jules for task [17738960453158844329](https://jules.google.com/task/17738960453158844329) started by @madmax983*