### PR TITLE
Add A/B experiment system with deterministic bucketing and exposure telemetry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["autumn", "autumn-macros", "autumn-cli", "autumn-admin-plugin", "autumn-storage-s3", "autumn-cache-redis", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/wiki", "examples/reddit-clone", "examples/custom_config_loader", "examples/ws-echo", "examples/signed-webhooks", "examples/outbound-http"]
+members = ["autumn", "autumn-macros", "autumn-cli", "autumn-admin-plugin", "autumn-storage-s3", "autumn-cache-redis", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/wiki", "examples/reddit-clone", "examples/custom_config_loader", "examples/ws-echo", "examples/signed-webhooks", "examples/outbound-http", "examples/experiments"]
 resolver = "3"
 
 # `cargo test --workspace` builds every example, plugin, integration test, and

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -187,6 +187,21 @@ blocks publishing `autumn-web` or `autumn-cli`.
 
 ---
 
+### `examples/experiments` - A/B Experiments
+
+<!-- catalog:example name=experiments tier=supported -->
+
+| Field | Value |
+|-------|-------|
+| **Persona** | Engineer adding feature experimentation to a production app |
+| **Journey** | Declare a 50/50 experiment, assign actors deterministically, emit exposure events, pin a QA override, and conclude with a winner |
+| **Key capabilities** | `ExperimentService`, `InMemoryExperimentStore`, `TracingExposureSink`, `Experiments` extractor, QA overrides, lifecycle transitions |
+| **Prerequisites** | Rust 1.88.0+ |
+| **Run command** | `cargo run -p experiments` |
+| **Success proof** | `cargo test -p experiments` passes; `curl http://localhost:3000/checkout/user:1` returns a variant; `qa:alice` always returns `treatment` |
+
+---
+
 ## Journey Map
 
 The table below maps each example to a distinct learning journey so evaluators
@@ -204,6 +219,7 @@ can pick the closest starting point without overlap.
 | Custom config loading | `custom_config_loader` | Replace the default config loader with a custom `ConfigLoader` |
 | WebSocket / SSE | `ws-echo` | Echo, fan-out channels, SSE, Redis multi-replica pub/sub |
 | Signed intake | `signed-webhooks` | Provider-shaped webhook HMAC verification and replay rejection |
+| A/B experiments | `experiments` | Deterministic bucketing, sticky assignments, exposure telemetry, QA overrides |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ See [EXAMPLES.md](EXAMPLES.md) for the full catalog with personas, journeys, pre
 | [`examples/ws-echo`](examples/ws-echo) | WebSocket echo server, SSE fan-out, htmx live list, and Redis-backed multi-replica pub/sub |
 | [`examples/signed-webhooks`](examples/signed-webhooks) | Signed webhook intake with provider-shaped HMAC verification, replay protection, and fixture tests |
 | [`examples/outbound-http`](examples/outbound-http) | Traced outbound HTTP client with automatic retries, `TestApp::http_mock` test harness, and Stripe-style charge endpoint |
+| [`examples/experiments`](examples/experiments) | A/B experiment system: deterministic 50/50 bucketing, sticky assignments, exposure telemetry, QA overrides, and lifecycle transitions |
 
 ## Documentation
 

--- a/autumn-admin-plugin/src/experiments.rs
+++ b/autumn-admin-plugin/src/experiments.rs
@@ -1,0 +1,682 @@
+//! Admin panel model for `autumn_experiments`.
+//!
+//! Registers an experiment management page at `/admin/experiments/` with:
+//! - List view: name, state, variants, winner
+//! - Edit view: update description, exclusion group, state, variants
+//! - History tab: per-experiment audit trail from `autumn_experiment_changes`
+
+use serde_json::Value;
+
+use crate::{
+    AdminError, AdminField, AdminFieldKind, AdminFuture, AdminHistoryPage, AdminModel, ListParams,
+    ListResult, SelectOption,
+};
+
+/// Admin panel model for A/B experiments.
+///
+/// Register this model with the admin plugin to get an experiment management UI
+/// at `/admin/experiments/`:
+///
+/// ```rust,ignore
+/// use autumn_admin_plugin::{prelude::*, AdminPlugin};
+/// use autumn_admin_plugin::experiments::ExperimentAdminModel;
+///
+/// autumn_web::app()
+///     .plugin(
+///         AdminPlugin::new()
+///             .register(ExperimentAdminModel::default()),
+///     )
+///     .run()
+///     .await;
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct ExperimentAdminModel;
+
+impl AdminModel for ExperimentAdminModel {
+    fn slug(&self) -> &'static str {
+        "experiments"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Experiment"
+    }
+
+    fn display_name_plural(&self) -> &'static str {
+        "Experiments"
+    }
+
+    fn record_display(&self, record: &Value) -> String {
+        record
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map_or_else(|| "Experiment".to_owned(), |n| format!("Experiment: {n}"))
+    }
+
+    fn fields(&self) -> Vec<AdminField> {
+        vec![
+            AdminField::new("name", AdminFieldKind::Text)
+                .label("Experiment Name")
+                .searchable(),
+            AdminField::new("description", AdminFieldKind::TextArea)
+                .label("Description")
+                .optional()
+                .searchable(),
+            AdminField::new(
+                "state",
+                AdminFieldKind::Select(vec![
+                    SelectOption {
+                        value: "draft".into(),
+                        label: "Draft".into(),
+                    },
+                    SelectOption {
+                        value: "running".into(),
+                        label: "Running".into(),
+                    },
+                    SelectOption {
+                        value: "concluded".into(),
+                        label: "Concluded".into(),
+                    },
+                    SelectOption {
+                        value: "archived".into(),
+                        label: "Archived".into(),
+                    },
+                ]),
+            )
+            .label("State"),
+            AdminField::new("variants", AdminFieldKind::Json)
+                .label("Variants (JSON)")
+                .optional()
+                .hide_from_list(),
+            AdminField::new("winner", AdminFieldKind::Text)
+                .label("Winner")
+                .optional(),
+            AdminField::new("exclusion_group", AdminFieldKind::Text)
+                .label("Exclusion Group")
+                .optional()
+                .hide_from_list(),
+            AdminField::new("updated_at", AdminFieldKind::DateTime)
+                .label("Last Updated")
+                .readonly()
+                .optional(),
+        ]
+    }
+
+    fn has_history(&self) -> bool {
+        true
+    }
+
+    fn list(
+        &self,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        params: ListParams,
+    ) -> AdminFuture<'_, ListResult> {
+        use diesel_async::RunQueryDsl;
+
+        let pool = pool.clone();
+        Box::pin(async move {
+            let mut conn = pool
+                .get()
+                .await
+                .map_err(|e| AdminError::Database(e.to_string()))?;
+
+            let per_page = if params.per_page == 0 {
+                25
+            } else {
+                params.per_page
+            };
+            let offset = (params.page.saturating_sub(1)) * per_page;
+            let search_pattern = format!("%{}%", params.search.as_deref().unwrap_or(""));
+
+            let total: i64 = diesel::sql_query(
+                "SELECT COUNT(*) FROM autumn_experiments \
+                 WHERE (name ILIKE $1 OR COALESCE(description,'') ILIKE $1)",
+            )
+            .bind::<diesel::sql_types::Text, _>(&search_pattern)
+            .get_result::<CountRow>(&mut conn)
+            .await
+            .map_or(0, |r| r.count);
+
+            let records: Vec<Value> = diesel::sql_query(
+                "SELECT id, name, description, state::text AS state, \
+                        variants::text AS variants, winner, updated_at \
+                 FROM autumn_experiments \
+                 WHERE (name ILIKE $1 OR COALESCE(description,'') ILIKE $1) \
+                 ORDER BY name \
+                 LIMIT $2 OFFSET $3",
+            )
+            .bind::<diesel::sql_types::Text, _>(&search_pattern)
+            .bind::<diesel::sql_types::BigInt, _>(i64::try_from(per_page).unwrap_or(i64::MAX))
+            .bind::<diesel::sql_types::BigInt, _>(i64::try_from(offset).unwrap_or(0))
+            .load::<ExperimentRow>(&mut conn)
+            .await
+            .map(|rows| rows.into_iter().map(ExperimentRow::into_json).collect())
+            .map_err(|e| AdminError::Database(e.to_string()))?;
+
+            Ok(ListResult {
+                total: u64::try_from(total).unwrap_or(0),
+                page: params.page,
+                per_page,
+                records,
+            })
+        })
+    }
+
+    fn get(
+        &self,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        id: i64,
+    ) -> AdminFuture<'_, Option<Value>> {
+        use diesel::prelude::*;
+        use diesel_async::RunQueryDsl;
+
+        let pool = pool.clone();
+        Box::pin(async move {
+            let mut conn = pool
+                .get()
+                .await
+                .map_err(|e| AdminError::Database(e.to_string()))?;
+
+            diesel::sql_query(
+                "SELECT id, name, description, state::text AS state, \
+                        variants::text AS variants, winner, exclusion_group, updated_at \
+                 FROM autumn_experiments WHERE id = $1",
+            )
+            .bind::<diesel::sql_types::BigInt, _>(id)
+            .get_result::<ExperimentDetailRow>(&mut conn)
+            .await
+            .optional()
+            .map(|r| r.map(ExperimentDetailRow::into_json))
+            .map_err(|e| AdminError::Database(e.to_string()))
+        })
+    }
+
+    fn create(
+        &self,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        data: Value,
+    ) -> AdminFuture<'_, Value> {
+        use diesel_async::RunQueryDsl;
+
+        let pool = pool.clone();
+        Box::pin(async move {
+            let mut conn = pool
+                .get()
+                .await
+                .map_err(|e| AdminError::Database(e.to_string()))?;
+
+            let name = data
+                .get("name")
+                .and_then(Value::as_str)
+                .ok_or_else(|| AdminError::Validation("'name' is required".into()))?;
+            let description = data.get("description").and_then(Value::as_str);
+            let state = data
+                .get("state")
+                .and_then(Value::as_str)
+                .unwrap_or("draft");
+            let variants = validate_variants_json(
+                data.get("variants")
+                    .and_then(Value::as_str)
+                    .unwrap_or("[]"),
+            )?;
+            let exclusion_group = data.get("exclusion_group").and_then(Value::as_str);
+
+            let row = diesel::sql_query(
+                "WITH inserted AS ( \
+                     INSERT INTO autumn_experiments \
+                         (name, description, state, variants, exclusion_group) \
+                     VALUES ($1, $2, $3::autumn_experiment_state, $4::jsonb, $5) \
+                     RETURNING id, name, description, state::text AS state, \
+                               variants::text AS variants, winner, updated_at \
+                 ), \
+                 _audit AS ( \
+                     INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
+                     SELECT name, 'created', NULL FROM inserted \
+                 ) \
+                 SELECT id, name, description, state, variants, winner, updated_at \
+                 FROM inserted",
+            )
+            .bind::<diesel::sql_types::Text, _>(name)
+            .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(
+                description.map(str::to_owned),
+            )
+            .bind::<diesel::sql_types::Text, _>(state)
+            .bind::<diesel::sql_types::Text, _>(variants)
+            .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(
+                exclusion_group.map(str::to_owned),
+            )
+            .get_result::<ExperimentRow>(&mut conn)
+            .await
+            .map_err(|e| {
+                if matches!(
+                    e,
+                    diesel::result::Error::DatabaseError(
+                        diesel::result::DatabaseErrorKind::UniqueViolation,
+                        _
+                    )
+                ) {
+                    AdminError::Validation(format!(
+                        "an experiment named '{name}' already exists"
+                    ))
+                } else {
+                    AdminError::Database(e.to_string())
+                }
+            })?;
+
+            Ok(ExperimentRow::into_json(row))
+        })
+    }
+
+    fn update(
+        &self,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        id: i64,
+        data: Value,
+    ) -> AdminFuture<'_, Value> {
+        use diesel_async::RunQueryDsl;
+
+        let pool = pool.clone();
+        Box::pin(async move {
+            let mut conn = pool
+                .get()
+                .await
+                .map_err(|e| AdminError::Database(e.to_string()))?;
+
+            let name = data
+                .get("name")
+                .and_then(Value::as_str)
+                .ok_or_else(|| AdminError::Validation("'name' is required".into()))?;
+            let description = data.get("description").and_then(Value::as_str);
+            let state = data
+                .get("state")
+                .and_then(Value::as_str)
+                .unwrap_or("draft");
+            let variants = validate_variants_json(
+                data.get("variants")
+                    .and_then(Value::as_str)
+                    .unwrap_or("[]"),
+            )?;
+            let winner = data.get("winner").and_then(Value::as_str);
+            let exclusion_group = data.get("exclusion_group").and_then(Value::as_str);
+
+            let row = diesel::sql_query(
+                "WITH updated AS ( \
+                     UPDATE autumn_experiments \
+                     SET name = $2, description = $3, \
+                         state = $4::autumn_experiment_state, \
+                         variants = $5::jsonb, winner = $6, \
+                         exclusion_group = $7, updated_at = NOW() \
+                     WHERE id = $1 \
+                     RETURNING id, name, description, state::text AS state, \
+                               variants::text AS variants, winner, updated_at \
+                 ), \
+                 _audit AS ( \
+                     INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
+                     SELECT name, 'updated', NULL FROM updated \
+                 ) \
+                 SELECT id, name, description, state, variants, winner, updated_at \
+                 FROM updated",
+            )
+            .bind::<diesel::sql_types::BigInt, _>(id)
+            .bind::<diesel::sql_types::Text, _>(name)
+            .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(
+                description.map(str::to_owned),
+            )
+            .bind::<diesel::sql_types::Text, _>(state)
+            .bind::<diesel::sql_types::Text, _>(variants)
+            .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(
+                winner.map(str::to_owned),
+            )
+            .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(
+                exclusion_group.map(str::to_owned),
+            )
+            .get_result::<ExperimentRow>(&mut conn)
+            .await
+            .map_err(|e| AdminError::Database(e.to_string()))?;
+
+            Ok(ExperimentRow::into_json(row))
+        })
+    }
+
+    fn delete(
+        &self,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        id: i64,
+    ) -> AdminFuture<'_, ()> {
+        use diesel_async::RunQueryDsl;
+
+        let pool = pool.clone();
+        Box::pin(async move {
+            let mut conn = pool
+                .get()
+                .await
+                .map_err(|e| AdminError::Database(e.to_string()))?;
+
+            diesel::sql_query(
+                "WITH deleted AS ( \
+                     DELETE FROM autumn_experiments WHERE id = $1 RETURNING name \
+                 ), \
+                 _audit AS ( \
+                     INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
+                     SELECT name, 'deleted', NULL FROM deleted \
+                 ) \
+                 SELECT COUNT(*) AS count FROM deleted",
+            )
+            .bind::<diesel::sql_types::BigInt, _>(id)
+            .get_result::<CountRow>(&mut conn)
+            .await
+            .map_err(|e| AdminError::Database(e.to_string()))?;
+
+            Ok(())
+        })
+    }
+
+    fn get_history<'a>(
+        &'a self,
+        pool: &'a diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        record_id: i64,
+        page: u64,
+        per_page: u64,
+    ) -> AdminFuture<'a, AdminHistoryPage> {
+        use diesel::prelude::*;
+        use diesel_async::RunQueryDsl;
+
+        let pool = pool.clone();
+        Box::pin(async move {
+            let mut conn = pool
+                .get()
+                .await
+                .map_err(|e| AdminError::Database(e.to_string()))?;
+
+            let name: Option<String> =
+                diesel::sql_query("SELECT name FROM autumn_experiments WHERE id = $1")
+                    .bind::<diesel::sql_types::BigInt, _>(record_id)
+                    .get_result::<NameRow>(&mut conn)
+                    .await
+                    .optional()
+                    .unwrap_or(None)
+                    .map(|r| r.name);
+
+            let Some(name) = name else {
+                return Ok(AdminHistoryPage {
+                    entries: vec![],
+                    total: 0,
+                    page,
+                    per_page,
+                });
+            };
+
+            let count: i64 = diesel::sql_query(
+                "SELECT COUNT(*) FROM autumn_experiment_changes WHERE experiment = $1",
+            )
+            .bind::<diesel::sql_types::Text, _>(&name)
+            .get_result::<CountRow>(&mut conn)
+            .await
+            .map_or(0, |r| r.count);
+
+            let offset = (page.saturating_sub(1)) * per_page;
+            let entries: Vec<crate::AdminHistoryEntry> = diesel::sql_query(
+                "SELECT id, mutation AS op, actor, changed_at \
+                 FROM autumn_experiment_changes \
+                 WHERE experiment = $1 \
+                 ORDER BY changed_at DESC \
+                 LIMIT $2 OFFSET $3",
+            )
+            .bind::<diesel::sql_types::Text, _>(&name)
+            .bind::<diesel::sql_types::BigInt, _>(i64::try_from(per_page).unwrap_or(i64::MAX))
+            .bind::<diesel::sql_types::BigInt, _>(i64::try_from(offset).unwrap_or(0))
+            .load::<HistoryRow>(&mut conn)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|r| crate::AdminHistoryEntry {
+                id: r.id,
+                actor: r.actor.unwrap_or_else(|| "cli".to_owned()),
+                op: r.op,
+                request_id: None,
+                changes: vec![],
+                recorded_at: r.changed_at,
+            })
+            .collect();
+
+            Ok(AdminHistoryPage {
+                entries,
+                total: u64::try_from(count).unwrap_or(0),
+                page,
+                per_page,
+            })
+        })
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Validate `raw` as a JSON array of `{"name": string, "weight": integer}` objects.
+fn validate_variants_json(raw: &str) -> Result<String, AdminError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok("[]".to_owned());
+    }
+    match serde_json::from_str::<Vec<serde_json::Value>>(trimmed) {
+        Ok(arr) => {
+            for (i, v) in arr.iter().enumerate() {
+                if v.get("name").and_then(|n| n.as_str()).is_none() {
+                    return Err(AdminError::Validation(format!(
+                        "variants[{i}].name must be a string"
+                    )));
+                }
+                if v.get("weight")
+                    .and_then(|w| w.as_u64())
+                    .is_none()
+                {
+                    return Err(AdminError::Validation(format!(
+                        "variants[{i}].weight must be a non-negative integer"
+                    )));
+                }
+            }
+            Ok(serde_json::to_string(&arr).unwrap_or_else(|_| "[]".to_owned()))
+        }
+        Err(_) => Err(AdminError::Validation(
+            "'variants' must be a valid JSON array".into(),
+        )),
+    }
+}
+
+// ── Row types ─────────────────────────────────────────────────────────────────
+
+#[derive(diesel::QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    count: i64,
+}
+
+#[derive(diesel::QueryableByName)]
+struct NameRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    name: String,
+}
+
+/// Row returned from list queries (no exclusion_group for brevity in list view).
+#[derive(diesel::QueryableByName)]
+struct ExperimentRow {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    id: i64,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    name: String,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    description: Option<String>,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    state: String,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    variants: Option<String>,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    winner: Option<String>,
+    #[diesel(sql_type = diesel::sql_types::Timestamptz)]
+    updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl ExperimentRow {
+    fn into_json(self) -> Value {
+        serde_json::json!({
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "state": self.state,
+            "variants": self.variants,
+            "winner": self.winner,
+            "updated_at": self.updated_at.to_rfc3339(),
+        })
+    }
+}
+
+/// Row returned from detail (get) queries — includes exclusion_group.
+#[derive(diesel::QueryableByName)]
+struct ExperimentDetailRow {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    id: i64,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    name: String,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    description: Option<String>,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    state: String,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    variants: Option<String>,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    winner: Option<String>,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    exclusion_group: Option<String>,
+    #[diesel(sql_type = diesel::sql_types::Timestamptz)]
+    updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl ExperimentDetailRow {
+    fn into_json(self) -> Value {
+        serde_json::json!({
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "state": self.state,
+            "variants": self.variants,
+            "winner": self.winner,
+            "exclusion_group": self.exclusion_group,
+            "updated_at": self.updated_at.to_rfc3339(),
+        })
+    }
+}
+
+#[derive(diesel::QueryableByName)]
+struct HistoryRow {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    id: i64,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    op: String,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    actor: Option<String>,
+    #[diesel(sql_type = diesel::sql_types::Timestamptz)]
+    changed_at: chrono::DateTime<chrono::Utc>,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn experiment_admin_model_slug() {
+        let model = ExperimentAdminModel::default();
+        assert_eq!(model.slug(), "experiments");
+    }
+
+    #[test]
+    fn experiment_admin_model_display_names() {
+        let model = ExperimentAdminModel::default();
+        assert_eq!(model.display_name(), "Experiment");
+        assert_eq!(model.display_name_plural(), "Experiments");
+    }
+
+    #[test]
+    fn experiment_admin_model_has_history() {
+        let model = ExperimentAdminModel::default();
+        assert!(model.has_history(), "experiment admin must expose history");
+    }
+
+    #[test]
+    fn experiment_admin_model_has_expected_fields() {
+        let model = ExperimentAdminModel::default();
+        let fields = model.fields();
+        let names: Vec<&str> = fields.iter().map(|f| f.name).collect();
+        assert!(names.contains(&"name"), "must have 'name' field");
+        assert!(names.contains(&"state"), "must have 'state' field");
+        assert!(names.contains(&"variants"), "must have 'variants' field");
+        assert!(names.contains(&"winner"), "must have 'winner' field");
+        assert!(
+            names.contains(&"exclusion_group"),
+            "must have 'exclusion_group' field"
+        );
+    }
+
+    #[test]
+    fn experiment_admin_model_state_field_has_all_lifecycle_states() {
+        let model = ExperimentAdminModel::default();
+        let state_field = model
+            .fields()
+            .into_iter()
+            .find(|f| f.name == "state")
+            .expect("state field must exist");
+        let AdminFieldKind::Select(options) = state_field.kind else {
+            panic!("state field must be Select");
+        };
+        let values: Vec<&str> = options.iter().map(|o| o.value.as_str()).collect();
+        assert!(values.contains(&"draft"));
+        assert!(values.contains(&"running"));
+        assert!(values.contains(&"concluded"));
+        assert!(values.contains(&"archived"));
+    }
+
+    #[test]
+    fn record_display_uses_experiment_name() {
+        let model = ExperimentAdminModel::default();
+        let record = serde_json::json!({"name": "checkout_v2", "state": "running"});
+        assert_eq!(model.record_display(&record), "Experiment: checkout_v2");
+    }
+
+    #[test]
+    fn record_display_fallback_when_no_name() {
+        let model = ExperimentAdminModel::default();
+        let record = serde_json::json!({});
+        assert_eq!(model.record_display(&record), "Experiment");
+    }
+
+    #[test]
+    fn validate_variants_json_accepts_valid_array() {
+        let json =
+            validate_variants_json(r#"[{"name":"control","weight":50},{"name":"treatment","weight":50}]"#)
+                .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v.as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn validate_variants_json_accepts_empty_string() {
+        assert_eq!(validate_variants_json("").unwrap(), "[]");
+    }
+
+    #[test]
+    fn validate_variants_json_rejects_missing_name() {
+        let err = validate_variants_json(r#"[{"weight":50}]"#).unwrap_err();
+        assert!(err.to_string().contains("name"));
+    }
+
+    #[test]
+    fn validate_variants_json_rejects_missing_weight() {
+        let err = validate_variants_json(r#"[{"name":"control"}]"#).unwrap_err();
+        assert!(err.to_string().contains("weight"));
+    }
+
+    #[test]
+    fn validate_variants_json_rejects_invalid_json() {
+        let err = validate_variants_json("{not json}").unwrap_err();
+        assert!(err.to_string().contains("JSON"));
+    }
+}

--- a/autumn-admin-plugin/src/experiments.rs
+++ b/autumn-admin-plugin/src/experiments.rs
@@ -213,11 +213,7 @@ impl AdminModel for ExperimentAdminModel {
                 .get("state")
                 .and_then(Value::as_str)
                 .unwrap_or("draft");
-            let variants = validate_variants_json(
-                data.get("variants")
-                    .and_then(Value::as_str)
-                    .unwrap_or("[]"),
-            )?;
+            let variants = validate_variants_json(&extract_variants_str(&data))?;
             let exclusion_group = data.get("exclusion_group").and_then(Value::as_str);
 
             let row = diesel::sql_query(
@@ -281,30 +277,24 @@ impl AdminModel for ExperimentAdminModel {
                 .await
                 .map_err(|e| AdminError::Database(e.to_string()))?;
 
-            let name = data
-                .get("name")
-                .and_then(Value::as_str)
-                .ok_or_else(|| AdminError::Validation("'name' is required".into()))?;
+            // name is read-only after creation; we read it only to satisfy field validation
+            // and for display — the SQL does not allow renaming an experiment.
             let description = data.get("description").and_then(Value::as_str);
             let state = data
                 .get("state")
                 .and_then(Value::as_str)
                 .unwrap_or("draft");
-            let variants = validate_variants_json(
-                data.get("variants")
-                    .and_then(Value::as_str)
-                    .unwrap_or("[]"),
-            )?;
+            let variants = validate_variants_json(&extract_variants_str(&data))?;
             let winner = data.get("winner").and_then(Value::as_str);
             let exclusion_group = data.get("exclusion_group").and_then(Value::as_str);
 
             let row = diesel::sql_query(
                 "WITH updated AS ( \
                      UPDATE autumn_experiments \
-                     SET name = $2, description = $3, \
-                         state = $4::autumn_experiment_state, \
-                         variants = $5::jsonb, winner = $6, \
-                         exclusion_group = $7, updated_at = NOW() \
+                     SET description = $2, \
+                         state = $3::autumn_experiment_state, \
+                         variants = $4::jsonb, winner = $5, \
+                         exclusion_group = $6, updated_at = NOW() \
                      WHERE id = $1 \
                      RETURNING id, name, description, state::text AS state, \
                                variants::text AS variants, winner, updated_at \
@@ -317,7 +307,6 @@ impl AdminModel for ExperimentAdminModel {
                  FROM updated",
             )
             .bind::<diesel::sql_types::BigInt, _>(id)
-            .bind::<diesel::sql_types::Text, _>(name)
             .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(
                 description.map(str::to_owned),
             )
@@ -354,6 +343,14 @@ impl AdminModel for ExperimentAdminModel {
             diesel::sql_query(
                 "WITH deleted AS ( \
                      DELETE FROM autumn_experiments WHERE id = $1 RETURNING name \
+                 ), \
+                 _del_assignments AS ( \
+                     DELETE FROM autumn_experiment_assignments \
+                     WHERE experiment IN (SELECT name FROM deleted) \
+                 ), \
+                 _del_overrides AS ( \
+                     DELETE FROM autumn_experiment_overrides \
+                     WHERE experiment IN (SELECT name FROM deleted) \
                  ), \
                  _audit AS ( \
                      INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
@@ -450,6 +447,18 @@ impl AdminModel for ExperimentAdminModel {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+/// Extract `variants` from admin form data, handling both pre-parsed JSON arrays
+/// (normalized by the admin route) and raw JSON strings submitted by the form.
+fn extract_variants_str(data: &Value) -> String {
+    match data.get("variants") {
+        Some(Value::String(s)) => s.clone(),
+        Some(v) if !v.is_null() => {
+            serde_json::to_string(v).unwrap_or_else(|_| "[]".to_owned())
+        }
+        _ => "[]".to_owned(),
+    }
+}
+
 /// Validate `raw` as a JSON array of `{"name": string, "weight": integer}` objects.
 fn validate_variants_json(raw: &str) -> Result<String, AdminError> {
     let trimmed = raw.trim();
@@ -465,7 +474,7 @@ fn validate_variants_json(raw: &str) -> Result<String, AdminError> {
                     )));
                 }
                 if v.get("weight")
-                    .and_then(|w| w.as_u64())
+                    .and_then(Value::as_u64)
                     .is_none()
                 {
                     return Err(AdminError::Validation(format!(
@@ -495,7 +504,7 @@ struct NameRow {
     name: String,
 }
 
-/// Row returned from list queries (no exclusion_group for brevity in list view).
+/// Row returned from list queries (no `exclusion_group` for brevity in list view).
 #[derive(diesel::QueryableByName)]
 struct ExperimentRow {
     #[diesel(sql_type = diesel::sql_types::BigInt)]
@@ -528,7 +537,7 @@ impl ExperimentRow {
     }
 }
 
-/// Row returned from detail (get) queries — includes exclusion_group.
+/// Row returned from detail (get) queries — includes `exclusion_group`.
 #[derive(diesel::QueryableByName)]
 struct ExperimentDetailRow {
     #[diesel(sql_type = diesel::sql_types::BigInt)]
@@ -584,26 +593,26 @@ mod tests {
 
     #[test]
     fn experiment_admin_model_slug() {
-        let model = ExperimentAdminModel::default();
+        let model = ExperimentAdminModel;
         assert_eq!(model.slug(), "experiments");
     }
 
     #[test]
     fn experiment_admin_model_display_names() {
-        let model = ExperimentAdminModel::default();
+        let model = ExperimentAdminModel;
         assert_eq!(model.display_name(), "Experiment");
         assert_eq!(model.display_name_plural(), "Experiments");
     }
 
     #[test]
     fn experiment_admin_model_has_history() {
-        let model = ExperimentAdminModel::default();
+        let model = ExperimentAdminModel;
         assert!(model.has_history(), "experiment admin must expose history");
     }
 
     #[test]
     fn experiment_admin_model_has_expected_fields() {
-        let model = ExperimentAdminModel::default();
+        let model = ExperimentAdminModel;
         let fields = model.fields();
         let names: Vec<&str> = fields.iter().map(|f| f.name).collect();
         assert!(names.contains(&"name"), "must have 'name' field");
@@ -618,7 +627,7 @@ mod tests {
 
     #[test]
     fn experiment_admin_model_state_field_has_all_lifecycle_states() {
-        let model = ExperimentAdminModel::default();
+        let model = ExperimentAdminModel;
         let state_field = model
             .fields()
             .into_iter()
@@ -636,14 +645,14 @@ mod tests {
 
     #[test]
     fn record_display_uses_experiment_name() {
-        let model = ExperimentAdminModel::default();
+        let model = ExperimentAdminModel;
         let record = serde_json::json!({"name": "checkout_v2", "state": "running"});
         assert_eq!(model.record_display(&record), "Experiment: checkout_v2");
     }
 
     #[test]
     fn record_display_fallback_when_no_name() {
-        let model = ExperimentAdminModel::default();
+        let model = ExperimentAdminModel;
         let record = serde_json::json!({});
         assert_eq!(model.record_display(&record), "Experiment");
     }

--- a/autumn-admin-plugin/src/experiments.rs
+++ b/autumn-admin-plugin/src/experiments.rs
@@ -209,10 +209,7 @@ impl AdminModel for ExperimentAdminModel {
                 .and_then(Value::as_str)
                 .ok_or_else(|| AdminError::Validation("'name' is required".into()))?;
             let description = data.get("description").and_then(Value::as_str);
-            let state = data
-                .get("state")
-                .and_then(Value::as_str)
-                .unwrap_or("draft");
+            let state = data.get("state").and_then(Value::as_str).unwrap_or("draft");
             let variants = validate_variants_json(&extract_variants_str(&data))?;
             let exclusion_group = data.get("exclusion_group").and_then(Value::as_str);
 
@@ -250,9 +247,7 @@ impl AdminModel for ExperimentAdminModel {
                         _
                     )
                 ) {
-                    AdminError::Validation(format!(
-                        "an experiment named '{name}' already exists"
-                    ))
+                    AdminError::Validation(format!("an experiment named '{name}' already exists"))
                 } else {
                     AdminError::Database(e.to_string())
                 }
@@ -280,10 +275,7 @@ impl AdminModel for ExperimentAdminModel {
             // name is read-only after creation; we read it only to satisfy field validation
             // and for display — the SQL does not allow renaming an experiment.
             let description = data.get("description").and_then(Value::as_str);
-            let state = data
-                .get("state")
-                .and_then(Value::as_str)
-                .unwrap_or("draft");
+            let state = data.get("state").and_then(Value::as_str).unwrap_or("draft");
             let variants = validate_variants_json(&extract_variants_str(&data))?;
             let winner = data.get("winner").and_then(Value::as_str);
             let exclusion_group = data.get("exclusion_group").and_then(Value::as_str);
@@ -452,9 +444,7 @@ impl AdminModel for ExperimentAdminModel {
 fn extract_variants_str(data: &Value) -> String {
     match data.get("variants") {
         Some(Value::String(s)) => s.clone(),
-        Some(v) if !v.is_null() => {
-            serde_json::to_string(v).unwrap_or_else(|_| "[]".to_owned())
-        }
+        Some(v) if !v.is_null() => serde_json::to_string(v).unwrap_or_else(|_| "[]".to_owned()),
         _ => "[]".to_owned(),
     }
 }
@@ -473,10 +463,7 @@ fn validate_variants_json(raw: &str) -> Result<String, AdminError> {
                         "variants[{i}].name must be a string"
                     )));
                 }
-                if v.get("weight")
-                    .and_then(Value::as_u64)
-                    .is_none()
-                {
+                if v.get("weight").and_then(Value::as_u64).is_none() {
                     return Err(AdminError::Validation(format!(
                         "variants[{i}].weight must be a non-negative integer"
                     )));
@@ -659,9 +646,10 @@ mod tests {
 
     #[test]
     fn validate_variants_json_accepts_valid_array() {
-        let json =
-            validate_variants_json(r#"[{"name":"control","weight":50},{"name":"treatment","weight":50}]"#)
-                .unwrap();
+        let json = validate_variants_json(
+            r#"[{"name":"control","weight":50},{"name":"treatment","weight":50}]"#,
+        )
+        .unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v.as_array().unwrap().len(), 2);
     }

--- a/autumn-admin-plugin/src/experiments.rs
+++ b/autumn-admin-plugin/src/experiments.rs
@@ -458,10 +458,18 @@ fn validate_variants_json(raw: &str) -> Result<String, AdminError> {
     match serde_json::from_str::<Vec<serde_json::Value>>(trimmed) {
         Ok(arr) => {
             for (i, v) in arr.iter().enumerate() {
-                if v.get("name").and_then(|n| n.as_str()).is_none() {
-                    return Err(AdminError::Validation(format!(
-                        "variants[{i}].name must be a string"
-                    )));
+                match v.get("name").and_then(|n| n.as_str()) {
+                    None => {
+                        return Err(AdminError::Validation(format!(
+                            "variants[{i}].name must be a string"
+                        )));
+                    }
+                    Some(n) if n.trim().is_empty() => {
+                        return Err(AdminError::Validation(format!(
+                            "variants[{i}].name must not be empty"
+                        )));
+                    }
+                    _ => {}
                 }
                 if v.get("weight").and_then(Value::as_u64).is_none() {
                     return Err(AdminError::Validation(format!(
@@ -675,5 +683,23 @@ mod tests {
     fn validate_variants_json_rejects_invalid_json() {
         let err = validate_variants_json("{not json}").unwrap_err();
         assert!(err.to_string().contains("JSON"));
+    }
+
+    #[test]
+    fn validate_variants_json_rejects_empty_name() {
+        let err = validate_variants_json(r#"[{"name":"","weight":100}]"#).unwrap_err();
+        assert!(
+            err.to_string().contains("empty"),
+            "expected empty-name error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_variants_json_rejects_whitespace_only_name() {
+        let err = validate_variants_json(r#"[{"name":"   ","weight":100}]"#).unwrap_err();
+        assert!(
+            err.to_string().contains("empty"),
+            "expected empty-name error, got: {err}"
+        );
     }
 }

--- a/autumn-admin-plugin/src/experiments.rs
+++ b/autumn-admin-plugin/src/experiments.rs
@@ -289,6 +289,7 @@ impl AdminModel for ExperimentAdminModel {
         id: i64,
         data: Value,
     ) -> AdminFuture<'_, Value> {
+        use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
 
         let pool = pool.clone();
@@ -297,6 +298,23 @@ impl AdminModel for ExperimentAdminModel {
                 .get()
                 .await
                 .map_err(|e| AdminError::Database(e.to_string()))?;
+
+            // Archived is a terminal state — reject any edit that tries to leave it.
+            let current_state: Option<String> = diesel::sql_query(
+                "SELECT state::text AS state FROM autumn_experiments WHERE id = $1",
+            )
+            .bind::<diesel::sql_types::BigInt, _>(id)
+            .get_result::<StateRow>(&mut conn)
+            .await
+            .optional()
+            .map_err(|e| AdminError::Database(e.to_string()))?
+            .map(|r| r.state);
+
+            if current_state.as_deref() == Some("archived") {
+                return Err(AdminError::Validation(
+                    "archived experiments cannot be edited".into(),
+                ));
+            }
 
             // name is read-only after creation; we read it only to satisfy field validation
             // and for display — the SQL does not allow renaming an experiment.
@@ -505,8 +523,9 @@ fn validate_variants_json(raw: &str) -> Result<String, AdminError> {
     }
     match serde_json::from_str::<Vec<serde_json::Value>>(trimmed) {
         Ok(arr) => {
+            let mut seen_names = std::collections::HashSet::new();
             for (i, v) in arr.iter().enumerate() {
-                match v.get("name").and_then(|n| n.as_str()) {
+                let name_str = match v.get("name").and_then(|n| n.as_str()) {
                     None => {
                         return Err(AdminError::Validation(format!(
                             "variants[{i}].name must be a string"
@@ -517,7 +536,12 @@ fn validate_variants_json(raw: &str) -> Result<String, AdminError> {
                             "variants[{i}].name must not be empty"
                         )));
                     }
-                    _ => {}
+                    Some(n) => n,
+                };
+                if !seen_names.insert(name_str) {
+                    return Err(AdminError::Validation(format!(
+                        "duplicate variant name '{name_str}' at variants[{i}]"
+                    )));
                 }
                 match v.get("weight").and_then(Value::as_u64) {
                     None => {
@@ -554,6 +578,12 @@ struct CountRow {
 struct NameRow {
     #[diesel(sql_type = diesel::sql_types::Text)]
     name: String,
+}
+
+#[derive(diesel::QueryableByName)]
+struct StateRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    state: String,
 }
 
 /// Row returned from list queries (no `exclusion_group` for brevity in list view).

--- a/autumn-admin-plugin/src/experiments.rs
+++ b/autumn-admin-plugin/src/experiments.rs
@@ -211,13 +211,36 @@ impl AdminModel for ExperimentAdminModel {
             let description = data.get("description").and_then(Value::as_str);
             let state = data.get("state").and_then(Value::as_str).unwrap_or("draft");
             let variants = validate_variants_json(&extract_variants_str(&data))?;
-            let exclusion_group = data.get("exclusion_group").and_then(Value::as_str);
+            let winner = data.get("winner").and_then(Value::as_str);
+            let exclusion_group = data
+                .get("exclusion_group")
+                .and_then(Value::as_str)
+                .filter(|s| !s.trim().is_empty());
+
+            // Concluding requires a non-empty winner that is a configured variant.
+            if state == "concluded" {
+                let w = winner.filter(|s| !s.trim().is_empty()).ok_or_else(|| {
+                    AdminError::Validation(
+                        "a concluded experiment requires a non-empty winner".into(),
+                    )
+                })?;
+                let arr: Vec<serde_json::Value> =
+                    serde_json::from_str(&variants).unwrap_or_default();
+                if !arr
+                    .iter()
+                    .any(|v| v.get("name").and_then(Value::as_str) == Some(w))
+                {
+                    return Err(AdminError::Validation(format!(
+                        "winner '{w}' is not a configured variant"
+                    )));
+                }
+            }
 
             let row = diesel::sql_query(
                 "WITH inserted AS ( \
                      INSERT INTO autumn_experiments \
-                         (name, description, state, variants, exclusion_group) \
-                     VALUES ($1, $2, $3::autumn_experiment_state, $4::jsonb, $5) \
+                         (name, description, state, variants, winner, exclusion_group) \
+                     VALUES ($1, $2, $3::autumn_experiment_state, $4::jsonb, $5, $6) \
                      RETURNING id, name, description, state::text AS state, \
                                variants::text AS variants, winner, updated_at \
                  ), \
@@ -234,6 +257,9 @@ impl AdminModel for ExperimentAdminModel {
             )
             .bind::<diesel::sql_types::Text, _>(state)
             .bind::<diesel::sql_types::Text, _>(variants)
+            .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(
+                winner.map(str::to_owned),
+            )
             .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(
                 exclusion_group.map(str::to_owned),
             )
@@ -297,7 +323,10 @@ impl AdminModel for ExperimentAdminModel {
                     )));
                 }
             }
-            let exclusion_group = data.get("exclusion_group").and_then(Value::as_str);
+            let exclusion_group = data
+                .get("exclusion_group")
+                .and_then(Value::as_str)
+                .filter(|s| !s.trim().is_empty());
 
             let row = diesel::sql_query(
                 "WITH updated AS ( \

--- a/autumn-admin-plugin/src/experiments.rs
+++ b/autumn-admin-plugin/src/experiments.rs
@@ -278,6 +278,25 @@ impl AdminModel for ExperimentAdminModel {
             let state = data.get("state").and_then(Value::as_str).unwrap_or("draft");
             let variants = validate_variants_json(&extract_variants_str(&data))?;
             let winner = data.get("winner").and_then(Value::as_str);
+
+            // Concluding requires a non-empty winner that is a configured variant.
+            if state == "concluded" {
+                let w = winner.filter(|s| !s.trim().is_empty()).ok_or_else(|| {
+                    AdminError::Validation(
+                        "a concluded experiment requires a non-empty winner".into(),
+                    )
+                })?;
+                let arr: Vec<serde_json::Value> =
+                    serde_json::from_str(&variants).unwrap_or_default();
+                if !arr
+                    .iter()
+                    .any(|v| v.get("name").and_then(Value::as_str) == Some(w))
+                {
+                    return Err(AdminError::Validation(format!(
+                        "winner '{w}' is not a configured variant"
+                    )));
+                }
+            }
             let exclusion_group = data.get("exclusion_group").and_then(Value::as_str);
 
             let row = diesel::sql_query(
@@ -471,10 +490,19 @@ fn validate_variants_json(raw: &str) -> Result<String, AdminError> {
                     }
                     _ => {}
                 }
-                if v.get("weight").and_then(Value::as_u64).is_none() {
-                    return Err(AdminError::Validation(format!(
-                        "variants[{i}].weight must be a non-negative integer"
-                    )));
+                match v.get("weight").and_then(Value::as_u64) {
+                    None => {
+                        return Err(AdminError::Validation(format!(
+                            "variants[{i}].weight must be a non-negative integer"
+                        )));
+                    }
+                    Some(w) if w > u64::from(u32::MAX) => {
+                        return Err(AdminError::Validation(format!(
+                            "variants[{i}].weight must not exceed {} (u32::MAX)",
+                            u32::MAX
+                        )));
+                    }
+                    _ => {}
                 }
             }
             Ok(serde_json::to_string(&arr).unwrap_or_else(|_| "[]".to_owned()))

--- a/autumn-admin-plugin/src/lib.rs
+++ b/autumn-admin-plugin/src/lib.rs
@@ -33,6 +33,7 @@
 //! First-party plugin: `autumn-<name>-plugin`.
 
 mod auth;
+pub mod experiments;
 pub mod feature_flags;
 mod registry;
 mod routes;

--- a/autumn-cli/src/experiments.rs
+++ b/autumn-cli/src/experiments.rs
@@ -71,7 +71,11 @@ INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
 COMMIT;";
 
 const CONCLUDE_SQL: &str = "BEGIN; \
-SELECT 1/(SELECT COUNT(*)::int FROM autumn_experiments WHERE name = :'name') AS exists_check; \
+SELECT 1/( \
+    SELECT COUNT(*)::int FROM autumn_experiments, \
+    jsonb_array_elements(variants::jsonb) v \
+    WHERE name = :'name' AND v->>'name' = :'winner' \
+) AS winner_check; \
 UPDATE autumn_experiments SET state = 'concluded', winner = :'winner', updated_at = NOW() \
     WHERE name = :'name'; \
 INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
@@ -79,7 +83,11 @@ INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
 COMMIT;";
 
 const OVERRIDE_SQL: &str = "BEGIN; \
-SELECT 1/(SELECT COUNT(*)::int FROM autumn_experiments WHERE name = :'name') AS exists_check; \
+SELECT 1/( \
+    SELECT COUNT(*)::int FROM autumn_experiments, \
+    jsonb_array_elements(variants::jsonb) v \
+    WHERE name = :'name' AND v->>'name' = :'variant' \
+) AS variant_check; \
 INSERT INTO autumn_experiment_overrides (experiment, actor, variant) \
     VALUES (:'name', :'actor_id', :'variant') \
     ON CONFLICT (experiment, actor) DO UPDATE SET variant = :'variant'; \
@@ -267,6 +275,22 @@ mod tests {
                 "mutation SQL must have an existence check: {sql}"
             );
         }
+    }
+
+    #[test]
+    fn conclude_sql_validates_winner_in_variants() {
+        assert!(
+            CONCLUDE_SQL.contains("jsonb_array_elements"),
+            "conclude SQL must check winner against variants: {CONCLUDE_SQL}"
+        );
+    }
+
+    #[test]
+    fn override_sql_validates_variant_in_variants() {
+        assert!(
+            OVERRIDE_SQL.contains("jsonb_array_elements"),
+            "override SQL must check variant against variants: {OVERRIDE_SQL}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/experiments.rs
+++ b/autumn-cli/src/experiments.rs
@@ -79,6 +79,7 @@ INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
 COMMIT;";
 
 const OVERRIDE_SQL: &str = "BEGIN; \
+SELECT 1/(SELECT COUNT(*)::int FROM autumn_experiments WHERE name = :'name') AS exists_check; \
 INSERT INTO autumn_experiment_overrides (experiment, actor, variant) \
     VALUES (:'name', :'actor_id', :'variant') \
     ON CONFLICT (experiment, actor) DO UPDATE SET variant = :'variant'; \
@@ -256,6 +257,16 @@ mod tests {
             OVERRIDE_SQL.contains("ON CONFLICT"),
             "override SQL must use INSERT ... ON CONFLICT"
         );
+    }
+
+    #[test]
+    fn mutation_sql_have_existence_checks() {
+        for sql in [SET_WEIGHTS_SQL, CONCLUDE_SQL, OVERRIDE_SQL] {
+            assert!(
+                sql.contains("EXISTS") || sql.contains("COUNT(*)"),
+                "mutation SQL must have an existence check: {sql}"
+            );
+        }
     }
 
     #[test]

--- a/autumn-cli/src/experiments.rs
+++ b/autumn-cli/src/experiments.rs
@@ -63,6 +63,7 @@ const STATUS_SQL: &str = "SELECT name, description, state, variants, winner, \
     FROM autumn_experiments WHERE name = :'name';";
 
 const SET_WEIGHTS_SQL: &str = "BEGIN; \
+SELECT 1/(SELECT COUNT(*)::int FROM autumn_experiments WHERE name = :'name') AS exists_check; \
 UPDATE autumn_experiments SET variants = :'variants'::jsonb, updated_at = NOW() \
     WHERE name = :'name'; \
 INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
@@ -70,6 +71,7 @@ INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
 COMMIT;";
 
 const CONCLUDE_SQL: &str = "BEGIN; \
+SELECT 1/(SELECT COUNT(*)::int FROM autumn_experiments WHERE name = :'name') AS exists_check; \
 UPDATE autumn_experiments SET state = 'concluded', winner = :'winner', updated_at = NOW() \
     WHERE name = :'name'; \
 INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
@@ -110,7 +112,10 @@ pub fn run_set_weights(opts: &SetWeightsOptions) {
     let db_url = resolve_database_url();
     let actor = opts.actor.as_deref().unwrap_or("cli");
     // Parse "control=50,treatment=50" into JSON array of variant objects.
-    let variants_json = parse_weights_to_json(&opts.weights);
+    let variants_json = parse_weights_to_json(&opts.weights).unwrap_or_else(|e| {
+        eprintln!("autumn experiments set-weights: {e}");
+        std::process::exit(1);
+    });
     let mut cmd = psql_command(&db_url);
     cmd.arg("--variable").arg(format!("name={}", opts.name));
     cmd.arg("--variable").arg(format!("variants={variants_json}"));
@@ -156,17 +161,25 @@ pub fn run_override(opts: &OverrideOptions) {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /// Convert `"control=50,treatment=50"` to `[{"name":"control","weight":50},...]`.
-fn parse_weights_to_json(weights: &str) -> String {
-    let parts: Vec<serde_json::Value> = weights
-        .split(',')
-        .filter_map(|pair| {
-            let mut it = pair.trim().splitn(2, '=');
-            let name = it.next()?.trim();
-            let weight: u32 = it.next()?.trim().parse().ok()?;
-            Some(serde_json::json!({"name": name, "weight": weight}))
-        })
-        .collect();
-    serde_json::to_string(&parts).unwrap_or_else(|_| "[]".to_owned())
+/// Returns an error message if any pair is malformed.
+fn parse_weights_to_json(weights: &str) -> Result<String, String> {
+    let mut parts: Vec<serde_json::Value> = Vec::new();
+    for raw in weights.split(',') {
+        let pair = raw.trim();
+        let mut it = pair.splitn(2, '=');
+        let name = it.next().unwrap_or("").trim();
+        if name.is_empty() {
+            return Err(format!("malformed weight spec {pair:?}: variant name is empty"));
+        }
+        let weight_str = it
+            .next()
+            .ok_or_else(|| format!("malformed weight spec {pair:?}: missing '=<weight>'"))?;
+        let weight: u32 = weight_str.trim().parse().map_err(|_| {
+            format!("malformed weight spec {pair:?}: weight must be a non-negative integer")
+        })?;
+        parts.push(serde_json::json!({"name": name, "weight": weight}));
+    }
+    Ok(serde_json::to_string(&parts).unwrap_or_else(|_| "[]".to_owned()))
 }
 
 fn resolve_database_url() -> String {
@@ -233,7 +246,7 @@ mod tests {
 
     #[test]
     fn parse_weights_to_json_produces_valid_json() {
-        let json = parse_weights_to_json("control=50,treatment=50");
+        let json = parse_weights_to_json("control=50,treatment=50").unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).expect("invalid JSON");
         let arr = v.as_array().unwrap();
         assert_eq!(arr.len(), 2);
@@ -245,16 +258,28 @@ mod tests {
 
     #[test]
     fn parse_weights_handles_three_variants() {
-        let json = parse_weights_to_json("control=33,treatment_a=33,treatment_b=34");
+        let json = parse_weights_to_json("control=33,treatment_a=33,treatment_b=34").unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).expect("invalid JSON");
         assert_eq!(v.as_array().unwrap().len(), 3);
     }
 
     #[test]
     fn parse_weights_handles_whitespace() {
-        let json = parse_weights_to_json(" control = 50 , treatment = 50 ");
+        let json = parse_weights_to_json(" control = 50 , treatment = 50 ").unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         let arr = v.as_array().unwrap();
         assert_eq!(arr[0]["name"], "control");
+    }
+
+    #[test]
+    fn parse_weights_errors_on_missing_equals() {
+        let err = parse_weights_to_json("control50").unwrap_err();
+        assert!(err.contains("malformed"), "expected malformed error, got: {err}");
+    }
+
+    #[test]
+    fn parse_weights_errors_on_non_integer_weight() {
+        let err = parse_weights_to_json("control=abc").unwrap_err();
+        assert!(err.contains("integer"), "expected integer error, got: {err}");
     }
 }

--- a/autumn-cli/src/experiments.rs
+++ b/autumn-cli/src/experiments.rs
@@ -179,6 +179,7 @@ pub fn run_override(opts: &OverrideOptions) {
 /// Returns an error message if any pair is malformed.
 fn parse_weights_to_json(weights: &str) -> Result<String, String> {
     let mut parts: Vec<serde_json::Value> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
     for raw in weights.split(',') {
         let pair = raw.trim();
         let mut it = pair.splitn(2, '=');
@@ -187,6 +188,9 @@ fn parse_weights_to_json(weights: &str) -> Result<String, String> {
             return Err(format!(
                 "malformed weight spec {pair:?}: variant name is empty"
             ));
+        }
+        if !seen.insert(name) {
+            return Err(format!("duplicate variant name {name:?} in weight spec"));
         }
         let weight_str = it
             .next()

--- a/autumn-cli/src/experiments.rs
+++ b/autumn-cli/src/experiments.rs
@@ -1,0 +1,260 @@
+//! `autumn experiments` — inspect and manage A/B experiments at runtime.
+//!
+//! All commands connect directly to the configured Postgres database.
+//! The database URL is resolved from `autumn.toml`, profile overrides, or
+//! the `AUTUMN_DATABASE__PRIMARY_URL` / `AUTUMN_DATABASE__URL` / `DATABASE_URL`
+//! environment variables.
+//!
+//! # Commands
+//!
+//! ```text
+//! autumn experiments list                                  # list all experiments
+//! autumn experiments status <name>                         # show experiment details
+//! autumn experiments set-weights <name> <v=w,v=w,...>      # update variant weights
+//! autumn experiments conclude <name> <winner>              # pin winner, stop assignments
+//! autumn experiments override <name> <actor_id> <variant>  # pin actor to variant (QA/staff)
+//! ```
+
+use std::process::Command;
+
+// ── Options ───────────────────────────────────────────────────────────────────
+
+/// Options for `autumn experiments list`.
+pub struct ListOptions;
+
+/// Options for `autumn experiments status <name>`.
+pub struct StatusOptions {
+    pub name: String,
+}
+
+/// Options for `autumn experiments set-weights <name> <variants>`.
+pub struct SetWeightsOptions {
+    pub name: String,
+    /// Comma-separated `variant=weight` pairs, e.g. `"control=50,treatment=50"`.
+    pub weights: String,
+    pub actor: Option<String>,
+}
+
+/// Options for `autumn experiments conclude <name> <winner>`.
+pub struct ConcludeOptions {
+    pub name: String,
+    pub winner: String,
+    pub actor: Option<String>,
+}
+
+/// Options for `autumn experiments override <name> <actor_id> <variant>`.
+pub struct OverrideOptions {
+    pub name: String,
+    pub actor_id: String,
+    pub variant: String,
+    pub actor: Option<String>,
+}
+
+// ── SQL helpers ──────────────────────────────────────────────────────────────
+
+const LIST_SQL: &str = "SELECT name, state, \
+    (SELECT string_agg(v->>'name' || '=' || v->>'weight', ', ' ORDER BY v->>'name') \
+        FROM jsonb_array_elements(variants::jsonb) v) AS variants, \
+    winner, updated_at \
+    FROM autumn_experiments ORDER BY name;";
+
+const STATUS_SQL: &str = "SELECT name, description, state, variants, winner, \
+    exclusion_group, updated_at \
+    FROM autumn_experiments WHERE name = :'name';";
+
+const SET_WEIGHTS_SQL: &str = "BEGIN; \
+UPDATE autumn_experiments SET variants = :'variants'::jsonb, updated_at = NOW() \
+    WHERE name = :'name'; \
+INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
+    VALUES (:'name', 'set_weights=' || :'variants', :'actor'); \
+COMMIT;";
+
+const CONCLUDE_SQL: &str = "BEGIN; \
+UPDATE autumn_experiments SET state = 'concluded', winner = :'winner', updated_at = NOW() \
+    WHERE name = :'name'; \
+INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
+    VALUES (:'name', 'concluded=' || :'winner', :'actor'); \
+COMMIT;";
+
+const OVERRIDE_SQL: &str = "BEGIN; \
+INSERT INTO autumn_experiment_overrides (experiment, actor, variant) \
+    VALUES (:'name', :'actor_id', :'variant') \
+    ON CONFLICT (experiment, actor) DO UPDATE SET variant = :'variant'; \
+INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
+    VALUES (:'name', 'override=' || :'actor_id' || ':' || :'variant', :'actor'); \
+COMMIT;";
+
+// ── Public runners ────────────────────────────────────────────────────────────
+
+/// Run `autumn experiments list`.
+pub fn run_list(_opts: &ListOptions) {
+    let db_url = resolve_database_url();
+    let mut cmd = psql_command(&db_url);
+    cmd.arg("--command").arg("\\pset footer off");
+    cmd.arg("--command").arg(LIST_SQL);
+    exec(cmd, "experiments list");
+}
+
+/// Run `autumn experiments status <name>`.
+pub fn run_status(opts: &StatusOptions) {
+    let db_url = resolve_database_url();
+    let mut cmd = psql_command(&db_url);
+    cmd.arg("--variable").arg(format!("name={}", opts.name));
+    cmd.arg("--command").arg("\\pset footer off");
+    cmd.arg("--command").arg(STATUS_SQL);
+    exec(cmd, "experiments status");
+}
+
+/// Run `autumn experiments set-weights <name> <weights>`.
+pub fn run_set_weights(opts: &SetWeightsOptions) {
+    let db_url = resolve_database_url();
+    let actor = opts.actor.as_deref().unwrap_or("cli");
+    // Parse "control=50,treatment=50" into JSON array of variant objects.
+    let variants_json = parse_weights_to_json(&opts.weights);
+    let mut cmd = psql_command(&db_url);
+    cmd.arg("--variable").arg(format!("name={}", opts.name));
+    cmd.arg("--variable").arg(format!("variants={variants_json}"));
+    cmd.arg("--variable").arg(format!("actor={actor}"));
+    cmd.arg("--command").arg(SET_WEIGHTS_SQL);
+    exec(cmd, "experiments set-weights");
+    println!("✓ Experiment '{}' weights updated to {}.", opts.name, opts.weights);
+}
+
+/// Run `autumn experiments conclude <name> <winner>`.
+pub fn run_conclude(opts: &ConcludeOptions) {
+    let db_url = resolve_database_url();
+    let actor = opts.actor.as_deref().unwrap_or("cli");
+    let mut cmd = psql_command(&db_url);
+    cmd.arg("--variable").arg(format!("name={}", opts.name));
+    cmd.arg("--variable").arg(format!("winner={}", opts.winner));
+    cmd.arg("--variable").arg(format!("actor={actor}"));
+    cmd.arg("--command").arg(CONCLUDE_SQL);
+    exec(cmd, "experiments conclude");
+    println!(
+        "✓ Experiment '{}' concluded with winner '{}'.",
+        opts.name, opts.winner
+    );
+}
+
+/// Run `autumn experiments override <name> <actor_id> <variant>`.
+pub fn run_override(opts: &OverrideOptions) {
+    let db_url = resolve_database_url();
+    let actor = opts.actor.as_deref().unwrap_or("cli");
+    let mut cmd = psql_command(&db_url);
+    cmd.arg("--variable").arg(format!("name={}", opts.name));
+    cmd.arg("--variable").arg(format!("actor_id={}", opts.actor_id));
+    cmd.arg("--variable").arg(format!("variant={}", opts.variant));
+    cmd.arg("--variable").arg(format!("actor={actor}"));
+    cmd.arg("--command").arg(OVERRIDE_SQL);
+    exec(cmd, "experiments override");
+    println!(
+        "✓ Actor '{}' pinned to variant '{}' in experiment '{}'.",
+        opts.actor_id, opts.variant, opts.name
+    );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Convert `"control=50,treatment=50"` to `[{"name":"control","weight":50},...]`.
+fn parse_weights_to_json(weights: &str) -> String {
+    let parts: Vec<serde_json::Value> = weights
+        .split(',')
+        .filter_map(|pair| {
+            let mut it = pair.trim().splitn(2, '=');
+            let name = it.next()?.trim();
+            let weight: u32 = it.next()?.trim().parse().ok()?;
+            Some(serde_json::json!({"name": name, "weight": weight}))
+        })
+        .collect();
+    serde_json::to_string(&parts).unwrap_or_else(|_| "[]".to_owned())
+}
+
+fn resolve_database_url() -> String {
+    crate::config::resolve_database_url()
+}
+
+fn psql_command(db_url: &str) -> Command {
+    let mut cmd = Command::new("psql");
+    cmd.arg(db_url);
+    cmd.arg("--no-psqlrc");
+    cmd.arg("--set=ON_ERROR_STOP=on");
+    cmd
+}
+
+fn exec(mut cmd: Command, label: &str) {
+    let status = cmd.status().unwrap_or_else(|e| {
+        eprintln!("autumn {label}: failed to run psql: {e}");
+        std::process::exit(1);
+    });
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sql_queries_reference_correct_tables() {
+        assert!(LIST_SQL.contains("autumn_experiments"));
+        assert!(STATUS_SQL.contains("autumn_experiments"));
+        assert!(SET_WEIGHTS_SQL.contains("autumn_experiments"));
+        assert!(SET_WEIGHTS_SQL.contains("autumn_experiment_changes"));
+        assert!(CONCLUDE_SQL.contains("autumn_experiments"));
+        assert!(CONCLUDE_SQL.contains("autumn_experiment_changes"));
+        assert!(OVERRIDE_SQL.contains("autumn_experiment_overrides"));
+        assert!(OVERRIDE_SQL.contains("autumn_experiment_changes"));
+    }
+
+    #[test]
+    fn sql_mutations_use_transactions() {
+        for sql in [SET_WEIGHTS_SQL, CONCLUDE_SQL, OVERRIDE_SQL] {
+            assert!(sql.starts_with("BEGIN;"), "mutation SQL must use BEGIN: {sql}");
+            assert!(sql.contains("COMMIT;"), "mutation SQL must use COMMIT: {sql}");
+        }
+    }
+
+    #[test]
+    fn conclude_sql_sets_winner_and_state() {
+        assert!(CONCLUDE_SQL.contains("state = 'concluded'"));
+        assert!(CONCLUDE_SQL.contains("winner = :'winner'"));
+    }
+
+    #[test]
+    fn override_sql_uses_upsert() {
+        assert!(
+            OVERRIDE_SQL.contains("ON CONFLICT"),
+            "override SQL must use INSERT ... ON CONFLICT"
+        );
+    }
+
+    #[test]
+    fn parse_weights_to_json_produces_valid_json() {
+        let json = parse_weights_to_json("control=50,treatment=50");
+        let v: serde_json::Value = serde_json::from_str(&json).expect("invalid JSON");
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["name"], "control");
+        assert_eq!(arr[0]["weight"], 50);
+        assert_eq!(arr[1]["name"], "treatment");
+        assert_eq!(arr[1]["weight"], 50);
+    }
+
+    #[test]
+    fn parse_weights_handles_three_variants() {
+        let json = parse_weights_to_json("control=33,treatment_a=33,treatment_b=34");
+        let v: serde_json::Value = serde_json::from_str(&json).expect("invalid JSON");
+        assert_eq!(v.as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn parse_weights_handles_whitespace() {
+        let json = parse_weights_to_json(" control = 50 , treatment = 50 ");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr[0]["name"], "control");
+    }
+}

--- a/autumn-cli/src/experiments.rs
+++ b/autumn-cli/src/experiments.rs
@@ -63,7 +63,8 @@ const STATUS_SQL: &str = "SELECT name, description, state, variants, winner, \
     FROM autumn_experiments WHERE name = :'name';";
 
 const SET_WEIGHTS_SQL: &str = "BEGIN; \
-SELECT 1/(SELECT COUNT(*)::int FROM autumn_experiments WHERE name = :'name') AS exists_check; \
+SELECT 1/(SELECT COUNT(*)::int FROM autumn_experiments \
+    WHERE name = :'name' AND state NOT IN ('concluded', 'archived')) AS exists_check; \
 UPDATE autumn_experiments SET variants = :'variants'::jsonb, updated_at = NOW() \
     WHERE name = :'name'; \
 INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
@@ -74,7 +75,7 @@ const CONCLUDE_SQL: &str = "BEGIN; \
 SELECT 1/( \
     SELECT COUNT(*)::int FROM autumn_experiments, \
     jsonb_array_elements(variants::jsonb) v \
-    WHERE name = :'name' AND v->>'name' = :'winner' \
+    WHERE name = :'name' AND state != 'archived' AND v->>'name' = :'winner' \
 ) AS winner_check; \
 UPDATE autumn_experiments SET state = 'concluded', winner = :'winner', updated_at = NOW() \
     WHERE name = :'name'; \
@@ -294,6 +295,22 @@ mod tests {
         assert!(
             OVERRIDE_SQL.contains("jsonb_array_elements"),
             "override SQL must check variant against variants: {OVERRIDE_SQL}"
+        );
+    }
+
+    #[test]
+    fn set_weights_sql_guards_non_editable_states() {
+        assert!(
+            SET_WEIGHTS_SQL.contains("concluded") && SET_WEIGHTS_SQL.contains("archived"),
+            "set_weights SQL must reject concluded and archived experiments: {SET_WEIGHTS_SQL}"
+        );
+    }
+
+    #[test]
+    fn conclude_sql_guards_against_archived() {
+        assert!(
+            CONCLUDE_SQL.contains("archived"),
+            "conclude SQL must reject archived experiments: {CONCLUDE_SQL}"
         );
     }
 

--- a/autumn-cli/src/experiments.rs
+++ b/autumn-cli/src/experiments.rs
@@ -118,11 +118,15 @@ pub fn run_set_weights(opts: &SetWeightsOptions) {
     });
     let mut cmd = psql_command(&db_url);
     cmd.arg("--variable").arg(format!("name={}", opts.name));
-    cmd.arg("--variable").arg(format!("variants={variants_json}"));
+    cmd.arg("--variable")
+        .arg(format!("variants={variants_json}"));
     cmd.arg("--variable").arg(format!("actor={actor}"));
     cmd.arg("--command").arg(SET_WEIGHTS_SQL);
     exec(cmd, "experiments set-weights");
-    println!("✓ Experiment '{}' weights updated to {}.", opts.name, opts.weights);
+    println!(
+        "✓ Experiment '{}' weights updated to {}.",
+        opts.name, opts.weights
+    );
 }
 
 /// Run `autumn experiments conclude <name> <winner>`.
@@ -147,8 +151,10 @@ pub fn run_override(opts: &OverrideOptions) {
     let actor = opts.actor.as_deref().unwrap_or("cli");
     let mut cmd = psql_command(&db_url);
     cmd.arg("--variable").arg(format!("name={}", opts.name));
-    cmd.arg("--variable").arg(format!("actor_id={}", opts.actor_id));
-    cmd.arg("--variable").arg(format!("variant={}", opts.variant));
+    cmd.arg("--variable")
+        .arg(format!("actor_id={}", opts.actor_id));
+    cmd.arg("--variable")
+        .arg(format!("variant={}", opts.variant));
     cmd.arg("--variable").arg(format!("actor={actor}"));
     cmd.arg("--command").arg(OVERRIDE_SQL);
     exec(cmd, "experiments override");
@@ -169,7 +175,9 @@ fn parse_weights_to_json(weights: &str) -> Result<String, String> {
         let mut it = pair.splitn(2, '=');
         let name = it.next().unwrap_or("").trim();
         if name.is_empty() {
-            return Err(format!("malformed weight spec {pair:?}: variant name is empty"));
+            return Err(format!(
+                "malformed weight spec {pair:?}: variant name is empty"
+            ));
         }
         let weight_str = it
             .next()
@@ -225,8 +233,14 @@ mod tests {
     #[test]
     fn sql_mutations_use_transactions() {
         for sql in [SET_WEIGHTS_SQL, CONCLUDE_SQL, OVERRIDE_SQL] {
-            assert!(sql.starts_with("BEGIN;"), "mutation SQL must use BEGIN: {sql}");
-            assert!(sql.contains("COMMIT;"), "mutation SQL must use COMMIT: {sql}");
+            assert!(
+                sql.starts_with("BEGIN;"),
+                "mutation SQL must use BEGIN: {sql}"
+            );
+            assert!(
+                sql.contains("COMMIT;"),
+                "mutation SQL must use COMMIT: {sql}"
+            );
         }
     }
 
@@ -274,12 +288,18 @@ mod tests {
     #[test]
     fn parse_weights_errors_on_missing_equals() {
         let err = parse_weights_to_json("control50").unwrap_err();
-        assert!(err.contains("malformed"), "expected malformed error, got: {err}");
+        assert!(
+            err.contains("malformed"),
+            "expected malformed error, got: {err}"
+        );
     }
 
     #[test]
     fn parse_weights_errors_on_non_integer_weight() {
         let err = parse_weights_to_json("control=abc").unwrap_err();
-        assert!(err.contains("integer"), "expected integer error, got: {err}");
+        assert!(
+            err.contains("integer"),
+            "expected integer error, got: {err}"
+        );
     }
 }

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -7,6 +7,7 @@ mod credentials;
 mod dev;
 mod dev_loop_bench;
 mod doctor;
+mod experiments;
 mod export;
 mod flags;
 mod generate;
@@ -217,6 +218,28 @@ enum Commands {
     #[command(subcommand, verbatim_doc_comment)]
     #[allow(clippy::doc_markdown)]
     Flags(FlagsCommands),
+
+    /// Manage A/B experiments at runtime.
+    ///
+    /// Experiments declare named variants with weights, assign actors to variants
+    /// deterministically, and emit structured exposure events to your analytics
+    /// pipeline.  Weight changes propagate to new actors immediately; existing
+    /// sticky assignments are preserved.
+    ///
+    /// The database URL is resolved from `autumn.toml`, profile overrides, or
+    /// the `AUTUMN_DATABASE__PRIMARY_URL` / `AUTUMN_DATABASE__URL` /
+    /// `DATABASE_URL` environment variables.
+    ///
+    /// # Examples
+    ///
+    ///   autumn experiments list
+    ///   autumn experiments status checkout_v2
+    ///   autumn experiments set-weights checkout_v2 control=50,treatment=50
+    ///   autumn experiments conclude checkout_v2 treatment
+    ///   autumn experiments override checkout_v2 qa@example.com treatment
+    #[command(subcommand, verbatim_doc_comment)]
+    #[allow(clippy::doc_markdown)]
+    Experiments(ExperimentsCommands),
 
     /// Run accessibility (WCAG 2.1 AA) checks against rendered HTML.
     ///
@@ -686,6 +709,83 @@ enum FlagsCommands {
     },
 }
 
+/// Subcommands for `autumn experiments`.
+#[derive(Subcommand)]
+enum ExperimentsCommands {
+    /// List all experiments and their current state.
+    List,
+    /// Show detailed status for a single experiment.
+    ///
+    /// # Example
+    ///
+    ///   autumn experiments status checkout_v2
+    #[command(verbatim_doc_comment)]
+    Status {
+        /// Experiment name.
+        name: String,
+    },
+    /// Update the variant weights for an experiment.
+    ///
+    /// Existing sticky assignments are NOT re-bucketed. New actors will be
+    /// bucketed against the updated weights immediately.
+    ///
+    /// Weights are specified as comma-separated `variant=weight` pairs. Weights
+    /// are relative and do not need to sum to 100.
+    ///
+    /// # Example
+    ///
+    ///   autumn experiments set-weights checkout_v2 control=50,treatment=50
+    ///   autumn experiments set-weights pricing_v3 control=33,low=33,high=34
+    #[command(name = "set-weights", verbatim_doc_comment)]
+    SetWeights {
+        /// Experiment name.
+        name: String,
+        /// Variant weights as `"variant=weight,..."` (e.g. `"control=50,treatment=50"`).
+        weights: String,
+        /// Actor identifier stored in the change log.
+        #[arg(long, value_name = "ACTOR")]
+        actor: Option<String>,
+    },
+    /// Conclude an experiment and pin a winning variant.
+    ///
+    /// After concluding, `assign()` returns the winner for all actors without
+    /// emitting new exposure events.
+    ///
+    /// # Example
+    ///
+    ///   autumn experiments conclude checkout_v2 treatment
+    #[command(verbatim_doc_comment)]
+    Conclude {
+        /// Experiment name.
+        name: String,
+        /// Winning variant name.
+        winner: String,
+        /// Actor identifier stored in the change log.
+        #[arg(long, value_name = "ACTOR")]
+        actor: Option<String>,
+    },
+    /// Pin a staff/QA actor to a specific variant, bypassing weight-based bucketing.
+    ///
+    /// The override is tagged with `is_override = true` in exposure events so
+    /// analytics pipelines can exclude overridden assignments from results.
+    ///
+    /// # Example
+    ///
+    ///   autumn experiments override checkout_v2 qa@example.com treatment
+    #[command(verbatim_doc_comment)]
+    Override {
+        /// Experiment name.
+        name: String,
+        /// Actor ID to pin (e.g. `user:42` or `qa@example.com`).
+        actor_id: String,
+        /// Variant to force for this actor.
+        variant: String,
+        /// Actor identifier stored in the change log.
+        #[arg(long, value_name = "ACTOR")]
+        actor: Option<String>,
+    },
+}
+
 /// Subcommands for `autumn release`.
 #[derive(Subcommand)]
 enum ReleaseCommands {
@@ -1084,6 +1184,47 @@ fn run_command(command: Commands) {
                 flags::run_allow(&flags::AllowOptions {
                     key,
                     actor_id,
+                    actor,
+                });
+            }
+        },
+        Commands::Experiments(cmd) => match cmd {
+            ExperimentsCommands::List => experiments::run_list(&experiments::ListOptions),
+            ExperimentsCommands::Status { name } => {
+                experiments::run_status(&experiments::StatusOptions { name });
+            }
+            ExperimentsCommands::SetWeights {
+                name,
+                weights,
+                actor,
+            } => {
+                experiments::run_set_weights(&experiments::SetWeightsOptions {
+                    name,
+                    weights,
+                    actor,
+                });
+            }
+            ExperimentsCommands::Conclude {
+                name,
+                winner,
+                actor,
+            } => {
+                experiments::run_conclude(&experiments::ConcludeOptions {
+                    name,
+                    winner,
+                    actor,
+                });
+            }
+            ExperimentsCommands::Override {
+                name,
+                actor_id,
+                variant,
+                actor,
+            } => {
+                experiments::run_override(&experiments::OverrideOptions {
+                    name,
+                    actor_id,
+                    variant,
                     actor,
                 });
             }

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -711,6 +711,7 @@ enum FlagsCommands {
 
 /// Subcommands for `autumn experiments`.
 #[derive(Subcommand)]
+#[allow(clippy::doc_markdown)]
 enum ExperimentsCommands {
     /// List all experiments and their current state.
     List,

--- a/autumn/migrations/20260530300000_create_experiments/down.sql
+++ b/autumn/migrations/20260530300000_create_experiments/down.sql
@@ -1,0 +1,7 @@
+DROP TRIGGER IF EXISTS autumn_experiment_change_notify ON autumn_experiment_changes;
+DROP FUNCTION IF EXISTS autumn_notify_experiment_change();
+DROP TABLE IF EXISTS autumn_experiment_changes;
+DROP TABLE IF EXISTS autumn_experiment_overrides;
+DROP TABLE IF EXISTS autumn_experiment_assignments;
+DROP TABLE IF EXISTS autumn_experiments;
+DROP TYPE IF EXISTS autumn_experiment_state;

--- a/autumn/migrations/20260530300000_create_experiments/up.sql
+++ b/autumn/migrations/20260530300000_create_experiments/up.sql
@@ -1,0 +1,102 @@
+-- A/B experiments: deterministic bucketing, sticky assignments, exposure telemetry.
+--
+-- autumn_experiments holds the current configuration of each experiment.
+-- autumn_experiment_assignments records sticky actor → variant assignments.
+-- autumn_experiment_overrides pins QA/staff actors to specific variants.
+-- autumn_experiment_changes is the append-only audit log.
+--
+-- Postgres LISTEN/NOTIFY: any weight/state mutation sends
+-- `NOTIFY autumn_experiments, <name>` so all replicas can reload cached
+-- experiment configs within seconds (consistent with feature-flags and
+-- runtime-config substrate).
+
+CREATE TYPE autumn_experiment_state AS ENUM ('draft', 'running', 'concluded', 'archived');
+
+CREATE TABLE IF NOT EXISTS autumn_experiments (
+    id               BIGSERIAL                NOT NULL PRIMARY KEY,
+    name             TEXT                     NOT NULL UNIQUE,
+    description      TEXT,
+    state            autumn_experiment_state  NOT NULL DEFAULT 'draft',
+    variants         JSONB                    NOT NULL DEFAULT '[]',
+    winner           TEXT,
+    exclusion_group  TEXT,
+    created_at       TIMESTAMPTZ              NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ              NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON COLUMN autumn_experiments.variants IS
+    'JSON array of {"name": string, "weight": integer} objects. '
+    'Weights are relative; they do not need to sum to 100.';
+COMMENT ON COLUMN autumn_experiments.winner IS
+    'Set on conclusion: the winning variant name. NULL while running.';
+COMMENT ON COLUMN autumn_experiments.exclusion_group IS
+    'Actors in any experiment with the same group are excluded from siblings.';
+
+CREATE INDEX IF NOT EXISTS idx_autumn_experiments_name
+    ON autumn_experiments (name);
+CREATE INDEX IF NOT EXISTS idx_autumn_experiments_state
+    ON autumn_experiments (state);
+
+-- Sticky assignments: once an actor is assigned to a variant the row is
+-- recorded here and returned on all subsequent assign() calls without
+-- re-computing the bucket.  is_override=true when the assignment came from
+-- an operator override rather than weight-based bucketing.
+CREATE TABLE IF NOT EXISTS autumn_experiment_assignments (
+    id               BIGSERIAL   NOT NULL PRIMARY KEY,
+    experiment       TEXT        NOT NULL,
+    actor            TEXT        NOT NULL,
+    variant          TEXT        NOT NULL,
+    is_override      BOOLEAN     NOT NULL DEFAULT FALSE,
+    assigned_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (experiment, actor)
+);
+
+CREATE INDEX IF NOT EXISTS idx_autumn_exp_assignments_experiment
+    ON autumn_experiment_assignments (experiment);
+CREATE INDEX IF NOT EXISTS idx_autumn_exp_assignments_actor
+    ON autumn_experiment_assignments (actor);
+
+-- QA/staff overrides: pins an actor to a specific variant bypassing weights.
+-- Takes precedence over sticky assignments on each assign() call.
+CREATE TABLE IF NOT EXISTS autumn_experiment_overrides (
+    id          BIGSERIAL   NOT NULL PRIMARY KEY,
+    experiment  TEXT        NOT NULL,
+    actor       TEXT        NOT NULL,
+    variant     TEXT        NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (experiment, actor)
+);
+
+CREATE INDEX IF NOT EXISTS idx_autumn_exp_overrides_experiment
+    ON autumn_experiment_overrides (experiment, actor);
+
+-- Audit log: every mutation (create, set_weights, state change, override) is
+-- appended here with the operator identity and a timestamp.
+CREATE TABLE IF NOT EXISTS autumn_experiment_changes (
+    id          BIGSERIAL   NOT NULL PRIMARY KEY,
+    experiment  TEXT        NOT NULL,
+    mutation    TEXT        NOT NULL,
+    actor       TEXT,
+    changed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON COLUMN autumn_experiment_changes.mutation IS
+    'Human-readable description: "created", "state=running", "set_weights", '
+    '"concluded=treatment", "override=user:42:treatment", etc.';
+
+CREATE INDEX IF NOT EXISTS idx_autumn_exp_changes_experiment_time
+    ON autumn_experiment_changes (experiment, changed_at DESC);
+
+-- LISTEN/NOTIFY trigger: replicas subscribe to autumn_experiments channel and
+-- reload cached experiment configs whenever a change is recorded.
+CREATE OR REPLACE FUNCTION autumn_notify_experiment_change()
+RETURNS trigger AS $$
+BEGIN
+    PERFORM pg_notify('autumn_experiments', NEW.experiment);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER autumn_experiment_change_notify
+AFTER INSERT ON autumn_experiment_changes
+FOR EACH ROW EXECUTE FUNCTION autumn_notify_experiment_change();

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1389,6 +1389,73 @@ impl AppBuilder {
         })
     }
 
+    /// Register an experiment store, enabling the [`Experiments`] extractor.
+    ///
+    /// Wrap any [`ExperimentStore`] implementation. Use [`InMemoryExperimentStore`]
+    /// for development and tests; use the Postgres-backed store for production.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use autumn_web::experiments::InMemoryExperimentStore;
+    ///
+    /// autumn_web::app()
+    ///     .with_experiment_store(InMemoryExperimentStore::new())
+    ///     .run()
+    ///     .await;
+    /// ```
+    ///
+    /// [`Experiments`]: crate::experiments::Experiments
+    /// [`ExperimentStore`]: crate::experiments::ExperimentStore
+    /// [`InMemoryExperimentStore`]: crate::experiments::InMemoryExperimentStore
+    #[must_use]
+    pub fn with_experiment_store<S>(self, store: S) -> Self
+    where
+        S: crate::experiments::ExperimentStore,
+    {
+        let service = crate::experiments::ExperimentService::new(Arc::new(store) as Arc<_>);
+        self.state_initializer(move |state| {
+            state.insert_extension(service);
+        })
+    }
+
+    /// Register an experiment store with a custom [`ExposureSink`].
+    ///
+    /// Use when you want to forward exposure events to an analytics pipeline
+    /// rather than the default `tracing` log.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use autumn_web::experiments::{InMemoryExperimentStore, NoOpExposureSink};
+    /// use std::sync::Arc;
+    ///
+    /// autumn_web::app()
+    ///     .with_experiment_store_and_sink(
+    ///         InMemoryExperimentStore::new(),
+    ///         Arc::new(NoOpExposureSink),
+    ///     )
+    ///     .run()
+    ///     .await;
+    /// ```
+    ///
+    /// [`ExposureSink`]: crate::experiments::ExposureSink
+    #[must_use]
+    pub fn with_experiment_store_and_sink<S>(
+        self,
+        store: S,
+        sink: Arc<dyn crate::experiments::ExposureSink>,
+    ) -> Self
+    where
+        S: crate::experiments::ExperimentStore,
+    {
+        let service = crate::experiments::ExperimentService::new(Arc::new(store) as Arc<_>)
+            .with_exposure_sink(sink);
+        self.state_initializer(move |state| {
+            state.insert_extension(service);
+        })
+    }
+
     /// Register a durable [`MailDeliveryQueue`](crate::mail::MailDeliveryQueue) for
     /// [`Mailer::deliver_later`](crate::mail::Mailer::deliver_later).
     ///

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1392,9 +1392,26 @@ impl AppBuilder {
     /// Register an experiment store, enabling the [`Experiments`] extractor.
     ///
     /// Wrap any [`ExperimentStore`] implementation. Use [`InMemoryExperimentStore`]
-    /// for development and tests; use the Postgres-backed store for production.
+    /// for development and tests; use
+    /// [`pg::PgExperimentStore`](crate::experiments::pg::PgExperimentStore)
+    /// for production against the `autumn_experiments` tables.
     ///
-    /// # Example
+    /// # Production example (Postgres-backed)
+    ///
+    /// ```rust,ignore
+    /// use std::sync::Arc;
+    /// use std::time::Duration;
+    /// use autumn_web::experiments::pg::PgExperimentStore;
+    ///
+    /// let store = Arc::new(PgExperimentStore::new(&config.database.primary_url));
+    /// PgExperimentStore::spawn_poll_listener(Arc::clone(&store), Duration::from_secs(5));
+    /// autumn_web::app()
+    ///     .with_experiment_store(Arc::clone(&store))
+    ///     .run()
+    ///     .await;
+    /// ```
+    ///
+    /// # Development / test example
     ///
     /// ```rust,ignore
     /// use autumn_web::experiments::InMemoryExperimentStore;

--- a/autumn/src/experiments.rs
+++ b/autumn/src/experiments.rs
@@ -1348,6 +1348,7 @@ impl axum::extract::FromRequestParts<crate::AppState> for Experiments {
 
 // ── pg module ─────────────────────────────────────────────────────────────────
 
+#[cfg(feature = "db")]
 pub mod pg {
     use super::{
         Assignment, ChangeRecord, ExperimentConfig, ExperimentState, ExperimentStore,

--- a/autumn/src/experiments.rs
+++ b/autumn/src/experiments.rs
@@ -1109,13 +1109,20 @@ impl ExperimentService {
 
     /// Transition a `Draft` or `Concluded` experiment to `Running`.
     ///
+    /// `Archived` experiments are terminal and cannot be restarted.
+    ///
     /// # Errors
     ///
     /// Returns [`ExperimentError::NotFound`] if the experiment is unknown.
+    /// Returns [`ExperimentError::Archived`] if the experiment is archived.
     pub fn start(&self, name: &str) -> Result<(), ExperimentError> {
-        self.store
+        let config = self
+            .store
             .get(name)?
             .ok_or_else(|| ExperimentError::NotFound(name.to_owned()))?;
+        if config.state == ExperimentState::Archived {
+            return Err(ExperimentError::Archived(name.to_owned()));
+        }
         self.store.set_state(name, ExperimentState::Running, None)?;
         Ok(())
     }
@@ -1788,9 +1795,14 @@ pub mod pg {
         ) -> Result<(), ExperimentStoreError> {
             let mut conn = self.connect()?;
             diesel::sql_query(
-                "INSERT INTO autumn_experiment_overrides (experiment, actor, variant) \
-                 VALUES ($1, $2, $3) \
-                 ON CONFLICT (experiment, actor) DO UPDATE SET variant = EXCLUDED.variant",
+                "WITH upserted AS ( \
+                     INSERT INTO autumn_experiment_overrides (experiment, actor, variant) \
+                     VALUES ($1, $2, $3) \
+                     ON CONFLICT (experiment, actor) DO UPDATE SET variant = EXCLUDED.variant \
+                     RETURNING experiment, actor, variant \
+                 ) \
+                 INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
+                 SELECT experiment, 'override=' || actor || ':' || variant, NULL FROM upserted",
             )
             .bind::<diesel::sql_types::Text, _>(experiment)
             .bind::<diesel::sql_types::Text, _>(actor)

--- a/autumn/src/experiments.rs
+++ b/autumn/src/experiments.rs
@@ -711,7 +711,11 @@ impl ExperimentStore for InMemoryExperimentStore {
 
     fn record_assignment(&self, assignment: Assignment) -> Result<(), ExperimentStoreError> {
         let key = (assignment.experiment.clone(), assignment.actor.clone());
-        self.inner.write().unwrap().assignments.insert(key, assignment);
+        self.inner
+            .write()
+            .unwrap()
+            .assignments
+            .insert(key, assignment);
         Ok(())
     }
 
@@ -1124,7 +1128,8 @@ impl ExperimentService {
         self.store
             .get(name)?
             .ok_or_else(|| ExperimentError::NotFound(name.to_owned()))?;
-        self.store.set_state(name, ExperimentState::Archived, None)?;
+        self.store
+            .set_state(name, ExperimentState::Archived, None)?;
         Ok(())
     }
 
@@ -1469,10 +1474,16 @@ mod tests {
         // To regenerate: run `experiment_bucket(name, actor)` and record the output.
         let b1 = experiment_bucket("checkout_v2", "user:1");
         let b2 = experiment_bucket("checkout_v2", "user:1");
-        assert_eq!(b1, b2, "hash must be deterministic (same input → same output)");
+        assert_eq!(
+            b1, b2,
+            "hash must be deterministic (same input → same output)"
+        );
 
         // Fixture values established on first run — sentinel against algorithm drift.
-        assert_eq!(b1, 4_830, "checkout_v2:user:1 bucket changed — hash regression");
+        assert_eq!(
+            b1, 4_830,
+            "checkout_v2:user:1 bucket changed — hash regression"
+        );
         assert_eq!(
             experiment_bucket("checkout_v2", "user:2"),
             6_619,
@@ -1547,10 +1558,7 @@ mod tests {
         let svc = make_svc();
         svc.create(ExperimentConfig::new(
             "exp",
-            vec![
-                VariantConfig::new("a", 0),
-                VariantConfig::new("b", 0),
-            ],
+            vec![VariantConfig::new("a", 0), VariantConfig::new("b", 0)],
         ))
         .unwrap();
         svc.start("exp").unwrap();
@@ -1616,11 +1624,23 @@ mod tests {
         let (svc, records) = make_svc_with_sink();
         running(&svc, "exp");
         svc.assign("exp", "user:1").unwrap();
-        assert_eq!(records.lock().unwrap().len(), 1, "first assign → 1 exposure");
+        assert_eq!(
+            records.lock().unwrap().len(),
+            1,
+            "first assign → 1 exposure"
+        );
         svc.assign("exp", "user:1").unwrap();
-        assert_eq!(records.lock().unwrap().len(), 2, "second assign → 2 total exposures");
+        assert_eq!(
+            records.lock().unwrap().len(),
+            2,
+            "second assign → 2 total exposures"
+        );
         svc.assign("exp", "user:2").unwrap();
-        assert_eq!(records.lock().unwrap().len(), 3, "different actor → 3 total exposures");
+        assert_eq!(
+            records.lock().unwrap().len(),
+            3,
+            "different actor → 3 total exposures"
+        );
     }
 
     // ── AC: exposure record contains correct fields ───────────────────────────
@@ -1669,7 +1689,10 @@ mod tests {
         svc.start("exp").unwrap();
         svc.set_override("exp", "qa:alice", "treatment").unwrap();
         let v = svc.assign("exp", "qa:alice").unwrap();
-        assert_eq!(v, "treatment", "override must bypass weight-based bucketing");
+        assert_eq!(
+            v, "treatment",
+            "override must bypass weight-based bucketing"
+        );
     }
 
     // ── AC: override emits exposure tagged as override ────────────────────────
@@ -1902,7 +1925,9 @@ mod tests {
         let asgn = arc_store.get_assignment("my_exp", "user:1").unwrap();
         assert_eq!(asgn.unwrap().variant, "control");
 
-        arc_store.set_override("my_exp", "qa:1", "treatment").unwrap();
+        arc_store
+            .set_override("my_exp", "qa:1", "treatment")
+            .unwrap();
         assert_eq!(
             arc_store.get_override("my_exp", "qa:1").unwrap().unwrap(),
             "treatment"
@@ -1923,18 +1948,26 @@ mod tests {
 
     #[test]
     fn experiment_error_display() {
-        assert!(ExperimentError::NotFound("x".to_owned())
-            .to_string()
-            .contains("not found"));
-        assert!(ExperimentError::Archived("x".to_owned())
-            .to_string()
-            .contains("archived"));
-        assert!(ExperimentError::ExcludedByGroup("x".to_owned(), "g".to_owned())
-            .to_string()
-            .contains("mutual exclusion"));
-        assert!(ExperimentError::NoVariant("x".to_owned())
-            .to_string()
-            .contains("weights are zero"));
+        assert!(
+            ExperimentError::NotFound("x".to_owned())
+                .to_string()
+                .contains("not found")
+        );
+        assert!(
+            ExperimentError::Archived("x".to_owned())
+                .to_string()
+                .contains("archived")
+        );
+        assert!(
+            ExperimentError::ExcludedByGroup("x".to_owned(), "g".to_owned())
+                .to_string()
+                .contains("mutual exclusion")
+        );
+        assert!(
+            ExperimentError::NoVariant("x".to_owned())
+                .to_string()
+                .contains("weights are zero")
+        );
     }
 
     // ── AC: service debug ─────────────────────────────────────────────────────

--- a/autumn/src/experiments.rs
+++ b/autumn/src/experiments.rs
@@ -1354,21 +1354,20 @@ impl axum::extract::FromRequestParts<crate::AppState> for Experiments {
             // the session ID so each anonymous visitor gets a stable, per-session
             // bucket rather than all collapsing into a single "anonymous" actor.
             let session_key = state.auth_session_key();
-            match session.get(session_key).await {
-                Some(uid) => Some(uid),
-                None => {
-                    // Use or create a stable per-session anonymous actor. We must
-                    // insert into the session (marking it dirty) so the framework
-                    // sets a cookie and the ID persists across requests; a bare
-                    // session.id() call does not mark the session dirty.
-                    const ANON_KEY: &str = "_autumn_anon_actor";
-                    if let Some(existing) = session.get(ANON_KEY).await {
-                        Some(existing)
-                    } else {
-                        let id = session.id().await;
-                        session.insert(ANON_KEY, &id).await;
-                        Some(id)
-                    }
+            if let Some(uid) = session.get(session_key).await {
+                Some(uid)
+            } else {
+                // Use or create a stable per-session anonymous actor. We must
+                // insert into the session (marking it dirty) so the framework
+                // sets a cookie and the ID persists across requests; a bare
+                // session.id() call does not mark the session dirty.
+                const ANON_KEY: &str = "_autumn_anon_actor";
+                if let Some(existing) = session.get(ANON_KEY).await {
+                    Some(existing)
+                } else {
+                    let id = session.id().await;
+                    session.insert(ANON_KEY, &id).await;
+                    Some(id)
                 }
             }
         } else {

--- a/autumn/src/experiments.rs
+++ b/autumn/src/experiments.rs
@@ -1636,13 +1636,7 @@ pub mod pg {
                      INSERT INTO autumn_experiments \
                          (name, description, state, variants, winner, exclusion_group) \
                      VALUES ($1, $2, $3::autumn_experiment_state, $4::jsonb, $5, $6) \
-                     ON CONFLICT (name) DO UPDATE \
-                         SET description = EXCLUDED.description, \
-                             state = EXCLUDED.state, \
-                             variants = EXCLUDED.variants, \
-                             winner = EXCLUDED.winner, \
-                             exclusion_group = EXCLUDED.exclusion_group, \
-                             updated_at = NOW() \
+                     ON CONFLICT (name) DO NOTHING \
                      RETURNING name \
                  ) \
                  INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \

--- a/autumn/src/experiments.rs
+++ b/autumn/src/experiments.rs
@@ -1163,6 +1163,9 @@ impl ExperimentService {
             .store
             .get(name)?
             .ok_or_else(|| ExperimentError::NotFound(name.to_owned()))?;
+        if config.state == ExperimentState::Archived {
+            return Err(ExperimentError::Archived(name.to_owned()));
+        }
         if !config.variants.iter().any(|v| v.name == winner) {
             return Err(ExperimentError::NoVariant(format!(
                 "'{winner}' is not a configured variant of experiment '{name}'"
@@ -1206,9 +1209,22 @@ impl ExperimentService {
         actor: Option<&str>,
     ) -> Result<(), ExperimentError> {
         validate_variants(&variants)?;
-        self.store
+        let config = self
+            .store
             .get(name)?
             .ok_or_else(|| ExperimentError::NotFound(name.to_owned()))?;
+        match config.state {
+            ExperimentState::Concluded => {
+                return Err(ExperimentError::NotRunning(
+                    name.to_owned(),
+                    ExperimentState::Concluded,
+                ));
+            }
+            ExperimentState::Archived => {
+                return Err(ExperimentError::Archived(name.to_owned()));
+            }
+            _ => {}
+        }
         self.store.set_variants(name, variants, actor)?;
         Ok(())
     }

--- a/autumn/src/experiments.rs
+++ b/autumn/src/experiments.rs
@@ -141,7 +141,7 @@ impl VariantConfig {
 // ── ExperimentConfig ─────────────────────────────────────────────────────────
 
 /// Full configuration of a single experiment.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExperimentConfig {
     /// Unique experiment name (e.g. `"checkout_v2"`).
     pub name: String,
@@ -626,21 +626,25 @@ impl ExperimentStore for InMemoryExperimentStore {
     }
 
     fn list(&self) -> Result<Vec<ExperimentConfig>, ExperimentStoreError> {
-        let inner = self.inner.read().unwrap();
-        let mut exps: Vec<ExperimentConfig> = inner.experiments.values().cloned().collect();
+        let mut exps: Vec<ExperimentConfig> = {
+            let inner = self.inner.read().unwrap();
+            inner.experiments.values().cloned().collect()
+        };
         exps.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(exps)
     }
 
     fn upsert(&self, config: ExperimentConfig) -> Result<(), ExperimentStoreError> {
         let name = config.name.clone();
-        let mut inner = self.inner.write().unwrap();
-        inner.experiments.insert(name.clone(), config);
-        inner
-            .changes
-            .entry(name.clone())
-            .or_default()
-            .push(ChangeRecord::now(&name, "created", None));
+        {
+            let mut inner = self.inner.write().unwrap();
+            inner.experiments.insert(name.clone(), config);
+            inner
+                .changes
+                .entry(name.clone())
+                .or_default()
+                .push(ChangeRecord::now(&name, "created", None));
+        }
         Ok(())
     }
 
@@ -650,27 +654,25 @@ impl ExperimentStore for InMemoryExperimentStore {
         state: ExperimentState,
         winner: Option<&str>,
     ) -> Result<(), ExperimentStoreError> {
-        let mut inner = self.inner.write().unwrap();
-        if let Some(exp) = inner.experiments.get_mut(name) {
-            exp.state = state;
-            if let Some(w) = winner {
-                exp.winner = Some(w.to_owned());
-            }
-            exp.updated_at_secs = now_secs();
-        }
-        inner
-            .changes
-            .entry(name.to_owned())
-            .or_default()
-            .push(ChangeRecord::now(
-                name,
+        {
+            let mut inner = self.inner.write().unwrap();
+            if let Some(exp) = inner.experiments.get_mut(name) {
+                exp.state = state;
                 if let Some(w) = winner {
-                    format!("concluded={w}")
-                } else {
-                    format!("state={state}")
-                },
-                None,
-            ));
+                    exp.winner = Some(w.to_owned());
+                }
+                exp.updated_at_secs = now_secs();
+            }
+            inner
+                .changes
+                .entry(name.to_owned())
+                .or_default()
+                .push(ChangeRecord::now(
+                    name,
+                    winner.map_or_else(|| format!("state={state}"), |w| format!("concluded={w}")),
+                    None,
+                ));
+        }
         Ok(())
     }
 
@@ -680,16 +682,18 @@ impl ExperimentStore for InMemoryExperimentStore {
         variants: Vec<VariantConfig>,
         actor: Option<&str>,
     ) -> Result<(), ExperimentStoreError> {
-        let mut inner = self.inner.write().unwrap();
-        if let Some(exp) = inner.experiments.get_mut(name) {
-            exp.variants = variants;
-            exp.updated_at_secs = now_secs();
+        {
+            let mut inner = self.inner.write().unwrap();
+            if let Some(exp) = inner.experiments.get_mut(name) {
+                exp.variants = variants;
+                exp.updated_at_secs = now_secs();
+            }
+            inner
+                .changes
+                .entry(name.to_owned())
+                .or_default()
+                .push(ChangeRecord::now(name, "set_weights", actor));
         }
-        inner
-            .changes
-            .entry(name.to_owned())
-            .or_default()
-            .push(ChangeRecord::now(name, "set_weights", actor));
         Ok(())
     }
 
@@ -767,18 +771,20 @@ impl ExperimentStore for InMemoryExperimentStore {
         experiment: &str,
         limit: usize,
     ) -> Result<Vec<ChangeRecord>, ExperimentStoreError> {
-        let inner = self.inner.read().unwrap();
-        let records = inner
-            .changes
-            .get(experiment)
-            .map(|v| {
-                if limit == 0 {
-                    v.clone()
-                } else {
-                    v.iter().rev().take(limit).cloned().collect()
-                }
-            })
-            .unwrap_or_default();
+        let records = {
+            let inner = self.inner.read().unwrap();
+            inner
+                .changes
+                .get(experiment)
+                .map(|v| {
+                    if limit == 0 {
+                        v.clone()
+                    } else {
+                        v.iter().rev().take(limit).cloned().collect()
+                    }
+                })
+                .unwrap_or_default()
+        };
         Ok(records)
     }
 }
@@ -988,7 +994,9 @@ impl ExperimentService {
             }
             ExperimentState::Concluded => {
                 // Return winner for all actors; no exposure emitted (experiment is done).
-                let winner = config.winner.clone().unwrap_or_else(|| "control".to_owned());
+                let winner = config
+                    .winner
+                    .ok_or_else(|| ExperimentError::NoVariant(experiment.to_owned()))?;
                 return Ok(winner);
             }
             ExperimentState::Draft => {
@@ -1021,16 +1029,15 @@ impl ExperimentService {
         }
 
         // Mutual exclusion group check.
-        if let Some(group) = &config.exclusion_group {
-            if self
+        if let Some(group) = &config.exclusion_group
+            && self
                 .store
                 .has_assignment_in_group(actor, group, experiment)?
-            {
-                return Err(ExperimentError::ExcludedByGroup(
-                    experiment.to_owned(),
-                    group.clone(),
-                ));
-            }
+        {
+            return Err(ExperimentError::ExcludedByGroup(
+                experiment.to_owned(),
+                group.clone(),
+            ));
         }
 
         // Bucket the actor and pick a variant.
@@ -1393,7 +1400,7 @@ mod tests {
         let (svc, records) = make_svc_with_sink();
         let store = Arc::new(InMemoryExperimentStore::new());
         let (sink2, records2) = RecordingExposureSink::new();
-        let svc2 = ExperimentService::new(store.clone() as Arc<dyn ExperimentStore>)
+        let svc2 = ExperimentService::new(store as Arc<dyn ExperimentStore>)
             .with_exposure_sink(Arc::new(sink2));
         svc2.create(fifty_fifty("exp")).unwrap();
         svc2.start("exp").unwrap();
@@ -1625,14 +1632,24 @@ mod tests {
         let variant = svc
             .assign_with_request_id("checkout_v2", "user:42", Some("req-abc"))
             .unwrap();
-        let rec = records.lock().unwrap();
-        assert_eq!(rec.len(), 1);
-        let exp = &rec[0];
-        assert_eq!(exp.experiment, "checkout_v2");
-        assert_eq!(exp.variant, variant);
-        assert_eq!(exp.actor, "user:42");
-        assert_eq!(exp.request_id.as_deref(), Some("req-abc"));
-        assert!(!exp.is_override);
+        let (len, exp_name, exp_variant, exp_actor, exp_req_id, exp_is_override) = {
+            let rec = records.lock().unwrap();
+            let r = &rec[0];
+            (
+                rec.len(),
+                r.experiment.clone(),
+                r.variant.clone(),
+                r.actor.clone(),
+                r.request_id.clone(),
+                r.is_override,
+            )
+        };
+        assert_eq!(len, 1);
+        assert_eq!(exp_name, "checkout_v2");
+        assert_eq!(exp_variant, variant);
+        assert_eq!(exp_actor, "user:42");
+        assert_eq!(exp_req_id.as_deref(), Some("req-abc"));
+        assert!(!exp_is_override);
     }
 
     // ── AC: override bypasses weight-based bucketing ──────────────────────────
@@ -1663,13 +1680,16 @@ mod tests {
         running(&svc, "exp");
         svc.set_override("exp", "qa:alice", "treatment").unwrap();
         svc.assign("exp", "qa:alice").unwrap();
-        let rec = records.lock().unwrap();
-        assert_eq!(rec.len(), 1);
+        let (len, is_override, exp_variant) = {
+            let rec = records.lock().unwrap();
+            (rec.len(), rec[0].is_override, rec[0].variant.clone())
+        };
+        assert_eq!(len, 1);
         assert!(
-            rec[0].is_override,
+            is_override,
             "exposure from override must be tagged is_override = true"
         );
-        assert_eq!(rec[0].variant, "treatment");
+        assert_eq!(exp_variant, "treatment");
     }
 
     // ── AC: mutual exclusion — second experiment in group is excluded ─────────

--- a/autumn/src/experiments.rs
+++ b/autumn/src/experiments.rs
@@ -889,6 +889,26 @@ pub enum ExperimentError {
     Store(#[from] ExperimentStoreError),
 }
 
+// ── Validation helpers ────────────────────────────────────────────────────────
+
+fn validate_variants(variants: &[VariantConfig]) -> Result<(), ExperimentError> {
+    let mut seen = std::collections::HashSet::new();
+    for v in variants {
+        if v.name.trim().is_empty() {
+            return Err(ExperimentError::NoVariant(
+                "variant name must not be empty".into(),
+            ));
+        }
+        if !seen.insert(v.name.as_str()) {
+            return Err(ExperimentError::NoVariant(format!(
+                "duplicate variant name: '{}'",
+                v.name
+            )));
+        }
+    }
+    Ok(())
+}
+
 // ── ExperimentService ─────────────────────────────────────────────────────────
 
 /// The main experiment service.
@@ -1082,6 +1102,7 @@ impl ExperimentService {
     ///
     /// Returns [`ExperimentError::Store`] on backend failure.
     pub fn create(&self, config: ExperimentConfig) -> Result<(), ExperimentError> {
+        validate_variants(&config.variants)?;
         self.store.upsert(config)?;
         Ok(())
     }
@@ -1108,9 +1129,15 @@ impl ExperimentService {
     ///
     /// Returns [`ExperimentError::NotFound`] if the experiment is unknown.
     pub fn conclude(&self, name: &str, winner: &str) -> Result<(), ExperimentError> {
-        self.store
+        let config = self
+            .store
             .get(name)?
             .ok_or_else(|| ExperimentError::NotFound(name.to_owned()))?;
+        if !config.variants.iter().any(|v| v.name == winner) {
+            return Err(ExperimentError::NoVariant(format!(
+                "'{winner}' is not a configured variant of experiment '{name}'"
+            )));
+        }
         self.store
             .set_state(name, ExperimentState::Concluded, Some(winner))?;
         Ok(())
@@ -1148,6 +1175,7 @@ impl ExperimentService {
         variants: Vec<VariantConfig>,
         actor: Option<&str>,
     ) -> Result<(), ExperimentError> {
+        validate_variants(&variants)?;
         self.store
             .get(name)?
             .ok_or_else(|| ExperimentError::NotFound(name.to_owned()))?;
@@ -1169,9 +1197,15 @@ impl ExperimentService {
         actor: &str,
         variant: &str,
     ) -> Result<(), ExperimentError> {
-        self.store
+        let config = self
+            .store
             .get(experiment)?
             .ok_or_else(|| ExperimentError::NotFound(experiment.to_owned()))?;
+        if !config.variants.iter().any(|v| v.name == variant) {
+            return Err(ExperimentError::NoVariant(format!(
+                "'{variant}' is not a configured variant of experiment '{experiment}'"
+            )));
+        }
         self.store.set_override(experiment, actor, variant)?;
         Ok(())
     }
@@ -1247,7 +1281,10 @@ pub struct Experiments {
 impl Experiments {
     /// Assign a variant for the current session actor.
     ///
-    /// Propagates the session `user_id` and `x-request-id` header automatically.
+    /// Propagates the session actor ID and `x-request-id` header automatically.
+    /// For logged-out sessions, falls back to the session ID so each visitor
+    /// gets a stable, per-session bucket rather than collapsing all anonymous
+    /// traffic into a single `"anonymous"` actor.
     ///
     /// # Errors
     ///
@@ -1283,7 +1320,14 @@ impl axum::extract::FromRequestParts<crate::AppState> for Experiments {
             })?;
 
         let actor_id = if let Some(session) = parts.extensions.get::<crate::session::Session>() {
-            session.get("user_id").await
+            // Use the configured auth session key (e.g. "user_id"); fall back to
+            // the session ID so each anonymous visitor gets a stable, per-session
+            // bucket rather than all collapsing into a single "anonymous" actor.
+            let session_key = state.auth_session_key();
+            match session.get(session_key).await {
+                Some(uid) => Some(uid),
+                None => Some(session.id().await),
+            }
         } else {
             None
         };
@@ -1299,6 +1343,517 @@ impl axum::extract::FromRequestParts<crate::AppState> for Experiments {
             actor_id,
             request_id,
         })
+    }
+}
+
+// ── pg module ─────────────────────────────────────────────────────────────────
+
+pub mod pg {
+    use super::{
+        Assignment, ChangeRecord, ExperimentConfig, ExperimentState, ExperimentStore,
+        ExperimentStoreError, VariantConfig,
+    };
+    use diesel::prelude::*;
+    use std::collections::HashMap;
+    use std::sync::RwLock;
+    use std::time::{Duration, Instant};
+
+    // ── Cache types ───────────────────────────────────────────────────────────
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum CacheLookup {
+        Hit(Option<ExperimentConfig>),
+        Miss,
+    }
+
+    #[derive(Debug, Clone)]
+    struct CachedEntry {
+        value: Option<ExperimentConfig>,
+        expires_at: Instant,
+    }
+
+    // ── Row structs ───────────────────────────────────────────────────────────
+
+    #[derive(diesel::QueryableByName)]
+    struct ExperimentRow {
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        name: String,
+        #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+        description: Option<String>,
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        state: String,
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        variants: String,
+        #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+        winner: Option<String>,
+        #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+        exclusion_group: Option<String>,
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        updated_at_secs: i64,
+    }
+
+    impl ExperimentRow {
+        fn into_config(self) -> ExperimentConfig {
+            let variants: Vec<VariantConfig> =
+                serde_json::from_str(&self.variants).unwrap_or_default();
+            let state = match self.state.as_str() {
+                "running" => ExperimentState::Running,
+                "concluded" => ExperimentState::Concluded,
+                "archived" => ExperimentState::Archived,
+                _ => ExperimentState::Draft,
+            };
+            ExperimentConfig {
+                name: self.name,
+                description: self.description,
+                state,
+                variants,
+                winner: self.winner,
+                exclusion_group: self.exclusion_group,
+                updated_at_secs: u64::try_from(self.updated_at_secs).unwrap_or(0),
+            }
+        }
+    }
+
+    #[derive(diesel::QueryableByName)]
+    struct AssignmentRow {
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        experiment: String,
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        actor: String,
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        variant: String,
+        #[diesel(sql_type = diesel::sql_types::Bool)]
+        is_override: bool,
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        assigned_at_secs: i64,
+    }
+
+    #[derive(diesel::QueryableByName)]
+    struct BoolRow {
+        #[diesel(sql_type = diesel::sql_types::Bool)]
+        result: bool,
+    }
+
+    #[derive(diesel::QueryableByName)]
+    struct VariantNameRow {
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        variant: String,
+    }
+
+    #[derive(diesel::QueryableByName)]
+    struct ChangeRow {
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        experiment: String,
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        mutation: String,
+        #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+        actor: Option<String>,
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        timestamp_secs: i64,
+    }
+
+    #[derive(diesel::QueryableByName)]
+    struct ChangeExperimentRow {
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        experiment: String,
+    }
+
+    // ── PgExperimentStore ─────────────────────────────────────────────────────
+
+    /// Postgres-backed [`ExperimentStore`] with a short-lived read-through cache.
+    ///
+    /// Writes trigger `pg_notify('autumn_experiments', name)` so replicas can
+    /// invalidate their caches quickly via a background poll listener.
+    #[derive(Debug)]
+    pub struct PgExperimentStore {
+        database_url: String,
+        cache_ttl: Duration,
+        cache: RwLock<HashMap<String, CachedEntry>>,
+    }
+
+    impl Clone for PgExperimentStore {
+        fn clone(&self) -> Self {
+            Self::with_cache_ttl(self.database_url.clone(), self.cache_ttl)
+        }
+    }
+
+    impl PgExperimentStore {
+        /// Default read-through cache lifetime.
+        pub const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(1);
+
+        /// Create a store using the default 1 s read-through cache.
+        #[must_use]
+        pub fn new(database_url: impl Into<String>) -> Self {
+            Self::with_cache_ttl(database_url, Self::DEFAULT_CACHE_TTL)
+        }
+
+        /// Create a store with an explicit cache TTL. Use `Duration::ZERO` to
+        /// disable caching.
+        #[must_use]
+        pub fn with_cache_ttl(database_url: impl Into<String>, cache_ttl: Duration) -> Self {
+            Self {
+                database_url: database_url.into(),
+                cache_ttl,
+                cache: RwLock::new(HashMap::new()),
+            }
+        }
+
+        /// Create a store from Autumn's primary database configuration.
+        #[must_use]
+        pub fn from_database_config(config: &crate::config::DatabaseConfig) -> Option<Self> {
+            config.effective_primary_url().map(Self::new)
+        }
+
+        fn connect(&self) -> Result<diesel::PgConnection, ExperimentStoreError> {
+            diesel::PgConnection::establish(&self.database_url)
+                .map_err(|e| ExperimentStoreError::Backend(e.to_string()))
+        }
+
+        fn cached(&self, name: &str) -> CacheLookup {
+            let now = Instant::now();
+            let Ok(cache) = self.cache.read() else {
+                return CacheLookup::Miss;
+            };
+            match cache.get(name) {
+                Some(c) if c.expires_at > now => CacheLookup::Hit(c.value.clone()),
+                _ => CacheLookup::Miss,
+            }
+        }
+
+        fn store_cache(&self, name: &str, value: Option<ExperimentConfig>) {
+            if self.cache_ttl.is_zero() {
+                return;
+            }
+            let Some(expires_at) = Instant::now().checked_add(self.cache_ttl) else {
+                return;
+            };
+            if let Ok(mut cache) = self.cache.write() {
+                cache.insert(name.to_owned(), CachedEntry { value, expires_at });
+            }
+        }
+
+        fn invalidate(&self, name: &str) {
+            if let Ok(mut cache) = self.cache.write() {
+                cache.remove(name);
+            }
+        }
+
+        /// Spawn a background thread that polls `autumn_experiment_changes` and
+        /// invalidates this store's cache for changed experiments.
+        ///
+        /// The thread runs indefinitely; the returned handle can be detached.
+        pub fn spawn_poll_listener(
+            store: std::sync::Arc<Self>,
+            poll_interval: Duration,
+        ) -> std::thread::JoinHandle<()> {
+            std::thread::spawn(move || {
+                const OVERLAP_SECS: i64 = 5;
+                let now_secs = || {
+                    i64::try_from(
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs(),
+                    )
+                    .unwrap_or(i64::MAX)
+                };
+                let mut last_polled_secs: i64 = now_secs() - OVERLAP_SECS;
+
+                loop {
+                    std::thread::sleep(poll_interval);
+                    let new_horizon = now_secs() - OVERLAP_SECS;
+                    if let Ok(mut conn) = store.connect() {
+                        let rows: Vec<ChangeExperimentRow> = diesel::sql_query(
+                            "SELECT DISTINCT experiment FROM autumn_experiment_changes \
+                             WHERE changed_at > to_timestamp($1)",
+                        )
+                        .bind::<diesel::sql_types::BigInt, _>(last_polled_secs)
+                        .load::<ChangeExperimentRow>(&mut conn)
+                        .unwrap_or_default();
+
+                        for row in rows {
+                            store.invalidate(&row.experiment);
+                        }
+                    }
+                    last_polled_secs = new_horizon;
+                }
+            })
+        }
+    }
+
+    // ── ExperimentStore impl ──────────────────────────────────────────────────
+
+    impl ExperimentStore for PgExperimentStore {
+        fn get(&self, name: &str) -> Result<Option<ExperimentConfig>, ExperimentStoreError> {
+            if let CacheLookup::Hit(v) = self.cached(name) {
+                return Ok(v);
+            }
+            let mut conn = self.connect()?;
+            let result = diesel::sql_query(
+                "SELECT name, description, state::text, variants::text, winner, \
+                        exclusion_group, \
+                        EXTRACT(EPOCH FROM updated_at)::bigint AS updated_at_secs \
+                 FROM autumn_experiments WHERE name = $1",
+            )
+            .bind::<diesel::sql_types::Text, _>(name)
+            .get_result::<ExperimentRow>(&mut conn)
+            .optional()
+            .map(|r| r.map(ExperimentRow::into_config))
+            .map_err(|e| ExperimentStoreError::Backend(e.to_string()))?;
+
+            self.store_cache(name, result.clone());
+            Ok(result)
+        }
+
+        fn list(&self) -> Result<Vec<ExperimentConfig>, ExperimentStoreError> {
+            let mut conn = self.connect()?;
+            diesel::sql_query(
+                "SELECT name, description, state::text, variants::text, winner, \
+                        exclusion_group, \
+                        EXTRACT(EPOCH FROM updated_at)::bigint AS updated_at_secs \
+                 FROM autumn_experiments ORDER BY name",
+            )
+            .load::<ExperimentRow>(&mut conn)
+            .map(|rows| rows.into_iter().map(ExperimentRow::into_config).collect())
+            .map_err(|e| ExperimentStoreError::Backend(e.to_string()))
+        }
+
+        fn upsert(&self, config: ExperimentConfig) -> Result<(), ExperimentStoreError> {
+            let variants_json =
+                serde_json::to_string(&config.variants).unwrap_or_else(|_| "[]".to_owned());
+            let state_str = config.state.to_string();
+            let mut conn = self.connect()?;
+            diesel::sql_query(
+                "WITH upserted AS ( \
+                     INSERT INTO autumn_experiments \
+                         (name, description, state, variants, winner, exclusion_group) \
+                     VALUES ($1, $2, $3::autumn_experiment_state, $4::jsonb, $5, $6) \
+                     ON CONFLICT (name) DO UPDATE \
+                         SET description = EXCLUDED.description, \
+                             state = EXCLUDED.state, \
+                             variants = EXCLUDED.variants, \
+                             winner = EXCLUDED.winner, \
+                             exclusion_group = EXCLUDED.exclusion_group, \
+                             updated_at = NOW() \
+                     RETURNING name \
+                 ) \
+                 INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
+                 SELECT name, 'created', NULL FROM upserted",
+            )
+            .bind::<diesel::sql_types::Text, _>(&config.name)
+            .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(config.description)
+            .bind::<diesel::sql_types::Text, _>(&state_str)
+            .bind::<diesel::sql_types::Text, _>(&variants_json)
+            .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(config.winner)
+            .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(config.exclusion_group)
+            .execute(&mut conn)
+            .map_err(|e| ExperimentStoreError::Backend(e.to_string()))?;
+            self.invalidate(&config.name);
+            Ok(())
+        }
+
+        fn set_state(
+            &self,
+            name: &str,
+            state: ExperimentState,
+            winner: Option<&str>,
+        ) -> Result<(), ExperimentStoreError> {
+            let state_str = state.to_string();
+            let mutation =
+                winner.map_or_else(|| format!("state={state}"), |w| format!("concluded={w}"));
+            let mut conn = self.connect()?;
+            diesel::sql_query(
+                "WITH updated AS ( \
+                     UPDATE autumn_experiments \
+                     SET state = $2::autumn_experiment_state, \
+                         winner = COALESCE($3, winner), \
+                         updated_at = NOW() \
+                     WHERE name = $1 \
+                     RETURNING name \
+                 ) \
+                 INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
+                 SELECT name, $4, NULL FROM updated",
+            )
+            .bind::<diesel::sql_types::Text, _>(name)
+            .bind::<diesel::sql_types::Text, _>(&state_str)
+            .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(
+                winner.map(str::to_owned),
+            )
+            .bind::<diesel::sql_types::Text, _>(&mutation)
+            .execute(&mut conn)
+            .map_err(|e| ExperimentStoreError::Backend(e.to_string()))?;
+            self.invalidate(name);
+            Ok(())
+        }
+
+        fn set_variants(
+            &self,
+            name: &str,
+            variants: Vec<VariantConfig>,
+            actor: Option<&str>,
+        ) -> Result<(), ExperimentStoreError> {
+            let variants_json =
+                serde_json::to_string(&variants).unwrap_or_else(|_| "[]".to_owned());
+            let mut conn = self.connect()?;
+            diesel::sql_query(
+                "WITH updated AS ( \
+                     UPDATE autumn_experiments \
+                     SET variants = $2::jsonb, updated_at = NOW() \
+                     WHERE name = $1 \
+                     RETURNING name \
+                 ) \
+                 INSERT INTO autumn_experiment_changes (experiment, mutation, actor) \
+                 SELECT name, 'set_weights', $3 FROM updated",
+            )
+            .bind::<diesel::sql_types::Text, _>(name)
+            .bind::<diesel::sql_types::Text, _>(&variants_json)
+            .bind::<diesel::sql_types::Nullable<diesel::sql_types::Text>, _>(
+                actor.map(str::to_owned),
+            )
+            .execute(&mut conn)
+            .map_err(|e| ExperimentStoreError::Backend(e.to_string()))?;
+            self.invalidate(name);
+            Ok(())
+        }
+
+        fn get_assignment(
+            &self,
+            experiment: &str,
+            actor: &str,
+        ) -> Result<Option<Assignment>, ExperimentStoreError> {
+            let mut conn = self.connect()?;
+            diesel::sql_query(
+                "SELECT experiment, actor, variant, is_override, \
+                        EXTRACT(EPOCH FROM assigned_at)::bigint AS assigned_at_secs \
+                 FROM autumn_experiment_assignments \
+                 WHERE experiment = $1 AND actor = $2",
+            )
+            .bind::<diesel::sql_types::Text, _>(experiment)
+            .bind::<diesel::sql_types::Text, _>(actor)
+            .get_result::<AssignmentRow>(&mut conn)
+            .optional()
+            .map(|r| {
+                r.map(|row| Assignment {
+                    experiment: row.experiment,
+                    actor: row.actor,
+                    variant: row.variant,
+                    is_override: row.is_override,
+                    assigned_at_secs: u64::try_from(row.assigned_at_secs).unwrap_or(0),
+                })
+            })
+            .map_err(|e| ExperimentStoreError::Backend(e.to_string()))
+        }
+
+        fn record_assignment(&self, assignment: Assignment) -> Result<(), ExperimentStoreError> {
+            let mut conn = self.connect()?;
+            diesel::sql_query(
+                "INSERT INTO autumn_experiment_assignments \
+                     (experiment, actor, variant, is_override) \
+                 VALUES ($1, $2, $3, $4) \
+                 ON CONFLICT (experiment, actor) DO NOTHING",
+            )
+            .bind::<diesel::sql_types::Text, _>(&assignment.experiment)
+            .bind::<diesel::sql_types::Text, _>(&assignment.actor)
+            .bind::<diesel::sql_types::Text, _>(&assignment.variant)
+            .bind::<diesel::sql_types::Bool, _>(assignment.is_override)
+            .execute(&mut conn)
+            .map_err(|e| ExperimentStoreError::Backend(e.to_string()))?;
+            Ok(())
+        }
+
+        fn get_override(
+            &self,
+            experiment: &str,
+            actor: &str,
+        ) -> Result<Option<String>, ExperimentStoreError> {
+            let mut conn = self.connect()?;
+            diesel::sql_query(
+                "SELECT variant FROM autumn_experiment_overrides \
+                 WHERE experiment = $1 AND actor = $2",
+            )
+            .bind::<diesel::sql_types::Text, _>(experiment)
+            .bind::<diesel::sql_types::Text, _>(actor)
+            .get_result::<VariantNameRow>(&mut conn)
+            .optional()
+            .map(|r| r.map(|row| row.variant))
+            .map_err(|e| ExperimentStoreError::Backend(e.to_string()))
+        }
+
+        fn set_override(
+            &self,
+            experiment: &str,
+            actor: &str,
+            variant: &str,
+        ) -> Result<(), ExperimentStoreError> {
+            let mut conn = self.connect()?;
+            diesel::sql_query(
+                "INSERT INTO autumn_experiment_overrides (experiment, actor, variant) \
+                 VALUES ($1, $2, $3) \
+                 ON CONFLICT (experiment, actor) DO UPDATE SET variant = EXCLUDED.variant",
+            )
+            .bind::<diesel::sql_types::Text, _>(experiment)
+            .bind::<diesel::sql_types::Text, _>(actor)
+            .bind::<diesel::sql_types::Text, _>(variant)
+            .execute(&mut conn)
+            .map_err(|e| ExperimentStoreError::Backend(e.to_string()))?;
+            Ok(())
+        }
+
+        fn has_assignment_in_group(
+            &self,
+            actor: &str,
+            group: &str,
+            exclude_experiment: &str,
+        ) -> Result<bool, ExperimentStoreError> {
+            let mut conn = self.connect()?;
+            diesel::sql_query(
+                "SELECT EXISTS ( \
+                     SELECT 1 \
+                     FROM autumn_experiment_assignments a \
+                     JOIN autumn_experiments e ON e.name = a.experiment \
+                     WHERE a.actor = $1 \
+                       AND e.exclusion_group = $2 \
+                       AND a.experiment <> $3 \
+                 ) AS result",
+            )
+            .bind::<diesel::sql_types::Text, _>(actor)
+            .bind::<diesel::sql_types::Text, _>(group)
+            .bind::<diesel::sql_types::Text, _>(exclude_experiment)
+            .get_result::<BoolRow>(&mut conn)
+            .map(|r| r.result)
+            .map_err(|e| ExperimentStoreError::Backend(e.to_string()))
+        }
+
+        fn history(
+            &self,
+            experiment: &str,
+            limit: usize,
+        ) -> Result<Vec<ChangeRecord>, ExperimentStoreError> {
+            let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+            let mut conn = self.connect()?;
+            diesel::sql_query(
+                "SELECT experiment, mutation, actor, \
+                        EXTRACT(EPOCH FROM changed_at)::bigint AS timestamp_secs \
+                 FROM autumn_experiment_changes \
+                 WHERE experiment = $1 \
+                 ORDER BY changed_at DESC \
+                 LIMIT NULLIF($2::bigint, 0)",
+            )
+            .bind::<diesel::sql_types::Text, _>(experiment)
+            .bind::<diesel::sql_types::BigInt, _>(limit)
+            .load::<ChangeRow>(&mut conn)
+            .map(|rows| {
+                rows.into_iter()
+                    .map(|r| ChangeRecord {
+                        experiment: r.experiment,
+                        mutation: r.mutation,
+                        actor: r.actor,
+                        timestamp_secs: u64::try_from(r.timestamp_secs).unwrap_or(0),
+                    })
+                    .collect()
+            })
+            .map_err(|e| ExperimentStoreError::Backend(e.to_string()))
+        }
     }
 }
 

--- a/autumn/src/experiments.rs
+++ b/autumn/src/experiments.rs
@@ -467,8 +467,13 @@ pub trait ExperimentStore: Send + Sync + 'static {
     ///
     /// # Errors
     ///
+    /// Returns the variant that was persisted (the existing row's variant on
+    /// conflict, or the newly-inserted variant on first write). Callers must
+    /// use this return value so that concurrent first-writers agree on the
+    /// same sticky bucket.
+    ///
     /// Returns [`ExperimentStoreError`] on backend failure.
-    fn record_assignment(&self, assignment: Assignment) -> Result<(), ExperimentStoreError>;
+    fn record_assignment(&self, assignment: Assignment) -> Result<String, ExperimentStoreError>;
 
     /// Return the override variant name for `(experiment, actor)`, or `None`.
     ///
@@ -555,7 +560,7 @@ impl<T: ExperimentStore> ExperimentStore for Arc<T> {
     ) -> Result<Option<Assignment>, ExperimentStoreError> {
         (**self).get_assignment(experiment, actor)
     }
-    fn record_assignment(&self, assignment: Assignment) -> Result<(), ExperimentStoreError> {
+    fn record_assignment(&self, assignment: Assignment) -> Result<String, ExperimentStoreError> {
         (**self).record_assignment(assignment)
     }
     fn get_override(
@@ -709,14 +714,15 @@ impl ExperimentStore for InMemoryExperimentStore {
             .cloned())
     }
 
-    fn record_assignment(&self, assignment: Assignment) -> Result<(), ExperimentStoreError> {
+    fn record_assignment(&self, assignment: Assignment) -> Result<String, ExperimentStoreError> {
+        let variant = assignment.variant.clone();
         let key = (assignment.experiment.clone(), assignment.actor.clone());
         self.inner
             .write()
             .unwrap()
             .assignments
             .insert(key, assignment);
-        Ok(())
+        Ok(variant)
     }
 
     fn get_override(
@@ -1070,12 +1076,13 @@ impl ExperimentService {
             .ok_or_else(|| ExperimentError::NoVariant(experiment.to_owned()))?
             .to_owned();
 
-        // Store sticky assignment and emit exposure.
+        // Store sticky assignment. Use the persisted variant (the winner of any
+        // concurrent first-write race), not the locally-computed one.
         let assignment = Assignment::new(experiment, actor, &variant_name, false);
-        self.store.record_assignment(assignment)?;
-        self.emit_exposure(experiment, &variant_name, actor, request_id, false);
+        let persisted_variant = self.store.record_assignment(assignment)?;
+        self.emit_exposure(experiment, &persisted_variant, actor, request_id, false);
 
-        Ok(variant_name)
+        Ok(persisted_variant)
     }
 
     fn emit_exposure(
@@ -1103,6 +1110,22 @@ impl ExperimentService {
     /// Returns [`ExperimentError::Store`] on backend failure.
     pub fn create(&self, config: ExperimentConfig) -> Result<(), ExperimentError> {
         validate_variants(&config.variants)?;
+        if config.state == ExperimentState::Concluded {
+            let winner = config
+                .winner
+                .as_deref()
+                .filter(|w| !w.trim().is_empty())
+                .ok_or_else(|| {
+                    ExperimentError::NoVariant(
+                        "concluded experiment requires a non-empty winner".into(),
+                    )
+                })?;
+            if !config.variants.iter().any(|v| v.name == winner) {
+                return Err(ExperimentError::NoVariant(format!(
+                    "'{winner}' is not a configured variant"
+                )));
+            }
+        }
         self.store.upsert(config)?;
         Ok(())
     }
@@ -1333,7 +1356,20 @@ impl axum::extract::FromRequestParts<crate::AppState> for Experiments {
             let session_key = state.auth_session_key();
             match session.get(session_key).await {
                 Some(uid) => Some(uid),
-                None => Some(session.id().await),
+                None => {
+                    // Use or create a stable per-session anonymous actor. We must
+                    // insert into the session (marking it dirty) so the framework
+                    // sets a cookie and the ID persists across requests; a bare
+                    // session.id() call does not mark the session dirty.
+                    const ANON_KEY: &str = "_autumn_anon_actor";
+                    if let Some(existing) = session.get(ANON_KEY).await {
+                        Some(existing)
+                    } else {
+                        let id = session.id().await;
+                        session.insert(ANON_KEY, &id).await;
+                        Some(id)
+                    }
+                }
             }
         } else {
             None
@@ -1746,21 +1782,30 @@ pub mod pg {
             .map_err(|e| ExperimentStoreError::Backend(e.to_string()))
         }
 
-        fn record_assignment(&self, assignment: Assignment) -> Result<(), ExperimentStoreError> {
+        fn record_assignment(
+            &self,
+            assignment: Assignment,
+        ) -> Result<String, ExperimentStoreError> {
             let mut conn = self.connect()?;
+            // The no-op DO UPDATE (setting each column to its existing value) forces
+            // Postgres to return a row even on conflict, giving us the first-writer's
+            // variant so concurrent replicas agree on the same sticky bucket.
             diesel::sql_query(
                 "INSERT INTO autumn_experiment_assignments \
                      (experiment, actor, variant, is_override) \
                  VALUES ($1, $2, $3, $4) \
-                 ON CONFLICT (experiment, actor) DO NOTHING",
+                 ON CONFLICT (experiment, actor) DO UPDATE \
+                     SET variant = autumn_experiment_assignments.variant, \
+                         is_override = autumn_experiment_assignments.is_override \
+                 RETURNING variant",
             )
             .bind::<diesel::sql_types::Text, _>(&assignment.experiment)
             .bind::<diesel::sql_types::Text, _>(&assignment.actor)
             .bind::<diesel::sql_types::Text, _>(&assignment.variant)
             .bind::<diesel::sql_types::Bool, _>(assignment.is_override)
-            .execute(&mut conn)
-            .map_err(|e| ExperimentStoreError::Backend(e.to_string()))?;
-            Ok(())
+            .get_result::<VariantNameRow>(&mut conn)
+            .map(|r| r.variant)
+            .map_err(|e| ExperimentStoreError::Backend(e.to_string()))
         }
 
         fn get_override(

--- a/autumn/src/experiments.rs
+++ b/autumn/src/experiments.rs
@@ -1040,13 +1040,13 @@ impl ExperimentService {
 
         // Check for staff/QA override (takes precedence over sticky).
         // Skip stale overrides whose variant was removed from the experiment config.
-        if let Some(override_variant) = self.store.get_override(experiment, actor)? {
-            if config.variants.iter().any(|v| v.name == override_variant) {
-                let sticky = Assignment::new(experiment, actor, &override_variant, true);
-                self.store.record_assignment(sticky)?;
-                self.emit_exposure(experiment, &override_variant, actor, request_id, true);
-                return Ok(override_variant);
-            }
+        if let Some(override_variant) = self.store.get_override(experiment, actor)?
+            && config.variants.iter().any(|v| v.name == override_variant)
+        {
+            let sticky = Assignment::new(experiment, actor, &override_variant, true);
+            self.store.record_assignment(sticky)?;
+            self.emit_exposure(experiment, &override_variant, actor, request_id, true);
+            return Ok(override_variant);
         }
 
         // Return existing sticky assignment (emit exposure each call).

--- a/autumn/src/experiments.rs
+++ b/autumn/src/experiments.rs
@@ -1039,11 +1039,14 @@ impl ExperimentService {
         }
 
         // Check for staff/QA override (takes precedence over sticky).
+        // Skip stale overrides whose variant was removed from the experiment config.
         if let Some(override_variant) = self.store.get_override(experiment, actor)? {
-            let sticky = Assignment::new(experiment, actor, &override_variant, true);
-            self.store.record_assignment(sticky)?;
-            self.emit_exposure(experiment, &override_variant, actor, request_id, true);
-            return Ok(override_variant);
+            if config.variants.iter().any(|v| v.name == override_variant) {
+                let sticky = Assignment::new(experiment, actor, &override_variant, true);
+                self.store.record_assignment(sticky)?;
+                self.emit_exposure(experiment, &override_variant, actor, request_id, true);
+                return Ok(override_variant);
+            }
         }
 
         // Return existing sticky assignment (emit exposure each call).

--- a/autumn/src/experiments.rs
+++ b/autumn/src/experiments.rs
@@ -1,0 +1,1927 @@
+//! A/B experiments with deterministic bucketing and exposure telemetry.
+//!
+//! Provides multi-variant experiment assignment with stable per-actor bucketing,
+//! sticky assignments, structured exposure events, override support for QA/staff,
+//! mutual exclusion groups, and experiment lifecycle management.
+//!
+//! # Quick start
+//!
+//! ```rust
+//! use autumn_web::experiments::{
+//!     ExperimentConfig, ExperimentService, InMemoryExperimentStore, VariantConfig,
+//! };
+//! use std::sync::Arc;
+//!
+//! // 1. Create a store and service.
+//! let store = Arc::new(InMemoryExperimentStore::new());
+//! let svc = ExperimentService::new(store);
+//!
+//! // 2. Declare an experiment with two 50/50 variants.
+//! svc.create(ExperimentConfig::new("checkout_v2", vec![
+//!     VariantConfig::new("control", 50),
+//!     VariantConfig::new("treatment", 50),
+//! ])).unwrap();
+//!
+//! // 3. Start it.
+//! svc.start("checkout_v2").unwrap();
+//!
+//! // 4. Assign an actor — stable and deterministic.
+//! let variant = svc.assign("checkout_v2", "user:1").unwrap();
+//! assert!(variant == "control" || variant == "treatment");
+//!
+//! // 5. Re-assignment returns the same sticky variant.
+//! let again = svc.assign("checkout_v2", "user:1").unwrap();
+//! assert_eq!(variant, again);
+//! ```
+//!
+//! # Assignment semantics
+//!
+//! Assignment is deterministic per `(experiment_name, actor_id)` using a
+//! FNV-1a 64-bit hash of the UTF-8 string `"<experiment>:<actor>"`, bucketed
+//! into `[0, 10 000)`. This hash function is **stable**: the same inputs always
+//! produce the same output across restarts, replicas, and library versions.
+//! Changing the hash function requires a documented migration path (see
+//! [`experiment_bucket`]).
+//!
+//! Variant selection maps the bucket to a variant proportionally by weight:
+//! given variants `[("control", 30), ("treatment", 70)]`, actors with
+//! buckets 0–2 999 are assigned `"control"` and the rest `"treatment"`.
+//!
+//! # Lifecycle
+//!
+//! Experiments move through states in order:
+//!
+//! ```text
+//! draft ─────── running ──── concluded
+//!        │              │
+//!        └── archived ──┘   (archived from any state)
+//! ```
+//!
+//! - **Draft**: declared but not yet accepting assignments.
+//! - **Running**: assignments + exposures active.
+//! - **Concluded**: winner pinned; all actors see the winner; no new exposures emitted.
+//! - **Archived**: `assign()` returns `Err(ExperimentError::Archived)`.
+//!
+//! # Exposure events
+//!
+//! Every successful `assign()` call on a `Running` experiment emits one
+//! [`ExposureRecord`] to the configured [`ExposureSink`]. The default sink
+//! logs at `INFO` via `tracing`. Supply a custom sink to forward events to
+//! your analytics pipeline.
+//!
+//! # Mutual exclusion groups
+//!
+//! Experiments can share a named group. An actor who has already been assigned
+//! to any experiment in the group will be excluded from all sibling experiments
+//! (`Err(ExperimentError::ExcludedByGroup)`). This prevents interaction effects
+//! between experiments targeting the same funnel.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+// ── ExperimentState ──────────────────────────────────────────────────────────
+
+/// Lifecycle state of an experiment.
+///
+/// Experiments move through `draft → running → concluded`. They may be
+/// archived from any state. See module-level documentation for semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExperimentState {
+    /// Declared but not yet accepting assignments.
+    Draft,
+    /// Accepting assignments and emitting exposures.
+    Running,
+    /// Winner pinned; all actors see the winner variant; no new exposures.
+    Concluded,
+    /// Archived; `assign()` returns [`ExperimentError::Archived`].
+    Archived,
+}
+
+impl std::fmt::Display for ExperimentState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Draft => write!(f, "draft"),
+            Self::Running => write!(f, "running"),
+            Self::Concluded => write!(f, "concluded"),
+            Self::Archived => write!(f, "archived"),
+        }
+    }
+}
+
+// ── VariantConfig ────────────────────────────────────────────────────────────
+
+/// A single variant in an experiment with its assignment weight.
+///
+/// Weights are relative — they do not need to sum to 100. For a 30/70 split
+/// use `[VariantConfig::new("control", 30), VariantConfig::new("treatment", 70)]`.
+/// Equal weights produce equal splits. Use weight `0` to disable a variant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VariantConfig {
+    /// Unique variant name within the experiment (e.g. `"control"`, `"treatment_a"`).
+    pub name: String,
+    /// Relative assignment weight. Use `0` to disable a variant without removing it.
+    pub weight: u32,
+}
+
+impl VariantConfig {
+    /// Create a new variant with the given name and weight.
+    #[must_use]
+    pub fn new(name: impl Into<String>, weight: u32) -> Self {
+        Self {
+            name: name.into(),
+            weight,
+        }
+    }
+}
+
+// ── ExperimentConfig ─────────────────────────────────────────────────────────
+
+/// Full configuration of a single experiment.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExperimentConfig {
+    /// Unique experiment name (e.g. `"checkout_v2"`).
+    pub name: String,
+    /// Optional human-readable description.
+    pub description: Option<String>,
+    /// Current lifecycle state.
+    pub state: ExperimentState,
+    /// Ordered list of variants and their relative weights.
+    pub variants: Vec<VariantConfig>,
+    /// Set when the experiment is concluded: name of the winning variant.
+    pub winner: Option<String>,
+    /// Named mutual-exclusion group. Actors assigned to any experiment in
+    /// this group are excluded from all sibling experiments in the group.
+    pub exclusion_group: Option<String>,
+    /// Wall-clock time the experiment was last modified (seconds since UNIX epoch).
+    pub updated_at_secs: u64,
+}
+
+impl ExperimentConfig {
+    /// Create a new experiment in `Draft` state with the given variants.
+    #[must_use]
+    pub fn new(name: impl Into<String>, variants: Vec<VariantConfig>) -> Self {
+        Self {
+            name: name.into(),
+            description: None,
+            state: ExperimentState::Draft,
+            variants,
+            winner: None,
+            exclusion_group: None,
+            updated_at_secs: now_secs(),
+        }
+    }
+
+    /// Set a human-readable description.
+    #[must_use]
+    pub fn description(mut self, desc: impl Into<String>) -> Self {
+        self.description = Some(desc.into());
+        self
+    }
+
+    /// Set the mutual exclusion group name.
+    #[must_use]
+    pub fn exclusion_group(mut self, group: impl Into<String>) -> Self {
+        self.exclusion_group = Some(group.into());
+        self
+    }
+}
+
+// ── Assignment ───────────────────────────────────────────────────────────────
+
+/// A recorded sticky assignment for an actor in an experiment.
+///
+/// Once an actor is assigned, subsequent `assign()` calls return the same
+/// variant without re-computing the bucket (sticky semantics).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Assignment {
+    /// Experiment name.
+    pub experiment: String,
+    /// Actor identifier.
+    pub actor: String,
+    /// Assigned variant name.
+    pub variant: String,
+    /// `true` when this assignment was produced by a staff/QA override rather
+    /// than weight-based bucketing.
+    pub is_override: bool,
+    /// Wall-clock time of first assignment (seconds since UNIX epoch).
+    pub assigned_at_secs: u64,
+}
+
+impl Assignment {
+    fn new(experiment: &str, actor: &str, variant: &str, is_override: bool) -> Self {
+        Self {
+            experiment: experiment.to_owned(),
+            actor: actor.to_owned(),
+            variant: variant.to_owned(),
+            is_override,
+            assigned_at_secs: now_secs(),
+        }
+    }
+}
+
+// ── ChangeRecord ─────────────────────────────────────────────────────────────
+
+/// A single mutation recorded in the experiment change log.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChangeRecord {
+    /// Experiment name.
+    pub experiment: String,
+    /// Human-readable description of the mutation.
+    pub mutation: String,
+    /// Actor who performed the mutation (username, `"cli"`, etc.).
+    pub actor: Option<String>,
+    /// Wall-clock time (seconds since UNIX epoch).
+    pub timestamp_secs: u64,
+}
+
+impl ChangeRecord {
+    fn now(experiment: &str, mutation: impl Into<String>, actor: Option<&str>) -> Self {
+        Self {
+            experiment: experiment.to_owned(),
+            mutation: mutation.into(),
+            actor: actor.map(str::to_owned),
+            timestamp_secs: now_secs(),
+        }
+    }
+}
+
+// ── ExposureRecord ────────────────────────────────────────────────────────────
+
+/// Structured exposure event emitted by each successful `assign()` call.
+///
+/// Consumers pipe these into their analytics pipeline to join exposures with
+/// outcome events (conversions, revenue, etc.).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExposureRecord {
+    /// Experiment name.
+    pub experiment: String,
+    /// Assigned variant name.
+    pub variant: String,
+    /// Actor identifier.
+    pub actor: String,
+    /// Optional request ID for correlation (propagated from the HTTP request).
+    pub request_id: Option<String>,
+    /// `true` when this assignment was produced by a staff/QA override.
+    pub is_override: bool,
+    /// Wall-clock time of exposure (seconds since UNIX epoch).
+    pub timestamp_secs: u64,
+}
+
+// ── ExposureSink ─────────────────────────────────────────────────────────────
+
+/// Pluggable sink for exposure events.
+///
+/// Every successful `assign()` call on a `Running` experiment emits one
+/// [`ExposureRecord`] to the configured sink. The default is
+/// [`TracingExposureSink`] which logs the event at `INFO` level via the
+/// `tracing` crate.
+///
+/// # Custom sink
+///
+/// ```rust,ignore
+/// use autumn_web::experiments::{ExposureSink, ExposureRecord, ExperimentService,
+///     InMemoryExperimentStore};
+/// use std::sync::Arc;
+///
+/// struct MyAnalyticsSink;
+///
+/// impl ExposureSink for MyAnalyticsSink {
+///     fn record(&self, exposure: ExposureRecord) {
+///         // Forward to your analytics pipeline.
+///         send_to_segment(&exposure);
+///     }
+/// }
+///
+/// let svc = ExperimentService::new(Arc::new(InMemoryExperimentStore::new()))
+///     .with_exposure_sink(Arc::new(MyAnalyticsSink));
+/// ```
+pub trait ExposureSink: Send + Sync + 'static {
+    /// Record a single exposure event.
+    fn record(&self, exposure: ExposureRecord);
+}
+
+/// Default [`ExposureSink`]: emits a structured `tracing::info!` event.
+///
+/// The event carries `experiment`, `variant`, `actor`, `request_id`, and
+/// `is_override` fields so structured logging pipelines (JSON, OTLP) can
+/// aggregate exposures without parsing message text.
+pub struct TracingExposureSink;
+
+impl ExposureSink for TracingExposureSink {
+    fn record(&self, exposure: ExposureRecord) {
+        tracing::info!(
+            experiment = %exposure.experiment,
+            variant    = %exposure.variant,
+            actor      = %exposure.actor,
+            request_id = exposure.request_id.as_deref().unwrap_or(""),
+            is_override = %exposure.is_override,
+            "experiment_exposure"
+        );
+    }
+}
+
+/// A no-op [`ExposureSink`] that discards all exposure events.
+///
+/// Useful in benchmarks or contexts where exposure recording is handled
+/// out-of-band.
+pub struct NoOpExposureSink;
+
+impl ExposureSink for NoOpExposureSink {
+    fn record(&self, _: ExposureRecord) {}
+}
+
+/// A recording [`ExposureSink`] that collects all exposure events in memory.
+///
+/// Primarily useful for integration tests.
+///
+/// ```rust
+/// use autumn_web::experiments::{
+///     RecordingExposureSink, ExperimentService, ExperimentConfig,
+///     VariantConfig, InMemoryExperimentStore,
+/// };
+/// use std::sync::Arc;
+///
+/// let (sink, records) = RecordingExposureSink::new();
+/// let store = Arc::new(InMemoryExperimentStore::new());
+/// let svc = ExperimentService::new(store)
+///     .with_exposure_sink(Arc::new(sink));
+/// svc.create(ExperimentConfig::new("exp", vec![
+///     VariantConfig::new("control", 1),
+///     VariantConfig::new("treatment", 1),
+/// ])).unwrap();
+/// svc.start("exp").unwrap();
+/// svc.assign("exp", "user:1").unwrap();
+/// assert_eq!(records.lock().unwrap().len(), 1);
+/// ```
+pub struct RecordingExposureSink {
+    records: Arc<Mutex<Vec<ExposureRecord>>>,
+}
+
+impl Default for RecordingExposureSink {
+    fn default() -> Self {
+        Self::new().0
+    }
+}
+
+impl RecordingExposureSink {
+    /// Create a new recording sink, returning it alongside a shared handle to
+    /// the collected records.
+    #[must_use]
+    pub fn new() -> (Self, Arc<Mutex<Vec<ExposureRecord>>>) {
+        let records = Arc::new(Mutex::new(Vec::new()));
+        let sink = Self {
+            records: Arc::clone(&records),
+        };
+        (sink, records)
+    }
+}
+
+impl ExposureSink for RecordingExposureSink {
+    fn record(&self, exposure: ExposureRecord) {
+        self.records.lock().unwrap().push(exposure);
+    }
+}
+
+// ── ExperimentStoreError ──────────────────────────────────────────────────────
+
+/// Error from an [`ExperimentStore`] backend.
+#[derive(Debug, thiserror::Error)]
+pub enum ExperimentStoreError {
+    /// The backend reported an I/O or connection failure.
+    #[error("experiment store backend error: {0}")]
+    Backend(String),
+}
+
+// ── ExperimentStore trait ─────────────────────────────────────────────────────
+
+/// Pluggable storage backend for experiments.
+///
+/// All mutation methods should record an audit trail in the change log
+/// (accessible via [`history`](ExperimentStore::history)).
+pub trait ExperimentStore: Send + Sync + 'static {
+    /// Return the current configuration for `name`, or `None` if unknown.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentStoreError`] on backend failure.
+    fn get(&self, name: &str) -> Result<Option<ExperimentConfig>, ExperimentStoreError>;
+
+    /// Return all known experiments, sorted by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentStoreError`] on backend failure.
+    fn list(&self) -> Result<Vec<ExperimentConfig>, ExperimentStoreError>;
+
+    /// Insert or update an experiment configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentStoreError`] on backend failure.
+    fn upsert(&self, config: ExperimentConfig) -> Result<(), ExperimentStoreError>;
+
+    /// Update the lifecycle state of an experiment.
+    ///
+    /// Set `winner` when concluding; ignored otherwise.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentStoreError`] on backend failure.
+    fn set_state(
+        &self,
+        name: &str,
+        state: ExperimentState,
+        winner: Option<&str>,
+    ) -> Result<(), ExperimentStoreError>;
+
+    /// Update the variants and weights for an experiment.
+    ///
+    /// Existing sticky assignments are NOT re-bucketed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentStoreError`] on backend failure.
+    fn set_variants(
+        &self,
+        name: &str,
+        variants: Vec<VariantConfig>,
+        actor: Option<&str>,
+    ) -> Result<(), ExperimentStoreError>;
+
+    /// Return the sticky assignment for `(experiment, actor)`, or `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentStoreError`] on backend failure.
+    fn get_assignment(
+        &self,
+        experiment: &str,
+        actor: &str,
+    ) -> Result<Option<Assignment>, ExperimentStoreError>;
+
+    /// Record a sticky assignment.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentStoreError`] on backend failure.
+    fn record_assignment(&self, assignment: Assignment) -> Result<(), ExperimentStoreError>;
+
+    /// Return the override variant name for `(experiment, actor)`, or `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentStoreError`] on backend failure.
+    fn get_override(
+        &self,
+        experiment: &str,
+        actor: &str,
+    ) -> Result<Option<String>, ExperimentStoreError>;
+
+    /// Pin `actor` to `variant` in `experiment`, bypassing weight-based bucketing.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentStoreError`] on backend failure.
+    fn set_override(
+        &self,
+        experiment: &str,
+        actor: &str,
+        variant: &str,
+    ) -> Result<(), ExperimentStoreError>;
+
+    /// Return `true` if `actor` has an existing assignment in any experiment
+    /// belonging to `group`, excluding `exclude_experiment` itself.
+    ///
+    /// Used to enforce mutual exclusion: once an actor is in one experiment
+    /// of a group, they are excluded from all siblings.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentStoreError`] on backend failure.
+    fn has_assignment_in_group(
+        &self,
+        actor: &str,
+        group: &str,
+        exclude_experiment: &str,
+    ) -> Result<bool, ExperimentStoreError>;
+
+    /// Return the change log for `experiment` (most-recent first), capped at
+    /// `limit` entries. Returns an empty `Vec` for unknown experiments.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentStoreError`] on backend failure.
+    fn history(
+        &self,
+        experiment: &str,
+        limit: usize,
+    ) -> Result<Vec<ChangeRecord>, ExperimentStoreError>;
+}
+
+impl<T: ExperimentStore> ExperimentStore for Arc<T> {
+    fn get(&self, name: &str) -> Result<Option<ExperimentConfig>, ExperimentStoreError> {
+        (**self).get(name)
+    }
+    fn list(&self) -> Result<Vec<ExperimentConfig>, ExperimentStoreError> {
+        (**self).list()
+    }
+    fn upsert(&self, config: ExperimentConfig) -> Result<(), ExperimentStoreError> {
+        (**self).upsert(config)
+    }
+    fn set_state(
+        &self,
+        name: &str,
+        state: ExperimentState,
+        winner: Option<&str>,
+    ) -> Result<(), ExperimentStoreError> {
+        (**self).set_state(name, state, winner)
+    }
+    fn set_variants(
+        &self,
+        name: &str,
+        variants: Vec<VariantConfig>,
+        actor: Option<&str>,
+    ) -> Result<(), ExperimentStoreError> {
+        (**self).set_variants(name, variants, actor)
+    }
+    fn get_assignment(
+        &self,
+        experiment: &str,
+        actor: &str,
+    ) -> Result<Option<Assignment>, ExperimentStoreError> {
+        (**self).get_assignment(experiment, actor)
+    }
+    fn record_assignment(&self, assignment: Assignment) -> Result<(), ExperimentStoreError> {
+        (**self).record_assignment(assignment)
+    }
+    fn get_override(
+        &self,
+        experiment: &str,
+        actor: &str,
+    ) -> Result<Option<String>, ExperimentStoreError> {
+        (**self).get_override(experiment, actor)
+    }
+    fn set_override(
+        &self,
+        experiment: &str,
+        actor: &str,
+        variant: &str,
+    ) -> Result<(), ExperimentStoreError> {
+        (**self).set_override(experiment, actor, variant)
+    }
+    fn has_assignment_in_group(
+        &self,
+        actor: &str,
+        group: &str,
+        exclude_experiment: &str,
+    ) -> Result<bool, ExperimentStoreError> {
+        (**self).has_assignment_in_group(actor, group, exclude_experiment)
+    }
+    fn history(
+        &self,
+        experiment: &str,
+        limit: usize,
+    ) -> Result<Vec<ChangeRecord>, ExperimentStoreError> {
+        (**self).history(experiment, limit)
+    }
+}
+
+// ── InMemoryExperimentStore ───────────────────────────────────────────────────
+
+#[derive(Default)]
+struct StoreInner {
+    experiments: HashMap<String, ExperimentConfig>,
+    assignments: HashMap<(String, String), Assignment>,
+    overrides: HashMap<(String, String), String>,
+    changes: HashMap<String, Vec<ChangeRecord>>,
+}
+
+/// In-memory [`ExperimentStore`] implementation.
+///
+/// All data is lost when the process exits. Best suited for tests and single-
+/// replica development setups where cross-restart persistence is not required.
+///
+/// For production, use the Postgres-backed store (coming soon) which persists
+/// assignments across restarts and propagates weight changes via LISTEN/NOTIFY.
+#[derive(Default)]
+pub struct InMemoryExperimentStore {
+    inner: RwLock<StoreInner>,
+}
+
+impl InMemoryExperimentStore {
+    /// Create an empty in-memory store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl ExperimentStore for InMemoryExperimentStore {
+    fn get(&self, name: &str) -> Result<Option<ExperimentConfig>, ExperimentStoreError> {
+        Ok(self.inner.read().unwrap().experiments.get(name).cloned())
+    }
+
+    fn list(&self) -> Result<Vec<ExperimentConfig>, ExperimentStoreError> {
+        let inner = self.inner.read().unwrap();
+        let mut exps: Vec<ExperimentConfig> = inner.experiments.values().cloned().collect();
+        exps.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(exps)
+    }
+
+    fn upsert(&self, config: ExperimentConfig) -> Result<(), ExperimentStoreError> {
+        let name = config.name.clone();
+        let mut inner = self.inner.write().unwrap();
+        inner.experiments.insert(name.clone(), config);
+        inner
+            .changes
+            .entry(name.clone())
+            .or_default()
+            .push(ChangeRecord::now(&name, "created", None));
+        Ok(())
+    }
+
+    fn set_state(
+        &self,
+        name: &str,
+        state: ExperimentState,
+        winner: Option<&str>,
+    ) -> Result<(), ExperimentStoreError> {
+        let mut inner = self.inner.write().unwrap();
+        if let Some(exp) = inner.experiments.get_mut(name) {
+            exp.state = state;
+            if let Some(w) = winner {
+                exp.winner = Some(w.to_owned());
+            }
+            exp.updated_at_secs = now_secs();
+        }
+        inner
+            .changes
+            .entry(name.to_owned())
+            .or_default()
+            .push(ChangeRecord::now(
+                name,
+                if let Some(w) = winner {
+                    format!("concluded={w}")
+                } else {
+                    format!("state={state}")
+                },
+                None,
+            ));
+        Ok(())
+    }
+
+    fn set_variants(
+        &self,
+        name: &str,
+        variants: Vec<VariantConfig>,
+        actor: Option<&str>,
+    ) -> Result<(), ExperimentStoreError> {
+        let mut inner = self.inner.write().unwrap();
+        if let Some(exp) = inner.experiments.get_mut(name) {
+            exp.variants = variants;
+            exp.updated_at_secs = now_secs();
+        }
+        inner
+            .changes
+            .entry(name.to_owned())
+            .or_default()
+            .push(ChangeRecord::now(name, "set_weights", actor));
+        Ok(())
+    }
+
+    fn get_assignment(
+        &self,
+        experiment: &str,
+        actor: &str,
+    ) -> Result<Option<Assignment>, ExperimentStoreError> {
+        let inner = self.inner.read().unwrap();
+        Ok(inner
+            .assignments
+            .get(&(experiment.to_owned(), actor.to_owned()))
+            .cloned())
+    }
+
+    fn record_assignment(&self, assignment: Assignment) -> Result<(), ExperimentStoreError> {
+        let key = (assignment.experiment.clone(), assignment.actor.clone());
+        self.inner.write().unwrap().assignments.insert(key, assignment);
+        Ok(())
+    }
+
+    fn get_override(
+        &self,
+        experiment: &str,
+        actor: &str,
+    ) -> Result<Option<String>, ExperimentStoreError> {
+        let inner = self.inner.read().unwrap();
+        Ok(inner
+            .overrides
+            .get(&(experiment.to_owned(), actor.to_owned()))
+            .cloned())
+    }
+
+    fn set_override(
+        &self,
+        experiment: &str,
+        actor: &str,
+        variant: &str,
+    ) -> Result<(), ExperimentStoreError> {
+        let key = (experiment.to_owned(), actor.to_owned());
+        self.inner
+            .write()
+            .unwrap()
+            .overrides
+            .insert(key, variant.to_owned());
+        Ok(())
+    }
+
+    fn has_assignment_in_group(
+        &self,
+        actor: &str,
+        group: &str,
+        exclude_experiment: &str,
+    ) -> Result<bool, ExperimentStoreError> {
+        let inner = self.inner.read().unwrap();
+        for (exp_name, config) in &inner.experiments {
+            if exp_name == exclude_experiment {
+                continue;
+            }
+            if config.exclusion_group.as_deref() != Some(group) {
+                continue;
+            }
+            if inner
+                .assignments
+                .contains_key(&(exp_name.clone(), actor.to_owned()))
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn history(
+        &self,
+        experiment: &str,
+        limit: usize,
+    ) -> Result<Vec<ChangeRecord>, ExperimentStoreError> {
+        let inner = self.inner.read().unwrap();
+        let records = inner
+            .changes
+            .get(experiment)
+            .map(|v| {
+                if limit == 0 {
+                    v.clone()
+                } else {
+                    v.iter().rev().take(limit).cloned().collect()
+                }
+            })
+            .unwrap_or_default();
+        Ok(records)
+    }
+}
+
+// ── Hash and bucketing helpers ────────────────────────────────────────────────
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// FNV-1a 64-bit hash of a byte slice.
+///
+/// Stable, dependency-free, and specified by the FNV standard.
+fn fnv1a_64(data: &[u8]) -> u64 {
+    const FNV_OFFSET: u64 = 14_695_981_039_346_656_037;
+    const FNV_PRIME: u64 = 1_099_511_628_211;
+    let mut hash = FNV_OFFSET;
+    for &byte in data {
+        #[allow(clippy::cast_lossless)]
+        {
+            hash ^= byte as u64;
+        }
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+/// Compute the assignment bucket for `(experiment_name, actor_id)`.
+///
+/// Returns a value in `[0, 10 000)`. The same inputs always produce the same
+/// output across restarts, replicas, and library versions.
+///
+/// ## Algorithm
+///
+/// FNV-1a 64-bit hash of the UTF-8 encoding of
+/// `"<experiment_name>:<actor_id>"`, reduced modulo 10 000.
+///
+/// **This function MUST NOT change** between releases without a documented
+/// migration path: changing it silently re-buckets every actor in every running
+/// experiment, corrupting all in-flight A/B tests. If the algorithm must change,
+/// bump the experiment schema version, migrate existing assignments, and update
+/// the regression test below.
+#[must_use]
+pub fn experiment_bucket(experiment: &str, actor_id: &str) -> u64 {
+    let key = format!("{experiment}:{actor_id}");
+    fnv1a_64(key.as_bytes()) % 10_000
+}
+
+/// Select a variant from `variants` given a `bucket` in `[0, 10 000)`.
+///
+/// Returns `None` if all variant weights are zero.
+fn select_variant(variants: &[VariantConfig], bucket: u64) -> Option<&str> {
+    let total_weight: u64 = variants.iter().map(|v| u64::from(v.weight)).sum();
+    if total_weight == 0 {
+        return None;
+    }
+    let threshold = bucket * total_weight / 10_000;
+    let mut cumulative: u64 = 0;
+    for v in variants {
+        cumulative += u64::from(v.weight);
+        if threshold < cumulative {
+            return Some(&v.name);
+        }
+    }
+    variants.last().map(|v| v.name.as_str())
+}
+
+// ── ExperimentError ───────────────────────────────────────────────────────────
+
+/// Error from [`ExperimentService::assign`] or other service methods.
+#[derive(Debug, thiserror::Error)]
+pub enum ExperimentError {
+    /// No experiment with this name was found.
+    #[error("experiment '{0}' not found")]
+    NotFound(String),
+
+    /// The experiment exists but is not in `Running` state.
+    #[error("experiment '{0}' is not running (state: {1})")]
+    NotRunning(String, ExperimentState),
+
+    /// The experiment is archived and rejects all assignments.
+    #[error("experiment '{0}' is archived")]
+    Archived(String),
+
+    /// The actor is excluded from this experiment by a mutual exclusion group.
+    #[error("actor excluded from experiment '{0}' by mutual exclusion group '{1}'")]
+    ExcludedByGroup(String, String),
+
+    /// No variant could be selected (all variant weights are zero).
+    #[error("experiment '{0}' has no assignable variant (all weights are zero)")]
+    NoVariant(String),
+
+    /// Store backend failure.
+    #[error(transparent)]
+    Store(#[from] ExperimentStoreError),
+}
+
+// ── ExperimentService ─────────────────────────────────────────────────────────
+
+/// The main experiment service.
+///
+/// Wrap an [`ExperimentStore`] (for persistence) and an optional
+/// [`ExposureSink`] (default: [`TracingExposureSink`]). The service is cheaply
+/// clone-able and intended to be stored as an `AppState` extension.
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::experiments::{
+///     ExperimentConfig, ExperimentService, InMemoryExperimentStore, VariantConfig,
+/// };
+/// use std::sync::Arc;
+///
+/// let store = Arc::new(InMemoryExperimentStore::new());
+/// let svc = ExperimentService::new(store);
+///
+/// svc.create(ExperimentConfig::new("onboarding_v3", vec![
+///     VariantConfig::new("control", 50),
+///     VariantConfig::new("wizard", 50),
+/// ])).unwrap();
+/// svc.start("onboarding_v3").unwrap();
+///
+/// let variant = svc.assign("onboarding_v3", "user:42").unwrap();
+/// assert!(matches!(variant.as_str(), "control" | "wizard"));
+/// ```
+#[derive(Clone)]
+pub struct ExperimentService {
+    store: Arc<dyn ExperimentStore>,
+    exposure_sink: Arc<dyn ExposureSink>,
+}
+
+impl std::fmt::Debug for ExperimentService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExperimentService").finish_non_exhaustive()
+    }
+}
+
+impl ExperimentService {
+    /// Create a new service backed by `store`, with the default
+    /// [`TracingExposureSink`].
+    #[must_use]
+    pub fn new(store: Arc<dyn ExperimentStore>) -> Self {
+        Self {
+            store,
+            exposure_sink: Arc::new(TracingExposureSink),
+        }
+    }
+
+    /// Override the default [`ExposureSink`].
+    #[must_use]
+    pub fn with_exposure_sink(mut self, sink: Arc<dyn ExposureSink>) -> Self {
+        self.exposure_sink = sink;
+        self
+    }
+
+    /// Assign a variant to `actor` in `experiment`.
+    ///
+    /// Assignment rules (evaluated in order):
+    /// 1. `Archived` → `Err(Archived)`.
+    /// 2. `Concluded` → `Ok(winner)` without emitting an exposure.
+    /// 3. `Draft` → `Err(NotRunning)`.
+    /// 4. Staff/QA override present → return override variant (exposure emitted,
+    ///    tagged `is_override = true`).
+    /// 5. Sticky assignment already recorded → return cached variant (exposure
+    ///    emitted each call).
+    /// 6. Mutual exclusion check → if `actor` has any assignment in a sibling
+    ///    experiment in the same group, return `Err(ExcludedByGroup)`.
+    /// 7. Compute bucket → select variant by weight → store sticky → emit exposure.
+    ///
+    /// # Errors
+    ///
+    /// - [`ExperimentError::NotFound`] — no such experiment.
+    /// - [`ExperimentError::Archived`] — experiment is archived.
+    /// - [`ExperimentError::NotRunning`] — experiment is in `Draft` state.
+    /// - [`ExperimentError::ExcludedByGroup`] — actor excluded by mutual exclusion.
+    /// - [`ExperimentError::NoVariant`] — all variant weights are zero.
+    /// - [`ExperimentError::Store`] — backend failure.
+    pub fn assign(&self, experiment: &str, actor: &str) -> Result<String, ExperimentError> {
+        self.assign_with_request_id(experiment, actor, None)
+    }
+
+    /// Like [`assign`](Self::assign) but propagates a `request_id` into the
+    /// exposure record.
+    ///
+    /// Call this from HTTP handlers where a request trace ID is available.
+    ///
+    /// # Errors
+    ///
+    /// See [`assign`](Self::assign).
+    pub fn assign_with_request_id(
+        &self,
+        experiment: &str,
+        actor: &str,
+        request_id: Option<&str>,
+    ) -> Result<String, ExperimentError> {
+        let config = self
+            .store
+            .get(experiment)?
+            .ok_or_else(|| ExperimentError::NotFound(experiment.to_owned()))?;
+
+        match config.state {
+            ExperimentState::Archived => {
+                return Err(ExperimentError::Archived(experiment.to_owned()));
+            }
+            ExperimentState::Concluded => {
+                // Return winner for all actors; no exposure emitted (experiment is done).
+                let winner = config.winner.clone().unwrap_or_else(|| "control".to_owned());
+                return Ok(winner);
+            }
+            ExperimentState::Draft => {
+                return Err(ExperimentError::NotRunning(
+                    experiment.to_owned(),
+                    ExperimentState::Draft,
+                ));
+            }
+            ExperimentState::Running => {}
+        }
+
+        // Check for staff/QA override (takes precedence over sticky).
+        if let Some(override_variant) = self.store.get_override(experiment, actor)? {
+            let sticky = Assignment::new(experiment, actor, &override_variant, true);
+            self.store.record_assignment(sticky)?;
+            self.emit_exposure(experiment, &override_variant, actor, request_id, true);
+            return Ok(override_variant);
+        }
+
+        // Return existing sticky assignment (emit exposure each call).
+        if let Some(existing) = self.store.get_assignment(experiment, actor)? {
+            self.emit_exposure(
+                experiment,
+                &existing.variant,
+                actor,
+                request_id,
+                existing.is_override,
+            );
+            return Ok(existing.variant);
+        }
+
+        // Mutual exclusion group check.
+        if let Some(group) = &config.exclusion_group {
+            if self
+                .store
+                .has_assignment_in_group(actor, group, experiment)?
+            {
+                return Err(ExperimentError::ExcludedByGroup(
+                    experiment.to_owned(),
+                    group.clone(),
+                ));
+            }
+        }
+
+        // Bucket the actor and pick a variant.
+        let bucket = experiment_bucket(experiment, actor);
+        let variant_name = select_variant(&config.variants, bucket)
+            .ok_or_else(|| ExperimentError::NoVariant(experiment.to_owned()))?
+            .to_owned();
+
+        // Store sticky assignment and emit exposure.
+        let assignment = Assignment::new(experiment, actor, &variant_name, false);
+        self.store.record_assignment(assignment)?;
+        self.emit_exposure(experiment, &variant_name, actor, request_id, false);
+
+        Ok(variant_name)
+    }
+
+    fn emit_exposure(
+        &self,
+        experiment: &str,
+        variant: &str,
+        actor: &str,
+        request_id: Option<&str>,
+        is_override: bool,
+    ) {
+        self.exposure_sink.record(ExposureRecord {
+            experiment: experiment.to_owned(),
+            variant: variant.to_owned(),
+            actor: actor.to_owned(),
+            request_id: request_id.map(str::to_owned),
+            is_override,
+            timestamp_secs: now_secs(),
+        });
+    }
+
+    /// Declare a new experiment (starts in `Draft` state).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentError::Store`] on backend failure.
+    pub fn create(&self, config: ExperimentConfig) -> Result<(), ExperimentError> {
+        self.store.upsert(config)?;
+        Ok(())
+    }
+
+    /// Transition a `Draft` or `Concluded` experiment to `Running`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentError::NotFound`] if the experiment is unknown.
+    pub fn start(&self, name: &str) -> Result<(), ExperimentError> {
+        self.store
+            .get(name)?
+            .ok_or_else(|| ExperimentError::NotFound(name.to_owned()))?;
+        self.store.set_state(name, ExperimentState::Running, None)?;
+        Ok(())
+    }
+
+    /// Conclude a running experiment, pinning `winner` as the result.
+    ///
+    /// After concluding, `assign()` returns `winner` for all actors without
+    /// emitting new exposure events.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentError::NotFound`] if the experiment is unknown.
+    pub fn conclude(&self, name: &str, winner: &str) -> Result<(), ExperimentError> {
+        self.store
+            .get(name)?
+            .ok_or_else(|| ExperimentError::NotFound(name.to_owned()))?;
+        self.store
+            .set_state(name, ExperimentState::Concluded, Some(winner))?;
+        Ok(())
+    }
+
+    /// Archive an experiment.
+    ///
+    /// Archived experiments reject all new assignments with
+    /// [`ExperimentError::Archived`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentError::NotFound`] if the experiment is unknown.
+    pub fn archive(&self, name: &str) -> Result<(), ExperimentError> {
+        self.store
+            .get(name)?
+            .ok_or_else(|| ExperimentError::NotFound(name.to_owned()))?;
+        self.store.set_state(name, ExperimentState::Archived, None)?;
+        Ok(())
+    }
+
+    /// Update the variant weights for `name`.
+    ///
+    /// Existing sticky assignments are **not** re-bucketed: already-assigned
+    /// actors keep their variant. New actors are bucketed against the updated
+    /// weights.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentError::NotFound`] if the experiment is unknown.
+    pub fn set_weights(
+        &self,
+        name: &str,
+        variants: Vec<VariantConfig>,
+        actor: Option<&str>,
+    ) -> Result<(), ExperimentError> {
+        self.store
+            .get(name)?
+            .ok_or_else(|| ExperimentError::NotFound(name.to_owned()))?;
+        self.store.set_variants(name, variants, actor)?;
+        Ok(())
+    }
+
+    /// Pin `actor` to `variant` in `experiment`, bypassing weight-based bucketing.
+    ///
+    /// Overrides are used by staff/QA to force a specific variant during manual
+    /// testing. Exposure events include `is_override: true`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentError::NotFound`] if the experiment is unknown.
+    pub fn set_override(
+        &self,
+        experiment: &str,
+        actor: &str,
+        variant: &str,
+    ) -> Result<(), ExperimentError> {
+        self.store
+            .get(experiment)?
+            .ok_or_else(|| ExperimentError::NotFound(experiment.to_owned()))?;
+        self.store.set_override(experiment, actor, variant)?;
+        Ok(())
+    }
+
+    /// List all declared experiments.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentError::Store`] on backend failure.
+    pub fn list(&self) -> Result<Vec<ExperimentConfig>, ExperimentError> {
+        Ok(self.store.list()?)
+    }
+
+    /// Return the current configuration for `name`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentError::NotFound`] if the experiment is unknown.
+    pub fn status(&self, name: &str) -> Result<ExperimentConfig, ExperimentError> {
+        self.store
+            .get(name)?
+            .ok_or_else(|| ExperimentError::NotFound(name.to_owned()))
+    }
+
+    /// Return the change log for `experiment` (most-recent first), capped at `limit`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExperimentError::Store`] on backend failure.
+    pub fn history(
+        &self,
+        experiment: &str,
+        limit: usize,
+    ) -> Result<Vec<ChangeRecord>, ExperimentError> {
+        Ok(self.store.history(experiment, limit)?)
+    }
+}
+
+// ── Experiments extractor ─────────────────────────────────────────────────────
+
+/// Request extractor that resolves the current user's experiment service handle.
+///
+/// Extracts [`ExperimentService`] from the `AppState` extension slot. Fails
+/// with `500 Internal Server Error` if no service has been registered.
+///
+/// Also resolves:
+/// - **`actor_id`** from the session `user_id` key (Autumn's default).
+/// - **`request_id`** from the `x-request-id` HTTP header (if present).
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::prelude::*;
+/// use autumn_web::experiments::Experiments;
+///
+/// #[get("/checkout")]
+/// async fn checkout(exps: Experiments) -> AutumnResult<Markup> {
+///     let variant = exps.assign("checkout_v2")?;
+///     Ok(html! {
+///         @match variant.as_str() {
+///             "treatment" => (render_new_checkout()),
+///             _           => (render_classic_checkout()),
+///         }
+///     })
+/// }
+/// ```
+pub struct Experiments {
+    service: ExperimentService,
+    actor_id: Option<String>,
+    request_id: Option<String>,
+}
+
+impl Experiments {
+    /// Assign a variant for the current session actor.
+    ///
+    /// Propagates the session `user_id` and `x-request-id` header automatically.
+    ///
+    /// # Errors
+    ///
+    /// See [`ExperimentService::assign_with_request_id`].
+    pub fn assign(&self, experiment: &str) -> Result<String, ExperimentError> {
+        let actor = self.actor_id.as_deref().unwrap_or("anonymous");
+        self.service
+            .assign_with_request_id(experiment, actor, self.request_id.as_deref())
+    }
+
+    /// Return the underlying service for direct access to admin operations.
+    #[must_use]
+    pub const fn service(&self) -> &ExperimentService {
+        &self.service
+    }
+}
+
+impl axum::extract::FromRequestParts<crate::AppState> for Experiments {
+    type Rejection = crate::AutumnError;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &crate::AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let service = state
+            .extension::<ExperimentService>()
+            .map(|arc| (*arc).clone())
+            .ok_or_else(|| {
+                crate::AutumnError::internal_server_error_msg(
+                    "experiment service not registered; \
+                     install an ExperimentStore via AppBuilder::with_experiment_store()",
+                )
+            })?;
+
+        let actor_id = if let Some(session) = parts.extensions.get::<crate::session::Session>() {
+            session.get("user_id").await
+        } else {
+            None
+        };
+
+        let request_id = parts
+            .headers
+            .get("x-request-id")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+
+        Ok(Self {
+            service,
+            actor_id,
+            request_id,
+        })
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn make_svc() -> ExperimentService {
+        ExperimentService::new(Arc::new(InMemoryExperimentStore::new()))
+    }
+
+    fn make_svc_with_sink() -> (ExperimentService, Arc<Mutex<Vec<ExposureRecord>>>) {
+        let (sink, records) = RecordingExposureSink::new();
+        let svc = ExperimentService::new(Arc::new(InMemoryExperimentStore::new()))
+            .with_exposure_sink(Arc::new(sink));
+        (svc, records)
+    }
+
+    fn fifty_fifty(name: &str) -> ExperimentConfig {
+        ExperimentConfig::new(
+            name,
+            vec![
+                VariantConfig::new("control", 50),
+                VariantConfig::new("treatment", 50),
+            ],
+        )
+    }
+
+    fn running(svc: &ExperimentService, name: &str) {
+        svc.create(fifty_fifty(name)).unwrap();
+        svc.start(name).unwrap();
+    }
+
+    // ═══════════════════════════════════ RED PHASE ═══════════════════════════
+    // These tests were written before the full implementation existed and drove
+    // the design of ExperimentService, ExperimentStore, and ExposureSink.
+    // ═════════════════════════════════════════════════════════════════════════
+
+    // ── AC: assign() returns unknown-experiment error ─────────────────────────
+
+    #[test]
+    fn assign_unknown_experiment_returns_not_found() {
+        let svc = make_svc();
+        let err = svc.assign("ghost", "user:1").unwrap_err();
+        assert!(
+            matches!(err, ExperimentError::NotFound(_)),
+            "expected NotFound, got {err}"
+        );
+    }
+
+    // ── AC: lifecycle — draft rejects assignments ─────────────────────────────
+
+    #[test]
+    fn assign_draft_experiment_returns_not_running() {
+        let svc = make_svc();
+        svc.create(fifty_fifty("exp")).unwrap();
+        let err = svc.assign("exp", "user:1").unwrap_err();
+        assert!(
+            matches!(err, ExperimentError::NotRunning(_, ExperimentState::Draft)),
+            "expected NotRunning(Draft), got {err}"
+        );
+    }
+
+    // ── AC: lifecycle — archived rejects assignments ──────────────────────────
+
+    #[test]
+    fn assign_archived_experiment_returns_archived() {
+        let svc = make_svc();
+        running(&svc, "exp");
+        svc.archive("exp").unwrap();
+        let err = svc.assign("exp", "user:1").unwrap_err();
+        assert!(
+            matches!(err, ExperimentError::Archived(_)),
+            "expected Archived, got {err}"
+        );
+    }
+
+    // ── AC: lifecycle — concluded returns winner for all actors ───────────────
+
+    #[test]
+    fn concluded_experiment_returns_winner_for_all_actors() {
+        let svc = make_svc();
+        running(&svc, "exp");
+        svc.conclude("exp", "treatment").unwrap();
+        // Every actor sees the winner — regardless of their bucket.
+        for i in 0..100_u32 {
+            let actor = format!("user:{i}");
+            let v = svc.assign("exp", &actor).unwrap();
+            assert_eq!(
+                v, "treatment",
+                "concluded experiment must return winner for {actor}"
+            );
+        }
+    }
+
+    // ── AC: concluded experiment emits no new exposures ───────────────────────
+
+    #[test]
+    fn concluded_experiment_emits_no_exposures() {
+        let (svc, records) = make_svc_with_sink();
+        let store = Arc::new(InMemoryExperimentStore::new());
+        let (sink2, records2) = RecordingExposureSink::new();
+        let svc2 = ExperimentService::new(store.clone() as Arc<dyn ExperimentStore>)
+            .with_exposure_sink(Arc::new(sink2));
+        svc2.create(fifty_fifty("exp")).unwrap();
+        svc2.start("exp").unwrap();
+        svc2.conclude("exp", "treatment").unwrap();
+        svc2.assign("exp", "user:1").unwrap();
+        assert_eq!(
+            records2.lock().unwrap().len(),
+            0,
+            "concluded experiment must not emit exposure events"
+        );
+        let _ = records; // silence unused-variable warning for the other sink
+        let _ = svc;
+    }
+
+    // ── AC: assign() returns deterministic variant for running experiment ─────
+
+    #[test]
+    fn assign_running_experiment_returns_valid_variant() {
+        let svc = make_svc();
+        running(&svc, "exp");
+        let v = svc.assign("exp", "user:1").unwrap();
+        assert!(
+            v == "control" || v == "treatment",
+            "variant must be one of the declared names, got {v:?}"
+        );
+    }
+
+    // ── AC: deterministic bucketing — same actor always gets same variant ─────
+
+    #[test]
+    fn assign_is_deterministic_for_same_actor() {
+        let svc = make_svc();
+        running(&svc, "exp");
+        let v1 = svc.assign("exp", "user:42").unwrap();
+        let v2 = svc.assign("exp", "exp").unwrap(); // different key — just to exercise more
+        // Re-create without sticky to verify pure hash determinism.
+        let svc2 = make_svc();
+        running(&svc2, "exp");
+        let v3 = svc2.assign("exp", "user:42").unwrap();
+        assert_eq!(
+            v1, v3,
+            "same actor must receive the same variant across different service instances"
+        );
+        let _ = v2;
+    }
+
+    // ── AC: 10 000 stable requests — zero reassignments ───────────────────────
+
+    #[test]
+    fn zero_reassignments_across_10000_requests() {
+        let svc = make_svc();
+        running(&svc, "exp");
+        let first = svc.assign("exp", "stable_user").unwrap();
+        for _ in 1..10_000 {
+            let v = svc.assign("exp", "stable_user").unwrap();
+            assert_eq!(v, first, "re-assignment must return the same variant");
+        }
+    }
+
+    // ── AC: stable hash regression — known fixture inputs ────────────────────
+
+    #[test]
+    fn stable_hash_regression_known_fixtures() {
+        // Pre-computed: FNV-1a 64-bit of "<experiment>:<actor>" mod 10 000.
+        // MUST NOT change without a documented migration path for existing assignments.
+        // To regenerate: run `experiment_bucket(name, actor)` and record the output.
+        let b1 = experiment_bucket("checkout_v2", "user:1");
+        let b2 = experiment_bucket("checkout_v2", "user:1");
+        assert_eq!(b1, b2, "hash must be deterministic (same input → same output)");
+
+        // Fixture values established on first run — sentinel against algorithm drift.
+        assert_eq!(b1, 4_830, "checkout_v2:user:1 bucket changed — hash regression");
+        assert_eq!(
+            experiment_bucket("checkout_v2", "user:2"),
+            6_619,
+            "checkout_v2:user:2 bucket changed — hash regression"
+        );
+        assert_eq!(
+            experiment_bucket("onboarding_v3", "user:100"),
+            6_602,
+            "onboarding_v3:user:100 bucket changed — hash regression"
+        );
+    }
+
+    // ── AC: weights — 0% weight variant is never assigned ────────────────────
+
+    #[test]
+    fn zero_weight_variant_never_assigned() {
+        let svc = make_svc();
+        svc.create(ExperimentConfig::new(
+            "exp",
+            vec![
+                VariantConfig::new("control", 100),
+                VariantConfig::new("dead", 0),
+            ],
+        ))
+        .unwrap();
+        svc.start("exp").unwrap();
+        for i in 0..200_u32 {
+            let v = svc.assign("exp", &format!("user:{i}")).unwrap();
+            assert_eq!(v, "control", "zero-weight variant must never be assigned");
+        }
+    }
+
+    // ── AC: weights — single variant at 100% is always assigned ──────────────
+
+    #[test]
+    fn single_variant_always_assigned() {
+        let svc = make_svc();
+        svc.create(ExperimentConfig::new(
+            "exp",
+            vec![VariantConfig::new("only", 100)],
+        ))
+        .unwrap();
+        svc.start("exp").unwrap();
+        for i in 0..100_u32 {
+            let v = svc.assign("exp", &format!("user:{i}")).unwrap();
+            assert_eq!(v, "only");
+        }
+    }
+
+    // ── AC: weights — roughly 50/50 split ────────────────────────────────────
+
+    #[test]
+    fn fifty_fifty_weights_split_roughly_evenly() {
+        let svc = make_svc();
+        running(&svc, "exp");
+        let mut control_count = 0_u32;
+        for i in 0..1000_u32 {
+            if svc.assign("exp", &format!("user:{i}")).unwrap() == "control" {
+                control_count += 1;
+            }
+        }
+        assert!(
+            (400..=600).contains(&control_count),
+            "expected ~500 control assignments, got {control_count}"
+        );
+    }
+
+    // ── AC: all-zero-weight returns NoVariant error ───────────────────────────
+
+    #[test]
+    fn all_zero_weights_returns_no_variant_error() {
+        let svc = make_svc();
+        svc.create(ExperimentConfig::new(
+            "exp",
+            vec![
+                VariantConfig::new("a", 0),
+                VariantConfig::new("b", 0),
+            ],
+        ))
+        .unwrap();
+        svc.start("exp").unwrap();
+        let err = svc.assign("exp", "user:1").unwrap_err();
+        assert!(
+            matches!(err, ExperimentError::NoVariant(_)),
+            "expected NoVariant, got {err}"
+        );
+    }
+
+    // ── AC: sticky assignment — subsequent calls return same variant ──────────
+
+    #[test]
+    fn sticky_assignment_returned_on_subsequent_calls() {
+        let svc = make_svc();
+        running(&svc, "exp");
+        let first = svc.assign("exp", "user:1").unwrap();
+        // Subsequent calls must return the same variant even with new service.
+        for _ in 0..10 {
+            assert_eq!(
+                svc.assign("exp", "user:1").unwrap(),
+                first,
+                "sticky assignment must be returned on all subsequent calls"
+            );
+        }
+    }
+
+    // ── AC: sticky assignment not re-bucketed on weight change ────────────────
+
+    #[test]
+    fn set_weights_does_not_rebucket_existing_assignments() {
+        let svc = make_svc();
+        running(&svc, "exp");
+        let original = svc.assign("exp", "user:1").unwrap();
+
+        // Flip weights completely — existing assignment must remain unchanged.
+        let (new_heavy, new_light) = if original == "control" {
+            (0_u32, 100_u32)
+        } else {
+            (100_u32, 0_u32)
+        };
+        svc.set_weights(
+            "exp",
+            vec![
+                VariantConfig::new("control", new_heavy),
+                VariantConfig::new("treatment", new_light),
+            ],
+            None,
+        )
+        .unwrap();
+
+        let after = svc.assign("exp", "user:1").unwrap();
+        assert_eq!(
+            original, after,
+            "existing sticky assignment must not be re-bucketed after weight change"
+        );
+    }
+
+    // ── AC: exposure emitted exactly once per assign() call ───────────────────
+
+    #[test]
+    fn exposure_emitted_exactly_once_per_assign_call() {
+        let (svc, records) = make_svc_with_sink();
+        running(&svc, "exp");
+        svc.assign("exp", "user:1").unwrap();
+        assert_eq!(records.lock().unwrap().len(), 1, "first assign → 1 exposure");
+        svc.assign("exp", "user:1").unwrap();
+        assert_eq!(records.lock().unwrap().len(), 2, "second assign → 2 total exposures");
+        svc.assign("exp", "user:2").unwrap();
+        assert_eq!(records.lock().unwrap().len(), 3, "different actor → 3 total exposures");
+    }
+
+    // ── AC: exposure record contains correct fields ───────────────────────────
+
+    #[test]
+    fn exposure_record_contains_correct_fields() {
+        let (svc, records) = make_svc_with_sink();
+        running(&svc, "checkout_v2");
+        let variant = svc
+            .assign_with_request_id("checkout_v2", "user:42", Some("req-abc"))
+            .unwrap();
+        let rec = records.lock().unwrap();
+        assert_eq!(rec.len(), 1);
+        let exp = &rec[0];
+        assert_eq!(exp.experiment, "checkout_v2");
+        assert_eq!(exp.variant, variant);
+        assert_eq!(exp.actor, "user:42");
+        assert_eq!(exp.request_id.as_deref(), Some("req-abc"));
+        assert!(!exp.is_override);
+    }
+
+    // ── AC: override bypasses weight-based bucketing ──────────────────────────
+
+    #[test]
+    fn override_bypasses_weights() {
+        let svc = make_svc();
+        // 100% control — without override every actor gets "control".
+        svc.create(ExperimentConfig::new(
+            "exp",
+            vec![
+                VariantConfig::new("control", 100),
+                VariantConfig::new("treatment", 0),
+            ],
+        ))
+        .unwrap();
+        svc.start("exp").unwrap();
+        svc.set_override("exp", "qa:alice", "treatment").unwrap();
+        let v = svc.assign("exp", "qa:alice").unwrap();
+        assert_eq!(v, "treatment", "override must bypass weight-based bucketing");
+    }
+
+    // ── AC: override emits exposure tagged as override ────────────────────────
+
+    #[test]
+    fn override_emits_exposure_tagged_as_override() {
+        let (svc, records) = make_svc_with_sink();
+        running(&svc, "exp");
+        svc.set_override("exp", "qa:alice", "treatment").unwrap();
+        svc.assign("exp", "qa:alice").unwrap();
+        let rec = records.lock().unwrap();
+        assert_eq!(rec.len(), 1);
+        assert!(
+            rec[0].is_override,
+            "exposure from override must be tagged is_override = true"
+        );
+        assert_eq!(rec[0].variant, "treatment");
+    }
+
+    // ── AC: mutual exclusion — second experiment in group is excluded ─────────
+
+    #[test]
+    fn mutual_exclusion_prevents_sibling_assignment() {
+        let svc = make_svc();
+        // Two experiments in the same group.
+        svc.create(
+            ExperimentConfig::new("exp_a", vec![VariantConfig::new("v1", 1)])
+                .exclusion_group("checkout"),
+        )
+        .unwrap();
+        svc.start("exp_a").unwrap();
+        svc.create(
+            ExperimentConfig::new("exp_b", vec![VariantConfig::new("v1", 1)])
+                .exclusion_group("checkout"),
+        )
+        .unwrap();
+        svc.start("exp_b").unwrap();
+
+        // Assign actor to exp_a first.
+        svc.assign("exp_a", "user:1").unwrap();
+
+        // exp_b must exclude the same actor.
+        let err = svc.assign("exp_b", "user:1").unwrap_err();
+        assert!(
+            matches!(err, ExperimentError::ExcludedByGroup(_, _)),
+            "expected ExcludedByGroup, got {err}"
+        );
+    }
+
+    // ── AC: mutual exclusion — different group allows both experiments ─────────
+
+    #[test]
+    fn different_groups_do_not_exclude_each_other() {
+        let svc = make_svc();
+        svc.create(
+            ExperimentConfig::new("exp_a", vec![VariantConfig::new("v1", 1)])
+                .exclusion_group("group_a"),
+        )
+        .unwrap();
+        svc.start("exp_a").unwrap();
+        svc.create(
+            ExperimentConfig::new("exp_b", vec![VariantConfig::new("v1", 1)])
+                .exclusion_group("group_b"),
+        )
+        .unwrap();
+        svc.start("exp_b").unwrap();
+
+        svc.assign("exp_a", "user:1").unwrap();
+        let result = svc.assign("exp_b", "user:1");
+        assert!(
+            result.is_ok(),
+            "experiments in different groups must not exclude each other"
+        );
+    }
+
+    // ── AC: mutual exclusion — no group means no exclusion ────────────────────
+
+    #[test]
+    fn no_exclusion_group_allows_both_assignments() {
+        let svc = make_svc();
+        running(&svc, "exp_a");
+        running(&svc, "exp_b");
+        svc.assign("exp_a", "user:1").unwrap();
+        let result = svc.assign("exp_b", "user:1");
+        assert!(
+            result.is_ok(),
+            "experiments without exclusion groups must not exclude each other"
+        );
+    }
+
+    // ── AC: experiment_bucket is stable and in range ──────────────────────────
+
+    #[test]
+    fn experiment_bucket_is_stable_and_in_range() {
+        for i in 0..100_u32 {
+            let actor = format!("user:{i}");
+            let b1 = experiment_bucket("my_exp", &actor);
+            let b2 = experiment_bucket("my_exp", &actor);
+            assert_eq!(b1, b2, "bucket must be deterministic for {actor}");
+            assert!(b1 < 10_000, "bucket must be in [0, 10000) for {actor}");
+        }
+    }
+
+    // ── AC: experiment_bucket differs across actors ───────────────────────────
+
+    #[test]
+    fn experiment_bucket_produces_diverse_values() {
+        let buckets: std::collections::HashSet<u64> = (0..100_u32)
+            .map(|i| experiment_bucket("exp", &format!("user:{i}")))
+            .collect();
+        assert!(
+            buckets.len() > 50,
+            "expected diverse buckets across 100 actors, got {}",
+            buckets.len()
+        );
+    }
+
+    // ── AC: list returns all experiments ─────────────────────────────────────
+
+    #[test]
+    fn list_returns_all_experiments() {
+        let svc = make_svc();
+        svc.create(fifty_fifty("alpha")).unwrap();
+        svc.create(fifty_fifty("beta")).unwrap();
+        svc.create(fifty_fifty("gamma")).unwrap();
+        let experiments = svc.list().unwrap();
+        assert_eq!(experiments.len(), 3);
+        assert_eq!(experiments[0].name, "alpha");
+        assert_eq!(experiments[1].name, "beta");
+        assert_eq!(experiments[2].name, "gamma");
+    }
+
+    // ── AC: status returns experiment config ─────────────────────────────────
+
+    #[test]
+    fn status_returns_current_config() {
+        let svc = make_svc();
+        running(&svc, "exp");
+        let cfg = svc.status("exp").unwrap();
+        assert_eq!(cfg.state, ExperimentState::Running);
+        assert_eq!(cfg.variants.len(), 2);
+    }
+
+    // ── AC: history records mutations ─────────────────────────────────────────
+
+    #[test]
+    fn history_records_create_and_start_mutations() {
+        let svc = make_svc();
+        svc.create(fifty_fifty("exp")).unwrap();
+        svc.start("exp").unwrap();
+        let hist = svc.history("exp", 10).unwrap();
+        assert!(!hist.is_empty(), "history must record mutations");
+    }
+
+    // ── AC: set_weights records mutation in history ───────────────────────────
+
+    #[test]
+    fn set_weights_recorded_in_history() {
+        let svc = make_svc();
+        running(&svc, "exp");
+        svc.set_weights(
+            "exp",
+            vec![
+                VariantConfig::new("control", 30),
+                VariantConfig::new("treatment", 70),
+            ],
+            Some("ops@example.com"),
+        )
+        .unwrap();
+        let hist = svc.history("exp", 10).unwrap();
+        let has_set_weights = hist.iter().any(|r| r.mutation == "set_weights");
+        assert!(has_set_weights, "set_weights must be recorded in history");
+    }
+
+    // ── AC: select_variant helper ─────────────────────────────────────────────
+
+    #[test]
+    fn select_variant_returns_none_for_empty_variants() {
+        assert_eq!(select_variant(&[], 0), None);
+    }
+
+    #[test]
+    fn select_variant_returns_none_for_all_zero_weights() {
+        let vs = vec![VariantConfig::new("a", 0), VariantConfig::new("b", 0)];
+        assert_eq!(select_variant(&vs, 5_000), None);
+    }
+
+    #[test]
+    fn select_variant_50_50_boundary() {
+        let vs = vec![
+            VariantConfig::new("control", 50),
+            VariantConfig::new("treatment", 50),
+        ];
+        // Bucket 0 (threshold = 0 * 100 / 10000 = 0) → cumulative[0]=50 > 0 → control
+        assert_eq!(select_variant(&vs, 0), Some("control"));
+        // Bucket 4999 (threshold = 4999 * 100 / 10000 = 49) → control
+        assert_eq!(select_variant(&vs, 4_999), Some("control"));
+        // Bucket 5000 (threshold = 5000 * 100 / 10000 = 50) → cumulative[0]=50 NOT > 50
+        // → cumulative[1]=100 > 50 → treatment
+        assert_eq!(select_variant(&vs, 5_000), Some("treatment"));
+        // Bucket 9999 → treatment
+        assert_eq!(select_variant(&vs, 9_999), Some("treatment"));
+    }
+
+    // ── AC: InMemoryExperimentStore — Arc delegation ──────────────────────────
+
+    #[test]
+    fn arc_experiment_store_delegates_all_operations() {
+        let store = Arc::new(InMemoryExperimentStore::new());
+        let arc_store: Arc<dyn ExperimentStore> = Arc::clone(&store) as _;
+
+        let cfg = fifty_fifty("my_exp");
+        arc_store.upsert(cfg).unwrap();
+        assert!(arc_store.get("my_exp").unwrap().is_some());
+
+        arc_store
+            .set_state("my_exp", ExperimentState::Running, None)
+            .unwrap();
+        assert_eq!(
+            arc_store.get("my_exp").unwrap().unwrap().state,
+            ExperimentState::Running
+        );
+
+        arc_store
+            .record_assignment(Assignment::new("my_exp", "user:1", "control", false))
+            .unwrap();
+        let asgn = arc_store.get_assignment("my_exp", "user:1").unwrap();
+        assert_eq!(asgn.unwrap().variant, "control");
+
+        arc_store.set_override("my_exp", "qa:1", "treatment").unwrap();
+        assert_eq!(
+            arc_store.get_override("my_exp", "qa:1").unwrap().unwrap(),
+            "treatment"
+        );
+    }
+
+    // ── AC: ExperimentState display ───────────────────────────────────────────
+
+    #[test]
+    fn experiment_state_display_matches_expected() {
+        assert_eq!(ExperimentState::Draft.to_string(), "draft");
+        assert_eq!(ExperimentState::Running.to_string(), "running");
+        assert_eq!(ExperimentState::Concluded.to_string(), "concluded");
+        assert_eq!(ExperimentState::Archived.to_string(), "archived");
+    }
+
+    // ── AC: ExperimentError display ───────────────────────────────────────────
+
+    #[test]
+    fn experiment_error_display() {
+        assert!(ExperimentError::NotFound("x".to_owned())
+            .to_string()
+            .contains("not found"));
+        assert!(ExperimentError::Archived("x".to_owned())
+            .to_string()
+            .contains("archived"));
+        assert!(ExperimentError::ExcludedByGroup("x".to_owned(), "g".to_owned())
+            .to_string()
+            .contains("mutual exclusion"));
+        assert!(ExperimentError::NoVariant("x".to_owned())
+            .to_string()
+            .contains("weights are zero"));
+    }
+
+    // ── AC: service debug ─────────────────────────────────────────────────────
+
+    #[test]
+    fn service_debug_does_not_panic() {
+        let svc = make_svc();
+        let _ = format!("{svc:?}");
+    }
+}

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -186,6 +186,7 @@ pub mod static_gen;
 pub mod storage;
 pub mod tenancy;
 
+pub mod experiments;
 pub mod feature_flags;
 pub mod form;
 pub mod job;

--- a/docs/guide/experiments.md
+++ b/docs/guide/experiments.md
@@ -1,0 +1,285 @@
+# A/B Experiments
+
+Autumn ships a first-party A/B experiment system that handles the hard parts: **deterministic bucketing, sticky assignments, and structured exposure telemetry**.  You declare experiments, start them, and assign actors — the framework emits exposure events that your analytics pipeline can join to outcome data.
+
+---
+
+## Quick start
+
+### 1. Register the experiment store
+
+```rust
+use autumn_web::experiments::InMemoryExperimentStore;
+
+autumn_web::app()
+    .with_experiment_store(InMemoryExperimentStore::new())
+    .routes(routes![checkout])
+    .run()
+    .await;
+```
+
+In production, the Postgres-backed store persists assignments across restarts and propagates weight changes via `LISTEN/NOTIFY`:
+
+```sh
+autumn migrate          # creates autumn_experiments, autumn_experiment_assignments, etc.
+```
+
+### 2. Declare and start an experiment
+
+Declare experiments at startup (or via the admin UI / CLI):
+
+```rust
+use autumn_web::experiments::{ExperimentConfig, ExperimentService, VariantConfig};
+use std::sync::Arc;
+
+let svc: ExperimentService = /* from AppState */;
+
+svc.create(ExperimentConfig::new("checkout_v2", vec![
+    VariantConfig::new("control",   50),
+    VariantConfig::new("treatment", 50),
+])).unwrap();
+
+svc.start("checkout_v2").unwrap();
+```
+
+### 3. Assign an actor in a handler
+
+The `Experiments` extractor resolves the actor from the session and the request ID from the `x-request-id` header:
+
+```rust
+use autumn_web::prelude::*;
+use autumn_web::experiments::Experiments;
+
+#[get("/checkout")]
+async fn checkout(exps: Experiments) -> AutumnResult<Markup> {
+    let variant = exps.assign("checkout_v2")?;
+    Ok(html! {
+        @match variant.as_str() {
+            "treatment" => (render_new_checkout()),
+            _           => (render_classic_checkout()),
+        }
+    })
+}
+```
+
+Or use the service directly with an explicit actor:
+
+```rust
+let variant = experiments.assign("checkout_v2", "user:42")?;
+```
+
+---
+
+## Assignment algorithm
+
+Assignment is **deterministic per `(experiment_name, actor_id)`**:
+
+1. Compute `bucket = FNV-1a_64("<experiment>:<actor>") mod 10 000`.
+2. Map bucket to a variant proportionally by weight.
+
+The same actor always gets the same bucket — across requests, restarts, and replicas.  Changing the hash function (never done without a migration) would re-bucket every actor in every running experiment.
+
+### Weights
+
+Weights are **relative**: `[("control", 30), ("treatment", 70)]` gives a 30/70 split.  They do not need to sum to 100.
+
+```rust
+VariantConfig::new("control",   30)   // 30%
+VariantConfig::new("treatment", 70)   // 70%
+```
+
+Use weight `0` to disable a variant without removing it:
+
+```rust
+VariantConfig::new("dead_end", 0)     // never assigned
+```
+
+---
+
+## Sticky assignments
+
+Once an actor is assigned, the assignment is **recorded and returned on all subsequent calls** (`InMemoryExperimentStore` keeps it in memory; the Postgres store persists across restarts).
+
+Changing weights **does not re-bucket** already-assigned actors — only new actors see the updated distribution.
+
+---
+
+## Exposure telemetry
+
+Every `assign()` call on a `Running` experiment emits one [`ExposureRecord`]:
+
+```json
+{
+  "experiment": "checkout_v2",
+  "variant":    "treatment",
+  "actor":      "user:42",
+  "request_id": "req-abc123",
+  "is_override": false,
+  "timestamp_secs": 1748000000
+}
+```
+
+The default sink logs at `INFO` via `tracing`.  Supply a custom [`ExposureSink`] to forward events to Segment, PostHog, or your data warehouse:
+
+```rust
+use autumn_web::experiments::{ExposureSink, ExposureRecord};
+use std::sync::Arc;
+
+struct SegmentSink { write_key: String }
+
+impl ExposureSink for SegmentSink {
+    fn record(&self, e: ExposureRecord) {
+        // POST to Segment Track API
+    }
+}
+
+autumn_web::app()
+    .with_experiment_store_and_sink(
+        InMemoryExperimentStore::new(),
+        Arc::new(SegmentSink { write_key: "...".into() }),
+    )
+    .run()
+    .await;
+```
+
+---
+
+## Experiment lifecycle
+
+```
+draft ──► running ──► concluded
+   │                  │
+   └──────── archived ┘   (from any state)
+```
+
+| State       | `assign()` behaviour                                       |
+|-------------|-------------------------------------------------------------|
+| `Draft`     | Returns `Err(NotRunning)`                                  |
+| `Running`   | Normal assignment + exposure emission                       |
+| `Concluded` | Returns winner for all actors; **no** new exposures        |
+| `Archived`  | Returns `Err(Archived)`                                    |
+
+Lifecycle transitions via service:
+
+```rust
+svc.start("checkout_v2").unwrap();
+svc.conclude("checkout_v2", "treatment").unwrap();
+svc.archive("checkout_v2").unwrap();
+```
+
+---
+
+## Staff / QA overrides
+
+Pin a specific actor to a variant, bypassing the bucket calculation:
+
+```rust
+svc.set_override("checkout_v2", "qa:alice", "treatment").unwrap();
+```
+
+Overrides are tagged with `is_override = true` in exposure events so analytics pipelines can exclude them from significance calculations.
+
+---
+
+## Mutual exclusion groups
+
+Prevent actors from being enrolled in multiple overlapping experiments (to avoid interaction effects):
+
+```rust
+svc.create(
+    ExperimentConfig::new("exp_a", variants_a)
+        .exclusion_group("checkout"),
+).unwrap();
+svc.create(
+    ExperimentConfig::new("exp_b", variants_b)
+        .exclusion_group("checkout"),
+).unwrap();
+```
+
+Once an actor is assigned to `exp_a`, `assign("exp_b", actor)` returns `Err(ExcludedByGroup)`.
+
+---
+
+## CLI
+
+```sh
+# List all experiments
+autumn experiments list
+
+# Show details for one experiment
+autumn experiments status checkout_v2
+
+# Update weights (existing assignments unchanged)
+autumn experiments set-weights checkout_v2 control=30,treatment=70
+
+# Conclude and pin a winner
+autumn experiments conclude checkout_v2 treatment
+
+# Pin a QA actor to a specific variant
+autumn experiments override checkout_v2 qa@example.com treatment
+```
+
+---
+
+## Admin UI
+
+Register the `ExperimentAdminModel` in the admin plugin to get a management page at `/admin/experiments/`:
+
+```rust
+use autumn_admin_plugin::{AdminPlugin, prelude::*};
+use autumn_admin_plugin::experiments::ExperimentAdminModel;
+
+autumn_web::app()
+    .plugin(
+        AdminPlugin::new()
+            .register(ExperimentAdminModel::default()),
+    )
+    .run()
+    .await;
+```
+
+The page includes:
+- **List view**: name, state, winner
+- **Edit view**: state transitions, variant weight editing
+- **History tab**: per-experiment audit trail
+
+---
+
+## Testing
+
+Use `InMemoryExperimentStore` and `RecordingExposureSink` in unit tests:
+
+```rust
+use autumn_web::experiments::{
+    ExperimentConfig, ExperimentService, InMemoryExperimentStore,
+    RecordingExposureSink, VariantConfig,
+};
+use std::sync::Arc;
+
+let (sink, records) = RecordingExposureSink::new();
+let store = Arc::new(InMemoryExperimentStore::new());
+let svc = ExperimentService::new(store)
+    .with_exposure_sink(Arc::new(sink));
+
+svc.create(ExperimentConfig::new("checkout_v2", vec![
+    VariantConfig::new("control",   50),
+    VariantConfig::new("treatment", 50),
+])).unwrap();
+svc.start("checkout_v2").unwrap();
+
+let variant = svc.assign("checkout_v2", "user:1").unwrap();
+assert_eq!(records.lock().unwrap().len(), 1);
+
+// Verify sticky assignment
+let again = svc.assign("checkout_v2", "user:1").unwrap();
+assert_eq!(variant, again);
+```
+
+---
+
+## Out of scope
+
+- **Analytics / significance**: autumn emits exposures; downstream tools join them to outcomes.
+- **Client-side delivery**: server-rendered assignment only.
+- **Multi-armed bandits**: fixed-weight experiments only.
+- **Cross-experiment causal inference**: use mutual exclusion groups for isolation.

--- a/examples/experiments/Cargo.toml
+++ b/examples/experiments/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "experiments"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+autumn-web = { path = "../../autumn" }
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/examples/experiments/README.md
+++ b/examples/experiments/README.md
@@ -1,0 +1,70 @@
+# A/B Experiments Example
+
+Demonstrates Autumn's built-in A/B experiment system: deterministic bucketing,
+sticky assignments, exposure telemetry, staff/QA overrides, and the experiment
+lifecycle.
+
+## Prerequisites
+
+- Rust 1.88.0+
+
+## Quick start
+
+```sh
+cargo run -p experiments
+```
+
+Then in a second terminal:
+
+```sh
+# Assign user:1 — variant printed + exposure logged to stdout
+curl http://localhost:3000/checkout/user:1
+
+# Same actor always gets the same variant (sticky)
+curl http://localhost:3000/checkout/user:1
+
+# Different actors may get different variants
+curl http://localhost:3000/checkout/user:2
+
+# QA actor is overridden to "treatment" regardless of bucket
+curl http://localhost:3000/checkout/qa:alice
+
+# Check current experiment status
+curl http://localhost:3000/status
+
+# Conclude the experiment (returns winner for everyone)
+curl -X POST http://localhost:3000/conclude
+curl http://localhost:3000/checkout/user:99
+```
+
+## What it shows
+
+| Feature | Where |
+|---------|-------|
+| 50/50 variant assignment | `ExperimentConfig::new` with two `VariantConfig`s |
+| Deterministic bucketing | FNV-1a hash of `"<experiment>:<actor>"` mod 10 000 |
+| Sticky assignments | Same actor always returns the same variant |
+| Exposure telemetry | `TracingExposureSink` logs to stdout via `tracing` |
+| QA override | `svc.set_override("checkout_v2", "qa:alice", "treatment")` |
+| Experiment lifecycle | `draft → running → concluded` via `start()` / `conclude()` |
+| Custom sink | Replace `TracingExposureSink` with `SegmentSink`, `PostHogSink`, etc. |
+
+## Key code
+
+```rust
+use autumn_web::experiments::{
+    ExperimentConfig, ExperimentService, InMemoryExperimentStore, VariantConfig,
+};
+
+let svc = ExperimentService::new(Arc::new(InMemoryExperimentStore::new()));
+
+svc.create(ExperimentConfig::new("checkout_v2", vec![
+    VariantConfig::new("control",   50),
+    VariantConfig::new("treatment", 50),
+])).unwrap();
+
+svc.start("checkout_v2").unwrap();
+
+// In a handler:
+let variant = svc.assign("checkout_v2", "user:42").unwrap();
+```

--- a/examples/experiments/src/main.rs
+++ b/examples/experiments/src/main.rs
@@ -1,0 +1,140 @@
+//! A/B experiment example: two-variant checkout flow with exposure events.
+//!
+//! Demonstrates:
+//! - Declaring a named experiment with two 50/50 variants
+//! - Deterministic, sticky actor assignment
+//! - Exposure events logged to stdout via the default tracing sink
+//! - Staff/QA override pinning a specific actor to a variant
+//! - Concluding an experiment with a winner
+//!
+//! # Quick start
+//!
+//! ```sh
+//! cargo run -p experiments
+//! ```
+//!
+//! Then in a second terminal:
+//!
+//! ```sh
+//! # Assign user:1 — variant printed + exposure logged to stdout
+//! curl http://localhost:3000/checkout/user:1
+//!
+//! # Same actor always gets the same variant (sticky)
+//! curl http://localhost:3000/checkout/user:1
+//!
+//! # Different actors may get different variants
+//! curl http://localhost:3000/checkout/user:2
+//!
+//! # QA actor is overridden to "treatment" regardless of bucket
+//! curl http://localhost:3000/checkout/qa:alice
+//!
+//! # Check current experiment status
+//! curl http://localhost:3000/status
+//!
+//! # Conclude the experiment (returns winner for everyone)
+//! curl -X POST http://localhost:3000/conclude
+//! curl http://localhost:3000/checkout/user:99
+//! ```
+
+use autumn_web::experiments::{
+    ExperimentConfig, ExperimentService, InMemoryExperimentStore, VariantConfig,
+};
+use autumn_web::prelude::*;
+
+const EXPERIMENT: &str = "checkout_v2";
+
+/// Assign a variant to the given actor and return it as plain text.
+///
+/// Exposure events are emitted automatically to tracing (stdout in this example).
+#[get("/checkout/{actor}")]
+async fn checkout(Path(actor): Path<String>, exps: autumn_web::experiments::Experiments) -> String {
+    match exps.service().assign(EXPERIMENT, &actor) {
+        Ok(variant) => format!(
+            "actor={actor} experiment={EXPERIMENT} variant={variant}\n\
+             (exposure event logged to stdout)\n"
+        ),
+        Err(e) => format!("assignment error: {e}\n"),
+    }
+}
+
+/// Show the current experiment configuration.
+#[get("/status")]
+async fn status(exps: autumn_web::experiments::Experiments) -> String {
+    match exps.service().status(EXPERIMENT) {
+        Ok(cfg) => {
+            let variants: String = cfg
+                .variants
+                .iter()
+                .map(|v| format!("  {}={}", v.name, v.weight))
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!(
+                "experiment: {}\nstate: {}\nvariants:\n{}\nwinner: {}\n",
+                cfg.name,
+                cfg.state,
+                variants,
+                cfg.winner.as_deref().unwrap_or("(none)")
+            )
+        }
+        Err(e) => format!("error: {e}\n"),
+    }
+}
+
+/// Conclude the experiment, pinning "treatment" as the winner.
+///
+/// After this, every `assign()` call returns "treatment" without emitting
+/// a new exposure event.
+#[post("/conclude")]
+async fn conclude(exps: autumn_web::experiments::Experiments) -> String {
+    match exps.service().conclude(EXPERIMENT, "treatment") {
+        Ok(()) => format!(
+            "experiment '{EXPERIMENT}' concluded — winner: treatment\n\
+             All actors will now see the winner variant.\n"
+        ),
+        Err(e) => format!("error: {e}\n"),
+    }
+}
+
+#[autumn_web::main]
+async fn main() {
+    let store = std::sync::Arc::new(InMemoryExperimentStore::new());
+    let svc = ExperimentService::new(
+        store as std::sync::Arc<dyn autumn_web::experiments::ExperimentStore>,
+    );
+
+    // Declare a 50/50 checkout experiment.
+    svc.create(
+        ExperimentConfig::new(
+            EXPERIMENT,
+            vec![
+                VariantConfig::new("control", 50),
+                VariantConfig::new("treatment", 50),
+            ],
+        )
+        .description("Two-variant checkout flow: classic (control) vs. redesign (treatment)"),
+    )
+    .expect("failed to create experiment");
+
+    // Start the experiment — assignments and exposures are now active.
+    svc.start(EXPERIMENT).expect("failed to start experiment");
+
+    // Override qa:alice to "treatment" for manual QA testing.
+    svc.set_override(EXPERIMENT, "qa:alice", "treatment")
+        .expect("failed to set override");
+
+    println!("✓ Experiment '{EXPERIMENT}' started with 50/50 variants.");
+    println!("  Visit http://localhost:3000/checkout/user:1");
+    println!("  QA actor 'qa:alice' is overridden to 'treatment'.");
+
+    autumn_web::app()
+        .with_experiment_store_and_sink(
+            InMemoryExperimentStore::new(),
+            std::sync::Arc::new(autumn_web::experiments::TracingExposureSink),
+        )
+        .state_initializer(move |state| {
+            state.insert_extension(svc.clone());
+        })
+        .routes(routes![checkout, status, conclude])
+        .run()
+        .await;
+}


### PR DESCRIPTION
## Summary

Introduces a complete A/B experiment framework to Autumn with deterministic bucketing, sticky assignments, structured exposure events, and lifecycle management. Experiments support multi-variant assignment with configurable weights, mutual exclusion groups, staff/QA overrides, and pluggable exposure sinks for analytics integration.

## Key Changes

- **Core experiment module** (`autumn/src/experiments.rs`): 
  - `ExperimentService` for managing experiment lifecycle (draft → running → concluded → archived)
  - Deterministic FNV-1a 64-bit bucketing algorithm producing stable assignments across restarts and replicas
  - `ExperimentStore` trait with in-memory implementation; Postgres-backed store ready for production
  - Sticky assignment semantics: once assigned, actors always receive the same variant
  - Mutual exclusion groups to prevent interaction effects between related experiments
  - Staff/QA override support for pinning specific actors to variants

- **Exposure telemetry**:
  - `ExposureRecord` struct emitted on every successful assignment
  - Pluggable `ExposureSink` trait with three implementations:
    - `TracingExposureSink` (default): logs structured events via `tracing` crate
    - `NoOpExposureSink`: discards events (benchmarks/testing)
    - `RecordingExposureSink`: collects events in memory (integration tests)

- **Database schema** (`autumn/migrations/20260530300000_create_experiments/`):
  - `autumn_experiments`: experiment configuration with state, variants, winner
  - `autumn_experiment_assignments`: sticky actor → variant mappings
  - `autumn_experiment_overrides`: QA/staff pinned assignments
  - `autumn_experiment_changes`: append-only audit log with NOTIFY triggers for cross-replica propagation

- **Admin UI integration** (`autumn-admin-plugin/src/experiments.rs`):
  - Full CRUD interface at `/admin/experiments/`
  - List view with state, variants, winner
  - Edit view for description, exclusion group, state transitions, weight updates
  - Per-experiment audit trail from change log

- **CLI commands** (`autumn-cli/src/experiments.rs`):
  - `autumn experiments list`: show all experiments
  - `autumn experiments status <name>`: detailed view
  - `autumn experiments set-weights <name> <v=w,...>`: update variant weights
  - `autumn experiments conclude <name> <winner>`: pin winner, stop new assignments
  - `autumn experiments override <name> <actor> <variant>`: QA/staff override

- **Framework integration**:
  - `Experiments` extractor resolves actor from session and request ID from headers
  - `AppBuilder::with_experiment_store()` registers store in app state
  - Example application demonstrating full workflow

- **Documentation**:
  - Comprehensive module-level docs with quick start, assignment semantics, lifecycle, exposure events
  - Guide at `docs/guide/experiments.md` with usage patterns and custom sink examples
  - Inline examples in trait/struct documentation

## Notable Implementation Details

- **Deterministic bucketing**: FNV-1a hash of `"<experiment>:<actor>"` mapped to `[0, 10000)` bucket range ensures identical assignments across all replicas without coordination
- **Weight changes are non-disruptive**: Updating variant weights only affects new actors; existing sticky assignments are preserved
- **Concluded experiments**: When an experiment concludes with a winner, all actors (including new ones) receive the winner variant; no new exposure events are emitted
- **Mutual exclusion**: Actors assigned to any experiment in a named group are automatically excluded from sibling experiments in that group
- **Audit trail**: All mutations (state changes, weight updates, overrides) are recorded with timestamp and actor for compliance and debugging

https://claude.ai/code/session_01T6mz3UByekwKhDu8WSsXPc