### PR TITLE
Add first-class response compression support with opt-in configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = "2"
 maud = { version = "0.27", features = ["axum"] }
 toml = "1.1"
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "fs", "trace", "compression-gzip", "compression-br"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 tracing-opentelemetry = "0.32.1"

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1579,11 +1579,15 @@ fn tailwind_enabled() -> bool {
 }
 
 fn resolve_compression_enabled() -> bool {
-    // 1. Env var takes highest precedence (matches apply_compression_env_overrides_with_env).
-    if let Ok(val) = std::env::var("AUTUMN_COMPRESSION__ENABLED")
-        && let Some(enabled) = parse_config_bool(&val)
-    {
-        return enabled;
+    // 1. Env var takes highest precedence. Use the same accepted values as the
+    //    runtime's parse_env_bool ("true"/"1"/"false"/"0") so doctor never
+    //    reports a different state than the app would observe.
+    if let Ok(val) = std::env::var("AUTUMN_COMPRESSION__ENABLED") {
+        match val.as_str() {
+            "true" | "1" => return true,
+            "false" | "0" => return false,
+            _ => {}
+        }
     }
 
     // 2. Read TOML, applying profile-specific override when a profile is active

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -54,6 +54,7 @@ const KNOWN_TOML_SECTIONS: &[&str] = &[
     "storage",
     "mail",
     "profile",
+    "compression",
 ];
 
 /// Result status for a single diagnostic check.
@@ -1577,6 +1578,23 @@ fn tailwind_enabled() -> bool {
         .unwrap_or_else(|| std::path::Path::new("build.rs").exists())
 }
 
+fn resolve_compression_enabled() -> bool {
+    if let Ok(val) = std::env::var("AUTUMN_COMPRESSION__ENABLED") {
+        if matches!(val.trim().to_ascii_lowercase().as_str(), "true" | "1" | "yes") {
+            return true;
+        }
+    }
+    std::fs::read_to_string("autumn.toml")
+        .ok()
+        .and_then(|c| toml::from_str::<toml::Table>(&c).ok())
+        .and_then(|t| {
+            t.get("compression")
+                .and_then(|v| v.get("enabled"))
+                .and_then(toml::Value::as_bool)
+        })
+        .unwrap_or(false)
+}
+
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
 /// Run all doctor checks and report results.
@@ -1615,6 +1633,7 @@ pub fn run(opts: DoctorOptions) {
     let is_production = resolve_is_production();
     let rate_limit_key_strategy = resolve_rate_limit_key_strategy();
     let auth_extractor_mounted = resolve_auth_extractor_mounted();
+    let compression_enabled = resolve_compression_enabled();
 
     // ── Phase 2: build tasks in display order ────────────────────────────────
     let mut tasks: Vec<Task> = Vec::new();
@@ -1703,6 +1722,11 @@ pub fn run(opts: DoctorOptions) {
     // 11. Maintenance mode state
     tasks.push(Box::new(check_maintenance_mode));
 
+    // 12. Compression (warn in production when disabled)
+    tasks.push(Box::new(move || {
+        check_compression_impl(compression_enabled, is_production)
+    }));
+
     // ── Phase 3: spawn all tasks concurrently ────────────────────────────────
     let handles: Vec<thread::JoinHandle<CheckResult>> =
         tasks.into_iter().map(thread::spawn).collect();
@@ -1739,6 +1763,41 @@ pub fn run(opts: DoctorOptions) {
 /// Check whether maintenance mode is currently active.
 ///
 /// Warns (not fails) so `autumn doctor` stays green during planned windows.
+/// Check whether response compression is configured for a production profile.
+///
+/// Compression is off by default (for BREACH/CRIME safety). When running in
+/// production without compression this check emits a `Warn` so operators know
+/// they may want to enable it (or document the deliberate choice to rely on a
+/// CDN / reverse-proxy for compression instead).
+pub fn check_compression_impl(compression_enabled: bool, is_production: bool) -> CheckResult {
+    if is_production && !compression_enabled {
+        return CheckResult {
+            name: "compression",
+            status: CheckStatus::Warn,
+            detail: Some(
+                "response compression is disabled in production; \
+                 text payloads (HTML/JSON/CSS) are served uncompressed"
+                    .into(),
+            ),
+            hint: Some(
+                "Set [compression] enabled = true in autumn.toml (or AUTUMN_COMPRESSION__ENABLED=true) \
+                 if you are not using a CDN or reverse-proxy that compresses for you. \
+                 Read the BREACH/CRIME tradeoff in docs/guide/compression.md before enabling.",
+            ),
+        };
+    }
+    CheckResult {
+        name: "compression",
+        status: CheckStatus::Pass,
+        detail: Some(if compression_enabled {
+            "response compression is enabled".into()
+        } else {
+            "response compression is disabled (off by default; use CDN or enable explicitly)".into()
+        }),
+        hint: None,
+    }
+}
+
 pub fn check_maintenance_mode() -> CheckResult {
     use autumn_web::maintenance::{MAINTENANCE_FLAG_FILE, MaintenanceState};
     let path = std::path::Path::new(MAINTENANCE_FLAG_FILE);
@@ -2713,6 +2772,41 @@ redirect_uri = "http://localhost/callback"
         assert_eq!(
             p.client_secret, "ghp_test_secret",
             "env var must override empty TOML client_secret"
+        );
+    }
+
+    // ── check_compression ────────────────────────────────────────────────────
+
+    #[test]
+    fn compression_warns_in_production_when_disabled() {
+        let result = check_compression_impl(false, true);
+        assert_eq!(result.name, "compression");
+        assert!(
+            matches!(result.status, CheckStatus::Warn),
+            "expected Warn, got {:?}",
+            result.status
+        );
+    }
+
+    #[test]
+    fn compression_passes_in_production_when_enabled() {
+        let result = check_compression_impl(true, true);
+        assert_eq!(result.name, "compression");
+        assert!(
+            matches!(result.status, CheckStatus::Pass),
+            "expected Pass, got {:?}",
+            result.status
+        );
+    }
+
+    #[test]
+    fn compression_passes_in_dev_when_disabled() {
+        let result = check_compression_impl(false, false);
+        assert_eq!(result.name, "compression");
+        assert!(
+            matches!(result.status, CheckStatus::Pass),
+            "expected Pass in dev profile, got {:?}",
+            result.status
         );
     }
 }

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1580,8 +1580,8 @@ fn tailwind_enabled() -> bool {
 
 fn resolve_compression_enabled() -> bool {
     if let Ok(val) = std::env::var("AUTUMN_COMPRESSION__ENABLED") {
-        if matches!(val.trim().to_ascii_lowercase().as_str(), "true" | "1" | "yes") {
-            return true;
+        if let Some(enabled) = parse_config_bool(&val) {
+            return enabled;
         }
     }
     std::fs::read_to_string("autumn.toml")

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1579,20 +1579,43 @@ fn tailwind_enabled() -> bool {
 }
 
 fn resolve_compression_enabled() -> bool {
+    // 1. Env var takes highest precedence (matches apply_compression_env_overrides_with_env).
     if let Ok(val) = std::env::var("AUTUMN_COMPRESSION__ENABLED") {
         if let Some(enabled) = parse_config_bool(&val) {
             return enabled;
         }
     }
-    std::fs::read_to_string("autumn.toml")
+
+    // 2. Read TOML, applying profile-specific override when a profile is active
+    //    (mirrors the five-layer config system so `[profile.prod] compression.enabled`
+    //    doesn't cause a spurious doctor warning in production).
+    let table = read_autumn_toml_table().unwrap_or_default();
+    let profile = std::env::var("AUTUMN_ENV")
         .ok()
-        .and_then(|c| toml::from_str::<toml::Table>(&c).ok())
-        .and_then(|t| {
-            t.get("compression")
-                .and_then(|v| v.get("enabled"))
-                .and_then(toml::Value::as_bool)
-        })
-        .unwrap_or(false)
+        .or_else(|| std::env::var("AUTUMN_PROFILE").ok())
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+
+    let parse_enabled = |root: &toml::Table| {
+        root.get("compression")
+            .and_then(|v| v.get("enabled"))
+            .and_then(toml::Value::as_bool)
+    };
+
+    // Profile-specific section takes precedence over base config.
+    if !profile.is_empty() {
+        if let Some(enabled) = table
+            .get("profile")
+            .and_then(|v| v.get(&profile))
+            .and_then(toml::Value::as_table)
+            .and_then(|t| parse_enabled(t))
+        {
+            return enabled;
+        }
+    }
+
+    parse_enabled(&table).unwrap_or(false)
 }
 
 // ─── Main entry point ─────────────────────────────────────────────────────────
@@ -2808,5 +2831,18 @@ redirect_uri = "http://localhost/callback"
             "expected Pass in dev profile, got {:?}",
             result.status
         );
+    }
+
+    #[test]
+    fn parse_config_bool_handles_false_values() {
+        assert_eq!(parse_config_bool("false"), Some(false));
+        assert_eq!(parse_config_bool("0"), Some(false));
+        assert_eq!(parse_config_bool("no"), Some(false));
+        assert_eq!(parse_config_bool("off"), Some(false));
+        assert_eq!(parse_config_bool("true"), Some(true));
+        assert_eq!(parse_config_bool("1"), Some(true));
+        assert_eq!(parse_config_bool("yes"), Some(true));
+        assert_eq!(parse_config_bool("on"), Some(true));
+        assert_eq!(parse_config_bool("garbage"), None);
     }
 }

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1580,10 +1580,10 @@ fn tailwind_enabled() -> bool {
 
 fn resolve_compression_enabled() -> bool {
     // 1. Env var takes highest precedence (matches apply_compression_env_overrides_with_env).
-    if let Ok(val) = std::env::var("AUTUMN_COMPRESSION__ENABLED") {
-        if let Some(enabled) = parse_config_bool(&val) {
-            return enabled;
-        }
+    if let Ok(val) = std::env::var("AUTUMN_COMPRESSION__ENABLED")
+        && let Some(enabled) = parse_config_bool(&val)
+    {
+        return enabled;
     }
 
     // 2. Read TOML, applying profile-specific override when a profile is active
@@ -1604,15 +1604,14 @@ fn resolve_compression_enabled() -> bool {
     };
 
     // Profile-specific section takes precedence over base config.
-    if !profile.is_empty() {
-        if let Some(enabled) = table
+    if !profile.is_empty()
+        && let Some(enabled) = table
             .get("profile")
             .and_then(|v| v.get(&profile))
             .and_then(toml::Value::as_table)
-            .and_then(|t| parse_enabled(t))
-        {
-            return enabled;
-        }
+            .and_then(&parse_enabled)
+    {
+        return enabled;
     }
 
     parse_enabled(&table).unwrap_or(false)

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -3170,12 +3170,12 @@ const fn default_cors_max_age() -> u64 {
 /// |----------|-------|------|
 /// | `AUTUMN_COMPRESSION__ENABLED` | `enabled` | `bool` |
 ///
-/// # ETag compatibility
+/// # `ETag` compatibility
 ///
 /// Autumn's framework-managed compression layer is applied **outside** any
-/// user-registered `EtagLayer`, so ETags are computed on the uncompressed body.
+/// user-registered `EtagLayer`, so `ETags` are computed on the uncompressed body.
 /// Because `CompressionLayer` sets `Vary: Accept-Encoding`, caches correctly
-/// store separate entries per encoding. Using weak ETags (`W/`) when
+/// store separate entries per encoding. Using weak `ETags` (`W/`) when
 /// compression is enabled is safe per RFC 7232 §2.1 (weak comparison allows
 /// encoding variations).
 ///
@@ -3187,7 +3187,7 @@ const fn default_cors_max_age() -> u64 {
 /// let cfg = CompressionConfig::default();
 /// assert!(!cfg.enabled);
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct CompressionConfig {
     /// Enable response compression. Default: `false`.
     ///
@@ -3198,12 +3198,6 @@ pub struct CompressionConfig {
     /// already carry `Content-Encoding` are passed through unchanged.
     #[serde(default)]
     pub enabled: bool,
-}
-
-impl Default for CompressionConfig {
-    fn default() -> Self {
-        Self { enabled: false }
-    }
 }
 
 /// Parse an environment variable into a typed target, logging a warning on failure.

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -120,6 +120,7 @@
 //! | `AUTUMN_DEV__INSPECTOR_PATH` | `dev.inspector_path` | `String` |
 //! | `AUTUMN_DEV__INSPECTOR_CAPACITY` | `dev.inspector_capacity` | `usize` |
 //! | `AUTUMN_DEV__INSPECTOR_N_PLUS_ONE_THRESHOLD` | `dev.inspector_n_plus_one_threshold` | `usize` |
+//! | `AUTUMN_COMPRESSION__ENABLED` | `compression.enabled` | `bool` |
 
 use std::path::{Path, PathBuf};
 
@@ -756,6 +757,17 @@ pub struct AutumnConfig {
     #[cfg(feature = "reporting")]
     #[serde(default)]
     pub reporting: ReportingConfig,
+
+    /// Response compression settings (`[compression]` section in `autumn.toml`).
+    ///
+    /// Compression is **off by default**. Enable with:
+    /// ```toml
+    /// [compression]
+    /// enabled = true
+    /// ```
+    /// or via `AUTUMN_COMPRESSION__ENABLED=true`.
+    #[serde(default)]
+    pub compression: CompressionConfig,
 }
 
 /// Error-reporting settings (`[reporting]` section in `autumn.toml`).
@@ -1776,6 +1788,7 @@ impl AutumnConfig {
         self.apply_security_env_overrides_with_env(env);
         self.apply_idempotency_env_overrides_with_env(env);
         self.apply_dev_env_overrides_with_env(env);
+        self.apply_compression_env_overrides_with_env(env);
         #[cfg(feature = "reporting")]
         self.apply_reporting_env_overrides_with_env(env);
         #[cfg(feature = "storage")]
@@ -1813,6 +1826,14 @@ impl AutumnConfig {
             env,
             "AUTUMN_DEV__INSPECTOR_N_PLUS_ONE_THRESHOLD",
             &mut self.dev.inspector_n_plus_one_threshold,
+        );
+    }
+
+    fn apply_compression_env_overrides_with_env(&mut self, env: &dyn Env) {
+        parse_env_bool(
+            env,
+            "AUTUMN_COMPRESSION__ENABLED",
+            &mut self.compression.enabled,
         );
     }
 
@@ -3121,6 +3142,68 @@ fn default_cors_headers() -> Vec<String> {
 
 const fn default_cors_max_age() -> u64 {
     86400
+}
+
+// ── CompressionConfig ──────────────────────────────────────────────────────
+
+/// Response compression settings (`[compression]` section in `autumn.toml`).
+///
+/// Compression is **off by default** to avoid the [BREACH/CRIME] class of
+/// compression side-channel attacks, where an attacker can infer secret
+/// content (e.g. CSRF tokens) by observing how the compressed size changes as
+/// they inject attacker-controlled bytes alongside the secret. Enable only when
+/// you understand the tradeoff — or when a CDN / reverse-proxy handles TLS and
+/// terminates there.
+///
+/// [BREACH/CRIME]: https://breachattack.com/
+///
+/// # One-liner opt-in
+///
+/// ```toml
+/// [compression]
+/// enabled = true
+/// ```
+///
+/// # Environment variable override
+///
+/// | Variable | Field | Type |
+/// |----------|-------|------|
+/// | `AUTUMN_COMPRESSION__ENABLED` | `enabled` | `bool` |
+///
+/// # ETag compatibility
+///
+/// Autumn's framework-managed compression layer is applied **outside** any
+/// user-registered `EtagLayer`, so ETags are computed on the uncompressed body.
+/// Because `CompressionLayer` sets `Vary: Accept-Encoding`, caches correctly
+/// store separate entries per encoding. Using weak ETags (`W/`) when
+/// compression is enabled is safe per RFC 7232 §2.1 (weak comparison allows
+/// encoding variations).
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::config::CompressionConfig;
+///
+/// let cfg = CompressionConfig::default();
+/// assert!(!cfg.enabled);
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+pub struct CompressionConfig {
+    /// Enable response compression. Default: `false`.
+    ///
+    /// When `true`, the framework inserts a `CompressionLayer` that honors the
+    /// client's `Accept-Encoding` header (gzip and brotli supported) and sets
+    /// `Vary: Accept-Encoding` on all compressible responses.
+    /// Non-compressible content types (images, archives) and responses that
+    /// already carry `Content-Encoding` are passed through unchanged.
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+impl Default for CompressionConfig {
+    fn default() -> Self {
+        Self { enabled: false }
+    }
 }
 
 /// Parse an environment variable into a typed target, logging a warning on failure.

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1045,7 +1045,22 @@ where
     S: Clone + Send + Sync + 'static,
 {
     if config.compression.enabled {
-        router = router.layer(tower_http::compression::CompressionLayer::new());
+        use tower_http::compression::predicate::{DefaultPredicate, NotForContentType, Predicate};
+        // Extend the default predicate (skips images, gRPC, SSE, small bodies) to also
+        // skip already-compressed archive types — compressing a zip/gz a second time
+        // wastes CPU and often increases transfer size.
+        let predicate = DefaultPredicate::new()
+            .and(NotForContentType::const_new("application/zip"))
+            .and(NotForContentType::const_new("application/gzip"))
+            .and(NotForContentType::const_new("application/x-gzip"))
+            .and(NotForContentType::const_new("application/zstd"))
+            .and(NotForContentType::const_new("application/x-bzip2"))
+            .and(NotForContentType::const_new("application/x-bzip"))
+            .and(NotForContentType::const_new("application/x-rar-compressed"))
+            .and(NotForContentType::const_new("application/vnd.rar"))
+            .and(NotForContentType::const_new("application/x-7z-compressed"));
+        router =
+            router.layer(tower_http::compression::CompressionLayer::new().compress_when(predicate));
         tracing::info!("Response compression enabled (gzip/brotli)");
     }
     router

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1037,6 +1037,20 @@ fn mount_raw_routers(
     router
 }
 
+fn apply_compression_middleware<S>(
+    mut router: axum::Router<S>,
+    config: &AutumnConfig,
+) -> axum::Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    if config.compression.enabled {
+        router = router.layer(tower_http::compression::CompressionLayer::new());
+        tracing::info!("Response compression enabled (gzip/brotli)");
+    }
+    router
+}
+
 fn apply_cors_middleware<S>(mut router: axum::Router<S>, config: &AutumnConfig) -> axum::Router<S>
 where
     S: Clone + Send + Sync + 'static,
@@ -1319,6 +1333,13 @@ fn apply_middleware(
         tracing::debug!(count = custom_layer_count, "Custom Tower layers applied");
     }
 
+    // Response compression. Applied AFTER user custom layers so that user-registered
+    // middleware (e.g. EtagLayer) runs first on the response path: ETags are computed
+    // on the uncompressed body, then the body is compressed. CompressionLayer honors
+    // Accept-Encoding, adds Vary: Accept-Encoding, skips already-encoded responses,
+    // and never compresses non-compressible content types (images, archives, etc.).
+    router = apply_compression_middleware(router, config);
+
     let mut router = router;
 
     if config.tenancy.enabled {
@@ -1334,7 +1355,7 @@ fn apply_middleware(
     //
     // Full ingress layer order (outermost → innermost):
     //   TraceContext → Metrics → ExceptionFilter → ErrorPageContext → Session →
-    //   SecurityHeaders → RequestId → Timeout → [user layers] → Tenancy →
+    //   SecurityHeaders → RequestId → Timeout → [user layers] → Compression → Tenancy →
     //   BodyLimit/UploadConfig → MethodOverride → RateLimit → CSRF → CORS → handler
     router = apply_request_timeout_middleware(router, config, state.metrics.clone());
 

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1353,13 +1353,6 @@ fn apply_middleware(
         tracing::debug!(count = custom_layer_count, "Custom Tower layers applied");
     }
 
-    // Response compression. Applied AFTER user custom layers so that user-registered
-    // middleware (e.g. EtagLayer) runs first on the response path: ETags are computed
-    // on the uncompressed body, then the body is compressed. CompressionLayer honors
-    // Accept-Encoding, adds Vary: Accept-Encoding, skips already-encoded responses,
-    // and never compresses non-compressible content types (images, archives, etc.).
-    router = apply_compression_middleware(router, config);
-
     let mut router = router;
 
     if config.tenancy.enabled {
@@ -1374,8 +1367,8 @@ fn apply_middleware(
     // layer is available when the timeout fires — see request_timeout_handler).
     //
     // Full ingress layer order (outermost → innermost):
-    //   TraceContext → Metrics → ExceptionFilter → ErrorPageContext → Session →
-    //   SecurityHeaders → RequestId → Timeout → [user layers] → Compression → Tenancy →
+    //   TraceContext → Compression → Metrics → ExceptionFilter → ErrorPageContext → Session →
+    //   SecurityHeaders → RequestId → Timeout → [user layers] → Tenancy →
     //   BodyLimit/UploadConfig → MethodOverride → RateLimit → CSRF → CORS → handler
     router = apply_request_timeout_middleware(router, config, state.metrics.clone());
 
@@ -1445,15 +1438,26 @@ fn apply_middleware(
     // Full ingress layer order (outermost -> innermost):
     //   TraceContext (applied outside the startup barrier so short-circuit
     //   responses still carry traceparent) ->
+    //   Compression (outer to ExceptionFilter — see note below) ->
     //   [user layers, when SSG/ISG dist dir active] ->
     //   StaticFileMiddleware (when SSG/ISG enabled) ->
     //   Metrics -> ExceptionFilter -> ErrorPageContext -> Session ->
     //   SecurityHeaders -> RequestId -> [user layers, non-static build] ->
-    //   RateLimit -> CSRF -> CORS -> handler
+    //   Tenancy -> RateLimit -> CSRF -> CORS -> handler
     let router = router
         .layer(crate::middleware::error_page_filter::ErrorPageContextLayer)
         .layer(ExceptionFilterLayer::new(all_filters))
         .layer(crate::middleware::MetricsLayer::new(state.metrics.clone()));
+
+    // Response compression is applied outermost (outside ExceptionFilter) so that
+    // exception filters which rebuild the response body (e.g. ProblemDetailsFilter
+    // normalising AutumnErrors to JSON Problem Details) do so before the body is
+    // encoded. If compression were inner to ExceptionFilter, the filter would
+    // inherit a Content-Encoding: gzip header on the rebuilt uncompressed body,
+    // causing clients to receive uncompressed bytes labeled as gzip.
+    // User-registered layers (EtagLayer etc.) remain inner to Compression, so
+    // ETags are still computed on the uncompressed body before encoding occurs.
+    let router = apply_compression_middleware(router, config);
 
     Ok(router)
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1727,6 +1727,12 @@ pub fn try_build_router_with_static_inner(
         );
     }
 
+    // Compression must also be applied OUTSIDE the static-first middleware so
+    // that pre-rendered HTML pages (served directly by StaticFileLayer without
+    // reaching inner_router) are also compressed. This mirrors the placement in
+    // apply_middleware for the dynamic-only path.
+    router = apply_compression_middleware(router, config);
+
     let router = router.layer(crate::security::SecurityHeadersLayer::from_config(
         &config.security.headers,
     ));

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1047,9 +1047,14 @@ where
     if config.compression.enabled {
         use tower_http::compression::predicate::{DefaultPredicate, NotForContentType, Predicate};
         // Extend the default predicate (skips images, gRPC, SSE, small bodies) to also
-        // skip already-compressed archive types — compressing a zip/gz a second time
-        // wastes CPU and often increases transfer size.
+        // skip binary media and already-compressed formats — compressing these wastes
+        // CPU, increases transfer size for archives, and can confuse media players.
         let predicate = DefaultPredicate::new()
+            // Binary media — already-encoded by codec, not compressible by gzip/br.
+            .and(NotForContentType::const_new("audio/"))
+            .and(NotForContentType::const_new("video/"))
+            .and(NotForContentType::const_new("application/octet-stream"))
+            // Compressed archive formats — re-compressing wastes CPU.
             .and(NotForContentType::const_new("application/zip"))
             .and(NotForContentType::const_new("application/gzip"))
             .and(NotForContentType::const_new("application/x-gzip"))

--- a/autumn/tests/compression_middleware.rs
+++ b/autumn/tests/compression_middleware.rs
@@ -268,10 +268,10 @@ fn compression_config_disabled_by_default() {
 
 #[test]
 fn compression_config_toml_round_trips() {
-    let toml_str = r#"
+    let toml_str = r"
 [compression]
 enabled = true
-"#;
+";
     let config: AutumnConfig = toml::from_str(toml_str).unwrap();
     assert!(config.compression.enabled);
 }

--- a/autumn/tests/compression_middleware.rs
+++ b/autumn/tests/compression_middleware.rs
@@ -1,0 +1,258 @@
+//! Integration tests for first-class response compression (#974).
+//!
+//! Covers:
+//! - Compressible dynamic response with `Accept-Encoding: gzip` → `Content-Encoding: gzip`
+//! - `Vary: Accept-Encoding` present on all compressible responses
+//! - Non-compressible content types are never compressed
+//! - No double-compression when `Content-Encoding` is already set
+//! - Compression is off by default (opt-in)
+
+use autumn_web::config::{AutumnConfig, CompressionConfig};
+use autumn_web::test::TestApp;
+use autumn_web::{get, routes};
+use axum::http::header;
+use axum::response::{IntoResponse, Response};
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+const HTML_BODY: &str = concat!(
+    "<!DOCTYPE html><html><body>",
+    // Pad to ensure the body is large enough that gzip savings are positive.
+    "Hello from Autumn! This is a compressible HTML response used to test ",
+    "that the framework correctly applies gzip compression when the client ",
+    "advertises Accept-Encoding: gzip. Lorem ipsum dolor sit amet. ",
+    "Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet. ",
+    "Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet. ",
+    "</body></html>"
+);
+
+#[get("/html")]
+async fn html_handler() -> impl IntoResponse {
+    (
+        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        HTML_BODY,
+    )
+}
+
+#[get("/json")]
+async fn json_handler() -> impl IntoResponse {
+    (
+        [(header::CONTENT_TYPE, "application/json")],
+        r#"{"message":"hello","data":"lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod"}"#,
+    )
+}
+
+#[get("/png")]
+async fn png_handler() -> impl IntoResponse {
+    // Simulate a binary image response (non-compressible content type).
+    (
+        [(header::CONTENT_TYPE, "image/png")],
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00".as_slice(),
+    )
+}
+
+#[get("/pre-encoded")]
+async fn pre_encoded_handler() -> Response {
+    // Simulate a response that already has Content-Encoding set (e.g. pre-compressed asset).
+    let mut resp = Response::new(axum::body::Body::from(vec![0u8; 32]));
+    resp.headers_mut().insert(
+        header::CONTENT_ENCODING,
+        "gzip".parse().unwrap(),
+    );
+    resp.headers_mut().insert(
+        header::CONTENT_TYPE,
+        "text/html; charset=utf-8".parse().unwrap(),
+    );
+    resp
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn compression_enabled_config() -> AutumnConfig {
+    let mut config = AutumnConfig::default();
+    config.compression.enabled = true;
+    config
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Compression is **off by default** — no Content-Encoding even with Accept-Encoding.
+#[tokio::test]
+async fn compression_disabled_by_default() {
+    let app = TestApp::new()
+        .routes(routes![html_handler])
+        .build();
+
+    let resp = app
+        .get("/html")
+        .header("accept-encoding", "gzip")
+        .send()
+        .await;
+
+    resp.assert_ok();
+    assert_eq!(
+        resp.header("content-encoding"),
+        None,
+        "compression must be opt-in; default config must not compress"
+    );
+}
+
+/// When enabled and client sends `Accept-Encoding: gzip`, response is gzip-compressed.
+#[tokio::test]
+async fn gzip_compression_applied_when_enabled_and_accepted() {
+    let app = TestApp::new()
+        .routes(routes![html_handler])
+        .config(compression_enabled_config())
+        .build();
+
+    let resp = app
+        .get("/html")
+        .header("accept-encoding", "gzip")
+        .send()
+        .await;
+
+    resp.assert_ok();
+    assert_eq!(
+        resp.header("content-encoding"),
+        Some("gzip"),
+        "should have Content-Encoding: gzip when compression is enabled and client accepts gzip"
+    );
+    // Compressed body should not equal the raw body (it's a different byte sequence).
+    assert_ne!(
+        resp.body,
+        HTML_BODY.as_bytes(),
+        "compressed body must differ from raw body"
+    );
+}
+
+/// JSON responses are also compressed.
+#[tokio::test]
+async fn json_response_compressed_when_enabled() {
+    let app = TestApp::new()
+        .routes(routes![json_handler])
+        .config(compression_enabled_config())
+        .build();
+
+    let resp = app
+        .get("/json")
+        .header("accept-encoding", "gzip")
+        .send()
+        .await;
+
+    resp.assert_ok();
+    assert_eq!(
+        resp.header("content-encoding"),
+        Some("gzip"),
+        "JSON should be compressed"
+    );
+}
+
+/// `Vary: Accept-Encoding` must be present on compressible responses when compression is enabled.
+#[tokio::test]
+async fn vary_accept_encoding_set_on_compressible_response() {
+    let app = TestApp::new()
+        .routes(routes![html_handler])
+        .config(compression_enabled_config())
+        .build();
+
+    // Even without Accept-Encoding the Vary header should tell caches the
+    // response could differ by encoding.
+    let resp = app.get("/html").send().await;
+
+    resp.assert_ok();
+    let vary = resp.header("vary").unwrap_or("");
+    assert!(
+        vary.to_lowercase().contains("accept-encoding"),
+        "Vary: Accept-Encoding must be set on compressible responses; got Vary: {vary:?}"
+    );
+}
+
+/// Binary / already-non-compressible content types (image/png) must not be compressed.
+#[tokio::test]
+async fn binary_content_type_not_compressed() {
+    let app = TestApp::new()
+        .routes(routes![png_handler])
+        .config(compression_enabled_config())
+        .build();
+
+    let resp = app
+        .get("/png")
+        .header("accept-encoding", "gzip")
+        .send()
+        .await;
+
+    resp.assert_ok();
+    assert_eq!(
+        resp.header("content-encoding"),
+        None,
+        "binary content types must not be compressed"
+    );
+}
+
+/// Responses that already carry `Content-Encoding` must not be double-compressed.
+#[tokio::test]
+async fn no_double_compression_when_already_encoded() {
+    let app = TestApp::new()
+        .routes(routes![pre_encoded_handler])
+        .config(compression_enabled_config())
+        .build();
+
+    let resp = app
+        .get("/pre-encoded")
+        .header("accept-encoding", "gzip")
+        .send()
+        .await;
+
+    resp.assert_ok();
+    // Content-Encoding should still be exactly "gzip" (the original), not "gzip, gzip".
+    let ce = resp.header("content-encoding").unwrap_or("");
+    assert_eq!(
+        ce, "gzip",
+        "double-compression must not occur; got Content-Encoding: {ce:?}"
+    );
+}
+
+/// Without `Accept-Encoding` header, no compression is applied even when enabled.
+#[tokio::test]
+async fn no_compression_when_client_does_not_accept() {
+    let app = TestApp::new()
+        .routes(routes![html_handler])
+        .config(compression_enabled_config())
+        .build();
+
+    let resp = app.get("/html").send().await;
+
+    resp.assert_ok();
+    assert_eq!(
+        resp.header("content-encoding"),
+        None,
+        "no Accept-Encoding → no Content-Encoding"
+    );
+}
+
+// ── Unit tests for CompressionConfig ─────────────────────────────────────────
+
+#[test]
+fn compression_config_disabled_by_default() {
+    let config = CompressionConfig::default();
+    assert!(!config.enabled, "compression must be off by default");
+}
+
+#[test]
+fn compression_config_toml_round_trips() {
+    let toml_str = r#"
+[compression]
+enabled = true
+"#;
+    let config: AutumnConfig = toml::from_str(toml_str).unwrap();
+    assert!(config.compression.enabled);
+}
+
+#[test]
+fn compression_config_env_override() {
+    use autumn_web::config::MockEnv;
+    let env = MockEnv::new().with("AUTUMN_COMPRESSION__ENABLED", "true");
+    let mut config = AutumnConfig::default();
+    config.apply_env_overrides_with_env(&env);
+    assert!(config.compression.enabled);
+}

--- a/autumn/tests/compression_middleware.rs
+++ b/autumn/tests/compression_middleware.rs
@@ -55,10 +55,8 @@ async fn png_handler() -> impl IntoResponse {
 async fn pre_encoded_handler() -> Response {
     // Simulate a response that already has Content-Encoding set (e.g. pre-compressed asset).
     let mut resp = Response::new(axum::body::Body::from(vec![0u8; 32]));
-    resp.headers_mut().insert(
-        header::CONTENT_ENCODING,
-        "gzip".parse().unwrap(),
-    );
+    resp.headers_mut()
+        .insert(header::CONTENT_ENCODING, "gzip".parse().unwrap());
     resp.headers_mut().insert(
         header::CONTENT_TYPE,
         "text/html; charset=utf-8".parse().unwrap(),
@@ -79,9 +77,7 @@ fn compression_enabled_config() -> AutumnConfig {
 /// Compression is **off by default** — no Content-Encoding even with Accept-Encoding.
 #[tokio::test]
 async fn compression_disabled_by_default() {
-    let app = TestApp::new()
-        .routes(routes![html_handler])
-        .build();
+    let app = TestApp::new().routes(routes![html_handler]).build();
 
     let resp = app
         .get("/html")

--- a/autumn/tests/compression_middleware.rs
+++ b/autumn/tests/compression_middleware.rs
@@ -51,6 +51,15 @@ async fn png_handler() -> impl IntoResponse {
     )
 }
 
+#[get("/zip")]
+async fn zip_handler() -> impl IntoResponse {
+    // Simulate a dynamic zip archive download (already compressed — should not be re-compressed).
+    (
+        [(header::CONTENT_TYPE, "application/zip")],
+        b"PK\x03\x04fake-zip-content-for-testing-purposes-only-padded".as_slice(),
+    )
+}
+
 #[get("/pre-encoded")]
 async fn pre_encoded_handler() -> Response {
     // Simulate a response that already has Content-Encoding set (e.g. pre-compressed asset).
@@ -223,6 +232,29 @@ async fn no_compression_when_client_does_not_accept() {
         resp.header("content-encoding"),
         None,
         "no Accept-Encoding → no Content-Encoding"
+    );
+}
+
+/// Archive content types (application/zip etc.) must not be compressed — they're
+/// already compressed and re-compressing wastes CPU and increases transfer size.
+#[tokio::test]
+async fn archive_content_type_not_compressed() {
+    let app = TestApp::new()
+        .routes(routes![zip_handler])
+        .config(compression_enabled_config())
+        .build();
+
+    let resp = app
+        .get("/zip")
+        .header("accept-encoding", "gzip")
+        .send()
+        .await;
+
+    resp.assert_ok();
+    assert_eq!(
+        resp.header("content-encoding"),
+        None,
+        "application/zip must not be compressed by the framework"
     );
 }
 

--- a/docs/guide/compression.md
+++ b/docs/guide/compression.md
@@ -1,0 +1,142 @@
+# Response Compression
+
+Autumn provides first-class, configurable response compression via a built-in
+[`CompressionLayer`][cl] that honors the client's `Accept-Encoding` header.
+
+[cl]: https://docs.rs/tower-http/latest/tower_http/compression/struct.CompressionLayer.html
+
+## Quick start
+
+Compression is **off by default**. Enable it with one line in `autumn.toml`:
+
+```toml
+[compression]
+enabled = true
+```
+
+Or via an environment variable (useful for deployment overrides without changing
+config files):
+
+```
+AUTUMN_COMPRESSION__ENABLED=true
+```
+
+That is all. Autumn's middleware stack automatically applies gzip or brotli
+compression to all compressible responses — HTML, JSON, CSS, JavaScript, SVG,
+XML, and plain text — based on what the client advertises in `Accept-Encoding`.
+
+## Supported algorithms
+
+| Algorithm | Feature flag |
+|-----------|-------------|
+| gzip / deflate | always available |
+| brotli (`br`) | always available |
+
+The `CompressionLayer` negotiates the best available algorithm automatically.
+
+## What gets compressed
+
+The layer uses standard content-type detection. Compressible types include:
+
+- `text/html`
+- `application/json`
+- `text/css`
+- `application/javascript`
+- `image/svg+xml`
+- `application/xml`, `text/xml`
+- `text/plain`
+
+Binary types (images, audio, video, archives) and responses that already carry a
+`Content-Encoding` header are passed through unchanged — no double-compression.
+
+## `Vary: Accept-Encoding`
+
+Autumn sets `Vary: Accept-Encoding` on all compressible responses so that HTTP
+caches store separate entries per encoding. This is done automatically; no extra
+configuration is needed.
+
+## ETag compatibility
+
+Autumn's compression layer is placed **outside** any user-registered `EtagLayer`
+in the middleware stack. This means:
+
+1. `EtagLayer` (or `fresh_when()`) computes the ETag on the **uncompressed** body.
+2. The compression layer then encodes the body for transit.
+3. The `Vary: Accept-Encoding` header ensures caches key entries by encoding.
+
+Weak ETags (`W/`) are safe to use with compression per RFC 7232 §2.1 — weak
+comparison explicitly allows encoding variations. When using explicit strong ETags
+(via `fresh_when()`), the ETag is still computed on the content before encoding,
+which is the correct semantic: the ETag identifies the *resource*, not the
+*representation encoding*.
+
+## Security: BREACH / CRIME tradeoff
+
+> **Read this section before enabling compression in production.**
+
+HTTP compression can leak secrets through a *compression oracle* attack (BREACH,
+CRIME). The attack works by injecting attacker-controlled bytes into a response
+that is compressed alongside a secret (such as a CSRF token). By measuring how
+the compressed length changes, an attacker can recover the secret bit-by-bit.
+
+**When compression is safe to enable:**
+
+- Your CSRF tokens or other secrets are not reflected in *dynamic, user-visible
+  response bodies*. Most apps fall into this category: secrets live in cookies or
+  HTTP headers, not HTML.
+- Your app uses per-request, nonce-based CSRF tokens (Autumn's default) rather
+  than long-lived tokens — each guess is burned.
+- You do not reflect attacker-controlled query params or form fields verbatim into
+  the same response that carries a CSRF token.
+
+**When to prefer CDN / reverse-proxy compression instead:**
+
+- Your responses regularly combine user-controlled input with secrets in the same
+  HTML fragment (e.g. a search results page that echoes the query alongside a
+  hidden form token).
+- You want zero application-level surface area for timing attacks.
+- Your hosting platform (Fly.io, Railway, Cloudflare, etc.) already compresses
+  at the edge.
+
+Autumn follows the same convention as Rails (`Rack::Deflater`), Django
+(`GZipMiddleware`), and Phoenix: compression is a documented, one-line opt-in,
+off by default, with the BREACH tradeoff explicitly surfaced here.
+
+## `autumn doctor`
+
+When you run `autumn doctor` in a production profile with compression disabled,
+you will see a warning:
+
+```
+⚠️  compression — response compression is disabled in production; text payloads
+                   (HTML/JSON/CSS) are served uncompressed
+   Hint: Set [compression] enabled = true in autumn.toml (or
+         AUTUMN_COMPRESSION__ENABLED=true) if you are not using a CDN or
+         reverse-proxy that compresses for you. Read the BREACH/CRIME tradeoff
+         in docs/guide/compression.md before enabling.
+```
+
+This is a *warning*, not a failure — running without compression is a legitimate
+choice (CDN compression, single-page app with pre-compressed assets, etc.). The
+doctor check is informational only.
+
+## Interaction with static asset serving
+
+Static files served from the `static/` directory (fingerprinted CSS/JS, images)
+are handled by `ServeDir` and are not affected by the `CompressionLayer`. If you
+want pre-compressed static assets, generate `.gz` or `.br` sidecar files during
+your build and configure `ServeDir` with `precompressed(true)`. See issue #752
+for the static-first SSG/ISG path.
+
+## Configuration reference
+
+```toml
+[compression]
+# Enable gzip/brotli response compression for dynamic handlers.
+# Off by default — read docs/guide/compression.md before enabling.
+enabled = false
+```
+
+| Environment variable | Type | Default |
+|----------------------|------|---------|
+| `AUTUMN_COMPRESSION__ENABLED` | `bool` | `false` |

--- a/docs/guide/compression.md
+++ b/docs/guide/compression.md
@@ -122,11 +122,17 @@ doctor check is informational only.
 
 ## Interaction with static asset serving
 
-Static files served from the `static/` directory (fingerprinted CSS/JS, images)
-are handled by `ServeDir` and are not affected by the `CompressionLayer`. If you
-want pre-compressed static assets, generate `.gz` or `.br` sidecar files during
-your build and configure `ServeDir` with `precompressed(true)`. See issue #752
-for the static-first SSG/ISG path.
+The `CompressionLayer` wraps the entire router, so static files under `/static`
+(fingerprinted CSS/JS etc.) **are** compressed on-the-fly when the client
+advertises `Accept-Encoding` and the content type is compressible. Images are
+excluded by `DefaultPredicate` and are served uncompressed regardless.
+
+If you prefer to serve pre-compressed sidecar files (`.gz` / `.br`) and skip
+on-the-fly CPU work, generate them during your build and configure `ServeDir`
+with `precompressed(true)`. When a sidecar is served, `ServeDir` sets
+`Content-Encoding` directly and the `CompressionLayer` skips re-encoding (the
+double-compression guard applies). See issue #752 for the static-first SSG/ISG
+path.
 
 ## Configuration reference
 


### PR DESCRIPTION
## Summary

This PR adds built-in response compression to Autumn via a configurable `CompressionLayer` that honors the client's `Accept-Encoding` header. Compression is **off by default** (opt-in) to avoid BREACH/CRIME side-channel attacks, with comprehensive documentation and tooling support.

## Key Changes

- **New `CompressionConfig` struct** in `autumn/src/config.rs`:
  - Single `enabled: bool` field (defaults to `false`)
  - Environment variable override: `AUTUMN_COMPRESSION__ENABLED`
  - TOML configuration: `[compression] enabled = true`

- **Middleware integration** in `autumn/src/router.rs`:
  - New `apply_compression_middleware()` function that wraps responses with `tower_http::compression::CompressionLayer`
  - Positioned in the middleware stack **after** user custom layers (e.g., `EtagLayer`) so ETags are computed on uncompressed bodies before compression
  - Automatically sets `Vary: Accept-Encoding` on compressible responses
  - Skips non-compressible content types (images, archives) and responses already carrying `Content-Encoding`

- **Doctor check** in `autumn-cli/src/doctor.rs`:
  - New `check_compression_impl()` function that warns (not fails) when compression is disabled in production
  - Helps operators understand the deliberate choice to rely on CDN/reverse-proxy compression
  - Includes hint linking to BREACH/CRIME documentation

- **Comprehensive test suite** in `autumn/tests/compression_middleware.rs`:
  - Verifies compression is off by default
  - Tests gzip compression when enabled and client accepts it
  - Validates `Vary: Accept-Encoding` header presence
  - Ensures binary content types are never compressed
  - Prevents double-compression of pre-encoded responses
  - Confirms no compression without `Accept-Encoding` header

- **Documentation** in `docs/guide/compression.md`:
  - Quick-start guide with one-line TOML configuration
  - Supported algorithms (gzip, brotli)
  - List of compressible content types
  - Detailed BREACH/CRIME security tradeoff analysis
  - ETag compatibility explanation
  - Static asset serving interaction notes

## Notable Implementation Details

- **Security-first design**: Compression is opt-in with explicit BREACH/CRIME warnings in docs and doctor output
- **ETag semantics**: ETags are computed on uncompressed content (correct per RFC 7232), with `Vary: Accept-Encoding` ensuring proper cache keying
- **Middleware ordering**: Compression layer is applied outside user layers so framework-managed concerns (compression) don't interfere with user middleware (e.g., custom ETag computation)
- **Content-type detection**: Uses `tower-http`'s built-in compressibility rules; only text-based and structured formats are compressed
- **No double-encoding**: Responses already carrying `Content-Encoding` are passed through unchanged

https://claude.ai/code/session_01YXbsTW3TTBmupLpZo1Tz7H