### PR TITLE
Add on-demand image variants with content-addressed caching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ time = { version = ">=0.3, <0.4" }
 csv = "1.3"
 pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
 chromiumoxide = { version = "0.7", default-features = false, features = ["tokio-runtime"] }
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 
 # Proc macro
 syn = { version = "2", features = ["full"] }

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -176,7 +176,7 @@ rusty-fork = "0.3.1"
 features = [
   "maud", "htmx", "tailwind", "db", "cache-moka",
   "ws", "flash", "multipart", "http-client", "oauth2", "openapi",
-  "redis", "i18n", "storage", "mail", "seed", "system-info", "markdown",
+  "redis", "i18n", "storage", "variants", "mail", "seed", "system-info", "markdown",
   "reporting", "csv",
 ]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -55,6 +55,11 @@ i18n = []
 # When combined with `db`, opts diesel into `serde_json` so the `Blob`
 # value type can round-trip through a Postgres `JSONB` column.
 storage = ["diesel?/serde_json"]
+# On-demand image variants (resize, rotate, strip metadata) with
+# content-addressed caching on top of the storage layer.
+# Pulls in the `image` crate (JPEG + PNG + WebP codecs) behind this flag
+# to keep the `storage`-only build lean.
+variants = ["storage", "dep:image"]
 # Pluggable error reporting: catch handler panics at the HTTP layer and route
 # panics + 5xx responses to configured `ErrorReporter`s. Ships a `tracing`-based
 # `LogReporter` as the default. On by default; disable to drop the panic-catch
@@ -141,6 +146,7 @@ hex = "0.4"
 csv = { workspace = true, optional = true }
 lettre = { version = "0.11.21", default-features = false, features = ["builder", "smtp-transport", "tokio1-rustls-tls"], optional = true }
 chromiumoxide = { workspace = true, optional = true, features = ["tokio-runtime"] }
+image = { workspace = true, optional = true }
 
 [dev-dependencies]
 diesel = { version = "2", features = ["chrono", "postgres"] }

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2550,6 +2550,21 @@ impl AutumnConfig {
             "AUTUMN_STORAGE__S3__DEFAULT_URL_EXPIRY_SECS",
             &mut self.storage.s3.default_url_expiry_secs,
         );
+        parse_env(
+            env,
+            "AUTUMN_STORAGE__VARIANTS__MAX_SOURCE_BYTES",
+            &mut self.storage.variants.max_source_bytes,
+        );
+        parse_env(
+            env,
+            "AUTUMN_STORAGE__VARIANTS__MAX_SOURCE_WIDTH",
+            &mut self.storage.variants.max_source_width,
+        );
+        parse_env(
+            env,
+            "AUTUMN_STORAGE__VARIANTS__MAX_SOURCE_HEIGHT",
+            &mut self.storage.variants.max_source_height,
+        );
     }
 
     #[cfg(feature = "mail")]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -4297,7 +4297,10 @@ path = "/healthz"
                 "AWS_SECRET_ACCESS_KEY",
             )
             .with("AUTUMN_STORAGE__S3__FORCE_PATH_STYLE", "true")
-            .with("AUTUMN_STORAGE__S3__DEFAULT_URL_EXPIRY_SECS", "99");
+            .with("AUTUMN_STORAGE__S3__DEFAULT_URL_EXPIRY_SECS", "99")
+            .with("AUTUMN_STORAGE__VARIANTS__MAX_SOURCE_BYTES", "5242880")
+            .with("AUTUMN_STORAGE__VARIANTS__MAX_SOURCE_WIDTH", "2000")
+            .with("AUTUMN_STORAGE__VARIANTS__MAX_SOURCE_HEIGHT", "1500");
         let mut config = AutumnConfig::default();
 
         config.apply_env_overrides_with_env(&env);
@@ -4329,6 +4332,9 @@ path = "/healthz"
         );
         assert!(config.storage.s3.force_path_style);
         assert_eq!(config.storage.s3.default_url_expiry_secs, 99);
+        assert_eq!(config.storage.variants.max_source_bytes, 5_242_880);
+        assert_eq!(config.storage.variants.max_source_width, 2_000);
+        assert_eq!(config.storage.variants.max_source_height, 1_500);
     }
 
     #[test]

--- a/autumn/src/storage/config.rs
+++ b/autumn/src/storage/config.rs
@@ -11,6 +11,53 @@ use std::path::PathBuf;
 use serde::Deserialize;
 use thiserror::Error;
 
+/// Configuration for the image-variant subsystem (`[storage.variants]`).
+///
+/// Used by the `variants` feature to bound variant-generation jobs so a
+/// pathologically large source image can't exhaust worker memory.
+///
+/// All limits can be overridden via environment variables under
+/// `AUTUMN_STORAGE__VARIANTS__*`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StorageVariantsConfig {
+    /// Maximum byte size of the source blob.
+    /// Default: 20 971 520 (20 MiB).
+    #[serde(default = "default_variants_max_source_bytes")]
+    pub max_source_bytes: u64,
+
+    /// Maximum pixel width of the source image.
+    /// Default: 10 000.
+    #[serde(default = "default_variants_max_source_width")]
+    pub max_source_width: u32,
+
+    /// Maximum pixel height of the source image.
+    /// Default: 10 000.
+    #[serde(default = "default_variants_max_source_height")]
+    pub max_source_height: u32,
+}
+
+impl Default for StorageVariantsConfig {
+    fn default() -> Self {
+        Self {
+            max_source_bytes: default_variants_max_source_bytes(),
+            max_source_width: default_variants_max_source_width(),
+            max_source_height: default_variants_max_source_height(),
+        }
+    }
+}
+
+const fn default_variants_max_source_bytes() -> u64 {
+    20 * 1024 * 1024 // 20 MiB
+}
+
+const fn default_variants_max_source_width() -> u32 {
+    10_000
+}
+
+const fn default_variants_max_source_height() -> u32 {
+    10_000
+}
+
 /// Top-level `[storage]` configuration section.
 #[derive(Debug, Clone, Deserialize)]
 pub struct StorageConfig {
@@ -37,6 +84,11 @@ pub struct StorageConfig {
     /// Configuration for the S3 backend.
     #[serde(default)]
     pub s3: StorageS3Config,
+
+    /// Resource limits for the image-variant subsystem.
+    /// Only meaningful when the `variants` feature is enabled.
+    #[serde(default)]
+    pub variants: StorageVariantsConfig,
 }
 
 impl Default for StorageConfig {
@@ -47,6 +99,7 @@ impl Default for StorageConfig {
             allow_local_in_production: false,
             local: StorageLocalConfig::default(),
             s3: StorageS3Config::default(),
+            variants: StorageVariantsConfig::default(),
         }
     }
 }

--- a/autumn/src/storage/mod.rs
+++ b/autumn/src/storage/mod.rs
@@ -69,13 +69,19 @@ pub mod migrations;
 #[cfg(feature = "maud")]
 pub mod form_helper;
 
+#[cfg(feature = "variants")]
+pub mod variant;
+
 pub use blob::{Blob, BlobMeta};
 pub use config::{
     StorageBackend, StorageBackendConfigError, StorageBackendPlan, StorageConfig,
-    StorageLocalConfig, StorageS3Config,
+    StorageLocalConfig, StorageS3Config, StorageVariantsConfig,
 };
 pub use direct_upload::{PresignPutResult, complete_direct_upload};
 pub use local::LocalBlobStore;
+
+#[cfg(feature = "variants")]
+pub use variant::{Transform, VariantBudget, VariantError, VariantHandle};
 
 /// Boxed future returned by [`BlobStore`] methods.
 ///

--- a/autumn/src/storage/variant.rs
+++ b/autumn/src/storage/variant.rs
@@ -223,9 +223,7 @@ impl VariantHandle {
         expires_in: Duration,
     ) -> Result<String, VariantError> {
         self.ensure_generated(store, budget).await?;
-        Ok(store
-            .presigned_url(&self.variant_key, expires_in)
-            .await?)
+        Ok(store.presigned_url(&self.variant_key, expires_in).await?)
     }
 
     /// Ensure the variant blob exists in the store, returning its handle.
@@ -272,6 +270,15 @@ impl VariantHandle {
         check_image_mime_type(&self.source.content_type)?;
 
         let source_bytes = store.get(&self.source.key).await?;
+
+        // Secondary guard on the real byte count — the Blob metadata could be
+        // stale or crafted; check the actual payload length too.
+        if source_bytes.len() as u64 > budget.max_source_bytes {
+            return Err(VariantError::SourceTooLarge {
+                byte_size: source_bytes.len() as u64,
+                max_bytes: budget.max_source_bytes,
+            });
+        }
 
         // Auto-detect format from bytes; the image crate's magic-byte
         // detection is more reliable than trusting the stored content_type
@@ -347,9 +354,14 @@ pub(crate) fn check_image_mime_type(content_type: &str) -> Result<(), VariantErr
         .next()
         .unwrap_or(content_type)
         .trim();
-    match base {
-        "image/jpeg" | "image/jpg" | "image/png" | "image/webp" => Ok(()),
-        other => Err(VariantError::UnsupportedMimeType(other.to_owned())),
+    if base.eq_ignore_ascii_case("image/jpeg")
+        || base.eq_ignore_ascii_case("image/jpg")
+        || base.eq_ignore_ascii_case("image/png")
+        || base.eq_ignore_ascii_case("image/webp")
+    {
+        Ok(())
+    } else {
+        Err(VariantError::UnsupportedMimeType(base.to_owned()))
     }
 }
 
@@ -365,15 +377,7 @@ pub(crate) fn content_addressed_key(source_key: &str, transforms: &[Transform]) 
     hasher.update(b"\0");
     hasher.update(spec.as_bytes());
     let hash = hasher.finalize();
-    let hash_hex: String = hash
-        .iter()
-        .flat_map(|b| {
-            let hi = (b >> 4) as usize;
-            let lo = (b & 0xf) as usize;
-            const HEX: &[u8] = b"0123456789abcdef";
-            [HEX[hi] as char, HEX[lo] as char]
-        })
-        .collect();
+    let hash_hex = hex::encode(hash);
     format!(
         "_variants/{}/{}/{}",
         &hash_hex[..2],
@@ -394,17 +398,15 @@ fn output_format_and_mime(content_type: &str) -> (image::ImageFormat, &'static s
         .next()
         .unwrap_or(content_type)
         .trim();
-    match base {
-        "image/png" => (image::ImageFormat::Png, "image/png"),
-        _ => (image::ImageFormat::Jpeg, "image/jpeg"),
+    if base.eq_ignore_ascii_case("image/png") {
+        (image::ImageFormat::Png, "image/png")
+    } else {
+        (image::ImageFormat::Jpeg, "image/jpeg")
     }
 }
 
 /// Apply each transform in order to the image.
-fn apply_transforms(
-    mut img: image::DynamicImage,
-    transforms: &[Transform],
-) -> image::DynamicImage {
+fn apply_transforms(mut img: image::DynamicImage, transforms: &[Transform]) -> image::DynamicImage {
     use image::imageops::FilterType;
 
     for transform in transforms {
@@ -523,15 +525,20 @@ mod tests {
     fn variant_key_passes_blob_validation() {
         use crate::storage::validate_key;
         let blob = Blob::new("local", "avatars/1.png", "image/png", 1024);
-        let key = blob.variant("t", &[Transform::resize_to_limit(200, 200)]).key().to_owned();
-        validate_key(&key)
-            .unwrap_or_else(|e| panic!("variant key {key:?} failed validation: {e}"));
+        let key = blob
+            .variant("t", &[Transform::resize_to_limit(200, 200)])
+            .key()
+            .to_owned();
+        validate_key(&key).unwrap_or_else(|e| panic!("variant key {key:?} failed validation: {e}"));
     }
 
     #[test]
     fn variant_key_starts_with_variants_prefix() {
         let blob = Blob::new("local", "avatars/1.png", "image/png", 1024);
-        let key = blob.variant("t", &[Transform::resize_to_limit(200, 200)]).key().to_owned();
+        let key = blob
+            .variant("t", &[Transform::resize_to_limit(200, 200)])
+            .key()
+            .to_owned();
         assert!(key.starts_with("_variants/"), "key: {key}");
     }
 
@@ -585,7 +592,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = test_store(dir.path());
         store
-            .put("doc.pdf", "application/pdf", Bytes::from_static(b"%PDF-1.4"))
+            .put(
+                "doc.pdf",
+                "application/pdf",
+                Bytes::from_static(b"%PDF-1.4"),
+            )
             .await
             .unwrap();
         let blob = Blob::new("test", "doc.pdf", "application/pdf", 8);
@@ -639,7 +650,7 @@ mod tests {
             .await
             .unwrap();
         let budget = VariantBudget {
-            max_source_width: 3,  // less than 4
+            max_source_width: 3, // less than 4
             max_source_height: 3,
             max_source_bytes: jpeg.len() as u64 * 10, // byte budget is fine
         };
@@ -748,7 +759,10 @@ mod tests {
             .unwrap();
 
         let out_bytes = store
-            .get(blob.variant("large", &[Transform::resize_to_limit(200, 200)]).key())
+            .get(
+                blob.variant("large", &[Transform::resize_to_limit(200, 200)])
+                    .key(),
+            )
             .await
             .unwrap();
         let out_img = image::load_from_memory(&out_bytes).unwrap();
@@ -776,7 +790,10 @@ mod tests {
             .unwrap();
 
         let out_bytes = store
-            .get(blob.variant("square", &[Transform::resize_to_fill(50, 50)]).key())
+            .get(
+                blob.variant("square", &[Transform::resize_to_fill(50, 50)])
+                    .key(),
+            )
             .await
             .unwrap();
         let out_img = image::load_from_memory(&out_bytes).unwrap();
@@ -858,7 +875,10 @@ mod tests {
             .unwrap();
 
         let out_bytes = store
-            .get(blob.variant("stripped", &[Transform::strip_metadata()]).key())
+            .get(
+                blob.variant("stripped", &[Transform::strip_metadata()])
+                    .key(),
+            )
             .await
             .unwrap();
         assert!(
@@ -940,7 +960,10 @@ mod tests {
             .url(&store, &VariantBudget::default(), Duration::from_secs(300))
             .await
             .unwrap();
-        assert!(url.contains("_variants/"), "URL must contain variant key: {url}");
+        assert!(
+            url.contains("_variants/"),
+            "URL must contain variant key: {url}"
+        );
         assert!(url.contains("exp="), "URL must contain expiry param: {url}");
         assert!(url.contains("sig="), "URL must contain signature: {url}");
     }
@@ -956,7 +979,10 @@ mod tests {
 
     #[test]
     fn handle_transforms_accessor() {
-        let transforms = vec![Transform::resize_to_limit(200, 200), Transform::strip_metadata()];
+        let transforms = vec![
+            Transform::resize_to_limit(200, 200),
+            Transform::strip_metadata(),
+        ];
         let blob = Blob::new("local", "a.png", "image/png", 1);
         let h = blob.variant("t", &transforms);
         assert_eq!(h.transforms(), &transforms);

--- a/autumn/src/storage/variant.rs
+++ b/autumn/src/storage/variant.rs
@@ -1111,4 +1111,67 @@ mod tests {
             "transform order must affect the content-addressed key"
         );
     }
+
+    // ── status() and into_autumn_error() ────────────────────────────────────
+
+    #[test]
+    fn variant_error_status_unsupported_mime_is_422() {
+        assert_eq!(
+            VariantError::UnsupportedMimeType("image/bmp".into()).status(),
+            http::StatusCode::UNPROCESSABLE_ENTITY
+        );
+    }
+
+    #[test]
+    fn variant_error_status_decode_error_is_422() {
+        assert_eq!(
+            VariantError::DecodeError("bad pixels".into()).status(),
+            http::StatusCode::UNPROCESSABLE_ENTITY
+        );
+    }
+
+    #[test]
+    fn variant_error_status_source_too_large_is_413() {
+        assert_eq!(
+            VariantError::SourceTooLarge {
+                byte_size: 999,
+                max_bytes: 100
+            }
+            .status(),
+            http::StatusCode::PAYLOAD_TOO_LARGE
+        );
+    }
+
+    #[test]
+    fn variant_error_status_dimensions_too_large_is_413() {
+        assert_eq!(
+            VariantError::SourceDimensionsTooLarge {
+                width: 200,
+                height: 200,
+                max_width: 100,
+                max_height: 100
+            }
+            .status(),
+            http::StatusCode::PAYLOAD_TOO_LARGE
+        );
+    }
+
+    #[test]
+    fn variant_error_status_storage_delegates_to_blob_store_error() {
+        use crate::storage::BlobStoreError;
+        assert_eq!(
+            VariantError::Storage(BlobStoreError::NotFound("k".into())).status(),
+            http::StatusCode::NOT_FOUND
+        );
+    }
+
+    #[test]
+    fn variant_error_into_autumn_error_carries_correct_status() {
+        let err = VariantError::SourceTooLarge {
+            byte_size: 999,
+            max_bytes: 100,
+        }
+        .into_autumn_error();
+        assert_eq!(err.status(), http::StatusCode::PAYLOAD_TOO_LARGE);
+    }
 }

--- a/autumn/src/storage/variant.rs
+++ b/autumn/src/storage/variant.rs
@@ -18,11 +18,12 @@
 //!
 //! ## Content addressing
 //!
-//! The variant key is `SHA-256(source_key + NUL + etag + NUL + JSON(transforms))`
+//! The variant key is
+//! `SHA-256(source_key + NUL + etag + NUL + content_type + NUL + JSON(transforms))`
 //! encoded under `_variants/{h0}{h1}/{h2}{h3}/{hash}`.  The same
-//! `(source content, transforms)` pair always produces the same key regardless
-//! of the `name` label; re-uploading to the same key (new `ETag`) produces a
-//! fresh variant key so stale thumbnails are never served.
+//! `(source content, transforms)` pair always maps to the same key; re-uploading
+//! to the same storage key (new `ETag`) or correcting a mis-tagged MIME type
+//! both produce a fresh variant key so stale thumbnails are never served.
 //!
 //! ## Budget
 //!
@@ -167,6 +168,46 @@ pub enum VariantError {
     /// A storage operation failed while checking for or writing the variant.
     #[error(transparent)]
     Storage(#[from] BlobStoreError),
+}
+
+impl VariantError {
+    /// HTTP status code that best represents this error.
+    ///
+    /// Routes using `?` on [`VariantHandle::url`] or
+    /// [`VariantHandle::ensure_generated`] get 500 by default via the blanket
+    /// `impl From<E: Error> for AutumnError`; call
+    /// [`VariantError::into_autumn_error`] instead to preserve the precise
+    /// status.
+    #[must_use]
+    pub const fn status(&self) -> http::StatusCode {
+        match self {
+            Self::UnsupportedMimeType(_) | Self::DecodeError(_) => {
+                http::StatusCode::UNPROCESSABLE_ENTITY
+            }
+            Self::SourceTooLarge { .. } | Self::SourceDimensionsTooLarge { .. } => {
+                http::StatusCode::PAYLOAD_TOO_LARGE
+            }
+            Self::Storage(e) => e.status(),
+        }
+    }
+
+    /// Promote into an [`AutumnError`](crate::AutumnError) carrying the
+    /// status from [`VariantError::status`].
+    ///
+    /// Use this instead of `?` when the route needs accurate HTTP status codes
+    /// for variant failures (e.g. 422 for a corrupt image, 413 for an
+    /// oversized source):
+    ///
+    /// ```rust,ignore
+    /// let url = handle.url(&*store, &budget, expires)
+    ///     .await
+    ///     .map_err(VariantError::into_autumn_error)?;
+    /// ```
+    #[must_use]
+    pub fn into_autumn_error(self) -> crate::AutumnError {
+        let status = self.status();
+        crate::AutumnError::internal_server_error(self).with_status(status)
+    }
 }
 
 /// Handle for a named, lazily-generated image variant.
@@ -398,12 +439,14 @@ pub(crate) fn check_image_mime_type(content_type: &str) -> Result<(), VariantErr
 /// transform spec.
 ///
 /// Format: `_variants/{h[0..2]}/{h[2..4]}/{h}` where `h` is the lowercase
-/// hex SHA-256 of `source_key + NUL + etag + NUL + JSON(transforms)`.
+/// hex SHA-256 of
+/// `source_key + NUL + etag + NUL + content_type + NUL + JSON(transforms)`.
 ///
-/// The `etag` component means that re-uploading to the same key (producing a
-/// new `ETag`) invalidates any previously cached variant — preventing stale
-/// thumbnails when avatars or other mutable blobs are replaced in-place.
-/// When the source blob has no `etag`, the hash falls back to key + transforms.
+/// Including `etag` ensures re-uploading to the same key invalidates cached
+/// variants.  Including `content_type` ensures that correcting a mis-tagged
+/// MIME type (PNG stored as `image/webp`) also produces a fresh variant key
+/// — the two produce different output formats, so the same bytes should not
+/// share a cached result.
 pub(crate) fn content_addressed_key(source_blob: &Blob, transforms: &[Transform]) -> String {
     let spec = serde_json::to_string(transforms).expect("Transform is always serialisable");
     let mut hasher = Sha256::new();
@@ -412,6 +455,8 @@ pub(crate) fn content_addressed_key(source_blob: &Blob, transforms: &[Transform]
     if let Some(etag) = &source_blob.etag {
         hasher.update(etag.as_bytes());
     }
+    hasher.update(b"\0");
+    hasher.update(source_blob.content_type.as_bytes());
     hasher.update(b"\0");
     hasher.update(spec.as_bytes());
     let hash = hasher.finalize();

--- a/autumn/src/storage/variant.rs
+++ b/autumn/src/storage/variant.rs
@@ -1,0 +1,986 @@
+//! On-demand image variants for stored blobs.
+//!
+//! Variants are lazily generated on first request, stored content-addressably
+//! in the same [`BlobStore`] as the source, and served with a strong ETag and
+//! far-future `Cache-Control: immutable` header from that point on.
+//!
+//! ## Quick start
+//!
+//! ```rust,ignore
+//! use autumn_web::storage::{BlobStoreState, variant::{Transform, VariantBudget}};
+//!
+//! // In your route handler:
+//! let store = blobs.store();
+//! let budget = VariantBudget::default();
+//! let handle = user.avatar.variant("thumb", &[Transform::resize_to_limit(200, 200)]);
+//! let url = handle.url(&**store, &budget, Duration::from_secs(3600)).await?;
+//! ```
+//!
+//! ## Content addressing
+//!
+//! The variant key is `SHA-256(source_key + NUL + JSON(transforms))` encoded
+//! under `_variants/{h0}{h1}/{h2}{h3}/{hash}`.  The same `(source, transforms)`
+//! pair always produces the same key regardless of the `name` label; two
+//! different transform specs always produce different keys.
+//!
+//! ## Budget
+//!
+//! Configurable via `[storage.variants]` in `autumn.toml`; the [`VariantBudget`]
+//! default caps source blobs at 20 MiB and 10 000 × 10 000 px to prevent
+//! runaway memory allocation.
+
+use std::io::Cursor;
+use std::time::Duration;
+
+use bytes::Bytes;
+use sha2::{Digest, Sha256};
+
+use super::{Blob, BlobStore, BlobStoreError};
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+/// A single transform applied to the source image.
+///
+/// Transforms are applied in order and serialised to JSON for content
+/// addressing — the order matters for both the visual output and the
+/// cache key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
+pub enum Transform {
+    /// Resize to fit within `width × height`, preserving aspect ratio.
+    /// Never upscales: an image smaller than the limit is stored as-is.
+    ResizeToLimit {
+        /// Maximum output width in pixels.
+        width: u32,
+        /// Maximum output height in pixels.
+        height: u32,
+    },
+    /// Resize and crop to exactly `width × height`, centred.
+    ResizeToFill {
+        /// Exact output width in pixels.
+        width: u32,
+        /// Exact output height in pixels.
+        height: u32,
+    },
+    /// Rotate clockwise by the given number of degrees.
+    /// Values outside {90, 180, 270} are treated as no-op rotations.
+    Rotate {
+        /// Clockwise rotation in degrees (0, 90, 180, or 270).
+        degrees: u16,
+    },
+    /// Strip all embedded metadata (EXIF, GPS, ICC profiles, comment chunks).
+    ///
+    /// Re-encoding through the `image` crate already drops EXIF data; this
+    /// variant is a no-op on pixel data but explicitly documents the intent so
+    /// the transform spec is unambiguous.
+    StripMetadata,
+}
+
+impl Transform {
+    /// Shorthand constructor for [`Transform::ResizeToLimit`].
+    #[must_use]
+    pub const fn resize_to_limit(width: u32, height: u32) -> Self {
+        Self::ResizeToLimit { width, height }
+    }
+
+    /// Shorthand constructor for [`Transform::ResizeToFill`].
+    #[must_use]
+    pub const fn resize_to_fill(width: u32, height: u32) -> Self {
+        Self::ResizeToFill { width, height }
+    }
+
+    /// Shorthand constructor for [`Transform::Rotate`].
+    #[must_use]
+    pub const fn rotate(degrees: u16) -> Self {
+        Self::Rotate { degrees }
+    }
+
+    /// Shorthand constructor for [`Transform::StripMetadata`].
+    #[must_use]
+    pub const fn strip_metadata() -> Self {
+        Self::StripMetadata
+    }
+}
+
+/// Resource limits for variant generation.
+///
+/// Set via `[storage.variants]` in `autumn.toml`; the defaults are
+/// deliberately conservative to prevent runaway memory allocation from
+/// pathologically large source images.
+#[derive(Debug, Clone)]
+pub struct VariantBudget {
+    /// Maximum byte size of the source blob. Default: 20 MiB.
+    pub max_source_bytes: u64,
+    /// Maximum pixel width of the source image. Default: 10 000.
+    pub max_source_width: u32,
+    /// Maximum pixel height of the source image. Default: 10 000.
+    pub max_source_height: u32,
+}
+
+impl Default for VariantBudget {
+    fn default() -> Self {
+        Self {
+            max_source_bytes: 20 * 1024 * 1024, // 20 MiB
+            max_source_width: 10_000,
+            max_source_height: 10_000,
+        }
+    }
+}
+
+/// Errors returned by variant operations.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum VariantError {
+    /// The source blob's content type is not a supported image format.
+    /// Only `image/jpeg`, `image/png`, and `image/webp` are accepted.
+    #[error("unsupported MIME type for image variant: {0}")]
+    UnsupportedMimeType(String),
+
+    /// The source blob exceeds [`VariantBudget::max_source_bytes`].
+    #[error(
+        "source blob too large for variant generation: {byte_size} bytes \
+         (budget: {max_bytes} bytes)"
+    )]
+    SourceTooLarge { byte_size: u64, max_bytes: u64 },
+
+    /// The decoded source image exceeds the pixel budget.
+    #[error(
+        "source image dimensions too large: {width}×{height} px \
+         (budget: {max_width}×{max_height} px)"
+    )]
+    SourceDimensionsTooLarge {
+        /// Actual source width.
+        width: u32,
+        /// Actual source height.
+        height: u32,
+        /// Configured maximum width.
+        max_width: u32,
+        /// Configured maximum height.
+        max_height: u32,
+    },
+
+    /// The source bytes could not be decoded as the claimed image format.
+    #[error("image decode/encode error: {0}")]
+    DecodeError(String),
+
+    /// A storage operation failed while checking for or writing the variant.
+    #[error(transparent)]
+    Storage(#[from] BlobStoreError),
+}
+
+/// Handle for a named, lazily-generated image variant.
+///
+/// Created by [`Blob::variant`]; call [`VariantHandle::url`] to generate
+/// the variant on first access and obtain a presigned serving URL.
+#[derive(Debug, Clone)]
+pub struct VariantHandle {
+    source: Blob,
+    name: String,
+    transforms: Vec<Transform>,
+    /// Content-addressed storage key for this variant.
+    variant_key: String,
+}
+
+impl VariantHandle {
+    /// The content-addressed key under which this variant is stored.
+    #[must_use]
+    pub fn key(&self) -> &str {
+        &self.variant_key
+    }
+
+    /// The human-readable label for this variant (does not affect caching).
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The transforms applied to the source image.
+    #[must_use]
+    pub fn transforms(&self) -> &[Transform] {
+        &self.transforms
+    }
+
+    /// Ensure the variant is generated, then return a presigned serving URL.
+    ///
+    /// On the first call the source image is fetched, transformed, and
+    /// persisted under the content-addressed key.  Subsequent calls skip
+    /// generation (`head` cache hit) and call [`BlobStore::presigned_url`]
+    /// directly.
+    ///
+    /// The returned URL is identical in form to any other presigned URL from
+    /// the backend: a route-served HMAC-signed URL for the Local backend and
+    /// a real S3 presigned URL for S3 backends.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VariantError`] when the source MIME type is unsupported,
+    /// the source exceeds the budget, decoding fails, or a storage operation
+    /// fails.
+    pub async fn url(
+        &self,
+        store: &dyn BlobStore,
+        budget: &VariantBudget,
+        expires_in: Duration,
+    ) -> Result<String, VariantError> {
+        self.ensure_generated(store, budget).await?;
+        Ok(store
+            .presigned_url(&self.variant_key, expires_in)
+            .await?)
+    }
+
+    /// Ensure the variant blob exists in the store, returning its handle.
+    ///
+    /// Idempotent: if the variant is already cached this is a single `head`
+    /// call with no image processing.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VariantError`] on generation or storage failure.
+    pub async fn ensure_generated(
+        &self,
+        store: &dyn BlobStore,
+        budget: &VariantBudget,
+    ) -> Result<Blob, VariantError> {
+        // Fast path: variant already in store.
+        if let Some(meta) = store.head(&self.variant_key).await? {
+            return Ok(Blob::new(
+                store.provider_id(),
+                &self.variant_key,
+                &meta.content_type,
+                meta.byte_size,
+            ));
+        }
+        self.generate(store, budget).await
+    }
+
+    /// Fetch the source, decode, transform, encode, and persist.
+    async fn generate(
+        &self,
+        store: &dyn BlobStore,
+        budget: &VariantBudget,
+    ) -> Result<Blob, VariantError> {
+        // Guard byte size before we even fetch — avoids streaming a huge blob
+        // into memory just to reject it.
+        if self.source.byte_size > budget.max_source_bytes {
+            return Err(VariantError::SourceTooLarge {
+                byte_size: self.source.byte_size,
+                max_bytes: budget.max_source_bytes,
+            });
+        }
+
+        // Reject non-image MIME types before touching the store.
+        check_image_mime_type(&self.source.content_type)?;
+
+        let source_bytes = store.get(&self.source.key).await?;
+
+        // Auto-detect format from bytes; the image crate's magic-byte
+        // detection is more reliable than trusting the stored content_type
+        // while still letting `check_image_mime_type` enforce the supported-
+        // format contract above.
+        let img = image::load_from_memory(&source_bytes)
+            .map_err(|e| VariantError::DecodeError(e.to_string()))?;
+
+        // Guard pixel dimensions after decode.
+        if img.width() > budget.max_source_width || img.height() > budget.max_source_height {
+            return Err(VariantError::SourceDimensionsTooLarge {
+                width: img.width(),
+                height: img.height(),
+                max_width: budget.max_source_width,
+                max_height: budget.max_source_height,
+            });
+        }
+
+        let transformed = apply_transforms(img, &self.transforms);
+        let (output_format, output_content_type) =
+            output_format_and_mime(&self.source.content_type);
+        let output_bytes = encode_image(&transformed, output_format)?;
+
+        let blob = store
+            .put(
+                &self.variant_key,
+                output_content_type,
+                Bytes::from(output_bytes),
+            )
+            .await?;
+
+        Ok(blob)
+    }
+}
+
+// ── `Blob` extension ─────────────────────────────────────────────────────────
+
+impl Blob {
+    /// Create a [`VariantHandle`] for the given `name` and `transforms`.
+    ///
+    /// The content-addressed storage key is derived from
+    /// `SHA-256(source_key || NUL || JSON(transforms))` so identical
+    /// transform specs always map to the same cached artifact — the
+    /// human-readable `name` is stored on the handle but does not affect
+    /// the cache key.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use autumn_web::storage::variant::{Transform, VariantBudget};
+    ///
+    /// let handle = user.avatar.variant("thumb", &[Transform::resize_to_limit(200, 200)]);
+    /// let url = handle.url(&*store, &budget, Duration::from_secs(3600)).await?;
+    /// ```
+    #[must_use]
+    pub fn variant(&self, name: &str, transforms: &[Transform]) -> VariantHandle {
+        let key = content_addressed_key(&self.key, transforms);
+        VariantHandle {
+            source: self.clone(),
+            name: name.to_owned(),
+            transforms: transforms.to_vec(),
+            variant_key: key,
+        }
+    }
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/// Return an error when the content type is not a supported image format.
+pub(crate) fn check_image_mime_type(content_type: &str) -> Result<(), VariantError> {
+    let base = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim();
+    match base {
+        "image/jpeg" | "image/jpg" | "image/png" | "image/webp" => Ok(()),
+        other => Err(VariantError::UnsupportedMimeType(other.to_owned())),
+    }
+}
+
+/// Derive the content-addressed storage key for a given source key and
+/// transform spec.
+///
+/// Format: `_variants/{h[0..2]}/{h[2..4]}/{h}` where `h` is the lowercase
+/// hex SHA-256 of `source_key + NUL + JSON(transforms)`.
+pub(crate) fn content_addressed_key(source_key: &str, transforms: &[Transform]) -> String {
+    let spec = serde_json::to_string(transforms).expect("Transform is always serialisable");
+    let mut hasher = Sha256::new();
+    hasher.update(source_key.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(spec.as_bytes());
+    let hash = hasher.finalize();
+    let hash_hex: String = hash
+        .iter()
+        .flat_map(|b| {
+            let hi = (b >> 4) as usize;
+            let lo = (b & 0xf) as usize;
+            const HEX: &[u8] = b"0123456789abcdef";
+            [HEX[hi] as char, HEX[lo] as char]
+        })
+        .collect();
+    format!(
+        "_variants/{}/{}/{}",
+        &hash_hex[..2],
+        &hash_hex[2..4],
+        &hash_hex
+    )
+}
+
+/// Determine the output image format and its MIME type from the source MIME.
+///
+/// - JPEG sources → JPEG output (`image/jpeg`)
+/// - PNG sources  → PNG output  (`image/png`)
+/// - WebP sources → JPEG output (`image/jpeg`) — WebP encode path is kept
+///   simple by transcoding; lossless round-trip is not a requirement here
+fn output_format_and_mime(content_type: &str) -> (image::ImageFormat, &'static str) {
+    let base = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim();
+    match base {
+        "image/png" => (image::ImageFormat::Png, "image/png"),
+        _ => (image::ImageFormat::Jpeg, "image/jpeg"),
+    }
+}
+
+/// Apply each transform in order to the image.
+fn apply_transforms(
+    mut img: image::DynamicImage,
+    transforms: &[Transform],
+) -> image::DynamicImage {
+    use image::imageops::FilterType;
+
+    for transform in transforms {
+        img = match transform {
+            Transform::ResizeToLimit { width, height } => {
+                // Never upscale: if the image already fits, return as-is.
+                if img.width() <= *width && img.height() <= *height {
+                    img
+                } else {
+                    img.resize(*width, *height, FilterType::Lanczos3)
+                }
+            }
+            Transform::ResizeToFill { width, height } => {
+                img.resize_to_fill(*width, *height, FilterType::Lanczos3)
+            }
+            Transform::Rotate { degrees } => match degrees % 360 {
+                90 => img.rotate90(),
+                180 => img.rotate180(),
+                270 => img.rotate270(),
+                _ => img,
+            },
+            // Re-encoding through the `image` crate already drops EXIF; this
+            // variant documents intent without additional pixel mutation.
+            Transform::StripMetadata => img,
+        };
+    }
+    img
+}
+
+/// Encode `img` to bytes using `format`.
+fn encode_image(
+    img: &image::DynamicImage,
+    format: image::ImageFormat,
+) -> Result<Vec<u8>, VariantError> {
+    let mut buf = Cursor::new(Vec::new());
+    img.write_to(&mut buf, format)
+        .map_err(|e| VariantError::DecodeError(e.to_string()))?;
+    Ok(buf.into_inner())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+//
+// TDD phases:
+//   RED   – test bodies written first; without the implementation above they
+//           would not compile / would panic.
+//   GREEN – the implementation above makes all tests pass.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::local::{LocalBlobStore, SigningKey};
+    use std::path::Path;
+    use std::time::Duration;
+
+    // ── test helpers ────────────────────────────────────────────────────
+
+    fn test_store(root: &Path) -> LocalBlobStore {
+        LocalBlobStore::new(
+            "test",
+            root.to_path_buf(),
+            "/_blobs",
+            Duration::from_secs(60),
+            SigningKey::new(b"test-variant-key".to_vec()),
+            vec![],
+        )
+        .unwrap()
+    }
+
+    /// Generate a solid-colour test image in the given format.
+    fn make_test_image(width: u32, height: u32, format: image::ImageFormat) -> Vec<u8> {
+        let img = image::DynamicImage::ImageRgb8(image::RgbImage::new(width, height));
+        let mut buf = Cursor::new(Vec::new());
+        img.write_to(&mut buf, format).unwrap();
+        buf.into_inner()
+    }
+
+    // ── RED: content addressing ──────────────────────────────────────────────
+
+    #[test]
+    fn transform_serialisation_is_stable() {
+        let t = Transform::resize_to_limit(200, 200);
+        let j1 = serde_json::to_string(&t).unwrap();
+        let j2 = serde_json::to_string(&t).unwrap();
+        assert_eq!(j1, j2, "serialisation must be deterministic");
+    }
+
+    #[test]
+    fn same_spec_produces_same_key() {
+        let blob = Blob::new("local", "avatars/1.png", "image/png", 1024);
+        let h1 = blob.variant("thumb", &[Transform::resize_to_limit(200, 200)]);
+        let h2 = blob.variant("thumbnail", &[Transform::resize_to_limit(200, 200)]);
+        assert_eq!(
+            h1.key(),
+            h2.key(),
+            "different names but same spec → same content-addressed key"
+        );
+    }
+
+    #[test]
+    fn different_specs_produce_different_keys() {
+        let blob = Blob::new("local", "avatars/1.png", "image/png", 1024);
+        let h1 = blob.variant("thumb", &[Transform::resize_to_limit(200, 200)]);
+        let h2 = blob.variant("large", &[Transform::resize_to_limit(400, 400)]);
+        assert_ne!(h1.key(), h2.key());
+    }
+
+    #[test]
+    fn different_sources_produce_different_keys() {
+        let b1 = Blob::new("local", "a/1.png", "image/png", 1024);
+        let b2 = Blob::new("local", "a/2.png", "image/png", 1024);
+        let spec = [Transform::resize_to_limit(200, 200)];
+        assert_ne!(b1.variant("t", &spec).key(), b2.variant("t", &spec).key());
+    }
+
+    #[test]
+    fn variant_key_passes_blob_validation() {
+        use crate::storage::validate_key;
+        let blob = Blob::new("local", "avatars/1.png", "image/png", 1024);
+        let key = blob.variant("t", &[Transform::resize_to_limit(200, 200)]).key().to_owned();
+        validate_key(&key)
+            .unwrap_or_else(|e| panic!("variant key {key:?} failed validation: {e}"));
+    }
+
+    #[test]
+    fn variant_key_starts_with_variants_prefix() {
+        let blob = Blob::new("local", "avatars/1.png", "image/png", 1024);
+        let key = blob.variant("t", &[Transform::resize_to_limit(200, 200)]).key().to_owned();
+        assert!(key.starts_with("_variants/"), "key: {key}");
+    }
+
+    // ── RED: MIME-type enforcement ───────────────────────────────────────────
+
+    #[test]
+    fn check_image_mime_type_accepts_jpeg() {
+        check_image_mime_type("image/jpeg").unwrap();
+        check_image_mime_type("image/jpg").unwrap();
+        check_image_mime_type("image/jpeg; charset=utf-8").unwrap();
+    }
+
+    #[test]
+    fn check_image_mime_type_accepts_png() {
+        check_image_mime_type("image/png").unwrap();
+    }
+
+    #[test]
+    fn check_image_mime_type_accepts_webp() {
+        check_image_mime_type("image/webp").unwrap();
+    }
+
+    #[test]
+    fn check_image_mime_type_rejects_pdf() {
+        let err = check_image_mime_type("application/pdf").unwrap_err();
+        assert!(matches!(err, VariantError::UnsupportedMimeType(_)));
+    }
+
+    #[test]
+    fn check_image_mime_type_rejects_video() {
+        let err = check_image_mime_type("video/mp4").unwrap_err();
+        assert!(matches!(err, VariantError::UnsupportedMimeType(_)));
+    }
+
+    #[test]
+    fn check_image_mime_type_rejects_plaintext() {
+        let err = check_image_mime_type("text/plain").unwrap_err();
+        assert!(matches!(err, VariantError::UnsupportedMimeType(_)));
+    }
+
+    #[test]
+    fn check_image_mime_type_rejects_octet_stream() {
+        let err = check_image_mime_type("application/octet-stream").unwrap_err();
+        assert!(matches!(err, VariantError::UnsupportedMimeType(_)));
+    }
+
+    // ── RED: budget enforcement ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn variant_rejects_non_image_blob() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = test_store(dir.path());
+        store
+            .put("doc.pdf", "application/pdf", Bytes::from_static(b"%PDF-1.4"))
+            .await
+            .unwrap();
+        let blob = Blob::new("test", "doc.pdf", "application/pdf", 8);
+        let handle = blob.variant("thumb", &[Transform::resize_to_limit(200, 200)]);
+        let err = handle
+            .ensure_generated(&store, &VariantBudget::default())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, VariantError::UnsupportedMimeType(_)),
+            "expected UnsupportedMimeType, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn variant_rejects_oversized_source_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = test_store(dir.path());
+        let jpeg = make_test_image(4, 4, image::ImageFormat::Jpeg);
+        let actual_size = jpeg.len() as u64;
+        store
+            .put("img.jpg", "image/jpeg", Bytes::from(jpeg))
+            .await
+            .unwrap();
+        // Budget smaller than the actual stored blob.
+        let budget = VariantBudget {
+            max_source_bytes: actual_size - 1,
+            ..Default::default()
+        };
+        // Lie about byte_size in the Blob so the pre-fetch check fires.
+        let blob = Blob::new("test", "img.jpg", "image/jpeg", actual_size);
+        let err = blob
+            .variant("t", &[Transform::resize_to_limit(2, 2)])
+            .ensure_generated(&store, &budget)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, VariantError::SourceTooLarge { .. }),
+            "expected SourceTooLarge, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn variant_rejects_oversized_source_dimensions() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = test_store(dir.path());
+        // 4×4 image.
+        let jpeg = make_test_image(4, 4, image::ImageFormat::Jpeg);
+        store
+            .put("big.jpg", "image/jpeg", Bytes::from(jpeg.clone()))
+            .await
+            .unwrap();
+        let budget = VariantBudget {
+            max_source_width: 3,  // less than 4
+            max_source_height: 3,
+            max_source_bytes: jpeg.len() as u64 * 10, // byte budget is fine
+        };
+        let blob = Blob::new("test", "big.jpg", "image/jpeg", jpeg.len() as u64);
+        let err = blob
+            .variant("t", &[Transform::resize_to_limit(2, 2)])
+            .ensure_generated(&store, &budget)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, VariantError::SourceDimensionsTooLarge { .. }),
+            "expected SourceDimensionsTooLarge, got {err:?}"
+        );
+    }
+
+    // ── RED: generation and caching ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn variant_generates_on_first_call() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = test_store(dir.path());
+        let jpeg = make_test_image(100, 100, image::ImageFormat::Jpeg);
+        store
+            .put("photo.jpg", "image/jpeg", Bytes::from(jpeg.clone()))
+            .await
+            .unwrap();
+        let blob = Blob::new("test", "photo.jpg", "image/jpeg", jpeg.len() as u64);
+        let handle = blob.variant("thumb", &[Transform::resize_to_limit(50, 50)]);
+
+        let variant_blob = handle
+            .ensure_generated(&store, &VariantBudget::default())
+            .await
+            .unwrap();
+        assert_eq!(variant_blob.key, handle.key());
+        assert!(variant_blob.byte_size > 0);
+        assert_eq!(variant_blob.content_type, "image/jpeg");
+    }
+
+    #[tokio::test]
+    async fn variant_is_idempotent_on_second_call() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = test_store(dir.path());
+        let jpeg = make_test_image(60, 60, image::ImageFormat::Jpeg);
+        store
+            .put("avatar.jpg", "image/jpeg", Bytes::from(jpeg.clone()))
+            .await
+            .unwrap();
+        let blob = Blob::new("test", "avatar.jpg", "image/jpeg", jpeg.len() as u64);
+        let handle = blob.variant("thumb", &[Transform::resize_to_limit(30, 30)]);
+        let budget = VariantBudget::default();
+
+        let first = handle.ensure_generated(&store, &budget).await.unwrap();
+        let second = handle.ensure_generated(&store, &budget).await.unwrap();
+        assert_eq!(first.key, second.key);
+        assert_eq!(first.byte_size, second.byte_size);
+    }
+
+    // ── RED: transforms ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn resize_to_limit_respects_max_dimensions() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = test_store(dir.path());
+        let jpeg = make_test_image(100, 80, image::ImageFormat::Jpeg);
+        store
+            .put("img.jpg", "image/jpeg", Bytes::from(jpeg.clone()))
+            .await
+            .unwrap();
+        let blob = Blob::new("test", "img.jpg", "image/jpeg", jpeg.len() as u64);
+        blob.variant("t", &[Transform::resize_to_limit(50, 50)])
+            .ensure_generated(&store, &VariantBudget::default())
+            .await
+            .unwrap();
+
+        let out_bytes = store
+            .get(
+                blob.variant("t", &[Transform::resize_to_limit(50, 50)])
+                    .key(),
+            )
+            .await
+            .unwrap();
+        let out_img = image::load_from_memory(&out_bytes).unwrap();
+        assert!(
+            out_img.width() <= 50 && out_img.height() <= 50,
+            "expected ≤50×50, got {}×{}",
+            out_img.width(),
+            out_img.height()
+        );
+        assert!(out_img.width() > 0 && out_img.height() > 0);
+    }
+
+    #[tokio::test]
+    async fn resize_to_limit_does_not_upscale() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = test_store(dir.path());
+        // Source is already smaller than the limit.
+        let jpeg = make_test_image(20, 20, image::ImageFormat::Jpeg);
+        store
+            .put("small.jpg", "image/jpeg", Bytes::from(jpeg.clone()))
+            .await
+            .unwrap();
+        let blob = Blob::new("test", "small.jpg", "image/jpeg", jpeg.len() as u64);
+        blob.variant("large", &[Transform::resize_to_limit(200, 200)])
+            .ensure_generated(&store, &VariantBudget::default())
+            .await
+            .unwrap();
+
+        let out_bytes = store
+            .get(blob.variant("large", &[Transform::resize_to_limit(200, 200)]).key())
+            .await
+            .unwrap();
+        let out_img = image::load_from_memory(&out_bytes).unwrap();
+        assert!(
+            out_img.width() <= 20 && out_img.height() <= 20,
+            "must not upscale: got {}×{}",
+            out_img.width(),
+            out_img.height()
+        );
+    }
+
+    #[tokio::test]
+    async fn resize_to_fill_produces_exact_dimensions() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = test_store(dir.path());
+        let jpeg = make_test_image(100, 150, image::ImageFormat::Jpeg);
+        store
+            .put("portrait.jpg", "image/jpeg", Bytes::from(jpeg.clone()))
+            .await
+            .unwrap();
+        let blob = Blob::new("test", "portrait.jpg", "image/jpeg", jpeg.len() as u64);
+        blob.variant("square", &[Transform::resize_to_fill(50, 50)])
+            .ensure_generated(&store, &VariantBudget::default())
+            .await
+            .unwrap();
+
+        let out_bytes = store
+            .get(blob.variant("square", &[Transform::resize_to_fill(50, 50)]).key())
+            .await
+            .unwrap();
+        let out_img = image::load_from_memory(&out_bytes).unwrap();
+        assert_eq!(
+            (out_img.width(), out_img.height()),
+            (50, 50),
+            "resize_to_fill must produce exact dimensions"
+        );
+    }
+
+    #[tokio::test]
+    async fn rotate_90_swaps_dimensions() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = test_store(dir.path());
+        // 100×50 landscape image.
+        let jpeg = make_test_image(100, 50, image::ImageFormat::Jpeg);
+        store
+            .put("land.jpg", "image/jpeg", Bytes::from(jpeg.clone()))
+            .await
+            .unwrap();
+        let blob = Blob::new("test", "land.jpg", "image/jpeg", jpeg.len() as u64);
+        blob.variant("rotated", &[Transform::rotate(90)])
+            .ensure_generated(&store, &VariantBudget::default())
+            .await
+            .unwrap();
+
+        let out_bytes = store
+            .get(blob.variant("rotated", &[Transform::rotate(90)]).key())
+            .await
+            .unwrap();
+        let out_img = image::load_from_memory(&out_bytes).unwrap();
+        assert_eq!(
+            (out_img.width(), out_img.height()),
+            (50, 100),
+            "90° rotation must swap width and height"
+        );
+    }
+
+    #[tokio::test]
+    async fn rotate_180_preserves_dimensions() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = test_store(dir.path());
+        let jpeg = make_test_image(100, 60, image::ImageFormat::Jpeg);
+        store
+            .put("img.jpg", "image/jpeg", Bytes::from(jpeg.clone()))
+            .await
+            .unwrap();
+        let blob = Blob::new("test", "img.jpg", "image/jpeg", jpeg.len() as u64);
+        blob.variant("r180", &[Transform::rotate(180)])
+            .ensure_generated(&store, &VariantBudget::default())
+            .await
+            .unwrap();
+
+        let out_bytes = store
+            .get(blob.variant("r180", &[Transform::rotate(180)]).key())
+            .await
+            .unwrap();
+        let out_img = image::load_from_memory(&out_bytes).unwrap();
+        assert_eq!(
+            (out_img.width(), out_img.height()),
+            (100, 60),
+            "180° rotation must preserve dimensions"
+        );
+    }
+
+    #[tokio::test]
+    async fn strip_metadata_produces_valid_image() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = test_store(dir.path());
+        let jpeg = make_test_image(10, 10, image::ImageFormat::Jpeg);
+        store
+            .put("meta.jpg", "image/jpeg", Bytes::from(jpeg.clone()))
+            .await
+            .unwrap();
+        let blob = Blob::new("test", "meta.jpg", "image/jpeg", jpeg.len() as u64);
+        blob.variant("stripped", &[Transform::strip_metadata()])
+            .ensure_generated(&store, &VariantBudget::default())
+            .await
+            .unwrap();
+
+        let out_bytes = store
+            .get(blob.variant("stripped", &[Transform::strip_metadata()]).key())
+            .await
+            .unwrap();
+        assert!(
+            image::load_from_memory(&out_bytes).is_ok(),
+            "StripMetadata output must be a valid image"
+        );
+    }
+
+    // ── RED: PNG source ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn png_source_is_processed_and_cached() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = test_store(dir.path());
+        let png = make_test_image(40, 40, image::ImageFormat::Png);
+        store
+            .put("icon.png", "image/png", Bytes::from(png.clone()))
+            .await
+            .unwrap();
+        let blob = Blob::new("test", "icon.png", "image/png", png.len() as u64);
+        let variant_blob = blob
+            .variant("small", &[Transform::resize_to_limit(20, 20)])
+            .ensure_generated(&store, &VariantBudget::default())
+            .await
+            .unwrap();
+        assert_eq!(variant_blob.content_type, "image/png");
+
+        let out_bytes = store.get(&variant_blob.key).await.unwrap();
+        let out_img = image::load_from_memory(&out_bytes).unwrap();
+        assert!(
+            out_img.width() <= 20 && out_img.height() <= 20,
+            "PNG variant dimensions: {}×{}",
+            out_img.width(),
+            out_img.height()
+        );
+    }
+
+    // ── RED: WebP source ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn webp_source_is_processed_to_jpeg() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = test_store(dir.path());
+        // Encode the source as WebP.
+        let webp = make_test_image(40, 40, image::ImageFormat::WebP);
+        store
+            .put("photo.webp", "image/webp", Bytes::from(webp.clone()))
+            .await
+            .unwrap();
+        let blob = Blob::new("test", "photo.webp", "image/webp", webp.len() as u64);
+        let variant_blob = blob
+            .variant("thumb", &[Transform::resize_to_limit(20, 20)])
+            .ensure_generated(&store, &VariantBudget::default())
+            .await
+            .unwrap();
+        // WebP sources are transcoded to JPEG.
+        assert_eq!(
+            variant_blob.content_type, "image/jpeg",
+            "WebP source must produce JPEG variant"
+        );
+        let out_bytes = store.get(&variant_blob.key).await.unwrap();
+        assert!(image::load_from_memory(&out_bytes).is_ok());
+    }
+
+    // ── RED: URL helper ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn variant_url_returns_presigned_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = test_store(dir.path());
+        let jpeg = make_test_image(100, 100, image::ImageFormat::Jpeg);
+        store
+            .put("photo.jpg", "image/jpeg", Bytes::from(jpeg.clone()))
+            .await
+            .unwrap();
+        let blob = Blob::new("test", "photo.jpg", "image/jpeg", jpeg.len() as u64);
+        let url = blob
+            .variant("thumb", &[Transform::resize_to_limit(50, 50)])
+            .url(&store, &VariantBudget::default(), Duration::from_secs(300))
+            .await
+            .unwrap();
+        assert!(url.contains("_variants/"), "URL must contain variant key: {url}");
+        assert!(url.contains("exp="), "URL must contain expiry param: {url}");
+        assert!(url.contains("sig="), "URL must contain signature: {url}");
+    }
+
+    // ── RED: handle accessors ────────────────────────────────────────────────
+
+    #[test]
+    fn handle_name_accessor() {
+        let blob = Blob::new("local", "a.png", "image/png", 1);
+        let h = blob.variant("thumbnail", &[Transform::resize_to_limit(200, 200)]);
+        assert_eq!(h.name(), "thumbnail");
+    }
+
+    #[test]
+    fn handle_transforms_accessor() {
+        let transforms = vec![Transform::resize_to_limit(200, 200), Transform::strip_metadata()];
+        let blob = Blob::new("local", "a.png", "image/png", 1);
+        let h = blob.variant("t", &transforms);
+        assert_eq!(h.transforms(), &transforms);
+    }
+
+    // ── RED: content_addressed_key internals ─────────────────────────────────
+
+    #[test]
+    fn content_addressed_key_hex_is_64_chars() {
+        let key = content_addressed_key("avatars/1.png", &[Transform::resize_to_limit(200, 200)]);
+        // format: _variants/xx/xx/<64-hex-chars>
+        let hash_part = key.rsplit('/').next().unwrap();
+        assert_eq!(hash_part.len(), 64, "hash part must be 64 hex chars");
+    }
+
+    #[test]
+    fn order_of_transforms_matters_for_content_addressing() {
+        let blob = Blob::new("local", "a.png", "image/png", 1);
+        let t1 = [Transform::resize_to_limit(200, 200), Transform::rotate(90)];
+        let t2 = [Transform::rotate(90), Transform::resize_to_limit(200, 200)];
+        assert_ne!(
+            blob.variant("x", &t1).key(),
+            blob.variant("x", &t2).key(),
+            "transform order must affect the content-addressed key"
+        );
+    }
+}

--- a/autumn/src/storage/variant.rs
+++ b/autumn/src/storage/variant.rs
@@ -1,7 +1,7 @@
 //! On-demand image variants for stored blobs.
 //!
 //! Variants are lazily generated on first request, stored content-addressably
-//! in the same [`BlobStore`] as the source, and served with a strong ETag and
+//! in the same [`BlobStore`] as the source, and served with a strong `ETag` and
 //! far-future `Cache-Control: immutable` header from that point on.
 //!
 //! ## Quick start
@@ -18,10 +18,11 @@
 //!
 //! ## Content addressing
 //!
-//! The variant key is `SHA-256(source_key + NUL + JSON(transforms))` encoded
-//! under `_variants/{h0}{h1}/{h2}{h3}/{hash}`.  The same `(source, transforms)`
-//! pair always produces the same key regardless of the `name` label; two
-//! different transform specs always produce different keys.
+//! The variant key is `SHA-256(source_key + NUL + etag + NUL + JSON(transforms))`
+//! encoded under `_variants/{h0}{h1}/{h2}{h3}/{hash}`.  The same
+//! `(source content, transforms)` pair always produces the same key regardless
+//! of the `name` label; re-uploading to the same key (new `ETag`) produces a
+//! fresh variant key so stale thumbnails are never served.
 //!
 //! ## Budget
 //!
@@ -280,27 +281,55 @@ impl VariantHandle {
             });
         }
 
-        // Auto-detect format from bytes; the image crate's magic-byte
-        // detection is more reliable than trusting the stored content_type
-        // while still letting `check_image_mime_type` enforce the supported-
-        // format contract above.
-        let img = image::load_from_memory(&source_bytes)
-            .map_err(|e| VariantError::DecodeError(e.to_string()))?;
+        // Offload CPU-bound decode/transform/encode to a blocking thread so
+        // Tokio worker threads are not stalled during image processing.
+        let transforms = self.transforms.clone();
+        let content_type = self.source.content_type.clone();
+        let max_width = budget.max_source_width;
+        let max_height = budget.max_source_height;
 
-        // Guard pixel dimensions after decode.
-        if img.width() > budget.max_source_width || img.height() > budget.max_source_height {
-            return Err(VariantError::SourceDimensionsTooLarge {
-                width: img.width(),
-                height: img.height(),
-                max_width: budget.max_source_width,
-                max_height: budget.max_source_height,
-            });
-        }
+        let (output_bytes, output_content_type) = tokio::task::spawn_blocking(
+            move || -> Result<(Vec<u8>, &'static str), VariantError> {
+                // Use decoder limits to guard against image bombs: a compressed
+                // file under `max_source_bytes` can still expand to gigabytes of
+                // pixel data without this guard.
+                let mut reader = image::ImageReader::new(Cursor::new(&source_bytes[..]))
+                    .with_guessed_format()
+                    .map_err(|e| VariantError::DecodeError(e.to_string()))?;
+                // image::Limits is #[non_exhaustive]; build via Default + field mutation.
+                let mut limits = image::Limits::default();
+                limits.max_image_width = Some(max_width);
+                limits.max_image_height = Some(max_height);
+                reader.limits(limits);
+                let img = reader.decode().map_err(|e| match &e {
+                    image::ImageError::Limits(_) => VariantError::SourceDimensionsTooLarge {
+                        width: 0,
+                        height: 0,
+                        max_width,
+                        max_height,
+                    },
+                    _ => VariantError::DecodeError(e.to_string()),
+                })?;
 
-        let transformed = apply_transforms(img, &self.transforms);
-        let (output_format, output_content_type) =
-            output_format_and_mime(&self.source.content_type);
-        let output_bytes = encode_image(&transformed, output_format)?;
+                // Belt-and-suspenders: if the decoder didn't enforce limits,
+                // catch oversized images here where we know the actual size.
+                if img.width() > max_width || img.height() > max_height {
+                    return Err(VariantError::SourceDimensionsTooLarge {
+                        width: img.width(),
+                        height: img.height(),
+                        max_width,
+                        max_height,
+                    });
+                }
+
+                let transformed = apply_transforms(img, &transforms);
+                let (output_format, output_content_type) = output_format_and_mime(&content_type);
+                let output_bytes = encode_image(&transformed, output_format)?;
+                Ok((output_bytes, output_content_type))
+            },
+        )
+        .await
+        .map_err(|e| VariantError::DecodeError(format!("variant worker panicked: {e}")))??;
 
         let blob = store
             .put(
@@ -335,7 +364,7 @@ impl Blob {
     /// ```
     #[must_use]
     pub fn variant(&self, name: &str, transforms: &[Transform]) -> VariantHandle {
-        let key = content_addressed_key(&self.key, transforms);
+        let key = content_addressed_key(self, transforms);
         VariantHandle {
             source: self.clone(),
             name: name.to_owned(),
@@ -365,15 +394,24 @@ pub(crate) fn check_image_mime_type(content_type: &str) -> Result<(), VariantErr
     }
 }
 
-/// Derive the content-addressed storage key for a given source key and
+/// Derive the content-addressed storage key for a given source blob and
 /// transform spec.
 ///
 /// Format: `_variants/{h[0..2]}/{h[2..4]}/{h}` where `h` is the lowercase
-/// hex SHA-256 of `source_key + NUL + JSON(transforms)`.
-pub(crate) fn content_addressed_key(source_key: &str, transforms: &[Transform]) -> String {
+/// hex SHA-256 of `source_key + NUL + etag + NUL + JSON(transforms)`.
+///
+/// The `etag` component means that re-uploading to the same key (producing a
+/// new `ETag`) invalidates any previously cached variant — preventing stale
+/// thumbnails when avatars or other mutable blobs are replaced in-place.
+/// When the source blob has no `etag`, the hash falls back to key + transforms.
+pub(crate) fn content_addressed_key(source_blob: &Blob, transforms: &[Transform]) -> String {
     let spec = serde_json::to_string(transforms).expect("Transform is always serialisable");
     let mut hasher = Sha256::new();
-    hasher.update(source_key.as_bytes());
+    hasher.update(source_blob.key.as_bytes());
+    hasher.update(b"\0");
+    if let Some(etag) = &source_blob.etag {
+        hasher.update(etag.as_bytes());
+    }
     hasher.update(b"\0");
     hasher.update(spec.as_bytes());
     let hash = hasher.finalize();
@@ -519,6 +557,23 @@ mod tests {
         let b2 = Blob::new("local", "a/2.png", "image/png", 1024);
         let spec = [Transform::resize_to_limit(200, 200)];
         assert_ne!(b1.variant("t", &spec).key(), b2.variant("t", &spec).key());
+    }
+
+    #[test]
+    fn same_source_key_different_etag_produces_different_keys() {
+        // Simulates a re-upload to the same key (e.g. avatars/{id}.bin):
+        // the new ETag must produce a different variant key so the old
+        // cached thumbnail is not served for the new content.
+        let mut b1 = Blob::new("local", "avatars/1.png", "image/png", 1024);
+        b1.etag = Some("sha256-aabbcc".to_owned());
+        let mut b2 = Blob::new("local", "avatars/1.png", "image/png", 2048);
+        b2.etag = Some("sha256-ddeeff".to_owned());
+        let spec = [Transform::resize_to_limit(100, 100)];
+        assert_ne!(
+            b1.variant("thumb", &spec).key(),
+            b2.variant("thumb", &spec).key(),
+            "different ETags on the same source key must yield different variant keys"
+        );
     }
 
     #[test]
@@ -992,7 +1047,8 @@ mod tests {
 
     #[test]
     fn content_addressed_key_hex_is_64_chars() {
-        let key = content_addressed_key("avatars/1.png", &[Transform::resize_to_limit(200, 200)]);
+        let blob = Blob::new("local", "avatars/1.png", "image/png", 1024);
+        let key = content_addressed_key(&blob, &[Transform::resize_to_limit(200, 200)]);
         // format: _variants/xx/xx/<64-hex-chars>
         let hash_part = key.rsplit('/').next().unwrap();
         assert_eq!(hash_part.len(), 64, "hash part must be 64 hex chars");

--- a/autumn/src/storage/variant.rs
+++ b/autumn/src/storage/variant.rs
@@ -283,12 +283,13 @@ impl VariantHandle {
     ) -> Result<Blob, VariantError> {
         // Fast path: variant already in store.
         if let Some(meta) = store.head(&self.variant_key).await? {
-            return Ok(Blob::new(
-                store.provider_id(),
-                &self.variant_key,
-                &meta.content_type,
-                meta.byte_size,
-            ));
+            return Ok(Blob {
+                provider_id: store.provider_id().to_owned(),
+                key: self.variant_key.clone(),
+                content_type: meta.content_type,
+                byte_size: meta.byte_size,
+                etag: meta.etag,
+            });
         }
         self.generate(store, budget).await
     }

--- a/docs/guide/storage-variants.md
+++ b/docs/guide/storage-variants.md
@@ -68,7 +68,7 @@ async fn upload_avatar(
 ```rust,ignore
 use std::time::Duration;
 use autumn_web::prelude::*;
-use autumn_web::storage::{BlobStoreState, variant::{Transform, VariantBudget}};
+use autumn_web::storage::{BlobStoreState, variant::{Transform, VariantBudget, VariantError}};
 
 #[get("/users/:id/avatar/thumb")]
 async fn avatar_thumb(
@@ -98,7 +98,7 @@ async fn avatar_thumb(
     let url = handle
         .url(&**store, &budget, Duration::from_secs(3600))
         .await
-        .map_err(|e| AutumnError::internal_server_error(e))?;
+        .map_err(VariantError::into_autumn_error)?;
 
     Ok(Redirect::to(url))
 }

--- a/docs/guide/storage-variants.md
+++ b/docs/guide/storage-variants.md
@@ -1,0 +1,297 @@
+# Image Variants
+
+On-demand image resizing, rotation, and metadata stripping for stored blobs —
+with content-addressed caching so transforms run at most once.
+
+## When you need it
+
+Use variants whenever you store user-uploaded images and need to serve them at
+different sizes or orientations without writing your own image pipeline, job
+glue, or cache invalidation.
+
+## Prerequisites
+
+Enable both the `storage` and `variants` features on `autumn-web`:
+
+```toml
+[dependencies]
+autumn-web = { version = "0.5", features = ["storage", "multipart", "variants"] }
+```
+
+The `variants` feature pulls in the `image` crate (JPEG, PNG, WebP codecs)
+behind this flag so apps that don't need image processing don't pay the compile
+cost.
+
+## Quick start: avatar → 200×200 thumbnail served from S3 with caching
+
+This walkthrough covers the full path from upload to cached thumbnail, under 100
+lines of user code.
+
+### 1. Upload the source image (unchanged from the storage guide)
+
+```rust,ignore
+use autumn_web::extract::{Multipart, State};
+use autumn_web::prelude::*;
+use autumn_web::storage::{Blob, BlobStoreState};
+
+#[post("/avatar")]
+async fn upload_avatar(
+    State(blobs): State<BlobStoreState>,
+    mut db: Db,
+    session: Session,
+    mut form: Multipart,
+) -> AutumnResult<Redirect> {
+    let store = blobs.store().clone();
+    let user_id: i64 = session.get("user_id").unwrap();
+
+    while let Some(field) = form.next_field().await? {
+        if field.name() == Some("avatar") {
+            let key = format!("avatars/{user_id}.jpg");
+            let blob: Blob = field
+                .save_to_blob_store(&*store, &key)
+                .await?;
+
+            diesel::update(users::table.find(user_id))
+                .set(users::avatar.eq(Some(blob)))
+                .execute(&mut *db)
+                .await?;
+
+            return Ok(Redirect::to("/profile"));
+        }
+    }
+    Err(AutumnError::bad_request_msg("missing 'avatar' field"))
+}
+```
+
+### 2. Serve the thumbnail
+
+```rust,ignore
+use std::time::Duration;
+use autumn_web::prelude::*;
+use autumn_web::storage::{BlobStoreState, variant::{Transform, VariantBudget}};
+
+#[get("/users/:id/avatar/thumb")]
+async fn avatar_thumb(
+    State(blobs): State<BlobStoreState>,
+    mut db: Db,
+    Path(user_id): Path<i64>,
+) -> AutumnResult<Redirect> {
+    let user: User = users::table.find(user_id).first(&mut *db).await?;
+    let avatar = user
+        .avatar
+        .ok_or_else(|| AutumnError::not_found_msg("no avatar"))?;
+
+    let store = blobs.store();
+    let budget = VariantBudget::default(); // or load from config
+
+    // Declare the variant: resize to fit within 200×200, strip EXIF.
+    let handle = avatar.variant(
+        "thumb",
+        &[
+            Transform::resize_to_limit(200, 200),
+            Transform::strip_metadata(),
+        ],
+    );
+
+    // First call: fetches source, generates variant, stores it, returns URL.
+    // Subsequent calls: skips generation (cache hit), returns URL directly.
+    let url = handle
+        .url(&**store, &budget, Duration::from_secs(3600))
+        .await
+        .map_err(|e| AutumnError::internal_server_error(e))?;
+
+    Ok(Redirect::to(url))
+}
+```
+
+The `url()` method:
+
+1. Calls `store.head(variant_key)` — if the variant is already cached, goes
+   directly to step 3.
+2. Fetches the source bytes, decodes the image, applies transforms, encodes,
+   and stores the result under a content-addressed key.
+3. Calls `store.presigned_url(variant_key, expires_in)` — a route-served
+   HMAC-signed URL on the Local backend; a real S3 presigned URL on the S3
+   backend.
+
+The behaviour is identical in `dev` (Local backend) and `prod` (S3 backend) —
+you write no backend-specific code.
+
+## Available transforms
+
+```rust,ignore
+use autumn_web::storage::variant::Transform;
+
+// Resize to fit within the box, maintaining aspect ratio.
+// Never upscales an image that already fits.
+Transform::resize_to_limit(width, height)
+
+// Resize and crop to exactly width × height (centred).
+Transform::resize_to_fill(width, height)
+
+// Rotate clockwise; valid values: 90, 180, 270 (others are no-ops).
+Transform::rotate(degrees)
+
+// Strip all embedded metadata (EXIF, GPS, ICC profiles).
+// Re-encoding through the image crate already drops EXIF; this transform
+// documents the intent explicitly.
+Transform::strip_metadata()
+```
+
+Transforms are applied in order and all four compose freely:
+
+```rust,ignore
+let handle = blob.variant("card", &[
+    Transform::resize_to_fill(400, 300),
+    Transform::strip_metadata(),
+]);
+```
+
+## Supported formats
+
+| Source format | Decoded by | Output format |
+|---|---|---|
+| JPEG (`image/jpeg`) | `image` crate | JPEG |
+| PNG  (`image/png`)  | `image` crate | PNG  |
+| WebP (`image/webp`) | `image` crate | JPEG (transcoded) |
+
+Non-image MIME types (PDFs, videos, binaries) are rejected with
+`VariantError::UnsupportedMimeType` before any bytes are fetched from storage.
+
+## Content addressing
+
+The variant's storage key is `SHA-256(source_key || NUL || JSON(transforms))`
+encoded as `_variants/{h[0..2]}/{h[2..4]}/{h}`:
+
+- The same source and same transforms always produce the same key.
+- The human-readable `name` label (e.g. `"thumb"`) is stored on the handle but
+  does not affect the cache key — it's a hint for your own code.
+- Different specs (different dimensions, different transform order) produce
+  different keys without any coordination.
+
+## ETag and cache headers
+
+Variants are stored as ordinary blobs and served through the same presigned-URL
+path as any other blob.  The Local backend's serving route adds `ETag` from the
+blob's SHA-256 sidecar; S3 returns the S3 ETag.  Because the key is content-
+addressed, the URL never changes for the same (source, spec) pair — you can
+safely set `Cache-Control: immutable` on the serving response, or let a CDN
+cache the presigned redirect.
+
+## Resource limits
+
+Variant generation is bounded to prevent a pathologically large source image
+from exhausting worker memory.  Set limits in `autumn.toml`:
+
+```toml
+[storage.variants]
+max_source_bytes  = 20971520  # 20 MiB (default)
+max_source_width  = 10000     # pixels (default)
+max_source_height = 10000     # pixels (default)
+```
+
+Requests that exceed the byte limit are rejected before the source is fetched.
+Requests that exceed the pixel limit are rejected after decode (but before
+transform).  Both produce a `VariantError` that maps to HTTP 413.
+
+Build a `VariantBudget` from your config:
+
+```rust,ignore
+use autumn_web::storage::variant::VariantBudget;
+
+let budget = VariantBudget {
+    max_source_bytes:  config.storage.variants.max_source_bytes,
+    max_source_width:  config.storage.variants.max_source_width,
+    max_source_height: config.storage.variants.max_source_height,
+};
+```
+
+Or use the defaults:
+
+```rust,ignore
+let budget = VariantBudget::default(); // 20 MiB, 10 000 × 10 000 px
+```
+
+## Background generation
+
+For routes where you can't afford the decode-and-encode latency on the request
+path, generate the variant in a background job and redirect to a placeholder
+while it completes:
+
+```rust,ignore
+use autumn_web::storage::variant::{Transform, VariantBudget};
+
+#[job]
+async fn generate_variant_job(state: AppState, payload: serde_json::Value) {
+    let blob: Blob = serde_json::from_value(payload["blob"].clone()).unwrap();
+    let transforms: Vec<Transform> = serde_json::from_value(payload["transforms"].clone()).unwrap();
+    let blobs = state.extension::<BlobStoreState>().unwrap();
+    let store = blobs.store();
+    let budget = VariantBudget::default();
+    blob.variant("thumb", &transforms)
+        .ensure_generated(&**store, &budget)
+        .await
+        .ok();
+}
+
+#[get("/images/:id/thumb")]
+async fn serve_thumb(
+    State(state): State<AppState>,
+    Path(image_id): Path<i64>,
+    mut db: Db,
+) -> AutumnResult<impl IntoResponse> {
+    let img: Image = images::table.find(image_id).first(&mut *db).await?;
+    let blob = img.file;
+    let store = state.extension::<BlobStoreState>().unwrap().store().clone();
+    let budget = VariantBudget::default();
+    let handle = blob.variant("thumb", &[Transform::resize_to_limit(200, 200)]);
+
+    // Try cache first; if cold, enqueue the job and return a placeholder redirect.
+    if store.head(handle.key()).await.ok().flatten().is_some() {
+        let url = store.presigned_url(handle.key(), Duration::from_secs(3600)).await?;
+        return Ok(Redirect::to(url).into_response());
+    }
+
+    // Enqueue generation job.
+    state.jobs().enqueue("generate_variant_job", serde_json::json!({
+        "blob": blob,
+        "transforms": [{"ResizeToLimit": {"width": 200, "height": 200}}],
+    })).await?;
+
+    // Return placeholder while job runs.
+    Ok(Redirect::to("/static/placeholder-thumb.png").into_response())
+}
+```
+
+## Error handling
+
+```rust,ignore
+use autumn_web::storage::variant::VariantError;
+
+match handle.ensure_generated(&**store, &budget).await {
+    Ok(blob) => { /* use blob.key for presigned_url */ }
+    Err(VariantError::UnsupportedMimeType(mime)) => {
+        // 400: caller uploaded a PDF, video, etc.
+    }
+    Err(VariantError::SourceTooLarge { byte_size, max_bytes }) => {
+        // 413: source exceeds budget.max_source_bytes
+    }
+    Err(VariantError::SourceDimensionsTooLarge { width, height, .. }) => {
+        // 413: decoded image too large
+    }
+    Err(VariantError::DecodeError(msg)) => {
+        // 422: corrupted or unsupported image data
+    }
+    Err(VariantError::Storage(err)) => {
+        // propagate the BlobStoreError
+    }
+}
+```
+
+## Works with both backends
+
+The variant layer is fully backend-agnostic: variants are stored via
+`BlobStore::put`, checked via `BlobStore::head`, and served via
+`BlobStore::presigned_url`.  Those three methods work identically on the Local
+backend and the `autumn-storage-s3` backend — no backend-specific user code is
+required.

--- a/docs/guide/storage.md
+++ b/docs/guide/storage.md
@@ -412,10 +412,13 @@ Recommended: set a bucket lifecycle rule (S3) or a cron sweeper (local) to
 delete objects with a well-known "orphan" prefix after a short window (e.g.,
 `tmp/` prefix, 24 h expiry).
 
-## What's out of scope (for now)
+## Image variants
 
-- **Image processing / resizing.** Track separately. `image` and
-  `imageproc` have their own dependency surfaces.
+Resize, rotate, and strip metadata from stored images — lazily, with
+content-addressed caching — via the `variants` feature.  See the
+[Image Variants guide](storage-variants.md) for the full walkthrough.
+
+## What's out of scope (for now)
 - **Native non-S3 backends (GCS, Azure Blob, B2 native).** Anyone
   whose object store speaks S3 is covered by `autumn-storage-s3`. Native
   backends are a future plugin-crate extension.

--- a/examples/reddit-clone/Cargo.toml
+++ b/examples/reddit-clone/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 default-run = "reddit-clone"
 
 [dependencies]
-autumn-web = { path = "../../autumn", features = ["mail", "ws", "presence", "storage", "multipart", "redis"] }
+autumn-web = { path = "../../autumn", features = ["mail", "ws", "presence", "storage", "multipart", "redis", "variants"] }
 async-stream = "0.3"
 axum = { workspace = true }
 bytes = "1"

--- a/examples/reddit-clone/src/routes/auth.rs
+++ b/examples/reddit-clone/src/routes/auth.rs
@@ -7,6 +7,7 @@ use autumn_web::auth::{hash_password, verify_password};
 use autumn_web::extract::Path;
 use autumn_web::extract::State;
 use autumn_web::prelude::*;
+use autumn_web::storage::{Transform, VariantBudget};
 use autumn_web::webhook_outbound::WebhookOutboundManager;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
@@ -387,20 +388,30 @@ pub async fn profile(
         .await
         .map_err(|_| AutumnError::not_found_msg(format!("User u/{name} not found")))?;
 
-    // Mint a presigned URL for the user's avatar (if any) through the
-    // configured BlobStore. In dev that's an HMAC-signed link served by
-    // the framework's mounted `/_blobs` route; in prod it's a real S3
-    // presigned URL.
+    // Serve the avatar as a lazily-generated 64×64 thumbnail with EXIF
+    // stripped.  The variant is content-addressed and generated at most
+    // once; subsequent requests are a single head() cache hit.  In dev
+    // the URL is an HMAC-signed `/_blobs/…` link; in prod it's a real
+    // S3 presigned URL.  The expiry is long because the variant key is
+    // immutable — same source + same spec always produces the same bytes.
     let avatar_url = match (
         user.avatar.as_ref(),
         state.extension::<autumn_web::storage::BlobStoreState>(),
     ) {
-        (Some(blob), Some(blobs)) => blobs
-            .store()
-            .clone()
-            .presigned_url(&blob.key, std::time::Duration::from_secs(300))
+        (Some(blob), Some(blobs)) => {
+            let store = blobs.store();
+            let budget = VariantBudget::default();
+            blob.variant(
+                "thumb",
+                &[
+                    Transform::resize_to_limit(64, 64),
+                    Transform::strip_metadata(),
+                ],
+            )
+            .url(&**store, &budget, std::time::Duration::from_secs(3600))
             .await
-            .ok(),
+            .ok()
+        }
         _ => None,
     };
     let is_self = current_user.as_deref() == Some(user.username.as_str());

--- a/examples/reddit-clone/src/routes/avatars.rs
+++ b/examples/reddit-clone/src/routes/avatars.rs
@@ -59,10 +59,7 @@ pub async fn avatar_form(
     // First visit generates it (and caches it content-addressably in the
     // same BlobStore as the source); subsequent visits are a single head()
     // cache hit.  EXIF/GPS metadata is stripped for privacy.
-    let preview_url = match (
-        user.avatar.as_ref(),
-        state.extension::<BlobStoreState>(),
-    ) {
+    let preview_url = match (user.avatar.as_ref(), state.extension::<BlobStoreState>()) {
         (Some(blob), Some(blobs)) => {
             let store = blobs.store();
             blob.variant(
@@ -72,7 +69,11 @@ pub async fn avatar_form(
                     Transform::strip_metadata(),
                 ],
             )
-            .url(&**store, &VariantBudget::default(), Duration::from_secs(3600))
+            .url(
+                &**store,
+                &VariantBudget::default(),
+                Duration::from_secs(3600),
+            )
             .await
             .ok()
         }

--- a/examples/reddit-clone/src/routes/avatars.rs
+++ b/examples/reddit-clone/src/routes/avatars.rs
@@ -1,15 +1,18 @@
 //! Profile-picture (avatar) upload routes.
 //!
-//! Demonstrates the autumn-web `[storage]` feature end-to-end: a
-//! `Blob` column on a `#[model]`, a multipart upload that streams
-//! straight into the configured `BlobStore`, and a presigned URL
-//! rendered in the user profile page. With `storage.backend = "local"`
-//! (the dev default) bytes land under `target/blobs/`; with `s3`
-//! they land in your bucket. The route is identical either way.
+//! Demonstrates the autumn-web `[storage]` and `[variants]` features
+//! end-to-end: a `Blob` column on a `#[model]`, a multipart upload that
+//! streams straight into the configured `BlobStore`, and on-demand
+//! thumbnail generation via `blob.variant(…)`.  With
+//! `storage.backend = "local"` (the dev default) bytes land under
+//! `target/blobs/`; with `s3` they land in your bucket.  The routes
+//! are identical either way.
+
+use std::time::Duration;
 
 use autumn_web::extract::{Multipart, State};
 use autumn_web::prelude::*;
-use autumn_web::storage::{Blob, BlobStoreState};
+use autumn_web::storage::{Blob, BlobStoreState, Transform, VariantBudget};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
@@ -35,7 +38,12 @@ const AVATAR_ALLOWED_MIME_TYPES: &[&str] = &["image/png", "image/jpeg", "image/w
 
 #[get("/settings/avatar")]
 #[secured]
-pub async fn avatar_form(session: Session, csrf: CsrfToken, mut db: Db) -> AutumnResult<Markup> {
+pub async fn avatar_form(
+    State(state): State<AppState>,
+    session: Session,
+    csrf: CsrfToken,
+    mut db: Db,
+) -> AutumnResult<Markup> {
     let username = session
         .get("username")
         .await
@@ -47,6 +55,30 @@ pub async fn avatar_form(session: Session, csrf: CsrfToken, mut db: Db) -> Autum
         .await
         .map_err(|_| AutumnError::not_found_msg("user record missing"))?;
 
+    // Lazily generate a 100×100 preview thumbnail for the settings form.
+    // First visit generates it (and caches it content-addressably in the
+    // same BlobStore as the source); subsequent visits are a single head()
+    // cache hit.  EXIF/GPS metadata is stripped for privacy.
+    let preview_url = match (
+        user.avatar.as_ref(),
+        state.extension::<BlobStoreState>(),
+    ) {
+        (Some(blob), Some(blobs)) => {
+            let store = blobs.store();
+            blob.variant(
+                "preview",
+                &[
+                    Transform::resize_to_limit(100, 100),
+                    Transform::strip_metadata(),
+                ],
+            )
+            .url(&**store, &VariantBudget::default(), Duration::from_secs(3600))
+            .await
+            .ok()
+        }
+        _ => None,
+    };
+
     Ok(layout(
         "Profile picture",
         Some(&username),
@@ -54,13 +86,11 @@ pub async fn avatar_form(session: Session, csrf: CsrfToken, mut db: Db) -> Autum
         html! {
             div class="max-w-md mx-auto bg-white rounded-lg shadow p-6" {
                 h1 class="text-2xl font-bold mb-4" { "Profile picture" }
-                @if let Some(blob) = &user.avatar {
-                    p class="text-sm text-gray-500 mb-3" {
-                        "Current: " (blob.byte_size) " bytes"
-                        @if let Some(etag) = &blob.etag {
-                            " · etag " span class="font-mono" { (&etag[..etag.len().min(8)]) }
-                        }
-                    }
+                @if let Some(url) = &preview_url {
+                    img src=(url) alt="current avatar"
+                        class="w-24 h-24 rounded-full object-cover mb-4";
+                } @else if user.avatar.is_some() {
+                    p class="text-sm text-gray-500 mb-3" { "Current avatar (preview unavailable)" }
                 }
                 form action="/settings/avatar" method="post" enctype="multipart/form-data"
                      class="space-y-3" {
@@ -74,8 +104,8 @@ pub async fn avatar_form(session: Session, csrf: CsrfToken, mut db: Db) -> Autum
                     }
                 }
                 p class="text-xs text-gray-400 mt-4" {
-                    "Max " (AVATAR_MAX_BYTES / 1024) " KiB. The bytes flow through the configured \
-                     BlobStore (local in dev, S3 in prod)."
+                    "Max " (AVATAR_MAX_BYTES / 1024) " KiB · JPEG, PNG, or WebP · "
+                    "EXIF metadata is stripped on save."
                 }
             }
         },

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -41,7 +41,7 @@ echo ""
 # Build each publishable crate with its declared docs.rs feature set.
 # autumn-web declares [package.metadata.docs.rs].features which cargo doc
 # does not read directly — we pass them explicitly here.
-AUTUMN_WEB_DOCS_FEATURES="maud,htmx,tailwind,db,cache-moka,ws,flash,multipart,http-client,oauth2,openapi,redis,i18n,storage,mail,seed,system-info,markdown,csv"
+AUTUMN_WEB_DOCS_FEATURES="maud,htmx,tailwind,db,cache-moka,ws,flash,multipart,http-client,oauth2,openapi,redis,i18n,storage,variants,mail,seed,system-info,markdown,csv"
 
 echo "==> autumn-web (explicit docs.rs features)"
 cargo doc -p autumn-web --no-deps \


### PR DESCRIPTION
## Summary

Implements a complete image variant system for stored blobs, enabling lazy generation of resized, rotated, and metadata-stripped images with content-addressed caching. Variants are generated on first request, stored durably in the same `BlobStore` as the source, and served with strong ETags and far-future cache headers.

## Key Changes

- **New `variant` module** (`autumn/src/storage/variant.rs`): 
  - `Transform` enum with four operations: `ResizeToLimit`, `ResizeToFill`, `Rotate`, `StripMetadata`
  - `VariantHandle` for lazy generation and presigned URL serving
  - `VariantBudget` for configurable resource limits (20 MiB, 10k×10k px defaults)
  - `VariantError` with specific error types for MIME validation, budget violations, and decode failures
  - Content-addressed key derivation: `SHA-256(source_key || NUL || JSON(transforms))`
  - Full test suite (40+ tests) covering content addressing, budget enforcement, all transforms, and format handling

- **`Blob::variant()` extension method**: Creates a `VariantHandle` for a named transform spec; identical specs always produce the same cache key regardless of the name label

- **Configuration support** (`autumn/src/storage/config.rs`):
  - New `StorageVariantsConfig` struct with `max_source_bytes`, `max_source_width`, `max_source_height`
  - Environment variable overrides via `AUTUMN_STORAGE__VARIANTS__*`
  - Integrated into `StorageConfig`

- **Feature flag**: New `variants` feature in `autumn/Cargo.toml` that gates the `image` crate dependency

- **Documentation** (`docs/guide/storage-variants.md`):
  - Quick-start guide with full upload-to-thumbnail example
  - Content addressing and cache key explanation
  - Budget configuration and error handling patterns
  - Background job example for latency-sensitive routes

- **Example integration** (`examples/reddit-clone`):
  - Updated avatar routes to generate 64×64 and 100×100 thumbnails on-demand
  - Demonstrates both presigned URL serving and template rendering with variant URLs
  - Shows how to handle variant generation errors

## Implementation Details

- **Lazy generation**: First call to `VariantHandle::url()` or `ensure_generated()` fetches source, decodes, transforms, encodes, and persists; subsequent calls skip generation (single `head` cache hit)
- **Format handling**: JPEG/PNG sources preserve format; WebP sources transcode to JPEG
- **Budget enforcement**: Byte size checked before fetch (avoids streaming); pixel dimensions checked after decode (before transform)
- **Backend-agnostic**: Works identically with Local and S3 backends via the `BlobStore` trait
- **Deterministic caching**: Transform specs are JSON-serialized for stable hashing; order matters for both visual output and cache keys

https://claude.ai/code/session_01Auz9JbgiZiHEEWxYJTHK1g