### PR TITLE
Add GDPR Article 15 & 17 compliance: data export & account deletion

### DIFF
--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2222,7 +2222,8 @@ fn resolve_gdpr_unregistered_tables() -> Vec<String> {
 }
 
 /// Scan all `*.rs` files under `src/` for `GdprRegistry` register calls and
-/// return the set of table names found.
+/// return the set of table names found. Handles both single-line and
+/// rustfmt-formatted multi-line `ModelRegistration::` calls.
 fn collect_gdpr_registered_tables_from_source() -> std::collections::HashSet<String> {
     let mut found = std::collections::HashSet::new();
     let Ok(entries) = glob_rs_files(std::path::Path::new("src")) else {
@@ -2232,25 +2233,49 @@ fn collect_gdpr_registered_tables_from_source() -> std::collections::HashSet<Str
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
-        // Look for patterns like `.register(ModelRegistration::hard_delete("posts"))`
-        // or `.register(ModelRegistration::anonymize("posts"))`.
-        // Start the quote search *after* the `ModelRegistration::` token so that
-        // any earlier string literals on the same line are not mistakenly extracted.
-        for line in content.lines() {
-            if let Some(idx) = line.find("ModelRegistration::") {
-                let rest = &line[idx..];
-                if let Some(start) = rest.find('"') {
-                    if let Some(end) = rest[start + 1..].find('"') {
-                        let name = &rest[start + 1..start + 1 + end];
-                        if !name.is_empty() && !name.contains(' ') {
-                            found.insert(name.to_owned());
-                        }
+        scan_source_for_gdpr_registrations(&content, &mut found);
+    }
+    found
+}
+
+/// Extract `ModelRegistration::` table names from source text, handling both
+/// single-line calls and multi-line rustfmt-formatted calls.
+fn scan_source_for_gdpr_registrations(
+    content: &str,
+    found: &mut std::collections::HashSet<String>,
+) {
+    let lines: Vec<&str> = content.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        if let Some(idx) = line.find("ModelRegistration::") {
+            let rest = &line[idx..];
+            // Try the same line first, then the next 3 lines for multi-line calls.
+            if extract_quoted_table_name(rest, found) {
+                continue;
+            }
+            for j in 1..=3 {
+                if let Some(next) = lines.get(i + j) {
+                    if extract_quoted_table_name(next.trim(), found) {
+                        break;
                     }
                 }
             }
         }
     }
-    found
+}
+
+/// Extract the first double-quoted string from `s` as a table name.
+/// Returns `true` if a non-empty, non-whitespace name was found and inserted.
+fn extract_quoted_table_name(s: &str, found: &mut std::collections::HashSet<String>) -> bool {
+    if let Some(start) = s.find('"') {
+        if let Some(end) = s[start + 1..].find('"') {
+            let name = &s[start + 1..start + 1 + end];
+            if !name.is_empty() && !name.contains(' ') {
+                found.insert(name.to_owned());
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// Recursively collect all `*.rs` file paths under `dir`.
@@ -3542,6 +3567,56 @@ redirect_uri = "http://localhost/callback"
         assert!(
             detail.contains('3') || detail.contains("3 "),
             "detail must mention the count of unregistered tables: {detail}"
+        );
+    }
+
+    // ── scan_source_for_gdpr_registrations / extract_quoted_table_name ─────────
+
+    #[test]
+    fn scanner_detects_single_line_hard_delete() {
+        let src = r#"registry.register(ModelRegistration::hard_delete("posts"));"#;
+        let mut found = std::collections::HashSet::new();
+        scan_source_for_gdpr_registrations(src, &mut found);
+        assert!(
+            found.contains("posts"),
+            "should detect single-line hard_delete: {found:?}"
+        );
+    }
+
+    #[test]
+    fn scanner_detects_multiline_retain_call() {
+        let src = "registry.register(ModelRegistration::retain(\n    \"invoices\",\n    \"7-year financial hold\",\n));";
+        let mut found = std::collections::HashSet::new();
+        scan_source_for_gdpr_registrations(src, &mut found);
+        assert!(
+            found.contains("invoices"),
+            "should detect multi-line retain registration: {found:?}"
+        );
+    }
+
+    #[test]
+    fn scanner_detects_multiline_anonymize_call() {
+        let src = "registry.register(ModelRegistration::anonymize(\n    \"comments\",\n));";
+        let mut found = std::collections::HashSet::new();
+        scan_source_for_gdpr_registrations(src, &mut found);
+        assert!(
+            found.contains("comments"),
+            "should detect multi-line anonymize registration: {found:?}"
+        );
+    }
+
+    #[test]
+    fn scanner_ignores_string_before_token() {
+        let src = r#"let _x = "not_a_table"; ModelRegistration::hard_delete("real_table");"#;
+        let mut found = std::collections::HashSet::new();
+        scan_source_for_gdpr_registrations(src, &mut found);
+        assert!(
+            found.contains("real_table"),
+            "should contain real_table: {found:?}"
+        );
+        assert!(
+            !found.contains("not_a_table"),
+            "should not contain string before token: {found:?}"
         );
     }
 }

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1913,8 +1913,7 @@ pub fn run(opts: DoctorOptions) {
     //     but #[repository] models are not registered in GdprRegistry).
     //     File-system work runs inside the task so it overlaps with other checks.
     tasks.push(Box::new(|| {
-        let has_auth_starter =
-            std::path::Path::new("src/routes/auth.rs").exists();
+        let has_auth_starter = std::path::Path::new("src/routes/auth.rs").exists();
         let unregistered = resolve_gdpr_unregistered_tables();
         check_gdpr_export_registration_impl(
             has_auth_starter,

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1910,11 +1910,12 @@ pub fn run(opts: DoctorOptions) {
     tasks.push(Box::new(check_system_test_browser));
 
     // 14. GDPR export/erasure registration (warn when auth starter is present
-    //     but #[repository] models are not registered in GdprRegistry)
-    let has_auth_starter =
-        std::path::Path::new("src/routes/auth.rs").exists();
-    let unregistered = resolve_gdpr_unregistered_tables();
-    tasks.push(Box::new(move || {
+    //     but #[repository] models are not registered in GdprRegistry).
+    //     File-system work runs inside the task so it overlaps with other checks.
+    tasks.push(Box::new(|| {
+        let has_auth_starter =
+            std::path::Path::new("src/routes/auth.rs").exists();
+        let unregistered = resolve_gdpr_unregistered_tables();
         check_gdpr_export_registration_impl(
             has_auth_starter,
             &unregistered.iter().map(String::as_str).collect::<Vec<_>>(),
@@ -2196,10 +2197,12 @@ fn resolve_gdpr_unregistered_tables() -> Vec<String> {
             // table name is on the same line or will appear shortly; skip for now
             let _ = rest;
         }
-        // Diesel schema emits bare identifiers like `    table_name (id) {`
-        if trimmed.ends_with("(id) {") || trimmed.ends_with("(id) { ") {
-            if let Some(name) = trimmed.split_whitespace().next() {
-                if !name.starts_with("//") && !name.starts_with("diesel") {
+        // Diesel schema emits bare identifiers like `    table_name (pk) {`
+        // where `pk` can be any column name (id, uuid, code, or composite).
+        if let Some(open_paren) = trimmed.find('(') {
+            if trimmed.ends_with('{') || trimmed.ends_with("{ ") {
+                let name = trimmed[..open_paren].trim();
+                if !name.is_empty() && !name.starts_with("//") && !name.starts_with("diesel") {
                     declared_tables.push(name.to_owned());
                 }
             }
@@ -2223,7 +2226,7 @@ fn resolve_gdpr_unregistered_tables() -> Vec<String> {
 /// return the set of table names found.
 fn collect_gdpr_registered_tables_from_source() -> std::collections::HashSet<String> {
     let mut found = std::collections::HashSet::new();
-    let Ok(entries) = glob_rs_files("src") else {
+    let Ok(entries) = glob_rs_files(std::path::Path::new("src")) else {
         return found;
     };
     for path in entries {
@@ -2232,12 +2235,14 @@ fn collect_gdpr_registered_tables_from_source() -> std::collections::HashSet<Str
         };
         // Look for patterns like `.register(ModelRegistration::hard_delete("posts"))`
         // or `.register(ModelRegistration::anonymize("posts"))`.
+        // Start the quote search *after* the `ModelRegistration::` token so that
+        // any earlier string literals on the same line are not mistakenly extracted.
         for line in content.lines() {
-            if line.contains("ModelRegistration::") {
-                // Extract the quoted table name from the argument list.
-                if let Some(start) = line.find('"') {
-                    if let Some(end) = line[start + 1..].find('"') {
-                        let name = &line[start + 1..start + 1 + end];
+            if let Some(idx) = line.find("ModelRegistration::") {
+                let rest = &line[idx..];
+                if let Some(start) = rest.find('"') {
+                    if let Some(end) = rest[start + 1..].find('"') {
+                        let name = &rest[start + 1..start + 1 + end];
                         if !name.is_empty() && !name.contains(' ') {
                             found.insert(name.to_owned());
                         }
@@ -2250,7 +2255,7 @@ fn collect_gdpr_registered_tables_from_source() -> std::collections::HashSet<Str
 }
 
 /// Recursively collect all `*.rs` file paths under `dir`.
-fn glob_rs_files(dir: &str) -> std::io::Result<Vec<std::path::PathBuf>> {
+fn glob_rs_files(dir: impl AsRef<std::path::Path>) -> std::io::Result<Vec<std::path::PathBuf>> {
     let mut out = Vec::new();
     let Ok(entries) = std::fs::read_dir(dir) else {
         return Ok(out);
@@ -2258,7 +2263,7 @@ fn glob_rs_files(dir: &str) -> std::io::Result<Vec<std::path::PathBuf>> {
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {
-            if let Ok(mut sub) = glob_rs_files(&path.to_string_lossy()) {
+            if let Ok(mut sub) = glob_rs_files(&path) {
                 out.append(&mut sub);
             }
         } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2177,9 +2177,8 @@ pub fn check_system_test_browser() -> CheckResult {
 /// when all tables appear to be registered.
 fn resolve_gdpr_unregistered_tables() -> Vec<String> {
     let schema_path = std::path::Path::new("src/schema.rs");
-    let schema = match std::fs::read_to_string(schema_path) {
-        Ok(s) => s,
-        Err(_) => return Vec::new(),
+    let Ok(schema) = std::fs::read_to_string(schema_path) else {
+        return Vec::new();
     };
 
     // Collect table names declared as `diesel::table! { <name> (id) { ... } }`.
@@ -2198,12 +2197,12 @@ fn resolve_gdpr_unregistered_tables() -> Vec<String> {
         }
         // Diesel schema emits bare identifiers like `    table_name (pk) {`
         // where `pk` can be any column name (id, uuid, code, or composite).
-        if let Some(open_paren) = trimmed.find('(') {
-            if trimmed.ends_with('{') || trimmed.ends_with("{ ") {
-                let name = trimmed[..open_paren].trim();
-                if !name.is_empty() && !name.starts_with("//") && !name.starts_with("diesel") {
-                    declared_tables.push(name.to_owned());
-                }
+        if let Some(open_paren) = trimmed.find('(')
+            && (trimmed.ends_with('{') || trimmed.ends_with("{ "))
+        {
+            let name = trimmed[..open_paren].trim();
+            if !name.is_empty() && !name.starts_with("//") && !name.starts_with("diesel") {
+                declared_tables.push(name.to_owned());
             }
         }
     }

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2156,6 +2156,54 @@ pub fn check_system_test_browser() -> CheckResult {
     }
 }
 
+/// Warn when the auth starter is present but one or more `#[repository]`-annotated
+/// tables have not been registered in the GDPR export/erasure registry.
+///
+/// This check implements GDPR issue #820 AC #8:
+/// > `autumn doctor` warns when repositories exist whose models are not registered
+/// > for export/erasure once the auth starter is present.
+///
+/// `has_auth_starter` should be `true` when the project's `src/routes/auth.rs` exists
+/// (indicating `autumn generate auth` was run).
+/// `unregistered_tables` is the list of `#[repository]`-annotated table names that
+/// have not been registered via `GdprRegistry`.
+pub fn check_gdpr_export_registration_impl(
+    has_auth_starter: bool,
+    unregistered_tables: &[&str],
+) -> CheckResult {
+    if !has_auth_starter {
+        return CheckResult {
+            name: "gdpr_export_registration",
+            status: CheckStatus::Pass,
+            detail: Some("auth starter not present; GDPR registration not required".into()),
+            hint: None,
+        };
+    }
+
+    if unregistered_tables.is_empty() {
+        return CheckResult {
+            name: "gdpr_export_registration",
+            status: CheckStatus::Pass,
+            detail: Some("all repositories are registered for GDPR export/erasure".into()),
+            hint: None,
+        };
+    }
+
+    let tables = unregistered_tables.join(", ");
+    CheckResult {
+        name: "gdpr_export_registration",
+        status: CheckStatus::Warn,
+        detail: Some(format!(
+            "{} repository model(s) not registered for GDPR export/erasure: {tables}",
+            unregistered_tables.len()
+        )),
+        hint: Some(
+            "Register each model via GdprRegistry in your application state. \
+             See docs/guide/gdpr-compliance.md for the export/erasure API.",
+        ),
+    }
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -3297,5 +3345,87 @@ redirect_uri = "http://localhost/callback"
     fn features_has_key_commented_header() {
         let toml = "[features] # project features\nsystem-tests = []\n";
         assert!(cargo_toml_features_has_key(toml, "system-tests"));
+    }
+
+    // ── check_gdpr_export_registration ───────────────────────────────────────
+
+    #[test]
+    fn gdpr_check_passes_when_no_auth_starter() {
+        let r = check_gdpr_export_registration_impl(false, &[]);
+        assert_eq!(
+            r.status,
+            CheckStatus::Pass,
+            "no auth starter → should always pass: {r:?}"
+        );
+    }
+
+    #[test]
+    fn gdpr_check_passes_when_no_auth_starter_even_with_unregistered_tables() {
+        let r = check_gdpr_export_registration_impl(false, &["posts", "comments"]);
+        assert_eq!(
+            r.status,
+            CheckStatus::Pass,
+            "no auth starter → must not warn about unregistered tables: {r:?}"
+        );
+    }
+
+    #[test]
+    fn gdpr_check_passes_when_all_tables_registered() {
+        let r = check_gdpr_export_registration_impl(true, &[]);
+        assert_eq!(
+            r.status,
+            CheckStatus::Pass,
+            "auth starter present + all tables registered → should pass: {r:?}"
+        );
+    }
+
+    #[test]
+    fn gdpr_check_warns_when_unregistered_tables_present() {
+        let r = check_gdpr_export_registration_impl(true, &["posts", "comments"]);
+        assert_eq!(
+            r.status,
+            CheckStatus::Warn,
+            "unregistered tables with auth starter must warn: {r:?}"
+        );
+    }
+
+    #[test]
+    fn gdpr_check_name_is_stable() {
+        let r = check_gdpr_export_registration_impl(false, &[]);
+        assert_eq!(r.name, "gdpr_export_registration");
+    }
+
+    #[test]
+    fn gdpr_check_detail_lists_unregistered_table_names() {
+        let r = check_gdpr_export_registration_impl(true, &["posts", "comments"]);
+        let detail = r.detail.as_deref().unwrap_or("");
+        assert!(
+            detail.contains("posts"),
+            "detail must mention unregistered table 'posts': {detail}"
+        );
+        assert!(
+            detail.contains("comments"),
+            "detail must mention unregistered table 'comments': {detail}"
+        );
+    }
+
+    #[test]
+    fn gdpr_check_hint_references_registry_api() {
+        let r = check_gdpr_export_registration_impl(true, &["orders"]);
+        let hint = r.hint.unwrap_or("");
+        assert!(
+            hint.contains("GdprRegistry") || hint.contains("gdpr"),
+            "hint must reference the GdprRegistry API: {hint}"
+        );
+    }
+
+    #[test]
+    fn gdpr_check_detail_mentions_count_of_unregistered_tables() {
+        let r = check_gdpr_export_registration_impl(true, &["t1", "t2", "t3"]);
+        let detail = r.detail.as_deref().unwrap_or("");
+        assert!(
+            detail.contains('3') || detail.contains("3 "),
+            "detail must mention the count of unregistered tables: {detail}"
+        );
     }
 }

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2226,10 +2226,7 @@ fn resolve_gdpr_unregistered_tables() -> Vec<String> {
 /// rustfmt-formatted multi-line `ModelRegistration::` calls.
 fn collect_gdpr_registered_tables_from_source() -> std::collections::HashSet<String> {
     let mut found = std::collections::HashSet::new();
-    let Ok(entries) = glob_rs_files(std::path::Path::new("src")) else {
-        return found;
-    };
-    for path in entries {
+    for path in glob_rs_files(std::path::Path::new("src")) {
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
@@ -2253,10 +2250,10 @@ fn scan_source_for_gdpr_registrations(
                 continue;
             }
             for j in 1..=3 {
-                if let Some(next) = lines.get(i + j) {
-                    if extract_quoted_table_name(next.trim(), found) {
-                        break;
-                    }
+                if let Some(next) = lines.get(i + j)
+                    && extract_quoted_table_name(next.trim(), found)
+                {
+                    break;
                 }
             }
         }
@@ -2266,35 +2263,33 @@ fn scan_source_for_gdpr_registrations(
 /// Extract the first double-quoted string from `s` as a table name.
 /// Returns `true` if a non-empty, non-whitespace name was found and inserted.
 fn extract_quoted_table_name(s: &str, found: &mut std::collections::HashSet<String>) -> bool {
-    if let Some(start) = s.find('"') {
-        if let Some(end) = s[start + 1..].find('"') {
-            let name = &s[start + 1..start + 1 + end];
-            if !name.is_empty() && !name.contains(' ') {
-                found.insert(name.to_owned());
-                return true;
-            }
+    if let Some(start) = s.find('"')
+        && let Some(end) = s[start + 1..].find('"')
+    {
+        let name = &s[start + 1..start + 1 + end];
+        if !name.is_empty() && !name.contains(' ') {
+            found.insert(name.to_owned());
+            return true;
         }
     }
     false
 }
 
 /// Recursively collect all `*.rs` file paths under `dir`.
-fn glob_rs_files(dir: impl AsRef<std::path::Path>) -> std::io::Result<Vec<std::path::PathBuf>> {
+fn glob_rs_files(dir: impl AsRef<std::path::Path>) -> Vec<std::path::PathBuf> {
     let mut out = Vec::new();
     let Ok(entries) = std::fs::read_dir(dir) else {
-        return Ok(out);
+        return out;
     };
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {
-            if let Ok(mut sub) = glob_rs_files(&path) {
-                out.append(&mut sub);
-            }
+            out.append(&mut glob_rs_files(&path));
         } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
             out.push(path);
         }
     }
-    Ok(out)
+    out
 }
 
 /// Warn when the auth starter is present but one or more `#[repository]`-annotated

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1909,6 +1909,18 @@ pub fn run(opts: DoctorOptions) {
     // 13. System-test browser (warn if missing; not all projects use system tests)
     tasks.push(Box::new(check_system_test_browser));
 
+    // 14. GDPR export/erasure registration (warn when auth starter is present
+    //     but #[repository] models are not registered in GdprRegistry)
+    let has_auth_starter =
+        std::path::Path::new("src/routes/auth.rs").exists();
+    let unregistered = resolve_gdpr_unregistered_tables();
+    tasks.push(Box::new(move || {
+        check_gdpr_export_registration_impl(
+            has_auth_starter,
+            &unregistered.iter().map(String::as_str).collect::<Vec<_>>(),
+        )
+    }));
+
     // ── Phase 3: spawn all tasks concurrently ────────────────────────────────
     let handles: Vec<thread::JoinHandle<CheckResult>> =
         tasks.into_iter().map(thread::spawn).collect();
@@ -2154,6 +2166,106 @@ pub fn check_system_test_browser() -> CheckResult {
             hint: None,
         }
     }
+}
+
+/// Resolve the list of `#[repository]`-annotated table names that are not yet
+/// registered in a `GdprRegistry` in the project source.
+///
+/// Currently uses a lightweight heuristic: scans `src/schema.rs` for `diesel::table!`
+/// declarations and returns those that have no matching `GdprRegistry::register` call
+/// in any `*.rs` source file. Returns an empty list when the project has no schema or
+/// when all tables appear to be registered.
+fn resolve_gdpr_unregistered_tables() -> Vec<String> {
+    let schema_path = std::path::Path::new("src/schema.rs");
+    let schema = match std::fs::read_to_string(schema_path) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+
+    // Collect table names declared as `diesel::table! { <name> (id) { ... } }`.
+    let mut declared_tables: Vec<String> = Vec::new();
+    for line in schema.lines() {
+        let trimmed = line.trim();
+        // Match lines like `diesel::table! {` followed by the table name on the next line,
+        // or inline `pub table_name (id) {` patterns.  Use a simple prefix scan.
+        if let Some(rest) = trimmed
+            .strip_prefix("diesel::table!")
+            .map(str::trim)
+            .filter(|r| r.starts_with('{'))
+        {
+            // table name is on the same line or will appear shortly; skip for now
+            let _ = rest;
+        }
+        // Diesel schema emits bare identifiers like `    table_name (id) {`
+        if trimmed.ends_with("(id) {") || trimmed.ends_with("(id) { ") {
+            if let Some(name) = trimmed.split_whitespace().next() {
+                if !name.starts_with("//") && !name.starts_with("diesel") {
+                    declared_tables.push(name.to_owned());
+                }
+            }
+        }
+    }
+
+    if declared_tables.is_empty() {
+        return Vec::new();
+    }
+
+    // Check which tables appear to be registered via GdprRegistry in the project.
+    let registered_tables = collect_gdpr_registered_tables_from_source();
+
+    declared_tables
+        .into_iter()
+        .filter(|t| !registered_tables.contains(t))
+        .collect()
+}
+
+/// Scan all `*.rs` files under `src/` for `GdprRegistry` register calls and
+/// return the set of table names found.
+fn collect_gdpr_registered_tables_from_source() -> std::collections::HashSet<String> {
+    let mut found = std::collections::HashSet::new();
+    let Ok(entries) = glob_rs_files("src") else {
+        return found;
+    };
+    for path in entries {
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        // Look for patterns like `.register(ModelRegistration::hard_delete("posts"))`
+        // or `.register(ModelRegistration::anonymize("posts"))`.
+        for line in content.lines() {
+            if line.contains("ModelRegistration::") {
+                // Extract the quoted table name from the argument list.
+                if let Some(start) = line.find('"') {
+                    if let Some(end) = line[start + 1..].find('"') {
+                        let name = &line[start + 1..start + 1 + end];
+                        if !name.is_empty() && !name.contains(' ') {
+                            found.insert(name.to_owned());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    found
+}
+
+/// Recursively collect all `*.rs` file paths under `dir`.
+fn glob_rs_files(dir: &str) -> std::io::Result<Vec<std::path::PathBuf>> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Ok(out);
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if let Ok(mut sub) = glob_rs_files(&path.to_string_lossy()) {
+                out.append(&mut sub);
+            }
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+    Ok(out)
 }
 
 /// Warn when the auth starter is present but one or more `#[repository]`-annotated

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -483,6 +483,9 @@ pub fn plan_auth_with_providers(
     user_field_tokens.push("confirm_token_digest:Option<String>");
     user_field_tokens.push("confirm_token_expires_at:Option<NaiveDateTime>");
     user_field_tokens.push("email_confirmed_at:Option<NaiveDateTime>");
+    user_field_tokens.push("export_requested_at:Option<NaiveDateTime>");
+    user_field_tokens.push("delete_requested_at:Option<NaiveDateTime>");
+    user_field_tokens.push("delete_scheduled_at:Option<NaiveDateTime>");
     let auth_fields: Vec<super::dsl::Field> = user_field_tokens
         .iter()
         .map(|t| super::dsl::parse_field(t).expect("auth field tokens are always valid"))
@@ -547,6 +550,10 @@ pub fn plan_auth_with_providers(
     plan.create(
         docs_dir.join("authentication.md"),
         render_docs_file(&pascal_name, totp),
+    );
+    plan.create(
+        docs_dir.join("gdpr-compliance.md"),
+        render_gdpr_docs_file(),
     );
 
     // ── src/main.rs — module declarations + route registration ────────────
@@ -1332,6 +1339,9 @@ fn render_migration_up(table: &str, totp: bool) -> String {
          \x20   confirm_token_digest TEXT NULL,\n\
          \x20   confirm_token_expires_at TIMESTAMP NULL,\n\
          \x20   email_confirmed_at TIMESTAMP NULL,\n\
+         \x20   export_requested_at TIMESTAMP NULL,\n\
+         \x20   delete_requested_at TIMESTAMP NULL,\n\
+         \x20   delete_scheduled_at TIMESTAMP NULL,\n\
          \x20   created_at TIMESTAMP NOT NULL DEFAULT NOW()\n\
          );\n"
     );
@@ -1406,6 +1416,12 @@ pub struct {pascal_name} {{
     pub confirm_token_expires_at: Option<chrono::NaiveDateTime>,
     #[default]
     pub email_confirmed_at: Option<chrono::NaiveDateTime>,
+    #[default]
+    pub export_requested_at: Option<chrono::NaiveDateTime>,
+    #[default]
+    pub delete_requested_at: Option<chrono::NaiveDateTime>,
+    #[default]
+    pub delete_scheduled_at: Option<chrono::NaiveDateTime>,
     #[default]
     pub created_at: chrono::NaiveDateTime,
 }}
@@ -2815,6 +2831,374 @@ async fn send_confirmation_email(mailer: &Mailer, to: &str, token: &str) -> Autu
         ))
     }})
 }}
+
+// ── GDPR: Data Export & Account Deletion (Issue #820) ─────────────────────────
+//
+// These routes satisfy GDPR Article 15 (right of access) and Article 17
+// (right to erasure) obligations. Edit freely — all logic is app code.
+
+/// `GET /account/data-export` — "Download my data" request form.
+///
+/// The authenticated user may request a full data archive. The request is
+/// recorded and a background job is enqueued to build the archive and email
+/// a signed download link.
+#[get("/account/data-export")]
+pub async fn data_export_form(
+    session: Session,
+    csrf: Option<CsrfToken>,
+    csrf_field: Option<CsrfFormField>,
+) -> AutumnResult<Response> {{
+    let auth = session
+        .get("{snake_name}_id")
+        .await
+        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
+    let _ = auth;
+    Ok(layout("Download My Data", html! {{
+        h1 {{ "Download My Data" }}
+        p {{
+            "Request a copy of all data we hold about you. You will receive an email \
+             with a secure download link when the archive is ready (usually within a few minutes)."
+        }}
+        form action="/account/data-export" method="post" {{
+            @if let Some(ref csrf) = csrf {{
+                input type="hidden"
+                    name=(csrf_field.as_ref().map_or("_csrf", |f| f.0.as_str()))
+                    value=(csrf.token());
+            }}
+            button type="submit" {{ "Request My Data Archive" }}
+        }}
+        p {{ a href="/account" {{ "← Back to account" }} }}
+    }}).into_response())
+}}
+
+/// `POST /account/data-export` — enqueue the export job (GDPR Article 15).
+///
+/// Stamps `export_requested_at` and enqueues a `data_export_job` that builds
+/// a JSON archive and emails a signed download link via the configured mailer.
+/// The job is idempotent: a second request within the same hour is a no-op.
+#[post("/account/data-export")]
+pub async fn data_export(
+    session: Session,
+    mut db: Db,
+    state: AppState,
+    mailer: Option<Mailer>,
+) -> AutumnResult<Response> {{
+    let {snake_name}_id: i64 = session
+        .get("{snake_name}_id")
+        .await
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
+
+    let now = chrono::Utc::now().naive_utc();
+    diesel::update({table}::table.find({snake_name}_id))
+        .set({table}::export_requested_at.eq(Some(now)))
+        .execute(&mut *db)
+        .await
+        .map_err(|_| AutumnError::internal_server_error_msg("Failed to record export request."))?;
+
+    // Enqueue the background export job.
+    enqueue_data_export_job(&state, {snake_name}_id, mailer.as_ref()).await;
+
+    autumn_web::audit::write_from_state(
+        &state,
+        autumn_web::audit::AuditEvent::new(
+            {snake_name}_id.to_string(),
+            "gdpr.export.requested",
+            {snake_name}_id.to_string(),
+            None,
+            autumn_web::audit::AuditStatus::Success,
+        ),
+    )
+    .await
+    .ok();
+
+    Ok(layout("Export Requested", html! {{
+        h1 {{ "Export Requested" }}
+        p {{
+            "Your data export is being prepared. You will receive an email with a \
+             secure download link when it is ready."
+        }}
+        p {{ a href="/account" {{ "← Back to account" }} }}
+    }}).into_response())
+}}
+
+/// Background export job: build the JSON archive and email a signed link.
+///
+/// In production, move this to a dedicated `src/jobs/data_export.rs` file and
+/// register it with `autumn_web::job::JobClient`. For now it is a plain async
+/// function invoked inline so the starter compiles without a job backend.
+async fn enqueue_data_export_job(
+    state: &AppState,
+    {snake_name}_id: i64,
+    mailer: Option<&Mailer>,
+) {{
+    // TODO: Replace with state.jobs().enqueue("data_export_job", payload).await
+    // when a job backend is configured. This inline stub satisfies the starter
+    // without requiring a running Redis/Postgres job queue.
+    let _ = (state, {snake_name}_id, mailer);
+    tracing::info!(
+        user_id = {snake_name}_id,
+        "data_export_job enqueued (stub — wire up JobClient for production)"
+    );
+}}
+
+#[derive(Deserialize)]
+pub struct DeleteAccountForm {{
+    /// User must type "DELETE" to confirm the irreversible operation.
+    pub confirmation: String,
+}}
+
+/// `GET /account/delete` — account deletion confirmation form.
+///
+/// Requires a confirmation step: the user types "DELETE" before submitting,
+/// reducing accidental deletions.
+#[get("/account/delete")]
+pub async fn delete_account_form(
+    session: Session,
+    csrf: Option<CsrfToken>,
+    csrf_field: Option<CsrfFormField>,
+) -> AutumnResult<Response> {{
+    let auth = session
+        .get("{snake_name}_id")
+        .await
+        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
+    let _ = auth;
+    Ok(layout("Delete My Account", html! {{
+        h1 {{ "Delete My Account" }}
+        p class="warning" {{
+            "⚠️ This action schedules your account for permanent deletion after a \
+             30-day grace period. You may cancel during the grace period by logging in."
+        }}
+        p {{
+            "All data we hold about you will be erased. Data we are legally required \
+             to retain (e.g. financial records) will be anonymized or held under legal-hold \
+             with the reason documented in our audit log."
+        }}
+        form action="/account/delete" method="post" {{
+            @if let Some(ref csrf) = csrf {{
+                input type="hidden"
+                    name=(csrf_field.as_ref().map_or("_csrf", |f| f.0.as_str()))
+                    value=(csrf.token());
+            }}
+            div {{
+                label for="confirmation" {{ "Type DELETE to confirm:" }}
+                input type="text" id="confirmation" name="confirmation"
+                    placeholder="DELETE" autocomplete="off" required;
+            }}
+            button type="submit" {{ "Schedule Account Deletion" }}
+        }}
+        p {{ a href="/account" {{ "← Back to account" }} }}
+    }}).into_response())
+}}
+
+/// `POST /account/delete` — schedule account for deletion (GDPR Article 17).
+///
+/// Records `delete_requested_at` and `delete_scheduled_at` (30-day grace period)
+/// then writes an audit log entry. A background sweeper handles the hard-delete
+/// once the grace period expires. The user is logged out immediately.
+#[post("/account/delete")]
+pub async fn delete_account(
+    session: Session,
+    mut db: Db,
+    state: AppState,
+    axum::Form(form): axum::Form<DeleteAccountForm>,
+) -> AutumnResult<Response> {{
+    let {snake_name}_id: i64 = session
+        .get("{snake_name}_id")
+        .await
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
+
+    // Require the user to type DELETE as a confirmation step.
+    if form.confirmation.trim() != "DELETE" {{
+        return Ok(layout("Delete My Account", html! {{
+            h1 {{ "Delete My Account" }}
+            p class="error" {{ "You must type DELETE (in uppercase) to confirm." }}
+            p {{ a href="/account/delete" {{ "← Back" }} }}
+        }}).into_response());
+    }}
+
+    let now = chrono::Utc::now().naive_utc();
+    let grace_until = now + chrono::Duration::days(30);
+
+    diesel::update({table}::table.find({snake_name}_id))
+        .set((
+            {table}::delete_requested_at.eq(Some(now)),
+            {table}::delete_scheduled_at.eq(Some(grace_until)),
+        ))
+        .execute(&mut *db)
+        .await
+        .map_err(|_| AutumnError::internal_server_error_msg("Failed to schedule deletion."))?;
+
+    autumn_web::audit::write_from_state(
+        &state,
+        autumn_web::audit::AuditEvent::new(
+            {snake_name}_id.to_string(),
+            "gdpr.erasure.requested",
+            {snake_name}_id.to_string(),
+            None,
+            autumn_web::audit::AuditStatus::Success,
+        ),
+    )
+    .await
+    .ok();
+
+    session.destroy().await;
+
+    Ok(layout("Deletion Scheduled", html! {{
+        h1 {{ "Account Deletion Scheduled" }}
+        p {{
+            "Your account has been scheduled for deletion in 30 days. \
+             You will receive a confirmation email."
+        }}
+        p {{
+            "If you change your mind, log in within 30 days and visit \
+             your account settings to cancel."
+        }}
+    }}).into_response())
+}}
+
+/// `POST /account/delete/cancel` — cancel a pending account deletion.
+///
+/// Clears the `delete_requested_at` / `delete_scheduled_at` columns and writes
+/// an audit log entry. Only available during the grace period.
+#[post("/account/delete/cancel")]
+pub async fn cancel_delete_account(
+    session: Session,
+    mut db: Db,
+    state: AppState,
+) -> AutumnResult<Response> {{
+    let {snake_name}_id: i64 = session
+        .get("{snake_name}_id")
+        .await
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
+
+    diesel::update({table}::table.find({snake_name}_id))
+        .set((
+            {table}::delete_requested_at.eq(None::<chrono::NaiveDateTime>),
+            {table}::delete_scheduled_at.eq(None::<chrono::NaiveDateTime>),
+        ))
+        .execute(&mut *db)
+        .await
+        .map_err(|_| AutumnError::internal_server_error_msg("Failed to cancel deletion."))?;
+
+    autumn_web::audit::write_from_state(
+        &state,
+        autumn_web::audit::AuditEvent::new(
+            {snake_name}_id.to_string(),
+            "gdpr.erasure.cancelled",
+            {snake_name}_id.to_string(),
+            None,
+            autumn_web::audit::AuditStatus::Success,
+        ),
+    )
+    .await
+    .ok();
+
+    Ok(redirect_to("/account").into_response())
+}}
+
+// ── Admin GDPR Operations (Issue #820 AC#6) ───────────────────────────────────
+//
+// These routes allow an admin operator to trigger export or erasure on behalf
+// of a user. All operations are fully audited with actor, reason, and timestamp.
+// Mount behind your admin authentication middleware.
+
+#[derive(Deserialize)]
+pub struct AdminGdprActionForm {{
+    /// Free-text reason recorded in the audit log (required for compliance).
+    pub reason: String,
+}}
+
+/// `POST /admin/{table}/:id/data-export` — admin triggers data export for a user.
+///
+/// Stamps `export_requested_at` and enqueues the export job.
+/// Records `actor_id` (the operator) + `reason` in the audit log.
+#[post("/admin/{table}/:id/data-export")]
+pub async fn admin_data_export(
+    Path(user_id): Path<i64>,
+    session: Session,
+    mut db: Db,
+    state: AppState,
+    mailer: Option<Mailer>,
+    axum::Form(form): axum::Form<AdminGdprActionForm>,
+) -> AutumnResult<Response> {{
+    let operator_id: String = session
+        .get("{snake_name}_id")
+        .await
+        .unwrap_or_else(|| "admin".to_owned());
+
+    let now = chrono::Utc::now().naive_utc();
+    diesel::update({table}::table.find(user_id))
+        .set({table}::export_requested_at.eq(Some(now)))
+        .execute(&mut *db)
+        .await
+        .map_err(|_| AutumnError::internal_server_error_msg("Failed to record export request."))?;
+
+    enqueue_data_export_job(&state, user_id, mailer.as_ref()).await;
+
+    autumn_web::audit::write_from_state(
+        &state,
+        autumn_web::audit::AuditEvent::new(
+            operator_id,
+            "gdpr.export.admin_triggered",
+            user_id.to_string(),
+            None,
+            autumn_web::audit::AuditStatus::Success,
+        ),
+    )
+    .await
+    .ok();
+
+    let _ = form.reason; // reason is logged via the audit system above
+    Ok(redirect_to(&format!("/admin/{table}/{{user_id}}")).into_response())
+}}
+
+/// `POST /admin/{table}/:id/delete` — admin triggers account erasure for a user.
+///
+/// Schedules the account for deletion (30-day grace period).
+/// Records `actor_id` (the operator), `reason`, and timestamp in the audit log.
+#[post("/admin/{table}/:id/delete")]
+pub async fn admin_delete_account(
+    Path(user_id): Path<i64>,
+    session: Session,
+    mut db: Db,
+    state: AppState,
+    axum::Form(form): axum::Form<AdminGdprActionForm>,
+) -> AutumnResult<Response> {{
+    let operator_id: String = session
+        .get("{snake_name}_id")
+        .await
+        .unwrap_or_else(|| "admin".to_owned());
+
+    let now = chrono::Utc::now().naive_utc();
+    let grace_until = now + chrono::Duration::days(30);
+
+    diesel::update({table}::table.find(user_id))
+        .set((
+            {table}::delete_requested_at.eq(Some(now)),
+            {table}::delete_scheduled_at.eq(Some(grace_until)),
+        ))
+        .execute(&mut *db)
+        .await
+        .map_err(|_| AutumnError::internal_server_error_msg("Failed to schedule deletion."))?;
+
+    autumn_web::audit::write_from_state(
+        &state,
+        autumn_web::audit::AuditEvent::new(
+            operator_id,
+            format!("gdpr.erasure.admin_triggered reason={{}}", form.reason),
+            user_id.to_string(),
+            None,
+            autumn_web::audit::AuditStatus::Success,
+        ),
+    )
+    .await
+    .ok();
+
+    Ok(redirect_to(&format!("/admin/{table}/{{user_id}}")).into_response())
+}}
 {totp_section}"#
     )
 }
@@ -3626,6 +4010,99 @@ Then open <http://localhost:3000/signup> to create your first account.
     )
 }
 
+/// Render `docs/guide/gdpr-compliance.md` — GDPR/CCPA compliance checklist.
+///
+/// Documents exactly which generated artifacts satisfy Article 15 (right of
+/// access) and Article 17 (right to erasure), and which obligations remain the
+/// application developer's responsibility.
+fn render_gdpr_docs_file() -> String {
+    r#"# GDPR & CCPA Compliance Checklist
+
+This document describes the data-privacy obligations covered by the generated
+auth starter and those that remain the application developer's responsibility.
+
+## What the Auth Starter Provides
+
+### Article 15 — Right of Access (`GET /account/data-export`)
+
+| Artifact | Location |
+|---|---|
+| Self-service "Download my data" form | `GET /account/data-export` |
+| Export-request POST handler | `POST /account/data-export` |
+| `export_requested_at` column on the users table | Migration + model |
+| Audit log entry on request (`gdpr.export.requested`) | `src/routes/auth.rs` |
+| Background export job stub (wire up `JobClient` for production) | `src/routes/auth.rs` |
+
+### Article 17 — Right to Erasure (`POST /account/delete`)
+
+| Artifact | Location |
+|---|---|
+| Self-service "Delete my account" confirmation form | `GET /account/delete` |
+| 30-day grace period with `delete_scheduled_at` column | Migration + model |
+| Typed confirmation step (user must type "DELETE") | `src/routes/auth.rs` |
+| Audit log entry on request (`gdpr.erasure.requested`) | `src/routes/auth.rs` |
+| Cancellation route during grace period | `POST /account/delete/cancel` |
+| Audit log entry on cancellation (`gdpr.erasure.cancelled`) | `src/routes/auth.rs` |
+
+## What the Application Developer Must Provide
+
+The following obligations are **not** automated by the framework and require
+per-application implementation:
+
+### Hard-Delete / Anonymize Sweeper
+
+The grace-period sweeper that reads `delete_scheduled_at` and performs the
+actual erasure is the application's responsibility. Implement it as a scheduled
+job or a cron task:
+
+1. Query for `WHERE delete_scheduled_at < NOW()`.
+2. For each model, apply the registered erasure strategy:
+   - `hard_delete` — `DELETE FROM <table> WHERE user_id = $1`.
+   - `anonymize` — replace PII columns with tombstone values (e.g. `DELETED_<hash>`).
+   - `retain` — keep the row, record the retention reason in your audit log.
+3. Finally, hard-delete the user row.
+
+### Third-Party Processor Erasure
+
+GDPR requires erasure from third-party processors (Stripe, SendGrid, analytics
+services, etc.). This is out of scope for the auth starter. Document your
+processor list and erasure API calls in a separate runbook.
+
+### Admin-Triggered Export and Erasure
+
+For Subject Access Requests (SARs) initiated by your legal/ops team, add admin
+routes that call the same export/erasure logic with the operator's identity
+recorded as the `actor_id` in the audit log.
+
+## Compliance Status Summary
+
+| Obligation | Status |
+|---|---|
+| Article 15 — right of access route | ✅ Generated |
+| Article 15 — audit log | ✅ Generated |
+| Article 17 — erasure request route | ✅ Generated |
+| Article 17 — grace period + cancellation | ✅ Generated |
+| Article 17 — audit log | ✅ Generated |
+| Article 17 — actual row deletion sweeper | ⚠️ Application responsibility |
+| Article 17 — third-party processor erasure | ⚠️ Application responsibility |
+| CCPA §1798.105 — deletion right | ✅ Covered by Article 17 routes |
+| Admin/operator SAR tooling | ⚠️ Application responsibility |
+
+## Running `autumn doctor`
+
+After registering your application's models, run:
+
+```bash
+autumn doctor
+```
+
+The `gdpr_export_registration` check will warn if any `#[repository]`-annotated
+models are not registered for export/erasure. Register models via `GdprRegistry`
+in your application state.
+"#
+    .to_owned()
+}
+
 fn auth_route_entries(totp: bool) -> Vec<String> {
     let mut entries = vec![
         "routes::auth::signup_form".to_owned(),
@@ -3646,6 +4123,13 @@ fn auth_route_entries(totp: bool) -> Vec<String> {
         "routes::auth::resend_confirmation_form".to_owned(),
         "routes::auth::resend_confirmation".to_owned(),
         "routes::auth::confirm_email".to_owned(),
+        "routes::auth::data_export_form".to_owned(),
+        "routes::auth::data_export".to_owned(),
+        "routes::auth::delete_account_form".to_owned(),
+        "routes::auth::delete_account".to_owned(),
+        "routes::auth::cancel_delete_account".to_owned(),
+        "routes::auth::admin_data_export".to_owned(),
+        "routes::auth::admin_delete_account".to_owned(),
     ];
     if totp {
         entries.extend([
@@ -8649,6 +9133,197 @@ mod tests {
         assert!(
             docs.contains("unlock"),
             "docs must document operator unlock path: {docs}"
+        );
+    }
+
+    // ── GDPR data export & account deletion (issue #820) ─────────────────────
+
+    #[test]
+    fn plan_auth_creates_data_export_route() {
+        // AC#1: auth starter generates a "Download my data" route
+        let tmp = project_with_main();
+        let plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/auth.rs")).unwrap();
+        assert!(
+            routes.contains("data_export") || routes.contains("download_my_data"),
+            "generated routes must include a data-export handler: {routes}"
+        );
+    }
+
+    #[test]
+    fn plan_auth_data_export_route_requires_auth() {
+        // AC#1: the export route must be protected by authentication
+        let tmp = project_with_main();
+        let plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/auth.rs")).unwrap();
+        // Find the data_export function and verify it extracts Auth
+        let export_pos = routes
+            .find("data_export")
+            .expect("data_export route must be present");
+        let export_body = &routes[export_pos..export_pos + 500.min(routes.len() - export_pos)];
+        assert!(
+            export_body.contains("Auth") || export_body.contains("auth"),
+            "data_export route must require authentication: {export_body}"
+        );
+    }
+
+    #[test]
+    fn plan_auth_creates_delete_account_route() {
+        // AC#3: auth starter generates a "Delete my account" flow
+        let tmp = project_with_main();
+        let plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/auth.rs")).unwrap();
+        assert!(
+            routes.contains("delete_account") || routes.contains("account_delete"),
+            "generated routes must include an account-deletion handler: {routes}"
+        );
+    }
+
+    #[test]
+    fn plan_auth_delete_account_has_confirmation_step() {
+        // AC#3: deletion flow requires a confirmation step
+        let tmp = project_with_main();
+        let plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/auth.rs")).unwrap();
+        assert!(
+            routes.contains("confirm") || routes.contains("confirmation"),
+            "delete_account handler must include a confirmation step: {routes}"
+        );
+    }
+
+    #[test]
+    fn plan_auth_delete_account_writes_audit_log() {
+        // AC#3: account deletion must write an audit log entry
+        let tmp = project_with_main();
+        let plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/auth.rs")).unwrap();
+        assert!(
+            routes.contains("audit") || routes.contains("AuditEvent"),
+            "delete_account handler must write an audit log entry: {routes}"
+        );
+    }
+
+    #[test]
+    fn plan_auth_migration_includes_deletion_tracking_columns() {
+        // AC#3: migration must include grace-period deletion tracking columns
+        let tmp = project_with_main();
+        let plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let up = fs::read_to_string(
+            tmp.path()
+                .join("migrations/20260508000000_create_users/up.sql"),
+        )
+        .unwrap();
+        assert!(
+            up.contains("delete_requested_at") || up.contains("deletion_requested_at"),
+            "migration must include a deletion-request timestamp column: {up}"
+        );
+        assert!(
+            up.contains("delete_scheduled_at")
+                || up.contains("deletion_scheduled_at")
+                || up.contains("delete_grace_until"),
+            "migration must include a grace-period deadline column: {up}"
+        );
+    }
+
+    #[test]
+    fn plan_auth_migration_includes_export_tracking_columns() {
+        // AC#1/#5: migration must include export-request tracking columns
+        let tmp = project_with_main();
+        let plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let up = fs::read_to_string(
+            tmp.path()
+                .join("migrations/20260508000000_create_users/up.sql"),
+        )
+        .unwrap();
+        assert!(
+            up.contains("export_requested_at") || up.contains("data_export_requested_at"),
+            "migration must include an export-request timestamp column: {up}"
+        );
+    }
+
+    #[test]
+    fn plan_auth_creates_export_job() {
+        // AC#5: auth starter generates a background export job
+        let tmp = project_with_main();
+        let plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/auth.rs")).unwrap();
+        assert!(
+            routes.contains("export_job") || routes.contains("ExportJob") || routes.contains("enqueue"),
+            "generated code must enqueue a background export job: {routes}"
+        );
+    }
+
+    #[test]
+    fn plan_auth_gdpr_docs_file_created() {
+        // AC#7: auth starter generates a GDPR compliance documentation file
+        let tmp = project_with_main();
+        let plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let paths: Vec<String> = plan
+            .actions
+            .iter()
+            .map(|a| {
+                a.path()
+                    .strip_prefix(tmp.path())
+                    .unwrap()
+                    .display()
+                    .to_string()
+                    .replace('\\', "/")
+            })
+            .collect();
+        assert!(
+            paths.iter().any(|p| p.contains("gdpr") || p.contains("compliance")),
+            "plan must include a GDPR/compliance documentation file; got: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn plan_auth_gdpr_docs_references_article_15_and_17() {
+        // AC#7: GDPR docs must reference Article 15 (right of access) and Article 17 (erasure)
+        let tmp = project_with_main();
+        let plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        // Find the GDPR compliance docs file
+        let docs_path = plan
+            .actions
+            .iter()
+            .find(|a| {
+                let path_str = a.path().to_string_lossy().to_lowercase();
+                path_str.contains("gdpr") || path_str.contains("compliance")
+            })
+            .map(|a| a.path().to_owned())
+            .expect("plan must include a GDPR/compliance documentation file");
+
+        let content = fs::read_to_string(&docs_path).unwrap();
+        assert!(
+            content.contains("Article 15") || content.contains("article 15"),
+            "GDPR docs must reference Article 15 (right of access): {content}"
+        );
+        assert!(
+            content.contains("Article 17") || content.contains("article 17"),
+            "GDPR docs must reference Article 17 (right to erasure): {content}"
+        );
+    }
+
+    #[test]
+    fn plan_auth_model_includes_delete_requested_at_field() {
+        // AC#3: generated User model must include deletion tracking fields
+        let tmp = project_with_main();
+        let plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let model = fs::read_to_string(tmp.path().join("src/models/user.rs")).unwrap();
+        assert!(
+            model.contains("delete_requested_at") || model.contains("deletion_requested_at"),
+            "User model must include deletion tracking field: {model}"
         );
     }
 }

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -2053,6 +2053,23 @@ pub async fn account(session: Session, mut db: Db, csrf: Option<CsrfToken>, csrf
 
     Ok(layout("Your Account", html! {{
         h1 {{ "Your Account" }}
+        @if let Some(scheduled) = {snake_name}.delete_scheduled_at {{
+            div style="border:1px solid #c00;padding:0.75rem;margin-bottom:1rem;" {{
+                p {{
+                    "⚠️ Your account is scheduled for deletion on "
+                    (scheduled.format("%Y-%m-%d").to_string())
+                    ". Log in before then to cancel."
+                }}
+                form action="/account/delete/cancel" method="post" {{
+                    @if let Some(ref csrf) = csrf {{
+                        input type="hidden"
+                            name=(csrf_field.as_ref().map_or("_csrf", |f| f.0.as_str()))
+                            value=(csrf.token());
+                    }}
+                    button type="submit" {{ "Cancel Deletion" }}
+                }}
+            }}
+        }}
         p {{ "Email: " ({snake_name}.email) }}
         p {{
             "Email confirmed: "
@@ -2064,10 +2081,11 @@ pub async fn account(session: Session, mut db: Db, csrf: Option<CsrfToken>, csrf
         }}
         details {{
             summary {{ "Delete account" }}
+            p {{ "For GDPR-compliant deletion with a 30-day grace period, use " a href="/account/delete" {{ "Delete My Account" }} "." }}
             form action="/account/destroy" method="post" {{
                 @if let Some(ref csrf) = csrf {{ input type="hidden" name=(csrf_field.as_ref().map_or("_csrf", |f| f.0.as_str())) value=(csrf.token()); }}
-                p {{ "This is permanent and cannot be undone." }}
-                button type="submit" {{ "Delete my account" }}
+                p {{ "Or use the legacy immediate hard-delete (no grace period):" }}
+                button type="submit" {{ "Delete my account (immediate)" }}
             }}
         }}
     }}).into_response())
@@ -3142,7 +3160,7 @@ pub async fn admin_data_export(
         &state,
         autumn_web::audit::AuditEvent::new(
             operator_id,
-            "gdpr.export.admin_triggered",
+            format!("gdpr.export.admin_triggered reason={{}}", form.reason),
             user_id.to_string(),
             None,
             autumn_web::audit::AuditStatus::Success,
@@ -3151,7 +3169,6 @@ pub async fn admin_data_export(
     .await
     .ok();
 
-    let _ = form.reason; // reason is logged via the audit system above
     Ok(redirect_to(&format!("/admin/{table}/{{user_id}}")).into_response())
 }}
 

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -551,10 +551,7 @@ pub fn plan_auth_with_providers(
         docs_dir.join("authentication.md"),
         render_docs_file(&pascal_name, totp),
     );
-    plan.create(
-        docs_dir.join("gdpr-compliance.md"),
-        render_gdpr_docs_file(),
-    );
+    plan.create(docs_dir.join("gdpr-compliance.md"), render_gdpr_docs_file());
 
     // ── src/main.rs — module declarations + route registration ────────────
     let main_path = project_root.join("src").join("main.rs");
@@ -9273,7 +9270,9 @@ mod tests {
         plan.execute(Flags::default()).unwrap();
         let routes = fs::read_to_string(tmp.path().join("src/routes/auth.rs")).unwrap();
         assert!(
-            routes.contains("export_job") || routes.contains("ExportJob") || routes.contains("enqueue"),
+            routes.contains("export_job")
+                || routes.contains("ExportJob")
+                || routes.contains("enqueue"),
             "generated code must enqueue a background export job: {routes}"
         );
     }
@@ -9297,7 +9296,9 @@ mod tests {
             })
             .collect();
         assert!(
-            paths.iter().any(|p| p.contains("gdpr") || p.contains("compliance")),
+            paths
+                .iter()
+                .any(|p| p.contains("gdpr") || p.contains("compliance")),
             "plan must include a GDPR/compliance documentation file; got: {paths:?}"
         );
     }

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -2898,7 +2898,7 @@ pub async fn data_export(
         .and_then(|s| s.parse().ok())
         .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
 
-    let mailer = state.extension::<Mailer>().cloned();
+    let mailer = state.extension::<Mailer>();
     let now = chrono::Utc::now().naive_utc();
     let one_hour_ago = now - chrono::Duration::hours(1);
 
@@ -2926,7 +2926,7 @@ pub async fn data_export(
     }}
 
     // Enqueue the background export job.
-    enqueue_data_export_job(&state, {snake_name}_id, mailer.as_ref()).await;
+    enqueue_data_export_job(&state, {snake_name}_id, mailer.as_deref()).await;
 
     autumn_web::audit::write_from_state(
         &state,
@@ -3174,7 +3174,7 @@ pub async fn admin_data_export(
         return Err(AutumnError::unprocessable_msg("Reason is required for admin GDPR actions."));
     }}
 
-    let mailer = state.extension::<Mailer>().cloned();
+    let mailer = state.extension::<Mailer>();
 
     let now = chrono::Utc::now().naive_utc();
     let updated = diesel::update({table}::table.find(user_id))
@@ -3187,7 +3187,7 @@ pub async fn admin_data_export(
         return Err(AutumnError::not_found_msg("User not found."));
     }}
 
-    enqueue_data_export_job(&state, user_id, mailer.as_ref()).await;
+    enqueue_data_export_job(&state, user_id, mailer.as_deref()).await;
 
     autumn_web::audit::write_from_state(
         &state,

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -2891,7 +2891,6 @@ pub async fn data_export(
     session: Session,
     mut db: Db,
     State(state): State<AppState>,
-    mailer: Option<Mailer>,
 ) -> AutumnResult<Response> {{
     let {snake_name}_id: i64 = session
         .get("{snake_name}_id")
@@ -2899,6 +2898,7 @@ pub async fn data_export(
         .and_then(|s| s.parse().ok())
         .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
 
+    let mailer = state.extension::<Mailer>().cloned();
     let now = chrono::Utc::now().naive_utc();
     let one_hour_ago = now - chrono::Duration::hours(1);
 
@@ -3163,7 +3163,6 @@ pub async fn admin_data_export(
     session: Session,
     mut db: Db,
     State(state): State<AppState>,
-    mailer: Option<Mailer>,
     axum::Form(form): axum::Form<AdminGdprActionForm>,
 ) -> AutumnResult<Response> {{
     let operator_id: String = session
@@ -3171,12 +3170,22 @@ pub async fn admin_data_export(
         .await
         .ok_or_else(|| AutumnError::unauthorized_msg("Admin access required."))?;
 
+    if form.reason.trim().is_empty() {{
+        return Err(AutumnError::unprocessable_msg("Reason is required for admin GDPR actions."));
+    }}
+
+    let mailer = state.extension::<Mailer>().cloned();
+
     let now = chrono::Utc::now().naive_utc();
-    diesel::update({table}::table.find(user_id))
+    let updated = diesel::update({table}::table.find(user_id))
         .set({table}::export_requested_at.eq(Some(now)))
         .execute(&mut *db)
         .await
         .map_err(|_| AutumnError::internal_server_error_msg("Failed to record export request."))?;
+
+    if updated == 0 {{
+        return Err(AutumnError::not_found_msg("User not found."));
+    }}
 
     enqueue_data_export_job(&state, user_id, mailer.as_ref()).await;
 
@@ -3214,10 +3223,14 @@ pub async fn admin_delete_account(
         .await
         .ok_or_else(|| AutumnError::unauthorized_msg("Admin access required."))?;
 
+    if form.reason.trim().is_empty() {{
+        return Err(AutumnError::unprocessable_msg("Reason is required for admin GDPR actions."));
+    }}
+
     let now = chrono::Utc::now().naive_utc();
     let grace_until = now + chrono::Duration::days(30);
 
-    diesel::update({table}::table.find(user_id))
+    let updated = diesel::update({table}::table.find(user_id))
         .set((
             {table}::delete_requested_at.eq(Some(now)),
             {table}::delete_scheduled_at.eq(Some(grace_until)),
@@ -3225,6 +3238,10 @@ pub async fn admin_delete_account(
         .execute(&mut *db)
         .await
         .map_err(|_| AutumnError::internal_server_error_msg("Failed to schedule deletion."))?;
+
+    if updated == 0 {{
+        return Err(AutumnError::not_found_msg("User not found."));
+    }}
 
     autumn_web::audit::write_from_state(
         &state,

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -2076,14 +2076,9 @@ pub async fn account(session: Session, mut db: Db, csrf: Option<CsrfToken>, csrf
             @if let Some(ref csrf) = csrf {{ input type="hidden" name=(csrf_field.as_ref().map_or("_csrf", |f| f.0.as_str())) value=(csrf.token()); }}
             button type="submit" {{ "Log Out" }}
         }}
-        details {{
-            summary {{ "Delete account" }}
-            p {{ "For GDPR-compliant deletion with a 30-day grace period, use " a href="/account/delete" {{ "Delete My Account" }} "." }}
-            form action="/account/destroy" method="post" {{
-                @if let Some(ref csrf) = csrf {{ input type="hidden" name=(csrf_field.as_ref().map_or("_csrf", |f| f.0.as_str())) value=(csrf.token()); }}
-                p {{ "Or use the legacy immediate hard-delete (no grace period):" }}
-                button type="submit" {{ "Delete my account (immediate)" }}
-            }}
+        p {{
+            a href="/account/delete" {{ "Delete my account" }}
+            " (30-day grace period — GDPR Article 17)"
         }}
     }}).into_response())
 }}
@@ -2895,7 +2890,7 @@ pub async fn data_export_form(
 pub async fn data_export(
     session: Session,
     mut db: Db,
-    state: AppState,
+    State(state): State<AppState>,
     mailer: Option<Mailer>,
 ) -> AutumnResult<Response> {{
     let {snake_name}_id: i64 = session
@@ -2905,11 +2900,30 @@ pub async fn data_export(
         .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
 
     let now = chrono::Utc::now().naive_utc();
-    diesel::update({table}::table.find({snake_name}_id))
+    let one_hour_ago = now - chrono::Duration::hours(1);
+
+    // Idempotency: only update (and enqueue) if no export was requested in the last hour.
+    let updated = diesel::update({table}::table.find({snake_name}_id))
+        .filter(
+            {table}::export_requested_at
+                .is_null()
+                .or({table}::export_requested_at.lt(Some(one_hour_ago))),
+        )
         .set({table}::export_requested_at.eq(Some(now)))
         .execute(&mut *db)
         .await
         .map_err(|_| AutumnError::internal_server_error_msg("Failed to record export request."))?;
+
+    if updated == 0 {{
+        return Ok(layout("Export Already Pending", html! {{
+            h1 {{ "Export Already Pending" }}
+            p {{
+                "A data export was already requested within the last hour. \
+                 Please check your email or try again later."
+            }}
+            p {{ a href="/account" {{ "← Back to account" }} }}
+        }}).into_response());
+    }}
 
     // Enqueue the background export job.
     enqueue_data_export_job(&state, {snake_name}_id, mailer.as_ref()).await;
@@ -3011,11 +3025,13 @@ pub async fn delete_account_form(
 /// Records `delete_requested_at` and `delete_scheduled_at` (30-day grace period)
 /// then writes an audit log entry. A background sweeper handles the hard-delete
 /// once the grace period expires. The user is logged out immediately.
+#[secured]
+#[step_up]
 #[post("/account/delete")]
 pub async fn delete_account(
     session: Session,
     mut db: Db,
-    state: AppState,
+    State(state): State<AppState>,
     axum::Form(form): axum::Form<DeleteAccountForm>,
 ) -> AutumnResult<Response> {{
     let {snake_name}_id: i64 = session
@@ -3076,12 +3092,14 @@ pub async fn delete_account(
 /// `POST /account/delete/cancel` — cancel a pending account deletion.
 ///
 /// Clears the `delete_requested_at` / `delete_scheduled_at` columns and writes
-/// an audit log entry. Only available during the grace period.
+/// an audit log entry. Returns an error if no deletion is pending or the grace
+/// period has already elapsed.
+#[secured]
 #[post("/account/delete/cancel")]
 pub async fn cancel_delete_account(
     session: Session,
     mut db: Db,
-    state: AppState,
+    State(state): State<AppState>,
 ) -> AutumnResult<Response> {{
     let {snake_name}_id: i64 = session
         .get("{snake_name}_id")
@@ -3089,7 +3107,9 @@ pub async fn cancel_delete_account(
         .and_then(|s| s.parse().ok())
         .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
 
-    diesel::update({table}::table.find({snake_name}_id))
+    // Only cancel if a future deletion is scheduled; reject once the deadline has passed.
+    let rows = diesel::update({table}::table.find({snake_name}_id))
+        .filter({table}::delete_scheduled_at.gt(Some(chrono::Utc::now().naive_utc())))
         .set((
             {table}::delete_requested_at.eq(None::<chrono::NaiveDateTime>),
             {table}::delete_scheduled_at.eq(None::<chrono::NaiveDateTime>),
@@ -3097,6 +3117,12 @@ pub async fn cancel_delete_account(
         .execute(&mut *db)
         .await
         .map_err(|_| AutumnError::internal_server_error_msg("Failed to cancel deletion."))?;
+
+    if rows == 0 {{
+        return Err(AutumnError::unprocessable_msg(
+            "No pending deletion found, or the grace period has already elapsed.",
+        ));
+    }}
 
     autumn_web::audit::write_from_state(
         &state,
@@ -3126,23 +3152,24 @@ pub struct AdminGdprActionForm {{
     pub reason: String,
 }}
 
-/// `POST /admin/{table}/:id/data-export` — admin triggers data export for a user.
+/// `POST /admin/{table}/{{id}}/data-export` — admin triggers data export for a user.
 ///
 /// Stamps `export_requested_at` and enqueues the export job.
 /// Records `actor_id` (the operator) + `reason` in the audit log.
-#[post("/admin/{table}/:id/data-export")]
+/// Mount behind your admin authentication middleware.
+#[post("/admin/{table}/{{id}}/data-export")]
 pub async fn admin_data_export(
     Path(user_id): Path<i64>,
     session: Session,
     mut db: Db,
-    state: AppState,
+    State(state): State<AppState>,
     mailer: Option<Mailer>,
     axum::Form(form): axum::Form<AdminGdprActionForm>,
 ) -> AutumnResult<Response> {{
     let operator_id: String = session
         .get("{snake_name}_id")
         .await
-        .unwrap_or_else(|| "admin".to_owned());
+        .ok_or_else(|| AutumnError::unauthorized_msg("Admin access required."))?;
 
     let now = chrono::Utc::now().naive_utc();
     diesel::update({table}::table.find(user_id))
@@ -3169,22 +3196,23 @@ pub async fn admin_data_export(
     Ok(redirect_to(&format!("/admin/{table}/{{user_id}}")).into_response())
 }}
 
-/// `POST /admin/{table}/:id/delete` — admin triggers account erasure for a user.
+/// `POST /admin/{table}/{{id}}/delete` — admin triggers account erasure for a user.
 ///
 /// Schedules the account for deletion (30-day grace period).
 /// Records `actor_id` (the operator), `reason`, and timestamp in the audit log.
-#[post("/admin/{table}/:id/delete")]
+/// Mount behind your admin authentication middleware.
+#[post("/admin/{table}/{{id}}/delete")]
 pub async fn admin_delete_account(
     Path(user_id): Path<i64>,
     session: Session,
     mut db: Db,
-    state: AppState,
+    State(state): State<AppState>,
     axum::Form(form): axum::Form<AdminGdprActionForm>,
 ) -> AutumnResult<Response> {{
     let operator_id: String = session
         .get("{snake_name}_id")
         .await
-        .unwrap_or_else(|| "admin".to_owned());
+        .ok_or_else(|| AutumnError::unauthorized_msg("Admin access required."))?;
 
     let now = chrono::Utc::now().naive_utc();
     let grace_until = now + chrono::Duration::days(30);

--- a/autumn/src/gdpr.rs
+++ b/autumn/src/gdpr.rs
@@ -1,0 +1,418 @@
+//! GDPR/CCPA data-export and account-erasure registry.
+//!
+//! Provides the [`GdprRegistry`] for registering application models and their
+//! erasure strategies, and the [`ExportArchive`] type used by the data-export
+//! background job.
+//!
+//! ## Usage
+//!
+//! Register each `#[repository]` model that holds user data when constructing
+//! the application state:
+//!
+//! ```rust,no_run
+//! use autumn_web::gdpr::{ErasureStrategy, GdprRegistry, ModelRegistration};
+//!
+//! let registry = GdprRegistry::new()
+//!     .register(ModelRegistration::hard_delete("posts"))
+//!     .register(ModelRegistration::anonymize("comments"))
+//!     .register(ModelRegistration::retain(
+//!         "invoices",
+//!         "financial records retained for 7 years (HMRC requirement)",
+//!     ));
+//! ```
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// How a model's data should be handled during account erasure (GDPR Article 17).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErasureStrategy {
+    /// Permanently delete all rows belonging to the user.
+    HardDelete,
+    /// Replace identifying columns with deterministic tombstone values so
+    /// referential integrity is maintained while PII is removed.
+    Anonymize,
+    /// Retain rows under legal hold. The retention reason is captured in the
+    /// audit log and surfaced in the export archive manifest.
+    Retain,
+}
+
+/// Registration for a single model in the GDPR export/erasure registry.
+#[derive(Debug, Clone)]
+pub struct ModelRegistration {
+    /// Database table name for this model.
+    pub table: String,
+    /// Strategy applied during account erasure.
+    pub erasure_strategy: ErasureStrategy,
+    /// Required when `erasure_strategy == Retain`. Documented in the audit log.
+    pub retain_reason: Option<String>,
+}
+
+impl ModelRegistration {
+    /// Register a model for hard deletion during erasure.
+    #[must_use]
+    pub fn hard_delete(table: impl Into<String>) -> Self {
+        Self {
+            table: table.into(),
+            erasure_strategy: ErasureStrategy::HardDelete,
+            retain_reason: None,
+        }
+    }
+
+    /// Register a model for anonymization during erasure.
+    #[must_use]
+    pub fn anonymize(table: impl Into<String>) -> Self {
+        Self {
+            table: table.into(),
+            erasure_strategy: ErasureStrategy::Anonymize,
+            retain_reason: None,
+        }
+    }
+
+    /// Register a model for legal-hold retention during erasure.
+    ///
+    /// `reason` is written to the audit log and included in the export archive
+    /// manifest so the user can see why certain data was retained.
+    #[must_use]
+    pub fn retain(table: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            table: table.into(),
+            erasure_strategy: ErasureStrategy::Retain,
+            retain_reason: Some(reason.into()),
+        }
+    }
+}
+
+/// Registry mapping model names to their GDPR export and erasure registrations.
+///
+/// Build once at application start-up and store in [`crate::AppState`]:
+///
+/// ```rust,no_run
+/// use autumn_web::gdpr::{GdprRegistry, ModelRegistration};
+///
+/// let registry = GdprRegistry::new()
+///     .register(ModelRegistration::hard_delete("posts"))
+///     .register(ModelRegistration::anonymize("comments"));
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct GdprRegistry {
+    registrations: Vec<ModelRegistration>,
+}
+
+impl GdprRegistry {
+    /// Create an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a model for GDPR export and erasure.
+    #[must_use]
+    pub fn register(mut self, registration: ModelRegistration) -> Self {
+        self.registrations.push(registration);
+        self
+    }
+
+    /// Returns all registered table names.
+    #[must_use]
+    pub fn registered_tables(&self) -> Vec<&str> {
+        self.registrations
+            .iter()
+            .map(|r| r.table.as_str())
+            .collect()
+    }
+
+    /// Look up the registration for a specific table.
+    #[must_use]
+    pub fn get(&self, table: &str) -> Option<&ModelRegistration> {
+        self.registrations.iter().find(|r| r.table == table)
+    }
+
+    /// Returns `true` when at least one model is registered.
+    #[must_use]
+    pub fn is_populated(&self) -> bool {
+        !self.registrations.is_empty()
+    }
+
+    /// Returns all registrations with the [`ErasureStrategy::Retain`] strategy.
+    #[must_use]
+    pub fn retained_tables(&self) -> Vec<&ModelRegistration> {
+        self.registrations
+            .iter()
+            .filter(|r| r.erasure_strategy == ErasureStrategy::Retain)
+            .collect()
+    }
+}
+
+/// Metadata attached to every data export archive.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ExportManifest {
+    /// The user identifier this export belongs to.
+    pub user_id: String,
+    /// RFC-3339 timestamp when the export was generated.
+    pub generated_at: String,
+    /// Autumn framework version that generated this export.
+    pub framework_version: String,
+    /// Tables included in this export.
+    pub tables_included: Vec<String>,
+    /// Tables retained under legal hold, with reasons.
+    pub tables_retained: Vec<RetainedTable>,
+}
+
+/// A table retained under legal hold rather than erased.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetainedTable {
+    /// The database table name.
+    pub table: String,
+    /// Human-readable reason for retention (captured in audit log).
+    pub reason: String,
+}
+
+/// The complete data export archive for a single user.
+///
+/// Serializes to a single JSON document with a `manifest` section and a
+/// `tables` map of per-table record arrays. Only fields annotated with
+/// `#[export]` are included (allowlist, not blocklist).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ExportArchive {
+    /// Metadata describing the export.
+    pub manifest: ExportManifest,
+    /// Per-table exported records, keyed by table name.
+    ///
+    /// Each value is the array of JSON objects for that table. Fields not
+    /// annotated with `#[export]` are excluded by the repository layer.
+    pub tables: HashMap<String, Vec<Value>>,
+}
+
+impl ExportArchive {
+    /// Create an empty archive for the given user.
+    #[must_use]
+    pub fn new(user_id: impl Into<String>) -> Self {
+        Self {
+            manifest: ExportManifest {
+                user_id: user_id.into(),
+                generated_at: chrono::Utc::now().to_rfc3339(),
+                framework_version: env!("CARGO_PKG_VERSION").to_owned(),
+                ..Default::default()
+            },
+            tables: HashMap::new(),
+        }
+    }
+
+    /// Add a table's records to the archive.
+    pub fn add_table(&mut self, table: impl Into<String>, records: Vec<Value>) {
+        let table = table.into();
+        self.manifest.tables_included.push(table.clone());
+        self.tables.insert(table, records);
+    }
+
+    /// Record a retained table in the manifest.
+    pub fn add_retained(&mut self, table: impl Into<String>, reason: impl Into<String>) {
+        self.manifest.tables_retained.push(RetainedTable {
+            table: table.into(),
+            reason: reason.into(),
+        });
+    }
+
+    /// Serialize the archive to a JSON string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when serde fails (not expected in practice for this type).
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── ErasureStrategy ───────────────────────────────────────────────────────
+
+    #[test]
+    fn erasure_strategy_hard_delete_serializes_as_snake_case() {
+        let s = serde_json::to_string(&ErasureStrategy::HardDelete).unwrap();
+        assert_eq!(s, r#""hard_delete""#);
+    }
+
+    #[test]
+    fn erasure_strategy_anonymize_serializes() {
+        let s = serde_json::to_string(&ErasureStrategy::Anonymize).unwrap();
+        assert_eq!(s, r#""anonymize""#);
+    }
+
+    #[test]
+    fn erasure_strategy_retain_serializes() {
+        let s = serde_json::to_string(&ErasureStrategy::Retain).unwrap();
+        assert_eq!(s, r#""retain""#);
+    }
+
+    #[test]
+    fn erasure_strategy_round_trips_through_json() {
+        for strategy in [
+            ErasureStrategy::HardDelete,
+            ErasureStrategy::Anonymize,
+            ErasureStrategy::Retain,
+        ] {
+            let json = serde_json::to_string(&strategy).unwrap();
+            let decoded: ErasureStrategy = serde_json::from_str(&json).unwrap();
+            assert_eq!(decoded, strategy);
+        }
+    }
+
+    // ── ModelRegistration ─────────────────────────────────────────────────────
+
+    #[test]
+    fn model_registration_hard_delete_sets_strategy() {
+        let r = ModelRegistration::hard_delete("posts");
+        assert_eq!(r.table, "posts");
+        assert_eq!(r.erasure_strategy, ErasureStrategy::HardDelete);
+        assert!(r.retain_reason.is_none());
+    }
+
+    #[test]
+    fn model_registration_anonymize_sets_strategy() {
+        let r = ModelRegistration::anonymize("comments");
+        assert_eq!(r.table, "comments");
+        assert_eq!(r.erasure_strategy, ErasureStrategy::Anonymize);
+        assert!(r.retain_reason.is_none());
+    }
+
+    #[test]
+    fn model_registration_retain_sets_strategy_and_reason() {
+        let r = ModelRegistration::retain("invoices", "7-year financial retention");
+        assert_eq!(r.table, "invoices");
+        assert_eq!(r.erasure_strategy, ErasureStrategy::Retain);
+        assert_eq!(
+            r.retain_reason.as_deref(),
+            Some("7-year financial retention")
+        );
+    }
+
+    // ── GdprRegistry ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn registry_empty_by_default() {
+        let registry = GdprRegistry::new();
+        assert!(!registry.is_populated());
+        assert!(registry.registered_tables().is_empty());
+    }
+
+    #[test]
+    fn registry_register_adds_model() {
+        let registry = GdprRegistry::new().register(ModelRegistration::hard_delete("posts"));
+        assert!(registry.is_populated());
+        assert_eq!(registry.registered_tables(), vec!["posts"]);
+    }
+
+    #[test]
+    fn registry_get_returns_registration_for_known_table() {
+        let registry = GdprRegistry::new()
+            .register(ModelRegistration::hard_delete("posts"))
+            .register(ModelRegistration::anonymize("comments"));
+        let reg = registry.get("posts").expect("posts must be registered");
+        assert_eq!(reg.erasure_strategy, ErasureStrategy::HardDelete);
+    }
+
+    #[test]
+    fn registry_get_returns_none_for_unknown_table() {
+        let registry = GdprRegistry::new().register(ModelRegistration::hard_delete("posts"));
+        assert!(registry.get("orders").is_none());
+    }
+
+    #[test]
+    fn registry_retained_tables_filters_correctly() {
+        let registry = GdprRegistry::new()
+            .register(ModelRegistration::hard_delete("posts"))
+            .register(ModelRegistration::retain("invoices", "financial hold"))
+            .register(ModelRegistration::anonymize("comments"))
+            .register(ModelRegistration::retain("contracts", "legal hold"));
+        let retained = registry.retained_tables();
+        assert_eq!(retained.len(), 2);
+        assert!(retained.iter().any(|r| r.table == "invoices"));
+        assert!(retained.iter().any(|r| r.table == "contracts"));
+    }
+
+    #[test]
+    fn registry_registered_tables_returns_all_table_names() {
+        let registry = GdprRegistry::new()
+            .register(ModelRegistration::hard_delete("posts"))
+            .register(ModelRegistration::anonymize("comments"))
+            .register(ModelRegistration::retain("invoices", "hold"));
+        let tables = registry.registered_tables();
+        assert_eq!(tables.len(), 3);
+        assert!(tables.contains(&"posts"));
+        assert!(tables.contains(&"comments"));
+        assert!(tables.contains(&"invoices"));
+    }
+
+    // ── ExportArchive ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn export_archive_new_sets_user_id() {
+        let archive = ExportArchive::new("user-42");
+        assert_eq!(archive.manifest.user_id, "user-42");
+    }
+
+    #[test]
+    fn export_archive_add_table_populates_tables_and_manifest() {
+        let mut archive = ExportArchive::new("u1");
+        archive.add_table("posts", vec![serde_json::json!({"id": 1, "title": "Hello"})]);
+        assert_eq!(archive.tables.len(), 1);
+        assert!(archive.tables.contains_key("posts"));
+        assert!(archive.manifest.tables_included.contains(&"posts".to_owned()));
+    }
+
+    #[test]
+    fn export_archive_add_retained_populates_manifest() {
+        let mut archive = ExportArchive::new("u1");
+        archive.add_retained("invoices", "7-year financial hold");
+        assert_eq!(archive.manifest.tables_retained.len(), 1);
+        assert_eq!(archive.manifest.tables_retained[0].table, "invoices");
+        assert_eq!(
+            archive.manifest.tables_retained[0].reason,
+            "7-year financial hold"
+        );
+    }
+
+    #[test]
+    fn export_archive_to_json_is_valid_json() {
+        let mut archive = ExportArchive::new("u1");
+        archive.add_table("posts", vec![serde_json::json!({"id": 1})]);
+        let json = archive.to_json().expect("serialization must succeed");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("must parse as valid JSON");
+        assert!(
+            parsed.get("manifest").is_some(),
+            "archive JSON must have a manifest key"
+        );
+        assert!(
+            parsed.get("tables").is_some(),
+            "archive JSON must have a tables key"
+        );
+    }
+
+    #[test]
+    fn export_archive_json_contains_user_id_in_manifest() {
+        let archive = ExportArchive::new("user-99");
+        let json = archive.to_json().unwrap();
+        assert!(
+            json.contains("user-99"),
+            "JSON must contain the user_id: {json}"
+        );
+    }
+
+    #[test]
+    fn export_archive_json_contains_framework_version() {
+        let archive = ExportArchive::new("u1");
+        let json = archive.to_json().unwrap();
+        assert!(
+            json.contains("framework_version"),
+            "JSON must include framework_version: {json}"
+        );
+    }
+}

--- a/autumn/src/gdpr.rs
+++ b/autumn/src/gdpr.rs
@@ -361,10 +361,18 @@ mod tests {
     #[test]
     fn export_archive_add_table_populates_tables_and_manifest() {
         let mut archive = ExportArchive::new("u1");
-        archive.add_table("posts", vec![serde_json::json!({"id": 1, "title": "Hello"})]);
+        archive.add_table(
+            "posts",
+            vec![serde_json::json!({"id": 1, "title": "Hello"})],
+        );
         assert_eq!(archive.tables.len(), 1);
         assert!(archive.tables.contains_key("posts"));
-        assert!(archive.manifest.tables_included.contains(&"posts".to_owned()));
+        assert!(
+            archive
+                .manifest
+                .tables_included
+                .contains(&"posts".to_owned())
+        );
     }
 
     #[test]

--- a/autumn/src/gdpr.rs
+++ b/autumn/src/gdpr.rs
@@ -133,7 +133,7 @@ impl GdprRegistry {
 
     /// Returns `true` when at least one model is registered.
     #[must_use]
-    pub fn is_populated(&self) -> bool {
+    pub const fn is_populated(&self) -> bool {
         !self.registrations.is_empty()
     }
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -198,6 +198,7 @@ pub mod time;
 pub mod experiments;
 pub mod feature_flags;
 pub mod form;
+pub mod gdpr;
 pub mod job;
 pub mod runtime_config;
 #[cfg(feature = "seed")]


### PR DESCRIPTION
## Summary

This PR implements GDPR Article 15 (right of access) and Article 17 (right to erasure) compliance features in the auth starter and framework. It adds self-service data export and account deletion flows with a 30-day grace period, comprehensive audit logging, and a registry system for managing model-level erasure strategies.

## Key Changes

### Auth Starter Generation (`autumn-cli/src/generate/auth.rs`)
- **Database schema**: Added three new timestamp columns to track GDPR operations:
  - `export_requested_at` — records when user requests data export
  - `delete_requested_at` — records when user initiates account deletion
  - `delete_scheduled_at` — records the 30-day grace period deadline
- **User model**: Updated struct to include the three new optional timestamp fields
- **Routes**: Generated 7 new endpoints:
  - `GET /account/data-export` — download data form
  - `POST /account/data-export` — enqueue export job (Article 15)
  - `GET /account/delete` — deletion confirmation form
  - `POST /account/delete` — schedule deletion with 30-day grace (Article 17)
  - `POST /account/delete/cancel` — cancel pending deletion during grace period
  - `POST /admin/{table}/:id/data-export` — admin-triggered export
  - `POST /admin/{table}/:id/delete` — admin-triggered deletion
- **Audit logging**: All GDPR operations write audit events (`gdpr.export.requested`, `gdpr.erasure.requested`, `gdpr.erasure.cancelled`, etc.)
- **Documentation**: Generated `docs/guide/gdpr-compliance.md` checklist documenting which obligations are framework-provided vs. application responsibility
- **Background job stub**: Added `enqueue_data_export_job()` placeholder for wiring up production job backends

### Framework Library (`autumn/src/gdpr.rs` — new file)
- **`ErasureStrategy` enum**: Defines three strategies for handling model data during erasure:
  - `HardDelete` — permanently remove rows
  - `Anonymize` — replace PII with tombstone values
  - `Retain` — keep under legal hold with documented reason
- **`ModelRegistration`**: Builder API for registering models with their erasure strategy
- **`GdprRegistry`**: Central registry for all application models, with methods to:
  - Register models with their erasure strategy
  - Query registered tables and strategies
  - Filter tables by retention status
- **`ExportArchive` & `ExportManifest`**: Types for building and serializing user data exports as JSON with metadata
- Comprehensive test coverage for all types and registry operations

### Doctor Checks (`autumn-cli/src/doctor.rs`)
- **New check**: `gdpr_export_registration` warns when:
  - Auth starter is present (`src/routes/auth.rs` exists)
  - One or more `#[repository]`-annotated models are not registered in `GdprRegistry`
- **Implementation**: Scans `src/schema.rs` for `diesel::table!` declarations and `src/**/*.rs` for `GdprRegistry::register()` calls to detect unregistered tables
- Provides actionable hint directing developers to the GDPR compliance guide

### Tests
- Added 20+ test cases covering:
  - Data export route generation and authentication requirements
  - Account deletion route generation with confirmation step
  - Audit log integration
  - Migration column presence
  - GDPR registry functionality (registration, lookup, filtering)
  - Export archive serialization and JSON validity
  - Doctor check logic for all scenarios

## Notable Implementation Details

1. **Grace Period Design**: Account deletion uses a 30-day grace period (stored in `delete_scheduled_at`) allowing users to cancel via `POST /account/delete/cancel` before permanent erasure occurs. The actual hard-delete sweeper is left to the application (documented in compliance guide).

2. **Confirmation Step**: Account deletion requires users to type "DELETE" in uppercase, reducing accidental deletions.

3. **Audit Trail**: All GDPR operations record the actor (user or admin operator), action type

https://claude.ai/code/session_014cn6fAEDu8cVZA65umYU2b