### PR TITLE
Add active search and autocomplete form widgets with htmx

### DIFF
--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -31,6 +31,22 @@ pub const HTMX_JS: &[u8] = include_bytes!("../vendor/htmx.min.js");
 /// Same-origin path where Autumn serves embedded htmx.
 pub const HTMX_JS_PATH: &str = "/static/js/htmx.min.js";
 
+/// Autumn widget runtime JavaScript, embedded at compile time.
+///
+/// Provides CSP-compatible event-listener wiring for built-in widgets
+/// (autocomplete selection, min-length enforcement). Served automatically
+/// at [`AUTUMN_WIDGETS_JS_PATH`] with immutable cache headers.
+///
+/// Reference it once in your layout template:
+///
+/// ```html
+/// <script src="/static/js/autumn-widgets.js" defer></script>
+/// ```
+pub const AUTUMN_WIDGETS_JS: &[u8] = include_bytes!("../vendor/autumn-widgets.js");
+
+/// Same-origin path where Autumn serves the widget runtime script.
+pub const AUTUMN_WIDGETS_JS_PATH: &str = "/static/js/autumn-widgets.js";
+
 /// Same-origin path where Autumn serves the htmx CSRF helper.
 ///
 /// The helper reads a CSRF token from either:

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -192,6 +192,11 @@ pub mod seed;
 pub mod task;
 pub mod telemetry;
 pub mod ui;
+/// Active search and autocomplete form primitives with htmx integration.
+///
+/// See [`widgets`] for the full API including [`widgets::active_search`],
+/// [`widgets::autocomplete_input`], and their configuration types.
+pub mod widgets;
 /// Changeset type carrying submitted values + per-field errors.
 pub use form::Changeset;
 /// Changeset form extractor — decodes body + validates, captures errors in [`form::Changeset`].

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -313,7 +313,7 @@ pub use validation::Validated;
 /// Useful for cache-busting or diagnostic logging. The corresponding
 /// minified JS is served automatically at `/static/js/htmx.min.js`.
 #[cfg(feature = "htmx")]
-pub use htmx::{HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HTMX_VERSION};
+pub use htmx::{AUTUMN_WIDGETS_JS_PATH, HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HTMX_VERSION};
 #[cfg(feature = "mail")]
 pub use mail::{
     Mail, MailConfig, MailDeliveryQueue, MailDeliveryQueueHandle, MailError, MailTransport, Mailer,

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -131,6 +131,17 @@ pub use validator::Validate;
 /// See [`crate::form`] for the full surface including Maud rendering helpers.
 pub use crate::form::{Changeset, ChangesetForm, IntoChangeset};
 
+// ── Search & autocomplete widgets ─────────────────────────────────
+/// Active search and autocomplete configuration types and rendering helpers.
+///
+/// See [`crate::widgets`] for the full API.
+#[cfg(feature = "maud")]
+pub use crate::widgets::{
+    ActiveSearchConfig, AutocompleteConfig, SearchMethod, active_search, active_search_empty_state,
+    active_search_input, active_search_results, autocomplete_empty_state, autocomplete_input,
+    autocomplete_option,
+};
+
 // ── Hooks ───────────────────────────────────────────────────────
 /// Mutation hook types for repository lifecycle callbacks.
 #[cfg(feature = "db")]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -608,6 +608,7 @@ fn reject_openapi_path_collisions(
     {
         claimed.insert(crate::htmx::HTMX_JS_PATH.to_owned());
         claimed.insert(crate::htmx::HTMX_CSRF_JS_PATH.to_owned());
+        claimed.insert(crate::htmx::AUTUMN_WIDGETS_JS_PATH.to_owned());
     }
     // Dev live-reload endpoints are only mounted when the env vars
     // that enable them are set, but reserving the paths regardless
@@ -807,6 +808,10 @@ fn mount_framework_routes(
             crate::htmx::HTMX_CSRF_JS_PATH,
             axum::routing::get(htmx_csrf_handler),
         );
+        router = router.route(
+            crate::htmx::AUTUMN_WIDGETS_JS_PATH,
+            axum::routing::get(autumn_widgets_handler),
+        );
         tracing::debug!(
             method = "GET",
             path = crate::htmx::HTMX_JS_PATH,
@@ -817,6 +822,12 @@ fn mount_framework_routes(
             method = "GET",
             path = crate::htmx::HTMX_CSRF_JS_PATH,
             name = "htmx csrf helper",
+            "Mounted route"
+        );
+        tracing::debug!(
+            method = "GET",
+            path = crate::htmx::AUTUMN_WIDGETS_JS_PATH,
+            name = "autumn widget runtime",
             "Mounted route"
         );
     }
@@ -1799,6 +1810,22 @@ pub async fn htmx_csrf_handler() -> axum::response::Response {
             ),
         ],
         crate::htmx::HTMX_CSRF_JS,
+    )
+        .into_response()
+}
+
+#[cfg(feature = "htmx")]
+pub async fn autumn_widgets_handler() -> axum::response::Response {
+    use axum::response::IntoResponse;
+    (
+        [
+            (http::header::CONTENT_TYPE, "application/javascript"),
+            (
+                http::header::CACHE_CONTROL,
+                "public, max-age=31536000, immutable",
+            ),
+        ],
+        crate::htmx::AUTUMN_WIDGETS_JS,
     )
         .into_response()
 }

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -115,7 +115,7 @@ impl<'a> ActiveSearchConfig<'a> {
     ///
     /// - `action` — URL of the search handler
     /// - `target` — CSS selector for the results container, e.g. `"#search-results"`
-    #[must_use] 
+    #[must_use]
     pub const fn new(action: &'a str, target: &'a str) -> Self {
         Self {
             action,
@@ -277,9 +277,8 @@ fn build_trigger(debounce_ms: u32, min_length: u32, initial_load: bool) -> Strin
     } else {
         String::new()
     };
-    let mut trigger = format!(
-        "input{filter} changed delay:{debounce_ms}ms, keyup[key=='Enter']{filter}"
-    );
+    let mut trigger =
+        format!("input{filter} changed delay:{debounce_ms}ms, keyup[key=='Enter']{filter}");
     // When a minimum length is configured, also fire when the value drops below
     // the threshold so stale results are cleared via the server's empty-state response.
     if min_length > 0 {
@@ -657,23 +656,37 @@ mod tests {
 
     #[test]
     fn config_debounce_builder() {
-        assert_eq!(ActiveSearchConfig::new("/s", "#r").debounce(500).debounce_ms, 500);
+        assert_eq!(
+            ActiveSearchConfig::new("/s", "#r")
+                .debounce(500)
+                .debounce_ms,
+            500
+        );
     }
 
     #[test]
     fn config_min_length_builder() {
-        assert_eq!(ActiveSearchConfig::new("/s", "#r").min_length(3).min_length, 3);
+        assert_eq!(
+            ActiveSearchConfig::new("/s", "#r").min_length(3).min_length,
+            3
+        );
     }
 
     #[test]
     fn config_initial_load_builder() {
-        assert!(ActiveSearchConfig::new("/s", "#r").initial_load().initial_load);
+        assert!(
+            ActiveSearchConfig::new("/s", "#r")
+                .initial_load()
+                .initial_load
+        );
     }
 
     #[test]
     fn config_indicator_builder() {
         assert_eq!(
-            ActiveSearchConfig::new("/s", "#r").indicator("#spin").indicator,
+            ActiveSearchConfig::new("/s", "#r")
+                .indicator("#spin")
+                .indicator,
             Some("#spin")
         );
     }
@@ -681,7 +694,9 @@ mod tests {
     #[test]
     fn config_placeholder_builder() {
         assert_eq!(
-            ActiveSearchConfig::new("/s", "#r").placeholder("hint").placeholder,
+            ActiveSearchConfig::new("/s", "#r")
+                .placeholder("hint")
+                .placeholder,
             Some("hint")
         );
     }
@@ -689,7 +704,9 @@ mod tests {
     #[test]
     fn config_param_name_builder() {
         assert_eq!(
-            ActiveSearchConfig::new("/s", "#r").param_name("query").param_name,
+            ActiveSearchConfig::new("/s", "#r")
+                .param_name("query")
+                .param_name,
             "query"
         );
     }
@@ -739,7 +756,10 @@ mod tests {
         let config = ActiveSearchConfig::new("/search", "#results").min_length(3);
         let html = active_search_input("q", "Search", &config).into_string();
         // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
-        assert!(html.contains("this.value.length") && html.contains("3"), "{html}");
+        assert!(
+            html.contains("this.value.length") && html.contains("3"),
+            "{html}"
+        );
     }
 
     #[test]
@@ -1048,7 +1068,10 @@ mod tests {
         let config = AutocompleteConfig::new("/ac", "value_field").min_length(2);
         let html = autocomplete_input("x", "Label", &config).into_string();
         // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
-        assert!(html.contains("this.value.length") && html.contains("2"), "{html}");
+        assert!(
+            html.contains("this.value.length") && html.contains("2"),
+            "{html}"
+        );
     }
 
     #[test]

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -757,7 +757,7 @@ mod tests {
         let html = active_search_input("q", "Search", &config).into_string();
         // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
         assert!(
-            html.contains("this.value.length") && html.contains("3"),
+            html.contains("this.value.length") && html.contains('3'),
             "{html}"
         );
     }
@@ -1069,7 +1069,7 @@ mod tests {
         let html = autocomplete_input("x", "Label", &config).into_string();
         // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
         assert!(
-            html.contains("this.value.length") && html.contains("2"),
+            html.contains("this.value.length") && html.contains('2'),
             "{html}"
         );
     }

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1,0 +1,1064 @@
+//! Active search and autocomplete form primitives with htmx integration.
+//!
+//! These helpers generate server-rendered HTML with embedded htmx attributes
+//! so Autumn applications can add live search and autocomplete with zero
+//! custom JavaScript.
+//!
+//! # Choosing the right primitive
+//!
+//! | Situation | Use |
+//! |-----------|-----|
+//! | Keyword search over a rendered list | [`active_search`] / [`active_search_input`] |
+//! | Select a single related record and store its ID | [`autocomplete_input`] |
+//! | Plain `GET` form is sufficient | `axum::extract::Query` |
+//! | You need unusual htmx wiring | Hand-write `hx-*` attributes |
+//!
+//! # Integration with the repository full-text search feature
+//!
+//! The widgets wire up the client side; your handler owns the Diesel query.
+//! If your repository has `#[repository(..., searchable)]`, the generated
+//! `repo.search(q)` method works directly with these widgets:
+//!
+//! ```rust,ignore
+//! use autumn_web::prelude::*;
+//! use autumn_web::widgets::{ActiveSearchConfig, active_search};
+//! use serde::Deserialize;
+//!
+//! #[derive(Deserialize)]
+//! struct SearchQuery { q: String }
+//!
+//! #[get("/posts")]
+//! async fn index() -> Markup {
+//!     let config = ActiveSearchConfig::new("/posts/search", "#post-results");
+//!     html! {
+//!         (active_search("post-search", "Search posts", &config))
+//!     }
+//! }
+//!
+//! #[get("/posts/search")]
+//! async fn search(
+//!     Query(params): Query<SearchQuery>,
+//!     repo: PgPostRepository,
+//! ) -> AutumnResult<Markup> {
+//!     if params.q.trim().is_empty() {
+//!         return Ok(active_search_empty_state("Enter a search term"));
+//!     }
+//!     let results = repo.search(&params.q).await?;
+//!     Ok(html! {
+//!         @if results.is_empty() {
+//!             (active_search_empty_state("No results found"))
+//!         } @else {
+//!             @for post in &results { li { (post.title) } }
+//!         }
+//!     })
+//! }
+//! ```
+//!
+//! # No-JavaScript fallback
+//!
+//! [`active_search`] and [`autocomplete_input`] include a `<noscript>` block
+//! with a plain HTML form or select that works without JavaScript. Your handler
+//! already returns an HTML fragment — the only addition for a full no-JS page
+//! is wrapping the response in your layout template.
+
+/// HTTP method for an [`ActiveSearchConfig`].
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum SearchMethod {
+    /// `GET` request — the default. Safe, idempotent, bookmarkable.
+    #[default]
+    Get,
+    /// `POST` request — opt-in for handlers that need a request body.
+    Post,
+}
+
+/// Configuration for an [`active_search_input`] widget.
+///
+/// Build with [`ActiveSearchConfig::new`] and chain builder methods for
+/// optional overrides.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::widgets::{ActiveSearchConfig, active_search};
+///
+/// let config = ActiveSearchConfig::new("/users/search", "#user-results")
+///     .debounce(500)
+///     .min_length(2)
+///     .placeholder("Search users…");
+///
+/// let widget = active_search("user-search", "Search users", &config);
+/// ```
+#[derive(Debug, Clone)]
+pub struct ActiveSearchConfig<'a> {
+    /// URL of the server-side search handler.
+    pub action: &'a str,
+    /// HTTP method (default: [`SearchMethod::Get`]).
+    pub method: SearchMethod,
+    /// CSS selector for the element that receives rendered results.
+    pub target: &'a str,
+    /// CSS selector for an element shown while the request is in flight.
+    pub indicator: Option<&'a str>,
+    /// Debounce delay in milliseconds (default: `300`).
+    pub debounce_ms: u32,
+    /// Minimum character count before triggering a search (default: `1`).
+    pub min_length: u32,
+    /// Query parameter name sent to the handler (default: `"q"`).
+    pub param_name: &'a str,
+    /// Whether to fire the search immediately on page load (default: `false`).
+    pub initial_load: bool,
+    /// Optional placeholder text for the search input.
+    pub placeholder: Option<&'a str>,
+}
+
+impl<'a> ActiveSearchConfig<'a> {
+    /// Create a new active search configuration with sensible defaults.
+    ///
+    /// - `action` — URL of the search handler
+    /// - `target` — CSS selector for the results container, e.g. `"#search-results"`
+    pub fn new(action: &'a str, target: &'a str) -> Self {
+        Self {
+            action,
+            method: SearchMethod::Get,
+            target,
+            indicator: None,
+            debounce_ms: 300,
+            min_length: 1,
+            param_name: "q",
+            initial_load: false,
+            placeholder: None,
+        }
+    }
+
+    /// Use `POST` instead of the default `GET` for the search request.
+    #[must_use]
+    pub fn post(mut self) -> Self {
+        self.method = SearchMethod::Post;
+        self
+    }
+
+    /// Set the debounce delay in milliseconds (default: `300`).
+    #[must_use]
+    pub fn debounce(mut self, ms: u32) -> Self {
+        self.debounce_ms = ms;
+        self
+    }
+
+    /// Set the minimum query length before a search is triggered (default: `1`).
+    #[must_use]
+    pub fn min_length(mut self, n: u32) -> Self {
+        self.min_length = n;
+        self
+    }
+
+    /// Set a CSS selector for the htmx loading indicator element.
+    #[must_use]
+    pub fn indicator(mut self, selector: &'a str) -> Self {
+        self.indicator = Some(selector);
+        self
+    }
+
+    /// Trigger a search on initial page load (useful for pre-populated results).
+    #[must_use]
+    pub fn initial_load(mut self) -> Self {
+        self.initial_load = true;
+        self
+    }
+
+    /// Set placeholder text for the search input.
+    #[must_use]
+    pub fn placeholder(mut self, text: &'a str) -> Self {
+        self.placeholder = Some(text);
+        self
+    }
+
+    /// Set a custom query parameter name (default: `"q"`).
+    #[must_use]
+    pub fn param_name(mut self, name: &'a str) -> Self {
+        self.param_name = name;
+        self
+    }
+}
+
+/// Configuration for an [`autocomplete_input`] widget.
+///
+/// Build with [`AutocompleteConfig::new`] and chain builder methods for
+/// optional overrides.
+#[derive(Debug, Clone)]
+pub struct AutocompleteConfig<'a> {
+    /// URL of the server-side autocomplete handler.
+    pub action: &'a str,
+    /// CSS selector for an element shown while the request is in flight.
+    pub indicator: Option<&'a str>,
+    /// Debounce delay in milliseconds (default: `300`).
+    pub debounce_ms: u32,
+    /// Minimum character count before triggering autocomplete (default: `1`).
+    pub min_length: u32,
+    /// Query parameter name sent to the handler (default: `"q"`).
+    pub query_param: &'a str,
+    /// `name` attribute for the visible text input showing the selected label.
+    pub display_name: &'a str,
+    /// `name` attribute for the hidden input storing the selected record ID.
+    pub value_name: &'a str,
+    /// Optional placeholder text for the visible input.
+    pub placeholder: Option<&'a str>,
+}
+
+impl<'a> AutocompleteConfig<'a> {
+    /// Create a new autocomplete configuration with sensible defaults.
+    ///
+    /// - `action` — URL of the autocomplete handler
+    /// - `display_name` — `name` attribute for the visible search/label input
+    /// - `value_name` — `name` attribute for the hidden selected-ID input
+    pub fn new(action: &'a str, display_name: &'a str, value_name: &'a str) -> Self {
+        Self {
+            action,
+            indicator: None,
+            debounce_ms: 300,
+            min_length: 1,
+            query_param: "q",
+            display_name,
+            value_name,
+            placeholder: None,
+        }
+    }
+
+    /// Set the debounce delay in milliseconds (default: `300`).
+    #[must_use]
+    pub fn debounce(mut self, ms: u32) -> Self {
+        self.debounce_ms = ms;
+        self
+    }
+
+    /// Set the minimum query length before autocomplete triggers (default: `1`).
+    #[must_use]
+    pub fn min_length(mut self, n: u32) -> Self {
+        self.min_length = n;
+        self
+    }
+
+    /// Set a CSS selector for the htmx loading indicator element.
+    #[must_use]
+    pub fn indicator(mut self, selector: &'a str) -> Self {
+        self.indicator = Some(selector);
+        self
+    }
+
+    /// Set a custom query parameter name (default: `"q"`).
+    #[must_use]
+    pub fn query_param(mut self, name: &'a str) -> Self {
+        self.query_param = name;
+        self
+    }
+
+    /// Set placeholder text for the visible input.
+    #[must_use]
+    pub fn placeholder(mut self, text: &'a str) -> Self {
+        self.placeholder = Some(text);
+        self
+    }
+}
+
+/// Build the `hx-trigger` value for active search / autocomplete inputs.
+///
+/// The canonical pattern is:
+/// `input[filter] changed delay:{n}ms, keyup[key=='Enter'][filter][, load]`
+fn build_trigger(debounce_ms: u32, min_length: u32, initial_load: bool) -> String {
+    let filter = if min_length > 0 {
+        format!("[this.value.length >= {min_length}]")
+    } else {
+        String::new()
+    };
+    let mut trigger = format!(
+        "input{filter} changed delay:{debounce_ms}ms, keyup[key=='Enter']{filter}"
+    );
+    if initial_load {
+        trigger.push_str(", load");
+    }
+    trigger
+}
+
+/// Strip a leading `#` from a CSS ID selector to get a bare element ID.
+///
+/// `aria-controls` takes an ID (no `#`), while `hx-target` takes a CSS selector.
+fn selector_to_id(selector: &str) -> &str {
+    selector.strip_prefix('#').unwrap_or(selector)
+}
+
+/// Render a labeled `<input type="search">` with htmx active-search attributes.
+///
+/// Fires debounced GET (or POST) requests as the user types and on Enter,
+/// targeting `config.target`. An accessible `<label>` and `aria-controls`
+/// pointing at the results container are included automatically.
+///
+/// Pair with [`active_search_results`] for the results container, or use
+/// [`active_search`] to emit the complete widget (input + results + noscript).
+///
+/// # htmx attributes emitted
+///
+/// | Attribute | Value |
+/// |-----------|-------|
+/// | `hx-get` / `hx-post` | `config.action` |
+/// | `hx-trigger` | `input[filter] changed delay:{n}ms, keyup[key=='Enter'][filter][, load]` |
+/// | `hx-target` | `config.target` |
+/// | `hx-indicator` | `config.indicator` (only when set) |
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn active_search_input(id: &str, label: &str, config: &ActiveSearchConfig<'_>) -> maud::Markup {
+    let trigger = build_trigger(config.debounce_ms, config.min_length, config.initial_load);
+    let aria_controls = selector_to_id(config.target);
+    let (hx_get, hx_post) = match config.method {
+        SearchMethod::Get => (Some(config.action), None::<&str>),
+        SearchMethod::Post => (None, Some(config.action)),
+    };
+
+    maud::html! {
+        div {
+            label for=(id) { (label) }
+            input
+                type="search"
+                id=(id)
+                name=(config.param_name)
+                autocomplete="off"
+                aria-label=(label)
+                aria-controls=(aria_controls)
+                placeholder=[config.placeholder]
+                hx-get=[hx_get]
+                hx-post=[hx_post]
+                hx-trigger=(trigger)
+                hx-target=(config.target)
+                hx-indicator=[config.indicator];
+        }
+    }
+}
+
+/// Render the results container element targeted by [`active_search_input`].
+///
+/// Uses `role="status"` and `aria-live="polite"` so screen readers announce
+/// result updates without moving keyboard focus.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn active_search_results(id: &str) -> maud::Markup {
+    maud::html! {
+        div
+            id=(id)
+            role="status"
+            aria-live="polite"
+            aria-atomic="true" {}
+    }
+}
+
+/// Render a complete active search widget.
+///
+/// Emits:
+/// - A labeled search input with htmx active-search attributes.
+/// - A results container (`id="{id}-results"`).
+/// - A `<noscript>` fallback form that works without JavaScript.
+///
+/// The results container id is `"{id}-results"`. Pass `"#{id}-results"` as
+/// `config.target` to connect the input to this container.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::widgets::{ActiveSearchConfig, active_search};
+///
+/// let config = ActiveSearchConfig::new("/bookmarks/search", "#bookmark-search-results")
+///     .placeholder("Search bookmarks…");
+///
+/// html! {
+///     (active_search("bookmark-search", "Search bookmarks", &config))
+/// }
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn active_search(id: &str, label: &str, config: &ActiveSearchConfig<'_>) -> maud::Markup {
+    let results_id = format!("{id}-results");
+    let noscript_method = match config.method {
+        SearchMethod::Get => "get",
+        SearchMethod::Post => "post",
+    };
+
+    maud::html! {
+        div id=(format!("{id}-wrapper")) {
+            (active_search_input(id, label, config))
+            (active_search_results(&results_id))
+            noscript {
+                form action=(config.action) method=(noscript_method) {
+                    label for=(format!("{id}-noscript")) { (label) }
+                    input
+                        type="search"
+                        id=(format!("{id}-noscript"))
+                        name=(config.param_name)
+                        placeholder=[config.placeholder];
+                    button type="submit" { "Search" }
+                }
+            }
+        }
+    }
+}
+
+/// Render an active search empty-state partial.
+///
+/// Return this from your search handler when no results match the query.
+/// The `role="status"` and `aria-live="polite"` attributes ensure screen
+/// readers announce the empty state.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn active_search_empty_state(message: &str) -> maud::Markup {
+    maud::html! {
+        div
+            role="status"
+            aria-live="polite"
+            class="search-empty" {
+            (message)
+        }
+    }
+}
+
+/// Render an autocomplete input widget.
+///
+/// Emits:
+/// - A visible `<input type="search" role="combobox">` for typing.
+/// - A hidden `<input>` for storing the selected record's ID.
+/// - A `<div role="listbox">` where the server renders option partials.
+/// - A `<noscript>` fallback `<select>`.
+///
+/// Use [`autocomplete_option`] and [`autocomplete_empty_state`] to render
+/// option partials returned by your handler.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::widgets::{AutocompleteConfig, autocomplete_input};
+///
+/// let config = AutocompleteConfig::new("/tags/autocomplete", "tag_label", "tag_id")
+///     .placeholder("Search tags…");
+///
+/// html! {
+///     (autocomplete_input("tag-picker", "Tag", &config))
+/// }
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn autocomplete_input(id: &str, label: &str, config: &AutocompleteConfig<'_>) -> maud::Markup {
+    let query_id = format!("{id}-query");
+    let value_id = format!("{id}-value");
+    let options_id = format!("{id}-options");
+    let trigger = build_trigger(config.debounce_ms, config.min_length, false);
+    let target = format!("#{options_id}");
+
+    maud::html! {
+        div id=(format!("{id}-wrapper")) {
+            label for=(query_id) { (label) }
+            input
+                type="search"
+                id=(query_id)
+                name=(config.display_name)
+                autocomplete="off"
+                role="combobox"
+                aria-expanded="false"
+                aria-autocomplete="list"
+                aria-controls=(options_id)
+                aria-label=(label)
+                placeholder=[config.placeholder]
+                hx-get=(config.action)
+                hx-trigger=(trigger)
+                hx-target=(target)
+                hx-indicator=[config.indicator];
+            input
+                type="hidden"
+                id=(value_id)
+                name=(config.value_name)
+                value="";
+            div
+                id=(options_id)
+                role="listbox"
+                aria-label=(label)
+                aria-live="polite" {}
+            noscript {
+                select name=(config.value_name) aria-label=(label) {
+                    option value="" { "— select —" }
+                }
+            }
+        }
+    }
+}
+
+/// Render a single autocomplete option partial returned by the server.
+///
+/// The `data-value` attribute carries the record ID. Wire a click handler
+/// via htmx (e.g. `hx-on:click`) or a minimal inline script to populate
+/// the hidden field and the visible label from `data-value` and the element's
+/// text content.
+///
+/// # Example response fragment
+///
+/// ```rust,ignore
+/// use autumn_web::widgets::autocomplete_option;
+///
+/// html! {
+///     @for tag in &tags {
+///         (autocomplete_option(&tag.id.to_string(), &tag.name))
+///     }
+/// }
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn autocomplete_option(value: &str, label: &str) -> maud::Markup {
+    maud::html! {
+        div
+            role="option"
+            tabindex="0"
+            data-value=(value) {
+            (label)
+        }
+    }
+}
+
+/// Render an autocomplete empty-state partial.
+///
+/// Return this from your autocomplete handler when no records match the query.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn autocomplete_empty_state(message: &str) -> maud::Markup {
+    maud::html! {
+        div
+            role="status"
+            aria-live="polite"
+            class="autocomplete-empty" {
+            (message)
+        }
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "maud"))]
+mod tests {
+    use super::*;
+
+    // ── build_trigger ──────────────────────────────────────────────────
+
+    #[test]
+    fn trigger_has_debounce_and_enter() {
+        let t = build_trigger(300, 1, false);
+        assert!(t.contains("delay:300ms"), "{t}");
+        assert!(t.contains("keyup[key=='Enter']"), "{t}");
+    }
+
+    #[test]
+    fn trigger_has_changed_modifier() {
+        let t = build_trigger(300, 0, false);
+        assert!(t.contains("changed"), "{t}");
+    }
+
+    #[test]
+    fn trigger_min_length_adds_filter() {
+        let t = build_trigger(300, 2, false);
+        // The trigger string itself uses `>=` (not HTML-encoded); encoding happens in the template
+        assert!(t.contains("[this.value.length >= 2]"), "{t}");
+    }
+
+    #[test]
+    fn trigger_min_length_zero_has_no_filter() {
+        let t = build_trigger(300, 0, false);
+        assert!(!t.contains("this.value.length"), "{t}");
+    }
+
+    #[test]
+    fn trigger_initial_load_appends_load() {
+        let t = build_trigger(300, 0, true);
+        assert!(t.contains(", load"), "{t}");
+    }
+
+    #[test]
+    fn trigger_no_initial_load_by_default() {
+        let t = build_trigger(300, 0, false);
+        assert!(!t.contains("load"), "{t}");
+    }
+
+    #[test]
+    fn trigger_custom_debounce() {
+        let t = build_trigger(750, 0, false);
+        assert!(t.contains("delay:750ms"), "{t}");
+    }
+
+    // ── selector_to_id ─────────────────────────────────────────────────
+
+    #[test]
+    fn selector_to_id_strips_hash() {
+        assert_eq!(selector_to_id("#my-results"), "my-results");
+    }
+
+    #[test]
+    fn selector_to_id_passthrough_without_hash() {
+        assert_eq!(selector_to_id("results"), "results");
+    }
+
+    // ── ActiveSearchConfig builder ─────────────────────────────────────
+
+    #[test]
+    fn config_defaults() {
+        let c = ActiveSearchConfig::new("/s", "#r");
+        assert_eq!(c.method, SearchMethod::Get);
+        assert_eq!(c.debounce_ms, 300);
+        assert_eq!(c.min_length, 1);
+        assert_eq!(c.param_name, "q");
+        assert!(!c.initial_load);
+        assert!(c.indicator.is_none());
+        assert!(c.placeholder.is_none());
+    }
+
+    #[test]
+    fn config_post_builder() {
+        assert_eq!(
+            ActiveSearchConfig::new("/s", "#r").post().method,
+            SearchMethod::Post
+        );
+    }
+
+    #[test]
+    fn config_debounce_builder() {
+        assert_eq!(ActiveSearchConfig::new("/s", "#r").debounce(500).debounce_ms, 500);
+    }
+
+    #[test]
+    fn config_min_length_builder() {
+        assert_eq!(ActiveSearchConfig::new("/s", "#r").min_length(3).min_length, 3);
+    }
+
+    #[test]
+    fn config_initial_load_builder() {
+        assert!(ActiveSearchConfig::new("/s", "#r").initial_load().initial_load);
+    }
+
+    #[test]
+    fn config_indicator_builder() {
+        assert_eq!(
+            ActiveSearchConfig::new("/s", "#r").indicator("#spin").indicator,
+            Some("#spin")
+        );
+    }
+
+    #[test]
+    fn config_placeholder_builder() {
+        assert_eq!(
+            ActiveSearchConfig::new("/s", "#r").placeholder("hint").placeholder,
+            Some("hint")
+        );
+    }
+
+    #[test]
+    fn config_param_name_builder() {
+        assert_eq!(
+            ActiveSearchConfig::new("/s", "#r").param_name("query").param_name,
+            "query"
+        );
+    }
+
+    // ── active_search_input ────────────────────────────────────────────
+
+    #[test]
+    fn input_defaults_to_hx_get() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains(r#"hx-get="/search""#), "{html}");
+        assert!(!html.contains("hx-post"), "{html}");
+    }
+
+    #[test]
+    fn input_uses_hx_post_when_configured() {
+        let config = ActiveSearchConfig::new("/search", "#results").post();
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains(r#"hx-post="/search""#), "{html}");
+        assert!(!html.contains("hx-get"), "{html}");
+    }
+
+    #[test]
+    fn input_trigger_has_default_debounce() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("delay:300ms"), "{html}");
+    }
+
+    #[test]
+    fn input_trigger_has_enter_key() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("keyup"), "{html}");
+        assert!(html.contains("Enter"), "{html}");
+    }
+
+    #[test]
+    fn input_configurable_debounce() {
+        let config = ActiveSearchConfig::new("/search", "#results").debounce(500);
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("delay:500ms"), "{html}");
+    }
+
+    #[test]
+    fn input_configurable_min_length() {
+        let config = ActiveSearchConfig::new("/search", "#results").min_length(3);
+        let html = active_search_input("q", "Search", &config).into_string();
+        // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
+        assert!(html.contains("this.value.length") && html.contains("3"), "{html}");
+    }
+
+    #[test]
+    fn input_no_filter_when_min_length_zero() {
+        let config = ActiveSearchConfig::new("/search", "#results").min_length(0);
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(!html.contains("this.value.length"), "{html}");
+    }
+
+    #[test]
+    fn input_initial_load_in_trigger() {
+        let config = ActiveSearchConfig::new("/search", "#results").initial_load();
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains(", load"), "{html}");
+    }
+
+    #[test]
+    fn input_no_initial_load_by_default() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(!html.contains(", load"), "{html}");
+    }
+
+    #[test]
+    fn input_target_selector() {
+        let config = ActiveSearchConfig::new("/search", "#my-results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("hx-target=\"#my-results\""), "{html}");
+    }
+
+    #[test]
+    fn input_indicator_when_configured() {
+        let config = ActiveSearchConfig::new("/search", "#results").indicator("#spinner");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("hx-indicator=\"#spinner\""), "{html}");
+    }
+
+    #[test]
+    fn input_no_indicator_by_default() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(!html.contains("hx-indicator"), "{html}");
+    }
+
+    #[test]
+    fn input_renders_label() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search Posts", &config).into_string();
+        assert!(html.contains("Search Posts"), "{html}");
+        assert!(html.contains("<label"), "{html}");
+    }
+
+    #[test]
+    fn input_label_for_matches_id() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("my-search", "Search", &config).into_string();
+        assert!(html.contains(r#"for="my-search""#), "{html}");
+        assert!(html.contains(r#"id="my-search""#), "{html}");
+    }
+
+    #[test]
+    fn input_has_aria_label() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Find Posts", &config).into_string();
+        assert!(html.contains(r#"aria-label="Find Posts""#), "{html}");
+    }
+
+    #[test]
+    fn input_has_aria_controls() {
+        let config = ActiveSearchConfig::new("/search", "#my-results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("aria-controls"), "{html}");
+        assert!(html.contains("my-results"), "{html}");
+    }
+
+    #[test]
+    fn input_type_is_search() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains(r#"type="search""#), "{html}");
+    }
+
+    #[test]
+    fn input_placeholder_when_configured() {
+        let config = ActiveSearchConfig::new("/search", "#results").placeholder("Type to search…");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("Type to search"), "{html}");
+    }
+
+    #[test]
+    fn input_no_placeholder_by_default() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(!html.contains("placeholder"), "{html}");
+    }
+
+    #[test]
+    fn input_custom_param_name() {
+        let config = ActiveSearchConfig::new("/search", "#results").param_name("query");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains(r#"name="query""#), "{html}");
+    }
+
+    // ── active_search_results ──────────────────────────────────────────
+
+    #[test]
+    fn results_correct_id() {
+        let html = active_search_results("my-results").into_string();
+        assert!(html.contains(r#"id="my-results""#), "{html}");
+    }
+
+    #[test]
+    fn results_role_status() {
+        let html = active_search_results("r").into_string();
+        assert!(html.contains(r#"role="status""#), "{html}");
+    }
+
+    #[test]
+    fn results_aria_live_polite() {
+        let html = active_search_results("r").into_string();
+        assert!(html.contains(r#"aria-live="polite""#), "{html}");
+    }
+
+    #[test]
+    fn results_aria_atomic() {
+        let html = active_search_results("r").into_string();
+        assert!(html.contains(r#"aria-atomic="true""#), "{html}");
+    }
+
+    // ── active_search (full widget) ────────────────────────────────────
+
+    #[test]
+    fn widget_includes_input_and_results() {
+        let config = ActiveSearchConfig::new("/search", "#s-results");
+        let html = active_search("s", "Search", &config).into_string();
+        assert!(html.contains(r#"type="search""#), "{html}");
+        assert!(html.contains(r#"id="s-results""#), "{html}");
+    }
+
+    #[test]
+    fn widget_has_noscript_fallback() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search("s", "Search", &config).into_string();
+        assert!(html.contains("<noscript>"), "{html}");
+        assert!(html.contains("<form"), "{html}");
+        assert!(html.contains(r#"type="submit""#), "{html}");
+    }
+
+    #[test]
+    fn widget_noscript_get_by_default() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search("s", "Search", &config).into_string();
+        assert!(html.contains(r#"method="get""#), "{html}");
+    }
+
+    #[test]
+    fn widget_noscript_post_when_configured() {
+        let config = ActiveSearchConfig::new("/search", "#results").post();
+        let html = active_search("s", "Search", &config).into_string();
+        assert!(html.contains(r#"method="post""#), "{html}");
+    }
+
+    // ── autocomplete_input ─────────────────────────────────────────────
+
+    #[test]
+    fn autocomplete_visible_search_input() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains(r#"type="search""#), "{html}");
+        assert!(html.contains(r#"name="label_field""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_hidden_value_field() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains(r#"type="hidden""#), "{html}");
+        assert!(html.contains(r#"name="value_field""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_hidden_field_empty_initial_value() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains(r#"type="hidden""#), "{html}");
+        assert!(html.contains(r#"value="""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_listbox_container() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains(r#"role="listbox""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_combobox_role() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains(r#"role="combobox""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_aria_expanded_false() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains(r#"aria-expanded="false""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_aria_autocomplete_list() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains(r#"aria-autocomplete="list""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_has_aria_controls() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains("aria-controls"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_renders_label() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "My Label", &config).into_string();
+        assert!(html.contains("My Label"), "{html}");
+        assert!(html.contains("<label"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_label_for_matches_query_input_id() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains(r#"for="tag-query""#), "{html}");
+        assert!(html.contains(r#"id="tag-query""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_has_noscript_fallback() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains("<noscript>"), "{html}");
+        assert!(html.contains("<select"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_noscript_select_uses_value_name() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains(r#"name="value_field""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_has_hx_get() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains(r#"hx-get="/ac""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_hx_trigger_has_debounce() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains("hx-trigger"), "{html}");
+        assert!(html.contains("delay:300ms"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_configurable_debounce() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field").debounce(600);
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains("delay:600ms"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_configurable_min_length() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field").min_length(2);
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
+        assert!(html.contains("this.value.length") && html.contains("2"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_indicator_when_configured() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field").indicator("#ld");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains("hx-indicator=\"#ld\""), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_no_indicator_by_default() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(!html.contains("hx-indicator"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_listbox_has_aria_live() {
+        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains("aria-live"), "{html}");
+    }
+
+    // ── autocomplete_option ────────────────────────────────────────────
+
+    #[test]
+    fn option_renders_label_and_value() {
+        let html = autocomplete_option("42", "My Tag").into_string();
+        assert!(html.contains("My Tag"), "{html}");
+        assert!(html.contains(r#"data-value="42""#), "{html}");
+    }
+
+    #[test]
+    fn option_has_role_option() {
+        let html = autocomplete_option("1", "Option").into_string();
+        assert!(html.contains(r#"role="option""#), "{html}");
+    }
+
+    #[test]
+    fn option_is_keyboard_focusable() {
+        let html = autocomplete_option("1", "Option").into_string();
+        assert!(html.contains("tabindex"), "{html}");
+    }
+
+    // ── autocomplete_empty_state ───────────────────────────────────────
+
+    #[test]
+    fn ac_empty_state_renders_message() {
+        let html = autocomplete_empty_state("No results found").into_string();
+        assert!(html.contains("No results found"), "{html}");
+    }
+
+    #[test]
+    fn ac_empty_state_announced_to_screen_readers() {
+        let html = autocomplete_empty_state("No results").into_string();
+        assert!(
+            html.contains(r#"role="status""#) || html.contains("aria-live"),
+            "{html}"
+        );
+    }
+
+    // ── active_search_empty_state ──────────────────────────────────────
+
+    #[test]
+    fn search_empty_state_renders_message() {
+        let html = active_search_empty_state("No matching posts").into_string();
+        assert!(html.contains("No matching posts"), "{html}");
+    }
+
+    #[test]
+    fn search_empty_state_announced_to_screen_readers() {
+        let html = active_search_empty_state("Nothing found").into_string();
+        assert!(
+            html.contains(r#"role="status""#) || html.contains("aria-live"),
+            "{html}"
+        );
+    }
+}

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -8,8 +8,8 @@
 //!
 //! | Situation | Use |
 //! |-----------|-----|
-//! | Keyword search over a rendered list | [`active_search`] / [`active_search_input`] |
-//! | Select a single related record and store its ID | [`autocomplete_input`] |
+//! | Keyword search over a rendered list | `active_search` / `active_search_input` |
+//! | Select a single related record and store its ID | `autocomplete_input` |
 //! | Plain `GET` form is sufficient | `axum::extract::Query` |
 //! | You need unusual htmx wiring | Hand-write `hx-*` attributes |
 //!
@@ -56,7 +56,7 @@
 //!
 //! # No-JavaScript fallback
 //!
-//! [`active_search`] and [`autocomplete_input`] include a `<noscript>` block
+//! `active_search` and `autocomplete_input` include a `<noscript>` block
 //! with a plain HTML form or select that works without JavaScript. Your handler
 //! already returns an HTML fragment — the only addition for a full no-JS page
 //! is wrapping the response in your layout template.
@@ -115,7 +115,8 @@ impl<'a> ActiveSearchConfig<'a> {
     ///
     /// - `action` — URL of the search handler
     /// - `target` — CSS selector for the results container, e.g. `"#search-results"`
-    pub fn new(action: &'a str, target: &'a str) -> Self {
+    #[must_use] 
+    pub const fn new(action: &'a str, target: &'a str) -> Self {
         Self {
             action,
             method: SearchMethod::Get,
@@ -131,49 +132,49 @@ impl<'a> ActiveSearchConfig<'a> {
 
     /// Use `POST` instead of the default `GET` for the search request.
     #[must_use]
-    pub fn post(mut self) -> Self {
+    pub const fn post(mut self) -> Self {
         self.method = SearchMethod::Post;
         self
     }
 
     /// Set the debounce delay in milliseconds (default: `300`).
     #[must_use]
-    pub fn debounce(mut self, ms: u32) -> Self {
+    pub const fn debounce(mut self, ms: u32) -> Self {
         self.debounce_ms = ms;
         self
     }
 
     /// Set the minimum query length before a search is triggered (default: `1`).
     #[must_use]
-    pub fn min_length(mut self, n: u32) -> Self {
+    pub const fn min_length(mut self, n: u32) -> Self {
         self.min_length = n;
         self
     }
 
     /// Set a CSS selector for the htmx loading indicator element.
     #[must_use]
-    pub fn indicator(mut self, selector: &'a str) -> Self {
+    pub const fn indicator(mut self, selector: &'a str) -> Self {
         self.indicator = Some(selector);
         self
     }
 
     /// Trigger a search on initial page load (useful for pre-populated results).
     #[must_use]
-    pub fn initial_load(mut self) -> Self {
+    pub const fn initial_load(mut self) -> Self {
         self.initial_load = true;
         self
     }
 
     /// Set placeholder text for the search input.
     #[must_use]
-    pub fn placeholder(mut self, text: &'a str) -> Self {
+    pub const fn placeholder(mut self, text: &'a str) -> Self {
         self.placeholder = Some(text);
         self
     }
 
     /// Set a custom query parameter name (default: `"q"`).
     #[must_use]
-    pub fn param_name(mut self, name: &'a str) -> Self {
+    pub const fn param_name(mut self, name: &'a str) -> Self {
         self.param_name = name;
         self
     }
@@ -193,67 +194,75 @@ pub struct AutocompleteConfig<'a> {
     pub debounce_ms: u32,
     /// Minimum character count before triggering autocomplete (default: `1`).
     pub min_length: u32,
-    /// Query parameter name sent to the handler (default: `"q"`).
+    /// Query parameter name sent to the handler and used as the visible input's
+    /// `name` (default: `"q"`).
     pub query_param: &'a str,
-    /// `name` attribute for the visible text input showing the selected label.
-    pub display_name: &'a str,
     /// `name` attribute for the hidden input storing the selected record ID.
     pub value_name: &'a str,
     /// Optional placeholder text for the visible input.
     pub placeholder: Option<&'a str>,
+    /// Static `(value, label)` pairs for the `<noscript>` `<select>` fallback.
+    pub fallback_options: Option<&'a [(&'a str, &'a str)]>,
 }
 
 impl<'a> AutocompleteConfig<'a> {
     /// Create a new autocomplete configuration with sensible defaults.
     ///
     /// - `action` — URL of the autocomplete handler
-    /// - `display_name` — `name` attribute for the visible search/label input
     /// - `value_name` — `name` attribute for the hidden selected-ID input
-    pub fn new(action: &'a str, display_name: &'a str, value_name: &'a str) -> Self {
+    #[must_use]
+    pub const fn new(action: &'a str, value_name: &'a str) -> Self {
         Self {
             action,
             indicator: None,
             debounce_ms: 300,
             min_length: 1,
             query_param: "q",
-            display_name,
             value_name,
             placeholder: None,
+            fallback_options: None,
         }
     }
 
     /// Set the debounce delay in milliseconds (default: `300`).
     #[must_use]
-    pub fn debounce(mut self, ms: u32) -> Self {
+    pub const fn debounce(mut self, ms: u32) -> Self {
         self.debounce_ms = ms;
         self
     }
 
     /// Set the minimum query length before autocomplete triggers (default: `1`).
     #[must_use]
-    pub fn min_length(mut self, n: u32) -> Self {
+    pub const fn min_length(mut self, n: u32) -> Self {
         self.min_length = n;
         self
     }
 
     /// Set a CSS selector for the htmx loading indicator element.
     #[must_use]
-    pub fn indicator(mut self, selector: &'a str) -> Self {
+    pub const fn indicator(mut self, selector: &'a str) -> Self {
         self.indicator = Some(selector);
         self
     }
 
     /// Set a custom query parameter name (default: `"q"`).
     #[must_use]
-    pub fn query_param(mut self, name: &'a str) -> Self {
+    pub const fn query_param(mut self, name: &'a str) -> Self {
         self.query_param = name;
         self
     }
 
     /// Set placeholder text for the visible input.
     #[must_use]
-    pub fn placeholder(mut self, text: &'a str) -> Self {
+    pub const fn placeholder(mut self, text: &'a str) -> Self {
         self.placeholder = Some(text);
+        self
+    }
+
+    /// Set static `(value, label)` pairs for the no-JavaScript `<select>` fallback.
+    #[must_use]
+    pub const fn fallback_options(mut self, options: &'a [(&'a str, &'a str)]) -> Self {
+        self.fallback_options = Some(options);
         self
     }
 }
@@ -271,6 +280,12 @@ fn build_trigger(debounce_ms: u32, min_length: u32, initial_load: bool) -> Strin
     let mut trigger = format!(
         "input{filter} changed delay:{debounce_ms}ms, keyup[key=='Enter']{filter}"
     );
+    // When a minimum length is configured, also fire when the value drops below
+    // the threshold so stale results are cleared via the server's empty-state response.
+    if min_length > 0 {
+        use std::fmt::Write as _;
+        let _ = write!(trigger, ", input[this.value.length < {min_length}] changed");
+    }
     if initial_load {
         trigger.push_str(", load");
     }
@@ -319,7 +334,6 @@ pub fn active_search_input(id: &str, label: &str, config: &ActiveSearchConfig<'_
                 id=(id)
                 name=(config.param_name)
                 autocomplete="off"
-                aria-label=(label)
                 aria-controls=(aria_controls)
                 placeholder=[config.placeholder]
                 hx-get=[hx_get]
@@ -372,7 +386,9 @@ pub fn active_search_results(id: &str) -> maud::Markup {
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn active_search(id: &str, label: &str, config: &ActiveSearchConfig<'_>) -> maud::Markup {
-    let results_id = format!("{id}-results");
+    // Derive the results container ID from the configured target selector so the
+    // rendered container always matches what the input's hx-target points at.
+    let results_id = selector_to_id(config.target).to_string();
     let noscript_method = match config.method {
         SearchMethod::Get => "get",
         SearchMethod::Post => "post",
@@ -446,6 +462,11 @@ pub fn autocomplete_input(id: &str, label: &str, config: &AutocompleteConfig<'_>
     let options_id = format!("{id}-options");
     let trigger = build_trigger(config.debounce_ms, config.min_length, false);
     let target = format!("#{options_id}");
+    // Populate the visible input and the hidden value field when a user clicks
+    // an autocomplete option. Uses event delegation on the listbox container.
+    let hx_on_click = format!(
+        "let o=event.target.closest('[role=option]');if(o){{document.getElementById('{query_id}').value=o.textContent.trim();document.getElementById('{value_id}').value=o.getAttribute('data-value');this.innerHTML='';}}"
+    );
 
     maud::html! {
         div id=(format!("{id}-wrapper")) {
@@ -453,13 +474,12 @@ pub fn autocomplete_input(id: &str, label: &str, config: &AutocompleteConfig<'_>
             input
                 type="search"
                 id=(query_id)
-                name=(config.display_name)
+                name=(config.query_param)
                 autocomplete="off"
                 role="combobox"
                 aria-expanded="false"
                 aria-autocomplete="list"
                 aria-controls=(options_id)
-                aria-label=(label)
                 placeholder=[config.placeholder]
                 hx-get=(config.action)
                 hx-trigger=(trigger)
@@ -474,10 +494,16 @@ pub fn autocomplete_input(id: &str, label: &str, config: &AutocompleteConfig<'_>
                 id=(options_id)
                 role="listbox"
                 aria-label=(label)
-                aria-live="polite" {}
+                aria-live="polite"
+                "hx-on:click"=(hx_on_click) {}
             noscript {
                 select name=(config.value_name) aria-label=(label) {
                     option value="" { "— select —" }
+                    @if let Some(opts) = config.fallback_options {
+                        @for (val, lbl) in opts {
+                            option value=(val) { (lbl) }
+                        }
+                    }
                 }
             }
         }
@@ -560,9 +586,21 @@ mod tests {
     }
 
     #[test]
+    fn trigger_min_length_adds_clear_below_threshold() {
+        let t = build_trigger(300, 2, false);
+        assert!(t.contains("[this.value.length < 2]"), "{t}");
+    }
+
+    #[test]
     fn trigger_min_length_zero_has_no_filter() {
         let t = build_trigger(300, 0, false);
         assert!(!t.contains("this.value.length"), "{t}");
+    }
+
+    #[test]
+    fn trigger_min_length_zero_has_no_clear_trigger() {
+        let t = build_trigger(300, 0, false);
+        assert!(!t.contains("this.value.length <"), "{t}");
     }
 
     #[test]
@@ -763,13 +801,6 @@ mod tests {
     }
 
     #[test]
-    fn input_has_aria_label() {
-        let config = ActiveSearchConfig::new("/search", "#results");
-        let html = active_search_input("q", "Find Posts", &config).into_string();
-        assert!(html.contains(r#"aria-label="Find Posts""#), "{html}");
-    }
-
-    #[test]
     fn input_has_aria_controls() {
         let config = ActiveSearchConfig::new("/search", "#my-results");
         let html = active_search_input("q", "Search", &config).into_string();
@@ -842,6 +873,14 @@ mod tests {
     }
 
     #[test]
+    fn widget_results_id_matches_target_selector() {
+        // Callers pass any target; the generated container must match.
+        let config = ActiveSearchConfig::new("/search", "#custom-results");
+        let html = active_search("search-widget", "Search", &config).into_string();
+        assert!(html.contains(r#"id="custom-results""#), "{html}");
+    }
+
+    #[test]
     fn widget_has_noscript_fallback() {
         let config = ActiveSearchConfig::new("/search", "#results");
         let html = active_search("s", "Search", &config).into_string();
@@ -868,15 +907,23 @@ mod tests {
 
     #[test]
     fn autocomplete_visible_search_input() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains(r#"type="search""#), "{html}");
-        assert!(html.contains(r#"name="label_field""#), "{html}");
+        // visible input uses query_param (default "q") so htmx sends ?q=...
+        assert!(html.contains(r#"name="q""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_visible_input_uses_query_param() {
+        let config = AutocompleteConfig::new("/ac", "value_field").query_param("search");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains(r#"name="search""#), "{html}");
     }
 
     #[test]
     fn autocomplete_hidden_value_field() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains(r#"type="hidden""#), "{html}");
         assert!(html.contains(r#"name="value_field""#), "{html}");
@@ -884,7 +931,7 @@ mod tests {
 
     #[test]
     fn autocomplete_hidden_field_empty_initial_value() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains(r#"type="hidden""#), "{html}");
         assert!(html.contains(r#"value="""#), "{html}");
@@ -892,42 +939,49 @@ mod tests {
 
     #[test]
     fn autocomplete_listbox_container() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains(r#"role="listbox""#), "{html}");
     }
 
     #[test]
+    fn autocomplete_listbox_has_click_handler() {
+        let config = AutocompleteConfig::new("/ac", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains("hx-on:click"), "{html}");
+    }
+
+    #[test]
     fn autocomplete_combobox_role() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains(r#"role="combobox""#), "{html}");
     }
 
     #[test]
     fn autocomplete_aria_expanded_false() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains(r#"aria-expanded="false""#), "{html}");
     }
 
     #[test]
     fn autocomplete_aria_autocomplete_list() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains(r#"aria-autocomplete="list""#), "{html}");
     }
 
     #[test]
     fn autocomplete_has_aria_controls() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains("aria-controls"), "{html}");
     }
 
     #[test]
     fn autocomplete_renders_label() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "My Label", &config).into_string();
         assert!(html.contains("My Label"), "{html}");
         assert!(html.contains("<label"), "{html}");
@@ -935,7 +989,7 @@ mod tests {
 
     #[test]
     fn autocomplete_label_for_matches_query_input_id() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains(r#"for="tag-query""#), "{html}");
         assert!(html.contains(r#"id="tag-query""#), "{html}");
@@ -943,7 +997,7 @@ mod tests {
 
     #[test]
     fn autocomplete_has_noscript_fallback() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains("<noscript>"), "{html}");
         assert!(html.contains("<select"), "{html}");
@@ -951,21 +1005,32 @@ mod tests {
 
     #[test]
     fn autocomplete_noscript_select_uses_value_name() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains(r#"name="value_field""#), "{html}");
     }
 
     #[test]
+    fn autocomplete_fallback_options_rendered_in_noscript() {
+        let opts: &[(&str, &str)] = &[("1", "Alpha"), ("2", "Beta")];
+        let config = AutocompleteConfig::new("/ac", "value_field").fallback_options(opts);
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains("Alpha"), "{html}");
+        assert!(html.contains("Beta"), "{html}");
+        assert!(html.contains(r#"value="1""#), "{html}");
+        assert!(html.contains(r#"value="2""#), "{html}");
+    }
+
+    #[test]
     fn autocomplete_has_hx_get() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains(r#"hx-get="/ac""#), "{html}");
     }
 
     #[test]
     fn autocomplete_hx_trigger_has_debounce() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains("hx-trigger"), "{html}");
         assert!(html.contains("delay:300ms"), "{html}");
@@ -973,14 +1038,14 @@ mod tests {
 
     #[test]
     fn autocomplete_configurable_debounce() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field").debounce(600);
+        let config = AutocompleteConfig::new("/ac", "value_field").debounce(600);
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains("delay:600ms"), "{html}");
     }
 
     #[test]
     fn autocomplete_configurable_min_length() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field").min_length(2);
+        let config = AutocompleteConfig::new("/ac", "value_field").min_length(2);
         let html = autocomplete_input("x", "Label", &config).into_string();
         // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
         assert!(html.contains("this.value.length") && html.contains("2"), "{html}");
@@ -988,21 +1053,21 @@ mod tests {
 
     #[test]
     fn autocomplete_indicator_when_configured() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field").indicator("#ld");
+        let config = AutocompleteConfig::new("/ac", "value_field").indicator("#ld");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains("hx-indicator=\"#ld\""), "{html}");
     }
 
     #[test]
     fn autocomplete_no_indicator_by_default() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(!html.contains("hx-indicator"), "{html}");
     }
 
     #[test]
     fn autocomplete_listbox_has_aria_live() {
-        let config = AutocompleteConfig::new("/ac", "label_field", "value_field");
+        let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains("aria-live"), "{html}");
     }

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -203,6 +203,14 @@ pub struct AutocompleteConfig<'a> {
     pub placeholder: Option<&'a str>,
     /// Static `(value, label)` pairs for the `<noscript>` `<select>` fallback.
     pub fallback_options: Option<&'a [(&'a str, &'a str)]>,
+    /// When `true`, the hidden field is kept in sync with whatever the user
+    /// types, so submitting without picking an option sends the typed text.
+    ///
+    /// Use this for tag-style fields where the submitted value is the text
+    /// itself (e.g. `name="tag"` with `autocomplete_option(tag, tag)`). Leave
+    /// `false` (the default) for ID-based lookups where the hidden field should
+    /// only carry a value selected from the option list.
+    pub free_text: bool,
 }
 
 impl<'a> AutocompleteConfig<'a> {
@@ -221,6 +229,7 @@ impl<'a> AutocompleteConfig<'a> {
             value_name,
             placeholder: None,
             fallback_options: None,
+            free_text: false,
         }
     }
 
@@ -263,6 +272,19 @@ impl<'a> AutocompleteConfig<'a> {
     #[must_use]
     pub const fn fallback_options(mut self, options: &'a [(&'a str, &'a str)]) -> Self {
         self.fallback_options = Some(options);
+        self
+    }
+
+    /// Enable free-text mode: the hidden field is kept in sync with whatever
+    /// the user types, so submitting without choosing an option sends the typed
+    /// text as the field value.
+    ///
+    /// Use for tag-style fields (`name="tag"`) where creating new values by
+    /// typing is allowed. Leave disabled (the default) for ID-based foreign-key
+    /// lookups where only values from the option list are valid.
+    #[must_use]
+    pub const fn free_text(mut self) -> Self {
+        self.free_text = true;
         self
     }
 }
@@ -324,6 +346,7 @@ pub fn active_search_input(id: &str, label: &str, config: &ActiveSearchConfig<'_
                 autocomplete="off"
                 aria-controls=(aria_controls)
                 placeholder=[config.placeholder]
+                data-ac-min-length=(config.min_length)
                 hx-get=[hx_get]
                 hx-post=[hx_post]
                 hx-trigger=(trigger)
@@ -353,11 +376,14 @@ pub fn active_search_results(id: &str) -> maud::Markup {
 ///
 /// Emits:
 /// - A labeled search input with htmx active-search attributes.
-/// - A results container (`id="{id}-results"`).
+/// - A results container whose `id` is derived from `config.target`.
 /// - A `<noscript>` fallback form that works without JavaScript.
 ///
-/// The results container id is `"{id}-results"`. Pass `"#{id}-results"` as
-/// `config.target` to connect the input to this container.
+/// **`config.target` must be a `#id` selector** (e.g. `"#bookmark-search-results"`).
+/// This function derives the results container `id` by stripping the leading `#`, so
+/// class selectors (`.foo`) or other forms produce an invalid HTML `id` attribute.
+/// Use [`active_search_input`] + [`active_search_results`] directly if you need a
+/// non-id htmx target.
 ///
 /// # Example
 ///
@@ -374,6 +400,12 @@ pub fn active_search_results(id: &str) -> maud::Markup {
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn active_search(id: &str, label: &str, config: &ActiveSearchConfig<'_>) -> maud::Markup {
+    debug_assert!(
+        config.target.starts_with('#'),
+        "active_search: config.target must be a #id selector (e.g. \"#my-results\"), got {:?}. \
+         Use active_search_input + active_search_results directly for other selectors.",
+        config.target
+    );
     // Derive the results container ID from the configured target selector so the
     // rendered container always matches what the input's hx-target points at.
     let results_id = selector_to_id(config.target).to_string();
@@ -450,28 +482,25 @@ pub fn autocomplete_input(id: &str, label: &str, config: &AutocompleteConfig<'_>
     let options_id = format!("{id}-options");
     let trigger = build_trigger(config.debounce_ms, false);
     let target = format!("#{options_id}");
-    let vn = config.value_name;
-    // Populate the visible input and the hidden value field when a user clicks
-    // an autocomplete option. Uses event delegation on the listbox container.
-    // v.name is set here so the hidden input gains a name only via JS — preventing
-    // the duplicate-field problem when JavaScript is disabled (the <noscript><select>
-    // already carries the name).
-    let hx_on_click = format!(
-        "let o=event.target.closest('[role=option]');if(o){{let v=document.getElementById('{value_id}');v.name='{vn}';v.value=o.getAttribute('data-value');document.getElementById('{query_id}').value=o.textContent.trim();this.innerHTML='';}}"
-    );
-    // Same selection logic for keyboard users: Enter or Space activates the focused option.
-    let hx_on_keydown = format!(
-        "let o=event.target.closest('[role=option]');if(o&&(event.key==='Enter'||event.key===' ')){{event.preventDefault();let v=document.getElementById('{value_id}');v.name='{vn}';v.value=o.getAttribute('data-value');document.getElementById('{query_id}').value=o.textContent.trim();this.innerHTML='';}}"
-    );
-    // Keep the hidden field in sync with the typed text so users can submit a value
-    // they typed directly (without picking from the list). v.name is also set here so
-    // the hidden input has no name attribute in HTML and only participates in JS-mode
-    // form submission.
-    let on_input_handler =
-        format!("let v=document.getElementById('{value_id}');v.name='{vn}';v.value=this.value");
+
+    // Interaction wiring is handled by the external autumn-widgets.js script
+    // (served at /static/js/autumn-widgets.js) via data-* attributes:
+    //
+    //  data-ac-value-id   — id of the hidden input that receives the selected value
+    //  data-ac-value-name — form field name assigned to the hidden input by JS
+    //  data-ac-free-text  — present when free-text typing is allowed (see free_text())
+    //  data-ac-query      — marks the visible search input
+    //  data-ac-min-length — minimum characters before htmx fires a request
+    //
+    // The hidden input has no name attribute in HTML so no-JS form submission
+    // only sees the <noscript><select>, avoiding a duplicate-field conflict.
 
     maud::html! {
-        div id=(format!("{id}-wrapper")) {
+        div
+            id=(format!("{id}-wrapper"))
+            data-ac-value-id=(value_id)
+            data-ac-value-name=(config.value_name)
+            data-ac-free-text[config.free_text] {
             label for=(query_id) { (label) }
             input
                 type="search"
@@ -483,7 +512,8 @@ pub fn autocomplete_input(id: &str, label: &str, config: &AutocompleteConfig<'_>
                 aria-autocomplete="list"
                 aria-controls=(options_id)
                 placeholder=[config.placeholder]
-                "hx-on:input"=(on_input_handler)
+                data-ac-query
+                data-ac-min-length=(config.min_length)
                 hx-get=(config.action)
                 hx-trigger=(trigger)
                 hx-target=(target)
@@ -496,9 +526,7 @@ pub fn autocomplete_input(id: &str, label: &str, config: &AutocompleteConfig<'_>
                 id=(options_id)
                 role="listbox"
                 aria-label=(label)
-                aria-live="polite"
-                "hx-on:click"=(hx_on_click)
-                "hx-on:keydown"=(hx_on_keydown) {}
+                aria-live="polite" {}
             noscript {
                 select name=(config.value_name) aria-label=(label) {
                     option value="" { "— select —" }
@@ -515,10 +543,9 @@ pub fn autocomplete_input(id: &str, label: &str, config: &AutocompleteConfig<'_>
 
 /// Render a single autocomplete option partial returned by the server.
 ///
-/// The `data-value` attribute carries the record ID. Wire a click handler
-/// via htmx (e.g. `hx-on:click`) or a minimal inline script to populate
-/// the hidden field and the visible label from `data-value` and the element's
-/// text content.
+/// The `data-value` attribute carries the record ID (or the value to submit).
+/// The `autumn-widgets.js` runtime listens for click and keyboard events on the
+/// listbox container and uses `data-value` to populate the hidden field.
 ///
 /// # Example response fragment
 ///
@@ -944,10 +971,31 @@ mod tests {
     }
 
     #[test]
-    fn autocomplete_listbox_has_click_handler() {
+    fn autocomplete_wrapper_has_data_attributes_for_runtime() {
         let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
-        assert!(html.contains("hx-on:click"), "{html}");
+        // The external autumn-widgets.js reads these to wire up interactions.
+        assert!(html.contains(r#"data-ac-value-id="x-value""#), "{html}");
+        assert!(
+            html.contains(r#"data-ac-value-name="value_field""#),
+            "{html}"
+        );
+        assert!(html.contains("data-ac-query"), "{html}");
+        assert!(html.contains("data-ac-min-length"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_free_text_mode_sets_data_attribute() {
+        let config = AutocompleteConfig::new("/ac", "value_field").free_text();
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains("data-ac-free-text"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_id_mode_no_free_text_attribute() {
+        let config = AutocompleteConfig::new("/ac", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(!html.contains("data-ac-free-text"), "{html}");
     }
 
     #[test]
@@ -1046,8 +1094,9 @@ mod tests {
     fn autocomplete_configurable_min_length() {
         let config = AutocompleteConfig::new("/ac", "value_field").min_length(2);
         let html = autocomplete_input("x", "Label", &config).into_string();
-        // min_length is enforced server-side; no filter expression in the trigger
-        assert!(html.contains("hx-trigger"), "{html}");
+        // min_length is carried as a data attribute for the autumn-widgets.js runtime
+        // to enforce client-side (via htmx:configRequest) and server-side.
+        assert!(html.contains(r#"data-ac-min-length="2""#), "{html}");
         assert!(!html.contains("this.value.length"), "{html}");
     }
 
@@ -1073,18 +1122,14 @@ mod tests {
     }
 
     #[test]
-    fn autocomplete_listbox_has_keyboard_handler() {
+    fn autocomplete_listbox_has_no_inline_handlers() {
+        // All interaction is wired by autumn-widgets.js, not inline hx-on:* attributes.
         let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
-        assert!(html.contains("hx-on:keydown"), "{html}");
-        assert!(html.contains("Enter"), "{html}");
-    }
-
-    #[test]
-    fn autocomplete_visible_input_syncs_hidden_on_input() {
-        let config = AutocompleteConfig::new("/ac", "value_field");
-        let html = autocomplete_input("x", "Label", &config).into_string();
-        assert!(html.contains("hx-on:input"), "{html}");
+        assert!(!html.contains("hx-on:keydown"), "{html}");
+        assert!(!html.contains("hx-on:click"), "{html}");
+        assert!(!html.contains("hx-on:input"), "{html}");
+        assert!(!html.contains("oninput"), "{html}");
     }
 
     // ── autocomplete_option ────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -269,22 +269,11 @@ impl<'a> AutocompleteConfig<'a> {
 
 /// Build the `hx-trigger` value for active search / autocomplete inputs.
 ///
-/// The canonical pattern is:
-/// `input[filter] changed delay:{n}ms, keyup[key=='Enter'][filter][, load]`
-fn build_trigger(debounce_ms: u32, min_length: u32, initial_load: bool) -> String {
-    let filter = if min_length > 0 {
-        format!("[this.value.length >= {min_length}]")
-    } else {
-        String::new()
-    };
-    let mut trigger =
-        format!("input{filter} changed delay:{debounce_ms}ms, keyup[key=='Enter']{filter}");
-    // When a minimum length is configured, also fire when the value drops below
-    // the threshold so stale results are cleared via the server's empty-state response.
-    if min_length > 0 {
-        use std::fmt::Write as _;
-        let _ = write!(trigger, ", input[this.value.length < {min_length}] changed");
-    }
+/// The canonical form is `input changed delay:{n}ms[, load]`.
+/// No filter expressions are emitted; `min_length` is enforced server-side so
+/// the trigger works under Autumn's default `script-src 'self'` CSP (no `unsafe-eval`).
+fn build_trigger(debounce_ms: u32, initial_load: bool) -> String {
+    let mut trigger = format!("input changed delay:{debounce_ms}ms");
     if initial_load {
         trigger.push_str(", load");
     }
@@ -312,13 +301,13 @@ fn selector_to_id(selector: &str) -> &str {
 /// | Attribute | Value |
 /// |-----------|-------|
 /// | `hx-get` / `hx-post` | `config.action` |
-/// | `hx-trigger` | `input[filter] changed delay:{n}ms, keyup[key=='Enter'][filter][, load]` |
+/// | `hx-trigger` | `input changed delay:{n}ms[, load]` |
 /// | `hx-target` | `config.target` |
 /// | `hx-indicator` | `config.indicator` (only when set) |
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn active_search_input(id: &str, label: &str, config: &ActiveSearchConfig<'_>) -> maud::Markup {
-    let trigger = build_trigger(config.debounce_ms, config.min_length, config.initial_load);
+    let trigger = build_trigger(config.debounce_ms, config.initial_load);
     let aria_controls = selector_to_id(config.target);
     let (hx_get, hx_post) = match config.method {
         SearchMethod::Get => (Some(config.action), None::<&str>),
@@ -446,7 +435,7 @@ pub fn active_search_empty_state(message: &str) -> maud::Markup {
 /// ```rust,ignore
 /// use autumn_web::widgets::{AutocompleteConfig, autocomplete_input};
 ///
-/// let config = AutocompleteConfig::new("/tags/autocomplete", "tag_label", "tag_id")
+/// let config = AutocompleteConfig::new("/tags/autocomplete", "tag_id")
 ///     .placeholder("Search tags…");
 ///
 /// html! {
@@ -459,20 +448,27 @@ pub fn autocomplete_input(id: &str, label: &str, config: &AutocompleteConfig<'_>
     let query_id = format!("{id}-query");
     let value_id = format!("{id}-value");
     let options_id = format!("{id}-options");
-    let trigger = build_trigger(config.debounce_ms, config.min_length, false);
+    let trigger = build_trigger(config.debounce_ms, false);
     let target = format!("#{options_id}");
+    let vn = config.value_name;
     // Populate the visible input and the hidden value field when a user clicks
     // an autocomplete option. Uses event delegation on the listbox container.
+    // v.name is set here so the hidden input gains a name only via JS — preventing
+    // the duplicate-field problem when JavaScript is disabled (the <noscript><select>
+    // already carries the name).
     let hx_on_click = format!(
-        "let o=event.target.closest('[role=option]');if(o){{document.getElementById('{query_id}').value=o.textContent.trim();document.getElementById('{value_id}').value=o.getAttribute('data-value');this.innerHTML='';}}"
+        "let o=event.target.closest('[role=option]');if(o){{let v=document.getElementById('{value_id}');v.name='{vn}';v.value=o.getAttribute('data-value');document.getElementById('{query_id}').value=o.textContent.trim();this.innerHTML='';}}"
     );
     // Same selection logic for keyboard users: Enter or Space activates the focused option.
     let hx_on_keydown = format!(
-        "let o=event.target.closest('[role=option]');if(o&&(event.key==='Enter'||event.key===' ')){{event.preventDefault();document.getElementById('{query_id}').value=o.textContent.trim();document.getElementById('{value_id}').value=o.getAttribute('data-value');this.innerHTML='';}}"
+        "let o=event.target.closest('[role=option]');if(o&&(event.key==='Enter'||event.key===' ')){{event.preventDefault();let v=document.getElementById('{value_id}');v.name='{vn}';v.value=o.getAttribute('data-value');document.getElementById('{query_id}').value=o.textContent.trim();this.innerHTML='';}}"
     );
-    // Clear the hidden value whenever the user edits the visible field so a stale
-    // selection is not submitted if they change their mind without picking again.
-    let on_input_clear = format!("document.getElementById('{value_id}').value=''");
+    // Keep the hidden field in sync with the typed text so users can submit a value
+    // they typed directly (without picking from the list). v.name is also set here so
+    // the hidden input has no name attribute in HTML and only participates in JS-mode
+    // form submission.
+    let on_input_handler =
+        format!("let v=document.getElementById('{value_id}');v.name='{vn}';v.value=this.value");
 
     maud::html! {
         div id=(format!("{id}-wrapper")) {
@@ -487,7 +483,7 @@ pub fn autocomplete_input(id: &str, label: &str, config: &AutocompleteConfig<'_>
                 aria-autocomplete="list"
                 aria-controls=(options_id)
                 placeholder=[config.placeholder]
-                oninput=(on_input_clear)
+                "hx-on:input"=(on_input_handler)
                 hx-get=(config.action)
                 hx-trigger=(trigger)
                 hx-target=(target)
@@ -495,7 +491,6 @@ pub fn autocomplete_input(id: &str, label: &str, config: &AutocompleteConfig<'_>
             input
                 type="hidden"
                 id=(value_id)
-                name=(config.value_name)
                 value="";
             div
                 id=(options_id)
@@ -574,58 +569,41 @@ mod tests {
     // ── build_trigger ──────────────────────────────────────────────────
 
     #[test]
-    fn trigger_has_debounce_and_enter() {
-        let t = build_trigger(300, 1, false);
+    fn trigger_has_debounce() {
+        let t = build_trigger(300, false);
         assert!(t.contains("delay:300ms"), "{t}");
-        assert!(t.contains("keyup[key=='Enter']"), "{t}");
     }
 
     #[test]
     fn trigger_has_changed_modifier() {
-        let t = build_trigger(300, 0, false);
+        let t = build_trigger(300, false);
         assert!(t.contains("changed"), "{t}");
     }
 
     #[test]
-    fn trigger_min_length_adds_filter() {
-        let t = build_trigger(300, 2, false);
-        // The trigger string itself uses `>=` (not HTML-encoded); encoding happens in the template
-        assert!(t.contains("[this.value.length >= 2]"), "{t}");
-    }
-
-    #[test]
-    fn trigger_min_length_adds_clear_below_threshold() {
-        let t = build_trigger(300, 2, false);
-        assert!(t.contains("[this.value.length < 2]"), "{t}");
-    }
-
-    #[test]
-    fn trigger_min_length_zero_has_no_filter() {
-        let t = build_trigger(300, 0, false);
+    fn trigger_has_no_filter_expressions() {
+        // No [condition] filters are emitted — min_length is server-side only.
+        // This ensures the trigger works under Autumn's default CSP (no unsafe-eval).
+        let t = build_trigger(300, false);
         assert!(!t.contains("this.value.length"), "{t}");
-    }
-
-    #[test]
-    fn trigger_min_length_zero_has_no_clear_trigger() {
-        let t = build_trigger(300, 0, false);
-        assert!(!t.contains("this.value.length <"), "{t}");
+        assert!(!t.contains('['), "{t}");
     }
 
     #[test]
     fn trigger_initial_load_appends_load() {
-        let t = build_trigger(300, 0, true);
+        let t = build_trigger(300, true);
         assert!(t.contains(", load"), "{t}");
     }
 
     #[test]
     fn trigger_no_initial_load_by_default() {
-        let t = build_trigger(300, 0, false);
+        let t = build_trigger(300, false);
         assert!(!t.contains("load"), "{t}");
     }
 
     #[test]
     fn trigger_custom_debounce() {
-        let t = build_trigger(750, 0, false);
+        let t = build_trigger(750, false);
         assert!(t.contains("delay:750ms"), "{t}");
     }
 
@@ -746,14 +724,6 @@ mod tests {
     }
 
     #[test]
-    fn input_trigger_has_enter_key() {
-        let config = ActiveSearchConfig::new("/search", "#results");
-        let html = active_search_input("q", "Search", &config).into_string();
-        assert!(html.contains("keyup"), "{html}");
-        assert!(html.contains("Enter"), "{html}");
-    }
-
-    #[test]
     fn input_configurable_debounce() {
         let config = ActiveSearchConfig::new("/search", "#results").debounce(500);
         let html = active_search_input("q", "Search", &config).into_string();
@@ -764,11 +734,9 @@ mod tests {
     fn input_configurable_min_length() {
         let config = ActiveSearchConfig::new("/search", "#results").min_length(3);
         let html = active_search_input("q", "Search", &config).into_string();
-        // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
-        assert!(
-            html.contains("this.value.length") && html.contains('3'),
-            "{html}"
-        );
+        // min_length is enforced server-side; no filter expression in the trigger
+        assert!(html.contains("hx-trigger"), "{html}");
+        assert!(!html.contains("this.value.length"), "{html}");
     }
 
     #[test]
@@ -955,7 +923,9 @@ mod tests {
         let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains(r#"type="hidden""#), "{html}");
-        assert!(html.contains(r#"name="value_field""#), "{html}");
+        // The hidden input has no name in HTML; name is set by JS on first interaction
+        // so no-JS forms don't see a duplicate field alongside the noscript <select>.
+        assert!(html.contains(r#"id="x-value""#), "{html}");
     }
 
     #[test]
@@ -1076,11 +1046,9 @@ mod tests {
     fn autocomplete_configurable_min_length() {
         let config = AutocompleteConfig::new("/ac", "value_field").min_length(2);
         let html = autocomplete_input("x", "Label", &config).into_string();
-        // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
-        assert!(
-            html.contains("this.value.length") && html.contains('2'),
-            "{html}"
-        );
+        // min_length is enforced server-side; no filter expression in the trigger
+        assert!(html.contains("hx-trigger"), "{html}");
+        assert!(!html.contains("this.value.length"), "{html}");
     }
 
     #[test]
@@ -1113,10 +1081,10 @@ mod tests {
     }
 
     #[test]
-    fn autocomplete_visible_input_clears_hidden_on_change() {
+    fn autocomplete_visible_input_syncs_hidden_on_input() {
         let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
-        assert!(html.contains("oninput"), "{html}");
+        assert!(html.contains("hx-on:input"), "{html}");
     }
 
     // ── autocomplete_option ────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -466,6 +466,13 @@ pub fn autocomplete_input(id: &str, label: &str, config: &AutocompleteConfig<'_>
     let hx_on_click = format!(
         "let o=event.target.closest('[role=option]');if(o){{document.getElementById('{query_id}').value=o.textContent.trim();document.getElementById('{value_id}').value=o.getAttribute('data-value');this.innerHTML='';}}"
     );
+    // Same selection logic for keyboard users: Enter or Space activates the focused option.
+    let hx_on_keydown = format!(
+        "let o=event.target.closest('[role=option]');if(o&&(event.key==='Enter'||event.key===' ')){{event.preventDefault();document.getElementById('{query_id}').value=o.textContent.trim();document.getElementById('{value_id}').value=o.getAttribute('data-value');this.innerHTML='';}}"
+    );
+    // Clear the hidden value whenever the user edits the visible field so a stale
+    // selection is not submitted if they change their mind without picking again.
+    let on_input_clear = format!("document.getElementById('{value_id}').value=''");
 
     maud::html! {
         div id=(format!("{id}-wrapper")) {
@@ -480,6 +487,7 @@ pub fn autocomplete_input(id: &str, label: &str, config: &AutocompleteConfig<'_>
                 aria-autocomplete="list"
                 aria-controls=(options_id)
                 placeholder=[config.placeholder]
+                oninput=(on_input_clear)
                 hx-get=(config.action)
                 hx-trigger=(trigger)
                 hx-target=(target)
@@ -494,7 +502,8 @@ pub fn autocomplete_input(id: &str, label: &str, config: &AutocompleteConfig<'_>
                 role="listbox"
                 aria-label=(label)
                 aria-live="polite"
-                "hx-on:click"=(hx_on_click) {}
+                "hx-on:click"=(hx_on_click)
+                "hx-on:keydown"=(hx_on_keydown) {}
             noscript {
                 select name=(config.value_name) aria-label=(label) {
                     option value="" { "— select —" }
@@ -1093,6 +1102,21 @@ mod tests {
         let config = AutocompleteConfig::new("/ac", "value_field");
         let html = autocomplete_input("x", "Label", &config).into_string();
         assert!(html.contains("aria-live"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_listbox_has_keyboard_handler() {
+        let config = AutocompleteConfig::new("/ac", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains("hx-on:keydown"), "{html}");
+        assert!(html.contains("Enter"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_visible_input_clears_hidden_on_change() {
+        let config = AutocompleteConfig::new("/ac", "value_field");
+        let html = autocomplete_input("x", "Label", &config).into_string();
+        assert!(html.contains("oninput"), "{html}");
     }
 
     // ── autocomplete_option ────────────────────────────────────────────

--- a/autumn/tests/form_search_widgets.rs
+++ b/autumn/tests/form_search_widgets.rs
@@ -81,7 +81,7 @@ mod active_search_tests {
         let html = active_search_input("q", "Search", &config).into_string();
         // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
         assert!(
-            html.contains("this.value.length") && html.contains("3"),
+            html.contains("this.value.length") && html.contains('3'),
             "{html}"
         );
     }
@@ -385,7 +385,7 @@ mod active_search_tests {
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
         assert!(
-            html.contains("this.value.length") && html.contains("2"),
+            html.contains("this.value.length") && html.contains('2'),
             "{html}"
         );
     }

--- a/autumn/tests/form_search_widgets.rs
+++ b/autumn/tests/form_search_widgets.rs
@@ -1,0 +1,474 @@
+//! Tests for active search and autocomplete form primitives (issue #768).
+//!
+//! Run with `cargo test --test form_search_widgets`.
+
+#![allow(clippy::must_use_candidate)]
+
+#[cfg(feature = "maud")]
+mod active_search_tests {
+    use autumn_web::widgets::{
+        ActiveSearchConfig, AutocompleteConfig, SearchMethod, active_search, active_search_empty_state,
+        active_search_input, active_search_results, autocomplete_empty_state, autocomplete_input,
+        autocomplete_option,
+    };
+
+    // ── active_search_input: HTTP method ──────────────────────────────
+
+    #[test]
+    fn active_search_defaults_to_get() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains(r#"hx-get="/search""#), "{html}");
+        assert!(!html.contains("hx-post"), "{html}");
+    }
+
+    #[test]
+    fn active_search_post_opt_in() {
+        let config = ActiveSearchConfig::new("/search", "#results").post();
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains(r#"hx-post="/search""#), "{html}");
+        assert!(!html.contains("hx-get"), "{html}");
+    }
+
+    #[test]
+    fn active_search_method_enum_default_is_get() {
+        assert_eq!(SearchMethod::default(), SearchMethod::Get);
+    }
+
+    // ── active_search_input: htmx trigger ────────────────────────────
+
+    #[test]
+    fn active_search_emits_hx_trigger() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("hx-trigger"), "{html}");
+    }
+
+    #[test]
+    fn active_search_trigger_has_input_changed_modifier() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("input"), "{html}");
+        assert!(html.contains("changed"), "{html}");
+    }
+
+    #[test]
+    fn active_search_default_debounce_is_300ms() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("delay:300ms"), "{html}");
+    }
+
+    #[test]
+    fn active_search_trigger_includes_enter_key() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("keyup"), "{html}");
+        assert!(html.contains("Enter"), "{html}");
+    }
+
+    #[test]
+    fn active_search_configurable_debounce() {
+        let config = ActiveSearchConfig::new("/search", "#results").debounce(500);
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("delay:500ms"), "{html}");
+        assert!(!html.contains("delay:300ms"), "{html}");
+    }
+
+    #[test]
+    fn active_search_configurable_min_length() {
+        let config = ActiveSearchConfig::new("/search", "#results").min_length(3);
+        let html = active_search_input("q", "Search", &config).into_string();
+        // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
+        assert!(html.contains("this.value.length") && html.contains("3"), "{html}");
+    }
+
+    #[test]
+    fn active_search_no_min_length_filter_when_zero() {
+        let config = ActiveSearchConfig::new("/search", "#results").min_length(0);
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(!html.contains("this.value.length"), "{html}");
+    }
+
+    #[test]
+    fn active_search_initial_load_in_trigger() {
+        let config = ActiveSearchConfig::new("/search", "#results").initial_load();
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains(", load"), "{html}");
+    }
+
+    #[test]
+    fn active_search_no_initial_load_by_default() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        // trigger should not contain ", load"
+        assert!(!html.contains(", load"), "{html}");
+    }
+
+    // ── active_search_input: target & indicator ───────────────────────
+
+    #[test]
+    fn active_search_target_selector() {
+        let config = ActiveSearchConfig::new("/search", "#my-results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("hx-target=\"#my-results\""), "{html}");
+    }
+
+    #[test]
+    fn active_search_indicator_when_configured() {
+        let config = ActiveSearchConfig::new("/search", "#results").indicator("#spinner");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("hx-indicator=\"#spinner\""), "{html}");
+    }
+
+    #[test]
+    fn active_search_no_indicator_by_default() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(!html.contains("hx-indicator"), "{html}");
+    }
+
+    // ── active_search_input: accessibility ───────────────────────────
+
+    #[test]
+    fn active_search_renders_label() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search Posts", &config).into_string();
+        assert!(html.contains("Search Posts"), "{html}");
+        assert!(html.contains("<label"), "{html}");
+    }
+
+    #[test]
+    fn active_search_label_for_matches_input_id() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("my-search", "Search", &config).into_string();
+        assert!(html.contains(r#"for="my-search""#), "{html}");
+        assert!(html.contains(r#"id="my-search""#), "{html}");
+    }
+
+    #[test]
+    fn active_search_has_aria_label() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Find Posts", &config).into_string();
+        assert!(html.contains(r#"aria-label="Find Posts""#), "{html}");
+    }
+
+    #[test]
+    fn active_search_has_aria_controls_pointing_at_results() {
+        let config = ActiveSearchConfig::new("/search", "#my-results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("aria-controls"), "{html}");
+        // aria-controls takes bare ID (no #)
+        assert!(html.contains("my-results"), "{html}");
+    }
+
+    #[test]
+    fn active_search_type_is_search() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains(r#"type="search""#), "{html}");
+    }
+
+    // ── active_search_input: misc ─────────────────────────────────────
+
+    #[test]
+    fn active_search_placeholder_when_configured() {
+        let config = ActiveSearchConfig::new("/search", "#results").placeholder("Type to search…");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains("Type to search"), "{html}");
+    }
+
+    #[test]
+    fn active_search_no_placeholder_by_default() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(!html.contains("placeholder"), "{html}");
+    }
+
+    #[test]
+    fn active_search_custom_param_name() {
+        let config = ActiveSearchConfig::new("/search", "#results").param_name("query");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains(r#"name="query""#), "{html}");
+    }
+
+    #[test]
+    fn active_search_default_param_name_is_q() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search_input("q", "Search", &config).into_string();
+        assert!(html.contains(r#"name="q""#), "{html}");
+    }
+
+    // ── active_search_results ─────────────────────────────────────────
+
+    #[test]
+    fn active_search_results_correct_id() {
+        let html = active_search_results("my-results").into_string();
+        assert!(html.contains(r#"id="my-results""#), "{html}");
+    }
+
+    #[test]
+    fn active_search_results_has_role_status() {
+        let html = active_search_results("r").into_string();
+        assert!(html.contains(r#"role="status""#), "{html}");
+    }
+
+    #[test]
+    fn active_search_results_has_aria_live_polite() {
+        let html = active_search_results("r").into_string();
+        assert!(html.contains(r#"aria-live="polite""#), "{html}");
+    }
+
+    #[test]
+    fn active_search_results_has_aria_atomic() {
+        let html = active_search_results("r").into_string();
+        assert!(html.contains(r#"aria-atomic="true""#), "{html}");
+    }
+
+    // ── active_search (full widget) ───────────────────────────────────
+
+    #[test]
+    fn active_search_widget_includes_input_and_results() {
+        let config = ActiveSearchConfig::new("/search", "#s-results");
+        let html = active_search("s", "Search", &config).into_string();
+        assert!(html.contains(r#"type="search""#), "{html}");
+        assert!(html.contains(r#"id="s-results""#), "{html}");
+    }
+
+    #[test]
+    fn active_search_widget_noscript_fallback_present() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search("s", "Search", &config).into_string();
+        assert!(html.contains("<noscript>"), "{html}");
+        assert!(html.contains("<form"), "{html}");
+        assert!(html.contains(r#"type="submit""#), "{html}");
+    }
+
+    #[test]
+    fn active_search_noscript_fallback_get_default() {
+        let config = ActiveSearchConfig::new("/search", "#results");
+        let html = active_search("s", "Search", &config).into_string();
+        assert!(html.contains(r#"method="get""#), "{html}");
+    }
+
+    #[test]
+    fn active_search_noscript_fallback_post_when_configured() {
+        let config = ActiveSearchConfig::new("/search", "#results").post();
+        let html = active_search("s", "Search", &config).into_string();
+        assert!(html.contains(r#"method="post""#), "{html}");
+    }
+
+    #[test]
+    fn active_search_noscript_form_action_matches_handler() {
+        let config = ActiveSearchConfig::new("/users/search", "#results");
+        let html = active_search("s", "Search", &config).into_string();
+        assert!(html.contains(r#"action="/users/search""#), "{html}");
+    }
+
+    // ── autocomplete_input ────────────────────────────────────────────
+
+    #[test]
+    fn autocomplete_has_visible_search_input() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains(r#"type="search""#), "{html}");
+        assert!(html.contains(r#"name="tag_label""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_has_hidden_value_field() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains(r#"type="hidden""#), "{html}");
+        assert!(html.contains(r#"name="tag_id""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_hidden_field_initial_value_is_empty() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        // Hidden field should be present with empty initial value
+        assert!(html.contains(r#"type="hidden""#), "{html}");
+        assert!(html.contains(r#"name="tag_id""#), "{html}");
+        assert!(html.contains(r#"value="""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_has_listbox_container() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains(r#"role="listbox""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_visible_input_has_combobox_role() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains(r#"role="combobox""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_aria_expanded_false_initially() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains(r#"aria-expanded="false""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_aria_autocomplete_attribute() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains(r#"aria-autocomplete="list""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_has_aria_controls() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains("aria-controls"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_renders_label() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag Name", &config).into_string();
+        assert!(html.contains("Tag Name"), "{html}");
+        assert!(html.contains("<label"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_label_for_matches_visible_input_id() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains(r#"for="tag-query""#), "{html}");
+        assert!(html.contains(r#"id="tag-query""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_has_noscript_fallback() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains("<noscript>"), "{html}");
+        assert!(html.contains("<select"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_noscript_select_has_value_name() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        // The noscript select should use the value field name
+        assert!(html.contains(r#"name="tag_id""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_has_htmx_get_on_visible_input() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains(r#"hx-get="/autocomplete""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_has_hx_trigger_with_debounce() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains("hx-trigger"), "{html}");
+        assert!(html.contains("delay:300ms"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_configurable_debounce() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id").debounce(600);
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains("delay:600ms"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_configurable_min_length() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id").min_length(2);
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
+        assert!(html.contains("this.value.length") && html.contains("2"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_indicator_when_configured() {
+        let config =
+            AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id").indicator("#loader");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains("hx-indicator=\"#loader\""), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_no_indicator_by_default() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(!html.contains("hx-indicator"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_listbox_has_aria_live() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains("aria-live"), "{html}");
+    }
+
+    // ── autocomplete_option ───────────────────────────────────────────
+
+    #[test]
+    fn autocomplete_option_renders_label() {
+        let html = autocomplete_option("42", "My Tag").into_string();
+        assert!(html.contains("My Tag"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_option_has_data_value() {
+        let html = autocomplete_option("42", "My Tag").into_string();
+        assert!(html.contains(r#"data-value="42""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_option_has_role_option() {
+        let html = autocomplete_option("1", "Option").into_string();
+        assert!(html.contains(r#"role="option""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_option_is_keyboard_focusable() {
+        let html = autocomplete_option("1", "Option").into_string();
+        assert!(html.contains("tabindex"), "{html}");
+    }
+
+    // ── autocomplete_empty_state ──────────────────────────────────────
+
+    #[test]
+    fn autocomplete_empty_state_renders_message() {
+        let html = autocomplete_empty_state("No results found").into_string();
+        assert!(html.contains("No results found"), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_empty_state_is_announced_to_screen_readers() {
+        let html = autocomplete_empty_state("No results").into_string();
+        assert!(
+            html.contains(r#"role="status""#) || html.contains("aria-live"),
+            "{html}"
+        );
+    }
+
+    // ── active_search_empty_state ─────────────────────────────────────
+
+    #[test]
+    fn search_empty_state_renders_message() {
+        let html = active_search_empty_state("No matching posts").into_string();
+        assert!(html.contains("No matching posts"), "{html}");
+    }
+
+    #[test]
+    fn search_empty_state_is_announced_to_screen_readers() {
+        let html = active_search_empty_state("Nothing found").into_string();
+        assert!(
+            html.contains(r#"role="status""#) || html.contains("aria-live"),
+            "{html}"
+        );
+    }
+}

--- a/autumn/tests/form_search_widgets.rs
+++ b/autumn/tests/form_search_widgets.rs
@@ -267,9 +267,19 @@ mod active_search_tests {
         let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains(r#"type="hidden""#), "{html}");
-        // The hidden input has no name in HTML; name is set by JS on first interaction
-        // to prevent duplicate-field submission when JavaScript is disabled.
+        // Hidden input has no name attribute in HTML; autumn-widgets.js sets
+        // it on first interaction to prevent duplicate submission in no-JS mode.
         assert!(html.contains(r#"id="tag-value""#), "{html}");
+    }
+
+    #[test]
+    fn autocomplete_wrapper_data_attributes_for_runtime() {
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
+        let html = autocomplete_input("tag", "Tag", &config).into_string();
+        assert!(html.contains(r#"data-ac-value-id="tag-value""#), "{html}");
+        assert!(html.contains(r#"data-ac-value-name="tag_id""#), "{html}");
+        assert!(html.contains("data-ac-query"), "{html}");
+        assert!(html.contains("data-ac-min-length"), "{html}");
     }
 
     #[test]

--- a/autumn/tests/form_search_widgets.rs
+++ b/autumn/tests/form_search_widgets.rs
@@ -7,9 +7,9 @@
 #[cfg(feature = "maud")]
 mod active_search_tests {
     use autumn_web::widgets::{
-        ActiveSearchConfig, AutocompleteConfig, SearchMethod, active_search, active_search_empty_state,
-        active_search_input, active_search_results, autocomplete_empty_state, autocomplete_input,
-        autocomplete_option,
+        ActiveSearchConfig, AutocompleteConfig, SearchMethod, active_search,
+        active_search_empty_state, active_search_input, active_search_results,
+        autocomplete_empty_state, autocomplete_input, autocomplete_option,
     };
 
     // ── active_search_input: HTTP method ──────────────────────────────
@@ -80,7 +80,10 @@ mod active_search_tests {
         let config = ActiveSearchConfig::new("/search", "#results").min_length(3);
         let html = active_search_input("q", "Search", &config).into_string();
         // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
-        assert!(html.contains("this.value.length") && html.contains("3"), "{html}");
+        assert!(
+            html.contains("this.value.length") && html.contains("3"),
+            "{html}"
+        );
     }
 
     #[test]
@@ -381,13 +384,15 @@ mod active_search_tests {
         let config = AutocompleteConfig::new("/autocomplete", "tag_id").min_length(2);
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
-        assert!(html.contains("this.value.length") && html.contains("2"), "{html}");
+        assert!(
+            html.contains("this.value.length") && html.contains("2"),
+            "{html}"
+        );
     }
 
     #[test]
     fn autocomplete_indicator_when_configured() {
-        let config =
-            AutocompleteConfig::new("/autocomplete", "tag_id").indicator("#loader");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id").indicator("#loader");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains("hx-indicator=\"#loader\""), "{html}");
     }

--- a/autumn/tests/form_search_widgets.rs
+++ b/autumn/tests/form_search_widgets.rs
@@ -60,14 +60,6 @@ mod active_search_tests {
     }
 
     #[test]
-    fn active_search_trigger_includes_enter_key() {
-        let config = ActiveSearchConfig::new("/search", "#results");
-        let html = active_search_input("q", "Search", &config).into_string();
-        assert!(html.contains("keyup"), "{html}");
-        assert!(html.contains("Enter"), "{html}");
-    }
-
-    #[test]
     fn active_search_configurable_debounce() {
         let config = ActiveSearchConfig::new("/search", "#results").debounce(500);
         let html = active_search_input("q", "Search", &config).into_string();
@@ -79,11 +71,9 @@ mod active_search_tests {
     fn active_search_configurable_min_length() {
         let config = ActiveSearchConfig::new("/search", "#results").min_length(3);
         let html = active_search_input("q", "Search", &config).into_string();
-        // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
-        assert!(
-            html.contains("this.value.length") && html.contains('3'),
-            "{html}"
-        );
+        // min_length is enforced server-side; no filter expression in the trigger
+        assert!(html.contains("hx-trigger"), "{html}");
+        assert!(!html.contains("this.value.length"), "{html}");
     }
 
     #[test]
@@ -277,16 +267,16 @@ mod active_search_tests {
         let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains(r#"type="hidden""#), "{html}");
-        assert!(html.contains(r#"name="tag_id""#), "{html}");
+        // The hidden input has no name in HTML; name is set by JS on first interaction
+        // to prevent duplicate-field submission when JavaScript is disabled.
+        assert!(html.contains(r#"id="tag-value""#), "{html}");
     }
 
     #[test]
     fn autocomplete_hidden_field_initial_value_is_empty() {
         let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
-        // Hidden field should be present with empty initial value
         assert!(html.contains(r#"type="hidden""#), "{html}");
-        assert!(html.contains(r#"name="tag_id""#), "{html}");
         assert!(html.contains(r#"value="""#), "{html}");
     }
 
@@ -383,11 +373,9 @@ mod active_search_tests {
     fn autocomplete_configurable_min_length() {
         let config = AutocompleteConfig::new("/autocomplete", "tag_id").min_length(2);
         let html = autocomplete_input("tag", "Tag", &config).into_string();
-        // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
-        assert!(
-            html.contains("this.value.length") && html.contains('2'),
-            "{html}"
-        );
+        // min_length is enforced server-side; no filter expression in the trigger
+        assert!(html.contains("hx-trigger"), "{html}");
+        assert!(!html.contains("this.value.length"), "{html}");
     }
 
     #[test]

--- a/autumn/tests/form_search_widgets.rs
+++ b/autumn/tests/form_search_widgets.rs
@@ -147,13 +147,6 @@ mod active_search_tests {
     }
 
     #[test]
-    fn active_search_has_aria_label() {
-        let config = ActiveSearchConfig::new("/search", "#results");
-        let html = active_search_input("q", "Find Posts", &config).into_string();
-        assert!(html.contains(r#"aria-label="Find Posts""#), "{html}");
-    }
-
-    #[test]
     fn active_search_has_aria_controls_pointing_at_results() {
         let config = ActiveSearchConfig::new("/search", "#my-results");
         let html = active_search_input("q", "Search", &config).into_string();
@@ -269,15 +262,16 @@ mod active_search_tests {
 
     #[test]
     fn autocomplete_has_visible_search_input() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains(r#"type="search""#), "{html}");
-        assert!(html.contains(r#"name="tag_label""#), "{html}");
+        // visible input uses query_param (default "q") so htmx sends ?q=...
+        assert!(html.contains(r#"name="q""#), "{html}");
     }
 
     #[test]
     fn autocomplete_has_hidden_value_field() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains(r#"type="hidden""#), "{html}");
         assert!(html.contains(r#"name="tag_id""#), "{html}");
@@ -285,7 +279,7 @@ mod active_search_tests {
 
     #[test]
     fn autocomplete_hidden_field_initial_value_is_empty() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         // Hidden field should be present with empty initial value
         assert!(html.contains(r#"type="hidden""#), "{html}");
@@ -295,42 +289,42 @@ mod active_search_tests {
 
     #[test]
     fn autocomplete_has_listbox_container() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains(r#"role="listbox""#), "{html}");
     }
 
     #[test]
     fn autocomplete_visible_input_has_combobox_role() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains(r#"role="combobox""#), "{html}");
     }
 
     #[test]
     fn autocomplete_aria_expanded_false_initially() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains(r#"aria-expanded="false""#), "{html}");
     }
 
     #[test]
     fn autocomplete_aria_autocomplete_attribute() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains(r#"aria-autocomplete="list""#), "{html}");
     }
 
     #[test]
     fn autocomplete_has_aria_controls() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains("aria-controls"), "{html}");
     }
 
     #[test]
     fn autocomplete_renders_label() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag Name", &config).into_string();
         assert!(html.contains("Tag Name"), "{html}");
         assert!(html.contains("<label"), "{html}");
@@ -338,7 +332,7 @@ mod active_search_tests {
 
     #[test]
     fn autocomplete_label_for_matches_visible_input_id() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains(r#"for="tag-query""#), "{html}");
         assert!(html.contains(r#"id="tag-query""#), "{html}");
@@ -346,7 +340,7 @@ mod active_search_tests {
 
     #[test]
     fn autocomplete_has_noscript_fallback() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains("<noscript>"), "{html}");
         assert!(html.contains("<select"), "{html}");
@@ -354,7 +348,7 @@ mod active_search_tests {
 
     #[test]
     fn autocomplete_noscript_select_has_value_name() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         // The noscript select should use the value field name
         assert!(html.contains(r#"name="tag_id""#), "{html}");
@@ -362,14 +356,14 @@ mod active_search_tests {
 
     #[test]
     fn autocomplete_has_htmx_get_on_visible_input() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains(r#"hx-get="/autocomplete""#), "{html}");
     }
 
     #[test]
     fn autocomplete_has_hx_trigger_with_debounce() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains("hx-trigger"), "{html}");
         assert!(html.contains("delay:300ms"), "{html}");
@@ -377,14 +371,14 @@ mod active_search_tests {
 
     #[test]
     fn autocomplete_configurable_debounce() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id").debounce(600);
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id").debounce(600);
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains("delay:600ms"), "{html}");
     }
 
     #[test]
     fn autocomplete_configurable_min_length() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id").min_length(2);
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id").min_length(2);
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         // Maud HTML-encodes `>=` as `&gt;=`; the browser decodes it before htmx sees it
         assert!(html.contains("this.value.length") && html.contains("2"), "{html}");
@@ -393,21 +387,21 @@ mod active_search_tests {
     #[test]
     fn autocomplete_indicator_when_configured() {
         let config =
-            AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id").indicator("#loader");
+            AutocompleteConfig::new("/autocomplete", "tag_id").indicator("#loader");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains("hx-indicator=\"#loader\""), "{html}");
     }
 
     #[test]
     fn autocomplete_no_indicator_by_default() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(!html.contains("hx-indicator"), "{html}");
     }
 
     #[test]
     fn autocomplete_listbox_has_aria_live() {
-        let config = AutocompleteConfig::new("/autocomplete", "tag_label", "tag_id");
+        let config = AutocompleteConfig::new("/autocomplete", "tag_id");
         let html = autocomplete_input("tag", "Tag", &config).into_string();
         assert!(html.contains("aria-live"), "{html}");
     }

--- a/autumn/vendor/autumn-widgets.js
+++ b/autumn/vendor/autumn-widgets.js
@@ -13,6 +13,8 @@
   // Cancel htmx requests from active-search or autocomplete inputs when the
   // typed value is non-empty but shorter than data-ac-min-length.
   // Empty inputs are NOT cancelled so the server can clear stale results.
+  // When a below-minimum request is cancelled, also clear the results container
+  // so results from a previous valid query don't remain visible.
   document.addEventListener('htmx:configRequest', function (e) {
     var elt = e.detail && e.detail.elt;
     if (!elt || !elt.dataset) return;
@@ -20,6 +22,13 @@
     var len = (elt.value || '').length;
     if (minLen > 0 && len > 0 && len < minLen) {
       e.preventDefault();
+      // Clear the htmx target so stale results from a previous valid query
+      // don't remain visible while the input is below the minimum length.
+      var targetSel = elt.getAttribute('hx-target');
+      if (targetSel) {
+        var target = document.querySelector(targetSel);
+        if (target) target.innerHTML = '';
+      }
     }
   });
 
@@ -37,6 +46,13 @@
     if (!queryInput || !valueId || !valueName || !listbox) return;
 
     function getHidden() { return document.getElementById(valueId); }
+
+    // Free-text mode: assign the name immediately so the field is always
+    // included in form submission even if the user never types in the input.
+    // This preserves any default value set on the hidden input in the HTML.
+    if (freeText) {
+      getHidden().name = valueName;
+    }
 
     function selectOption(opt) {
       var hidden = getHidden();
@@ -91,9 +107,14 @@
   }
 
   // Re-initialize after htmx swaps in new autocomplete widgets.
+  // Also check the swapped-in target itself in case it IS the wrapper
+  // (e.g. hx-swap="outerHTML" on the wrapper element).
   document.addEventListener('htmx:afterSwap', function (e) {
-    if (e.detail && e.detail.target) {
-      e.detail.target.querySelectorAll('[data-ac-value-id]').forEach(initAutocomplete);
+    if (!e.detail || !e.detail.target) return;
+    var t = e.detail.target;
+    if (t.dataset && t.dataset.acValueId) {
+      initAutocomplete(t);
     }
+    t.querySelectorAll('[data-ac-value-id]').forEach(initAutocomplete);
   });
 })();

--- a/autumn/vendor/autumn-widgets.js
+++ b/autumn/vendor/autumn-widgets.js
@@ -1,0 +1,99 @@
+// Autumn widget runtime — ships as a same-origin static asset so it works
+// under the default `script-src 'self'` Content Security Policy.
+// Include once in your layout:
+//   <script src="/static/js/autumn-widgets.js" defer></script>
+(function () {
+  'use strict';
+
+  // Guard: only initialize once even when the script tag appears multiple times.
+  if (window.__autumnWidgets) return;
+  window.__autumnWidgets = true;
+
+  // ── Min-length enforcement ────────────────────────────────────────────────
+  // Cancel htmx requests from active-search or autocomplete inputs when the
+  // typed value is non-empty but shorter than data-ac-min-length.
+  // Empty inputs are NOT cancelled so the server can clear stale results.
+  document.addEventListener('htmx:configRequest', function (e) {
+    var elt = e.detail && e.detail.elt;
+    if (!elt || !elt.dataset) return;
+    var minLen = parseInt(elt.dataset.acMinLength || '0', 10);
+    var len = (elt.value || '').length;
+    if (minLen > 0 && len > 0 && len < minLen) {
+      e.preventDefault();
+    }
+  });
+
+  // ── Autocomplete widget ───────────────────────────────────────────────────
+
+  function initAutocomplete(wrapper) {
+    if (wrapper.dataset.acInit) return;
+    wrapper.dataset.acInit = '1';
+
+    var queryInput = wrapper.querySelector('[data-ac-query]');
+    var valueId = wrapper.dataset.acValueId;
+    var valueName = wrapper.dataset.acValueName;
+    var freeText = 'acFreeText' in wrapper.dataset;
+    var listbox = wrapper.querySelector('[role="listbox"]');
+    if (!queryInput || !valueId || !valueName || !listbox) return;
+
+    function getHidden() { return document.getElementById(valueId); }
+
+    function selectOption(opt) {
+      var hidden = getHidden();
+      hidden.name = valueName;
+      hidden.value = opt.dataset.value || '';
+      queryInput.value = opt.textContent.trim();
+      listbox.innerHTML = '';
+    }
+
+    listbox.addEventListener('click', function (e) {
+      var opt = e.target.closest('[role="option"]');
+      if (opt) selectOption(opt);
+    });
+
+    listbox.addEventListener('keydown', function (e) {
+      var opt = e.target.closest('[role="option"]');
+      if (!opt || (e.key !== 'Enter' && e.key !== ' ')) return;
+      e.preventDefault();
+      selectOption(opt);
+    });
+
+    queryInput.addEventListener('input', function () {
+      var hidden = getHidden();
+      var minLen = parseInt(queryInput.dataset.acMinLength || '0', 10);
+      if (freeText) {
+        // Free-text mode: keep the hidden field in sync with the typed query.
+        // Use this for tag-style fields where the submitted value is the text itself.
+        hidden.name = valueName;
+        hidden.value = queryInput.value;
+      } else {
+        // ID mode (default): a stale selection is invalid once the user edits
+        // the query. The hidden field gains its name only when an option is
+        // selected so no-JS forms are not broken by a phantom empty field.
+        hidden.name = '';
+        hidden.value = '';
+      }
+      // Clear stale options when the query drops below the minimum length.
+      if (minLen > 0 && queryInput.value.length < minLen) {
+        listbox.innerHTML = '';
+      }
+    });
+  }
+
+  function initAll() {
+    document.querySelectorAll('[data-ac-value-id]').forEach(initAutocomplete);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAll);
+  } else {
+    initAll();
+  }
+
+  // Re-initialize after htmx swaps in new autocomplete widgets.
+  document.addEventListener('htmx:afterSwap', function (e) {
+    if (e.detail && e.detail.target) {
+      e.detail.target.querySelectorAll('[data-ac-value-id]').forEach(initAutocomplete);
+    }
+  });
+})();

--- a/docs/guide/active-search-and-autocomplete.md
+++ b/docs/guide/active-search-and-autocomplete.md
@@ -1,0 +1,290 @@
+# Active Search & Autocomplete
+
+Autumn provides first-class helpers for two common query-driven UI patterns:
+**active search** (results appear as the user types) and
+**autocomplete/lookup** (pick a related record and store its ID).
+Both are built on htmx and server-rendered Maud fragments — no client-side
+libraries required.
+
+## When to use what
+
+| Situation | Recommended approach |
+|-----------|---------------------|
+| Keyword search over a list, rendered server-side | `active_search` / `active_search_input` |
+| Select a single related record, store its ID | `autocomplete_input` |
+| Simple filter that works fine as a plain `GET` form | `axum::extract::Query` |
+| The htmx wiring needs unusual attributes | Hand-write `hx-*` attributes |
+| Full-text ranking, stemming, or GIN index search | [`Repository#search`](./full-text-search.md) paired with `active_search_input` |
+
+Out of scope: search indexing, ranking, stemming, typo tolerance, vector
+search, infinite scrolling, client-side autocomplete, or command palettes.
+
+---
+
+## Active search
+
+### Page template
+
+```rust
+use autumn_web::prelude::*;
+use autumn_web::widgets::{ActiveSearchConfig, active_search};
+
+#[get("/posts")]
+async fn index() -> Markup {
+    let config = ActiveSearchConfig::new("/posts/search", "#post-results")
+        .placeholder("Search posts…")
+        .debounce(400)       // ms before request fires (default: 300)
+        .min_length(2);      // minimum characters (default: 1)
+
+    html! {
+        (active_search("post-search", "Search posts", &config))
+        // ^ emits input + results container + noscript fallback
+    }
+}
+```
+
+`active_search` emits:
+- A `<div id="post-search-wrapper">` containing:
+  - A `<label>` + `<input type="search">` with htmx attributes
+  - A `<div id="post-search-results" role="status" aria-live="polite">` results container
+  - A `<noscript>` fallback `<form method="get">` for non-JavaScript browsers
+
+### htmx attributes emitted
+
+The search input receives:
+
+```html
+<input
+  type="search"
+  id="post-search"
+  name="q"
+  autocomplete="off"
+  aria-label="Search posts"
+  aria-controls="post-results"
+  hx-get="/posts/search"
+  hx-trigger="input[this.value.length >= 2] changed delay:400ms, keyup[key=='Enter'][this.value.length >= 2]"
+  hx-target="#post-results"
+>
+```
+
+### Search handler
+
+Your handler is an ordinary Autumn route that returns a `Markup` partial:
+
+```rust
+use autumn_web::prelude::*;
+use autumn_web::widgets::active_search_empty_state;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct SearchQuery { q: String }
+
+#[get("/posts/search")]
+async fn search(
+    Query(params): Query<SearchQuery>,
+    repo: PgPostRepository,        // your repository
+) -> AutumnResult<Markup> {
+    let q = params.q.trim();
+    if q.is_empty() {
+        return Ok(active_search_empty_state("Enter a search term"));
+    }
+
+    // Works with the full-text search repository feature:
+    let results = repo.search(q).await?;
+
+    Ok(html! {
+        @if results.is_empty() {
+            (active_search_empty_state("No results found"))
+        } @else {
+            ul {
+                @for post in &results {
+                    li { (post.title) }
+                }
+            }
+        }
+    })
+}
+```
+
+### Integration with full-text search
+
+If your model uses `#[repository(..., searchable)]`, the generated
+`repo.search(q)` method returns results ranked by relevance. Pass the query
+string straight through:
+
+```rust
+// The handler stays the same — no special plumbing needed.
+let results = repo.search(params.q.trim()).await?;
+```
+
+See [Full-Text Search](./full-text-search.md) for repository configuration.
+
+### Configuration options
+
+| Builder method | Default | Effect |
+|----------------|---------|--------|
+| `.debounce(ms)` | `300` | Debounce delay before the request fires |
+| `.min_length(n)` | `1` | Minimum character count before triggering |
+| `.indicator(selector)` | *(none)* | CSS selector for an `htmx-indicator` element |
+| `.initial_load()` | `false` | Fire the search immediately on page load |
+| `.placeholder(text)` | *(none)* | Placeholder text for the input |
+| `.param_name(name)` | `"q"` | Query parameter name |
+| `.post()` | *(GET)* | Use `hx-post` instead of the default `hx-get` |
+
+### POST opt-in
+
+`GET` is the default because search queries are idempotent, cacheable, and
+bookmarkable. Use `.post()` only when the handler genuinely needs a request
+body (e.g. large filter payloads or CSRF-protected endpoints):
+
+```rust
+let config = ActiveSearchConfig::new("/posts/search", "#post-results").post();
+```
+
+---
+
+## Autocomplete / lookup
+
+Autocomplete lets a user type into a visible search field and pick a related
+record. The selected record's ID is stored in a hidden field and submitted with
+the form.
+
+### Page template
+
+```rust
+use autumn_web::widgets::{AutocompleteConfig, autocomplete_input};
+
+let config = AutocompleteConfig::new(
+    "/tags/autocomplete", // handler URL
+    "tag_label",          // name of the visible input (shows the selected label)
+    "tag_id",             // name of the hidden input (stores the selected ID)
+)
+.placeholder("Search tags…");
+
+html! {
+    form action="/posts" method="post" {
+        // … other fields …
+        (autocomplete_input("tag-picker", "Tag", &config))
+        button type="submit" { "Save" }
+    }
+}
+```
+
+Rendered HTML (abbreviated):
+
+```html
+<div id="tag-picker-wrapper">
+  <label for="tag-picker-query">Tag</label>
+  <input type="search" id="tag-picker-query" name="tag_label"
+         role="combobox" aria-expanded="false" aria-autocomplete="list"
+         aria-controls="tag-picker-options"
+         hx-get="/tags/autocomplete"
+         hx-trigger="input[…] changed delay:300ms, keyup[key=='Enter'][…]"
+         hx-target="#tag-picker-options">
+  <input type="hidden" id="tag-picker-value" name="tag_id" value="">
+  <div id="tag-picker-options" role="listbox" aria-live="polite"></div>
+  <noscript>
+    <select name="tag_id">…</select>
+  </noscript>
+</div>
+```
+
+### Autocomplete handler
+
+Your handler returns option partials using `autocomplete_option` and
+`autocomplete_empty_state`:
+
+```rust
+use autumn_web::widgets::{autocomplete_option, autocomplete_empty_state};
+
+#[get("/tags/autocomplete")]
+async fn tags_autocomplete(
+    Query(params): Query<SearchQuery>,
+    mut db: Db,
+) -> AutumnResult<Markup> {
+    let q = params.q.trim();
+    if q.is_empty() {
+        return Ok(autocomplete_empty_state("Type to search tags."));
+    }
+
+    let tags: Vec<Tag> = /* your Diesel query */ ...;
+
+    Ok(html! {
+        @if tags.is_empty() {
+            (autocomplete_empty_state("No matching tags found."))
+        } @else {
+            @for tag in &tags {
+                (autocomplete_option(&tag.id.to_string(), &tag.name))
+            }
+        }
+    })
+}
+```
+
+`autocomplete_option(value, label)` renders:
+
+```html
+<div role="option" tabindex="0" data-value="42">Tag Name</div>
+```
+
+Use `data-value` in a small `hx-on:click` handler or a server round-trip to
+populate the hidden field and the visible label when the user selects an option.
+
+---
+
+## No-JavaScript fallback
+
+Both `active_search` and `autocomplete_input` emit a `<noscript>` block that
+works without JavaScript:
+
+- **Active search** — a plain `<form method="get">` that submits the query.
+  Your handler already returns a correct response; wrap it in your layout
+  for the full-page no-JS case.
+- **Autocomplete** — a `<select name="...">` that submits the value directly.
+  Populate its options server-side for the fallback path.
+
+For a seamless no-JS experience, detect whether the request is an htmx
+request using `HxRequest` and wrap the response in a full layout if not:
+
+```rust
+#[get("/posts/search")]
+async fn search(hx: HxRequest, Query(params): Query<SearchQuery>, ...) -> AutumnResult<impl IntoResponse> {
+    let partial = /* render results */;
+    if hx.is_htmx {
+        Ok(partial.into_response())
+    } else {
+        Ok(layout("Search results", partial).into_response())
+    }
+}
+```
+
+---
+
+## Accessibility
+
+All widgets include:
+
+- `<label>` associated with the input via `for`/`id`
+- `aria-label` on the input
+- `aria-controls` pointing at the results container
+- `role="status"` and `aria-live="polite"` on the results container (so screen
+  readers announce updates without moving focus)
+- `aria-atomic="true"` on the active search results container
+- `role="combobox"` + `aria-expanded` + `aria-autocomplete="list"` on the
+  autocomplete visible input
+- `role="listbox"` on the autocomplete options container
+- `role="option"` + `tabindex="0"` on each autocomplete option
+- `role="status"` + `aria-live="polite"` on empty-state partials
+
+---
+
+## Example: bookmarks app
+
+The `examples/bookmarks` app demonstrates both primitives:
+
+- **Active search** on `GET /bookmarks` — searches across `title`, `url`, and
+  `tag` fields using an ILIKE query.
+- **Tag autocomplete** on `GET /bookmarks/new` — lists existing tags matching
+  the typed prefix via `GET /bookmarks/tags/autocomplete`.
+
+See `examples/bookmarks/src/routes/bookmarks.rs` for the full implementation.

--- a/docs/guide/active-search-and-autocomplete.md
+++ b/docs/guide/active-search-and-autocomplete.md
@@ -171,21 +171,29 @@ html! {
 Rendered HTML (abbreviated):
 
 ```html
-<div id="tag-picker-wrapper">
+<div id="tag-picker-wrapper"
+     data-ac-value-id="tag-picker-value"
+     data-ac-value-name="tag_id">
   <label for="tag-picker-query">Tag</label>
   <input type="search" id="tag-picker-query" name="q"
          role="combobox" aria-expanded="false" aria-autocomplete="list"
          aria-controls="tag-picker-options"
+         data-ac-query data-ac-min-length="1"
          hx-get="/tags/autocomplete"
          hx-trigger="input changed delay:300ms"
          hx-target="#tag-picker-options">
   <input type="hidden" id="tag-picker-value" value="">
-  <div id="tag-picker-options" role="listbox" aria-live="polite"
-       hx-on:click="let o=event.target.closest('[role=option]');if(o){…}"></div>
+  <div id="tag-picker-options" role="listbox" aria-live="polite"></div>
   <noscript>
     <select name="tag_id">…</select>
   </noscript>
 </div>
+```
+
+Option selection and input sync are handled by the `autumn-widgets.js` runtime (no inline JS, CSP-compatible). Include it once in your layout:
+
+```html
+<script src="/static/js/autumn-widgets.js" defer></script>
 ```
 
 ### Autocomplete handler
@@ -226,10 +234,25 @@ async fn tags_autocomplete(
 <div role="option" tabindex="0" data-value="42">Tag Name</div>
 ```
 
-The listbox container has a built-in `hx-on:click` delegating handler that
-fires when the user clicks an option. It copies the option's `textContent` into
-the visible input and its `data-value` into the hidden field, then clears the
-listbox. No additional wiring is needed.
+The `autumn-widgets.js` runtime handles click and keyboard (Enter/Space) selection
+on the listbox. It copies the option's `textContent` into the visible input and
+its `data-value` into the hidden field, then clears the listbox. No additional
+wiring is needed beyond including the script in your layout.
+
+### Free-text mode (tag-style fields)
+
+By default, the hidden field is **only** set when an option is selected from the
+list — typing a value and submitting without selecting leaves the field empty.
+This is the safe default for foreign-key ID fields (submitting unvalidated text
+as an ID would break form deserialization).
+
+For tag-style fields where users should be able to submit typed text directly
+(e.g. creating a new tag), enable free-text mode:
+
+```rust
+let config = AutocompleteConfig::new("/tags/autocomplete", "tag")
+    .free_text(); // keep hidden field in sync with typed text
+```
 
 ---
 

--- a/docs/guide/active-search-and-autocomplete.md
+++ b/docs/guide/active-search-and-autocomplete.md
@@ -59,10 +59,9 @@ The search input receives:
   id="post-search"
   name="q"
   autocomplete="off"
-  aria-label="Search posts"
   aria-controls="post-results"
   hx-get="/posts/search"
-  hx-trigger="input[this.value.length >= 2] changed delay:400ms, keyup[key=='Enter'][this.value.length >= 2]"
+  hx-trigger="input[this.value.length >= 2] changed delay:400ms, keyup[key=='Enter'][this.value.length >= 2], input[this.value.length < 2] changed"
   hx-target="#post-results"
 >
 ```
@@ -156,7 +155,6 @@ use autumn_web::widgets::{AutocompleteConfig, autocomplete_input};
 
 let config = AutocompleteConfig::new(
     "/tags/autocomplete", // handler URL
-    "tag_label",          // name of the visible input (shows the selected label)
     "tag_id",             // name of the hidden input (stores the selected ID)
 )
 .placeholder("Search tags…");
@@ -175,14 +173,15 @@ Rendered HTML (abbreviated):
 ```html
 <div id="tag-picker-wrapper">
   <label for="tag-picker-query">Tag</label>
-  <input type="search" id="tag-picker-query" name="tag_label"
+  <input type="search" id="tag-picker-query" name="q"
          role="combobox" aria-expanded="false" aria-autocomplete="list"
          aria-controls="tag-picker-options"
          hx-get="/tags/autocomplete"
-         hx-trigger="input[…] changed delay:300ms, keyup[key=='Enter'][…]"
+         hx-trigger="input[…] changed delay:300ms, keyup[key=='Enter'][…], input[this.value.length < 1] changed"
          hx-target="#tag-picker-options">
   <input type="hidden" id="tag-picker-value" name="tag_id" value="">
-  <div id="tag-picker-options" role="listbox" aria-live="polite"></div>
+  <div id="tag-picker-options" role="listbox" aria-live="polite"
+       hx-on:click="let o=event.target.closest('[role=option]');if(o){…}"></div>
   <noscript>
     <select name="tag_id">…</select>
   </noscript>
@@ -227,8 +226,10 @@ async fn tags_autocomplete(
 <div role="option" tabindex="0" data-value="42">Tag Name</div>
 ```
 
-Use `data-value` in a small `hx-on:click` handler or a server round-trip to
-populate the hidden field and the visible label when the user selects an option.
+The listbox container has a built-in `hx-on:click` delegating handler that
+fires when the user clicks an option. It copies the option's `textContent` into
+the visible input and its `data-value` into the hidden field, then clears the
+listbox. No additional wiring is needed.
 
 ---
 
@@ -241,7 +242,8 @@ works without JavaScript:
   Your handler already returns a correct response; wrap it in your layout
   for the full-page no-JS case.
 - **Autocomplete** — a `<select name="...">` that submits the value directly.
-  Populate its options server-side for the fallback path.
+  Pass `.fallback_options(&[("val", "Label"), …])` to `AutocompleteConfig` to
+  populate its options server-side for the fallback path.
 
 For a seamless no-JS experience, detect whether the request is an htmx
 request using `HxRequest` and wrap the response in a full layout if not:
@@ -265,7 +267,6 @@ async fn search(hx: HxRequest, Query(params): Query<SearchQuery>, ...) -> Autumn
 All widgets include:
 
 - `<label>` associated with the input via `for`/`id`
-- `aria-label` on the input
 - `aria-controls` pointing at the results container
 - `role="status"` and `aria-live="polite"` on the results container (so screen
   readers announce updates without moving focus)

--- a/docs/guide/active-search-and-autocomplete.md
+++ b/docs/guide/active-search-and-autocomplete.md
@@ -61,7 +61,7 @@ The search input receives:
   autocomplete="off"
   aria-controls="post-results"
   hx-get="/posts/search"
-  hx-trigger="input[this.value.length >= 2] changed delay:400ms, keyup[key=='Enter'][this.value.length >= 2], input[this.value.length < 2] changed"
+  hx-trigger="input changed delay:400ms"
   hx-target="#post-results"
 >
 ```
@@ -123,7 +123,7 @@ See [Full-Text Search](./full-text-search.md) for repository configuration.
 | Builder method | Default | Effect |
 |----------------|---------|--------|
 | `.debounce(ms)` | `300` | Debounce delay before the request fires |
-| `.min_length(n)` | `1` | Minimum character count before triggering |
+| `.min_length(n)` | `1` | Minimum characters required (enforced server-side) |
 | `.indicator(selector)` | *(none)* | CSS selector for an `htmx-indicator` element |
 | `.initial_load()` | `false` | Fire the search immediately on page load |
 | `.placeholder(text)` | *(none)* | Placeholder text for the input |
@@ -177,9 +177,9 @@ Rendered HTML (abbreviated):
          role="combobox" aria-expanded="false" aria-autocomplete="list"
          aria-controls="tag-picker-options"
          hx-get="/tags/autocomplete"
-         hx-trigger="input[…] changed delay:300ms, keyup[key=='Enter'][…], input[this.value.length < 1] changed"
+         hx-trigger="input changed delay:300ms"
          hx-target="#tag-picker-options">
-  <input type="hidden" id="tag-picker-value" name="tag_id" value="">
+  <input type="hidden" id="tag-picker-value" value="">
   <div id="tag-picker-options" role="listbox" aria-live="polite"
        hx-on:click="let o=event.target.closest('[role=option]');if(o){…}"></div>
   <noscript>

--- a/examples/bookmarks/src/main.rs
+++ b/examples/bookmarks/src/main.rs
@@ -22,6 +22,8 @@ async fn main() {
         .routes(routes![
             home,
             routes::bookmarks::index,
+            routes::bookmarks::search,
+            routes::bookmarks::tags_autocomplete,
             routes::bookmarks::show,
             routes::bookmarks::by_tag,
             routes::bookmarks::new_form,

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -2,6 +2,19 @@
 //!
 //! The generated scaffold provides the resource shape. The shipped example adds
 //! Tailwind styling, htmx affordances, tag filtering, and local-demo writes.
+//!
+//! # Active Search & Autocomplete (issue #768)
+//!
+//! Two widget-driven routes are included to demonstrate the primitives:
+//!
+//! - `GET /bookmarks/search?q=…` — returns a rendered partial of matching
+//!   bookmarks. The index page wires this up via [`autumn_web::widgets::active_search`].
+//! - `GET /bookmarks/tags/autocomplete?q=…` — returns matching tag option
+//!   partials. The new/edit forms wire this up via
+//!   [`autumn_web::widgets::autocomplete_input`].
+//!
+//! Both handlers are ordinary Autumn route handlers that return `Markup`.
+//! They own the Diesel query; the widgets own the htmx wiring.
 
 use autumn_web::extract::{Form, Path};
 use autumn_web::prelude::*;
@@ -79,6 +92,14 @@ fn bookmark_card(bookmark: &Bookmark) -> Markup {
 #[get("/bookmarks")]
 pub async fn index(repo: PgBookmarkRepository) -> AutumnResult<Markup> {
     let rows = repo.find_all().await?;
+    let search_config = autumn_web::widgets::ActiveSearchConfig::new(
+        "/bookmarks/search",
+        "#bookmark-search-results",
+    )
+    .placeholder("Search by title, URL, or tag…")
+    .debounce(400)
+    .min_length(2);
+
     Ok(layout(
         "All",
         html! {
@@ -89,12 +110,23 @@ pub async fn index(repo: PgBookmarkRepository) -> AutumnResult<Markup> {
                     "+ Add"
                 }
             }
-            ul class="space-y-3" {
-                @for row in &rows {
-                    (bookmark_card(row))
-                }
-                @if rows.is_empty() {
-                    li class="text-gray-400 text-center py-8" { "No bookmarks yet." }
+            // ── Active search widget ──────────────────────────────────────
+            div class="mb-6" {
+                (autumn_web::widgets::active_search_input(
+                    "bookmark-search",
+                    "Search bookmarks",
+                    &search_config,
+                ))
+            }
+            // ── Results (initial list; replaced by search partial) ────────
+            div id="bookmark-search-results" role="status" aria-live="polite" aria-atomic="true" {
+                ul class="space-y-3" {
+                    @for row in &rows {
+                        (bookmark_card(row))
+                    }
+                    @if rows.is_empty() {
+                        li class="text-gray-400 text-center py-8" { "No bookmarks yet." }
+                    }
                 }
             }
         },
@@ -145,6 +177,14 @@ pub async fn by_tag(Path(tag): Path<String>, repo: PgBookmarkRepository) -> Autu
 
 #[get("/bookmarks/new")]
 pub async fn new_form() -> AutumnResult<Markup> {
+    let tag_ac = autumn_web::widgets::AutocompleteConfig::new(
+        "/bookmarks/tags/autocomplete",
+        "tag_label",
+        "tag",
+    )
+    .placeholder("Search existing tags…")
+    .min_length(1);
+
     Ok(layout(
         "Add Bookmark",
         html! {
@@ -162,10 +202,17 @@ pub async fn new_form() -> AutumnResult<Markup> {
                           placeholder="My favorite site"
                           class="w-full border rounded p-2 mt-1";
                 }
+                // ── Tag autocomplete ──────────────────────────────────────
+                // Use the autocomplete widget to look up existing tags.
+                // The hidden <input name="tag"> carries the selected value.
+                // The noscript fallback renders a plain text input.
                 div {
-                    label for="tag" class="block text-sm font-medium" { "Tag" }
-                    input type="text" id="tag" name="tag" value="general" required
-                          class="w-full border rounded p-2 mt-1";
+                    (autumn_web::widgets::autocomplete_input("tag-picker", "Tag", &tag_ac))
+                    // Fallback for non-htmx submit: also accept direct text entry
+                    noscript {
+                        input type="text" id="tag" name="tag" value="general" required
+                              class="w-full border rounded p-2 mt-1";
+                    }
                 }
                 button type="submit"
                        class="bg-indigo-600 text-white px-6 py-2 rounded hover:bg-indigo-700" {
@@ -249,4 +296,93 @@ pub async fn update(
     }
 
     Ok(Redirect::to(&format!("/bookmarks/{}", *id)))
+}
+
+// ── Active search handler ─────────────────────────────────────────────────────
+
+#[derive(serde::Deserialize)]
+pub struct SearchQuery {
+    #[serde(default)]
+    pub q: String,
+}
+
+/// Active search handler — returns a `<ul>` partial of matching bookmarks.
+///
+/// Wired up by [`autumn_web::widgets::active_search_input`] on the index page.
+/// Works equally well without JavaScript (direct GET form submission).
+#[get("/bookmarks/search")]
+pub async fn search(
+    Query(params): Query<SearchQuery>,
+    mut db: Db,
+) -> AutumnResult<Markup> {
+    let q = params.q.trim();
+    if q.is_empty() {
+        return Ok(autumn_web::widgets::active_search_empty_state(
+            "Enter at least two characters to search.",
+        ));
+    }
+
+    let pattern = format!("%{}%", q.to_lowercase());
+    let results: Vec<Bookmark> = bookmarks::table
+        .filter(
+            diesel::dsl::sql::<diesel::sql_types::Bool>(
+                "lower(title) LIKE $1 OR lower(url) LIKE $1 OR lower(tag) LIKE $1",
+            )
+            .bind::<diesel::sql_types::Text, _>(pattern),
+        )
+        .select(Bookmark::as_select())
+        .load(&mut *db)
+        .await?;
+
+    Ok(html! {
+        @if results.is_empty() {
+            (autumn_web::widgets::active_search_empty_state("No bookmarks match your search."))
+        } @else {
+            ul class="space-y-3" {
+                @for row in &results {
+                    (bookmark_card(row))
+                }
+            }
+        }
+    })
+}
+
+// ── Tag autocomplete handler ──────────────────────────────────────────────────
+
+/// Tag autocomplete handler — returns option partials for matching tags.
+///
+/// Wired up by [`autumn_web::widgets::autocomplete_input`] on the new/edit forms.
+#[get("/bookmarks/tags/autocomplete")]
+pub async fn tags_autocomplete(
+    Query(params): Query<SearchQuery>,
+    mut db: Db,
+) -> AutumnResult<Markup> {
+    let q = params.q.trim();
+    if q.is_empty() {
+        return Ok(autumn_web::widgets::autocomplete_empty_state(
+            "Type to search tags.",
+        ));
+    }
+
+    let pattern = format!("%{}%", q.to_lowercase());
+    let tags: Vec<String> = bookmarks::table
+        .select(bookmarks::tag)
+        .filter(
+            diesel::dsl::sql::<diesel::sql_types::Bool>("lower(tag) LIKE $1")
+                .bind::<diesel::sql_types::Text, _>(pattern),
+        )
+        .distinct()
+        .order(bookmarks::tag.asc())
+        .load(&mut *db)
+        .await?;
+
+    Ok(html! {
+        @if tags.is_empty() {
+            (autumn_web::widgets::autocomplete_empty_state("No matching tags found."))
+        } @else {
+            @for tag in &tags {
+                (autumn_web::widgets::autocomplete_option(tag, tag))
+            }
+        }
+    })
 }

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -35,7 +35,7 @@ fn layout(title: &str, content: Markup) -> Markup {
                 title { (title) " - Bookmarks" }
                 link rel="stylesheet" href="/static/css/autumn.css";
                 script src="/static/js/htmx.min.js" {}
-                script src=(autumn_web::htmx::AUTUMN_WIDGETS_JS_PATH) defer {}
+                script src=(autumn_web::AUTUMN_WIDGETS_JS_PATH) defer {}
 
             }
             body class="bg-gray-50 min-h-screen" {

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -35,6 +35,8 @@ fn layout(title: &str, content: Markup) -> Markup {
                 title { (title) " - Bookmarks" }
                 link rel="stylesheet" href="/static/css/autumn.css";
                 script src="/static/js/htmx.min.js" {}
+                script src=(autumn_web::htmx::AUTUMN_WIDGETS_JS_PATH) defer {}
+
             }
             body class="bg-gray-50 min-h-screen" {
                 nav class="bg-indigo-600 text-white p-4" {
@@ -180,7 +182,8 @@ pub async fn new_form() -> AutumnResult<Markup> {
     let tag_ac =
         autumn_web::widgets::AutocompleteConfig::new("/bookmarks/tags/autocomplete", "tag")
             .placeholder("Search existing tags…")
-            .min_length(1);
+            .min_length(1)
+            .free_text(); // tags are plain strings; allow typing a new tag
 
     Ok(layout(
         "Add Bookmark",

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -179,7 +179,6 @@ pub async fn by_tag(Path(tag): Path<String>, repo: PgBookmarkRepository) -> Autu
 pub async fn new_form() -> AutumnResult<Markup> {
     let tag_ac = autumn_web::widgets::AutocompleteConfig::new(
         "/bookmarks/tags/autocomplete",
-        "tag_label",
         "tag",
     )
     .placeholder("Search existing tags…")
@@ -316,19 +315,19 @@ pub async fn search(
     mut db: Db,
 ) -> AutumnResult<Markup> {
     let q = params.q.trim();
-    if q.is_empty() {
+    if q.chars().count() < 2 {
         return Ok(autumn_web::widgets::active_search_empty_state(
             "Enter at least two characters to search.",
         ));
     }
 
-    let pattern = format!("%{}%", q.to_lowercase());
+    let pattern = format!("%{q}%");
     let results: Vec<Bookmark> = bookmarks::table
         .filter(
-            diesel::dsl::sql::<diesel::sql_types::Bool>(
-                "lower(title) LIKE $1 OR lower(url) LIKE $1 OR lower(tag) LIKE $1",
-            )
-            .bind::<diesel::sql_types::Text, _>(pattern),
+            bookmarks::title
+                .ilike(pattern.clone())
+                .or(bookmarks::url.ilike(pattern.clone()))
+                .or(bookmarks::tag.ilike(pattern)),
         )
         .select(Bookmark::as_select())
         .load(&mut *db)
@@ -364,13 +363,10 @@ pub async fn tags_autocomplete(
         ));
     }
 
-    let pattern = format!("%{}%", q.to_lowercase());
+    let pattern = format!("%{q}%");
     let tags: Vec<String> = bookmarks::table
         .select(bookmarks::tag)
-        .filter(
-            diesel::dsl::sql::<diesel::sql_types::Bool>("lower(tag) LIKE $1")
-                .bind::<diesel::sql_types::Text, _>(pattern),
-        )
+        .filter(bookmarks::tag.ilike(pattern))
         .distinct()
         .order(bookmarks::tag.asc())
         .load(&mut *db)

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -200,16 +200,10 @@ pub async fn new_form() -> AutumnResult<Markup> {
                           class="w-full border rounded p-2 mt-1";
                 }
                 // ── Tag autocomplete ──────────────────────────────────────
-                // Use the autocomplete widget to look up existing tags.
-                // The hidden <input name="tag"> carries the selected value.
-                // The noscript fallback renders a plain text input.
+                // The widget renders a hidden <input name="tag"> for the selected
+                // value and a <noscript><select name="tag"> for the no-JS path.
                 div {
                     (autumn_web::widgets::autocomplete_input("tag-picker", "Tag", &tag_ac))
-                    // Fallback for non-htmx submit: also accept direct text entry
-                    noscript {
-                        input type="text" id="tag" name="tag" value="general" required
-                              class="w-full border rounded p-2 mt-1";
-                    }
                 }
                 button type="submit"
                        class="bg-indigo-600 text-white px-6 py-2 rounded hover:bg-indigo-700" {
@@ -303,6 +297,14 @@ pub struct SearchQuery {
     pub q: String,
 }
 
+/// Escape LIKE/ILIKE wildcards so user input is treated as literal characters.
+/// PostgreSQL's default escape character is `\`, so `%` → `\%`, `_` → `\_`.
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 /// Active search handler — returns a `<ul>` partial of matching bookmarks.
 ///
 /// Wired up by [`autumn_web::widgets::active_search_input`] on the index page.
@@ -316,7 +318,7 @@ pub async fn search(Query(params): Query<SearchQuery>, mut db: Db) -> AutumnResu
         ));
     }
 
-    let pattern = format!("%{q}%");
+    let pattern = format!("%{}%", escape_like(q));
     let results: Vec<Bookmark> = bookmarks::table
         .filter(
             bookmarks::title
@@ -358,7 +360,7 @@ pub async fn tags_autocomplete(
         ));
     }
 
-    let pattern = format!("%{q}%");
+    let pattern = format!("%{}%", escape_like(q));
     let tags: Vec<String> = bookmarks::table
         .select(bookmarks::tag)
         .filter(bookmarks::tag.ilike(pattern))

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -177,12 +177,10 @@ pub async fn by_tag(Path(tag): Path<String>, repo: PgBookmarkRepository) -> Autu
 
 #[get("/bookmarks/new")]
 pub async fn new_form() -> AutumnResult<Markup> {
-    let tag_ac = autumn_web::widgets::AutocompleteConfig::new(
-        "/bookmarks/tags/autocomplete",
-        "tag",
-    )
-    .placeholder("Search existing tags…")
-    .min_length(1);
+    let tag_ac =
+        autumn_web::widgets::AutocompleteConfig::new("/bookmarks/tags/autocomplete", "tag")
+            .placeholder("Search existing tags…")
+            .min_length(1);
 
     Ok(layout(
         "Add Bookmark",
@@ -310,10 +308,7 @@ pub struct SearchQuery {
 /// Wired up by [`autumn_web::widgets::active_search_input`] on the index page.
 /// Works equally well without JavaScript (direct GET form submission).
 #[get("/bookmarks/search")]
-pub async fn search(
-    Query(params): Query<SearchQuery>,
-    mut db: Db,
-) -> AutumnResult<Markup> {
+pub async fn search(Query(params): Query<SearchQuery>, mut db: Db) -> AutumnResult<Markup> {
     let q = params.q.trim();
     if q.chars().count() < 2 {
         return Ok(autumn_web::widgets::active_search_empty_state(


### PR DESCRIPTION
## Summary

Introduces two new server-rendered form primitives for live search and autocomplete functionality, built on htmx and Maud templates. These widgets eliminate the need for custom JavaScript while providing accessible, progressively-enhanced HTML forms.

## Key Changes

- **New `widgets` module** (`autumn/src/widgets.rs`): Comprehensive implementation of search and autocomplete primitives
  - `ActiveSearchConfig` builder for configurable live search with debounce, min-length filtering, and optional POST support
  - `active_search_input()`, `active_search_results()`, and `active_search()` functions for rendering search UI with htmx attributes
  - `AutocompleteConfig` builder for record lookup/selection patterns
  - `autocomplete_input()`, `autocomplete_option()`, and `autocomplete_empty_state()` functions for rendering autocomplete UI
  - Helper functions `build_trigger()` and `selector_to_id()` for htmx attribute generation
  - Comprehensive test suite covering all configuration options and HTML output

- **Documentation** (`docs/guide/active-search-and-autocomplete.md`): Complete guide covering:
  - When to use each widget vs. alternatives
  - Integration with repository full-text search feature
  - Configuration options and POST opt-in behavior
  - No-JavaScript fallback patterns
  - Handler implementation examples

- **Example integration** (`examples/bookmarks/`):
  - Added `search()` handler demonstrating active search with live results
  - Added `tags_autocomplete()` handler demonstrating autocomplete for related record selection
  - Updated index page to wire up active search widget
  - Updated new/edit forms to wire up autocomplete widget for tag selection

- **API exports**: Added `widgets` module to `autumn/src/lib.rs` and re-exported key types in `autumn/src/prelude.rs`

## Implementation Details

- **htmx integration**: Widgets emit proper `hx-get`/`hx-post`, `hx-trigger`, `hx-target`, and `hx-indicator` attributes with debounce and min-length filtering
- **Accessibility**: Includes `aria-label`, `aria-controls`, `role="status"`, `aria-live="polite"` for screen reader support
- **Progressive enhancement**: All widgets include `<noscript>` fallbacks (plain form for search, select for autocomplete)
- **Builder pattern**: Both config types use fluent builders with sensible defaults (300ms debounce, 1 char min-length, GET method)
- **Feature-gated**: All rendering functions are behind `#[cfg(feature = "maud")]` to maintain optional dependency

The implementation is handler-agnostic—widgets own the htmx wiring while handlers own the Diesel queries, allowing seamless integration with the existing repository full-text search feature.

https://claude.ai/code/session_01XRCH5wU2v8m64S4jKpQGBZ