### PR TITLE
feat: add transactional test isolation for database tests

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -869,7 +869,8 @@ impl Db {
             .await
             .ok()
             .flatten()
-            .as_deref() == Some("true");
+            .as_deref()
+                == Some("true");
 
             if !is_test_tx {
                 let _ = spawn_committed_after_commit_callbacks(callbacks);

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -758,6 +758,7 @@ pub struct Db {
     metrics: Option<crate::middleware::MetricsCollector>,
     slow_query_threshold: std::time::Duration,
     start_time: std::time::Instant,
+    is_test_tx: bool,
 }
 
 impl Db {
@@ -815,7 +816,6 @@ impl Db {
             + 'a,
     {
         use diesel_async::AsyncConnection as _;
-        use diesel_async::RunQueryDsl as _;
 
         if self.tx_poisoned {
             return Err(crate::error::AutumnError::service_unavailable_msg(
@@ -860,19 +860,7 @@ impl Db {
                 std::mem::take(&mut *reg)
             };
 
-            let is_test_tx = diesel::select(diesel::dsl::sql::<
-                diesel::sql_types::Nullable<diesel::sql_types::Text>,
-            >(
-                "current_setting('autumn.test_transaction_started', true)",
-            ))
-            .get_result::<Option<String>>(&mut *self.conn)
-            .await
-            .ok()
-            .flatten()
-            .as_deref()
-                == Some("true");
-
-            if !is_test_tx {
+            if !callbacks.is_empty() && !self.is_test_tx {
                 let _ = spawn_committed_after_commit_callbacks(callbacks);
             }
         }
@@ -979,6 +967,7 @@ where
         let metrics = state.metrics();
         let slow_query_threshold = state.slow_query_threshold();
         let start_time = std::time::Instant::now();
+        let is_test_tx = interceptors.iter().any(|i| i.is_transactional_test());
 
         Ok(Self {
             conn,
@@ -989,6 +978,7 @@ where
             metrics: metrics.cloned(),
             slow_query_threshold,
             start_time,
+            is_test_tx,
         })
     }
 }

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -815,6 +815,7 @@ impl Db {
             + 'a,
     {
         use diesel_async::AsyncConnection as _;
+        use diesel_async::RunQueryDsl as _;
 
         if self.tx_poisoned {
             return Err(crate::error::AutumnError::service_unavailable_msg(
@@ -859,7 +860,6 @@ impl Db {
                 std::mem::take(&mut *reg)
             };
 
-            use diesel_async::RunQueryDsl;
             let is_test_tx = diesel::select(diesel::dsl::sql::<
                 diesel::sql_types::Nullable<diesel::sql_types::Text>,
             >(

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -851,12 +851,29 @@ impl Db {
         // connection, but await them sequentially inside that task so callback
         // dependencies observe registration order.
         // Errors are counted and logged; they do NOT affect the committed tx.
+        // In transactional tests (outer transaction is rolled back), we suppress
+        // spawning these callbacks to prevent observing uncommitted side effects.
         if result.is_ok() {
             let callbacks: Vec<CommitCallback> = {
                 let mut reg = registry.lock().expect("registry lock");
                 std::mem::take(&mut *reg)
             };
-            let _ = spawn_committed_after_commit_callbacks(callbacks);
+
+            use diesel_async::RunQueryDsl;
+            let is_test_tx = diesel::select(diesel::dsl::sql::<
+                diesel::sql_types::Nullable<diesel::sql_types::Text>,
+            >(
+                "current_setting('autumn.test_transaction_started', true)",
+            ))
+            .get_result::<Option<String>>(&mut *self.conn)
+            .await
+            .ok()
+            .flatten()
+            .as_deref() == Some("true");
+
+            if !is_test_tx {
+                let _ = spawn_committed_after_commit_callbacks(callbacks);
+            }
         }
 
         result

--- a/autumn/src/interceptor.rs
+++ b/autumn/src/interceptor.rs
@@ -60,6 +60,11 @@ pub trait DbConnectionInterceptor: Send + Sync + 'static {
                 + 'a,
         >,
     >;
+
+    /// Returns whether this interceptor enables transactional test isolation mode.
+    fn is_transactional_test(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(feature = "ws")]

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -171,6 +171,10 @@ pub struct TestApp {
     pool: Option<Pool<AsyncPgConnection>>,
     #[cfg(feature = "db")]
     replica_pool: Option<Pool<AsyncPgConnection>>,
+    #[cfg(feature = "db")]
+    transactional: bool,
+    #[cfg(feature = "db")]
+    transactional_url: Option<String>,
     /// Deferred policy / scope registrations applied during
     /// [`TestApp::build`].
     policy_registrations: Vec<TestPolicyRegistration>,
@@ -228,6 +232,10 @@ impl TestApp {
             pool: None,
             #[cfg(feature = "db")]
             replica_pool: None,
+            #[cfg(feature = "db")]
+            transactional: false,
+            #[cfg(feature = "db")]
+            transactional_url: None,
             policy_registrations: Vec::new(),
             forbidden_response_override: None,
             #[cfg(feature = "mail")]
@@ -634,6 +642,24 @@ impl TestApp {
         self
     }
 
+    /// Enable transactional test isolation using the database URL configured
+    /// in the application's configuration.
+    #[cfg(feature = "db")]
+    #[must_use]
+    pub const fn transactional(mut self) -> Self {
+        self.transactional = true;
+        self
+    }
+
+    /// Enable transactional test isolation with an explicit database URL.
+    #[cfg(feature = "db")]
+    #[must_use]
+    pub fn with_transactional_db(mut self, url: impl Into<String>) -> Self {
+        self.transactional = true;
+        self.transactional_url = Some(url.into());
+        self
+    }
+
     /// Register a canned HTTP response for outbound requests made via the
     /// [`Client`](crate::http_client::Client) extractor during this test.
     ///
@@ -695,6 +721,35 @@ impl TestApp {
         // Reset the global cache to prevent cross-test contamination.
         crate::cache::clear_global_cache();
 
+        #[cfg(feature = "db")]
+        let (pool, replica_pool, db_interceptor) = if self.transactional {
+            let url = self.transactional_url.as_deref()
+                .or_else(|| self.config.database.effective_primary_url())
+                .expect("Transactional isolation enabled but database URL is not configured. Use `with_transactional_db(url)` or configure database.primary_url/database.url");
+
+            let manager = diesel_async::pooled_connection::AsyncDieselConnectionManager::<
+                diesel_async::AsyncPgConnection,
+            >::new(url);
+            let pool = Pool::builder(manager)
+                .max_size(1)
+                .build()
+                .expect("failed to build transactional pool of size 1");
+
+            let interceptor = std::sync::Arc::new(TransactionalDbInterceptor {
+                started: std::sync::atomic::AtomicBool::new(false),
+            });
+
+            (
+                Some(pool),
+                None,
+                Some(
+                    interceptor as std::sync::Arc<dyn crate::interceptor::DbConnectionInterceptor>,
+                ),
+            )
+        } else {
+            (self.pool, self.replica_pool, self.db_interceptor)
+        };
+
         let probes = crate::probe::ProbeState::ready_for_test();
         #[cfg(feature = "ws")]
         let test_channels = crate::channels::Channels::new(32);
@@ -704,9 +759,9 @@ impl TestApp {
                 std::collections::HashMap::new(),
             )),
             #[cfg(feature = "db")]
-            pool: self.pool,
+            pool,
             #[cfg(feature = "db")]
-            replica_pool: self.replica_pool,
+            replica_pool,
             profile: self.config.profile.clone(),
             started_at: std::time::Instant::now(),
             health_detailed: self.config.health.detailed,
@@ -752,7 +807,7 @@ impl TestApp {
             state.insert_extension(interceptor);
         }
         #[cfg(feature = "db")]
-        if let Some(interceptor) = self.db_interceptor {
+        if let Some(interceptor) = db_interceptor {
             state.insert_extension(interceptor);
         }
         #[cfg(feature = "ws")]
@@ -1285,6 +1340,49 @@ impl TestResponse {
             String::from_utf8_lossy(&self.body)
         );
         self
+    }
+}
+
+#[cfg(feature = "db")]
+struct TransactionalDbInterceptor {
+    started: std::sync::atomic::AtomicBool,
+}
+
+#[cfg(feature = "db")]
+impl crate::interceptor::DbConnectionInterceptor for TransactionalDbInterceptor {
+    fn intercept_checkout<'a>(
+        &'a self,
+        _ctx: crate::interceptor::DbCheckoutContext,
+        next: std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = Result<crate::db::PooledConnection, crate::AutumnError>,
+                    > + Send
+                    + 'a,
+            >,
+        >,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<crate::db::PooledConnection, crate::AutumnError>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            let mut conn = next.await?;
+            if !self.started.load(std::sync::atomic::Ordering::SeqCst) {
+                use diesel_async::AsyncConnection;
+                conn.begin_test_transaction().await.map_err(|e| {
+                    crate::AutumnError::internal_server_error_msg(format!(
+                        "failed to start test transaction: {e}"
+                    ))
+                })?;
+                self.started
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+            Ok(conn)
+        })
     }
 }
 

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -130,6 +130,8 @@ use crate::state::AppState;
 #[cfg(feature = "db")]
 use diesel_async::AsyncPgConnection;
 #[cfg(feature = "db")]
+use diesel_async::RunQueryDsl;
+#[cfg(feature = "db")]
 use diesel_async::pooled_connection::deadpool::Pool;
 
 // ── TestApp ────────────────────────────────────────────────────
@@ -735,17 +737,45 @@ impl TestApp {
                 .build()
                 .expect("failed to build transactional pool of size 1");
 
-            let interceptor = std::sync::Arc::new(TransactionalDbInterceptor {
-                started: std::sync::atomic::AtomicBool::new(false),
+            let trans_interceptor = std::sync::Arc::new(TransactionalDbInterceptor);
+            let interceptor = if let Some(user_interceptor) = self.db_interceptor {
+                std::sync::Arc::new(ComposedDbInterceptor {
+                    first: user_interceptor,
+                    second: trans_interceptor,
+                })
+                    as std::sync::Arc<dyn crate::interceptor::DbConnectionInterceptor>
+            } else {
+                trans_interceptor as std::sync::Arc<dyn crate::interceptor::DbConnectionInterceptor>
+            };
+
+            // Eagerly acquire connection in the background to start test transaction before any request/seed runs
+            let pool_cloned = pool.clone();
+            tokio::spawn(async move {
+                if let Ok(mut conn) = pool_cloned.get().await {
+                    let is_started: Option<String> = diesel::select(diesel::dsl::sql::<
+                        diesel::sql_types::Nullable<diesel::sql_types::Text>,
+                    >(
+                        "current_setting('autumn.test_transaction_started', true)",
+                    ))
+                    .get_result(&mut *conn)
+                    .await
+                    .ok()
+                    .flatten();
+
+                    if is_started.as_deref() != Some("true") {
+                        use diesel_async::AsyncConnection;
+                        use diesel_async::RunQueryDsl;
+                        if conn.begin_test_transaction().await.is_ok() {
+                            let _ =
+                                diesel::sql_query("SET autumn.test_transaction_started = 'true'")
+                                    .execute(&mut *conn)
+                                    .await;
+                        }
+                    }
+                }
             });
 
-            (
-                Some(pool),
-                None,
-                Some(
-                    interceptor as std::sync::Arc<dyn crate::interceptor::DbConnectionInterceptor>,
-                ),
-            )
+            (Some(pool), None, Some(interceptor))
         } else {
             (self.pool, self.replica_pool, self.db_interceptor)
         };
@@ -1344,9 +1374,7 @@ impl TestResponse {
 }
 
 #[cfg(feature = "db")]
-struct TransactionalDbInterceptor {
-    started: std::sync::atomic::AtomicBool,
-}
+struct TransactionalDbInterceptor;
 
 #[cfg(feature = "db")]
 impl crate::interceptor::DbConnectionInterceptor for TransactionalDbInterceptor {
@@ -1371,18 +1399,71 @@ impl crate::interceptor::DbConnectionInterceptor for TransactionalDbInterceptor 
     > {
         Box::pin(async move {
             let mut conn = next.await?;
-            if !self.started.load(std::sync::atomic::Ordering::SeqCst) {
+
+            // Check if transaction has already been started on this connection
+            let is_started: Option<String> = diesel::select(diesel::dsl::sql::<
+                diesel::sql_types::Nullable<diesel::sql_types::Text>,
+            >(
+                "current_setting('autumn.test_transaction_started', true)",
+            ))
+            .get_result(&mut *conn)
+            .await
+            .ok()
+            .flatten();
+
+            if is_started.as_deref() != Some("true") {
                 use diesel_async::AsyncConnection;
+                use diesel_async::RunQueryDsl;
+
                 conn.begin_test_transaction().await.map_err(|e| {
                     crate::AutumnError::internal_server_error_msg(format!(
                         "failed to start test transaction: {e}"
                     ))
                 })?;
-                self.started
-                    .store(true, std::sync::atomic::Ordering::SeqCst);
+
+                diesel::sql_query("SET autumn.test_transaction_started = 'true'")
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(|e| {
+                        crate::AutumnError::internal_server_error_msg(format!(
+                            "failed to set transaction session GUC: {e}"
+                        ))
+                    })?;
             }
             Ok(conn)
         })
+    }
+}
+
+#[cfg(feature = "db")]
+struct ComposedDbInterceptor {
+    first: std::sync::Arc<dyn crate::interceptor::DbConnectionInterceptor>,
+    second: std::sync::Arc<dyn crate::interceptor::DbConnectionInterceptor>,
+}
+
+#[cfg(feature = "db")]
+impl crate::interceptor::DbConnectionInterceptor for ComposedDbInterceptor {
+    fn intercept_checkout<'a>(
+        &'a self,
+        ctx: crate::interceptor::DbCheckoutContext,
+        next: std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = Result<crate::db::PooledConnection, crate::AutumnError>,
+                    > + Send
+                    + 'a,
+            >,
+        >,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<crate::db::PooledConnection, crate::AutumnError>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        let next_wrapped = self.second.intercept_checkout(ctx.clone(), next);
+        self.first.intercept_checkout(ctx, next_wrapped)
     }
 }
 

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -1405,34 +1405,41 @@ impl crate::interceptor::DbConnectionInterceptor for TransactionalDbInterceptor 
             let mut conn = next.await?;
 
             // Check if transaction has already been started on this connection
-            let is_started: Option<String> = diesel::select(diesel::dsl::sql::<
+            let guc_result = diesel::select(diesel::dsl::sql::<
                 diesel::sql_types::Nullable<diesel::sql_types::Text>,
             >(
                 "current_setting('autumn.test_transaction_started', true)",
             ))
-            .get_result(&mut *conn)
-            .await
-            .ok()
-            .flatten();
+            .get_result::<Option<String>>(&mut *conn)
+            .await;
 
-            if is_started.as_deref() != Some("true") {
-                use diesel_async::AsyncConnection;
-                use diesel_async::RunQueryDsl;
+            match guc_result {
+                Ok(Some(ref s)) if s == "true" => {
+                    // Already started and healthy
+                }
+                Ok(_) => {
+                    use diesel_async::AsyncConnection;
+                    use diesel_async::RunQueryDsl;
 
-                conn.begin_test_transaction().await.map_err(|e| {
-                    crate::AutumnError::internal_server_error_msg(format!(
-                        "failed to start test transaction: {e}"
-                    ))
-                })?;
-
-                diesel::sql_query("SET autumn.test_transaction_started = 'true'")
-                    .execute(&mut *conn)
-                    .await
-                    .map_err(|e| {
+                    conn.begin_test_transaction().await.map_err(|e| {
                         crate::AutumnError::internal_server_error_msg(format!(
-                            "failed to set transaction session GUC: {e}"
+                            "failed to start test transaction: {e}"
                         ))
                     })?;
+
+                    diesel::sql_query("SET autumn.test_transaction_started = 'true'")
+                        .execute(&mut *conn)
+                        .await
+                        .map_err(|e| {
+                            crate::AutumnError::internal_server_error_msg(format!(
+                                "failed to set transaction session GUC: {e}"
+                            ))
+                        })?;
+                }
+                Err(_) => {
+                    // The GUC query failed. This happens when the connection is in a failed/aborted transaction block.
+                    // Since the transaction is already active (but aborted), do not retry begin_test_transaction!
+                }
             }
             Ok(conn)
         })

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -1444,6 +1444,10 @@ impl crate::interceptor::DbConnectionInterceptor for TransactionalDbInterceptor 
             Ok(conn)
         })
     }
+
+    fn is_transactional_test(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(feature = "db")]
@@ -1475,6 +1479,10 @@ impl crate::interceptor::DbConnectionInterceptor for ComposedDbInterceptor {
     > {
         let next_wrapped = self.second.intercept_checkout(ctx.clone(), next);
         self.first.intercept_checkout(ctx, next_wrapped)
+    }
+
+    fn is_transactional_test(&self) -> bool {
+        self.first.is_transactional_test() || self.second.is_transactional_test()
     }
 }
 

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -740,25 +740,31 @@ impl TestApp {
                 .wait_timeout(Some(timeout))
                 .create_timeout(Some(timeout))
                 .runtime(deadpool::Runtime::Tokio1)
-                .post_create(deadpool::managed::Hook::async_fn(|conn: &mut diesel_async::AsyncPgConnection, _metrics| {
-                    Box::pin(async move {
-                        use diesel_async::AsyncConnection;
-                        use diesel_async::RunQueryDsl;
+                .post_create(deadpool::managed::Hook::async_fn(
+                    |conn: &mut diesel_async::AsyncPgConnection, _metrics| {
+                        Box::pin(async move {
+                            use diesel_async::AsyncConnection;
+                            use diesel_async::RunQueryDsl;
 
-                        conn.begin_test_transaction().await.map_err(|e| {
-                            deadpool::managed::HookError::Backend(diesel_async::pooled_connection::PoolError::QueryError(e))
-                        })?;
-
-                        diesel::sql_query("SET autumn.test_transaction_started = 'true'")
-                            .execute(conn)
-                            .await
-                            .map_err(|e| {
-                                deadpool::managed::HookError::Backend(diesel_async::pooled_connection::PoolError::QueryError(e))
+                            conn.begin_test_transaction().await.map_err(|e| {
+                                deadpool::managed::HookError::Backend(
+                                    diesel_async::pooled_connection::PoolError::QueryError(e),
+                                )
                             })?;
 
-                        Ok(())
-                    })
-                }))
+                            diesel::sql_query("SET autumn.test_transaction_started = 'true'")
+                                .execute(conn)
+                                .await
+                                .map_err(|e| {
+                                    deadpool::managed::HookError::Backend(
+                                        diesel_async::pooled_connection::PoolError::QueryError(e),
+                                    )
+                                })?;
+
+                            Ok(())
+                        })
+                    },
+                ))
                 .build()
                 .expect("failed to build transactional pool of size 1");
 

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -729,11 +729,36 @@ impl TestApp {
                 .or_else(|| self.config.database.effective_primary_url())
                 .expect("Transactional isolation enabled but database URL is not configured. Use `with_transactional_db(url)` or configure database.primary_url/database.url");
 
+            let connect_timeout_secs = self.config.database.connect_timeout_secs;
+            let timeout = std::time::Duration::from_secs(connect_timeout_secs);
+
             let manager = diesel_async::pooled_connection::AsyncDieselConnectionManager::<
                 diesel_async::AsyncPgConnection,
             >::new(url);
             let pool = Pool::builder(manager)
                 .max_size(1)
+                .wait_timeout(Some(timeout))
+                .create_timeout(Some(timeout))
+                .runtime(deadpool::Runtime::Tokio1)
+                .post_create(deadpool::managed::Hook::async_fn(|conn: &mut diesel_async::AsyncPgConnection, _metrics| {
+                    Box::pin(async move {
+                        use diesel_async::AsyncConnection;
+                        use diesel_async::RunQueryDsl;
+
+                        conn.begin_test_transaction().await.map_err(|e| {
+                            deadpool::managed::HookError::Backend(diesel_async::pooled_connection::PoolError::QueryError(e))
+                        })?;
+
+                        diesel::sql_query("SET autumn.test_transaction_started = 'true'")
+                            .execute(conn)
+                            .await
+                            .map_err(|e| {
+                                deadpool::managed::HookError::Backend(diesel_async::pooled_connection::PoolError::QueryError(e))
+                            })?;
+
+                        Ok(())
+                    })
+                }))
                 .build()
                 .expect("failed to build transactional pool of size 1");
 
@@ -747,33 +772,6 @@ impl TestApp {
             } else {
                 trans_interceptor as std::sync::Arc<dyn crate::interceptor::DbConnectionInterceptor>
             };
-
-            // Eagerly acquire connection in the background to start test transaction before any request/seed runs
-            let pool_cloned = pool.clone();
-            tokio::spawn(async move {
-                if let Ok(mut conn) = pool_cloned.get().await {
-                    let is_started: Option<String> = diesel::select(diesel::dsl::sql::<
-                        diesel::sql_types::Nullable<diesel::sql_types::Text>,
-                    >(
-                        "current_setting('autumn.test_transaction_started', true)",
-                    ))
-                    .get_result(&mut *conn)
-                    .await
-                    .ok()
-                    .flatten();
-
-                    if is_started.as_deref() != Some("true") {
-                        use diesel_async::AsyncConnection;
-                        use diesel_async::RunQueryDsl;
-                        if conn.begin_test_transaction().await.is_ok() {
-                            let _ =
-                                diesel::sql_query("SET autumn.test_transaction_started = 'true'")
-                                    .execute(&mut *conn)
-                                    .await;
-                        }
-                    }
-                }
-            });
 
             (Some(pool), None, Some(interceptor))
         } else {

--- a/autumn/tests/transactional_test_integration.rs
+++ b/autumn/tests/transactional_test_integration.rs
@@ -57,6 +57,36 @@ mod transactional_tests {
         Ok((axum::http::StatusCode::CREATED, Json(item)))
     }
 
+    static AFTER_COMMIT_RUN_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+    #[post("/items-with-callback")]
+    async fn create_item_with_callback(
+        mut db: Db,
+        Json(new_item): Json<NewItem>,
+    ) -> AutumnResult<(axum::http::StatusCode, Json<Item>)> {
+        use scoped_futures::ScopedFutureExt;
+        db.tx(|conn| {
+            async move {
+                let item = diesel::insert_into(transactional_items::table)
+                    .values(&new_item)
+                    .returning(Item::as_returning())
+                    .get_result(conn)
+                    .await?;
+                
+                autumn_web::db::register_after_commit(|| async move {
+                    AFTER_COMMIT_RUN_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(())
+                })
+                .await;
+                
+                Ok::<_, diesel::result::Error>(item)
+            }
+            .scope_boxed()
+        })
+        .await
+        .map(|item| (axum::http::StatusCode::CREATED, Json(item)))
+    }
+
     // ── Setup ──────────────────────────────────────────────────
 
     static SETUP_CELL: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
@@ -137,5 +167,35 @@ mod transactional_tests {
                 .assert_ok()
                 .assert_body_eq("[]");
         }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn test_after_commit_suppression() {
+        let db = TestDb::shared().await;
+        setup_table(db).await;
+
+        // Reset the counter
+        AFTER_COMMIT_RUN_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
+
+        let client = TestApp::new()
+            .routes(routes![create_item_with_callback])
+            .with_transactional_db(db.url())
+            .build();
+
+        // Trigger the handler which registers an after-commit callback
+        client
+            .post("/items-with-callback")
+            .json(&serde_json::json!({"name": "Item with Callback"}))
+            .send()
+            .await
+            .assert_status(201);
+
+        // Verify that the callback was NOT run (suppressed due to transactional test mode)
+        assert_eq!(
+            std::sync::atomic::AtomicUsize::load(&AFTER_COMMIT_RUN_COUNT, std::sync::atomic::Ordering::SeqCst),
+            0,
+            "after_commit callback should be suppressed in transactional test mode"
+        );
     }
 }

--- a/autumn/tests/transactional_test_integration.rs
+++ b/autumn/tests/transactional_test_integration.rs
@@ -192,6 +192,9 @@ mod transactional_tests {
             .await
             .assert_status(201);
 
+        // Sleep to yield control and let any background task execute if suppression failed
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
         // Verify that the callback was NOT run (suppressed due to transactional test mode)
         assert_eq!(
             std::sync::atomic::AtomicUsize::load(

--- a/autumn/tests/transactional_test_integration.rs
+++ b/autumn/tests/transactional_test_integration.rs
@@ -1,0 +1,143 @@
+//! Integration tests for transactional DB test isolation.
+//!
+//! Run with:
+//!
+//!     cargo test --test transactional_test_integration -- --include-ignored
+
+#[cfg(all(feature = "db", feature = "test-support"))]
+mod transactional_tests {
+    use autumn_web::prelude::*;
+    use autumn_web::test::{TestApp, TestDb};
+    use diesel::prelude::*;
+    use diesel_async::RunQueryDsl;
+
+    // ── Schema ─────────────────────────────────────────────────
+
+    diesel::table! {
+        transactional_items (id) {
+            id -> Int8,
+            name -> Text,
+        }
+    }
+
+    #[derive(Debug, Queryable, Selectable, serde::Serialize)]
+    #[diesel(table_name = transactional_items)]
+    struct Item {
+        pub id: i64,
+        pub name: String,
+    }
+
+    #[derive(Debug, Insertable, serde::Deserialize)]
+    #[diesel(table_name = transactional_items)]
+    struct NewItem {
+        pub name: String,
+    }
+
+    // ── Handlers ───────────────────────────────────────────────
+
+    #[get("/items")]
+    async fn list_items(mut db: Db) -> AutumnResult<Json<Vec<Item>>> {
+        let items = transactional_items::table
+            .select(Item::as_select())
+            .load(&mut *db)
+            .await?;
+        Ok(Json(items))
+    }
+
+    #[post("/items")]
+    async fn create_item(
+        mut db: Db,
+        Json(new_item): Json<NewItem>,
+    ) -> AutumnResult<(axum::http::StatusCode, Json<Item>)> {
+        let item = diesel::insert_into(transactional_items::table)
+            .values(&new_item)
+            .returning(Item::as_returning())
+            .get_result(&mut *db)
+            .await?;
+        Ok((axum::http::StatusCode::CREATED, Json(item)))
+    }
+
+    // ── Setup ──────────────────────────────────────────────────
+
+    static SETUP_CELL: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+
+    async fn setup_table(db: &TestDb) {
+        SETUP_CELL
+            .get_or_init(|| async {
+                db.execute_sql(
+                    "CREATE TABLE IF NOT EXISTS transactional_items (
+                    id BIGSERIAL PRIMARY KEY,
+                    name TEXT NOT NULL
+                )",
+                )
+                .await;
+            })
+            .await;
+    }
+
+    // ── Tests ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn test_1_insert_without_cleanup() {
+        let db = TestDb::shared().await;
+        setup_table(db).await;
+
+        let client = TestApp::new()
+            .routes(routes![list_items, create_item])
+            .with_transactional_db(db.url())
+            .build();
+
+        // 1. Initially empty
+        client
+            .get("/items")
+            .send()
+            .await
+            .assert_ok()
+            .assert_body_eq("[]");
+
+        // 2. Insert item
+        client
+            .post("/items")
+            .json(&serde_json::json!({"name": "Persisted Item"}))
+            .send()
+            .await
+            .assert_status(201);
+
+        // 3. Verify it is visible inside the same test session
+        client
+            .get("/items")
+            .send()
+            .await
+            .assert_ok()
+            .assert_json::<Vec<serde_json::Value>, _>(|items| {
+                assert_eq!(items.len(), 1);
+                assert_eq!(items[0]["name"], "Persisted Item");
+            });
+
+        // We finish the test WITHOUT running any TRUNCATE or DELETE.
+        // Under transactional isolation, this transaction should be rolled back!
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn test_2_verify_isolation() {
+        let db = TestDb::shared().await;
+        setup_table(db).await;
+
+        let client = TestApp::new()
+            .routes(routes![list_items])
+            .with_transactional_db(db.url())
+            .build();
+
+        // Verify that the table is completely empty!
+        // This proves that test_1's uncommitted transaction was rolled back
+        // and did not leak any state to this test.
+        client
+            .get("/items")
+            .send()
+            .await
+            .assert_ok()
+            .assert_body_eq("[]");
+    }
+}

--- a/autumn/tests/transactional_test_integration.rs
+++ b/autumn/tests/transactional_test_integration.rs
@@ -79,65 +79,63 @@ mod transactional_tests {
 
     #[tokio::test]
     #[ignore = "requires Docker (testcontainers)"]
-    async fn test_1_insert_without_cleanup() {
+    async fn test_transactional_isolation() {
         let db = TestDb::shared().await;
         setup_table(db).await;
 
-        let client = TestApp::new()
-            .routes(routes![list_items, create_item])
-            .with_transactional_db(db.url())
-            .build();
+        // --- Phase 1: Insert item inside a transactional client ---
+        {
+            let client = TestApp::new()
+                .routes(routes![list_items, create_item])
+                .with_transactional_db(db.url())
+                .build();
 
-        // 1. Initially empty
-        client
-            .get("/items")
-            .send()
-            .await
-            .assert_ok()
-            .assert_body_eq("[]");
+            // 1. Initially empty
+            client
+                .get("/items")
+                .send()
+                .await
+                .assert_ok()
+                .assert_body_eq("[]");
 
-        // 2. Insert item
-        client
-            .post("/items")
-            .json(&serde_json::json!({"name": "Persisted Item"}))
-            .send()
-            .await
-            .assert_status(201);
+            // 2. Insert item
+            client
+                .post("/items")
+                .json(&serde_json::json!({"name": "Persisted Item"}))
+                .send()
+                .await
+                .assert_status(201);
 
-        // 3. Verify it is visible inside the same test session
-        client
-            .get("/items")
-            .send()
-            .await
-            .assert_ok()
-            .assert_json::<Vec<serde_json::Value>, _>(|items| {
-                assert_eq!(items.len(), 1);
-                assert_eq!(items[0]["name"], "Persisted Item");
-            });
+            // 3. Verify it is visible inside the same test session
+            client
+                .get("/items")
+                .send()
+                .await
+                .assert_ok()
+                .assert_json::<Vec<serde_json::Value>, _>(|items| {
+                    assert_eq!(items.len(), 1);
+                    assert_eq!(items[0]["name"], "Persisted Item");
+                });
 
-        // We finish the test WITHOUT running any TRUNCATE or DELETE.
-        // Under transactional isolation, this transaction should be rolled back!
-    }
+            // client goes out of scope here and is dropped.
+            // Under transactional isolation, the connection pool is dropped, closing the PostgreSQL connection and rolling back the transaction.
+        }
 
-    #[tokio::test]
-    #[ignore = "requires Docker (testcontainers)"]
-    async fn test_2_verify_isolation() {
-        let db = TestDb::shared().await;
-        setup_table(db).await;
+        // --- Phase 2: Verify isolation in a fresh transactional client ---
+        {
+            let client = TestApp::new()
+                .routes(routes![list_items])
+                .with_transactional_db(db.url())
+                .build();
 
-        let client = TestApp::new()
-            .routes(routes![list_items])
-            .with_transactional_db(db.url())
-            .build();
-
-        // Verify that the table is completely empty!
-        // This proves that test_1's uncommitted transaction was rolled back
-        // and did not leak any state to this test.
-        client
-            .get("/items")
-            .send()
-            .await
-            .assert_ok()
-            .assert_body_eq("[]");
+            // Verify that the table is completely empty!
+            // This proves that the first test client's uncommitted transaction was rolled back and did not leak any state.
+            client
+                .get("/items")
+                .send()
+                .await
+                .assert_ok()
+                .assert_body_eq("[]");
+        }
     }
 }

--- a/autumn/tests/transactional_test_integration.rs
+++ b/autumn/tests/transactional_test_integration.rs
@@ -57,7 +57,8 @@ mod transactional_tests {
         Ok((axum::http::StatusCode::CREATED, Json(item)))
     }
 
-    static AFTER_COMMIT_RUN_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    static AFTER_COMMIT_RUN_COUNT: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
 
     #[post("/items-with-callback")]
     async fn create_item_with_callback(
@@ -72,13 +73,13 @@ mod transactional_tests {
                     .returning(Item::as_returning())
                     .get_result(conn)
                     .await?;
-                
+
                 autumn_web::db::register_after_commit(|| async move {
                     AFTER_COMMIT_RUN_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                     Ok(())
                 })
                 .await;
-                
+
                 Ok::<_, diesel::result::Error>(item)
             }
             .scope_boxed()
@@ -193,7 +194,10 @@ mod transactional_tests {
 
         // Verify that the callback was NOT run (suppressed due to transactional test mode)
         assert_eq!(
-            std::sync::atomic::AtomicUsize::load(&AFTER_COMMIT_RUN_COUNT, std::sync::atomic::Ordering::SeqCst),
+            std::sync::atomic::AtomicUsize::load(
+                &AFTER_COMMIT_RUN_COUNT,
+                std::sync::atomic::Ordering::SeqCst
+            ),
             0,
             "after_commit callback should be suppressed in transactional test mode"
         );

--- a/docs/plans/2026-06-01-transactional-test-isolation.md
+++ b/docs/plans/2026-06-01-transactional-test-isolation.md
@@ -1,0 +1,53 @@
+# Transactional Test Isolation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add transactional test isolation to Autumn database integration tests so that DB tests don't leak state between runs.
+
+**Architecture:** 
+Implement transactional isolation by adding a dedicated, private connection pool of `max_size(1)` for each transactional `TestApp`. We install a `TransactionalDbInterceptor` on the pool that starts a transaction (`BEGIN`) on the first checkout. When the test finishes and the `TestClient` is dropped, the pool is dropped, the connection is closed, and PostgreSQL automatically rolls back the transaction.
+
+**Tech Stack:** Rust, diesel-async, deadpool, testcontainers
+
+---
+
+## User Review Required
+
+> [!IMPORTANT]
+> Transactional test isolation requires a dedicated, private connection pool of `max_size(1)` for each test. This ensures that all database operations within the test and HTTP handlers run within the same PostgreSQL transaction and can see each other's uncommitted changes. Concurrent database operations within the same test are queued sequentially.
+
+---
+
+## Proposed Changes
+
+### Component: Autumn Web Testing utilities
+
+#### [MODIFY] [test.rs](file:///c:/Users/markm/autumn/autumn/src/test.rs)
+
+1. Add `transactional: bool` and `transactional_url: Option<String>` to `TestApp`.
+2. Add `TestApp::transactional(mut self) -> Self` to enable transactional isolation using the configured database URL.
+3. Add `TestApp::with_transactional_db(mut self, url: impl Into<String>) -> Self` to enable transactional isolation with an explicit database URL.
+4. Modify `TestApp::build` to:
+   - If transactional isolation is enabled:
+     - Resolve the database URL (either from `transactional_url` or from `self.config.database.effective_primary_url()`).
+     - Build a private pool of `max_size(1)` using that URL.
+     - Register the `TransactionalDbInterceptor` as a DB connection interceptor.
+     - Set this pool as the primary pool on `AppState`.
+5. Implement the `TransactionalDbInterceptor` in `test.rs` or `db.rs`.
+
+---
+
+## Verification Plan
+
+### Automated Tests
+- Create a new integration test file [transactional_test_integration.rs](file:///c:/Users/markm/autumn/autumn/tests/transactional_test_integration.rs).
+- Implement two tests that run against the same Postgres container:
+  - `test_1_insert_without_cleanup`: Inserts an item into `test_items` table and does not clean up.
+  - `test_2_verify_isolation`: Verifies that the `test_items` table is completely empty, proving that `test_1`'s changes were rolled back and did not leak.
+- Run the new integration tests with:
+  ```bash
+  cargo test --test transactional_test_integration -- --include-ignored
+  ```
+
+### Manual Verification
+- Verify that standard tests in [test_db_integration.rs](file:///c:/Users/markm/autumn/autumn/tests/test_db_integration.rs) continue to pass.


### PR DESCRIPTION
This PR implements transactional test isolation for database integration tests in the Autumn web framework.

### Features Added
- Add transactional() and with_transactional_db() builder methods to TestApp in src/test.rs.
- Implement TransactionalDbInterceptor to begin a test transaction (conn.begin_test_transaction()) on the first connection checkout.
- Configured private, max_size(1) connection pools for transactional tests.
- When TestClient is dropped, the pool is dropped and PostgreSQL automatically rolls back the transaction.
- Created tests/transactional_test_integration.rs to verify that state does not leak between test runs.

All quality gates, formatting, lints (cargo clippy), and the full test suite passed.