### PR TITLE
⚡ Bolt: [performance improvement] Use hex crate for faster byte-to-hex string conversions

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -1047,13 +1047,7 @@ pub trait ApiTokenStore: Send + Sync + 'static {
 #[must_use]
 pub fn hash_api_token(raw: &str) -> String {
     use sha2::Digest as _;
-    sha2::Sha256::digest(raw.as_bytes())
-        .iter()
-        .fold(String::with_capacity(64), |mut s, b| {
-            use std::fmt::Write as _;
-            let _ = write!(s, "{b:02x}");
-            s
-        })
+    hex::encode(sha2::Sha256::digest(raw.as_bytes()))
 }
 
 /// Generate a 256-bit random raw API token as a lowercase hex string.

--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -48,14 +48,7 @@ fn compute_body_hash(bytes: &[u8], content_type: Option<&[u8]>) -> Vec<u8> {
 }
 
 fn hex_lower(bytes: impl AsRef<[u8]>) -> String {
-    bytes.as_ref().iter().fold(
-        String::with_capacity(bytes.as_ref().len() * 2),
-        |mut out, byte| {
-            use std::fmt::Write as _;
-            let _ = write!(out, "{byte:02x}");
-            out
-        },
-    )
+    hex::encode(bytes)
 }
 
 fn principal_scope_digest(session_id: Option<&str>) -> String {
@@ -1818,14 +1811,7 @@ mod tests {
     }
 
     fn hex_lower(bytes: impl AsRef<[u8]>) -> String {
-        bytes.as_ref().iter().fold(
-            String::with_capacity(bytes.as_ref().len() * 2),
-            |mut out, byte| {
-                use std::fmt::Write as _;
-                let _ = write!(out, "{byte:02x}");
-                out
-            },
-        )
+        hex::encode(bytes)
     }
 
     fn expected_principal_digest(session_id: Option<&str>) -> String {

--- a/autumn/src/repository_commit_hooks.rs
+++ b/autumn/src/repository_commit_hooks.rs
@@ -1279,14 +1279,7 @@ fn push_hook_id_component(hasher: &mut sha2::Sha256, label: &str, value: &[u8]) 
 }
 
 fn hex_lower(bytes: impl AsRef<[u8]>) -> String {
-    bytes.as_ref().iter().fold(
-        String::with_capacity(bytes.as_ref().len() * 2),
-        |mut out, byte| {
-            use std::fmt::Write as _;
-            let _ = write!(out, "{byte:02x}");
-            out
-        },
-    )
+    hex::encode(bytes)
 }
 
 fn repository_commit_hook_worker_id() -> String {

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -242,11 +242,7 @@ pub fn hmac_sha256_hex(key: &[u8], message: &[u8]) -> String {
     let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(key).expect("HMAC accepts any key length");
     mac.update(message);
     let bytes = mac.finalize().into_bytes();
-    bytes.iter().fold(String::with_capacity(64), |mut acc, b| {
-        use std::fmt::Write as _;
-        let _ = write!(acc, "{b:02x}");
-        acc
-    })
+    hex::encode(bytes)
 }
 
 /// Constant-time string comparison for HMAC verification.

--- a/autumn/tests/idempotency_middleware.rs
+++ b/autumn/tests/idempotency_middleware.rs
@@ -78,14 +78,7 @@ fn principal_digest() -> String {
     let mut hasher = sha2::Sha256::new();
     hasher.update(b"authorization:");
     hasher.update(b"\nsession:");
-    hasher
-        .finalize()
-        .iter()
-        .fold(String::with_capacity(64), |mut out, byte| {
-            use std::fmt::Write as _;
-            let _ = write!(out, "{byte:02x}");
-            out
-        })
+    hex::encode(hasher.finalize())
 }
 
 fn storage_key(method: &str, path: &str, idempotency_key: &str) -> String {
@@ -108,17 +101,7 @@ fn storage_key(method: &str, path: &str, idempotency_key: &str) -> String {
     push_component(&mut storage, "scope-header-count", b"0");
     push_component(&mut storage, "principal", principal.as_bytes());
     push_component(&mut storage, "idempotency-key", idempotency_key.as_bytes());
-    format!(
-        "v2:{}",
-        storage
-            .finalize()
-            .iter()
-            .fold(String::with_capacity(64), |mut out, byte| {
-                use std::fmt::Write as _;
-                let _ = write!(out, "{byte:02x}");
-                out
-            })
-    )
+    format!("v2:{}", hex::encode(storage.finalize()))
 }
 
 /// Axum middleware that injects a 5-byte `UploadConfig` limit into extensions.


### PR DESCRIPTION
💡 What: Switched manual hex string generation in `auth.rs`, `security/config.rs`, `idempotency.rs`, and `repository_commit_hooks.rs` to use `hex::encode`.
🎯 Why: Using `fold` with `write!` allocates the string properly but processes formatting macro machinery for every single byte during hash conversions. `hex::encode` is a much faster, zero-cost abstraction for doing exactly this without the format overhead.
📊 Impact: Faster string allocation/formatting across hot paths (like idempotency hashing and token hashing), resulting in fewer CPU cycles spent on format machinery.
🔭 Measurement: Verified through `cargo test -p autumn-web --lib --release` and `cargo test -p autumn-web --test idempotency_middleware --release` that there are no regressions in idempotency or security hash checks.

---
*PR created automatically by Jules for task [6743382773471357907](https://jules.google.com/task/6743382773471357907) started by @madmax983*