### PR TITLE
⚒️ Forge: Extract dev inspector mounting logic

### DIFF
--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -346,30 +346,7 @@ fn build_router_pre_state(
             .layer(axum::middleware::from_fn(dev::inject_live_reload));
     }
 
-    // Dev request inspector: mount UI and apply recording middleware.
-    // Only active when profile = "dev"; returns 404 for all other profiles.
-    let is_dev_profile = matches!(config.profile.as_deref(), Some("dev" | "development"));
-    if is_dev_profile {
-        let buf = crate::inspector::InspectorBuffer::new(config.dev.inspector_capacity);
-        let inspector_path = config.dev.inspector_path.clone();
-        let threshold = config.dev.inspector_n_plus_one_threshold;
-
-        // Mount the inspector UI routes.
-        router = router.merge(crate::inspector::inspector_router(
-            buf.clone(),
-            &inspector_path,
-        ));
-        tracing::debug!(
-            path = %inspector_path,
-            "Mounted dev request inspector"
-        );
-
-        // Apply the recording middleware (outermost layer so it captures
-        // all routes). Self-excludes inspector's own path prefix.
-        let layer = crate::inspector::InspectorLayer::new(buf, threshold, inspector_path)
-            .with_session_cookie_name(config.session.cookie_name.clone());
-        router = router.layer(layer);
-    }
+    router = mount_dev_inspector(router, config);
 
     #[cfg(feature = "oauth2")]
     let router = router.layer(axum::middleware::from_fn_with_state(
@@ -3892,4 +3869,34 @@ impl TrustedHostPolicy {
             )
         })
     }
+}
+
+fn mount_dev_inspector(
+    mut router: axum::Router<AppState>,
+    config: &AutumnConfig,
+) -> axum::Router<AppState> {
+    let is_dev_profile = matches!(config.profile.as_deref(), Some("dev" | "development"));
+    if !is_dev_profile {
+        return router;
+    }
+
+    let buf = crate::inspector::InspectorBuffer::new(config.dev.inspector_capacity);
+    let inspector_path = config.dev.inspector_path.clone();
+    let threshold = config.dev.inspector_n_plus_one_threshold;
+
+    // Mount the inspector UI routes.
+    router = router.merge(crate::inspector::inspector_router(
+        buf.clone(),
+        &inspector_path,
+    ));
+    tracing::debug!(
+        path = %inspector_path,
+        "Mounted dev request inspector"
+    );
+
+    // Apply the recording middleware (outermost layer so it captures
+    // all routes). Self-excludes inspector's own path prefix.
+    let layer = crate::inspector::InspectorLayer::new(buf, threshold, inspector_path)
+        .with_session_cookie_name(config.session.cookie_name.clone());
+    router.layer(layer)
 }


### PR DESCRIPTION
🚮 Smell: The `build_router_pre_state` function was getting long, containing a large block of logic specifically for mounting the dev request inspector.
✨ Solution: Extracted the dev request inspector setup into a dedicated helper function `mount_dev_inspector`.
🧼 Benefit: Reduces the size and cognitive load of `build_router_pre_state`, making the main routing pipeline easier to read.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [11419348996879876107](https://jules.google.com/task/11419348996879876107) started by @madmax983*