### PR TITLE
⚡ Bolt: Remove intermediate Vec allocation in route normalization

### DIFF
--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -350,17 +350,26 @@ pub fn check_route_prefix(
 /// Both named params (`{id}`) and catch-all params (`{*rest}`) normalize to
 /// `{}`. matchit (Axum's router) treats a named param and a catch-all at the
 /// same path position as a conflict, so they must map to the same key.
+///
+/// ⚡ Bolt: Optimization - Replaces `.map(...).collect::<Vec<_>>().join("/")` with a
+/// pre-allocated `String` and `.push_str()`/`.push()` to avoid an intermediate
+/// heap allocation per route path.
 fn normalize_path_for_collision(path: &str) -> String {
-    path.split('/')
-        .map(|seg| {
-            if seg.starts_with('{') && seg.ends_with('}') {
-                "{}"
-            } else {
-                seg
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
+    let mut normalized = String::with_capacity(path.len());
+    let mut first = true;
+    for seg in path.split('/') {
+        if !first {
+            normalized.push('/');
+        }
+        first = false;
+
+        if seg.starts_with('{') && seg.ends_with('}') {
+            normalized.push_str("{}");
+        } else {
+            normalized.push_str(seg);
+        }
+    }
+    normalized
 }
 
 /// Detect route collisions: any two routes sharing the same (method, path) pair.


### PR DESCRIPTION
💡 What: Replaced `.map(...).collect::<Vec<_>>().join("/")` with a pre-allocated `String::with_capacity()` and `.push_str()`/`.push()` in `normalize_path_for_collision`.
🎯 Why: The previous method allocated an intermediate `Vec<&str>` on the heap for every single route parsed during collision detection, only to immediately join it into a String.
📊 Impact: Removes exactly one unnecessary intermediate heap allocation (`Vec`) per registered route path during plugin conformance checking.
🔬 Measurement: Run `cargo test -p autumn-web --lib plugin_conformance` and `cargo test -p autumn-web --lib --release` to verify functionality.

---
*PR created automatically by Jules for task [12816370300342592562](https://jules.google.com/task/12816370300342592562) started by @madmax983*