### PR TITLE
🗺️ Atlas: Extract AuthorizationState trait

### DIFF
--- a/autumn/src/authorization.rs
+++ b/autumn/src/authorization.rs
@@ -75,6 +75,27 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn std::future::Future<Output = T> + Send +
 /// re-threading state), and a clone of the database pool so
 /// policies can consult related rows. `Clone + Send + Sync` — flows
 /// freely across `.await` points.
+///
+/// Trait to abstract the state requirement for authorization functions.
+/// This breaks the circular dependency between the authorization module
+/// and the central `AppState`.
+pub trait AuthorizationState {
+    /// Returns the configured policy registry.
+    fn policy_registry(&self) -> &PolicyRegistry;
+
+    /// Returns the configured forbidden response shape.
+    fn forbidden_response(&self) -> ForbiddenResponse;
+
+    /// Returns the session key used to identify the authenticated user.
+    fn auth_session_key(&self) -> &str;
+
+    /// Returns the database connection pool, if configured.
+    #[cfg(feature = "db")]
+    fn pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>;
+}
+
 #[derive(Clone)]
 pub struct PolicyContext {
     /// The full per-request [`Session`]. Read raw values via
@@ -130,7 +151,10 @@ impl PolicyContext {
     /// Build a fully-populated [`PolicyContext`] from `AppState` +
     /// `Session`. Used by the `#[authorize]` macro and
     /// `#[repository(policy = ...)]`-generated handlers.
-    pub async fn from_request(state: &crate::AppState, session: &Session) -> Self {
+    pub async fn from_request(
+        state: &(impl AuthorizationState + Send + Sync + ?Sized),
+        session: &Session,
+    ) -> Self {
         let mut ctx = Self::from_session(session, state.auth_session_key()).await;
         ctx.policy_registry = state.policy_registry().clone();
         #[cfg(feature = "db")]
@@ -621,7 +645,7 @@ impl<'de> serde::Deserialize<'de> for ForbiddenResponse {
 /// }
 /// ```
 pub async fn authorize<R>(
-    state: &crate::AppState,
+    state: &(impl AuthorizationState + Send + Sync + ?Sized),
     session: &Session,
     action: &str,
     resource: &R,
@@ -651,7 +675,7 @@ where
 /// the public API** — call [`authorize`] from user code.
 #[doc(hidden)]
 pub async fn __check_policy<R>(
-    state: &crate::AppState,
+    state: &(impl AuthorizationState + Send + Sync + ?Sized),
     session: &Session,
     action: &str,
     resource: &R,
@@ -673,7 +697,7 @@ where
 /// alias for older macro output.
 #[doc(hidden)]
 pub async fn __check_policy_create<R>(
-    state: &crate::AppState,
+    state: &(impl AuthorizationState + Send + Sync + ?Sized),
     session: &Session,
 ) -> crate::AutumnResult<()>
 where
@@ -692,7 +716,7 @@ where
 /// only `autumn-web` is upgraded.
 #[doc(hidden)]
 pub async fn __check_policy_create_payload<R>(
-    state: &crate::AppState,
+    state: &(impl AuthorizationState + Send + Sync + ?Sized),
     session: &Session,
     payload: &serde_json::Value,
 ) -> crate::AutumnResult<()>
@@ -713,7 +737,7 @@ where
 /// Returns the configured deny response when the policy denies.
 /// Returns `500` when no policy is registered for `R`.
 pub async fn authorize_create<R>(
-    state: &crate::AppState,
+    state: &(impl AuthorizationState + Send + Sync + ?Sized),
     session: &Session,
 ) -> crate::AutumnResult<()>
 where
@@ -749,7 +773,7 @@ where
 /// Returns the configured deny response when the policy denies.
 /// Returns `500` when no policy is registered for `R`.
 pub async fn authorize_create_payload<R>(
-    state: &crate::AppState,
+    state: &(impl AuthorizationState + Send + Sync + ?Sized),
     session: &Session,
     payload: &serde_json::Value,
 ) -> crate::AutumnResult<()>

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -669,6 +669,28 @@ impl std::fmt::Debug for AppState {
     }
 }
 
+impl crate::authorization::AuthorizationState for AppState {
+    fn policy_registry(&self) -> &crate::authorization::PolicyRegistry {
+        self.policy_registry()
+    }
+
+    fn forbidden_response(&self) -> crate::authorization::ForbiddenResponse {
+        self.forbidden_response()
+    }
+
+    fn auth_session_key(&self) -> &str {
+        self.auth_session_key()
+    }
+
+    #[cfg(feature = "db")]
+    fn pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
+        self.pool.as_ref()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
🕸️ Tangle: The codebase had a circular dependency between `authorization.rs` and `state.rs`, where `state.rs` imported `ForbiddenResponse` and `PolicyRegistry` from `authorization`, and `authorization.rs` imported `AppState` to check policies.

📐 Blueprint: Extracted an `AuthorizationState` trait in `authorization.rs` that requires implementations to provide access to the policy registry, forbidden response, auth session key, and database pool. Implemented this trait for `AppState` in `state.rs` and updated `authorization.rs` functions to depend abstractly on `impl AuthorizationState + Send + Sync + ?Sized` instead of concretely on `AppState`.

🧱 Stability: This inversion of dependency ensures `authorization.rs` no longer depends on the concrete top-level `AppState`, achieving a strict unidirectional dependency graph. By using `impl Trait` instead of named generics for the state parameter, backwards compatibility for existing macro users calling `authorize::<MyResource>(...)` with turbofish syntax is strictly preserved. 

🔬 Verification: Builds successfully, strict separation enforced. Tested across all profiles (`cargo check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, `cargo test --release`, `cargo test --test authorization_integration --release`). No warnings or compilation errors.

---
*PR created automatically by Jules for task [16039654010017837645](https://jules.google.com/task/16039654010017837645) started by @madmax983*