### PR TITLE
fix: use batch_execute for multi-statement feature flags test migration

### DIFF
--- a/autumn/tests/feature_flags_pg_integration.rs
+++ b/autumn/tests/feature_flags_pg_integration.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 use autumn_web::feature_flags::FlagStore;
 use autumn_web::feature_flags::pg::PgFlagStore;
+use diesel::connection::SimpleConnection;
 use diesel::prelude::*;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
@@ -35,9 +36,7 @@ async fn setup_pg_store() -> (PgFlagStore, testcontainers::ContainerAsync<Postgr
 
     // Run the migration on a synchronous connection (PgFlagStore uses sync diesel).
     let mut conn = PgConnection::establish(&url).expect("db connection");
-    diesel::sql_query(MIGRATION_SQL)
-        .execute(&mut conn)
-        .expect("migration");
+    conn.batch_execute(MIGRATION_SQL).expect("migration");
 
     // Use TTL=0 so every test reads from the DB, not the cache.
     let store = PgFlagStore::with_cache_ttl(&url, Duration::ZERO);
@@ -168,9 +167,7 @@ async fn pg_store_cache_hit_avoids_second_db_call() {
     let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
 
     let mut conn = PgConnection::establish(&url).expect("conn");
-    diesel::sql_query(MIGRATION_SQL)
-        .execute(&mut conn)
-        .expect("migration");
+    conn.batch_execute(MIGRATION_SQL).expect("migration");
 
     // Use a 60-second TTL so reads populate the cache.
     let store = PgFlagStore::with_cache_ttl(&url, Duration::from_secs(60));


### PR DESCRIPTION
Resolves the integration test failure on Ubuntu Docker where `diesel::sql_query(MIGRATION_SQL)` panics with a `DatabaseError(Unknown, "cannot insert multiple commands into a prepared statement")`.

Under the hood, Diesel's synchronous `sql_query().execute()` method compiles the raw SQL string into a single prepared statement using `libpq`'s `PQprepare`. PostgreSQL strictly forbids multiple statements (commands separated by semicolons) within a single prepared statement.

This PR replaces those calls with `SimpleConnection::batch_execute(MIGRATION_SQL)`, which successfully executes multi-statement SQL strings as transactional raw statement batches.
