### PR TITLE
🎸 Bard: Fix broken intra-doc links

### DIFF
--- a/autumn/src/reporting.rs
+++ b/autumn/src/reporting.rs
@@ -2,24 +2,24 @@
 //! route them to one or more configured reporters.
 //!
 //! When an Autumn handler panics or returns a server error, the failure is
-//! turned into a structured [`ErrorEvent`] and delivered to every registered
-//! [`ErrorReporter`]. This is the "where do my errors go?" seam: ship events to
+//! turned into a structured [`ErrorEvent`](crate::reporting::ErrorEvent) and delivered to every registered
+//! [`ErrorReporter`](crate::reporting::ErrorReporter). This is the "where do my errors go?" seam: ship events to
 //! Sentry, Honeycomb, Slack, or a custom sink by implementing a single trait
 //! and wiring it once with
 //! [`AppBuilder::with_error_reporter`](crate::app::AppBuilder::with_error_reporter).
 //!
 //! The design mirrors Rails' [Error Reporter] and Autumn's other pluggable
 //! backends ([`BlobStore`](crate::storage::BlobStore),
-//! [`Cache`](crate::cache::Cache)): a built-in [`LogReporter`] (which uses
+//! [`Cache`](crate::cache::Cache)): a built-in [`LogReporter`](crate::reporting::LogReporter) (which uses
 //! `tracing`) ships as the default so the feature is useful with zero extra
 //! dependencies, and one builder call swaps in your own sink.
 //!
 //! # What gets reported
 //!
-//! - **Handler panics.** A [`ReportingLayer`] catches unwinding panics at the
+//! - **Handler panics.** A [`ReportingLayer`](crate::reporting::ReportingLayer) catches unwinding panics at the
 //!   HTTP layer (so a single panicking handler can never abort the worker
 //!   task), converts them into a sanitized [`AutumnError`](crate::AutumnError)
-//!   `500` Problem Details response, and reports an [`ErrorEvent`] carrying the
+//!   `500` Problem Details response, and reports an [`ErrorEvent`](crate::reporting::ErrorEvent) carrying the
 //!   panic payload and (when `RUST_BACKTRACE` is set) a backtrace.
 //! - **Server errors.** Any response with a `5xx` status is reported with its
 //!   status, message, and Problem Details type.
@@ -134,7 +134,7 @@ pub struct PanicInfo {
     pub backtrace: Option<String>,
 }
 
-/// A sink for [`ErrorEvent`]s.
+/// A sink for [`ErrorEvent`](crate::reporting::ErrorEvent)s.
 ///
 /// Implement this trait to ship unhandled panics and server errors to an
 /// external service. Register implementations with
@@ -145,7 +145,7 @@ pub struct PanicInfo {
 /// not block the client response. Any panic raised inside `report` is caught
 /// and logged — a misbehaving reporter never affects the response.
 pub trait ErrorReporter: Send + Sync + 'static {
-    /// Deliver an [`ErrorEvent`] to the sink.
+    /// Deliver an [`ErrorEvent`](crate::reporting::ErrorEvent) to the sink.
     ///
     /// Implementations should swallow their own transport errors; returning is
     /// the only signal the framework needs.
@@ -189,7 +189,7 @@ impl ErrorReporter for LogReporter {
 
 /// Runtime holder for the registered reporters, installed on
 /// [`AppState`](crate::state::AppState) extensions so the
-/// [`ReportingLayer`] can pick them up at router-build time.
+/// [`ReportingLayer`](crate::reporting::ReportingLayer) can pick them up at router-build time.
 #[derive(Clone, Default)]
 pub(crate) struct RegisteredReporters(pub(crate) Vec<Arc<dyn ErrorReporter>>);
 
@@ -298,7 +298,7 @@ struct CapturedPanic {
 static HOOK_INSTALLED: Once = Once::new();
 
 /// Install a panic hook (once) that records a backtrace for the panicking
-/// thread so the [`ReportingLayer`] can attach it to the [`ErrorEvent`] after
+/// thread so the [`ReportingLayer`](crate::reporting::ReportingLayer) can attach it to the [`ErrorEvent`](crate::reporting::ErrorEvent) after
 /// `catch_unwind` returns. The previous hook is preserved and still runs, so
 /// the default panic logging behavior is unchanged.
 fn ensure_panic_hook() {
@@ -340,7 +340,7 @@ struct RequestContext {
 }
 
 /// Tower [`Layer`] that catches handler panics and reports panics + 5xx
-/// responses to the registered [`ErrorReporter`]s.
+/// responses to the registered [`ErrorReporter`](crate::reporting::ErrorReporter)s.
 ///
 /// Applied automatically by the framework inner to
 /// [`RequestIdLayer`](crate::middleware::RequestIdLayer) (so the request id is
@@ -353,7 +353,7 @@ pub struct ReportingLayer {
 impl ReportingLayer {
     /// Build a reporting layer from the registered reporters and config knobs.
     ///
-    /// When `reporters` is empty, the built-in [`LogReporter`] is installed so
+    /// When `reporters` is empty, the built-in [`LogReporter`](crate::reporting::LogReporter) is installed so
     /// panics and server errors are still surfaced.
     #[must_use]
     pub(crate) fn new(
@@ -388,7 +388,7 @@ impl<S> Layer<S> for ReportingLayer {
     }
 }
 
-/// Tower [`Service`] produced by [`ReportingLayer`].
+/// Tower [`Service`] produced by [`ReportingLayer`](crate::reporting::ReportingLayer).
 #[derive(Clone)]
 pub struct ReportingService<S> {
     inner: S,

--- a/autumn/src/system_test.rs
+++ b/autumn/src/system_test.rs
@@ -290,7 +290,7 @@ impl SystemTest {
     }
 
     /// Supply a pre-configured [`AppState`] to use instead of
-    /// [`AppState::for_test()`].
+    /// `AppState::for_test()`.
     ///
     /// Use this when the routes under test require a real database pool, API
     /// version registrations, authorization policies, or any other state that

--- a/examples/todo-app/src/routes/todos.rs
+++ b/examples/todo-app/src/routes/todos.rs
@@ -41,7 +41,7 @@
 //!
 //! ## Inline field validation (htmx)
 //!
-//! A field rendered with [`text_input_htmx`] POSTs to a validation endpoint
+//! A field rendered with `text_input_htmx` POSTs to a validation endpoint
 //! when its value changes. The handler extracts [`ChangesetForm`], validates,
 //! and returns just that field's wrapper partial — htmx swaps it with `outerHTML`.
 //! When JavaScript is disabled, the normal `#[post("/todos")]` handler still


### PR DESCRIPTION
📖 Chapter: The `reporting`, `system_test`, and `todo-app` modules
🔦 Insight: Cleaned up unresolved intra-doc links that triggered rustdoc warnings. `ErrorEvent`, `ErrorReporter`, `LogReporter`, and `ReportingLayer` in `reporting.rs` were qualified with the full crate path (`crate::reporting::*`) to ensure they resolve properly from the crate root. `AppState::for_test()` and `text_input_htmx` were converted to inline code because they were unresolvable from their respective doc locations.
🧪 Example: N/A - pure documentation link syntax updates.
🖼️ Preview: `cargo doc --workspace --no-deps --all-features` now successfully completes without any "unresolved link" warnings.

---
*PR created automatically by Jules for task [13225954347585595352](https://jules.google.com/task/13225954347585595352) started by @madmax983*