### PR TITLE
🔓 Eris: Fix X-Forwarded header spoofing in method override

### DIFF
--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -396,9 +396,14 @@ fn origin_matches_request(origin: &str, headers: &http::HeaderMap) -> bool {
         return false;
     };
 
+    #[allow(clippy::double_ended_iterator_last)]
     let expected_host = headers
-        .get("x-forwarded-host")
-        .and_then(|v| v.to_str().ok())
+        .get_all("x-forwarded-host")
+        .into_iter()
+        .flat_map(|v| v.to_str().unwrap_or("").split(','))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .last()
         .or_else(|| {
             headers
                 .get(http::header::HOST)
@@ -411,14 +416,17 @@ fn origin_matches_request(origin: &str, headers: &http::HeaderMap) -> bool {
         return false;
     }
 
-    if let Some(scheme) = headers
-        .get("x-forwarded-proto")
-        .and_then(|v| v.to_str().ok())
+    #[allow(clippy::double_ended_iterator_last)]
+    if let Some(outermost) = headers
+        .get_all("x-forwarded-proto")
+        .into_iter()
+        .flat_map(|v| v.to_str().unwrap_or("").split(','))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .last()
     {
         // Multiple `X-Forwarded-Proto` values can be chained by
-        // intermediaries; the leftmost (client-facing) is the one
-        // that matters here.
-        let outermost = scheme.split(',').next().unwrap_or(scheme).trim();
+        // intermediaries; the proxy-appended value is the rightmost one.
         return outermost.eq_ignore_ascii_case(origin_scheme);
     }
 
@@ -1189,8 +1197,8 @@ mod tests {
     }
 
     /// `X-Forwarded-Proto` may carry a chained list (e.g. through
-    /// nested proxies). The leftmost (client-facing) value is what
-    /// the browser saw; that's the value we must compare against.
+    /// nested proxies). The rightmost (proxy-appended) value is what
+    /// we must trust to prevent spoofing.
     #[tokio::test]
     async fn origin_scheme_match_via_chained_forwarded_proto() {
         let app = layered_router();
@@ -1202,10 +1210,9 @@ mod tests {
                     .header("content-type", "application/x-www-form-urlencoded")
                     .header("origin", "https://app.example")
                     .header("host", "app.example")
-                    // First hop saw HTTPS; later hops were HTTP between
-                    // proxy and app. Only the client-facing scheme
-                    // matters for the same-origin comparison.
-                    .header("x-forwarded-proto", "https, http")
+                    // Attacker spoofed HTTP; proxy appended HTTPS.
+                    // The rightmost value is the proxy-appended one.
+                    .header("x-forwarded-proto", "http, https")
                     .body(Body::from("_method=DELETE"))
                     .unwrap(),
             )

--- a/autumn/tests/security/method_override_spoofing.rs
+++ b/autumn/tests/security/method_override_spoofing.rs
@@ -1,0 +1,31 @@
+use axum::{body::Body, http::Request, routing::{post, put}, Router};
+use tower::ServiceExt;
+use http_body_util::BodyExt;
+
+#[tokio::test]
+async fn eris_poc_method_override_forwarded_header_spoofing() {
+    let app = Router::new()
+        .route("/target", post(|| async { "POST" }))
+        .route("/target", put(|| async { "PUT" }))
+        .layer(autumn_web::middleware::MethodOverrideLayer::new());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/target")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .header("origin", "https://evil.com")
+        .header("x-forwarded-host", "evil.com, app.example")
+        .header("x-forwarded-proto", "https, https")
+        .body(Body::from("_method=PUT"))
+        .unwrap();
+
+    let response = app.clone().oneshot(req).await.unwrap();
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+    assert_eq!(
+        body_str,
+        "POST",
+        "VULNERABILITY: X-Forwarded-Host spoofing allowed the method override to execute! Expected 'POST' body, got '{body_str}'"
+    );
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -10,6 +10,7 @@ pub mod csrf_path_traversal;
 pub mod csrf_timing;
 pub mod ctf;
 pub mod fallback_middleware_bypass;
+pub mod method_override_spoofing;
 pub mod rate_limit_xff_bypass;
 pub mod session_exhaustion;
 pub mod session_fixation;


### PR DESCRIPTION
🎯 **What:**
The `method_override` middleware's origin validation previously extracted the leftmost (client-facing) value from `X-Forwarded-Host` and `X-Forwarded-Proto` headers.

⚠️ **Risk:**
An attacker could perform a cross-origin method override (CSRF bypass) by injecting their own `X-Forwarded-Host` and `X-Forwarded-Proto` headers. Because the middleware extracted the leftmost value (the attacker's spoofed value), it would incorrectly trust the attacker's origin, allowing them to submit cross-origin `PUT`, `PATCH`, or `DELETE` requests without a valid CSRF token.

🛡️ **Solution:**
Updated `origin_matches_request` in `autumn/src/middleware/method_override.rs` to extract the rightmost valid proxy-appended value for both headers. This was accomplished by using `get_all()`, flattening comma-separated values, and using `.last()`. A permanent security PoC test has been added to `autumn/tests/security/method_override_spoofing.rs` to prevent regressions.

---
*PR created automatically by Jules for task [10788477243703220192](https://jules.google.com/task/10788477243703220192) started by @madmax983*