### PR TITLE
🔐 Eris: Path traversal in CSRF/Rate-limiting middleware (Bypass)

### DIFF
--- a/autumn/src/paths.rs
+++ b/autumn/src/paths.rs
@@ -77,12 +77,12 @@ pub(crate) fn normalize_path(path: &str) -> String {
         res = if decoded.starts_with('/') {
             "/".to_string()
         } else {
-            "".to_string()
+            String::new()
         };
     }
 
     if has_trailing && !res.ends_with('/') {
-        format!("{}/", res)
+        format!("{res}/")
     } else {
         res
     }

--- a/autumn/src/paths.rs
+++ b/autumn/src/paths.rs
@@ -50,6 +50,44 @@ pub fn encode_path_segment(value: impl std::fmt::Display) -> String {
     percent_encode(&value.to_string())
 }
 
+/// Normalize a raw HTTP request path by percent-decoding it and resolving `.` and `..` segments.
+///
+/// Ensures security checks (like CSRF and rate limits) operate on the logical path
+/// intended by the client, preventing traversal bypasses (e.g., `/api/../protected`).
+pub(crate) fn normalize_path(path: &str) -> String {
+    let decoded = percent_encoding::percent_decode_str(path).decode_utf8_lossy();
+    let has_trailing = decoded.ends_with('/') && decoded.len() > 1;
+
+    let mut segments = Vec::new();
+    for segment in decoded.split('/') {
+        if segment == ".." {
+            segments.pop();
+        } else if segment != "." && !segment.is_empty() {
+            segments.push(segment);
+        }
+    }
+
+    let mut res = if decoded.starts_with('/') {
+        format!("/{}", segments.join("/"))
+    } else {
+        segments.join("/")
+    };
+
+    if res.is_empty() {
+        res = if decoded.starts_with('/') {
+            "/".to_string()
+        } else {
+            "".to_string()
+        };
+    }
+
+    if has_trailing && !res.ends_with('/') {
+        format!("{}/", res)
+    } else {
+        res
+    }
+}
+
 /// Percent-encode a query component per RFC 3986.
 ///
 /// Unreserved characters (ALPHA / DIGIT / `-` / `_` / `.` / `~`) are left

--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -342,12 +342,12 @@ where
     }
 
     fn call(&mut self, mut req: Request<axum::body::Body>) -> Self::Future {
-        let path = req.uri().path();
+        let normalized_path = crate::paths::normalize_path(req.uri().path());
         let is_exempt = self
             .settings
             .exempt_paths
             .iter()
-            .any(|prefix| path.starts_with(prefix.as_str()));
+            .any(|prefix| normalized_path.starts_with(prefix.as_str()));
         let is_safe = is_exempt || self.settings.safe_methods.contains(req.method());
         let raw_cookie_token = extract_cookie_token(req.headers(), &self.settings.cookie_name);
 

--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -588,9 +588,9 @@ impl Limiter {
     /// is non-empty when a path override matched (used to isolate buckets from the
     /// global default pool).
     fn effective_params_with_ns<B>(&self, req: &Request<B>) -> (Option<f64>, Option<f64>, &str) {
-        let path = req.uri().path();
+        let normalized_path = crate::paths::normalize_path(req.uri().path());
         for (prefix, override_) in &self.path_overrides {
-            if path.starts_with(prefix.as_str()) {
+            if normalized_path.starts_with(prefix.as_str()) {
                 let burst = override_.burst.map(|b| f64::from(b.max(1)));
                 let rps = override_
                     .requests_per_second

--- a/autumn/tests/security/csrf_bypass.rs
+++ b/autumn/tests/security/csrf_bypass.rs
@@ -1,0 +1,57 @@
+use autumn_web::security::{CsrfConfig, CsrfLayer};
+use axum::{body::Body, http::Request, routing::post, Router};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn csrf_bypass_via_path_normalization() {
+    let mut config = CsrfConfig::default();
+    config.enabled = true;
+    config.exempt_paths = vec!["/api/".to_string()];
+
+    // A catch-all route that processes the logical path after CSRF middleware.
+    // If an attacker sends `/api/../protected`, the raw path starts with `/api/`,
+    // but the logical path is `/protected`.
+    let app = Router::new()
+        .route(
+            "/{*path}",
+            post(
+                |axum::extract::Path(path): axum::extract::Path<String>| async move {
+                    if path == "protected" {
+                        "hacked".to_string()
+                    } else {
+                        "ok".to_string()
+                    }
+                },
+            ),
+        )
+        .layer(CsrfLayer::from_config(&config));
+
+    // Request with path traversal should be denied by CSRF middleware
+    // because the normalized path `/protected` is not exempt.
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/../protected")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(
+        res.status(),
+        axum::http::StatusCode::FORBIDDEN,
+        "CSRF middleware should reject requests where the normalized path is not exempt"
+    );
+
+    // Another bypass attempt using percent-encoding
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/%2e%2e/protected")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(
+        res.status(),
+        axum::http::StatusCode::FORBIDDEN,
+        "CSRF middleware should reject requests where the percent-decoded normalized path is not exempt"
+    );
+}

--- a/autumn/tests/security/csrf_path_traversal.rs
+++ b/autumn/tests/security/csrf_path_traversal.rs
@@ -30,7 +30,7 @@ async fn eris_csrf_path_traversal_bypass() {
     let response = app.clone().oneshot(malicious_req).await.unwrap();
 
     // Axum routes strictly based on exact URI match and does not resolve '..'.
-    // Therefore, the request to /api/../submit safely falls through to a 404
+    // Therefore, the request to /api/../submit safely returns 403
     // instead of executing the /submit handler, averting the CSRF bypass entirely.
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }

--- a/autumn/tests/security/rate_limit_bypass.rs
+++ b/autumn/tests/security/rate_limit_bypass.rs
@@ -1,0 +1,67 @@
+use autumn_web::security::{RateLimitConfig, RateLimitLayer};
+use axum::{body::Body, http::Request, routing::get, Router};
+use std::collections::BTreeMap;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn rate_limit_bypass_via_path_normalization() {
+    let mut path_overrides = BTreeMap::new();
+    // Exemption / generous rate limit for /static/
+    path_overrides.insert(
+        "/static/".to_string(),
+        autumn_web::security::RateLimitOverride {
+            requests_per_second: Some(100.0),
+            burst: Some(100),
+        },
+    );
+
+    let config = RateLimitConfig {
+        enabled: true,
+        requests_per_second: 0.1, // Strict default
+        burst: 1,
+        trust_forwarded_headers: false,
+        path_overrides,
+    };
+
+    let app = Router::new()
+        .route(
+            "/{*path}",
+            get(
+                |axum::extract::Path(path): axum::extract::Path<String>| async move {
+                    format!("path: {}", path)
+                },
+            ),
+        )
+        .layer(RateLimitLayer::from_config(&config));
+
+    // First request should pass the strict rate limit
+    let req = Request::builder()
+        .uri("/protected")
+        .body(Body::empty())
+        .unwrap();
+    let res = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(res.status(), axum::http::StatusCode::OK);
+
+    // Second request to /protected should fail because of burst=1
+    let req2 = Request::builder()
+        .uri("/protected")
+        .body(Body::empty())
+        .unwrap();
+    let res2 = app.clone().oneshot(req2).await.unwrap();
+    assert_eq!(res2.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+
+    // Bypassing by using /static/../protected should ALSO fail because the
+    // logical path is /protected, which hits the strict rate limit bucket
+    // (Wait, actually if it hit the /protected bucket, it would be rate limited.
+    // If it incorrectly bypassed, it would hit the /static/ bucket and succeed.)
+    let req_bypass = Request::builder()
+        .uri("/static/../protected")
+        .body(Body::empty())
+        .unwrap();
+    let res_bypass = app.clone().oneshot(req_bypass).await.unwrap();
+    assert_eq!(
+        res_bypass.status(),
+        axum::http::StatusCode::TOO_MANY_REQUESTS,
+        "RateLimit middleware should use the normalized path for path overrides"
+    );
+}


### PR DESCRIPTION
Reconnaissance:
During an offensive security audit of the HTTP routing layer, it was discovered that Autumn's `CsrfLayer` and `RateLimitLayer` match paths against configured exemptions/overrides using a simple `req.uri().path().starts_with(prefix)` check. Because the Axum framework does not implicitly normalize `.` and `..` traversal segments or percent-encoded characters in `req.uri().path()`, the raw path from the HTTP request is evaluated against the prefix.

Hypothesis:
An attacker can submit a request with a crafted path, such as `/api/../protected`, or its percent-encoded equivalent `/api/%2e%2e/protected`. If `/api/` is a configured CSRF-exempt path, the `CsrfLayer` will incorrectly mark the request as exempt because the raw string starts with `/api/`. When the request proceeds to the router, a catch-all route (like `/{*path}`) or a frontend proxy configuration might resolve the path to the protected resource, effectively bypassing the CSRF protection. The exact same technique allows an attacker to bypass strict rate limits configured on the target endpoint.

Exploit development:
Two proof-of-concept exploits were written:
1. `autumn/tests/security/csrf_bypass.rs`: Demonstrates bypassing CSRF protection on a protected endpoint using the `/api/../protected` and `/api/%2e%2e/protected` vectors.
2. `autumn/tests/security/rate_limit_bypass.rs`: Demonstrates bypassing a strict `0.1 RPS` rate limit on `/protected` by requesting `/static/../protected` and incorrectly hitting the generous `/static/` bucket.

Verification:
Both tests confirmed the bypass vulnerabilities by successfully completing requests that should have been rejected (403 Forbidden or 429 Too Many Requests). After applying the patch, both tests pass because the security layers now appropriately evaluate the logical, normalized paths, returning the expected error codes.

Severity assessment:
CVSS 3.1 Base Score: 7.4 (High)
The vulnerability relies on the existence of a permissive exemption prefix (which is common) and an endpoint that can be reached via path traversal (e.g., via a catch-all route or a normalizing upstream proxy). Given those conditions, it leads to a complete bypass of CSRF controls for sensitive state-changing operations and a bypass of rate limiting for anti-abuse.

Remediation recommendation:
Introduce a strict, robust `normalize_path` utility that percent-decodes the path and fully resolves `.` and `..` segments. Apply this normalization before any security middleware evaluates the path against prefix exemptions or overrides. This ensures the security policies are evaluated against the *logical* path the client intends to access.

---
*PR created automatically by Jules for task [7390166407799005016](https://jules.google.com/task/7390166407799005016) started by @madmax983*