### PR TITLE
🛡️ Sentry: Add test coverage for split_host_port

### DIFF
--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -2275,6 +2275,48 @@ mod tests {
     }
 
     #[test]
+    fn split_host_port_handles_basic_cases() {
+        assert_eq!(split_host_port("example.com"), ("example.com", None));
+        assert_eq!(
+            split_host_port("example.com:8080"),
+            ("example.com", Some("8080"))
+        );
+        assert_eq!(
+            split_host_port("localhost:3000"),
+            ("localhost", Some("3000"))
+        );
+    }
+
+    #[test]
+    fn split_host_port_handles_ipv6() {
+        assert_eq!(split_host_port("[::1]"), ("[::1]", None));
+        assert_eq!(split_host_port("[::1]:8080"), ("[::1]", Some("8080")));
+        assert_eq!(
+            split_host_port("[2001:db8::1]:443"),
+            ("[2001:db8::1]", Some("443"))
+        );
+    }
+
+    #[test]
+    fn split_host_port_rejects_invalid_ipv6() {
+        // Missing closing bracket
+        assert_eq!(split_host_port("[::1"), ("[::1", None));
+        assert_eq!(split_host_port("[::1:8080"), ("[::1:8080", None));
+    }
+
+    #[test]
+    fn split_host_port_rejects_invalid_port() {
+        // Non-digit port
+        assert_eq!(
+            split_host_port("example.com:abc"),
+            ("example.com:abc", None)
+        );
+        assert_eq!(split_host_port("example.com:"), ("example.com:", None));
+        assert_eq!(split_host_port("[::1]:abc"), ("[::1]:abc", None));
+        assert_eq!(split_host_port("[::1]:"), ("[::1]:", None));
+    }
+
+    #[test]
     fn origin_allowlist_enforced() {
         let s = server(vec!["https://ok.example".to_owned()]);
         assert!(s.origin_allowed("https://ok.example", None, None));


### PR DESCRIPTION
🎯 Target: `autumn/src/mcp.rs` (`split_host_port` function)
💣 Risk: The `split_host_port` function lacked test coverage. A regression here could lead to incorrect extraction of hosts and ports from authorities, potentially breaking the same-origin bypass for `origin_allowed`, resulting in either a bypass of CORS protections for spoofed headers or false-positive rejection of valid same-origin clients.
🧪 Strategy: Added unit tests `split_host_port_handles_basic_cases`, `split_host_port_handles_ipv6`, `split_host_port_rejects_invalid_ipv6`, and `split_host_port_rejects_invalid_port` covering the core functionality, bracketed IPv6 literals, missing closing brackets on IPv6, and non-numeric port strings.
🔬 Verification: Run `cargo test -p autumn-web --lib mcp::`

---
*PR created automatically by Jules for task [846061399144063232](https://jules.google.com/task/846061399144063232) started by @madmax983*