### PR TITLE
Add per-principal and API-token rate limiting with tiered quotas

### DIFF
--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1205,12 +1205,11 @@ fn parse_config_bool(value: &str) -> Option<bool> {
     }
 }
 
-/// Resolve the signing secret from the environment or `autumn.toml`.
+/// Resolve the rate-limit key strategy from config/env.
 ///
 /// Priority:
-/// 1. `AUTUMN_SECURITY__SIGNING_SECRET` env var
-/// 2. `[security] signing_secret` in `autumn.toml`
-/// Resolve the rate-limit key strategy from config/env.
+/// 1. `AUTUMN_SECURITY__RATE_LIMIT__KEY_STRATEGY` env var
+/// 2. `[security.rate_limit] key_strategy` in `autumn.toml`
 fn resolve_rate_limit_key_strategy() -> String {
     if let Ok(val) = std::env::var("AUTUMN_SECURITY__RATE_LIMIT__KEY_STRATEGY")
         && !val.is_empty()
@@ -1235,12 +1234,12 @@ fn resolve_rate_limit_key_strategy() -> String {
 /// and is not explicitly disabled).
 fn resolve_auth_extractor_mounted() -> bool {
     if let Ok(val) = std::env::var("AUTUMN_AUTH__ENABLED") {
-        return val.trim().to_ascii_lowercase() != "false";
+        return !val.trim().eq_ignore_ascii_case("false");
     }
     std::fs::read_to_string("autumn.toml")
         .ok()
         .and_then(|c| toml::from_str::<toml::Table>(&c).ok())
-        .map_or(false, |t| {
+        .is_some_and(|t| {
             // [auth] section present and not explicitly disabled.
             t.get("auth").is_some_and(|auth| {
                 auth.get("enabled")
@@ -1357,6 +1356,7 @@ fn tailwind_enabled() -> bool {
 /// 2. **Check phase** (parallel) — every applicable check is spawned on its own
 ///    thread so that slow operations (TCP connect, subprocess calls) overlap.
 ///    Results are joined back in display order.
+#[allow(clippy::too_many_lines)]
 pub fn run(opts: DoctorOptions) {
     use std::thread;
     type Task = Box<dyn FnOnce() -> CheckResult + Send>;

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -167,6 +167,50 @@ pub fn check_signing_secret_impl(secret: Option<&str>, is_production: bool) -> C
     }
 }
 
+/// Check that the rate-limit key strategy is consistent with mounted auth middleware.
+///
+/// When `key_strategy = "authenticated_principal"`, the rate limiter reads a
+/// `RateLimitPrincipal` extension that must be set by the auth layer. If no
+/// auth extractor is mounted, unauthenticated requests still fall back to IP
+/// keying, but authenticated routes will never use the principal bucket.
+///
+/// `auth_extractor_mounted` should be `true` when the project has auth configured
+/// (e.g. `[auth]` section present and enabled in `autumn.toml`).
+///
+/// In strict mode (`autumn doctor --strict`), a warning is surfaced as an error.
+pub fn check_rate_limit_key_strategy_impl(
+    key_strategy: &str,
+    auth_extractor_mounted: bool,
+) -> CheckResult {
+    if key_strategy == "authenticated_principal" && !auth_extractor_mounted {
+        return CheckResult {
+            name: "rate_limit_key_strategy",
+            status: CheckStatus::Warn,
+            detail: Some(
+                "rate_limit.key_strategy = \"authenticated_principal\" is configured \
+                 but no auth extractor is mounted — unauthenticated requests will \
+                 always fall back to IP keying, so the per-principal budget \
+                 is never applied to authenticated callers"
+                    .into(),
+            ),
+            hint: Some(
+                "Mount an auth layer (e.g. `[auth]` in autumn.toml) or change \
+                 key_strategy to \"ip\" or \"api_token\"",
+            ),
+        };
+    }
+
+    CheckResult {
+        name: "rate_limit_key_strategy",
+        status: CheckStatus::Pass,
+        detail: Some(format!(
+            "rate_limit.key_strategy = {:?} is compatible with the current auth configuration",
+            if key_strategy.is_empty() { "ip" } else { key_strategy }
+        )),
+        hint: None,
+    }
+}
+
 pub fn check_trusted_hosts_impl(hosts: &[String], is_production: bool) -> CheckResult {
     let normalized: Vec<String> = hosts
         .iter()
@@ -1147,6 +1191,46 @@ fn parse_config_bool(value: &str) -> Option<bool> {
 /// Priority:
 /// 1. `AUTUMN_SECURITY__SIGNING_SECRET` env var
 /// 2. `[security] signing_secret` in `autumn.toml`
+/// Resolve the rate-limit key strategy from config/env.
+fn resolve_rate_limit_key_strategy() -> String {
+    if let Ok(val) = std::env::var("AUTUMN_SECURITY__RATE_LIMIT__KEY_STRATEGY")
+        && !val.is_empty()
+    {
+        return val;
+    }
+    std::fs::read_to_string("autumn.toml")
+        .ok()
+        .and_then(|c| toml::from_str::<toml::Table>(&c).ok())
+        .and_then(|t| {
+            t.get("security")
+                .and_then(|s| s.get("rate_limit"))
+                .and_then(|rl| rl.get("key_strategy"))
+                .and_then(toml::Value::as_str)
+                .filter(|v| !v.is_empty())
+                .map(std::borrow::ToOwned::to_owned)
+        })
+        .unwrap_or_default()
+}
+
+/// Detect whether an auth extractor is mounted (i.e. `[auth]` section exists
+/// and is not explicitly disabled).
+fn resolve_auth_extractor_mounted() -> bool {
+    if let Ok(val) = std::env::var("AUTUMN_AUTH__ENABLED") {
+        return val.trim().to_ascii_lowercase() != "false";
+    }
+    std::fs::read_to_string("autumn.toml")
+        .ok()
+        .and_then(|c| toml::from_str::<toml::Table>(&c).ok())
+        .map_or(false, |t| {
+            // [auth] section present and not explicitly disabled.
+            t.get("auth").is_some_and(|auth| {
+                auth.get("enabled")
+                    .and_then(toml::Value::as_bool)
+                    .unwrap_or(true) // enabled by default when section exists
+            })
+        })
+}
+
 fn resolve_optional_signing_secret() -> Option<String> {
     if let Ok(val) = std::env::var("AUTUMN_SECURITY__SIGNING_SECRET")
         && !val.is_empty()
@@ -1279,6 +1363,8 @@ pub fn run(opts: DoctorOptions) {
     let signing_secret = resolve_optional_signing_secret();
     let trusted_hosts = resolve_trusted_hosts();
     let is_production = resolve_is_production();
+    let rate_limit_key_strategy = resolve_rate_limit_key_strategy();
+    let auth_extractor_mounted = resolve_auth_extractor_mounted();
 
     // ── Phase 2: build tasks in display order ────────────────────────────────
     let mut tasks: Vec<Task> = Vec::new();
@@ -1346,6 +1432,11 @@ pub fn run(opts: DoctorOptions) {
     }));
     tasks.push(Box::new(move || {
         check_trusted_hosts_impl(&trusted_hosts, is_production)
+    }));
+
+    // 8b. Rate-limit key-strategy misconfiguration
+    tasks.push(Box::new(move || {
+        check_rate_limit_key_strategy_impl(&rate_limit_key_strategy, auth_extractor_mounted)
     }));
 
     // 9. Stale artifacts (warn only, never fail)
@@ -2196,6 +2287,53 @@ foo = "bar"
         let json = to_json_output(&results, &summary);
         // Should parse as valid JSON
         assert!(serde_json::from_str::<serde_json::Value>(&json).is_ok());
+    }
+
+    // ── check_rate_limit_key_strategy ────────────────────────────────────────
+
+    #[test]
+    fn rate_limit_key_strategy_ip_always_passes() {
+        let r = check_rate_limit_key_strategy_impl("ip", false);
+        assert_eq!(r.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn rate_limit_key_strategy_api_token_always_passes() {
+        let r = check_rate_limit_key_strategy_impl("api_token", false);
+        assert_eq!(r.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn rate_limit_key_strategy_authenticated_principal_without_auth_warns_in_strict() {
+        let r = check_rate_limit_key_strategy_impl("authenticated_principal", false);
+        assert_eq!(r.status, CheckStatus::Warn);
+        assert!(r.hint.is_some());
+        assert!(
+            r.detail
+                .as_deref()
+                .unwrap_or("")
+                .contains("auth extractor"),
+            "detail should mention auth extractor"
+        );
+    }
+
+    #[test]
+    fn rate_limit_key_strategy_authenticated_principal_with_auth_passes() {
+        let r = check_rate_limit_key_strategy_impl("authenticated_principal", true);
+        assert_eq!(r.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn rate_limit_key_strategy_name_is_stable() {
+        let r = check_rate_limit_key_strategy_impl("authenticated_principal", false);
+        assert_eq!(r.name, "rate_limit_key_strategy");
+    }
+
+    #[test]
+    fn rate_limit_key_strategy_empty_strategy_passes() {
+        // Unconfigured / empty strategy is treated as default (ip).
+        let r = check_rate_limit_key_strategy_impl("", false);
+        assert_eq!(r.status, CheckStatus::Pass);
     }
 
     // ── check_maintenance_mode ────────────────────────────────────────────────

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -182,6 +182,21 @@ pub fn check_rate_limit_key_strategy_impl(
     key_strategy: &str,
     auth_extractor_mounted: bool,
 ) -> CheckResult {
+    if !key_strategy.is_empty()
+        && key_strategy != "ip"
+        && key_strategy != "api_token"
+        && key_strategy != "authenticated_principal"
+    {
+        return CheckResult {
+            name: "rate_limit_key_strategy",
+            status: CheckStatus::Fail,
+            detail: Some(format!(
+                "rate_limit.key_strategy = {key_strategy:?} is not a valid strategy"
+            )),
+            hint: Some("Expected \"ip\", \"api_token\", or \"authenticated_principal\""),
+        };
+    }
+
     if key_strategy == "authenticated_principal" && !auth_extractor_mounted {
         return CheckResult {
             name: "rate_limit_key_strategy",
@@ -205,7 +220,11 @@ pub fn check_rate_limit_key_strategy_impl(
         status: CheckStatus::Pass,
         detail: Some(format!(
             "rate_limit.key_strategy = {:?} is compatible with the current auth configuration",
-            if key_strategy.is_empty() { "ip" } else { key_strategy }
+            if key_strategy.is_empty() {
+                "ip"
+            } else {
+                key_strategy
+            }
         )),
         hint: None,
     }
@@ -2309,10 +2328,7 @@ foo = "bar"
         assert_eq!(r.status, CheckStatus::Warn);
         assert!(r.hint.is_some());
         assert!(
-            r.detail
-                .as_deref()
-                .unwrap_or("")
-                .contains("auth extractor"),
+            r.detail.as_deref().unwrap_or("").contains("auth extractor"),
             "detail should mention auth extractor"
         );
     }
@@ -2334,6 +2350,18 @@ foo = "bar"
         // Unconfigured / empty strategy is treated as default (ip).
         let r = check_rate_limit_key_strategy_impl("", false);
         assert_eq!(r.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn rate_limit_key_strategy_invalid_value_fails() {
+        let r = check_rate_limit_key_strategy_impl("authenticated_principals", false);
+        assert_eq!(r.status, CheckStatus::Fail);
+        assert!(
+            r.detail
+                .as_deref()
+                .unwrap_or("")
+                .contains("not a valid strategy")
+        );
     }
 
     // ── check_maintenance_mode ────────────────────────────────────────────────

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2158,6 +2158,15 @@ impl AutumnConfig {
             "AUTUMN_SECURITY__RATE_LIMIT__TRUSTED_PROXIES",
             &mut self.security.rate_limit.trusted_proxies,
         );
+        if let Ok(val) = env.var("AUTUMN_SECURITY__RATE_LIMIT__KEY_STRATEGY") {
+            match crate::security::config::KeyStrategy::from_env_value(&val) {
+                Some(strategy) => self.security.rate_limit.key_strategy = strategy,
+                None => eprintln!(
+                    "Warning: AUTUMN_SECURITY__RATE_LIMIT__KEY_STRATEGY={val:?} is not valid \
+                     (expected ip, api_token, or authenticated_principal), ignoring"
+                ),
+            }
+        }
         // BACKEND is always parsed so misconfiguration is surfaced even without
         // the redis feature (build_backend will warn and fall back to memory).
         if let Ok(val) = env.var("AUTUMN_SECURITY__RATE_LIMIT__BACKEND") {

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -661,7 +661,7 @@ impl KeyStrategy {
 /// Declare named tiers under `[security.rate_limit.tiers.<name>]` in `autumn.toml`.
 /// Each tier gets its own token bucket with independent `requests_per_second` and
 /// `burst` values. The app maps callers to a tier via a tier-assignment hook
-/// (see [`RateLimitLayer::with_tier_hook`]).
+/// (see [`crate::security::rate_limit::RateLimitLayer::with_tier_hook`]).
 ///
 /// # `autumn.toml` example
 ///

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -60,6 +60,7 @@
 //! Setting any header value to an empty string disables it (the header is
 //! not emitted). This is the escape hatch for opting out of a default.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use serde::Deserialize;
@@ -614,11 +615,83 @@ impl Default for CsrfConfig {
     }
 }
 
+/// Strategy for identifying which client a rate-limit bucket belongs to.
+///
+/// Controls what value is used as the bucket key for incoming requests.
+///
+/// # `autumn.toml` example
+///
+/// ```toml
+/// [security.rate_limit]
+/// enabled = true
+/// key_strategy = "authenticated_principal"
+/// ```
+///
+/// | Value | Description |
+/// |-------|-------------|
+/// | `"ip"` | Connection peer address (default). Safe against header spoofing. |
+/// | `"api_token"` | `Authorization: Bearer <token>` value. Falls back to IP when no token. |
+/// | `"authenticated_principal"` | Principal ID set by auth middleware via `RateLimitPrincipal` extension. Falls back to IP for unauthenticated requests. |
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KeyStrategy {
+    /// Key on client IP address (connection peer or trusted-proxy-resolved). **Default.**
+    #[default]
+    Ip,
+    /// Key on the `Authorization: Bearer` token value. Falls back to IP when absent.
+    ApiToken,
+    /// Key on the authenticated principal ID from the `RateLimitPrincipal` request
+    /// extension (set by the auth middleware). Falls back to IP for unauthenticated requests.
+    AuthenticatedPrincipal,
+}
+
+impl KeyStrategy {
+    pub(crate) fn from_env_value(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "ip" => Some(Self::Ip),
+            "api_token" => Some(Self::ApiToken),
+            "authenticated_principal" => Some(Self::AuthenticatedPrincipal),
+            _ => None,
+        }
+    }
+}
+
+/// Per-tier rate limit parameters for tiered quota configuration.
+///
+/// Declare named tiers under `[security.rate_limit.tiers.<name>]` in `autumn.toml`.
+/// Each tier gets its own token bucket with independent `requests_per_second` and
+/// `burst` values. The app maps callers to a tier via a tier-assignment hook
+/// (see [`RateLimitLayer::with_tier_hook`]).
+///
+/// # `autumn.toml` example
+///
+/// ```toml
+/// [security.rate_limit.tiers.free]
+/// requests_per_second = 1.0
+/// burst = 10
+///
+/// [security.rate_limit.tiers.pro]
+/// requests_per_second = 10.0
+/// burst = 100
+///
+/// [security.rate_limit.tiers.enterprise]
+/// requests_per_second = 100.0
+/// burst = 1000
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+pub struct RateLimitTierConfig {
+    /// Steady-state refill rate for this tier in requests per second.
+    pub requests_per_second: f64,
+    /// Maximum burst capacity (token bucket size) for this tier.
+    pub burst: u32,
+}
+
 /// Rate limiting configuration.
 ///
-/// Applies a per-client-IP token bucket to every request. When a client
-/// exceeds their bucket, the middleware returns `429 Too Many Requests`
-/// with a `Retry-After` header indicating when to retry.
+/// Applies a token bucket to every request, keyed by client IP (default)
+/// or by authenticated principal / API token. When a client exhausts their
+/// bucket, the middleware returns `429 Too Many Requests` with `Retry-After`
+/// and Problem Details (RFC 9457).
 ///
 /// # Defaults
 ///
@@ -629,6 +702,8 @@ impl Default for CsrfConfig {
 /// | `burst` | `20` |
 /// | `trust_forwarded_headers` | `false` |
 /// | `trusted_proxies` | `[]` |
+/// | `key_strategy` | `"ip"` |
+/// | `tiers` | `{}` (no tiers; all callers share the default config) |
 ///
 /// # Client IP resolution
 ///
@@ -643,6 +718,34 @@ impl Default for CsrfConfig {
 /// then walks the header from right to left, skips those trusted proxy
 /// hops, and keys the bucket on the nearest untrusted client IP.
 ///
+/// # Per-principal / API-token keying
+///
+/// Set `key_strategy = "authenticated_principal"` to key on the authenticated
+/// user identity instead of IP. Auth middleware must insert a
+/// `RateLimitPrincipal` extension on the request before the rate limiter runs.
+/// Unauthenticated requests fall through to IP-based keying — never silently
+/// unbounded.
+///
+/// Set `key_strategy = "api_token"` to key on the `Authorization: Bearer`
+/// token value. Falls back to IP when no `Authorization` header is present.
+///
+/// # Tiered quotas
+///
+/// Declare named tiers and register a tier-assignment hook at startup:
+///
+/// ```toml
+/// [security.rate_limit]
+/// key_strategy = "authenticated_principal"
+///
+/// [security.rate_limit.tiers.free]
+/// requests_per_second = 1.0
+/// burst = 10
+///
+/// [security.rate_limit.tiers.pro]
+/// requests_per_second = 10.0
+/// burst = 100
+/// ```
+///
 /// # Examples
 ///
 /// ```toml
@@ -652,6 +755,7 @@ impl Default for CsrfConfig {
 /// burst = 10
 /// trust_forwarded_headers = false
 /// trusted_proxies = ["10.0.0.10", "203.0.113.0/24"]
+/// key_strategy = "authenticated_principal"
 ///
 /// # Multi-replica: share the budget across all pods
 /// backend = "redis"
@@ -668,11 +772,16 @@ pub struct RateLimitConfig {
     pub enabled: bool,
 
     /// Steady-state refill rate in requests per second. Default: `10.0`.
+    ///
+    /// Used as the default when no tier matches. Configure per-tier values
+    /// under `[security.rate_limit.tiers.<name>]`.
     #[serde(default = "default_rps")]
     pub requests_per_second: f64,
 
     /// Maximum burst capacity (number of tokens the bucket can hold).
     /// Default: `20`.
+    ///
+    /// Used as the default when no tier matches.
     #[serde(default = "default_burst")]
     pub burst: u32,
 
@@ -695,6 +804,21 @@ pub struct RateLimitConfig {
     /// entry is invalid, forwarded headers are ignored rather than trusted.
     #[serde(default)]
     pub trusted_proxies: Vec<String>,
+
+    /// Key extraction strategy. Default: `"ip"`.
+    ///
+    /// Determines what value is used as the rate-limit bucket key.
+    /// See [`KeyStrategy`] for the available options.
+    #[serde(default)]
+    pub key_strategy: KeyStrategy,
+
+    /// Named tiers with per-tier `requests_per_second` and `burst` values.
+    ///
+    /// When a tier-assignment hook is registered and returns a tier name that
+    /// matches a key here, that tier's config is used for the caller's bucket
+    /// instead of the top-level defaults.
+    #[serde(default)]
+    pub tiers: HashMap<String, RateLimitTierConfig>,
 
     /// Bucket store backend. Default: `"memory"` (in-process, single-replica).
     ///
@@ -731,6 +855,8 @@ impl Default for RateLimitConfig {
             burst: default_burst(),
             trust_forwarded_headers: false,
             trusted_proxies: Vec::new(),
+            key_strategy: KeyStrategy::default(),
+            tiers: HashMap::new(),
             backend: RateLimitBackend::default(),
             #[cfg(feature = "redis")]
             redis: RateLimitRedisConfig::default(),

--- a/autumn/src/security/mod.rs
+++ b/autumn/src/security/mod.rs
@@ -106,15 +106,16 @@
 pub(crate) mod config;
 pub(crate) mod csrf;
 pub(crate) mod headers;
-pub(crate) mod rate_limit;
+pub mod rate_limit;
 
 // Re-export commonly used types at the module level.
 pub use config::{
-    CspNonceConfig, CsrfConfig, HeadersConfig, RateLimitBackend, RateLimitConfig, SecurityConfig,
-    UploadConfig, default_content_security_policy, hmac_sha256_hex,
+    CspNonceConfig, CsrfConfig, HeadersConfig, KeyStrategy, RateLimitBackend, RateLimitConfig,
+    RateLimitTierConfig, SecurityConfig, UploadConfig, default_content_security_policy,
+    hmac_sha256_hex,
 };
 #[cfg(feature = "redis")]
 pub use config::{RateLimitBackendFailure, RateLimitRedisConfig};
 pub use csrf::{CsrfFormField, CsrfLayer, CsrfToken};
 pub use headers::{CspNonce, SecurityHeadersLayer};
-pub use rate_limit::RateLimitLayer;
+pub use rate_limit::{RateLimitLayer, RateLimitOverride, RateLimitPrincipal};

--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -380,6 +380,7 @@ enum BucketBackend {
 
 // ── Limiter (shared state) ────────────────────────────────────────────────────
 
+#[allow(clippy::type_complexity)]
 struct TierHookFn(Arc<dyn Fn(&str) -> Option<String> + Send + Sync>);
 
 impl TierHookFn {
@@ -608,14 +609,14 @@ impl Limiter {
         // Path overrides always take precedence over tier limits when explicitly set.
         if let Some(hook) = &self.tier_hook {
             let value = strip_key_prefix(&raw_key);
-            if let Some(tier_name) = hook.call(value) {
-                if let Some(tier) = self.tiers.get(&tier_name) {
-                    if opt_burst.is_none() {
-                        burst = f64::from(tier.burst.max(1));
-                    }
-                    if opt_rps.is_none() {
-                        rps = tier.requests_per_second.max(f64::MIN_POSITIVE);
-                    }
+            if let Some(tier_name) = hook.call(value)
+                && let Some(tier) = self.tiers.get(&tier_name)
+            {
+                if opt_burst.is_none() {
+                    burst = f64::from(tier.burst.max(1));
+                }
+                if opt_rps.is_none() {
+                    rps = tier.requests_per_second.max(f64::MIN_POSITIVE);
                 }
             }
         }
@@ -977,14 +978,14 @@ where
                 None => None,
             };
 
-            let burst_for_header =
-                resolved
-                    .as_ref()
-                    .map_or(limiter.burst_header.clone(), |(_, burst, _)| {
-                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                        let b = *burst as u32;
-                        HeaderValue::from(b)
-                    });
+            let burst_for_header = resolved.as_ref().map_or_else(
+                || limiter.burst_header.clone(),
+                |(_, burst, _)| {
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    let b = *burst as u32;
+                    HeaderValue::from(b)
+                },
+            );
 
             match decision {
                 Some(Decision::Denied {

--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -205,9 +205,21 @@ impl MemoryStore {
             Ok(remaining_tokens) => {
                 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                 let remaining = remaining_tokens.floor() as u32;
+                // When the bucket has fewer than one token left after consuming,
+                // the next request will be denied. Compute the earliest future
+                // time at which a new token will arrive so clients can back off.
+                let reset_at_unix = if remaining_tokens < 1.0 {
+                    let secs_to_next = ((1.0 - remaining_tokens) / refill_per_sec).ceil().max(1.0);
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    {
+                        now_unix + secs_to_next as u64
+                    }
+                } else {
+                    now_unix
+                };
                 Decision::Allowed {
                     remaining,
-                    reset_at_unix: now_unix,
+                    reset_at_unix,
                 }
             }
             Err(current_tokens) => {
@@ -386,6 +398,12 @@ struct TierHookFn(Arc<dyn Fn(&str) -> Option<String> + Send + Sync>);
 impl TierHookFn {
     fn call(&self, key: &str) -> Option<String> {
         (self.0)(key)
+    }
+}
+
+impl Clone for TierHookFn {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
     }
 }
 
@@ -661,11 +679,14 @@ impl Limiter {
     }
 }
 
-/// Strip the "scheme:" prefix from an extracted bucket key before passing
+/// Strip the known scheme prefix from an extracted bucket key before passing
 /// to the tier hook, so hooks receive the raw value (e.g. "user-42" rather
-/// than "principal:user-42").
+/// than "principal:user-42"). Only removes `"token:"` and `"principal:"`
+/// — bare IP keys (including IPv6 addresses containing colons) are passed through unchanged.
 fn strip_key_prefix(key: &str) -> &str {
-    key.find(':').map_or(key, |pos| &key[pos + 1..])
+    key.strip_prefix("token:")
+        .or_else(|| key.strip_prefix("principal:"))
+        .unwrap_or(key)
 }
 
 /// Extract the key string from the `Authorization: Bearer <token>` header.
@@ -874,8 +895,7 @@ impl RateLimitLayer {
     where
         F: Fn(&str) -> Option<String> + Send + Sync + 'static,
     {
-        let mut limiter =
-            Arc::try_unwrap(self.limiter).unwrap_or_else(|arc| (*arc).clone_without_hook());
+        let mut limiter = Arc::try_unwrap(self.limiter).unwrap_or_else(|arc| (*arc).deep_clone());
         limiter.tier_hook = Some(TierHookFn(Arc::new(hook)));
         Self {
             limiter: Arc::new(limiter),
@@ -901,8 +921,7 @@ impl RateLimitLayer {
         path_prefix: impl Into<String>,
         override_: RateLimitOverride,
     ) -> Self {
-        let mut limiter =
-            Arc::try_unwrap(self.limiter).unwrap_or_else(|arc| (*arc).clone_without_hook());
+        let mut limiter = Arc::try_unwrap(self.limiter).unwrap_or_else(|arc| (*arc).deep_clone());
         limiter.path_overrides.push((path_prefix.into(), override_));
         Self {
             limiter: Arc::new(limiter),
@@ -911,8 +930,8 @@ impl RateLimitLayer {
 }
 
 impl Limiter {
-    /// Clone all fields except the tier hook (used when we need to mutate).
-    fn clone_without_hook(&self) -> Self {
+    /// Deep-clone for builder mutation (used when `Arc::try_unwrap` fails).
+    fn deep_clone(&self) -> Self {
         Self {
             refill_per_sec: self.refill_per_sec,
             burst: self.burst,
@@ -922,7 +941,7 @@ impl Limiter {
             trusted_proxies: self.trusted_proxies.clone(),
             key_strategy: self.key_strategy,
             tiers: Arc::clone(&self.tiers),
-            tier_hook: None,
+            tier_hook: self.tier_hook.clone(),
             path_overrides: self.path_overrides.clone(),
             backend: self.backend.clone(),
         }

--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -146,15 +146,23 @@ struct Bucket {
 /// Per-key token bucket state stored in-process.
 #[derive(Debug)]
 struct MemoryStore {
-    buckets: Mutex<LruCache<String, Bucket>>,
+    buckets: Arc<Mutex<LruCache<String, Bucket>>>,
+}
+
+impl Clone for MemoryStore {
+    fn clone(&self) -> Self {
+        Self {
+            buckets: Arc::clone(&self.buckets),
+        }
+    }
 }
 
 impl MemoryStore {
     fn new() -> Self {
         Self {
-            buckets: Mutex::new(LruCache::new(
+            buckets: Arc::new(Mutex::new(LruCache::new(
                 NonZeroUsize::new(10_000).expect("10_000 is non-zero"),
-            )),
+            ))),
         }
     }
 
@@ -227,7 +235,19 @@ struct RedisStore {
     key_prefix: String,
     failure_mode: RateLimitBackendFailure,
     /// Set to `true` once on the first Redis error; reset when it recovers.
-    outage_logged: std::sync::atomic::AtomicBool,
+    outage_logged: Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[cfg(feature = "redis")]
+impl Clone for RedisStore {
+    fn clone(&self) -> Self {
+        Self {
+            connection: self.connection.clone(),
+            key_prefix: self.key_prefix.clone(),
+            failure_mode: self.failure_mode,
+            outage_logged: Arc::clone(&self.outage_logged),
+        }
+    }
 }
 
 #[cfg(feature = "redis")]
@@ -242,7 +262,7 @@ impl std::fmt::Debug for RedisStore {
 
 #[cfg(feature = "redis")]
 impl RedisStore {
-    const fn new(
+    fn new(
         connection: redis::aio::ConnectionManager,
         key_prefix: String,
         failure_mode: RateLimitBackendFailure,
@@ -251,7 +271,7 @@ impl RedisStore {
             connection,
             key_prefix,
             failure_mode,
-            outage_logged: std::sync::atomic::AtomicBool::new(false),
+            outage_logged: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 
@@ -351,7 +371,7 @@ impl RedisStore {
 
 // ── Backend enum ──────────────────────────────────────────────────────────────
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum BucketBackend {
     Memory(MemoryStore),
     #[cfg(feature = "redis")]
@@ -542,25 +562,24 @@ impl Limiter {
         BucketBackend::Memory(MemoryStore::new())
     }
 
-    /// Resolve effective burst/rps for this request, consulting path overrides.
+    /// Resolve explicit path-override params for this request.
     ///
-    /// Returns `(burst, rps, key_namespace)` where `key_namespace` is a
-    /// non-empty string when a path override matched (used to isolate buckets
-    /// from the global default pool).
-    fn effective_params_with_ns<B>(&self, req: &Request<B>) -> (f64, f64, &str) {
+    /// Returns `(opt_burst, opt_rps, key_namespace)` where the `Option` values
+    /// are `Some` only when the override explicitly sets that field. `key_namespace`
+    /// is non-empty when a path override matched (used to isolate buckets from the
+    /// global default pool).
+    fn effective_params_with_ns<B>(&self, req: &Request<B>) -> (Option<f64>, Option<f64>, &str) {
         let path = req.uri().path();
         for (prefix, override_) in &self.path_overrides {
             if path.starts_with(prefix.as_str()) {
-                let burst = override_
-                    .burst
-                    .map_or(self.burst, |b| f64::from(b.max(1)));
+                let burst = override_.burst.map(|b| f64::from(b.max(1)));
                 let rps = override_
                     .requests_per_second
-                    .map_or(self.refill_per_sec, |r| r.max(f64::MIN_POSITIVE));
+                    .map(|r| r.max(f64::MIN_POSITIVE));
                 return (burst, rps, prefix.as_str());
             }
         }
-        (self.burst, self.refill_per_sec, "")
+        (None, None, "")
     }
 
     /// Resolve the bucket key and effective tier params for a request.
@@ -568,7 +587,7 @@ impl Limiter {
     /// Returns `(bucket_key, burst, rps)` or `None` if rate limiting should
     /// be bypassed for this request (in-process caller with no identifiable peer).
     fn resolve_key_and_params<B>(&self, req: &Request<B>) -> Option<(String, f64, f64)> {
-        let (path_burst, path_rps, key_ns) = self.effective_params_with_ns(req);
+        let (opt_burst, opt_rps, key_ns) = self.effective_params_with_ns(req);
 
         let raw_key = self.extract_key(req)?;
 
@@ -581,31 +600,27 @@ impl Limiter {
             format!("{key_ns}\0{raw_key}")
         };
 
+        let mut burst = opt_burst.unwrap_or(self.burst);
+        let mut rps = opt_rps.unwrap_or(self.refill_per_sec);
+
         // Apply tier hook if configured. Pass the raw (un-prefixed) value so
         // hooks receive e.g. "user-42" rather than "principal:user-42".
+        // Path overrides always take precedence over tier limits when explicitly set.
         if let Some(hook) = &self.tier_hook {
             let value = strip_key_prefix(&raw_key);
             if let Some(tier_name) = hook.call(value) {
                 if let Some(tier) = self.tiers.get(&tier_name) {
-                    let tier_burst = f64::from(tier.burst.max(1));
-                    let tier_rps = tier.requests_per_second.max(f64::MIN_POSITIVE);
-                    // Path overrides take precedence over tier when explicitly set.
-                    let burst = if path_burst != self.burst {
-                        path_burst
-                    } else {
-                        tier_burst
-                    };
-                    let rps = if path_rps != self.refill_per_sec {
-                        path_rps
-                    } else {
-                        tier_rps
-                    };
-                    return Some((key, burst, rps));
+                    if opt_burst.is_none() {
+                        burst = f64::from(tier.burst.max(1));
+                    }
+                    if opt_rps.is_none() {
+                        rps = tier.requests_per_second.max(f64::MIN_POSITIVE);
+                    }
                 }
             }
         }
 
-        Some((key, path_burst, path_rps))
+        Some((key, burst, rps))
     }
 
     /// Extract the bucket key based on the configured strategy.
@@ -638,9 +653,7 @@ impl Limiter {
     #[allow(clippy::unused_async)]
     async fn decide(&self, key: &str, burst: f64, rps: f64) -> Option<Decision> {
         match &self.backend {
-            BucketBackend::Memory(store) => {
-                Some(store.decide(key, Instant::now(), burst, rps))
-            }
+            BucketBackend::Memory(store) => Some(store.decide(key, Instant::now(), burst, rps)),
             #[cfg(feature = "redis")]
             BucketBackend::Redis(store) => store.decide(key, burst, rps).await,
         }
@@ -860,8 +873,8 @@ impl RateLimitLayer {
     where
         F: Fn(&str) -> Option<String> + Send + Sync + 'static,
     {
-        let mut limiter = Arc::try_unwrap(self.limiter)
-            .unwrap_or_else(|arc| (*arc).clone_without_hook());
+        let mut limiter =
+            Arc::try_unwrap(self.limiter).unwrap_or_else(|arc| (*arc).clone_without_hook());
         limiter.tier_hook = Some(TierHookFn(Arc::new(hook)));
         Self {
             limiter: Arc::new(limiter),
@@ -882,9 +895,13 @@ impl RateLimitLayer {
     ///     });
     /// ```
     #[must_use]
-    pub fn with_path_override(self, path_prefix: impl Into<String>, override_: RateLimitOverride) -> Self {
-        let mut limiter = Arc::try_unwrap(self.limiter)
-            .unwrap_or_else(|arc| (*arc).clone_without_hook());
+    pub fn with_path_override(
+        self,
+        path_prefix: impl Into<String>,
+        override_: RateLimitOverride,
+    ) -> Self {
+        let mut limiter =
+            Arc::try_unwrap(self.limiter).unwrap_or_else(|arc| (*arc).clone_without_hook());
         limiter.path_overrides.push((path_prefix.into(), override_));
         Self {
             limiter: Arc::new(limiter),
@@ -906,7 +923,7 @@ impl Limiter {
             tiers: Arc::clone(&self.tiers),
             tier_hook: None,
             path_overrides: self.path_overrides.clone(),
-            backend: BucketBackend::Memory(MemoryStore::new()),
+            backend: self.backend.clone(),
         }
     }
 }
@@ -960,13 +977,14 @@ where
                 None => None,
             };
 
-            let burst_for_header = resolved
-                .as_ref()
-                .map_or(limiter.burst_header.clone(), |(_, burst, _)| {
-                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                    let b = *burst as u32;
-                    HeaderValue::from(b)
-                });
+            let burst_for_header =
+                resolved
+                    .as_ref()
+                    .map_or(limiter.burst_header.clone(), |(_, burst, _)| {
+                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                        let b = *burst as u32;
+                        HeaderValue::from(b)
+                    });
 
             match decision {
                 Some(Decision::Denied {
@@ -1266,21 +1284,27 @@ mod tests {
 
         // Immediately after, bucket.tokens = 0.0. Deficit = 1.0. Secs = 1.0 / 0.1 = 10.0
         match store.decide("ip1", now, 1.0, 0.1) {
-            Decision::Denied { retry_after_secs, .. } => assert_eq!(retry_after_secs, 10),
+            Decision::Denied {
+                retry_after_secs, ..
+            } => assert_eq!(retry_after_secs, 10),
             Decision::Allowed { .. } => panic!("Expected Denied"),
         }
 
         // 5 seconds later, bucket.tokens = 0.5. Deficit = 0.5. Secs = 0.5 / 0.1 = 5.0
         let later = now + Duration::from_secs(5);
         match store.decide("ip1", later, 1.0, 0.1) {
-            Decision::Denied { retry_after_secs, .. } => assert_eq!(retry_after_secs, 5),
+            Decision::Denied {
+                retry_after_secs, ..
+            } => assert_eq!(retry_after_secs, 5),
             Decision::Allowed { .. } => panic!("Expected Denied"),
         }
 
         // 9.5 seconds later, bucket.tokens = 0.95. Deficit = 0.05. Secs = 0.05 / 0.1 = 0.5 -> ceil -> 1.0
         let even_later = now + Duration::from_millis(9500);
         match store.decide("ip1", even_later, 1.0, 0.1) {
-            Decision::Denied { retry_after_secs, .. } => assert_eq!(retry_after_secs, 1),
+            Decision::Denied {
+                retry_after_secs, ..
+            } => assert_eq!(retry_after_secs, 1),
             Decision::Allowed { .. } => panic!("Expected Denied"),
         }
     }
@@ -1695,7 +1719,10 @@ mod tests {
             .header("authorization", "Bearer my-secret-token")
             .body(())
             .unwrap();
-        assert_eq!(extract_bearer_token(&req).as_deref(), Some("my-secret-token"));
+        assert_eq!(
+            extract_bearer_token(&req).as_deref(),
+            Some("my-secret-token")
+        );
     }
 
     #[test]
@@ -1734,7 +1761,10 @@ mod tests {
 
     #[test]
     fn key_class_label_principal() {
-        assert_eq!(key_class_label("principal:user-42"), "authenticated principal");
+        assert_eq!(
+            key_class_label("principal:user-42"),
+            "authenticated principal"
+        );
     }
 
     #[test]
@@ -1931,8 +1961,8 @@ mod tests {
 
     #[tokio::test]
     async fn tier_hook_assigns_correct_burst_to_tier() {
-        use std::collections::HashMap;
         use super::super::config::RateLimitTierConfig;
+        use std::collections::HashMap;
 
         let mut tiers = HashMap::new();
         tiers.insert(

--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -1,63 +1,52 @@
 //! Rate limiting middleware.
 //!
-//! Protects endpoints from abuse by applying a per-client-IP token bucket.
-//! Requests that exhaust their bucket receive `429 Too Many Requests` with
-//! a `Retry-After` header indicating when to retry.
+//! Protects endpoints from abuse by applying a per-client token bucket.
+//! The bucket key defaults to client IP and can be changed to
+//! authenticated principal or API bearer token via [`KeyStrategy`].
+//! Requests that exhaust their bucket receive `429 Too Many Requests`
+//! in Problem Details format (RFC 9457) with `Retry-After` and
+//! `X-RateLimit-*` headers.
 //!
-//! # How it works
+//! # Key strategies
 //!
-//! Each client IP gets its own token bucket holding up to `burst` tokens
-//! that refill at `requests_per_second`. Every incoming request costs one
-//! token. When the bucket is empty the middleware rejects the request
-//! without invoking the handler.
+//! | Strategy | Key source | Fallback |
+//! |----------|-----------|---------|
+//! | `ip` (default) | Connection peer / `X-Forwarded-For` | — |
+//! | `api_token` | `Authorization: Bearer <token>` | client IP |
+//! | `authenticated_principal` | [`RateLimitPrincipal`] extension | client IP |
 //!
-//! Client IP is extracted from the connection peer address
-//! ([`ConnectInfo<SocketAddr>`]) by default. When
-//! [`RateLimitConfig::trust_forwarded_headers`] is `true` — which should
-//! only be set behind a reverse proxy that strips and rewrites these
-//! headers — the limiter consults `X-Forwarded-For` and `X-Real-IP` first,
-//! falling back to the peer address. If
-//! [`RateLimitConfig::trusted_proxies`] is configured, trusted proxy
-//! addresses at the right side of the `X-Forwarded-For` chain are skipped,
-//! but only when the request peer address is present and trusted, so
-//! appended proxy chains still key on the nearest untrusted client without
-//! trusting spoofable headers from direct callers.
+//! # Tiered quotas
 //!
-//! Requests with no identifiable client (no trusted forwarding header
-//! AND no `ConnectInfo`) bypass rate limiting entirely. In-process
-//! callers such as the static site generator and test harnesses that
-//! invoke the router via [`tower::ServiceExt::oneshot`] fall into this
-//! bucket and must not be throttled.
+//! Register named tiers in `autumn.toml` and map principals to tiers via
+//! [`RateLimitLayer::with_tier_hook`]. Callers not assigned a tier use the
+//! top-level `requests_per_second` / `burst` defaults.
+//!
+//! # Per-path overrides
+//!
+//! Call [`RateLimitLayer::with_path_override`] to apply stricter or laxer
+//! limits on specific URL paths without disabling the global limiter.
 //!
 //! # Backends
 //!
-//! The bucket store is configurable via [`RateLimitConfig::backend`]:
-//!
-//! - `"memory"` (default): in-process LRU of token buckets. Zero-config for
-//!   development. Each replica enforces the limit independently, so a
-//!   3-replica deployment permits up to 3× the configured rate.
-//! - `"redis"`: shared bucket store coordinated across replicas via an atomic
-//!   Lua script. The configured rate is enforced globally regardless of replica
-//!   count. Reuses the same Redis connection as sessions, cache, and the
-//!   scheduler.
-//!
-//! When the Redis backend is unavailable, behavior is controlled by
-//! [`RateLimitConfig::on_backend_failure`]:
-//! - `"fail_open"` (default): allow the request through, matching the
-//!   existing single-replica posture.
-//! - `"fail_closed"`: return `429` until the backend recovers.
-//!
-//! A single `tracing::warn!` is emitted per outage, not per request.
+//! - `"memory"` (default): in-process LRU, zero-config for development.
+//! - `"redis"`: shared atomic bucket across replicas (requires `redis` feature).
 //!
 //! # Configuration
-//!
-//! See [`RateLimitConfig`] for available settings.
 //!
 //! ```toml
 //! [security.rate_limit]
 //! enabled = true
 //! requests_per_second = 10.0
 //! burst = 20
+//! key_strategy = "authenticated_principal"
+//!
+//! [security.rate_limit.tiers.free]
+//! requests_per_second = 1.0
+//! burst = 10
+//!
+//! [security.rate_limit.tiers.pro]
+//! requests_per_second = 10.0
+//! burst = 100
 //!
 //! # Multi-replica: share the budget across all pods
 //! backend = "redis"
@@ -79,21 +68,71 @@ use std::time::Instant;
 
 use axum::extract::ConnectInfo;
 use axum::http::{HeaderValue, Request, Response, StatusCode};
-use http::header::{HeaderName, RETRY_AFTER};
+use http::header::{CONTENT_TYPE, HeaderName, RETRY_AFTER};
 use tower::{Layer, Service};
 
 #[cfg(feature = "redis")]
 use super::config::RateLimitBackendFailure;
-use super::config::{RateLimitBackend, RateLimitConfig};
+use super::config::{KeyStrategy, RateLimitBackend, RateLimitConfig, RateLimitTierConfig};
 
 const X_RATELIMIT_LIMIT: HeaderName = HeaderName::from_static("x-ratelimit-limit");
 const X_RATELIMIT_REMAINING: HeaderName = HeaderName::from_static("x-ratelimit-remaining");
+const X_RATELIMIT_RESET: HeaderName = HeaderName::from_static("x-ratelimit-reset");
+
+// ── Public extension types ────────────────────────────────────────────────────
+
+/// Request extension inserted by auth middleware to identify the authenticated
+/// principal for rate-limit keying.
+///
+/// Auth middleware that wants to participate in principal-keyed rate limiting
+/// should insert this type into the request extensions before the rate limiter
+/// runs. The value is typically the user ID or session principal ID.
+///
+/// ```rust,ignore
+/// // In auth middleware:
+/// req.extensions_mut().insert(RateLimitPrincipal(user_id.to_string()));
+/// ```
+///
+/// When `key_strategy = "authenticated_principal"` and this extension is absent,
+/// the limiter falls back to IP-based keying so unauthenticated callers are
+/// never silently unbounded.
+#[derive(Clone, Debug)]
+pub struct RateLimitPrincipal(pub String);
+
+/// Per-path rate limit override.
+///
+/// Apply a stricter or laxer limit on a specific URL prefix without disabling
+/// the global rate limiter. Register via [`RateLimitLayer::with_path_override`].
+///
+/// `None` fields inherit from the global config.
+///
+/// ```rust,ignore
+/// let layer = RateLimitLayer::from_config(&config)
+///     .with_path_override("/api/free", RateLimitOverride { burst: Some(5), requests_per_second: Some(1.0) });
+/// ```
+#[derive(Clone, Debug)]
+pub struct RateLimitOverride {
+    /// Override `requests_per_second` for this path prefix. `None` uses the global value.
+    pub requests_per_second: Option<f64>,
+    /// Override `burst` for this path prefix. `None` uses the global value.
+    pub burst: Option<u32>,
+}
+
+// ── Decision ──────────────────────────────────────────────────────────────────
 
 /// Outcome of consuming one token from a bucket.
 #[derive(Debug, Clone, Copy)]
 enum Decision {
-    Allowed { remaining: u32 },
-    Denied { retry_after_secs: u64 },
+    Allowed {
+        remaining: u32,
+        /// Unix timestamp (seconds) of when the bucket will be available again.
+        reset_at_unix: u64,
+    },
+    Denied {
+        retry_after_secs: u64,
+        /// Unix timestamp (seconds) of when the next token will be available.
+        reset_at_unix: u64,
+    },
 }
 
 // ── In-memory bucket store ────────────────────────────────────────────────────
@@ -104,7 +143,7 @@ struct Bucket {
     last_refill: Instant,
 }
 
-/// Per-IP token bucket state stored in-process.
+/// Per-key token bucket state stored in-process.
 #[derive(Debug)]
 struct MemoryStore {
     buckets: Mutex<LruCache<String, Bucket>>,
@@ -121,6 +160,11 @@ impl MemoryStore {
 
     #[allow(clippy::significant_drop_tightening)]
     fn decide(&self, key: &str, now: Instant, burst: f64, refill_per_sec: f64) -> Decision {
+        let now_unix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
         let tokens_after = {
             let mut buckets = match self.buckets.lock() {
                 Ok(guard) => guard,
@@ -153,14 +197,20 @@ impl MemoryStore {
             Ok(remaining_tokens) => {
                 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                 let remaining = remaining_tokens.floor() as u32;
-                Decision::Allowed { remaining }
+                Decision::Allowed {
+                    remaining,
+                    reset_at_unix: now_unix,
+                }
             }
             Err(current_tokens) => {
                 let deficit = 1.0 - current_tokens;
                 let secs = (deficit / refill_per_sec).ceil().max(1.0);
                 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                 let retry_after_secs = secs as u64;
-                Decision::Denied { retry_after_secs }
+                Decision::Denied {
+                    retry_after_secs,
+                    reset_at_unix: now_unix + retry_after_secs,
+                }
             }
         }
     }
@@ -208,6 +258,11 @@ impl RedisStore {
     async fn decide(&self, key: &str, burst: f64, refill_per_sec: f64) -> Option<Decision> {
         use std::time::{SystemTime, UNIX_EPOCH};
 
+        let now_unix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
         let redis_key = format!("{}:{}", self.key_prefix, key);
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -235,11 +290,17 @@ impl RedisStore {
                 if allowed {
                     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                     let remaining = values[1] as u32;
-                    Some(Decision::Allowed { remaining })
+                    Some(Decision::Allowed {
+                        remaining,
+                        reset_at_unix: now_unix,
+                    })
                 } else {
                     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                     let retry_after_secs = values[2].max(1) as u64;
-                    Some(Decision::Denied { retry_after_secs })
+                    Some(Decision::Denied {
+                        retry_after_secs,
+                        reset_at_unix: now_unix + retry_after_secs,
+                    })
                 }
             }
             Err(err) => {
@@ -259,6 +320,7 @@ impl RedisStore {
                     RateLimitBackendFailure::FailOpen => None,
                     RateLimitBackendFailure::FailClosed => Some(Decision::Denied {
                         retry_after_secs: 1,
+                        reset_at_unix: now_unix + 1,
                     }),
                 }
             }
@@ -279,6 +341,7 @@ impl RedisStore {
                     RateLimitBackendFailure::FailOpen => None,
                     RateLimitBackendFailure::FailClosed => Some(Decision::Denied {
                         retry_after_secs: 1,
+                        reset_at_unix: now_unix + 1,
                     }),
                 }
             }
@@ -297,6 +360,20 @@ enum BucketBackend {
 
 // ── Limiter (shared state) ────────────────────────────────────────────────────
 
+struct TierHookFn(Arc<dyn Fn(&str) -> Option<String> + Send + Sync>);
+
+impl TierHookFn {
+    fn call(&self, key: &str) -> Option<String> {
+        (self.0)(key)
+    }
+}
+
+impl std::fmt::Debug for TierHookFn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("TierHookFn")
+    }
+}
+
 /// Shared rate limiter state.
 #[derive(Debug)]
 struct Limiter {
@@ -306,6 +383,10 @@ struct Limiter {
     trust_forwarded_headers: bool,
     trusted_proxies_configured: bool,
     trusted_proxies: Vec<TrustedProxy>,
+    key_strategy: KeyStrategy,
+    tiers: Arc<std::collections::HashMap<String, RateLimitTierConfig>>,
+    tier_hook: Option<TierHookFn>,
+    path_overrides: Vec<(String, RateLimitOverride)>,
     backend: BucketBackend,
 }
 
@@ -397,6 +478,10 @@ impl Limiter {
             trust_forwarded_headers: config.trust_forwarded_headers,
             trusted_proxies_configured,
             trusted_proxies,
+            key_strategy: config.key_strategy,
+            tiers: Arc::new(config.tiers.clone()),
+            tier_hook: None,
+            path_overrides: Vec::new(),
             backend,
         }
     }
@@ -457,39 +542,137 @@ impl Limiter {
         BucketBackend::Memory(MemoryStore::new())
     }
 
-    /// Consume one token for `key`. Returns `None` when throttling must be bypassed
-    /// (no client, or Redis fail-open).
-    #[allow(clippy::unused_async)] // async is needed for the Redis arm when that feature is active
-    async fn decide(&self, key: &str) -> Option<Decision> {
-        match &self.backend {
-            BucketBackend::Memory(store) => {
-                Some(store.decide(key, Instant::now(), self.burst, self.refill_per_sec))
+    /// Resolve effective burst/rps for this request, consulting path overrides.
+    ///
+    /// Returns `(burst, rps, key_namespace)` where `key_namespace` is a
+    /// non-empty string when a path override matched (used to isolate buckets
+    /// from the global default pool).
+    fn effective_params_with_ns<B>(&self, req: &Request<B>) -> (f64, f64, &str) {
+        let path = req.uri().path();
+        for (prefix, override_) in &self.path_overrides {
+            if path.starts_with(prefix.as_str()) {
+                let burst = override_
+                    .burst
+                    .map_or(self.burst, |b| f64::from(b.max(1)));
+                let rps = override_
+                    .requests_per_second
+                    .map_or(self.refill_per_sec, |r| r.max(f64::MIN_POSITIVE));
+                return (burst, rps, prefix.as_str());
             }
-            #[cfg(feature = "redis")]
-            BucketBackend::Redis(store) => store.decide(key, self.burst, self.refill_per_sec).await,
+        }
+        (self.burst, self.refill_per_sec, "")
+    }
+
+    /// Resolve the bucket key and effective tier params for a request.
+    ///
+    /// Returns `(bucket_key, burst, rps)` or `None` if rate limiting should
+    /// be bypassed for this request (in-process caller with no identifiable peer).
+    fn resolve_key_and_params<B>(&self, req: &Request<B>) -> Option<(String, f64, f64)> {
+        let (path_burst, path_rps, key_ns) = self.effective_params_with_ns(req);
+
+        let raw_key = self.extract_key(req)?;
+
+        // Namespace the bucket key by the active path prefix so that different
+        // path overrides get independent token buckets (avoids burst-value
+        // collision when /strict and /normal share the same client IP).
+        let key = if key_ns.is_empty() {
+            raw_key.clone()
+        } else {
+            format!("{key_ns}\0{raw_key}")
+        };
+
+        // Apply tier hook if configured. Pass the raw (un-prefixed) value so
+        // hooks receive e.g. "user-42" rather than "principal:user-42".
+        if let Some(hook) = &self.tier_hook {
+            let value = strip_key_prefix(&raw_key);
+            if let Some(tier_name) = hook.call(value) {
+                if let Some(tier) = self.tiers.get(&tier_name) {
+                    let tier_burst = f64::from(tier.burst.max(1));
+                    let tier_rps = tier.requests_per_second.max(f64::MIN_POSITIVE);
+                    // Path overrides take precedence over tier when explicitly set.
+                    let burst = if path_burst != self.burst {
+                        path_burst
+                    } else {
+                        tier_burst
+                    };
+                    let rps = if path_rps != self.refill_per_sec {
+                        path_rps
+                    } else {
+                        tier_rps
+                    };
+                    return Some((key, burst, rps));
+                }
+            }
+        }
+
+        Some((key, path_burst, path_rps))
+    }
+
+    /// Extract the bucket key based on the configured strategy.
+    fn extract_key<B>(&self, req: &Request<B>) -> Option<String> {
+        match self.key_strategy {
+            KeyStrategy::Ip => self.client_ip(req),
+            KeyStrategy::ApiToken => {
+                let token = extract_bearer_token(req);
+                if token.is_some() {
+                    token.map(|t| format!("token:{t}"))
+                } else {
+                    self.client_ip(req)
+                }
+            }
+            KeyStrategy::AuthenticatedPrincipal => {
+                let principal = req
+                    .extensions()
+                    .get::<RateLimitPrincipal>()
+                    .map(|p| format!("principal:{}", p.0));
+                if principal.is_some() {
+                    principal
+                } else {
+                    self.client_ip(req)
+                }
+            }
         }
     }
+
+    /// Consume one token for `key`. Returns `None` when throttling must be bypassed.
+    #[allow(clippy::unused_async)]
+    async fn decide(&self, key: &str, burst: f64, rps: f64) -> Option<Decision> {
+        match &self.backend {
+            BucketBackend::Memory(store) => {
+                Some(store.decide(key, Instant::now(), burst, rps))
+            }
+            #[cfg(feature = "redis")]
+            BucketBackend::Redis(store) => store.decide(key, burst, rps).await,
+        }
+    }
+}
+
+/// Strip the "scheme:" prefix from an extracted bucket key before passing
+/// to the tier hook, so hooks receive the raw value (e.g. "user-42" rather
+/// than "principal:user-42").
+fn strip_key_prefix(key: &str) -> &str {
+    key.find(':').map_or(key, |pos| &key[pos + 1..])
+}
+
+/// Extract the key string from the `Authorization: Bearer <token>` header.
+fn extract_bearer_token<B>(req: &Request<B>) -> Option<String> {
+    req.headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| {
+            let mut parts = s.splitn(2, ' ');
+            let scheme = parts.next()?;
+            if !scheme.eq_ignore_ascii_case("bearer") {
+                return None;
+            }
+            parts.next().map(|t| t.trim().to_owned())
+        })
+        .filter(|t| !t.is_empty())
 }
 
 impl Limiter {
     /// Extract the originating client IP from a request, honoring this
     /// limiter's trusted-proxy policy.
-    ///
-    /// Returns `None` when no identifiable client is present, signalling
-    /// the middleware to bypass throttling. In-process callers such as
-    /// the static site generator and `Router::oneshot`-style test
-    /// harnesses fall into this path.
-    ///
-    /// When `trust_forwarded_headers` is `true`, `X-Forwarded-For` and
-    /// then `X-Real-IP` are consulted before [`ConnectInfo<SocketAddr>`].
-    /// If trusted proxies are configured, the `X-Forwarded-For` chain is
-    /// walked from right to left and configured proxy IPs/CIDRs are
-    /// skipped, but only when the request peer is present and trusted.
-    /// Without a trusted proxy list, the last non-empty XFF entry is used
-    /// for the existing single-proxy setup where proxies append the peer
-    /// address after any client-supplied header value. If that entry is
-    /// the immediate socket peer, the peer has appended its own address,
-    /// so the client entry immediately to its left is used instead.
     fn client_ip<B>(&self, req: &Request<B>) -> Option<String> {
         let peer_ip = Self::peer_ip(req);
 
@@ -582,11 +765,67 @@ impl Limiter {
     }
 }
 
+// ── Response building helpers ─────────────────────────────────────────────────
+
+/// Build the `application/problem+json` 429 body per RFC 9457.
+fn rate_limit_problem_json(key_class: &str) -> String {
+    use crate::error::problem_details_json_string;
+    use axum::http::StatusCode;
+
+    problem_details_json_string(
+        StatusCode::TOO_MANY_REQUESTS,
+        format!("Rate limit exceeded for {key_class}"),
+        None,
+        Some("https://autumn.dev/problems/rate-limited"),
+        None,
+        None,
+        true,
+    )
+}
+
+/// Classify the bucket key for user-facing error messages without leaking the value.
+fn key_class_label(key: &str) -> &'static str {
+    if key.starts_with("token:") {
+        "api token"
+    } else if key.starts_with("principal:") {
+        "authenticated principal"
+    } else {
+        "ip"
+    }
+}
+
 // ── Tower layer & service ─────────────────────────────────────────────────────
 
 /// Tower [`Layer`] that applies rate limiting.
 ///
 /// Applied automatically when `security.rate_limit.enabled = true`.
+///
+/// # Per-principal / API-token keying
+///
+/// Configure `key_strategy` in `autumn.toml` or set it programmatically:
+///
+/// ```rust,ignore
+/// let layer = RateLimitLayer::from_config(&config.security.rate_limit);
+/// ```
+///
+/// # Tiered quotas
+///
+/// Register a tier-assignment hook after creating the layer:
+///
+/// ```rust,ignore
+/// let layer = RateLimitLayer::from_config(&config.security.rate_limit)
+///     .with_tier_hook(|principal_id| match db.get_plan(principal_id) {
+///         "pro" => Some("pro".into()),
+///         _ => None,
+///     });
+/// ```
+///
+/// # Per-path overrides
+///
+/// ```rust,ignore
+/// let layer = RateLimitLayer::from_config(&config.security.rate_limit)
+///     .with_path_override("/api/free/", RateLimitOverride { burst: Some(5), requests_per_second: Some(1.0) });
+/// ```
 #[derive(Clone, Debug)]
 pub struct RateLimitLayer {
     limiter: Arc<Limiter>,
@@ -598,6 +837,76 @@ impl RateLimitLayer {
     pub fn from_config(config: &RateLimitConfig) -> Self {
         Self {
             limiter: Arc::new(Limiter::from_config(config)),
+        }
+    }
+
+    /// Register an app-supplied tier-assignment hook.
+    ///
+    /// The hook receives the extracted bucket key (principal ID or token, without
+    /// the scheme prefix) and returns a tier name that matches a key in
+    /// `[security.rate_limit.tiers]`. Returning `None` uses the top-level
+    /// `requests_per_second` / `burst` defaults.
+    ///
+    /// The hook is called synchronously on every request; keep it O(1).
+    ///
+    /// ```rust,ignore
+    /// let layer = RateLimitLayer::from_config(&config)
+    ///     .with_tier_hook(|key| {
+    ///         if key.starts_with("pro_") { Some("pro".into()) } else { None }
+    ///     });
+    /// ```
+    #[must_use]
+    pub fn with_tier_hook<F>(self, hook: F) -> Self
+    where
+        F: Fn(&str) -> Option<String> + Send + Sync + 'static,
+    {
+        let mut limiter = Arc::try_unwrap(self.limiter)
+            .unwrap_or_else(|arc| (*arc).clone_without_hook());
+        limiter.tier_hook = Some(TierHookFn(Arc::new(hook)));
+        Self {
+            limiter: Arc::new(limiter),
+        }
+    }
+
+    /// Register a per-path rate limit override.
+    ///
+    /// Requests whose URL path starts with `path_prefix` use the override's
+    /// `burst` / `requests_per_second` values instead of the global defaults.
+    /// The first matching prefix wins (registration order matters).
+    ///
+    /// ```rust,ignore
+    /// let layer = RateLimitLayer::from_config(&config)
+    ///     .with_path_override("/api/strict/", RateLimitOverride {
+    ///         burst: Some(1),
+    ///         requests_per_second: Some(0.1),
+    ///     });
+    /// ```
+    #[must_use]
+    pub fn with_path_override(self, path_prefix: impl Into<String>, override_: RateLimitOverride) -> Self {
+        let mut limiter = Arc::try_unwrap(self.limiter)
+            .unwrap_or_else(|arc| (*arc).clone_without_hook());
+        limiter.path_overrides.push((path_prefix.into(), override_));
+        Self {
+            limiter: Arc::new(limiter),
+        }
+    }
+}
+
+impl Limiter {
+    /// Clone all fields except the tier hook (used when we need to mutate).
+    fn clone_without_hook(&self) -> Self {
+        Self {
+            refill_per_sec: self.refill_per_sec,
+            burst: self.burst,
+            burst_header: self.burst_header.clone(),
+            trust_forwarded_headers: self.trust_forwarded_headers,
+            trusted_proxies_configured: self.trusted_proxies_configured,
+            trusted_proxies: self.trusted_proxies.clone(),
+            key_strategy: self.key_strategy,
+            tiers: Arc::clone(&self.tiers),
+            tier_hook: None,
+            path_overrides: self.path_overrides.clone(),
+            backend: BucketBackend::Memory(MemoryStore::new()),
         }
     }
 }
@@ -626,7 +935,7 @@ where
     S::Future: Send + 'static,
     S::Error: Send + 'static,
     ReqBody: Send + 'static,
-    ResBody: Default + Send + 'static,
+    ResBody: Default + From<String> + Send + 'static,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -637,8 +946,8 @@ where
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        // Extract the client key synchronously (no I/O required).
-        let client_key = self.limiter.client_ip(&req);
+        // Resolve key and effective params synchronously (no I/O).
+        let resolved = self.limiter.resolve_key_and_params(&req);
 
         let limiter = Arc::clone(&self.limiter);
         let mut inner = self.inner.clone();
@@ -646,27 +955,51 @@ where
         std::mem::swap(&mut self.inner, &mut inner);
 
         Box::pin(async move {
-            // Resolve the rate-limit decision (may be async for the Redis backend).
-            let decision = match client_key {
-                Some(key) => limiter.decide(&key).await,
+            let decision = match resolved {
+                Some((ref key, burst, rps)) => limiter.decide(key, burst, rps).await,
                 None => None,
             };
 
+            let burst_for_header = resolved
+                .as_ref()
+                .map_or(limiter.burst_header.clone(), |(_, burst, _)| {
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    let b = *burst as u32;
+                    HeaderValue::from(b)
+                });
+
             match decision {
-                Some(Decision::Denied { retry_after_secs }) => {
-                    let mut response = Response::new(ResBody::default());
+                Some(Decision::Denied {
+                    retry_after_secs,
+                    reset_at_unix,
+                }) => {
+                    let key_class = resolved
+                        .as_ref()
+                        .map_or("ip", |(k, _, _)| key_class_label(k));
+                    let body_json = rate_limit_problem_json(key_class);
+
+                    let mut response = Response::new(ResBody::from(body_json));
                     *response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
                     let headers = response.headers_mut();
                     headers.insert(RETRY_AFTER, HeaderValue::from(retry_after_secs));
-                    headers.insert(X_RATELIMIT_LIMIT, limiter.burst_header.clone());
+                    headers.insert(X_RATELIMIT_LIMIT, burst_for_header);
                     headers.insert(X_RATELIMIT_REMAINING, HeaderValue::from_static("0"));
+                    headers.insert(X_RATELIMIT_RESET, HeaderValue::from(reset_at_unix));
+                    headers.insert(
+                        CONTENT_TYPE,
+                        HeaderValue::from_static("application/problem+json"),
+                    );
                     Ok(response)
                 }
-                Some(Decision::Allowed { remaining }) => {
+                Some(Decision::Allowed {
+                    remaining,
+                    reset_at_unix,
+                }) => {
                     let mut response = inner.call(req).await?;
                     let headers = response.headers_mut();
-                    headers.insert(X_RATELIMIT_LIMIT, limiter.burst_header.clone());
+                    headers.insert(X_RATELIMIT_LIMIT, burst_for_header);
                     headers.insert(X_RATELIMIT_REMAINING, HeaderValue::from(remaining));
+                    headers.insert(X_RATELIMIT_RESET, HeaderValue::from(reset_at_unix));
                     Ok(response)
                 }
                 None => inner.call(req).await,
@@ -801,6 +1134,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn request_429_has_problem_details_body() {
+        let app = app(&cfg(true, 1.0, 1));
+
+        let _ = app.clone().oneshot(req_with_ip("9.9.9.9")).await.unwrap();
+        let response = app.clone().oneshot(req_with_ip("9.9.9.9")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        let ct = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.contains("application/problem+json"),
+            "content-type should be application/problem+json, got {ct}"
+        );
+
+        let reset = response.headers().get("x-ratelimit-reset");
+        assert!(reset.is_some(), "x-ratelimit-reset must be present on 429");
+    }
+
+    #[tokio::test]
+    async fn request_ok_has_ratelimit_reset_header() {
+        let app = app(&cfg(true, 10.0, 5));
+        let response = app.clone().oneshot(req_with_ip("8.8.8.8")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            response.headers().get("x-ratelimit-reset").is_some(),
+            "x-ratelimit-reset must be present on allowed responses"
+        );
+    }
+
+    #[tokio::test]
     async fn different_ips_are_independent() {
         let app = app(&cfg(true, 0.1, 1));
 
@@ -900,21 +1266,21 @@ mod tests {
 
         // Immediately after, bucket.tokens = 0.0. Deficit = 1.0. Secs = 1.0 / 0.1 = 10.0
         match store.decide("ip1", now, 1.0, 0.1) {
-            Decision::Denied { retry_after_secs } => assert_eq!(retry_after_secs, 10),
+            Decision::Denied { retry_after_secs, .. } => assert_eq!(retry_after_secs, 10),
             Decision::Allowed { .. } => panic!("Expected Denied"),
         }
 
         // 5 seconds later, bucket.tokens = 0.5. Deficit = 0.5. Secs = 0.5 / 0.1 = 5.0
         let later = now + Duration::from_secs(5);
         match store.decide("ip1", later, 1.0, 0.1) {
-            Decision::Denied { retry_after_secs } => assert_eq!(retry_after_secs, 5),
+            Decision::Denied { retry_after_secs, .. } => assert_eq!(retry_after_secs, 5),
             Decision::Allowed { .. } => panic!("Expected Denied"),
         }
 
         // 9.5 seconds later, bucket.tokens = 0.95. Deficit = 0.05. Secs = 0.05 / 0.1 = 0.5 -> ceil -> 1.0
         let even_later = now + Duration::from_millis(9500);
         match store.decide("ip1", even_later, 1.0, 0.1) {
-            Decision::Denied { retry_after_secs } => assert_eq!(retry_after_secs, 1),
+            Decision::Denied { retry_after_secs, .. } => assert_eq!(retry_after_secs, 1),
             Decision::Allowed { .. } => panic!("Expected Denied"),
         }
     }
@@ -1216,9 +1582,6 @@ mod tests {
 
     #[tokio::test]
     async fn requests_without_connect_info_bypass_rate_limit() {
-        // Static site generation and `Router::oneshot`-style callers
-        // don't set ConnectInfo. The limiter must pass them through so
-        // build-time rendering isn't throttled onto a shared bucket.
         let config = RateLimitConfig {
             enabled: true,
             requests_per_second: 0.001,
@@ -1324,13 +1687,111 @@ mod tests {
         assert_eq!(blocked.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 
+    // ── Key strategy unit tests ───────────────────────────────────────────────
+
+    #[test]
+    fn extract_bearer_token_parses_authorization_header() {
+        let req = Request::builder()
+            .header("authorization", "Bearer my-secret-token")
+            .body(())
+            .unwrap();
+        assert_eq!(extract_bearer_token(&req).as_deref(), Some("my-secret-token"));
+    }
+
+    #[test]
+    fn extract_bearer_token_case_insensitive_scheme() {
+        let req = Request::builder()
+            .header("authorization", "BEARER token123")
+            .body(())
+            .unwrap();
+        assert_eq!(extract_bearer_token(&req).as_deref(), Some("token123"));
+    }
+
+    #[test]
+    fn extract_bearer_token_returns_none_for_non_bearer() {
+        let req = Request::builder()
+            .header("authorization", "Basic dXNlcjpwYXNz")
+            .body(())
+            .unwrap();
+        assert!(extract_bearer_token(&req).is_none());
+    }
+
+    #[test]
+    fn extract_bearer_token_returns_none_when_absent() {
+        let req = Request::builder().body(()).unwrap();
+        assert!(extract_bearer_token(&req).is_none());
+    }
+
+    #[test]
+    fn key_class_label_ip() {
+        assert_eq!(key_class_label("1.2.3.4"), "ip");
+    }
+
+    #[test]
+    fn key_class_label_token() {
+        assert_eq!(key_class_label("token:abc123"), "api token");
+    }
+
+    #[test]
+    fn key_class_label_principal() {
+        assert_eq!(key_class_label("principal:user-42"), "authenticated principal");
+    }
+
+    #[test]
+    fn key_strategy_extract_api_token_with_header() {
+        let config = RateLimitConfig {
+            key_strategy: KeyStrategy::ApiToken,
+            trust_forwarded_headers: true,
+            ..Default::default()
+        };
+        let limiter = Limiter::from_config(&config);
+        let req = Request::builder()
+            .header("authorization", "Bearer tok-abc")
+            .header("X-Forwarded-For", "1.2.3.4")
+            .body(())
+            .unwrap();
+        let key = limiter.extract_key(&req).unwrap();
+        assert_eq!(key, "token:tok-abc");
+    }
+
+    #[test]
+    fn key_strategy_principal_uses_extension() {
+        let config = RateLimitConfig {
+            key_strategy: KeyStrategy::AuthenticatedPrincipal,
+            trust_forwarded_headers: true,
+            ..Default::default()
+        };
+        let limiter = Limiter::from_config(&config);
+        let mut req: Request<()> = Request::builder().body(()).unwrap();
+        req.extensions_mut()
+            .insert(RateLimitPrincipal("user-99".to_owned()));
+        let key = limiter.extract_key(&req).unwrap();
+        assert_eq!(key, "principal:user-99");
+    }
+
+    #[test]
+    fn key_strategy_principal_falls_back_to_ip() {
+        let config = RateLimitConfig {
+            key_strategy: KeyStrategy::AuthenticatedPrincipal,
+            trust_forwarded_headers: true,
+            ..Default::default()
+        };
+        let limiter = Limiter::from_config(&config);
+        let req: Request<()> = Request::builder()
+            .header("X-Forwarded-For", "5.5.5.5")
+            .body(())
+            .unwrap();
+        // No RateLimitPrincipal extension → falls back to IP.
+        let key = limiter.extract_key(&req).unwrap();
+        assert_eq!(key, "5.5.5.5");
+    }
+
     // ── Redis backend build_backend fallback tests ────────────────────────────
 
     #[cfg(feature = "redis")]
     #[tokio::test]
     async fn redis_store_debug_format() {
         use super::super::config::RateLimitBackendFailure;
-        // Check that RedisStore implements Debug correctly, logging key_prefix and failure_mode
         let client = redis::Client::open("redis://127.0.0.1/").unwrap();
         let connection = redis::aio::ConnectionManager::new_lazy_with_config(
             client,
@@ -1368,9 +1829,8 @@ mod tests {
                 key_prefix: "test:rl".to_owned(),
             },
             on_backend_failure: RateLimitBackendFailure::FailOpen,
+            ..Default::default()
         };
-        // When no Redis URL is provided, build_backend must not panic and the
-        // limiter must still enforce in-memory rate limits.
         let limiter = Limiter::from_config(&config);
         assert!(matches!(limiter.backend, BucketBackend::Memory(_)));
     }
@@ -1393,6 +1853,7 @@ mod tests {
                 key_prefix: "test:rl".to_owned(),
             },
             on_backend_failure: RateLimitBackendFailure::FailClosed,
+            ..Default::default()
         };
         let limiter = Limiter::from_config(&config);
         assert!(matches!(limiter.backend, BucketBackend::Memory(_)));
@@ -1409,5 +1870,124 @@ mod tests {
 
         let untrusted_ip: IpAddr = "192.168.1.1".parse().unwrap();
         assert!(!limiter.is_trusted_proxy(untrusted_ip));
+    }
+
+    // ── Path override tests ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn path_override_applies_stricter_burst() {
+        let config = RateLimitConfig {
+            enabled: true,
+            requests_per_second: 0.1,
+            burst: 5, // global: 5
+            trust_forwarded_headers: true,
+            ..Default::default()
+        };
+
+        let layer = RateLimitLayer::from_config(&config).with_path_override(
+            "/strict",
+            RateLimitOverride {
+                burst: Some(1), // override: 1
+                requests_per_second: None,
+            },
+        );
+
+        let app = Router::new()
+            .route("/strict", get(|| async { "strict" }))
+            .route("/normal", get(|| async { "normal" }))
+            .layer(layer);
+
+        let strict_req = || {
+            Request::builder()
+                .method("GET")
+                .uri("/strict")
+                .header("X-Forwarded-For", "2.2.2.2")
+                .body(Body::empty())
+                .unwrap()
+        };
+        let normal_req = || {
+            Request::builder()
+                .method("GET")
+                .uri("/normal")
+                .header("X-Forwarded-For", "2.2.2.2")
+                .body(Body::empty())
+                .unwrap()
+        };
+
+        // /strict: 1 allowed, then denied.
+        let r = app.clone().oneshot(strict_req()).await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        let r = app.clone().oneshot(strict_req()).await.unwrap();
+        assert_eq!(r.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        // /normal: still uses global burst=5, should pass.
+        for _ in 0..3 {
+            let r = app.clone().oneshot(normal_req()).await.unwrap();
+            assert_eq!(r.status(), StatusCode::OK);
+        }
+    }
+
+    // ── Tier hook tests ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn tier_hook_assigns_correct_burst_to_tier() {
+        use std::collections::HashMap;
+        use super::super::config::RateLimitTierConfig;
+
+        let mut tiers = HashMap::new();
+        tiers.insert(
+            "premium".to_owned(),
+            RateLimitTierConfig {
+                requests_per_second: 0.1,
+                burst: 10,
+            },
+        );
+
+        let config = RateLimitConfig {
+            enabled: true,
+            requests_per_second: 0.1,
+            burst: 1, // default
+            key_strategy: KeyStrategy::AuthenticatedPrincipal,
+            tiers,
+            ..Default::default()
+        };
+
+        let layer = RateLimitLayer::from_config(&config).with_tier_hook(|key| {
+            // key is the raw value after stripping the scheme prefix.
+            if key.starts_with("vip_") {
+                Some("premium".to_owned())
+            } else {
+                None
+            }
+        });
+
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(layer);
+
+        let make_req = |principal: &str| {
+            let mut req = Request::builder()
+                .method("GET")
+                .uri("/")
+                .body(Body::empty())
+                .unwrap();
+            req.extensions_mut()
+                .insert(RateLimitPrincipal(principal.to_owned()));
+            req
+        };
+
+        // Premium user: burst=10.
+        for i in 0..10 {
+            let r = app.clone().oneshot(make_req("vip_user")).await.unwrap();
+            assert_eq!(r.status(), StatusCode::OK, "premium request {i} failed");
+        }
+        let r = app.clone().oneshot(make_req("vip_user")).await.unwrap();
+        assert_eq!(r.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        // Regular user: burst=1.
+        let r = app.clone().oneshot(make_req("regular_user")).await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        let r = app.clone().oneshot(make_req("regular_user")).await.unwrap();
+        assert_eq!(r.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 }

--- a/autumn/tests/rate_limit_principal.rs
+++ b/autumn/tests/rate_limit_principal.rs
@@ -21,6 +21,7 @@ use autumn_web::{get, routes};
 use axum::Router;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -139,8 +140,6 @@ async fn principal_strategy_keys_on_principal_extension() {
             .insert(RateLimitPrincipal(principal.to_owned()));
         req
     };
-
-    use tower::ServiceExt;
 
     // Principal A uses 1 token.
     let r = app.clone().oneshot(make_req("user-42")).await.unwrap();

--- a/autumn/tests/rate_limit_principal.rs
+++ b/autumn/tests/rate_limit_principal.rs
@@ -1,0 +1,607 @@
+//! Integration tests for per-principal and API-token rate limiting (issue #794).
+//!
+//! Covers:
+//! - `key_strategy = "ip"` (existing default, preserved)
+//! - `key_strategy = "api_token"` (keys on Bearer token)
+//! - `key_strategy = "authenticated_principal"` (keys on principal ID from extensions)
+//! - Tiered limits via `tiers` table in config
+//! - `X-RateLimit-Reset` header presence on allowed and denied responses
+//! - Problem Details (RFC 9457) body and `application/problem+json` content-type on 429
+//! - Per-path override via `RateLimitLayer::with_path_override`
+//! - Unauthenticated fallback to IP when principal strategy is active
+//! - Tier assignment hook
+
+use autumn_web::config::AutumnConfig;
+use autumn_web::security::{KeyStrategy, RateLimitConfig, RateLimitLayer, RateLimitOverride, RateLimitPrincipal, RateLimitTierConfig};
+use autumn_web::test::TestApp;
+use autumn_web::{get, routes};
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn ip_config(rps: f64, burst: u32) -> AutumnConfig {
+    let mut config = AutumnConfig::default();
+    config.security.rate_limit.enabled = true;
+    config.security.rate_limit.requests_per_second = rps;
+    config.security.rate_limit.burst = burst;
+    config.security.rate_limit.trust_forwarded_headers = true;
+    config.security.rate_limit.key_strategy = KeyStrategy::Ip;
+    config
+}
+
+fn api_token_config(rps: f64, burst: u32) -> AutumnConfig {
+    let mut config = AutumnConfig::default();
+    config.security.rate_limit.enabled = true;
+    config.security.rate_limit.requests_per_second = rps;
+    config.security.rate_limit.burst = burst;
+    config.security.rate_limit.key_strategy = KeyStrategy::ApiToken;
+    config
+}
+
+fn principal_config(rps: f64, burst: u32) -> AutumnConfig {
+    let mut config = AutumnConfig::default();
+    config.security.rate_limit.enabled = true;
+    config.security.rate_limit.requests_per_second = rps;
+    config.security.rate_limit.burst = burst;
+    config.security.rate_limit.trust_forwarded_headers = true;
+    config.security.rate_limit.key_strategy = KeyStrategy::AuthenticatedPrincipal;
+    config
+}
+
+#[get("/ping")]
+async fn ping() -> &'static str {
+    "pong"
+}
+
+// ── Key strategy: api_token ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn api_token_strategy_keys_on_bearer_token() {
+    let client = TestApp::new()
+        .routes(routes![ping])
+        .config(api_token_config(0.1, 1))
+        .build();
+
+    // Token A gets one request.
+    client
+        .get("/ping")
+        .header("Authorization", "Bearer token-alpha")
+        .send()
+        .await
+        .assert_status(200);
+
+    // Token A's bucket is now exhausted.
+    client
+        .get("/ping")
+        .header("Authorization", "Bearer token-alpha")
+        .send()
+        .await
+        .assert_status(429);
+
+    // Token B still has a fresh bucket.
+    client
+        .get("/ping")
+        .header("Authorization", "Bearer token-beta")
+        .send()
+        .await
+        .assert_status(200);
+}
+
+#[tokio::test]
+async fn api_token_strategy_falls_back_to_ip_when_no_bearer() {
+    // When api_token strategy is active and no Authorization header is present,
+    // the limiter falls back to IP-based keying.
+    let mut config = api_token_config(0.1, 1);
+    config.security.rate_limit.trust_forwarded_headers = true;
+    let client = TestApp::new()
+        .routes(routes![ping])
+        .config(config)
+        .build();
+
+    client
+        .get("/ping")
+        .header("X-Forwarded-For", "10.0.0.1")
+        .send()
+        .await
+        .assert_status(200);
+
+    // Same IP without a token: exhausted.
+    client
+        .get("/ping")
+        .header("X-Forwarded-For", "10.0.0.1")
+        .send()
+        .await
+        .assert_status(429);
+}
+
+// ── Key strategy: authenticated_principal ─────────────────────────────────────
+
+#[tokio::test]
+async fn principal_strategy_keys_on_principal_extension() {
+    // Auth middleware sets RateLimitPrincipal on the request before the rate
+    // limiter runs. This test simulates that by injecting the extension directly.
+    let config = principal_config(0.1, 1);
+    let rl_layer = RateLimitLayer::from_config(&config.security.rate_limit);
+
+    let app = Router::new()
+        .route("/ping", axum::routing::get(|| async { "pong" }))
+        .layer(rl_layer);
+
+    let make_req = |principal: &str| {
+        let mut req = Request::builder()
+            .method("GET")
+            .uri("/ping")
+            .body(Body::empty())
+            .expect("request builds");
+        req.extensions_mut()
+            .insert(RateLimitPrincipal(principal.to_owned()));
+        req
+    };
+
+    use tower::ServiceExt;
+
+    // Principal A uses 1 token.
+    let r = app.clone().oneshot(make_req("user-42")).await.unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+
+    // Principal A is now exhausted.
+    let r = app.clone().oneshot(make_req("user-42")).await.unwrap();
+    assert_eq!(r.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    // Principal B still has a full bucket.
+    let r = app.clone().oneshot(make_req("user-99")).await.unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn principal_strategy_falls_back_to_ip_for_unauthenticated() {
+    // Without a RateLimitPrincipal extension, fall back to IP keying.
+    use axum::extract::ConnectInfo;
+    use std::net::SocketAddr;
+    use tower::ServiceExt;
+
+    let config = principal_config(0.1, 1);
+    let rl_layer = RateLimitLayer::from_config(&config.security.rate_limit);
+
+    let app = Router::new()
+        .route("/ping", axum::routing::get(|| async { "pong" }))
+        .layer(rl_layer);
+
+    let make_req = |peer: &str| {
+        let mut req = Request::builder()
+            .method("GET")
+            .uri("/ping")
+            .body(Body::empty())
+            .expect("request builds");
+        let addr: SocketAddr = peer.parse().expect("peer parses");
+        req.extensions_mut().insert(ConnectInfo(addr));
+        req
+    };
+
+    let r = app.clone().oneshot(make_req("10.0.0.1:1234")).await.unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+
+    let r = app.clone().oneshot(make_req("10.0.0.1:1234")).await.unwrap();
+    assert_eq!(r.status(), StatusCode::TOO_MANY_REQUESTS);
+}
+
+// ── X-RateLimit-Reset header ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn x_ratelimit_reset_present_on_allowed_response() {
+    let client = TestApp::new()
+        .routes(routes![ping])
+        .config(ip_config(10.0, 20))
+        .build();
+
+    let response = client
+        .get("/ping")
+        .header("X-Forwarded-For", "1.2.3.4")
+        .send()
+        .await;
+    response.assert_status(200);
+    let reset = response
+        .header("x-ratelimit-reset")
+        .expect("X-RateLimit-Reset must be present on allowed responses");
+    let reset_val: u64 = reset.parse().expect("X-RateLimit-Reset is a unix timestamp");
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    assert!(
+        reset_val <= now + 120,
+        "X-RateLimit-Reset={reset_val} should be within 120s of now={now}"
+    );
+}
+
+#[tokio::test]
+async fn x_ratelimit_reset_present_on_429_response() {
+    let client = TestApp::new()
+        .routes(routes![ping])
+        .config(ip_config(0.1, 1))
+        .build();
+
+    client
+        .get("/ping")
+        .header("X-Forwarded-For", "5.5.5.5")
+        .send()
+        .await
+        .assert_status(200);
+
+    let throttled = client
+        .get("/ping")
+        .header("X-Forwarded-For", "5.5.5.5")
+        .send()
+        .await;
+    throttled.assert_status(429);
+    let reset = throttled
+        .header("x-ratelimit-reset")
+        .expect("X-RateLimit-Reset must be present on 429 responses");
+    let reset_val: u64 = reset.parse().expect("X-RateLimit-Reset is a unix timestamp");
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    assert!(
+        reset_val >= now,
+        "X-RateLimit-Reset={reset_val} should be >= now={now} on a 429"
+    );
+}
+
+// ── 429 Problem Details body ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn throttled_response_is_problem_details_json() {
+    let client = TestApp::new()
+        .routes(routes![ping])
+        .config(ip_config(0.1, 1))
+        .build();
+
+    client
+        .get("/ping")
+        .header("X-Forwarded-For", "6.6.6.6")
+        .send()
+        .await
+        .assert_status(200);
+
+    let throttled = client
+        .get("/ping")
+        .header("X-Forwarded-For", "6.6.6.6")
+        .send()
+        .await;
+    throttled.assert_status(429);
+    throttled.assert_header_contains("content-type", "application/problem+json");
+
+    let body: serde_json::Value = throttled.json();
+    assert_eq!(body["status"], 429);
+    assert!(
+        body["type"].as_str().is_some_and(|t| !t.is_empty()),
+        "Problem Details must have a type URI"
+    );
+    assert!(
+        body["title"].as_str().is_some_and(|t| !t.is_empty()),
+        "Problem Details must have a title"
+    );
+    assert!(
+        body["detail"].as_str().is_some_and(|d| !d.is_empty()),
+        "Problem Details must have a detail"
+    );
+    // Must not leak the raw key value.
+    let body_str = body.to_string();
+    assert!(
+        !body_str.contains("6.6.6.6"),
+        "429 Problem Details must not leak the raw rate-limit key"
+    );
+}
+
+#[tokio::test]
+async fn problem_details_includes_stable_type_uri() {
+    let client = TestApp::new()
+        .routes(routes![ping])
+        .config(ip_config(0.1, 1))
+        .build();
+
+    client
+        .get("/ping")
+        .header("X-Forwarded-For", "7.7.7.7")
+        .send()
+        .await
+        .assert_status(200);
+
+    let throttled = client
+        .get("/ping")
+        .header("X-Forwarded-For", "7.7.7.7")
+        .send()
+        .await;
+    throttled.assert_status(429);
+
+    let body: serde_json::Value = throttled.json();
+    assert_eq!(
+        body["type"].as_str(),
+        Some("https://autumn.dev/problems/rate-limited"),
+        "Rate limit 429 must use the stable type URI"
+    );
+    assert!(
+        body["code"].as_str().is_some(),
+        "Rate limit 429 must include a stable code"
+    );
+}
+
+// ── Problem Details does not leak key class ──────────────────────────────────
+
+#[tokio::test]
+async fn problem_details_includes_key_class_without_leaking_key() {
+    let client = TestApp::new()
+        .routes(routes![ping])
+        .config(api_token_config(0.1, 1))
+        .build();
+
+    client
+        .get("/ping")
+        .header("Authorization", "Bearer secret-token-value")
+        .send()
+        .await
+        .assert_status(200);
+
+    let throttled = client
+        .get("/ping")
+        .header("Authorization", "Bearer secret-token-value")
+        .send()
+        .await;
+    throttled.assert_status(429);
+
+    let body: serde_json::Value = throttled.json();
+    let body_str = body.to_string();
+    // The key class (token, ip, principal) may appear; the raw value must not.
+    assert!(
+        !body_str.contains("secret-token-value"),
+        "429 body must not leak the raw token value"
+    );
+    // The detail should mention what kind of key was rate-limited.
+    let detail = body["detail"].as_str().unwrap_or("");
+    assert!(!detail.is_empty(), "detail must be non-empty");
+}
+
+// ── Tiered limits ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn tier_assignment_hook_selects_correct_limits() {
+    use tower::ServiceExt;
+
+    let mut rl_config = RateLimitConfig {
+        enabled: true,
+        requests_per_second: 0.1,
+        burst: 1, // default for unrecognized tier
+        key_strategy: KeyStrategy::AuthenticatedPrincipal,
+        ..Default::default()
+    };
+    rl_config.tiers.insert(
+        "pro".to_owned(),
+        RateLimitTierConfig {
+            requests_per_second: 0.1,
+            burst: 5,
+        },
+    );
+
+    let rl_layer = RateLimitLayer::from_config(&rl_config).with_tier_hook(|principal_id: &str| {
+        if principal_id.starts_with("pro_") {
+            Some("pro".to_owned())
+        } else {
+            None
+        }
+    });
+
+    let app = Router::new()
+        .route("/ping", axum::routing::get(|| async { "pong" }))
+        .layer(rl_layer);
+
+    // Pro user: burst=5, can make 5 requests.
+    for i in 0..5 {
+        let mut req = Request::builder()
+            .method("GET")
+            .uri("/ping")
+            .body(Body::empty())
+            .expect("request builds");
+        req.extensions_mut()
+            .insert(RateLimitPrincipal("pro_user123".to_owned()));
+        let r = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(
+            r.status(),
+            StatusCode::OK,
+            "pro user request {i} should be allowed"
+        );
+    }
+
+    // Pro user: 6th request is over burst=5.
+    let mut req = Request::builder()
+        .method("GET")
+        .uri("/ping")
+        .body(Body::empty())
+        .expect("request builds");
+    req.extensions_mut()
+        .insert(RateLimitPrincipal("pro_user123".to_owned()));
+    let r = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(
+        r.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "6th pro request should be throttled"
+    );
+
+    // Free user: burst=1, exhausted after 1 request.
+    let mut req = Request::builder()
+        .method("GET")
+        .uri("/ping")
+        .body(Body::empty())
+        .expect("request builds");
+    req.extensions_mut()
+        .insert(RateLimitPrincipal("free_user456".to_owned()));
+    let r = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(r.status(), StatusCode::OK, "first free user request should pass");
+
+    let mut req = Request::builder()
+        .method("GET")
+        .uri("/ping")
+        .body(Body::empty())
+        .expect("request builds");
+    req.extensions_mut()
+        .insert(RateLimitPrincipal("free_user456".to_owned()));
+    let r = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(
+        r.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "second free user request should be throttled"
+    );
+}
+
+// ── Per-path override ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn per_path_override_applies_stricter_limit() {
+    use tower::ServiceExt;
+
+    let rl_config = RateLimitConfig {
+        enabled: true,
+        requests_per_second: 0.1,
+        burst: 10, // global: generous
+        trust_forwarded_headers: true,
+        key_strategy: KeyStrategy::Ip,
+        ..Default::default()
+    };
+
+    let rl_layer = RateLimitLayer::from_config(&rl_config).with_path_override(
+        "/strict",
+        RateLimitOverride {
+            requests_per_second: Some(0.1),
+            burst: Some(1),
+        },
+    );
+
+    let app = Router::new()
+        .route("/strict", axum::routing::get(|| async { "strict" }))
+        .route("/normal", axum::routing::get(|| async { "normal" }))
+        .layer(rl_layer);
+
+    let make_req = |path: &str| {
+        use axum::extract::ConnectInfo;
+        use std::net::SocketAddr;
+        let mut req = Request::builder()
+            .method("GET")
+            .uri(path)
+            .body(Body::empty())
+            .expect("request builds");
+        let addr: SocketAddr = "1.2.3.4:1234".parse().unwrap();
+        req.extensions_mut().insert(ConnectInfo(addr));
+        req
+    };
+
+    // /strict: first request OK with burst=1, second throttled.
+    let r = app.clone().oneshot(make_req("/strict")).await.unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+    let r = app.clone().oneshot(make_req("/strict")).await.unwrap();
+    assert_eq!(r.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    // /normal uses global burst=10, should still pass for many requests.
+    for _ in 0..5 {
+        let r = app.clone().oneshot(make_req("/normal")).await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+    }
+}
+
+// ── Migration: existing ip config keys still work ─────────────────────────────
+
+#[tokio::test]
+async fn default_key_strategy_is_ip() {
+    let config = RateLimitConfig::default();
+    assert_eq!(config.key_strategy, KeyStrategy::Ip);
+}
+
+#[tokio::test]
+async fn existing_ip_config_still_works() {
+    let mut config = AutumnConfig::default();
+    config.security.rate_limit.enabled = true;
+    config.security.rate_limit.requests_per_second = 0.1;
+    config.security.rate_limit.burst = 1;
+    config.security.rate_limit.trust_forwarded_headers = true;
+    // No key_strategy set — uses default (Ip).
+
+    let client = TestApp::new()
+        .routes(routes![ping])
+        .config(config)
+        .build();
+
+    client
+        .get("/ping")
+        .header("X-Forwarded-For", "9.9.9.9")
+        .send()
+        .await
+        .assert_status(200);
+
+    client
+        .get("/ping")
+        .header("X-Forwarded-For", "9.9.9.9")
+        .send()
+        .await
+        .assert_status(429);
+}
+
+// ── Config deserialization ────────────────────────────────────────────────────
+
+#[test]
+fn key_strategy_deserializes_from_toml() {
+    let toml = r#"
+        enabled = true
+        key_strategy = "api_token"
+    "#;
+    let config: RateLimitConfig = toml::from_str(toml).unwrap();
+    assert_eq!(config.key_strategy, KeyStrategy::ApiToken);
+}
+
+#[test]
+fn key_strategy_authenticated_principal_deserializes() {
+    let toml = r#"
+        enabled = true
+        key_strategy = "authenticated_principal"
+    "#;
+    let config: RateLimitConfig = toml::from_str(toml).unwrap();
+    assert_eq!(config.key_strategy, KeyStrategy::AuthenticatedPrincipal);
+}
+
+#[test]
+fn key_strategy_ip_deserializes() {
+    let toml = r#"
+        enabled = true
+        key_strategy = "ip"
+    "#;
+    let config: RateLimitConfig = toml::from_str(toml).unwrap();
+    assert_eq!(config.key_strategy, KeyStrategy::Ip);
+}
+
+#[test]
+fn tiers_deserialize_from_toml() {
+    let toml = r#"
+        enabled = true
+        key_strategy = "authenticated_principal"
+
+        [tiers.free]
+        requests_per_second = 1.0
+        burst = 10
+
+        [tiers.pro]
+        requests_per_second = 10.0
+        burst = 100
+    "#;
+    let config: RateLimitConfig = toml::from_str(toml).unwrap();
+    assert_eq!(config.tiers.len(), 2);
+    assert!((config.tiers["free"].requests_per_second - 1.0).abs() < f64::EPSILON);
+    assert_eq!(config.tiers["free"].burst, 10);
+    assert!((config.tiers["pro"].requests_per_second - 10.0).abs() < f64::EPSILON);
+    assert_eq!(config.tiers["pro"].burst, 100);
+}
+
+#[test]
+fn tiers_empty_by_default() {
+    let config = RateLimitConfig::default();
+    assert!(config.tiers.is_empty());
+}

--- a/autumn/tests/rate_limit_principal.rs
+++ b/autumn/tests/rate_limit_principal.rs
@@ -12,7 +12,10 @@
 //! - Tier assignment hook
 
 use autumn_web::config::AutumnConfig;
-use autumn_web::security::{KeyStrategy, RateLimitConfig, RateLimitLayer, RateLimitOverride, RateLimitPrincipal, RateLimitTierConfig};
+use autumn_web::security::{
+    KeyStrategy, RateLimitConfig, RateLimitLayer, RateLimitOverride, RateLimitPrincipal,
+    RateLimitTierConfig,
+};
 use autumn_web::test::TestApp;
 use autumn_web::{get, routes};
 use axum::Router;
@@ -95,10 +98,7 @@ async fn api_token_strategy_falls_back_to_ip_when_no_bearer() {
     // the limiter falls back to IP-based keying.
     let mut config = api_token_config(0.1, 1);
     config.security.rate_limit.trust_forwarded_headers = true;
-    let client = TestApp::new()
-        .routes(routes![ping])
-        .config(config)
-        .build();
+    let client = TestApp::new().routes(routes![ping]).config(config).build();
 
     client
         .get("/ping")
@@ -180,10 +180,18 @@ async fn principal_strategy_falls_back_to_ip_for_unauthenticated() {
         req
     };
 
-    let r = app.clone().oneshot(make_req("10.0.0.1:1234")).await.unwrap();
+    let r = app
+        .clone()
+        .oneshot(make_req("10.0.0.1:1234"))
+        .await
+        .unwrap();
     assert_eq!(r.status(), StatusCode::OK);
 
-    let r = app.clone().oneshot(make_req("10.0.0.1:1234")).await.unwrap();
+    let r = app
+        .clone()
+        .oneshot(make_req("10.0.0.1:1234"))
+        .await
+        .unwrap();
     assert_eq!(r.status(), StatusCode::TOO_MANY_REQUESTS);
 }
 
@@ -205,7 +213,9 @@ async fn x_ratelimit_reset_present_on_allowed_response() {
     let reset = response
         .header("x-ratelimit-reset")
         .expect("X-RateLimit-Reset must be present on allowed responses");
-    let reset_val: u64 = reset.parse().expect("X-RateLimit-Reset is a unix timestamp");
+    let reset_val: u64 = reset
+        .parse()
+        .expect("X-RateLimit-Reset is a unix timestamp");
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -239,7 +249,9 @@ async fn x_ratelimit_reset_present_on_429_response() {
     let reset = throttled
         .header("x-ratelimit-reset")
         .expect("X-RateLimit-Reset must be present on 429 responses");
-    let reset_val: u64 = reset.parse().expect("X-RateLimit-Reset is a unix timestamp");
+    let reset_val: u64 = reset
+        .parse()
+        .expect("X-RateLimit-Reset is a unix timestamp");
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -438,7 +450,11 @@ async fn tier_assignment_hook_selects_correct_limits() {
     req.extensions_mut()
         .insert(RateLimitPrincipal("free_user456".to_owned()));
     let r = app.clone().oneshot(req).await.unwrap();
-    assert_eq!(r.status(), StatusCode::OK, "first free user request should pass");
+    assert_eq!(
+        r.status(),
+        StatusCode::OK,
+        "first free user request should pass"
+    );
 
     let mut req = Request::builder()
         .method("GET")
@@ -526,10 +542,7 @@ async fn existing_ip_config_still_works() {
     config.security.rate_limit.trust_forwarded_headers = true;
     // No key_strategy set — uses default (Ip).
 
-    let client = TestApp::new()
-        .routes(routes![ping])
-        .config(config)
-        .build();
+    let client = TestApp::new().routes(routes![ping]).config(config).build();
 
     client
         .get("/ping")

--- a/autumn/tests/rate_limit_redis_integration.rs
+++ b/autumn/tests/rate_limit_redis_integration.rs
@@ -71,6 +71,8 @@ async fn two_replicas_share_global_budget() {
             key_prefix: "test:rl".to_owned(),
         },
         on_backend_failure: RateLimitBackendFailure::FailOpen,
+        key_strategy: Default::default(),
+        tiers: Default::default(),
     };
     let app_a = app_from_config(&config);
     let app_b = app_from_config(&config);
@@ -118,6 +120,8 @@ async fn memory_replicas_have_independent_budgets() {
         backend: RateLimitBackend::Memory,
         redis: RateLimitRedisConfig::default(),
         on_backend_failure: RateLimitBackendFailure::FailOpen,
+        key_strategy: Default::default(),
+        tiers: Default::default(),
     };
     let app_a = app_from_config(&config);
     let app_b = app_from_config(&config);
@@ -162,6 +166,8 @@ async fn fail_open_allows_requests_when_redis_unavailable() {
             key_prefix: "test:rl".to_owned(),
         },
         on_backend_failure: RateLimitBackendFailure::FailOpen,
+        key_strategy: Default::default(),
+        tiers: Default::default(),
     };
     let app = app_from_config(&config);
 
@@ -194,6 +200,8 @@ async fn fail_closed_blocks_requests_when_redis_unavailable() {
             key_prefix: "test:rl".to_owned(),
         },
         on_backend_failure: RateLimitBackendFailure::FailClosed,
+        key_strategy: Default::default(),
+        tiers: Default::default(),
     };
     let app = app_from_config(&config);
 

--- a/autumn/tests/rate_limit_redis_integration.rs
+++ b/autumn/tests/rate_limit_redis_integration.rs
@@ -13,7 +13,7 @@
 //! on the `test-support` feature (which pulls in `testcontainers`).
 
 use autumn_web::security::{
-    RateLimitBackend, RateLimitBackendFailure, RateLimitConfig, RateLimitLayer,
+    KeyStrategy, RateLimitBackend, RateLimitBackendFailure, RateLimitConfig, RateLimitLayer,
     RateLimitRedisConfig,
 };
 use axum::Router;
@@ -71,8 +71,8 @@ async fn two_replicas_share_global_budget() {
             key_prefix: "test:rl".to_owned(),
         },
         on_backend_failure: RateLimitBackendFailure::FailOpen,
-        key_strategy: Default::default(),
-        tiers: Default::default(),
+        key_strategy: KeyStrategy::default(),
+        tiers: std::collections::HashMap::new(),
     };
     let app_a = app_from_config(&config);
     let app_b = app_from_config(&config);
@@ -120,8 +120,8 @@ async fn memory_replicas_have_independent_budgets() {
         backend: RateLimitBackend::Memory,
         redis: RateLimitRedisConfig::default(),
         on_backend_failure: RateLimitBackendFailure::FailOpen,
-        key_strategy: Default::default(),
-        tiers: Default::default(),
+        key_strategy: KeyStrategy::default(),
+        tiers: std::collections::HashMap::new(),
     };
     let app_a = app_from_config(&config);
     let app_b = app_from_config(&config);
@@ -166,8 +166,8 @@ async fn fail_open_allows_requests_when_redis_unavailable() {
             key_prefix: "test:rl".to_owned(),
         },
         on_backend_failure: RateLimitBackendFailure::FailOpen,
-        key_strategy: Default::default(),
-        tiers: Default::default(),
+        key_strategy: KeyStrategy::default(),
+        tiers: std::collections::HashMap::new(),
     };
     let app = app_from_config(&config);
 
@@ -200,8 +200,8 @@ async fn fail_closed_blocks_requests_when_redis_unavailable() {
             key_prefix: "test:rl".to_owned(),
         },
         on_backend_failure: RateLimitBackendFailure::FailClosed,
-        key_strategy: Default::default(),
-        tiers: Default::default(),
+        key_strategy: KeyStrategy::default(),
+        tiers: std::collections::HashMap::new(),
     };
     let app = app_from_config(&config);
 


### PR DESCRIPTION
## Summary

Extends the rate limiting middleware to support keying on authenticated principals and API bearer tokens, in addition to the existing IP-based approach. Adds support for tiered quotas, per-path overrides, and RFC 9457 Problem Details responses with improved headers.

## Key Changes

- **Key Strategy Configuration**: Introduced `KeyStrategy` enum with three modes:
  - `Ip` (default): Existing behavior, keys on client IP
  - `ApiToken`: Keys on `Authorization: Bearer <token>` value, falls back to IP
  - `AuthenticatedPrincipal`: Keys on principal ID from `RateLimitPrincipal` request extension, falls back to IP for unauthenticated requests

- **Tiered Quotas**: Added `RateLimitTierConfig` and tier-assignment hook support via `RateLimitLayer::with_tier_hook()`. Apps can now define named tiers in config and map callers to tiers dynamically.

- **Per-Path Overrides**: New `RateLimitOverride` type and `RateLimitLayer::with_path_override()` method to apply stricter or laxer limits on specific URL prefixes without disabling the global limiter.

- **Improved 429 Responses**:
  - Added `X-RateLimit-Reset` header (Unix timestamp) on both allowed and denied responses
  - Changed 429 body to RFC 9457 Problem Details JSON format with `application/problem+json` content-type
  - Responses include key class label (ip/token/principal) without leaking the actual key value

- **Public API Exports**: Made `rate_limit` module public and exported `RateLimitPrincipal`, `RateLimitOverride`, and `KeyStrategy` for use by auth middleware and application code.

- **Doctor Check**: Added `check_rate_limit_key_strategy_impl()` to detect misconfigurations where `authenticated_principal` strategy is set without auth middleware mounted.

## Implementation Details

- Bucket keys are namespaced by path prefix when overrides are active to prevent collision between different path limits on the same client.
- Tier hook receives the raw key value (without scheme prefix) so hooks can match on e.g. "user-42" rather than "principal:user-42".
- Path overrides take precedence over tier-assigned limits when explicitly set.
- Unauthenticated fallback to IP is automatic for all non-IP strategies, ensuring in-process callers and test harnesses are never silently unbounded.
- Both memory and Redis backends updated to track and return `reset_at_unix` timestamps for the new header.

https://claude.ai/code/session_016hgjGxnA3kMPEoBSzc1mKq