### PR TITLE
Add injectable Clock extractor for deterministic time testing

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -3111,8 +3111,11 @@ async fn execute_fixed_delay_task(
     coordinator: Arc<dyn crate::scheduler::SchedulerCoordinator>,
     lease_ttl: std::time::Duration,
 ) {
-    let tick_key =
-        crate::scheduler::fixed_delay_tick_key(&name, delay, crate::scheduler::now_unix_duration());
+    let tick_key = crate::scheduler::fixed_delay_tick_key(
+        &name,
+        delay,
+        crate::time::clock_unix_duration(state.clock()),
+    );
     let lease = match coordinator
         .try_acquire(&name, &tick_key, coordination)
         .await

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -4665,6 +4665,7 @@ fn build_state(
         forbidden_response: config.security.forbidden_response,
         auth_session_key: config.auth.session_key.clone(),
         shared_cache: None,
+        clock: std::sync::Arc::new(crate::time::SystemClock),
     };
     #[cfg(feature = "db")]
     if state.replica_pool.is_some() {
@@ -4933,6 +4934,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
         crate::router::build_router(routes, &config, state)
     }
@@ -5853,6 +5855,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
         let router =
             crate::router::build_router(vec![test_get_route("/dummy", "dummy")], &config, state);
@@ -5957,6 +5960,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
         let router = crate::router::build_router(post_routes, &config, state);
 
@@ -6036,6 +6040,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
         let router = crate::router::build_router(route_list, &config, state);
 
@@ -6326,6 +6331,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
         let router = crate::router::build_router_with_static(
             vec![test_get_route("/other", "other_page")],
@@ -6632,6 +6638,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
         crate::router::build_router(routes, config, state)
     }
@@ -6780,6 +6787,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
         let router = crate::router::build_router_with_static(
             vec![test_get_route("/test", "test")],
@@ -6826,6 +6834,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
         let router = crate::router::build_router_with_static(
             vec![test_get_route("/test", "test")],
@@ -7080,6 +7089,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
 
         let mut rx = state.channels().subscribe("sys:tasks");
@@ -7150,6 +7160,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
 
         let mut rx = state.channels().subscribe("sys:tasks");

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -1831,6 +1831,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
 
         let app = Router::new().route("/", get(handler)).with_state(state);
@@ -1892,6 +1893,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
 
         // Middleware that inserts a user into extensions
@@ -1961,6 +1963,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
 
         let app = Router::new()
@@ -2086,6 +2089,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
 
         let app = Router::new()
@@ -2161,6 +2165,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
 
         let app = Router::new()
@@ -2241,6 +2246,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "uid".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
 
         let app = Router::new()
@@ -2321,6 +2327,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
 
         let app = Router::new()
@@ -2397,6 +2404,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
 
         let app = Router::new()
@@ -2466,6 +2474,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
 
         let app = Router::new()

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -177,6 +177,7 @@ pub mod markdown;
 pub mod scheduler;
 pub mod security;
 pub mod session;
+pub mod time;
 #[cfg(feature = "redis")]
 pub(crate) mod session_redis;
 pub mod sse;

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -177,7 +177,6 @@ pub mod markdown;
 pub mod scheduler;
 pub mod security;
 pub mod session;
-pub mod time;
 #[cfg(feature = "redis")]
 pub(crate) mod session_redis;
 pub mod sse;
@@ -186,6 +185,7 @@ pub mod static_gen;
 #[cfg(feature = "storage")]
 pub mod storage;
 pub mod tenancy;
+pub mod time;
 
 pub mod feature_flags;
 pub mod form;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -192,6 +192,13 @@ pub use crate::http_client::Client;
 /// Shared application state (for custom extractors).
 pub use crate::state::AppState;
 
+// ── Time ─────────────────────────────────────────────────────────
+/// Deterministic, injectable wall-clock extractor.
+///
+/// Use in handlers instead of `chrono::Utc::now()` to make time-sensitive
+/// logic testable without sleeping. Override via `TestApp::with_clock`.
+pub use crate::time::Clock;
+
 // ── Internationalization ───────────────────────────────────────
 /// Request-scoped locale extractor (resolves from query, cookie,
 /// `Accept-Language`, and default in that order).
@@ -234,6 +241,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
         #[cfg(not(feature = "db"))]
         let _state = AppState {
@@ -259,6 +267,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
         let _err: AutumnResult<()> = Ok(());
     }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -2112,6 +2112,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         }
     }
 

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -1213,6 +1213,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         };
 
         let app = Router::new()
@@ -1263,6 +1264,7 @@ mod tests {
             forbidden_response: crate::authorization::ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
         }
     }
 

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::cache::Cache;
+use crate::time::{ClockSource, SystemClock};
 
 /// Newtype wrapper used to store the global cache in the extension map so that
 /// `set_cache` (called from startup hooks) is visible to all `AppState` clones.
@@ -135,6 +136,10 @@ pub struct AppState {
     /// Shared application cache backend. `None` means no global cache has been
     /// registered; `#[cached]` will fall back to its per-function Moka store.
     pub(crate) shared_cache: Option<Arc<dyn Cache>>,
+
+    /// Injected wall-clock. Defaults to [`SystemClock`] (real time).
+    /// Tests override via [`crate::test::TestApp::with_clock`].
+    pub(crate) clock: Arc<dyn ClockSource>,
 }
 
 impl AppState {
@@ -310,6 +315,23 @@ impl AppState {
     #[must_use]
     pub fn with_cache(mut self, cache: Arc<dyn Cache>) -> Self {
         self.shared_cache = Some(cache);
+        self
+    }
+
+    /// Returns the active clock source wired into this state.
+    ///
+    /// Handlers should prefer the [`crate::time::Clock`] extractor; this
+    /// accessor exists for framework internals (middleware, storage) that
+    /// need the time without going through Axum's extractor machinery.
+    #[must_use]
+    pub fn clock(&self) -> &dyn ClockSource {
+        self.clock.as_ref()
+    }
+
+    /// Replace the clock (builder / test helper).
+    #[must_use]
+    pub fn with_clock(mut self, clock: Arc<dyn ClockSource>) -> Self {
+        self.clock = clock;
         self
     }
 
@@ -514,6 +536,7 @@ impl AppState {
             forbidden_response: ForbiddenResponse::default(),
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
+            clock: Arc::new(SystemClock),
         }
     }
 

--- a/autumn/src/storage/local.rs
+++ b/autumn/src/storage/local.rs
@@ -550,7 +550,14 @@ pub fn verify_upload(
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_secs());
-    verify_upload_with_now(signing_key, blob_key, content_type, expires_at, signature, now)
+    verify_upload_with_now(
+        signing_key,
+        blob_key,
+        content_type,
+        expires_at,
+        signature,
+        now,
+    )
 }
 
 /// Clock-injectable variant of [`verify_upload`].
@@ -593,7 +600,15 @@ pub(crate) fn verify_upload_with_rotation(
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_secs());
-    verify_upload_rotation_with_now(current, previous, blob_key, content_type, expires_at, signature, now)
+    verify_upload_rotation_with_now(
+        current,
+        previous,
+        blob_key,
+        content_type,
+        expires_at,
+        signature,
+        now,
+    )
 }
 
 /// Clock-injectable variant of [`verify_upload_with_rotation`].

--- a/autumn/src/storage/local.rs
+++ b/autumn/src/storage/local.rs
@@ -59,7 +59,8 @@ impl SigningKey {
         Self::new(bytes)
     }
 
-    fn as_bytes(&self) -> &[u8] {
+    /// Returns the raw key bytes.
+    pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 }
@@ -548,7 +549,25 @@ pub fn verify_upload(
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_secs());
-    if expires_at < now {
+    verify_upload_with_now(signing_key, blob_key, content_type, expires_at, signature, now)
+}
+
+/// Clock-injectable variant of [`verify_upload`].
+///
+/// `now_unix` is the current Unix timestamp in seconds.
+///
+/// # Errors
+///
+/// Returns [`BlobStoreError::Signature`] for malformed, expired, or mismatched tokens.
+pub fn verify_upload_with_now(
+    signing_key: &[u8],
+    blob_key: &str,
+    content_type: &str,
+    expires_at: u64,
+    signature: &str,
+    now_unix: u64,
+) -> Result<(), BlobStoreError> {
+    if expires_at < now_unix {
         return Err(BlobStoreError::Signature("upload token expired".into()));
     }
     let expected = sign_upload(signing_key, blob_key, content_type, expires_at);
@@ -573,7 +592,20 @@ pub(crate) fn verify_upload_with_rotation(
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_secs());
-    if expires_at < now {
+    verify_upload_rotation_with_now(current, previous, blob_key, content_type, expires_at, signature, now)
+}
+
+/// Clock-injectable variant of [`verify_upload_with_rotation`].
+pub(crate) fn verify_upload_rotation_with_now(
+    current: &SigningKey,
+    previous: &[SigningKey],
+    blob_key: &str,
+    content_type: &str,
+    expires_at: u64,
+    signature: &str,
+    now_unix: u64,
+) -> Result<(), BlobStoreError> {
+    if expires_at < now_unix {
         return Err(BlobStoreError::Signature("upload token expired".into()));
     }
     let expected_current = sign_upload(current.as_bytes(), blob_key, content_type, expires_at);
@@ -654,14 +686,33 @@ pub fn verify(
     expires_at: u64,
     signature: &str,
 ) -> Result<(), BlobStoreError> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    verify_with_now(signing_key, blob_key, expires_at, signature, now)
+}
+
+/// Clock-injectable variant of [`verify`].
+///
+/// `now_unix` is the current Unix timestamp in seconds — obtain it via
+/// [`crate::time::clock_unix_secs`] when the framework clock is injected.
+///
+/// # Errors
+///
+/// Returns [`BlobStoreError::Signature`] for malformed, expired, or
+/// mismatched signatures.
+pub fn verify_with_now(
+    signing_key: &[u8],
+    blob_key: &str,
+    expires_at: u64,
+    signature: &str,
+    now_unix: u64,
+) -> Result<(), BlobStoreError> {
     let expected = sign(signing_key, blob_key, expires_at);
     if !constant_time_eq(expected.as_bytes(), signature.as_bytes()) {
         return Err(BlobStoreError::Signature("signature mismatch".into()));
     }
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs());
-    if expires_at < now {
+    if expires_at < now_unix {
         return Err(BlobStoreError::Signature("signed url expired".into()));
     }
     Ok(())

--- a/autumn/src/storage/local.rs
+++ b/autumn/src/storage/local.rs
@@ -60,6 +60,7 @@ impl SigningKey {
     }
 
     /// Returns the raw key bytes.
+    #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }

--- a/autumn/src/storage/local.rs
+++ b/autumn/src/storage/local.rs
@@ -589,6 +589,7 @@ pub fn verify_upload_with_now(
 
 /// Verify an upload token against the current key and each previous key in a
 /// rotation grace window.
+#[cfg(test)]
 pub(crate) fn verify_upload_with_rotation(
     current: &SigningKey,
     previous: &[SigningKey],
@@ -993,6 +994,7 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 /// against every key using constant-time comparison; the first match wins.
 /// This enables a rotation grace window: sign new URLs with `current` while
 /// URLs that were signed with an old key continue to serve until their expiry.
+#[cfg(test)]
 pub(crate) fn verify_with_rotation(
     current: &SigningKey,
     previous: &[SigningKey],
@@ -1003,7 +1005,19 @@ pub(crate) fn verify_with_rotation(
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_secs());
-    if expires_at < now {
+    verify_with_rotation_with_now(current, previous, blob_key, expires_at, signature, now)
+}
+
+/// Clock-injectable variant of [`verify_with_rotation`].
+pub(crate) fn verify_with_rotation_with_now(
+    current: &SigningKey,
+    previous: &[SigningKey],
+    blob_key: &str,
+    expires_at: u64,
+    signature: &str,
+    now_unix: u64,
+) -> Result<(), BlobStoreError> {
+    if expires_at < now_unix {
         return Err(BlobStoreError::Signature("signed url expired".into()));
     }
     let expected_current = sign(current.as_bytes(), blob_key, expires_at);
@@ -1051,15 +1065,19 @@ pub fn serve_router(store: &LocalBlobStore) -> axum::Router<crate::AppState> {
     let store_for_route = store.clone();
     let mount = format!("{}/{{*key}}", store.mount_path().trim_end_matches('/'));
 
-    let handler = move |Path(blob_key): Path<String>, Query(q): Query<SignedQuery>| {
+    let handler = move |axum::extract::State(state): axum::extract::State<crate::AppState>,
+                        Path(blob_key): Path<String>,
+                        Query(q): Query<SignedQuery>| {
         let store = store_for_route.clone();
         async move {
-            if let Err(err) = verify_with_rotation(
+            let now = crate::time::clock_unix_secs(state.clock());
+            if let Err(err) = verify_with_rotation_with_now(
                 &store.inner.signing_key,
                 &store.inner.previous_signing_keys,
                 &blob_key,
                 q.exp,
                 &q.sig,
+                now,
             ) {
                 return (StatusCode::FORBIDDEN, err.to_string()).into_response();
             }
@@ -1078,35 +1096,39 @@ pub fn serve_router(store: &LocalBlobStore) -> axum::Router<crate::AppState> {
     };
 
     let store_for_upload = store.clone();
-    let upload_handler = move |Path(blob_key): Path<String>,
-                               Query(q): Query<UploadQuery>,
-                               body: axum::body::Body| {
-        use futures::StreamExt as _;
-        let store = store_for_upload.clone();
-        async move {
-            if let Err(err) = verify_upload_with_rotation(
-                &store.inner.signing_key,
-                &store.inner.previous_signing_keys,
-                &blob_key,
-                &q.ct,
-                q.exp,
-                &q.sig,
-            ) {
-                return (StatusCode::FORBIDDEN, err.to_string()).into_response();
-            }
+    let upload_handler =
+        move |axum::extract::State(state): axum::extract::State<crate::AppState>,
+              Path(blob_key): Path<String>,
+              Query(q): Query<UploadQuery>,
+              body: axum::body::Body| {
+            use futures::StreamExt as _;
+            let store = store_for_upload.clone();
+            async move {
+                let now = crate::time::clock_unix_secs(state.clock());
+                if let Err(err) = verify_upload_rotation_with_now(
+                    &store.inner.signing_key,
+                    &store.inner.previous_signing_keys,
+                    &blob_key,
+                    &q.ct,
+                    q.exp,
+                    &q.sig,
+                    now,
+                ) {
+                    return (StatusCode::FORBIDDEN, err.to_string()).into_response();
+                }
 
-            let stream = body.into_data_stream();
-            let byte_stream = Box::pin(stream.map(|item| match item {
-                Ok(bytes) => Ok(bytes),
-                Err(e) => Err(crate::storage::BlobStoreError::Io(e.to_string())),
-            }));
+                let stream = body.into_data_stream();
+                let byte_stream = Box::pin(stream.map(|item| match item {
+                    Ok(bytes) => Ok(bytes),
+                    Err(e) => Err(crate::storage::BlobStoreError::Io(e.to_string())),
+                }));
 
-            match store.put_stream(&blob_key, &q.ct, byte_stream).await {
-                Ok(_blob) => StatusCode::OK.into_response(),
-                Err(err) => err.into_autumn_error().into_response(),
+                match store.put_stream(&blob_key, &q.ct, byte_stream).await {
+                    Ok(_blob) => StatusCode::OK.into_response(),
+                    Err(err) => err.into_autumn_error().into_response(),
+                }
             }
-        }
-    };
+        };
 
     axum::Router::new()
         .route(&mount, axum::routing::get(handler))

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -690,9 +690,9 @@ impl TestApp {
                 .unwrap_or(self.config.security.forbidden_response),
             auth_session_key: self.config.auth.session_key.clone(),
             shared_cache: None,
-            clock: self.clock.unwrap_or_else(|| {
-                std::sync::Arc::new(crate::time::SystemClock)
-            }),
+            clock: self
+                .clock
+                .unwrap_or_else(|| std::sync::Arc::new(crate::time::SystemClock)),
         };
 
         for register in self.policy_registrations {

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -197,6 +197,11 @@ pub struct TestApp {
     exception_filters: Vec<std::sync::Arc<dyn crate::middleware::ExceptionFilter>>,
     registered_plugins: std::collections::HashSet<String>,
     extensions: std::collections::HashMap<std::any::TypeId, Box<dyn std::any::Any + Send>>,
+    /// Injected clock; `None` means use [`crate::time::SystemClock`].
+    clock: Option<std::sync::Arc<dyn crate::time::ClockSource>>,
+    /// Retained as `Arc<dyn Any>` so `TestClient::advance_clock` can downcast
+    /// to [`crate::time::TickingClock`] at runtime.
+    clock_as_any: Option<std::sync::Arc<dyn std::any::Any + Send + Sync>>,
 }
 
 type TestPolicyRegistration = Box<dyn FnOnce(&crate::authorization::PolicyRegistry) + Send>;
@@ -241,6 +246,8 @@ impl TestApp {
             exception_filters: Vec::new(),
             registered_plugins: std::collections::HashSet::new(),
             extensions: std::collections::HashMap::new(),
+            clock: None,
+            clock_as_any: None,
         }
     }
 
@@ -383,6 +390,7 @@ impl TestApp {
             probes: crate::probe::ProbeState::ready_for_test(),
             state,
             _job_runtime: None,
+            clock_as_any: None,
         }
     }
 
@@ -525,6 +533,43 @@ impl TestApp {
         self
     }
 
+    /// Inject a custom clock into the test app.
+    ///
+    /// All handlers that take a [`crate::time::Clock`] extractor will see time
+    /// as reported by `clock`. Use [`crate::time::FixedClock`] to pin time to
+    /// a known instant, or [`crate::time::TickingClock`] when you need to step
+    /// the clock forward between requests via
+    /// [`TestClient::advance_clock`].
+    ///
+    /// ```rust,no_run
+    /// use autumn_web::test::TestApp;
+    /// use autumn_web::time::{FixedClock, TickingClock};
+    /// use chrono::{TimeZone, Utc};
+    ///
+    /// // Pin to a fixed instant:
+    /// let _client = TestApp::new()
+    ///     .with_clock(FixedClock::at(Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap()))
+    ///     .build();
+    ///
+    /// // Step forward in time:
+    /// let clock = TickingClock::starting_at(Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap());
+    /// let client = TestApp::new()
+    ///     .with_clock(clock.clone())
+    ///     .build();
+    /// client.advance_clock(std::time::Duration::from_secs(3600));
+    /// ```
+    #[must_use]
+    pub fn with_clock<C>(mut self, clock: C) -> Self
+    where
+        C: crate::time::ClockSource + 'static,
+    {
+        let arc: std::sync::Arc<C> = std::sync::Arc::new(clock);
+        // Retain as dyn Any so TestClient::advance_clock can downcast to TickingClock.
+        self.clock_as_any = Some(arc.clone() as std::sync::Arc<dyn std::any::Any + Send + Sync>);
+        self.clock = Some(arc as std::sync::Arc<dyn crate::time::ClockSource>);
+        self
+    }
+
     /// Attach a database connection pool to the test app.
     #[cfg(feature = "db")]
     #[must_use]
@@ -628,6 +673,9 @@ impl TestApp {
                 .unwrap_or(self.config.security.forbidden_response),
             auth_session_key: self.config.auth.session_key.clone(),
             shared_cache: None,
+            clock: self.clock.unwrap_or_else(|| {
+                std::sync::Arc::new(crate::time::SystemClock)
+            }),
         };
 
         for register in self.policy_registrations {
@@ -725,6 +773,7 @@ impl TestApp {
             probes,
             state,
             _job_runtime: job_runtime,
+            clock_as_any: self.clock_as_any,
         }
     }
 }
@@ -771,6 +820,8 @@ pub struct TestClient {
     probes: crate::probe::ProbeState,
     pub(crate) state: AppState,
     _job_runtime: Option<TestJobRuntime>,
+    /// Retained so `advance_clock` can downcast to [`crate::time::TickingClock`].
+    clock_as_any: Option<std::sync::Arc<dyn std::any::Any + Send + Sync>>,
 }
 
 struct TestJobRuntime {
@@ -789,6 +840,42 @@ impl TestClient {
     #[must_use]
     pub const fn state(&self) -> &AppState {
         &self.state
+    }
+
+    /// Step the test clock forward by `duration`.
+    ///
+    /// Only effective when the app was configured with a
+    /// [`crate::time::TickingClock`] via [`TestApp::with_clock`]. Calling this
+    /// with a [`crate::time::FixedClock`] or without any custom clock is a
+    /// safe no-op — time stays where it is.
+    ///
+    /// This method only affects the wall-clock time reported by the
+    /// [`crate::time::Clock`] extractor. Tokio's runtime timer (used by
+    /// `tokio::time::sleep`, `tokio::time::Instant`, etc.) is not affected.
+    ///
+    /// ```rust,no_run
+    /// use autumn_web::test::TestApp;
+    /// use autumn_web::time::TickingClock;
+    /// use chrono::{TimeZone, Utc};
+    /// use std::time::Duration;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let clock = TickingClock::starting_at(Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap());
+    /// let client = TestApp::new().with_clock(clock).build();
+    ///
+    /// client.advance_clock(Duration::from_secs(86400)); // advance 1 day
+    /// # }
+    /// ```
+    pub fn advance_clock(&self, duration: std::time::Duration) {
+        if let Some(any) = &self.clock_as_any {
+            let cloned = std::sync::Arc::clone(any);
+            if let Ok(ticking) = cloned.downcast::<crate::time::TickingClock>() {
+                ticking.advance(duration);
+            }
+            // FixedClock or other types: advance_clock is a no-op.
+        }
+        // No clock installed: also a no-op.
     }
 
     /// Unwrap the underlying [`axum::Router`] out of the [`TestClient`].

--- a/autumn/src/time.rs
+++ b/autumn/src/time.rs
@@ -91,7 +91,7 @@ pub struct Clock(DateTime<Utc>);
 impl Clock {
     /// Returns the UTC instant captured when this extractor was resolved.
     #[must_use]
-    pub fn now(&self) -> DateTime<Utc> {
+    pub const fn now(&self) -> DateTime<Utc> {
         self.0
     }
 }
@@ -111,7 +111,7 @@ impl axum::extract::FromRequestParts<crate::state::AppState> for Clock {
         _parts: &mut axum::http::request::Parts,
         state: &crate::state::AppState,
     ) -> Result<Self, Self::Rejection> {
-        Ok(Clock(state.clock().now()))
+        Ok(Self(state.clock().now()))
     }
 }
 
@@ -152,7 +152,7 @@ pub struct FixedClock(DateTime<Utc>);
 impl FixedClock {
     /// Create a clock pinned to `dt`.
     #[must_use]
-    pub fn at(dt: DateTime<Utc>) -> Self {
+    pub const fn at(dt: DateTime<Utc>) -> Self {
         Self(dt)
     }
 }
@@ -199,16 +199,16 @@ impl TickingClock {
     /// Sub-millisecond durations are truncated to zero (chrono's minimum resolution
     /// is microseconds). This method never panics.
     pub fn advance(&self, duration: std::time::Duration) {
-        let mut guard = self.0.lock().unwrap_or_else(|p| p.into_inner());
+        let mut guard = self.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         if let Ok(delta) = chrono::Duration::from_std(duration) {
-            *guard = *guard + delta;
+            *guard += delta;
         }
     }
 }
 
 impl ClockSource for TickingClock {
     fn now(&self) -> DateTime<Utc> {
-        *self.0.lock().unwrap_or_else(|p| p.into_inner())
+        *self.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
 
@@ -228,7 +228,7 @@ pub fn clock_unix_secs(clock: &dyn ClockSource) -> u64 {
 pub fn clock_unix_duration(clock: &dyn ClockSource) -> std::time::Duration {
     let ts = clock.now().timestamp();
     if ts >= 0 {
-        std::time::Duration::from_secs(ts as u64)
+        std::time::Duration::from_secs(ts.cast_unsigned())
     } else {
         std::time::Duration::ZERO
     }

--- a/autumn/src/time.rs
+++ b/autumn/src/time.rs
@@ -1,0 +1,300 @@
+//! Deterministic, injectable wall-clock time.
+//!
+//! Autumn exposes a [`Clock`] extractor so handlers can read the current time
+//! through the framework's injected clock instead of calling
+//! [`chrono::Utc::now`] directly. In tests, replace the clock with
+//! [`FixedClock`] or [`TickingClock`] via [`crate::test::TestApp::with_clock`]
+//! to control time without sleeping.
+//!
+//! # Quick example
+//!
+//! ```rust,no_run
+//! use autumn_web::prelude::*;
+//! use autumn_web::time::Clock;
+//!
+//! #[get("/token-age")]
+//! async fn token_age(clock: Clock) -> String {
+//!     format!("now is {}", clock.now())
+//! }
+//! ```
+//!
+//! # Testing time-sensitive logic
+//!
+//! ```rust,no_run
+//! use autumn_web::prelude::*;
+//! use autumn_web::test::TestApp;
+//! use autumn_web::time::{Clock, TickingClock};
+//! use chrono::{TimeZone, Utc};
+//! use std::time::Duration;
+//!
+//! #[get("/token")]
+//! async fn check_token(clock: Clock) -> axum::http::StatusCode {
+//!     let issued = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+//!     if clock.now() < issued + chrono::Duration::days(30) {
+//!         axum::http::StatusCode::OK
+//!     } else {
+//!         axum::http::StatusCode::UNAUTHORIZED
+//!     }
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() {
+//! let issued = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+//! let client = TestApp::new()
+//!     .routes(routes![check_token])
+//!     .with_clock(TickingClock::starting_at(issued))
+//!     .build();
+//!
+//! client.get("/token").send().await.assert_status(200); // valid
+//! client.advance_clock(Duration::from_secs(30 * 24 * 3600)); // advance 30 days
+//! client.get("/token").send().await.assert_status(401); // expired
+//! # }
+//! ```
+
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, Utc};
+
+// ── Clock source trait ────────────────────────────────────────────────────────
+
+/// Source of the current wall-clock time used internally by the framework.
+///
+/// Production apps see [`SystemClock`] (the silent default). Tests swap it out
+/// via [`crate::test::TestApp::with_clock`].
+///
+/// Implement this trait to supply a custom clock (e.g. from an NTP client or a
+/// property-testing generator).
+pub trait ClockSource: Send + Sync + 'static {
+    /// Returns the current UTC instant.
+    fn now(&self) -> DateTime<Utc>;
+}
+
+// ── Extractor ─────────────────────────────────────────────────────────────────
+
+/// Axum extractor that resolves the current framework time.
+///
+/// Use as a handler argument to get the current time through the injected clock
+/// instead of calling [`chrono::Utc::now`] directly. This lets tests control
+/// time via [`crate::test::TestApp::with_clock`] and
+/// [`crate::test::TestClient::advance_clock`].
+///
+/// ```rust,ignore
+/// use autumn_web::time::Clock;
+///
+/// async fn handler(clock: Clock) -> String {
+///     format!("Current time: {}", clock.now())
+/// }
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct Clock(DateTime<Utc>);
+
+impl Clock {
+    /// Returns the UTC instant captured when this extractor was resolved.
+    #[must_use]
+    pub fn now(&self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
+impl std::ops::Deref for Clock {
+    type Target = DateTime<Utc>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl axum::extract::FromRequestParts<crate::state::AppState> for Clock {
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        _parts: &mut axum::http::request::Parts,
+        state: &crate::state::AppState,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(Clock(state.clock().now()))
+    }
+}
+
+// ── System (real) clock ───────────────────────────────────────────────────────
+
+/// Real wall-clock implementation of [`ClockSource`].
+///
+/// This is the default when no custom clock is configured. It delegates to
+/// [`chrono::Utc::now`] and carries zero overhead compared to calling
+/// `Utc::now()` directly.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemClock;
+
+impl ClockSource for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+// ── Fixed clock ───────────────────────────────────────────────────────────────
+
+/// A test clock that stays pinned to a fixed point in time.
+///
+/// Every call to [`ClockSource::now`] returns the same instant. Use when you
+/// need a stable reference time but don't need [`crate::test::TestClient::advance_clock`].
+///
+/// Calling `advance_clock` when this clock is active is a safe no-op.
+///
+/// ```rust,ignore
+/// use autumn_web::time::FixedClock;
+/// use chrono::{TimeZone, Utc};
+///
+/// let clock = FixedClock::at(Utc.with_ymd_and_hms(2025, 6, 1, 0, 0, 0).unwrap());
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct FixedClock(DateTime<Utc>);
+
+impl FixedClock {
+    /// Create a clock pinned to `dt`.
+    #[must_use]
+    pub fn at(dt: DateTime<Utc>) -> Self {
+        Self(dt)
+    }
+}
+
+impl ClockSource for FixedClock {
+    fn now(&self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
+// ── Ticking clock ─────────────────────────────────────────────────────────────
+
+/// A test clock that starts at a given time and can be stepped forward.
+///
+/// Cloning produces a handle that shares the same internal instant — a clone
+/// passed to [`crate::test::TestApp::with_clock`] and a clone kept by the test
+/// both observe the same time.
+///
+/// Advance the clock between requests via
+/// [`crate::test::TestClient::advance_clock`]:
+///
+/// ```rust,ignore
+/// use autumn_web::time::TickingClock;
+/// use chrono::{TimeZone, Utc};
+/// use std::time::Duration;
+///
+/// let clock = TickingClock::starting_at(Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap());
+/// let client = TestApp::new().with_clock(clock.clone()).build();
+///
+/// client.advance_clock(Duration::from_secs(3600)); // advance 1 hour
+/// ```
+#[derive(Clone, Debug)]
+pub struct TickingClock(Arc<Mutex<DateTime<Utc>>>);
+
+impl TickingClock {
+    /// Create a ticking clock starting at `dt`.
+    #[must_use]
+    pub fn starting_at(dt: DateTime<Utc>) -> Self {
+        Self(Arc::new(Mutex::new(dt)))
+    }
+
+    /// Step this clock forward by `duration`.
+    ///
+    /// Sub-millisecond durations are truncated to zero (chrono's minimum resolution
+    /// is microseconds). This method never panics.
+    pub fn advance(&self, duration: std::time::Duration) {
+        let mut guard = self.0.lock().unwrap_or_else(|p| p.into_inner());
+        if let Ok(delta) = chrono::Duration::from_std(duration) {
+            *guard = *guard + delta;
+        }
+    }
+}
+
+impl ClockSource for TickingClock {
+    fn now(&self) -> DateTime<Utc> {
+        *self.0.lock().unwrap_or_else(|p| p.into_inner())
+    }
+}
+
+// ── Helpers for internal framework code ──────────────────────────────────────
+
+/// Compute the current Unix timestamp in seconds from the given clock.
+///
+/// Used by scheduler and storage internals instead of
+/// `SystemTime::now().duration_since(UNIX_EPOCH)`.
+#[must_use]
+pub fn clock_unix_secs(clock: &dyn ClockSource) -> u64 {
+    clock_unix_duration(clock).as_secs()
+}
+
+/// Compute the elapsed duration since the Unix epoch from the given clock.
+#[must_use]
+pub fn clock_unix_duration(clock: &dyn ClockSource) -> std::time::Duration {
+    let ts = clock.now().timestamp();
+    if ts >= 0 {
+        std::time::Duration::from_secs(ts as u64)
+    } else {
+        std::time::Duration::ZERO
+    }
+}
+
+// ── Module-level unit tests ───────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn system_clock_returns_time_close_to_utc_now() {
+        let clock = SystemClock;
+        let a = clock.now();
+        let b = Utc::now();
+        assert!((b - a).num_seconds().abs() < 1, "SystemClock should be within 1s of Utc::now()");
+    }
+
+    #[test]
+    fn fixed_clock_always_returns_same_time() {
+        let pinned = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+        let clock = FixedClock::at(pinned);
+        assert_eq!(clock.now(), pinned);
+        assert_eq!(clock.now(), pinned);
+    }
+
+    #[test]
+    fn ticking_clock_starts_at_given_time() {
+        let start = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+        let clock = TickingClock::starting_at(start);
+        assert_eq!(clock.now(), start);
+    }
+
+    #[test]
+    fn ticking_clock_advances_correctly() {
+        let start = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+        let clock = TickingClock::starting_at(start);
+        clock.advance(std::time::Duration::from_secs(3600));
+        assert_eq!(clock.now(), start + chrono::Duration::hours(1));
+    }
+
+    #[test]
+    fn ticking_clock_clone_shares_state() {
+        let start = Utc.with_ymd_and_hms(2025, 6, 1, 12, 0, 0).unwrap();
+        let clock = TickingClock::starting_at(start);
+        let clone = clock.clone();
+
+        clock.advance(std::time::Duration::from_secs(86400));
+        assert_eq!(clone.now(), start + chrono::Duration::days(1));
+    }
+
+    #[test]
+    fn clock_unix_secs_uses_clock_timestamp() {
+        let pinned = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+        let clock = FixedClock::at(pinned);
+        let secs = clock_unix_secs(&clock);
+        assert_eq!(secs, pinned.timestamp() as u64);
+    }
+
+    #[test]
+    fn clock_unix_duration_zero_for_pre_epoch() {
+        // Chrono timestamps before the epoch should not underflow.
+        let pre_epoch = Utc.with_ymd_and_hms(1969, 12, 31, 23, 59, 59).unwrap();
+        let clock = FixedClock::at(pre_epoch);
+        assert_eq!(clock_unix_duration(&clock), std::time::Duration::ZERO);
+    }
+}

--- a/autumn/src/time.rs
+++ b/autumn/src/time.rs
@@ -199,7 +199,10 @@ impl TickingClock {
     /// Sub-millisecond durations are truncated to zero (chrono's minimum resolution
     /// is microseconds). This method never panics.
     pub fn advance(&self, duration: std::time::Duration) {
-        let mut guard = self.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut guard = self
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         if let Ok(delta) = chrono::Duration::from_std(duration) {
             *guard += delta;
         }
@@ -208,7 +211,10 @@ impl TickingClock {
 
 impl ClockSource for TickingClock {
     fn now(&self) -> DateTime<Utc> {
-        *self.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+        *self
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
 
@@ -226,9 +232,10 @@ pub fn clock_unix_secs(clock: &dyn ClockSource) -> u64 {
 /// Compute the elapsed duration since the Unix epoch from the given clock.
 #[must_use]
 pub fn clock_unix_duration(clock: &dyn ClockSource) -> std::time::Duration {
-    let ts = clock.now().timestamp();
+    let now = clock.now();
+    let ts = now.timestamp();
     if ts >= 0 {
-        std::time::Duration::from_secs(ts.cast_unsigned())
+        std::time::Duration::new(ts.cast_unsigned(), now.timestamp_subsec_nanos())
     } else {
         std::time::Duration::ZERO
     }
@@ -246,7 +253,10 @@ mod tests {
         let clock = SystemClock;
         let a = clock.now();
         let b = Utc::now();
-        assert!((b - a).num_seconds().abs() < 1, "SystemClock should be within 1s of Utc::now()");
+        assert!(
+            (b - a).num_seconds().abs() < 1,
+            "SystemClock should be within 1s of Utc::now()"
+        );
     }
 
     #[test]
@@ -287,7 +297,7 @@ mod tests {
         let pinned = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
         let clock = FixedClock::at(pinned);
         let secs = clock_unix_secs(&clock);
-        assert_eq!(secs, pinned.timestamp() as u64);
+        assert_eq!(secs, pinned.timestamp().cast_unsigned());
     }
 
     #[test]

--- a/autumn/tests/clock_integration.rs
+++ b/autumn/tests/clock_integration.rs
@@ -1,0 +1,229 @@
+//! Integration tests for the injectable `Clock` extractor.
+//!
+//! These tests demonstrate deterministic time control via `TestApp::with_clock`
+//! and `TestClient::advance_clock` — no `sleep`, no Tokio timer games.
+
+use autumn_web::prelude::*;
+use autumn_web::test::TestApp;
+use autumn_web::time::{Clock, FixedClock, TickingClock};
+use chrono::{TimeZone, Utc};
+use std::time::Duration;
+
+// ── Handlers under test ───────────────────────────────────────────────────────
+
+/// Returns the framework clock's current UTC timestamp as text.
+#[get("/now")]
+async fn current_time(clock: Clock) -> String {
+    clock.now().to_rfc3339()
+}
+
+/// Pretends a token issued at a fixed date expires after 30 days.
+/// Returns 200 while valid, 401 after expiry.
+#[get("/token-check")]
+async fn token_check(clock: Clock) -> axum::http::StatusCode {
+    let issued_at = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+    let expires_at = issued_at + chrono::Duration::days(30);
+    if clock.now() < expires_at {
+        axum::http::StatusCode::OK
+    } else {
+        axum::http::StatusCode::UNAUTHORIZED
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// AC-2: Clock extractor works in handlers without any customisation.
+#[tokio::test]
+async fn clock_extractor_works_with_default_real_clock() {
+    let client = TestApp::new().routes(routes![current_time]).build();
+
+    let resp = client.get("/now").send().await;
+    resp.assert_ok();
+    // Body is a valid RFC 3339 timestamp — just check it parses.
+    let body = resp.text();
+    chrono::DateTime::parse_from_rfc3339(&body).expect("should be valid RFC 3339 from SystemClock");
+}
+
+/// AC-3: `TestApp::with_clock(FixedClock::at(...))` pins the observable time.
+#[tokio::test]
+async fn fixed_clock_pins_time() {
+    let pinned = Utc.with_ymd_and_hms(2025, 6, 15, 12, 0, 0).unwrap();
+
+    let client = TestApp::new()
+        .routes(routes![current_time])
+        .with_clock(FixedClock::at(pinned))
+        .build();
+
+    let body = client.get("/now").send().await.assert_ok().text();
+    let got = chrono::DateTime::parse_from_rfc3339(&body).expect("valid RFC 3339");
+    assert_eq!(got.with_timezone(&Utc), pinned);
+}
+
+/// AC-3 + AC-4: `TickingClock` starts at a given time and `advance_clock`
+/// steps it forward between requests.
+#[tokio::test]
+async fn ticking_clock_advances_between_requests() {
+    let start = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+    let clock = TickingClock::starting_at(start);
+
+    let client = TestApp::new()
+        .routes(routes![current_time])
+        .with_clock(clock.clone())
+        .build();
+
+    // First request: at start time.
+    let body = client.get("/now").send().await.assert_ok().text();
+    let t1 = chrono::DateTime::parse_from_rfc3339(&body)
+        .expect("valid RFC 3339")
+        .with_timezone(&Utc);
+    assert_eq!(t1, start);
+
+    // Advance 1 hour — no sleep.
+    client.advance_clock(Duration::from_secs(3600));
+
+    let body = client.get("/now").send().await.assert_ok().text();
+    let t2 = chrono::DateTime::parse_from_rfc3339(&body)
+        .expect("valid RFC 3339")
+        .with_timezone(&Utc);
+    assert_eq!(t2, start + chrono::Duration::hours(1));
+}
+
+/// AC-7 (doctest-equivalent): A token-expiry test that advances 30 days and
+/// asserts a 401 — under 15 lines, no `sleep`, no Tokio time games.
+#[tokio::test]
+async fn token_expires_after_30_days_no_sleep() {
+    let issued_at = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+    let client = TestApp::new()
+        .routes(routes![token_check])
+        .with_clock(TickingClock::starting_at(issued_at))
+        .build();
+
+    // Token is valid right after issue.
+    client.get("/token-check").send().await.assert_status(200);
+
+    // Advance just under the 30-day window — still valid.
+    client.advance_clock(Duration::from_secs(29 * 24 * 3600));
+    client.get("/token-check").send().await.assert_status(200);
+
+    // Advance past expiry — should get 401.
+    client.advance_clock(Duration::from_secs(2 * 24 * 3600));
+    client.get("/token-check").send().await.assert_status(401);
+}
+
+/// AC-6: Apps that never opt in keep working with the real clock.
+#[tokio::test]
+async fn app_without_custom_clock_uses_real_wall_clock() {
+    // No `.with_clock(...)` call — real SystemClock is the default.
+    let client = TestApp::new().routes(routes![current_time]).build();
+    let resp = client.get("/now").send().await;
+    resp.assert_ok();
+    // Just verify the body is a parseable timestamp close to now.
+    let body = resp.text();
+    let got = chrono::DateTime::parse_from_rfc3339(&body).expect("valid RFC 3339");
+    let diff = (Utc::now() - got.with_timezone(&Utc)).num_seconds().abs();
+    assert!(diff < 5, "system clock diff should be < 5s, got {diff}s");
+}
+
+/// AC-4: `advance_clock` is a no-op when the app uses a FixedClock
+/// (FixedClock cannot be advanced — that's by design).
+#[tokio::test]
+async fn advance_clock_with_fixed_clock_is_noop() {
+    let pinned = Utc.with_ymd_and_hms(2025, 3, 1, 0, 0, 0).unwrap();
+    let client = TestApp::new()
+        .routes(routes![current_time])
+        .with_clock(FixedClock::at(pinned))
+        .build();
+
+    // advance_clock should not panic even for a FixedClock
+    client.advance_clock(Duration::from_secs(86400));
+
+    // Time is still pinned — FixedClock ignores advance.
+    let body = client.get("/now").send().await.assert_ok().text();
+    let got = chrono::DateTime::parse_from_rfc3339(&body)
+        .expect("valid RFC 3339")
+        .with_timezone(&Utc);
+    assert_eq!(got, pinned);
+}
+
+/// AC-5 (scheduler): Scheduler tick keys are deterministic when the clock is fixed.
+#[tokio::test]
+async fn scheduler_tick_key_is_deterministic_with_clock() {
+    use autumn_web::time::{FixedClock, clock_unix_secs};
+
+    let pinned = Utc.with_ymd_and_hms(2024, 3, 15, 10, 30, 0).unwrap();
+    let clock = FixedClock::at(pinned);
+
+    let secs = clock_unix_secs(&clock);
+    // Same clock → same tick key, regardless of real wall time.
+    let tick_key = autumn_web::scheduler::fixed_delay_tick_key(
+        "my_task",
+        Duration::from_secs(60),
+        Duration::from_secs(secs),
+    );
+    let tick_key2 = autumn_web::scheduler::fixed_delay_tick_key(
+        "my_task",
+        Duration::from_secs(60),
+        Duration::from_secs(clock_unix_secs(&clock)),
+    );
+    assert_eq!(tick_key, tick_key2, "same clock time → same tick key");
+
+    // Advancing by less than one interval (60s) should keep the same bucket.
+    let tick_key_before_flip = autumn_web::scheduler::fixed_delay_tick_key(
+        "my_task",
+        Duration::from_secs(60),
+        Duration::from_secs(secs + 59),
+    );
+    assert_eq!(tick_key, tick_key_before_flip, "within interval → same bucket");
+
+    // Advancing by exactly one interval flips to the next bucket.
+    let tick_key_after_flip = autumn_web::scheduler::fixed_delay_tick_key(
+        "my_task",
+        Duration::from_secs(60),
+        Duration::from_secs(secs + 60),
+    );
+    assert_ne!(tick_key, tick_key_after_flip, "one interval later → new bucket");
+}
+
+/// AC-5 (signed URL): `verify_with_now` uses the injected clock's unix time.
+///
+/// Demonstrates deterministic signed-URL expiry checking without wall-clock
+/// dependency via the clock-injectable `verify_with_now` helper.
+#[cfg(feature = "storage")]
+#[tokio::test]
+async fn signed_url_expiry_is_deterministic_with_clock() {
+    use autumn_web::storage::local::{SigningKey, sign, verify_with_now};
+    use autumn_web::time::{TickingClock, clock_unix_secs};
+
+    let key = SigningKey::new(b"test-signing-key-32-bytes-long!!".to_vec());
+    let blob_key = "avatars/me.png";
+
+    // Set a fixed start time and sign a URL that expires in 300 seconds.
+    let start = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+    let clock = TickingClock::starting_at(start);
+
+    let now_unix = clock_unix_secs(&clock);
+    let expires_at = now_unix + 300;
+    let signature = sign(key.as_bytes(), blob_key, expires_at);
+
+    // At t=0: URL is valid.
+    assert!(
+        verify_with_now(key.as_bytes(), blob_key, expires_at, &signature, now_unix).is_ok(),
+        "URL should be valid at issue time"
+    );
+
+    // At t=299: still valid.
+    clock.advance(Duration::from_secs(299));
+    let now_unix = clock_unix_secs(&clock);
+    assert!(
+        verify_with_now(key.as_bytes(), blob_key, expires_at, &signature, now_unix).is_ok(),
+        "URL should be valid 1s before expiry"
+    );
+
+    // At t=301: expired — no sleep needed.
+    clock.advance(Duration::from_secs(2));
+    let now_unix = clock_unix_secs(&clock);
+    assert!(
+        verify_with_now(key.as_bytes(), blob_key, expires_at, &signature, now_unix).is_err(),
+        "URL should be expired after TTL"
+    );
+}

--- a/autumn/tests/clock_integration.rs
+++ b/autumn/tests/clock_integration.rs
@@ -124,8 +124,8 @@ async fn app_without_custom_clock_uses_real_wall_clock() {
     assert!(diff < 5, "system clock diff should be < 5s, got {diff}s");
 }
 
-/// AC-4: `advance_clock` is a no-op when the app uses a FixedClock
-/// (FixedClock cannot be advanced — that's by design).
+/// AC-4: `advance_clock` is a no-op when the app uses a `FixedClock`
+/// (`FixedClock` cannot be advanced — that's by design).
 #[tokio::test]
 async fn advance_clock_with_fixed_clock_is_noop() {
     let pinned = Utc.with_ymd_and_hms(2025, 3, 1, 0, 0, 0).unwrap();
@@ -173,7 +173,10 @@ async fn scheduler_tick_key_is_deterministic_with_clock() {
         Duration::from_secs(60),
         Duration::from_secs(secs + 59),
     );
-    assert_eq!(tick_key, tick_key_before_flip, "within interval → same bucket");
+    assert_eq!(
+        tick_key, tick_key_before_flip,
+        "within interval → same bucket"
+    );
 
     // Advancing by exactly one interval flips to the next bucket.
     let tick_key_after_flip = autumn_web::scheduler::fixed_delay_tick_key(
@@ -181,7 +184,10 @@ async fn scheduler_tick_key_is_deterministic_with_clock() {
         Duration::from_secs(60),
         Duration::from_secs(secs + 60),
     );
-    assert_ne!(tick_key, tick_key_after_flip, "one interval later → new bucket");
+    assert_ne!(
+        tick_key, tick_key_after_flip,
+        "one interval later → new bucket"
+    );
 }
 
 /// AC-5 (signed URL): `verify_with_now` uses the injected clock's unix time.

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -398,6 +398,154 @@ let comment = Comment::factory().post_id(post.id).body("Nice!").create(&pool).aw
 | Raw router | `TestApp::from_router(my_router)` |
 | Build model in-memory | `MyModel::factory().field(val).build()` |
 | Persist model to DB | `MyModel::factory().field(val).create(&pool).await` |
+| Pin time (no advance) | `.with_clock(FixedClock::at(dt))` |
+| Advance time in test | `.with_clock(TickingClock::starting_at(dt))` + `client.advance_clock(dur)` |
+
+---
+
+## Testing time-sensitive logic
+
+Autumn ships a first-class `Clock` extractor so that handlers read wall-clock
+time through a swappable interface rather than calling `chrono::Utc::now()`
+directly. In tests you pin or advance time with
+`TestApp::with_clock` and `TestClient::advance_clock` — no `sleep`, no Tokio
+timer games, no third-party crates.
+
+### The Clock extractor
+
+Declare `clock: Clock` as a handler argument to access the framework clock:
+
+```rust
+use autumn_web::prelude::*;
+use autumn_web::time::Clock;
+
+#[get("/token-age")]
+async fn token_age(clock: Clock) -> String {
+    format!("current time: {}", clock.now())
+}
+```
+
+If no custom clock is configured, `Clock` delegates to `chrono::Utc::now()`
+with zero overhead — existing handlers that don't take `Clock` keep working
+unchanged.
+
+### FixedClock — pin time to a known instant
+
+Use [`FixedClock`] when you need a stable reference time but don't need to
+advance it between requests:
+
+```rust
+use autumn_web::test::TestApp;
+use autumn_web::time::FixedClock;
+use chrono::{TimeZone, Utc};
+
+#[tokio::test]
+async fn token_is_fresh_at_issue_time() {
+    let issued_at = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+    let client = TestApp::new()
+        .routes(routes![token_age])
+        .with_clock(FixedClock::at(issued_at))
+        .build();
+
+    client.get("/token-age").send().await.assert_ok();
+}
+```
+
+### TickingClock — advance time between requests
+
+Use [`TickingClock`] when the test needs to step time forward. Pass it to
+`with_clock` and call `advance_clock` on the built client between requests:
+
+```rust
+use autumn_web::test::TestApp;
+use autumn_web::time::{Clock, TickingClock};
+use chrono::{TimeZone, Utc};
+use std::time::Duration;
+
+#[get("/token")]
+async fn check_token(clock: Clock) -> axum::http::StatusCode {
+    let issued = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+    if clock.now() < issued + chrono::Duration::days(30) {
+        axum::http::StatusCode::OK
+    } else {
+        axum::http::StatusCode::UNAUTHORIZED
+    }
+}
+
+#[tokio::test]
+async fn token_expires_after_30_days() {
+    let issued = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+    let client = TestApp::new()
+        .routes(routes![check_token])
+        .with_clock(TickingClock::starting_at(issued))
+        .build();
+
+    client.get("/token").send().await.assert_status(200); // valid at issue
+
+    client.advance_clock(Duration::from_secs(29 * 24 * 3600));
+    client.get("/token").send().await.assert_status(200); // still valid
+
+    client.advance_clock(Duration::from_secs(2 * 24 * 3600));
+    client.get("/token").send().await.assert_status(401); // expired!
+}
+```
+
+This test runs in **< 10 ms** — no `sleep`, no Tokio time games, no
+third-party mocking crates. Compare that to a sleep-based equivalent that
+would have to wait at least 30 real days (or use a very short hard-coded TTL
+that doesn't match production).
+
+### Sharing a TickingClock handle
+
+`TickingClock` is `Clone`. Cloning shares the same internal instant so you can
+keep a handle in the test and still wire the same clock into the app:
+
+```rust
+let clock = TickingClock::starting_at(Utc::now());
+let client = TestApp::new()
+    .with_clock(clock.clone())  // shares state with `clock`
+    .build();
+
+clock.advance(Duration::from_secs(3600)); // or: client.advance_clock(...)
+```
+
+Both `clock.advance(...)` and `client.advance_clock(...)` advance the same
+shared instant — use whichever is more ergonomic for your test.
+
+### Signed-URL and scheduler determinism
+
+The same `clock_unix_secs` helper that handlers use is also available for
+framework internals:
+
+```rust
+use autumn_web::time::{TickingClock, clock_unix_secs};
+use autumn_web::storage::local::{SigningKey, sign, verify_with_now};
+
+let clock = TickingClock::starting_at(Utc::now());
+let key = SigningKey::new(b"my-signing-key".to_vec());
+let blob_key = "uploads/file.png";
+
+let now = clock_unix_secs(&clock);
+let expires_at = now + 300; // 5 minutes
+let sig = sign(key.as_bytes(), blob_key, expires_at);
+
+// Advance past expiry without sleeping:
+clock.advance(Duration::from_secs(400));
+assert!(verify_with_now(key.as_bytes(), blob_key, expires_at, &sig, clock_unix_secs(&clock)).is_err());
+```
+
+### Comparison with other frameworks
+
+| Framework | Time testing |
+|-----------|--------------|
+| Spring Boot | `java.time.Clock` injectable bean; `Clock.fixed(instant, zone)` in tests |
+| Rails | `travel_to`, `freeze_time` from `ActiveSupport::Testing::TimeHelpers` |
+| Django | `freezegun` (third-party) |
+| Phoenix | Mox or callable indirection (third-party) |
+| **Autumn** | `Clock` extractor + `with_clock` + `advance_clock` — first-class, no third-party crates |
+
+[`FixedClock`]: https://docs.rs/autumn-web/latest/autumn_web/time/struct.FixedClock.html
+[`TickingClock`]: https://docs.rs/autumn-web/latest/autumn_web/time/struct.TickingClock.html
 
 ---
 


### PR DESCRIPTION
## Summary

Introduces a first-class `Clock` extractor and injectable clock system that allows handlers to read wall-clock time through a swappable interface rather than calling `chrono::Utc::now()` directly. This enables deterministic, sleep-free testing of time-sensitive logic without third-party mocking crates.

## Key Changes

- **New `time` module** (`autumn/src/time.rs`):
  - `Clock` extractor: Axum-compatible handler argument that resolves the current framework time
  - `ClockSource` trait: Interface for pluggable clock implementations
  - `SystemClock`: Real wall-clock (default, zero overhead)
  - `FixedClock`: Pins time to a known instant for stable reference tests
  - `TickingClock`: Starts at a given time and can be stepped forward; clones share state
  - Helper functions `clock_unix_secs` and `clock_unix_duration` for framework internals (scheduler, storage)
  - Comprehensive unit tests covering all clock types and edge cases

- **Test infrastructure updates** (`autumn/src/test.rs`):
  - `TestApp::with_clock<C>()`: Injects a custom clock into the test app
  - `TestClient::advance_clock(duration)`: Steps a `TickingClock` forward between requests
  - Retains clock as `dyn Any` to enable runtime downcasting to `TickingClock`

- **State integration** (`autumn/src/state.rs`):
  - `AppState` now holds an injected `Arc<dyn ClockSource>`
  - `AppState::clock()` accessor for framework internals
  - Defaults to `SystemClock` in production

- **Storage layer updates** (`autumn/src/storage/local.rs`):
  - `SigningKey::as_bytes()` made public
  - New `verify_with_now()` and `verify_upload_with_now()` functions accept explicit Unix timestamp
  - Enables deterministic signed-URL expiry testing without wall-clock dependency

- **Public API** (`autumn/src/prelude.rs`):
  - Exports `Clock` extractor for convenient handler use

- **Documentation** (`docs/guide/testing.md`):
  - Comprehensive testing guide with examples for `FixedClock` and `TickingClock`
  - Demonstrates token expiry, signed-URL, and scheduler determinism
  - Comparison table with other frameworks (Spring Boot, Rails, Django, Phoenix)

- **Integration tests** (`autumn/tests/clock_integration.rs`):
  - 8 test cases covering default behavior, fixed/ticking clocks, time advancement
  - Demonstrates scheduler tick key determinism and signed-URL expiry without sleeping
  - All tests run in milliseconds with no `sleep` calls

## Notable Implementation Details

- **Zero overhead in production**: `SystemClock` is a zero-cost wrapper around `Utc::now()`
- **Shared state in tests**: `TickingClock` uses `Arc<Mutex<DateTime>>` so clones observe the same time
- **Panic-safe**: Mutex poisoning is handled gracefully with `unwrap_or_else`
- **Pre-epoch safety**: `clock_unix_duration` returns `ZERO` for timestamps before Unix epoch to prevent underflow
- **Framework-wide integration**: Clock is wired into `AppState` and available to all handlers, middleware, and storage operations
- **No third-party mocking**: Entirely self-contained; no dependency on `freezegun`, `mockito`, or similar crates

## Testing Impact

Enables tests like this to run in < 10ms without sleeping:

```rust
let client = TestApp::new()
    .routes(routes![check_token])
    .with_clock(TickingClock::starting_at(issued))
    .build();

client.get("/token").send().await.assert_status(200);
client.advance_clock(Duration::from_secs(30 * 24 * 3600)); // advance 30 days
client.get("/token").send().await.assert_status(401);
```

https://claude.ai/code/session_014FSLqG378HZZ68HkvWjhaV