### PR TITLE
⚡ Bolt: Optimize plugin conformance route normalization

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2943,19 +2943,16 @@ async fn execute_task_result_with_optional_lease_ttl(
         execute_task_result(state, handler, start, name, schedule),
     )
     .await
-    .map_or_else(
-        |_| {
-            let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-            Err((
-                duration_ms,
-                format!(
-                    "scheduled task exceeded lease TTL of {}s",
-                    lease_ttl.as_secs()
-                ),
-            ))
-        },
-        std::convert::identity,
-    )
+    .unwrap_or_else(|_| {
+        let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+        Err((
+            duration_ms,
+            format!(
+                "scheduled task exceeded lease TTL of {}s",
+                lease_ttl.as_secs()
+            ),
+        ))
+    })
 }
 
 /// Handle the execution of a single fixed-delay task.

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -350,17 +350,30 @@ pub fn check_route_prefix(
 /// Both named params (`{id}`) and catch-all params (`{*rest}`) normalize to
 /// `{}`. matchit (Axum's router) treats a named param and a catch-all at the
 /// same path position as a conflict, so they must map to the same key.
+///
+/// ⚡ Bolt Optimization:
+/// Eliminates intermediate `Vec` allocation and `.join("/")` strings by writing
+/// sequentially into a pre-allocated `String`. This removes a heap allocation
+/// per route when validating plugin conformance.
 fn normalize_path_for_collision(path: &str) -> String {
-    path.split('/')
-        .map(|seg| {
-            if seg.starts_with('{') && seg.ends_with('}') {
-                "{}"
-            } else {
-                seg
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
+    let mut result = String::with_capacity(path.len());
+    let mut segments = path.split('/');
+    if let Some(first) = segments.next() {
+        if first.starts_with('{') && first.ends_with('}') {
+            result.push_str("{}");
+        } else {
+            result.push_str(first);
+        }
+    }
+    for seg in segments {
+        result.push('/');
+        if seg.starts_with('{') && seg.ends_with('}') {
+            result.push_str("{}");
+        } else {
+            result.push_str(seg);
+        }
+    }
+    result
 }
 
 /// Detect route collisions: any two routes sharing the same (method, path) pair.


### PR DESCRIPTION
💡 What: Replaced iterator chain `.collect::<Vec<_>>().join("/")` in `normalize_path_for_collision` with pre-allocation and sequential `push_str` into a `String`.
🎯 Why: The existing normalization incurred an unnecessary heap allocation of an intermediate `Vec` when joining route segments for collision detection.
📊 Impact: Removes one `Vec` allocation per route inspected during the plugin conformance check.
🔬 Measurement: Verified output correctness by running `cargo test -p autumn-web --lib plugin_conformance`.

---
*PR created automatically by Jules for task [13484201842169537707](https://jules.google.com/task/13484201842169537707) started by @madmax983*