### PR TITLE
🗺️ Atlas: [Break state and authorization circular dependency]

### DIFF
--- a/autumn/src/authorization.rs
+++ b/autumn/src/authorization.rs
@@ -75,6 +75,18 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn std::future::Future<Output = T> + Send +
 /// re-threading state), and a clone of the database pool so
 /// policies can consult related rows. `Clone + Send + Sync` — flows
 /// freely across `.await` points.
+
+/// Trait implemented by application state to provide dependencies
+/// required by the authorization module.
+pub trait ProvideAuthorizationState {
+    fn policy_registry(&self) -> &PolicyRegistry;
+    fn auth_session_key(&self) -> &str;
+    fn forbidden_response(&self) -> ForbiddenResponse;
+
+    #[cfg(feature = "db")]
+    fn pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>;
+}
+
 #[derive(Clone)]
 pub struct PolicyContext {
     /// The full per-request [`Session`]. Read raw values via
@@ -130,7 +142,7 @@ impl PolicyContext {
     /// Build a fully-populated [`PolicyContext`] from `AppState` +
     /// `Session`. Used by the `#[authorize]` macro and
     /// `#[repository(policy = ...)]`-generated handlers.
-    pub async fn from_request(state: &crate::AppState, session: &Session) -> Self {
+    pub async fn from_request(state: &(impl ProvideAuthorizationState + Sync), session: &Session) -> Self {
         let mut ctx = Self::from_session(session, state.auth_session_key()).await;
         ctx.policy_registry = state.policy_registry().clone();
         #[cfg(feature = "db")]
@@ -621,7 +633,7 @@ impl<'de> serde::Deserialize<'de> for ForbiddenResponse {
 /// }
 /// ```
 pub async fn authorize<R>(
-    state: &crate::AppState,
+    state: &(impl ProvideAuthorizationState + Sync),
     session: &Session,
     action: &str,
     resource: &R,
@@ -651,7 +663,7 @@ where
 /// the public API** — call [`authorize`] from user code.
 #[doc(hidden)]
 pub async fn __check_policy<R>(
-    state: &crate::AppState,
+    state: &(impl ProvideAuthorizationState + Sync),
     session: &Session,
     action: &str,
     resource: &R,
@@ -673,7 +685,7 @@ where
 /// alias for older macro output.
 #[doc(hidden)]
 pub async fn __check_policy_create<R>(
-    state: &crate::AppState,
+    state: &(impl ProvideAuthorizationState + Sync),
     session: &Session,
 ) -> crate::AutumnResult<()>
 where
@@ -692,7 +704,7 @@ where
 /// only `autumn-web` is upgraded.
 #[doc(hidden)]
 pub async fn __check_policy_create_payload<R>(
-    state: &crate::AppState,
+    state: &(impl ProvideAuthorizationState + Sync),
     session: &Session,
     payload: &serde_json::Value,
 ) -> crate::AutumnResult<()>
@@ -713,7 +725,7 @@ where
 /// Returns the configured deny response when the policy denies.
 /// Returns `500` when no policy is registered for `R`.
 pub async fn authorize_create<R>(
-    state: &crate::AppState,
+    state: &(impl ProvideAuthorizationState + Sync),
     session: &Session,
 ) -> crate::AutumnResult<()>
 where
@@ -749,7 +761,7 @@ where
 /// Returns the configured deny response when the policy denies.
 /// Returns `500` when no policy is registered for `R`.
 pub async fn authorize_create_payload<R>(
-    state: &crate::AppState,
+    state: &(impl ProvideAuthorizationState + Sync),
     session: &Session,
     payload: &serde_json::Value,
 ) -> crate::AutumnResult<()>
@@ -1054,7 +1066,7 @@ mod tests {
         _registry: PolicyRegistry,
         forbidden: ForbiddenResponse,
     ) -> crate::AppState {
-        crate::AppState::detached()
+        crate::state::AppState::detached()
             .with_forbidden_response(forbidden)
             .with_auth_session_key("user_id")
     }
@@ -1102,7 +1114,7 @@ mod tests {
 
     #[tokio::test]
     async fn authorize_returns_ok_when_policy_allows() {
-        let state = crate::AppState::detached();
+        let state = crate::state::AppState::detached();
         state
             .policy_registry()
             .register_policy::<Note, _>(AdminOrOwnerPolicy);
@@ -1115,7 +1127,7 @@ mod tests {
 
     #[tokio::test]
     async fn authorize_create_returns_500_when_no_policy_registered() {
-        let state = crate::AppState::detached();
+        let state = crate::state::AppState::detached();
         let session = session_with(Some("42"), None);
         let err = authorize_create::<Note>(&state, &session)
             .await
@@ -1133,7 +1145,7 @@ mod tests {
         }
 
         let state =
-            crate::AppState::detached().with_forbidden_response(ForbiddenResponse::Forbidden403);
+            crate::state::AppState::detached().with_forbidden_response(ForbiddenResponse::Forbidden403);
         state
             .policy_registry()
             .register_policy::<Note, _>(AuthOnlyCreatePolicy);
@@ -1165,7 +1177,7 @@ mod tests {
         }
 
         let state =
-            crate::AppState::detached().with_forbidden_response(ForbiddenResponse::Forbidden403);
+            crate::state::AppState::detached().with_forbidden_response(ForbiddenResponse::Forbidden403);
         state
             .policy_registry()
             .register_policy::<Note, _>(OwnerPayloadPolicy);
@@ -1193,7 +1205,7 @@ mod tests {
         }
 
         let state =
-            crate::AppState::detached().with_forbidden_response(ForbiddenResponse::Forbidden403);
+            crate::state::AppState::detached().with_forbidden_response(ForbiddenResponse::Forbidden403);
         state
             .policy_registry()
             .register_policy::<Note, _>(AuthOnlyCreatePolicy);
@@ -1227,7 +1239,7 @@ mod tests {
         }
 
         let state =
-            crate::AppState::detached().with_forbidden_response(ForbiddenResponse::Forbidden403);
+            crate::state::AppState::detached().with_forbidden_response(ForbiddenResponse::Forbidden403);
         state
             .policy_registry()
             .register_policy::<Note, _>(OwnerPayloadPolicy);
@@ -1241,7 +1253,7 @@ mod tests {
 
     #[tokio::test]
     async fn check_policy_alias_round_trips() {
-        let state = crate::AppState::detached();
+        let state = crate::state::AppState::detached();
         state
             .policy_registry()
             .register_policy::<Note, _>(AdminOrOwnerPolicy);
@@ -1256,7 +1268,7 @@ mod tests {
 
     #[tokio::test]
     async fn from_request_clones_pool_and_registry_from_state() {
-        let state = crate::AppState::detached();
+        let state = crate::state::AppState::detached();
         state
             .policy_registry()
             .register_policy::<Note, _>(AdminOrOwnerPolicy);
@@ -1270,7 +1282,7 @@ mod tests {
 
     #[tokio::test]
     async fn scoped_blanket_trait_constructible_without_registered_scope() {
-        let state = crate::AppState::detached();
+        let state = crate::state::AppState::detached();
         let session = session_with(Some("1"), None);
         let ctx = PolicyContext::from_request(&state, &session).await;
         // No scope registered for `Note`.

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -985,3 +985,22 @@ mod tests {
         assert_eq!(stored.as_str(), "haunted");
     }
 }
+
+impl crate::authorization::ProvideAuthorizationState for AppState {
+    fn policy_registry(&self) -> &crate::authorization::PolicyRegistry {
+        self.policy_registry()
+    }
+
+    fn auth_session_key(&self) -> &str {
+        self.auth_session_key()
+    }
+
+    fn forbidden_response(&self) -> crate::authorization::ForbiddenResponse {
+        self.forbidden_response()
+    }
+
+    #[cfg(feature = "db")]
+    fn pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>> {
+        self.pool()
+    }
+}


### PR DESCRIPTION
🕸️ Tangle: The structural problem: Circular dependency between `authorization` and `state` modules (`state` imports `authorization` primitives, `authorization` explicitly relies on `AppState`).
📐 Blueprint: The solution: Extracted a `ProvideAuthorizationState` trait in `authorization.rs` that `AppState` implements. `authorize` now takes an `impl ProvideAuthorizationState` parameter instead of coupling to `AppState`.
🧱 Stability: Reduced coupling, enforces one-way domain boundaries, and eliminates circular import knots.
🔬 Verification: Builds successfully, strict separation enforced. Tested across workspace and integration tests.

---
*PR created automatically by Jules for task [8427380700802868577](https://jules.google.com/task/8427380700802868577) started by @madmax983*