### PR TITLE
⚡ Bolt: Optimize path normalization to avoid intermediate allocations

### DIFF
--- a/autumn-cli/src/plugin_check.rs
+++ b/autumn-cli/src/plugin_check.rs
@@ -427,17 +427,20 @@ fn check_duplicate_registration(plugin_name: &str, routes: &[RouteInfo]) -> Chec
     }
 }
 
+/// ⚡ Bolt: Optimization - Pre-allocates a string buffer based on the input path length to avoid intermediate Vec allocations and string concatenation during route segment normalization.
 fn normalize_path_for_collision(path: &str) -> String {
-    path.split('/')
-        .map(|seg| {
-            if seg.starts_with('{') && seg.ends_with('}') {
-                "{}"
-            } else {
-                seg
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
+    let mut normalized = String::with_capacity(path.len());
+    for (i, seg) in path.split('/').enumerate() {
+        if i > 0 {
+            normalized.push('/');
+        }
+        if seg.starts_with('{') && seg.ends_with('}') {
+            normalized.push_str("{}");
+        } else {
+            normalized.push_str(seg);
+        }
+    }
+    normalized
 }
 
 fn check_collisions(routes: &[RouteInfo]) -> CheckResult {

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -350,17 +350,20 @@ pub fn check_route_prefix(
 /// Both named params (`{id}`) and catch-all params (`{*rest}`) normalize to
 /// `{}`. matchit (Axum's router) treats a named param and a catch-all at the
 /// same path position as a conflict, so they must map to the same key.
+/// ⚡ Bolt: Optimization - Pre-allocates a string buffer based on the input path length to avoid intermediate Vec allocations and string concatenation during route segment normalization.
 fn normalize_path_for_collision(path: &str) -> String {
-    path.split('/')
-        .map(|seg| {
-            if seg.starts_with('{') && seg.ends_with('}') {
-                "{}"
-            } else {
-                seg
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
+    let mut normalized = String::with_capacity(path.len());
+    for (i, seg) in path.split('/').enumerate() {
+        if i > 0 {
+            normalized.push('/');
+        }
+        if seg.starts_with('{') && seg.ends_with('}') {
+            normalized.push_str("{}");
+        } else {
+            normalized.push_str(seg);
+        }
+    }
+    normalized
 }
 
 /// Detect route collisions: any two routes sharing the same (method, path) pair.


### PR DESCRIPTION
💡 What: Refactored `normalize_path_for_collision` in both `autumn/src/plugin_conformance.rs` and `autumn-cli/src/plugin_check.rs` to use a pre-allocated `String` and sequential `.push_str()`/`.push()` calls instead of mapping, collecting into a `Vec`, and then calling `.join("/")`.

🎯 Why: The previous implementation created an unnecessary intermediate `Vec` and intermediate strings via `.join("/")`. Route collision detection runs on all registered routes during application startup or CLI check, making this a frequent operation that benefits from zero-cost abstractions.

📊 Impact: Eliminates one `Vec` allocation and one intermediate `String` allocation per path segment evaluated during route normalization.

🔭 Measurement: Run `cargo test -p autumn-web --lib plugin_conformance --release` and `cargo test -p autumn-cli --release`. Check that the test suite still passes without the allocations.

---
*PR created automatically by Jules for task [17496073283792538608](https://jules.google.com/task/17496073283792538608) started by @madmax983*