### PR TITLE
⚒️ Forge: Extract string and numeric parsing logic from `scrub_sql`

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -266,6 +266,64 @@ pub trait DbState {
 ///
 /// Called after the opening `'` has already been consumed. Handles
 /// `\'` backslash-escaped quotes so they do not prematurely close the string.
+/// Consumes a positional parameter like `$1`.
+fn consume_positional_parameter(
+    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    out: &mut String,
+) {
+    while chars.peek().is_some_and(char::is_ascii_digit) {
+        if let Some(d) = chars.next() {
+            out.push(d);
+        }
+    }
+}
+
+/// Consumes the body of a standard single-quoted string literal.
+/// Consumes the body of an unquoted numeric literal (including decimals and exponents).
+fn consume_numeric_literal_body(
+    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    is_leading_dot: bool,
+) {
+    if is_leading_dot {
+        chars.next(); // consume the leading dot
+    }
+    // Consume integer/decimal digits, underscores, and dots.
+    while chars
+        .peek()
+        .is_some_and(|d| d.is_ascii_digit() || *d == '.' || *d == '_')
+    {
+        chars.next();
+    }
+    // Consume optional scientific-notation exponent: e/E [+/-] <digits>.
+    if chars.peek().is_some_and(|e| *e == 'e' || *e == 'E') {
+        chars.next(); // consume 'e'/'E'
+        if chars.peek().is_some_and(|s| *s == '+' || *s == '-') {
+            chars.next(); // consume optional sign
+        }
+        while chars.peek().is_some_and(char::is_ascii_digit) {
+            chars.next();
+        }
+    }
+}
+
+fn consume_single_quoted_body(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
+    loop {
+        match chars.next() {
+            None => break,
+            Some('\'') => {
+                if chars.peek() == Some(&'\'') {
+                    // Escaped quote ('') — consume both, stay inside string
+                    chars.next();
+                } else {
+                    // Closing quote
+                    break;
+                }
+            }
+            Some(_) => {}
+        }
+    }
+}
+
 fn consume_estring_body(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
     loop {
         match chars.next() {
@@ -289,6 +347,37 @@ fn consume_estring_body(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
 ///
 /// Called after the opening `$tag$` delimiter has already been consumed.
 /// Uses a simple sliding-window match — sufficient for valid SQL.
+/// Extracts a dollar-quote tag, returning `(tag, is_valid_dollar_quote)`.
+fn consume_dollar_quote_tag(
+    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    next_ch: Option<char>,
+) -> (String, bool) {
+    let mut tag = String::new();
+    let mut found_closing_dollar = false;
+
+    if next_ch == Some('$') {
+        // Anonymous $$: consume the second `$`.
+        chars.next();
+        found_closing_dollar = true;
+    } else if next_ch.is_some_and(|nc| nc.is_alphabetic() || nc == '_') {
+        // Accumulate tag chars until we hit `$` or a non-identifier char.
+        while let Some(&tc) = chars.peek() {
+            if tc == '$' {
+                chars.next(); // consume the closing `$` of the opening tag
+                found_closing_dollar = true;
+                break;
+            } else if tc.is_alphanumeric() || tc == '_' {
+                tag.push(tc);
+                chars.next();
+            } else {
+                // Not a valid tag character — not a dollar-quoted string.
+                break;
+            }
+        }
+    }
+    (tag, found_closing_dollar)
+}
+
 fn consume_dollar_quoted_body(chars: &mut std::iter::Peekable<std::str::Chars<'_>>, tag: &str) {
     let closing: Vec<char> = format!("${tag}$").chars().collect();
     let clen = closing.len();
@@ -349,21 +438,7 @@ pub fn scrub_sql(sql: &str) -> String {
         if c == '\'' {
             out.push_str("'?'");
             prev_is_sep = false;
-            loop {
-                match chars.next() {
-                    None => break,
-                    Some('\'') => {
-                        if chars.peek() == Some(&'\'') {
-                            // Escaped quote ('') — consume both, stay inside string
-                            chars.next();
-                        } else {
-                            // Closing quote
-                            break;
-                        }
-                    }
-                    Some(_) => {}
-                }
-            }
+            consume_single_quoted_body(&mut chars);
             continue;
         }
 
@@ -375,39 +450,11 @@ pub fn scrub_sql(sql: &str) -> String {
             if next_ch.is_some_and(|nc| nc.is_ascii_digit()) {
                 out.push('$');
                 prev_is_sep = false;
-                while chars.peek().is_some_and(char::is_ascii_digit) {
-                    if let Some(d) = chars.next() {
-                        out.push(d);
-                    }
-                }
+                consume_positional_parameter(&mut chars, &mut out);
                 continue;
             }
 
-            // Dollar-quoted string: $$ (anonymous) or $tag$ (tagged).
-            // Collect the optional tag, looking for the second `$`.
-            let mut tag = String::new();
-            let mut found_closing_dollar = false;
-
-            if next_ch == Some('$') {
-                // Anonymous $$: consume the second `$`.
-                chars.next();
-                found_closing_dollar = true;
-            } else if next_ch.is_some_and(|nc| nc.is_alphabetic() || nc == '_') {
-                // Accumulate tag chars until we hit `$` or a non-identifier char.
-                while let Some(&tc) = chars.peek() {
-                    if tc == '$' {
-                        chars.next(); // consume the closing `$` of the opening tag
-                        found_closing_dollar = true;
-                        break;
-                    } else if tc.is_alphanumeric() || tc == '_' {
-                        tag.push(tc);
-                        chars.next();
-                    } else {
-                        // Not a valid tag character — not a dollar-quoted string.
-                        break;
-                    }
-                }
-            }
+            let (tag, found_closing_dollar) = consume_dollar_quote_tag(&mut chars, next_ch);
 
             if found_closing_dollar {
                 out.push_str("'?'");
@@ -429,26 +476,7 @@ pub fn scrub_sql(sql: &str) -> String {
             c == '.' && prev_is_sep && chars.peek().is_some_and(char::is_ascii_digit);
         if (c.is_ascii_digit() && prev_is_sep) || is_leading_dot {
             out.push('?');
-            if is_leading_dot {
-                chars.next(); // consume the leading dot
-            }
-            // Consume integer/decimal digits, underscores, and dots.
-            while chars
-                .peek()
-                .is_some_and(|d| d.is_ascii_digit() || *d == '.' || *d == '_')
-            {
-                chars.next();
-            }
-            // Consume optional scientific-notation exponent: e/E [+/-] <digits>.
-            if chars.peek().is_some_and(|e| *e == 'e' || *e == 'E') {
-                chars.next(); // consume 'e'/'E'
-                if chars.peek().is_some_and(|s| *s == '+' || *s == '-') {
-                    chars.next(); // consume optional sign
-                }
-                while chars.peek().is_some_and(char::is_ascii_digit) {
-                    chars.next();
-                }
-            }
+            consume_numeric_literal_body(&mut chars, is_leading_dot);
             prev_is_sep = false;
             continue;
         }


### PR DESCRIPTION
🚨 Smell: The `scrub_sql` function in `autumn/src/db.rs` was a "God Function" with deep nesting ("Pyramid of Doom") inside a `while let` loop handling SQL parsing logic.

✨ Solution: Extracted the deeply nested logic into specific, well-named helper functions (`consume_positional_parameter`, `consume_single_quoted_body`, `consume_dollar_quote_tag`, and `consume_numeric_literal_body`), and called them within the main function.

🧼 Benefit: This significantly reduces the cognitive load, flattens the structure of `scrub_sql`, and makes the parsing logic much easier to read and maintain.

🛡️ Verification: Tests passed (`cargo test -p autumn-web --lib db::`). No logic changed.

---
*PR created automatically by Jules for task [10605554630618683800](https://jules.google.com/task/10605554630618683800) started by @madmax983*