### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -1113,4 +1113,25 @@ mod tests {
         assert_eq!(hx_trigger, r#"{"autumn:conflict":true}"#);
         Ok(())
     }
+
+    #[test]
+    fn test_problem_code_for_fallback_val() {
+        let status = axum::http::StatusCode::from_u16(599).unwrap();
+        // Since 599 is a server error, it returns "autumn.server_error"
+        assert_eq!(
+            super::problem_code_for(status, false),
+            "autumn.server_error"
+        );
+        // We can test the actual fallback with 199
+        let status = axum::http::StatusCode::from_u16(199).unwrap();
+        assert_eq!(super::problem_code_for(status, false), "autumn.error");
+    }
+
+    #[test]
+    fn test_default_reason_fallback_val() {
+        let status = axum::http::StatusCode::from_u16(599).unwrap();
+        // default_reason isn't accessible, we test it through `.canonical_reason()` indirectly
+        // Actually, we can just test `problem_title_for` which is accessible and relies on it!
+        assert_eq!(super::problem_title_for(status, false), "Error");
+    }
 }

--- a/autumn/src/error_pages/defaults.rs
+++ b/autumn/src/error_pages/defaults.rs
@@ -329,4 +329,15 @@ mod tests {
         assert!(s.contains("599"));
         assert!(s.contains("Error"));
     }
+
+    #[test]
+    fn test_unwrap_or_fallback() {
+        let pages = DefaultErrorPages;
+        let ctx = make_ctx(StatusCode::from_u16(599).unwrap());
+        let html = pages.render_error(&ctx);
+        let s = html.into_string();
+        // Verifies the fallback "Error" is rendered because 599 has no canonical reason
+        assert!(s.contains("Error"));
+        assert!(s.contains("599"));
+    }
 }


### PR DESCRIPTION
🎯 **Target:** `autumn/src/error.rs` (`problem_code_for`, `default_reason`) and `autumn/src/error_pages/defaults.rs` (`render_error`).
💣 **Risk:** The `canonical_reason()` on `StatusCode` can return `None` for non-standard HTTP status codes, falling back to a default value. If this behavior were to change or break, we wouldn't have tests to catch it.
🧪 **Strategy:** Added targeted tests that explicitly invoke methods with `StatusCode::from_u16(599).unwrap()` to guarantee the execution reaches the `unwrap_or` fallback branch.
🔬 **Verification:** `cargo test -p autumn-web --lib error` and `cargo test -p autumn-web --lib error_pages`.

---
*PR created automatically by Jules for task [12748009186362616063](https://jules.google.com/task/12748009186362616063) started by @madmax983*