### PR TITLE
🌟 Nova: Add HX-Reselect support to HxResponseExt

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -409,7 +409,7 @@ pub struct AuthConfig {
     #[serde(default)]
     pub oauth_linking_policy: OAuthLinkingPolicy,
 
-    /// WebAuthn / passkey configuration.
+    /// `WebAuthn` / passkey configuration.
     ///
     /// Required when using `autumn generate auth --passkeys`. Set in `autumn.toml`:
     ///
@@ -424,7 +424,7 @@ pub struct AuthConfig {
     pub webauthn: WebAuthnConfig,
 }
 
-/// WebAuthn / passkey Relying Party configuration.
+/// `WebAuthn` / passkey Relying Party configuration.
 ///
 /// Read from the `[auth.webauthn]` section of `autumn.toml`.
 #[cfg(feature = "webauthn")]
@@ -453,6 +453,7 @@ impl Default for WebAuthnConfig {
 }
 
 #[cfg(feature = "webauthn")]
+#[allow(clippy::missing_const_for_fn)]
 fn default_rp_id() -> String {
     String::new()
 }
@@ -463,6 +464,7 @@ fn default_rp_name() -> String {
 }
 
 #[cfg(feature = "webauthn")]
+#[allow(clippy::missing_const_for_fn)]
 fn default_rp_origin() -> String {
     String::new()
 }

--- a/autumn/src/data/csv.rs
+++ b/autumn/src/data/csv.rs
@@ -110,12 +110,14 @@ pub struct ImportReport {
 impl ImportReport {
     /// Total data rows processed (inserted + updated + skipped + errors).
     #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
     pub fn total_rows(&self) -> u64 {
         self.inserted + self.updated + self.skipped + self.errors.len() as u64
     }
 
     /// `true` if no errors were recorded.
     #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
     pub fn is_ok(&self) -> bool {
         self.errors.is_empty()
     }
@@ -299,11 +301,11 @@ where
     for result in rdr.records() {
         let (line, record) = match result {
             Ok(r) => {
-                let pos = r.position().map_or(0, |p| p.line());
+                let pos = r.position().map_or(0, csv::Position::line);
                 (pos, r)
             }
             Err(e) => {
-                let pos = e.position().map_or(0, |p| p.line());
+                let pos = e.position().map_or(0, csv::Position::line);
                 report
                     .errors
                     .push(CsvRowError::row(pos, format!("CSV parse error: {e}")));
@@ -536,18 +538,13 @@ mod tests {
             csv.as_ref(),
             &ImportOptions::default(),
             |_line, row, _mode| {
-                if !row
-                    .get("email")
-                    .map(String::as_str)
-                    .unwrap_or("")
-                    .contains('@')
-                {
+                if row.get("email").map_or("", String::as_str).contains('@') {
+                    ImportRowResult::Inserted
+                } else {
                     ImportRowResult::FieldError {
                         column: "email".into(),
                         message: "must be a valid email".into(),
                     }
-                } else {
-                    ImportRowResult::Inserted
                 }
             },
         );

--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -175,6 +175,11 @@ pub trait HxResponseExt: IntoResponse + Sized {
         append_hx_header(self, "hx-reswap", swap)
     }
 
+    /// Specifies a CSS selector to use to choose which part of the response should be used to be swapped in (`HX-Reselect`).
+    fn hx_reselect(self, selector: &str) -> Response {
+        append_hx_header(self, "hx-reselect", selector)
+    }
+
     /// Specifies the target element to update (`HX-Retarget`).
     fn hx_retarget(self, target: &str) -> Response {
         append_hx_header(self, "hx-retarget", target)
@@ -284,6 +289,7 @@ mod tests {
             .hx_refresh()
             .hx_replace_url("/old-url")
             .hx_reswap("innerHTML")
+            .hx_reselect("#some-content")
             .hx_retarget("#target")
             .hx_trigger("my-event")
             .hx_trigger_after_settle("settled-event")
@@ -297,6 +303,7 @@ mod tests {
         assert_eq!(headers.get("hx-refresh").unwrap(), "true");
         assert_eq!(headers.get("hx-replace-url").unwrap(), "/old-url");
         assert_eq!(headers.get("hx-reswap").unwrap(), "innerHTML");
+        assert_eq!(headers.get("hx-reselect").unwrap(), "#some-content");
         assert_eq!(headers.get("hx-retarget").unwrap(), "#target");
         assert_eq!(headers.get("hx-trigger").unwrap(), "my-event");
         assert_eq!(
@@ -324,6 +331,7 @@ mod tests {
             .hx_refresh() // valid by default
             .hx_replace_url(invalid_header_value)
             .hx_reswap(invalid_header_value)
+            .hx_reselect(invalid_header_value)
             .hx_retarget(invalid_header_value)
             .hx_trigger(invalid_header_value)
             .hx_trigger_after_settle(invalid_header_value)
@@ -338,6 +346,7 @@ mod tests {
         assert_eq!(headers.get("hx-refresh").unwrap(), "true");
         assert!(headers.get("hx-replace-url").is_none());
         assert!(headers.get("hx-reswap").is_none());
+        assert!(headers.get("hx-reselect").is_none());
         assert!(headers.get("hx-retarget").is_none());
         assert!(headers.get("hx-trigger").is_none());
         assert!(headers.get("hx-trigger-after-settle").is_none());


### PR DESCRIPTION
💡 **The Spark:** I noticed we have comprehensive support for htmx response headers in `HxResponseExt`, but we are missing `HX-Reselect`.
🚀 **The Feature:** Implemented the `hx_reselect` method on `HxResponseExt` to set the `HX-Reselect` response header.
🔮 **The Potential:** Allows the server to dynamically change which part of the response is selected for swapping, giving developers more flexibility when returning partials or full pages where only a specific fragment is needed.
⚠️ **Risk:** Low. Isolated addition to the existing `HxResponseExt` trait. Also fixed some minor pre-existing clippy warnings in `auth.rs` and `csv.rs` to ensure a green build.

---
*PR created automatically by Jules for task [4487267183057093259](https://jules.google.com/task/4487267183057093259) started by @madmax983*