### PR TITLE
⚒️ Forge: Idiomatic Rust refactoring in auth and csv

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -409,7 +409,7 @@ pub struct AuthConfig {
     #[serde(default)]
     pub oauth_linking_policy: OAuthLinkingPolicy,
 
-    /// WebAuthn / passkey configuration.
+    /// `WebAuthn` / passkey configuration.
     ///
     /// Required when using `autumn generate auth --passkeys`. Set in `autumn.toml`:
     ///
@@ -424,7 +424,7 @@ pub struct AuthConfig {
     pub webauthn: WebAuthnConfig,
 }
 
-/// WebAuthn / passkey Relying Party configuration.
+/// `WebAuthn` / passkey Relying Party configuration.
 ///
 /// Read from the `[auth.webauthn]` section of `autumn.toml`.
 #[cfg(feature = "webauthn")]
@@ -453,7 +453,7 @@ impl Default for WebAuthnConfig {
 }
 
 #[cfg(feature = "webauthn")]
-fn default_rp_id() -> String {
+const fn default_rp_id() -> String {
     String::new()
 }
 
@@ -463,7 +463,7 @@ fn default_rp_name() -> String {
 }
 
 #[cfg(feature = "webauthn")]
-fn default_rp_origin() -> String {
+const fn default_rp_origin() -> String {
     String::new()
 }
 

--- a/autumn/src/data/csv.rs
+++ b/autumn/src/data/csv.rs
@@ -110,13 +110,13 @@ pub struct ImportReport {
 impl ImportReport {
     /// Total data rows processed (inserted + updated + skipped + errors).
     #[must_use]
-    pub fn total_rows(&self) -> u64 {
+    pub const fn total_rows(&self) -> u64 {
         self.inserted + self.updated + self.skipped + self.errors.len() as u64
     }
 
     /// `true` if no errors were recorded.
     #[must_use]
-    pub fn is_ok(&self) -> bool {
+    pub const fn is_ok(&self) -> bool {
         self.errors.is_empty()
     }
 }
@@ -299,11 +299,11 @@ where
     for result in rdr.records() {
         let (line, record) = match result {
             Ok(r) => {
-                let pos = r.position().map_or(0, |p| p.line());
+                let pos = r.position().map_or(0, csv::Position::line);
                 (pos, r)
             }
             Err(e) => {
-                let pos = e.position().map_or(0, |p| p.line());
+                let pos = e.position().map_or(0, csv::Position::line);
                 report
                     .errors
                     .push(CsvRowError::row(pos, format!("CSV parse error: {e}")));
@@ -536,18 +536,14 @@ mod tests {
             csv.as_ref(),
             &ImportOptions::default(),
             |_line, row, _mode| {
-                if !row
-                    .get("email")
-                    .map(String::as_str)
-                    .unwrap_or("")
-                    .contains('@')
-                {
+                let is_valid_email = row.get("email").is_some_and(|s| s.contains('@'));
+                if is_valid_email {
+                    ImportRowResult::Inserted
+                } else {
                     ImportRowResult::FieldError {
                         column: "email".into(),
                         message: "must be a valid email".into(),
                     }
-                } else {
-                    ImportRowResult::Inserted
                 }
             },
         );


### PR DESCRIPTION
🚮 Smell:
- Redundant closures were being used to extract the line number from `csv::Position` (`|p| p.line()`).
- Unnecessary negated boolean logic combining `.map()`, `.unwrap_or()`, and `.contains()` made the email validation tests harder to read.
- Some functions (`default_rp_id`, `default_rp_origin`) were not marked as `const fn` even though they could be, missing out on potential compile-time evaluations.
- Doc comments for WebAuthn in `auth.rs` were missing backticks, violating formatting consistency.

✨ Solution:
- Replaced the redundant closures with the `csv::Position::line` method reference.
- Simplified the email validation check using `.is_some_and(|s| s.contains('@'))`.
- Converted `default_rp_id` and `default_rp_origin` to `const fn`s in `auth.rs`.
- Added the missing backticks to the `[auth.webauthn]` doc comments in `auth.rs`.

🧼 Benefit:
- Enforces strict adherence to idiomatic Rust patterns by resolving `clippy::redundant_closure`, `clippy::missing_const_for_fn`, and `clippy::doc_markdown` warnings.
- Improves test readability by flattening the boolean logic.

🛡️ Verification:
Tests passed. No logic changed. Checked with `cargo clippy -j 1 --workspace --all-targets --all-features -- -D warnings` and `cargo test -p autumn-web --lib`.

---
*PR created automatically by Jules for task [3875238080261685717](https://jules.google.com/task/3875238080261685717) started by @madmax983*