### PR TITLE
Add VersionedRecord trait impl and admin history conversion

### DIFF
--- a/autumn-admin-plugin/src/traits.rs
+++ b/autumn-admin-plugin/src/traits.rs
@@ -472,9 +472,13 @@ pub trait AdminModel: Send + Sync + 'static {
     /// When `true`, the admin panel renders a **History** tab on the
     /// detail page. No route configuration is required from the app.
     ///
-    /// Override and return `true` in models registered with
-    /// `#[repository(Model, versioned = true)]`. The `#[repository]` macro
-    /// generates this override automatically.
+    /// Override and return `true` when using
+    /// `#[repository(Model, versioned = true)]`. The generated
+    /// `PgXxxRepository::version_history(record_id, filter)` method can be
+    /// called from [`get_history`](AdminModel::get_history) to bridge the
+    /// repository's history store into the admin panel. See
+    /// [`VersionedAdminBridge`] for a convenience wrapper that handles the
+    /// delegation automatically.
     fn has_history(&self) -> bool {
         false
     }
@@ -483,7 +487,9 @@ pub trait AdminModel: Send + Sync + 'static {
     ///
     /// The default implementation returns [`AdminError::Other`] so models
     /// that do not opt in get a clear error instead of a silent no-op.
-    /// Models with `versioned = true` must override this method.
+    /// Override this when `has_history` returns `true`, delegating to the
+    /// repository's generated `version_history` method or to
+    /// [`VersionedAdminBridge`].
     fn get_history<'a>(
         &'a self,
         _pool: &'a diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
@@ -498,6 +504,59 @@ pub trait AdminModel: Send + Sync + 'static {
                     .to_owned(),
             ))
         })
+    }
+}
+
+// ── VersionPage → AdminHistoryPage conversion ──────────────────────
+
+impl From<autumn_web::version_history::VersionEntry> for AdminHistoryEntry {
+    fn from(e: autumn_web::version_history::VersionEntry) -> Self {
+        Self {
+            id: e.id,
+            actor: e.actor,
+            op: e.op.to_string(),
+            request_id: e.request_id,
+            changes: e
+                .changes
+                .into_iter()
+                .map(|c| serde_json::to_value(&c).unwrap_or(serde_json::Value::Null))
+                .collect(),
+            recorded_at: e.recorded_at,
+        }
+    }
+}
+
+impl From<autumn_web::version_history::VersionPage> for AdminHistoryPage {
+    /// Convert a [`autumn_web::version_history::VersionPage`] returned by a
+    /// versioned repository's `version_history()` method into an
+    /// [`AdminHistoryPage`] for the admin panel.
+    ///
+    /// ```rust,ignore
+    /// fn get_history<'a>(
+    ///     &'a self, pool: &'a Pool<AsyncPgConnection>,
+    ///     record_id: i64, page: u64, per_page: u64,
+    /// ) -> AdminFuture<'a, AdminHistoryPage> {
+    ///     let pool = pool.clone();
+    ///     Box::pin(async move {
+    ///         let repo = PgPostRepository::from_pool(pool);
+    ///         let filter = autumn_web::VersionFilter { page, per_page, ..Default::default() };
+    ///         repo.version_history(record_id, filter).await
+    ///             .map(AdminHistoryPage::from)
+    ///             .map_err(|e| AdminError::Database(e.to_string()))
+    ///     })
+    /// }
+    /// ```
+    fn from(vp: autumn_web::version_history::VersionPage) -> Self {
+        Self {
+            entries: vp
+                .entries
+                .into_iter()
+                .map(AdminHistoryEntry::from)
+                .collect(),
+            total: vp.total,
+            page: vp.page,
+            per_page: vp.per_page,
+        }
     }
 }
 
@@ -1186,7 +1245,10 @@ mod tests {
     #[test]
     fn admin_field_hide_from_list_sets_list_display_false() {
         let field = AdminField::new("internal_token", AdminFieldKind::Text).hide_from_list();
-        assert!(!field.list_display, "hide_from_list() must set list_display = false");
+        assert!(
+            !field.list_display,
+            "hide_from_list() must set list_display = false"
+        );
     }
 
     #[test]
@@ -1216,5 +1278,68 @@ mod tests {
             fail_on: None,
         };
         assert_eq!(model.per_page(), 25);
+    }
+
+    #[test]
+    fn version_page_converts_to_admin_history_page() {
+        use autumn_web::version_history::{ColumnChange, VersionEntry, VersionOp, VersionPage};
+        use chrono::Utc;
+
+        let entry = VersionEntry {
+            id: 1,
+            table_name: "posts".to_owned(),
+            record_id: 42,
+            op: VersionOp::Update,
+            actor: "admin".to_owned(),
+            request_id: Some("req-1".to_owned()),
+            changes: vec![ColumnChange::new(
+                "title",
+                Some(serde_json::json!("old")),
+                Some(serde_json::json!("new")),
+            )],
+            recorded_at: Utc::now(),
+        };
+        let vp = VersionPage {
+            entries: vec![entry],
+            total: 1,
+            page: 1,
+            per_page: 25,
+        };
+
+        let ap = AdminHistoryPage::from(vp);
+        assert_eq!(ap.total, 1);
+        assert_eq!(ap.page, 1);
+        assert_eq!(ap.per_page, 25);
+        assert_eq!(ap.entries.len(), 1);
+        let e = &ap.entries[0];
+        assert_eq!(e.id, 1);
+        assert_eq!(e.actor, "admin");
+        assert_eq!(e.op, "update");
+        assert_eq!(e.request_id.as_deref(), Some("req-1"));
+        assert_eq!(e.changes.len(), 1);
+    }
+
+    #[test]
+    fn version_entry_converts_to_admin_history_entry() {
+        use autumn_web::version_history::{ColumnChange, VersionEntry, VersionOp};
+        use chrono::Utc;
+
+        let entry = VersionEntry {
+            id: 7,
+            table_name: "users".to_owned(),
+            record_id: 3,
+            op: VersionOp::Delete,
+            actor: "system".to_owned(),
+            request_id: None,
+            changes: vec![ColumnChange::sensitive("password_digest")],
+            recorded_at: Utc::now(),
+        };
+
+        let admin_entry = AdminHistoryEntry::from(entry);
+        assert_eq!(admin_entry.id, 7);
+        assert_eq!(admin_entry.actor, "system");
+        assert_eq!(admin_entry.op, "delete");
+        assert!(admin_entry.request_id.is_none());
+        assert_eq!(admin_entry.changes.len(), 1);
     }
 }

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -13,6 +13,35 @@ use quote::{format_ident, quote};
 use syn::parse::Parser as _;
 use syn::{Ident, ItemTrait, LitStr, TraitItem};
 
+/// Parse `#[version_history(sensitive = ["col1", "col2"])]` from a trait's
+/// outer attributes. Returns the column names, or an empty vec if the
+/// attribute is absent or contains no `sensitive` key.
+fn parse_version_history_sensitive(attrs: &[syn::Attribute]) -> Vec<String> {
+    for attr in attrs {
+        if attr.path().is_ident("version_history") {
+            let mut cols: Vec<String> = Vec::new();
+            let _ = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("sensitive") {
+                    let value = meta.value()?;
+                    let arr: syn::ExprArray = value.parse()?;
+                    for elem in arr.elems {
+                        if let syn::Expr::Lit(syn::ExprLit {
+                            lit: syn::Lit::Str(s),
+                            ..
+                        }) = elem
+                        {
+                            cols.push(s.value());
+                        }
+                    }
+                }
+                Ok(())
+            });
+            return cols;
+        }
+    }
+    Vec::new()
+}
+
 use crate::model::infer_table_name;
 
 fn to_snake_case(name: &str) -> String {
@@ -835,7 +864,15 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         // ── save (hooked) ─────────────────────────────────
         // Pre-compute version-history snippet for CREATE in commit_hooks paths.
         let vh_create_in_hooks = if config.versioned {
-            let vh = vh_insert_ts(table_name, "insert", true, &quote! { record }, None, &quote! { conn }, model_name);
+            let vh = vh_insert_ts(
+                table_name,
+                "insert",
+                true,
+                &quote! { record },
+                None,
+                &quote! { conn },
+                model_name,
+            );
             quote! { #vh }
         } else {
             quote! {}
@@ -1239,7 +1276,15 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         let draft_ext_trait = format_ident!("{}DraftExt", model_name);
         // Pre-compute version-history snippet for UPDATE in commit_hooks paths.
         let vh_update_in_hooks = if config.versioned {
-            let vh = vh_insert_ts(table_name, "update", true, &quote! { record }, Some(&quote! { __vh_before }), &quote! { conn }, model_name);
+            let vh = vh_insert_ts(
+                table_name,
+                "update",
+                true,
+                &quote! { record },
+                Some(&quote! { __vh_before }),
+                &quote! { conn },
+                model_name,
+            );
             quote! { #vh }
         } else {
             quote! {}
@@ -2001,7 +2046,15 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         // Pre-compute version-history snippets for DELETE in commit_hooks and no-hooks paths.
         let vh_delete_in_hooks = if config.versioned {
-            let vh = vh_insert_ts(table_name, "delete", true, &quote! { record }, None, &quote! { conn }, model_name);
+            let vh = vh_insert_ts(
+                table_name,
+                "delete",
+                true,
+                &quote! { record },
+                None,
+                &quote! { conn },
+                model_name,
+            );
             quote! { #vh }
         } else {
             quote! {}
@@ -3675,8 +3728,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let save_body = if config.tenant_scoped && config.versioned {
             let vh_insert = vh_insert_ts(
-                table_name, "insert", false, &quote! { record }, None,
-                &quote! { conn }, model_name,
+                table_name,
+                "insert",
+                false,
+                &quote! { record },
+                None,
+                &quote! { conn },
+                model_name,
             );
             quote! {
                 use ::autumn_web::reexports::diesel::prelude::*;
@@ -3776,8 +3834,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let update_body = if config.tenant_scoped && config.versioned {
             let vh_insert = vh_insert_ts(
-                table_name, "update", false, &quote! { record },
-                Some(&quote! { current }), &quote! { conn }, model_name,
+                table_name,
+                "update",
+                false,
+                &quote! { record },
+                Some(&quote! { current }),
+                &quote! { conn },
+                model_name,
             );
             quote! {
                 use ::autumn_web::reexports::diesel::prelude::*;
@@ -4089,8 +4152,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             };
             if config.soft_delete && config.versioned {
                 let vh_insert = vh_insert_ts(
-                    table_name, "delete", false, &quote! { record }, None,
-                    &quote! { conn }, model_name,
+                    table_name,
+                    "delete",
+                    false,
+                    &quote! { record },
+                    None,
+                    &quote! { conn },
+                    model_name,
                 );
                 quote! {
                     use ::autumn_web::reexports::diesel::prelude::*;
@@ -4164,8 +4232,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
             } else if config.versioned {
                 let vh_insert = vh_insert_ts(
-                    table_name, "delete", false, &quote! { record }, None,
-                    &quote! { conn }, model_name,
+                    table_name,
+                    "delete",
+                    false,
+                    &quote! { record },
+                    None,
+                    &quote! { conn },
+                    model_name,
                 );
                 quote! {
                     use ::autumn_web::reexports::diesel::prelude::*;
@@ -4359,8 +4432,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let save_many_body = if config.tenant_scoped && config.versioned {
             let vh_r = vh_insert_ts(
-                table_name, "insert", false, &quote! { r }, None,
-                &quote! { conn }, model_name,
+                table_name,
+                "insert",
+                false,
+                &quote! { r },
+                None,
+                &quote! { conn },
+                model_name,
             );
             quote! {
                 use ::autumn_web::reexports::diesel::prelude::*;
@@ -4540,13 +4618,29 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let save_many_skip_invalid_body = {
             let vh_skip_batch = if config.versioned {
-                let vh = vh_insert_ts(table_name, "insert", false, &quote! { r }, None, &quote! { conn }, model_name);
+                let vh = vh_insert_ts(
+                    table_name,
+                    "insert",
+                    false,
+                    &quote! { r },
+                    None,
+                    &quote! { conn },
+                    model_name,
+                );
                 quote! { for r in &results { #vh } }
             } else {
                 quote! {}
             };
             let vh_skip_row = if config.versioned {
-                let vh = vh_insert_ts(table_name, "insert", false, &quote! { model }, None, &quote! { conn }, model_name);
+                let vh = vh_insert_ts(
+                    table_name,
+                    "insert",
+                    false,
+                    &quote! { model },
+                    None,
+                    &quote! { conn },
+                    model_name,
+                );
                 quote! { #vh }
             } else {
                 quote! {}
@@ -4701,7 +4795,15 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let update_many_body = {
             let vh_update_pair = if config.versioned {
-                let vh = vh_insert_ts(table_name, "update", false, &quote! { after_rec }, Some(&quote! { before_rec }), &quote! { conn }, model_name);
+                let vh = vh_insert_ts(
+                    table_name,
+                    "update",
+                    false,
+                    &quote! { after_rec },
+                    Some(&quote! { before_rec }),
+                    &quote! { conn },
+                    model_name,
+                );
                 quote! {
                     for after_rec in &chunk_updated {
                         if let ::core::option::Option::Some(before_rec) = __vh_before_map.get(&after_rec.id) {
@@ -4948,7 +5050,15 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 quote! {}
             };
             let vh_delete_write = if config.versioned {
-                let vh = vh_insert_ts(table_name, "delete", false, &quote! { r }, None, &quote! { conn }, model_name);
+                let vh = vh_insert_ts(
+                    table_name,
+                    "delete",
+                    false,
+                    &quote! { r },
+                    None,
+                    &quote! { conn },
+                    model_name,
+                );
                 quote! {
                     for r in &__vh_deleted_records {
                         #vh
@@ -5123,8 +5233,24 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let upsert_many_body = {
             let vh_upsert_write = if config.versioned {
-                let vh_ins = vh_insert_ts(table_name, "insert", false, &quote! { r }, None, &quote! { conn }, model_name);
-                let vh_upd = vh_insert_ts(table_name, "update", false, &quote! { r }, Some(&quote! { before_rec }), &quote! { conn }, model_name);
+                let vh_ins = vh_insert_ts(
+                    table_name,
+                    "insert",
+                    false,
+                    &quote! { r },
+                    None,
+                    &quote! { conn },
+                    model_name,
+                );
+                let vh_upd = vh_insert_ts(
+                    table_name,
+                    "update",
+                    false,
+                    &quote! { r },
+                    Some(&quote! { before_rec }),
+                    &quote! { conn },
+                    model_name,
+                );
                 quote! {
                     // Classification is based on the pre-upsert snapshot. Under
                     // concurrent inserts of the same ID between the SELECT FOR UPDATE
@@ -7128,6 +7254,38 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let upsert_execution_ext_impl = quote! {};
     let correlate_ext_impl = quote! {};
 
+    // ── VersionedRecord impl (issue #700) ────────────────────────
+    // When versioned = true, generate `impl VersionedRecord for Model` so
+    // that the write paths (which call <Model as VersionedRecord>::…) compile.
+    let versioned_record_impl = if config.versioned {
+        let sensitive_cols = parse_version_history_sensitive(&trait_def.attrs);
+        let sensitive_ts = if sensitive_cols.is_empty() {
+            quote! { &[] }
+        } else {
+            let col_lits: Vec<_> = sensitive_cols.iter().map(|c| quote! { #c }).collect();
+            quote! { &[#(#col_lits),*] }
+        };
+        quote! {
+            impl ::autumn_web::version_history::VersionedRecord for #model_name {
+                fn version_table_name() -> &'static str {
+                    #table_name
+                }
+                fn version_record_id(&self) -> i64 {
+                    self.id
+                }
+                fn version_column_values(&self) -> ::autumn_web::reexports::serde_json::Value {
+                    ::autumn_web::reexports::serde_json::to_value(self)
+                        .unwrap_or(::autumn_web::reexports::serde_json::Value::Object(Default::default()))
+                }
+                fn version_sensitive_columns() -> &'static [&'static str] {
+                    #sensitive_ts
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
     // ── Versioned history (issue #700) ────────────────────────────
     // When versioned = true, generate a `version_history` associated
     // function on the repository struct that queries _autumn_version_history.
@@ -7508,6 +7666,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         #upsert_execution_ext_impl
 
         #correlate_ext_impl
+
+        #versioned_record_impl
 
         #versioned_history_impl
 
@@ -8475,6 +8635,60 @@ mod tests {
         assert!(
             generated.contains("version_history") || generated.contains("versioned"),
             "versioned = true must generate version-history-related code: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_versioned_generates_versioned_record_impl() {
+        let generated = repository_macro(
+            quote! { Post, versioned = true },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("VersionedRecord"),
+            "versioned = true must generate impl VersionedRecord for Post: {generated}"
+        );
+        assert!(
+            generated.contains("version_table_name"),
+            "generated VersionedRecord impl must include version_table_name: {generated}"
+        );
+        assert!(
+            generated.contains("version_sensitive_columns"),
+            "generated VersionedRecord impl must include version_sensitive_columns: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_versioned_sensitive_columns_parsed_from_attr() {
+        let generated = repository_macro(
+            quote! { Post, versioned = true },
+            quote! {
+                #[version_history(sensitive = ["password_digest", "reset_token"])]
+                pub trait PostRepository {}
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("password_digest"),
+            "sensitive columns must appear in the generated VersionedRecord impl: {generated}"
+        );
+        assert!(
+            generated.contains("reset_token"),
+            "all sensitive columns must appear in the generated VersionedRecord impl: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_non_versioned_does_not_emit_versioned_record_impl() {
+        let generated =
+            repository_macro(quote! { Post }, quote! { pub trait PostRepository {} }).to_string();
+
+        assert!(
+            !generated.contains("VersionedRecord"),
+            "non-versioned repository must not generate VersionedRecord impl: {generated}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -14,25 +14,31 @@ use syn::parse::Parser as _;
 use syn::{Ident, ItemTrait, LitStr, TraitItem};
 
 /// Parse `#[version_history(sensitive = ["col1", "col2"])]` from a trait's
-/// outer attributes. Returns the column names, or an empty vec if the
-/// attribute is absent. Returns a `syn::Error` if the attribute exists but
-/// contains a typo or unsupported key — this converts silently-missed sensitive
-/// columns (a security risk) into a hard compile error.
+/// outer attributes. Accumulates columns from ALL `#[version_history(...)]`
+/// attributes (so columns may be split across multiple attributes).
+/// Returns a `syn::Error` if any attribute contains a typo or unsupported
+/// key, or if an array element is not a string literal — converting
+/// silently-missed sensitive columns into a hard compile error.
 fn parse_version_history_sensitive(attrs: &[syn::Attribute]) -> syn::Result<Vec<String>> {
+    let mut cols: Vec<String> = Vec::new();
     for attr in attrs {
         if attr.path().is_ident("version_history") {
-            let mut cols: Vec<String> = Vec::new();
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("sensitive") {
                     let value = meta.value()?;
                     let arr: syn::ExprArray = value.parse()?;
                     for elem in arr.elems {
-                        if let syn::Expr::Lit(syn::ExprLit {
-                            lit: syn::Lit::Str(s),
-                            ..
-                        }) = elem
-                        {
-                            cols.push(s.value());
+                        match elem {
+                            syn::Expr::Lit(syn::ExprLit {
+                                lit: syn::Lit::Str(s),
+                                ..
+                            }) => cols.push(s.value()),
+                            other => {
+                                return Err(syn::Error::new_spanned(
+                                    other,
+                                    "sensitive column names must be string literals (e.g. `sensitive = [\"my_col\"]`)",
+                                ));
+                            }
                         }
                     }
                     Ok(())
@@ -42,10 +48,9 @@ fn parse_version_history_sensitive(attrs: &[syn::Attribute]) -> syn::Result<Vec<
                     ))
                 }
             })?;
-            return Ok(cols);
         }
     }
-    Ok(Vec::new())
+    Ok(cols)
 }
 
 use crate::model::infer_table_name;
@@ -94,6 +99,11 @@ struct RepoConfig {
     /// `_autumn_version_history`. Generates a `Model::history(id, &mut db, filter)`
     /// associated function on the repository.
     versioned: bool,
+    /// When `true`, suppress the auto-generated `impl VersionedRecord for Model`.
+    /// Use this when the model already has a hand-written `VersionedRecord`
+    /// implementation (custom serialization, non-`i64` primary key, etc.) to
+    /// avoid the duplicate-impl compile error (E0119).
+    no_versioned_record_impl: bool,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -112,6 +122,7 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
     let mut no_upsert_trait = false;
     let mut searchable = false;
     let mut versioned = false;
+    let mut no_versioned_record_impl = false;
 
     syn::meta::parser(|meta| {
         // `hooks = Ident` must be checked before the catch-all model_name case,
@@ -164,12 +175,15 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
             let value: syn::LitBool = meta.value()?.parse()?;
             versioned = value.value;
             Ok(())
+        } else if meta.path.is_ident("no_versioned_record_impl") {
+            no_versioned_record_impl = true;
+            Ok(())
         } else if meta.path.get_ident().is_some() && model_name.is_none() {
             model_name = Some(meta.path.get_ident().unwrap().clone());
             Ok(())
         } else {
             Err(meta.error(
-                "expected model name, table = \"...\", hooks = Type, commit_hooks = true, api = \"/path\", policy = Type, scope = Type, cursor_key = field, cursor_key_type = Type, soft_delete, tenant_scoped, no_upsert_trait, searchable, or versioned = true",
+                "expected model name, table = \"...\", hooks = Type, commit_hooks = true, api = \"/path\", policy = Type, scope = Type, cursor_key = field, cursor_key_type = Type, soft_delete, tenant_scoped, no_upsert_trait, searchable, versioned = true, or no_versioned_record_impl",
             ))
         }
     })
@@ -204,6 +218,7 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
         no_upsert_trait,
         searchable,
         versioned,
+        no_versioned_record_impl,
     })
 }
 
@@ -7263,7 +7278,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     // ── VersionedRecord impl (issue #700) ────────────────────────
     // When versioned = true, generate `impl VersionedRecord for Model` so
     // that the write paths (which call <Model as VersionedRecord>::…) compile.
-    let versioned_record_impl = if config.versioned {
+    let versioned_record_impl = if config.versioned && !config.no_versioned_record_impl {
         let sensitive_cols = match parse_version_history_sensitive(&trait_def.attrs) {
             Ok(cols) => cols,
             Err(err) => return err.to_compile_error(),
@@ -8691,6 +8706,55 @@ mod tests {
     }
 
     #[test]
+    fn repository_macro_versioned_sensitive_columns_merged_from_multiple_attrs() {
+        // Columns split across two #[version_history(...)] attrs must all appear.
+        let generated = repository_macro(
+            quote! { Post, versioned = true },
+            quote! {
+                #[version_history(sensitive = ["password_digest"])]
+                #[version_history(sensitive = ["api_key"])]
+                pub trait PostRepository {}
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("password_digest"),
+            "first attr sensitive columns must be present: {generated}"
+        );
+        assert!(
+            generated.contains("api_key"),
+            "second attr sensitive columns must be present: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_versioned_non_string_in_sensitive_is_compile_error() {
+        // A non-string element (e.g. a bare identifier instead of a quoted
+        // string) must produce a compile error rather than silently being
+        // skipped and leaving the column unredacted.
+        let generated = repository_macro(
+            quote! { Post, versioned = true },
+            quote! {
+                #[version_history(sensitive = [password_digest])]
+                pub trait PostRepository {}
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("compile_error"),
+            "non-string element in sensitive list must produce a compile error: {generated}"
+        );
+        // The compile_error must not also produce a working VersionedRecord impl
+        // (version_table_name is only present in the generated impl block).
+        assert!(
+            !generated.contains("version_table_name"),
+            "a compile-error output must not also contain a working impl: {generated}"
+        );
+    }
+
+    #[test]
     fn repository_macro_versioned_typo_in_sensitive_attr_is_compile_error() {
         // A typo in the key name (e.g. "sensitve") must NOT silently compile
         // and leave sensitive columns unredacted.  The macro must emit a
@@ -8711,6 +8775,30 @@ mod tests {
         assert!(
             !generated.contains("password_digest"),
             "typo must not cause sensitive column to be silently omitted: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_no_versioned_record_impl_suppresses_generated_impl() {
+        // When a model already has a manual VersionedRecord impl, use
+        // no_versioned_record_impl to avoid the duplicate-impl (E0119) error.
+        let generated = repository_macro(
+            quote! { Post, versioned = true, no_versioned_record_impl },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+
+        // version_table_name is only emitted inside the impl VersionedRecord for Model
+        // block; its absence proves the impl was suppressed.  VersionedRecord itself
+        // still appears in the write-path call sites, so we cannot check for that.
+        assert!(
+            !generated.contains("version_table_name"),
+            "no_versioned_record_impl must suppress the generated impl block: {generated}"
+        );
+        // The write paths and version_history query method must still be present.
+        assert!(
+            generated.contains("version_history"),
+            "version_history query method must still be generated: {generated}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -15,12 +15,14 @@ use syn::{Ident, ItemTrait, LitStr, TraitItem};
 
 /// Parse `#[version_history(sensitive = ["col1", "col2"])]` from a trait's
 /// outer attributes. Returns the column names, or an empty vec if the
-/// attribute is absent or contains no `sensitive` key.
-fn parse_version_history_sensitive(attrs: &[syn::Attribute]) -> Vec<String> {
+/// attribute is absent. Returns a `syn::Error` if the attribute exists but
+/// contains a typo or unsupported key — this converts silently-missed sensitive
+/// columns (a security risk) into a hard compile error.
+fn parse_version_history_sensitive(attrs: &[syn::Attribute]) -> syn::Result<Vec<String>> {
     for attr in attrs {
         if attr.path().is_ident("version_history") {
             let mut cols: Vec<String> = Vec::new();
-            let _ = attr.parse_nested_meta(|meta| {
+            attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("sensitive") {
                     let value = meta.value()?;
                     let arr: syn::ExprArray = value.parse()?;
@@ -33,13 +35,17 @@ fn parse_version_history_sensitive(attrs: &[syn::Attribute]) -> Vec<String> {
                             cols.push(s.value());
                         }
                     }
+                    Ok(())
+                } else {
+                    Err(meta.error(
+                        "unknown version_history key; expected `sensitive = [\"col\", ...]`",
+                    ))
                 }
-                Ok(())
-            });
-            return cols;
+            })?;
+            return Ok(cols);
         }
     }
-    Vec::new()
+    Ok(Vec::new())
 }
 
 use crate::model::infer_table_name;
@@ -7258,7 +7264,10 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     // When versioned = true, generate `impl VersionedRecord for Model` so
     // that the write paths (which call <Model as VersionedRecord>::…) compile.
     let versioned_record_impl = if config.versioned {
-        let sensitive_cols = parse_version_history_sensitive(&trait_def.attrs);
+        let sensitive_cols = match parse_version_history_sensitive(&trait_def.attrs) {
+            Ok(cols) => cols,
+            Err(err) => return err.to_compile_error(),
+        };
         let sensitive_ts = if sensitive_cols.is_empty() {
             quote! { &[] }
         } else {
@@ -8678,6 +8687,30 @@ mod tests {
         assert!(
             generated.contains("reset_token"),
             "all sensitive columns must appear in the generated VersionedRecord impl: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_versioned_typo_in_sensitive_attr_is_compile_error() {
+        // A typo in the key name (e.g. "sensitve") must NOT silently compile
+        // and leave sensitive columns unredacted.  The macro must emit a
+        // compile_error token stream so the build fails with a clear message.
+        let generated = repository_macro(
+            quote! { Post, versioned = true },
+            quote! {
+                #[version_history(sensitve = ["password_digest"])]
+                pub trait PostRepository {}
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("compile_error") || generated.contains("unknown version_history"),
+            "typo in sensitive attribute must produce a compile error, not silently succeed: {generated}"
+        );
+        assert!(
+            !generated.contains("password_digest"),
+            "typo must not cause sensitive column to be silently omitted: {generated}"
         );
     }
 


### PR DESCRIPTION
## Summary
This PR implements support for versioned record history in the admin panel by generating a `VersionedRecord` trait implementation for models with `versioned = true`, and adds conversion utilities to bridge repository history data into the admin UI.

## Key Changes

- **New `parse_version_history_sensitive()` function**: Parses the `#[version_history(sensitive = ["col1", "col2"])]` attribute from trait definitions to extract sensitive column names that should be masked in version history.

- **Auto-generated `VersionedRecord` impl**: When `versioned = true`, the repository macro now generates an implementation of `VersionedRecord` for the model, providing:
  - `version_table_name()`: Returns the table name
  - `version_record_id()`: Extracts the record ID
  - `version_column_values()`: Serializes the record to JSON
  - `version_sensitive_columns()`: Returns the list of sensitive columns to mask

- **History conversion traits**: Added `From` implementations in `autumn-admin-plugin` to convert:
  - `VersionEntry` → `AdminHistoryEntry`
  - `VersionPage` → `AdminHistoryPage`
  
  These enable seamless integration of repository history data into the admin panel's history UI.

- **Updated documentation**: Enhanced docstrings for `AdminModel::has_history()` and `get_history()` to clarify the versioning workflow and reference the new conversion utilities.

- **Code formatting**: Reformatted multiple `vh_insert_ts()` function calls throughout the macro for improved readability (multi-line argument lists).

- **Comprehensive tests**: Added three new tests validating:
  - `VersionedRecord` impl generation for versioned repositories
  - Sensitive column parsing from attributes
  - Non-versioned repositories don't emit the impl
  - Version page/entry conversion to admin history types

## Implementation Details

The `VersionedRecord` trait implementation is conditionally generated only when `config.versioned` is true. Sensitive columns are parsed from the trait's outer attributes and embedded as a static string slice in the generated code. The conversion implementations use standard `From` traits to allow idiomatic Rust integration between the repository and admin layers.

https://claude.ai/code/session_01XqkeDUbxnM8ndokBGjcvBC