### PR TITLE
Decouple Prometheus scrape endpoint from sensitive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the Autumn framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **actuator:** Decouple the Prometheus scrape endpoint from sensitive mode (#857)
+  - New `actuator.prometheus` config flag (default `true`) controls
+    `/actuator/prometheus` **independently of** `actuator.sensitive`. Production
+    apps can expose Prometheus metrics for platform scraping (e.g. Fly.io
+    `[metrics]`) while keeping `sensitive = false`, so `/actuator/env`,
+    `/actuator/configprops`, `/actuator/loggers`, `/actuator/tasks`,
+    `/actuator/jobs`, and the actuator task UI stay off the public surface.
+  - Set `actuator.prometheus = false` to remove the scrape endpoint entirely
+    (it then returns `404`). The flag is surfaced in `/actuator/configprops`.
+  - Docs: `docs/guide/deployment.md` now describes the safe Fly.io deployment
+    shape, including scraping a private/non-public metrics port, and clarifies
+    that OTLP tracing and the Prometheus scrape endpoint are separate telemetry
+    paths — enabling OTLP does not add OpenTelemetry metrics to
+    `/actuator/prometheus` without an explicit bridge/exporter.
+
 ## [0.5.0] - 2026-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `[metrics]`) while keeping `sensitive = false`, so `/actuator/env`,
     `/actuator/configprops`, `/actuator/loggers`, `/actuator/tasks`,
     `/actuator/jobs`, and the actuator task UI stay off the public surface.
-  - Set `actuator.prometheus = false` to remove the scrape endpoint entirely
-    (it then returns `404`). The flag is surfaced in `/actuator/configprops`.
+  - Set `actuator.prometheus = false` (or `AUTUMN_ACTUATOR__PROMETHEUS=false`)
+    to remove the scrape endpoint entirely (it then returns `404`). The flag is
+    surfaced in `/actuator/configprops`.
+  - The `[actuator]` section now honors environment overrides
+    (`AUTUMN_ACTUATOR__PREFIX`, `AUTUMN_ACTUATOR__SENSITIVE`,
+    `AUTUMN_ACTUATOR__PROMETHEUS`), matching the documented
+    `AUTUMN_SECTION__FIELD` convention. Previously the actuator section was only
+    configurable via TOML.
   - Docs: `docs/guide/deployment.md` now describes the safe Fly.io deployment
     shape, including scraping a private/non-public metrics port, and clarifies
     that OTLP tracing and the Prometheus scrape endpoint are separate telemetry

--- a/autumn-cli/src/templates/release/fly.toml.tmpl
+++ b/autumn-cli/src/templates/release/fly.toml.tmpl
@@ -51,7 +51,12 @@ kill_timeout = 45
   cpus     = 1
 
 # Fly scrapes this Prometheus text endpoint and surfaces it in the dashboard.
-# /actuator/prometheus is always available (not gated by actuator.sensitive).
+# /actuator/prometheus is controlled by `actuator.prometheus` (default true) and
+# is independent of `actuator.sensitive`: metrics stay scrapeable while
+# env/configprops/loggers/tasks/jobs remain off the public surface.
+# To keep metrics off public traffic, bind a separate internal listener and set
+# `port` here to that non-public port (no [http_service] mapping) — Fly scrapes
+# it over the private network. See docs/guide/deployment.md.
 [metrics]
   port = 3000
   path = "/actuator/prometheus"

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1022,6 +1022,13 @@ impl ConfigProperties {
             &defaults.actuator.sensitive.to_string(),
             profile_str,
         );
+        Self::track_property(
+            props,
+            "actuator.prometheus",
+            &config.actuator.prometheus.to_string(),
+            &defaults.actuator.prometheus.to_string(),
+            profile_str,
+        );
     }
 
     fn track_session_props(
@@ -2514,7 +2521,11 @@ pub(crate) fn actuator_route_path(prefix: &str, suffix: &str) -> String {
     }
 }
 
-pub(crate) fn actuator_endpoint_paths(prefix: &str, sensitive: bool) -> Vec<String> {
+pub(crate) fn actuator_endpoint_paths(
+    prefix: &str,
+    sensitive: bool,
+    prometheus_enabled: bool,
+) -> Vec<String> {
     let mut paths = vec![
         actuator_route_path(prefix, "/health"),
         actuator_route_path(prefix, "/info"),
@@ -2524,7 +2535,9 @@ pub(crate) fn actuator_endpoint_paths(prefix: &str, sensitive: bool) -> Vec<Stri
         actuator_route_path(prefix, "/ui/metrics"),
     ];
 
-    paths.push(actuator_route_path(prefix, "/prometheus"));
+    if prometheus_enabled {
+        paths.push(actuator_route_path(prefix, "/prometheus"));
+    }
 
     if sensitive {
         paths.push(actuator_route_path(prefix, "/env"));
@@ -2552,20 +2565,28 @@ pub(crate) fn actuator_endpoint_paths(prefix: &str, sensitive: bool) -> Vec<Stri
 ///
 /// In dev mode (or when `actuator.sensitive = true`), all endpoints are
 /// exposed. In prod mode, only health, info, and metrics are available.
+///
+/// The Prometheus scrape endpoint is mounted (independent of `sensitive`); use
+/// [`actuator_router_with_prefix`] to control it explicitly.
 pub fn actuator_router<S: ProvideActuatorState + Send + Sync + Clone + 'static>(
     sensitive: bool,
 ) -> axum::Router<S> {
-    actuator_router_with_prefix("/actuator", sensitive)
+    actuator_router_with_prefix("/actuator", sensitive, true)
 }
 
 /// Build the actuator router at a configured prefix.
 ///
 /// This is the prefix-aware variant used by the framework router.
+///
+/// `prometheus_enabled` controls the `/actuator/prometheus` scrape endpoint
+/// independently of `sensitive`, so platform metrics scraping can be exposed
+/// without also exposing sensitive actuator surfaces.
 pub(crate) fn actuator_router_with_prefix<
     S: ProvideActuatorState + Send + Sync + Clone + 'static,
 >(
     prefix: &str,
     sensitive: bool,
+    prometheus_enabled: bool,
 ) -> axum::Router<S> {
     let mut router = axum::Router::new()
         .route(
@@ -2583,11 +2604,14 @@ pub(crate) fn actuator_router_with_prefix<
         .route(
             &actuator_route_path(prefix, "/a11y"),
             axum::routing::get(a11y_endpoint::<S>),
-        )
-        .route(
+        );
+
+    if prometheus_enabled {
+        router = router.route(
             &actuator_route_path(prefix, "/prometheus"),
             axum::routing::get(prometheus_endpoint::<S>),
         );
+    }
 
     if sensitive {
         router = router
@@ -3228,7 +3252,7 @@ mod tests {
 
     #[tokio::test]
     async fn actuator_routes_respect_custom_prefix() {
-        let app = actuator_router_with_prefix("/ops", true).with_state(test_state());
+        let app = actuator_router_with_prefix("/ops", true, true).with_state(test_state());
 
         let prefixed = app
             .clone()
@@ -3672,6 +3696,97 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
+    #[tokio::test]
+    async fn actuator_prometheus_available_when_export_enabled_and_nonsensitive() {
+        // Metrics export decoupled from sensitive: prometheus is reachable even
+        // though sensitive endpoints (env/configprops/loggers/tasks) are not.
+        let app = actuator_router_with_prefix("/actuator", false, true).with_state(test_state());
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Sensitive surfaces stay closed under the non-sensitive metrics config.
+        for sensitive_path in [
+            "/actuator/env",
+            "/actuator/configprops",
+            "/actuator/loggers",
+            "/actuator/tasks",
+            "/actuator/jobs",
+            "/actuator/ui/tasks",
+        ] {
+            let resp = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(sensitive_path)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::NOT_FOUND,
+                "{sensitive_path} should be unavailable when actuator is non-sensitive"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn actuator_prometheus_unavailable_when_export_disabled() {
+        // Regression: with metrics export disabled, the scrape endpoint is gone.
+        let app = actuator_router_with_prefix("/actuator", false, false).with_state(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn actuator_prometheus_unavailable_when_export_disabled_even_if_sensitive() {
+        // Disabling export wins even when sensitive endpoints are enabled.
+        let app = actuator_router_with_prefix("/actuator", true, false).with_state(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn actuator_endpoint_paths_respects_prometheus_toggle() {
+        let enabled = actuator_endpoint_paths("/actuator", false, true);
+        assert!(
+            enabled.iter().any(|p| p == "/actuator/prometheus"),
+            "prometheus path should be listed when export is enabled: {enabled:?}"
+        );
+
+        let disabled = actuator_endpoint_paths("/actuator", false, false);
+        assert!(
+            !disabled.iter().any(|p| p == "/actuator/prometheus"),
+            "prometheus path should be absent when export is disabled: {disabled:?}"
+        );
+    }
+
     // ── Tasks endpoint tests ───────────────────────────────────
 
     #[tokio::test]
@@ -4081,7 +4196,7 @@ mod tests {
 
     #[tokio::test]
     async fn actuator_a11y_endpoint_paths_includes_a11y() {
-        let paths = actuator_endpoint_paths("/actuator", false);
+        let paths = actuator_endpoint_paths("/actuator", false, true);
         assert!(
             paths.iter().any(|p| p == "/actuator/a11y"),
             "a11y path not found in: {paths:?}"

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -2566,8 +2566,9 @@ pub(crate) fn actuator_endpoint_paths(
 /// In dev mode (or when `actuator.sensitive = true`), all endpoints are
 /// exposed. In prod mode, only health, info, and metrics are available.
 ///
-/// The Prometheus scrape endpoint is mounted (independent of `sensitive`); use
-/// [`actuator_router_with_prefix`] to control it explicitly.
+/// The Prometheus scrape endpoint is mounted unconditionally here (independent
+/// of `sensitive`). The framework router mounts the actuator from configuration
+/// and gates `/actuator/prometheus` on the `actuator.prometheus` flag.
 pub fn actuator_router<S: ProvideActuatorState + Send + Sync + Clone + 'static>(
     sensitive: bool,
 ) -> axum::Router<S> {

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1810,6 +1810,7 @@ impl AutumnConfig {
         self.apply_idempotency_env_overrides_with_env(env);
         self.apply_dev_env_overrides_with_env(env);
         self.apply_compression_env_overrides_with_env(env);
+        self.apply_actuator_env_overrides_with_env(env);
         #[cfg(feature = "reporting")]
         self.apply_reporting_env_overrides_with_env(env);
         #[cfg(feature = "storage")]
@@ -1855,6 +1856,23 @@ impl AutumnConfig {
             env,
             "AUTUMN_COMPRESSION__ENABLED",
             &mut self.compression.enabled,
+        );
+    }
+
+    fn apply_actuator_env_overrides_with_env(&mut self, env: &dyn Env) {
+        parse_env_string(env, "AUTUMN_ACTUATOR__PREFIX", &mut self.actuator.prefix);
+        parse_env_bool(
+            env,
+            "AUTUMN_ACTUATOR__SENSITIVE",
+            &mut self.actuator.sensitive,
+        );
+        // Security-sensitive: operators disable the Prometheus scrape endpoint
+        // with AUTUMN_ACTUATOR__PROMETHEUS=false; the override must be honored
+        // so the endpoint is not left exposed against the operator's intent.
+        parse_env_bool(
+            env,
+            "AUTUMN_ACTUATOR__PROMETHEUS",
+            &mut self.actuator.prometheus,
         );
     }
 
@@ -4213,6 +4231,37 @@ path = "/healthz"
             config.database.url.as_deref(),
             Some("postgres://override:5432/test")
         );
+    }
+
+    #[test]
+    fn env_override_actuator_prometheus_disables() {
+        // Operators must be able to remove the scrape endpoint via the
+        // documented AUTUMN_SECTION__FIELD convention, not just TOML.
+        let env = MockEnv::new().with("AUTUMN_ACTUATOR__PROMETHEUS", "false");
+        let mut config = AutumnConfig::default();
+        assert!(config.actuator.prometheus, "default should be enabled");
+        config.apply_env_overrides_with_env(&env);
+        assert!(
+            !config.actuator.prometheus,
+            "AUTUMN_ACTUATOR__PROMETHEUS=false must disable the scrape endpoint"
+        );
+    }
+
+    #[test]
+    fn env_override_actuator_sensitive() {
+        let env = MockEnv::new().with("AUTUMN_ACTUATOR__SENSITIVE", "true");
+        let mut config = AutumnConfig::default();
+        assert!(!config.actuator.sensitive);
+        config.apply_env_overrides_with_env(&env);
+        assert!(config.actuator.sensitive);
+    }
+
+    #[test]
+    fn env_override_actuator_prefix() {
+        let env = MockEnv::new().with("AUTUMN_ACTUATOR__PREFIX", "/ops");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.actuator.prefix, "/ops");
     }
 
     #[test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -5568,10 +5568,10 @@ path = "/healthz"
 
     #[test]
     fn actuator_prometheus_can_be_disabled_via_toml() {
-        let toml = r#"
+        let toml = r"
             sensitive = false
             prometheus = false
-        "#;
+        ";
         let config: ActuatorConfig = toml::from_str(toml).unwrap();
         assert!(!config.sensitive);
         assert!(!config.prometheus);

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -3089,6 +3089,16 @@ pub struct ActuatorConfig {
     /// Defaults vary by profile: `true` for dev, `false` for prod.
     #[serde(default)]
     pub sensitive: bool,
+
+    /// When `true`, mount the `/actuator/prometheus` scrape endpoint.
+    ///
+    /// This is **independent of [`Self::sensitive`]**: a production app can
+    /// expose Prometheus metrics for platform scraping (e.g. Fly.io `[metrics]`)
+    /// while keeping `sensitive = false` so env/configprops/loggers/tasks/jobs
+    /// stay off the public surface. Set to `false` to remove the scrape
+    /// endpoint entirely (it then returns `404`). Default: `true`.
+    #[serde(default = "default_actuator_prometheus")]
+    pub prometheus: bool,
 }
 
 impl Default for ActuatorConfig {
@@ -3096,12 +3106,17 @@ impl Default for ActuatorConfig {
         Self {
             prefix: default_actuator_prefix(),
             sensitive: false,
+            prometheus: default_actuator_prometheus(),
         }
     }
 }
 
 fn default_actuator_prefix() -> String {
     "/actuator".to_owned()
+}
+
+const fn default_actuator_prometheus() -> bool {
+    true
 }
 
 /// CORS (Cross-Origin Resource Sharing) configuration.
@@ -5546,6 +5561,20 @@ path = "/healthz"
         let config = ActuatorConfig::default();
         assert_eq!(config.prefix, "/actuator");
         assert!(!config.sensitive);
+        // Prometheus metrics export is on by default and independent of
+        // `sensitive`, so platform scraping works without exposing env/loggers.
+        assert!(config.prometheus);
+    }
+
+    #[test]
+    fn actuator_prometheus_can_be_disabled_via_toml() {
+        let toml = r#"
+            sensitive = false
+            prometheus = false
+        "#;
+        let config: ActuatorConfig = toml::from_str(toml).unwrap();
+        assert!(!config.sensitive);
+        assert!(!config.prometheus);
     }
 
     #[test]

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -202,9 +202,11 @@ pub(crate) fn append_framework_routes(
         }
     }
 
-    for path in
-        crate::actuator::actuator_endpoint_paths(&config.actuator.prefix, config.actuator.sensitive)
-    {
+    for path in crate::actuator::actuator_endpoint_paths(
+        &config.actuator.prefix,
+        config.actuator.sensitive,
+        config.actuator.prometheus,
+    ) {
         infos.push(RouteInfo {
             method: "GET".to_owned(),
             path,

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -683,9 +683,11 @@ fn reject_openapi_path_collisions(
     claimed.insert(config.health.live_path.clone());
     claimed.insert(config.health.ready_path.clone());
     claimed.insert(config.health.startup_path.clone());
-    for path in
-        crate::actuator::actuator_endpoint_paths(&config.actuator.prefix, config.actuator.sensitive)
-    {
+    for path in crate::actuator::actuator_endpoint_paths(
+        &config.actuator.prefix,
+        config.actuator.sensitive,
+        config.actuator.prometheus,
+    ) {
         claimed.insert(path);
     }
     #[cfg(feature = "htmx")]
@@ -1016,8 +1018,12 @@ fn mount_actuator_endpoints(
 ) -> Result<axum::Router<AppState>, RouterBuildError> {
     // Actuator endpoints
     let actuator_sensitive = config.actuator.sensitive;
-    let actuator_paths =
-        crate::actuator::actuator_endpoint_paths(&config.actuator.prefix, actuator_sensitive);
+    let actuator_prometheus = config.actuator.prometheus;
+    let actuator_paths = crate::actuator::actuator_endpoint_paths(
+        &config.actuator.prefix,
+        actuator_sensitive,
+        actuator_prometheus,
+    );
     if let Some(path) = actuator_paths
         .iter()
         .find(|path| mounted_probe_paths.contains(path.as_str()))
@@ -1031,9 +1037,11 @@ fn mount_actuator_endpoints(
     router = router.merge(crate::actuator::actuator_router_with_prefix(
         &config.actuator.prefix,
         actuator_sensitive,
+        actuator_prometheus,
     ));
     tracing::debug!(
         sensitive = actuator_sensitive,
+        prometheus = actuator_prometheus,
         prefix = %config.actuator.prefix,
         "Mounted actuator endpoints"
     );
@@ -1970,6 +1978,7 @@ impl StartupBarrierState {
             actuator_paths: crate::actuator::actuator_endpoint_paths(
                 &config.actuator.prefix,
                 config.actuator.sensitive,
+                config.actuator.prometheus,
             ),
             actuator_subtree_paths,
         }

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -231,7 +231,7 @@ The generated `fly.toml` includes four first-class integrations:
 |---|---|
 | `/live` + `/ready` checks | Fly uses `/live` to decide machine restarts; `/ready` to gate traffic routing. Autumn flips `/ready` to 503 at drain start so Fly deregisters before the listener closes. |
 | `kill_timeout = 45` | Fly waits 45 s after SIGTERM before SIGKILL — `prestop_grace_secs (5) + shutdown_timeout_secs (30) + 10 s buffer` for the process to log and exit cleanly. Value is an integer (seconds); Fly does not accept a string like `"45s"`. |
-| `[metrics]` → `/actuator/prometheus` | Fly scrapes Autumn's Prometheus text endpoint and surfaces it in the dashboard. No extra agent needed. |
+| `[metrics]` → `/actuator/prometheus` | Fly scrapes Autumn's Prometheus text endpoint and surfaces it in the dashboard. No extra agent needed. Controlled by `actuator.prometheus` (default on) and independent of `actuator.sensitive` — see [Prometheus metrics for platform scraping](#prometheus-metrics-for-platform-scraping). |
 | `[deploy]` `release_command` (opt-in) | When uncommented, migrations run in a one-shot machine before new app machines start; a failed migration aborts the deploy before any traffic-serving machine is replaced. |
 
 Deploy:
@@ -259,6 +259,73 @@ which would fail the first deploy of a database-free app.
 
 If you add a read replica, set `AUTUMN_DATABASE__REPLICA_URL` as a secret and
 Autumn gates `/ready` until the replica has replayed the latest migration.
+
+---
+
+## Prometheus metrics for platform scraping
+
+Autumn exposes a Prometheus text endpoint at `/actuator/prometheus`. It is
+controlled by `actuator.prometheus` (default **`true`**) and is **independent of
+`actuator.sensitive`**. That separation is the whole point: a production app can
+let Fly.io (or any scraper) collect metrics while keeping `actuator.sensitive =
+false`, so `/actuator/env`, `/actuator/configprops`, `/actuator/loggers`,
+`/actuator/tasks`, `/actuator/jobs`, and the actuator task UI stay off the
+public surface.
+
+```toml
+# autumn.toml — metrics on, sensitive surfaces off (the safe production shape)
+[actuator]
+sensitive  = false   # env/configprops/loggers/tasks/jobs NOT mounted
+prometheus = true    # /actuator/prometheus still scrapeable
+```
+
+To remove the scrape endpoint entirely (it then returns `404`), set
+`prometheus = false`. Regression tests assert both directions — the endpoint is
+present under the non-sensitive config and absent when export is disabled.
+
+The generated `fly.toml` wires Fly's `[metrics]` block to this endpoint:
+
+```toml
+[metrics]
+  port = 3000
+  path = "/actuator/prometheus"
+```
+
+### Keeping metrics off the public HTTP service
+
+`/actuator/prometheus` carries operational counters, not secrets, but you may
+still want it unreachable from public traffic. The Fly-native way is to scrape a
+**separate, non-public port** rather than the port behind `[http_service]`.
+Bind a second internal listener and point `[metrics]` at it:
+
+```toml
+[metrics]
+  port = 9091                       # internal-only; no [http_service] on it
+  path = "/actuator/prometheus"
+```
+
+Fly scrapes `[metrics]` over the private 6PN network, so a port that has no
+`[http_service]` / `force_https` mapping is reachable by the Fly metrics
+collector but not by the public internet. Front the public app on its own port
+and reserve the metrics port for scraping. (If you only run a single listener,
+gate access at the edge or accept that the counters are publicly readable —
+they contain no credentials.)
+
+### OTLP tracing and Prometheus are separate telemetry paths
+
+Enabling OTLP tracing (`telemetry.enabled = true` + `telemetry.otlp_endpoint`)
+initializes **span export to an OTLP collector**. It does **not** feed
+OpenTelemetry metrics into `/actuator/prometheus`. The Prometheus endpoint is
+backed by Autumn's in-process request `MetricsCollector` snapshot plus any
+registered [`MetricsSource`](metrics-sources.md) families — it is a distinct
+pipeline from the OTLP trace exporter. Treat them as two independent channels:
+
+- **Tracing** → OTLP collector (Jaeger, Tempo, Honeycomb, …) via the OTLP path.
+- **Metrics** → `/actuator/prometheus` scraped by Fly `[metrics]` or Prometheus.
+
+Turning on one does not populate the other. Bridging OTLP metrics into the
+Prometheus scrape would require an explicit metrics exporter/bridge, which
+Autumn does not add implicitly.
 
 ---
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -280,8 +280,11 @@ prometheus = true    # /actuator/prometheus still scrapeable
 ```
 
 To remove the scrape endpoint entirely (it then returns `404`), set
-`prometheus = false`. Regression tests assert both directions — the endpoint is
-present under the non-sensitive config and absent when export is disabled.
+`prometheus = false` — either in `autumn.toml` or via the environment override
+`AUTUMN_ACTUATOR__PROMETHEUS=false` (the whole `[actuator]` section follows the
+standard `AUTUMN_SECTION__FIELD` convention). Regression tests assert both
+directions — the endpoint is present under the non-sensitive config and absent
+when export is disabled.
 
 The generated `fly.toml` wires Fly's `[metrics]` block to this endpoint:
 

--- a/docs/guide/metrics-sources.md
+++ b/docs/guide/metrics-sources.md
@@ -215,7 +215,31 @@ current scrapers are not affected.
 
 ## Actuator exposure config
 
-Sources respect the same actuator exposure settings as the built-in families.
-If `/actuator/prometheus` is only reachable in sensitive mode (see
-`actuator.sensitive` in `autumn.toml`), plugin-contributed families are also
-behind that gate — no per-source exposure config is needed.
+Sources respect the same actuator exposure settings as the built-in families —
+no per-source exposure config is needed. Two independent toggles in
+`autumn.toml` govern the scrape endpoint:
+
+```toml
+[actuator]
+sensitive  = false   # env/configprops/loggers/tasks/jobs — off by default in prod
+prometheus = true    # /actuator/prometheus scrape endpoint — on by default
+```
+
+`actuator.prometheus` controls `/actuator/prometheus` **independently of**
+`actuator.sensitive`. The safe production shape is `sensitive = false` +
+`prometheus = true`: platform scrapers (e.g. Fly.io `[metrics]`) collect metrics
+while sensitive actuator surfaces stay unmounted. Set `prometheus = false` to
+remove the scrape endpoint entirely (`404`). See the
+[deployment guide](deployment.md#prometheus-metrics-for-platform-scraping) for
+the Fly.io shape, including scraping a private/non-public metrics port.
+
+## Relationship to OTLP tracing
+
+The Prometheus scrape endpoint and OTLP tracing are **separate telemetry
+paths**. Enabling OTLP (`telemetry.enabled = true` + `telemetry.otlp_endpoint`)
+initializes span export to an OTLP collector; it does **not** add OpenTelemetry
+metrics to `/actuator/prometheus`. The Prometheus endpoint is backed by Autumn's
+in-process request `MetricsCollector` snapshot plus any registered
+`MetricsSource` families — a distinct pipeline from the OTLP trace exporter.
+Bridging OTLP metrics into the scrape would require an explicit metrics
+exporter/bridge, which Autumn does not add implicitly.

--- a/docs/guide/tutorial/10-configuration.md
+++ b/docs/guide/tutorial/10-configuration.md
@@ -91,7 +91,10 @@ Recommended use:
 
 Actuator endpoints live under `/actuator` by default and expose health, info,
 metrics, config properties, loggers, and task visibility based on the
-`actuator.sensitive` setting.
+`actuator.sensitive` setting. The Prometheus scrape endpoint
+(`/actuator/prometheus`) is governed separately by `actuator.prometheus`
+(default `true`), so platform scraping works with `sensitive = false` — see the
+[deployment guide](../deployment.md#prometheus-metrics-for-platform-scraping).
 
 ## Telemetry
 


### PR DESCRIPTION
## Summary

Introduces a new `actuator.prometheus` configuration flag that controls the `/actuator/prometheus` scrape endpoint **independently of** `actuator.sensitive`. This allows production deployments to expose Prometheus metrics for platform scraping (e.g., Fly.io `[metrics]`) while keeping sensitive actuator surfaces (`/env`, `/configprops`, `/loggers`, `/tasks`, `/jobs`) off the public surface.

## Key Changes

- **New config flag:** `actuator.prometheus` (default `true`) in `autumn.toml` controls whether `/actuator/prometheus` is mounted
- **Decoupled logic:** The Prometheus endpoint is no longer gated by `actuator.sensitive`; both flags are now independent toggles
- **Router updates:** `actuator_router_with_prefix()` and `actuator_endpoint_paths()` now accept a `prometheus_enabled` parameter
- **Property tracking:** Added `actuator.prometheus` to the config properties tracking in `ConfigProperties::track_actuator_props()`
- **Comprehensive tests:** Added four new test cases covering:
  - Prometheus available when export enabled and non-sensitive
  - Prometheus unavailable when export disabled (regardless of sensitive mode)
  - Endpoint paths respecting the prometheus toggle
- **Documentation:** Updated deployment guide with safe production shape (sensitive=false, prometheus=true), guidance on scraping private metrics ports, and clarification that OTLP tracing and Prometheus metrics are separate telemetry paths
- **CLI template:** Updated `fly.toml.tmpl` to document the new flag and recommend private port scraping pattern

## Implementation Details

- The `prometheus_enabled` parameter flows through the router construction chain: `mount_actuator_endpoints()` → `actuator_router_with_prefix()` → conditional route registration
- When `prometheus_enabled = false`, the `/prometheus` route is not registered, returning `404` instead of `403` or `401`
- All call sites updated to pass the new parameter (router, route listing, startup barrier state)
- Default behavior preserves backward compatibility: Prometheus metrics are on by default, matching the previous implicit behavior

https://claude.ai/code/session_01C6MWwowrdNG1pN7xN25xwC