### PR TITLE
🔓 Eris: [ERIS-NOTE] Advisory Lock Hash Collisions

### DIFF
--- a/autumn/tests/security/advisory_lock_starvation.rs
+++ b/autumn/tests/security/advisory_lock_starvation.rs
@@ -1,0 +1,12 @@
+
+#[tokio::test]
+async fn eris_advisory_lock_starvation() {
+    // [ERIS-NOTE]
+    // The `pg_advisory_xact_lock(hashtext($1))` call in `experiments.rs` and
+    // `pg_advisory_xact_lock(1, hashtext($1))` in `runtime_config.rs` cast
+    // a 32-bit `hashtext` return value into the Postgres lock key space.
+    // This makes collisions possible (1 in 2^32), potentially leading to
+    // transient starvation or deadlocks between unrelated actors.
+    // Given the transaction-level scoping of these locks, the practical
+    // severity is low, but the invariant is technically broken.
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -14,3 +14,4 @@ pub mod maintenance;
 pub mod rate_limit_xff_bypass;
 pub mod session_exhaustion;
 pub mod session_fixation;
+pub mod advisory_lock_starvation;

--- a/eris_advisories.md
+++ b/eris_advisories.md
@@ -1,3 +1,7 @@
 # [ERIS-NOTE] CSRF on HTMX Endpoints
 
 The hypothesis that "I can bypass CSRF protection on htmx endpoints by omitting the HX-Request header and submitting a standard form POST" was extensively tested and found to be false. The `CsrfLayer` securely applies validation on all non-safe methods regardless of the presence of htmx-specific headers, and gracefully falls back to checking the URL-encoded body if the header token is absent.
+
+# [ERIS-NOTE] Advisory Lock Hash Collisions
+
+The `pg_advisory_xact_lock(hashtext($1))` call in `experiments.rs` and `pg_advisory_xact_lock(1, hashtext($1))` in `runtime_config.rs` cast a 32-bit `hashtext` return value into the Postgres lock key space. This makes collisions possible (1 in 2^32), potentially leading to transient starvation or deadlocks between unrelated actors. Given the transaction-level scoping of these locks, the practical severity is low, but the invariant is technically broken.


### PR DESCRIPTION
Reconnaissance: The framework uses `pg_advisory_xact_lock` in Postgres via `autumn_web::experiments` and `autumn_web::runtime_config` to coordinate access among concurrent workers or request handlers. In both cases, the input actor/key is passed via `hashtext($1)`.

Hypothesis: `hashtext()` returns a signed 32-bit integer (`int4`). In `experiments.rs`, the lock uses the single-argument variant `pg_advisory_xact_lock(bigint)`. The `int4` returned by `hashtext` is implicitly cast to `int8`, meaning the upper 32 bits are padded, reducing the lock key space to only 2^32 possibilities. In `runtime_config.rs`, it uses the `(int4, int4)` variant with `1` as the first argument and `hashtext` as the second argument, which also has a 2^32 key space. A malicious user who can control the hashed inputs could trigger collisions, taking the lock intended for another user or resource.

Exploit development: Given the transaction-level scope of the locks (meaning the locks are released as soon as the transaction completes in milliseconds) and the reliance on statistical collisions in a 2^32 keyspace, a reliable starvation or denial of service exploit is not practical. Thus, this finding is downgraded to an [ERIS-NOTE] theoretical weakness.

Verification: `cargo test -p autumn-web --test security_tests` passes successfully with the newly added advisory placeholder test `eris_advisory_lock_starvation`.

Severity assessment: None / Theoretical. CVSS 3.1: 0.0 (Unexploitable).

Remediation recommendation: Replace `hashtext($1)` with a 64-bit non-cryptographic hash (like `xxhash64` or SipHash) generated locally in Rust and passed as a `bigint`/`i64` binding to `pg_advisory_xact_lock($1)`. This expands the keyspace to 2^64, eliminating practical collision risks.

---
*PR created automatically by Jules for task [11507505208637252504](https://jules.google.com/task/11507505208637252504) started by @madmax983*