### PR TITLE
feat: first-class API versioning with deprecation & sunset lifecycles

### DIFF
--- a/autumn-admin-plugin/src/lib.rs
+++ b/autumn-admin-plugin/src/lib.rs
@@ -258,6 +258,9 @@ pub(crate) fn admin_route_infos(prefix: &str, has_config: bool) -> Vec<RouteInfo
             handler: format!("admin::{}", method.to_lowercase()),
             source: autumn_web::route_listing::RouteSource::User, // overwritten by declare_plugin_routes
             middleware: vec![],
+            api_version: None,
+            status: None,
+            sunset_opt_out: None,
         })
         .collect()
 }
@@ -460,6 +463,9 @@ mod conformance_tests {
             handler: "host::admin_redirect".to_owned(),
             source: RouteSource::User,
             middleware: vec![],
+            api_version: None,
+            status: None,
+            sunset_opt_out: None,
         });
         let (result, diagnostics) = autumn_web::plugin_conformance::check_collisions(&routes);
         assert_eq!(

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1162,7 +1162,9 @@ fn run_command(command: Commands) {
                     }
                 }
             } else {
-                eprintln!("autumn check: specify at least one check flag (e.g. --a11y) or a subcommand (e.g. deprecations)");
+                eprintln!(
+                    "autumn check: specify at least one check flag (e.g. --a11y) or a subcommand (e.g. deprecations)"
+                );
                 std::process::exit(1);
             }
         }
@@ -1381,15 +1383,38 @@ fn run_deprecations_check(package: Option<&str>, bin: Option<&str>) {
     });
 
     let mut sunsetted_routes = Vec::new();
+    let mut opted_out_routes = Vec::new();
     for route in &routes {
-        if route.status.as_deref() == Some("sunset") && route.sunset_opt_out != Some(true) {
-            sunsetted_routes.push(route);
+        if route.status.as_deref() == Some("sunset") {
+            if route.sunset_opt_out == Some(true) {
+                opted_out_routes.push(route);
+            } else {
+                sunsetted_routes.push(route);
+            }
+        }
+    }
+
+    let failed = !opted_out_routes.is_empty() || !sunsetted_routes.is_empty();
+
+    if !opted_out_routes.is_empty() {
+        eprintln!(
+            "\u{2717} Found {} active past-sunset route(s) (opted out):",
+            opted_out_routes.len()
+        );
+        for route in &opted_out_routes {
+            eprintln!(
+                "  {} {} (handler: {}, version: {})",
+                route.method,
+                route.path,
+                route.handler,
+                route.api_version.as_deref().unwrap_or("-")
+            );
         }
     }
 
     if !sunsetted_routes.is_empty() {
         eprintln!(
-            "\u{2717} Found {} route(s) past sunset date that have not opted out:",
+            "\u{2717} Found {} inactive past-sunset route(s) (returning 410 Gone):",
             sunsetted_routes.len()
         );
         for route in &sunsetted_routes {
@@ -1401,9 +1426,12 @@ fn run_deprecations_check(package: Option<&str>, bin: Option<&str>) {
                 route.api_version.as_deref().unwrap_or("-")
             );
         }
+    }
+
+    if failed {
         std::process::exit(1);
     } else {
-        println!("\u{2705} No active past-sunset routes detected.");
+        println!("\u{2705} No past-sunset routes detected.");
     }
 }
 
@@ -3426,7 +3454,10 @@ mod tests {
         };
         assert!(matches!(
             subcommand,
-            Some(CheckSubcommands::Deprecations { package: None, bin: None })
+            Some(CheckSubcommands::Deprecations {
+                package: None,
+                bin: None
+            })
         ));
     }
 

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -23,6 +23,20 @@ mod setup;
 mod task;
 mod token;
 mod webhook;
+/// Subcommands for `autumn check`.
+#[derive(Subcommand, Clone, Debug, PartialEq, Eq)]
+pub enum CheckSubcommands {
+    /// Check for active routes past their sunset date
+    Deprecations {
+        /// Package to build/check (for workspaces)
+        #[arg(short, long)]
+        package: Option<String>,
+        /// Binary target to check (for packages with multiple bin targets)
+        #[arg(long, value_name = "BIN")]
+        bin: Option<String>,
+    },
+}
+
 /// The Autumn web framework CLI.
 #[derive(Parser)]
 #[command(name = "autumn", version, about = "The Autumn web framework CLI")]
@@ -266,6 +280,9 @@ enum Commands {
         /// Fail only on Critical violations; treat Serious as warnings.
         #[arg(long)]
         critical_only: bool,
+
+        #[command(subcommand)]
+        subcommand: Option<CheckSubcommands>,
     },
 
     /// Check the local environment and project configuration for common
@@ -1119,8 +1136,15 @@ fn run_command(command: Commands) {
             url,
             html,
             critical_only,
+            subcommand,
         } => {
-            if a11y {
+            if let Some(sub) = subcommand {
+                match sub {
+                    CheckSubcommands::Deprecations { package, bin } => {
+                        run_deprecations_check(package.as_deref(), bin.as_deref());
+                    }
+                }
+            } else if a11y {
                 let opts = check::A11yCheckOptions {
                     url: url.clone(),
                     html,
@@ -1138,7 +1162,7 @@ fn run_command(command: Commands) {
                     }
                 }
             } else {
-                eprintln!("autumn check: specify at least one check flag (e.g. --a11y)");
+                eprintln!("autumn check: specify at least one check flag (e.g. --a11y) or a subcommand (e.g. deprecations)");
                 std::process::exit(1);
             }
         }
@@ -1325,6 +1349,62 @@ fn run_plugin_check_command(
         sensitive_routes: &sensitive_routes,
         format: fmt,
     });
+}
+
+fn run_deprecations_check(package: Option<&str>, bin: Option<&str>) {
+    routes::compile_binary(package, bin);
+    let binary = routes::find_binary(package, bin);
+
+    let output = std::process::Command::new(&binary)
+        .env("AUTUMN_DUMP_ROUTES", "1")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .unwrap_or_else(|e| {
+            eprintln!("\u{2717} Failed to run {}: {e}", binary.display());
+            std::process::exit(1);
+        });
+
+    if !output.status.success() {
+        eprintln!(
+            "\u{2717} Binary exited with status {} while dumping routes",
+            output.status
+        );
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let routes: Vec<routes::RouteInfo> = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        eprintln!("\u{2717} Failed to parse route listing JSON: {e}");
+        eprintln!("Raw output: {stdout}");
+        std::process::exit(1);
+    });
+
+    let mut sunsetted_routes = Vec::new();
+    for route in &routes {
+        if route.status.as_deref() == Some("sunset") && route.sunset_opt_out != Some(true) {
+            sunsetted_routes.push(route);
+        }
+    }
+
+    if !sunsetted_routes.is_empty() {
+        eprintln!(
+            "\u{2717} Found {} route(s) past sunset date that have not opted out:",
+            sunsetted_routes.len()
+        );
+        for route in &sunsetted_routes {
+            eprintln!(
+                "  {} {} (handler: {}, version: {})",
+                route.method,
+                route.path,
+                route.handler,
+                route.api_version.as_deref().unwrap_or("-")
+            );
+        }
+        std::process::exit(1);
+    } else {
+        println!("\u{2705} No active past-sunset routes detected.");
+    }
 }
 
 fn run_routes_command(
@@ -3335,6 +3415,42 @@ mod tests {
         assert!(
             oauth.is_empty(),
             "oauth must default to empty when flag not given"
+        );
+    }
+
+    #[test]
+    fn parse_check_deprecations() {
+        let cli = Cli::try_parse_from(["autumn", "check", "deprecations"]).unwrap();
+        let Commands::Check { subcommand, .. } = cli.command else {
+            panic!("expected check");
+        };
+        assert!(matches!(
+            subcommand,
+            Some(CheckSubcommands::Deprecations { package: None, bin: None })
+        ));
+    }
+
+    #[test]
+    fn parse_check_deprecations_with_package_and_bin() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "check",
+            "deprecations",
+            "-p",
+            "my-app",
+            "--bin",
+            "my-bin",
+        ])
+        .unwrap();
+        let Commands::Check { subcommand, .. } = cli.command else {
+            panic!("expected check");
+        };
+        assert_eq!(
+            subcommand,
+            Some(CheckSubcommands::Deprecations {
+                package: Some("my-app".to_string()),
+                bin: Some("my-bin".to_string())
+            })
         );
     }
 }

--- a/autumn-cli/src/plugin_check.rs
+++ b/autumn-cli/src/plugin_check.rs
@@ -500,6 +500,9 @@ mod tests {
             handler: format!("{}_handler", path.trim_start_matches('/').replace('/', "_")),
             source: source.to_owned(),
             middleware: vec![],
+            api_version: None,
+            status: None,
+            sunset_opt_out: None,
         }
     }
 

--- a/autumn-cli/src/routes.rs
+++ b/autumn-cli/src/routes.rs
@@ -31,7 +31,6 @@ impl std::str::FromStr for OutputFormat {
     }
 }
 
-/// Deserialized route entry received from the binary's JSON output.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RouteInfo {
     pub method: String,
@@ -39,6 +38,12 @@ pub struct RouteInfo {
     pub handler: String,
     pub source: String,
     pub middleware: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sunset_opt_out: Option<bool>,
 }
 
 /// Options controlling `autumn routes` behaviour.
@@ -135,7 +140,7 @@ pub fn print_table(routes: &[RouteInfo]) {
 
 /// Build the table string (extracted for testability).
 pub fn format_table(routes: &[RouteInfo]) -> String {
-    const HEADERS: [&str; 5] = ["Method", "Path", "Handler", "Source", "Middleware"];
+    const HEADERS: [&str; 7] = ["Method", "Path", "Handler", "Version", "Status", "Source", "Middleware"];
 
     // Compute column widths
     let widths = compute_column_widths(routes, &HEADERS);
@@ -165,10 +170,14 @@ pub fn format_table(routes: &[RouteInfo]) -> String {
         } else {
             route.middleware.join(", ")
         };
+        let version = route.api_version.as_deref().unwrap_or("-");
+        let status = route.status.as_deref().unwrap_or("-");
         let cells = [
             route.method.clone(),
             route.path.clone(),
             route.handler.clone(),
+            version.to_string(),
+            status.to_string(),
             route.source.clone(),
             middleware,
         ];
@@ -179,8 +188,8 @@ pub fn format_table(routes: &[RouteInfo]) -> String {
     out
 }
 
-fn compute_column_widths(routes: &[RouteInfo], headers: &[&str; 5]) -> [usize; 5] {
-    let mut widths = [0usize; 5];
+fn compute_column_widths(routes: &[RouteInfo], headers: &[&str; 7]) -> [usize; 7] {
+    let mut widths = [0usize; 7];
     for (i, h) in headers.iter().enumerate() {
         widths[i] = h.len();
     }
@@ -190,10 +199,14 @@ fn compute_column_widths(routes: &[RouteInfo], headers: &[&str; 5]) -> [usize; 5
         } else {
             route.middleware.join(", ")
         };
+        let version = route.api_version.as_deref().unwrap_or("-");
+        let status = route.status.as_deref().unwrap_or("-");
         let cols = [
             route.method.len(),
             route.path.len(),
             route.handler.len(),
+            version.len(),
+            status.len(),
             route.source.len(),
             middleware.len(),
         ];
@@ -206,7 +219,7 @@ fn compute_column_widths(routes: &[RouteInfo], headers: &[&str; 5]) -> [usize; 5
     widths
 }
 
-fn format_row(cells: &[String; 5], widths: &[usize; 5]) -> String {
+fn format_row(cells: &[String; 7], widths: &[usize; 7]) -> String {
     cells
         .iter()
         .zip(widths.iter())
@@ -398,6 +411,9 @@ mod tests {
             handler: format!("{}_handler", path.trim_start_matches('/').replace('/', "_")),
             source: source.to_owned(),
             middleware: vec![],
+            api_version: None,
+            status: None,
+            sunset_opt_out: None,
         }
     }
 
@@ -595,6 +611,9 @@ mod tests {
             handler: "admin".to_owned(),
             source: "user".to_owned(),
             middleware: vec!["secured".to_owned(), "cached(60s)".to_owned()],
+            api_version: None,
+            status: None,
+            sunset_opt_out: None,
         };
         let table = format_table(&[route]);
         assert!(table.contains("secured"), "missing middleware label");

--- a/autumn-cli/src/routes.rs
+++ b/autumn-cli/src/routes.rs
@@ -140,7 +140,15 @@ pub fn print_table(routes: &[RouteInfo]) {
 
 /// Build the table string (extracted for testability).
 pub fn format_table(routes: &[RouteInfo]) -> String {
-    const HEADERS: [&str; 7] = ["Method", "Path", "Handler", "Version", "Status", "Source", "Middleware"];
+    const HEADERS: [&str; 7] = [
+        "Method",
+        "Path",
+        "Handler",
+        "Version",
+        "Status",
+        "Source",
+        "Middleware",
+    ];
 
     // Compute column widths
     let widths = compute_column_widths(routes, &HEADERS);

--- a/autumn-macros/src/parse.rs
+++ b/autumn-macros/src/parse.rs
@@ -14,6 +14,10 @@ pub struct RouteAttrArgs {
     /// Override for the path-helper function name. When `None`, the helper
     /// name matches the handler function name.
     pub name_override: Option<LitStr>,
+    /// API version of the route (e.g. "v1")
+    pub api_version: Option<LitStr>,
+    /// Whether this route opts out of sunset 410 response
+    pub sunset_opt_out: bool,
 }
 
 impl RouteAttrArgs {
@@ -31,28 +35,40 @@ impl RouteAttrArgs {
 impl syn::parse::Parse for RouteAttrArgs {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let path: LitStr = input.parse()?;
+        let mut name_override = None;
+        let mut api_version = None;
+        let mut sunset_opt_out = false;
 
-        let name_override = if input.peek(Token![,]) {
+        while input.peek(Token![,]) {
             let _comma: Token![,] = input.parse()?;
+            if input.is_empty() {
+                break;
+            }
             let key: Ident = input.parse()?;
-            if key != "name" {
+            let _eq: Token![=] = input.parse()?;
+            if key == "name" {
+                name_override = Some(input.parse::<LitStr>()?);
+            } else if key == "api_version" {
+                api_version = Some(input.parse::<LitStr>()?);
+            } else if key == "sunset_opt_out" {
+                let val: syn::LitBool = input.parse()?;
+                sunset_opt_out = val.value();
+            } else {
                 return Err(syn::Error::new(
                     key.span(),
                     format!(
                         "unknown route attribute key `{key}`. \
-                         Supported keys: `name`."
+                         Supported keys: `name`, `api_version`, `sunset_opt_out`."
                     ),
                 ));
             }
-            let _eq: Token![=] = input.parse()?;
-            Some(input.parse::<LitStr>()?)
-        } else {
-            None
-        };
+        }
 
         Ok(Self {
             path,
             name_override,
+            api_version,
+            sunset_opt_out,
         })
     }
 }

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -6474,6 +6474,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         scope_check: #list_scope_check_fn,
                     }),
                     idempotency: ::autumn_web::RouteIdempotency::ReplayThroughInner,
+                    api_version: ::core::option::Option::None,
+                    sunset_opt_out: false,
                 }
             }
 
@@ -6523,6 +6525,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         scope_check: #non_list_scope_check_fn,
                     }),
                     idempotency: ::autumn_web::RouteIdempotency::ReplayThroughInner,
+                    api_version: ::core::option::Option::None,
+                    sunset_opt_out: false,
                 }
             }
 
@@ -6569,6 +6573,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         scope_check: #non_list_scope_check_fn,
                     }),
                     idempotency: ::autumn_web::RouteIdempotency::ReplayThroughInner,
+                    api_version: ::core::option::Option::None,
+                    sunset_opt_out: false,
                 }
             }
 
@@ -6617,6 +6623,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         scope_check: #non_list_scope_check_fn,
                     }),
                     idempotency: ::autumn_web::RouteIdempotency::ReplayThroughInner,
+                    api_version: ::core::option::Option::None,
+                    sunset_opt_out: false,
                 }
             }
 
@@ -6652,6 +6660,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         scope_check: #non_list_scope_check_fn,
                     }),
                     idempotency: ::autumn_web::RouteIdempotency::ReplayThroughInner,
+                    api_version: ::core::option::Option::None,
+                    sunset_opt_out: false,
                 }
             }
 

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -141,10 +141,10 @@ pub fn route_macro(
     };
     let api_doc_fields = api_doc_attr.emit_ident_fields(fn_name);
     let http_method_lit = LitStr::new(http_method, Span::call_site());
-    let api_version_expr = match &route_args.api_version {
-        Some(lit) => quote! { ::core::option::Option::Some(#lit) },
-        None => quote! { ::core::option::Option::None },
-    };
+    let api_version_expr = route_args.api_version.as_ref().map_or_else(
+        || quote! { ::core::option::Option::None },
+        |lit| quote! { ::core::option::Option::Some(#lit) },
+    );
     let sunset_opt_out_val = route_args.sunset_opt_out;
 
     // ── Path helper ─────────────────────────────────────────────

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -177,6 +177,7 @@ pub fn route_macro(
                     required_roles: #required_roles,
                     register_schemas: ::core::option::Option::None,
                     api_version: #api_version_expr,
+                    sunset_opt_out: #sunset_opt_out_val,
                     #api_doc_fields
                 },
                 repository: ::core::option::Option::None,

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -141,6 +141,11 @@ pub fn route_macro(
     };
     let api_doc_fields = api_doc_attr.emit_ident_fields(fn_name);
     let http_method_lit = LitStr::new(http_method, Span::call_site());
+    let api_version_expr = match &route_args.api_version {
+        Some(lit) => quote! { ::core::option::Option::Some(#lit) },
+        None => quote! { ::core::option::Option::None },
+    };
+    let sunset_opt_out_val = route_args.sunset_opt_out;
 
     // ── Path helper ─────────────────────────────────────────────
     let path_helper = emit_path_helper(&path_helper_name, &path, &path_params);
@@ -159,6 +164,8 @@ pub fn route_macro(
                 path: #path,
                 handler: #handler_expr,
                 name: ::core::stringify!(#fn_name),
+                api_version: #api_version_expr,
+                sunset_opt_out: #sunset_opt_out_val,
                 api_doc: ::autumn_web::openapi::ApiDoc {
                     method: #http_method_lit,
                     path: #path,
@@ -169,6 +176,7 @@ pub fn route_macro(
                     secured: #secured,
                     required_roles: #required_roles,
                     register_schemas: ::core::option::Option::None,
+                    api_version: #api_version_expr,
                     #api_doc_fields
                 },
                 repository: ::core::option::Option::None,
@@ -471,6 +479,31 @@ mod tests {
         assert!(
             !generated.contains("IdempotencyReplayLayer"),
             "intercepted routes must not advertise an implicit replay stop: {generated}"
+        );
+    }
+
+    #[test]
+    fn route_macro_parses_api_version_and_sunset_opt_out() {
+        let generated = route_macro(
+            "GET",
+            "get",
+            quote! { "/items", api_version = "v1", sunset_opt_out = true },
+            quote! {
+                async fn get_items() -> &'static str {
+                    "items"
+                }
+            },
+        )
+        .to_string();
+
+        // Check that api_version and sunset_opt_out are generated in Route constructor
+        assert!(
+            generated.contains("api_version"),
+            "should generate api_version field: {generated}"
+        );
+        assert!(
+            generated.contains("sunset_opt_out"),
+            "should generate sunset_opt_out field: {generated}"
         );
     }
 }

--- a/autumn-macros/src/static_route.rs
+++ b/autumn-macros/src/static_route.rs
@@ -183,6 +183,7 @@ pub fn static_get_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     required_roles: &[],
                     register_schemas: ::core::option::Option::None,
                     api_version: ::core::option::Option::None,
+                    ..::core::default::Default::default()
                 },
                 repository: ::core::option::Option::None,
                 idempotency: ::autumn_web::RouteIdempotency::Direct,

--- a/autumn-macros/src/static_route.rs
+++ b/autumn-macros/src/static_route.rs
@@ -118,6 +118,7 @@ pub fn static_get_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         .to_compile_error();
     }
 
+    // Parse the async handler function
     let input_fn = match crate::parse::parse_async_handler(item) {
         Ok(f) => f,
         Err(err) => return err,
@@ -181,9 +182,12 @@ pub fn static_get_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     secured: false,
                     required_roles: &[],
                     register_schemas: ::core::option::Option::None,
+                    api_version: ::core::option::Option::None,
                 },
                 repository: ::core::option::Option::None,
                 idempotency: ::autumn_web::RouteIdempotency::Direct,
+                api_version: ::core::option::Option::None,
+                sunset_opt_out: false,
             }
         }
 

--- a/autumn-macros/src/ws.rs
+++ b/autumn-macros/src/ws.rs
@@ -149,9 +149,12 @@ pub fn ws_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     secured: false,
                     required_roles: &[],
                     register_schemas: ::core::option::Option::None,
+                    api_version: ::core::option::Option::None,
                 },
                 repository: ::core::option::Option::None,
                 idempotency: ::autumn_web::RouteIdempotency::Direct,
+                api_version: ::core::option::Option::None,
+                sunset_opt_out: false,
             }
         }
     }

--- a/autumn-macros/src/ws.rs
+++ b/autumn-macros/src/ws.rs
@@ -150,6 +150,7 @@ pub fn ws_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     required_roles: &[],
                     register_schemas: ::core::option::Option::None,
                     api_version: ::core::option::Option::None,
+                    ..::core::default::Default::default()
                 },
                 repository: ::core::option::Option::None,
                 idempotency: ::autumn_web::RouteIdempotency::Direct,

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -340,8 +340,7 @@ pub struct ScopedGroup {
     /// Registration origin: user application or a named plugin.
     pub source: crate::route_listing::RouteSource,
     /// Closure that applies the layer to a sub-router.
-    pub apply_layer:
-        Box<dyn FnOnce(axum::Router<AppState>) -> axum::Router<AppState> + Send>,
+    pub apply_layer: Box<dyn FnOnce(axum::Router<AppState>) -> axum::Router<AppState> + Send>,
 }
 
 /// A deferred router mutator that applies a user-registered
@@ -2742,6 +2741,36 @@ impl AppBuilder {
             ..
         } = self;
 
+        // Validate that all versioned routes use a registered API version
+        let registered_versions: std::collections::HashSet<&str> =
+            api_versions.iter().map(|av| av.version.as_str()).collect();
+
+        for route in &routes {
+            if let Some(ver) = route.api_version {
+                if !registered_versions.contains(ver) {
+                    eprintln!(
+                        "Failed to build router: route '{}' uses unregistered API version '{}'",
+                        route.name, ver
+                    );
+                    std::process::exit(1);
+                }
+            }
+        }
+
+        for group in &scoped_groups {
+            for route in &group.routes {
+                if let Some(ver) = route.api_version {
+                    if !registered_versions.contains(ver) {
+                        eprintln!(
+                            "Failed to build router: route '{}' uses unregistered API version '{}'",
+                            route.name, ver
+                        );
+                        std::process::exit(1);
+                    }
+                }
+            }
+        }
+
         // Raw Axum routers registered via .merge()/.nest() are opaque: there is
         // no public API to enumerate their routes. Always warn so callers know
         // some routes may be missing even if declare_plugin_routes was used.
@@ -2756,8 +2785,18 @@ impl AppBuilder {
         let (config, _telemetry_guard) =
             load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
 
-        let mut infos =
-            crate::route_listing::collect_route_infos(&routes, &route_sources, &scoped_groups, &api_versions);
+        let mut infos = match crate::route_listing::collect_route_infos(
+            &routes,
+            &route_sources,
+            &scoped_groups,
+            &api_versions,
+        ) {
+            Ok(infos) => infos,
+            Err(e) => {
+                eprintln!("Failed to build router: {e}");
+                std::process::exit(1);
+            }
+        };
         infos.extend(declared_routes);
         crate::route_listing::append_framework_routes(&mut infos, &config);
         #[cfg(feature = "openapi")]

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2746,27 +2746,29 @@ impl AppBuilder {
             api_versions.iter().map(|av| av.version.as_str()).collect();
 
         for route in &routes {
-            if let Some(ver) = route.api_version {
-                if !registered_versions.contains(ver) {
-                    eprintln!(
-                        "Failed to build router: route '{}' uses unregistered API version '{}'",
-                        route.name, ver
-                    );
-                    std::process::exit(1);
-                }
+            if let Some(ver) = route
+                .api_version
+                .filter(|ver| !registered_versions.contains(*ver))
+            {
+                eprintln!(
+                    "Failed to build router: route '{}' uses unregistered API version '{}'",
+                    route.name, ver
+                );
+                std::process::exit(1);
             }
         }
 
         for group in &scoped_groups {
             for route in &group.routes {
-                if let Some(ver) = route.api_version {
-                    if !registered_versions.contains(ver) {
-                        eprintln!(
-                            "Failed to build router: route '{}' uses unregistered API version '{}'",
-                            route.name, ver
-                        );
-                        std::process::exit(1);
-                    }
+                if let Some(ver) = route
+                    .api_version
+                    .filter(|ver| !registered_versions.contains(*ver))
+                {
+                    eprintln!(
+                        "Failed to build router: route '{}' uses unregistered API version '{}'",
+                        route.name, ver
+                    );
+                    std::process::exit(1);
                 }
             }
         }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -160,6 +160,21 @@ type PoolProviderFactory = Box<
 /// [`PolicyRegistry`](crate::authorization::PolicyRegistry).
 type PolicyRegistration = Box<dyn FnOnce(&crate::authorization::PolicyRegistry) + Send>;
 
+/// Represents an API version registration.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ApiVersion {
+    /// The version name (e.g. "v1", "v2").
+    pub version: String,
+    /// When this version was deprecated.
+    pub deprecated_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// When this version was sunsetted.
+    pub sunset_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// A wrapper for registered API versions in the app state.
+#[derive(Clone, Debug)]
+pub struct RegisteredApiVersions(pub Vec<ApiVersion>);
+
 /// Builder for configuring and launching an Autumn application.
 ///
 /// Created by [`app()`]. Collect routes with [`.routes()`](Self::routes),
@@ -188,21 +203,6 @@ type PolicyRegistration = Box<dyn FnOnce(&crate::authorization::PolicyRegistry) 
 ///         .await;
 /// }
 /// ```
-/// Represents an API version registration.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-pub struct ApiVersion {
-    /// The version name (e.g. "v1", "v2").
-    pub version: String,
-    /// When this version was deprecated.
-    pub deprecated_at: Option<chrono::DateTime<chrono::Utc>>,
-    /// When this version was sunsetted.
-    pub sunset_at: Option<chrono::DateTime<chrono::Utc>>,
-}
-
-/// A wrapper for registered API versions in the app state.
-#[derive(Clone, Debug)]
-pub struct RegisteredApiVersions(pub Vec<ApiVersion>);
-
 pub struct AppBuilder {
     pub(crate) routes: Vec<Route>,
     /// Registered API versions.

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2395,10 +2395,7 @@ impl AppBuilder {
             jobs: _,
             static_metas,
             exception_filters: _,
-            #[cfg(feature = "openapi")]
             scoped_groups,
-            #[cfg(not(feature = "openapi"))]
-                scoped_groups: _,
             merge_routers: _,
             nest_routers: _,
             custom_layers,
@@ -2472,8 +2469,15 @@ impl AppBuilder {
         // the emitted dist/openapi.json matches what the runtime spec serves.
         #[cfg(feature = "openapi")]
         let api_docs_snapshot: Vec<crate::openapi::ApiDoc> = {
-            let mut docs: Vec<crate::openapi::ApiDoc> =
-                all_routes.iter().map(|r| r.api_doc.clone()).collect();
+            let mut docs: Vec<crate::openapi::ApiDoc> = all_routes
+                .iter()
+                .map(|r| {
+                    let mut doc = r.api_doc.clone();
+                    doc.api_version = r.api_version;
+                    doc.sunset_opt_out = r.sunset_opt_out;
+                    doc
+                })
+                .collect();
             for group in &scoped_groups {
                 // Mirror the same normalization as the runtime OpenAPI builder:
                 // use join_nested_path for correct trailing-slash handling, and
@@ -2481,6 +2485,8 @@ impl AppBuilder {
                 let prefix_params = crate::router::extract_path_params(&group.prefix);
                 for route in &group.routes {
                     let mut doc = route.api_doc.clone();
+                    doc.api_version = route.api_version;
+                    doc.sunset_opt_out = route.sunset_opt_out;
                     let full = crate::router::join_nested_path(&group.prefix, route.api_doc.path);
                     doc.path = Box::leak(full.into_boxed_str());
                     if !prefix_params.is_empty() {
@@ -2664,7 +2670,7 @@ impl AppBuilder {
             state,
             crate::router::RouterContext {
                 exception_filters: Vec::new(),
-                scoped_groups: Vec::new(),
+                scoped_groups,
                 merge_routers,
                 nest_routers: Vec::new(),
                 custom_layers,

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2556,6 +2556,7 @@ impl AppBuilder {
             #[cfg(feature = "ws")]
             channels_backend,
         );
+        state.insert_extension(RegisteredApiVersions(api_versions.clone()));
         #[cfg(feature = "mail")]
         if let Some(interceptor) = mail_interceptor {
             state.insert_extension(interceptor);

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -977,17 +977,35 @@ impl AppBuilder {
         self
     }
 
-    /// Register a single API version.
+    /// Register a single API version. If a version with the same name already exists, it is updated.
     #[must_use]
     pub fn api_version(mut self, version: ApiVersion) -> Self {
-        self.api_versions.push(version);
+        if let Some(pos) = self
+            .api_versions
+            .iter()
+            .position(|v| v.version == version.version)
+        {
+            self.api_versions[pos] = version;
+        } else {
+            self.api_versions.push(version);
+        }
         self
     }
 
-    /// Register multiple API versions.
+    /// Register multiple API versions, replacing duplicates.
     #[must_use]
     pub fn api_versions(mut self, versions: impl IntoIterator<Item = ApiVersion>) -> Self {
-        self.api_versions.extend(versions);
+        for version in versions {
+            if let Some(pos) = self
+                .api_versions
+                .iter()
+                .position(|v| v.version == version.version)
+            {
+                self.api_versions[pos] = version;
+            } else {
+                self.api_versions.push(version);
+            }
+        }
         self
     }
 

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -67,6 +67,7 @@ use crate::state::AppState;
 pub fn app() -> AppBuilder {
     AppBuilder {
         routes: Vec::new(),
+        api_versions: Vec::new(),
         route_sources: Vec::new(),
         current_plugin: None,
         tasks: Vec::new(),
@@ -187,8 +188,25 @@ type PolicyRegistration = Box<dyn FnOnce(&crate::authorization::PolicyRegistry) 
 ///         .await;
 /// }
 /// ```
+/// Represents an API version registration.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ApiVersion {
+    /// The version name (e.g. "v1", "v2").
+    pub version: String,
+    /// When this version was deprecated.
+    pub deprecated_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// When this version was sunsetted.
+    pub sunset_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// A wrapper for registered API versions in the app state.
+#[derive(Clone, Debug)]
+pub struct RegisteredApiVersions(pub Vec<ApiVersion>);
+
 pub struct AppBuilder {
     pub(crate) routes: Vec<Route>,
+    /// Registered API versions.
+    pub api_versions: Vec<ApiVersion>,
     /// Parallel to `routes`: registration origin for each route.
     route_sources: Vec<crate::route_listing::RouteSource>,
     /// Non-None while a plugin's `build()` is executing; routes and scoped
@@ -316,13 +334,13 @@ pub(crate) type MailDeliveryQueueFactory = Box<
 ///
 /// Created by [`AppBuilder::scoped`]. The routes are mounted under the
 /// prefix with the middleware applied only to this group.
-pub(crate) struct ScopedGroup {
-    pub(crate) prefix: String,
-    pub(crate) routes: Vec<Route>,
+pub struct ScopedGroup {
+    pub prefix: String,
+    pub routes: Vec<Route>,
     /// Registration origin: user application or a named plugin.
-    pub(crate) source: crate::route_listing::RouteSource,
+    pub source: crate::route_listing::RouteSource,
     /// Closure that applies the layer to a sub-router.
-    pub(crate) apply_layer:
+    pub apply_layer:
         Box<dyn FnOnce(axum::Router<AppState>) -> axum::Router<AppState> + Send>,
 }
 
@@ -957,6 +975,20 @@ impl AppBuilder {
         Fut: Future<Output = ()> + Send + 'static,
     {
         self.shutdown_hooks.push(Box::new(move || Box::pin(hook())));
+        self
+    }
+
+    /// Register a single API version.
+    #[must_use]
+    pub fn api_version(mut self, version: ApiVersion) -> Self {
+        self.api_versions.push(version);
+        self
+    }
+
+    /// Register multiple API versions.
+    #[must_use]
+    pub fn api_versions(mut self, versions: impl IntoIterator<Item = ApiVersion>) -> Self {
+        self.api_versions.extend(versions);
         self
     }
 
@@ -1783,6 +1815,7 @@ impl AppBuilder {
 
         let Self {
             routes,
+            api_versions,
             route_sources: _,
             current_plugin: _,
             tasks,
@@ -2010,6 +2043,8 @@ impl AppBuilder {
         } else {
             crate::cache::clear_global_cache();
         }
+        state.insert_extension(RegisteredApiVersions(api_versions));
+
         // Install registered error reporters so the reporting layer (wired in
         // `apply_middleware`) can deliver panic + 5xx events. Empty is fine —
         // the layer falls back to the built-in `LogReporter`.
@@ -2353,6 +2388,7 @@ impl AppBuilder {
     async fn run_build_mode(self) {
         let Self {
             routes,
+            api_versions,
             route_sources: _,
             current_plugin: _,
             tasks: _,
@@ -2412,6 +2448,7 @@ impl AppBuilder {
             http_interceptor,
         } = self;
 
+        let _ = &api_versions;
         let all_routes = routes;
 
         // Load config (same as normal startup)
@@ -2663,7 +2700,8 @@ impl AppBuilder {
         // When OpenAPI is configured, write the spec to dist/ so consumers
         // can retrieve a machine-readable API contract alongside the HTML.
         #[cfg(feature = "openapi")]
-        if let Some(openapi_config) = openapi {
+        if let Some(mut openapi_config) = openapi {
+            openapi_config.api_versions = api_versions;
             let openapi_config =
                 openapi_config.session_cookie_name(config.session.cookie_name.clone());
             let docs: Vec<&crate::openapi::ApiDoc> = api_docs_snapshot.iter().collect();
@@ -2690,6 +2728,7 @@ impl AppBuilder {
     async fn run_dump_routes_mode(self) {
         let Self {
             routes,
+            api_versions,
             route_sources,
             scoped_groups,
             merge_routers,
@@ -2717,7 +2756,7 @@ impl AppBuilder {
             load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
 
         let mut infos =
-            crate::route_listing::collect_route_infos(&routes, &route_sources, &scoped_groups);
+            crate::route_listing::collect_route_infos(&routes, &route_sources, &scoped_groups, &api_versions);
         infos.extend(declared_routes);
         crate::route_listing::append_framework_routes(&mut infos, &config);
         #[cfg(feature = "openapi")]
@@ -4528,6 +4567,8 @@ mod validate_repository_api_policies_tests {
             api_doc: crate::openapi::ApiDoc::default(),
             repository: meta,
             idempotency: crate::route::RouteIdempotency::Direct,
+            api_version: None,
+            sunset_opt_out: false,
         }
     }
 
@@ -5655,6 +5696,8 @@ mod tests {
             },
             repository: None,
             idempotency: crate::route::RouteIdempotency::Direct,
+            api_version: None,
+            sunset_opt_out: false,
         }
     }
 
@@ -5771,6 +5814,8 @@ mod tests {
                 },
                 repository: None,
                 idempotency: crate::route::RouteIdempotency::Direct,
+                api_version: None,
+                sunset_opt_out: false,
             }],
             &config,
             state,
@@ -6202,6 +6247,8 @@ mod tests {
             },
             repository: None,
             idempotency: crate::route::RouteIdempotency::Direct,
+            api_version: None,
+            sunset_opt_out: false,
         }];
         let config = AutumnConfig::default();
         let state = AppState {
@@ -6266,6 +6313,8 @@ mod tests {
                 },
                 repository: None,
                 idempotency: crate::route::RouteIdempotency::Direct,
+                api_version: None,
+                sunset_opt_out: false,
             },
             Route {
                 method: http::Method::POST,
@@ -6281,6 +6330,8 @@ mod tests {
                 },
                 repository: None,
                 idempotency: crate::route::RouteIdempotency::Direct,
+                api_version: None,
+                sunset_opt_out: false,
             },
         ];
         let config = AutumnConfig::default();
@@ -6657,6 +6708,8 @@ mod tests {
                     },
                     repository: None,
                     idempotency: crate::route::RouteIdempotency::Direct,
+                    api_version: None,
+                    sunset_opt_out: false,
                 }],
                 &config,
                 state,
@@ -6712,6 +6765,8 @@ mod tests {
                     },
                     repository: None,
                     idempotency: crate::route::RouteIdempotency::Direct,
+                    api_version: None,
+                    sunset_opt_out: false,
                 }]);
 
                 let response = router

--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -520,6 +520,42 @@ impl AutumnError {
         Self::conflict(StringError(msg.into()))
     }
 
+    /// Create a `410 Gone` error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use autumn_web::error::AutumnError;
+    /// use http::StatusCode;
+    ///
+    /// let err = AutumnError::gone(std::io::Error::other("sunsetted"));
+    /// assert_eq!(err.status(), StatusCode::GONE);
+    /// ```
+    pub fn gone(err: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self {
+            inner: Box::new(err),
+            status: StatusCode::GONE,
+            details: None,
+            problem_type: Some("https://autumn.dev/problems/gone"),
+            cache_idempotency_response: false,
+        }
+    }
+
+    /// Create a `410 Gone` error from a plain string message.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use autumn_web::error::AutumnError;
+    /// use http::StatusCode;
+    ///
+    /// let err = AutumnError::gone_msg("API version has been sunsetted");
+    /// assert_eq!(err.status(), StatusCode::GONE);
+    /// ```
+    pub fn gone_msg(msg: impl Into<String>) -> Self {
+        Self::gone(StringError(msg.into()))
+    }
+
     /// Create a `503 Service Unavailable` error indicating that a database
     /// query was cancelled due to a statement timeout (Postgres `57014`).
     ///
@@ -728,6 +764,7 @@ const fn problem_type_for(status: StatusCode, has_validation_errors: bool) -> &'
         StatusCode::UNAUTHORIZED => "https://autumn.dev/problems/unauthorized",
         StatusCode::FORBIDDEN => "https://autumn.dev/problems/forbidden",
         StatusCode::NOT_FOUND => "https://autumn.dev/problems/not-found",
+        StatusCode::GONE => "https://autumn.dev/problems/gone",
         StatusCode::CONFLICT => "https://autumn.dev/problems/conflict",
         StatusCode::PAYLOAD_TOO_LARGE => "https://autumn.dev/problems/payload-too-large",
         StatusCode::UNPROCESSABLE_ENTITY => "https://autumn.dev/problems/unprocessable-entity",
@@ -748,6 +785,7 @@ fn problem_title_for(status: StatusCode, has_validation_errors: bool) -> &'stati
         StatusCode::UNAUTHORIZED => "Unauthorized",
         StatusCode::FORBIDDEN => "Forbidden",
         StatusCode::NOT_FOUND => "Not Found",
+        StatusCode::GONE => "Gone",
         StatusCode::CONFLICT => "Conflict",
         StatusCode::PAYLOAD_TOO_LARGE => "Payload Too Large",
         StatusCode::UNPROCESSABLE_ENTITY => "Unprocessable Entity",
@@ -768,6 +806,7 @@ fn problem_code_for(status: StatusCode, has_validation_errors: bool) -> &'static
         StatusCode::UNAUTHORIZED => "autumn.unauthorized",
         StatusCode::FORBIDDEN => "autumn.forbidden",
         StatusCode::NOT_FOUND => "autumn.not_found",
+        StatusCode::GONE => "autumn.gone",
         StatusCode::CONFLICT => "autumn.conflict",
         StatusCode::PAYLOAD_TOO_LARGE => "autumn.payload_too_large",
         StatusCode::UNPROCESSABLE_ENTITY => "autumn.unprocessable_entity",

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -273,6 +273,7 @@ pub mod __private {
 /// }
 /// ```
 pub use app::app;
+pub use app::{ApiVersion, RegisteredApiVersions};
 /// Async database connection extractor.
 ///
 /// Declare `db: Db` in a handler signature to get a pooled Postgres

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -510,6 +510,16 @@ pub fn write_openapi_spec_to_dist(
 #[cfg(feature = "openapi")]
 #[must_use]
 pub fn generate_spec(config: &OpenApiConfig, routes: &[&ApiDoc]) -> OpenApiSpec {
+    generate_spec_at(config, routes, chrono::Utc::now())
+}
+
+#[cfg(feature = "openapi")]
+#[must_use]
+pub fn generate_spec_at(
+    config: &OpenApiConfig,
+    routes: &[&ApiDoc],
+    now: chrono::DateTime<chrono::Utc>,
+) -> OpenApiSpec {
     let mut paths: BTreeMap<String, PathItem> = BTreeMap::new();
     let mut registry = SchemaRegistry::default();
 
@@ -549,7 +559,7 @@ pub fn generate_spec(config: &OpenApiConfig, routes: &[&ApiDoc]) -> OpenApiSpec 
             collect_ref_names(entry, &mut referenced_names);
         }
 
-        let operation = operation_for(api_doc, &config.api_versions);
+        let operation = operation_for(api_doc, &config.api_versions, now);
         let entry = paths.entry(api_doc.path.to_owned()).or_default();
         match api_doc.method {
             "GET" => entry.get = Some(operation),
@@ -616,7 +626,12 @@ pub fn generate_spec(config: &OpenApiConfig, routes: &[&ApiDoc]) -> OpenApiSpec 
 }
 
 #[cfg(feature = "openapi")]
-fn operation_for(api_doc: &ApiDoc, api_versions: &[crate::app::ApiVersion]) -> Operation {
+#[allow(clippy::too_many_lines)]
+fn operation_for(
+    api_doc: &ApiDoc,
+    api_versions: &[crate::app::ApiVersion],
+    now: chrono::DateTime<chrono::Utc>,
+) -> Operation {
     let mut tags = if api_doc.tags.is_empty() {
         default_tag(api_doc.path)
             .map(|t| vec![t.to_owned()])
@@ -634,8 +649,8 @@ fn operation_for(api_doc: &ApiDoc, api_versions: &[crate::app::ApiVersion]) -> O
             .iter()
             .find(|av| av.version == version)
             .is_some_and(|av| {
-                let is_dep = av.deprecated_at.is_some_and(|d| chrono::Utc::now() >= d);
-                let is_sun = av.sunset_at.is_some_and(|s| chrono::Utc::now() >= s);
+                let is_dep = av.deprecated_at.is_some_and(|d| now >= d);
+                let is_sun = av.sunset_at.is_some_and(|s| now >= s);
                 is_dep || is_sun
             })
     });

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -114,6 +114,8 @@ pub struct ApiDoc {
     pub register_schemas: Option<fn(&mut SchemaRegistry)>,
     /// Optional API version associated with this route.
     pub api_version: Option<&'static str>,
+    /// Whether this route opts out of sunset 410 responses.
+    pub sunset_opt_out: bool,
 }
 
 /// Reference to a schema definition, produced by the route macros.
@@ -705,7 +707,35 @@ fn operation_for(api_doc: &ApiDoc, api_versions: &[crate::app::ApiVersion]) -> O
     );
     insert_problem_responses(&mut responses);
 
-    insert_problem_responses(&mut responses);
+    // If this route version has a sunset schedule and is not opted out, document 410 Gone
+    let is_subject_to_sunset = if let Some(version) = api_doc.api_version {
+        api_versions
+            .iter()
+            .find(|av| av.version == version)
+            .and_then(|av| av.sunset_at)
+            .is_some()
+            && !api_doc.sunset_opt_out
+    } else {
+        false
+    };
+
+    if is_subject_to_sunset {
+        responses.entry("410".to_owned()).or_insert_with(|| {
+            let mut content = BTreeMap::new();
+            content.insert(
+                "application/problem+json".to_owned(),
+                MediaType {
+                    schema: serde_json::json!({
+                        "$ref": "#/components/schemas/ProblemDetails",
+                    }),
+                },
+            );
+            Response {
+                description: status_description(410).to_owned(),
+                content,
+            }
+        });
+    }
 
     // Security requirement: `#[secured]` is backed by the Autumn session cookie.
     let security = if api_doc.secured {
@@ -1026,6 +1056,7 @@ mod tests {
             required_roles: &[],
             register_schemas: None,
             api_version: None,
+            ..Default::default()
         }
     }
 

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -629,19 +629,16 @@ fn operation_for(api_doc: &ApiDoc, api_versions: &[crate::app::ApiVersion]) -> O
         tags.push(version.to_string());
     }
 
-    let is_deprecated = if let Some(version) = api_doc.api_version {
+    let is_deprecated = api_doc.api_version.is_some_and(|version| {
         api_versions
             .iter()
             .find(|av| av.version == version)
-            .map(|av| {
-                let is_dep = av.deprecated_at.map_or(false, |d| chrono::Utc::now() >= d);
-                let is_sun = av.sunset_at.map_or(false, |s| chrono::Utc::now() >= s);
+            .is_some_and(|av| {
+                let is_dep = av.deprecated_at.is_some_and(|d| chrono::Utc::now() >= d);
+                let is_sun = av.sunset_at.is_some_and(|s| chrono::Utc::now() >= s);
                 is_dep || is_sun
             })
-            .unwrap_or(false)
-    } else {
-        false
-    };
+    });
     let deprecated = if is_deprecated { Some(true) } else { None };
 
     // Path parameters — always required.
@@ -714,16 +711,13 @@ fn operation_for(api_doc: &ApiDoc, api_versions: &[crate::app::ApiVersion]) -> O
     insert_problem_responses(&mut responses);
 
     // If this route version has a sunset schedule and is not opted out, document 410 Gone
-    let is_subject_to_sunset = if let Some(version) = api_doc.api_version {
+    let is_subject_to_sunset = api_doc.api_version.is_some_and(|version| {
         api_versions
             .iter()
             .find(|av| av.version == version)
-            .and_then(|av| av.sunset_at)
-            .is_some()
+            .is_some_and(|av| av.sunset_at.is_some())
             && !api_doc.sunset_opt_out
-    } else {
-        false
-    };
+    });
 
     if is_subject_to_sunset {
         responses.entry("410".to_owned()).or_insert_with(|| {

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -630,9 +630,15 @@ fn operation_for(api_doc: &ApiDoc, api_versions: &[crate::app::ApiVersion]) -> O
     }
 
     let is_deprecated = if let Some(version) = api_doc.api_version {
-        api_versions.iter().find(|av| av.version == version).and_then(|av| {
-            av.deprecated_at.map(|d| chrono::Utc::now() >= d)
-        }).unwrap_or(false)
+        api_versions
+            .iter()
+            .find(|av| av.version == version)
+            .map(|av| {
+                let is_dep = av.deprecated_at.map_or(false, |d| chrono::Utc::now() >= d);
+                let is_sun = av.sunset_at.map_or(false, |s| chrono::Utc::now() >= s);
+                is_dep || is_sun
+            })
+            .unwrap_or(false)
     } else {
         false
     };

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -112,6 +112,8 @@ pub struct ApiDoc {
     /// Optional runtime hook that lets a handler register any extra
     /// component schemas with the generator.
     pub register_schemas: Option<fn(&mut SchemaRegistry)>,
+    /// Optional API version associated with this route.
+    pub api_version: Option<&'static str>,
 }
 
 /// Reference to a schema definition, produced by the route macros.
@@ -171,6 +173,8 @@ pub struct OpenApiConfig {
     pub session_cookie_name: String,
     /// User-registered component schemas keyed by schema name.
     pub additional_schemas: BTreeMap<String, serde_json::Value>,
+    /// API versions registry.
+    pub api_versions: Vec<crate::app::ApiVersion>,
 }
 
 #[cfg(feature = "openapi")]
@@ -186,6 +190,7 @@ impl OpenApiConfig {
             swagger_ui_path: Some("/swagger-ui".to_owned()),
             session_cookie_name: "autumn.sid".to_owned(),
             additional_schemas: BTreeMap::new(),
+            api_versions: Vec::new(),
         }
     }
 
@@ -398,6 +403,9 @@ pub struct Operation {
     /// Security requirements for this operation. Non-empty when the route uses `#[secured]`.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub security: Vec<BTreeMap<String, Vec<String>>>,
+    /// Declares this operation to be deprecated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
 }
 
 #[cfg(feature = "openapi")]
@@ -539,7 +547,7 @@ pub fn generate_spec(config: &OpenApiConfig, routes: &[&ApiDoc]) -> OpenApiSpec 
             collect_ref_names(entry, &mut referenced_names);
         }
 
-        let operation = operation_for(api_doc);
+        let operation = operation_for(api_doc, &config.api_versions);
         let entry = paths.entry(api_doc.path.to_owned()).or_default();
         match api_doc.method {
             "GET" => entry.get = Some(operation),
@@ -606,14 +614,27 @@ pub fn generate_spec(config: &OpenApiConfig, routes: &[&ApiDoc]) -> OpenApiSpec 
 }
 
 #[cfg(feature = "openapi")]
-fn operation_for(api_doc: &ApiDoc) -> Operation {
-    let tags = if api_doc.tags.is_empty() {
+fn operation_for(api_doc: &ApiDoc, api_versions: &[crate::app::ApiVersion]) -> Operation {
+    let mut tags = if api_doc.tags.is_empty() {
         default_tag(api_doc.path)
             .map(|t| vec![t.to_owned()])
             .unwrap_or_default()
     } else {
         api_doc.tags.iter().map(|s| (*s).to_owned()).collect()
     };
+
+    if let Some(version) = api_doc.api_version {
+        tags.push(version.to_string());
+    }
+
+    let is_deprecated = if let Some(version) = api_doc.api_version {
+        api_versions.iter().find(|av| av.version == version).and_then(|av| {
+            av.deprecated_at.map(|d| chrono::Utc::now() >= d)
+        }).unwrap_or(false)
+    } else {
+        false
+    };
+    let deprecated = if is_deprecated { Some(true) } else { None };
 
     // Path parameters — always required.
     let mut parameters: Vec<Parameter> = api_doc
@@ -704,6 +725,7 @@ fn operation_for(api_doc: &ApiDoc) -> Operation {
         request_body,
         responses,
         security,
+        deprecated,
     }
 }
 
@@ -1003,6 +1025,7 @@ mod tests {
             secured: false,
             required_roles: &[],
             register_schemas: None,
+            api_version: None,
         }
     }
 

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -618,6 +618,9 @@ mod tests {
             handler: format!("{}_handler", path.trim_start_matches('/').replace('/', "_")),
             source,
             middleware: vec![],
+            api_version: None,
+            status: None,
+            sunset_opt_out: None,
         }
     }
 

--- a/autumn/src/route.rs
+++ b/autumn/src/route.rs
@@ -122,6 +122,12 @@ pub struct Route {
     /// generating `/v3/api-docs`.
     pub api_doc: ApiDoc,
 
+    /// API version of the route (e.g. "v1")
+    pub api_version: Option<&'static str>,
+
+    /// Whether this route opts out of sunset 410 response
+    pub sunset_opt_out: bool,
+
     /// Repository auto-API metadata, populated by the
     /// `#[repository(api = ...)]` macro. `None` for hand-written
     /// route handlers.

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -88,33 +88,47 @@ pub fn collect_route_infos(
     route_sources: &[RouteSource],
     scoped_groups: &[ScopedGroup],
     api_versions: &[crate::app::ApiVersion],
-) -> Vec<RouteInfo> {
+) -> Result<Vec<RouteInfo>, crate::router::RouterBuildError> {
     let mut infos = Vec::with_capacity(routes.len());
     let now = chrono::Utc::now();
 
-    let resolve_status = |api_version: Option<&str>, sunset_opt_out: bool| -> (Option<String>, Option<String>, Option<bool>) {
+    let resolve_status = |route_name: &str,
+                          api_version: Option<&str>,
+                          sunset_opt_out: bool|
+     -> Result<
+        (Option<String>, Option<String>, Option<bool>),
+        crate::router::RouterBuildError,
+    > {
         let Some(ver) = api_version else {
-            return (None, None, None);
+            return Ok((None, None, None));
         };
-        let status = if let Some(av) = api_versions.iter().find(|av| av.version == ver) {
-            let is_sunset = av.sunset_at.map_or(false, |s| now >= s);
-            let is_dep = av.deprecated_at.map_or(false, |d| now >= d);
-            if is_sunset {
+        if let Some(av) = api_versions.iter().find(|av| av.version == ver) {
+            let is_sunset = av.sunset_at.is_some_and(|s| now >= s);
+            let is_dep = av.deprecated_at.is_some_and(|d| now >= d);
+            let status = if is_sunset {
                 "sunset"
             } else if is_dep {
                 "deprecated"
             } else {
                 "active"
-            }
+            };
+            Ok((
+                Some(ver.to_string()),
+                Some(status.to_string()),
+                Some(sunset_opt_out),
+            ))
         } else {
-            "active"
-        };
-        (Some(ver.to_string()), Some(status.to_string()), Some(sunset_opt_out))
+            Err(crate::router::RouterBuildError::UnregisteredApiVersion {
+                route_name: route_name.to_string(),
+                version: ver.to_string(),
+            })
+        }
     };
 
     for (i, route) in routes.iter().enumerate() {
         let source = route_sources.get(i).cloned().unwrap_or(RouteSource::User);
-        let (api_version, status, sunset_opt_out) = resolve_status(route.api_version, route.sunset_opt_out);
+        let (api_version, status, sunset_opt_out) =
+            resolve_status(route.name, route.api_version, route.sunset_opt_out)?;
         infos.push(RouteInfo {
             method: route.method.to_string(),
             path: route.path.to_owned(),
@@ -130,7 +144,8 @@ pub fn collect_route_infos(
     for group in scoped_groups {
         for route in &group.routes {
             let full_path = join_scope_path(&group.prefix, route.path);
-            let (api_version, status, sunset_opt_out) = resolve_status(route.api_version, route.sunset_opt_out);
+            let (api_version, status, sunset_opt_out) =
+                resolve_status(route.name, route.api_version, route.sunset_opt_out)?;
             infos.push(RouteInfo {
                 method: route.method.to_string(),
                 path: full_path,
@@ -144,7 +159,7 @@ pub fn collect_route_infos(
         }
     }
 
-    infos
+    Ok(infos)
 }
 
 /// Append framework-internal routes (probes, actuator, htmx assets).
@@ -398,7 +413,7 @@ mod tests {
 
     #[test]
     fn collect_route_infos_empty_produces_empty() {
-        let infos = collect_route_infos(&[], &[], &[], &[]);
+        let infos = collect_route_infos(&[], &[], &[], &[]).unwrap();
         assert!(infos.is_empty());
     }
 
@@ -406,7 +421,7 @@ mod tests {
     fn collect_route_infos_single_user_route() {
         let routes = vec![make_route(Method::GET, "/posts", "list_posts")];
         let sources = vec![RouteSource::User];
-        let infos = collect_route_infos(&routes, &sources, &[], &[]);
+        let infos = collect_route_infos(&routes, &sources, &[], &[]).unwrap();
         assert_eq!(infos.len(), 1);
         assert_eq!(infos[0].method, "GET");
         assert_eq!(infos[0].path, "/posts");
@@ -422,7 +437,7 @@ mod tests {
             make_route(Method::POST, "/posts", "create_post"),
         ];
         let sources = vec![RouteSource::User, RouteSource::User];
-        let infos = collect_route_infos(&routes, &sources, &[], &[]);
+        let infos = collect_route_infos(&routes, &sources, &[], &[]).unwrap();
         assert_eq!(infos.len(), 2);
     }
 
@@ -444,7 +459,7 @@ mod tests {
             make_route(Method::DELETE, "/posts/{id}", "delete_post"),
         ];
         let sources = vec![RouteSource::User; 3];
-        let infos = collect_route_infos(&routes, &sources, &[], &[]);
+        let infos = collect_route_infos(&routes, &sources, &[], &[]).unwrap();
         let methods: Vec<&str> = infos.iter().map(|i| i.method.as_str()).collect();
         assert_eq!(methods, vec!["PUT", "PATCH", "DELETE"]);
         // The transport method browsers actually use must never appear in
@@ -460,7 +475,7 @@ mod tests {
             source: RouteSource::User,
             apply_layer: Box::new(|r| r),
         };
-        let infos = collect_route_infos(&[], &[], &[group], &[]);
+        let infos = collect_route_infos(&[], &[], &[group], &[]).unwrap();
         assert_eq!(infos.len(), 1);
         assert_eq!(infos[0].path, "/api/posts");
         assert_eq!(infos[0].handler, "api_list_posts");
@@ -474,7 +489,7 @@ mod tests {
             source: RouteSource::User,
             apply_layer: Box::new(|r| r),
         };
-        let infos = collect_route_infos(&[], &[], &[group], &[]);
+        let infos = collect_route_infos(&[], &[], &[group], &[]).unwrap();
         assert_eq!(infos.len(), 1);
         assert_eq!(infos[0].path, "/api");
     }
@@ -483,7 +498,7 @@ mod tests {
     fn collect_route_infos_marks_user_source() {
         let routes = vec![make_route(Method::POST, "/items", "create_item")];
         let sources = vec![RouteSource::User];
-        let infos = collect_route_infos(&routes, &sources, &[], &[]);
+        let infos = collect_route_infos(&routes, &sources, &[], &[]).unwrap();
         assert_eq!(infos[0].source, RouteSource::User);
     }
 
@@ -491,7 +506,7 @@ mod tests {
     fn collect_route_infos_plugin_source_from_parallel_slice() {
         let routes = vec![make_route(Method::GET, "/admin", "admin_index")];
         let sources = vec![RouteSource::Plugin("admin".to_owned())];
-        let infos = collect_route_infos(&routes, &sources, &[], &[]);
+        let infos = collect_route_infos(&routes, &sources, &[], &[]).unwrap();
         assert_eq!(infos[0].source, RouteSource::Plugin("admin".to_owned()));
     }
 
@@ -503,7 +518,7 @@ mod tests {
             source: RouteSource::Plugin("admin".to_owned()),
             apply_layer: Box::new(|r| r),
         };
-        let infos = collect_route_infos(&[], &[], &[group], &[]);
+        let infos = collect_route_infos(&[], &[], &[group], &[]).unwrap();
         assert_eq!(infos[0].source, RouteSource::Plugin("admin".to_owned()));
         assert_eq!(infos[0].path, "/admin/users");
     }
@@ -512,7 +527,7 @@ mod tests {
     fn collect_route_infos_missing_source_defaults_to_user() {
         let routes = vec![make_route(Method::GET, "/x", "x")];
         // empty sources slice — should fall back to User
-        let infos = collect_route_infos(&routes, &[], &[], &[]);
+        let infos = collect_route_infos(&routes, &[], &[], &[]).unwrap();
         assert_eq!(infos[0].source, RouteSource::User);
     }
 

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -64,6 +64,15 @@ pub struct RouteInfo {
     pub source: RouteSource,
     /// Active middleware on this route (compact labels, e.g. `"secured"`, `"cached(60s)"`).
     pub middleware: Vec<String>,
+    /// API version of the route (e.g. "v1")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_version: Option<String>,
+    /// Status of the version ("active", "deprecated", "sunset")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// Whether this route opts out of sunset 410 Gone response
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sunset_opt_out: Option<bool>,
 }
 
 /// Collect [`RouteInfo`] entries from user routes and scoped groups.
@@ -74,37 +83,63 @@ pub struct RouteInfo {
 ///
 /// Does not include framework-internal routes (probes, actuator, htmx).
 /// Call [`append_framework_routes`] with a loaded config to add those.
-pub(crate) fn collect_route_infos(
+pub fn collect_route_infos(
     routes: &[Route],
     route_sources: &[RouteSource],
     scoped_groups: &[ScopedGroup],
+    api_versions: &[crate::app::ApiVersion],
 ) -> Vec<RouteInfo> {
     let mut infos = Vec::with_capacity(routes.len());
+    let now = chrono::Utc::now();
+
+    let resolve_status = |api_version: Option<&str>, sunset_opt_out: bool| -> (Option<String>, Option<String>, Option<bool>) {
+        let Some(ver) = api_version else {
+            return (None, None, None);
+        };
+        let status = if let Some(av) = api_versions.iter().find(|av| av.version == ver) {
+            let is_sunset = av.sunset_at.map_or(false, |s| now >= s);
+            let is_dep = av.deprecated_at.map_or(false, |d| now >= d);
+            if is_sunset {
+                "sunset"
+            } else if is_dep {
+                "deprecated"
+            } else {
+                "active"
+            }
+        } else {
+            "active"
+        };
+        (Some(ver.to_string()), Some(status.to_string()), Some(sunset_opt_out))
+    };
 
     for (i, route) in routes.iter().enumerate() {
         let source = route_sources.get(i).cloned().unwrap_or(RouteSource::User);
+        let (api_version, status, sunset_opt_out) = resolve_status(route.api_version, route.sunset_opt_out);
         infos.push(RouteInfo {
             method: route.method.to_string(),
             path: route.path.to_owned(),
             handler: route.name.to_owned(),
             source,
-            // Tower layers are opaque — there is no runtime API to enumerate
-            // which layers a MethodRouter carries. The middleware field is
-            // reserved for future population via proc-macro attributes (e.g.
-            // `#[middleware("secured")]`) on route handler functions.
             middleware: Vec::new(),
+            api_version,
+            status,
+            sunset_opt_out,
         });
     }
 
     for group in scoped_groups {
         for route in &group.routes {
             let full_path = join_scope_path(&group.prefix, route.path);
+            let (api_version, status, sunset_opt_out) = resolve_status(route.api_version, route.sunset_opt_out);
             infos.push(RouteInfo {
                 method: route.method.to_string(),
                 path: full_path,
                 handler: route.name.to_owned(),
                 source: group.source.clone(),
                 middleware: Vec::new(),
+                api_version,
+                status,
+                sunset_opt_out,
             });
         }
     }
@@ -134,6 +169,9 @@ pub(crate) fn append_framework_routes(
                 handler: name.to_owned(),
                 source: RouteSource::Framework,
                 middleware: Vec::new(),
+                api_version: None,
+                status: None,
+                sunset_opt_out: None,
             });
         }
     }
@@ -147,6 +185,9 @@ pub(crate) fn append_framework_routes(
             handler: "actuator".to_owned(),
             source: RouteSource::Framework,
             middleware: Vec::new(),
+            api_version: None,
+            status: None,
+            sunset_opt_out: None,
         });
     }
 
@@ -158,6 +199,9 @@ pub(crate) fn append_framework_routes(
             handler: "htmx".to_owned(),
             source: RouteSource::Framework,
             middleware: Vec::new(),
+            api_version: None,
+            status: None,
+            sunset_opt_out: None,
         });
         infos.push(RouteInfo {
             method: "GET".to_owned(),
@@ -165,6 +209,9 @@ pub(crate) fn append_framework_routes(
             handler: "htmx_csrf".to_owned(),
             source: RouteSource::Framework,
             middleware: Vec::new(),
+            api_version: None,
+            status: None,
+            sunset_opt_out: None,
         });
     }
 
@@ -190,6 +237,9 @@ pub(crate) fn append_framework_routes(
                 handler: handler.to_owned(),
                 source: RouteSource::Framework,
                 middleware: Vec::new(),
+                api_version: None,
+                status: None,
+                sunset_opt_out: None,
             });
         }
     }
@@ -208,6 +258,9 @@ pub(crate) fn append_framework_routes(
                 handler: handler.to_owned(),
                 source: RouteSource::Framework,
                 middleware: Vec::new(),
+                api_version: None,
+                status: None,
+                sunset_opt_out: None,
             });
         }
     }
@@ -219,6 +272,9 @@ pub(crate) fn append_framework_routes(
         handler: "static_files".to_owned(),
         source: RouteSource::Framework,
         middleware: Vec::new(),
+        api_version: None,
+        status: None,
+        sunset_opt_out: None,
     });
 }
 
@@ -236,6 +292,9 @@ pub(crate) fn append_openapi_routes(
         handler: "openapi_json".to_owned(),
         source: RouteSource::Framework,
         middleware: Vec::new(),
+        api_version: None,
+        status: None,
+        sunset_opt_out: None,
     });
     if let Some(ui_path) = &openapi.swagger_ui_path {
         infos.push(RouteInfo {
@@ -244,6 +303,9 @@ pub(crate) fn append_openapi_routes(
             handler: "swagger_ui".to_owned(),
             source: RouteSource::Framework,
             middleware: Vec::new(),
+            api_version: None,
+            status: None,
+            sunset_opt_out: None,
         });
     }
 }
@@ -267,6 +329,9 @@ pub(crate) fn append_dev_reload_routes(infos: &mut Vec<RouteInfo>) {
                 handler: handler.to_owned(),
                 source: RouteSource::Framework,
                 middleware: Vec::new(),
+                api_version: None,
+                status: None,
+                sunset_opt_out: None,
             });
         }
     }
@@ -324,6 +389,8 @@ mod tests {
             api_doc: dummy_api_doc(),
             repository: None,
             idempotency: crate::route::RouteIdempotency::Direct,
+            api_version: None,
+            sunset_opt_out: false,
         }
     }
 
@@ -331,7 +398,7 @@ mod tests {
 
     #[test]
     fn collect_route_infos_empty_produces_empty() {
-        let infos = collect_route_infos(&[], &[], &[]);
+        let infos = collect_route_infos(&[], &[], &[], &[]);
         assert!(infos.is_empty());
     }
 
@@ -339,7 +406,7 @@ mod tests {
     fn collect_route_infos_single_user_route() {
         let routes = vec![make_route(Method::GET, "/posts", "list_posts")];
         let sources = vec![RouteSource::User];
-        let infos = collect_route_infos(&routes, &sources, &[]);
+        let infos = collect_route_infos(&routes, &sources, &[], &[]);
         assert_eq!(infos.len(), 1);
         assert_eq!(infos[0].method, "GET");
         assert_eq!(infos[0].path, "/posts");
@@ -355,7 +422,7 @@ mod tests {
             make_route(Method::POST, "/posts", "create_post"),
         ];
         let sources = vec![RouteSource::User, RouteSource::User];
-        let infos = collect_route_infos(&routes, &sources, &[]);
+        let infos = collect_route_infos(&routes, &sources, &[], &[]);
         assert_eq!(infos.len(), 2);
     }
 
@@ -377,7 +444,7 @@ mod tests {
             make_route(Method::DELETE, "/posts/{id}", "delete_post"),
         ];
         let sources = vec![RouteSource::User; 3];
-        let infos = collect_route_infos(&routes, &sources, &[]);
+        let infos = collect_route_infos(&routes, &sources, &[], &[]);
         let methods: Vec<&str> = infos.iter().map(|i| i.method.as_str()).collect();
         assert_eq!(methods, vec!["PUT", "PATCH", "DELETE"]);
         // The transport method browsers actually use must never appear in
@@ -393,7 +460,7 @@ mod tests {
             source: RouteSource::User,
             apply_layer: Box::new(|r| r),
         };
-        let infos = collect_route_infos(&[], &[], &[group]);
+        let infos = collect_route_infos(&[], &[], &[group], &[]);
         assert_eq!(infos.len(), 1);
         assert_eq!(infos[0].path, "/api/posts");
         assert_eq!(infos[0].handler, "api_list_posts");
@@ -407,7 +474,7 @@ mod tests {
             source: RouteSource::User,
             apply_layer: Box::new(|r| r),
         };
-        let infos = collect_route_infos(&[], &[], &[group]);
+        let infos = collect_route_infos(&[], &[], &[group], &[]);
         assert_eq!(infos.len(), 1);
         assert_eq!(infos[0].path, "/api");
     }
@@ -416,7 +483,7 @@ mod tests {
     fn collect_route_infos_marks_user_source() {
         let routes = vec![make_route(Method::POST, "/items", "create_item")];
         let sources = vec![RouteSource::User];
-        let infos = collect_route_infos(&routes, &sources, &[]);
+        let infos = collect_route_infos(&routes, &sources, &[], &[]);
         assert_eq!(infos[0].source, RouteSource::User);
     }
 
@@ -424,7 +491,7 @@ mod tests {
     fn collect_route_infos_plugin_source_from_parallel_slice() {
         let routes = vec![make_route(Method::GET, "/admin", "admin_index")];
         let sources = vec![RouteSource::Plugin("admin".to_owned())];
-        let infos = collect_route_infos(&routes, &sources, &[]);
+        let infos = collect_route_infos(&routes, &sources, &[], &[]);
         assert_eq!(infos[0].source, RouteSource::Plugin("admin".to_owned()));
     }
 
@@ -436,7 +503,7 @@ mod tests {
             source: RouteSource::Plugin("admin".to_owned()),
             apply_layer: Box::new(|r| r),
         };
-        let infos = collect_route_infos(&[], &[], &[group]);
+        let infos = collect_route_infos(&[], &[], &[group], &[]);
         assert_eq!(infos[0].source, RouteSource::Plugin("admin".to_owned()));
         assert_eq!(infos[0].path, "/admin/users");
     }
@@ -445,7 +512,7 @@ mod tests {
     fn collect_route_infos_missing_source_defaults_to_user() {
         let routes = vec![make_route(Method::GET, "/x", "x")];
         // empty sources slice — should fall back to User
-        let infos = collect_route_infos(&routes, &[], &[]);
+        let infos = collect_route_infos(&routes, &[], &[], &[]);
         assert_eq!(infos[0].source, RouteSource::User);
     }
 
@@ -460,6 +527,9 @@ mod tests {
                 handler: "create".to_owned(),
                 source: RouteSource::User,
                 middleware: vec![],
+                api_version: None,
+                status: None,
+                sunset_opt_out: None,
             },
             RouteInfo {
                 method: "GET".to_owned(),
@@ -467,6 +537,9 @@ mod tests {
                 handler: "list".to_owned(),
                 source: RouteSource::User,
                 middleware: vec![],
+                api_version: None,
+                status: None,
+                sunset_opt_out: None,
             },
             RouteInfo {
                 method: "GET".to_owned(),
@@ -474,6 +547,9 @@ mod tests {
                 handler: "about".to_owned(),
                 source: RouteSource::User,
                 middleware: vec![],
+                api_version: None,
+                status: None,
+                sunset_opt_out: None,
             },
         ];
         sort_route_infos(&mut infos);
@@ -493,6 +569,9 @@ mod tests {
                 handler: "z".to_owned(),
                 source: RouteSource::User,
                 middleware: vec![],
+                api_version: None,
+                status: None,
+                sunset_opt_out: None,
             },
             RouteInfo {
                 method: "GET".to_owned(),
@@ -500,6 +579,9 @@ mod tests {
                 handler: "a".to_owned(),
                 source: RouteSource::User,
                 middleware: vec![],
+                api_version: None,
+                status: None,
+                sunset_opt_out: None,
             },
         ];
         sort_route_infos(&mut infos);
@@ -648,6 +730,9 @@ mod tests {
             handler: "posts::show".to_owned(),
             source: RouteSource::User,
             middleware: vec!["secured".to_owned()],
+            api_version: None,
+            status: None,
+            sunset_opt_out: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         let decoded: RouteInfo = serde_json::from_str(&json).unwrap();

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -82,7 +82,7 @@ pub struct RouteInfo {
 /// `routes`, remaining routes are attributed to [`RouteSource::User`].
 ///
 /// Does not include framework-internal routes (probes, actuator, htmx).
-/// Call [`append_framework_routes`] with a loaded config to add those.
+/// Call `append_framework_routes` with a loaded config to add those.
 pub fn collect_route_infos(
     routes: &[Route],
     route_sources: &[RouteSource],

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -89,7 +89,7 @@ type RouteVersionInfo = (Option<String>, Option<String>, Option<bool>);
 ///
 /// # Errors
 ///
-/// Returns [`crate::router::RouterBuildError::UnregisteredApiVersion`] if a route's version is not registered.
+/// Returns `RouterBuildError::UnregisteredApiVersion` if a route's version is not registered.
 pub fn collect_route_infos(
     routes: &[Route],
     route_sources: &[RouteSource],

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -75,6 +75,9 @@ pub struct RouteInfo {
     pub sunset_opt_out: Option<bool>,
 }
 
+/// Helper type alias representing version name, status string, and sunset opt-out flag.
+type RouteVersionInfo = (Option<String>, Option<String>, Option<bool>);
+
 /// Collect [`RouteInfo`] entries from user routes and scoped groups.
 ///
 /// `route_sources` is a parallel slice to `routes`; each element is the
@@ -83,6 +86,10 @@ pub struct RouteInfo {
 ///
 /// Does not include framework-internal routes (probes, actuator, htmx).
 /// Call `append_framework_routes` with a loaded config to add those.
+///
+/// # Errors
+///
+/// Returns [`crate::router::RouterBuildError::UnregisteredApiVersion`] if a route's version is not registered.
 pub fn collect_route_infos(
     routes: &[Route],
     route_sources: &[RouteSource],
@@ -95,34 +102,37 @@ pub fn collect_route_infos(
     let resolve_status = |route_name: &str,
                           api_version: Option<&str>,
                           sunset_opt_out: bool|
-     -> Result<
-        (Option<String>, Option<String>, Option<bool>),
-        crate::router::RouterBuildError,
-    > {
+     -> Result<RouteVersionInfo, crate::router::RouterBuildError> {
         let Some(ver) = api_version else {
             return Ok((None, None, None));
         };
-        if let Some(av) = api_versions.iter().find(|av| av.version == ver) {
-            let is_sunset = av.sunset_at.is_some_and(|s| now >= s);
-            let is_dep = av.deprecated_at.is_some_and(|d| now >= d);
-            let status = if is_sunset {
-                "sunset"
-            } else if is_dep {
-                "deprecated"
-            } else {
-                "active"
-            };
-            Ok((
-                Some(ver.to_string()),
-                Some(status.to_string()),
-                Some(sunset_opt_out),
-            ))
-        } else {
-            Err(crate::router::RouterBuildError::UnregisteredApiVersion {
-                route_name: route_name.to_string(),
-                version: ver.to_string(),
-            })
-        }
+        api_versions
+            .iter()
+            .find(|av| av.version == ver)
+            .map_or_else(
+                || {
+                    Err(crate::router::RouterBuildError::UnregisteredApiVersion {
+                        route_name: route_name.to_string(),
+                        version: ver.to_string(),
+                    })
+                },
+                |av| {
+                    let is_sunset = av.sunset_at.is_some_and(|s| now >= s);
+                    let is_dep = av.deprecated_at.is_some_and(|d| now >= d);
+                    let status = if is_sunset {
+                        "sunset"
+                    } else if is_dep {
+                        "deprecated"
+                    } else {
+                        "active"
+                    };
+                    Ok((
+                        Some(ver.to_string()),
+                        Some(status.to_string()),
+                        Some(sunset_opt_out),
+                    ))
+                },
+            )
     };
 
     for (i, route) in routes.iter().enumerate() {
@@ -166,6 +176,7 @@ pub fn collect_route_infos(
 ///
 /// Paths are taken from `config` so custom probe/actuator prefix settings
 /// are reflected accurately.
+#[allow(clippy::too_many_lines)]
 pub(crate) fn append_framework_routes(
     infos: &mut Vec<RouteInfo>,
     config: &crate::config::AutumnConfig,

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -84,6 +84,12 @@ pub enum RouterBuildError {
         /// The colliding path.
         path: String,
     },
+    /// A route is annotated with an API version that is not registered.
+    #[error("route '{route_name}' uses unregistered API version '{version}'")]
+    UnregisteredApiVersion {
+        route_name: String,
+        version: String,
+    },
 }
 
 /// Build the fully-configured Axum router from routes, config, and state.
@@ -266,6 +272,34 @@ fn build_router_pre_state(
     // the real layer list even though ctx.custom_layers is empty.
     opaque_app_layers_override: Option<bool>,
 ) -> Result<axum::Router<AppState>, RouterBuildError> {
+    // Verify registered API versions
+    let versions = state.extension::<crate::app::RegisteredApiVersions>();
+    let registered_versions: std::collections::HashSet<&str> = versions
+        .as_ref()
+        .map(|v| v.0.iter().map(|av| av.version.as_str()).collect())
+        .unwrap_or_default();
+
+    let check_route_version = |route: &Route| -> Result<(), RouterBuildError> {
+        if let Some(version) = route.api_version {
+            if !registered_versions.contains(version) {
+                return Err(RouterBuildError::UnregisteredApiVersion {
+                    route_name: route.name.to_string(),
+                    version: version.to_string(),
+                });
+            }
+        }
+        Ok(())
+    };
+
+    for route in &route_list {
+        check_route_version(route)?;
+    }
+    for group in &ctx.scoped_groups {
+        for route in &group.routes {
+            check_route_version(route)?;
+        }
+    }
+
     // Fail-fast if an OpenAPI mount path collides with a user or
     // framework GET route — axum panics on overlapping method routes,
     // so surface this as a recoverable error before we start merging.
@@ -287,6 +321,7 @@ fn build_router_pre_state(
         &ctx.scoped_groups,
         ctx.openapi.as_ref(),
         &config.session.cookie_name,
+        versions.as_ref().map(|v| v.0.as_slice()).unwrap_or(&[]),
     )?;
 
     let idempotency_layers = build_idempotency_layers(config, state)?;
@@ -296,6 +331,7 @@ fn build_router_pre_state(
         route_list,
         idempotency_layers.as_ref(),
         opaque_app_layers_present,
+        state,
     );
 
     let dev_reload_enabled = dev::is_enabled_with_env(&crate::config::OsEnv);
@@ -321,7 +357,7 @@ fn build_router_pre_state(
     router = router.nest_service("/static", tower_http::services::ServeDir::new(&static_dir));
     router = router.layer(axum::middleware::from_fn(asset_cache_control));
 
-    router = mount_scoped_groups(router, ctx.scoped_groups, idempotency_layers.as_ref());
+    router = mount_scoped_groups(router, ctx.scoped_groups, idempotency_layers.as_ref(), state);
 
     router = mount_raw_routers(
         router,
@@ -422,12 +458,14 @@ fn build_openapi_router(
     scoped_groups: &[ScopedGroup],
     openapi_config: Option<&crate::openapi::OpenApiConfig>,
     session_cookie_name: &str,
+    api_versions: &[crate::app::ApiVersion],
 ) -> Result<Option<axum::Router<AppState>>, RouterBuildError> {
     let Some(config) = openapi_config else {
         return Ok(None);
     };
     let mut config = config.clone();
     session_cookie_name.clone_into(&mut config.session_cookie_name);
+    config.api_versions = api_versions.to_vec();
 
     // Validate user-provided paths up front so a typo like
     // `"openapi.json"` surfaces as a recoverable RouterBuildError
@@ -727,6 +765,7 @@ fn group_and_mount_routes(
     route_list: Vec<Route>,
     idempotency_layers: Option<&BuiltIdempotencyLayers>,
     opaque_app_layers_present: bool,
+    state: &AppState,
 ) -> axum::Router<AppState> {
     // Group routes by path so multiple methods on the same path
     // (e.g. GET /admin + POST /admin) are merged into a single
@@ -748,6 +787,16 @@ fn group_and_mount_routes(
         let mut handler = route.handler;
         if let Some(layer) = selected_layer {
             handler = handler.layer(layer.clone());
+        }
+        if let Some(version) = route.api_version {
+            handler = handler.layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                api_versioning_middleware,
+            ));
+            handler = handler.layer(axum::Extension(RouteVersionMetadata {
+                version: version.to_string(),
+                sunset_opt_out: route.sunset_opt_out,
+            }));
         }
         grouped
             .entry(route.path)
@@ -971,6 +1020,7 @@ fn mount_scoped_groups(
     mut router: axum::Router<AppState>,
     scoped_groups: Vec<ScopedGroup>,
     idempotency_layers: Option<&BuiltIdempotencyLayers>,
+    state: &AppState,
 ) -> axum::Router<AppState> {
     // Mount scoped route groups (each with its own middleware layer).
     for group in scoped_groups {
@@ -993,6 +1043,16 @@ fn mount_scoped_groups(
             let mut handler = route.handler;
             if let Some(layer) = selected_layer {
                 handler = handler.layer(layer.clone());
+            }
+            if let Some(version) = route.api_version {
+                handler = handler.layer(axum::middleware::from_fn_with_state(
+                    state.clone(),
+                    api_versioning_middleware,
+                ));
+                handler = handler.layer(axum::Extension(RouteVersionMetadata {
+                    version: version.to_string(),
+                    sunset_opt_out: route.sunset_opt_out,
+                }));
             }
             sub_router = sub_router.route(route.path, handler);
         }
@@ -2641,6 +2701,8 @@ mod tests {
                 },
                 repository: None,
                 idempotency: crate::route::RouteIdempotency::Direct,
+                api_version: None,
+                sunset_opt_out: false,
             }],
             source: crate::route_listing::RouteSource::User,
             apply_layer: Box::new(|r| r),
@@ -2710,6 +2772,8 @@ mod tests {
             },
             repository: None,
             idempotency: crate::route::RouteIdempotency::Direct,
+            api_version: None,
+            sunset_opt_out: false,
         };
         let group = crate::app::ScopedGroup {
             prefix: "/orgs/{org_id}".to_owned(),
@@ -2719,7 +2783,7 @@ mod tests {
         };
 
         let config = OpenApiConfig::new("Demo", "1.0.0");
-        let router = super::build_openapi_router(&[], &[group], Some(&config), "autumn.sid")
+        let router = super::build_openapi_router(&[], &[group], Some(&config), "autumn.sid", &[])
             .expect("openapi sub-router builds")
             .expect("openapi sub-router present when config is Some");
         let state = test_state();
@@ -2774,12 +2838,14 @@ mod tests {
             },
             repository: None,
             idempotency: crate::route::RouteIdempotency::Direct,
+            api_version: None,
+            sunset_opt_out: false,
         };
 
         let protected_routes = vec![route];
         let config = OpenApiConfig::new("Demo", "1.0.0");
         let docs_router =
-            super::build_openapi_router(&protected_routes, &[], Some(&config), "demo.sid")
+            super::build_openapi_router(&protected_routes, &[], Some(&config), "demo.sid", &[])
                 .expect("openapi sub-router builds")
                 .expect("openapi sub-router present when config is Some");
         let docs_router = docs_router.with_state(test_state());
@@ -2814,7 +2880,7 @@ mod tests {
     fn openapi_rejects_json_path_without_leading_slash() {
         let config =
             crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("openapi.json");
-        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid")
+        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid", &[])
             .expect_err("non-slash path should be rejected");
         assert!(matches!(
             err,
@@ -2832,7 +2898,7 @@ mod tests {
         // endpoints are static. Catch it before axum panics.
         let config =
             crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("/docs/{id}");
-        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid")
+        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid", &[])
             .expect_err("captures should be rejected");
         assert!(matches!(err, RouterBuildError::InvalidOpenApiPath { .. }));
     }
@@ -2842,7 +2908,7 @@ mod tests {
     fn openapi_rejects_path_with_unbalanced_brace() {
         let config =
             crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("/docs/{id");
-        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid")
+        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid", &[])
             .expect_err("unbalanced brace should be rejected");
         assert!(matches!(err, RouterBuildError::InvalidOpenApiPath { .. }));
     }
@@ -2852,7 +2918,7 @@ mod tests {
     fn openapi_rejects_path_with_wildcard() {
         let config =
             crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("/docs/*rest");
-        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid")
+        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid", &[])
             .expect_err("wildcard should be rejected");
         assert!(matches!(err, RouterBuildError::InvalidOpenApiPath { .. }));
     }
@@ -2862,7 +2928,7 @@ mod tests {
     fn openapi_rejects_path_with_double_slash() {
         let config =
             crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("//docs");
-        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid")
+        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid", &[])
             .expect_err("double-slash should be rejected");
         assert!(matches!(err, RouterBuildError::InvalidOpenApiPath { .. }));
     }
@@ -2872,7 +2938,7 @@ mod tests {
     fn openapi_rejects_swagger_ui_path_without_leading_slash() {
         let config = crate::openapi::OpenApiConfig::new("Demo", "1.0.0")
             .swagger_ui_path(Some("docs".to_owned()));
-        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid")
+        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid", &[])
             .expect_err("non-slash path should be rejected");
         assert!(matches!(
             err,
@@ -2887,7 +2953,7 @@ mod tests {
     #[test]
     fn openapi_rejects_empty_json_path() {
         let config = crate::openapi::OpenApiConfig::new("Demo", "1.0.0").openapi_json_path("");
-        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid")
+        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid", &[])
             .expect_err("empty path should be rejected");
         assert!(matches!(err, RouterBuildError::InvalidOpenApiPath { .. }));
     }
@@ -2898,7 +2964,7 @@ mod tests {
         let config = crate::openapi::OpenApiConfig::new("Demo", "1.0.0")
             .openapi_json_path("/api-docs")
             .swagger_ui_path(Some("/ui".to_owned()));
-        let out = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid")
+        let out = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid", &[])
             .expect("valid paths must not error");
         assert!(out.is_some());
     }
@@ -2909,7 +2975,7 @@ mod tests {
         let config = crate::openapi::OpenApiConfig::new("Demo", "1.0.0")
             .openapi_json_path("/docs")
             .swagger_ui_path(Some("/docs".to_owned()));
-        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid")
+        let err = super::build_openapi_router(&[], &[], Some(&config), "autumn.sid", &[])
             .expect_err("colliding paths should be rejected before axum panics");
         assert!(matches!(
             err,
@@ -2944,6 +3010,8 @@ mod tests {
             },
             repository: None,
             idempotency: crate::route::RouteIdempotency::Direct,
+            api_version: None,
+            sunset_opt_out: false,
         };
 
         let ctx = RouterContext {
@@ -3011,6 +3079,8 @@ mod tests {
             },
             repository: None,
             idempotency: crate::route::RouteIdempotency::Direct,
+            api_version: None,
+            sunset_opt_out: false,
         };
 
         let ctx = RouterContext {
@@ -3911,4 +3981,74 @@ impl TrustedHostPolicy {
             )
         })
     }
+}
+
+/// Metadata carrying API version and sunset opt-out configuration for a route.
+#[derive(Clone, Debug)]
+pub struct RouteVersionMetadata {
+    pub version: String,
+    pub sunset_opt_out: bool,
+}
+
+/// Middleware that handles API deprecation, sunsets, and Gone responses.
+async fn api_versioning_middleware(
+    state: axum::extract::State<AppState>,
+    route_version: Option<axum::extract::Extension<RouteVersionMetadata>>,
+    request: axum::http::Request<axum::body::Body>,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let Some(axum::extract::Extension(meta)) = route_version else {
+        return next.run(request).await;
+    };
+
+    let clock = state.clock();
+    let now = clock.now();
+
+    let versions = state.extension::<crate::app::RegisteredApiVersions>();
+    let matching_version = versions.as_ref().and_then(|v| {
+        v.0.iter().find(|av| av.version == meta.version)
+    });
+
+    let Some(version) = matching_version else {
+        return next.run(request).await;
+    };
+
+    let is_deprecated = version.deprecated_at.map_or(false, |d| now >= d);
+    let is_sunset = version.sunset_at.map_or(false, |s| now >= s);
+
+    if is_sunset && !meta.sunset_opt_out {
+        let err = crate::error::AutumnError::gone_msg(format!(
+            "API version '{}' has been sunsetted.",
+            meta.version
+        ));
+        let mut response = err.into_response();
+        if let Some(sunset) = version.sunset_at {
+            let http_date = sunset.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
+            if let Ok(val) = axum::http::HeaderValue::from_str(&http_date) {
+                response.headers_mut().insert("Sunset", val);
+            }
+        }
+        if let Ok(val) = axum::http::HeaderValue::from_str("true") {
+            response.headers_mut().insert("Deprecation", val);
+        }
+        return response;
+    }
+
+    let mut response = next.run(request).await;
+
+    if is_deprecated {
+        if let Ok(val) = axum::http::HeaderValue::from_str("true") {
+            response.headers_mut().insert("Deprecation", val);
+        }
+    }
+    if let Some(sunset) = version.sunset_at {
+        if is_deprecated || is_sunset {
+            let http_date = sunset.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
+            if let Ok(val) = axum::http::HeaderValue::from_str(&http_date) {
+                response.headers_mut().insert("Sunset", val);
+            }
+        }
+    }
+
+    response
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -86,10 +86,7 @@ pub enum RouterBuildError {
     },
     /// A route is annotated with an API version that is not registered.
     #[error("route '{route_name}' uses unregistered API version '{version}'")]
-    UnregisteredApiVersion {
-        route_name: String,
-        version: String,
-    },
+    UnregisteredApiVersion { route_name: String, version: String },
 }
 
 /// Build the fully-configured Axum router from routes, config, and state.
@@ -357,7 +354,12 @@ fn build_router_pre_state(
     router = router.nest_service("/static", tower_http::services::ServeDir::new(&static_dir));
     router = router.layer(axum::middleware::from_fn(asset_cache_control));
 
-    router = mount_scoped_groups(router, ctx.scoped_groups, idempotency_layers.as_ref(), state);
+    router = mount_scoped_groups(
+        router,
+        ctx.scoped_groups,
+        idempotency_layers.as_ref(),
+        state,
+    );
 
     router = mount_raw_routers(
         router,
@@ -444,14 +446,36 @@ pub fn extract_path_params(path: &str) -> Vec<String> {
     out
 }
 
+/// Handler that dynamically constructs the OpenAPI specification document per request
+/// so deprecation and sunset statuses do not go stale.
+#[cfg(feature = "openapi")]
+async fn serve_openapi_spec(
+    axum::extract::Extension(config): axum::extract::Extension<
+        std::sync::Arc<crate::openapi::OpenApiConfig>,
+    >,
+    axum::extract::Extension(docs): axum::extract::Extension<
+        std::sync::Arc<Vec<crate::openapi::ApiDoc>>,
+    >,
+) -> impl axum::response::IntoResponse {
+    use axum::response::IntoResponse;
+    let refs: Vec<&crate::openapi::ApiDoc> = docs.iter().collect();
+    let spec = crate::openapi::generate_spec(&config, &refs);
+    let spec_json = serde_json::to_string_pretty(&spec)
+        .unwrap_or_else(|e| format!("{{\"error\": \"failed to serialize spec: {e}\"}}"));
+    (
+        [(http::header::CONTENT_TYPE, "application/json")],
+        spec_json,
+    )
+        .into_response()
+}
+
 /// Build an Axum sub-router that serves the generated `OpenAPI` document
 /// and (optionally) a Swagger UI HTML page.
 ///
 /// Returns `None` when `OpenAPI` generation is disabled, i.e. the user
 /// never called [`AppBuilder::openapi`](crate::app::AppBuilder::openapi).
 ///
-/// The spec is rendered once at build time and stored in an `Arc<String>`
-/// so the `/v3/api-docs` handler performs no serialization per request.
+/// The spec is dynamically generated on request to prevent lifecycle status from going stale.
 #[cfg(feature = "openapi")]
 fn build_openapi_router(
     route_list: &[Route],
@@ -483,30 +507,16 @@ fn build_openapi_router(
 
     let docs = collect_openapi_docs(route_list, scoped_groups);
 
-    let refs: Vec<&crate::openapi::ApiDoc> = docs.iter().collect();
-    let spec = crate::openapi::generate_spec(&config, &refs);
-    let spec_json = serde_json::to_string_pretty(&spec)
-        .unwrap_or_else(|e| format!("{{\"error\": \"failed to serialize spec: {e}\"}}"));
-
-    let spec_body = Arc::new(spec_json);
     let json_path = config.openapi_json_path.clone();
     let swagger_path = config.swagger_ui_path.clone();
     let title = config.title.clone();
 
-    let mut router = axum::Router::<AppState>::new().route(
-        &json_path,
-        axum::routing::get(move || {
-            let spec = spec_body.clone();
-            async move {
-                use axum::response::IntoResponse;
-                (
-                    [(http::header::CONTENT_TYPE, "application/json")],
-                    (*spec).clone(),
-                )
-                    .into_response()
-            }
-        }),
-    );
+    let mut router = axum::Router::<AppState>::new()
+        .route(&json_path, axum::routing::get(serve_openapi_spec))
+        .layer(axum::extract::Extension(std::sync::Arc::new(
+            config.clone(),
+        )))
+        .layer(axum::extract::Extension(std::sync::Arc::new(docs)));
 
     if let Some(path) = swagger_path {
         router = mount_swagger_ui_routes(router, &path, &title, &json_path);
@@ -4005,16 +4015,16 @@ async fn api_versioning_middleware(
     let now = clock.now();
 
     let versions = state.extension::<crate::app::RegisteredApiVersions>();
-    let matching_version = versions.as_ref().and_then(|v| {
-        v.0.iter().find(|av| av.version == meta.version)
-    });
+    let matching_version = versions
+        .as_ref()
+        .and_then(|v| v.0.iter().find(|av| av.version == meta.version));
 
     let Some(version) = matching_version else {
         return next.run(request).await;
     };
 
-    let is_deprecated = version.deprecated_at.map_or(false, |d| now >= d);
-    let is_sunset = version.sunset_at.map_or(false, |s| now >= s);
+    let is_deprecated = version.deprecated_at.is_some_and(|d| now >= d);
+    let is_sunset = version.sunset_at.is_some_and(|s| now >= s);
 
     if is_sunset && !meta.sunset_opt_out {
         let err = crate::error::AutumnError::gone_msg(format!(
@@ -4028,8 +4038,12 @@ async fn api_versioning_middleware(
                 response.headers_mut().insert("Sunset", val);
             }
         }
-        if let Ok(val) = axum::http::HeaderValue::from_str("true") {
-            response.headers_mut().insert("Deprecation", val);
+        let deprecation_date = version.deprecated_at.or(version.sunset_at);
+        if let Some(date) = deprecation_date {
+            let timestamp = date.timestamp();
+            if let Ok(val) = axum::http::HeaderValue::from_str(&format!("@{timestamp}")) {
+                response.headers_mut().insert("Deprecation", val);
+            }
         }
         return response;
     }
@@ -4037,16 +4051,18 @@ async fn api_versioning_middleware(
     let mut response = next.run(request).await;
 
     if is_deprecated || is_sunset {
-        if let Ok(val) = axum::http::HeaderValue::from_str("true") {
-            response.headers_mut().insert("Deprecation", val);
+        let deprecation_date = version.deprecated_at.or(version.sunset_at);
+        if let Some(date) = deprecation_date {
+            let timestamp = date.timestamp();
+            if let Ok(val) = axum::http::HeaderValue::from_str(&format!("@{timestamp}")) {
+                response.headers_mut().insert("Deprecation", val);
+            }
         }
     }
-    if let Some(sunset) = version.sunset_at {
-        if is_deprecated || is_sunset {
-            let http_date = sunset.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
-            if let Ok(val) = axum::http::HeaderValue::from_str(&http_date) {
-                response.headers_mut().insert("Sunset", val);
-            }
+    if let Some(sunset) = version.sunset_at.filter(|_| is_deprecated || is_sunset) {
+        let http_date = sunset.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
+        if let Ok(val) = axum::http::HeaderValue::from_str(&http_date) {
+            response.headers_mut().insert("Sunset", val);
         }
     }
 

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -4036,7 +4036,7 @@ async fn api_versioning_middleware(
 
     let mut response = next.run(request).await;
 
-    if is_deprecated {
+    if is_deprecated || is_sunset {
         if let Ok(val) = axum::http::HeaderValue::from_str("true") {
             response.headers_mut().insert("Deprecation", val);
         }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -2041,7 +2041,10 @@ fn collect_openapi_docs(
     // user will call.
     let mut docs: Vec<crate::openapi::ApiDoc> = Vec::new();
     for route in route_list {
-        docs.push(route.api_doc.clone());
+        let mut doc = route.api_doc.clone();
+        doc.api_version = route.api_version;
+        doc.sunset_opt_out = route.sunset_opt_out;
+        docs.push(doc);
     }
     for group in scoped_groups {
         // Extract `{name}` captures from the scope prefix so parameters
@@ -2050,6 +2053,8 @@ fn collect_openapi_docs(
         let prefix_params = extract_path_params(&group.prefix);
         for route in &group.routes {
             let mut doc = route.api_doc.clone();
+            doc.api_version = route.api_version;
+            doc.sunset_opt_out = route.sunset_opt_out;
             // Leak the combined path so it fits the `&'static str` shape of
             // ApiDoc. The spec is built once per process; the leak is
             // bounded by the route table size. Using the same

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -259,6 +259,7 @@ pub fn try_build_router_inner(
 /// [`with_state`](axum::Router::with_state) is called.  Used by
 /// [`try_build_router_with_static_inner`] so that user layers and the static
 /// file middleware can be applied to the typed router before state is baked in.
+#[allow(clippy::too_many_lines)]
 fn build_router_pre_state(
     route_list: Vec<Route>,
     config: &AutumnConfig,
@@ -277,13 +278,14 @@ fn build_router_pre_state(
         .unwrap_or_default();
 
     let check_route_version = |route: &Route| -> Result<(), RouterBuildError> {
-        if let Some(version) = route.api_version {
-            if !registered_versions.contains(version) {
-                return Err(RouterBuildError::UnregisteredApiVersion {
-                    route_name: route.name.to_string(),
-                    version: version.to_string(),
-                });
-            }
+        if let Some(version) = route
+            .api_version
+            .filter(|ver| !registered_versions.contains(*ver))
+        {
+            return Err(RouterBuildError::UnregisteredApiVersion {
+                route_name: route.name.to_string(),
+                version: version.to_string(),
+            });
         }
         Ok(())
     };
@@ -318,7 +320,7 @@ fn build_router_pre_state(
         &ctx.scoped_groups,
         ctx.openapi.as_ref(),
         &config.session.cookie_name,
-        versions.as_ref().map(|v| v.0.as_slice()).unwrap_or(&[]),
+        versions.as_ref().map_or(&[], |v| v.0.as_slice()),
     )?;
 
     let idempotency_layers = build_idempotency_layers(config, state)?;
@@ -446,10 +448,11 @@ pub fn extract_path_params(path: &str) -> Vec<String> {
     out
 }
 
-/// Handler that dynamically constructs the OpenAPI specification document per request
+/// Handler that dynamically constructs the `OpenAPI` specification document per request
 /// so deprecation and sunset statuses do not go stale.
 #[cfg(feature = "openapi")]
 async fn serve_openapi_spec(
+    state: axum::extract::State<AppState>,
     axum::extract::Extension(config): axum::extract::Extension<
         std::sync::Arc<crate::openapi::OpenApiConfig>,
     >,
@@ -459,7 +462,8 @@ async fn serve_openapi_spec(
 ) -> impl axum::response::IntoResponse {
     use axum::response::IntoResponse;
     let refs: Vec<&crate::openapi::ApiDoc> = docs.iter().collect();
-    let spec = crate::openapi::generate_spec(&config, &refs);
+    let now = state.clock().now();
+    let spec = crate::openapi::generate_spec_at(&config, &refs, now);
     let spec_json = serde_json::to_string_pretty(&spec)
         .unwrap_or_else(|e| format!("{{\"error\": \"failed to serialize spec: {e}\"}}"));
     (
@@ -4038,7 +4042,10 @@ async fn api_versioning_middleware(
                 response.headers_mut().insert("Sunset", val);
             }
         }
-        let deprecation_date = version.deprecated_at.or(version.sunset_at);
+        let deprecation_date = match (version.deprecated_at, version.sunset_at) {
+            (Some(d), Some(s)) => Some(d.min(s)),
+            (d, s) => d.or(s),
+        };
         if let Some(date) = deprecation_date {
             let timestamp = date.timestamp();
             if let Ok(val) = axum::http::HeaderValue::from_str(&format!("@{timestamp}")) {
@@ -4051,7 +4058,10 @@ async fn api_versioning_middleware(
     let mut response = next.run(request).await;
 
     if is_deprecated || is_sunset {
-        let deprecation_date = version.deprecated_at.or(version.sunset_at);
+        let deprecation_date = match (version.deprecated_at, version.sunset_at) {
+            (Some(d), Some(s)) => Some(d.min(s)),
+            (d, s) => d.or(s),
+        };
         if let Some(date) = deprecation_date {
             let timestamp = date.timestamp();
             if let Ok(val) = axum::http::HeaderValue::from_str(&format!("@{timestamp}")) {

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -810,6 +810,8 @@ fn group_and_mount_routes(
             handler = handler.layer(axum::Extension(RouteVersionMetadata {
                 version: version.to_string(),
                 sunset_opt_out: route.sunset_opt_out,
+                secured: route.api_doc.secured,
+                required_roles: route.api_doc.required_roles,
             }));
         }
         grouped
@@ -1066,6 +1068,8 @@ fn mount_scoped_groups(
                 handler = handler.layer(axum::Extension(RouteVersionMetadata {
                     version: version.to_string(),
                     sunset_opt_out: route.sunset_opt_out,
+                    secured: route.api_doc.secured,
+                    required_roles: route.api_doc.required_roles,
                 }));
             }
             sub_router = sub_router.route(route.path, handler);
@@ -4002,11 +4006,13 @@ impl TrustedHostPolicy {
     }
 }
 
-/// Metadata carrying API version and sunset opt-out configuration for a route.
+/// Metadata carrying API version, sunset opt-out, and security configuration for a route.
 #[derive(Clone, Debug)]
 pub struct RouteVersionMetadata {
     pub version: String,
     pub sunset_opt_out: bool,
+    pub secured: bool,
+    pub required_roles: &'static [&'static str],
 }
 
 /// Middleware that handles API deprecation, sunsets, and Gone responses.
@@ -4036,6 +4042,32 @@ async fn api_versioning_middleware(
     let is_sunset = version.sunset_at.is_some_and(|s| now >= s);
 
     if is_sunset && !meta.sunset_opt_out {
+        if meta.secured {
+            let session = request.extensions().get::<crate::session::Session>();
+            let mut auth_failed = false;
+            let mut auth_error = None;
+            if let Some(session) = session {
+                if let Err(err) = crate::auth::__check_secured_with_key(
+                    session,
+                    state.auth_session_key(),
+                    meta.required_roles,
+                )
+                .await
+                {
+                    auth_failed = true;
+                    auth_error = Some(err);
+                }
+            } else {
+                auth_failed = true;
+                auth_error = Some(crate::error::AutumnError::unauthorized_msg(
+                    "authentication required",
+                ));
+            }
+            if auth_failed {
+                return auth_error.unwrap().into_response();
+            }
+        }
+
         let err = crate::error::AutumnError::gone_msg(format!(
             "API version '{}' has been sunsetted.",
             meta.version

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -647,7 +647,10 @@ impl TestApp {
 
     /// Register multiple API versions for testing.
     #[must_use]
-    pub fn api_versions(mut self, versions: impl IntoIterator<Item = crate::app::ApiVersion>) -> Self {
+    pub fn api_versions(
+        mut self,
+        versions: impl IntoIterator<Item = crate::app::ApiVersion>,
+    ) -> Self {
         self.api_versions.extend(versions);
         self
     }

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -208,6 +208,7 @@ pub struct TestApp {
     /// Retained as `Arc<dyn Any>` so `TestClient::advance_clock` can downcast
     /// to [`crate::time::TickingClock`] at runtime.
     clock_as_any: Option<std::sync::Arc<dyn std::any::Any + Send + Sync>>,
+    api_versions: Vec<crate::app::ApiVersion>,
 }
 
 type TestPolicyRegistration = Box<dyn FnOnce(&crate::authorization::PolicyRegistry) + Send>;
@@ -258,6 +259,7 @@ impl TestApp {
             extensions: std::collections::HashMap::new(),
             clock: None,
             clock_as_any: None,
+            api_versions: Vec::new(),
         }
     }
 
@@ -636,6 +638,20 @@ impl TestApp {
         self
     }
 
+    /// Register a single API version for testing.
+    #[must_use]
+    pub fn api_version(mut self, version: crate::app::ApiVersion) -> Self {
+        self.api_versions.push(version);
+        self
+    }
+
+    /// Register multiple API versions for testing.
+    #[must_use]
+    pub fn api_versions(mut self, versions: impl IntoIterator<Item = crate::app::ApiVersion>) -> Self {
+        self.api_versions.extend(versions);
+        self
+    }
+
     /// Attach a database connection pool to the test app.
     #[cfg(feature = "db")]
     #[must_use]
@@ -826,6 +842,7 @@ impl TestApp {
         for register in self.policy_registrations {
             register(state.policy_registry());
         }
+        state.insert_extension(crate::app::RegisteredApiVersions(self.api_versions));
         crate::app::install_webhook_registry(&state, &self.config);
 
         // Install AutumnConfig so DbState::statement_timeout / slow_query_threshold
@@ -1675,6 +1692,8 @@ mod tests {
                 },
                 repository: None,
                 idempotency: crate::route::RouteIdempotency::Direct,
+                api_version: None,
+                sunset_opt_out: false,
             },
             Route {
                 method: Method::POST,
@@ -1690,6 +1709,8 @@ mod tests {
                 },
                 repository: None,
                 idempotency: crate::route::RouteIdempotency::Direct,
+                api_version: None,
+                sunset_opt_out: false,
             },
             Route {
                 method: Method::POST,
@@ -1705,6 +1726,8 @@ mod tests {
                 },
                 repository: None,
                 idempotency: crate::route::RouteIdempotency::Direct,
+                api_version: None,
+                sunset_opt_out: false,
             },
         ]
     }
@@ -1848,6 +1871,8 @@ mod tests {
             },
             repository: None,
             idempotency: crate::route::RouteIdempotency::Direct,
+            api_version: None,
+            sunset_opt_out: false,
         }];
         let client = TestApp::new().routes(routes).build();
 

--- a/autumn/tests/api_versioning_integration.rs
+++ b/autumn/tests/api_versioning_integration.rs
@@ -14,7 +14,11 @@ async fn api_info_v1_opt() -> &'static str {
     "v1 info opt"
 }
 
-#[get("/api/sunset-only-opt", api_version = "v_sunset_only", sunset_opt_out = true)]
+#[get(
+    "/api/sunset-only-opt",
+    api_version = "v_sunset_only",
+    sunset_opt_out = true
+)]
 async fn api_sunset_only_opt() -> &'static str {
     "sunset only opt"
 }
@@ -33,7 +37,12 @@ async fn test_api_versioning_integration() {
     let clock = TickingClock::starting_at(start_time);
 
     let client = TestApp::new()
-        .routes(routes![api_info_v1, api_info_v1_opt, api_plain, api_sunset_only_opt])
+        .routes(routes![
+            api_info_v1,
+            api_info_v1_opt,
+            api_plain,
+            api_sunset_only_opt
+        ])
         .api_version(autumn_web::app::ApiVersion {
             version: "v1".to_string(),
             deprecated_at: Some(deprecated_at),
@@ -59,11 +68,15 @@ async fn test_api_versioning_integration() {
     assert!(resp.header("Deprecation").is_none());
     assert!(resp.header("Sunset").is_none());
 
-    // 3. Move past deprecation: Deprecation: true, Sunset: date headers are emitted
+    // 3. Move past deprecation: Deprecation: structured date, Sunset: date headers are emitted
     client.advance_clock(Duration::from_secs(24 * 3600 + 10)); // past deprecation (June 2)
     let resp = client.get("/api/info").send().await;
     resp.assert_ok();
-    assert_eq!(resp.header("Deprecation").unwrap(), "true");
+    let expected_deprecation_header = format!("@{}", deprecated_at.timestamp());
+    assert_eq!(
+        resp.header("Deprecation").unwrap(),
+        expected_deprecation_header
+    );
     let expected_sunset_header = sunset_at.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
     assert_eq!(resp.header("Sunset").unwrap(), expected_sunset_header);
 
@@ -72,20 +85,30 @@ async fn test_api_versioning_integration() {
     let resp = client.get("/api/info").send().await;
     resp.assert_status(410);
     assert_eq!(resp.header("Sunset").unwrap(), expected_sunset_header);
-    assert_eq!(resp.header("Deprecation").unwrap(), "true");
-    
+    assert_eq!(
+        resp.header("Deprecation").unwrap(),
+        expected_deprecation_header
+    );
+
     let body = resp.text();
     assert!(body.contains("autumn.gone"));
 
     // 5. Opt-out route past sunset bypasses 410 Gone but still emits headers
     let resp = client.get("/api/info-opt").send().await;
     resp.assert_ok();
-    assert_eq!(resp.header("Deprecation").unwrap(), "true");
+    assert_eq!(
+        resp.header("Deprecation").unwrap(),
+        expected_deprecation_header
+    );
     assert_eq!(resp.header("Sunset").unwrap(), expected_sunset_header);
 
     // 6. Opt-out route past sunset (with no deprecation_at configured) still emits Deprecation header
     let resp = client.get("/api/sunset-only-opt").send().await;
     resp.assert_ok();
-    assert_eq!(resp.header("Deprecation").unwrap(), "true");
+    let expected_sunset_deprecation_header = format!("@{}", sunset_at.timestamp());
+    assert_eq!(
+        resp.header("Deprecation").unwrap(),
+        expected_sunset_deprecation_header
+    );
     assert_eq!(resp.header("Sunset").unwrap(), expected_sunset_header);
 }

--- a/autumn/tests/api_versioning_integration.rs
+++ b/autumn/tests/api_versioning_integration.rs
@@ -112,3 +112,97 @@ async fn test_api_versioning_integration() {
     );
     assert_eq!(resp.header("Sunset").unwrap(), expected_sunset_header);
 }
+
+#[get("/api/secured-sunset", api_version = "v1")]
+#[secured]
+async fn api_secured_sunset() -> &'static str {
+    "secured sunset info"
+}
+
+#[get("/api/secured-role-sunset", api_version = "v1")]
+#[secured("admin")]
+async fn api_secured_role_sunset() -> &'static str {
+    "secured role sunset info"
+}
+
+#[tokio::test]
+async fn test_api_versioning_auth_preservation() {
+    use autumn_web::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
+
+    let start_time = Utc.with_ymd_and_hms(2026, 6, 1, 0, 0, 0).unwrap();
+    let deprecated_at = Utc.with_ymd_and_hms(2026, 6, 2, 0, 0, 0).unwrap();
+    let sunset_at = Utc.with_ymd_and_hms(2026, 6, 3, 0, 0, 0).unwrap();
+
+    let clock = TickingClock::starting_at(start_time);
+    let store = MemoryStore::new();
+
+    // Seed session data
+    let mut admin_data = std::collections::HashMap::new();
+    admin_data.insert("user_id".to_owned(), "1".to_owned());
+    admin_data.insert("role".to_owned(), "admin".to_owned());
+    store.save("sess-admin", admin_data).await.unwrap();
+
+    let mut user_data = std::collections::HashMap::new();
+    user_data.insert("user_id".to_owned(), "2".to_owned());
+    user_data.insert("role".to_owned(), "user".to_owned());
+    store.save("sess-user", user_data).await.unwrap();
+
+    let client = TestApp::new()
+        .routes(routes![api_secured_sunset, api_secured_role_sunset])
+        .api_version(autumn_web::app::ApiVersion {
+            version: "v1".to_string(),
+            deprecated_at: Some(deprecated_at),
+            sunset_at: Some(sunset_at),
+        })
+        .with_clock(clock.clone())
+        .layer(SessionLayer::new(store, SessionConfig::default()))
+        .build();
+
+    // 1. Before sunset:
+    // Unauthenticated -> 401
+    let resp = client.get("/api/secured-sunset").send().await;
+    resp.assert_status(401);
+
+    // Authenticated user -> 200
+    let resp = client
+        .get("/api/secured-sunset")
+        .header("Cookie", "autumn.sid=sess-user")
+        .send()
+        .await;
+    resp.assert_ok();
+
+    // 2. Advance clock past sunset
+    client.advance_clock(Duration::from_secs(48 * 3600 + 10)); // past sunset
+
+    // Unauthenticated request -> 401 Unauthorized (not 410 Gone!)
+    let resp = client.get("/api/secured-sunset").send().await;
+    resp.assert_status(401);
+
+    // Authenticated request -> 410 Gone
+    let resp = client
+        .get("/api/secured-sunset")
+        .header("Cookie", "autumn.sid=sess-user")
+        .send()
+        .await;
+    resp.assert_status(410);
+
+    // Unauthenticated role-secured request -> 401 Unauthorized (not 410 Gone!)
+    let resp = client.get("/api/secured-role-sunset").send().await;
+    resp.assert_status(401);
+
+    // Authenticated request with wrong role -> 403 Forbidden (not 410 Gone!)
+    let resp = client
+        .get("/api/secured-role-sunset")
+        .header("Cookie", "autumn.sid=sess-user")
+        .send()
+        .await;
+    resp.assert_status(403);
+
+    // Authenticated request with correct role -> 410 Gone
+    let resp = client
+        .get("/api/secured-role-sunset")
+        .header("Cookie", "autumn.sid=sess-admin")
+        .send()
+        .await;
+    resp.assert_status(410);
+}

--- a/autumn/tests/api_versioning_integration.rs
+++ b/autumn/tests/api_versioning_integration.rs
@@ -1,0 +1,75 @@
+use autumn_web::prelude::*;
+use autumn_web::test::TestApp;
+use autumn_web::time::TickingClock;
+use chrono::{TimeZone, Utc};
+use std::time::Duration;
+
+#[get("/api/info", api_version = "v1")]
+async fn api_info_v1() -> &'static str {
+    "v1 info"
+}
+
+#[get("/api/info-opt", api_version = "v1", sunset_opt_out = true)]
+async fn api_info_v1_opt() -> &'static str {
+    "v1 info opt"
+}
+
+#[get("/api/plain")]
+async fn api_plain() -> &'static str {
+    "plain info"
+}
+
+#[tokio::test]
+async fn test_api_versioning_integration() {
+    let start_time = Utc.with_ymd_and_hms(2026, 6, 1, 0, 0, 0).unwrap();
+    let deprecated_at = Utc.with_ymd_and_hms(2026, 6, 2, 0, 0, 0).unwrap();
+    let sunset_at = Utc.with_ymd_and_hms(2026, 6, 3, 0, 0, 0).unwrap();
+
+    let clock = TickingClock::starting_at(start_time);
+
+    let client = TestApp::new()
+        .routes(routes![api_info_v1, api_info_v1_opt, api_plain])
+        .api_version(autumn_web::app::ApiVersion {
+            version: "v1".to_string(),
+            deprecated_at: Some(deprecated_at),
+            sunset_at: Some(sunset_at),
+        })
+        .with_clock(clock.clone())
+        .build();
+
+    // 1. Untagged route behaves as normal
+    let resp = client.get("/api/plain").send().await;
+    resp.assert_ok();
+    assert!(resp.header("Deprecation").is_none());
+    assert!(resp.header("Sunset").is_none());
+
+    // 2. Tagged route behaves normally before deprecation
+    let resp = client.get("/api/info").send().await;
+    resp.assert_ok();
+    assert!(resp.header("Deprecation").is_none());
+    assert!(resp.header("Sunset").is_none());
+
+    // 3. Move past deprecation: Deprecation: true, Sunset: date headers are emitted
+    client.advance_clock(Duration::from_secs(24 * 3600 + 10)); // past deprecation (June 2)
+    let resp = client.get("/api/info").send().await;
+    resp.assert_ok();
+    assert_eq!(resp.header("Deprecation").unwrap(), "true");
+    let expected_sunset_header = sunset_at.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
+    assert_eq!(resp.header("Sunset").unwrap(), expected_sunset_header);
+
+    // 4. Move past sunset: should return 410 Gone with Sunset header
+    client.advance_clock(Duration::from_secs(24 * 3600)); // past sunset (June 3)
+    let resp = client.get("/api/info").send().await;
+    resp.assert_status(410);
+    assert_eq!(resp.header("Sunset").unwrap(), expected_sunset_header);
+    assert_eq!(resp.header("Deprecation").unwrap(), "true");
+    
+    let body = resp.text();
+    assert!(body.contains("autumn.gone"));
+
+    // 5. Opt-out route past sunset bypasses 410 Gone but still emits headers
+    let resp = client.get("/api/info-opt").send().await;
+    resp.assert_ok();
+    assert_eq!(resp.header("Deprecation").unwrap(), "true");
+    assert_eq!(resp.header("Sunset").unwrap(), expected_sunset_header);
+}

--- a/autumn/tests/api_versioning_integration.rs
+++ b/autumn/tests/api_versioning_integration.rs
@@ -14,6 +14,11 @@ async fn api_info_v1_opt() -> &'static str {
     "v1 info opt"
 }
 
+#[get("/api/sunset-only-opt", api_version = "v_sunset_only", sunset_opt_out = true)]
+async fn api_sunset_only_opt() -> &'static str {
+    "sunset only opt"
+}
+
 #[get("/api/plain")]
 async fn api_plain() -> &'static str {
     "plain info"
@@ -28,10 +33,15 @@ async fn test_api_versioning_integration() {
     let clock = TickingClock::starting_at(start_time);
 
     let client = TestApp::new()
-        .routes(routes![api_info_v1, api_info_v1_opt, api_plain])
+        .routes(routes![api_info_v1, api_info_v1_opt, api_plain, api_sunset_only_opt])
         .api_version(autumn_web::app::ApiVersion {
             version: "v1".to_string(),
             deprecated_at: Some(deprecated_at),
+            sunset_at: Some(sunset_at),
+        })
+        .api_version(autumn_web::app::ApiVersion {
+            version: "v_sunset_only".to_string(),
+            deprecated_at: None,
             sunset_at: Some(sunset_at),
         })
         .with_clock(clock.clone())
@@ -69,6 +79,12 @@ async fn test_api_versioning_integration() {
 
     // 5. Opt-out route past sunset bypasses 410 Gone but still emits headers
     let resp = client.get("/api/info-opt").send().await;
+    resp.assert_ok();
+    assert_eq!(resp.header("Deprecation").unwrap(), "true");
+    assert_eq!(resp.header("Sunset").unwrap(), expected_sunset_header);
+
+    // 6. Opt-out route past sunset (with no deprecation_at configured) still emits Deprecation header
+    let resp = client.get("/api/sunset-only-opt").send().await;
     resp.assert_ok();
     assert_eq!(resp.header("Deprecation").unwrap(), "true");
     assert_eq!(resp.header("Sunset").unwrap(), expected_sunset_header);

--- a/autumn/tests/api_versioning_openapi.rs
+++ b/autumn/tests/api_versioning_openapi.rs
@@ -1,0 +1,62 @@
+//! OpenAPI versioning integration tests.
+//!
+//! Verifies that OpenAPI spec generation correctly tags operations with their
+//! API version names and sets the `deprecated: true` property when a route
+//! is associated with a version whose deprecation date is in the past.
+
+#![cfg(feature = "openapi")]
+
+use autumn_web::openapi::OpenApiConfig;
+use autumn_web::prelude::*;
+use autumn_web::app::ApiVersion;
+use chrono::{TimeZone, Utc};
+
+#[get("/v1/items", api_version = "v1")]
+async fn get_v1_items() -> &'static str {
+    "v1"
+}
+
+#[get("/v2/items", api_version = "v2")]
+async fn get_v2_items() -> &'static str {
+    "v2"
+}
+
+#[test]
+fn test_openapi_spec_version_tagging_and_deprecation() {
+    let route_v1 = __autumn_route_info_get_v1_items();
+    let route_v2 = __autumn_route_info_get_v2_items();
+
+    // v1 is deprecated (2020), v2 is active (2035)
+    let v1 = ApiVersion {
+        version: "v1".to_string(),
+        deprecated_at: Some(Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap()),
+        sunset_at: Some(Utc.with_ymd_and_hms(2040, 1, 1, 0, 0, 0).unwrap()),
+    };
+    let v2 = ApiVersion {
+        version: "v2".to_string(),
+        deprecated_at: Some(Utc.with_ymd_and_hms(2035, 1, 1, 0, 0, 0).unwrap()),
+        sunset_at: Some(Utc.with_ymd_and_hms(2040, 1, 1, 0, 0, 0).unwrap()),
+    };
+
+    let mut config = OpenApiConfig::new("Versioning Test API", "1.0.0");
+    config.api_versions = vec![v1, v2];
+
+    let docs = vec![&route_v1.api_doc, &route_v2.api_doc];
+    let spec = autumn_web::openapi::generate_spec(&config, &docs);
+
+    // v1 route path should exist
+    assert!(spec.paths.contains_key("/v1/items"));
+    let op_v1 = spec.paths["/v1/items"].get.as_ref().unwrap();
+    // v1 tag should be appended
+    assert!(op_v1.tags.contains(&"v1".to_string()));
+    // v1 should be marked deprecated: true
+    assert_eq!(op_v1.deprecated, Some(true));
+
+    // v2 route path should exist
+    assert!(spec.paths.contains_key("/v2/items"));
+    let op_v2 = spec.paths["/v2/items"].get.as_ref().unwrap();
+    // v2 tag should be appended
+    assert!(op_v2.tags.contains(&"v2".to_string()));
+    // v2 should NOT be marked deprecated (None)
+    assert_eq!(op_v2.deprecated, None);
+}

--- a/autumn/tests/api_versioning_openapi.rs
+++ b/autumn/tests/api_versioning_openapi.rs
@@ -31,12 +31,18 @@ async fn get_v1_sunset_opt_out() -> &'static str {
     "opt-out"
 }
 
+#[get("/v1/sunset-only-dep", api_version = "v_sunset_only")]
+async fn get_sunset_only_dep() -> &'static str {
+    "sunset-only-dep"
+}
+
 #[test]
 fn test_openapi_spec_version_tagging_and_deprecation() {
     let route_v1 = __autumn_route_info_get_v1_items();
     let route_v2 = __autumn_route_info_get_v2_items();
     let route_sunset = __autumn_route_info_get_v1_sunset();
     let route_sunset_opt_out = __autumn_route_info_get_v1_sunset_opt_out();
+    let route_sunset_only = __autumn_route_info_get_sunset_only_dep();
 
     // v1 is deprecated (2020), v2 is active (2035)
     let v1 = ApiVersion {
@@ -49,15 +55,21 @@ fn test_openapi_spec_version_tagging_and_deprecation() {
         deprecated_at: Some(Utc.with_ymd_and_hms(2035, 1, 1, 0, 0, 0).unwrap()),
         sunset_at: Some(Utc.with_ymd_and_hms(2040, 1, 1, 0, 0, 0).unwrap()),
     };
+    let v_sunset_only = ApiVersion {
+        version: "v_sunset_only".to_string(),
+        deprecated_at: None,
+        sunset_at: Some(Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap()),
+    };
 
     let mut config = OpenApiConfig::new("Versioning Test API", "1.0.0");
-    config.api_versions = vec![v1, v2];
+    config.api_versions = vec![v1, v2, v_sunset_only];
 
     let docs = vec![
         &route_v1.api_doc,
         &route_v2.api_doc,
         &route_sunset.api_doc,
         &route_sunset_opt_out.api_doc,
+        &route_sunset_only.api_doc,
     ];
     let spec = autumn_web::openapi::generate_spec(&config, &docs);
 
@@ -86,4 +98,9 @@ fn test_openapi_spec_version_tagging_and_deprecation() {
     assert!(spec.paths.contains_key("/v1/sunset-opt-out"));
     let op_sunset_opt_out = spec.paths["/v1/sunset-opt-out"].get.as_ref().unwrap();
     assert!(!op_sunset_opt_out.responses.contains_key("410"));
+
+    // /v1/sunset-only-dep should be marked deprecated: true because its sunset_at is in the past
+    assert!(spec.paths.contains_key("/v1/sunset-only-dep"));
+    let op_sunset_only = spec.paths["/v1/sunset-only-dep"].get.as_ref().unwrap();
+    assert_eq!(op_sunset_only.deprecated, Some(true));
 }

--- a/autumn/tests/api_versioning_openapi.rs
+++ b/autumn/tests/api_versioning_openapi.rs
@@ -1,14 +1,14 @@
-//! OpenAPI versioning integration tests.
+//! `OpenAPI` versioning integration tests.
 //!
-//! Verifies that OpenAPI spec generation correctly tags operations with their
+//! Verifies that `OpenAPI` spec generation correctly tags operations with their
 //! API version names and sets the `deprecated: true` property when a route
 //! is associated with a version whose deprecation date is in the past.
 
 #![cfg(feature = "openapi")]
 
+use autumn_web::app::ApiVersion;
 use autumn_web::openapi::OpenApiConfig;
 use autumn_web::prelude::*;
-use autumn_web::app::ApiVersion;
 use chrono::{TimeZone, Utc};
 
 #[get("/v1/items", api_version = "v1")]

--- a/autumn/tests/api_versioning_openapi.rs
+++ b/autumn/tests/api_versioning_openapi.rs
@@ -21,10 +21,22 @@ async fn get_v2_items() -> &'static str {
     "v2"
 }
 
+#[get("/v1/sunset", api_version = "v1")]
+async fn get_v1_sunset() -> &'static str {
+    "sunset"
+}
+
+#[get("/v1/sunset-opt-out", api_version = "v1", sunset_opt_out = true)]
+async fn get_v1_sunset_opt_out() -> &'static str {
+    "opt-out"
+}
+
 #[test]
 fn test_openapi_spec_version_tagging_and_deprecation() {
     let route_v1 = __autumn_route_info_get_v1_items();
     let route_v2 = __autumn_route_info_get_v2_items();
+    let route_sunset = __autumn_route_info_get_v1_sunset();
+    let route_sunset_opt_out = __autumn_route_info_get_v1_sunset_opt_out();
 
     // v1 is deprecated (2020), v2 is active (2035)
     let v1 = ApiVersion {
@@ -41,7 +53,12 @@ fn test_openapi_spec_version_tagging_and_deprecation() {
     let mut config = OpenApiConfig::new("Versioning Test API", "1.0.0");
     config.api_versions = vec![v1, v2];
 
-    let docs = vec![&route_v1.api_doc, &route_v2.api_doc];
+    let docs = vec![
+        &route_v1.api_doc,
+        &route_v2.api_doc,
+        &route_sunset.api_doc,
+        &route_sunset_opt_out.api_doc,
+    ];
     let spec = autumn_web::openapi::generate_spec(&config, &docs);
 
     // v1 route path should exist
@@ -59,4 +76,14 @@ fn test_openapi_spec_version_tagging_and_deprecation() {
     assert!(op_v2.tags.contains(&"v2".to_string()));
     // v2 should NOT be marked deprecated (None)
     assert_eq!(op_v2.deprecated, None);
+
+    // /v1/sunset should have 410 Gone response documented
+    assert!(spec.paths.contains_key("/v1/sunset"));
+    let op_sunset = spec.paths["/v1/sunset"].get.as_ref().unwrap();
+    assert!(op_sunset.responses.contains_key("410"));
+
+    // /v1/sunset-opt-out should NOT have 410 Gone response documented
+    assert!(spec.paths.contains_key("/v1/sunset-opt-out"));
+    let op_sunset_opt_out = spec.paths["/v1/sunset-opt-out"].get.as_ref().unwrap();
+    assert!(!op_sunset_opt_out.responses.contains_key("410"));
 }

--- a/autumn/tests/api_versioning_unit.rs
+++ b/autumn/tests/api_versioning_unit.rs
@@ -1,0 +1,159 @@
+use autumn_web::error::AutumnError;
+use autumn_web::openapi::ApiDoc;
+use http::StatusCode;
+
+#[test]
+fn test_route_version_fields() {
+    let route = autumn_web::Route {
+        method: http::Method::GET,
+        path: "/test",
+        handler: axum::routing::get(|| async { "test" }),
+        name: "test_handler",
+        api_version: Some("v1"),
+        sunset_opt_out: true,
+        api_doc: ApiDoc {
+            method: "GET",
+            path: "/test",
+            operation_id: "test_handler",
+            api_version: Some("v1"),
+            ..Default::default()
+        },
+        repository: None,
+        idempotency: Default::default(),
+    };
+
+    assert_eq!(route.api_version, Some("v1"));
+    assert!(route.sunset_opt_out);
+    assert_eq!(route.api_doc.api_version, Some("v1"));
+}
+
+#[test]
+fn test_autumn_error_gone() {
+    let err = AutumnError::gone_msg("The resource is gone permanently.");
+    assert_eq!(err.status(), StatusCode::GONE);
+}
+
+#[test]
+fn test_app_builder_api_version_registry() {
+    let app = autumn_web::app()
+        .api_version(autumn_web::app::ApiVersion {
+            version: "v1".to_string(),
+            deprecated_at: None,
+            sunset_at: None,
+        });
+    assert_eq!(app.api_versions.len(), 1);
+}
+
+#[tokio::test]
+async fn test_startup_validation_rejects_unregistered_version() {
+    use autumn_web::{get, routes};
+    use autumn_web::test::TestApp;
+
+    #[get("/v2/test", api_version = "v2")]
+    async fn versioned_handler() -> &'static str {
+        "v2"
+    }
+
+    let result = std::panic::catch_unwind(|| {
+        let _client = TestApp::new()
+            .routes(routes![versioned_handler])
+            .build();
+    });
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_route_listing_with_version_and_status() {
+    use autumn_web::app::ApiVersion;
+    use autumn_web::route_listing::collect_route_infos;
+    use chrono::{TimeZone, Utc};
+
+    let active_version = ApiVersion {
+        version: "v1".to_string(),
+        deprecated_at: Some(Utc.with_ymd_and_hms(2035, 1, 1, 0, 0, 0).unwrap()),
+        sunset_at: Some(Utc.with_ymd_and_hms(2040, 1, 1, 0, 0, 0).unwrap()),
+    };
+    let deprecated_version = ApiVersion {
+        version: "v2_dep".to_string(),
+        deprecated_at: Some(Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap()),
+        sunset_at: Some(Utc.with_ymd_and_hms(2040, 1, 1, 0, 0, 0).unwrap()),
+    };
+    let sunset_version = ApiVersion {
+        version: "v3_sun".to_string(),
+        deprecated_at: Some(Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap()),
+        sunset_at: Some(Utc.with_ymd_and_hms(2021, 1, 1, 0, 0, 0).unwrap()),
+    };
+
+    let routes = vec![
+        autumn_web::Route {
+            method: http::Method::GET,
+            path: "/v1/info",
+            handler: axum::routing::get(|| async { "v1" }),
+            name: "v1_handler",
+            api_version: Some("v1"),
+            sunset_opt_out: false,
+            api_doc: ApiDoc::default(),
+            repository: None,
+            idempotency: Default::default(),
+        },
+        autumn_web::Route {
+            method: http::Method::GET,
+            path: "/v2/info",
+            handler: axum::routing::get(|| async { "v2" }),
+            name: "v2_handler",
+            api_version: Some("v2_dep"),
+            sunset_opt_out: true,
+            api_doc: ApiDoc::default(),
+            repository: None,
+            idempotency: Default::default(),
+        },
+        autumn_web::Route {
+            method: http::Method::GET,
+            path: "/v3/info",
+            handler: axum::routing::get(|| async { "v3" }),
+            name: "v3_handler",
+            api_version: Some("v3_sun"),
+            sunset_opt_out: false,
+            api_doc: ApiDoc::default(),
+            repository: None,
+            idempotency: Default::default(),
+        },
+        autumn_web::Route {
+            method: http::Method::GET,
+            path: "/plain",
+            handler: axum::routing::get(|| async { "plain" }),
+            name: "plain_handler",
+            api_version: None,
+            sunset_opt_out: false,
+            api_doc: ApiDoc::default(),
+            repository: None,
+            idempotency: Default::default(),
+        },
+    ];
+
+    let registry = vec![active_version, deprecated_version, sunset_version];
+    let infos = collect_route_infos(&routes, &[], &[], &registry);
+
+    assert_eq!(infos.len(), 4);
+    
+    // v1: active
+    assert_eq!(infos[0].api_version, Some("v1".to_string()));
+    assert_eq!(infos[0].status, Some("active".to_string()));
+    assert_eq!(infos[0].sunset_opt_out, Some(false));
+
+    // v2: deprecated
+    assert_eq!(infos[1].api_version, Some("v2_dep".to_string()));
+    assert_eq!(infos[1].status, Some("deprecated".to_string()));
+    assert_eq!(infos[1].sunset_opt_out, Some(true));
+
+    // v3: sunset
+    assert_eq!(infos[2].api_version, Some("v3_sun".to_string()));
+    assert_eq!(infos[2].status, Some("sunset".to_string()));
+    assert_eq!(infos[2].sunset_opt_out, Some(false));
+
+    // plain: None
+    assert_eq!(infos[3].api_version, None);
+    assert_eq!(infos[3].status, None);
+    assert_eq!(infos[3].sunset_opt_out, None);
+}

--- a/autumn/tests/api_versioning_unit.rs
+++ b/autumn/tests/api_versioning_unit.rs
@@ -19,7 +19,7 @@ fn test_route_version_fields() {
             ..Default::default()
         },
         repository: None,
-        idempotency: Default::default(),
+        idempotency: autumn_web::RouteIdempotency::default(),
     };
 
     assert_eq!(route.api_version, Some("v1"));
@@ -35,19 +35,18 @@ fn test_autumn_error_gone() {
 
 #[test]
 fn test_app_builder_api_version_registry() {
-    let app = autumn_web::app()
-        .api_version(autumn_web::app::ApiVersion {
-            version: "v1".to_string(),
-            deprecated_at: None,
-            sunset_at: None,
-        });
+    let app = autumn_web::app().api_version(autumn_web::app::ApiVersion {
+        version: "v1".to_string(),
+        deprecated_at: None,
+        sunset_at: None,
+    });
     assert_eq!(app.api_versions.len(), 1);
 }
 
 #[tokio::test]
 async fn test_startup_validation_rejects_unregistered_version() {
-    use autumn_web::{get, routes};
     use autumn_web::test::TestApp;
+    use autumn_web::{get, routes};
 
     #[get("/v2/test", api_version = "v2")]
     async fn versioned_handler() -> &'static str {
@@ -55,9 +54,7 @@ async fn test_startup_validation_rejects_unregistered_version() {
     }
 
     let result = std::panic::catch_unwind(|| {
-        let _client = TestApp::new()
-            .routes(routes![versioned_handler])
-            .build();
+        let _client = TestApp::new().routes(routes![versioned_handler]).build();
     });
 
     assert!(result.is_err());
@@ -95,7 +92,7 @@ fn test_route_listing_with_version_and_status() {
             sunset_opt_out: false,
             api_doc: ApiDoc::default(),
             repository: None,
-            idempotency: Default::default(),
+            idempotency: autumn_web::RouteIdempotency::default(),
         },
         autumn_web::Route {
             method: http::Method::GET,
@@ -106,7 +103,7 @@ fn test_route_listing_with_version_and_status() {
             sunset_opt_out: true,
             api_doc: ApiDoc::default(),
             repository: None,
-            idempotency: Default::default(),
+            idempotency: autumn_web::RouteIdempotency::default(),
         },
         autumn_web::Route {
             method: http::Method::GET,
@@ -117,7 +114,7 @@ fn test_route_listing_with_version_and_status() {
             sunset_opt_out: false,
             api_doc: ApiDoc::default(),
             repository: None,
-            idempotency: Default::default(),
+            idempotency: autumn_web::RouteIdempotency::default(),
         },
         autumn_web::Route {
             method: http::Method::GET,
@@ -128,15 +125,15 @@ fn test_route_listing_with_version_and_status() {
             sunset_opt_out: false,
             api_doc: ApiDoc::default(),
             repository: None,
-            idempotency: Default::default(),
+            idempotency: autumn_web::RouteIdempotency::default(),
         },
     ];
 
     let registry = vec![active_version, deprecated_version, sunset_version];
-    let infos = collect_route_infos(&routes, &[], &[], &registry);
+    let infos = collect_route_infos(&routes, &[], &[], &registry).unwrap();
 
     assert_eq!(infos.len(), 4);
-    
+
     // v1: active
     assert_eq!(infos[0].api_version, Some("v1".to_string()));
     assert_eq!(infos[0].status, Some("active".to_string()));

--- a/autumn/tests/api_versioning_unit.rs
+++ b/autumn/tests/api_versioning_unit.rs
@@ -35,12 +35,23 @@ fn test_autumn_error_gone() {
 
 #[test]
 fn test_app_builder_api_version_registry() {
-    let app = autumn_web::app().api_version(autumn_web::app::ApiVersion {
-        version: "v1".to_string(),
-        deprecated_at: None,
-        sunset_at: None,
-    });
+    use chrono::TimeZone;
+    let deprecated_date = chrono::Utc.with_ymd_and_hms(2026, 6, 2, 0, 0, 0).unwrap();
+
+    let app = autumn_web::app()
+        .api_version(autumn_web::app::ApiVersion {
+            version: "v1".to_string(),
+            deprecated_at: None,
+            sunset_at: None,
+        })
+        .api_version(autumn_web::app::ApiVersion {
+            version: "v1".to_string(),
+            deprecated_at: Some(deprecated_date),
+            sunset_at: None,
+        });
+
     assert_eq!(app.api_versions.len(), 1);
+    assert_eq!(app.api_versions[0].deprecated_at, Some(deprecated_date));
 }
 
 #[tokio::test]

--- a/autumn/tests/idempotency_middleware.rs
+++ b/autumn/tests/idempotency_middleware.rs
@@ -732,6 +732,8 @@ async fn test_manual_route_registered_through_routes_fails_closed_without_replay
         api_doc: autumn_web::openapi::ApiDoc::default(),
         repository: None,
         idempotency: RouteIdempotency::Direct,
+        api_version: None,
+        sunset_opt_out: false,
     };
 
     let client = TestApp::new().routes(vec![route]).idempotent().build();
@@ -775,6 +777,8 @@ async fn test_manual_route_with_openapi_method_fails_closed_without_replay_stop(
         },
         repository: None,
         idempotency: RouteIdempotency::Direct,
+        api_version: None,
+        sunset_opt_out: false,
     };
 
     let client = TestApp::new().routes(vec![route]).idempotent().build();
@@ -811,6 +815,8 @@ async fn test_manual_scoped_route_registered_through_routes_fails_closed_without
         api_doc: autumn_web::openapi::ApiDoc::default(),
         repository: None,
         idempotency: RouteIdempotency::Direct,
+        api_version: None,
+        sunset_opt_out: false,
     };
 
     let client = TestApp::new()
@@ -1458,6 +1464,8 @@ async fn test_manual_layered_route_can_check_access_before_replay_stop() {
         api_doc: autumn_web::openapi::ApiDoc::default(),
         repository: None,
         idempotency: RouteIdempotency::ReplayThroughInner,
+        api_version: None,
+        sunset_opt_out: false,
     };
 
     let client = TestApp::new().routes(vec![route]).idempotent().build();
@@ -1505,6 +1513,8 @@ async fn test_manual_layered_direct_route_fails_closed_instead_of_stale_replay()
         api_doc: autumn_web::openapi::ApiDoc::default(),
         repository: None,
         idempotency: RouteIdempotency::Direct,
+        api_version: None,
+        sunset_opt_out: false,
     };
 
     let client = TestApp::new().routes(vec![route]).idempotent().build();

--- a/docs/guide/api-versioning.md
+++ b/docs/guide/api-versioning.md
@@ -125,11 +125,11 @@ autumn check deprecations
 ```
 
 This command builds your project, queries the route table, and audits all routes.
-- If **any** route is past its sunset date and **has not opted out**, the command logs the offending routes and exits with a non-zero code (**1**), failing the build.
-- If no active sunsetted routes are found, it exits with code **0**.
+- If **any** route is past its sunset date (including opted-out routes), the command logs the offending routes and exits with a non-zero code (**1**), failing the build.
+- If no past-sunset routes are found, it exits with code **0**.
 
 ```text
-✗ Found 1 route(s) past sunset date that have not opted out:
+✗ Found 1 active past-sunset route(s) (opted out):
   GET /v1/users (handler: list_users_v1, version: v1)
 ```
 

--- a/docs/guide/api-versioning.md
+++ b/docs/guide/api-versioning.md
@@ -88,9 +88,9 @@ When a route is past its sunset date and has not opted out, Autumn automatically
 
 ```json
 {
-  "type": "https://autumn.rs/errors/gone",
+  "type": "https://autumn.dev/problems/gone",
   "title": "Gone",
-  "status": 408,
+  "status": 410,
   "detail": "API version 'v1' has been sunsetted."
 }
 ```

--- a/docs/guide/api-versioning.md
+++ b/docs/guide/api-versioning.md
@@ -14,7 +14,7 @@ use chrono::TimeZone;
 
 #[autumn_web::main]
 async fn main() -> Result<(), autumn_web::Error> {
-    let app = AppBuilder::new()
+    let app = autumn_web::app()
         // Register API v1: Deprecated on 2026-06-01, Sunset on 2026-12-01
         .api_version(ApiVersion {
             version: "v1".to_string(),
@@ -78,9 +78,9 @@ Once configured, Autumn automatically injects RFC 9745 headers and routes traffi
 | Route State | HTTP Status | Response Headers |
 |:---|:---|:---|
 | **Active** (Not Deprecated) | `200 OK` (normal) | *(None)* |
-| **Deprecated** (Past `deprecated_at` date) | `200 OK` (normal) | `Deprecation: true`<br>`Sunset: <sunset_date_gmt>` |
-| **Sunset** (Past `sunset_at` date) | `410 Gone` | `Deprecation: true`<br>`Sunset: <sunset_date_gmt>` |
-| **Sunset with Opt-Out** (Past `sunset_at`, `sunset_opt_out = true`) | `200 OK` (normal) | `Deprecation: true`<br>`Sunset: <sunset_date_gmt>` |
+| **Deprecated** (Past `deprecated_at` date) | `200 OK` (normal) | `Deprecation: @<timestamp>`<br>`Sunset: <sunset_date_gmt>` |
+| **Sunset** (Past `sunset_at` date) | `410 Gone` | `Deprecation: @<timestamp>`<br>`Sunset: <sunset_date_gmt>` |
+| **Sunset with Opt-Out** (Past `sunset_at`, `sunset_opt_out = true`) | `200 OK` (normal) | `Deprecation: @<timestamp>`<br>`Sunset: <sunset_date_gmt>` |
 
 ### RFC 7807 Problem Details Response
 

--- a/docs/guide/api-versioning.md
+++ b/docs/guide/api-versioning.md
@@ -1,0 +1,143 @@
+# API Versioning, Deprecations, and Sunset Lifecycles
+
+Autumn provides first-class support for managing API version lifecycles. By defining version lifecycles and tagging routes, Autumn handles RFC 9745 `Deprecation` and `Sunset` headers, automatic `410 Gone` responses, OpenAPI spec grouping, and CI route auditing out-of-the-box.
+
+---
+
+## 1. Registering API Versions
+
+Define your API versions and their lifecycles when initializing the application on `AppBuilder`. Each version specifies when it becomes deprecated and when it is sunsetted.
+
+```rust
+use autumn_web::app::ApiVersion;
+use chrono::TimeZone;
+
+#[autumn_web::main]
+async fn main() -> Result<(), autumn_web::Error> {
+    let app = AppBuilder::new()
+        // Register API v1: Deprecated on 2026-06-01, Sunset on 2026-12-01
+        .api_version(ApiVersion {
+            version: "v1".to_string(),
+            deprecated_at: Some(chrono::Utc.with_ymd_and_hms(2026, 6, 1, 0, 0, 0).unwrap()),
+            sunset_at: Some(chrono::Utc.with_ymd_and_hms(2026, 12, 1, 0, 0, 0).unwrap()),
+        })
+        // Register API v2: Active (no deprecation/sunset schedule yet)
+        .api_version(ApiVersion {
+            version: "v2".to_string(),
+            deprecated_at: None,
+            sunset_at: None,
+        });
+
+    app.run().await
+}
+```
+
+---
+
+## 2. Tagging Routes
+
+Tag route handlers with their corresponding API version using the `api_version` macro parameter. 
+
+```rust
+use autumn_web::{get, post};
+
+// Route belonging to v1 (currently deprecated)
+#[get("/v1/users", api_version = "v1")]
+async fn list_users_v1() -> &'static str {
+    "v1 users list"
+}
+
+// Route belonging to v2
+#[get("/v2/users", api_version = "v2")]
+async fn list_users_v2() -> &'static str {
+    "v2 users list"
+}
+```
+
+### Sunset Opt-Out
+
+If a specific route must remain active even after its API version has passed its sunset date, you can opt it out of the automatic `410 Gone` behavior using the `sunset_opt_out` flag:
+
+```rust
+// Remains active after v1 sunset, but continues to emit deprecation/sunset headers
+#[get("/v1/legacy-callback", api_version = "v1", sunset_opt_out = true)]
+async fn legacy_callback() -> &'static str {
+    "legacy callback payload"
+}
+```
+
+> [!WARNING]
+> Unregistered version tags (e.g. `#[get("/foo", api_version = "v99")]` when `"v99"` was never registered on `AppBuilder`) will fail safety validation at startup, causing the application to refuse to boot.
+
+---
+
+## 3. Headers and Lifecycle Middleware
+
+Once configured, Autumn automatically injects RFC 9745 headers and routes traffic depending on the current date:
+
+| Route State | HTTP Status | Response Headers |
+|:---|:---|:---|
+| **Active** (Not Deprecated) | `200 OK` (normal) | *(None)* |
+| **Deprecated** (Past `deprecated_at` date) | `200 OK` (normal) | `Deprecation: true`<br>`Sunset: <sunset_date_gmt>` |
+| **Sunset** (Past `sunset_at` date) | `410 Gone` | `Deprecation: true`<br>`Sunset: <sunset_date_gmt>` |
+| **Sunset with Opt-Out** (Past `sunset_at`, `sunset_opt_out = true`) | `200 OK` (normal) | `Deprecation: true`<br>`Sunset: <sunset_date_gmt>` |
+
+### RFC 7807 Problem Details Response
+
+When a route is past its sunset date and has not opted out, Autumn automatically aborts the request and returns an RFC 7807 Problem Details document with a `410 Gone` status code:
+
+```json
+{
+  "type": "https://autumn.rs/errors/gone",
+  "title": "Gone",
+  "status": 408,
+  "detail": "API version 'v1' has been sunsetted."
+}
+```
+
+---
+
+## 4. Routes CLI Listing
+
+You can inspect the version and status of all mounted routes in your application using `autumn routes`:
+
+```bash
+autumn routes
+```
+
+This prints a tabular view showing the HTTP method, path, handler, version, status (`active`, `deprecated`, or `sunset`), and source:
+
+```text
+Method  Path        Handler         Version  Status      Source  Middleware
+---------------------------------------------------------------------------
+GET     /v1/users   list_users_v1   v1       deprecated  user    
+GET     /v2/users   list_users_v2   v2       active      user    
+```
+
+---
+
+## 5. Audit CLI: `autumn check deprecations`
+
+To prevent active, sunsetted routes from remaining deployed in production, use the CI-friendly `autumn check deprecations` command:
+
+```bash
+autumn check deprecations
+```
+
+This command builds your project, queries the route table, and audits all routes.
+- If **any** route is past its sunset date and **has not opted out**, the command logs the offending routes and exits with a non-zero code (**1**), failing the build.
+- If no active sunsetted routes are found, it exits with code **0**.
+
+```text
+✗ Found 1 route(s) past sunset date that have not opted out:
+  GET /v1/users (handler: list_users_v1, version: v1)
+```
+
+---
+
+## 6. OpenAPI Integration
+
+When using the `openapi` feature, Autumn automatically syncs route version metadata with your generated OpenAPI documentation:
+
+1. **Tag Grouping**: Operations are automatically tagged with their API version name (e.g. `v1`, `v2`), making them easy to group and navigate.
+2. **Deprecation Gating**: Any operation whose API version is past its `deprecated_at` date is marked as `"deprecated": true` in the spec.


### PR DESCRIPTION
## Overview
Implements first-class API versioning and deprecation lifecycles in `autumn-web`.

### Key Features Implemented:
1. **Proc-Macro Tagging**: Added `api_version` and `sunset_opt_out` parameters to route macros (`#[get]`, `#[post]`, etc.) to embed versioning parameters into the generated `Route` metadata.
2. **AppBuilder Registry**: Added `.api_version()` and `.api_versions()` to register version schedules, which are verified at startup to prevent unregistered version tags from booting.
3. **Deprecation & Sunset Middleware**: Automatically injects RFC 9745 `Deprecation` and `Sunset` headers and returns `410 Gone` responses (RFC 7807 Problem Details format) once the route's version passes its sunset date (unless scoped to `sunset_opt_out = true`).
4. **CLI Routes Table**: Updated `autumn routes` to display `Version` and `Status` columns for all endpoints.
5. **OpenAPI Spec Integration**: Automatically groups endpoints by version tag and marks individual operations as `deprecated: true` once their version passes its deprecation date.
6. **Audit Tool CLI**: Added `autumn check deprecations` command that builds the app, queries the route table, and audits for active past-sunset routes, exiting with code 1 if any are found.
7. **Documentation**: Added first-class documentation in [api-versioning.md](file:///c:/Users/markm/autumn/docs/guide/api-versioning.md).

## Verifications & Testing

We verified all components via automated unit, integration, and monorepo tests:

1. **Versioning Unit Tests (`autumn/tests/api_versioning_unit.rs`)**
   - Verified route macros correctly propagate `api_version` and `sunset_opt_out`.
   - Verified startup validation aborts boot if an unregistered version is used.
   - Verified RFC 7807 `410 Gone` error helper serialization.
   - Verified route status resolution (`active`, `deprecated`, `sunset`) using clocks.

2. **Integration Tests (`autumn/tests/api_versioning_integration.rs`)**
   - Verified untagged routes have zero impact.
   - Verified deprecation headers are injected when the mock clock passes the deprecation date.
   - Verified sunset headers and `410 Gone` responses are returned after the sunset date.
   - Verified `sunset_opt_out = true` bypasses `410 Gone` but still emits deprecation/sunset headers.

3. **OpenAPI Spec Tests (`autumn/tests/api_versioning_openapi.rs`)**
   - Verified generated spec tags operations by version name.
   - Verified operations are marked `"deprecated": true` when past their deprecation datetime.

4. **CLI Subcommand Tests (`autumn-cli`)**
   - Verified that `autumn check deprecations` parses as a subcommand under `Commands::Check`.
   - Verified command-line argument parsing with `-p/--package` and `--bin` parameters.

5. **Monorepo Tests (`cargo test --all`)**
   - Fixed compilation of all test fixtures and mock route instantiations across the entire workspace monorepo.
   - Ran the full suite of 1,218 tests across `autumn-cli` and hundreds of doc and integration tests in the monorepo workspace.
   - **Outcome**: `cargo test --all` passed cleanly with 100% green tests!