### PR TITLE
🔓 Eris: Fix X-Forwarded header spoofing in method override

### DIFF
--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -396,9 +396,15 @@ fn origin_matches_request(origin: &str, headers: &http::HeaderMap) -> bool {
         return false;
     };
 
+    #[allow(clippy::double_ended_iterator_last)]
     let expected_host = headers
-        .get("x-forwarded-host")
-        .and_then(|v| v.to_str().ok())
+        .get_all("x-forwarded-host")
+        .into_iter()
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|s| s.split(','))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .last()
         .or_else(|| {
             headers
                 .get(http::header::HOST)
@@ -411,14 +417,17 @@ fn origin_matches_request(origin: &str, headers: &http::HeaderMap) -> bool {
         return false;
     }
 
-    if let Some(scheme) = headers
-        .get("x-forwarded-proto")
-        .and_then(|v| v.to_str().ok())
-    {
-        // Multiple `X-Forwarded-Proto` values can be chained by
-        // intermediaries; the leftmost (client-facing) is the one
-        // that matters here.
-        let outermost = scheme.split(',').next().unwrap_or(scheme).trim();
+    #[allow(clippy::double_ended_iterator_last)]
+    let forwarded_proto = headers
+        .get_all("x-forwarded-proto")
+        .into_iter()
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|s| s.split(','))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .last();
+
+    if let Some(outermost) = forwarded_proto {
         return outermost.eq_ignore_ascii_case(origin_scheme);
     }
 
@@ -1188,9 +1197,10 @@ mod tests {
         );
     }
 
-    /// `X-Forwarded-Proto` may carry a chained list (e.g. through
-    /// nested proxies). The leftmost (client-facing) value is what
-    /// the browser saw; that's the value we must compare against.
+    /// `X-Forwarded-Proto` may carry a chained list. The rightmost value
+    /// is the one appended by the trusted proxy closest to the app, so
+    /// we must extract the rightmost value to prevent spoofing by an attacker
+    /// who prepends their own scheme.
     #[tokio::test]
     async fn origin_scheme_match_via_chained_forwarded_proto() {
         let app = layered_router();
@@ -1202,10 +1212,9 @@ mod tests {
                     .header("content-type", "application/x-www-form-urlencoded")
                     .header("origin", "https://app.example")
                     .header("host", "app.example")
-                    // First hop saw HTTPS; later hops were HTTP between
-                    // proxy and app. Only the client-facing scheme
-                    // matters for the same-origin comparison.
-                    .header("x-forwarded-proto", "https, http")
+                    // Attacker spoofed HTTP; trusted proxy appended HTTPS.
+                    // The rightmost scheme (HTTPS) is what matters for the comparison.
+                    .header("x-forwarded-proto", "http, https")
                     .body(Body::from("_method=DELETE"))
                     .unwrap(),
             )

--- a/autumn/tests/security/method_override_spoofing.rs
+++ b/autumn/tests/security/method_override_spoofing.rs
@@ -1,0 +1,64 @@
+use autumn_web::middleware::{MethodOverrideLayer, method_override_rejection_filter};
+use axum::{body::Body, http::{Request, HeaderValue, StatusCode}, routing::delete, Router};
+use tower::{Layer, ServiceExt};
+
+#[tokio::test]
+async fn test_x_forwarded_host_spoofing() {
+    let router = Router::new()
+        .route("/items/{id}", delete(|| async { "deleted" }))
+        .layer(axum::middleware::from_fn(method_override_rejection_filter));
+    let app = MethodOverrideLayer::new().layer(router);
+
+    // Attacker sends a request with spoofed X-Forwarded-Host
+    let mut req = Request::builder()
+        .method("POST")
+        .uri("/items/1")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .header("origin", "https://attacker.com")
+        .header("host", "app.example.com")
+        .body(Body::from("_method=DELETE"))
+        .unwrap();
+
+    // Add attacker's spoofed header
+    req.headers_mut().append("x-forwarded-host", HeaderValue::from_static("attacker.com"));
+    // Add proxy's appended header
+    req.headers_mut().append("x-forwarded-host", HeaderValue::from_static("app.example.com"));
+
+    // Add attacker's spoofed proto
+    req.headers_mut().append("x-forwarded-proto", HeaderValue::from_static("https"));
+    // Add proxy's appended proto
+    req.headers_mut().append("x-forwarded-proto", HeaderValue::from_static("https"));
+
+    let response = app.oneshot(req).await.unwrap();
+
+    // It should be 405 Method Not Allowed, because the leftmost x-forwarded-host is attacker.com
+    // which shouldn't be trusted, it should use the rightmost one (app.example.com).
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+
+#[tokio::test]
+async fn test_x_forwarded_proto_spoofing() {
+    let router = Router::new()
+        .route("/items/{id}", delete(|| async { "deleted" }))
+        .layer(axum::middleware::from_fn(method_override_rejection_filter));
+    let app = MethodOverrideLayer::new().layer(router);
+
+    // Attacker sends a request with spoofed X-Forwarded-Proto
+    let mut req = Request::builder()
+        .method("POST")
+        .uri("/items/1")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .header("origin", "http://app.example.com")
+        .header("host", "app.example.com")
+        .body(Body::from("_method=DELETE"))
+        .unwrap();
+
+    // Attacker injects `http` to match their origin. Proxy appends `https`.
+    req.headers_mut().append("x-forwarded-proto", HeaderValue::from_static("http, https"));
+
+    let response = app.oneshot(req).await.unwrap();
+
+    // It should be 405 Method Not Allowed, because the leftmost x-forwarded-proto is http
+    // which shouldn't be trusted, it should use the rightmost one (https).
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -13,3 +13,4 @@ pub mod fallback_middleware_bypass;
 pub mod rate_limit_xff_bypass;
 pub mod session_exhaustion;
 pub mod session_fixation;
+pub mod method_override_spoofing;


### PR DESCRIPTION
🎯 **What:** Ensure method override middleware extracts the rightmost `X-Forwarded-Host` and `X-Forwarded-Proto` header values.

⚠️ **Risk:** Attackers could bypass Same-Origin verification by prepending spoofed `X-Forwarded` headers. Since the proxy appends to the end of the header string, relying on the leftmost value allows untrusted user input to masquerade as the verified origin.

🛡️ **Solution:** Updated `origin_matches_request` to extract the rightmost, proxy-appended values using `.last()`. We also added two permanent regression tests in `tests/security/` to demonstrate and verify the fix.

---
*PR created automatically by Jules for task [4532943558572583514](https://jules.google.com/task/4532943558572583514) started by @madmax983*