### PR TITLE
⚒️ Forge: Refactor string literal parsing loops in SQL scrubber

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -267,20 +267,19 @@ pub trait DbState {
 /// Called after the opening `'` has already been consumed. Handles
 /// `\'` backslash-escaped quotes so they do not prematurely close the string.
 fn consume_estring_body(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
-    loop {
-        match chars.next() {
-            None => break,
-            Some('\'') => {
+    while let Some(c) = chars.next() {
+        match c {
+            '\'' => {
                 if chars.peek() == Some(&'\'') {
                     chars.next(); // consume the doubled quote
                 } else {
                     break;
                 }
             }
-            Some('\\') => {
+            '\\' => {
                 chars.next(); // skip the character after the backslash
             }
-            Some(_) => {}
+            _ => {}
         }
     }
 }
@@ -349,19 +348,15 @@ pub fn scrub_sql(sql: &str) -> String {
         if c == '\'' {
             out.push_str("'?'");
             prev_is_sep = false;
-            loop {
-                match chars.next() {
-                    None => break,
-                    Some('\'') => {
-                        if chars.peek() == Some(&'\'') {
-                            // Escaped quote ('') — consume both, stay inside string
-                            chars.next();
-                        } else {
-                            // Closing quote
-                            break;
-                        }
+            while let Some(sc) = chars.next() {
+                if sc == '\'' {
+                    if chars.peek() == Some(&'\'') {
+                        // Escaped quote ('') — consume both, stay inside string
+                        chars.next();
+                    } else {
+                        // Closing quote
+                        break;
                     }
-                    Some(_) => {}
                 }
             }
             continue;


### PR DESCRIPTION
🚮 Smell: `loop { match chars.next() { ... } }` inside SQL parsing code adds unnecessary nesting and boilerplate `None => break` branches.
✨ Solution: Replaced with idiomatic `while let Some(c) = chars.next()` loops. Also changed a single-arm match inside the loop to an `if` per clippy suggestions.
🧼 Benefit: Flattens structure and improves readability without changing parsing logic.
🛡️ Verification: Ran tests and clippy.

---
*PR created automatically by Jules for task [10866038780227137509](https://jules.google.com/task/10866038780227137509) started by @madmax983*