### PR TITLE
Export SelectOption from admin plugin prelude

### DIFF
--- a/autumn-admin-plugin/src/lib.rs
+++ b/autumn-admin-plugin/src/lib.rs
@@ -41,14 +41,14 @@ mod traits;
 pub use registry::AdminRegistry;
 pub use traits::{
     AdminAction, AdminError, AdminField, AdminFieldKind, AdminFuture, AdminModel, ListParams,
-    ListResult, SortDirection,
+    ListResult, SelectOption, SortDirection,
 };
 
 /// Common downstream imports for implementing admin models.
 pub mod prelude {
     pub use crate::{
         AdminError, AdminField, AdminFieldKind, AdminFuture, AdminModel, ListParams, ListResult,
-        SortDirection,
+        SelectOption, SortDirection,
     };
 }
 

--- a/autumn-cli/src/generate/admin.rs
+++ b/autumn-cli/src/generate/admin.rs
@@ -1605,6 +1605,44 @@ pub struct Post {
         );
     }
 
+    // Regression test for issue #782: SelectOption must be resolvable from
+    // `autumn_admin_plugin::prelude::*` so generated select adapters compile
+    // without downstream hand-patches.
+    #[test]
+    fn select_option_generated_code_uses_prelude_importable_type() {
+        let tmp = project_with_model("ticket");
+        let options = AdminOptions {
+            select: vec![SelectSpec {
+                field: "priority".into(),
+                values: vec!["low".into(), "medium".into(), "high".into()],
+            }],
+            ..Default::default()
+        };
+        let plan =
+            plan_admin_with_options(tmp.path(), "Ticket", &["priority:String".into()], &options)
+                .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let admin = fs::read_to_string(tmp.path().join("src/admin/ticket.rs")).unwrap();
+
+        // Generated file must use the glob prelude import so SelectOption is in scope.
+        assert!(
+            admin.contains("use autumn_admin_plugin::prelude::*;"),
+            "generated adapter must use prelude glob import"
+        );
+        // SelectOption must appear as a struct literal in the generated body —
+        // it is brought in by `prelude::*` once SelectOption is exported from prelude.
+        assert!(
+            admin.contains("SelectOption {"),
+            "generated adapter must emit SelectOption struct literals for select fields"
+        );
+        // Verify the option values are present.
+        assert!(admin.contains("\"low\""), "option value 'low' must appear");
+        assert!(admin.contains("\"medium\""), "option value 'medium' must appear");
+        assert!(admin.contains("\"high\""), "option value 'high' must appear");
+
+    }
+
     #[test]
     fn parse_select_specs_parses_field_with_values() {
         let specs = parse_select_specs(&["status=draft,published,archived".into()]).unwrap();

--- a/autumn-cli/src/generate/admin.rs
+++ b/autumn-cli/src/generate/admin.rs
@@ -1638,9 +1638,14 @@ pub struct Post {
         );
         // Verify the option values are present.
         assert!(admin.contains("\"low\""), "option value 'low' must appear");
-        assert!(admin.contains("\"medium\""), "option value 'medium' must appear");
-        assert!(admin.contains("\"high\""), "option value 'high' must appear");
-
+        assert!(
+            admin.contains("\"medium\""),
+            "option value 'medium' must appear"
+        );
+        assert!(
+            admin.contains("\"high\""),
+            "option value 'high' must appear"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This PR fixes issue #782 by exporting `SelectOption` from the `autumn_admin_plugin` prelude, making it available to generated code without requiring downstream hand-patches.

## Key Changes
- **autumn-admin-plugin/src/lib.rs**: Added `SelectOption` to both the public exports and the `prelude` module, making it accessible via `use autumn_admin_plugin::prelude::*;`
- **autumn-cli/src/generate/admin.rs**: Added a regression test (`select_option_generated_code_uses_prelude_importable_type`) that verifies:
  - Generated admin adapters use the prelude glob import
  - `SelectOption` struct literals are properly emitted in generated code
  - Select field option values are correctly included in the generated output

## Implementation Details
The fix ensures that when the code generator creates select field adapters with `SelectOption` struct literals, those types are automatically in scope through the prelude import. This eliminates the need for manual imports or patches in downstream code that uses the generated admin modules.

https://claude.ai/code/session_01Uksu9aH4vFEVnByLbsHkDP