### PR TITLE
Disable static export serving in dev mode to prevent route shadowing

### DIFF
--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -3335,8 +3335,8 @@ mod tests {
         std::fs::create_dir_all(&dist).expect("mkdir dist");
 
         // Write a manifest that references a file we do NOT create.
-        let mut routes = std::collections::HashMap::new();
-        routes.insert(
+        let mut route_map = std::collections::HashMap::new();
+        route_map.insert(
             "/ghost".to_owned(),
             crate::static_gen::ManifestEntry {
                 file: "ghost/index.html".to_owned(),
@@ -3346,7 +3346,7 @@ mod tests {
         let manifest = crate::static_gen::StaticManifest {
             generated_at: "2026-05-29T00:00:00Z".to_owned(),
             autumn_version: "0.4.0".to_owned(),
-            routes,
+            routes: route_map,
         };
         let json = serde_json::to_string(&manifest).expect("serialize manifest");
         std::fs::write(dist.join("manifest.json"), json).expect("write manifest");

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1465,6 +1465,26 @@ pub fn try_build_router_with_static_inner(
         ));
     };
 
+    // In dev mode (autumn dev / AUTUMN_DEV_RELOAD active) do NOT mount the
+    // static-first middleware so that app routes always take priority over
+    // pre-rendered HTML in dist/. This prevents stale exports from shadowing
+    // handlers whose templates have just been edited — the exact DX trap
+    // described in issue #754. Normal /static/* assets are unaffected.
+    if crate::middleware::dev::is_enabled() {
+        tracing::warn!(
+            dist = %dist.display(),
+            "Dev mode: static export HTML in dist/ is disabled so app routes \
+             take priority. Pre-rendered pages will not be served this session. \
+             Stop `autumn dev` and run the app normally to serve static exports."
+        );
+        let app_router = try_build_router_inner(route_list, config, state, ctx)?;
+        return Ok(apply_startup_barrier(
+            app_router,
+            config,
+            &startup_barrier_state,
+        ));
+    }
+
     for (route, entry) in &layer.manifest().routes {
         tracing::debug!(
             route = %route,
@@ -3014,24 +3034,34 @@ mod tests {
         let dist = tmp.path().join("dist");
         let config = AutumnConfig::default();
 
-        let router = try_build_router_with_static(Vec::new(), &config, test_state(), Some(&dist))
-            .expect("router builds");
+        temp_env::async_with_vars(
+            [
+                ("AUTUMN_DEV_RELOAD", None::<&str>),
+                ("AUTUMN_DEV_RELOAD_STATE", None::<&str>),
+            ],
+            async move {
+                let router =
+                    try_build_router_with_static(Vec::new(), &config, test_state(), Some(&dist))
+                        .expect("router builds");
 
-        let response = router
-            .oneshot(
-                Request::builder()
-                    .uri("/about")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+                let response = router
+                    .oneshot(
+                        Request::builder()
+                            .uri("/about")
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        assert_eq!(body.as_ref(), b"<h1>About</h1>");
+                assert_eq!(response.status(), StatusCode::OK);
+                let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                assert_eq!(body.as_ref(), b"<h1>About</h1>");
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -3040,25 +3070,35 @@ mod tests {
         let dist = tmp.path().join("dist");
         let config = AutumnConfig::default();
 
-        let router = try_build_router_with_static(Vec::new(), &config, test_state(), Some(&dist))
-            .expect("router builds");
+        temp_env::async_with_vars(
+            [
+                ("AUTUMN_DEV_RELOAD", None::<&str>),
+                ("AUTUMN_DEV_RELOAD_STATE", None::<&str>),
+            ],
+            async move {
+                let router =
+                    try_build_router_with_static(Vec::new(), &config, test_state(), Some(&dist))
+                        .expect("router builds");
 
-        let response = router
-            .oneshot(
-                Request::builder()
-                    .method("HEAD")
-                    .uri("/about")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+                let response = router
+                    .oneshot(
+                        Request::builder()
+                            .method("HEAD")
+                            .uri("/about")
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        assert!(body.is_empty(), "HEAD response body should be empty");
+                assert_eq!(response.status(), StatusCode::OK);
+                let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                assert!(body.is_empty(), "HEAD response body should be empty");
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -3067,20 +3107,30 @@ mod tests {
         let dist = tmp.path().join("dist");
         let config = AutumnConfig::default();
 
-        let router = try_build_router_with_static(Vec::new(), &config, test_state(), Some(&dist))
-            .expect("router builds");
+        temp_env::async_with_vars(
+            [
+                ("AUTUMN_DEV_RELOAD", None::<&str>),
+                ("AUTUMN_DEV_RELOAD_STATE", None::<&str>),
+            ],
+            async move {
+                let router =
+                    try_build_router_with_static(Vec::new(), &config, test_state(), Some(&dist))
+                        .expect("router builds");
 
-        let response = router
-            .oneshot(
-                Request::builder()
-                    .uri("/about/")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+                let response = router
+                    .oneshot(
+                        Request::builder()
+                            .uri("/about/")
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
+                assert_eq!(response.status(), StatusCode::OK);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -3089,20 +3139,30 @@ mod tests {
         let dist = tmp.path().join("dist");
         let config = AutumnConfig::default();
 
-        let router = try_build_router_with_static(Vec::new(), &config, test_state(), Some(&dist))
-            .expect("router builds");
+        temp_env::async_with_vars(
+            [
+                ("AUTUMN_DEV_RELOAD", None::<&str>),
+                ("AUTUMN_DEV_RELOAD_STATE", None::<&str>),
+            ],
+            async move {
+                let router =
+                    try_build_router_with_static(Vec::new(), &config, test_state(), Some(&dist))
+                        .expect("router builds");
 
-        let response = router
-            .oneshot(
-                Request::builder()
-                    .uri("/not-in-manifest")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+                let response = router
+                    .oneshot(
+                        Request::builder()
+                            .uri("/not-in-manifest")
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
 
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+                assert_eq!(response.status(), StatusCode::NOT_FOUND);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -3129,20 +3189,142 @@ mod tests {
         let dist = tmp.path().join("dist");
         let config = AutumnConfig::default();
 
-        let router = try_build_router_with_static(Vec::new(), &config, test_state(), Some(&dist))
-            .expect("router with ISR manifest should build");
+        temp_env::async_with_vars(
+            [
+                ("AUTUMN_DEV_RELOAD", None::<&str>),
+                ("AUTUMN_DEV_RELOAD_STATE", None::<&str>),
+            ],
+            async move {
+                let router =
+                    try_build_router_with_static(Vec::new(), &config, test_state(), Some(&dist))
+                        .expect("router with ISR manifest should build");
 
-        let response = router
-            .oneshot(
-                Request::builder()
-                    .uri("/about")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+                let response = router
+                    .oneshot(
+                        Request::builder()
+                            .uri("/about")
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
+                assert_eq!(response.status(), StatusCode::OK);
+            },
+        )
+        .await;
+    }
+
+    // --- Dev-mode static-export shadowing tests (issue #754) ---
+
+    #[tokio::test]
+    async fn static_serving_skipped_in_dev_mode_app_routes_take_priority() {
+        // When dev mode is active (AUTUMN_DEV_RELOAD set), dist/ HTML must NOT
+        // shadow app routes. Without a registered handler the router should
+        // return 404 rather than the pre-rendered HTML.
+        let tmp = create_static_dist(None);
+        let dist = tmp.path().join("dist");
+        let config = AutumnConfig::default();
+
+        temp_env::async_with_vars(
+            [
+                ("AUTUMN_DEV_RELOAD", Some("1")),
+                ("AUTUMN_DEV_RELOAD_STATE", Some("/tmp/autumn-reload-test")),
+            ],
+            async move {
+                let router =
+                    try_build_router_with_static(Vec::new(), &config, test_state(), Some(&dist))
+                        .expect("router builds in dev mode");
+
+                let response = router
+                    .oneshot(
+                        Request::builder()
+                            .uri("/about")
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+
+                assert_eq!(
+                    response.status(),
+                    StatusCode::NOT_FOUND,
+                    "static HTML must not shadow app routes in dev mode"
+                );
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn static_serving_active_outside_dev_mode() {
+        // Baseline: without dev env vars, static export HTML is still served
+        // before dynamic routes (existing non-dev behaviour must not regress).
+        let tmp = create_static_dist(None);
+        let dist = tmp.path().join("dist");
+        let config = AutumnConfig::default();
+
+        temp_env::async_with_vars(
+            [
+                ("AUTUMN_DEV_RELOAD", None::<&str>),
+                ("AUTUMN_DEV_RELOAD_STATE", None::<&str>),
+            ],
+            async move {
+                let router =
+                    try_build_router_with_static(Vec::new(), &config, test_state(), Some(&dist))
+                        .expect("router builds without dev mode");
+
+                let response = router
+                    .oneshot(
+                        Request::builder()
+                            .uri("/about")
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+
+                assert_eq!(response.status(), StatusCode::OK);
+                let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                assert_eq!(body.as_ref(), b"<h1>About</h1>");
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn static_serving_skipped_in_dev_mode_root_route_falls_through() {
+        // The root path is a common shadowing case: dist/index.html must not
+        // be served when dev mode is active.
+        let tmp = create_static_dist(None);
+        let dist = tmp.path().join("dist");
+        let config = AutumnConfig::default();
+
+        temp_env::async_with_vars(
+            [
+                ("AUTUMN_DEV_RELOAD", Some("1")),
+                ("AUTUMN_DEV_RELOAD_STATE", Some("/tmp/autumn-reload-test")),
+            ],
+            async move {
+                let router =
+                    try_build_router_with_static(Vec::new(), &config, test_state(), Some(&dist))
+                        .expect("router builds");
+
+                let response = router
+                    .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+                    .await
+                    .unwrap();
+
+                assert_eq!(
+                    response.status(),
+                    StatusCode::NOT_FOUND,
+                    "dist/index.html must not shadow / in dev mode"
+                );
+            },
+        )
+        .await;
     }
 }
 

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1434,6 +1434,41 @@ pub fn try_build_router_with_static(
     )
 }
 
+/// Middleware helper: try to serve `req` from the static file layer; fall
+/// through to the next handler if the path is not in the manifest.
+async fn serve_static_or_fallthrough(
+    layer: Arc<crate::static_gen::StaticFileLayer>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> http::Response<axum::body::Body> {
+    let is_get = req.method() == http::Method::GET;
+    let is_head = req.method() == http::Method::HEAD;
+    if is_get || is_head {
+        let path = req.uri().path();
+        // Normalize trailing slash: /about/ → /about (but keep / as /)
+        let normalized = if path.len() > 1 && path.ends_with('/') {
+            &path[..path.len() - 1]
+        } else {
+            path
+        };
+        if let Some(file_path) = layer.resolve(normalized)
+            && let Ok(contents) = tokio::fs::read(&file_path).await
+        {
+            let body = if is_head {
+                axum::body::Body::empty()
+            } else {
+                axum::body::Body::from(contents)
+            };
+            return http::Response::builder()
+                .status(http::StatusCode::OK)
+                .header(http::header::CONTENT_TYPE, "text/html; charset=utf-8")
+                .body(body)
+                .expect("infallible response builder");
+        }
+    }
+    next.run(req).await
+}
+
 pub fn try_build_router_with_static_inner(
     route_list: Vec<Route>,
     config: &AutumnConfig,
@@ -1452,24 +1487,9 @@ pub fn try_build_router_with_static_inner(
         ));
     };
 
-    let Some(layer) = crate::static_gen::StaticFileLayer::new(dist) else {
-        tracing::debug!(
-            dist = %dist.display(),
-            "No valid manifest.json in dist dir; skipping static file layer"
-        );
-        let app_router = try_build_router_inner(route_list, config, state, ctx)?;
-        return Ok(apply_startup_barrier(
-            app_router,
-            config,
-            &startup_barrier_state,
-        ));
-    };
-
-    // In dev mode (autumn dev / AUTUMN_DEV_RELOAD active) do NOT mount the
-    // static-first middleware so that app routes always take priority over
-    // pre-rendered HTML in dist/. This prevents stale exports from shadowing
-    // handlers whose templates have just been edited — the exact DX trap
-    // described in issue #754. Normal /static/* assets are unaffected.
+    // In dev mode, skip static export HTML entirely (issue #754): app routes
+    // must take priority so edits are visible immediately. Check before
+    // StaticFileLayer::new() to skip the manifest.json read entirely.
     if crate::middleware::dev::is_enabled() {
         tracing::warn!(
             dist = %dist.display(),
@@ -1484,6 +1504,19 @@ pub fn try_build_router_with_static_inner(
             &startup_barrier_state,
         ));
     }
+
+    let Some(layer) = crate::static_gen::StaticFileLayer::new(dist) else {
+        tracing::debug!(
+            dist = %dist.display(),
+            "No valid manifest.json in dist dir; skipping static file layer"
+        );
+        let app_router = try_build_router_inner(route_list, config, state, ctx)?;
+        return Ok(apply_startup_barrier(
+            app_router,
+            config,
+            &startup_barrier_state,
+        ));
+    };
 
     for (route, entry) in &layer.manifest().routes {
         tracing::debug!(
@@ -1530,47 +1563,12 @@ pub fn try_build_router_with_static_inner(
 
     // Static-first serving: intercept GET/HEAD requests whose path appears
     // in the manifest and serve pre-built HTML directly — BEFORE the dynamic
-    // router (and session layer) runs. This preserves availability of static
-    // pages even when the session backend is unavailable.
-    //
-    // Requests not in the manifest (including non-GET/HEAD methods) fall
-    // through to the dynamic router unchanged.
-    //
-    // ISR staleness checking happens inside `resolve()`: stale pages are
-    // still served immediately while background regeneration runs
-    // (stale-while-revalidate).
-    let static_layer = layer;
+    // router (and session layer) runs. Requests not in the manifest fall
+    // through. ISR staleness is checked inside `resolve()` (stale-while-
+    // revalidate).
     let mut router: axum::Router<AppState> = inner_router.layer(axum::middleware::from_fn(
         move |req: axum::extract::Request, next: axum::middleware::Next| {
-            let static_layer = static_layer.clone();
-            async move {
-                let is_get = req.method() == http::Method::GET;
-                let is_head = req.method() == http::Method::HEAD;
-                if is_get || is_head {
-                    let path = req.uri().path();
-                    // Normalize trailing slash: /about/ → /about (but keep / as /)
-                    let normalized = if path.len() > 1 && path.ends_with('/') {
-                        &path[..path.len() - 1]
-                    } else {
-                        path
-                    };
-                    if let Some(file_path) = static_layer.resolve(normalized)
-                        && let Ok(contents) = tokio::fs::read(&file_path).await
-                    {
-                        let body = if is_head {
-                            axum::body::Body::empty()
-                        } else {
-                            axum::body::Body::from(contents)
-                        };
-                        return http::Response::builder()
-                            .status(http::StatusCode::OK)
-                            .header(http::header::CONTENT_TYPE, "text/html; charset=utf-8")
-                            .body(body)
-                            .expect("infallible response builder");
-                    }
-                }
-                next.run(req).await
-            }
+            serve_static_or_fallthrough(layer.clone(), req, next)
         },
     ));
 

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -3324,6 +3324,61 @@ mod tests {
         )
         .await;
     }
+
+    #[tokio::test]
+    async fn static_serving_falls_through_when_manifest_file_missing_on_disk() {
+        // Manifest lists a route but the corresponding file has been deleted.
+        // The middleware must fall through to the dynamic router rather than
+        // error, because dist/ can be partially regenerated at any time.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dist = dir.path().join("dist");
+        std::fs::create_dir_all(&dist).expect("mkdir dist");
+
+        // Write a manifest that references a file we do NOT create.
+        let mut routes = std::collections::HashMap::new();
+        routes.insert(
+            "/ghost".to_owned(),
+            crate::static_gen::ManifestEntry {
+                file: "ghost/index.html".to_owned(),
+                revalidate: None,
+            },
+        );
+        let manifest = crate::static_gen::StaticManifest {
+            generated_at: "2026-05-29T00:00:00Z".to_owned(),
+            autumn_version: "0.4.0".to_owned(),
+            routes,
+        };
+        let json = serde_json::to_string(&manifest).expect("serialize manifest");
+        std::fs::write(dist.join("manifest.json"), json).expect("write manifest");
+
+        let config = AutumnConfig::default();
+
+        temp_env::async_with_vars(
+            [
+                ("AUTUMN_DEV_RELOAD", None::<&str>),
+                ("AUTUMN_DEV_RELOAD_STATE", None::<&str>),
+            ],
+            async move {
+                let router =
+                    try_build_router_with_static(Vec::new(), &config, test_state(), Some(&dist))
+                        .expect("router builds");
+
+                let response = router
+                    .oneshot(
+                        Request::builder()
+                            .uri("/ghost")
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+
+                // Should fall through to dynamic router, not error.
+                assert_eq!(response.status(), StatusCode::NOT_FOUND);
+            },
+        )
+        .await;
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
This PR fixes issue #754 by disabling static export HTML serving when dev mode is active (`AUTUMN_DEV_RELOAD`). This ensures app routes always take priority over pre-rendered HTML in `dist/`, preventing stale exports from shadowing recently edited handler templates during development.

## Key Changes
- **Dev mode static-first middleware bypass**: Added a check in `try_build_router_with_static_inner()` that skips mounting the static-first middleware when dev mode is enabled, allowing dynamic app routes to take priority
- **Developer warning**: Added a warning log message when dev mode disables static exports, informing users that pre-rendered pages won't be served during the session
- **Test environment isolation**: Wrapped all existing static-serving tests with `temp_env::async_with_vars()` to ensure they run with dev mode disabled, preventing test interference
- **New dev-mode test coverage**: Added three new tests to verify the fix:
  - `static_serving_skipped_in_dev_mode_app_routes_take_priority`: Confirms static HTML doesn't shadow app routes in dev mode
  - `static_serving_active_outside_dev_mode`: Baseline test ensuring static serving still works normally outside dev mode
  - `static_serving_skipped_in_dev_mode_root_route_falls_through`: Verifies root path (`/`) doesn't serve `dist/index.html` in dev mode

## Implementation Details
- The dev mode check uses the existing `crate::middleware::dev::is_enabled()` function to detect when `AUTUMN_DEV_RELOAD` is active
- When dev mode is detected, the router is built without the static-first middleware layer, allowing normal route resolution to proceed
- The startup barrier is still applied to maintain consistent behavior
- All tests properly isolate environment variables to prevent cross-test contamination

https://claude.ai/code/session_013oYAqGGKJXdmxtaXTi5t5f