### PR TITLE
👺 Havoc: Fuzzing & Looming State and Auth Concurrency

### DIFF
--- a/autumn/tests/chaos_api_token_store_fuzz.rs
+++ b/autumn/tests/chaos_api_token_store_fuzz.rs
@@ -1,0 +1,38 @@
+use autumn_web::auth::{ApiTokenStore, InMemoryApiTokenStore};
+use proptest::prelude::*;
+use std::collections::HashMap;
+use std::future::Future;
+
+fn block_on<F: Future>(f: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap()
+        .block_on(f)
+}
+
+proptest! {
+    #[test]
+    fn token_issue_and_verify_fuzz(
+        users in proptest::collection::vec(proptest::string::string_regex("[a-zA-Z0-9]+").unwrap(), 1..100)
+    ) {
+        let store = InMemoryApiTokenStore::default();
+        let mut tokens = HashMap::new();
+
+        for user in &users {
+            let token = block_on(store.issue(user)).unwrap();
+            tokens.insert(token, user.clone());
+        }
+
+        for (token, user) in &tokens {
+            let v = block_on(store.verify(token)).unwrap();
+            assert_eq!(v, Some(user.clone()));
+        }
+
+        // Test revoke
+        if let Some((token, _)) = tokens.iter().next() {
+             block_on(store.revoke(token)).unwrap();
+             let v = block_on(store.verify(token)).unwrap();
+             assert_eq!(v, None);
+        }
+    }
+}

--- a/autumn/tests/chaos_api_token_store_loom.rs
+++ b/autumn/tests/chaos_api_token_store_loom.rs
@@ -1,0 +1,31 @@
+use autumn_web::auth::{ApiTokenStore, InMemoryApiTokenStore};
+use loom::sync::Arc;
+use loom::thread;
+use std::future::Future;
+
+fn block_on<F: Future>(f: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap()
+        .block_on(f)
+}
+
+#[test]
+fn concurrent_token_issue() {
+    loom::model(|| {
+        let store = Arc::new(InMemoryApiTokenStore::default());
+
+        let s1 = store.clone();
+        let t1 = thread::spawn(move || {
+            block_on(s1.issue("user:1")).unwrap();
+        });
+
+        let s2 = store;
+        let t2 = thread::spawn(move || {
+            block_on(s2.issue("user:2")).unwrap();
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+    });
+}

--- a/autumn/tests/chaos_api_token_store_loom_delete.rs
+++ b/autumn/tests/chaos_api_token_store_loom_delete.rs
@@ -1,0 +1,37 @@
+use autumn_web::auth::{ApiTokenStore, InMemoryApiTokenStore};
+use loom::sync::Arc;
+use loom::thread;
+use std::future::Future;
+
+fn block_on<F: Future>(f: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap()
+        .block_on(f)
+}
+
+#[test]
+fn concurrent_token_revoke() {
+    loom::model(|| {
+        let store = Arc::new(InMemoryApiTokenStore::default());
+        let token = block_on(store.issue("user:1")).unwrap();
+
+        let s1 = store.clone();
+        let t1 = token.clone();
+        let th1 = thread::spawn(move || {
+            block_on(s1.revoke(&t1)).unwrap();
+        });
+
+        let s2 = store.clone();
+        let t2 = token.clone();
+        let th2 = thread::spawn(move || {
+            block_on(s2.revoke(&t2)).unwrap();
+        });
+
+        th1.join().unwrap();
+        th2.join().unwrap();
+
+        let verified = block_on(store.verify(&token)).unwrap();
+        assert_eq!(verified, None);
+    });
+}

--- a/autumn/tests/chaos_api_token_store_loom_verify.rs
+++ b/autumn/tests/chaos_api_token_store_loom_verify.rs
@@ -1,0 +1,34 @@
+use autumn_web::auth::{ApiTokenStore, InMemoryApiTokenStore};
+use loom::sync::Arc;
+use loom::thread;
+use std::future::Future;
+
+fn block_on<F: Future>(f: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap()
+        .block_on(f)
+}
+
+#[test]
+fn concurrent_token_verify() {
+    loom::model(|| {
+        let store = Arc::new(InMemoryApiTokenStore::default());
+        let token = block_on(store.issue("user:1")).unwrap();
+
+        let s1 = store.clone();
+        let t1 = token.clone();
+        let th1 = thread::spawn(move || {
+            let _ = block_on(s1.verify(&t1));
+        });
+
+        let s2 = store;
+        let t2 = token;
+        let th2 = thread::spawn(move || {
+            let _ = block_on(s2.verify(&t2));
+        });
+
+        th1.join().unwrap();
+        th2.join().unwrap();
+    });
+}

--- a/autumn/tests/chaos_app_state_extensions_loom.rs
+++ b/autumn/tests/chaos_app_state_extensions_loom.rs
@@ -1,0 +1,31 @@
+use autumn_web::AppState;
+use loom::sync::Arc;
+use loom::thread;
+
+#[test]
+fn app_state_concurrent_extensions() {
+    loom::model(|| {
+        let state = AppState::for_test();
+        let state = Arc::new(state);
+
+        let s1 = state.clone();
+        let t1 = thread::spawn(move || {
+            s1.insert_extension(42_u32);
+        });
+
+        let s2 = state.clone();
+        let t2 = thread::spawn(move || {
+            s2.insert_extension(String::from("hello"));
+        });
+
+        let s3 = state;
+        let t3 = thread::spawn(move || {
+            let _ = s3.extension::<u32>();
+            let _ = s3.extension::<String>();
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+        t3.join().unwrap();
+    });
+}

--- a/autumn/tests/chaos_app_state_fuzz.rs
+++ b/autumn/tests/chaos_app_state_fuzz.rs
@@ -1,0 +1,21 @@
+use autumn_web::AppState;
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn app_state_extensions_fuzz(
+        exts1 in proptest::collection::vec(any::<u32>(), 0..10),
+        exts2 in proptest::collection::vec(proptest::string::string_regex("[a-z]+").unwrap(), 0..10)
+    ) {
+        let state = AppState::for_test();
+        for ext in exts1 {
+            state.insert_extension(ext);
+            assert_eq!(state.extension::<u32>().map(|a| *a), Some(ext));
+        }
+        for ext in exts2 {
+            let e = ext.clone();
+            state.insert_extension(e);
+            assert_eq!(state.extension::<String>().map(|a| a.to_string()), Some(ext));
+        }
+    }
+}

--- a/autumn/tests/chaos_global_cache_loom.rs
+++ b/autumn/tests/chaos_global_cache_loom.rs
@@ -1,0 +1,43 @@
+use autumn_web::cache::{Cache, clear_global_cache, global_cache, set_global_cache};
+use loom::thread;
+use std::any::Any;
+use std::sync::{Arc, Mutex};
+
+struct DummyCache {
+    _values: Mutex<std::collections::HashMap<String, Arc<dyn Any + Send + Sync>>>,
+}
+
+impl Cache for DummyCache {
+    fn get_value(&self, _key: &str) -> Option<Arc<dyn Any + Send + Sync>> {
+        None
+    }
+    fn insert_value(&self, _key: &str, _value: Arc<dyn Any + Send + Sync>) {}
+    fn invalidate(&self, _key: &str) {}
+    fn clear(&self) {}
+}
+
+#[test]
+fn global_cache_concurrent_mutations() {
+    loom::model(|| {
+        clear_global_cache();
+
+        let t1 = thread::spawn(|| {
+            let cache = Arc::new(DummyCache {
+                _values: Mutex::new(std::collections::HashMap::new()),
+            });
+            set_global_cache(cache);
+        });
+
+        let t2 = thread::spawn(|| {
+            let _ = global_cache();
+        });
+
+        let t3 = thread::spawn(|| {
+            clear_global_cache();
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+        t3.join().unwrap();
+    });
+}

--- a/autumn/tests/chaos_method_override_loom.rs
+++ b/autumn/tests/chaos_method_override_loom.rs
@@ -1,0 +1,60 @@
+use autumn_web::middleware::MethodOverrideLayer;
+use axum::body::Body;
+use axum::http::{Method, Request};
+use loom::thread;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+#[derive(Clone)]
+struct MockService;
+
+impl Service<Request<Body>> for MockService {
+    type Response = axum::http::Response<Body>;
+    type Error = std::convert::Infallible;
+    type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: Request<Body>) -> Self::Future {
+        std::future::ready(Ok(axum::http::Response::new(Body::empty())))
+    }
+}
+
+#[test]
+fn method_override_concurrent() {
+    loom::model(|| {
+        let layer = MethodOverrideLayer::new();
+        let svc = layer.layer(MockService);
+
+        let mut s1 = svc.clone();
+        let t1 = thread::spawn(move || {
+            let req = Request::builder()
+                .method(Method::POST)
+                .header("X-HTTP-Method-Override", "PUT")
+                .body(Body::empty())
+                .unwrap();
+            let _ = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap()
+                .block_on(s1.call(req));
+        });
+
+        let mut s2 = svc;
+        let t2 = thread::spawn(move || {
+            let req = Request::builder()
+                .method(Method::POST)
+                .header("X-HTTP-Method-Override", "DELETE")
+                .body(Body::empty())
+                .unwrap();
+            let _ = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap()
+                .block_on(s2.call(req));
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+    });
+}


### PR DESCRIPTION
🧊 **The Trigger:** Fuzzing and Loom models stress testing the concurrent safety of `InMemoryApiTokenStore` token issuance/revocation and `AppState` extension insertion.
📉 **The Stack Trace:** No panics found yet! The thread-safety limits hold strong under permutation torture.
🧪 **Reproduction:** Run `cargo test -p autumn-web --test "chaos_*"`.
😈 **Comment:** You assumed the token store and app state wouldn't be hammered concurrently. I hammered them, and they survived... for now.

---
*PR created automatically by Jules for task [9105345757497799576](https://jules.google.com/task/9105345757497799576) started by @madmax983*