### PR TITLE
Add pluggable MetricsSource trait for custom Prometheus metrics

### DIFF
--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -40,6 +40,215 @@ impl A11yPosture {
     }
 }
 
+// ── Plugin-contributed metrics ──────────────────────────────────
+
+/// Kind of a Prometheus metric family.
+///
+/// Used in [`MetricFamily`] to emit the correct `# TYPE` line in the
+/// Prometheus text format.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MetricKind {
+    /// A monotonically increasing value (e.g., request count).
+    Counter,
+    /// An arbitrary up-or-down value (e.g., queue depth, active connections).
+    Gauge,
+    /// A sampled distribution (e.g., latency buckets).
+    Histogram,
+}
+
+impl MetricKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Counter => "counter",
+            Self::Gauge => "gauge",
+            Self::Histogram => "histogram",
+        }
+    }
+}
+
+/// A single metric sample with optional label set and a value.
+///
+/// Labels are `(name, value)` pairs rendered as `{name="value"}` in
+/// Prometheus text format.
+#[derive(Debug, Clone)]
+pub struct MetricSample {
+    /// Label key-value pairs. Empty means no labels.
+    pub labels: Vec<(String, String)>,
+    /// The metric value.
+    pub value: f64,
+}
+
+/// A complete metric family: name, kind, help text, and current samples.
+///
+/// Each `MetricFamily` is rendered as one `# HELP` / `# TYPE` block followed
+/// by one line per sample in the Prometheus text format.
+#[derive(Debug, Clone)]
+pub struct MetricFamily {
+    /// Unique metric name (e.g., `"harvest_workflow_completions_total"`).
+    ///
+    /// Use a stable namespace prefix so names don't collide with the built-in
+    /// `autumn_*` families or other registered sources.
+    pub name: String,
+    /// One-line description emitted as `# HELP` in the Prometheus output.
+    pub help: String,
+    /// Metric type: counter, gauge, or histogram.
+    pub kind: MetricKind,
+    /// Current samples.  Each sample produces one line in the scrape output.
+    pub samples: Vec<MetricSample>,
+}
+
+/// Contract for a subsystem that contributes metrics to the unified actuator endpoints.
+///
+/// Implement this trait and register the implementation via
+/// [`AppBuilder::metrics_source`] to publish metric families that appear in
+/// `/actuator/prometheus` alongside the built-in `autumn_http_*` families, and
+/// in `/actuator/metrics` under the `sources` key.
+///
+/// # Naming rules
+///
+/// Prefix every metric name with a stable namespace (e.g. `harvest_` for
+/// autumn-harvest, `myapp_` for an application-level source).  The registry
+/// enforces that two sources cannot share the same **registration name**; metric
+/// family name uniqueness is the source's responsibility.
+///
+/// # Sync-snapshot contract
+///
+/// `collect` is called synchronously on the HTTP request goroutine.
+/// Implementations **must not block on I/O** — read from atomics,
+/// `RwLock`-protected snapshots, or channels that already have buffered data.
+/// If async work is needed, collect it into a pre-computed cache and update
+/// that cache from a background task.
+pub trait MetricsSource: Send + Sync + 'static {
+    /// Return zero or more metric families, all read from in-memory state.
+    fn collect(&self) -> Vec<MetricFamily>;
+}
+
+/// Registry of named [`MetricsSource`] implementations.
+///
+/// Maintained by [`crate::app::AppBuilder`] and stored on
+/// [`crate::AppState`]. Provides duplicate-registration detection at startup
+/// and per-source panic isolation at scrape time.
+#[derive(Clone, Default)]
+pub struct MetricsSourceRegistry {
+    inner: Arc<RwLock<MetricsSourceRegistryInner>>,
+}
+
+#[derive(Default)]
+struct MetricsSourceRegistryInner {
+    /// Registered sources in insertion order.
+    sources: Vec<(String, Arc<dyn MetricsSource>)>,
+    /// Per-source scrape-error counter incremented when a source panics.
+    error_counts: HashMap<String, u64>,
+}
+
+impl MetricsSourceRegistry {
+    /// Create a new, empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a named source.
+    ///
+    /// Returns `Err` containing a message if a source with `name` has already
+    /// been registered (startup-time collision detection).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string when `name` is already registered.
+    pub fn register(
+        &self,
+        name: impl Into<String>,
+        source: Arc<dyn MetricsSource>,
+    ) -> Result<(), String> {
+        let name = name.into();
+        let mut inner = self
+            .inner
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if inner.sources.iter().any(|(n, _)| n == &name) {
+            return Err(format!(
+                "MetricsSource '{}' is already registered; skipping duplicate",
+                name
+            ));
+        }
+        inner.sources.push((name, source));
+        Ok(())
+    }
+
+    /// Collect from all registered sources, isolating panics.
+    ///
+    /// Returns one entry per registered source; panicking sources contribute an
+    /// empty `Vec<MetricFamily>` and increment their error counter.
+    pub fn collect_all(&self) -> Vec<(String, Vec<MetricFamily>)> {
+        let sources: Vec<(String, Arc<dyn MetricsSource>)> = self
+            .inner
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .sources
+            .clone();
+
+        let mut results = Vec::with_capacity(sources.len());
+        let mut panicked = Vec::new();
+
+        for (name, source) in &sources {
+            let result =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| source.collect()));
+            match result {
+                Ok(families) => results.push((name.clone(), families)),
+                Err(_) => {
+                    panicked.push(name.clone());
+                    results.push((name.clone(), vec![]));
+                }
+            }
+        }
+
+        if !panicked.is_empty() {
+            let mut inner = self
+                .inner
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            for name in panicked {
+                *inner.error_counts.entry(name).or_insert(0) += 1;
+            }
+        }
+
+        results
+    }
+
+    /// Current per-source scrape-error counts (incremented on panic isolation).
+    #[must_use]
+    pub fn error_counts(&self) -> HashMap<String, u64> {
+        self.inner
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .error_counts
+            .clone()
+    }
+
+    /// Names of all registered sources, in insertion order.
+    #[must_use]
+    pub fn source_names(&self) -> Vec<String> {
+        self.inner
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .sources
+            .iter()
+            .map(|(n, _)| n.clone())
+            .collect()
+    }
+
+    /// Returns `true` when no sources have been registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .sources
+            .is_empty()
+    }
+}
+
 /// Trait to abstract the state requirements for actuator handlers.
 ///
 /// Implement this trait on your application's state type to provide
@@ -97,6 +306,15 @@ pub trait ProvideActuatorState {
     /// returns all-false (no concerns addressed) — a conservative safe default.
     fn a11y_posture(&self) -> A11yPosture {
         A11yPosture::default()
+    }
+
+    /// Returns the registry of plugin-contributed [`MetricsSource`] implementations.
+    ///
+    /// The default returns `None`, meaning no plugin sources are consulted.
+    /// [`crate::AppState`] overrides this to return its registry, which is
+    /// populated by [`crate::app::AppBuilder::metrics_source`].
+    fn metrics_source_registry(&self) -> Option<&MetricsSourceRegistry> {
+        None
     }
 
     #[cfg(feature = "http-client")]
@@ -1129,30 +1347,78 @@ pub(crate) async fn metrics_endpoint<S: ProvideActuatorState + Send + Sync + 'st
     State(state): State<S>,
 ) -> Json<serde_json::Value> {
     let snapshot = state.metrics().snapshot();
-    let result = serde_json::to_value(&snapshot).unwrap_or_default();
+    let mut result = serde_json::to_value(&snapshot).unwrap_or_default();
 
     // Include DB pool stats if available
     #[cfg(feature = "db")]
-    let result = {
-        let mut result = result;
-        if let Some(pool) = state.pool() {
-            let status = pool.status();
-            let db_stats = serde_json::json!({
-                "pool_size": status.max_size,
-                "active_connections": (status.max_size as u64).saturating_sub(status.available as u64),
-                "idle_connections": status.available,
-            });
-            if let serde_json::Value::Object(ref mut map) = result {
-                map.insert("database".to_string(), db_stats);
-            }
+    if let Some(pool) = state.pool() {
+        let status = pool.status();
+        let db_stats = serde_json::json!({
+            "pool_size": status.max_size,
+            "active_connections": (status.max_size as u64).saturating_sub(status.available as u64),
+            "idle_connections": status.available,
+        });
+        if let serde_json::Value::Object(ref mut map) = result {
+            map.insert("database".to_string(), db_stats);
         }
-        result
-    };
+    }
+
+    // Include plugin-contributed sources under the "sources" key
+    if let Some(registry) = state.metrics_source_registry() {
+        let all = registry.collect_all();
+        let mut sources = serde_json::Map::new();
+        for (source_name, families) in all {
+            let families_json: Vec<serde_json::Value> = families
+                .iter()
+                .map(|f| {
+                    serde_json::json!({
+                        "name": f.name,
+                        "help": f.help,
+                        "kind": f.kind.as_str(),
+                        "samples": f.samples.iter().map(|s| serde_json::json!({
+                            "labels": s.labels.iter().map(|(k, v)| serde_json::json!({k: v})).collect::<Vec<_>>(),
+                            "value": s.value,
+                        })).collect::<Vec<_>>(),
+                    })
+                })
+                .collect();
+            sources.insert(source_name, serde_json::Value::Array(families_json));
+        }
+        if let serde_json::Value::Object(ref mut map) = result {
+            map.insert("sources".to_string(), serde_json::Value::Object(sources));
+        }
+    }
 
     Json(result)
 }
 
 // ── Prometheus ─────────────────────────────────────────────────
+
+/// Escape a Prometheus label value: backslash, newline, and double-quote need escaping.
+fn escape_label_value(v: &str) -> String {
+    let mut out = String::with_capacity(v.len());
+    for c in v.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '"' => out.push_str("\\\""),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Render label set `{k="v",...}` or empty string for no labels.
+fn render_labels(labels: &[(String, String)]) -> String {
+    if labels.is_empty() {
+        return String::new();
+    }
+    let pairs: Vec<String> = labels
+        .iter()
+        .map(|(k, v)| format!("{}=\"{}\"", k, escape_label_value(v)))
+        .collect();
+    format!("{{{}}}", pairs.join(","))
+}
 
 /// `GET <actuator-prefix>/prometheus` -- export metrics in Prometheus format.
 pub(crate) async fn prometheus_endpoint<S: ProvideActuatorState + Send + Sync + 'static>(
@@ -1161,7 +1427,7 @@ pub(crate) async fn prometheus_endpoint<S: ProvideActuatorState + Send + Sync + 
     use std::fmt::Write;
 
     let snapshot = state.metrics().snapshot();
-    let mut out = String::with_capacity(1024);
+    let mut out = String::with_capacity(2048);
 
     // requests_total
     out.push_str("# HELP autumn_http_requests_total Total number of HTTP requests\n");
@@ -1233,13 +1499,51 @@ pub(crate) async fn prometheus_endpoint<S: ProvideActuatorState + Send + Sync + 
     if !snapshot.http.by_route.is_empty() {
         out.push_str("# HELP autumn_http_route_requests_total HTTP requests by route and method\n");
         out.push_str("# TYPE autumn_http_route_requests_total counter\n");
-        for (route_key, metrics) in &snapshot.http.by_route {
+        let mut route_keys: Vec<&String> = snapshot.http.by_route.keys().collect();
+        route_keys.sort();
+        for route_key in route_keys {
+            let metrics = &snapshot.http.by_route[route_key];
             // route_key is formatted as "METHOD /path"
             if let Some((method, path)) = route_key.split_once(' ') {
                 let _ = writeln!(
                     out,
                     "autumn_http_route_requests_total{{method=\"{}\",route=\"{}\"}} {}",
                     method, path, metrics.count
+                );
+            }
+        }
+    }
+
+    // Plugin-contributed metric families
+    if let Some(registry) = state.metrics_source_registry() {
+        let all_sources = registry.collect_all();
+        for (_source_name, families) in &all_sources {
+            for family in families {
+                let _ = writeln!(out, "# HELP {} {}", family.name, family.help);
+                let _ = writeln!(out, "# TYPE {} {}", family.name, family.kind.as_str());
+                for sample in &family.samples {
+                    let labels = render_labels(&sample.labels);
+                    let _ = writeln!(out, "{}{} {}", family.name, labels, sample.value);
+                }
+            }
+        }
+
+        // Emit error counter family for any source that panicked during this scrape
+        let error_counts = registry.error_counts();
+        if !error_counts.is_empty() {
+            out.push_str(
+                "# HELP autumn_metrics_source_errors_total \
+                 Number of scrape errors (panics) per plugin metrics source\n",
+            );
+            out.push_str("# TYPE autumn_metrics_source_errors_total counter\n");
+            let mut names: Vec<&String> = error_counts.keys().collect();
+            names.sort();
+            for name in names {
+                let _ = writeln!(
+                    out,
+                    "autumn_metrics_source_errors_total{{source=\"{}\"}} {}",
+                    name,
+                    error_counts[name]
                 );
             }
         }
@@ -1960,6 +2264,7 @@ mod tests {
         task_registry: TaskRegistry,
         job_registry: JobRegistry,
         config_props: ConfigProperties,
+        metrics_source_registry: MetricsSourceRegistry,
         #[cfg(feature = "http-client")]
         webhook_outbound: Option<crate::webhook_outbound::WebhookOutboundManager>,
         #[cfg(feature = "db")]
@@ -1994,6 +2299,9 @@ mod tests {
         fn uptime_display(&self) -> String {
             "test_uptime".to_string()
         }
+        fn metrics_source_registry(&self) -> Option<&MetricsSourceRegistry> {
+            Some(&self.metrics_source_registry)
+        }
         #[cfg(feature = "http-client")]
         fn webhook_outbound(&self) -> Option<crate::webhook_outbound::WebhookOutboundManager> {
             self.webhook_outbound.clone()
@@ -2027,6 +2335,7 @@ mod tests {
             task_registry: TaskRegistry::new(),
             job_registry: JobRegistry::new(),
             config_props: ConfigProperties::from_config(config),
+            metrics_source_registry: MetricsSourceRegistry::new(),
             #[cfg(feature = "http-client")]
             webhook_outbound: None,
             #[cfg(feature = "db")]
@@ -3254,6 +3563,248 @@ mod tests {
             paths.iter().any(|p| p == "/actuator/a11y"),
             "a11y path not found in: {paths:?}"
         );
+    }
+
+    // ── MetricsSource / MetricsSourceRegistry tests ────────────
+
+    #[test]
+    fn metrics_source_registry_registers_and_collects() {
+        struct FixedSource;
+        impl MetricsSource for FixedSource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                vec![MetricFamily {
+                    name: "plugin_requests_total".to_string(),
+                    help: "Plugin request count".to_string(),
+                    kind: MetricKind::Counter,
+                    samples: vec![MetricSample {
+                        labels: vec![],
+                        value: 42.0,
+                    }],
+                }]
+            }
+        }
+
+        let registry = MetricsSourceRegistry::new();
+        registry
+            .register("myplugin", Arc::new(FixedSource))
+            .unwrap();
+
+        let all = registry.collect_all();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].0, "myplugin");
+        assert_eq!(all[0].1[0].name, "plugin_requests_total");
+        assert_eq!(all[0].1[0].samples[0].value, 42.0);
+    }
+
+    #[test]
+    fn metrics_source_registry_rejects_duplicate_name() {
+        struct EmptySource;
+        impl MetricsSource for EmptySource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                vec![]
+            }
+        }
+
+        let registry = MetricsSourceRegistry::new();
+        registry.register("dup", Arc::new(EmptySource)).unwrap();
+        let result = registry.register("dup", Arc::new(EmptySource));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("dup"));
+    }
+
+    #[test]
+    fn metrics_source_registry_isolates_panicking_source() {
+        struct PanickingSource;
+        impl MetricsSource for PanickingSource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                panic!("source panicked!")
+            }
+        }
+
+        let registry = MetricsSourceRegistry::new();
+        registry
+            .register("panicker", Arc::new(PanickingSource))
+            .unwrap();
+
+        let all = registry.collect_all();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].1.len(), 0, "panicking source should yield no families");
+
+        let errors = registry.error_counts();
+        assert_eq!(errors.get("panicker"), Some(&1));
+    }
+
+    #[tokio::test]
+    async fn prometheus_endpoint_includes_plugin_source_families() {
+        struct GaugeSource;
+        impl MetricsSource for GaugeSource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                vec![MetricFamily {
+                    name: "plugin_queue_depth".to_string(),
+                    help: "Plugin queue depth".to_string(),
+                    kind: MetricKind::Gauge,
+                    samples: vec![MetricSample {
+                        labels: vec![("shard".to_string(), "a".to_string())],
+                        value: 7.0,
+                    }],
+                }]
+            }
+        }
+
+        let state = test_state();
+        state
+            .metrics_source_registry
+            .register("gauge_plugin", Arc::new(GaugeSource))
+            .unwrap();
+
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(
+            text.contains("# HELP plugin_queue_depth Plugin queue depth"),
+            "missing HELP line in:\n{text}"
+        );
+        assert!(
+            text.contains("# TYPE plugin_queue_depth gauge"),
+            "missing TYPE line in:\n{text}"
+        );
+        assert!(
+            text.contains("plugin_queue_depth{shard=\"a\"} 7"),
+            "missing sample line in:\n{text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn prometheus_endpoint_emits_error_counter_for_panicking_source() {
+        struct PanickingSource;
+        impl MetricsSource for PanickingSource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                panic!("oops")
+            }
+        }
+
+        let state = test_state();
+        state
+            .metrics_source_registry
+            .register("panic_src", Arc::new(PanickingSource))
+            .unwrap();
+
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(
+            text.contains("autumn_metrics_source_errors_total{source=\"panic_src\"} 1"),
+            "missing error counter in:\n{text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn metrics_endpoint_includes_sources_section() {
+        struct SampleSource;
+        impl MetricsSource for SampleSource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                vec![MetricFamily {
+                    name: "custom_counter".to_string(),
+                    help: "A custom counter".to_string(),
+                    kind: MetricKind::Counter,
+                    samples: vec![MetricSample {
+                        labels: vec![],
+                        value: 5.0,
+                    }],
+                }]
+            }
+        }
+
+        let state = test_state();
+        state
+            .metrics_source_registry
+            .register("my_source", Arc::new(SampleSource))
+            .unwrap();
+
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert!(
+            json.get("sources").is_some(),
+            "metrics JSON missing 'sources' key"
+        );
+        assert!(
+            json["sources"].get("my_source").is_some(),
+            "sources missing 'my_source' key"
+        );
+    }
+
+    #[test]
+    fn metrics_source_registry_preserves_insertion_order() {
+        struct NamedSource(&'static str);
+        impl MetricsSource for NamedSource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                vec![MetricFamily {
+                    name: self.0.to_string(),
+                    help: "".to_string(),
+                    kind: MetricKind::Counter,
+                    samples: vec![],
+                }]
+            }
+        }
+
+        let registry = MetricsSourceRegistry::new();
+        registry
+            .register("alpha", Arc::new(NamedSource("alpha_metric")))
+            .unwrap();
+        registry
+            .register("beta", Arc::new(NamedSource("beta_metric")))
+            .unwrap();
+        registry
+            .register("gamma", Arc::new(NamedSource("gamma_metric")))
+            .unwrap();
+
+        let all = registry.collect_all();
+        assert_eq!(all[0].0, "alpha");
+        assert_eq!(all[1].0, "beta");
+        assert_eq!(all[2].0, "gamma");
     }
 }
 

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1522,6 +1522,9 @@ fn render_plugin_sources(
                 if bad_key {
                     continue;
                 }
+                // Sort by key so {a="1",b="2"} and {b="2",a="1"} produce the
+                // same canonical string and are treated as one series.
+                valid_labels.sort_by(|(a, _), (b, _)| a.cmp(b));
                 let labels = render_labels(&valid_labels);
                 if !emitted_series.insert(labels.clone()) {
                     tracing::warn!(

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -3673,7 +3673,7 @@ mod tests {
         assert_eq!(all.len(), 1);
         assert_eq!(all[0].0, "myplugin");
         assert_eq!(all[0].1[0].name, "plugin_requests_total");
-        assert_eq!(all[0].1[0].samples[0].value, 42.0);
+        assert!((all[0].1[0].samples[0].value - 42.0).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -3867,7 +3867,7 @@ mod tests {
             fn collect(&self) -> Vec<MetricFamily> {
                 vec![MetricFamily {
                     name: self.0.to_string(),
-                    help: "".to_string(),
+                    help: String::new(),
                     kind: MetricKind::Counter,
                     samples: vec![],
                 }]

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -3891,6 +3891,215 @@ mod tests {
         assert_eq!(all[1].0, "beta");
         assert_eq!(all[2].0, "gamma");
     }
+
+    // ── render_plugin_sources edge-case coverage ──────────────────────────
+
+    #[test]
+    fn escape_help_text_escapes_backslash_and_newline() {
+        assert_eq!(escape_help_text("a\\b\nc"), "a\\\\b\\nc");
+        assert_eq!(escape_help_text("plain"), "plain");
+        assert_eq!(escape_help_text(""), "");
+    }
+
+    #[test]
+    fn format_sample_value_handles_special_floats() {
+        assert_eq!(format_sample_value(f64::INFINITY), "+Inf");
+        assert_eq!(format_sample_value(f64::NEG_INFINITY), "-Inf");
+        assert_eq!(format_sample_value(f64::NAN), "NaN");
+        assert_eq!(format_sample_value(0.0), "0");
+        assert_eq!(format_sample_value(1.5), "1.5");
+    }
+
+    #[test]
+    fn is_valid_metric_name_accepts_valid_and_rejects_invalid() {
+        assert!(is_valid_metric_name("http_requests_total"));
+        assert!(is_valid_metric_name("_private"));
+        assert!(is_valid_metric_name("ns:metric"));
+        assert!(!is_valid_metric_name(""));
+        assert!(!is_valid_metric_name("0starts_with_digit"));
+        assert!(!is_valid_metric_name("has-hyphen"));
+    }
+
+    #[test]
+    fn is_valid_label_name_accepts_valid_and_rejects_invalid() {
+        assert!(is_valid_label_name("shard"));
+        assert!(is_valid_label_name("_internal"));
+        assert!(is_valid_label_name("a1"));
+        assert!(!is_valid_label_name(""));
+        assert!(!is_valid_label_name("0starts_digit"));
+        assert!(!is_valid_label_name("has-hyphen"));
+        assert!(!is_valid_label_name("has.dot"));
+    }
+
+    #[tokio::test]
+    async fn prometheus_endpoint_skips_family_with_invalid_metric_name() {
+        struct BadNameSource;
+        impl MetricsSource for BadNameSource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                vec![
+                    MetricFamily {
+                        name: "invalid-name".to_string(),
+                        help: "should be skipped".to_string(),
+                        kind: MetricKind::Counter,
+                        samples: vec![],
+                    },
+                    MetricFamily {
+                        name: "valid_name".to_string(),
+                        help: "should appear".to_string(),
+                        kind: MetricKind::Counter,
+                        samples: vec![MetricSample {
+                            labels: vec![],
+                            value: 1.0,
+                        }],
+                    },
+                ]
+            }
+        }
+
+        let state = test_state();
+        state
+            .metrics_source_registry
+            .register("bad_name_src", Arc::new(BadNameSource))
+            .unwrap();
+
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(
+            !text.contains("invalid-name"),
+            "invalid family must be skipped:\n{text}"
+        );
+        assert!(
+            text.contains("valid_name"),
+            "valid family must appear:\n{text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn prometheus_endpoint_drops_invalid_and_duplicate_label_keys() {
+        struct DirtyLabelsSource;
+        impl MetricsSource for DirtyLabelsSource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                vec![MetricFamily {
+                    name: "dirty_labels_metric".to_string(),
+                    help: "test".to_string(),
+                    kind: MetricKind::Counter,
+                    samples: vec![MetricSample {
+                        labels: vec![
+                            ("good".to_string(), "a".to_string()),
+                            ("bad-key".to_string(), "b".to_string()),
+                            ("good".to_string(), "dup".to_string()),
+                        ],
+                        value: 1.0,
+                    }],
+                }]
+            }
+        }
+
+        let state = test_state();
+        state
+            .metrics_source_registry
+            .register("dirty", Arc::new(DirtyLabelsSource))
+            .unwrap();
+
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(
+            text.contains("dirty_labels_metric{good=\"a\"} 1"),
+            "expected only valid, non-duplicate label in:\n{text}"
+        );
+        assert!(
+            !text.contains("bad-key"),
+            "invalid label key must be dropped:\n{text}"
+        );
+        assert!(
+            !text.contains("dup"),
+            "duplicate label value must be dropped:\n{text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn prometheus_endpoint_escapes_help_text_and_formats_inf() {
+        struct SpecialSource;
+        impl MetricsSource for SpecialSource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                vec![MetricFamily {
+                    name: "inf_gauge".to_string(),
+                    help: "has\\backslash and\nnewline".to_string(),
+                    kind: MetricKind::Gauge,
+                    samples: vec![
+                        MetricSample {
+                            labels: vec![],
+                            value: f64::INFINITY,
+                        },
+                        MetricSample {
+                            labels: vec![],
+                            value: f64::NEG_INFINITY,
+                        },
+                    ],
+                }]
+            }
+        }
+
+        let state = test_state();
+        state
+            .metrics_source_registry
+            .register("special", Arc::new(SpecialSource))
+            .unwrap();
+
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(
+            text.contains("# HELP inf_gauge has\\\\backslash and\\nnewline"),
+            "help text must be escaped in:\n{text}"
+        );
+        assert!(
+            text.contains("inf_gauge +Inf"),
+            "must render +Inf in:\n{text}"
+        );
+        assert!(
+            text.contains("inf_gauge -Inf"),
+            "must render -Inf in:\n{text}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -197,6 +197,7 @@ impl MetricsSourceRegistry {
             match result {
                 Ok(families) => results.push((name.clone(), families)),
                 Err(_) => {
+                    tracing::error!(source_name = %name, "MetricsSource panicked during collection");
                     panicked.push(name.clone());
                     results.push((name.clone(), vec![]));
                 }
@@ -1375,10 +1376,16 @@ pub(crate) async fn metrics_endpoint<S: ProvideActuatorState + Send + Sync + 'st
                         "name": f.name,
                         "help": f.help,
                         "kind": f.kind.as_str(),
-                        "samples": f.samples.iter().map(|s| serde_json::json!({
-                            "labels": s.labels.iter().map(|(k, v)| serde_json::json!({k: v})).collect::<Vec<_>>(),
-                            "value": s.value,
-                        })).collect::<Vec<_>>(),
+                        "samples": f.samples.iter().map(|s| {
+                            let labels: serde_json::Map<String, serde_json::Value> = s.labels
+                                .iter()
+                                .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                                .collect();
+                            serde_json::json!({
+                                "labels": labels,
+                                "value": s.value,
+                            })
+                        }).collect::<Vec<_>>(),
                     })
                 })
                 .collect();
@@ -1394,30 +1401,33 @@ pub(crate) async fn metrics_endpoint<S: ProvideActuatorState + Send + Sync + 'st
 
 // ── Prometheus ─────────────────────────────────────────────────
 
-/// Escape a Prometheus label value: backslash, newline, and double-quote need escaping.
-fn escape_label_value(v: &str) -> String {
-    let mut out = String::with_capacity(v.len());
-    for c in v.chars() {
-        match c {
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '"' => out.push_str("\\\""),
-            other => out.push(other),
-        }
-    }
-    out
-}
-
 /// Render label set `{k="v",...}` or empty string for no labels.
+///
+/// Writes directly into a pre-allocated `String` to avoid per-pair heap allocations.
 fn render_labels(labels: &[(String, String)]) -> String {
     if labels.is_empty() {
         return String::new();
     }
-    let pairs: Vec<String> = labels
-        .iter()
-        .map(|(k, v)| format!("{}=\"{}\"", k, escape_label_value(v)))
-        .collect();
-    format!("{{{}}}", pairs.join(","))
+    let mut out = String::with_capacity(64);
+    out.push('{');
+    for (i, (k, v)) in labels.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push_str(k);
+        out.push_str("=\"");
+        for c in v.chars() {
+            match c {
+                '\\' => out.push_str("\\\\"),
+                '\n' => out.push_str("\\n"),
+                '"' => out.push_str("\\\""),
+                other => out.push(other),
+            }
+        }
+        out.push('"');
+    }
+    out.push('}');
+    out
 }
 
 /// `GET <actuator-prefix>/prometheus` -- export metrics in Prometheus format.
@@ -1542,8 +1552,7 @@ pub(crate) async fn prometheus_endpoint<S: ProvideActuatorState + Send + Sync + 
                 let _ = writeln!(
                     out,
                     "autumn_metrics_source_errors_total{{source=\"{}\"}} {}",
-                    name,
-                    error_counts[name]
+                    name, error_counts[name]
                 );
             }
         }
@@ -3628,7 +3637,11 @@ mod tests {
 
         let all = registry.collect_all();
         assert_eq!(all.len(), 1);
-        assert_eq!(all[0].1.len(), 0, "panicking source should yield no families");
+        assert_eq!(
+            all[0].1.len(),
+            0,
+            "panicking source should yield no families"
+        );
 
         let errors = registry.error_counts();
         assert_eq!(errors.get("panicker"), Some(&1));

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -55,7 +55,7 @@ pub enum MetricKind {
 }
 
 impl MetricKind {
-    fn as_str(&self) -> &'static str {
+    const fn as_str(&self) -> &'static str {
         match self {
             Self::Counter => "counter",
             Self::Gauge => "gauge",
@@ -159,17 +159,18 @@ impl MetricsSourceRegistry {
         source: Arc<dyn MetricsSource>,
     ) -> Result<(), String> {
         let name = name.into();
-        let mut inner = self
-            .inner
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if inner.sources.iter().any(|(n, _)| n == &name) {
-            return Err(format!(
-                "MetricsSource '{}' is already registered; skipping duplicate",
-                name
-            ));
+        {
+            let mut inner = self
+                .inner
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if inner.sources.iter().any(|(n, _)| n == &name) {
+                return Err(format!(
+                    "MetricsSource '{name}' is already registered; skipping duplicate"
+                ));
+            }
+            inner.sources.push((name, source));
         }
-        inner.sources.push((name, source));
         Ok(())
     }
 
@@ -191,13 +192,12 @@ impl MetricsSourceRegistry {
         for (name, source) in &sources {
             let result =
                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| source.collect()));
-            match result {
-                Ok(families) => results.push((name.clone(), families)),
-                Err(_) => {
-                    tracing::error!(source_name = %name, "MetricsSource panicked during collection");
-                    panicked.push(name.clone());
-                    results.push((name.clone(), vec![]));
-                }
+            if let Ok(families) = result {
+                results.push((name.clone(), families));
+            } else {
+                tracing::error!(source_name = %name, "MetricsSource panicked during collection");
+                panicked.push(name.clone());
+                results.push((name.clone(), vec![]));
             }
         }
 
@@ -1427,6 +1427,109 @@ fn render_labels(labels: &[(String, String)]) -> String {
     out
 }
 
+/// Returns true if `s` is a valid Prometheus metric name (`[a-zA-Z_:][a-zA-Z0-9_:]*`).
+fn is_valid_metric_name(s: &str) -> bool {
+    let mut it = s.chars();
+    matches!(it.next(), Some(c) if c.is_ascii_alphabetic() || c == '_' || c == ':')
+        && it.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == ':')
+}
+
+/// Returns true if `s` is a valid Prometheus label name (`[a-zA-Z_][a-zA-Z0-9_]*`).
+fn is_valid_label_name(s: &str) -> bool {
+    let mut it = s.chars();
+    matches!(it.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && it.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Escape a Prometheus HELP string (backslash and newline only).
+fn escape_help_text(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Format a sample value per Prometheus text format (handles ±Inf and NaN).
+fn format_sample_value(v: f64) -> String {
+    if v == f64::INFINITY {
+        "+Inf".to_string()
+    } else if v == f64::NEG_INFINITY {
+        "-Inf".to_string()
+    } else if v.is_nan() {
+        "NaN".to_string()
+    } else {
+        v.to_string()
+    }
+}
+
+/// Append all plugin-contributed metric families (and their error counters) to `out`.
+fn render_plugin_sources(registry: &MetricsSourceRegistry, out: &mut String) {
+    use std::fmt::Write;
+
+    let all_sources = registry.collect_all();
+    for (_source_name, families) in &all_sources {
+        for family in families {
+            if !is_valid_metric_name(&family.name) {
+                tracing::warn!(name = %family.name, "MetricsSource returned invalid metric name; skipping family");
+                continue;
+            }
+            let _ = writeln!(
+                out,
+                "# HELP {} {}",
+                family.name,
+                escape_help_text(&family.help)
+            );
+            let _ = writeln!(out, "# TYPE {} {}", family.name, family.kind.as_str());
+            for sample in &family.samples {
+                let valid_labels: Vec<(String, String)> = sample
+                    .labels
+                    .iter()
+                    .filter(|(k, _)| {
+                        let ok = is_valid_label_name(k);
+                        if !ok {
+                            tracing::warn!(label_name = %k, "MetricsSource returned invalid label name; dropping label");
+                        }
+                        ok
+                    })
+                    .cloned()
+                    .collect();
+                let labels = render_labels(&valid_labels);
+                let _ = writeln!(
+                    out,
+                    "{}{} {}",
+                    family.name,
+                    labels,
+                    format_sample_value(sample.value)
+                );
+            }
+        }
+    }
+
+    let error_counts = registry.error_counts();
+    if !error_counts.is_empty() {
+        out.push_str(
+            "# HELP autumn_metrics_source_errors_total \
+             Number of scrape errors (panics) per plugin metrics source\n",
+        );
+        out.push_str("# TYPE autumn_metrics_source_errors_total counter\n");
+        let mut names: Vec<&String> = error_counts.keys().collect();
+        names.sort();
+        for name in names {
+            let label = render_labels(&[("source".to_string(), name.clone())]);
+            let _ = writeln!(
+                out,
+                "autumn_metrics_source_errors_total{} {}",
+                label, error_counts[name]
+            );
+        }
+    }
+}
+
 /// `GET <actuator-prefix>/prometheus` -- export metrics in Prometheus format.
 pub(crate) async fn prometheus_endpoint<S: ProvideActuatorState + Send + Sync + 'static>(
     State(state): State<S>,
@@ -1523,37 +1626,7 @@ pub(crate) async fn prometheus_endpoint<S: ProvideActuatorState + Send + Sync + 
 
     // Plugin-contributed metric families
     if let Some(registry) = state.metrics_source_registry() {
-        let all_sources = registry.collect_all();
-        for (_source_name, families) in &all_sources {
-            for family in families {
-                let _ = writeln!(out, "# HELP {} {}", family.name, family.help);
-                let _ = writeln!(out, "# TYPE {} {}", family.name, family.kind.as_str());
-                for sample in &family.samples {
-                    let labels = render_labels(&sample.labels);
-                    let _ = writeln!(out, "{}{} {}", family.name, labels, sample.value);
-                }
-            }
-        }
-
-        // Emit error counter family for any source that panicked during this scrape
-        let error_counts = registry.error_counts();
-        if !error_counts.is_empty() {
-            out.push_str(
-                "# HELP autumn_metrics_source_errors_total \
-                 Number of scrape errors (panics) per plugin metrics source\n",
-            );
-            out.push_str("# TYPE autumn_metrics_source_errors_total counter\n");
-            let mut names: Vec<&String> = error_counts.keys().collect();
-            names.sort();
-            for name in names {
-                let label = render_labels(&[("source".to_string(), name.to_string())]);
-                let _ = writeln!(
-                    out,
-                    "autumn_metrics_source_errors_total{} {}",
-                    label, error_counts[name]
-                );
-            }
-        }
+        render_plugin_sources(registry, &mut out);
     }
 
     (

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1468,7 +1468,15 @@ fn format_sample_value(v: f64) -> String {
 }
 
 /// Append all plugin-contributed metric families (and their error counters) to `out`.
-fn render_plugin_sources(registry: &MetricsSourceRegistry, out: &mut String) {
+///
+/// `emitted_families` must be pre-seeded with the names of every built-in
+/// metric family already written to `out`; families whose names collide are
+/// skipped with a warning so no duplicate `# HELP`/`# TYPE` blocks are emitted.
+fn render_plugin_sources(
+    registry: &MetricsSourceRegistry,
+    out: &mut String,
+    emitted_families: &mut std::collections::HashSet<String>,
+) {
     use std::fmt::Write;
 
     let all_sources = registry.collect_all();
@@ -1478,6 +1486,10 @@ fn render_plugin_sources(registry: &MetricsSourceRegistry, out: &mut String) {
                 tracing::warn!(name = %family.name, "MetricsSource returned invalid metric name; skipping family");
                 continue;
             }
+            if !emitted_families.insert(family.name.clone()) {
+                tracing::warn!(name = %family.name, "MetricsSource returned duplicate metric family name; skipping family");
+                continue;
+            }
             let _ = writeln!(
                 out,
                 "# HELP {} {}",
@@ -1485,6 +1497,8 @@ fn render_plugin_sources(registry: &MetricsSourceRegistry, out: &mut String) {
                 escape_help_text(&family.help)
             );
             let _ = writeln!(out, "# TYPE {} {}", family.name, family.kind.as_str());
+            let mut emitted_series: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
             for sample in &family.samples {
                 let mut bad_key = false;
                 let mut seen_keys = std::collections::HashSet::new();
@@ -1509,6 +1523,14 @@ fn render_plugin_sources(registry: &MetricsSourceRegistry, out: &mut String) {
                     continue;
                 }
                 let labels = render_labels(&valid_labels);
+                if !emitted_series.insert(labels.clone()) {
+                    tracing::warn!(
+                        metric = %family.name,
+                        labels = %labels,
+                        "MetricsSource returned duplicate series; skipping sample"
+                    );
+                    continue;
+                }
                 let _ = writeln!(
                     out,
                     "{}{} {}",
@@ -1634,9 +1656,22 @@ pub(crate) async fn prometheus_endpoint<S: ProvideActuatorState + Send + Sync + 
         }
     }
 
-    // Plugin-contributed metric families
+    // Plugin-contributed metric families — seed with built-in names so
+    // plugins cannot shadow or duplicate them.
     if let Some(registry) = state.metrics_source_registry() {
-        render_plugin_sources(registry, &mut out);
+        let mut emitted_families: std::collections::HashSet<String> = [
+            "autumn_http_requests_total",
+            "autumn_http_requests_active",
+            "autumn_http_responses_total",
+            "autumn_shutdown_aborted_requests_total",
+            "autumn_request_timeouts_total",
+            "autumn_http_route_requests_total",
+            "autumn_metrics_source_errors_total",
+        ]
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+        render_plugin_sources(registry, &mut out, &mut emitted_families);
     }
 
     (
@@ -4121,11 +4156,11 @@ mod tests {
                     kind: MetricKind::Gauge,
                     samples: vec![
                         MetricSample {
-                            labels: vec![],
+                            labels: vec![("dir".to_string(), "pos".to_string())],
                             value: f64::INFINITY,
                         },
                         MetricSample {
-                            labels: vec![],
+                            labels: vec![("dir".to_string(), "neg".to_string())],
                             value: f64::NEG_INFINITY,
                         },
                     ],
@@ -4159,12 +4194,179 @@ mod tests {
             "help text must be escaped in:\n{text}"
         );
         assert!(
-            text.contains("inf_gauge +Inf"),
+            text.contains("inf_gauge{dir=\"pos\"} +Inf"),
             "must render +Inf in:\n{text}"
         );
         assert!(
-            text.contains("inf_gauge -Inf"),
+            text.contains("inf_gauge{dir=\"neg\"} -Inf"),
             "must render -Inf in:\n{text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn prometheus_endpoint_skips_duplicate_family_name_across_sources() {
+        struct FirstSource;
+        impl MetricsSource for FirstSource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                vec![MetricFamily {
+                    name: "shared_counter".to_string(),
+                    help: "from first".to_string(),
+                    kind: MetricKind::Counter,
+                    samples: vec![MetricSample {
+                        labels: vec![],
+                        value: 1.0,
+                    }],
+                }]
+            }
+        }
+        struct SecondSource;
+        impl MetricsSource for SecondSource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                vec![MetricFamily {
+                    name: "shared_counter".to_string(),
+                    help: "from second".to_string(),
+                    kind: MetricKind::Counter,
+                    samples: vec![MetricSample {
+                        labels: vec![],
+                        value: 2.0,
+                    }],
+                }]
+            }
+        }
+
+        let state = test_state();
+        state
+            .metrics_source_registry
+            .register("first", Arc::new(FirstSource))
+            .unwrap();
+        state
+            .metrics_source_registry
+            .register("second", Arc::new(SecondSource))
+            .unwrap();
+
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        let occurrences = text.matches("# HELP shared_counter").count();
+        assert_eq!(
+            occurrences, 1,
+            "must emit exactly one HELP block for shared_counter:\n{text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn prometheus_endpoint_skips_builtin_name_collision() {
+        struct ShadowSource;
+        impl MetricsSource for ShadowSource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                vec![MetricFamily {
+                    name: "autumn_http_requests_total".to_string(),
+                    help: "plugin trying to shadow built-in".to_string(),
+                    kind: MetricKind::Counter,
+                    samples: vec![MetricSample {
+                        labels: vec![],
+                        value: 999.0,
+                    }],
+                }]
+            }
+        }
+
+        let state = test_state();
+        state
+            .metrics_source_registry
+            .register("shadow", Arc::new(ShadowSource))
+            .unwrap();
+
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        let occurrences = text.matches("# HELP autumn_http_requests_total").count();
+        assert_eq!(
+            occurrences, 1,
+            "built-in must not be shadowed by plugin:\n{text}"
+        );
+        assert!(
+            !text.contains("999"),
+            "plugin shadow value must not appear:\n{text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn prometheus_endpoint_skips_duplicate_series_within_family() {
+        struct DupSeriesSource;
+        impl MetricsSource for DupSeriesSource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                vec![MetricFamily {
+                    name: "dup_series_metric".to_string(),
+                    help: "test".to_string(),
+                    kind: MetricKind::Counter,
+                    samples: vec![
+                        MetricSample {
+                            labels: vec![("region".to_string(), "us".to_string())],
+                            value: 10.0,
+                        },
+                        MetricSample {
+                            labels: vec![("region".to_string(), "us".to_string())],
+                            value: 20.0,
+                        },
+                    ],
+                }]
+            }
+        }
+
+        let state = test_state();
+        state
+            .metrics_source_registry
+            .register("dup_series", Arc::new(DupSeriesSource))
+            .unwrap();
+
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        // First occurrence kept, second skipped
+        assert!(
+            text.contains("dup_series_metric{region=\"us\"} 10"),
+            "first sample must appear:\n{text}"
+        );
+        assert!(
+            !text.contains("dup_series_metric{region=\"us\"} 20"),
+            "duplicate series must be dropped:\n{text}"
         );
     }
 }

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1486,18 +1486,19 @@ fn render_plugin_sources(registry: &MetricsSourceRegistry, out: &mut String) {
             );
             let _ = writeln!(out, "# TYPE {} {}", family.name, family.kind.as_str());
             for sample in &family.samples {
-                let valid_labels: Vec<(String, String)> = sample
-                    .labels
-                    .iter()
-                    .filter(|(k, _)| {
-                        let ok = is_valid_label_name(k);
-                        if !ok {
-                            tracing::warn!(label_name = %k, "MetricsSource returned invalid label name; dropping label");
-                        }
-                        ok
-                    })
-                    .cloned()
-                    .collect();
+                let mut seen_keys = std::collections::HashSet::new();
+                let mut valid_labels: Vec<(String, String)> = Vec::new();
+                for (k, v) in &sample.labels {
+                    if !is_valid_label_name(k) {
+                        tracing::warn!(label_name = %k, "MetricsSource returned invalid label name; dropping label");
+                        continue;
+                    }
+                    if !seen_keys.insert(k.as_str()) {
+                        tracing::warn!(label_name = %k, "MetricsSource returned duplicate label name; dropping duplicate");
+                        continue;
+                    }
+                    valid_labels.push((k.clone(), v.clone()));
+                }
                 let labels = render_labels(&valid_labels);
                 let _ = writeln!(
                     out,

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1486,18 +1486,27 @@ fn render_plugin_sources(registry: &MetricsSourceRegistry, out: &mut String) {
             );
             let _ = writeln!(out, "# TYPE {} {}", family.name, family.kind.as_str());
             for sample in &family.samples {
+                let mut bad_key = false;
                 let mut seen_keys = std::collections::HashSet::new();
                 let mut valid_labels: Vec<(String, String)> = Vec::new();
                 for (k, v) in &sample.labels {
                     if !is_valid_label_name(k) {
-                        tracing::warn!(label_name = %k, "MetricsSource returned invalid label name; dropping label");
-                        continue;
+                        tracing::warn!(
+                            label_name = %k,
+                            metric = %family.name,
+                            "MetricsSource returned invalid label name; skipping sample"
+                        );
+                        bad_key = true;
+                        break;
                     }
                     if !seen_keys.insert(k.as_str()) {
                         tracing::warn!(label_name = %k, "MetricsSource returned duplicate label name; dropping duplicate");
                         continue;
                     }
                     valid_labels.push((k.clone(), v.clone()));
+                }
+                if bad_key {
+                    continue;
                 }
                 let labels = render_labels(&valid_labels);
                 let _ = writeln!(
@@ -3988,7 +3997,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prometheus_endpoint_drops_invalid_and_duplicate_label_keys() {
+    async fn prometheus_endpoint_skips_sample_with_invalid_label_key() {
+        // A sample containing an invalid label key (bad-key) must be skipped
+        // entirely — not emitted with the bad key dropped — to avoid creating
+        // a phantom duplicate series in the Prometheus scrape.
         struct DirtyLabelsSource;
         impl MetricsSource for DirtyLabelsSource {
             fn collect(&self) -> Vec<MetricFamily> {
@@ -3996,14 +4008,19 @@ mod tests {
                     name: "dirty_labels_metric".to_string(),
                     help: "test".to_string(),
                     kind: MetricKind::Counter,
-                    samples: vec![MetricSample {
-                        labels: vec![
-                            ("good".to_string(), "a".to_string()),
-                            ("bad-key".to_string(), "b".to_string()),
-                            ("good".to_string(), "dup".to_string()),
-                        ],
-                        value: 1.0,
-                    }],
+                    samples: vec![
+                        MetricSample {
+                            labels: vec![
+                                ("good".to_string(), "a".to_string()),
+                                ("bad-key".to_string(), "b".to_string()),
+                            ],
+                            value: 1.0,
+                        },
+                        MetricSample {
+                            labels: vec![("good".to_string(), "a".to_string())],
+                            value: 2.0,
+                        },
+                    ],
                 }]
             }
         }
@@ -4029,17 +4046,67 @@ mod tests {
             .unwrap();
         let text = String::from_utf8(body.to_vec()).unwrap();
 
+        // First sample (bad-key) must be absent entirely
         assert!(
-            text.contains("dirty_labels_metric{good=\"a\"} 1"),
-            "expected only valid, non-duplicate label in:\n{text}"
+            !text.contains("dirty_labels_metric{good=\"a\"} 1"),
+            "sample with invalid label key must be skipped:\n{text}"
+        );
+        // Second (clean) sample must still appear
+        assert!(
+            text.contains("dirty_labels_metric{good=\"a\"} 2"),
+            "clean sample must appear:\n{text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn prometheus_endpoint_deduplicates_label_keys() {
+        struct DupLabelSource;
+        impl MetricsSource for DupLabelSource {
+            fn collect(&self) -> Vec<MetricFamily> {
+                vec![MetricFamily {
+                    name: "dup_label_metric".to_string(),
+                    help: "test".to_string(),
+                    kind: MetricKind::Counter,
+                    samples: vec![MetricSample {
+                        labels: vec![
+                            ("env".to_string(), "prod".to_string()),
+                            ("env".to_string(), "staging".to_string()),
+                        ],
+                        value: 5.0,
+                    }],
+                }]
+            }
+        }
+
+        let state = test_state();
+        state
+            .metrics_source_registry
+            .register("dup_src", Arc::new(DupLabelSource))
+            .unwrap();
+
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        // Only the first occurrence of `env` is kept
+        assert!(
+            text.contains("dup_label_metric{env=\"prod\"} 5"),
+            "first env value must be kept:\n{text}"
         );
         assert!(
-            !text.contains("bad-key"),
-            "invalid label key must be dropped:\n{text}"
-        );
-        assert!(
-            !text.contains("dup"),
-            "duplicate label value must be dropped:\n{text}"
+            !text.contains("staging"),
+            "duplicate env key value must be dropped:\n{text}"
         );
     }
 

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -52,8 +52,6 @@ pub enum MetricKind {
     Counter,
     /// An arbitrary up-or-down value (e.g., queue depth, active connections).
     Gauge,
-    /// A sampled distribution (e.g., latency buckets).
-    Histogram,
 }
 
 impl MetricKind {
@@ -61,7 +59,6 @@ impl MetricKind {
         match self {
             Self::Counter => "counter",
             Self::Gauge => "gauge",
-            Self::Histogram => "histogram",
         }
     }
 }
@@ -100,7 +97,7 @@ pub struct MetricFamily {
 /// Contract for a subsystem that contributes metrics to the unified actuator endpoints.
 ///
 /// Implement this trait and register the implementation via
-/// [`AppBuilder::metrics_source`] to publish metric families that appear in
+/// [`crate::app::AppBuilder::metrics_source`] to publish metric families that appear in
 /// `/actuator/prometheus` alongside the built-in `autumn_http_*` families, and
 /// in `/actuator/metrics` under the `sources` key.
 ///
@@ -1549,10 +1546,11 @@ pub(crate) async fn prometheus_endpoint<S: ProvideActuatorState + Send + Sync + 
             let mut names: Vec<&String> = error_counts.keys().collect();
             names.sort();
             for name in names {
+                let label = render_labels(&[("source".to_string(), name.to_string())]);
                 let _ = writeln!(
                     out,
-                    "autumn_metrics_source_errors_total{{source=\"{}\"}} {}",
-                    name, error_counts[name]
+                    "autumn_metrics_source_errors_total{} {}",
+                    label, error_counts[name]
                 );
             }
         }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -322,7 +322,7 @@ pub struct AppBuilder {
     #[cfg(feature = "oauth2")]
     http_interceptor: Option<Arc<dyn crate::interceptor::HttpInterceptor>>,
     /// Plugin-contributed metrics sources registered via [`AppBuilder::metrics_source`].
-    metrics_sources: Vec<(String, Arc<dyn crate::actuator::MetricsSource>)>,
+    pub(crate) metrics_sources: Vec<(String, Arc<dyn crate::actuator::MetricsSource>)>,
 }
 
 /// Boxed builder closure that constructs a durable

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -7561,6 +7561,7 @@ mod tests {
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
             clock: std::sync::Arc::new(crate::time::SystemClock),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
         };
 
         let mut rx = state.channels().subscribe("sys:tasks");
@@ -7632,6 +7633,7 @@ mod tests {
             auth_session_key: "user_id".to_owned(),
             shared_cache: None,
             clock: std::sync::Arc::new(crate::time::SystemClock),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
         };
 
         let mut rx = state.channels().subscribe("sys:tasks");

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -122,6 +122,7 @@ pub fn app() -> AppBuilder {
         channels_interceptor: None,
         #[cfg(feature = "oauth2")]
         http_interceptor: None,
+        metrics_sources: Vec::new(),
     }
 }
 
@@ -320,6 +321,8 @@ pub struct AppBuilder {
     channels_interceptor: Option<Arc<dyn crate::interceptor::ChannelsInterceptor>>,
     #[cfg(feature = "oauth2")]
     http_interceptor: Option<Arc<dyn crate::interceptor::HttpInterceptor>>,
+    /// Plugin-contributed metrics sources registered via [`AppBuilder::metrics_source`].
+    metrics_sources: Vec<(String, Arc<dyn crate::actuator::MetricsSource>)>,
 }
 
 /// Boxed builder closure that constructs a durable
@@ -1748,6 +1751,60 @@ impl AppBuilder {
         self.registered_plugins.contains(name)
     }
 
+    /// Register a named [`MetricsSource`](crate::actuator::MetricsSource) that contributes
+    /// metric families to `/actuator/prometheus` and `/actuator/metrics`.
+    ///
+    /// The `name` is a stable identifier used for:
+    /// - Duplicate-registration detection (same behaviour as duplicate plugins: a
+    ///   `tracing::warn!` is emitted and the second registration is skipped).
+    /// - The `source` label in the `autumn_metrics_source_errors_total` counter
+    ///   that increments when a source panics during a scrape.
+    ///
+    /// `Plugin::build` implementations can call this to wire a source with no
+    /// extra application-level glue code.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use autumn_web::actuator::{MetricsSource, MetricFamily, MetricKind, MetricSample};
+    /// use autumn_web::app::AppBuilder;
+    /// use std::sync::Arc;
+    ///
+    /// struct QueueMetrics;
+    ///
+    /// impl MetricsSource for QueueMetrics {
+    ///     fn collect(&self) -> Vec<MetricFamily> {
+    ///         vec![MetricFamily {
+    ///             name: "myapp_queue_depth".to_string(),
+    ///             help: "Current queue depth".to_string(),
+    ///             kind: MetricKind::Gauge,
+    ///             samples: vec![MetricSample { labels: vec![], value: 42.0 }],
+    ///         }]
+    ///     }
+    /// }
+    ///
+    /// autumn_web::app()
+    ///     .metrics_source("myapp_queue", Arc::new(QueueMetrics));
+    /// ```
+    #[must_use]
+    pub fn metrics_source(
+        mut self,
+        name: impl Into<String>,
+        source: Arc<dyn crate::actuator::MetricsSource>,
+    ) -> Self {
+        let name = name.into();
+        if self.metrics_sources.iter().any(|(n, _)| n == &name) {
+            tracing::warn!(
+                source_name = %name,
+                "MetricsSource '{}' is already registered; skipping duplicate",
+                name
+            );
+            return self;
+        }
+        self.metrics_sources.push((name, source));
+        self
+    }
+
     /// Register embedded Diesel migrations with the application.
     ///
     /// When migrations are registered:
@@ -1887,6 +1944,7 @@ impl AppBuilder {
             channels_interceptor,
             #[cfg(feature = "oauth2")]
             http_interceptor,
+            metrics_sources,
         } = self;
 
         let all_routes = routes;
@@ -2050,6 +2108,16 @@ impl AppBuilder {
         if let Some(interceptor) = http_interceptor {
             state.insert_extension(interceptor);
         }
+
+        // Populate the metrics source registry from builder registrations.
+        // Duplicate names were already rejected in `metrics_source()`, so
+        // all entries here are unique.
+        for (name, source) in metrics_sources {
+            if let Err(e) = state.metrics_source_registry.register(name, source) {
+                tracing::warn!("{e}");
+            }
+        }
+
         #[cfg(feature = "db")]
         configure_replica_migration_check(&state, replica_migration_check);
         #[cfg(feature = "db")]
@@ -2460,9 +2528,11 @@ impl AppBuilder {
             channels_interceptor,
             #[cfg(feature = "oauth2")]
             http_interceptor,
+            metrics_sources,
         } = self;
 
         let _ = &api_versions;
+        let _ = &metrics_sources;
         let all_routes = routes;
 
         // Load config (same as normal startup)
@@ -5033,6 +5103,7 @@ fn build_state(
         task_registry: crate::actuator::TaskRegistry::new(),
         job_registry: crate::actuator::JobRegistry::new(),
         config_props: crate::actuator::ConfigProperties::from_config(config),
+        metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
         #[cfg(feature = "presence")]
         presence: crate::presence::Presence::new(channels.clone()),
         #[cfg(feature = "ws")]
@@ -5302,6 +5373,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -6227,6 +6299,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -6334,6 +6407,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -6418,6 +6492,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -6709,6 +6784,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -7020,6 +7096,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -7169,6 +7246,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -7216,6 +7294,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -2153,6 +2153,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -2215,6 +2216,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -2285,6 +2287,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -2411,6 +2414,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -2487,6 +2491,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -2568,6 +2573,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -2649,6 +2655,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -2726,6 +2733,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -2796,6 +2804,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -241,6 +241,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -267,6 +268,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -2262,6 +2262,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -1203,6 +1203,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]
@@ -1254,6 +1255,7 @@ mod tests {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "ws")]
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "presence")]

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -97,6 +97,10 @@ pub struct AppState {
     /// Resolved config properties with source tracking for `/actuator/configprops`.
     pub(crate) config_props: actuator::ConfigProperties,
 
+    /// Registry of plugin-contributed metrics sources, populated by
+    /// [`crate::app::AppBuilder::metrics_source`].
+    pub(crate) metrics_source_registry: actuator::MetricsSourceRegistry,
+
     /// Named broadcast channel registry for real-time messaging.
     ///
     /// Available when the `ws` feature is enabled. Use
@@ -264,6 +268,12 @@ impl AppState {
     #[must_use]
     pub const fn config_props(&self) -> &actuator::ConfigProperties {
         &self.config_props
+    }
+
+    /// Returns the registry of plugin-contributed metrics sources.
+    #[must_use]
+    pub const fn metrics_source_registry(&self) -> &actuator::MetricsSourceRegistry {
+        &self.metrics_source_registry
     }
 
     /// Returns the resolved [`crate::config::AutumnConfig`] from the extension map.
@@ -552,6 +562,7 @@ impl AppState {
             task_registry: actuator::TaskRegistry::new(),
             job_registry: actuator::JobRegistry::new(),
             config_props: actuator::ConfigProperties::default(),
+            metrics_source_registry: actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "presence")]
             presence: Presence::new(channels.clone()),
             #[cfg(feature = "ws")]
@@ -683,6 +694,10 @@ impl crate::actuator::ProvideActuatorState for AppState {
 
     fn uptime_display(&self) -> String {
         self.uptime_display()
+    }
+
+    fn metrics_source_registry(&self) -> Option<&crate::actuator::MetricsSourceRegistry> {
+        Some(&self.metrics_source_registry)
     }
 
     #[cfg(feature = "ws")]

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -904,14 +904,16 @@ impl TestApp {
             state.insert_extension(crate::http_client::HttpMockRegistryExt(registry));
         }
 
-        for initializer in self.state_initializers {
-            initializer(&state);
-        }
-
+        // Register metrics sources before state initializers — mirrors production
+        // AppBuilder::run ordering so initializers can observe the registry.
         for (name, source) in self.metrics_sources {
             if let Err(e) = state.metrics_source_registry.register(name, source) {
                 tracing::warn!("{e}");
             }
+        }
+
+        for initializer in self.state_initializers {
+            initializer(&state);
         }
 
         for job in &self.jobs {

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -209,6 +209,8 @@ pub struct TestApp {
     /// to [`crate::time::TickingClock`] at runtime.
     clock_as_any: Option<std::sync::Arc<dyn std::any::Any + Send + Sync>>,
     api_versions: Vec<crate::app::ApiVersion>,
+    /// Plugin-contributed metrics sources registered via [`AppBuilder::metrics_source`].
+    metrics_sources: Vec<(String, std::sync::Arc<dyn crate::actuator::MetricsSource>)>,
 }
 
 type TestPolicyRegistration = Box<dyn FnOnce(&crate::authorization::PolicyRegistry) + Send>;
@@ -260,6 +262,7 @@ impl TestApp {
             clock: None,
             clock_as_any: None,
             api_versions: Vec::new(),
+            metrics_sources: Vec::new(),
         }
     }
 
@@ -491,6 +494,7 @@ impl TestApp {
         self.custom_layers.extend(app_builder.custom_layers);
         self.jobs.extend(app_builder.jobs);
         self.exception_filters.extend(app_builder.exception_filters);
+        self.metrics_sources.extend(app_builder.metrics_sources);
 
         // Carry plugin-registered error reporters into the test app so
         // reporting-enabled plugins exercise the same behavior under `TestApp`
@@ -902,6 +906,12 @@ impl TestApp {
 
         for initializer in self.state_initializers {
             initializer(&state);
+        }
+
+        for (name, source) in self.metrics_sources {
+            if let Err(e) = state.metrics_source_registry.register(name, source) {
+                tracing::warn!("{e}");
+            }
         }
 
         for job in &self.jobs {

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -824,6 +824,7 @@ impl TestApp {
             task_registry: crate::actuator::TaskRegistry::new(),
             job_registry: crate::actuator::JobRegistry::new(),
             config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
             #[cfg(feature = "presence")]
             presence: crate::presence::Presence::new(test_channels.clone()),
             #[cfg(feature = "ws")]

--- a/docs/guide/metrics-sources.md
+++ b/docs/guide/metrics-sources.md
@@ -1,0 +1,221 @@
+# Plugin Metrics Sources
+
+Autumn's `/actuator/prometheus` and `/actuator/metrics` endpoints expose the
+framework's built-in `autumn_http_*` metric families.  The `MetricsSource`
+trait lets any in-process subsystem — a background-worker plugin, a workflow
+engine, an application-level queue — contribute additional families to the
+**same scrape endpoint**, with no second port or exporter.
+
+This is the metrics analogue of the pluggable `HealthIndicator` model and
+mirrors Spring Boot's `MeterRegistry` pattern.
+
+---
+
+## Quick start
+
+### 1. Implement `MetricsSource`
+
+```rust
+use autumn_web::actuator::{MetricFamily, MetricKind, MetricSample, MetricsSource};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+pub struct QueueMetrics {
+    depth: Arc<AtomicU64>,
+}
+
+impl QueueMetrics {
+    pub fn new(depth: Arc<AtomicU64>) -> Self {
+        Self { depth }
+    }
+}
+
+impl MetricsSource for QueueMetrics {
+    fn collect(&self) -> Vec<MetricFamily> {
+        vec![MetricFamily {
+            name: "myapp_queue_depth".to_string(),
+            help: "Current number of items in the processing queue".to_string(),
+            kind: MetricKind::Gauge,
+            samples: vec![MetricSample {
+                labels: vec![],
+                value: self.depth.load(Ordering::Relaxed) as f64,
+            }],
+        }]
+    }
+}
+```
+
+### 2. Register it with `AppBuilder`
+
+```rust
+use std::sync::Arc;
+
+let depth = Arc::new(std::sync::atomic::AtomicU64::new(0));
+let metrics = QueueMetrics::new(depth.clone());
+
+autumn_web::app()
+    .routes(routes![...])
+    .metrics_source("myapp_queue", Arc::new(metrics))
+    .run()
+    .await;
+```
+
+### 3. Scrape the unified endpoint
+
+```
+$ curl http://localhost:3000/actuator/prometheus
+# HELP autumn_http_requests_total Total number of HTTP requests
+# TYPE autumn_http_requests_total counter
+autumn_http_requests_total 1234
+...
+# HELP myapp_queue_depth Current number of items in the processing queue
+# TYPE myapp_queue_depth gauge
+myapp_queue_depth 42
+```
+
+---
+
+## Naming and namespacing rules
+
+- **Prefix every metric name** with a stable namespace that identifies your
+  subsystem (e.g. `harvest_` for autumn-harvest, `myapp_` for application-level
+  sources, `admin_` for autumn-admin-plugin).  This avoids collisions with the
+  built-in `autumn_*` families and other sources.
+- **The registration name** passed to `.metrics_source(name, ...)` is the
+  stable identifier used for duplicate detection and the error-isolation counter
+  label.  Choose something short and unique (e.g. `"myapp_queue"`).
+- **Family names** within a source are your responsibility — the registry does
+  not enforce cross-source uniqueness of individual `MetricFamily::name` values.
+
+---
+
+## Multi-label samples
+
+`MetricSample::labels` is a `Vec<(String, String)>`, rendered as
+`{key="value",...}` in the Prometheus text format.  Label values are
+automatically escaped (backslash, newline, double-quote).
+
+```rust
+MetricFamily {
+    name: "harvest_activity_retries_total".to_string(),
+    help: "Activity retries by queue".to_string(),
+    kind: MetricKind::Counter,
+    samples: vec![
+        MetricSample {
+            labels: vec![("queue".to_string(), "email".to_string())],
+            value: 12.0,
+        },
+        MetricSample {
+            labels: vec![("queue".to_string(), "sms".to_string())],
+            value: 3.0,
+        },
+    ],
+}
+```
+
+---
+
+## Error isolation
+
+If a `MetricsSource` implementation **panics** during a scrape:
+
+- Its families are **omitted** from that scrape's output — the rest of the
+  response is unaffected.
+- An `autumn_metrics_source_errors_total{source="<name>"}` counter
+  **increments** so you can alert on broken sources.
+- The panic is caught and swallowed; it does not propagate to the HTTP handler.
+
+```
+# HELP autumn_metrics_source_errors_total Number of scrape errors (panics) per plugin metrics source
+# TYPE autumn_metrics_source_errors_total counter
+autumn_metrics_source_errors_total{source="my_broken_source"} 1
+```
+
+The sync-snapshot contract — `collect` **must not block on I/O** — is
+enforced by convention, not by the framework.  If you need async data, collect
+it into an `Arc<RwLock<Snapshot>>` and refresh that snapshot from a background
+task.
+
+---
+
+## Duplicate registration
+
+Registering two sources with the same name is caught at **startup time**:
+
+```rust
+app
+    .metrics_source("payments", Arc::new(PaymentsMetrics))
+    .metrics_source("payments", Arc::new(PaymentsMetrics)) // ← duplicate
+```
+
+The second registration emits a `tracing::warn!` and is **skipped**.  The
+same behaviour applies when a plugin calls `.metrics_source` from `Plugin::build`
+and the user also calls it directly.
+
+---
+
+## Registering from a plugin
+
+`Plugin::build` receives an `AppBuilder` so plugins can wire a source with no
+app-level glue code:
+
+```rust
+use autumn_web::app::AppBuilder;
+use autumn_web::plugin::Plugin;
+use std::sync::Arc;
+
+pub struct HarvestPlugin { /* ... */ }
+
+impl Plugin for HarvestPlugin {
+    fn build(self, app: AppBuilder) -> AppBuilder {
+        let metrics = Arc::new(HarvestMetrics::new(/* ... */));
+        app
+            .on_startup(/* ... */)
+            .metrics_source("harvest", metrics)
+    }
+}
+```
+
+Users of the plugin call only:
+
+```rust
+autumn_web::app()
+    .plugins(HarvestPlugin::new())
+    .run()
+    .await;
+```
+
+---
+
+## JSON endpoint (`/actuator/metrics`)
+
+Plugin-contributed sources also appear in the JSON endpoint under the `sources`
+key, alongside the existing top-level HTTP and database keys:
+
+```json
+{
+  "http": { "requests_total": 1234, ... },
+  "sources": {
+    "myapp_queue": [
+      {
+        "name": "myapp_queue_depth",
+        "help": "Current number of items in the processing queue",
+        "kind": "gauge",
+        "samples": [{ "labels": [], "value": 42.0 }]
+      }
+    ]
+  }
+}
+```
+
+The existing top-level JSON keys (`http`, `database`) are unchanged —
+current scrapers are not affected.
+
+---
+
+## Actuator exposure config
+
+Sources respect the same actuator exposure settings as the built-in families.
+If `/actuator/prometheus` is only reachable in sensitive mode (see
+`actuator.sensitive` in `autumn.toml`), plugin-contributed families are also
+behind that gate — no per-source exposure config is needed.

--- a/docs/guide/metrics-sources.md
+++ b/docs/guide/metrics-sources.md
@@ -201,7 +201,7 @@ key, alongside the existing top-level HTTP and database keys:
         "name": "myapp_queue_depth",
         "help": "Current number of items in the processing queue",
         "kind": "gauge",
-        "samples": [{ "labels": [], "value": 42.0 }]
+        "samples": [{ "labels": {}, "value": 42.0 }]
       }
     ]
   }

--- a/examples/experiments/src/main.rs
+++ b/examples/experiments/src/main.rs
@@ -41,8 +41,8 @@
 //! curl http://localhost:3000/checkout/user:99
 //! ```
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use autumn_web::actuator::{MetricFamily, MetricKind, MetricSample, MetricsSource};
 use autumn_web::experiments::{

--- a/examples/experiments/src/main.rs
+++ b/examples/experiments/src/main.rs
@@ -6,6 +6,8 @@
 //! - Exposure events logged to stdout via the default tracing sink
 //! - Staff/QA override pinning a specific actor to a variant
 //! - Concluding an experiment with a winner
+//! - A custom `MetricsSource` that surfaces experiment exposure counts in
+//!   `/actuator/prometheus` alongside the built-in `autumn_http_*` families
 //!
 //! # Quick start
 //!
@@ -31,28 +33,88 @@
 //! # Check current experiment status
 //! curl http://localhost:3000/status
 //!
+//! # See experiment metrics alongside HTTP metrics in one scrape
+//! curl http://localhost:3000/actuator/prometheus
+//!
 //! # Conclude the experiment (returns winner for everyone)
 //! curl -X POST http://localhost:3000/conclude
 //! curl http://localhost:3000/checkout/user:99
 //! ```
 
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use autumn_web::actuator::{MetricFamily, MetricKind, MetricSample, MetricsSource};
 use autumn_web::experiments::{
     ExperimentConfig, ExperimentService, InMemoryExperimentStore, VariantConfig,
 };
 use autumn_web::prelude::*;
 
+// ── Custom MetricsSource ──────────────────────────────────────────────────────
+
+/// Reports per-variant assignment counts to `/actuator/prometheus`.
+///
+/// This is registered via `AppBuilder::metrics_source` in `main` and updates
+/// atomically from the HTTP handlers, so `collect` never blocks on I/O.
+struct ExperimentMetrics {
+    control_assignments: Arc<AtomicU64>,
+    treatment_assignments: Arc<AtomicU64>,
+}
+
+impl MetricsSource for ExperimentMetrics {
+    fn collect(&self) -> Vec<MetricFamily> {
+        vec![MetricFamily {
+            name: "experiments_assignments_total".to_string(),
+            help: "Total variant assignments for the checkout_v2 experiment".to_string(),
+            kind: MetricKind::Counter,
+            samples: vec![
+                MetricSample {
+                    labels: vec![("variant".to_string(), "control".to_string())],
+                    value: self.control_assignments.load(Ordering::Relaxed) as f64,
+                },
+                MetricSample {
+                    labels: vec![("variant".to_string(), "treatment".to_string())],
+                    value: self.treatment_assignments.load(Ordering::Relaxed) as f64,
+                },
+            ],
+        }]
+    }
+}
+
 const EXPERIMENT: &str = "checkout_v2";
+
+/// Shared assignment counters updated from the checkout handler.
+#[derive(Clone)]
+struct AssignmentCounters {
+    control: Arc<AtomicU64>,
+    treatment: Arc<AtomicU64>,
+}
 
 /// Assign a variant to the given actor and return it as plain text.
 ///
 /// Exposure events are emitted automatically to tracing (stdout in this example).
+/// Assignment counts are also incremented so `ExperimentMetrics::collect` can
+/// report them without any blocking I/O.
 #[get("/checkout/{actor}")]
-async fn checkout(Path(actor): Path<String>, exps: autumn_web::experiments::Experiments) -> String {
+async fn checkout(
+    Path(actor): Path<String>,
+    exps: autumn_web::experiments::Experiments,
+    State(state): State<autumn_web::AppState>,
+) -> String {
     match exps.service().assign(EXPERIMENT, &actor) {
-        Ok(variant) => format!(
-            "actor={actor} experiment={EXPERIMENT} variant={variant}\n\
-             (exposure event logged to stdout)\n"
-        ),
+        Ok(variant) => {
+            if let Some(counters) = state.extension::<AssignmentCounters>() {
+                match variant.as_str() {
+                    "control" => counters.control.fetch_add(1, Ordering::Relaxed),
+                    "treatment" => counters.treatment.fetch_add(1, Ordering::Relaxed),
+                    _ => 0,
+                };
+            }
+            format!(
+                "actor={actor} experiment={EXPERIMENT} variant={variant}\n\
+                 (exposure event logged to stdout)\n"
+            )
+        }
         Err(e) => format!("assignment error: {e}\n"),
     }
 }
@@ -125,6 +187,21 @@ async fn main() {
     println!("✓ Experiment '{EXPERIMENT}' started with 50/50 variants.");
     println!("  Visit http://localhost:3000/checkout/user:1");
     println!("  QA actor 'qa:alice' is overridden to 'treatment'.");
+    println!("  Scrape http://localhost:3000/actuator/prometheus for unified metrics.");
+
+    // Shared atomic counters updated by the checkout handler.
+    let counters = AssignmentCounters {
+        control: Arc::new(AtomicU64::new(0)),
+        treatment: Arc::new(AtomicU64::new(0)),
+    };
+
+    // Register the experiment metrics source so variant assignment counts
+    // appear in /actuator/prometheus alongside autumn_http_* families —
+    // no second port or exporter needed.
+    let metrics_source = Arc::new(ExperimentMetrics {
+        control_assignments: counters.control.clone(),
+        treatment_assignments: counters.treatment.clone(),
+    });
 
     autumn_web::app()
         .with_experiment_store_and_sink(
@@ -133,7 +210,9 @@ async fn main() {
         )
         .state_initializer(move |state| {
             state.insert_extension(svc.clone());
+            state.insert_extension(counters.clone());
         })
+        .metrics_source("experiments", metrics_source)
         .routes(routes![checkout, status, conclude])
         .run()
         .await;


### PR DESCRIPTION
## Summary

This PR introduces a pluggable metrics system that allows in-process subsystems (plugins, background workers, application-level services) to contribute custom metric families to the unified `/actuator/prometheus` and `/actuator/metrics` endpoints, without requiring a separate metrics port or exporter.

## Key Changes

- **New `MetricsSource` trait** (`actuator.rs`): Defines the contract for subsystems to contribute metric families. Implementations must be synchronous and non-blocking, reading from atomics or pre-computed snapshots.

- **Supporting types** (`actuator.rs`):
  - `MetricKind` enum: Counter, Gauge, Histogram types matching Prometheus conventions
  - `MetricSample` struct: Individual metric with optional labels and value
  - `MetricFamily` struct: Complete metric family with name, help text, kind, and samples

- **`MetricsSourceRegistry`** (`actuator.rs`): Thread-safe registry that:
  - Registers named sources with duplicate-detection at startup
  - Collects from all sources with panic isolation (panicking sources yield empty results and increment an error counter)
  - Tracks per-source scrape errors for alerting

- **`AppBuilder::metrics_source()`** (`app.rs`): Builder method to register sources, with duplicate-name warnings matching plugin behavior

- **Updated actuator endpoints**:
  - `/actuator/prometheus`: Emits plugin-contributed families alongside built-in `autumn_http_*` families; includes `autumn_metrics_source_errors_total` counter for panicking sources
  - `/actuator/metrics`: Adds `sources` key to JSON output containing all plugin-contributed families

- **Prometheus text format helpers** (`actuator.rs`):
  - `escape_label_value()`: Escapes backslash, newline, and double-quote in label values
  - `render_labels()`: Formats label set as `{k="v",...}` or empty string

- **`ProvideActuatorState` trait** (`actuator.rs`): Added `metrics_source_registry()` method (default returns `None`)

- **`AppState`** (`state.rs`): Added `metrics_source_registry` field, populated during app initialization

- **Comprehensive tests** (`actuator.rs`): 
  - Registry registration and collection
  - Duplicate-name rejection
  - Panic isolation with error counting
  - Prometheus endpoint integration with plugin families
  - Error counter emission
  - JSON endpoint `sources` section
  - Insertion-order preservation

- **Example** (`examples/experiments/src/main.rs`): Demonstrates a custom `ExperimentMetrics` source that reports per-variant assignment counts to `/actuator/prometheus` using atomic counters

- **Documentation** (`docs/guide/metrics-sources.md`): Complete guide covering quick start, naming rules, multi-label samples, error isolation, duplicate registration, plugin integration, JSON endpoint format, and actuator exposure config

## Notable Implementation Details

- Panic isolation uses `std::panic::catch_unwind` to prevent broken sources from affecting the scrape response
- Label values are automatically escaped to prevent Prometheus format corruption
- Sources are collected in insertion order and sorted by name in Prometheus output for deterministic scraping
- The sync-snapshot contract is enforced by convention (non-blocking `collect` implementations)
- Duplicate registration is caught at startup via `AppBuilder`, with warnings matching plugin behavior
- All test state structs updated to include the new `metrics_source_registry` field

https://claude.ai/code/session_0128WMhKzCwoKjmGmRXJiik4