### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -323,6 +323,27 @@ const fn is_separator(c: char) -> bool {
     )
 }
 
+/// Scrubs raw literal values from a SQL query string to prevent PII leaks.
+///
+/// This function normalizes SQL statements before they are emitted to logs,
+/// error trackers, or metrics. It strips out strings, numbers, and identifiers
+/// that might contain sensitive data (like user IDs, email addresses, or
+/// password hashes) and replaces them with `?` placeholders.
+///
+/// By scrubbing literals, telemetry systems can safely group structurally identical
+/// queries (e.g., `SELECT * FROM users WHERE id = ?`) without logging the
+/// actual parameters used.
+///
+/// # Examples
+///
+/// ```
+/// use autumn_web::db::scrub_sql;
+///
+/// let raw = "SELECT * FROM users WHERE email = 'test@example.com' AND age > 21;";
+/// let scrubbed = scrub_sql(raw);
+///
+/// assert_eq!(scrubbed, "SELECT * FROM users WHERE email = '?' AND age > ?;");
+/// ```
 #[must_use]
 pub fn scrub_sql(sql: &str) -> String {
     let mut out = String::with_capacity(sql.len());


### PR DESCRIPTION
📖 Chapter: `db::scrub_sql`
🔦 Insight: Explained *why* the function exists (stripping literals from SQL for telemetry to prevent PII leaks) and how it safely normalizes queries.
🧪 Example: Added an executable doctest demonstrating the transformation of a query with a string literal and a numeric literal into a query with `?` placeholders.
🖼️ Preview: Evaluated by `cargo doc --no-deps -p autumn-web` and visual rendering verified.

---
*PR created automatically by Jules for task [5230293668972463205](https://jules.google.com/task/5230293668972463205) started by @madmax983*