### PR TITLE
👺 Havoc: Prevent Instant panic on Duration overflow in Idempotency

### DIFF
--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -464,10 +464,11 @@ impl IdempotencyStore for MemoryIdempotencyStore {
     }
 
     fn set(&self, key: &str, record: IdempotencyRecord, body_hash: Vec<u8>, ttl: Duration) {
+        let now = Instant::now();
         let entry = IdempotencyEntry {
             record,
             body_hash,
-            expires_at: Instant::now() + ttl,
+            expires_at: now.checked_add(ttl).unwrap_or_else(|| now + Duration::from_secs(315_360_000)),
         };
         let mut entries = self.entries.write().unwrap();
         entries.insert(key.to_owned(), entry);
@@ -504,7 +505,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
             key.to_owned(),
             MemoryInFlightLock {
                 owner: owner.to_owned(),
-                expires_at: now + ttl,
+                expires_at: now.checked_add(ttl).unwrap_or_else(|| now + Duration::from_secs(315_360_000)),
             },
         );
         true

--- a/autumn/tests/havoc.rs
+++ b/autumn/tests/havoc.rs
@@ -1,0 +1,19 @@
+use std::time::Duration;
+use autumn_web::idempotency::{MemoryIdempotencyStore, IdempotencyStore, IdempotencyRecord};
+
+#[test]
+fn havoc_idempotency_store_survives_max_duration() {
+    let store = MemoryIdempotencyStore::new(Duration::from_secs(60));
+
+    // Panic 1: try_lock with Duration::MAX
+    let lock_success = store.try_lock("test_key", Duration::MAX);
+    assert!(lock_success);
+
+    // Panic 2: set with Duration::MAX
+    store.set("test_key2", IdempotencyRecord {
+        status: 200,
+        headers: vec![],
+        body: vec![],
+        metadata: vec![],
+    }, vec![], Duration::MAX);
+}


### PR DESCRIPTION
🧨 **The Trigger:** Passing `Duration::MAX` (or very large durations) as the TTL to `MemoryIdempotencyStore::try_lock` or `MemoryIdempotencyStore::set` causes an overflow.
📉 **The Stack Trace:**
```
thread 'havoc_idempotency_store_survives_max_duration' panicked at library/std/src/time.rs:429:33:
overflow when adding duration to instant
```
🧪 **Reproduction:**
```rust
let store = MemoryIdempotencyStore::new(Duration::from_secs(60));
store.try_lock("test_key", Duration::MAX);
```
😈 **Comment:** You assumed the user-supplied TTL would fit comfortably within an `Instant` when added to `Instant::now()`. You were wrong. I added `checked_add` and fell back to a distant 10-year future to prevent the crash while honoring the infinite intent.

---
*PR created automatically by Jules for task [14350679277668728426](https://jules.google.com/task/14350679277668728426) started by @madmax983*