### PR TITLE
⚡ Bolt: [Remove heap allocation in consume_dollar_quoted_body]

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -290,20 +290,35 @@ fn consume_estring_body(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
 /// Called after the opening `$tag$` delimiter has already been consumed.
 /// Uses a simple sliding-window match — sufficient for valid SQL.
 fn consume_dollar_quoted_body(chars: &mut std::iter::Peekable<std::str::Chars<'_>>, tag: &str) {
-    let closing: Vec<char> = format!("${tag}$").chars().collect();
-    let clen = closing.len();
-    let mut match_count = 0usize;
+    let expected_iter = || {
+        std::iter::once('$')
+            .chain(tag.chars())
+            .chain(std::iter::once('$'))
+    };
+    let mut current_expected = expected_iter();
+    let mut expected_char = current_expected
+        .next()
+        .expect("iterator has at least one item");
+
     for sc in chars.by_ref() {
-        if sc == closing[match_count] {
-            match_count += 1;
-            if match_count == clen {
+        if sc == expected_char {
+            if let Some(next) = current_expected.next() {
+                expected_char = next;
+            } else {
                 break; // Found the closing delimiter.
             }
         } else {
-            match_count = 0;
+            current_expected = expected_iter();
+            // The first character is always '$'
+            expected_char = current_expected
+                .next()
+                .expect("iterator has at least one item");
+
             // The current char may start a new partial match.
-            if sc == closing[0] {
-                match_count = 1;
+            if sc == expected_char {
+                expected_char = current_expected
+                    .next()
+                    .expect("iterator has at least two items");
             }
         }
     }


### PR DESCRIPTION
💡 What: Replaced the dynamic formatting and collection of `Vec<char>` for the matching sequence with a zero-allocation, lazily instantiated chain iterator in `consume_dollar_quoted_body`.

🎯 Why: `consume_dollar_quoted_body` is repeatedly called while scrubbing SQL queries for telemetry. The existing implementation incurred a `Vec` and `String` heap allocation per dollar-quoted string parsed.

📊 Impact: Eliminates one `String` allocation, one `Vec` allocation per dollar-quoted body.

🔬 Measurement: Run the unit test suite (`cargo test -p autumn-web --lib db:: --release`).

---
*PR created automatically by Jules for task [6598536443677744116](https://jules.google.com/task/6598536443677744116) started by @madmax983*