### PR TITLE
🗺️ Atlas: [architectural change] Reduce visibility of internal modules

### DIFF
--- a/autumn/src/middleware/mod.rs
+++ b/autumn/src/middleware/mod.rs
@@ -19,7 +19,7 @@
 pub(crate) mod dev;
 pub(crate) mod error_page_filter;
 pub(crate) mod exception_filter;
-pub mod maintenance;
+pub(crate) mod maintenance;
 pub(crate) mod method_override;
 pub(crate) mod metrics;
 pub(crate) mod request_id;

--- a/autumn/src/security/mod.rs
+++ b/autumn/src/security/mod.rs
@@ -106,7 +106,7 @@
 pub(crate) mod config;
 pub(crate) mod csrf;
 pub(crate) mod headers;
-pub mod rate_limit;
+pub(crate) mod rate_limit;
 
 // Re-export commonly used types at the module level.
 pub use config::{


### PR DESCRIPTION
🕸️ Tangle: The `autumn/src/middleware/maintenance` and `autumn/src/security/rate_limit` modules were exported as `pub mod`, potentially leaking internal implementation details as part of the public API surface.

📐 Blueprint: Restricted the visibility of these modules by changing `pub mod` to `pub(crate) mod`. They remain accessible within the workspace components where they are needed but are no longer publicly visible.

🧱 Stability: This reduces coupling by hiding the internal structures of `maintenance` and `rate_limit`, enforcing domain boundaries.

🔭 Verification: Ran `cargo check`, `cargo clippy`, and unit/integration tests across the workspace to ensure the change compiles successfully and no other crates or tests depend on these being publicly exposed.

---
*PR created automatically by Jules for task [4318951804796186667](https://jules.google.com/task/4318951804796186667) started by @madmax983*