### PR TITLE
Add `autumn generate pwa` command for Progressive Web App scaffolding

### DIFF
--- a/autumn-cli/src/generate/mod.rs
+++ b/autumn-cli/src/generate/mod.rs
@@ -19,6 +19,7 @@ pub mod mailer;
 pub mod migration;
 pub mod model;
 pub mod naming;
+pub mod pwa;
 pub mod scaffold;
 pub mod schema_edit;
 pub mod system_test;

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -1,16 +1,17 @@
 //! `autumn generate pwa` — scaffold an installable Progressive Web App.
 //!
 //! Creates:
-//!   - `static/manifest.webmanifest` — Web App Manifest (application/manifest+json)
-//!   - `static/service-worker.js`    — Service Worker with offline-shell caching
-//!   - `static/icons/icon.svg`       — Placeholder app icon (replace with real PNG)
+//!   - `static/manifest.webmanifest`   — Web App Manifest (application/manifest+json)
+//!   - `static/service-worker.js`      — Service Worker with offline-shell caching
+//!   - `static/pwa-register.js`        — SW registration script (avoids CSP inline-script issues)
+//!   - `static/icons/icon.svg`         — Placeholder app icon (replace with real PNG)
 //!   - `static/icons/maskable-icon.svg` — Maskable variant (safe-zone compliant)
-//!   - `src/main.rs`                 — Route handlers for `/manifest.webmanifest`,
-//!                                     `/service-worker.js`, and `/offline`; PWA
-//!                                     `<link>` / `<meta>` tags injected into the
-//!                                     shared `layout` head block.
-//!   - `tests/system/pwa_smoke.rs`   — Smoke test (manifest content-type + SW registration)
-//!   - `Cargo.toml`                  — `system-tests` feature added if absent
+//!   - `src/main.rs`                   — Route handlers for `/manifest.webmanifest`,
+//!                                       `/service-worker.js`, `/pwa-register.js`, and
+//!                                       `/offline`; PWA `<link>` / `<meta>` tags
+//!                                       injected into the shared `layout` head block.
+//!   - `tests/system/pwa_smoke.rs`     — Smoke test (manifest content-type + SW registration)
+//!   - `Cargo.toml`                    — `system-tests` feature added if absent
 
 use std::path::Path;
 
@@ -39,6 +40,10 @@ pub fn plan_pwa(project_root: &Path) -> Result<Plan, GenerateError> {
     plan.create(
         project_root.join("static").join("service-worker.js"),
         render_service_worker(),
+    );
+    plan.create(
+        project_root.join("static").join("pwa-register.js"),
+        render_pwa_register_js(),
     );
     plan.create(
         project_root.join("static").join("icons").join("icon.svg"),
@@ -210,6 +215,17 @@ fn render_maskable_icon_svg() -> String {
     .to_owned()
 }
 
+fn render_pwa_register_js() -> String {
+    // Served as a same-origin script to avoid CSP `script-src 'self'` blocking
+    // inline scripts that the default SecurityHeadersLayer enforces.
+    "if('serviceWorker'in navigator)\
+     navigator.serviceWorker\
+     .register('/service-worker.js',{scope:'/'})\
+     .then(()=>document.documentElement.dataset.swRegistered='true')\
+     .catch(console.error);\n"
+        .to_owned()
+}
+
 fn render_pwa_system_test() -> String {
     let manifest_selector = r#"link[rel="manifest"]"#;
     format!(
@@ -223,13 +239,17 @@ fn render_pwa_system_test() -> String {
          use autumn_web::system_test::SystemTest;\n\
          \n\
          /// Checks that `GET /manifest.webmanifest` returns `application/manifest+json`\n\
-         /// and that the `<link rel=\"manifest\">` tag is present in the root page DOM.\n\
+         /// and that the `<link rel=\"manifest\">` tag is present in the page DOM.\n\
          #[tokio::test]\n\
          #[ignore = \"requires Chromium; run with --include-ignored\"]\n\
          async fn pwa_manifest_loads_with_correct_content_type() {{\n\
-             let runner = SystemTest::new().build().await.expect(\"test runner\");\n\
+             let runner = SystemTest::new()\n\
+                 .routes(routes![pwa_manifest, pwa_service_worker, pwa_register_js, pwa_offline])\n\
+                 .build()\n\
+                 .await\n\
+                 .expect(\"test runner\");\n\
              let base_url = runner.base_url();\n\
-             let page = runner.page();\n\
+             let page = runner.page().await.expect(\"page\");\n\
              \n\
              // Verify HTTP content-type via raw TCP to avoid a reqwest dev-dependency.\n\
              {{\n\
@@ -239,7 +259,7 @@ fn render_pwa_system_test() -> String {
                      .trim_start_matches(\"https://\");\n\
                  let mut stream = std::net::TcpStream::connect(host_port)\n\
                      .expect(\"connect to test server\");\n\
-                 let req = \"GET /manifest.webmanifest HTTP/1.1\\r\\nHost: {{host_port}}\\r\\nConnection: close\\r\\n\\r\\n\";\n\
+                 let req = format!(\"GET /manifest.webmanifest HTTP/1.1\\r\\nHost: {{host_port}}\\r\\nConnection: close\\r\\n\\r\\n\");\n\
                  stream.write_all(req.as_bytes()).expect(\"write request\");\n\
                  let mut response = String::new();\n\
                  stream.read_to_string(&mut response).expect(\"read response\");\n\
@@ -254,23 +274,28 @@ fn render_pwa_system_test() -> String {
              }}\n\
              \n\
              // Browser check: <link rel=\"manifest\"> is in <head>\n\
-             page.visit(\"/\").await.expect(\"root page loaded\");\n\
+             page.visit(\"/offline\").await.expect(\"offline page loaded\");\n\
              page.expect_attribute({manifest_selector:?}, \"href\", \"/manifest.webmanifest\")\n\
                  .await\n\
                  .expect(\"manifest link present in DOM\");\n\
          }}\n\
          \n\
-         /// Verifies that the service worker registers successfully (scope covers the whole app)\n\
-         /// and that the offline shell renders when navigating offline.\n\
+         /// Verifies that the service worker registers successfully (scope covers the whole app).\n\
+         /// The `/offline` page is used as the test shell since it is always available.\n\
          #[tokio::test]\n\
          #[ignore = \"requires Chromium; run with --include-ignored\"]\n\
          async fn service_worker_registers_successfully() {{\n\
-             let runner = SystemTest::new().build().await.expect(\"test runner\");\n\
-             let page = runner.page();\n\
+             let runner = SystemTest::new()\n\
+                 .routes(routes![pwa_manifest, pwa_service_worker, pwa_register_js, pwa_offline])\n\
+                 .build()\n\
+                 .await\n\
+                 .expect(\"test runner\");\n\
+             let page = runner.page().await.expect(\"page\");\n\
              \n\
-             // The layout injects an inline SW registration script that sets\n\
-             // `data-sw-registered=\"true\"` on `<html>` upon successful registration.\n\
-             page.visit(\"/\").await.expect(\"root page loaded\");\n\
+             // `/pwa-register.js` sets `data-sw-registered=\"true\"` on `<html>`\n\
+             // after the SW registers.  Visiting `/offline` (which uses layout)\n\
+             // loads the script without needing the user's root route.\n\
+             page.visit(\"/offline\").await.expect(\"offline page loaded\");\n\
              page.expect_attribute(\"html\", \"data-sw-registered\", \"true\")\n\
                  .await\n\
                  .expect(\"service worker registered and controlling page\");\n\
@@ -281,8 +306,8 @@ fn render_pwa_system_test() -> String {
 // ── src/main.rs patching ──────────────────────────────────────────────────────
 
 /// Inject all PWA additions into `src/main.rs` in a single idempotent pass:
-/// 1. Add PWA `<meta>` / `<link>` tags to the `head {}` block in `layout`.
-/// 2. Add `pwa_manifest`, `pwa_service_worker`, and `pwa_offline` handlers.
+/// 1. Add PWA `<meta>` / `<link>` tags + external register script to the `head {}` block.
+/// 2. Add `pwa_manifest`, `pwa_service_worker`, `pwa_register_js`, and `pwa_offline` handlers.
 /// 3. Register those handlers in `routes![…]`.
 pub fn inject_pwa_into_main(source: &str) -> String {
     let with_meta = inject_pwa_meta_into_head(source);
@@ -290,6 +315,7 @@ pub fn inject_pwa_into_main(source: &str) -> String {
     let route_entries = vec![
         "pwa_manifest".to_owned(),
         "pwa_service_worker".to_owned(),
+        "pwa_register_js".to_owned(),
         "pwa_offline".to_owned(),
     ];
     update_main_rs(&with_handlers, &[], &route_entries)
@@ -299,7 +325,7 @@ pub fn inject_pwa_into_main(source: &str) -> String {
 /// `layout` function.  Idempotent — skipped if `rel="manifest"` is already
 /// present.
 fn inject_pwa_meta_into_head(source: &str) -> String {
-    if source.contains(r#"rel="manifest""#) {
+    if source.contains("/pwa-register.js") {
         return source.to_owned();
     }
 
@@ -327,17 +353,14 @@ fn inject_pwa_meta_into_head(source: &str) -> String {
     let close_idx = head_idx + 1 + close_rel;
 
     let inner_indent = " ".repeat(head_indent + 4);
-    // SW registration script uses dataset to signal completion — the system
-    // test polls for `data-sw-registered="true"` on `<html>`.
-    let sw_register_js = "if('serviceWorker'in navigator)navigator.serviceWorker\
-         .register('/service-worker.js',{scope:'/'})\
-         .then(()=>document.documentElement.dataset.swRegistered='true')\
-         .catch(console.error);";
+    // Use an external script to stay compliant with `script-src 'self'` CSP.
+    // The script sets `data-sw-registered="true"` on `<html>` after registration;
+    // the system test polls for that attribute.
     let meta_block = format!(
         "{inner_indent}link rel=\"manifest\" href=\"/manifest.webmanifest\";\n\
          {inner_indent}meta name=\"theme-color\" content=\"#ffffff\";\n\
          {inner_indent}link rel=\"apple-touch-icon\" href=\"/static/icons/icon.svg\";\n\
-         {inner_indent}script {{ (maud::PreEscaped(\"{sw_register_js}\")) }}\n"
+         {inner_indent}script src=\"/pwa-register.js\" {{}}\n"
     );
 
     let mut result = lines[..close_idx].join("\n");
@@ -354,8 +377,8 @@ fn inject_pwa_meta_into_head(source: &str) -> String {
     result
 }
 
-/// Append `pwa_manifest`, `pwa_service_worker`, and `pwa_offline` handler
-/// functions just before `#[autumn_web::main]`.  Idempotent — skipped when
+/// Append `pwa_manifest`, `pwa_service_worker`, `pwa_register_js`, and `pwa_offline`
+/// handler functions just before `#[autumn_web::main]`.  Idempotent — skipped when
 /// `pwa_manifest` is already defined.
 fn inject_pwa_handlers(source: &str) -> String {
     if source.contains("async fn pwa_manifest()") {
@@ -383,6 +406,17 @@ async fn pwa_service_worker() -> impl IntoResponse {\n\
             (\"cache-control\", \"no-cache\"),\n\
         ],\n\
         include_str!(\"../static/service-worker.js\"),\n\
+    )\n\
+}\n\
+\n\
+#[get(\"/pwa-register.js\")]\n\
+async fn pwa_register_js() -> impl IntoResponse {\n\
+    (\n\
+        [\n\
+            (\"content-type\", \"text/javascript; charset=utf-8\"),\n\
+            (\"cache-control\", \"public, max-age=3600\"),\n\
+        ],\n\
+        include_str!(\"../static/pwa-register.js\"),\n\
     )\n\
 }\n\
 \n\
@@ -532,6 +566,18 @@ async fn main() {
     }
 
     #[test]
+    fn plan_creates_pwa_register_js() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        let plan = plan_pwa(tmp.path()).unwrap();
+        assert!(
+            plan.actions
+                .iter()
+                .any(|a| a.path().ends_with("pwa-register.js")),
+            "plan must include pwa-register.js"
+        );
+    }
+
+    #[test]
     fn plan_creates_icons() {
         let tmp = project_with_main(DEFAULT_MAIN);
         let plan = plan_pwa(tmp.path()).unwrap();
@@ -654,6 +700,19 @@ async fn main() {
     }
 
     #[test]
+    fn inject_adds_external_register_script() {
+        let updated = inject_pwa_meta_into_head(DEFAULT_MAIN);
+        assert!(
+            updated.contains("src=\"/pwa-register.js\""),
+            "must add external SW registration script (avoids CSP inline-script issues)"
+        );
+        assert!(
+            !updated.contains("serviceWorker"),
+            "must not embed inline serviceWorker JS"
+        );
+    }
+
+    #[test]
     fn inject_adds_theme_color_meta() {
         let updated = inject_pwa_meta_into_head(DEFAULT_MAIN);
         assert!(
@@ -722,6 +781,19 @@ async fn main() {
     }
 
     #[test]
+    fn inject_handlers_adds_register_js_route() {
+        let updated = inject_pwa_handlers(DEFAULT_MAIN);
+        assert!(
+            updated.contains("async fn pwa_register_js()"),
+            "must add pwa_register_js handler"
+        );
+        assert!(
+            updated.contains("include_str!(\"../static/pwa-register.js\")"),
+            "pwa_register_js must embed file at compile time via include_str!"
+        );
+    }
+
+    #[test]
     fn inject_handlers_adds_offline_route() {
         let updated = inject_pwa_handlers(DEFAULT_MAIN);
         assert!(
@@ -778,6 +850,10 @@ async fn main() {
         assert!(
             updated.contains("pwa_service_worker"),
             "routes![] must include pwa_service_worker"
+        );
+        assert!(
+            updated.contains("pwa_register_js"),
+            "routes![] must include pwa_register_js"
         );
         assert!(
             updated.contains("pwa_offline"),
@@ -841,6 +917,24 @@ async fn main() {
     }
 
     #[test]
+    fn plan_execute_creates_pwa_register_js_file() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(
+            tmp.path().join("static/pwa-register.js").exists(),
+            "static/pwa-register.js must exist"
+        );
+        let content = fs::read_to_string(tmp.path().join("static/pwa-register.js")).unwrap();
+        assert!(
+            content.contains("serviceWorker"),
+            "pwa-register.js must contain SW registration code"
+        );
+    }
+
+    #[test]
     fn plan_execute_creates_icon_files() {
         let tmp = project_with_main(DEFAULT_MAIN);
         plan_pwa(tmp.path())
@@ -879,8 +973,10 @@ async fn main() {
             .unwrap();
         let main_rs = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
         assert!(main_rs.contains(r#"rel="manifest""#));
+        assert!(main_rs.contains("src=\"/pwa-register.js\""));
         assert!(main_rs.contains("async fn pwa_manifest()"));
         assert!(main_rs.contains("async fn pwa_service_worker()"));
+        assert!(main_rs.contains("async fn pwa_register_js()"));
         assert!(main_rs.contains("async fn pwa_offline()"));
     }
 

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -7,9 +7,8 @@
 //!   - `static/icons/icon.svg`         — Placeholder app icon (replace with real PNG)
 //!   - `static/icons/maskable-icon.svg` — Maskable variant (safe-zone compliant)
 //!   - `src/main.rs`                   — Route handlers for `/manifest.webmanifest`,
-//!                                       `/service-worker.js`, `/pwa-register.js`, and
-//!                                       `/offline`; PWA `<link>` / `<meta>` tags
-//!                                       injected into the shared `layout` head block.
+//!     `/service-worker.js`, `/pwa-register.js`, and `/offline`; PWA `<link>` /
+//!     `<meta>` tags injected into the shared `layout` head block.
 //!   - `tests/system/pwa_smoke.rs`     — Smoke test (manifest content-type + SW registration)
 //!   - `Cargo.toml`                    — `system-tests` feature added if absent
 
@@ -138,9 +137,9 @@ fn render_manifest() -> String {
 }
 
 fn render_service_worker() -> String {
-    r#"const CACHE_NAME = 'autumn-pwa-v1';
+    r"const CACHE_NAME = 'autumn-pwa-v1';
 const OFFLINE_URL = '/offline';
-const PRECACHE_URLS = ['/', OFFLINE_URL];
+const PRECACHE_URLS = [OFFLINE_URL];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -187,7 +186,7 @@ self.addEventListener('fetch', (event) => {
     );
   }
 });
-"#
+"
     .to_owned()
 }
 
@@ -432,23 +431,25 @@ async fn pwa_offline() -> maud::Markup {\n\
 }\n\
 \n";
 
-    // Insert before `#[autumn_web::main]`
-    if let Some(pos) = source.find("#[autumn_web::main]") {
-        let mut result = String::with_capacity(source.len() + handlers.len());
-        result.push_str(&source[..pos]);
-        result.push_str(handlers);
-        result.push_str(&source[pos..]);
-        result
-    } else {
-        // Fallback: append at end
-        let mut result = source.to_owned();
-        if !result.ends_with('\n') {
+    // Insert before `#[autumn_web::main]`, or append at end as fallback.
+    source.find("#[autumn_web::main]").map_or_else(
+        || {
+            let mut result = source.to_owned();
+            if !result.ends_with('\n') {
+                result.push('\n');
+            }
             result.push('\n');
-        }
-        result.push('\n');
-        result.push_str(handlers);
-        result
-    }
+            result.push_str(handlers);
+            result
+        },
+        |pos| {
+            let mut result = String::with_capacity(source.len() + handlers.len());
+            result.push_str(&source[..pos]);
+            result.push_str(handlers);
+            result.push_str(&source[pos..]);
+            result
+        },
+    )
 }
 
 fn indent_count(line: &str) -> usize {
@@ -581,13 +582,14 @@ async fn main() {
     fn plan_creates_icons() {
         let tmp = project_with_main(DEFAULT_MAIN);
         let plan = plan_pwa(tmp.path()).unwrap();
-        let paths: Vec<_> = plan.actions.iter().map(|a| a.path()).collect();
         assert!(
-            paths.iter().any(|p| p.ends_with("icon.svg")),
+            plan.actions.iter().any(|a| a.path().ends_with("icon.svg")),
             "plan must include icon.svg"
         );
         assert!(
-            paths.iter().any(|p| p.ends_with("maskable-icon.svg")),
+            plan.actions
+                .iter()
+                .any(|a| a.path().ends_with("maskable-icon.svg")),
             "plan must include maskable-icon.svg"
         );
     }

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -33,9 +33,7 @@ pub fn plan_pwa(project_root: &Path) -> Result<Plan, GenerateError> {
 
     // Static assets (served via generated route handlers + participate in fingerprinting)
     plan.create(
-        project_root
-            .join("static")
-            .join("manifest.webmanifest"),
+        project_root.join("static").join("manifest.webmanifest"),
         render_manifest(),
     );
     plan.create(
@@ -43,10 +41,7 @@ pub fn plan_pwa(project_root: &Path) -> Result<Plan, GenerateError> {
         render_service_worker(),
     );
     plan.create(
-        project_root
-            .join("static")
-            .join("icons")
-            .join("icon.svg"),
+        project_root.join("static").join("icons").join("icon.svg"),
         render_icon_svg(),
     );
     plan.create(
@@ -161,6 +156,9 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
   if (event.request.mode === 'navigate') {
     event.respondWith(
       fetch(event.request).catch(() =>
@@ -174,7 +172,10 @@ self.addEventListener('fetch', (event) => {
       caches.match(event.request).then((cached) => {
         if (cached) return cached;
         return fetch(event.request).then((response) => {
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, response.clone()));
+          if (response.ok) {
+            const copy = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          }
           return response;
         });
       })
@@ -230,19 +231,27 @@ fn render_pwa_system_test() -> String {
              let base_url = runner.base_url();\n\
              let page = runner.page();\n\
              \n\
-             // Verify HTTP content-type via reqwest (no browser needed for this check)\n\
-             let resp = reqwest::get(format!(\"{{base_url}}/manifest.webmanifest\"))\n\
-                 .await\n\
-                 .expect(\"manifest request\");\n\
-             assert_eq!(resp.status(), 200, \"manifest must return 200\");\n\
-             let ct = resp.headers()\n\
-                 .get(\"content-type\")\n\
-                 .and_then(|v| v.to_str().ok())\n\
-                 .unwrap_or(\"\");\n\
-             assert!(\n\
-                 ct.contains(\"application/manifest+json\"),\n\
-                 \"manifest content-type must be application/manifest+json, got: {{ct}}\"\n\
-             );\n\
+             // Verify HTTP content-type via raw TCP to avoid a reqwest dev-dependency.\n\
+             {{\n\
+                 use std::io::{{Read, Write}};\n\
+                 let host_port = base_url\n\
+                     .trim_start_matches(\"http://\")\n\
+                     .trim_start_matches(\"https://\");\n\
+                 let mut stream = std::net::TcpStream::connect(host_port)\n\
+                     .expect(\"connect to test server\");\n\
+                 let req = \"GET /manifest.webmanifest HTTP/1.1\\r\\nHost: {{host_port}}\\r\\nConnection: close\\r\\n\\r\\n\";\n\
+                 stream.write_all(req.as_bytes()).expect(\"write request\");\n\
+                 let mut response = String::new();\n\
+                 stream.read_to_string(&mut response).expect(\"read response\");\n\
+                 assert!(\n\
+                     response.starts_with(\"HTTP/1.1 200\") || response.starts_with(\"HTTP/1.0 200\"),\n\
+                     \"manifest must return 200, got: {{response}}\"\n\
+                 );\n\
+                 assert!(\n\
+                     response.contains(\"application/manifest+json\"),\n\
+                     \"manifest content-type must be application/manifest+json\"\n\
+                 );\n\
+             }}\n\
              \n\
              // Browser check: <link rel=\"manifest\"> is in <head>\n\
              page.visit(\"/\").await.expect(\"root page loaded\");\n\
@@ -296,8 +305,12 @@ fn inject_pwa_meta_into_head(source: &str) -> String {
 
     let lines: Vec<&str> = source.lines().collect();
 
-    // Find the first `head {` line (Maud DSL — no leading keyword)
-    let Some(head_idx) = lines.iter().position(|l| l.trim() == "head {") else {
+    // Find the first `head {` line (Maud DSL — no leading keyword).
+    // Support both `head {` and `head{` (both are valid Maud syntax).
+    let Some(head_idx) = lines.iter().position(|l| {
+        let t = l.trim();
+        t == "head {" || t == "head{"
+    }) else {
         return source.to_owned();
     };
 
@@ -305,9 +318,10 @@ fn inject_pwa_meta_into_head(source: &str) -> String {
 
     // Find the closing `}` of the head block (first `}` at the same indent
     // level as `head {`, after `head {`).
-    let Some(close_rel) = lines[head_idx + 1..].iter().position(|l| {
-        indent_count(l) == head_indent && l.trim() == "}"
-    }) else {
+    let Some(close_rel) = lines[head_idx + 1..]
+        .iter()
+        .position(|l| indent_count(l) == head_indent && l.trim() == "}")
+    else {
         return source.to_owned();
     };
     let close_idx = head_idx + 1 + close_rel;
@@ -315,8 +329,7 @@ fn inject_pwa_meta_into_head(source: &str) -> String {
     let inner_indent = " ".repeat(head_indent + 4);
     // SW registration script uses dataset to signal completion — the system
     // test polls for `data-sw-registered="true"` on `<html>`.
-    let sw_register_js =
-        "if('serviceWorker'in navigator)navigator.serviceWorker\
+    let sw_register_js = "if('serviceWorker'in navigator)navigator.serviceWorker\
          .register('/service-worker.js',{scope:'/'})\
          .then(()=>document.documentElement.dataset.swRegistered='true')\
          .catch(console.error);";
@@ -550,8 +563,8 @@ async fn main() {
     #[test]
     fn manifest_is_valid_json() {
         let content = render_manifest();
-        let parsed: serde_json::Value = serde_json::from_str(&content)
-            .expect("manifest.webmanifest must be valid JSON");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&content).expect("manifest.webmanifest must be valid JSON");
         assert!(parsed["name"].is_string(), "manifest must have a name");
         assert!(parsed["icons"].is_array(), "manifest must have icons array");
     }
@@ -561,9 +574,10 @@ async fn main() {
         let content = render_manifest();
         let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
         assert!(parsed["start_url"].is_string());
-        assert!(["fullscreen", "standalone", "minimal-ui"].contains(
-            &parsed["display"].as_str().unwrap_or("")
-        ));
+        assert!(
+            ["fullscreen", "standalone", "minimal-ui"]
+                .contains(&parsed["display"].as_str().unwrap_or(""))
+        );
         let icons = parsed["icons"].as_array().unwrap();
         assert!(!icons.is_empty(), "at least one icon required");
     }
@@ -573,12 +587,11 @@ async fn main() {
         let content = render_manifest();
         let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
         let icons = parsed["icons"].as_array().unwrap();
-        let purposes: Vec<&str> = icons
-            .iter()
-            .filter_map(|i| i["purpose"].as_str())
-            .collect();
+        let purposes: Vec<&str> = icons.iter().filter_map(|i| i["purpose"].as_str()).collect();
         assert!(
-            purposes.iter().any(|p| p.contains("any") || p.contains("monochrome")),
+            purposes
+                .iter()
+                .any(|p| p.contains("any") || p.contains("monochrome")),
             "must have a general-purpose icon"
         );
         assert!(
@@ -592,15 +605,24 @@ async fn main() {
     #[test]
     fn service_worker_has_offline_fallback_for_navigation() {
         let sw = render_service_worker();
-        assert!(sw.contains("navigate"), "SW must handle navigation requests");
+        assert!(
+            sw.contains("navigate"),
+            "SW must handle navigation requests"
+        );
         assert!(sw.contains("offline"), "SW must have offline fallback");
     }
 
     #[test]
     fn service_worker_precaches_offline_url() {
         let sw = render_service_worker();
-        assert!(sw.contains("PRECACHE_URLS"), "SW must declare precache list");
-        assert!(sw.contains("/offline"), "SW must precache the offline shell");
+        assert!(
+            sw.contains("PRECACHE_URLS"),
+            "SW must declare precache list"
+        );
+        assert!(
+            sw.contains("/offline"),
+            "SW must precache the offline shell"
+        );
     }
 
     #[test]
@@ -796,7 +818,10 @@ async fn main() {
             .execute(Flags::default())
             .unwrap();
         let manifest_path = tmp.path().join("static/manifest.webmanifest");
-        assert!(manifest_path.exists(), "static/manifest.webmanifest must exist");
+        assert!(
+            manifest_path.exists(),
+            "static/manifest.webmanifest must exist"
+        );
         let content = fs::read_to_string(&manifest_path).unwrap();
         let _: serde_json::Value = serde_json::from_str(&content)
             .expect("manifest.webmanifest must be valid JSON after execution");
@@ -904,5 +929,4 @@ async fn main() {
         let after = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
         assert_eq!(original_main, after, "dry-run must not modify main.rs");
     }
-
 }

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -1,0 +1,908 @@
+//! `autumn generate pwa` — scaffold an installable Progressive Web App.
+//!
+//! Creates:
+//!   - `static/manifest.webmanifest` — Web App Manifest (application/manifest+json)
+//!   - `static/service-worker.js`    — Service Worker with offline-shell caching
+//!   - `static/icons/icon.svg`       — Placeholder app icon (replace with real PNG)
+//!   - `static/icons/maskable-icon.svg` — Maskable variant (safe-zone compliant)
+//!   - `src/main.rs`                 — Route handlers for `/manifest.webmanifest`,
+//!                                     `/service-worker.js`, and `/offline`; PWA
+//!                                     `<link>` / `<meta>` tags injected into the
+//!                                     shared `layout` head block.
+//!   - `tests/system/pwa_smoke.rs`   — Smoke test (manifest content-type + SW registration)
+//!   - `Cargo.toml`                  — `system-tests` feature added if absent
+
+use std::path::Path;
+
+use super::emit::Plan;
+use super::schema_edit::update_main_rs;
+use super::system_test::patch_cargo_toml as patch_system_test_cargo_toml;
+use super::{Flags, GenerateError, ensure_project_root};
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Compute the file actions for `autumn generate pwa`.
+///
+/// # Errors
+/// Returns [`GenerateError::NotInProject`] when not at a project root, or
+/// [`GenerateError::Io`] if `src/main.rs` / `Cargo.toml` can't be read.
+pub fn plan_pwa(project_root: &Path) -> Result<Plan, GenerateError> {
+    ensure_project_root(project_root)?;
+
+    let mut plan = Plan::new(project_root);
+
+    // Static assets (served via generated route handlers + participate in fingerprinting)
+    plan.create(
+        project_root
+            .join("static")
+            .join("manifest.webmanifest"),
+        render_manifest(),
+    );
+    plan.create(
+        project_root.join("static").join("service-worker.js"),
+        render_service_worker(),
+    );
+    plan.create(
+        project_root
+            .join("static")
+            .join("icons")
+            .join("icon.svg"),
+        render_icon_svg(),
+    );
+    plan.create(
+        project_root
+            .join("static")
+            .join("icons")
+            .join("maskable-icon.svg"),
+        render_maskable_icon_svg(),
+    );
+
+    // src/main.rs: inject PWA meta tags + route handlers (idempotent)
+    let main_path = project_root.join("src").join("main.rs");
+    let main_existing = std::fs::read_to_string(&main_path).map_err(|_| {
+        GenerateError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("missing {}", main_path.display()),
+        ))
+    })?;
+    let updated_main = inject_pwa_into_main(&main_existing);
+    if updated_main != main_existing {
+        plan.modify(main_path, updated_main);
+    }
+
+    // System test
+    let system_test_path = project_root
+        .join("tests")
+        .join("system")
+        .join("pwa_smoke.rs");
+    plan.create(system_test_path, render_pwa_system_test());
+
+    // Cargo.toml: add system-tests feature if absent
+    let cargo_path = project_root.join("Cargo.toml");
+    let cargo_existing = std::fs::read_to_string(&cargo_path).map_err(GenerateError::Io)?;
+    let patched_cargo = patch_system_test_cargo_toml(&cargo_existing, "pwa_smoke");
+    if patched_cargo != cargo_existing {
+        plan.modify(cargo_path, patched_cargo);
+    }
+
+    Ok(plan)
+}
+
+/// CLI entry point.
+pub fn run(flags: Flags) {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: cannot determine current directory: {e}");
+            std::process::exit(1);
+        }
+    };
+    match plan_pwa(&cwd).and_then(|p| p.execute(flags)) {
+        Ok(()) => {}
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+// ── Content renderers ─────────────────────────────────────────────────────────
+
+fn render_manifest() -> String {
+    concat!(
+        "{\n",
+        "  \"name\": \"My App\",\n",
+        "  \"short_name\": \"My App\",\n",
+        "  \"description\": \"Built with Autumn\",\n",
+        "  \"start_url\": \"/\",\n",
+        "  \"display\": \"standalone\",\n",
+        "  \"background_color\": \"#ffffff\",\n",
+        "  \"theme_color\": \"#ffffff\",\n",
+        "  \"icons\": [\n",
+        "    {\n",
+        "      \"src\": \"/static/icons/icon.svg\",\n",
+        "      \"sizes\": \"any\",\n",
+        "      \"type\": \"image/svg+xml\",\n",
+        "      \"purpose\": \"any\"\n",
+        "    },\n",
+        "    {\n",
+        "      \"src\": \"/static/icons/maskable-icon.svg\",\n",
+        "      \"sizes\": \"any\",\n",
+        "      \"type\": \"image/svg+xml\",\n",
+        "      \"purpose\": \"maskable\"\n",
+        "    }\n",
+        "  ]\n",
+        "}\n",
+    )
+    .to_owned()
+}
+
+fn render_service_worker() -> String {
+    r#"const CACHE_NAME = 'autumn-pwa-v1';
+const OFFLINE_URL = '/offline';
+const PRECACHE_URLS = ['/', OFFLINE_URL];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then((cache) => cache.addAll(PRECACHE_URLS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys()
+      .then((names) => Promise.all(
+        names.filter((n) => n !== CACHE_NAME).map((n) => caches.delete(n))
+      ))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() =>
+        caches.match(OFFLINE_URL).then((r) => r || new Response('Offline', { status: 503 }))
+      )
+    );
+    return;
+  }
+  if (event.request.url.includes('/static/')) {
+    event.respondWith(
+      caches.match(event.request).then((cached) => {
+        if (cached) return cached;
+        return fetch(event.request).then((response) => {
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, response.clone()));
+          return response;
+        });
+      })
+    );
+  }
+});
+"#
+    .to_owned()
+}
+
+fn render_icon_svg() -> String {
+    // Note: using concat! to avoid raw-string issues with #ffffff and system-ui
+    concat!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 192 192\">\n",
+        "  <!-- Replace this placeholder with your app icon (PNG recommended for broad compatibility) -->\n",
+        "  <rect width=\"192\" height=\"192\" rx=\"24\" fill=\"#4F7942\"/>\n",
+        "  <text x=\"96\" y=\"140\" font-size=\"110\" text-anchor=\"middle\" font-family=\"system-ui\">&#x1F342;</text>\n",
+        "</svg>\n",
+    )
+    .to_owned()
+}
+
+fn render_maskable_icon_svg() -> String {
+    concat!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 192 192\">\n",
+        "  <!-- Maskable icon: keep important content within the inner 116x116 safe zone -->\n",
+        "  <!-- Replace this placeholder with your app icon (PNG recommended for broad compatibility) -->\n",
+        "  <rect width=\"192\" height=\"192\" fill=\"#4F7942\"/>\n",
+        "  <text x=\"96\" y=\"124\" font-size=\"72\" text-anchor=\"middle\" font-family=\"system-ui\">&#x1F342;</text>\n",
+        "</svg>\n",
+    )
+    .to_owned()
+}
+
+fn render_pwa_system_test() -> String {
+    let manifest_selector = r#"link[rel="manifest"]"#;
+    format!(
+        "//! PWA smoke test \u{2014} manifest content-type + service-worker registration.\n\
+         //!\n\
+         //! Run with:\n\
+         //!   cargo test --features system-tests --test pwa_smoke -- --include-ignored\n\
+         \n\
+         #![cfg(feature = \"system-tests\")]\n\
+         \n\
+         use autumn_web::system_test::SystemTest;\n\
+         \n\
+         /// Checks that `GET /manifest.webmanifest` returns `application/manifest+json`\n\
+         /// and that the `<link rel=\"manifest\">` tag is present in the root page DOM.\n\
+         #[tokio::test]\n\
+         #[ignore = \"requires Chromium; run with --include-ignored\"]\n\
+         async fn pwa_manifest_loads_with_correct_content_type() {{\n\
+             let runner = SystemTest::new().build().await.expect(\"test runner\");\n\
+             let base_url = runner.base_url();\n\
+             let page = runner.page();\n\
+             \n\
+             // Verify HTTP content-type via reqwest (no browser needed for this check)\n\
+             let resp = reqwest::get(format!(\"{{base_url}}/manifest.webmanifest\"))\n\
+                 .await\n\
+                 .expect(\"manifest request\");\n\
+             assert_eq!(resp.status(), 200, \"manifest must return 200\");\n\
+             let ct = resp.headers()\n\
+                 .get(\"content-type\")\n\
+                 .and_then(|v| v.to_str().ok())\n\
+                 .unwrap_or(\"\");\n\
+             assert!(\n\
+                 ct.contains(\"application/manifest+json\"),\n\
+                 \"manifest content-type must be application/manifest+json, got: {{ct}}\"\n\
+             );\n\
+             \n\
+             // Browser check: <link rel=\"manifest\"> is in <head>\n\
+             page.visit(\"/\").await.expect(\"root page loaded\");\n\
+             page.expect_attribute({manifest_selector:?}, \"href\", \"/manifest.webmanifest\")\n\
+                 .await\n\
+                 .expect(\"manifest link present in DOM\");\n\
+         }}\n\
+         \n\
+         /// Verifies that the service worker registers successfully (scope covers the whole app)\n\
+         /// and that the offline shell renders when navigating offline.\n\
+         #[tokio::test]\n\
+         #[ignore = \"requires Chromium; run with --include-ignored\"]\n\
+         async fn service_worker_registers_successfully() {{\n\
+             let runner = SystemTest::new().build().await.expect(\"test runner\");\n\
+             let page = runner.page();\n\
+             \n\
+             // The layout injects an inline SW registration script that sets\n\
+             // `data-sw-registered=\"true\"` on `<html>` upon successful registration.\n\
+             page.visit(\"/\").await.expect(\"root page loaded\");\n\
+             page.expect_attribute(\"html\", \"data-sw-registered\", \"true\")\n\
+                 .await\n\
+                 .expect(\"service worker registered and controlling page\");\n\
+         }}\n"
+    )
+}
+
+// ── src/main.rs patching ──────────────────────────────────────────────────────
+
+/// Inject all PWA additions into `src/main.rs` in a single idempotent pass:
+/// 1. Add PWA `<meta>` / `<link>` tags to the `head {}` block in `layout`.
+/// 2. Add `pwa_manifest`, `pwa_service_worker`, and `pwa_offline` handlers.
+/// 3. Register those handlers in `routes![…]`.
+pub fn inject_pwa_into_main(source: &str) -> String {
+    let with_meta = inject_pwa_meta_into_head(source);
+    let with_handlers = inject_pwa_handlers(&with_meta);
+    let route_entries = vec![
+        "pwa_manifest".to_owned(),
+        "pwa_service_worker".to_owned(),
+        "pwa_offline".to_owned(),
+    ];
+    update_main_rs(&with_handlers, &[], &route_entries)
+}
+
+/// Insert PWA `<link>` / `<meta>` tags into the `head {}` block of the
+/// `layout` function.  Idempotent — skipped if `rel="manifest"` is already
+/// present.
+fn inject_pwa_meta_into_head(source: &str) -> String {
+    if source.contains(r#"rel="manifest""#) {
+        return source.to_owned();
+    }
+
+    let lines: Vec<&str> = source.lines().collect();
+
+    // Find the first `head {` line (Maud DSL — no leading keyword)
+    let Some(head_idx) = lines.iter().position(|l| l.trim() == "head {") else {
+        return source.to_owned();
+    };
+
+    let head_indent = indent_count(lines[head_idx]);
+
+    // Find the closing `}` of the head block (first `}` at the same indent
+    // level as `head {`, after `head {`).
+    let Some(close_rel) = lines[head_idx + 1..].iter().position(|l| {
+        indent_count(l) == head_indent && l.trim() == "}"
+    }) else {
+        return source.to_owned();
+    };
+    let close_idx = head_idx + 1 + close_rel;
+
+    let inner_indent = " ".repeat(head_indent + 4);
+    // SW registration script uses dataset to signal completion — the system
+    // test polls for `data-sw-registered="true"` on `<html>`.
+    let sw_register_js =
+        "if('serviceWorker'in navigator)navigator.serviceWorker\
+         .register('/service-worker.js',{scope:'/'})\
+         .then(()=>document.documentElement.dataset.swRegistered='true')\
+         .catch(console.error);";
+    let meta_block = format!(
+        "{inner_indent}link rel=\"manifest\" href=\"/manifest.webmanifest\";\n\
+         {inner_indent}meta name=\"theme-color\" content=\"#ffffff\";\n\
+         {inner_indent}link rel=\"apple-touch-icon\" href=\"/static/icons/icon.svg\";\n\
+         {inner_indent}script {{ (maud::PreEscaped(\"{sw_register_js}\")) }}\n"
+    );
+
+    let mut result = lines[..close_idx].join("\n");
+    result.push('\n');
+    result.push_str(&meta_block);
+    result.push_str(lines[close_idx]);
+    if close_idx + 1 < lines.len() {
+        result.push('\n');
+        result.push_str(&lines[close_idx + 1..].join("\n"));
+    }
+    if source.ends_with('\n') {
+        result.push('\n');
+    }
+    result
+}
+
+/// Append `pwa_manifest`, `pwa_service_worker`, and `pwa_offline` handler
+/// functions just before `#[autumn_web::main]`.  Idempotent — skipped when
+/// `pwa_manifest` is already defined.
+fn inject_pwa_handlers(source: &str) -> String {
+    if source.contains("async fn pwa_manifest()") {
+        return source.to_owned();
+    }
+
+    let handlers = "\
+#[get(\"/manifest.webmanifest\")]\n\
+async fn pwa_manifest() -> impl IntoResponse {\n\
+    (\n\
+        [\n\
+            (\"content-type\", \"application/manifest+json\"),\n\
+            (\"cache-control\", \"public, max-age=3600\"),\n\
+        ],\n\
+        include_str!(\"../static/manifest.webmanifest\"),\n\
+    )\n\
+}\n\
+\n\
+#[get(\"/service-worker.js\")]\n\
+async fn pwa_service_worker() -> impl IntoResponse {\n\
+    (\n\
+        [\n\
+            (\"content-type\", \"text/javascript; charset=utf-8\"),\n\
+            (\"service-worker-allowed\", \"/\"),\n\
+            (\"cache-control\", \"no-cache\"),\n\
+        ],\n\
+        include_str!(\"../static/service-worker.js\"),\n\
+    )\n\
+}\n\
+\n\
+#[get(\"/offline\")]\n\
+async fn pwa_offline() -> maud::Markup {\n\
+    layout(\n\
+        \"Offline\",\n\
+        maud::html! {\n\
+            h1 { \"You are offline\" }\n\
+            p { \"Check your internet connection and try again.\" }\n\
+        },\n\
+    )\n\
+}\n\
+\n";
+
+    // Insert before `#[autumn_web::main]`
+    if let Some(pos) = source.find("#[autumn_web::main]") {
+        let mut result = String::with_capacity(source.len() + handlers.len());
+        result.push_str(&source[..pos]);
+        result.push_str(handlers);
+        result.push_str(&source[pos..]);
+        result
+    } else {
+        // Fallback: append at end
+        let mut result = source.to_owned();
+        if !result.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push('\n');
+        result.push_str(handlers);
+        result
+    }
+}
+
+fn indent_count(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::generate::Flags;
+
+    // ── Fixtures ──────────────────────────────────────────────────────────────
+
+    fn project_with_main(main_rs: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"my-app\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\n[dependencies]\nautumn-web = \"0.5.0\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/main.rs"), main_rs).unwrap();
+        tmp
+    }
+
+    const DEFAULT_MAIN: &str = "\
+use autumn_web::form::skip_link;
+use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
+use autumn_web::prelude::*;
+
+const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
+
+pub fn layout(title: &str, content: maud::Markup) -> maud::Markup {
+    maud::html! {
+        (maud::DOCTYPE)
+        html lang=\"en\" {
+            head {
+                meta charset=\"utf-8\";
+                meta name=\"viewport\" content=\"width=device-width, initial-scale=1\";
+                title { (title) }
+                link rel=\"stylesheet\" href=\"/static/css/app.css\";
+            }
+            body {
+                (skip_link(\"#main-content\", \"Skip to main content\"))
+                header role=\"banner\" {
+                    nav aria-label=\"Main navigation\" {
+                        a href=\"/\" { \"My App\" }
+                    }
+                }
+                main id=\"main-content\" role=\"main\" {
+                    (content)
+                }
+                footer role=\"contentinfo\" {
+                    p { \"Built with Autumn\" }
+                }
+            }
+        }
+    }
+}
+
+#[get(\"/\")]
+async fn index() -> maud::Markup {
+    layout(\"Welcome\", maud::html! {
+        h1 { \"Welcome!\" }
+    })
+}
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .routes(routes![index])
+        .migrations(MIGRATIONS)
+        .run()
+        .await;
+}
+";
+
+    // ── plan_pwa: file plan tests ─────────────────────────────────────────────
+
+    #[test]
+    fn plan_pwa_requires_project_root() {
+        let tmp = TempDir::new().unwrap();
+        let err = plan_pwa(tmp.path()).unwrap_err();
+        assert!(matches!(err, GenerateError::NotInProject));
+    }
+
+    #[test]
+    fn plan_creates_manifest_webmanifest() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        let plan = plan_pwa(tmp.path()).unwrap();
+        assert!(
+            plan.actions
+                .iter()
+                .any(|a| a.path().ends_with("manifest.webmanifest")),
+            "plan must include manifest.webmanifest"
+        );
+    }
+
+    #[test]
+    fn plan_creates_service_worker_js() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        let plan = plan_pwa(tmp.path()).unwrap();
+        assert!(
+            plan.actions
+                .iter()
+                .any(|a| a.path().ends_with("service-worker.js")),
+            "plan must include service-worker.js"
+        );
+    }
+
+    #[test]
+    fn plan_creates_icons() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        let plan = plan_pwa(tmp.path()).unwrap();
+        let paths: Vec<_> = plan.actions.iter().map(|a| a.path()).collect();
+        assert!(
+            paths.iter().any(|p| p.ends_with("icon.svg")),
+            "plan must include icon.svg"
+        );
+        assert!(
+            paths.iter().any(|p| p.ends_with("maskable-icon.svg")),
+            "plan must include maskable-icon.svg"
+        );
+    }
+
+    #[test]
+    fn plan_creates_system_test() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        let plan = plan_pwa(tmp.path()).unwrap();
+        assert!(
+            plan.actions
+                .iter()
+                .any(|a| a.path().ends_with("pwa_smoke.rs")),
+            "plan must include pwa_smoke.rs"
+        );
+    }
+
+    // ── manifest content ──────────────────────────────────────────────────────
+
+    #[test]
+    fn manifest_is_valid_json() {
+        let content = render_manifest();
+        let parsed: serde_json::Value = serde_json::from_str(&content)
+            .expect("manifest.webmanifest must be valid JSON");
+        assert!(parsed["name"].is_string(), "manifest must have a name");
+        assert!(parsed["icons"].is_array(), "manifest must have icons array");
+    }
+
+    #[test]
+    fn manifest_has_required_fields_for_installability() {
+        let content = render_manifest();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(parsed["start_url"].is_string());
+        assert!(["fullscreen", "standalone", "minimal-ui"].contains(
+            &parsed["display"].as_str().unwrap_or("")
+        ));
+        let icons = parsed["icons"].as_array().unwrap();
+        assert!(!icons.is_empty(), "at least one icon required");
+    }
+
+    #[test]
+    fn manifest_has_both_icon_purposes() {
+        let content = render_manifest();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let icons = parsed["icons"].as_array().unwrap();
+        let purposes: Vec<&str> = icons
+            .iter()
+            .filter_map(|i| i["purpose"].as_str())
+            .collect();
+        assert!(
+            purposes.iter().any(|p| p.contains("any") || p.contains("monochrome")),
+            "must have a general-purpose icon"
+        );
+        assert!(
+            purposes.iter().any(|p| p.contains("maskable")),
+            "must have a maskable icon"
+        );
+    }
+
+    // ── service worker content ────────────────────────────────────────────────
+
+    #[test]
+    fn service_worker_has_offline_fallback_for_navigation() {
+        let sw = render_service_worker();
+        assert!(sw.contains("navigate"), "SW must handle navigation requests");
+        assert!(sw.contains("offline"), "SW must have offline fallback");
+    }
+
+    #[test]
+    fn service_worker_precaches_offline_url() {
+        let sw = render_service_worker();
+        assert!(sw.contains("PRECACHE_URLS"), "SW must declare precache list");
+        assert!(sw.contains("/offline"), "SW must precache the offline shell");
+    }
+
+    #[test]
+    fn service_worker_has_install_and_activate_handlers() {
+        let sw = render_service_worker();
+        assert!(sw.contains("install"), "SW must have install handler");
+        assert!(sw.contains("activate"), "SW must have activate handler");
+    }
+
+    #[test]
+    fn service_worker_caches_static_assets_first() {
+        let sw = render_service_worker();
+        assert!(sw.contains("/static/"), "SW must cache static assets");
+    }
+
+    // ── inject_pwa_meta_into_head ─────────────────────────────────────────────
+
+    #[test]
+    fn inject_adds_manifest_link() {
+        let updated = inject_pwa_meta_into_head(DEFAULT_MAIN);
+        assert!(
+            updated.contains(r#"rel="manifest""#),
+            "must add rel=manifest link"
+        );
+        assert!(
+            updated.contains("/manifest.webmanifest"),
+            "must reference /manifest.webmanifest"
+        );
+    }
+
+    #[test]
+    fn inject_adds_theme_color_meta() {
+        let updated = inject_pwa_meta_into_head(DEFAULT_MAIN);
+        assert!(
+            updated.contains("theme-color"),
+            "must add theme-color meta tag"
+        );
+    }
+
+    #[test]
+    fn inject_adds_apple_touch_icon() {
+        let updated = inject_pwa_meta_into_head(DEFAULT_MAIN);
+        assert!(
+            updated.contains("apple-touch-icon"),
+            "must add apple-touch-icon link"
+        );
+    }
+
+    #[test]
+    fn inject_meta_is_idempotent() {
+        let once = inject_pwa_meta_into_head(DEFAULT_MAIN);
+        let twice = inject_pwa_meta_into_head(&once);
+        assert_eq!(once, twice, "inject_pwa_meta_into_head must be idempotent");
+    }
+
+    #[test]
+    fn inject_meta_preserves_existing_content() {
+        let updated = inject_pwa_meta_into_head(DEFAULT_MAIN);
+        assert!(updated.contains(r#"meta charset="utf-8""#));
+        assert!(updated.contains(r#"meta name="viewport""#));
+        assert!(updated.contains(r#"link rel="stylesheet""#));
+    }
+
+    #[test]
+    fn inject_meta_no_op_when_head_absent() {
+        let src = "fn main() { println!(\"hello\"); }\n";
+        let result = inject_pwa_meta_into_head(src);
+        assert_eq!(result, src, "must be unchanged if no head {{}} block found");
+    }
+
+    // ── inject_pwa_handlers ───────────────────────────────────────────────────
+
+    #[test]
+    fn inject_handlers_adds_manifest_route() {
+        let updated = inject_pwa_handlers(DEFAULT_MAIN);
+        assert!(
+            updated.contains("async fn pwa_manifest()"),
+            "must add pwa_manifest handler"
+        );
+        assert!(
+            updated.contains("application/manifest+json"),
+            "pwa_manifest must set correct content-type"
+        );
+    }
+
+    #[test]
+    fn inject_handlers_adds_service_worker_route() {
+        let updated = inject_pwa_handlers(DEFAULT_MAIN);
+        assert!(
+            updated.contains("async fn pwa_service_worker()"),
+            "must add pwa_service_worker handler"
+        );
+        assert!(
+            updated.contains("service-worker-allowed"),
+            "service-worker handler must set Service-Worker-Allowed header"
+        );
+    }
+
+    #[test]
+    fn inject_handlers_adds_offline_route() {
+        let updated = inject_pwa_handlers(DEFAULT_MAIN);
+        assert!(
+            updated.contains("async fn pwa_offline()"),
+            "must add pwa_offline handler"
+        );
+    }
+
+    #[test]
+    fn inject_handlers_is_idempotent() {
+        let once = inject_pwa_handlers(DEFAULT_MAIN);
+        let twice = inject_pwa_handlers(&once);
+        assert_eq!(once, twice, "inject_pwa_handlers must be idempotent");
+    }
+
+    #[test]
+    fn inject_handlers_places_before_main() {
+        let updated = inject_pwa_handlers(DEFAULT_MAIN);
+        let handler_pos = updated.find("async fn pwa_manifest()").unwrap();
+        let main_pos = updated.find("#[autumn_web::main]").unwrap();
+        assert!(
+            handler_pos < main_pos,
+            "PWA handlers must appear before #[autumn_web::main]"
+        );
+    }
+
+    #[test]
+    fn pwa_manifest_handler_uses_include_str() {
+        let updated = inject_pwa_handlers(DEFAULT_MAIN);
+        assert!(
+            updated.contains("include_str!(\"../static/manifest.webmanifest\")"),
+            "pwa_manifest must embed file at compile time via include_str!"
+        );
+    }
+
+    #[test]
+    fn pwa_service_worker_handler_uses_include_str() {
+        let updated = inject_pwa_handlers(DEFAULT_MAIN);
+        assert!(
+            updated.contains("include_str!(\"../static/service-worker.js\")"),
+            "pwa_service_worker must embed file at compile time via include_str!"
+        );
+    }
+
+    // ── inject_pwa_into_main (combined) ──────────────────────────────────────
+
+    #[test]
+    fn full_inject_adds_routes_to_routes_macro() {
+        let updated = inject_pwa_into_main(DEFAULT_MAIN);
+        assert!(
+            updated.contains("pwa_manifest"),
+            "routes![] must include pwa_manifest"
+        );
+        assert!(
+            updated.contains("pwa_service_worker"),
+            "routes![] must include pwa_service_worker"
+        );
+        assert!(
+            updated.contains("pwa_offline"),
+            "routes![] must include pwa_offline"
+        );
+    }
+
+    #[test]
+    fn full_inject_is_idempotent() {
+        let once = inject_pwa_into_main(DEFAULT_MAIN);
+        let twice = inject_pwa_into_main(&once);
+        assert_eq!(once, twice, "inject_pwa_into_main must be idempotent");
+    }
+
+    #[test]
+    fn full_inject_does_not_duplicate_manifest_link() {
+        let once = inject_pwa_into_main(DEFAULT_MAIN);
+        let twice = inject_pwa_into_main(&once);
+        let count = twice.matches(r#"rel="manifest""#).count();
+        assert_eq!(count, 1, "must not duplicate rel=manifest link");
+    }
+
+    #[test]
+    fn full_inject_does_not_duplicate_pwa_routes() {
+        let once = inject_pwa_into_main(DEFAULT_MAIN);
+        let twice = inject_pwa_into_main(&once);
+        let handler_count = twice.matches("async fn pwa_manifest()").count();
+        assert_eq!(handler_count, 1, "must not duplicate pwa_manifest handler");
+    }
+
+    // ── plan execution ────────────────────────────────────────────────────────
+
+    #[test]
+    fn plan_execute_creates_manifest_file() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        let manifest_path = tmp.path().join("static/manifest.webmanifest");
+        assert!(manifest_path.exists(), "static/manifest.webmanifest must exist");
+        let content = fs::read_to_string(&manifest_path).unwrap();
+        let _: serde_json::Value = serde_json::from_str(&content)
+            .expect("manifest.webmanifest must be valid JSON after execution");
+    }
+
+    #[test]
+    fn plan_execute_creates_service_worker_file() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(
+            tmp.path().join("static/service-worker.js").exists(),
+            "static/service-worker.js must exist"
+        );
+    }
+
+    #[test]
+    fn plan_execute_creates_icon_files() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(
+            tmp.path().join("static/icons/icon.svg").exists(),
+            "static/icons/icon.svg must exist"
+        );
+        assert!(
+            tmp.path().join("static/icons/maskable-icon.svg").exists(),
+            "static/icons/maskable-icon.svg must exist"
+        );
+    }
+
+    #[test]
+    fn plan_execute_creates_system_test_file() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(
+            tmp.path().join("tests/system/pwa_smoke.rs").exists(),
+            "tests/system/pwa_smoke.rs must exist"
+        );
+    }
+
+    #[test]
+    fn plan_execute_updates_main_rs_with_pwa_meta_and_handlers() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        let main_rs = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(main_rs.contains(r#"rel="manifest""#));
+        assert!(main_rs.contains("async fn pwa_manifest()"));
+        assert!(main_rs.contains("async fn pwa_service_worker()"));
+        assert!(main_rs.contains("async fn pwa_offline()"));
+    }
+
+    #[test]
+    fn plan_execute_is_idempotent_with_force() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags {
+                force: true,
+                dry_run: false,
+            })
+            .unwrap();
+        let main_rs = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert_eq!(
+            main_rs.matches(r#"rel="manifest""#).count(),
+            1,
+            "re-running must not duplicate manifest link"
+        );
+        assert_eq!(
+            main_rs.matches("async fn pwa_manifest()").count(),
+            1,
+            "re-running must not duplicate pwa_manifest handler"
+        );
+    }
+
+    #[test]
+    fn dry_run_writes_nothing() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        let original_main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags {
+                dry_run: true,
+                force: false,
+            })
+            .unwrap();
+        assert!(
+            !tmp.path().join("static/manifest.webmanifest").exists(),
+            "dry-run must not create manifest"
+        );
+        let after = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert_eq!(original_main, after, "dry-run must not modify main.rs");
+    }
+
+}

--- a/autumn-cli/src/generate/system_test.rs
+++ b/autumn-cli/src/generate/system_test.rs
@@ -326,7 +326,7 @@ fn find_features_header_end(cargo_toml: &str) -> Option<usize> {
 /// Patch `Cargo.toml` content to add the `system-tests` feature (under
 /// `[features]` only, not in `[dependencies]`) and a `[[test]]` entry for this
 /// test file if they are not already present.
-fn patch_cargo_toml(existing: &str, snake_name: &str) -> String {
+pub(super) fn patch_cargo_toml(existing: &str, snake_name: &str) -> String {
     let mut out = existing.to_owned();
 
     // 1. Add [features] system-tests entry if not already in the [features] table.

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1104,6 +1104,30 @@ enum GenerateCommands {
         #[arg(long)]
         force: bool,
     },
+    /// Scaffold an installable Progressive Web App (manifest, service worker,
+    /// icons, and layout meta tags).
+    ///
+    /// Creates:
+    ///   - `static/manifest.webmanifest` — Web App Manifest (served as application/manifest+json)
+    ///   - `static/service-worker.js`    — Offline-shell service worker
+    ///   - `static/icons/icon.svg`       — Placeholder icon (replace with real PNG for full compat)
+    ///   - `static/icons/maskable-icon.svg` — Maskable icon variant
+    ///   - `src/main.rs`                 — Route handlers + PWA `<link>`/`<meta>` tags in layout
+    ///   - `tests/system/pwa_smoke.rs`   — Smoke test for manifest content-type + SW registration
+    ///
+    /// Example:
+    ///
+    ///   autumn generate pwa
+    ///   autumn generate pwa --dry-run
+    #[command(verbatim_doc_comment)]
+    Pwa {
+        /// Print the file plan and exit without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Overwrite existing files instead of erroring on collision.
+        #[arg(long)]
+        force: bool,
+    },
     /// Generate model, migration, repository, HTML routes, smoke test, and
     /// register the new routes in `src/main.rs`.
     Scaffold {
@@ -1673,6 +1697,9 @@ fn run_generate_command(cmd: GenerateCommands) {
             dry_run,
             force,
         } => generate::system_test::run(&name, generate::Flags { dry_run, force }),
+        GenerateCommands::Pwa { dry_run, force } => {
+            generate::pwa::run(generate::Flags { dry_run, force });
+        }
         GenerateCommands::Auth {
             name,
             oauth,
@@ -3692,6 +3719,40 @@ mod tests {
         let Commands::Generate(GenerateCommands::SystemTest { force, .. }) = cli.command else {
             panic!("expected SystemTest variant");
         };
+        assert!(force);
+    }
+
+    // ── autumn generate pwa ────────────────────────────────────────────────
+
+    #[test]
+    fn parse_generate_pwa() {
+        let cli = Cli::try_parse_from(["autumn", "generate", "pwa"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Generate(GenerateCommands::Pwa {
+                dry_run: false,
+                force: false
+            })
+        ));
+    }
+
+    #[test]
+    fn parse_generate_pwa_dry_run() {
+        let cli = Cli::try_parse_from(["autumn", "generate", "pwa", "--dry-run"]).unwrap();
+        let Commands::Generate(GenerateCommands::Pwa { dry_run, force }) = cli.command else {
+            panic!("expected Pwa variant");
+        };
+        assert!(dry_run);
+        assert!(!force);
+    }
+
+    #[test]
+    fn parse_generate_pwa_force() {
+        let cli = Cli::try_parse_from(["autumn", "generate", "pwa", "--force"]).unwrap();
+        let Commands::Generate(GenerateCommands::Pwa { dry_run, force }) = cli.command else {
+            panic!("expected Pwa variant");
+        };
+        assert!(!dry_run);
         assert!(force);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a new `autumn generate pwa` command that scaffolds a complete Progressive Web App setup, including a Web App Manifest, service worker with offline-shell caching, placeholder icons, PWA meta tags in the layout, and a system test for manifest and service worker registration.

## Key Changes

- **New module `autumn-cli/src/generate/pwa.rs`** (908 lines):
  - `plan_pwa()` — computes file actions for PWA scaffolding
  - `run()` — CLI entry point
  - Content renderers for manifest, service worker, and SVG icons
  - `inject_pwa_into_main()` — idempotent patching of `src/main.rs` to add PWA meta tags, route handlers, and route registration
  - `inject_pwa_meta_into_head()` — inserts `<link rel="manifest">`, theme-color meta, apple-touch-icon, and inline SW registration script into the layout's `head {}` block
  - `inject_pwa_handlers()` — appends three route handlers (`pwa_manifest`, `pwa_service_worker`, `pwa_offline`) before `#[autumn_web::main]`
  - Comprehensive test suite (40+ tests) covering manifest validity, service worker functionality, idempotency, and file creation

- **Updated `autumn-cli/src/main.rs`**:
  - Added `GenerateCommands::Pwa` variant with `--dry-run` and `--force` flags
  - Wired command to `generate::pwa::run()` in `run_generate_command()`
  - Added CLI parsing tests for the new command

- **Updated `autumn-cli/src/generate/mod.rs`**:
  - Exported new `pwa` module

## Notable Implementation Details

- **Idempotent patching**: All modifications to `src/main.rs` are guarded by checks (e.g., `rel="manifest"` presence) to prevent duplication on re-runs
- **Service worker**: Implements offline-shell pattern with precaching of `/` and `/offline`, cache-first for static assets, network-first for navigation
- **Manifest**: Includes both general-purpose and maskable icon variants for broad platform support
- **System test**: Verifies manifest content-type (`application/manifest+json`) and service worker registration via `data-sw-registered` attribute on `<html>`
- **Cargo.toml patching**: Reuses existing `patch_system_test_cargo_toml()` to add `system-tests` feature if absent
- **SVG icons**: Placeholder leaf emoji icons with safe-zone guidance for maskable variant; comments encourage replacement with PNG for broader compatibility

https://claude.ai/code/session_01AdBMuUboWS6SzuLPTUBVB9