### PR TITLE
🎻 Bard: [db module documentation]

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -323,6 +323,22 @@ const fn is_separator(c: char) -> bool {
     )
 }
 
+/// Scrubs SQL queries by removing literals and collapsing structural elements.
+///
+/// This function normalizes a SQL query so that structurally identical queries
+/// differing only in values (e.g., `WHERE id = 1` vs `WHERE id = 2`) produce
+/// the same fingerprinted string. This prevents sensitive data leakage in logs
+/// and telemetry and enables grouping similar queries for performance analysis.
+///
+/// # Examples
+///
+/// ```rust
+/// use autumn_web::db::scrub_sql;
+///
+/// let raw = "SELECT * FROM users WHERE age > 21 AND name = 'Alice'";
+/// let scrubbed = scrub_sql(raw);
+/// assert_eq!(scrubbed, "SELECT * FROM users WHERE age > ? AND name = '?'");
+/// ```
 #[must_use]
 pub fn scrub_sql(sql: &str) -> String {
     let mut out = String::with_capacity(sql.len());
@@ -743,6 +759,28 @@ impl Drop for TxDepthGuard<'_> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StatementTimeout(pub std::time::Duration);
 
+/// A managed database connection configured with the active transaction context.
+///
+/// `Db` is the primary database interaction struct in Autumn. As an Axum extractor,
+/// it provides a ready-to-use connection from the pool. It transparently handles
+/// transaction nesting, metrics collection, and slow query logging.
+///
+/// It implements `std::ops::Deref<Target = AsyncPgConnection>`, meaning it can be
+/// passed directly to Diesel query executions.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use autumn_web::prelude::*;
+/// use diesel_async::RunQueryDsl;
+///
+/// #[get("/ping-db")]
+/// async fn ping_db(mut db: Db) -> AutumnResult<&'static str> {
+///     // `db` dereferences to AsyncPgConnection for query execution
+///     diesel::sql_query("SELECT 1").execute(&mut *db).await?;
+///     Ok("database is reachable")
+/// }
+/// ```
 pub struct Db {
     conn: PooledConnection,
     /// Span covering the full checkout-to-release window. Dropped when


### PR DESCRIPTION
📖 Chapter: The `db` module (`Db` extractor and `scrub_sql` utility).

🔦 Insight: Explained the purpose and transaction management responsibilities of the `Db` struct, clarifying that it acts as the primary database interaction struct and Axum extractor for Autumn. Documented the `scrub_sql` function to clarify its purpose in neutralizing literals and collapsing structural SQL queries for telemetry and metric grouping, which prevents sensitive data leaks.

🧪 Example: Added an executable, `no_run` example for `Db` to demonstrate how it is extracted and dereferenced in a web handler. Added an executable doc test for `scrub_sql` that shows exactly how query variables are transformed.

🖼️ Preview: Documentation is available via `cargo doc --no-deps --open`. Both items now include clear examples and explanations that clarify *why* they exist instead of merely what they do.

---
*PR created automatically by Jules for task [11607459231050428955](https://jules.google.com/task/11607459231050428955) started by @madmax983*