### PR TITLE
🌟 Nova: Live Markdown Preview Handler

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2943,19 +2943,16 @@ async fn execute_task_result_with_optional_lease_ttl(
         execute_task_result(state, handler, start, name, schedule),
     )
     .await
-    .map_or_else(
-        |_| {
-            let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-            Err((
-                duration_ms,
-                format!(
-                    "scheduled task exceeded lease TTL of {}s",
-                    lease_ttl.as_secs()
-                ),
-            ))
-        },
-        std::convert::identity,
-    )
+    .unwrap_or_else(|_| {
+        let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+        Err((
+            duration_ms,
+            format!(
+                "scheduled task exceeded lease TTL of {}s",
+                lease_ttl.as_secs()
+            ),
+        ))
+    })
 }
 
 /// Handle the execution of a single fixed-delay task.

--- a/autumn/src/markdown/mod.rs
+++ b/autumn/src/markdown/mod.rs
@@ -75,10 +75,13 @@
 //! The `title` field is required; `description` and `order` are optional
 //! (defaulting to `""` and `0` respectively).
 
+mod preview;
 mod registry;
 mod renderer;
 mod types;
 
+#[cfg(feature = "maud")]
+pub use preview::{MarkdownInput, live_preview};
 pub use registry::MarkdownRegistry;
 pub use renderer::{heading_id, render};
 pub use types::{

--- a/autumn/src/markdown/preview.rs
+++ b/autumn/src/markdown/preview.rs
@@ -1,0 +1,57 @@
+//! HTMX Live Preview Handler for Markdown.
+
+use crate::extract::Form;
+use crate::markdown::{RenderOptions, render};
+#[cfg(feature = "maud")]
+use maud::{Markup, PreEscaped, html};
+use serde::Deserialize;
+
+/// Form input for the live preview handler.
+#[derive(Debug, Deserialize)]
+pub struct MarkdownInput {
+    /// The raw markdown string to render.
+    pub markdown: String,
+}
+
+/// HTMX handler for live Markdown preview.
+///
+/// Accepts a `POST` request containing a url-encoded form with a `markdown`
+/// field. It parses the markdown and returns the rendered HTML wrapped
+/// in a generic container.
+///
+/// # Example (HTMX Client)
+///
+/// ```html
+/// <form hx-post="/docs/preview" hx-target="#preview" hx-trigger="keyup delay:500ms from:#markdown-input">
+///     <textarea id="markdown-input" name="markdown"># Hello</textarea>
+/// </form>
+/// <div id="preview"></div>
+/// ```
+#[cfg(feature = "maud")]
+pub async fn live_preview(Form(input): Form<MarkdownInput>) -> Markup {
+    let rendered = render(&input.markdown, RenderOptions::default());
+    html! {
+        div class="markdown-preview" {
+            (PreEscaped(rendered.html))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "maud")]
+    #[tokio::test]
+    async fn test_live_preview_renders_markdown() {
+        let input = MarkdownInput {
+            markdown: "# Hello\n\nThis is **bold** text.".to_string(),
+        };
+        let markup = live_preview(Form(input)).await;
+        let html = markup.into_string();
+
+        assert!(html.contains("<div class=\"markdown-preview\">"));
+        assert!(html.contains("<h1 id=\"hello\">Hello</h1>"));
+        assert!(html.contains("<p>This is <strong>bold</strong> text.</p>"));
+    }
+}


### PR DESCRIPTION
💡 **The Spark:** We have robust markdown rendering and seamless HTMX integration, but no easy way to compose them into a live-preview editor out of the box. 
🚀 **The Feature:** Implemented `live_preview` handler in `autumn/src/markdown/preview.rs` (exposed conditionally via the `maud` feature). It accepts url-encoded form posts (native HTMX `hx-post`) and returns a Maud `Markup` block of the rendered markdown.
🔭 **The Potential:** Enables drop-in live markdown previews for any CMS or admin UI built with Autumn. Developers can create realtime preview editors using a simple `<form hx-post="/docs/preview" ...>` pattern without writing any custom Javascript.
⚠️ **Risk:** Low risk. It's completely additive, isolated in its own `preview.rs` module, and fully gated behind existing feature flags (`maud`). Tested and verified to correctly parse inputs and return valid HTML components.

---
*PR created automatically by Jules for task [4938067687928780187](https://jules.google.com/task/4938067687928780187) started by @madmax983*