### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -246,7 +246,7 @@ pub struct AppBuilder {
     /// Error reporters registered via [`AppBuilder::with_error_reporter`].
     /// Installed onto `AppState` so the
     /// [`ReportingLayer`](crate::reporting::ReportingLayer) delivers panic and
-    /// 5xx [`ErrorEvent`](crate::reporting::ErrorEvent)s to each. Empty means
+    /// 5xx [`crate::reporting::ErrorEvent`]s to each. Empty means
     /// the built-in [`LogReporter`](crate::reporting::LogReporter) is used.
     #[cfg(feature = "reporting")]
     pub(crate) error_reporters: Vec<Arc<dyn crate::reporting::ErrorReporter>>,
@@ -1311,7 +1311,7 @@ impl AppBuilder {
     /// unhandled panics and 5xx responses.
     ///
     /// Reporters receive a structured
-    /// [`ErrorEvent`](crate::reporting::ErrorEvent) for every caught handler
+    /// [`crate::reporting::ErrorEvent`] for every caught handler
     /// panic and every server-error response, carrying request context (route,
     /// method, request id, status) and — for panics — the panic payload and a
     /// backtrace (when `RUST_BACKTRACE` is set). Call this multiple times to

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -409,7 +409,7 @@ pub struct AuthConfig {
     #[serde(default)]
     pub oauth_linking_policy: OAuthLinkingPolicy,
 
-    /// WebAuthn / passkey configuration.
+    /// `WebAuthn` / passkey configuration.
     ///
     /// Required when using `autumn generate auth --passkeys`. Set in `autumn.toml`:
     ///
@@ -424,7 +424,7 @@ pub struct AuthConfig {
     pub webauthn: WebAuthnConfig,
 }
 
-/// WebAuthn / passkey Relying Party configuration.
+/// `WebAuthn` / passkey Relying Party configuration.
 ///
 /// Read from the `[auth.webauthn]` section of `autumn.toml`.
 #[cfg(feature = "webauthn")]
@@ -453,7 +453,7 @@ impl Default for WebAuthnConfig {
 }
 
 #[cfg(feature = "webauthn")]
-fn default_rp_id() -> String {
+const fn default_rp_id() -> String {
     String::new()
 }
 
@@ -463,7 +463,7 @@ fn default_rp_name() -> String {
 }
 
 #[cfg(feature = "webauthn")]
-fn default_rp_origin() -> String {
+const fn default_rp_origin() -> String {
     String::new()
 }
 

--- a/autumn/src/data/csv.rs
+++ b/autumn/src/data/csv.rs
@@ -110,13 +110,13 @@ pub struct ImportReport {
 impl ImportReport {
     /// Total data rows processed (inserted + updated + skipped + errors).
     #[must_use]
-    pub fn total_rows(&self) -> u64 {
+    pub const fn total_rows(&self) -> u64 {
         self.inserted + self.updated + self.skipped + self.errors.len() as u64
     }
 
     /// `true` if no errors were recorded.
     #[must_use]
-    pub fn is_ok(&self) -> bool {
+    pub const fn is_ok(&self) -> bool {
         self.errors.is_empty()
     }
 }
@@ -299,11 +299,11 @@ where
     for result in rdr.records() {
         let (line, record) = match result {
             Ok(r) => {
-                let pos = r.position().map_or(0, |p| p.line());
+                let pos = r.position().map_or(0, csv::Position::line);
                 (pos, r)
             }
             Err(e) => {
-                let pos = e.position().map_or(0, |p| p.line());
+                let pos = e.position().map_or(0, csv::Position::line);
                 report
                     .errors
                     .push(CsvRowError::row(pos, format!("CSV parse error: {e}")));
@@ -536,18 +536,17 @@ mod tests {
             csv.as_ref(),
             &ImportOptions::default(),
             |_line, row, _mode| {
-                if !row
+                if row
                     .get("email")
-                    .map(String::as_str)
-                    .unwrap_or("")
+                    .map_or("", String::as_str)
                     .contains('@')
                 {
+                    ImportRowResult::Inserted
+                } else {
                     ImportRowResult::FieldError {
                         column: "email".into(),
                         message: "must be a valid email".into(),
                     }
-                } else {
-                    ImportRowResult::Inserted
                 }
             },
         );

--- a/autumn/src/data/mod.rs
+++ b/autumn/src/data/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! # Modules
 //!
-//! - [`csv`] — CSV schema trait, streaming export, row-by-row import with
+//! - `csv` — CSV schema trait, streaming export, row-by-row import with
 //!   structured error reporting.
 
 #[cfg(feature = "csv")]

--- a/autumn/src/reporting.rs
+++ b/autumn/src/reporting.rs
@@ -2,24 +2,24 @@
 //! route them to one or more configured reporters.
 //!
 //! When an Autumn handler panics or returns a server error, the failure is
-//! turned into a structured [`ErrorEvent`] and delivered to every registered
-//! [`ErrorReporter`]. This is the "where do my errors go?" seam: ship events to
+//! turned into a structured [`crate::reporting::ErrorEvent`] and delivered to every registered
+//! [`crate::reporting::ErrorReporter`]. This is the "where do my errors go?" seam: ship events to
 //! Sentry, Honeycomb, Slack, or a custom sink by implementing a single trait
 //! and wiring it once with
 //! [`AppBuilder::with_error_reporter`](crate::app::AppBuilder::with_error_reporter).
 //!
 //! The design mirrors Rails' [Error Reporter] and Autumn's other pluggable
 //! backends ([`BlobStore`](crate::storage::BlobStore),
-//! [`Cache`](crate::cache::Cache)): a built-in [`LogReporter`] (which uses
+//! [`Cache`](crate::cache::Cache)): a built-in [`crate::reporting::LogReporter`] (which uses
 //! `tracing`) ships as the default so the feature is useful with zero extra
 //! dependencies, and one builder call swaps in your own sink.
 //!
 //! # What gets reported
 //!
-//! - **Handler panics.** A [`ReportingLayer`] catches unwinding panics at the
+//! - **Handler panics.** A [`crate::reporting::ReportingLayer`] catches unwinding panics at the
 //!   HTTP layer (so a single panicking handler can never abort the worker
 //!   task), converts them into a sanitized [`AutumnError`](crate::AutumnError)
-//!   `500` Problem Details response, and reports an [`ErrorEvent`] carrying the
+//!   `500` Problem Details response, and reports an [`crate::reporting::ErrorEvent`] carrying the
 //!   panic payload and (when `RUST_BACKTRACE` is set) a backtrace.
 //! - **Server errors.** Any response with a `5xx` status is reported with its
 //!   status, message, and Problem Details type.
@@ -134,7 +134,7 @@ pub struct PanicInfo {
     pub backtrace: Option<String>,
 }
 
-/// A sink for [`ErrorEvent`]s.
+/// A sink for [`crate::reporting::ErrorEvent`]s.
 ///
 /// Implement this trait to ship unhandled panics and server errors to an
 /// external service. Register implementations with
@@ -145,7 +145,7 @@ pub struct PanicInfo {
 /// not block the client response. Any panic raised inside `report` is caught
 /// and logged — a misbehaving reporter never affects the response.
 pub trait ErrorReporter: Send + Sync + 'static {
-    /// Deliver an [`ErrorEvent`] to the sink.
+    /// Deliver an [`crate::reporting::ErrorEvent`] to the sink.
     ///
     /// Implementations should swallow their own transport errors; returning is
     /// the only signal the framework needs.
@@ -189,7 +189,7 @@ impl ErrorReporter for LogReporter {
 
 /// Runtime holder for the registered reporters, installed on
 /// [`AppState`](crate::state::AppState) extensions so the
-/// [`ReportingLayer`] can pick them up at router-build time.
+/// [`crate::reporting::ReportingLayer`] can pick them up at router-build time.
 #[derive(Clone, Default)]
 pub(crate) struct RegisteredReporters(pub(crate) Vec<Arc<dyn ErrorReporter>>);
 
@@ -298,7 +298,7 @@ struct CapturedPanic {
 static HOOK_INSTALLED: Once = Once::new();
 
 /// Install a panic hook (once) that records a backtrace for the panicking
-/// thread so the [`ReportingLayer`] can attach it to the [`ErrorEvent`] after
+/// thread so the [`crate::reporting::ReportingLayer`] can attach it to the [`crate::reporting::ErrorEvent`] after
 /// `catch_unwind` returns. The previous hook is preserved and still runs, so
 /// the default panic logging behavior is unchanged.
 fn ensure_panic_hook() {
@@ -340,7 +340,7 @@ struct RequestContext {
 }
 
 /// Tower [`Layer`] that catches handler panics and reports panics + 5xx
-/// responses to the registered [`ErrorReporter`]s.
+/// responses to the registered [`crate::reporting::ErrorReporter`]s.
 ///
 /// Applied automatically by the framework inner to
 /// [`RequestIdLayer`](crate::middleware::RequestIdLayer) (so the request id is
@@ -353,7 +353,7 @@ pub struct ReportingLayer {
 impl ReportingLayer {
     /// Build a reporting layer from the registered reporters and config knobs.
     ///
-    /// When `reporters` is empty, the built-in [`LogReporter`] is installed so
+    /// When `reporters` is empty, the built-in [`crate::reporting::LogReporter`] is installed so
     /// panics and server errors are still surfaced.
     #[must_use]
     pub(crate) fn new(
@@ -388,7 +388,7 @@ impl<S> Layer<S> for ReportingLayer {
     }
 }
 
-/// Tower [`Service`] produced by [`ReportingLayer`].
+/// Tower [`Service`] produced by [`crate::reporting::ReportingLayer`].
 #[derive(Clone)]
 pub struct ReportingService<S> {
     inner: S,

--- a/autumn/src/storage/local.rs
+++ b/autumn/src/storage/local.rs
@@ -612,7 +612,7 @@ pub(crate) fn verify_upload_with_rotation(
     )
 }
 
-/// Clock-injectable variant of [`verify_upload_with_rotation`].
+/// Clock-injectable variant of `verify_upload_with_rotation`.
 pub(crate) fn verify_upload_rotation_with_now(
     current: &SigningKey,
     previous: &[SigningKey],
@@ -1008,7 +1008,7 @@ pub(crate) fn verify_with_rotation(
     verify_with_rotation_with_now(current, previous, blob_key, expires_at, signature, now)
 }
 
-/// Clock-injectable variant of [`verify_with_rotation`].
+/// Clock-injectable variant of `verify_with_rotation`.
 pub(crate) fn verify_with_rotation_with_now(
     current: &SigningKey,
     previous: &[SigningKey],

--- a/examples/todo-app/src/routes/todos.rs
+++ b/examples/todo-app/src/routes/todos.rs
@@ -41,7 +41,7 @@
 //!
 //! ## Inline field validation (htmx)
 //!
-//! A field rendered with [`text_input_htmx`] POSTs to a validation endpoint
+//! A field rendered with `text_input_htmx` POSTs to a validation endpoint
 //! when its value changes. The handler extracts [`ChangesetForm`], validates,
 //! and returns just that field's wrapper partial — htmx swaps it with `outerHTML`.
 //! When JavaScript is disabled, the normal `#[post("/todos")]` handler still


### PR DESCRIPTION
📖 Chapter: Documentation hygiene and compile warnings.
🔦 Insight: Resolved multiple `cargo doc` broken intra-doc links, redundant explicit link target warnings, and `cargo clippy` suggestions (`const fn`, redundant closures, positive conditions).
🧪 Example: Changed `[ErrorEvent]` to `[crate::reporting::ErrorEvent]` to correctly resolve links without triggering redundancy warnings.
🖼️ Preview: (None needed; all `cargo doc` and `cargo clippy` tests now pass cleanly).

---
*PR created automatically by Jules for task [5978036800179494191](https://jules.google.com/task/5978036800179494191) started by @madmax983*