### PR TITLE
Add first-class Markdown rendering with frontmatter and SSG support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Normalise line endings for all text files on checkout.
+* text=auto
+
+# Force LF for embedded Markdown content used via include_str! so that
+# git autocrlf on Windows does not corrupt the frontmatter delimiters.
+examples/wiki/content/*.md text eol=lf
+autumn/src/**/*.md text eol=lf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ testcontainers-modules = { version = "0.15", features = ["postgres", "redis", "m
 # graph used by integration tests.
 time = { version = ">=0.3, <0.4" }
 
+pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
+
 # Proc macro
 syn = { version = "2", features = ["full"] }
 quote = "1"

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -23,6 +23,8 @@ tailwind = []
 http-client = ["dep:reqwest"]
 oauth2 = ["http-client"]
 openapi = ["dep:serde_yaml"]
+# Optional Markdown rendering with frontmatter parsing and SSG integration.
+markdown = ["dep:pulldown-cmark"]
 db = [
     "dep:deadpool",
     "dep:diesel",
@@ -105,6 +107,7 @@ testcontainers = { workspace = true, optional = true }
 testcontainers-modules = { workspace = true, optional = true }
 serde_urlencoded = "0.7"
 serde_yaml = { version = "0.9", optional = true }
+pulldown-cmark = { workspace = true, optional = true }
 subtle = "2.6.1"
 base64 = "0.22"
 url = "2.5.8"
@@ -147,7 +150,7 @@ rusty-fork = "0.3.1"
 features = [
   "maud", "htmx", "tailwind", "db", "cache-moka",
   "ws", "flash", "multipart", "http-client", "oauth2", "openapi",
-  "redis", "i18n", "storage", "mail", "seed", "system-info",
+  "redis", "i18n", "storage", "mail", "seed", "system-info", "markdown",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -155,6 +155,11 @@ pub mod prelude;
 pub use paths::PathExt;
 pub(crate) mod route;
 pub use route::{RepositoryApiMeta, Route, RouteIdempotency};
+/// First-class Markdown rendering with frontmatter parsing and SSG integration.
+///
+/// Enable with the Cargo feature `markdown`.
+#[cfg(feature = "markdown")]
+pub mod markdown;
 pub mod scheduler;
 pub mod security;
 pub mod session;
@@ -163,11 +168,6 @@ pub(crate) mod session_redis;
 pub mod sse;
 /// Static site generation support.
 pub mod static_gen;
-/// First-class Markdown rendering with frontmatter parsing and SSG integration.
-///
-/// Enable with the Cargo feature `markdown`.
-#[cfg(feature = "markdown")]
-pub mod markdown;
 #[cfg(feature = "storage")]
 pub mod storage;
 pub mod tenancy;

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -163,6 +163,11 @@ pub(crate) mod session_redis;
 pub mod sse;
 /// Static site generation support.
 pub mod static_gen;
+/// First-class Markdown rendering with frontmatter parsing and SSG integration.
+///
+/// Enable with the Cargo feature `markdown`.
+#[cfg(feature = "markdown")]
+pub mod markdown;
 #[cfg(feature = "storage")]
 pub mod storage;
 pub mod tenancy;

--- a/autumn/src/markdown/mod.rs
+++ b/autumn/src/markdown/mod.rs
@@ -1,0 +1,87 @@
+//! First-class Markdown rendering with frontmatter parsing and SSG integration.
+//!
+//! Enable with the Cargo feature `markdown`.
+//!
+//! ## Quick start
+//!
+//! ### 1. Embed Markdown files at compile time
+//!
+//! ```rust,ignore
+//! use std::sync::OnceLock;
+//! use autumn_web::markdown::{MarkdownRegistry, MarkdownSource, RenderOptions, render};
+//!
+//! static DOCS: OnceLock<MarkdownRegistry> = OnceLock::new();
+//!
+//! fn docs() -> &'static MarkdownRegistry {
+//!     DOCS.get_or_init(|| {
+//!         MarkdownRegistry::from_embedded(&[
+//!             MarkdownSource { slug: "intro", content: include_str!("../content/intro.md") },
+//!             MarkdownSource { slug: "api",   content: include_str!("../content/api.md") },
+//!         ]).expect("embedded docs are valid")
+//!     })
+//! }
+//! ```
+//!
+//! ### 2. Render a page dynamically
+//!
+//! ```rust,ignore
+//! #[get("/docs/{slug}")]
+//! async fn show_doc(Path(slug): Path<String>) -> AutumnResult<Markup> {
+//!     let page = docs().get(&slug)
+//!         .ok_or_else(|| AutumnError::not_found())?;
+//!     let out = render(&page.body, RenderOptions::default());
+//!     Ok(layout(&page.frontmatter.title, html! {
+//!         (PreEscaped(&out.html))
+//!     }))
+//! }
+//! ```
+//!
+//! ### 3. Wire up static pre-rendering
+//!
+//! ```rust,ignore
+//! async fn doc_params(_router: axum::Router) -> Vec<StaticParams> {
+//!     docs().static_params()
+//! }
+//!
+//! #[static_get("/docs/{slug}", params = doc_params)]
+//! async fn show_doc_static(Path(slug): Path<String>) -> AutumnResult<Markup> {
+//!     // same as the dynamic handler above
+//! }
+//!
+//! // In main():
+//! autumn_web::app()
+//!     .routes(routes![show_doc_static, ...])
+//!     .static_routes(static_routes![show_doc_static])
+//!     .run()
+//!     .await;
+//! ```
+//!
+//! ## Frontmatter format
+//!
+//! Each `.md` file must begin with a TOML block enclosed in `+++` delimiters:
+//!
+//! ```text
+//! +++
+//! title = "Getting Started"
+//! description = "Set up your app in minutes."
+//! order = 1
+//! +++
+//!
+//! # Getting Started
+//!
+//! ...
+//! ```
+//!
+//! The `title` field is required; `description` and `order` are optional
+//! (defaulting to `""` and `0` respectively).
+
+mod registry;
+mod renderer;
+mod types;
+
+pub use registry::MarkdownRegistry;
+pub use renderer::{heading_id, render};
+pub use types::{
+    MarkdownError, MarkdownFrontmatter, MarkdownPage, MarkdownSource, RenderOptions,
+    RenderedMarkdown, TocItem,
+};

--- a/autumn/src/markdown/registry.rs
+++ b/autumn/src/markdown/registry.rs
@@ -80,12 +80,14 @@ impl MarkdownRegistry {
     }
 
     /// Retrieve a page by slug, returning `None` if no such page exists.
+    #[must_use]
     pub fn get(&self, slug: &str) -> Option<&MarkdownPage> {
         self.pages.get(slug)
     }
 
     /// All pages sorted by `frontmatter.order` ascending, then by slug
     /// as a tiebreaker.
+    #[must_use]
     pub fn all_sorted(&self) -> Vec<&MarkdownPage> {
         let mut sorted: Vec<_> = self.pages.values().collect();
         sorted.sort_by_key(|p| (p.frontmatter.order, p.slug.as_str()));
@@ -108,6 +110,7 @@ impl MarkdownRegistry {
     /// #[static_get("/docs/{slug}", params = doc_params)]
     /// async fn show_doc(Path(slug): Path<String>) -> AutumnResult<Markup> { ... }
     /// ```
+    #[must_use]
     pub fn static_params(&self) -> Vec<StaticParams> {
         self.all_sorted()
             .into_iter()
@@ -120,11 +123,13 @@ impl MarkdownRegistry {
     }
 
     /// Number of pages in the registry.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.pages.len()
     }
 
     /// Returns `true` if the registry contains no pages.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.pages.is_empty()
     }

--- a/autumn/src/markdown/registry.rs
+++ b/autumn/src/markdown/registry.rs
@@ -1,0 +1,475 @@
+//! [`MarkdownRegistry`]: a keyed collection of parsed Markdown pages.
+
+use std::path::Path;
+
+use crate::markdown::types::{
+    MarkdownError, MarkdownFrontmatter, MarkdownPage, MarkdownSource,
+};
+use crate::static_gen::StaticParams;
+
+/// A registry of Markdown pages keyed by slug.
+///
+/// Build from embedded sources via [`MarkdownRegistry::from_embedded`] or
+/// from a directory of `.md` files via [`MarkdownRegistry::from_dir`].
+pub struct MarkdownRegistry {
+    pages: indexmap::IndexMap<String, MarkdownPage>,
+}
+
+impl MarkdownRegistry {
+    /// Build a registry from a slice of embedded [`MarkdownSource`] values.
+    ///
+    /// Each source must contain a valid `+++` TOML frontmatter block followed
+    /// by a Markdown body.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MarkdownError::FrontmatterMissing`] or
+    /// [`MarkdownError::FrontmatterInvalid`] if any source cannot be parsed.
+    pub fn from_embedded(sources: &[MarkdownSource]) -> Result<Self, MarkdownError> {
+        let mut pages = indexmap::IndexMap::new();
+        for source in sources {
+            let page = parse_page(source.slug.to_owned(), source.content)?;
+            pages.insert(page.slug.clone(), page);
+        }
+        Ok(Self { pages })
+    }
+
+    /// Load all `.md` files from `dir` and parse them into pages.
+    ///
+    /// The slug for each page is derived from the file stem
+    /// (e.g. `getting-started.md` → `"getting-started"`).
+    /// Files that are not `.md` are silently ignored.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the directory cannot be read, any file cannot be
+    /// opened, or any frontmatter is missing or invalid.
+    pub fn from_dir(dir: &Path) -> Result<Self, MarkdownError> {
+        let mut pages = indexmap::IndexMap::new();
+
+        let read_dir = std::fs::read_dir(dir).map_err(|source| MarkdownError::Io {
+            path: dir.to_owned(),
+            source,
+        })?;
+
+        for entry in read_dir {
+            let entry = entry.map_err(|source| MarkdownError::Io {
+                path: dir.to_owned(),
+                source,
+            })?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("md") {
+                continue;
+            }
+            let slug = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .ok_or_else(|| MarkdownError::InvalidFileName {
+                    name: path.display().to_string(),
+                })?
+                .to_owned();
+            let content = std::fs::read_to_string(&path).map_err(|source| MarkdownError::Io {
+                path: path.clone(),
+                source,
+            })?;
+            let page = parse_page(slug.clone(), &content)?;
+            pages.insert(slug, page);
+        }
+
+        Ok(Self { pages })
+    }
+
+    /// Retrieve a page by slug, returning `None` if no such page exists.
+    pub fn get(&self, slug: &str) -> Option<&MarkdownPage> {
+        self.pages.get(slug)
+    }
+
+    /// All pages sorted by `frontmatter.order` ascending, then by slug
+    /// as a tiebreaker.
+    pub fn all_sorted(&self) -> Vec<&MarkdownPage> {
+        let mut sorted: Vec<_> = self.pages.values().collect();
+        sorted.sort_by_key(|p| (p.frontmatter.order, p.slug.as_str()));
+        sorted
+    }
+
+    /// Derive one [`StaticParams`] per page for use with `#[static_get]`
+    /// parameterized routes.
+    ///
+    /// Pages are returned in sorted order (same as [`MarkdownRegistry::all_sorted`]).
+    /// Each entry maps `"slug"` to the page's slug.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// async fn doc_params(_router: axum::Router) -> Vec<StaticParams> {
+    ///     docs_registry().static_params()
+    /// }
+    ///
+    /// #[static_get("/docs/{slug}", params = doc_params)]
+    /// async fn show_doc(Path(slug): Path<String>) -> AutumnResult<Markup> { ... }
+    /// ```
+    pub fn static_params(&self) -> Vec<StaticParams> {
+        self.all_sorted()
+            .into_iter()
+            .map(|p| {
+                let mut params = StaticParams::new();
+                params.insert("slug".to_owned(), p.slug.clone());
+                params
+            })
+            .collect()
+    }
+
+    /// Number of pages in the registry.
+    pub fn len(&self) -> usize {
+        self.pages.len()
+    }
+
+    /// Returns `true` if the registry contains no pages.
+    pub fn is_empty(&self) -> bool {
+        self.pages.is_empty()
+    }
+}
+
+/// Parse a Markdown document (with `+++` TOML frontmatter) into a [`MarkdownPage`].
+fn parse_page(slug: String, content: &str) -> Result<MarkdownPage, MarkdownError> {
+    let (frontmatter, body) = split_frontmatter(&slug, content)?;
+    Ok(MarkdownPage {
+        slug,
+        frontmatter,
+        body: body.trim_start().to_owned(),
+    })
+}
+
+/// Split a document into its TOML frontmatter and raw Markdown body.
+///
+/// Expects the content to start with `+++\n`, followed by TOML, followed
+/// by `\n+++` on its own line. The body is everything after the closing
+/// delimiter.
+fn split_frontmatter<'a>(
+    slug: &str,
+    content: &'a str,
+) -> Result<(MarkdownFrontmatter, &'a str), MarkdownError> {
+    let content = content.trim_start();
+
+    let after_open = content
+        .strip_prefix("+++\n")
+        .or_else(|| content.strip_prefix("+++\r\n"))
+        .ok_or_else(|| MarkdownError::FrontmatterMissing {
+            slug: slug.to_owned(),
+        })?;
+
+    let close_pos =
+        after_open
+            .find("\n+++")
+            .ok_or_else(|| MarkdownError::FrontmatterMissing {
+                slug: slug.to_owned(),
+            })?;
+
+    let toml_str = &after_open[..close_pos];
+    let after_close = &after_open[close_pos + 4..]; // skip "\n+++"
+
+    // Skip the optional newline(s) immediately after the closing +++
+    let body = after_close
+        .strip_prefix("\r\n")
+        .or_else(|| after_close.strip_prefix('\n'))
+        .unwrap_or(after_close);
+
+    let frontmatter: MarkdownFrontmatter =
+        toml::from_str(toml_str).map_err(|source| MarkdownError::FrontmatterInvalid {
+            slug: slug.to_owned(),
+            source,
+        })?;
+
+    Ok((frontmatter, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GETTING_STARTED: MarkdownSource = MarkdownSource {
+        slug: "getting-started",
+        content: "+++\ntitle = \"Getting Started\"\ndescription = \"How to get started\"\norder = 1\n+++\n\n# Getting Started\n\nWelcome!\n",
+    };
+
+    const API_REFERENCE: MarkdownSource = MarkdownSource {
+        slug: "api-reference",
+        content: "+++\ntitle = \"API Reference\"\ndescription = \"API docs\"\norder = 2\n+++\n\n# API Reference\n\nRoutes and types.\n",
+    };
+
+    // ---- Unit tests: parsing ----
+
+    #[test]
+    fn parses_frontmatter_correctly() {
+        let page = parse_page(
+            "test".to_owned(),
+            "+++\ntitle = \"My Title\"\ndescription = \"A desc\"\norder = 3\n+++\n\n# Body\n",
+        )
+        .unwrap();
+        assert_eq!(page.frontmatter.title, "My Title");
+        assert_eq!(page.frontmatter.description, "A desc");
+        assert_eq!(page.frontmatter.order, 3);
+        assert_eq!(page.body, "# Body\n");
+    }
+
+    #[test]
+    fn description_defaults_to_empty_string() {
+        let page = parse_page(
+            "no-desc".to_owned(),
+            "+++\ntitle = \"No Desc\"\norder = 5\n+++\n\n# Body\n",
+        )
+        .unwrap();
+        assert_eq!(page.frontmatter.description, "");
+    }
+
+    #[test]
+    fn order_defaults_to_zero() {
+        let page = parse_page(
+            "no-order".to_owned(),
+            "+++\ntitle = \"No Order\"\n+++\n\n# Body\n",
+        )
+        .unwrap();
+        assert_eq!(page.frontmatter.order, 0);
+    }
+
+    #[test]
+    fn missing_opening_delimiter_returns_error() {
+        let result = parse_page("bad".to_owned(), "# No frontmatter\n");
+        assert!(matches!(
+            result,
+            Err(MarkdownError::FrontmatterMissing { .. })
+        ));
+    }
+
+    #[test]
+    fn missing_closing_delimiter_returns_error() {
+        let result = parse_page("bad".to_owned(), "+++\ntitle = \"Test\"\n# No closing\n");
+        assert!(matches!(
+            result,
+            Err(MarkdownError::FrontmatterMissing { .. })
+        ));
+    }
+
+    #[test]
+    fn invalid_toml_returns_error() {
+        let result = parse_page(
+            "bad".to_owned(),
+            "+++\nnot valid toml = [[[\n+++\n\n# Body\n",
+        );
+        assert!(matches!(
+            result,
+            Err(MarkdownError::FrontmatterInvalid { .. })
+        ));
+    }
+
+    #[test]
+    fn body_leading_whitespace_stripped() {
+        let page = parse_page(
+            "test".to_owned(),
+            "+++\ntitle = \"T\"\n+++\n\n\n\n# Body\n",
+        )
+        .unwrap();
+        assert!(page.body.starts_with("# Body"));
+    }
+
+    // ---- Unit tests: registry operations ----
+
+    #[test]
+    fn builds_registry_from_embedded() {
+        let registry =
+            MarkdownRegistry::from_embedded(&[GETTING_STARTED, API_REFERENCE]).unwrap();
+        assert_eq!(registry.len(), 2);
+        assert!(registry.get("getting-started").is_some());
+        assert!(registry.get("api-reference").is_some());
+    }
+
+    #[test]
+    fn get_returns_correct_page() {
+        let registry = MarkdownRegistry::from_embedded(&[GETTING_STARTED]).unwrap();
+        let page = registry.get("getting-started").unwrap();
+        assert_eq!(page.frontmatter.title, "Getting Started");
+        assert_eq!(page.frontmatter.order, 1);
+        assert_eq!(page.slug, "getting-started");
+    }
+
+    #[test]
+    fn get_unknown_slug_returns_none() {
+        let registry = MarkdownRegistry::from_embedded(&[GETTING_STARTED]).unwrap();
+        assert!(registry.get("nonexistent").is_none());
+    }
+
+    #[test]
+    fn all_sorted_orders_by_order_field() {
+        // Sources given in reverse order — sorted output must be by `order`.
+        let registry =
+            MarkdownRegistry::from_embedded(&[API_REFERENCE, GETTING_STARTED]).unwrap();
+        let pages = registry.all_sorted();
+        assert_eq!(pages[0].slug, "getting-started"); // order = 1
+        assert_eq!(pages[1].slug, "api-reference"); // order = 2
+    }
+
+    #[test]
+    fn all_sorted_tiebreaks_by_slug() {
+        let a = MarkdownSource {
+            slug: "zebra",
+            content: "+++\ntitle = \"Zebra\"\norder = 1\n+++\n\n# Z\n",
+        };
+        let b = MarkdownSource {
+            slug: "apple",
+            content: "+++\ntitle = \"Apple\"\norder = 1\n+++\n\n# A\n",
+        };
+        let registry = MarkdownRegistry::from_embedded(&[a, b]).unwrap();
+        let pages = registry.all_sorted();
+        assert_eq!(pages[0].slug, "apple");
+        assert_eq!(pages[1].slug, "zebra");
+    }
+
+    #[test]
+    fn static_params_returns_one_entry_per_page() {
+        let registry =
+            MarkdownRegistry::from_embedded(&[GETTING_STARTED, API_REFERENCE]).unwrap();
+        let params = registry.static_params();
+        assert_eq!(params.len(), 2);
+    }
+
+    #[test]
+    fn static_params_uses_slug_key() {
+        let registry = MarkdownRegistry::from_embedded(&[GETTING_STARTED]).unwrap();
+        let params = registry.static_params();
+        assert_eq!(params[0].get("slug").unwrap(), "getting-started");
+    }
+
+    #[test]
+    fn static_params_sorted_by_order() {
+        let registry =
+            MarkdownRegistry::from_embedded(&[API_REFERENCE, GETTING_STARTED]).unwrap();
+        let params = registry.static_params();
+        assert_eq!(params[0].get("slug").unwrap(), "getting-started");
+        assert_eq!(params[1].get("slug").unwrap(), "api-reference");
+    }
+
+    #[test]
+    fn empty_registry_is_empty() {
+        let registry = MarkdownRegistry::from_embedded(&[]).unwrap();
+        assert!(registry.is_empty());
+        assert_eq!(registry.len(), 0);
+        assert!(registry.all_sorted().is_empty());
+        assert!(registry.static_params().is_empty());
+    }
+
+    #[test]
+    fn missing_frontmatter_propagates_error_from_embedded() {
+        let bad = MarkdownSource {
+            slug: "bad",
+            content: "# No frontmatter\n",
+        };
+        let result = MarkdownRegistry::from_embedded(&[bad]);
+        assert!(matches!(
+            result,
+            Err(MarkdownError::FrontmatterMissing { .. })
+        ));
+    }
+
+    #[test]
+    fn loads_from_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("page-one.md"),
+            "+++\ntitle = \"Page One\"\norder = 1\n+++\n\n# Page One\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("page-two.md"),
+            "+++\ntitle = \"Page Two\"\norder = 2\n+++\n\n# Page Two\n",
+        )
+        .unwrap();
+        // Non-md file must be ignored
+        std::fs::write(dir.path().join("README.txt"), "ignore me").unwrap();
+
+        let registry = MarkdownRegistry::from_dir(dir.path()).unwrap();
+        assert_eq!(registry.len(), 2);
+        assert!(registry.get("page-one").is_some());
+        assert!(registry.get("page-two").is_some());
+    }
+
+    #[test]
+    fn directory_not_found_returns_io_error() {
+        let result =
+            MarkdownRegistry::from_dir(std::path::Path::new("/nonexistent/path/that/does/not/exist"));
+        assert!(matches!(result, Err(MarkdownError::Io { .. })));
+    }
+
+    // ---- Integration test: statically renders at least two Markdown pages ----
+
+    #[tokio::test]
+    async fn integration_statically_renders_two_markdown_pages() {
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::sync::Arc;
+
+        use crate::markdown::render;
+        use crate::markdown::RenderOptions;
+        use crate::static_gen::{StaticRouteMeta, render_static_routes};
+
+        let registry = Arc::new(
+            MarkdownRegistry::from_embedded(&[GETTING_STARTED, API_REFERENCE]).unwrap(),
+        );
+
+        // Build a router that renders pages from the registry.
+        let reg = registry.clone();
+        let router = axum::Router::new().route(
+            "/docs/{slug}",
+            axum::routing::get({
+                let r = reg.clone();
+                move |axum::extract::Path(slug): axum::extract::Path<String>| {
+                    let r = r.clone();
+                    async move {
+                        match r.get(&slug) {
+                            Some(page) => {
+                                let rendered = render(&page.body, RenderOptions::default());
+                                (axum::http::StatusCode::OK, rendered.html)
+                            }
+                            None => (
+                                axum::http::StatusCode::NOT_FOUND,
+                                "not found".to_owned(),
+                            ),
+                        }
+                    }
+                }
+            }),
+        );
+
+        // params function enumerating all doc slugs (fn pointer, not closure).
+        fn doc_params(
+            _: axum::Router,
+        ) -> Pin<Box<dyn Future<Output = Vec<StaticParams>> + Send>> {
+            Box::pin(async {
+                vec![
+                    crate::static_params! { "slug" => "getting-started" },
+                    crate::static_params! { "slug" => "api-reference" },
+                ]
+            })
+        }
+
+        let meta = StaticRouteMeta {
+            path: "/docs/{slug}",
+            name: "test_show_doc",
+            revalidate: None,
+            params_fn: Some(doc_params),
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dist = tmp.path().join("dist");
+
+        render_static_routes(router, &[meta], &dist).await.unwrap();
+
+        // Both pages must be pre-rendered.
+        let html_a =
+            std::fs::read_to_string(dist.join("docs/getting-started/index.html")).unwrap();
+        assert!(html_a.contains("Getting Started"));
+
+        let html_b =
+            std::fs::read_to_string(dist.join("docs/api-reference/index.html")).unwrap();
+        assert!(html_b.contains("API Reference"));
+    }
+}

--- a/autumn/src/markdown/registry.rs
+++ b/autumn/src/markdown/registry.rs
@@ -416,6 +416,18 @@ mod tests {
         use crate::markdown::RenderOptions;
         use crate::static_gen::{StaticRouteMeta, render_static_routes};
 
+        // Defined before any `let` statements to satisfy `items_after_statements`.
+        fn doc_params(
+            _: axum::Router,
+        ) -> Pin<Box<dyn Future<Output = Vec<StaticParams>> + Send>> {
+            Box::pin(async {
+                vec![
+                    crate::static_params! { "slug" => "getting-started" },
+                    crate::static_params! { "slug" => "api-reference" },
+                ]
+            })
+        }
+
         let registry = Arc::new(
             MarkdownRegistry::from_embedded(&[GETTING_STARTED, API_REFERENCE]).unwrap(),
         );
@@ -429,32 +441,17 @@ mod tests {
                 move |axum::extract::Path(slug): axum::extract::Path<String>| {
                     let r = r.clone();
                     async move {
-                        match r.get(&slug) {
-                            Some(page) => {
+                        r.get(&slug).map_or_else(
+                            || (axum::http::StatusCode::NOT_FOUND, "not found".to_owned()),
+                            |page| {
                                 let rendered = render(&page.body, RenderOptions::default());
                                 (axum::http::StatusCode::OK, rendered.html)
-                            }
-                            None => (
-                                axum::http::StatusCode::NOT_FOUND,
-                                "not found".to_owned(),
-                            ),
-                        }
+                            },
+                        )
                     }
                 }
             }),
         );
-
-        // params function enumerating all doc slugs (fn pointer, not closure).
-        fn doc_params(
-            _: axum::Router,
-        ) -> Pin<Box<dyn Future<Output = Vec<StaticParams>> + Send>> {
-            Box::pin(async {
-                vec![
-                    crate::static_params! { "slug" => "getting-started" },
-                    crate::static_params! { "slug" => "api-reference" },
-                ]
-            })
-        }
 
         let meta = StaticRouteMeta {
             path: "/docs/{slug}",

--- a/autumn/src/markdown/registry.rs
+++ b/autumn/src/markdown/registry.rs
@@ -445,6 +445,53 @@ mod tests {
         assert!(matches!(result, Err(MarkdownError::Io { .. })));
     }
 
+    #[test]
+    fn from_dir_skips_subdirectory_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("real-page.md"),
+            "+++\ntitle = \"Real\"\norder = 1\n+++\n\n# Real\n",
+        )
+        .unwrap();
+        // A subdirectory whose name ends in .md must be skipped.
+        std::fs::create_dir(dir.path().join("subdir.md")).unwrap();
+
+        let registry = MarkdownRegistry::from_dir(dir.path()).unwrap();
+        assert_eq!(registry.len(), 1);
+        assert!(registry.get("real-page").is_some());
+    }
+
+    #[test]
+    fn from_dir_duplicate_slug_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // Two files with the same stem produce a duplicate slug.
+        std::fs::write(
+            dir.path().join("page.md"),
+            "+++\ntitle = \"Page A\"\norder = 1\n+++\n\n# A\n",
+        )
+        .unwrap();
+        // On most filesystems a second `page.md` cannot exist; simulate the
+        // duplicate by writing a file whose stem matches an already-inserted
+        // slug.  We achieve this via a wrapper that inserts the same slug twice
+        // using from_embedded instead, since from_dir cannot have two files with
+        // the same name in the same directory.
+        // Test the embedded path only (the from_dir duplicate path is identical code).
+        let dup = MarkdownSource {
+            slug: "page",
+            content: "+++\ntitle = \"Page B\"\norder = 2\n+++\n\n# B\n",
+        };
+        let base = MarkdownSource {
+            slug: "page",
+            content: "+++\ntitle = \"Page A\"\norder = 1\n+++\n\n# A\n",
+        };
+        let result = MarkdownRegistry::from_embedded(&[base, dup]);
+        assert!(matches!(result, Err(MarkdownError::DuplicateSlug { .. })));
+        // Also verify from_dir returns one page cleanly (no duplicate possible
+        // in a real filesystem with identical filenames).
+        let registry = MarkdownRegistry::from_dir(dir.path()).unwrap();
+        assert_eq!(registry.len(), 1);
+    }
+
     // ---- Integration test: statically renders at least two Markdown pages ----
 
     #[tokio::test]

--- a/autumn/src/markdown/registry.rs
+++ b/autumn/src/markdown/registry.rs
@@ -2,9 +2,7 @@
 
 use std::path::Path;
 
-use crate::markdown::types::{
-    MarkdownError, MarkdownFrontmatter, MarkdownPage, MarkdownSource,
-};
+use crate::markdown::types::{MarkdownError, MarkdownFrontmatter, MarkdownPage, MarkdownSource};
 use crate::static_gen::StaticParams;
 
 /// A registry of Markdown pages keyed by slug.
@@ -163,12 +161,11 @@ fn split_frontmatter<'a>(
             slug: slug.to_owned(),
         })?;
 
-    let close_pos =
-        after_open
-            .find("\n+++")
-            .ok_or_else(|| MarkdownError::FrontmatterMissing {
-                slug: slug.to_owned(),
-            })?;
+    let close_pos = after_open
+        .find("\n+++")
+        .ok_or_else(|| MarkdownError::FrontmatterMissing {
+            slug: slug.to_owned(),
+        })?;
 
     let toml_str = &after_open[..close_pos];
     let after_close = &after_open[close_pos + 4..]; // skip "\n+++"
@@ -269,11 +266,8 @@ mod tests {
 
     #[test]
     fn body_leading_whitespace_stripped() {
-        let page = parse_page(
-            "test".to_owned(),
-            "+++\ntitle = \"T\"\n+++\n\n\n\n# Body\n",
-        )
-        .unwrap();
+        let page =
+            parse_page("test".to_owned(), "+++\ntitle = \"T\"\n+++\n\n\n\n# Body\n").unwrap();
         assert!(page.body.starts_with("# Body"));
     }
 
@@ -281,8 +275,7 @@ mod tests {
 
     #[test]
     fn builds_registry_from_embedded() {
-        let registry =
-            MarkdownRegistry::from_embedded(&[GETTING_STARTED, API_REFERENCE]).unwrap();
+        let registry = MarkdownRegistry::from_embedded(&[GETTING_STARTED, API_REFERENCE]).unwrap();
         assert_eq!(registry.len(), 2);
         assert!(registry.get("getting-started").is_some());
         assert!(registry.get("api-reference").is_some());
@@ -306,8 +299,7 @@ mod tests {
     #[test]
     fn all_sorted_orders_by_order_field() {
         // Sources given in reverse order — sorted output must be by `order`.
-        let registry =
-            MarkdownRegistry::from_embedded(&[API_REFERENCE, GETTING_STARTED]).unwrap();
+        let registry = MarkdownRegistry::from_embedded(&[API_REFERENCE, GETTING_STARTED]).unwrap();
         let pages = registry.all_sorted();
         assert_eq!(pages[0].slug, "getting-started"); // order = 1
         assert_eq!(pages[1].slug, "api-reference"); // order = 2
@@ -331,8 +323,7 @@ mod tests {
 
     #[test]
     fn static_params_returns_one_entry_per_page() {
-        let registry =
-            MarkdownRegistry::from_embedded(&[GETTING_STARTED, API_REFERENCE]).unwrap();
+        let registry = MarkdownRegistry::from_embedded(&[GETTING_STARTED, API_REFERENCE]).unwrap();
         let params = registry.static_params();
         assert_eq!(params.len(), 2);
     }
@@ -346,8 +337,7 @@ mod tests {
 
     #[test]
     fn static_params_sorted_by_order() {
-        let registry =
-            MarkdownRegistry::from_embedded(&[API_REFERENCE, GETTING_STARTED]).unwrap();
+        let registry = MarkdownRegistry::from_embedded(&[API_REFERENCE, GETTING_STARTED]).unwrap();
         let params = registry.static_params();
         assert_eq!(params[0].get("slug").unwrap(), "getting-started");
         assert_eq!(params[1].get("slug").unwrap(), "api-reference");
@@ -399,8 +389,9 @@ mod tests {
 
     #[test]
     fn directory_not_found_returns_io_error() {
-        let result =
-            MarkdownRegistry::from_dir(std::path::Path::new("/nonexistent/path/that/does/not/exist"));
+        let result = MarkdownRegistry::from_dir(std::path::Path::new(
+            "/nonexistent/path/that/does/not/exist",
+        ));
         assert!(matches!(result, Err(MarkdownError::Io { .. })));
     }
 
@@ -412,14 +403,12 @@ mod tests {
         use std::pin::Pin;
         use std::sync::Arc;
 
-        use crate::markdown::render;
         use crate::markdown::RenderOptions;
+        use crate::markdown::render;
         use crate::static_gen::{StaticRouteMeta, render_static_routes};
 
         // Defined before any `let` statements to satisfy `items_after_statements`.
-        fn doc_params(
-            _: axum::Router,
-        ) -> Pin<Box<dyn Future<Output = Vec<StaticParams>> + Send>> {
+        fn doc_params(_: axum::Router) -> Pin<Box<dyn Future<Output = Vec<StaticParams>> + Send>> {
             Box::pin(async {
                 vec![
                     crate::static_params! { "slug" => "getting-started" },
@@ -428,9 +417,8 @@ mod tests {
             })
         }
 
-        let registry = Arc::new(
-            MarkdownRegistry::from_embedded(&[GETTING_STARTED, API_REFERENCE]).unwrap(),
-        );
+        let registry =
+            Arc::new(MarkdownRegistry::from_embedded(&[GETTING_STARTED, API_REFERENCE]).unwrap());
 
         // Build a router that renders pages from the registry.
         let reg = registry.clone();
@@ -466,12 +454,10 @@ mod tests {
         render_static_routes(router, &[meta], &dist).await.unwrap();
 
         // Both pages must be pre-rendered.
-        let html_a =
-            std::fs::read_to_string(dist.join("docs/getting-started/index.html")).unwrap();
+        let html_a = std::fs::read_to_string(dist.join("docs/getting-started/index.html")).unwrap();
         assert!(html_a.contains("Getting Started"));
 
-        let html_b =
-            std::fs::read_to_string(dist.join("docs/api-reference/index.html")).unwrap();
+        let html_b = std::fs::read_to_string(dist.join("docs/api-reference/index.html")).unwrap();
         assert!(html_b.contains("API Reference"));
     }
 }

--- a/autumn/src/markdown/registry.rs
+++ b/autumn/src/markdown/registry.rs
@@ -176,8 +176,20 @@ fn split_frontmatter<'a>(
         .or_else(|| after_close.strip_prefix('\n'))
         .unwrap_or(after_close);
 
+    // Normalize CRLF → LF before TOML parsing so that embedded files checked
+    // out on Windows (where git autocrlf converts line endings) parse correctly.
+    // The toml crate rejects bare \r that results when find("\n+++") lands on
+    // the \n of a \r\n sequence, leaving a trailing \r in the TOML slice.
+    let toml_normalized;
+    let toml_for_parse: &str = if toml_str.contains('\r') {
+        toml_normalized = toml_str.replace('\r', "");
+        &toml_normalized
+    } else {
+        toml_str
+    };
+
     let frontmatter: MarkdownFrontmatter =
-        toml::from_str(toml_str).map_err(|source| MarkdownError::FrontmatterInvalid {
+        toml::from_str(toml_for_parse).map_err(|source| MarkdownError::FrontmatterInvalid {
             slug: slug.to_owned(),
             source,
         })?;
@@ -232,6 +244,18 @@ mod tests {
         )
         .unwrap();
         assert_eq!(page.frontmatter.order, 0);
+    }
+
+    #[test]
+    fn parses_crlf_frontmatter() {
+        // Simulate a file checked out on Windows with git autocrlf=true.
+        let page = parse_page(
+            "crlf".to_owned(),
+            "+++\r\ntitle = \"CRLF Page\"\r\norder = 7\r\n+++\r\n\r\n# Body\r\n",
+        )
+        .unwrap();
+        assert_eq!(page.frontmatter.title, "CRLF Page");
+        assert_eq!(page.frontmatter.order, 7);
     }
 
     #[test]

--- a/autumn/src/markdown/registry.rs
+++ b/autumn/src/markdown/registry.rs
@@ -22,13 +22,21 @@ impl MarkdownRegistry {
     /// # Errors
     ///
     /// Returns [`MarkdownError::FrontmatterMissing`] or
-    /// [`MarkdownError::FrontmatterInvalid`] if any source cannot be parsed.
+    /// [`MarkdownError::FrontmatterInvalid`] if any source cannot be parsed,
+    /// or [`MarkdownError::DuplicateSlug`] if two sources share a slug.
     pub fn from_embedded(sources: &[MarkdownSource]) -> Result<Self, MarkdownError> {
         let mut pages = indexmap::IndexMap::new();
         for source in sources {
             let page = parse_page(source.slug.to_owned(), source.content)?;
-            pages.insert(page.slug.clone(), page);
+            if pages.insert(page.slug.clone(), page).is_some() {
+                return Err(MarkdownError::DuplicateSlug {
+                    slug: source.slug.to_owned(),
+                });
+            }
         }
+        pages.sort_by(|_, a, _, b| {
+            (a.frontmatter.order, a.slug.as_str()).cmp(&(b.frontmatter.order, b.slug.as_str()))
+        });
         Ok(Self { pages })
     }
 
@@ -36,12 +44,13 @@ impl MarkdownRegistry {
     ///
     /// The slug for each page is derived from the file stem
     /// (e.g. `getting-started.md` → `"getting-started"`).
-    /// Files that are not `.md` are silently ignored.
+    /// Non-`.md` entries and non-file entries (subdirectories, symlinks) are
+    /// silently ignored.
     ///
     /// # Errors
     ///
     /// Returns an error if the directory cannot be read, any file cannot be
-    /// opened, or any frontmatter is missing or invalid.
+    /// opened, frontmatter is missing or invalid, or two files share a slug.
     pub fn from_dir(dir: &Path) -> Result<Self, MarkdownError> {
         let mut pages = indexmap::IndexMap::new();
 
@@ -55,6 +64,10 @@ impl MarkdownRegistry {
                 path: dir.to_owned(),
                 source,
             })?;
+            // Skip non-regular files (symlinks, subdirectories, …).
+            if !entry.file_type().is_ok_and(|t| t.is_file()) {
+                continue;
+            }
             let path = entry.path();
             if path.extension().and_then(|e| e.to_str()) != Some("md") {
                 continue;
@@ -71,9 +84,13 @@ impl MarkdownRegistry {
                 source,
             })?;
             let page = parse_page(slug.clone(), &content)?;
-            pages.insert(slug, page);
+            if pages.insert(slug.clone(), page).is_some() {
+                return Err(MarkdownError::DuplicateSlug { slug });
+            }
         }
-
+        pages.sort_by(|_, a, _, b| {
+            (a.frontmatter.order, a.slug.as_str()).cmp(&(b.frontmatter.order, b.slug.as_str()))
+        });
         Ok(Self { pages })
     }
 
@@ -83,13 +100,12 @@ impl MarkdownRegistry {
         self.pages.get(slug)
     }
 
-    /// All pages sorted by `frontmatter.order` ascending, then by slug
-    /// as a tiebreaker.
+    /// All pages in sort order: `frontmatter.order` ascending, then slug as
+    /// a tiebreaker.  The registry is pre-sorted at construction so this is a
+    /// simple iterator collect with no runtime sorting overhead.
     #[must_use]
     pub fn all_sorted(&self) -> Vec<&MarkdownPage> {
-        let mut sorted: Vec<_> = self.pages.values().collect();
-        sorted.sort_by_key(|p| (p.frontmatter.order, p.slug.as_str()));
-        sorted
+        self.pages.values().collect()
     }
 
     /// Derive one [`StaticParams`] per page for use with `#[static_get]`
@@ -387,6 +403,16 @@ mod tests {
             result,
             Err(MarkdownError::FrontmatterMissing { .. })
         ));
+    }
+
+    #[test]
+    fn duplicate_slug_returns_error_from_embedded() {
+        let dup = MarkdownSource {
+            slug: "getting-started",
+            content: "+++\ntitle = \"Dup\"\norder = 99\n+++\n\n# Dup\n",
+        };
+        let result = MarkdownRegistry::from_embedded(&[GETTING_STARTED, dup]);
+        assert!(matches!(result, Err(MarkdownError::DuplicateSlug { .. })));
     }
 
     #[test]

--- a/autumn/src/markdown/renderer.rs
+++ b/autumn/src/markdown/renderer.rs
@@ -20,6 +20,7 @@ use crate::markdown::types::{RenderOptions, RenderedMarkdown, TocItem};
 /// assert!(out.html.contains(r#"id="hello""#));
 /// assert_eq!(out.toc[0].text, "Hello");
 /// ```
+#[must_use]
 pub fn render(body: &str, options: RenderOptions) -> RenderedMarkdown {
     let mut pulldown_opts = Options::empty();
     if options.enable_tables {
@@ -85,7 +86,7 @@ pub fn render(body: &str, options: RenderOptions) -> RenderedMarkdown {
     RenderedMarkdown { html, toc }
 }
 
-fn heading_level_to_u8(level: HeadingLevel) -> u8 {
+const fn heading_level_to_u8(level: HeadingLevel) -> u8 {
     match level {
         HeadingLevel::H1 => 1,
         HeadingLevel::H2 => 2,
@@ -108,11 +109,12 @@ fn heading_level_to_u8(level: HeadingLevel) -> u8 {
 /// assert_eq!(heading_id("Hello, World!"), "hello-world");
 /// assert_eq!(heading_id("Getting Started"), "getting-started");
 /// ```
+#[must_use]
 pub fn heading_id(text: &str) -> String {
     let words: Vec<String> = text
         .split(|c: char| !c.is_ascii_alphanumeric())
         .filter(|s| !s.is_empty())
-        .map(|s| s.to_ascii_lowercase())
+        .map(str::to_ascii_lowercase)
         .collect();
     words.join("-")
 }

--- a/autumn/src/markdown/renderer.rs
+++ b/autumn/src/markdown/renderer.rs
@@ -58,16 +58,25 @@ pub fn render(body: &str, options: RenderOptions) -> RenderedMarkdown {
                     j += 1;
                 }
                 let id = heading_id(&text);
-                toc.push(TocItem {
-                    level: level_u8,
-                    id: id.clone(),
-                    text,
-                });
-                // Replace the pulldown heading-start event with raw HTML that
-                // carries the generated id attribute.
-                output.push(Event::Html(CowStr::from(format!(
-                    "<h{level_u8} id=\"{id}\">"
-                ))));
+                // Only inject an id and add a TOC entry when the heading has
+                // at least one alphanumeric character.  An empty id (e.g. a
+                // punctuation-only heading like `# !!!`) would produce invalid
+                // markup `<h1 id="">` and a broken TOC link pointing to `#`.
+                if id.is_empty() {
+                    // No alphanumeric text — plain heading, no id, no TOC entry.
+                    // An empty id would produce invalid `<h1 id="">` markup and
+                    // a broken TOC link pointing to bare `#`.
+                    output.push(Event::Html(CowStr::from(format!("<h{level_u8}>"))));
+                } else {
+                    toc.push(TocItem {
+                        level: level_u8,
+                        id: id.clone(),
+                        text,
+                    });
+                    output.push(Event::Html(CowStr::from(format!(
+                        "<h{level_u8} id=\"{id}\">"
+                    ))));
+                }
                 i += 1;
             }
             Event::End(TagEnd::Heading(level)) => {
@@ -289,5 +298,16 @@ mod tests {
         let result = render(md, RenderOptions::default());
         assert_eq!(result.toc[0].text, "Hello World");
         assert!(result.html.contains(r#"id="hello-world""#));
+    }
+
+    #[test]
+    fn punctuation_only_heading_emits_no_id_and_no_toc_entry() {
+        // heading_id("!!!") returns ""; the renderer must not emit id=""
+        // or add a broken TOC entry pointing to "#".
+        let result = render("# !!!\n\nText.", RenderOptions::default());
+        assert!(!result.html.contains("id="));
+        assert!(result.toc.is_empty());
+        // The heading tag itself must still be present.
+        assert!(result.html.contains("<h1>"));
     }
 }

--- a/autumn/src/markdown/renderer.rs
+++ b/autumn/src/markdown/renderer.rs
@@ -1,0 +1,259 @@
+//! Markdown-to-HTML renderer with heading ID injection and TOC extraction.
+
+use pulldown_cmark::{CowStr, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+
+use crate::markdown::types::{RenderOptions, RenderedMarkdown, TocItem};
+
+/// Render Markdown body text to HTML, injecting stable `id` attributes on
+/// every heading and returning an ordered table of contents.
+///
+/// Fenced code blocks preserve their language hint as a `language-{lang}`
+/// CSS class. The output HTML is safe: it is produced by pulldown-cmark's
+/// built-in HTML writer, which escapes raw HTML by default.
+///
+/// # Example
+///
+/// ```
+/// use autumn_web::markdown::{RenderOptions, render};
+///
+/// let out = render("# Hello\n\nWorld.", RenderOptions::default());
+/// assert!(out.html.contains(r#"id="hello""#));
+/// assert_eq!(out.toc[0].text, "Hello");
+/// ```
+pub fn render(body: &str, options: RenderOptions) -> RenderedMarkdown {
+    let mut pulldown_opts = Options::empty();
+    if options.enable_tables {
+        pulldown_opts.insert(Options::ENABLE_TABLES);
+    }
+    if options.enable_strikethrough {
+        pulldown_opts.insert(Options::ENABLE_STRIKETHROUGH);
+    }
+    if options.enable_tasklists {
+        pulldown_opts.insert(Options::ENABLE_TASKLISTS);
+    }
+
+    let parser = Parser::new_ext(body, pulldown_opts);
+    let raw: Vec<Event<'_>> = parser.collect();
+
+    let mut toc: Vec<TocItem> = Vec::new();
+    let mut output: Vec<Event<'_>> = Vec::with_capacity(raw.len());
+
+    let mut i = 0;
+    while i < raw.len() {
+        match &raw[i] {
+            Event::Start(Tag::Heading { level, .. }) => {
+                let level_u8 = heading_level_to_u8(*level);
+                // Look ahead to collect the heading's plain-text content.
+                let mut text = String::new();
+                let mut j = i + 1;
+                while j < raw.len() {
+                    match &raw[j] {
+                        Event::Text(t) | Event::Code(t) => text.push_str(t),
+                        Event::End(TagEnd::Heading(_)) => break,
+                        _ => {}
+                    }
+                    j += 1;
+                }
+                let id = heading_id(&text);
+                toc.push(TocItem {
+                    level: level_u8,
+                    id: id.clone(),
+                    text,
+                });
+                // Replace the pulldown heading-start event with raw HTML that
+                // carries the generated id attribute.
+                output.push(Event::Html(CowStr::from(format!(
+                    "<h{level_u8} id=\"{id}\">"
+                ))));
+                i += 1;
+            }
+            Event::End(TagEnd::Heading(level)) => {
+                let level_u8 = heading_level_to_u8(*level);
+                output.push(Event::Html(CowStr::from(format!("</h{level_u8}>"))));
+                i += 1;
+            }
+            _ => {
+                output.push(raw[i].clone());
+                i += 1;
+            }
+        }
+    }
+
+    let mut html = String::new();
+    pulldown_cmark::html::push_html(&mut html, output.into_iter());
+
+    RenderedMarkdown { html, toc }
+}
+
+fn heading_level_to_u8(level: HeadingLevel) -> u8 {
+    match level {
+        HeadingLevel::H1 => 1,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 3,
+        HeadingLevel::H4 => 4,
+        HeadingLevel::H5 => 5,
+        HeadingLevel::H6 => 6,
+    }
+}
+
+/// Derive a stable, URL-safe anchor ID from heading text.
+///
+/// Lowercases all ASCII characters, splits on non-alphanumeric characters,
+/// filters empty parts, and joins with `-`.
+///
+/// # Examples
+///
+/// ```
+/// # use autumn_web::markdown::heading_id;
+/// assert_eq!(heading_id("Hello, World!"), "hello-world");
+/// assert_eq!(heading_id("Getting Started"), "getting-started");
+/// ```
+pub fn heading_id(text: &str) -> String {
+    let words: Vec<String> = text
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_ascii_lowercase())
+        .collect();
+    words.join("-")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_simple_paragraph() {
+        let result = render("Hello **world**!", RenderOptions::default());
+        assert!(result.html.contains("<strong>world</strong>"));
+        assert!(result.toc.is_empty());
+    }
+
+    #[test]
+    fn generates_stable_heading_ids() {
+        let result = render("# Hello World\n\nSome text.", RenderOptions::default());
+        assert!(result.html.contains(r#"id="hello-world""#));
+        assert_eq!(result.toc.len(), 1);
+        assert_eq!(result.toc[0].id, "hello-world");
+        assert_eq!(result.toc[0].text, "Hello World");
+        assert_eq!(result.toc[0].level, 1);
+    }
+
+    #[test]
+    fn extracts_ordered_toc() {
+        let md = "# Title\n\n## Section 1\n\nText.\n\n### Subsection\n\n## Section 2\n";
+        let result = render(md, RenderOptions::default());
+        assert_eq!(result.toc.len(), 4);
+        assert_eq!(result.toc[0].level, 1);
+        assert_eq!(result.toc[0].id, "title");
+        assert_eq!(result.toc[1].level, 2);
+        assert_eq!(result.toc[1].id, "section-1");
+        assert_eq!(result.toc[2].level, 3);
+        assert_eq!(result.toc[2].id, "subsection");
+        assert_eq!(result.toc[3].level, 2);
+        assert_eq!(result.toc[3].id, "section-2");
+    }
+
+    #[test]
+    fn preserves_fenced_code_language() {
+        let md = "```rust\nfn main() {}\n```";
+        let result = render(md, RenderOptions::default());
+        assert!(result.html.contains("language-rust"));
+    }
+
+    #[test]
+    fn renders_tables_when_enabled() {
+        let md = "| a | b |\n|---|---|\n| 1 | 2 |\n";
+        let result = render(
+            md,
+            RenderOptions {
+                enable_tables: true,
+                ..Default::default()
+            },
+        );
+        assert!(result.html.contains("<table>"));
+    }
+
+    #[test]
+    fn suppresses_tables_when_disabled() {
+        let md = "| a | b |\n|---|---|\n| 1 | 2 |\n";
+        let result = render(
+            md,
+            RenderOptions {
+                enable_tables: false,
+                ..Default::default()
+            },
+        );
+        assert!(!result.html.contains("<table>"));
+    }
+
+    #[test]
+    fn renders_strikethrough_when_enabled() {
+        let result = render(
+            "~~strike~~",
+            RenderOptions {
+                enable_strikethrough: true,
+                ..Default::default()
+            },
+        );
+        assert!(result.html.contains("<del>"));
+    }
+
+    #[test]
+    fn suppresses_strikethrough_when_disabled() {
+        let result = render(
+            "~~strike~~",
+            RenderOptions {
+                enable_strikethrough: false,
+                ..Default::default()
+            },
+        );
+        assert!(!result.html.contains("<del>"));
+    }
+
+    #[test]
+    fn empty_body_renders_empty_html() {
+        let result = render("", RenderOptions::default());
+        assert_eq!(result.html.trim(), "");
+        assert!(result.toc.is_empty());
+    }
+
+    #[test]
+    fn heading_id_strips_special_chars() {
+        assert_eq!(heading_id("Hello, World!"), "hello-world");
+        assert_eq!(heading_id("Getting Started"), "getting-started");
+        assert_eq!(heading_id("  Leading Spaces  "), "leading-spaces");
+    }
+
+    #[test]
+    fn heading_id_unique_for_different_texts() {
+        assert_ne!(heading_id("Section 1"), heading_id("Section 2"));
+    }
+
+    #[test]
+    fn heading_id_level6() {
+        let result = render("###### Deep\n", RenderOptions::default());
+        assert!(result.html.contains(r#"<h6 id="deep">"#));
+        assert_eq!(result.toc[0].level, 6);
+    }
+
+    #[test]
+    fn multiple_headings_all_in_toc() {
+        let md = "# One\n## Two\n### Three\n";
+        let result = render(md, RenderOptions::default());
+        assert_eq!(result.toc.len(), 3);
+        assert!(result.html.contains(r#"id="one""#));
+        assert!(result.html.contains(r#"id="two""#));
+        assert!(result.html.contains(r#"id="three""#));
+    }
+
+    #[test]
+    fn heading_id_apostrophe_handled() {
+        // apostrophe becomes a separator, collapsed
+        assert_eq!(heading_id("What's New"), "what-s-new");
+    }
+
+    #[test]
+    fn heading_id_all_special_chars() {
+        assert_eq!(heading_id("!!!"), "");
+    }
+}

--- a/autumn/src/markdown/renderer.rs
+++ b/autumn/src/markdown/renderer.rs
@@ -45,11 +45,13 @@ pub fn render(body: &str, options: RenderOptions) -> RenderedMarkdown {
             Event::Start(Tag::Heading { level, .. }) => {
                 let level_u8 = heading_level_to_u8(*level);
                 // Look ahead to collect the heading's plain-text content.
-                let mut text = String::new();
+                let mut text = String::with_capacity(128);
                 let mut j = i + 1;
                 while j < raw.len() {
                     match &raw[j] {
                         Event::Text(t) | Event::Code(t) => text.push_str(t),
+                        // Preserve word boundaries across soft/hard line breaks.
+                        Event::SoftBreak | Event::HardBreak => text.push(' '),
                         Event::End(TagEnd::Heading(_)) => break,
                         _ => {}
                     }
@@ -99,8 +101,10 @@ const fn heading_level_to_u8(level: HeadingLevel) -> u8 {
 
 /// Derive a stable, URL-safe anchor ID from heading text.
 ///
-/// Lowercases all ASCII characters, splits on non-alphanumeric characters,
-/// filters empty parts, and joins with `-`.
+/// Splits on non-alphanumeric characters (Unicode-aware), lowercases the
+/// remaining parts, filters empty parts, and joins with `-`.  Non-ASCII
+/// scripts (e.g. German umlauts, CJK characters) are preserved so that
+/// anchors remain meaningful for non-English content.
 ///
 /// # Examples
 ///
@@ -108,13 +112,14 @@ const fn heading_level_to_u8(level: HeadingLevel) -> u8 {
 /// # use autumn_web::markdown::heading_id;
 /// assert_eq!(heading_id("Hello, World!"), "hello-world");
 /// assert_eq!(heading_id("Getting Started"), "getting-started");
+/// assert_eq!(heading_id("Über uns"), "über-uns");
 /// ```
 #[must_use]
 pub fn heading_id(text: &str) -> String {
     let words: Vec<String> = text
-        .split(|c: char| !c.is_ascii_alphanumeric())
+        .split(|c: char| !c.is_alphanumeric())
         .filter(|s| !s.is_empty())
-        .map(str::to_ascii_lowercase)
+        .map(str::to_lowercase)
         .collect();
     words.join("-")
 }
@@ -257,5 +262,23 @@ mod tests {
     #[test]
     fn heading_id_all_special_chars() {
         assert_eq!(heading_id("!!!"), "");
+    }
+
+    #[test]
+    fn heading_id_unicode_preserved() {
+        // Non-ASCII alphanumerics are kept and lowercased.
+        assert_eq!(heading_id("Über uns"), "über-uns");
+        assert_eq!(heading_id("日本語"), "日本語");
+    }
+
+    #[test]
+    fn soft_break_in_heading_preserved_as_space() {
+        // Setext headings may span multiple lines; the SoftBreak between lines
+        // must produce a space so adjacent words are not merged in the TOC text
+        // and the generated anchor ID.
+        let md = "Hello\nWorld\n=====\n";
+        let result = render(md, RenderOptions::default());
+        assert_eq!(result.toc[0].text, "Hello World");
+        assert!(result.html.contains(r#"id="hello-world""#));
     }
 }

--- a/autumn/src/markdown/renderer.rs
+++ b/autumn/src/markdown/renderer.rs
@@ -281,4 +281,13 @@ mod tests {
         assert_eq!(result.toc[0].text, "Hello World");
         assert!(result.html.contains(r#"id="hello-world""#));
     }
+
+    #[test]
+    fn hard_break_in_heading_preserved_as_space() {
+        // A backslash hard-break inside a setext heading must not merge words.
+        let md = "Hello\\\nWorld\n=====\n";
+        let result = render(md, RenderOptions::default());
+        assert_eq!(result.toc[0].text, "Hello World");
+        assert!(result.html.contains(r#"id="hello-world""#));
+    }
 }

--- a/autumn/src/markdown/types.rs
+++ b/autumn/src/markdown/types.rs
@@ -49,7 +49,7 @@ pub struct TocItem {
 }
 
 /// Options controlling the Markdown renderer behaviour.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct RenderOptions {
     /// Render GFM tables (default: `true`).
     pub enable_tables: bool,

--- a/autumn/src/markdown/types.rs
+++ b/autumn/src/markdown/types.rs
@@ -1,0 +1,118 @@
+//! Public types for the Markdown module.
+
+use std::path::PathBuf;
+
+/// A named Markdown document to embed at compile time via `include_str!`.
+#[derive(Debug, Clone, Copy)]
+pub struct MarkdownSource {
+    /// URL-safe slug used as a route parameter (e.g. `"getting-started"`).
+    pub slug: &'static str,
+    /// Full Markdown content including the `+++` frontmatter block.
+    pub content: &'static str,
+}
+
+/// Parsed frontmatter from a Markdown document.
+///
+/// Uses TOML between `+++` delimiters at the start of the file.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct MarkdownFrontmatter {
+    /// Display title of the page.
+    pub title: String,
+    /// Short description used in listings and meta tags.
+    #[serde(default)]
+    pub description: String,
+    /// Sort order for navigation listings (lower numbers appear first).
+    #[serde(default)]
+    pub order: u32,
+}
+
+/// A parsed Markdown page ready for rendering.
+#[derive(Debug, Clone)]
+pub struct MarkdownPage {
+    /// URL-safe identifier, e.g. `"getting-started"`.
+    pub slug: String,
+    /// Parsed frontmatter metadata.
+    pub frontmatter: MarkdownFrontmatter,
+    /// Raw Markdown body with frontmatter stripped.
+    pub body: String,
+}
+
+/// A single entry in the rendered table of contents.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TocItem {
+    /// Heading level 1–6.
+    pub level: u8,
+    /// Stable anchor ID derived from the heading text.
+    pub id: String,
+    /// Plain-text heading content.
+    pub text: String,
+}
+
+/// Options controlling the Markdown renderer behaviour.
+#[derive(Debug, Clone)]
+pub struct RenderOptions {
+    /// Render GFM tables (default: `true`).
+    pub enable_tables: bool,
+    /// Render GFM strikethrough (default: `true`).
+    pub enable_strikethrough: bool,
+    /// Render GFM task lists (default: `true`).
+    pub enable_tasklists: bool,
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self {
+            enable_tables: true,
+            enable_strikethrough: true,
+            enable_tasklists: true,
+        }
+    }
+}
+
+/// The output from rendering a [`MarkdownPage`].
+#[derive(Debug, Clone)]
+pub struct RenderedMarkdown {
+    /// Safe HTML produced from the Markdown body.
+    pub html: String,
+    /// Table of contents extracted from headings, in document order.
+    pub toc: Vec<TocItem>,
+}
+
+/// Errors from the Markdown module.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum MarkdownError {
+    /// The document is missing the required `+++` frontmatter delimiters.
+    #[error("frontmatter delimiters `+++` not found in '{slug}'")]
+    FrontmatterMissing {
+        /// The slug that failed to parse.
+        slug: String,
+    },
+
+    /// The frontmatter TOML could not be parsed.
+    #[error("frontmatter TOML parse error in '{slug}': {source}")]
+    FrontmatterInvalid {
+        /// The slug that failed.
+        slug: String,
+        /// Underlying TOML error.
+        #[source]
+        source: toml::de::Error,
+    },
+
+    /// A filesystem I/O error occurred while loading from a directory.
+    #[error("I/O error reading '{path}': {source}")]
+    Io {
+        /// The path that caused the error.
+        path: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A file name could not be converted to a valid slug.
+    #[error("file name cannot be converted to a slug: '{name}'")]
+    InvalidFileName {
+        /// The problematic file name.
+        name: String,
+    },
+}

--- a/autumn/src/markdown/types.rs
+++ b/autumn/src/markdown/types.rs
@@ -115,4 +115,11 @@ pub enum MarkdownError {
         /// The problematic file name.
         name: String,
     },
+
+    /// Two pages share the same slug in the registry.
+    #[error("duplicate slug '{slug}' in registry")]
+    DuplicateSlug {
+        /// The slug that appeared more than once.
+        slug: String,
+    },
 }

--- a/examples/wiki/Cargo.toml
+++ b/examples/wiki/Cargo.toml
@@ -5,7 +5,7 @@ version.workspace = true
 publish = false
 
 [dependencies]
-autumn-web = { path = "../../autumn" }
+autumn-web = { path = "../../autumn", features = ["markdown"] }
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "2", features = ["postgres", "chrono"] }
 diesel-async = { version = "0.8", features = ["postgres"] }

--- a/examples/wiki/README.md
+++ b/examples/wiki/README.md
@@ -1,8 +1,9 @@
 # Autumn Wiki Example
 
-A small wiki showing how Autumn's mutation hooks and generated repositories fit
-together when you need lifecycle logic, revision history, and a JSON API
-without hand-writing the CRUD boilerplate twice.
+A small wiki showing how Autumn's mutation hooks, generated repositories, and
+Markdown documentation primitives fit together when you need lifecycle logic,
+revision history, and a JSON API without hand-writing the CRUD boilerplate
+twice.
 
 ## What it demonstrates
 
@@ -12,6 +13,8 @@ without hand-writing the CRUD boilerplate twice.
 - Maud templates for a server-rendered editing flow
 - Embedded migrations on startup
 - Framework health and actuator endpoints
+- **Markdown docs with SSG** — `autumn_web::markdown` registry, `#[static_get]`
+  pre-rendering, and embedded `.md` content files (see `src/routes/docs.rs`)
 
 ## Prerequisites
 
@@ -68,6 +71,42 @@ behavior automatically.
 | POST | `/api/v1/pages` | Create a page |
 | PUT | `/api/v1/pages/{id}` | Update a page |
 | DELETE | `/api/v1/pages/{id}` | Delete a page |
+
+### Docs (Markdown + SSG)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/docs` | Documentation index (all pages sorted by `order`) |
+| GET | `/docs/{slug}` | Rendered Markdown page with TOC |
+
+The docs routes use `autumn_web::markdown`:
+
+```rust
+// ~10 lines of glue; layout markup excluded
+static REGISTRY: OnceLock<MarkdownRegistry> = OnceLock::new();
+
+fn docs() -> &'static MarkdownRegistry {
+    REGISTRY.get_or_init(|| {
+        MarkdownRegistry::from_embedded(&[
+            MarkdownSource { slug: "getting-started", content: include_str!("../../content/getting-started.md") },
+            MarkdownSource { slug: "configuration",   content: include_str!("../../content/configuration.md") },
+        ]).expect("valid embedded docs")
+    })
+}
+
+pub async fn doc_params(_router: axum::Router) -> Vec<StaticParams> {
+    docs().static_params()
+}
+
+#[static_get("/docs/{slug}", params = doc_params)]
+pub async fn show(Path(slug): Path<String>) -> AutumnResult<Markup> { ... }
+```
+
+Pre-render to `dist/` with:
+
+```bash
+cargo run -p autumn-cli -- build -p wiki
+```
 
 ### Framework
 

--- a/examples/wiki/content/configuration.md
+++ b/examples/wiki/content/configuration.md
@@ -1,0 +1,73 @@
++++
+title = "Configuration"
+description = "Configure the Autumn Wiki via autumn.toml and environment variables."
+order = 2
++++
+
+# Configuration
+
+The wiki is configured via `autumn.toml`, profile overrides, and environment
+variables. All settings have sensible defaults so the app runs with zero
+configuration in development.
+
+## Database
+
+Set the Postgres connection URL:
+
+```toml
+[database]
+url = "postgres://localhost/wiki_dev"
+```
+
+Or use the environment variable:
+
+```bash
+DATABASE_URL=postgres://localhost/wiki_dev cargo run -p wiki
+```
+
+## Server
+
+```toml
+[server]
+port = 3000        # default
+host = "0.0.0.0"  # default
+```
+
+## Logging
+
+```toml
+[logging]
+level = "info"  # trace | debug | info | warn | error
+```
+
+## Environment Profiles
+
+Autumn merges configuration files in this order:
+
+| File | When loaded |
+|------|-------------|
+| `autumn.toml` | Always |
+| `autumn-dev.toml` | Only in development mode |
+
+The `autumn-dev.toml` in this example overrides the database URL to point at
+a local Docker instance.
+
+## Static Site Generation
+
+Pre-render all `#[static_get]` routes (including these docs pages) to `dist/`:
+
+```bash
+cargo run -p autumn-cli -- build -p wiki
+```
+
+The generated files are written to `dist/` and can be served as static assets
+or baked into a container image.
+
+## Health Endpoints
+
+| Path | Description |
+|------|-------------|
+| `/health` | Liveness probe (200 OK when the app is up) |
+| `/actuator/health` | Detailed health view with pool stats |
+| `/actuator/info` | Build and runtime metadata |
+| `/actuator/metrics` | Request counts and pool metrics |

--- a/examples/wiki/content/getting-started.md
+++ b/examples/wiki/content/getting-started.md
@@ -1,0 +1,61 @@
++++
+title = "Getting Started"
+description = "Set up and run the Autumn Wiki example from scratch."
+order = 1
++++
+
+# Getting Started
+
+This guide walks you through setting up the Autumn Wiki example, which
+demonstrates Autumn's mutation hooks, generated repositories, and Markdown
+documentation pages.
+
+## Prerequisites
+
+- Rust 1.88.0 or later
+- PostgreSQL (or Docker for a quick start)
+
+## Installation
+
+Clone the repository and navigate to the wiki example:
+
+```bash
+git clone https://github.com/madmax983/autumn
+cd autumn
+```
+
+## Running Locally
+
+Start PostgreSQL, then launch the app:
+
+```bash
+# Download Tailwind CSS (first time only)
+cargo run -p autumn-cli -- setup
+
+# Start Postgres
+docker compose -f examples/wiki/docker-compose.yml up -d
+
+# Run the wiki
+cargo run -p wiki
+```
+
+Open <http://localhost:3000> in your browser.
+
+## Project Layout
+
+| Path | Purpose |
+|------|---------|
+| `src/main.rs` | App entry point |
+| `src/models.rs` | `Page` and `Revision` models |
+| `src/repositories.rs` | Generated repository + API routes |
+| `src/hooks.rs` | `PageHooks`: slug generation, revision auditing |
+| `src/routes/pages.rs` | HTML templates and route handlers |
+| `src/routes/docs.rs` | Markdown docs routes (this feature!) |
+| `content/` | Embedded Markdown documentation |
+| `migrations/` | Diesel database migrations |
+
+## Next Steps
+
+- Read the [Configuration](/docs/configuration) guide.
+- Explore the JSON API at `/api/v1/pages`.
+- Check the `/actuator/health` endpoint for runtime status.

--- a/examples/wiki/src/main.rs
+++ b/examples/wiki/src/main.rs
@@ -32,7 +32,10 @@ async fn main() {
             repositories::page_api_create,
             repositories::page_api_update,
             repositories::page_api_delete,
+            routes::docs::show,
+            routes::docs::index,
         ])
+        .static_routes(static_routes![routes::docs::show])
         .run()
         .await;
 }

--- a/examples/wiki/src/routes/docs.rs
+++ b/examples/wiki/src/routes/docs.rs
@@ -1,0 +1,176 @@
+//! Markdown documentation routes.
+//!
+//! Demonstrates Autumn's `markdown` feature: embedded `.md` files rendered
+//! dynamically during development and pre-rendered via `#[static_get]` for
+//! production.
+//!
+//! The entire docs section — registry setup, a dynamic index, and a
+//! statically pre-renderable detail page — fits in under 30 lines of app
+//! glue (excluding layout markup).
+
+use std::sync::OnceLock;
+
+use autumn_web::extract::Path;
+use autumn_web::markdown::{MarkdownRegistry, MarkdownSource, RenderOptions, render};
+use autumn_web::prelude::*;
+use autumn_web::static_gen::StaticParams;
+
+// ---------------------------------------------------------------------------
+// Registry (initialised once at startup from embedded .md files)
+// ---------------------------------------------------------------------------
+
+static REGISTRY: OnceLock<MarkdownRegistry> = OnceLock::new();
+
+fn docs() -> &'static MarkdownRegistry {
+    REGISTRY.get_or_init(|| {
+        MarkdownRegistry::from_embedded(&[
+            MarkdownSource {
+                slug: "getting-started",
+                content: include_str!("../../content/getting-started.md"),
+            },
+            MarkdownSource {
+                slug: "configuration",
+                content: include_str!("../../content/configuration.md"),
+            },
+        ])
+        .expect("embedded docs content is valid")
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Params function for SSG pre-rendering
+// ---------------------------------------------------------------------------
+
+/// Called by `autumn build` to enumerate every slug that must be pre-rendered.
+pub async fn doc_params(_router: autumn_web::reexports::axum::Router) -> Vec<StaticParams> {
+    docs().static_params()
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+/// Statically pre-renderable doc page.  Annotated with `#[static_get]` so
+/// `autumn build` writes `dist/docs/{slug}/index.html` for every page in the
+/// registry.  The same handler also serves live requests during development.
+#[static_get("/docs/{slug}", params = doc_params)]
+pub async fn show(Path(slug): Path<String>) -> AutumnResult<Markup> {
+    let page = docs()
+        .get(&slug)
+        .ok_or_else(|| AutumnError::not_found_msg(format!("Doc '{slug}' not found")))?;
+
+    let rendered = render(&page.body, RenderOptions::default());
+
+    Ok(crate::routes::pages::layout(
+        &page.frontmatter.title,
+        html! {
+            nav class="mb-4 text-sm" {
+                a href="/docs" class="text-emerald-600 hover:underline" { "← Docs" }
+            }
+            article class="bg-white rounded shadow p-6" {
+                h1 class="text-3xl font-bold mb-2" { (page.frontmatter.title) }
+                @if !page.frontmatter.description.is_empty() {
+                    p class="text-gray-500 mb-6 text-sm" { (page.frontmatter.description) }
+                }
+                @if !rendered.toc.is_empty() {
+                    nav class="mb-6 p-4 bg-gray-50 rounded border text-sm" {
+                        p class="font-semibold mb-2" { "Contents" }
+                        ul class="space-y-1" {
+                            @for item in &rendered.toc {
+                                li style=(format!("margin-left: {}rem", (item.level - 1) as f32 * 1.0)) {
+                                    a href=(format!("#{}", item.id))
+                                      class="text-emerald-600 hover:underline" {
+                                        (item.text)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                div class="prose max-w-none" {
+                    (PreEscaped(&rendered.html))
+                }
+            }
+        },
+    ))
+}
+
+/// Documentation index — lists all pages sorted by `order`.
+#[get("/docs")]
+pub async fn index() -> Markup {
+    let pages = docs().all_sorted();
+    crate::routes::pages::layout(
+        "Documentation",
+        html! {
+            h1 class="text-2xl font-bold mb-6" { "Documentation" }
+            ul class="space-y-3" {
+                @for page in &pages {
+                    li class="p-4 bg-white rounded shadow" {
+                        a href=(format!("/docs/{}", page.slug))
+                          class="text-emerald-700 font-medium hover:underline text-lg" {
+                            (page.frontmatter.title)
+                        }
+                        @if !page.frontmatter.description.is_empty() {
+                            p class="text-sm text-gray-500 mt-1" {
+                                (page.frontmatter.description)
+                            }
+                        }
+                    }
+                }
+                @if pages.is_empty() {
+                    li class="text-gray-400 text-center py-8" { "No docs pages found." }
+                }
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn registry_loads_two_embedded_pages() {
+        let registry = docs();
+        assert_eq!(registry.len(), 2);
+        assert!(registry.get("getting-started").is_some());
+        assert!(registry.get("configuration").is_some());
+    }
+
+    #[test]
+    fn registry_sorted_by_order() {
+        let pages = docs().all_sorted();
+        assert_eq!(pages[0].slug, "getting-started");
+        assert_eq!(pages[1].slug, "configuration");
+    }
+
+    #[test]
+    fn static_params_has_slug_keys() {
+        let params = docs().static_params();
+        assert_eq!(params.len(), 2);
+        let slugs: Vec<_> = params.iter().map(|p| p["slug"].as_str()).collect();
+        assert!(slugs.contains(&"getting-started"));
+        assert!(slugs.contains(&"configuration"));
+    }
+
+    #[tokio::test]
+    async fn show_doc_renders_html() {
+        let result = show(Path("getting-started".to_owned())).await;
+        let markup = result.expect("route should succeed");
+        let html = markup.into_string();
+        assert!(html.contains("Getting Started"));
+    }
+
+    #[tokio::test]
+    async fn show_doc_returns_not_found_for_unknown_slug() {
+        let result = show(Path("nonexistent".to_owned())).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn index_renders_both_pages() {
+        let markup = index().await;
+        let html = markup.into_string();
+        assert!(html.contains("Getting Started"));
+        assert!(html.contains("Configuration"));
+    }
+}

--- a/examples/wiki/src/routes/mod.rs
+++ b/examples/wiki/src/routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod docs;
 pub mod pages;
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive Markdown module to Autumn Web that enables embedded Markdown documents with TOML frontmatter, dynamic rendering, and static site generation (SSG) integration. The feature is gated behind a `markdown` Cargo feature flag.

## Key Changes

- **New `autumn_web::markdown` module** with four main components:
  - `MarkdownRegistry`: A keyed collection of parsed Markdown pages supporting both embedded sources and filesystem loading
  - `MarkdownPage`: Parsed document with slug, frontmatter metadata, and raw body
  - `render()` function: Converts Markdown to HTML with automatic heading ID injection and table-of-contents extraction
  - Type definitions: `MarkdownSource`, `MarkdownFrontmatter`, `RenderOptions`, `RenderedMarkdown`, `TocItem`, and `MarkdownError`

- **Frontmatter parsing**: Documents must begin with `+++\n` delimited TOML blocks containing required `title` field and optional `description` and `order` fields

- **Heading ID generation**: Stable, URL-safe anchor IDs derived from heading text (e.g., "Hello, World!" → "hello-world")

- **Table of contents extraction**: Automatically builds an ordered list of headings with levels and generated IDs during rendering

- **SSG integration**: `MarkdownRegistry::static_params()` generates `StaticParams` for use with `#[static_get]` parameterized routes, enabling pre-rendering of all documentation pages

- **Flexible loading**: Pages can be loaded from embedded `MarkdownSource` slices (via `include_str!`) or from a filesystem directory

- **Configurable rendering**: `RenderOptions` controls GFM extensions (tables, strikethrough, task lists)

- **Wiki example**: Demonstrates the feature with a `/docs` index and `/docs/{slug}` detail routes, including two embedded Markdown files (`getting-started.md` and `configuration.md`)

## Implementation Details

- Uses `pulldown-cmark` for Markdown parsing and HTML generation
- Implements custom heading processing to inject stable `id` attributes while preserving all other Markdown features
- Comprehensive test coverage including unit tests for parsing, registry operations, and an integration test demonstrating SSG pre-rendering
- Error handling via `MarkdownError` enum covering missing/invalid frontmatter, I/O errors, and invalid file names
- Maintains insertion order of pages via `indexmap::IndexMap`
- Sorting by `order` field with slug as tiebreaker for consistent navigation ordering

https://claude.ai/code/session_01KMX2Eom6pWw8LFnpUBTRyJ