### PR TITLE
⚒️ Forge: Extract shared app startup logic

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -7920,27 +7920,28 @@ mod tests {
     }
 }
 
-
 #[allow(clippy::too_many_arguments)]
 fn setup_state_and_extensions(
     config: &crate::config::AutumnConfig,
-    #[cfg(feature = "db")]
-    pool: Option<&crate::db::DatabaseTopology>,
-    #[cfg(feature = "ws")]
-    channels_backend: Option<std::sync::Arc<dyn crate::channels::ChannelsBackend>>,
-    #[cfg(feature = "mail")]
-    mail_interceptor: Option<std::sync::Arc<dyn crate::interceptor::MailInterceptor>>,
+    #[cfg(feature = "db")] pool: Option<&crate::db::DatabaseTopology>,
+    #[cfg(feature = "ws")] channels_backend: Option<
+        std::sync::Arc<dyn crate::channels::ChannelsBackend>,
+    >,
+    #[cfg(feature = "mail")] mail_interceptor: Option<
+        std::sync::Arc<dyn crate::interceptor::MailInterceptor>,
+    >,
     job_interceptor: Option<std::sync::Arc<dyn crate::interceptor::JobInterceptor>>,
-    #[cfg(feature = "db")]
-    db_interceptor: Option<std::sync::Arc<dyn crate::interceptor::DbConnectionInterceptor>>,
-    #[cfg(feature = "ws")]
-    channels_interceptor: Option<std::sync::Arc<dyn crate::interceptor::ChannelsInterceptor>>,
-    #[cfg(feature = "oauth2")]
-    http_interceptor: Option<std::sync::Arc<dyn crate::interceptor::HttpInterceptor>>,
-    #[cfg(feature = "db")]
-    replica_migration_check: Option<(String, String)>,
-    #[cfg(feature = "db")]
-    replica_readiness: Option<crate::migrate::ReplicaMigrationReadiness>,
+    #[cfg(feature = "db")] db_interceptor: Option<
+        std::sync::Arc<dyn crate::interceptor::DbConnectionInterceptor>,
+    >,
+    #[cfg(feature = "ws")] channels_interceptor: Option<
+        std::sync::Arc<dyn crate::interceptor::ChannelsInterceptor>,
+    >,
+    #[cfg(feature = "oauth2")] http_interceptor: Option<
+        std::sync::Arc<dyn crate::interceptor::HttpInterceptor>,
+    >,
+    #[cfg(feature = "db")] replica_migration_check: Option<(String, String)>,
+    #[cfg(feature = "db")] replica_readiness: Option<crate::migrate::ReplicaMigrationReadiness>,
     cache_backend: Option<std::sync::Arc<dyn crate::cache::Cache>>,
 ) -> AppState {
     let mut state = build_state(

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -1826,52 +1826,27 @@ impl AppBuilder {
         validate_repository_api_policies(&all_routes, &scoped_groups, &config);
 
         // 6. Build the router (with optional static-file layer)
-        let mut state = build_state(
+        let state = setup_state_and_extensions(
             &config,
             #[cfg(feature = "db")]
             pool.as_ref(),
             #[cfg(feature = "ws")]
             channels_backend,
+            #[cfg(feature = "mail")]
+            mail_interceptor,
+            job_interceptor,
+            #[cfg(feature = "db")]
+            db_interceptor,
+            #[cfg(feature = "ws")]
+            channels_interceptor,
+            #[cfg(feature = "oauth2")]
+            http_interceptor,
+            #[cfg(feature = "db")]
+            replica_migration_check,
+            #[cfg(feature = "db")]
+            replica_readiness,
+            cache_backend,
         );
-        #[cfg(feature = "mail")]
-        if let Some(interceptor) = mail_interceptor {
-            state.insert_extension(interceptor);
-        }
-        if let Some(interceptor) = job_interceptor {
-            state.insert_extension(interceptor);
-        }
-        #[cfg(feature = "db")]
-        if let Some(interceptor) = db_interceptor {
-            state.insert_extension(interceptor);
-        }
-        #[cfg(feature = "ws")]
-        if let Some(interceptor) = channels_interceptor {
-            state.insert_extension(interceptor.clone());
-            state.channels = crate::channels::Channels::with_shared_backend(std::sync::Arc::new(
-                crate::channels::InterceptedChannelsBackend::new(
-                    state.channels.backend().clone(),
-                    vec![interceptor],
-                ),
-            ));
-            #[cfg(feature = "presence")]
-            {
-                state.presence = crate::presence::Presence::new(state.channels.clone());
-            }
-        }
-        #[cfg(feature = "oauth2")]
-        if let Some(interceptor) = http_interceptor {
-            state.insert_extension(interceptor);
-        }
-        #[cfg(feature = "db")]
-        configure_replica_migration_check(&state, replica_migration_check);
-        #[cfg(feature = "db")]
-        apply_replica_migration_readiness(&state, replica_readiness);
-        if let Some(cache) = cache_backend {
-            crate::cache::set_global_cache(cache.clone());
-            state.shared_cache = Some(cache);
-        } else {
-            crate::cache::clear_global_cache();
-        }
         // Apply deferred policy / scope registrations onto the live
         // app state. Done before the router is built so any panic
         // from double-registration surfaces during startup, not
@@ -2364,52 +2339,27 @@ impl AppBuilder {
         #[cfg(feature = "db")]
         let replica_migration_check = database.replica_migration_check;
 
-        let mut state = build_state(
+        let mut state = setup_state_and_extensions(
             &config,
             #[cfg(feature = "db")]
             pool.as_ref(),
             #[cfg(feature = "ws")]
             channels_backend,
+            #[cfg(feature = "mail")]
+            mail_interceptor,
+            job_interceptor,
+            #[cfg(feature = "db")]
+            db_interceptor,
+            #[cfg(feature = "ws")]
+            channels_interceptor,
+            #[cfg(feature = "oauth2")]
+            http_interceptor,
+            #[cfg(feature = "db")]
+            replica_migration_check,
+            #[cfg(feature = "db")]
+            replica_readiness,
+            cache_backend,
         );
-        #[cfg(feature = "mail")]
-        if let Some(interceptor) = mail_interceptor {
-            state.insert_extension(interceptor);
-        }
-        if let Some(interceptor) = job_interceptor {
-            state.insert_extension(interceptor);
-        }
-        #[cfg(feature = "db")]
-        if let Some(interceptor) = db_interceptor {
-            state.insert_extension(interceptor);
-        }
-        #[cfg(feature = "ws")]
-        if let Some(interceptor) = channels_interceptor {
-            state.insert_extension(interceptor.clone());
-            state.channels = crate::channels::Channels::with_shared_backend(std::sync::Arc::new(
-                crate::channels::InterceptedChannelsBackend::new(
-                    state.channels.backend().clone(),
-                    vec![interceptor],
-                ),
-            ));
-            #[cfg(feature = "presence")]
-            {
-                state.presence = crate::presence::Presence::new(state.channels.clone());
-            }
-        }
-        #[cfg(feature = "oauth2")]
-        if let Some(interceptor) = http_interceptor {
-            state.insert_extension(interceptor);
-        }
-        #[cfg(feature = "db")]
-        configure_replica_migration_check(&state, replica_migration_check);
-        #[cfg(feature = "db")]
-        apply_replica_migration_readiness(&state, replica_readiness);
-        if let Some(cache) = cache_backend {
-            crate::cache::set_global_cache(cache.clone());
-            state.shared_cache = Some(cache);
-        } else {
-            crate::cache::clear_global_cache();
-        }
         // Static-site builds are short-lived and don't run the request loop,
         // so deliver_later is never invoked. install_mailer_with_factory skips
         // the queue factory when enforce_durable_guard is false (the factory
@@ -2712,52 +2662,27 @@ impl AppBuilder {
         #[cfg(feature = "db")]
         let replica_migration_check = database.replica_migration_check;
 
-        let mut state = build_state(
+        let state = setup_state_and_extensions(
             &config,
             #[cfg(feature = "db")]
             pool.as_ref(),
             #[cfg(feature = "ws")]
             channels_backend,
+            #[cfg(feature = "mail")]
+            mail_interceptor,
+            job_interceptor,
+            #[cfg(feature = "db")]
+            db_interceptor,
+            #[cfg(feature = "ws")]
+            channels_interceptor,
+            #[cfg(feature = "oauth2")]
+            http_interceptor,
+            #[cfg(feature = "db")]
+            replica_migration_check,
+            #[cfg(feature = "db")]
+            replica_readiness,
+            cache_backend,
         );
-        #[cfg(feature = "mail")]
-        if let Some(interceptor) = mail_interceptor {
-            state.insert_extension(interceptor);
-        }
-        if let Some(interceptor) = job_interceptor {
-            state.insert_extension(interceptor);
-        }
-        #[cfg(feature = "db")]
-        if let Some(interceptor) = db_interceptor {
-            state.insert_extension(interceptor);
-        }
-        #[cfg(feature = "ws")]
-        if let Some(interceptor) = channels_interceptor {
-            state.insert_extension(interceptor.clone());
-            state.channels = crate::channels::Channels::with_shared_backend(std::sync::Arc::new(
-                crate::channels::InterceptedChannelsBackend::new(
-                    state.channels.backend().clone(),
-                    vec![interceptor],
-                ),
-            ));
-            #[cfg(feature = "presence")]
-            {
-                state.presence = crate::presence::Presence::new(state.channels.clone());
-            }
-        }
-        #[cfg(feature = "oauth2")]
-        if let Some(interceptor) = http_interceptor {
-            state.insert_extension(interceptor);
-        }
-        #[cfg(feature = "db")]
-        configure_replica_migration_check(&state, replica_migration_check);
-        #[cfg(feature = "db")]
-        apply_replica_migration_readiness(&state, replica_readiness);
-        if let Some(cache) = cache_backend {
-            crate::cache::set_global_cache(cache.clone());
-            state.shared_cache = Some(cache);
-        } else {
-            crate::cache::clear_global_cache();
-        }
 
         for register in policy_registrations {
             register(state.policy_registry());
@@ -7993,4 +7918,76 @@ mod tests {
             "fast hook must still run even after slow hook overruns its per-hook budget"
         );
     }
+}
+
+
+#[allow(clippy::too_many_arguments)]
+fn setup_state_and_extensions(
+    config: &crate::config::AutumnConfig,
+    #[cfg(feature = "db")]
+    pool: Option<&crate::db::DatabaseTopology>,
+    #[cfg(feature = "ws")]
+    channels_backend: Option<std::sync::Arc<dyn crate::channels::ChannelsBackend>>,
+    #[cfg(feature = "mail")]
+    mail_interceptor: Option<std::sync::Arc<dyn crate::interceptor::MailInterceptor>>,
+    job_interceptor: Option<std::sync::Arc<dyn crate::interceptor::JobInterceptor>>,
+    #[cfg(feature = "db")]
+    db_interceptor: Option<std::sync::Arc<dyn crate::interceptor::DbConnectionInterceptor>>,
+    #[cfg(feature = "ws")]
+    channels_interceptor: Option<std::sync::Arc<dyn crate::interceptor::ChannelsInterceptor>>,
+    #[cfg(feature = "oauth2")]
+    http_interceptor: Option<std::sync::Arc<dyn crate::interceptor::HttpInterceptor>>,
+    #[cfg(feature = "db")]
+    replica_migration_check: Option<(String, String)>,
+    #[cfg(feature = "db")]
+    replica_readiness: Option<crate::migrate::ReplicaMigrationReadiness>,
+    cache_backend: Option<std::sync::Arc<dyn crate::cache::Cache>>,
+) -> AppState {
+    let mut state = build_state(
+        config,
+        #[cfg(feature = "db")]
+        pool,
+        #[cfg(feature = "ws")]
+        channels_backend,
+    );
+    #[cfg(feature = "mail")]
+    if let Some(interceptor) = mail_interceptor {
+        state.insert_extension(interceptor);
+    }
+    if let Some(interceptor) = job_interceptor {
+        state.insert_extension(interceptor);
+    }
+    #[cfg(feature = "db")]
+    if let Some(interceptor) = db_interceptor {
+        state.insert_extension(interceptor);
+    }
+    #[cfg(feature = "ws")]
+    if let Some(interceptor) = channels_interceptor {
+        state.insert_extension(interceptor.clone());
+        state.channels = crate::channels::Channels::with_shared_backend(std::sync::Arc::new(
+            crate::channels::InterceptedChannelsBackend::new(
+                state.channels.backend().clone(),
+                vec![interceptor],
+            ),
+        ));
+        #[cfg(feature = "presence")]
+        {
+            state.presence = crate::presence::Presence::new(state.channels.clone());
+        }
+    }
+    #[cfg(feature = "oauth2")]
+    if let Some(interceptor) = http_interceptor {
+        state.insert_extension(interceptor);
+    }
+    #[cfg(feature = "db")]
+    configure_replica_migration_check(&state, replica_migration_check);
+    #[cfg(feature = "db")]
+    apply_replica_migration_readiness(&state, replica_readiness);
+    if let Some(cache) = cache_backend {
+        crate::cache::set_global_cache(cache.clone());
+        state.shared_cache = Some(cache);
+    } else {
+        crate::cache::clear_global_cache();
+    }
+    state
 }


### PR DESCRIPTION
🚷 Smell
The `run`, `run_build_mode`, and `run_one_off_task_mode` methods in `AppBuilder` are massive "God Functions" (580, 324, and 235 lines respectively). They duplicate an immense amount of boilerplate logic to create the core `AppState` with all extensions and interceptors correctly inserted.

✨ Solution
Extracted the core `AppState` assembly and extension logic into a unified, reusable `setup_state_and_extensions` helper function. Updated the three run modes to pass their distinct arguments to the helper instead of redefining the entire logic flow inline.

🧊 Benefit
Dramatically flattens the structure, removes hundreds of lines of duplicate boilerplate, and makes the individual run modes highly cohesive. The unique logic of each run mode (e.g. failing fast on configurations, specific database migrations, different router endpoints) is preserved exactly as it was, while the identical shared state initialization is safely centralized.

🛡️ Verification
Ran `cargo check`, `cargo fmt`, `cargo clippy`, and `cargo test`. All pass. The refactoring introduces zero behavior change and maintains all mode-specific properties including the strict text-order requirements enforced by the `app::tests` suite.

---
*PR created automatically by Jules for task [16137201564312581147](https://jules.google.com/task/16137201564312581147) started by @madmax983*