### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/autumn/src/data/csv.rs
+++ b/autumn/src/data/csv.rs
@@ -178,7 +178,12 @@ pub enum ImportRowResult {
     /// A row-level error occurred.
     RowError(String),
     /// A field-level error occurred (column name + message).
-    FieldError { column: String, message: String },
+    FieldError {
+        /// The name of the column that caused the error.
+        column: String,
+        /// The error message detailing why the field is invalid.
+        message: String,
+    },
 }
 
 // ── CsvSchema trait ───────────────────────────────────────────────────────────

--- a/autumn/src/reporting.rs
+++ b/autumn/src/reporting.rs
@@ -2,24 +2,24 @@
 //! route them to one or more configured reporters.
 //!
 //! When an Autumn handler panics or returns a server error, the failure is
-//! turned into a structured [`ErrorEvent`] and delivered to every registered
-//! [`ErrorReporter`]. This is the "where do my errors go?" seam: ship events to
+//! turned into a structured [`crate::reporting::ErrorEvent`] and delivered to every registered
+//! [`crate::reporting::ErrorReporter`]. This is the "where do my errors go?" seam: ship events to
 //! Sentry, Honeycomb, Slack, or a custom sink by implementing a single trait
 //! and wiring it once with
 //! [`AppBuilder::with_error_reporter`](crate::app::AppBuilder::with_error_reporter).
 //!
 //! The design mirrors Rails' [Error Reporter] and Autumn's other pluggable
 //! backends ([`BlobStore`](crate::storage::BlobStore),
-//! [`Cache`](crate::cache::Cache)): a built-in [`LogReporter`] (which uses
+//! [`Cache`](crate::cache::Cache)): a built-in [`crate::reporting::LogReporter`] (which uses
 //! `tracing`) ships as the default so the feature is useful with zero extra
 //! dependencies, and one builder call swaps in your own sink.
 //!
 //! # What gets reported
 //!
-//! - **Handler panics.** A [`ReportingLayer`] catches unwinding panics at the
+//! - **Handler panics.** A [`crate::reporting::ReportingLayer`] catches unwinding panics at the
 //!   HTTP layer (so a single panicking handler can never abort the worker
 //!   task), converts them into a sanitized [`AutumnError`](crate::AutumnError)
-//!   `500` Problem Details response, and reports an [`ErrorEvent`] carrying the
+//!   `500` Problem Details response, and reports an [`crate::reporting::ErrorEvent`] carrying the
 //!   panic payload and (when `RUST_BACKTRACE` is set) a backtrace.
 //! - **Server errors.** Any response with a `5xx` status is reported with its
 //!   status, message, and Problem Details type.

--- a/autumn/src/runtime_config.rs
+++ b/autumn/src/runtime_config.rs
@@ -638,7 +638,12 @@ pub enum RegistryError {
     },
     /// The declared default value does not satisfy the declared validators.
     #[error("config key '{key}': default value is invalid: {reason}")]
-    InvalidDefault { key: String, reason: String },
+    InvalidDefault {
+        /// The name of the configuration key.
+        key: String,
+        /// The reason the default value failed validation.
+        reason: String,
+    },
     /// The key name is empty or contains disallowed characters (only `[a-z0-9_]` allowed).
     #[error("invalid config key name '{0}': must match [a-z][a-z0-9_]*")]
     InvalidKeyName(String),
@@ -1327,11 +1332,21 @@ pub enum ConfigError {
 
     /// The raw string could not be parsed as the key's declared type.
     #[error("config key '{key}': type error — {reason}")]
-    TypeMismatch { key: String, reason: String },
+    TypeMismatch {
+        /// The name of the configuration key.
+        key: String,
+        /// The parsing error reason.
+        reason: String,
+    },
 
     /// A declared validator rejected the value.
     #[error("config key '{key}': validation failed — {reason}")]
-    ValidationFailed { key: String, reason: String },
+    ValidationFailed {
+        /// The name of the configuration key.
+        key: String,
+        /// The validation error reason.
+        reason: String,
+    },
 
     /// The backing store returned an error.
     #[error("config store error: {0}")]
@@ -1343,11 +1358,17 @@ pub enum ConfigError {
 /// A snapshot of a single config key: schema defaults + current override.
 #[derive(Debug, Clone)]
 pub struct ConfigEntry {
+    /// The name of the configuration key.
     pub name: String,
+    /// The type of the value this key holds.
     pub value_type: ConfigValueType,
+    /// The currently active value (either the override or the default).
     pub current: ConfigValue,
+    /// The fallback default value declared in the schema.
     pub default: ConfigValue,
+    /// Whether the current value comes from an explicit override in the store.
     pub is_overridden: bool,
+    /// Human-readable description of what this key controls.
     pub description: Option<String>,
 }
 

--- a/autumn/src/system_test.rs
+++ b/autumn/src/system_test.rs
@@ -290,7 +290,7 @@ impl SystemTest {
     }
 
     /// Supply a pre-configured [`AppState`] to use instead of
-    /// [`AppState::for_test()`].
+    /// [`crate::state::AppState::for_test()`].
     ///
     /// Use this when the routes under test require a real database pool, API
     /// version registrations, authorization policies, or any other state that

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -538,6 +538,7 @@ impl TestApp {
         self
     }
 
+    /// Attach a test interceptor for outbound emails.
     #[cfg(feature = "mail")]
     #[must_use]
     pub fn with_mail_interceptor(
@@ -548,6 +549,7 @@ impl TestApp {
         self
     }
 
+    /// Attach a test interceptor for background jobs.
     #[must_use]
     pub fn with_job_interceptor(
         mut self,
@@ -557,6 +559,7 @@ impl TestApp {
         self
     }
 
+    /// Attach a test interceptor for database connections.
     #[cfg(feature = "db")]
     #[must_use]
     pub fn with_db_interceptor(
@@ -567,6 +570,7 @@ impl TestApp {
         self
     }
 
+    /// Attach a test interceptor for WebSocket channels.
     #[cfg(feature = "ws")]
     #[must_use]
     pub fn with_channels_interceptor(
@@ -577,6 +581,7 @@ impl TestApp {
         self
     }
 
+    /// Attach a test interceptor for outbound HTTP requests.
     #[cfg(feature = "oauth2")]
     #[must_use]
     pub fn with_http_interceptor(

--- a/autumn/src/webhook_outbound.rs
+++ b/autumn/src/webhook_outbound.rs
@@ -22,8 +22,11 @@ const TRUNCATED_RESPONSE_BODY_SUFFIX: &str = "\n[truncated]";
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum WebhookSubscriptionStatus {
+    /// The subscription is active and delivering events.
     Active,
+    /// The subscription is intentionally disabled by the user or an admin.
     Disabled,
+    /// The subscription has been automatically disabled due to excessive consecutive delivery failures.
     Failed,
 }
 
@@ -48,29 +51,48 @@ impl std::fmt::Display for WebhookSubscriptionStatus {
 /// A registered webhook subscription targeting a consumer endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebhookSubscription {
+    /// The unique identifier of the subscription.
     pub id: String,
+    /// The URL endpoint where webhook events should be delivered.
     pub target_url: String,
+    /// The list of event topics the subscription is listening for (e.g. `["orders.created"]`).
     pub event_topics: Vec<String>,
+    /// The cryptographic secret used to sign outgoing webhook payloads.
     pub secret: String,
+    /// The current delivery status of the subscription.
     pub status: WebhookSubscriptionStatus,
+    /// The number of consecutive failed delivery attempts (auto-fails at 50).
     pub consecutive_failures: u32,
 }
 
 /// A structured log of an outbound webhook delivery attempt.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebhookDeliveryLog {
+    /// The unique identifier of this delivery attempt.
     pub id: String,
+    /// The ID of the subscription this delivery belongs to.
     pub subscription_id: String,
+    /// The event topic being delivered.
     pub topic: String,
+    /// The serialized JSON payload being sent.
     pub payload: String,
+    /// The HTTP headers included in the delivery request.
     pub request_headers: HashMap<String, String>,
+    /// The HTTP status code returned by the receiver, if reachable.
     pub response_status: Option<u16>,
+    /// The response body returned by the receiver, truncated to a reasonable size.
     pub response_body: Option<String>,
+    /// The time taken for the HTTP request in milliseconds.
     pub elapsed_ms: u64,
+    /// The attempt number for this delivery (1 for first try).
     pub attempt: u32,
+    /// The maximum number of attempts allowed for this delivery before failing permanently.
     pub max_attempts: u32,
+    /// Whether this delivery has exhausted all attempts and is now in the Dead Letter Queue.
     pub is_dlq: bool,
+    /// A description of the last error encountered, if the request failed without an HTTP response.
     pub last_error: Option<String>,
+    /// The timestamp when the delivery was attempted.
     pub timestamp: DateTime<Utc>,
 }
 


### PR DESCRIPTION
📖 Chapter: The "Missing Link" and the "Ghost Params/Fields"
🔦 Insight: Fixed unresolved intra-doc links in the `reporting` and `system_test` modules by using explicit `crate::` paths so `cargo doc` can resolve them from module-level context. Added clear explanations for previously undocumented public struct fields and enum variants in `csv`, `runtime_config`, `webhook_outbound`, and `test`. Now, a tired developer will know exactly what an `InvalidDefault` config error implies or what `consecutive_failures` does for a webhook subscription without guessing.
🧪 Example: Cleaned up numerous `cargo doc` warnings.
🖼️ Preview: (Generates clean docs for autumn-web with reduced warnings and functional links).

---
*PR created automatically by Jules for task [9329974737683111888](https://jules.google.com/task/9329974737683111888) started by @madmax983*