### PR TITLE
Add streaming MCP tool support via SSE (issue #1118)

### DIFF
--- a/autumn-macros/src/api_doc.rs
+++ b/autumn-macros/src/api_doc.rs
@@ -39,6 +39,9 @@ use syn::parse::{Parse, ParseStream, Parser as _};
 use syn::{Attribute, Expr, ExprLit, Ident, Lit, LitBool, LitStr, Token};
 
 /// Parsed `#[api_doc(...)]` attribute arguments.
+// Each bool models a distinct, orthogonal attribute flag (`hidden`, `mcp`,
+// `mcp = false`, `stream`); grouping them would obscure rather than clarify.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Default)]
 pub struct ApiDocAttr {
     pub summary: Option<LitStr>,
@@ -53,6 +56,13 @@ pub struct ApiDocAttr {
     /// `#[api_doc(mcp = false)]` — explicitly exclude from MCP, honored
     /// even under the whole-API hatch.
     pub mcp_exclude: bool,
+    /// `#[api_doc(mcp, stream)]` — this MCP tool returns an Autumn `Sse`
+    /// stream, projected onto the MCP Streamable-HTTP SSE channel as
+    /// `notifications/progress` messages terminated by the final result.
+    /// Only meaningful together with `mcp`; it also exempts the tool from
+    /// the JSON-response eligibility gate (an `Sse` handler has no JSON
+    /// response schema).
+    pub mcp_stream: bool,
 }
 
 enum KeyValue {
@@ -65,6 +75,8 @@ enum KeyValue {
     Hidden,
     /// `true` => opt in as a tool, `false` => explicit exclusion.
     Mcp(bool),
+    /// `stream` flag — this MCP tool streams over SSE.
+    Stream,
 }
 
 impl Parse for KeyValue {
@@ -99,6 +111,21 @@ impl Parse for KeyValue {
             return Ok(KeyValue::Mcp(true));
         }
 
+        if key_str == "stream" {
+            if input.peek(Token![=]) {
+                let _eq: Token![=] = input.parse()?;
+                let value: LitBool = input.parse()?;
+                return Ok(if value.value {
+                    KeyValue::Stream
+                } else {
+                    // `stream = false` is the default; emit a no-op marker.
+                    KeyValue::Tags(Vec::new())
+                });
+            }
+            // Bare `stream` flag opts in.
+            return Ok(KeyValue::Stream);
+        }
+
         let _eq: Token![=] = input.parse()?;
         match key_str.as_str() {
             "summary" => Ok(KeyValue::Summary(input.parse()?)),
@@ -122,7 +149,7 @@ impl Parse for KeyValue {
                 key.span(),
                 format!(
                     "unknown key `{other}` in `#[api_doc(...)]`. \
-                     Supported keys: summary, description, tag, tags, operation_id, status, hidden, mcp."
+                     Supported keys: summary, description, tag, tags, operation_id, status, hidden, mcp, stream."
                 ),
             )),
         }
@@ -156,6 +183,7 @@ impl ApiDocAttr {
             KeyValue::Hidden => self.hidden = true,
             KeyValue::Mcp(true) => self.mcp_tool = true,
             KeyValue::Mcp(false) => self.mcp_exclude = true,
+            KeyValue::Stream => self.mcp_stream = true,
         }
     }
 }
@@ -238,6 +266,9 @@ impl ApiDocAttr {
         if other.mcp_exclude {
             self.mcp_exclude = true;
         }
+        if other.mcp_stream {
+            self.mcp_stream = true;
+        }
     }
 
     /// Emit field initializers `summary: ..., description: ..., tags: ..., hidden: ...`
@@ -258,6 +289,7 @@ impl ApiDocAttr {
         let hidden = self.hidden;
         let mcp_tool = self.mcp_tool;
         let mcp_exclude = self.mcp_exclude;
+        let mcp_stream = self.mcp_stream;
         quote! {
             operation_id: #op_id,
             summary: #summary,
@@ -267,6 +299,7 @@ impl ApiDocAttr {
             hidden: #hidden,
             mcp_tool: #mcp_tool,
             mcp_exclude: #mcp_exclude,
+            mcp_stream: #mcp_stream,
         }
     }
 }

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -155,6 +155,7 @@ image = { workspace = true, optional = true }
 [dev-dependencies]
 diesel = { version = "2", features = ["chrono", "postgres"] }
 filetime = "0.2"
+futures.workspace = true
 http.workspace = true
 serde_json = "1"
 tempfile = "3"

--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -1006,8 +1006,10 @@ async fn serve_mcp(
             if let Some((id, params)) = single_tools_call(&msg) {
                 serve_tools_call(&server, &ctx, id, params).await
             } else {
-                handle_message(&server, &msg)
-                    .map_or_else(|| StatusCode::ACCEPTED.into_response(), |v| json_response(&v))
+                handle_message(&server, &msg).map_or_else(
+                    || StatusCode::ACCEPTED.into_response(),
+                    |v| json_response(&v),
+                )
             }
         }
         // Anything else (scalar, null) is not a valid JSON-RPC message.
@@ -1221,7 +1223,11 @@ async fn serve_tools_call(
         .headers()
         .get(header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
-        .is_some_and(|c| c.trim_start().to_ascii_lowercase().starts_with("text/event-stream"));
+        .is_some_and(|c| {
+            c.trim_start()
+                .to_ascii_lowercase()
+                .starts_with("text/event-stream")
+        });
     let client_accepts_sse = ctx
         .headers
         .get(header::ACCEPT)
@@ -1274,7 +1280,10 @@ async fn serve_tools_call(
     } else {
         success(
             id,
-            tool_error(&format!("handler returned HTTP {}: {text}", status.as_u16())),
+            tool_error(&format!(
+                "handler returned HTTP {}: {text}",
+                status.as_u16()
+            )),
         )
     };
     let mut resp = json_response(&value);
@@ -1879,9 +1888,15 @@ mod tests {
         d.response = None;
         d.mcp_stream = true;
         // Still requires opt-in: `stream` alone (no `mcp`) is not exposed.
-        assert!(!should_expose(&d, false), "stream without opt-in stays hidden");
+        assert!(
+            !should_expose(&d, false),
+            "stream without opt-in stays hidden"
+        );
         d.mcp_tool = true;
-        assert!(should_expose(&d, false), "opted-in streaming tool is exposed");
+        assert!(
+            should_expose(&d, false),
+            "opted-in streaming tool is exposed"
+        );
         // Exclusion still wins.
         d.mcp_exclude = true;
         assert!(!should_expose(&d, false));
@@ -1948,8 +1963,11 @@ mod tests {
         assert_eq!(plain["params"]["progress"], 2.0);
         assert_eq!(plain["params"]["message"], "working");
         // Structured JSON with a numeric `progress` → forwarded verbatim.
-        let structured =
-            progress_notification(&token, 99.0, r#"{"progress":50,"total":100,"message":"half"}"#);
+        let structured = progress_notification(
+            &token,
+            99.0,
+            r#"{"progress":50,"total":100,"message":"half"}"#,
+        );
         assert_eq!(structured["params"]["progress"], 50);
         assert_eq!(structured["params"]["total"], 100);
         assert_eq!(structured["params"]["message"], "half");

--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -34,20 +34,32 @@
 //!   [`RequireApiToken`](crate::auth::RequireApiToken) surface; the
 //!   `Authorization` header is forwarded into the dispatched call.
 //!
+//! Results are buffered by default. A tool tagged `#[api_doc(mcp, stream)]`
+//! (issue #1118) returns an Autumn [`Sse`](crate::sse::Sse) stream that this
+//! module projects onto the Streamable-HTTP SSE channel as
+//! `notifications/progress` messages terminated by the final `tools/call`
+//! result — see [`serve_tools_call`] / [`stream_tool_result`]. Streaming is
+//! strictly opt-in per tool; the buffered path is unchanged.
+//!
 //! [`AppBuilder::expose_all_as_mcp`]: crate::app::AppBuilder::expose_all_as_mcp
 //!
 //! [mcp]: https://modelcontextprotocol.io
 
 #![cfg(feature = "mcp")]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::convert::Infallible;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use axum::body::{Body, Bytes};
-use axum::http::{HeaderMap, StatusCode, header};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
+use futures::{Stream, StreamExt as _};
 use serde_json::{Value, json};
 use tower::ServiceExt as _;
+
+use crate::sse::{Event, Sse};
 
 use crate::openapi::{ApiDoc, schema_entry_to_value};
 
@@ -55,8 +67,10 @@ use crate::openapi::{ApiDoc, schema_entry_to_value};
 /// none). Also the newest version this server implements.
 const DEFAULT_PROTOCOL_VERSION: &str = "2025-06-18";
 
-/// MCP protocol revisions whose semantics this buffered, tools-only server
-/// honors. A client's requested version is echoed only if it appears here;
+/// MCP protocol revisions whose semantics this tools-only server honors
+/// (results are buffered by default, with opt-in SSE streaming per tool — see
+/// [`serve_tools_call`]). A client's requested version is echoed only if it
+/// appears here;
 /// otherwise the server replies with [`DEFAULT_PROTOCOL_VERSION`] and the
 /// client decides whether it can proceed.
 const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26", "2024-11-05"];
@@ -144,6 +158,9 @@ struct McpTool {
     path_params: Vec<String>,
     has_body: bool,
     has_query: bool,
+    /// True for a `#[api_doc(mcp, stream)]` tool whose handler returns an
+    /// Autumn `Sse` stream, projected onto the Streamable-HTTP SSE channel.
+    streams: bool,
 }
 
 impl McpTool {
@@ -329,6 +346,16 @@ fn should_expose(doc: &ApiDoc, expose_all: bool) -> bool {
     if doc.hidden || doc.mcp_exclude {
         return false;
     }
+    // A streaming tool (`#[api_doc(mcp, stream)]`) returns an `Sse` body, so it
+    // has no JSON response schema by nature. It is eligible purely on its
+    // explicit opt-in (or the hatch, for a read-only verb), bypassing the
+    // JSON-out gate below that would otherwise exclude every schema-less route.
+    if doc.mcp_stream {
+        if doc.mcp_tool {
+            return true;
+        }
+        return expose_all && is_read_only(doc.method);
+    }
     // JSON-out only: a response schema is the structural signal that this is a
     // JSON endpoint rather than an HTML/Maud route.
     //
@@ -498,8 +525,11 @@ pub fn derive_tools(
     let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
     for doc in docs {
         // Surface the "opted in but ineligible" case as a build-time note.
+        // Streaming tools legitimately have no JSON response schema, so they
+        // are exempt from this "missing response" warning/skip.
         if (doc.mcp_tool || (expose_all && is_read_only(doc.method)))
             && doc.response.is_none()
+            && !doc.mcp_stream
             && !doc.mcp_exclude
             && !doc.hidden
         {
@@ -540,6 +570,7 @@ pub fn derive_tools(
             path_params: doc.path_params.iter().map(|p| (*p).to_owned()).collect(),
             has_body: doc.request_body.is_some(),
             has_query: doc.query_schema.is_some(),
+            streams: doc.mcp_stream,
         });
     }
     tools
@@ -559,6 +590,7 @@ pub struct McpToolInfo {
     path_params: Vec<String>,
     has_body: bool,
     has_query: bool,
+    streams: bool,
 }
 
 impl McpServer {
@@ -578,6 +610,7 @@ impl McpServer {
                 path_params: t.path_params,
                 has_body: t.has_body,
                 has_query: t.has_query,
+                streams: t.streams,
             })
             .collect();
         let by_name = tools
@@ -785,8 +818,11 @@ fn apply_cors_headers(
     }
 }
 
-/// MCP over Streamable HTTP: GET opens a server-initiated stream. This buffered
-/// v1 has nothing to stream, so we politely decline (SSE is tracked in #1118).
+/// MCP over Streamable HTTP: a `GET` opens a *server-initiated* stream (for
+/// unsolicited server→client messages). Autumn only streams *in response to a
+/// `tools/call`* — a streaming tool's SSE rides the POST response (see
+/// [`serve_tools_call`]) — so there is nothing to serve on a bare `GET`, and we
+/// decline it per spec.
 async fn serve_mcp_get() -> Response {
     (
         StatusCode::METHOD_NOT_ALLOWED,
@@ -949,12 +985,9 @@ async fn serve_mcp(
         Value::Array(batch) => {
             let mut out = Vec::new();
             for msg in batch {
-                // No cookies are propagated from a batch: the only cookie-setting
-                // path is `tools/call`, which is rejected above before reaching a
-                // batch, so the remaining metadata methods never set one. The sink
-                // is kept to satisfy `handle_message`'s signature and is discarded.
-                let mut discard = Vec::new();
-                if let Some(resp) = handle_message(&server, &ctx, msg, &mut discard).await {
+                // Only metadata methods reach here (a batched `tools/call` is
+                // rejected above), so none set a `Set-Cookie`.
+                if let Some(resp) = handle_message(&server, &msg) {
                     out.push(resp);
                 }
             }
@@ -965,23 +998,17 @@ async fn serve_mcp(
                 json_response(&Value::Array(out))
             }
         }
-        // A single request object. A notification (no `id`) yields `None` → 202.
+        // A single request object. A `tools/call` is dispatched through a path
+        // that can answer with the Streamable-HTTP SSE channel (a streaming
+        // tool) or buffered JSON; everything else (initialize/tools/list/ping)
+        // is buffered. A notification (no `id`) yields `None` → 202.
         msg @ Value::Object(_) => {
-            let mut cookies = Vec::new();
-            handle_message(&server, &ctx, msg, &mut cookies)
-                .await
-                .map_or_else(
-                    || StatusCode::ACCEPTED.into_response(),
-                    |v| {
-                        let mut resp = json_response(&v);
-                        // Replay the inner handler's `Set-Cookie`s so a session- or
-                        // CSRF-cookie-mutating tool behaves like a direct call.
-                        for cookie in cookies {
-                            resp.headers_mut().append(header::SET_COOKIE, cookie);
-                        }
-                        resp
-                    },
-                )
+            if let Some((id, params)) = single_tools_call(&msg) {
+                serve_tools_call(&server, &ctx, id, params).await
+            } else {
+                handle_message(&server, &msg)
+                    .map_or_else(|| StatusCode::ACCEPTED.into_response(), |v| json_response(&v))
+            }
         }
         // Anything else (scalar, null) is not a valid JSON-RPC message.
         _ => json_response(&error(
@@ -1027,18 +1054,10 @@ fn reject_unsupported_protocol_version(headers: &HeaderMap, parsed: &Value) -> O
     )
 }
 
-/// Handle a single JSON-RPC message. Returns `None` only for a *valid*
-/// notification (a `2.0` message with a `method` and no `id`).
-///
-/// `cookies` collects any `Set-Cookie` headers a replayed `tools/call`
-/// response carried, so a single (non-batch) call can propagate session/CSRF
-/// cookie updates to the outer HTTP response.
-async fn handle_message(
-    server: &McpServer,
-    ctx: &ReplayContext<'_>,
-    msg: Value,
-    cookies: &mut Vec<axum::http::HeaderValue>,
-) -> Option<Value> {
+/// Handle a single buffered JSON-RPC message (everything except `tools/call`,
+/// which [`serve_tools_call`] handles so it can stream). Returns `None` only
+/// for a *valid* notification (a `2.0` message with a `method` and no `id`).
+fn handle_message(server: &McpServer, msg: &Value) -> Option<Value> {
     let id = msg.get("id").cloned();
 
     // A JSON-RPC 2.0 `id`, when present, must be a string, number, or null;
@@ -1074,7 +1093,12 @@ async fn handle_message(
         "initialize" => Ok(initialize_result(server, &params)),
         "ping" => Ok(json!({})),
         "tools/list" => Ok(tools_list_result(server)),
-        "tools/call" => return Some(tools_call(server, ctx, id, &params, cookies).await),
+        // A single `tools/call` is diverted to `serve_tools_call` before reaching
+        // here, and a batched one is rejected upstream; this arm is defensive.
+        "tools/call" => Err((
+            -32600,
+            "tools/call must be sent as a single JSON-RPC request".to_owned(),
+        )),
         other => Err((-32601, format!("method not found: {other}"))),
     };
 
@@ -1106,26 +1130,51 @@ fn tools_list_result(server: &McpServer) -> Value {
     json!({ "tools": tools })
 }
 
-/// Dispatch a `tools/call` through the real router and shape the response as
-/// an MCP tool result.
-async fn tools_call(
+/// Whether `msg` is a well-formed single `tools/call` request (JSON-RPC 2.0
+/// object, `method == "tools/call"`, with a usable `id`). Returns the cloned
+/// `id` and `params`. A `tools/call` is handled apart from [`handle_message`]
+/// so its (possibly streaming) result can ride the Streamable-HTTP SSE channel.
+///
+/// A malformed one (bad `jsonrpc`/`id`) returns `None` and falls through to
+/// [`handle_message`], which produces the standard `-32600` error; a
+/// `tools/call` *notification* (no `id`) likewise falls through and is treated
+/// as a no-op notification (`202`), matching the pre-streaming behavior.
+fn single_tools_call(msg: &Value) -> Option<(Value, Value)> {
+    let obj = msg.as_object()?;
+    if obj.get("jsonrpc").and_then(Value::as_str) != Some("2.0") {
+        return None;
+    }
+    if obj.get("method").and_then(Value::as_str) != Some("tools/call") {
+        return None;
+    }
+    let id = obj.get("id")?;
+    if !(id.is_string() || id.is_number() || id.is_null()) {
+        return None;
+    }
+    let params = obj.get("params").cloned().unwrap_or(Value::Null);
+    Some((id.clone(), params))
+}
+
+/// Dispatch a `tools/call` through the real router and shape the response as an
+/// MCP tool result — buffered JSON for an ordinary tool, or a progressive SSE
+/// stream for a `#[api_doc(mcp, stream)]` tool whose handler returns `Sse`.
+async fn serve_tools_call(
     server: &McpServer,
     ctx: &ReplayContext<'_>,
     id: Value,
-    params: &Value,
-    cookies: &mut Vec<axum::http::HeaderValue>,
-) -> Value {
+    params: Value,
+) -> Response {
     let name = params.get("name").and_then(Value::as_str).unwrap_or("");
     // `inputSchema` is always an object; reject a non-object `arguments`
     // (null/string/array) rather than coercing it to `{}` and dispatching.
     let arguments = match params.get("arguments") {
         None => json!({}),
         Some(value) if value.is_object() => value.clone(),
-        Some(_) => return error(id, -32602, "`arguments` must be a JSON object"),
+        Some(_) => return json_response(&error(id, -32602, "`arguments` must be a JSON object")),
     };
 
     let Some(&idx) = server.by_name.get(name) else {
-        return error(id, -32602, &format!("unknown tool: {name}"));
+        return json_response(&error(id, -32602, &format!("unknown tool: {name}")));
     };
     let tool = &server.tools[idx];
 
@@ -1137,7 +1186,7 @@ async fn tools_call(
         server.tenant_header.as_deref(),
     ) {
         Ok(req) => req,
-        Err(message) => return error(id, -32602, &message),
+        Err(message) => return json_response(&error(id, -32602, &message)),
     };
 
     // Carry the caller's resolved identity and connection peer into the replay
@@ -1163,44 +1212,386 @@ async fn tools_call(
     let response = match server.dispatch.clone().oneshot(request).await {
         Ok(resp) => resp,
         Err(e) => {
-            return success(id, tool_error(&format!("dispatch failed: {e}")));
+            return json_response(&success(id, tool_error(&format!("dispatch failed: {e}"))));
         }
     };
 
     let status = response.status();
+    let is_event_stream = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|c| c.trim_start().to_ascii_lowercase().starts_with("text/event-stream"));
+    let client_accepts_sse = ctx
+        .headers
+        .get(header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(accept_includes_event_stream);
+
     // Capture any `Set-Cookie` the inner handler/middleware set (session
     // renewal, CSRF-cookie refresh, login) before the body is consumed, so a
-    // single (non-batch) call can replay them onto the outer HTTP response —
-    // matching what the equivalent direct call would have sent. The caller only
-    // applies these for a single request; a batch leaves them unused.
+    // single call replays them onto the outer HTTP response — matching what the
+    // equivalent direct call would have sent.
+    let mut cookies: Vec<HeaderValue> = Vec::new();
     for value in response.headers().get_all(header::SET_COOKIE) {
         cookies.push(value.clone());
     }
+
+    // A streaming tool whose handler streamed (text/event-stream) and whose
+    // client can read SSE: project the stream onto the MCP SSE channel. This is
+    // the only path that escapes buffering; every other case (a buffered tool, a
+    // streaming handler that errored before streaming, or a client that can't
+    // read SSE) falls through to the buffered branch below — so the base #1117
+    // path and non-SSE clients are entirely unaffected.
+    if tool.streams && status.is_success() && is_event_stream && client_accepts_sse {
+        return stream_tool_result(id, &params, response, cookies);
+    }
+
     // Unlike a normal HTTP response (streamed straight to the socket), the MCP
     // path buffers the whole body to repackage it as a tool result. Cap that
     // buffer so a runaway handler can't OOM the process; report an overflow as
     // an explicit tool error rather than silently truncating to an empty body.
     let Ok(bytes) = axum::body::to_bytes(response.into_body(), MAX_TOOL_RESPONSE_BYTES).await
     else {
-        return success(
+        return json_response(&success(
             id,
             tool_error(&format!(
                 "handler response exceeded the {MAX_TOOL_RESPONSE_BYTES}-byte MCP tool-result limit"
             )),
-        );
+        ));
     };
-    let text = String::from_utf8_lossy(&bytes).into_owned();
+    // A streaming handler buffered for a non-SSE client: collapse the SSE wire
+    // frames into their concatenated data payload so the client still receives a
+    // usable single result instead of raw `data:`-framed text.
+    let text = if is_event_stream {
+        collapse_sse_body(&bytes)
+    } else {
+        String::from_utf8_lossy(&bytes).into_owned()
+    };
 
-    if status.is_success() {
+    let value = if status.is_success() {
         success(id, tool_ok(&text))
     } else {
         success(
             id,
-            tool_error(&format!(
-                "handler returned HTTP {}: {text}",
-                status.as_u16()
-            )),
+            tool_error(&format!("handler returned HTTP {}: {text}", status.as_u16())),
         )
+    };
+    let mut resp = json_response(&value);
+    for cookie in cookies {
+        resp.headers_mut().append(header::SET_COOKIE, cookie);
+    }
+    resp
+}
+
+// ── Progressive (SSE) tool-result projection ──────────────────────
+//
+// A streaming tool is a normal Autumn route returning `Sse` (issue #1118). Its
+// dispatched response is already SSE wire bytes (`event:`/`data:` frames). The
+// MCP endpoint *re-projects* those frames onto the Streamable-HTTP SSE channel:
+// each handler event becomes a `notifications/progress` message (when the
+// client supplied `_meta.progressToken`), and the stream is terminated by the
+// final id-correlated `tools/call` result. The developer writes a plain Autumn
+// stream — zero hand-written JSON-RPC/SSE framing — and time-to-first-signal is
+// decoupled from total tool duration because frames are forwarded as they
+// arrive rather than buffered.
+
+/// Whether an `Accept` header opts the client in to an SSE response. The MCP
+/// Streamable-HTTP transport has a streaming client advertise
+/// `Accept: ..., text/event-stream`; a client that does not is served a
+/// buffered JSON result instead (see [`serve_tools_call`]). `*/*` is treated as
+/// "does not explicitly accept SSE" so a plain JSON client isn't handed a body
+/// it can't parse.
+fn accept_includes_event_stream(accept: &str) -> bool {
+    accept.split(',').any(|part| {
+        let media = part
+            .split(';')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_ascii_lowercase();
+        media == "text/event-stream" || media == "text/*"
+    })
+}
+
+/// Build the JSON-RPC `notifications/progress` message for one streamed event.
+///
+/// When the event's data is a JSON object carrying a numeric `progress`, its
+/// `progress`/`total`/`message` fields are forwarded verbatim (structured
+/// progress). Otherwise the event text is the human-readable `message` and
+/// `progress` is the running per-event counter.
+fn progress_notification(token: &Value, progress: f64, message: &str) -> Value {
+    if let Ok(Value::Object(map)) = serde_json::from_str::<Value>(message)
+        && map.get("progress").is_some_and(Value::is_number)
+    {
+        let mut params = serde_json::Map::new();
+        params.insert("progressToken".into(), token.clone());
+        for key in ["progress", "total", "message"] {
+            if let Some(v) = map.get(key) {
+                params.insert((*key).to_owned(), v.clone());
+            }
+        }
+        return json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/progress",
+            "params": Value::Object(params),
+        });
+    }
+    json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/progress",
+        "params": { "progressToken": token, "progress": progress, "message": message },
+    })
+}
+
+/// Phase of the SSE projection state machine.
+enum ProjectionPhase {
+    /// Reading frames from the handler's stream.
+    Streaming,
+    /// Handler stream ended; the final `tools/call` result is pending.
+    Final,
+    /// Final result emitted; the stream is complete.
+    Done,
+}
+
+/// State threaded through the projection `unfold` (see [`stream_tool_result`]).
+struct StreamProjection {
+    /// The handler's SSE response body, as a byte stream of wire frames.
+    body: Pin<Box<dyn Stream<Item = Result<Bytes, axum::Error>> + Send>>,
+    parser: SseWireParser,
+    /// MCP messages parsed but not yet emitted (one inner chunk may yield many).
+    ready: VecDeque<Event>,
+    /// The client's `_meta.progressToken`, if any; absent ⇒ no progress notes.
+    progress_token: Option<Value>,
+    /// The original request id, echoed on the terminating result.
+    id: Value,
+    /// Running per-event progress counter (used when the handler doesn't supply
+    /// its own structured `progress`).
+    progress: f64,
+    /// Accumulated text of progress (default/`progress`-typed) events.
+    progress_parts: Vec<String>,
+    /// Accumulated text of explicit `event: result` frames, if the handler uses
+    /// them to distinguish the final payload from incremental progress.
+    result_parts: Vec<String>,
+    phase: ProjectionPhase,
+}
+
+/// Project a streaming handler's `Sse` response onto the MCP SSE channel.
+///
+/// Back-pressure / disconnect: the returned [`Sse`] writes frames to the socket
+/// as the agent consumes them; if the agent disconnects, axum drops the
+/// response future, which drops this `unfold` state — and with it the boxed
+/// handler body stream — so the handler's task unwinds with no leak and no panic
+/// on a closed stream, exactly as `sse.rs` handles a dropped subscriber.
+fn stream_tool_result(
+    id: Value,
+    params: &Value,
+    response: Response,
+    cookies: Vec<HeaderValue>,
+) -> Response {
+    let progress_token = params
+        .get("_meta")
+        .and_then(|m| m.get("progressToken"))
+        .cloned();
+
+    let state = StreamProjection {
+        body: Box::pin(response.into_body().into_data_stream()),
+        parser: SseWireParser::new(),
+        ready: VecDeque::new(),
+        progress_token,
+        id,
+        progress: 0.0,
+        progress_parts: Vec::new(),
+        result_parts: Vec::new(),
+        phase: ProjectionPhase::Streaming,
+    };
+
+    let stream = futures::stream::unfold(state, project_next);
+    let mut resp = Sse::new(stream)
+        .keep_alive(crate::sse::keep_alive())
+        .into_response();
+    for cookie in cookies {
+        resp.headers_mut().append(header::SET_COOKIE, cookie);
+    }
+    resp
+}
+
+/// Yield the next MCP message (as an SSE [`Event`]) for the projection.
+async fn project_next(
+    mut st: StreamProjection,
+) -> Option<(Result<Event, Infallible>, StreamProjection)> {
+    loop {
+        if let Some(event) = st.ready.pop_front() {
+            return Some((Ok(event), st));
+        }
+        match st.phase {
+            ProjectionPhase::Done => return None,
+            ProjectionPhase::Final => {
+                // Prefer explicit `event: result` payloads; otherwise the joined
+                // progress text is the complete result.
+                let content = if st.result_parts.is_empty() {
+                    st.progress_parts.join("\n")
+                } else {
+                    st.result_parts.concat()
+                };
+                let value = success(st.id.clone(), tool_ok(&content));
+                st.phase = ProjectionPhase::Done;
+                return Some((Ok(Event::default().data(value.to_string())), st));
+            }
+            ProjectionPhase::Streaming => {
+                if let Some(Ok(bytes)) = st.body.next().await {
+                    let events = st.parser.push(&bytes);
+                    enqueue_projected(&mut st, events);
+                } else {
+                    // End of stream (or a body error): flush any trailing frame
+                    // and move on to the terminating result.
+                    let trailing = st.parser.finish();
+                    enqueue_projected(&mut st, trailing);
+                    st.phase = ProjectionPhase::Final;
+                }
+            }
+        }
+    }
+}
+
+/// Fold parsed handler frames into the projection: accumulate their text for the
+/// final result and, when a `progressToken` is present, enqueue a
+/// `notifications/progress` message per incremental frame.
+fn enqueue_projected(st: &mut StreamProjection, events: Vec<ParsedSseEvent>) {
+    for ev in events {
+        if ev.event.as_deref() == Some("result") {
+            // Explicit final-result content — not surfaced as progress.
+            st.result_parts.push(ev.data);
+            continue;
+        }
+        st.progress_parts.push(ev.data.clone());
+        if let Some(token) = &st.progress_token {
+            st.progress += 1.0;
+            let note = progress_notification(token, st.progress, &ev.data);
+            st.ready.push_back(Event::default().data(note.to_string()));
+        }
+    }
+}
+
+/// One logical SSE frame parsed off the wire.
+struct ParsedSseEvent {
+    /// The `event:` field, if any (`None` ⇒ the default unnamed event).
+    event: Option<String>,
+    /// The `data:` payload (multiple `data:` lines joined by `\n`).
+    data: String,
+}
+
+/// Incremental parser for the SSE wire format (`event:`/`data:` lines, blank
+/// line dispatches, `:`-comment keep-alives ignored). Fed arbitrary byte chunks;
+/// emits one [`ParsedSseEvent`] per completed frame.
+struct SseWireParser {
+    /// Bytes received but not yet split into a complete line.
+    buffer: String,
+    event_type: Option<String>,
+    data_lines: Vec<String>,
+    /// Whether any field line has been seen since the last dispatch (so a lone
+    /// blank line or a comment doesn't emit an empty frame).
+    has_fields: bool,
+}
+
+impl SseWireParser {
+    const fn new() -> Self {
+        Self {
+            buffer: String::new(),
+            event_type: None,
+            data_lines: Vec::new(),
+            has_fields: false,
+        }
+    }
+
+    /// Feed a chunk; return any frames completed by it.
+    fn push(&mut self, bytes: &[u8]) -> Vec<ParsedSseEvent> {
+        self.buffer.push_str(&String::from_utf8_lossy(bytes));
+        let mut out = Vec::new();
+        while let Some(pos) = self.buffer.find('\n') {
+            let line: String = self.buffer.drain(..=pos).collect();
+            if let Some(event) = self.process_line(line.trim_end_matches(['\n', '\r'])) {
+                out.push(event);
+            }
+        }
+        out
+    }
+
+    /// Flush the trailing partial line and any pending (unterminated) frame.
+    fn finish(&mut self) -> Vec<ParsedSseEvent> {
+        let mut out = Vec::new();
+        if !self.buffer.is_empty() {
+            let line = std::mem::take(&mut self.buffer);
+            if let Some(event) = self.process_line(line.trim_end_matches(['\n', '\r'])) {
+                out.push(event);
+            }
+        }
+        if let Some(event) = self.dispatch() {
+            out.push(event);
+        }
+        out
+    }
+
+    fn process_line(&mut self, line: &str) -> Option<ParsedSseEvent> {
+        if line.is_empty() {
+            return self.dispatch();
+        }
+        // A leading colon marks a comment line (SSE keep-alive); ignore it.
+        if line.starts_with(':') {
+            return None;
+        }
+        let (field, value) = match line.split_once(':') {
+            // One optional leading space after the colon is stripped per spec.
+            Some((f, v)) => (f, v.strip_prefix(' ').unwrap_or(v)),
+            None => (line, ""),
+        };
+        match field {
+            "event" => {
+                self.event_type = Some(value.to_owned());
+                self.has_fields = true;
+            }
+            "data" => {
+                self.data_lines.push(value.to_owned());
+                self.has_fields = true;
+            }
+            // `id:`/`retry:` and any unknown field are irrelevant to projection.
+            _ => {}
+        }
+        None
+    }
+
+    fn dispatch(&mut self) -> Option<ParsedSseEvent> {
+        if !self.has_fields {
+            return None;
+        }
+        let event = ParsedSseEvent {
+            event: self.event_type.take(),
+            data: self.data_lines.join("\n"),
+        };
+        self.data_lines.clear();
+        self.has_fields = false;
+        Some(event)
+    }
+}
+
+/// Collapse a fully-buffered SSE body into a single result string — the
+/// non-SSE-client fallback for a streaming tool. Mirrors the streaming final
+/// content: explicit `event: result` frames win, else the joined frame data.
+fn collapse_sse_body(bytes: &[u8]) -> String {
+    let mut parser = SseWireParser::new();
+    let mut events = parser.push(bytes);
+    events.extend(parser.finish());
+    let (results, progress): (Vec<_>, Vec<_>) = events
+        .into_iter()
+        .partition(|e| e.event.as_deref() == Some("result"));
+    if results.is_empty() {
+        progress
+            .into_iter()
+            .map(|e| e.data)
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        results.into_iter().map(|e| e.data).collect()
     }
 }
 
@@ -1481,6 +1872,100 @@ mod tests {
     }
 
     #[test]
+    fn streaming_tool_is_eligible_without_response_schema() {
+        // A streaming tool returns `Sse` (no JSON response schema); the `stream`
+        // flag exempts it from the JSON-out gate that excludes HTML routes.
+        let mut d = doc("GET", "/api/search", "search");
+        d.response = None;
+        d.mcp_stream = true;
+        // Still requires opt-in: `stream` alone (no `mcp`) is not exposed.
+        assert!(!should_expose(&d, false), "stream without opt-in stays hidden");
+        d.mcp_tool = true;
+        assert!(should_expose(&d, false), "opted-in streaming tool is exposed");
+        // Exclusion still wins.
+        d.mcp_exclude = true;
+        assert!(!should_expose(&d, false));
+    }
+
+    #[test]
+    fn streaming_get_is_included_under_the_hatch() {
+        // Under `expose_all`, a read-only streaming GET is auto-included even
+        // without an explicit `mcp` tag (and despite having no response schema).
+        let mut d = doc("GET", "/api/search", "search");
+        d.response = None;
+        d.mcp_stream = true;
+        assert!(should_expose(&d, true));
+        // A mutating streaming verb still needs an explicit opt-in.
+        let mut w = doc("POST", "/api/search", "search2");
+        w.response = None;
+        w.mcp_stream = true;
+        assert!(!should_expose(&w, true));
+    }
+
+    #[test]
+    fn accept_header_gates_sse() {
+        assert!(accept_includes_event_stream(
+            "application/json, text/event-stream"
+        ));
+        assert!(accept_includes_event_stream("text/event-stream;q=1.0"));
+        assert!(accept_includes_event_stream("text/*"));
+        // A plain JSON client (or a generic `*/*`) does not opt in to SSE.
+        assert!(!accept_includes_event_stream("application/json"));
+        assert!(!accept_includes_event_stream("*/*"));
+    }
+
+    #[test]
+    fn sse_parser_splits_frames_and_joins_data() {
+        let mut p = SseWireParser::new();
+        // A multi-data frame, an `event:`-typed frame, and a comment keep-alive.
+        let mut events = p.push(b"data: line1\ndata: line2\n\n");
+        events.extend(p.push(b": keep-alive\n\nevent: result\ndata: final\n\n"));
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event, None);
+        assert_eq!(events[0].data, "line1\nline2");
+        assert_eq!(events[1].event.as_deref(), Some("result"));
+        assert_eq!(events[1].data, "final");
+    }
+
+    #[test]
+    fn sse_parser_handles_chunk_boundaries_mid_frame() {
+        // A frame split across chunk boundaries must still parse once complete.
+        let mut p = SseWireParser::new();
+        assert!(p.push(b"data: hel").is_empty());
+        assert!(p.push(b"lo\n").is_empty());
+        let events = p.push(b"\n");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data, "hello");
+    }
+
+    #[test]
+    fn progress_notification_plain_and_structured() {
+        let token = json!("tok");
+        // Plain text → message + running counter.
+        let plain = progress_notification(&token, 2.0, "working");
+        assert_eq!(plain["method"], "notifications/progress");
+        assert_eq!(plain["params"]["progressToken"], "tok");
+        assert_eq!(plain["params"]["progress"], 2.0);
+        assert_eq!(plain["params"]["message"], "working");
+        // Structured JSON with a numeric `progress` → forwarded verbatim.
+        let structured =
+            progress_notification(&token, 99.0, r#"{"progress":50,"total":100,"message":"half"}"#);
+        assert_eq!(structured["params"]["progress"], 50);
+        assert_eq!(structured["params"]["total"], 100);
+        assert_eq!(structured["params"]["message"], "half");
+    }
+
+    #[test]
+    fn collapse_sse_body_prefers_result_frames() {
+        // No `result` frame: data joined.
+        let joined = collapse_sse_body(b"data: a\n\ndata: b\n\n");
+        assert_eq!(joined, "a\nb");
+        // With a `result` frame: only the result content is kept.
+        let result = collapse_sse_body(b"data: progress\n\nevent: result\ndata: done\n\n");
+        assert_eq!(result, "done");
+    }
+
+    #[test]
     fn annotations_track_method() {
         assert_eq!(annotations_for("GET", "t")["readOnlyHint"], json!(true));
         assert_eq!(annotations_for("POST", "t")["readOnlyHint"], json!(false));
@@ -1533,6 +2018,7 @@ mod tests {
             path_params: Vec::new(),
             has_body,
             has_query,
+            streams: false,
         }
     }
 

--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -38,7 +38,7 @@
 //! (issue #1118) returns an Autumn [`Sse`](crate::sse::Sse) stream that this
 //! module projects onto the Streamable-HTTP SSE channel as
 //! `notifications/progress` messages terminated by the final `tools/call`
-//! result — see [`serve_tools_call`] / [`stream_tool_result`]. Streaming is
+//! result — see `serve_tools_call` / `stream_tool_result`. Streaming is
 //! strictly opt-in per tool; the buffered path is unchanged.
 //!
 //! [`AppBuilder::expose_all_as_mcp`]: crate::app::AppBuilder::expose_all_as_mcp

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -132,6 +132,14 @@ pub struct ApiDoc {
     /// always compiled, but the builder method is gated behind the `mcp`
     /// feature, so a hard link would break docs built without it.
     pub mcp_exclude: bool,
+    /// True when the endpoint opts in to *streaming* MCP exposure via
+    /// `#[api_doc(mcp, stream)]`. A streaming tool returns an Autumn `Sse`
+    /// stream that the MCP endpoint projects onto the Streamable-HTTP SSE
+    /// channel as `notifications/progress` messages terminated by the final
+    /// `tools/call` result. Because an `Sse` handler has no JSON response
+    /// schema, this flag also exempts the tool from the JSON-out eligibility
+    /// gate that otherwise excludes schema-less routes.
+    pub mcp_stream: bool,
 }
 
 /// Reference to a schema definition, produced by the route macros.

--- a/autumn/tests/mcp_streaming.rs
+++ b/autumn/tests/mcp_streaming.rs
@@ -118,7 +118,8 @@ async fn streaming_tool_emits_progress_then_final_result() {
     resp.assert_ok();
     // The response rides the Streamable-HTTP SSE channel.
     assert_eq!(
-        resp.header("content-type").map(|c| c.starts_with("text/event-stream")),
+        resp.header("content-type")
+            .map(|c| c.starts_with("text/event-stream")),
         Some(true),
         "streaming tool must answer with text/event-stream, got {:?}",
         resp.header("content-type")
@@ -132,7 +133,11 @@ async fn streaming_tool_emits_progress_then_final_result() {
         .iter()
         .filter(|m| m["method"] == "notifications/progress")
         .collect();
-    assert_eq!(progress.len(), 3, "one progress per streamed event: {messages:?}");
+    assert_eq!(
+        progress.len(),
+        3,
+        "one progress per streamed event: {messages:?}"
+    );
     for p in &progress {
         assert_eq!(p["params"]["progressToken"], "tok-1");
     }
@@ -146,7 +151,10 @@ async fn streaming_tool_emits_progress_then_final_result() {
         .expect("a final id-correlated result terminates the stream");
     assert_ne!(final_msg["result"]["isError"], true);
     let text = final_msg["result"]["content"][0]["text"].as_str().unwrap();
-    assert!(text.contains("match 1") && text.contains("match 3"), "got: {text}");
+    assert!(
+        text.contains("match 1") && text.contains("match 3"),
+        "got: {text}"
+    );
 }
 
 #[tokio::test]
@@ -169,10 +177,15 @@ async fn streaming_without_progress_token_still_terminates_with_result() {
     resp.assert_ok();
     let messages = sse_messages(&resp.text());
     assert!(
-        messages.iter().all(|m| m["method"] != "notifications/progress"),
+        messages
+            .iter()
+            .all(|m| m["method"] != "notifications/progress"),
         "no progressToken => no progress notifications: {messages:?}"
     );
-    let final_msg = messages.iter().find(|m| m["id"] == 7).expect("final result");
+    let final_msg = messages
+        .iter()
+        .find(|m| m["id"] == 7)
+        .expect("final result");
     assert_ne!(final_msg["result"]["isError"], true);
 }
 
@@ -196,7 +209,8 @@ async fn client_without_sse_accept_gets_buffered_result() {
         .await;
     resp.assert_ok();
     assert_eq!(
-        resp.header("content-type").map(|c| c.starts_with("application/json")),
+        resp.header("content-type")
+            .map(|c| c.starts_with("application/json")),
         Some(true),
         "non-SSE client gets buffered JSON, got {:?}",
         resp.header("content-type")
@@ -204,7 +218,10 @@ async fn client_without_sse_accept_gets_buffered_result() {
     let out = resp.json::<serde_json::Value>();
     assert_eq!(out["id"], 9);
     let text = out["result"]["content"][0]["text"].as_str().unwrap();
-    assert!(text.contains("match 1"), "buffered content joins the stream: {text}");
+    assert!(
+        text.contains("match 1"),
+        "buffered content joins the stream: {text}"
+    );
 }
 
 #[tokio::test]
@@ -225,7 +242,8 @@ async fn buffered_tool_is_unchanged_by_streaming_support() {
         .await;
     resp.assert_ok();
     assert_eq!(
-        resp.header("content-type").map(|c| c.starts_with("application/json")),
+        resp.header("content-type")
+            .map(|c| c.starts_with("application/json")),
         Some(true),
         "buffered tool still answers application/json"
     );
@@ -243,12 +261,12 @@ async fn first_progress_arrives_before_the_slow_tool_completes() {
     #[get("/api/slow")]
     #[api_doc(mcp, stream, summary = "Slow streaming tool")]
     async fn slow_stream() -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
-        let s = stream::once(async { Ok(Event::default().data("started")) }).chain(
-            stream::once(async {
+        let s = stream::once(async { Ok(Event::default().data("started")) }).chain(stream::once(
+            async {
                 tokio::time::sleep(Duration::from_millis(300)).await;
                 Ok(Event::default().data("done"))
-            }),
-        );
+            },
+        ));
         Sse::new(s)
     }
 

--- a/autumn/tests/mcp_streaming.rs
+++ b/autumn/tests/mcp_streaming.rs
@@ -1,0 +1,296 @@
+//! Integration tests for progressive (streaming) MCP tool results over the
+//! Streamable-HTTP SSE channel (issue #1118).
+//!
+//! Covers the acceptance criteria:
+//! * An opted-in tool (`#[api_doc(mcp, stream)]`) returns an Autumn `Sse`
+//!   stream rather than a single buffered value.
+//! * When the client supplies `_meta.progressToken`, the server emits
+//!   `notifications/progress` messages referencing that token over SSE.
+//! * Streamed content is delivered over SSE, terminated by the final
+//!   `tools/call` result.
+//! * Buffered (non-streaming) tools continue to work unchanged.
+//! * A client that does not accept `text/event-stream` gets a buffered
+//!   JSON result (graceful fallback), so streaming is opt-in end to end.
+
+#![cfg(feature = "mcp")]
+
+use std::convert::Infallible;
+use std::time::Duration;
+
+use autumn_web::prelude::*;
+use autumn_web::sse::{Event, Sse};
+use autumn_web::test::{TestApp, TestClient};
+use futures::stream::{self, Stream, StreamExt};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone)]
+struct Todo {
+    id: u32,
+    title: String,
+}
+
+// A streaming MCP tool: emits three incremental "matches" then completes. The
+// handler writes a *normal* Autumn `Sse` stream — no MCP/JSON-RPC framing.
+#[get("/api/search")]
+#[api_doc(mcp, stream, summary = "Streaming code search")]
+async fn streaming_search() -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let stream = stream::iter(vec![
+        Ok(Event::default().data("match 1")),
+        Ok(Event::default().data("match 2")),
+        Ok(Event::default().data("match 3")),
+    ]);
+    Sse::new(stream)
+}
+
+// A buffered (non-streaming) tool, to prove the base path is unchanged.
+#[get("/api/todos")]
+#[api_doc(mcp, summary = "List todos")]
+async fn list_todos() -> AutumnResult<Json<Vec<Todo>>> {
+    Ok(Json(vec![Todo {
+        id: 1,
+        title: "first".into(),
+    }]))
+}
+
+/// Parse the `data:` payloads out of an SSE response body into JSON values,
+/// skipping comments/keep-alives.
+fn sse_messages(body: &str) -> Vec<serde_json::Value> {
+    body.lines()
+        .filter_map(|line| line.strip_prefix("data:"))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+        .collect()
+}
+
+async fn post_sse(client: &TestClient, body: serde_json::Value) -> autumn_web::test::TestResponse {
+    client
+        .post("/mcp")
+        .header("accept", "application/json, text/event-stream")
+        .json(&body)
+        .send()
+        .await
+}
+
+#[tokio::test]
+async fn streaming_tool_is_listed_with_input_schema() {
+    let client = TestApp::new()
+        .routes(routes![streaming_search])
+        .mount_mcp("/mcp")
+        .build();
+
+    let resp = client
+        .post("/mcp")
+        .json(&serde_json::json!({"jsonrpc":"2.0","id":1,"method":"tools/list"}))
+        .send()
+        .await;
+    resp.assert_ok();
+    let out = resp.json::<serde_json::Value>();
+    let tools = out["result"]["tools"].as_array().unwrap();
+    let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+    // A streaming tool has no JSON response schema, but `stream` exempts it
+    // from the JSON-out eligibility gate, so it is still advertised.
+    assert!(
+        names.contains(&"streaming_search"),
+        "streaming tool must be listed: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn streaming_tool_emits_progress_then_final_result() {
+    let client = TestApp::new()
+        .routes(routes![streaming_search])
+        .mount_mcp("/mcp")
+        .build();
+
+    let resp = post_sse(
+        &client,
+        serde_json::json!({
+            "jsonrpc":"2.0","id":42,"method":"tools/call",
+            "params": {
+                "name":"streaming_search",
+                "arguments":{},
+                "_meta": { "progressToken": "tok-1" }
+            }
+        }),
+    )
+    .await;
+    resp.assert_ok();
+    // The response rides the Streamable-HTTP SSE channel.
+    assert_eq!(
+        resp.header("content-type").map(|c| c.starts_with("text/event-stream")),
+        Some(true),
+        "streaming tool must answer with text/event-stream, got {:?}",
+        resp.header("content-type")
+    );
+
+    let messages = sse_messages(&resp.text());
+
+    // Progress notifications reference the client's token and carry the
+    // incremental matches as their `message`.
+    let progress: Vec<&serde_json::Value> = messages
+        .iter()
+        .filter(|m| m["method"] == "notifications/progress")
+        .collect();
+    assert_eq!(progress.len(), 3, "one progress per streamed event: {messages:?}");
+    for p in &progress {
+        assert_eq!(p["params"]["progressToken"], "tok-1");
+    }
+    assert_eq!(progress[0]["params"]["message"], "match 1");
+    assert_eq!(progress[2]["params"]["message"], "match 3");
+
+    // The stream terminates with the final tools/call result (id-correlated).
+    let final_msg = messages
+        .iter()
+        .find(|m| m["id"] == 42)
+        .expect("a final id-correlated result terminates the stream");
+    assert_ne!(final_msg["result"]["isError"], true);
+    let text = final_msg["result"]["content"][0]["text"].as_str().unwrap();
+    assert!(text.contains("match 1") && text.contains("match 3"), "got: {text}");
+}
+
+#[tokio::test]
+async fn streaming_without_progress_token_still_terminates_with_result() {
+    // No `_meta.progressToken`: the spec forbids progress notifications without
+    // a token, but the final result must still be delivered over the channel.
+    let client = TestApp::new()
+        .routes(routes![streaming_search])
+        .mount_mcp("/mcp")
+        .build();
+
+    let resp = post_sse(
+        &client,
+        serde_json::json!({
+            "jsonrpc":"2.0","id":7,"method":"tools/call",
+            "params": {"name":"streaming_search","arguments":{}}
+        }),
+    )
+    .await;
+    resp.assert_ok();
+    let messages = sse_messages(&resp.text());
+    assert!(
+        messages.iter().all(|m| m["method"] != "notifications/progress"),
+        "no progressToken => no progress notifications: {messages:?}"
+    );
+    let final_msg = messages.iter().find(|m| m["id"] == 7).expect("final result");
+    assert_ne!(final_msg["result"]["isError"], true);
+}
+
+#[tokio::test]
+async fn client_without_sse_accept_gets_buffered_result() {
+    // A client that only accepts application/json must still get a usable
+    // (buffered) tool result rather than an SSE body it can't read.
+    let client = TestApp::new()
+        .routes(routes![streaming_search])
+        .mount_mcp("/mcp")
+        .build();
+
+    let resp = client
+        .post("/mcp")
+        .header("accept", "application/json")
+        .json(&serde_json::json!({
+            "jsonrpc":"2.0","id":9,"method":"tools/call",
+            "params": {"name":"streaming_search","arguments":{}}
+        }))
+        .send()
+        .await;
+    resp.assert_ok();
+    assert_eq!(
+        resp.header("content-type").map(|c| c.starts_with("application/json")),
+        Some(true),
+        "non-SSE client gets buffered JSON, got {:?}",
+        resp.header("content-type")
+    );
+    let out = resp.json::<serde_json::Value>();
+    assert_eq!(out["id"], 9);
+    let text = out["result"]["content"][0]["text"].as_str().unwrap();
+    assert!(text.contains("match 1"), "buffered content joins the stream: {text}");
+}
+
+#[tokio::test]
+async fn buffered_tool_is_unchanged_by_streaming_support() {
+    // The base #1117 buffered path must regress in no way.
+    let client = TestApp::new()
+        .routes(routes![list_todos])
+        .mount_mcp("/mcp")
+        .build();
+
+    let resp = client
+        .post("/mcp")
+        .json(&serde_json::json!({
+            "jsonrpc":"2.0","id":3,"method":"tools/call",
+            "params": {"name":"list_todos","arguments":{}}
+        }))
+        .send()
+        .await;
+    resp.assert_ok();
+    assert_eq!(
+        resp.header("content-type").map(|c| c.starts_with("application/json")),
+        Some(true),
+        "buffered tool still answers application/json"
+    );
+    let out = resp.json::<serde_json::Value>();
+    assert_ne!(out["result"]["isError"], true);
+    let text = out["result"]["content"][0]["text"].as_str().unwrap();
+    assert!(text.contains("first"));
+}
+
+#[tokio::test]
+async fn first_progress_arrives_before_the_slow_tool_completes() {
+    // Success metric: time-to-first-signal is decoupled from total duration.
+    // The handler sleeps after the first event; the first SSE frame must be
+    // observable well before the whole tool finishes.
+    #[get("/api/slow")]
+    #[api_doc(mcp, stream, summary = "Slow streaming tool")]
+    async fn slow_stream() -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+        let s = stream::once(async { Ok(Event::default().data("started")) }).chain(
+            stream::once(async {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                Ok(Event::default().data("done"))
+            }),
+        );
+        Sse::new(s)
+    }
+
+    // Drive the raw streaming response so we can observe the first frame's
+    // arrival time rather than waiting for the buffered whole body.
+    let router = TestApp::new()
+        .routes(routes![slow_stream])
+        .mount_mcp("/mcp")
+        .build()
+        .into_router();
+    let request = http::Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("accept", "text/event-stream")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "jsonrpc":"2.0","id":1,"method":"tools/call",
+                "params": {
+                    "name":"slow_stream","arguments":{},
+                    "_meta": {"progressToken": 1}
+                }
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+
+    let start = std::time::Instant::now();
+    let response = tower::ServiceExt::oneshot(router, request).await.unwrap();
+    let mut body = response.into_body().into_data_stream();
+    // Pull the first non-empty chunk.
+    let mut first_at = None;
+    while let Some(chunk) = body.next().await {
+        let bytes = chunk.unwrap();
+        if !bytes.is_empty() {
+            first_at = Some(start.elapsed());
+            break;
+        }
+    }
+    let elapsed = first_at.expect("a first frame");
+    assert!(
+        elapsed < Duration::from_millis(250),
+        "first signal should precede the 300ms tail; took {elapsed:?}"
+    );
+}

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -178,7 +178,114 @@ curl -s http://127.0.0.1:3000/mcp \
 
 ---
 
-## 5. Authentication: reuse your bearer tokens
+## 5. Streaming progressive results over SSE
+
+A long-running tool — a code search over a large graph, a multi-step report, a
+slow scan — feels broken if the agent waits in silence for the whole result.
+The MCP Streamable-HTTP transport lets a `tools/call` emit
+`notifications/progress` messages (and partial content) over the response's SSE
+channel *before* the final result lands. Autumn already ships a first-class SSE
+primitive (`sse.rs`: `Sse`/`Event`/`keep_alive`) — the exact transport MCP
+streaming rides — so a streaming tool is just **a normal Autumn `Sse` stream
+wearing an MCP hat**. You write zero JSON-RPC or SSE framing.
+
+### Opt in with `stream`
+
+Add the `stream` flag to `#[api_doc(mcp, stream)]` and return an `Sse` stream
+of `Event`s. Because an `Sse` handler has no JSON response schema, `stream` also
+exempts the tool from the JSON-out eligibility gate (see §8):
+
+```rust
+use std::convert::Infallible;
+use autumn_web::prelude::*;
+use autumn_web::sse::{Event, Sse};
+use futures::stream::{self, Stream};
+
+#[get("/api/search")]
+#[api_doc(mcp, stream, summary = "Streaming code search")]
+async fn search() -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    // A plain Autumn stream — each event is one incremental chunk of work.
+    let stream = stream::iter(vec![
+        Ok(Event::default().data("match src/a.rs:12")),
+        Ok(Event::default().data("match src/b.rs:48")),
+    ]);
+    Sse::new(stream)
+}
+```
+
+### What rides the wire
+
+When a client calls a streaming tool **and** advertises it can read SSE
+(`Accept: application/json, text/event-stream`), Autumn answers the `POST /mcp`
+with `Content-Type: text/event-stream` and projects your stream onto it:
+
+- **Each `Event` you yield** becomes a `notifications/progress` message — *but
+  only when the client supplied a progress token* in `params._meta.progressToken`
+  (per spec, progress requires a token). The event's text is the progress
+  `message`; `progress` auto-increments per event.
+- **The stream is terminated** by the final id-correlated `tools/call` result,
+  whose content is the joined text of the streamed events.
+
+```jsonc
+// client → server
+{
+  "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+  "params": {
+    "name": "search", "arguments": {},
+    "_meta": { "progressToken": "tok-1" }
+  }
+}
+
+// server → client, as SSE frames (one JSON-RPC message per `data:` frame)
+data: {"jsonrpc":"2.0","method":"notifications/progress",
+       "params":{"progressToken":"tok-1","progress":1,"message":"match src/a.rs:12"}}
+
+data: {"jsonrpc":"2.0","method":"notifications/progress",
+       "params":{"progressToken":"tok-1","progress":2,"message":"match src/b.rs:48"}}
+
+data: {"jsonrpc":"2.0","id":7,"result":{"content":[{"type":"text",
+       "text":"match src/a.rs:12\nmatch src/b.rs:48"}],"isError":false}}
+```
+
+The **time-to-first-signal is decoupled from total duration**: frames are
+forwarded as your stream produces them, so the first progress notification
+reaches the agent immediately even when the whole tool takes seconds.
+
+### Structured progress and an explicit final payload
+
+Two optional conventions, still framing-free:
+
+- **Structured progress** — yield an `Event` whose data is a JSON object with a
+  numeric `progress` (and optional `total`/`message`); those fields are
+  forwarded verbatim into the notification's params instead of the
+  auto-incrementing counter.
+- **An explicit final result** — yield `Event::default().event("result").data(…)`
+  to set the terminating result's content directly. Frames typed `result` are
+  *not* surfaced as progress; everything else is.
+
+### Buffered tools and non-SSE clients are unaffected
+
+Streaming is **strictly opt-in per tool**. A tool without `stream` follows the
+exact buffered path from §4 — nothing about it changes. And a streaming tool
+called by a client that does *not* accept `text/event-stream` is served a
+buffered JSON result (its streamed events collapsed into one tool result), so a
+plain JSON client is never handed a body it can't read.
+
+### Back-pressure and disconnect
+
+The projection reuses the same lifecycle `sse.rs` uses for a dropped subscriber:
+if the agent disconnects mid-stream, axum drops the response and Autumn drops
+the underlying handler stream — the handler's task unwinds with no leaked task
+and no panic on the closed stream. A `keep_alive` comment is sent on idle so
+proxies don't drop a slow stream.
+
+> **Server-initiated `GET` streams are not supported.** Streaming rides the
+> `tools/call` `POST` response; a bare `GET /mcp` (for unsolicited server→client
+> messages) returns `405`.
+
+---
+
+## 6. Authentication: reuse your bearer tokens
 
 `tools/call` runs through the **real handler pipeline** — the same in-process
 path Autumn's [test client](testing.md) uses. That means `#[secured]`,
@@ -270,7 +377,7 @@ origin to your CORS config; agent clients need no configuration.
 
 ---
 
-## 6. The whole-API hatch
+## 7. The whole-API hatch
 
 For internal tools or trusted agents you can expose every eligible **read**
 endpoint at once, without tagging each one, via `expose_all_as_mcp()`:
@@ -294,7 +401,7 @@ conservative:
 
 ---
 
-## 7. Eligibility: JSON in, JSON out
+## 8. Eligibility: JSON in, JSON out
 
 Only JSON endpoints are eligible. Autumn detects this structurally: a route is
 eligible when its handler has a JSON **response schema** (it returns
@@ -311,28 +418,35 @@ WARN skipping MCP exposure: endpoint has no JSON response schema
 
 ---
 
-## 8. End-to-end example
+## 9. End-to-end example
 
-`examples/todo-app` ships an `/mcp` endpoint. Its bearer-token JSON API
-(`list_json`, `create_json`) is mounted in a `scoped("/api", RequireApiToken,
-…)` group and tagged `#[api_doc(mcp)]`, exposing one read tool and one
-explicitly-opted-in write tool behind the same token auth a mobile client uses:
+`examples/todo-app` ships an `/mcp` endpoint. Its bearer-token JSON API is
+mounted in a `scoped("/api", RequireApiToken, …)` group and tagged
+`#[api_doc(mcp)]`, exposing a read tool (`list_json`), an explicitly-opted-in
+write tool (`create_json`), and a **streaming** tool (`scan_json`, tagged
+`#[api_doc(mcp, stream)]`) — all behind the same token auth a mobile client uses:
 
 ```rust
 .scoped(
     "/api",
     RequireApiToken::new(Arc::new(deferred.clone())),
-    routes![routes::api::list_json, routes::api::create_json],
+    routes![
+        routes::api::list_json,
+        routes::api::create_json,
+        routes::api::scan_json, // streaming: Sse → notifications/progress
+    ],
 )
 .mount_mcp("/mcp")
 ```
 
 Run it, issue a token via `POST /api/tokens`, then `tools/list` and
-`tools/call` against `/mcp` with that token in the `Authorization` header.
+`tools/call` against `/mcp` with that token in the `Authorization` header. Call
+`scan_json` with a `_meta.progressToken` and an `Accept: text/event-stream`
+header to watch progress frames arrive as the scan runs.
 
 ---
 
-## 9. How a tool call is dispatched (and why it can't loop)
+## 10. How a tool call is dispatched (and why it can't loop)
 
 When a `tools/call` arrives, the MCP handler reconstructs an ordinary HTTP
 request — filling the path template, building the query string, and attaching
@@ -362,15 +476,12 @@ that from convention to a structural guarantee.)
 
 ---
 
-## 10. Scope and roadmap
+## 11. Scope and roadmap
 
-This slice is intentionally **tools-only and buffered**. The following are
-**out of scope for v1** and tracked as follow-ups:
+This slice is **tools-only**. Tool results are buffered by default, with
+**opt-in progressive streaming over SSE** (§5). The following remain **out of
+scope** and are tracked as follow-ups:
 
-- **Streaming / partial tool results** (SSE-style progressive output) — rides
-  the existing `sse.rs` transport. Tracked in
-  [#1118](https://github.com/madmax983/autumn/issues/1118). Base tool exposure
-  stays buffered happy-path; streaming layers on top.
 - **Daemon lifetime** for long-running, session-surviving work —
   [#1119](https://github.com/madmax983/autumn/issues/1119).
 - **Durable workflow tools** — exposing Harvest `#[workflow]`s as

--- a/examples/todo-app/Cargo.toml
+++ b/examples/todo-app/Cargo.toml
@@ -16,6 +16,7 @@ system-tests = ["autumn-web/system-tests"]
 [dependencies]
 autumn-web = { path = "../../autumn", features = ["seed", "mcp"] }
 chrono = { version = "0.4", features = ["serde"] }
+futures = "0.3"
 http = "1"
 diesel = { version = "2", features = ["postgres", "chrono"] }
 diesel-async = { version = "0.8", features = ["postgres"] }

--- a/examples/todo-app/src/main.rs
+++ b/examples/todo-app/src/main.rs
@@ -94,7 +94,13 @@ async fn main() {
         .scoped(
             "/api",
             RequireApiToken::new(Arc::new(deferred.clone())),
-            routes![routes::api::list_json, routes::api::create_json],
+            routes![
+                routes::api::list_json,
+                routes::api::create_json,
+                // A streaming MCP tool (#1118): its `Sse` stream is projected
+                // onto the MCP SSE channel as progressive `notifications/progress`.
+                routes::api::scan_json,
+            ],
         )
         // Expose the tagged endpoints as agent-callable MCP tools. `tools/call`
         // dispatches through the real pipeline above, so the bearer token an

--- a/examples/todo-app/src/routes/api.rs
+++ b/examples/todo-app/src/routes/api.rs
@@ -7,10 +7,15 @@
 //!
 //! The HTML routes at `/todos` are unaffected — they use session auth as usual.
 
+use std::convert::Infallible;
+use std::time::Duration;
+
 use autumn_web::auth::{DbApiTokenStore, issue_api_token};
 use autumn_web::prelude::*;
+use autumn_web::sse::{Event, Sse};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
+use futures::stream::{self, Stream, StreamExt};
 use serde::Deserialize;
 
 use crate::models::{NewTodo, Todo};
@@ -82,4 +87,49 @@ pub async fn create_json(
         .get_result(&mut db)
         .await?;
     Ok(Json(created))
+}
+
+// ── Streaming MCP tool (issue #1118) ────────────────────────────────────────────
+//
+// A slow tool — imagine scanning a large codebase rather than a todo list —
+// feels broken if the agent waits in silence for the whole result. `stream`
+// projects this handler's *normal Autumn `Sse` stream* onto the MCP
+// Streamable-HTTP SSE channel: each yielded `Event` becomes a
+// `notifications/progress` message (when the client sends `_meta.progressToken`),
+// and the stream is terminated by the final `tools/call` result. The developer
+// writes zero JSON-RPC/SSE framing — just a stream of events.
+
+/// Scan all todos, emitting incremental progress per item, then a final summary.
+///
+/// Tagged `#[api_doc(mcp, stream)]`: the `stream` flag opts this tool into
+/// progressive output and exempts it from the JSON-response eligibility gate
+/// (an `Sse` handler has no JSON response schema). It dispatches through the
+/// same `RequireApiToken` pipeline as the buffered tools above, so an agent's
+/// bearer token is still enforced.
+#[get("/todos/scan")]
+#[api_doc(mcp, stream, summary = "Scan todos, streaming progress")]
+pub async fn scan_json(
+    ApiToken(caller): ApiToken,
+    mut db: Db,
+) -> AutumnResult<Sse<impl Stream<Item = Result<Event, Infallible>>>> {
+    let _ = caller; // available for per-user filtering; unused in this demo
+    let all = Todo::all(&mut db).await?;
+    let total = all.len();
+
+    // A normal Autumn stream. `.then` simulates incremental work so the first
+    // progress frame reaches the agent long before the scan completes — the
+    // success metric for #1118 (time-to-first-signal decoupled from duration).
+    let stream = stream::iter(all.into_iter().enumerate()).then(move |(index, todo)| async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Structured progress: a numeric `progress`/`total` plus a human
+        // message are forwarded into the `notifications/progress` params.
+        let frame = serde_json::json!({
+            "progress": index + 1,
+            "total": total,
+            "message": format!("scanned todo #{}: {}", todo.id, todo.title),
+        });
+        Ok(Event::default().data(frame.to_string()))
+    });
+
+    Ok(Sse::new(stream))
 }


### PR DESCRIPTION
## Summary

Implements progressive (streaming) MCP tool results over the Streamable-HTTP SSE channel. Tools can now opt in with `#[api_doc(mcp, stream)]` to return an Autumn `Sse` stream, which is projected onto the MCP response as `notifications/progress` messages terminated by the final `tools/call` result. Streaming is strictly opt-in per tool; buffered tools and non-SSE clients are unaffected.

## Key Changes

- **New `stream` attribute flag**: Added `#[api_doc(mcp, stream)]` to mark tools that return `Sse` streams. The flag also exempts streaming tools from the JSON-response eligibility gate since `Sse` handlers have no JSON schema.

- **SSE projection logic**: Implemented `stream_tool_result()` and `project_next()` to re-project handler SSE frames onto the MCP channel:
  - Each handler event becomes a `notifications/progress` message (when client supplies `_meta.progressToken`)
  - Stream terminates with the final id-correlated `tools/call` result
  - Supports structured progress (JSON objects with numeric `progress` field) and explicit `event: result` payloads

- **SSE wire parser**: Added `SseWireParser` to incrementally parse handler SSE frames (`event:`/`data:` lines) from arbitrary byte chunks, handling multi-line data and comments.

- **Graceful fallback**: Streaming tools called by non-SSE clients (missing `Accept: text/event-stream`) are served buffered JSON results. A helper `collapse_sse_body()` joins SSE frames for non-SSE clients.

- **Request routing**: Extracted `single_tools_call()` to identify well-formed `tools/call` requests before `handle_message()`, routing them to `serve_tools_call()` which handles both buffered and streaming paths.

- **Back-pressure handling**: Leverages axum's stream lifecycle — if the agent disconnects, the response future is dropped, which drops the handler stream, unwinding the handler task cleanly with no leak or panic.

- **Documentation**: Updated `docs/guide/mcp.md` with a new §5 covering streaming tools, structured progress, and the opt-in nature of the feature.

- **Integration tests**: Added `autumn/tests/mcp_streaming.rs` covering acceptance criteria: streaming tool listing, progress notifications, final result termination, buffered tool regression, non-SSE client fallback, and time-to-first-signal decoupling.

- **Example**: Extended `examples/todo-app` with a `scan_json()` streaming tool demonstrating the pattern.

## Implementation Details

- Streaming is **response-level only**: the `POST /mcp` response rides SSE; a bare `GET /mcp` (for unsolicited server→client messages) still returns `405`.
- The projection state machine (`ProjectionPhase`) manages three phases: `Streaming` (reading frames), `Final` (stream ended, result pending), and `Done` (complete).
- Progress counter auto-increments per event unless the handler supplies structured `progress`; `progressToken` is required by spec to emit progress notifications.
- Cookies set by the handler (session renewal, CSRF refresh) are captured and replayed onto the outer HTTP response, matching direct-call behavior.

https://claude.ai/code/session_01Tz3hYh16AryFPoN9ySrtYw