### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -1631,6 +1631,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn after_commit_panic_message_extracts_static_str() {
+        let payload: &'static str = "a static string panic";
+        let any_payload: &(dyn std::any::Any + Send) = &payload;
+        assert_eq!(
+            super::after_commit_panic_message(any_payload),
+            "a static string panic"
+        );
+    }
+
+    #[test]
+    fn after_commit_panic_message_extracts_owned_string() {
+        let payload: String = "an owned string panic".to_string();
+        let any_payload: &(dyn std::any::Any + Send) = &payload;
+        assert_eq!(
+            super::after_commit_panic_message(any_payload),
+            "an owned string panic"
+        );
+    }
+
+    #[test]
+    fn after_commit_panic_message_handles_non_string_payload() {
+        let payload: i32 = 42;
+        let any_payload: &(dyn std::any::Any + Send) = &payload;
+        assert_eq!(
+            super::after_commit_panic_message(any_payload),
+            "non-string panic payload"
+        );
+    }
+
     // ── scrub_sql tests ───────────────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
🎯 **Target:** `after_commit_panic_message` function inside `autumn/src/db.rs`.

💣 **Risk:** The function extracts panic payloads wrapped in `Box<dyn Any + Send>`, representing a potential crash point or data-loss bug if standard panic signatures differ across architectures or rustc versions. There were no unit tests verifying this panic payload extraction.

🧪 **Strategy:** Added three focused unit tests within `db::tests` targeting string literals (`&'static str`), owned strings (`String`), and fallback handling for non-string payloads (e.g., `i32`).

🔭 **Verification:** `cargo test -p autumn-web --lib db::tests::after_commit_panic_message`

---
*PR created automatically by Jules for task [10350904524264090192](https://jules.google.com/task/10350904524264090192) started by @madmax983*