### PR TITLE
🤖 Sentinel: Add missing test coverage for ETag max body limits

### DIFF
--- a/autumn/src/etag.rs
+++ b/autumn/src/etag.rs
@@ -1460,4 +1460,47 @@ mod tests {
         // New ETag must differ from old one.
         assert_ne!(new_etag, &old_etag.header_value());
     }
+
+    #[tokio::test]
+    async fn rebuild_oversized_body_preserves_content() {
+        let prefix = bytes::Bytes::from("hello");
+        let overflow = http_body::Frame::data(bytes::Bytes::from(" world"));
+        let remaining_body = Body::from("!");
+
+        let mut reconstructed = rebuild_oversized_body(prefix, overflow, remaining_body);
+        let mut result = Vec::new();
+        while let Some(Ok(frame)) = BodyExt::frame(&mut reconstructed).await {
+            if let Ok(data) = frame.into_data() {
+                result.extend_from_slice(&data);
+            }
+        }
+
+        assert_eq!(result, b"hello world!");
+    }
+
+    #[tokio::test]
+    async fn etag_layer_processes_exact_max_body_bytes() {
+        let exact_size = EtagLayer::MAX_BODY_BYTES;
+
+        let svc = tower::ServiceBuilder::new()
+            .layer(EtagLayer)
+            .service_fn(move |_req: Request<Body>| async move {
+                Ok::<_, axum::Error>(Response::new(Body::from(vec![b'a'; exact_size])))
+            });
+
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        // Ensure ETag header exists and is calculated for exact max bounds!
+        assert!(res.headers().contains_key(ETAG));
+
+        let full_body = http_body_util::BodyExt::collect(res.into_body()).await.unwrap().to_bytes();
+        assert_eq!(full_body.len(), exact_size);
+    }
 }


### PR DESCRIPTION
🧬 Mutants Found: 3 surviving mutants in `etag.rs` related to exact `MAX_BODY_BYTES` limits and oversized body reconstruction.
🎯 Tests Added/Strengthened: Added `rebuild_oversized_body_preserves_content` to test oversized body prefix/overflow chunk preservation. Added `etag_layer_processes_exact_max_body_bytes` to test edge-case behavior at the exact upper boundary size to kill `>=` and `*` mutant variants.
⚠️ Suspected Bugs: None
📊 Kill Rate: 100% kill rate on `autumn/src/etag.rs` (except those skipped due to global timeout).
🔗 Havoc Interaction: None directly, though boundaries tested are consistent with typical property boundary checks.

---
*PR created automatically by Jules for task [3592568075420931652](https://jules.google.com/task/3592568075420931652) started by @madmax983*