### PR TITLE
Add declarative state machine support via #[state_machine] attribute

### DIFF
--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -53,7 +53,8 @@ fn validate_attrs(field: &Field) -> Vec<&syn::Attribute> {
 }
 
 /// Filter out framework-specific attributes (`#[id]`, `#[indexed]`, `#[validate]`,
-/// `#[default]`, `#[factory_assoc]`, `#[lock_version]`, `#[searchable]`) that shouldn't be on the query struct
+/// `#[default]`, `#[factory_assoc]`, `#[lock_version]`, `#[searchable]`,
+/// `#[state_machine]`) that shouldn't be on the query struct
 /// (they'd confuse Diesel derives).
 fn user_attrs(field: &Field) -> Vec<&syn::Attribute> {
     field
@@ -68,6 +69,7 @@ fn user_attrs(field: &Field) -> Vec<&syn::Attribute> {
                 && !a.path().is_ident("lock_version")
                 && !a.path().is_ident("searchable")
                 && !a.path().is_ident("encrypted")
+                && !a.path().is_ident("state_machine")
         })
         .collect()
 }
@@ -649,6 +651,149 @@ fn emit_schema_fn_body_ext(
     }
 }
 
+// ── State machine support ────────────────────────────────────────────────────
+
+/// A single allowed transition between two named states.
+struct StateMachineTransition {
+    from: String,
+    to: String,
+    /// Optional guard: name of a `&self` bool method that must return `true`.
+    guard: Option<String>,
+}
+
+/// Parsed `#[state_machine(transitions(...))]` spec for one field.
+struct StateMachineSpec {
+    field_ident: syn::Ident,
+    transitions: Vec<StateMachineTransition>,
+}
+
+/// Parse the inner `transitions(a -> b, b -> c: "guard", ...)` token tree.
+fn parse_transitions(input: syn::parse::ParseStream<'_>) -> syn::Result<Vec<StateMachineTransition>> {
+    let kw: syn::Ident = input.parse()?;
+    if kw != "transitions" {
+        return Err(syn::Error::new(kw.span(), "expected `transitions(...)`"));
+    }
+    let content;
+    syn::parenthesized!(content in input);
+
+    let mut transitions = Vec::new();
+    while !content.is_empty() {
+        let from: syn::Ident = content.parse()?;
+        content.parse::<syn::Token![->]>()?;
+        let to: syn::Ident = content.parse()?;
+        let guard = if content.peek(syn::Token![:]) {
+            content.parse::<syn::Token![:]>()?;
+            let lit: syn::LitStr = content.parse()?;
+            Some(lit.value())
+        } else {
+            None
+        };
+        transitions.push(StateMachineTransition {
+            from: from.to_string(),
+            to: to.to_string(),
+            guard,
+        });
+        if content.peek(syn::Token![,]) {
+            content.parse::<syn::Token![,]>()?;
+        }
+    }
+    Ok(transitions)
+}
+
+/// Parse `#[state_machine(transitions(...))]` from a field, returning the spec when present.
+fn parse_state_machine_spec(field: &syn::Field) -> syn::Result<Option<StateMachineSpec>> {
+    let Some(ident) = field.ident.as_ref() else {
+        return Ok(None);
+    };
+    for attr in &field.attrs {
+        if attr.path().is_ident("state_machine") {
+            let transitions = attr.parse_args_with(parse_transitions)?;
+            return Ok(Some(StateMachineSpec {
+                field_ident: ident.clone(),
+                transitions,
+            }));
+        }
+    }
+    Ok(None)
+}
+
+/// Emit the three state machine items for one field: a transitions constant,
+/// a `can_transition_{field}_to` predicate, and a `transition_{field}_to` method.
+fn emit_state_machine_impl(model_name: &syn::Ident, spec: &StateMachineSpec) -> TokenStream {
+    let field = &spec.field_ident;
+    let field_str = field.to_string();
+    let field_upper = field_str.to_uppercase();
+
+    let const_name = format_ident!("__AUTUMN_SM_{field_upper}_TRANSITIONS");
+    let can_fn = format_ident!("can_transition_{field_str}_to");
+    let transition_fn = format_ident!("transition_{field_str}_to");
+
+    let const_entries: Vec<TokenStream> = spec
+        .transitions
+        .iter()
+        .map(|t| {
+            let from = &t.from;
+            let to = &t.to;
+            match &t.guard {
+                Some(g) => quote! { (#from, #to, ::core::option::Option::Some(#g)) },
+                None => quote! { (#from, #to, ::core::option::Option::None) },
+            }
+        })
+        .collect();
+
+    let match_arms: Vec<TokenStream> = spec
+        .transitions
+        .iter()
+        .map(|t| {
+            let from = &t.from;
+            let to = &t.to;
+            if let Some(g) = &t.guard {
+                let guard_fn = format_ident!("{g}");
+                quote! { (#from, #to) => self.#guard_fn() }
+            } else {
+                quote! { (#from, #to) => true }
+            }
+        })
+        .collect();
+
+    quote! {
+        impl #model_name {
+            #[doc(hidden)]
+            pub const #const_name: &'static [(&'static str, &'static str, ::core::option::Option<&'static str>)] = &[
+                #(#const_entries,)*
+            ];
+
+            /// Returns `true` when this record's `{field}` can transition to `target`.
+            ///
+            /// For guarded transitions the corresponding guard method is called first.
+            pub fn #can_fn(&self, target: &str) -> bool {
+                match (self.#field.as_str(), target) {
+                    #(#match_arms,)*
+                    _ => false,
+                }
+            }
+
+            /// Attempts to transition `{field}` to `target`, returning the new state value.
+            ///
+            /// Returns `Err` if the transition is not defined or a guard rejects it.
+            pub fn #transition_fn(&self, target: &str) -> ::autumn_web::AutumnResult<::std::string::String> {
+                if self.#can_fn(target) {
+                    ::core::result::Result::Ok(::std::string::String::from(target))
+                } else {
+                    ::core::result::Result::Err(::autumn_web::AutumnError::bad_request_msg(
+                        ::std::format!(
+                            "Cannot transition `{}` from `{}` to `{}`",
+                            #field_str,
+                            self.#field,
+                            target,
+                        ),
+                    ))
+                }
+            }
+        }
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 #[allow(clippy::cognitive_complexity)]
 pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -696,6 +841,18 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     // Classify fields
     let all_fields: Vec<&Field> = fields.named.iter().collect();
+
+    // Collect state machine specs from all fields (RED → GREEN: declarative SM support).
+    let mut state_machine_impls: Vec<TokenStream> = Vec::new();
+    for field in &all_fields {
+        match parse_state_machine_spec(field) {
+            Ok(Some(spec)) => {
+                state_machine_impls.push(emit_state_machine_impl(name, &spec));
+            }
+            Ok(None) => {}
+            Err(err) => return err.to_compile_error(),
+        }
+    }
 
     let mut search_field_names = Vec::new();
     let mut search_field_weights = Vec::new();
@@ -2229,6 +2386,9 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #((#search_field_names, #search_field_weights)),*
             ];
         }
+
+        // ── State machine impls (one per #[state_machine] field) ────────────
+        #(#state_machine_impls)*
     }
 }
 
@@ -2553,6 +2713,259 @@ mod tests {
         assert!(
             generated.contains("lock_version"),
             "etag() method body must reference the lock_version field: {generated}"
+        );
+    }
+
+    // ── RED: declarative state machines ───────────────────────────────────────
+    // These tests define the expected generated API for `#[state_machine(...)]`
+    // field attributes. All will fail until the feature is implemented.
+
+    #[test]
+    fn state_machine_emits_can_transition_method() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        pending -> processing,
+                        processing -> shipped,
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("can_transition_status_to"),
+            "#[state_machine] must emit `can_transition_status_to`: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_emits_transition_to_method() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        pending -> processing,
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("transition_status_to"),
+            "#[state_machine] must emit `transition_status_to`: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_emits_transitions_constant() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        pending -> processing,
+                        processing -> shipped,
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("__AUTUMN_SM_STATUS_TRANSITIONS"),
+            "#[state_machine] must emit `__AUTUMN_SM_STATUS_TRANSITIONS` constant: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_transition_table_contains_from_to_pairs() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        pending -> processing,
+                        processing -> shipped,
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("\"pending\"") && generated.contains("\"processing\""),
+            "transition table must contain the from/to state strings: {generated}"
+        );
+        assert!(
+            generated.contains("\"shipped\""),
+            "transition table must contain all destination states: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_with_guard_calls_guard_method() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        processing -> shipped: "can_ship",
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("can_ship"),
+            "guarded transition must call the guard method `can_ship`: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_guard_stored_in_transition_table() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        processing -> shipped: "can_ship",
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("Some (\"can_ship\")")
+                || generated.contains("Some(\"can_ship\")"),
+            "guarded transition must store the guard name in the transition table: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_unguarded_transition_table_entry_has_none() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        pending -> processing,
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("None"),
+            "unguarded transition must store None in the transition table: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_transition_method_returns_autumn_result() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        pending -> processing,
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("AutumnResult"),
+            "transition_*_to must return AutumnResult: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_attribute_not_leaked_to_diesel_struct() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        pending -> processing,
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        // The `state_machine` attribute must not appear inside the Diesel struct
+        // definition — Diesel doesn't know about it and would emit errors.
+        // We check that it does NOT appear as a field-level #[state_machine].
+        // The generated constant/methods may contain the word though.
+        let struct_block = generated
+            .find("pub struct Order")
+            .map(|i| &generated[i..i + 500])
+            .unwrap_or("");
+        assert!(
+            !struct_block.contains("# [state_machine]")
+                && !struct_block.contains("#[state_machine]"),
+            "`state_machine` attribute must not appear on the generated Diesel struct field: {struct_block}"
+        );
+    }
+
+    #[test]
+    fn state_machine_multiple_fields_emit_separate_methods() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Ticket {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(open -> in_progress, in_progress -> closed))]
+                    pub status: String,
+                    #[state_machine(transitions(low -> medium, medium -> high))]
+                    pub priority: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("can_transition_status_to"),
+            "multi-sm model must emit `can_transition_status_to`: {generated}"
+        );
+        assert!(
+            generated.contains("can_transition_priority_to"),
+            "multi-sm model must emit `can_transition_priority_to`: {generated}"
+        );
+        assert!(
+            generated.contains("transition_status_to"),
+            "multi-sm model must emit `transition_status_to`: {generated}"
+        );
+        assert!(
+            generated.contains("transition_priority_to"),
+            "multi-sm model must emit `transition_priority_to`: {generated}"
         );
     }
 }

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -2947,8 +2947,7 @@ mod tests {
         // The generated constant/methods may contain the word though.
         let struct_block = generated
             .find("pub struct Order")
-            .map(|i| &generated[i..i + 500])
-            .unwrap_or("");
+            .map_or("", |i| &generated[i..i + 500]);
         assert!(
             !struct_block.contains("# [state_machine]")
                 && !struct_block.contains("#[state_machine]"),

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -516,6 +516,8 @@ fn excluded_from_new(field: &Field) -> bool {
 
 /// Convert a `snake_case` identifier to `PascalCase`.
 fn pascal_case(s: &str) -> String {
+    // Strip the raw-identifier prefix so `r#type` produces `Type`, not `R#type`.
+    let s = s.strip_prefix("r#").unwrap_or(s);
     s.split('_')
         .map(|word| {
             let mut chars = word.chars();
@@ -754,7 +756,10 @@ fn parse_state_machine_spec(field: &syn::Field) -> syn::Result<Option<StateMachi
 /// a `can_transition_{field}_to` predicate, and a `transition_{field}_to` method.
 fn emit_state_machine_impl(model_name: &syn::Ident, spec: &StateMachineSpec) -> TokenStream {
     let field = &spec.field_ident;
-    let field_str = field.to_string();
+    let raw_field_str = field.to_string();
+    // Strip the raw-identifier prefix so `r#type` produces `type`-derived names
+    // rather than trying to create identifiers like `can_transition_r#type_to`.
+    let field_str = raw_field_str.strip_prefix("r#").unwrap_or(&raw_field_str);
     let field_upper = field_str.to_uppercase();
 
     let const_name = format_ident!("__AUTUMN_SM_{field_upper}_TRANSITIONS");
@@ -3027,6 +3032,32 @@ mod tests {
         assert!(
             generated.contains("not a valid Rust identifier"),
             "invalid guard identifier must emit a compile error: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_raw_identifier_field_generates_clean_names() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        pending -> processing,
+                    ))]
+                    pub r#type: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("can_transition_type_to"),
+            "raw identifier field must strip r# prefix for generated method name: {generated}"
+        );
+        assert!(
+            generated.contains("__AUTUMN_SM_TYPE_TRANSITIONS"),
+            "raw identifier field must strip r# prefix for generated const name: {generated}"
         );
     }
 

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -686,7 +686,19 @@ fn parse_transitions(
         let guard = if content.peek(syn::Token![:]) {
             content.parse::<syn::Token![:]>()?;
             let lit: syn::LitStr = content.parse()?;
-            Some(lit.value())
+            let guard_str = lit.value();
+            // Validate that the guard name is a plain Rust identifier so that
+            // format_ident! doesn't panic on names like "can-ship" or "can ship".
+            syn::parse_str::<syn::Ident>(&guard_str).map_err(|_| {
+                syn::Error::new_spanned(
+                    &lit,
+                    format!(
+                        "`{guard_str}` is not a valid Rust identifier; \
+                         guard names must be a plain function name such as `can_ship`"
+                    ),
+                )
+            })?;
+            Some(guard_str)
         } else {
             None
         };
@@ -2993,6 +3005,28 @@ mod tests {
         assert!(
             generated.contains("multiple `#[state_machine]` attributes are not allowed"),
             "duplicate #[state_machine] on same field must emit a compile error: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_invalid_guard_identifier_is_rejected() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        pending -> processing: "can-ship",
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("not a valid Rust identifier"),
+            "invalid guard identifier must emit a compile error: {generated}"
         );
     }
 

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -755,10 +755,10 @@ fn emit_state_machine_impl(model_name: &syn::Ident, spec: &StateMachineSpec) -> 
         .map(|t| {
             let from = &t.from;
             let to = &t.to;
-            match &t.guard {
-                Some(g) => quote! { (#from, #to, ::core::option::Option::Some(#g)) },
-                None => quote! { (#from, #to, ::core::option::Option::None) },
-            }
+            t.guard.as_ref().map_or_else(
+                || quote! { (#from, #to, ::core::option::Option::None) },
+                |g| quote! { (#from, #to, ::core::option::Option::Some(#g)) },
+            )
         })
         .collect();
 
@@ -768,12 +768,13 @@ fn emit_state_machine_impl(model_name: &syn::Ident, spec: &StateMachineSpec) -> 
         .map(|t| {
             let from = &t.from;
             let to = &t.to;
-            if let Some(g) = &t.guard {
-                let guard_fn = format_ident!("{g}");
-                quote! { (#from, #to) => self.#guard_fn() }
-            } else {
-                quote! { (#from, #to) => true }
-            }
+            t.guard.as_ref().map_or_else(
+                || quote! { (#from, #to) => true },
+                |g| {
+                    let guard_fn = format_ident!("{g}");
+                    quote! { (#from, #to) => self.#guard_fn() }
+                },
+            )
         })
         .collect();
 

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -668,7 +668,9 @@ struct StateMachineSpec {
 }
 
 /// Parse the inner `transitions(a -> b, b -> c: "guard", ...)` token tree.
-fn parse_transitions(input: syn::parse::ParseStream<'_>) -> syn::Result<Vec<StateMachineTransition>> {
+fn parse_transitions(
+    input: syn::parse::ParseStream<'_>,
+) -> syn::Result<Vec<StateMachineTransition>> {
     let kw: syn::Ident = input.parse()?;
     if kw != "transitions" {
         return Err(syn::Error::new(kw.span(), "expected `transitions(...)`"));
@@ -701,20 +703,39 @@ fn parse_transitions(input: syn::parse::ParseStream<'_>) -> syn::Result<Vec<Stat
 }
 
 /// Parse `#[state_machine(transitions(...))]` from a field, returning the spec when present.
+///
+/// Validates:
+/// - Only `String` fields are supported (the generated `.as_str()` call requires it).
+/// - Multiple `#[state_machine]` attributes on the same field are rejected.
 fn parse_state_machine_spec(field: &syn::Field) -> syn::Result<Option<StateMachineSpec>> {
     let Some(ident) = field.ident.as_ref() else {
         return Ok(None);
     };
+    let mut spec: Option<StateMachineSpec> = None;
     for attr in &field.attrs {
         if attr.path().is_ident("state_machine") {
+            if spec.is_some() {
+                return Err(syn::Error::new_spanned(
+                    attr,
+                    "multiple `#[state_machine]` attributes are not allowed on a single field",
+                ));
+            }
+            let is_string = matches!(&field.ty, syn::Type::Path(p)
+                if p.path.segments.last().is_some_and(|s| s.ident == "String"));
+            if !is_string {
+                return Err(syn::Error::new_spanned(
+                    &field.ty,
+                    "`#[state_machine]` is only supported on `String` fields",
+                ));
+            }
             let transitions = attr.parse_args_with(parse_transitions)?;
-            return Ok(Some(StateMachineSpec {
+            spec = Some(StateMachineSpec {
                 field_ident: ident.clone(),
                 transitions,
-            }));
+            });
         }
     }
-    Ok(None)
+    Ok(spec)
 }
 
 /// Emit the three state machine items for one field: a transitions constant,
@@ -2854,8 +2875,7 @@ mod tests {
         );
         let generated = output.to_string();
         assert!(
-            generated.contains("Some (\"can_ship\")")
-                || generated.contains("Some(\"can_ship\")"),
+            generated.contains("Some (\"can_ship\")") || generated.contains("Some(\"can_ship\")"),
             "guarded transition must store the guard name in the transition table: {generated}"
         );
     }
@@ -2932,6 +2952,47 @@ mod tests {
             !struct_block.contains("# [state_machine]")
                 && !struct_block.contains("#[state_machine]"),
             "`state_machine` attribute must not appear on the generated Diesel struct field: {struct_block}"
+        );
+    }
+
+    #[test]
+    fn state_machine_on_non_string_field_is_rejected() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(pending -> processing))]
+                    pub amount: i64,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("only supported on `String` fields"),
+            "#[state_machine] on a non-String field must emit a compile error: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_duplicate_attribute_on_same_field_is_rejected() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(pending -> processing))]
+                    #[state_machine(transitions(processing -> shipped))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("multiple `#[state_machine]` attributes are not allowed"),
+            "duplicate #[state_machine] on same field must emit a compile error: {generated}"
         );
     }
 

--- a/autumn/tests/compile-pass/model_state_machine.rs
+++ b/autumn/tests/compile-pass/model_state_machine.rs
@@ -1,0 +1,94 @@
+use autumn_web::model;
+
+// ── State machine on a single field ──────────────────────────────────────────
+
+diesel::table! {
+    orders (id) {
+        id -> BigInt,
+        amount -> BigInt,
+        status -> Text,
+    }
+}
+
+#[model(table = "orders")]
+pub struct Order {
+    #[id]
+    pub id: i64,
+    pub amount: i64,
+    #[state_machine(transitions(
+        pending -> processing,
+        processing -> shipped: "can_ship",
+        processing -> cancelled,
+        shipped -> delivered,
+    ))]
+    pub status: String,
+}
+
+impl Order {
+    fn can_ship(&self) -> bool {
+        self.amount > 0
+    }
+}
+
+// ── Multiple state machine fields on the same model ──────────────────────────
+
+diesel::table! {
+    tickets (id) {
+        id -> BigInt,
+        status -> Text,
+        priority -> Text,
+    }
+}
+
+#[model(table = "tickets")]
+pub struct Ticket {
+    #[id]
+    pub id: i64,
+    #[state_machine(transitions(
+        open -> in_progress: "can_start",
+        in_progress -> closed,
+    ))]
+    pub status: String,
+    #[state_machine(transitions(
+        low -> medium,
+        medium -> high,
+    ))]
+    pub priority: String,
+}
+
+impl Ticket {
+    fn can_start(&self) -> bool {
+        true
+    }
+}
+
+// ── Unguarded single-transition machine ──────────────────────────────────────
+
+diesel::table! {
+    workflows (id) {
+        id -> BigInt,
+        phase -> Text,
+    }
+}
+
+#[model(table = "workflows")]
+pub struct Workflow {
+    #[id]
+    pub id: i64,
+    #[state_machine(transitions(draft -> active, active -> archived))]
+    pub phase: String,
+}
+
+fn _assert_can_transition_compiles(order: &Order) {
+    let _ = order.can_transition_status_to("processing");
+    let _ = order.transition_status_to("processing");
+}
+
+fn _assert_constant_accessible() {
+    let _: &[(&str, &str, Option<&str>)] = Order::__AUTUMN_SM_STATUS_TRANSITIONS;
+    let _: &[(&str, &str, Option<&str>)] = Ticket::__AUTUMN_SM_STATUS_TRANSITIONS;
+    let _: &[(&str, &str, Option<&str>)] = Ticket::__AUTUMN_SM_PRIORITY_TRANSITIONS;
+    let _: &[(&str, &str, Option<&str>)] = Workflow::__AUTUMN_SM_PHASE_TRANSITIONS;
+}
+
+fn main() {}

--- a/autumn/tests/compile_fail.rs
+++ b/autumn/tests/compile_fail.rs
@@ -123,6 +123,10 @@ fn compile_pass_tests() {
     #[cfg(feature = "db")]
     t.pass("tests/compile-pass/repository_lock_version.rs");
 
+    // Declarative state machines: #[state_machine(transitions(...))] (requires db feature)
+    #[cfg(feature = "db")]
+    t.pass("tests/compile-pass/model_state_machine.rs");
+
     // Soft delete (requires db feature)
     #[cfg(feature = "db")]
     t.pass("tests/compile-pass/repository_soft_delete.rs");

--- a/docs/guide/state-machines.md
+++ b/docs/guide/state-machines.md
@@ -1,0 +1,210 @@
+# Declarative State Machines
+
+Autumn's `#[state_machine]` field attribute lets you declare valid status
+transitions directly in your model struct. The macro generates a compile-time
+transition table, a `can_transition_{field}_to` predicate, and a
+`transition_{field}_to` method that enforces the graph at runtime — no
+hand-written `match` blocks or scattered `if old_status == "draft" { ... }`
+checks spread across route handlers.
+
+---
+
+## Model setup
+
+Add `#[state_machine(transitions(...))]` to any `String` field:
+
+```rust
+#[autumn_web::model]
+pub struct Order {
+    #[id]
+    pub id: i64,
+    pub amount: i64,
+    #[state_machine(transitions(
+        pending -> processing,
+        processing -> shipped: "can_ship",
+        processing -> cancelled,
+        shipped -> delivered,
+    ))]
+    pub status: String,
+}
+
+impl Order {
+    fn can_ship(&self) -> bool {
+        self.amount > 0
+    }
+}
+```
+
+Each line inside `transitions(...)` declares one edge:
+
+```
+from_state -> to_state
+from_state -> to_state: "guard_method_name"
+```
+
+A trailing comma after the last transition is accepted. State names are
+unquoted identifiers; underscores and digits are allowed (`in_progress`,
+`state_2`). Guard names are quoted strings that must name a `&self -> bool`
+method on the model.
+
+---
+
+## Generated API
+
+For a field named `status` the macro generates three items on the struct:
+
+| Item | Signature | Purpose |
+|------|-----------|---------|
+| `__AUTUMN_SM_STATUS_TRANSITIONS` | `&'static [(&'static str, &'static str, Option<&'static str>)]` | Compile-time edge list `(from, to, guard_name)` |
+| `can_transition_status_to` | `(&self, target: &str) -> bool` | Predicate — true when the transition is defined and all guards pass |
+| `transition_status_to` | `(&self, target: &str) -> AutumnResult<String>` | Enforcing version — returns `Ok(target.to_owned())` or a 400 error |
+
+For a field named `phase`, replace `STATUS` / `status` with `PHASE` / `phase`
+throughout.
+
+---
+
+## Guard methods
+
+A guard is called on `self` at the time `transition_{field}_to` (or
+`can_transition_{field}_to`) is called. The record it receives is whatever
+you pass — usually the current database snapshot.
+
+```rust
+// In a route or service:
+let new_status = order.transition_status_to("shipped")?;
+// → calls order.can_ship(); returns Err if false or if edge doesn't exist
+```
+
+Because the guard receives the record as-is, you can check any field:
+
+```rust
+impl Invoice {
+    fn can_approve(&self) -> bool {
+        self.line_item_count > 0 && self.total_cents > 0
+    }
+}
+```
+
+An unguarded edge (`pending -> processing`) always succeeds when the `from`
+state matches.
+
+---
+
+## Enforcing transitions in `before_update`
+
+The most common integration point is the `before_update` hook. Check the
+incoming status change against the transition table before the SQL runs:
+
+```rust
+impl MutationHooks for OrderHooks {
+    type Model = Order;
+    type NewModel = NewOrder;
+    type UpdateModel = UpdateOrder;
+
+    async fn before_update(
+        &self,
+        _ctx: &mut MutationContext,
+        draft: &mut UpdateDraft<Order>,
+    ) -> AutumnResult<()> {
+        if draft.after.status != draft.before.status {
+            // Validate the edge and call any guards; returns 400 on failure.
+            draft.before.transition_status_to(&draft.after.status)?;
+        }
+        Ok(())
+    }
+}
+```
+
+`draft.before` holds the record's current state from the database. Calling
+`transition_status_to` on it checks whether the `before` status can move to the
+`after` status, and whether any guard defined on that edge passes.
+
+If you only want to check without returning an error (for example, to pick a
+default):
+
+```rust
+if !draft.before.can_transition_status_to(&draft.after.status) {
+    draft.after.status = draft.before.status.clone(); // revert silently
+}
+```
+
+---
+
+## Multiple state machine fields
+
+A single model can have several `#[state_machine]` fields. Each generates its
+own constant and pair of methods:
+
+```rust
+#[autumn_web::model]
+pub struct Ticket {
+    #[id]
+    pub id: i64,
+    #[state_machine(transitions(
+        open -> in_progress: "can_start",
+        in_progress -> closed,
+    ))]
+    pub status: String,
+    #[state_machine(transitions(
+        low -> medium,
+        medium -> high,
+    ))]
+    pub priority: String,
+}
+```
+
+This generates:
+- `Ticket::__AUTUMN_SM_STATUS_TRANSITIONS`
+- `Ticket::can_transition_status_to` / `Ticket::transition_status_to`
+- `Ticket::__AUTUMN_SM_PRIORITY_TRANSITIONS`
+- `Ticket::can_transition_priority_to` / `Ticket::transition_priority_to`
+
+---
+
+## Runtime reflection
+
+The transitions constant is public and carries the guard name as a string so
+you can build UI or API metadata from it at runtime:
+
+```rust
+for (from, to, guard) in Order::__AUTUMN_SM_STATUS_TRANSITIONS {
+    println!("{from} → {to}{}",
+        guard.map_or(String::new(), |g| format!(" [guard: {g}]")));
+}
+```
+
+You can also expose allowed next states to a client:
+
+```rust
+let next_states: Vec<&str> = Order::__AUTUMN_SM_STATUS_TRANSITIONS
+    .iter()
+    .filter(|(from, _, _)| *from == order.status.as_str())
+    .map(|(_, to, _)| *to)
+    .collect();
+```
+
+---
+
+## Constraints
+
+- Only `String` fields are supported. Attempting `#[state_machine]` on an `i32`
+  or other type is a compile error.
+- Multiple `#[state_machine]` attributes on the same field are rejected at
+  compile time.
+- State names and guard names must be valid Rust identifiers (no spaces, no
+  hyphens). Use underscores: `in_progress`, not `in-progress`.
+- The transition graph is not validated for reachability or completeness. Dead
+  states and disconnected subgraphs compile fine — they just can never be
+  reached at runtime.
+
+---
+
+## Wiki example
+
+The wiki example ships a `Page` model with `draft`, `published`, and `archived`
+states. `#[state_machine]` is added to its `status` field and the
+`PageHooks::before_update` implementation enforces valid transitions, so a
+direct API call or form submission cannot skip `draft → published → archived`
+or jump backward. See `examples/wiki/src/models.rs` and
+`examples/wiki/src/hooks.rs`.

--- a/docs/guide/state-machines.md
+++ b/docs/guide/state-machines.md
@@ -108,23 +108,27 @@ impl MutationHooks for OrderHooks {
         draft: &mut UpdateDraft<Order>,
     ) -> AutumnResult<()> {
         if draft.after.status != draft.before.status {
-            // Validate the edge and call any guards; returns 400 on failure.
-            draft.before.transition_status_to(&draft.after.status)?;
+            // Build a "proposed" record: new field values but the current
+            // status, so guards evaluate the content being persisted rather
+            // than stale before-state values.
+            let mut proposed = draft.after.clone();
+            proposed.status = draft.before.status.clone();
+            proposed.transition_status_to(&draft.after.status)?;
         }
         Ok(())
     }
 }
 ```
 
-`draft.before` holds the record's current state from the database. Calling
-`transition_status_to` on it checks whether the `before` status can move to the
-`after` status, and whether any guard defined on that edge passes.
+**Why clone?** Guards run on `self`, which in the simple `draft.before.transition_status_to(...)` pattern means they see the record's *old* field values. If a user submits a status change together with edits to fields the guard reads (e.g. clearing a body field while publishing), the guard would evaluate the old data and give the wrong answer. Cloning `draft.after` and then restoring only the `status` to the before-value lets the edge lookup work correctly while the guard sees the *proposed* final content.
 
 If you only want to check without returning an error (for example, to pick a
 default):
 
 ```rust
-if !draft.before.can_transition_status_to(&draft.after.status) {
+let mut proposed = draft.after.clone();
+proposed.status = draft.before.status.clone();
+if !proposed.can_transition_status_to(&draft.after.status) {
     draft.after.status = draft.before.status.clone(); // revert silently
 }
 ```

--- a/examples/wiki/src/hooks.rs
+++ b/examples/wiki/src/hooks.rs
@@ -38,6 +38,12 @@ impl MutationHooks for PageHooks {
             draft.after.slug = slugify(&draft.after.title);
         }
 
+        // Enforce state machine transitions; returns 400 for invalid edges or
+        // when the can_publish guard rejects draft -> published.
+        if draft.after.status != draft.before.status {
+            draft.before.transition_status_to(&draft.after.status)?;
+        }
+
         Ok(())
     }
 }

--- a/examples/wiki/src/hooks.rs
+++ b/examples/wiki/src/hooks.rs
@@ -307,6 +307,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_before_create_defaults_empty_status_to_draft() {
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let mut new = NewPage {
+            title: "My Page".into(),
+            slug: String::new(),
+            body: "Some content".into(),
+            status: String::new(), // empty — should be defaulted to "draft"
+        };
+        hooks.before_create(&mut ctx, &mut new).await.unwrap();
+        assert_eq!(new.status, "draft");
+    }
+
+    #[tokio::test]
     async fn test_before_create_rejects_invalid_initial_status() {
         let hooks = PageHooks;
         let mut ctx = MutationContext::new(MutationOp::Update);

--- a/examples/wiki/src/hooks.rs
+++ b/examples/wiki/src/hooks.rs
@@ -150,4 +150,50 @@ mod tests {
         assert!(err.to_string().contains("99"));
         assert!(err.to_string().contains("3"));
     }
+
+    #[tokio::test]
+    async fn test_before_update_allows_valid_status_transition() {
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let before = Page {
+            id: 1,
+            title: "My Page".into(),
+            slug: "my-page".into(),
+            body: "Some content".into(),
+            status: "draft".into(),
+            lock_version: 0,
+            created_at: Utc::now().naive_utc(),
+            updated_at: Utc::now().naive_utc(),
+        };
+        let mut after = before.clone();
+        after.status = "published".into();
+
+        let mut draft = UpdateDraft { before, after };
+        hooks.before_update(&mut ctx, &mut draft).await.unwrap();
+
+        assert_eq!(draft.after.status, "published");
+    }
+
+    #[tokio::test]
+    async fn test_before_update_rejects_invalid_status_transition() {
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let before = Page {
+            id: 1,
+            title: "My Page".into(),
+            slug: "my-page".into(),
+            body: "Some content".into(),
+            status: "published".into(),
+            lock_version: 0,
+            created_at: Utc::now().naive_utc(),
+            updated_at: Utc::now().naive_utc(),
+        };
+        let mut after = before.clone();
+        after.status = "draft".into(); // published -> draft is not a defined edge
+
+        let mut draft = UpdateDraft { before, after };
+        let result = hooks.before_update(&mut ctx, &mut draft).await;
+
+        assert!(result.is_err());
+    }
 }

--- a/examples/wiki/src/hooks.rs
+++ b/examples/wiki/src/hooks.rs
@@ -27,7 +27,8 @@ impl MutationHooks for PageHooks {
 
         // Enforce the can_publish guard even on direct creates so a page
         // cannot be born already published with an empty title or body.
-        if new.status == "published" && (new.title.trim().is_empty() || new.body.trim().is_empty()) {
+        if new.status == "published" && (new.title.trim().is_empty() || new.body.trim().is_empty())
+        {
             return Err(autumn_web::AutumnError::bad_request_msg(
                 "Cannot create a published page with an empty title or body",
             ));
@@ -233,7 +234,10 @@ mod tests {
         let mut draft = UpdateDraft { before, after };
         let result = hooks.before_update(&mut ctx, &mut draft).await;
 
-        assert!(result.is_err(), "guard must reject publishing with empty body");
+        assert!(
+            result.is_err(),
+            "guard must reject publishing with empty body"
+        );
     }
 
     #[tokio::test]
@@ -247,7 +251,10 @@ mod tests {
             status: "published".into(),
         };
         let result = hooks.before_create(&mut ctx, &mut new).await;
-        assert!(result.is_err(), "creating published page with empty body must fail");
+        assert!(
+            result.is_err(),
+            "creating published page with empty body must fail"
+        );
     }
 
     #[tokio::test]

--- a/examples/wiki/src/hooks.rs
+++ b/examples/wiki/src/hooks.rs
@@ -67,6 +67,15 @@ impl MutationHooks for PageHooks {
             proposed.transition_status_to(&draft.after.status)?;
         }
 
+        // Maintain the published-page content invariant even when status is
+        // unchanged; an edit that clears title/body on an already-published
+        // page must be rejected the same way a direct published create would be.
+        if draft.after.status == "published" && !draft.after.can_publish() {
+            return Err(autumn_web::AutumnError::bad_request_msg(
+                "A published page must have a non-empty title and body",
+            ));
+        }
+
         Ok(())
     }
 }
@@ -247,6 +256,54 @@ mod tests {
             result.is_err(),
             "guard must reject publishing with empty body"
         );
+    }
+
+    #[tokio::test]
+    async fn test_before_update_rejects_clearing_body_on_published_page() {
+        // Status stays "published" but body is cleared — must be rejected.
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let before = Page {
+            id: 1,
+            title: "My Page".into(),
+            slug: "my-page".into(),
+            body: "Original content".into(),
+            status: "published".into(),
+            lock_version: 0,
+            created_at: Utc::now().naive_utc(),
+            updated_at: Utc::now().naive_utc(),
+        };
+        let mut after = before.clone();
+        after.body = String::new(); // clear body without changing status
+
+        let mut draft = UpdateDraft { before, after };
+        let result = hooks.before_update(&mut ctx, &mut draft).await;
+        assert!(
+            result.is_err(),
+            "clearing body on a published page must fail"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_before_update_allows_content_edits_on_published_page() {
+        // Editing title/body on a published page is fine as long as they stay non-empty.
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let before = Page {
+            id: 1,
+            title: "My Page".into(),
+            slug: "my-page".into(),
+            body: "Original content".into(),
+            status: "published".into(),
+            lock_version: 0,
+            created_at: Utc::now().naive_utc(),
+            updated_at: Utc::now().naive_utc(),
+        };
+        let mut after = before.clone();
+        after.body = "Updated content".into();
+
+        let mut draft = UpdateDraft { before, after };
+        hooks.before_update(&mut ctx, &mut draft).await.unwrap();
     }
 
     #[tokio::test]

--- a/examples/wiki/src/hooks.rs
+++ b/examples/wiki/src/hooks.rs
@@ -25,6 +25,14 @@ impl MutationHooks for PageHooks {
             new.status = "draft".into();
         }
 
+        // Enforce the can_publish guard even on direct creates so a page
+        // cannot be born already published with an empty title or body.
+        if new.status == "published" && (new.title.trim().is_empty() || new.body.trim().is_empty()) {
+            return Err(autumn_web::AutumnError::bad_request_msg(
+                "Cannot create a published page with an empty title or body",
+            ));
+        }
+
         Ok(())
     }
 
@@ -40,8 +48,13 @@ impl MutationHooks for PageHooks {
 
         // Enforce state machine transitions; returns 400 for invalid edges or
         // when the can_publish guard rejects draft -> published.
+        // Evaluate guards against the proposed (after) content by cloning the
+        // new record and restoring the current status, so can_publish sees the
+        // title/body the user is submitting, not the old values.
         if draft.after.status != draft.before.status {
-            draft.before.transition_status_to(&draft.after.status)?;
+            let mut proposed = draft.after.clone();
+            proposed.status = draft.before.status.clone();
+            proposed.transition_status_to(&draft.after.status)?;
         }
 
         Ok(())
@@ -195,5 +208,59 @@ mod tests {
         let result = hooks.before_update(&mut ctx, &mut draft).await;
 
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_before_update_guard_sees_proposed_content() {
+        // Updating status AND clearing body in the same request must be rejected —
+        // the guard should evaluate the body being submitted, not the old body.
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let before = Page {
+            id: 1,
+            title: "My Page".into(),
+            slug: "my-page".into(),
+            body: "Has content".into(),
+            status: "draft".into(),
+            lock_version: 0,
+            created_at: Utc::now().naive_utc(),
+            updated_at: Utc::now().naive_utc(),
+        };
+        let mut after = before.clone();
+        after.status = "published".into();
+        after.body = String::new(); // clearing body in the same update
+
+        let mut draft = UpdateDraft { before, after };
+        let result = hooks.before_update(&mut ctx, &mut draft).await;
+
+        assert!(result.is_err(), "guard must reject publishing with empty body");
+    }
+
+    #[tokio::test]
+    async fn test_before_create_rejects_published_with_empty_body() {
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let mut new = NewPage {
+            title: "My Page".into(),
+            slug: String::new(),
+            body: String::new(),
+            status: "published".into(),
+        };
+        let result = hooks.before_create(&mut ctx, &mut new).await;
+        assert!(result.is_err(), "creating published page with empty body must fail");
+    }
+
+    #[tokio::test]
+    async fn test_before_create_allows_published_with_content() {
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let mut new = NewPage {
+            title: "My Page".into(),
+            slug: String::new(),
+            body: "Non-empty body".into(),
+            status: "published".into(),
+        };
+        hooks.before_create(&mut ctx, &mut new).await.unwrap();
+        assert_eq!(new.status, "published");
     }
 }

--- a/examples/wiki/src/hooks.rs
+++ b/examples/wiki/src/hooks.rs
@@ -25,6 +25,15 @@ impl MutationHooks for PageHooks {
             new.status = "draft".into();
         }
 
+        // Only draft and published are valid initial statuses; archived can only
+        // be reached via a transition from published.
+        if !matches!(new.status.as_str(), "draft" | "published") {
+            return Err(autumn_web::AutumnError::bad_request_msg(format!(
+                "Invalid initial status `{}`; pages must start as `draft` or `published`",
+                new.status
+            )));
+        }
+
         // Enforce the can_publish guard even on direct creates so a page
         // cannot be born already published with an empty title or body.
         if new.status == "published" && (new.title.trim().is_empty() || new.body.trim().is_empty())
@@ -237,6 +246,49 @@ mod tests {
         assert!(
             result.is_err(),
             "guard must reject publishing with empty body"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_before_create_rejects_invalid_initial_status() {
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let mut new = NewPage {
+            title: "My Page".into(),
+            slug: String::new(),
+            body: "Content".into(),
+            status: "archived".into(),
+        };
+        let result = hooks.before_create(&mut ctx, &mut new).await;
+        assert!(
+            result.is_err(),
+            "creating a page with status=archived must fail"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_before_update_rejects_whitespace_only_publish() {
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let before = Page {
+            id: 1,
+            title: "My Page".into(),
+            slug: "my-page".into(),
+            body: "Some content".into(),
+            status: "draft".into(),
+            lock_version: 0,
+            created_at: Utc::now().naive_utc(),
+            updated_at: Utc::now().naive_utc(),
+        };
+        let mut after = before.clone();
+        after.status = "published".into();
+        after.body = "   ".into(); // whitespace-only
+
+        let mut draft = UpdateDraft { before, after };
+        let result = hooks.before_update(&mut ctx, &mut draft).await;
+        assert!(
+            result.is_err(),
+            "guard must reject publishing with whitespace-only body"
         );
     }
 

--- a/examples/wiki/src/models.rs
+++ b/examples/wiki/src/models.rs
@@ -34,6 +34,11 @@ pub struct Page {
     pub slug: String,
     #[searchable(weight = "B")]
     pub body: String,
+    #[state_machine(transitions(
+        draft -> published: "can_publish",
+        published -> archived,
+        draft -> archived,
+    ))]
     pub status: String,
     #[lock_version]
     pub lock_version: i32,
@@ -41,6 +46,12 @@ pub struct Page {
     pub created_at: chrono::NaiveDateTime,
     #[default]
     pub updated_at: chrono::NaiveDateTime,
+}
+
+impl Page {
+    pub fn can_publish(&self) -> bool {
+        !self.title.is_empty() && !self.body.is_empty()
+    }
 }
 
 // Revision is manual — write-only from hooks, read-only from routes

--- a/examples/wiki/src/models.rs
+++ b/examples/wiki/src/models.rs
@@ -50,7 +50,7 @@ pub struct Page {
 
 impl Page {
     pub fn can_publish(&self) -> bool {
-        !self.title.is_empty() && !self.body.is_empty()
+        !self.title.trim().is_empty() && !self.body.trim().is_empty()
     }
 }
 

--- a/examples/wiki/src/models.rs
+++ b/examples/wiki/src/models.rs
@@ -37,7 +37,6 @@ pub struct Page {
     #[state_machine(transitions(
         draft -> published: "can_publish",
         published -> archived,
-        draft -> archived,
     ))]
     pub status: String,
     #[lock_version]


### PR DESCRIPTION
## Summary
Implements declarative state machine support for model fields through a new `#[state_machine(transitions(...))]` attribute. This allows developers to define allowed state transitions directly on fields, with optional guard methods for conditional transitions.

## Key Changes

- **New `#[state_machine]` attribute**: Fields can now declare allowed transitions using `#[state_machine(transitions(from -> to, ...))]` syntax
- **Guard method support**: Transitions can be guarded by optional `&self` methods using the syntax `from -> to: "guard_method_name"`
- **Generated methods**: For each state machine field, three items are generated:
  - `can_transition_{field}_to(target: &str) -> bool`: Checks if a transition is allowed (evaluates guards)
  - `transition_{field}_to(target: &str) -> AutumnResult<String>`: Attempts the transition, returning error if invalid
  - `__AUTUMN_SM_{FIELD}_TRANSITIONS` constant: Stores the transition table as `&[(&str, &str, Option<&str>)]`
- **Attribute filtering**: The `#[state_machine]` attribute is properly filtered out from the generated Diesel struct to prevent conflicts
- **Multiple state machines**: Models can have multiple state machine fields, each generating independent methods and constants
- **Comprehensive tests**: Added 11 unit tests covering parsing, code generation, guard handling, and multi-field scenarios
- **Compile-pass tests**: Added integration tests demonstrating real-world usage with guarded and unguarded transitions

## Implementation Details

- Parser handles the `transitions(a -> b, b -> c: "guard", ...)` syntax using syn's parsing utilities
- Guard names are stored as `Option<&'static str>` in the transition table for runtime introspection
- Generated `transition_*_to` methods return `AutumnResult` with descriptive error messages on invalid transitions
- State machine specs are collected during field classification and emitted as impl blocks after the main model definition

https://claude.ai/code/session_01R2PCzUujgPFUVMR2tDLFkP