### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1087,12 +1087,12 @@ enum GenerateCommands {
     ///
     /// Example:
     ///
-    ///   autumn generate system-test <Name>
-    ///   autumn generate system-test <Name> --dry-run
+    ///   autumn generate system-test `<Name>`
+    ///   autumn generate system-test `<Name>` --dry-run
     ///
     /// After generation, run with:
     ///
-    ///   cargo test --features system-tests --test <name> -- --include-ignored
+    ///   cargo test --features system-tests --test `<name>` -- --include-ignored
     #[command(name = "system-test", verbatim_doc_comment)]
     SystemTest {
         /// Test name (`PascalCase` or `snake_case`, e.g. `TodoFlow`).

--- a/autumn/src/reporting.rs
+++ b/autumn/src/reporting.rs
@@ -2,24 +2,24 @@
 //! route them to one or more configured reporters.
 //!
 //! When an Autumn handler panics or returns a server error, the failure is
-//! turned into a structured [`ErrorEvent`] and delivered to every registered
-//! [`ErrorReporter`]. This is the "where do my errors go?" seam: ship events to
+//! turned into a structured [`crate::reporting::ErrorEvent`] and delivered to every registered
+//! [`crate::reporting::ErrorReporter`]. This is the "where do my errors go?" seam: ship events to
 //! Sentry, Honeycomb, Slack, or a custom sink by implementing a single trait
 //! and wiring it once with
 //! [`AppBuilder::with_error_reporter`](crate::app::AppBuilder::with_error_reporter).
 //!
 //! The design mirrors Rails' [Error Reporter] and Autumn's other pluggable
 //! backends ([`BlobStore`](crate::storage::BlobStore),
-//! [`Cache`](crate::cache::Cache)): a built-in [`LogReporter`] (which uses
+//! [`Cache`](crate::cache::Cache)): a built-in [`crate::reporting::LogReporter`] (which uses
 //! `tracing`) ships as the default so the feature is useful with zero extra
 //! dependencies, and one builder call swaps in your own sink.
 //!
 //! # What gets reported
 //!
-//! - **Handler panics.** A [`ReportingLayer`] catches unwinding panics at the
+//! - **Handler panics.** A [`crate::reporting::ReportingLayer`] catches unwinding panics at the
 //!   HTTP layer (so a single panicking handler can never abort the worker
 //!   task), converts them into a sanitized [`AutumnError`](crate::AutumnError)
-//!   `500` Problem Details response, and reports an [`ErrorEvent`] carrying the
+//!   `500` Problem Details response, and reports an [`crate::reporting::ErrorEvent`] carrying the
 //!   panic payload and (when `RUST_BACKTRACE` is set) a backtrace.
 //! - **Server errors.** Any response with a `5xx` status is reported with its
 //!   status, message, and Problem Details type.

--- a/autumn/src/system_test.rs
+++ b/autumn/src/system_test.rs
@@ -293,7 +293,7 @@ impl SystemTest {
     }
 
     /// Supply a pre-configured [`AppState`] to use instead of
-    /// [`AppState::for_test()`].
+    /// [`crate::state::AppState::for_test()`].
     ///
     /// Use this when the routes under test require a real database pool, API
     /// version registrations, authorization policies, or any other state that

--- a/examples/todo-app/src/routes/todos.rs
+++ b/examples/todo-app/src/routes/todos.rs
@@ -41,7 +41,7 @@
 //!
 //! ## Inline field validation (htmx)
 //!
-//! A field rendered with [`text_input_htmx`] POSTs to a validation endpoint
+//! A field rendered with [`autumn_web::form::text_input_htmx`] POSTs to a validation endpoint
 //! when its value changes. The handler extracts [`ChangesetForm`], validates,
 //! and returns just that field's wrapper partial — htmx swaps it with `outerHTML`.
 //! When JavaScript is disabled, the normal `#[post("/todos")]` handler still


### PR DESCRIPTION
📖 Chapter: `autumn_web::reporting`, `autumn_web::system_test`, `todo-app`, and `autumn-cli`
🔦 Insight: Several intra-doc links were broken because they were not fully qualified or missing from scope. Unclosed HTML tag warnings were being generated for placeholder parameters `<Name>` and `<name>` in the CLI's doc comments. These were fixed by providing full paths (`crate::reporting::ErrorEvent`) and wrapping placeholder syntax in backticks (`` `<Name>` ``) to ensure they resolve correctly and parse as code.
🧪 Example: Run `cargo doc --no-deps --workspace --all-features` to see a warning-free output.
🖼️ Preview: (All links now resolve correctly, and CLI docs display `<Name>` properly without generating HTML parse warnings).

---
*PR created automatically by Jules for task [9136888952771600299](https://jules.google.com/task/9136888952771600299) started by @madmax983*