### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -853,6 +853,29 @@ mod tests {
     use super::*;
     use axum::http::StatusCode;
 
+    #[test]
+    fn string_error_display() {
+        let err = StringError("test error message".to_string());
+        assert_eq!(err.to_string(), "test error message");
+    }
+
+    #[test]
+    fn autumn_error_display() {
+        let inner = StringError("inner error message".to_string());
+        let err = AutumnError::internal_server_error(inner);
+        assert_eq!(err.to_string(), "inner error message");
+    }
+
+    #[test]
+    fn autumn_error_debug() {
+        let inner = StringError("inner error message".to_string());
+        let err = AutumnError::internal_server_error(inner);
+        let debug_str = format!("{:?}", err);
+        assert!(debug_str.contains("AutumnError"));
+        assert!(debug_str.contains("status: 500"));
+        assert!(debug_str.contains("inner error message"));
+    }
+
     #[derive(Debug)]
     struct TestError(String);
 


### PR DESCRIPTION
🎯 Target: `autumn/src/error.rs` `StringError` and `AutumnError` traits `Display` and `Debug` implementations.
💣 Risk: Prevents regressions on the error string representations.
🧪 Strategy: Added explicit tests for `to_string()` and debug formatting.
🔭 Verification: `cargo test -p autumn-web --lib error::tests`

---
*PR created automatically by Jules for task [6348290483849367458](https://jules.google.com/task/6348290483849367458) started by @madmax983*