### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -1579,6 +1579,33 @@ mod tests {
         assert_eq!(state.read_pool().expect("read pool").status().max_size, 3);
     }
 
+    #[test]
+    fn is_query_canceled_matches_57014() {
+        let err = diesel::result::Error::DatabaseError(
+            diesel::result::DatabaseErrorKind::Unknown,
+            Box::new("canceling statement due to user request (SQLSTATE 57014)".to_string()),
+        );
+        assert!(is_query_canceled(&err));
+    }
+
+    #[test]
+    fn is_query_canceled_matches_timeout() {
+        let err = diesel::result::Error::DatabaseError(
+            diesel::result::DatabaseErrorKind::Unknown,
+            Box::new("canceling statement due to statement timeout".to_string()),
+        );
+        assert!(is_query_canceled(&err));
+    }
+
+    #[test]
+    fn is_query_canceled_returns_false_for_unrelated_errors() {
+        let err = diesel::result::Error::DatabaseError(
+            diesel::result::DatabaseErrorKind::UniqueViolation,
+            Box::new("duplicate key value violates unique constraint".to_string()),
+        );
+        assert!(!is_query_canceled(&err));
+    }
+
     #[tokio::test]
     async fn db_extractor_rejects_when_no_pool() {
         use axum::Router;


### PR DESCRIPTION
🎯 Target: The `is_query_canceled` error handling helper inside `autumn/src/db.rs`.
💣 Risk: Untested string-matching and tokio_postgres error downcasting logic meant to correctly translate `57014` into timeout errors. If broken, it could silently swallow timeouts or miscategorize valid timeouts as internal server errors.
🧪 Strategy: Added unit tests spanning three vectors: explicit "SQLSTATE 57014" strings, plain "statement timeout" messages, and unrelated errors that must return false.
🔬 Verification: Run `cargo test -p autumn-web --lib db::tests::is_query_canceled`

---
*PR created automatically by Jules for task [18314349501436169104](https://jules.google.com/task/18314349501436169104) started by @madmax983*