### PR TITLE
Add active session management with device list and revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **auth:** Active session management with device list and revocation in the auth starter (#819)
+  - `autumn generate auth` now persists a `{user}_sessions` row per login
+    (SHA-256 digest of the opaque session id — never the raw id — plus user id,
+    IP at login, raw + parsed User-Agent, optional device label, `created_at`,
+    `last_seen_at`), created on password login, email confirmation, TOTP verify,
+    and passkey login, and removed on logout.
+  - Generated handler APIs on the user model: `sessions()`, `revoke_session(id)`,
+    `revoke_other_sessions(current_digest)`, and `revoke_all_sessions()`, plus a
+    `require_tracked_session` gate used by every generated authenticated route.
+    The row is the source of truth: revoking it makes the device's **next**
+    request 401 (the cookie session is destroyed too), with no reliance on
+    cookie expiry. `last_seen_at` writes are throttled to at most one per
+    `[auth.sessions].last_seen_update_secs` (default 60 s) per session.
+  - New `/account/sessions` Maud + htmx page: per-session revoke buttons,
+    device labels, and a one-click "Sign out everywhere else".
+  - Credential-changing events — password reset, TOTP enrollment/disable, and
+    passkey add/remove — revoke all *other* sessions by default, configurable
+    via the new `[auth.sessions] revoke_on_credential_change` flag (default on).
+  - New `autumn_web::user_agent` module: a dependency-free heuristic
+    `parse_user_agent` (browser family / OS / device class) with a documented
+    one-line swap point for custom parsers.
+  - Generated `tests/auth_sessions.rs` covers the two-client flow (log in twice,
+    revoke from one client, the other's replayed cookie 401s) and generated
+    `docs/guide/session-management.md` documents the APIs, the privacy posture
+    for stored IP/UA (purpose limitation, retention scrubbing SQL, IP
+    truncation), and the migration path for existing auth-starter apps.
+  - Additive only: one new table in the auth-starter migration; no public API
+    removed.
+
 - **log:** Request-scoped log context that auto-tags every log line (#1169)
   - An always-on `LogContextLayer` establishes a fresh `tokio::task_local`
     `log::context::LogContext` for **every** HTTP request, seeded with the same

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -5291,6 +5291,11 @@ pub async fn oauth_callback(
     //
     //   session.insert(&auth_cfg.session_key, local_user_id.to_string()).await;
     //
+    //   // Track the OAuth login as an active session (device list + revocation,
+    //   // issue #819) — add `MaybeClientIp(addr_ip)` and `headers: HeaderMap`
+    //   // extractors to this handler, then:
+    //   crate::routes::auth::record_login_session(&mut db, &session, local_user_id, addr_ip, &headers).await?;
+    //
     // Until the above is implemented the user will NOT be logged in after the OAuth
     // callback — that is intentional to avoid authenticating without a local account.
 {totp_callback_note}    let _ = identity;

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -10246,8 +10246,12 @@ mod tests {
             .find("data_export")
             .expect("data_export route must be present");
         let export_body = &routes[export_pos..export_pos + 500.min(routes.len() - export_pos)];
+        // Authentication is enforced either via the tracked-session gate
+        // (#819) or a session/Auth extractor check.
         assert!(
-            export_body.contains("Auth") || export_body.contains("auth"),
+            export_body.contains("require_tracked_session")
+                || export_body.contains("Auth")
+                || export_body.contains("auth"),
             "data_export route must require authentication: {export_body}"
         );
     }

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -1778,6 +1778,7 @@ use autumn_web::prelude::*;
 use axum::extract::Path;
 use axum::response::{{IntoResponse, Response}};
 use diesel::prelude::*;
+use diesel_async::AsyncConnection as _;
 use diesel_async::RunQueryDsl;
 use serde::Deserialize;
 
@@ -1884,6 +1885,27 @@ pub async fn rebind_tracked_session(
     .map_err(|e| {{
         AutumnError::internal_server_error_msg(format!(
             "Failed to rebind tracked session: {{e}}"
+        ))
+    }})?;
+    Ok(())
+}}
+
+/// Delete the tracked row for the *current* session id, if any.
+///
+/// Login flows call this before `session.rotate_id()`: the rotation
+/// destroys the old server-side session, so a row keyed to its digest
+/// could never authenticate again and would linger as a phantom device on
+/// the previous account's sessions page. Logout uses it too.
+pub async fn untrack_current_session(db: &mut Db, session: &Session) -> AutumnResult<()> {{
+    let token_digest = session_token_digest(session).await;
+    diesel::delete(
+        {sess_table}::table.filter({sess_table}::token_digest.eq(&token_digest)),
+    )
+    .execute(&mut **db)
+    .await
+    .map_err(|e| {{
+        AutumnError::internal_server_error_msg(format!(
+            "Failed to clean up tracked session: {{e}}"
         ))
     }})?;
     Ok(())
@@ -2515,6 +2537,10 @@ pub async fn login(
         return Err(auth_err());
     }}
 
+    // This browser may already hold a tracked session (re-login or account
+    // switch). The rotation below destroys that session id, so drop its row
+    // now — otherwise it would linger as a phantom device.
+    untrack_current_session(&mut db, &session).await?;
 {totp_login_branch}
     session.rotate_id().await;
 {totp_clear_pending}    session.insert("{snake_name}_id", {snake_name}.id.to_string()).await;
@@ -2537,12 +2563,8 @@ pub async fn login(
 /// too so the device disappears from the active-sessions list.
 #[post("/logout")]
 pub async fn logout(session: Session, mut db: Db) -> AutumnResult<Response> {{
-    let token_digest = session_token_digest(&session).await;
-    let _ = diesel::delete(
-        {sess_table}::table.filter({sess_table}::token_digest.eq(&token_digest)),
-    )
-    .execute(&mut *db)
-    .await;
+    // Best-effort: the device must sign out even if the row delete hiccups.
+    let _ = untrack_current_session(&mut db, &session).await;
     session.destroy().await;
     Ok(redirect_to("/login"))
 }}
@@ -3106,24 +3128,46 @@ pub async fn reset_password(
     if {snake_name}.email_confirmed_at.is_none() {{
         return Ok(redirect_to("/check-your-email"));
     }}
-{totp_reset_branch}
-    diesel::update({table}::table.find({snake_name}.id))
-        .set((
-            {table}::password_digest.eq(&new_digest),
-            {table}::reset_token_digest.eq(None::<String>),
-            {table}::reset_token_expires_at.eq(None::<chrono::NaiveDateTime>),
-        ))
-        .execute(&mut *db)
-        .await?;
 
-    // Credential changed: revoke every existing session (defaulted on,
-    // configurable via [auth.sessions].revoke_on_credential_change). The
-    // standard response to credential theft — a stolen session on another
-    // device must not survive the password rotation. This brand-new login
-    // is recorded below.
-    if state.config().auth.sessions.revoke_on_credential_change {{
-        let _ = {snake_name}.revoke_all_sessions(&mut *db).await?;
-    }}
+    // This browser may already hold a tracked session. The rotation below
+    // (or inside the 2FA branch) destroys that session id, so drop its row
+    // now — otherwise it would linger as a phantom device.
+    untrack_current_session(&mut db, &session).await?;
+{totp_reset_branch}
+    // Commit the password change, the reset-token consumption, and the
+    // session revocation atomically: if any part fails everything rolls
+    // back, so the reset link stays usable and no state is half-applied.
+    // Revoking every existing session is the standard response to
+    // credential theft (defaulted on, configurable via
+    // [auth.sessions].revoke_on_credential_change); this brand-new login is
+    // recorded below.
+    let revoke_existing_sessions = state.config().auth.sessions.revoke_on_credential_change;
+    let {snake_name}_id = {snake_name}.id;
+    (*db)
+        .transaction::<_, diesel::result::Error, _>(|conn| {{
+            Box::pin(async move {{
+                diesel::update({table}::table.find({snake_name}_id))
+                    .set((
+                        {table}::password_digest.eq(&new_digest),
+                        {table}::reset_token_digest.eq(None::<String>),
+                        {table}::reset_token_expires_at.eq(None::<chrono::NaiveDateTime>),
+                    ))
+                    .execute(conn)
+                    .await?;
+                if revoke_existing_sessions {{
+                    diesel::delete(
+                        {sess_table}::table.filter({sess_table}::user_id.eq({snake_name}_id)),
+                    )
+                    .execute(conn)
+                    .await?;
+                }}
+                Ok(())
+            }})
+        }})
+        .await
+        .map_err(|e| {{
+            AutumnError::internal_server_error_msg(format!("Failed to reset password: {{e}}"))
+        }})?;
 
     // Rotate session to invalidate any previous authenticated state.
     session.rotate_id().await;
@@ -3264,6 +3308,11 @@ pub async fn confirm_email(
              Please request a new confirmation email.",
         )
     }})?;
+
+    // This browser may already hold a tracked session for another account.
+    // The rotation below (or inside the 2FA branch) destroys that session
+    // id, so drop its row now — otherwise it would linger as a phantom device.
+    untrack_current_session(&mut db, &session).await?;
 
     // For 2FA-enabled accounts, redirect to /login/verify before granting a
     // full session — email confirmation proves address ownership, not TOTP possession.
@@ -5530,7 +5579,6 @@ const fn totp_imports_src() -> &'static str {
      use aes_gcm::{Aes256Gcm, Key, Nonce};\n\
      use base64::Engine as _;\n\
      use base64::engine::general_purpose::STANDARD as B64;\n\
-     use diesel_async::AsyncConnection as _;\n\
      use totp_rs::{Algorithm, Secret, TOTP};\n\
      use crate::models::recovery_code::{NewRecoveryCode, RecoveryCode};\n\
      use crate::schema::recovery_codes;\n"
@@ -6162,6 +6210,11 @@ pub async fn two_factor_confirm(
         plaintext_codes.push(code);
     }
 
+    // Capture the revocation policy up front so the delete can run inside
+    // the same transaction as the enablement (a post-commit failure here
+    // would 500 before the one-time recovery codes are ever shown).
+    let revoke_other_sessions_in_txn = state.config().auth.sessions.revoke_on_credential_change;
+    let current_token_digest = session_token_digest(&session).await;
     let txn_result = (*db)
         .transaction::<_, diesel::result::Error, _>(|conn| {
         Box::pin(async move {
@@ -6202,6 +6255,18 @@ pub async fn two_factor_confirm(
             if claimed != 1 {
                 return Err(diesel::result::Error::RollbackTransaction);
             }
+            // Credential change (second factor enrolled): sign out every
+            // *other* device in the same transaction (defaulted on,
+            // configurable via [auth.sessions].revoke_on_credential_change).
+            if revoke_other_sessions_in_txn {
+                diesel::delete(
+                    __SESSTABLE__::table
+                        .filter(__SESSTABLE__::user_id.eq(user_id))
+                        .filter(__SESSTABLE__::token_digest.ne(current_token_digest)),
+                )
+                .execute(conn)
+                .await?;
+            }
             Ok(())
         })
         })
@@ -6221,17 +6286,6 @@ pub async fn two_factor_confirm(
     }
 
     session.remove("totp_pending_secret").await;
-
-    // Credential change (second factor enrolled): sign out every *other*
-    // device (defaulted on, configurable via
-    // [auth.sessions].revoke_on_credential_change). A stolen session on
-    // another device must not survive a 2FA enrollment.
-    if state.config().auth.sessions.revoke_on_credential_change {
-        let current_digest = session_token_digest(&session).await;
-        let _ = __SNAKE__
-            .revoke_other_sessions(&mut *db, &current_digest)
-            .await?;
-    }
 
     Ok(layout("Save Your Recovery Codes", html! {
         h1 { "Two-factor authentication enabled" }
@@ -6303,10 +6357,14 @@ pub async fn two_factor_disable(
         ));
     }
 
-    // Disable the factor and delete the recovery codes in one transaction so a
-    // mid-operation failure can't leave the account with 2FA turned off but
-    // stale recovery codes still present (or vice versa).
+    // Disable the factor, delete the recovery codes, and revoke every
+    // *other* session in one transaction so a mid-operation failure can't
+    // leave the account half-changed — and so a revocation failure can't
+    // 500 after the factor was already removed. Revocation is defaulted on,
+    // configurable via [auth.sessions].revoke_on_credential_change.
     let user_id = __SNAKE__.id;
+    let revoke_other_sessions_in_txn = state.config().auth.sessions.revoke_on_credential_change;
+    let current_token_digest = session_token_digest(&session).await;
     (*db)
         .transaction::<_, diesel::result::Error, _>(|conn| {
             Box::pin(async move {
@@ -6321,21 +6379,20 @@ pub async fn two_factor_disable(
                 diesel::delete(recovery_codes::table.filter(recovery_codes::user_id.eq(user_id)))
                     .execute(conn)
                     .await?;
+                if revoke_other_sessions_in_txn {
+                    diesel::delete(
+                        __SESSTABLE__::table
+                            .filter(__SESSTABLE__::user_id.eq(user_id))
+                            .filter(__SESSTABLE__::token_digest.ne(current_token_digest)),
+                    )
+                    .execute(conn)
+                    .await?;
+                }
                 Ok(())
             })
         })
         .await
         .map_err(|_| AutumnError::internal_server_error_msg("Failed to disable two-factor."))?;
-
-    // Credential change (second factor removed): sign out every *other*
-    // device (defaulted on, configurable via
-    // [auth.sessions].revoke_on_credential_change).
-    if state.config().auth.sessions.revoke_on_credential_change {
-        let current_digest = session_token_digest(&session).await;
-        let _ = __SNAKE__
-            .revoke_other_sessions(&mut *db, &current_digest)
-            .await?;
-    }
 
     Ok(redirect_to("/account/2fa"))
 }
@@ -6471,17 +6528,41 @@ pub async fn login_verify(
         session.remove("totp_pending_reset_token").await;
         let committed = if let Some(token) = stored_token {
             let now = chrono::Utc::now().naive_utc();
-            let updated = diesel::update(__TABLE__::table.find(__SNAKE__.id))
-                .filter(__TABLE__::reset_token_digest.eq(Some(token.as_str())))
-                .filter(__TABLE__::reset_token_expires_at.gt(now))
-                .set((
-                    __TABLE__::password_digest.eq(&new_digest),
-                    __TABLE__::reset_token_digest.eq(None::<String>),
-                    __TABLE__::reset_token_expires_at.eq(None::<chrono::NaiveDateTime>),
-                ))
-                .execute(&mut *db)
-                .await?;
-            updated == 1
+            // Commit the password change and the session revocation
+            // atomically; a transaction error rolls both back (token
+            // preserved) and is treated as not-committed below.
+            let revoke_existing_sessions =
+                state.config().auth.sessions.revoke_on_credential_change;
+            let user_id = __SNAKE__.id;
+            (*db)
+                .transaction::<_, diesel::result::Error, _>(|conn| {
+                    Box::pin(async move {
+                        let updated = diesel::update(__TABLE__::table.find(user_id))
+                            .filter(__TABLE__::reset_token_digest.eq(Some(token.as_str())))
+                            .filter(__TABLE__::reset_token_expires_at.gt(now))
+                            .set((
+                                __TABLE__::password_digest.eq(&new_digest),
+                                __TABLE__::reset_token_digest.eq(None::<String>),
+                                __TABLE__::reset_token_expires_at.eq(None::<chrono::NaiveDateTime>),
+                            ))
+                            .execute(conn)
+                            .await?;
+                        // Password changed: revoke every existing session in
+                        // the same transaction (defaulted on, configurable via
+                        // [auth.sessions].revoke_on_credential_change). The
+                        // fresh login is recorded below.
+                        if updated == 1 && revoke_existing_sessions {
+                            diesel::delete(
+                                __SESSTABLE__::table.filter(__SESSTABLE__::user_id.eq(user_id)),
+                            )
+                            .execute(conn)
+                            .await?;
+                        }
+                        Ok(updated == 1)
+                    })
+                })
+                .await
+                .unwrap_or(false)
         } else {
             false
         };
@@ -6497,15 +6578,11 @@ pub async fn login_verify(
                 "Reset link expired or already used. Please restart the password reset.",
             ));
         }
-        // Password changed: revoke every existing session (defaulted on,
-        // configurable via [auth.sessions].revoke_on_credential_change).
-        // The fresh login is recorded below.
-        if state.config().auth.sessions.revoke_on_credential_change {
-            let _ = __SNAKE__.revoke_all_sessions(&mut *db).await?;
-        }
     }
 
-    // Promote the pending session to a fully authenticated one.
+    // Promote the pending session to a fully authenticated one. Drop any
+    // tracked row for the pending id first — the rotation destroys it.
+    untrack_current_session(&mut db, &session).await?;
     let from_confirmation = session.get("totp_pending_confirmation").await.is_some();
     session.rotate_id().await;
     session.remove("totp_pending_id").await;
@@ -6537,6 +6614,7 @@ pub async fn login_verify(
     TPL.replace("__PASCAL__", pascal_name)
         .replace("__SNAKE__", snake_name)
         .replace("__TABLE__", table)
+        .replace("__SESSTABLE__", &sessions_table_name(snake_name))
 }
 
 /// Markdown appended to `docs/guide/authentication.md` under `--totp`.
@@ -6978,12 +7056,18 @@ pub async fn passkey_register_finish(
         .map_err(|_| AutumnError::internal_server_error_msg("Failed to store passkey."))?;
     // Credential change (passkey added): sign out every *other* device
     // (defaulted on, configurable via
-    // [auth.sessions].revoke_on_credential_change).
+    // [auth.sessions].revoke_on_credential_change). Best-effort: the
+    // passkey is already stored, so a revocation hiccup must not turn the
+    // successful registration into a 500 (the client could retry and store
+    // a duplicate credential).
     if state.config().auth.sessions.revoke_on_credential_change {
         let current_digest = crate::routes::auth::session_token_digest(&session).await;
-        let _ = current
+        if let Err(e) = current
             .revoke_other_sessions(&mut *db, &current_digest)
-            .await?;
+            .await
+        {
+            tracing::warn!("failed to revoke other sessions after passkey registration: {e}");
+        }
     }
     Ok(axum::Json(serde_json::json!({ "ok": true })))
 }
@@ -7163,6 +7247,9 @@ pub async fn passkey_login_finish(
                 AutumnError::internal_server_error_msg("Failed to update credential timestamp.")
             })?;
     }
+    // Drop any tracked row for the pre-login session — the rotation below
+    // destroys its id, which would otherwise leave a phantom device.
+    crate::routes::auth::untrack_current_session(&mut db, &session).await?;
     session.rotate_id().await;
     session
         .insert("__SNAKE___id", __SNAKE___id.to_string())
@@ -7260,12 +7347,17 @@ pub async fn passkey_revoke(
     .map_err(|_| AutumnError::internal_server_error_msg("Failed to revoke passkey."))?;
     // Credential change (passkey removed): sign out every *other* device
     // (defaulted on, configurable via
-    // [auth.sessions].revoke_on_credential_change).
+    // [auth.sessions].revoke_on_credential_change). Best-effort: the
+    // passkey is already deleted, so a revocation hiccup must not turn the
+    // successful removal into a 500.
     if state.config().auth.sessions.revoke_on_credential_change {
         let current_digest = crate::routes::auth::session_token_digest(&session).await;
-        let _ = current
+        if let Err(e) = current
             .revoke_other_sessions(&mut *db, &current_digest)
-            .await?;
+            .await
+        {
+            tracing::warn!("failed to revoke other sessions after passkey removal: {e}");
+        }
     }
     Ok(redirect_to("/passkeys"))
 }
@@ -9215,7 +9307,8 @@ mod tests {
         let reset_pos = routes
             .find("pub async fn reset_password(")
             .expect("reset_password fn");
-        let reset_body = &routes[reset_pos..reset_pos + 3200.min(routes.len() - reset_pos)];
+        let reset_tail = &routes[reset_pos..];
+        let reset_body = &reset_tail[..reset_tail.find("\n/// `").unwrap_or(reset_tail.len())];
         // The deferral branch (which returns to /login/verify) must come BEFORE
         // the password_digest UPDATE in the handler body.
         let park_at = reset_body
@@ -9251,7 +9344,8 @@ mod tests {
         let reset_pos = routes
             .find("pub async fn reset_password(")
             .expect("reset_password fn");
-        let reset_body = &routes[reset_pos..reset_pos + 3200.min(routes.len() - reset_pos)];
+        let reset_tail = &routes[reset_pos..];
+        let reset_body = &reset_tail[..reset_tail.find("\n/// `").unwrap_or(reset_tail.len())];
         assert!(
             reset_body.contains("totp_pending_reset_token"),
             "reset_password 2FA branch must park the token digest: {reset_body}"

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -1862,6 +1862,33 @@ pub async fn record_login_session(
     Ok(())
 }}
 
+/// Re-point the tracked session row at the current (rotated) session id.
+///
+/// `session.rotate_id()` changes the opaque id, and with it the digest the
+/// row is keyed by. Any flow that rotates while *staying logged in* (e.g.
+/// step-up reauth) must call this with the digest captured before the
+/// rotation, or the very next request would look up a missing row, be
+/// treated as revoked, and 401.
+pub async fn rebind_tracked_session(
+    db: &mut Db,
+    session: &Session,
+    old_token_digest: &str,
+) -> AutumnResult<()> {{
+    let new_digest = session_token_digest(session).await;
+    diesel::update(
+        {sess_table}::table.filter({sess_table}::token_digest.eq(old_token_digest)),
+    )
+    .set({sess_table}::token_digest.eq(&new_digest))
+    .execute(&mut **db)
+    .await
+    .map_err(|e| {{
+        AutumnError::internal_server_error_msg(format!(
+            "Failed to rebind tracked session: {{e}}"
+        ))
+    }})?;
+    Ok(())
+}}
+
 /// Validate the tracked session row for the authenticated user and return
 /// the current {pascal_name}.
 ///
@@ -1949,9 +1976,16 @@ fn sessions_list_fragment(
                             " · last seen " (s.last_seen_at.format("%Y-%m-%d %H:%M UTC").to_string())
                         }}
                         @if !current {{
-                            button hx-post={{ "/account/sessions/" (s.id) "/revoke" }}
-                                hx-target="#session-list" hx-swap="outerHTML" {{
-                                "Revoke"
+                            // Real form so revocation works without JavaScript;
+                            // htmx intercepts the submit for an in-place swap.
+                            form method="post" action={{ "/account/sessions/" (s.id) "/revoke" }}
+                                hx-post={{ "/account/sessions/" (s.id) "/revoke" }}
+                                hx-target="#session-list" hx-swap="outerHTML"
+                                style="display:inline" {{
+                                @if let Some(csrf) = csrf {{
+                                    input type="hidden" name=(csrf_name) value=(csrf.token());
+                                }}
+                                button type="submit" {{ "Revoke" }}
                             }}
                         }}
                         form action={{ "/account/sessions/" (s.id) "/label" }} method="post"
@@ -1966,9 +2000,15 @@ fn sessions_list_fragment(
                     }}
                 }}
             }}
-            button hx-post="/account/sessions/revoke-others"
+            // Real form so bulk revocation works without JavaScript; htmx
+            // intercepts the submit for an in-place swap.
+            form method="post" action="/account/sessions/revoke-others"
+                hx-post="/account/sessions/revoke-others"
                 hx-target="#session-list" hx-swap="outerHTML" {{
-                "Sign out everywhere else"
+                @if let Some(csrf) = csrf {{
+                    input type="hidden" name=(csrf_name) value=(csrf.token());
+                }}
+                button type="submit" {{ "Sign out everywhere else" }}
             }}
         }}
     }}
@@ -2674,6 +2714,8 @@ pub struct ReauthForm {{
 #[get("/reauth")]
 pub async fn reauth_form(
     session: Session,
+    State(state): State<AppState>,
+    mut db: Db,
     Query(params): Query<std::collections::HashMap<String, String>>,
     csrf: Option<CsrfToken>,
     csrf_field: Option<CsrfFormField>,
@@ -2681,6 +2723,8 @@ pub async fn reauth_form(
     if session.get("{snake_name}_id").await.is_none() {{
         return Ok(redirect_to("/login").into_response());
     }}
+    // Validates the tracked session row (401s immediately if revoked).
+    let _ = require_tracked_session(&session, &mut db, &state).await?;
     let return_to = params.get("return_to").cloned().unwrap_or_default();
     Ok(layout("Confirm your identity", html! {{
         h1 {{ "Confirm your identity" }}
@@ -2864,7 +2908,12 @@ pub async fn reauth(
     {totp_reauth_check}
     // Rotate session ID before elevating privileges to prevent session fixation
     // attacks where a stolen cookie is used to benefit from a legitimate reauth.
+    // The tracked session row is keyed by the digest of the id, so capture the
+    // pre-rotation digest and re-point the row at the new id — otherwise the
+    // redirected step-up request would find no row and be treated as revoked.
+    let pre_rotation_digest = session_token_digest(&session).await;
     session.rotate_id().await;
+    rebind_tracked_session(&mut db, &session, &pre_rotation_digest).await?;
     session.remove("reauth_pw_ok").await;
     // Refresh the step-up claim.
     autumn_web::step_up::set_last_strong_auth_at(&session).await;
@@ -3402,14 +3451,13 @@ async fn send_confirmation_email(mailer: &Mailer, to: &str, token: &str) -> Autu
 #[get("/account/data-export")]
 pub async fn data_export_form(
     session: Session,
+    State(state): State<AppState>,
+    mut db: Db,
     csrf: Option<CsrfToken>,
     csrf_field: Option<CsrfFormField>,
 ) -> AutumnResult<Response> {{
-    let auth = session
-        .get("{snake_name}_id")
-        .await
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
-    let _ = auth;
+    // Validates the tracked session row (401s immediately if revoked).
+    let _ = require_tracked_session(&session, &mut db, &state).await?;
     Ok(layout("Download My Data", html! {{
         h1 {{ "Download My Data" }}
         p {{
@@ -3527,14 +3575,13 @@ pub struct DeleteAccountForm {{
 #[get("/account/delete")]
 pub async fn delete_account_form(
     session: Session,
+    State(state): State<AppState>,
+    mut db: Db,
     csrf: Option<CsrfToken>,
     csrf_field: Option<CsrfFormField>,
 ) -> AutumnResult<Response> {{
-    let auth = session
-        .get("{snake_name}_id")
-        .await
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
-    let _ = auth;
+    // Validates the tracked session row (401s immediately if revoked).
+    let _ = require_tracked_session(&session, &mut db, &state).await?;
     Ok(layout("Delete My Account", html! {{
         h1 {{ "Delete My Account" }}
         p class="warning" {{
@@ -6763,11 +6810,13 @@ pub struct PasskeyRevokeForm {
 pub async fn passkey_register_page(
     session: Session,
     State(state): State<AppState>,
+    mut db: Db,
     csrf: Option<CsrfToken>,
     csrf_header: Option<CsrfTokenHeader>,
     nonce: Option<CspNonce>,
 ) -> AutumnResult<Markup> {
-    let _ = (session, state);
+    // Validates the tracked session row (401s immediately if revoked).
+    let _ = crate::routes::auth::require_tracked_session(&session, &mut db, &state).await?;
     let csrf_token = csrf.map(|t| t.token().to_owned()).unwrap_or_default();
     let csrf_header_name = csrf_header.map(|h| h.0.clone()).unwrap_or_else(|| "X-CSRF-Token".to_owned());
     let script_nonce = nonce.map(|n| n.value().to_owned());
@@ -6821,11 +6870,11 @@ pub async fn passkey_register_begin(
     State(state): State<AppState>,
     mut db: Db,
 ) -> AutumnResult<axum::Json<serde_json::Value>> {
-    let __SNAKE___id: i64 = session
-        .get(state.auth_session_key())
-        .await
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
+    // Validates the tracked session row (401s immediately if revoked).
+    let __SNAKE___id: i64 =
+        crate::routes::auth::require_tracked_session(&session, &mut db, &state)
+            .await?
+            .id;
     let __SNAKE___email = session
         .get("__SNAKE___email")
         .await

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -1822,18 +1822,17 @@ pub async fn session_token_digest(session: &Session) -> String {{
     sha256_hex(&session.id().await)
 }}
 
-/// Persist a `{sess_table}` row for a successful login on this device.
+/// Build the tracked-session row for the current session id and device.
 ///
 /// To plug in a custom User-Agent parser, replace the
 /// `autumn_web::user_agent::parse_user_agent` call below — this is the only
 /// parse site. See docs/guide/session-management.md.
-pub async fn record_login_session(
-    db: &mut Db,
+pub async fn build_session_row(
     session: &Session,
     {snake_name}_id: i64,
     ip: std::net::IpAddr,
     headers: &axum::http::HeaderMap,
-) -> AutumnResult<()> {{
+) -> New{pascal_name}Session {{
     let user_agent = headers
         .get(axum::http::header::USER_AGENT)
         .and_then(|v| v.to_str().ok())
@@ -1842,17 +1841,28 @@ pub async fn record_login_session(
         .take(512)
         .collect::<String>();
     let parsed = autumn_web::user_agent::parse_user_agent(&user_agent);
-    let token_digest = session_token_digest(session).await;
+    New{pascal_name}Session {{
+        user_id: {snake_name}_id,
+        token_digest: session_token_digest(session).await,
+        ip: ip.to_string(),
+        user_agent,
+        ua_family: parsed.family,
+        ua_os: parsed.os,
+        ua_device: parsed.device_class.to_string(),
+    }}
+}}
+
+/// Persist a `{sess_table}` row for a successful login on this device.
+pub async fn record_login_session(
+    db: &mut Db,
+    session: &Session,
+    {snake_name}_id: i64,
+    ip: std::net::IpAddr,
+    headers: &axum::http::HeaderMap,
+) -> AutumnResult<()> {{
+    let row = build_session_row(session, {snake_name}_id, ip, headers).await;
     diesel::insert_into({sess_table}::table)
-        .values(&New{pascal_name}Session {{
-            user_id: {snake_name}_id,
-            token_digest,
-            ip: ip.to_string(),
-            user_agent,
-            ua_family: parsed.family,
-            ua_os: parsed.os,
-            ua_device: parsed.device_class.to_string(),
-        }})
+        .values(&row)
         .execute(&mut **db)
         .await
         .map_err(|e| {{
@@ -2262,7 +2272,13 @@ pub async fn signup(
 
     // Rotate session to prevent any pending 2FA or enrollment state from a
     // previous flow in this browser from being resumed under the new account.
+    // The rotation preserves any existing login's keys, so re-point that
+    // login's tracked row at the new session id — otherwise the next
+    // authenticated request would miss the row (treated as revoked) and the
+    // old row would linger as a phantom device.
+    let pre_rotation_digest = session_token_digest(&session).await;
     session.rotate_id().await;
+    rebind_tracked_session(&mut db, &session, &pre_rotation_digest).await?;
     session.remove("totp_pending_id").await;
     session.remove("totp_pending_reset_digest").await;
     session.remove("totp_pending_reset_token").await;
@@ -3134,13 +3150,18 @@ pub async fn reset_password(
     // now — otherwise it would linger as a phantom device.
     untrack_current_session(&mut db, &session).await?;
 {totp_reset_branch}
-    // Commit the password change, the reset-token consumption, and the
-    // session revocation atomically: if any part fails everything rolls
-    // back, so the reset link stays usable and no state is half-applied.
-    // Revoking every existing session is the standard response to
-    // credential theft (defaulted on, configurable via
-    // [auth.sessions].revoke_on_credential_change); this brand-new login is
-    // recorded below.
+    // Rotate before the commit so the fresh session's row can be inserted
+    // in the same transaction (the rotation itself is in-memory until the
+    // response is sent, so a rollback leaves no half-applied state).
+    session.rotate_id().await;
+    let new_session_row = build_session_row(&session, {snake_name}.id, addr_ip, &headers).await;
+
+    // Commit the password change, the reset-token consumption, the session
+    // revocation, and the new session row atomically: if any part fails
+    // everything rolls back, so the reset link stays usable and no state is
+    // half-applied. Revoking every existing session is the standard
+    // response to credential theft (defaulted on, configurable via
+    // [auth.sessions].revoke_on_credential_change).
     let revoke_existing_sessions = state.config().auth.sessions.revoke_on_credential_change;
     let {snake_name}_id = {snake_name}.id;
     (*db)
@@ -3154,6 +3175,8 @@ pub async fn reset_password(
                     ))
                     .execute(conn)
                     .await?;
+                // Revoke before inserting so the bulk delete cannot eat the
+                // fresh row.
                 if revoke_existing_sessions {{
                     diesel::delete(
                         {sess_table}::table.filter({sess_table}::user_id.eq({snake_name}_id)),
@@ -3161,6 +3184,10 @@ pub async fn reset_password(
                     .execute(conn)
                     .await?;
                 }}
+                diesel::insert_into({sess_table}::table)
+                    .values(&new_session_row)
+                    .execute(conn)
+                    .await?;
                 Ok(())
             }})
         }})
@@ -3169,16 +3196,12 @@ pub async fn reset_password(
             AutumnError::internal_server_error_msg(format!("Failed to reset password: {{e}}"))
         }})?;
 
-    // Rotate session to invalidate any previous authenticated state.
-    session.rotate_id().await;
 {totp_clear_pending}    session.insert("{snake_name}_id", {snake_name}.id.to_string()).await;
     session.insert("{snake_name}_email", &{snake_name}.email).await;
     // Use the same session key checked by `#[secured]` / `#[authorize]`.
     session.insert(state.auth_session_key(), {snake_name}.id.to_string()).await;
     // Stamp the step-up claim so `#[step_up]` routes are immediately accessible.
     autumn_web::step_up::set_last_strong_auth_at(&session).await;
-    // Track this fresh login as an active session.
-    record_login_session(&mut db, &session, {snake_name}.id, addr_ip, &headers).await?;
     Ok(redirect_to("/account"))
 }}
 
@@ -4591,7 +4614,7 @@ recognise their own devices. Treat both as personal data:
   Pair this with your session cookie `max_age_secs` so rows do not outlive
   the cookies that reference them.
 - **Scrubbing/minimisation.** If full IPs are more than you need, truncate
-  before storing (e.g. zero the last IPv4 octet) in `record_login_session`,
+  before storing (e.g. zero the last IPv4 octet) in `build_session_row`,
   or store only the parsed UA fields and set `user_agent` to `""`.
 - **No geolocation.** The framework stores the IP only; GeoIP lookups are
   deliberately left to userland.
@@ -4602,11 +4625,11 @@ recognise their own devices. Treat both as personal data:
 
 The default parser (`autumn_web::user_agent::parse_user_agent`) is a small
 heuristic covering the major browser/OS families. Every parse goes through
-one call site — `record_login_session` in `src/routes/auth.rs` — so
+one call site — `build_session_row` in `src/routes/auth.rs` — so
 swapping in a dedicated crate is a one-line change:
 
 ```rust
-// In record_login_session, replace:
+// In build_session_row, replace:
 let parsed = autumn_web::user_agent::parse_user_agent(&user_agent);
 // with your parser of choice, mapping into the same three fields:
 let ua = my_ua_crate::parse(&user_agent);
@@ -6824,6 +6847,7 @@ fn render_passkeys_routes_file(pascal_name: &str, snake_name: &str, user_table: 
 
 use autumn_web::prelude::*;
 use diesel::prelude::*;
+use diesel_async::AsyncConnection as _;
 use diesel_async::RunQueryDsl;
 use serde::{Deserialize, Serialize};
 use webauthn_rs::prelude::*;
@@ -7044,31 +7068,40 @@ pub async fn passkey_register_finish(
     let cred_id = passkey.cred_id().to_string();
     let cred_json = serde_json::to_string(&passkey)
         .map_err(|_| AutumnError::internal_server_error_msg("Failed to serialise passkey."))?;
-    diesel::insert_into(crate::schema::webauthn_credentials::table)
-        .values((
-            crate::schema::webauthn_credentials::user_id.eq(__SNAKE___id),
-            crate::schema::webauthn_credentials::credential_id.eq(&cred_id),
-            crate::schema::webauthn_credentials::credential_json.eq(&cred_json),
-            crate::schema::webauthn_credentials::name.eq("Passkey"),
-        ))
-        .execute(&mut *db)
+    // Store the passkey and revoke every *other* session in one
+    // transaction: the documented revoke-on-credential-change guarantee
+    // (defaulted on, configurable via
+    // [auth.sessions].revoke_on_credential_change) can never be silently
+    // skipped, and a failure rolls the credential back so the client can
+    // retry without storing a duplicate.
+    let revoke_other_sessions_in_txn = state.config().auth.sessions.revoke_on_credential_change;
+    let current_token_digest = crate::routes::auth::session_token_digest(&session).await;
+    (*db)
+        .transaction::<_, diesel::result::Error, _>(|conn| {
+            Box::pin(async move {
+                diesel::insert_into(crate::schema::webauthn_credentials::table)
+                    .values((
+                        crate::schema::webauthn_credentials::user_id.eq(__SNAKE___id),
+                        crate::schema::webauthn_credentials::credential_id.eq(&cred_id),
+                        crate::schema::webauthn_credentials::credential_json.eq(&cred_json),
+                        crate::schema::webauthn_credentials::name.eq("Passkey"),
+                    ))
+                    .execute(conn)
+                    .await?;
+                if revoke_other_sessions_in_txn {
+                    diesel::delete(
+                        crate::schema::__SESSTABLE__::table
+                            .filter(crate::schema::__SESSTABLE__::user_id.eq(__SNAKE___id))
+                            .filter(crate::schema::__SESSTABLE__::token_digest.ne(current_token_digest)),
+                    )
+                    .execute(conn)
+                    .await?;
+                }
+                Ok(())
+            })
+        })
         .await
         .map_err(|_| AutumnError::internal_server_error_msg("Failed to store passkey."))?;
-    // Credential change (passkey added): sign out every *other* device
-    // (defaulted on, configurable via
-    // [auth.sessions].revoke_on_credential_change). Best-effort: the
-    // passkey is already stored, so a revocation hiccup must not turn the
-    // successful registration into a 500 (the client could retry and store
-    // a duplicate credential).
-    if state.config().auth.sessions.revoke_on_credential_change {
-        let current_digest = crate::routes::auth::session_token_digest(&session).await;
-        if let Err(e) = current
-            .revoke_other_sessions(&mut *db, &current_digest)
-            .await
-        {
-            tracing::warn!("failed to revoke other sessions after passkey registration: {e}");
-        }
-    }
     Ok(axum::Json(serde_json::json!({ "ok": true })))
 }
 
@@ -7337,34 +7370,47 @@ pub async fn passkey_revoke(
     // Validates the tracked session row (401s immediately if revoked).
     let current =
         crate::routes::auth::require_tracked_session(&session, &mut db, &state).await?;
-    diesel::delete(
-        crate::schema::webauthn_credentials::table
-            .filter(crate::schema::webauthn_credentials::id.eq(form.id))
-            .filter(crate::schema::webauthn_credentials::user_id.eq(current.id)),
-    )
-    .execute(&mut *db)
-    .await
-    .map_err(|_| AutumnError::internal_server_error_msg("Failed to revoke passkey."))?;
-    // Credential change (passkey removed): sign out every *other* device
+    // Remove the passkey and revoke every *other* session in one
+    // transaction: the documented revoke-on-credential-change guarantee
     // (defaulted on, configurable via
-    // [auth.sessions].revoke_on_credential_change). Best-effort: the
-    // passkey is already deleted, so a revocation hiccup must not turn the
-    // successful removal into a 500.
-    if state.config().auth.sessions.revoke_on_credential_change {
-        let current_digest = crate::routes::auth::session_token_digest(&session).await;
-        if let Err(e) = current
-            .revoke_other_sessions(&mut *db, &current_digest)
-            .await
-        {
-            tracing::warn!("failed to revoke other sessions after passkey removal: {e}");
-        }
-    }
+    // [auth.sessions].revoke_on_credential_change) can never be silently
+    // skipped, and a failure rolls the removal back instead of 500ing
+    // after it.
+    let user_id = current.id;
+    let credential_id = form.id;
+    let revoke_other_sessions_in_txn = state.config().auth.sessions.revoke_on_credential_change;
+    let current_token_digest = crate::routes::auth::session_token_digest(&session).await;
+    (*db)
+        .transaction::<_, diesel::result::Error, _>(|conn| {
+            Box::pin(async move {
+                diesel::delete(
+                    crate::schema::webauthn_credentials::table
+                        .filter(crate::schema::webauthn_credentials::id.eq(credential_id))
+                        .filter(crate::schema::webauthn_credentials::user_id.eq(user_id)),
+                )
+                .execute(conn)
+                .await?;
+                if revoke_other_sessions_in_txn {
+                    diesel::delete(
+                        crate::schema::__SESSTABLE__::table
+                            .filter(crate::schema::__SESSTABLE__::user_id.eq(user_id))
+                            .filter(crate::schema::__SESSTABLE__::token_digest.ne(current_token_digest)),
+                    )
+                    .execute(conn)
+                    .await?;
+                }
+                Ok(())
+            })
+        })
+        .await
+        .map_err(|_| AutumnError::internal_server_error_msg("Failed to revoke passkey."))?;
     Ok(redirect_to("/passkeys"))
 }
 "##;
     tpl.replace("__PASCAL__", pascal_name)
         .replace("__SNAKE__", snake_name)
         .replace("__TABLE__", user_table)
+        .replace("__SESSTABLE__", &sessions_table_name(snake_name))
 }
 
 fn render_passkeys_tests_file(pascal_name: &str, _snake_name: &str) -> String {

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -12,6 +12,7 @@
 //! - Login and reset-password rotate the session ID (prevents session fixation).
 //! - Logout destroys the session (old session cannot remain authenticated).
 
+use std::fmt::Write as _;
 use std::path::Path;
 
 use super::emit::Plan;
@@ -438,10 +439,13 @@ pub fn plan_auth_with_providers(
     let mig_dir = project_root
         .join("migrations")
         .join(format!("{timestamp}_create_{table}"));
-    plan.create(mig_dir.join("up.sql"), render_migration_up(&table, totp));
+    plan.create(
+        mig_dir.join("up.sql"),
+        render_migration_up(&snake_name, &table, totp),
+    );
     plan.create(
         mig_dir.join("down.sql"),
-        render_migration_down(&table, totp),
+        render_migration_down(&snake_name, &table, totp),
     );
 
     // ── Model ──────────────────────────────────────────────────────────────
@@ -460,6 +464,12 @@ pub fn plan_auth_with_providers(
         );
         model_mod = add_mod_declaration(&model_mod, "recovery_code");
     }
+    // Active login sessions (issue #819) live in their own model + table.
+    plan.create(
+        models_dir.join(format!("{snake_name}_session.rs")),
+        render_session_model_file(&pascal_name, &snake_name, &table),
+    );
+    model_mod = add_mod_declaration(&model_mod, &format!("{snake_name}_session"));
     plan.modify(model_mod_path, model_mod);
 
     // ── src/schema.rs entry ────────────────────────────────────────────────
@@ -506,6 +516,23 @@ pub fn plan_auth_with_providers(
                 .to_owned(),
         ));
     }
+    // Same guard for the session-tracking helper table (issue #819). Only
+    // reject a *foreign* table: when the auth table itself is also present,
+    // this is a re-run over our own output (`--force`), where the schema
+    // append below is an idempotent no-op.
+    let sess_table = sessions_table_name(&snake_name);
+    if schema_has_table(&schema_existing, &sess_table)
+        && !schema_has_table(&schema_existing, &table)
+    {
+        return Err(GenerateError::InvalidName(
+            name.to_owned(),
+            format!(
+                "this project already defines a `{sess_table}` table, which the auth \
+                 starter needs for login-session tracking; rename or remove the \
+                 existing table first."
+            ),
+        ));
+    }
     let mut schema_new = append_schema_table(&schema_existing, &table, &auth_fields);
     if totp {
         let recovery_fields: Vec<super::dsl::Field> = [
@@ -518,6 +545,21 @@ pub fn plan_auth_with_providers(
         .collect();
         schema_new = append_schema_table(&schema_new, "recovery_codes", &recovery_fields);
     }
+    let session_fields: Vec<super::dsl::Field> = [
+        "user_id:i64",
+        "token_digest:String",
+        "ip:String",
+        "user_agent:String",
+        "ua_family:String",
+        "ua_os:String",
+        "ua_device:String",
+        "label:Option<String>",
+        "last_seen_at:NaiveDateTime",
+    ]
+    .iter()
+    .map(|t| super::dsl::parse_field(t).expect("session field tokens are always valid"))
+    .collect();
+    schema_new = append_schema_table(&schema_new, &sess_table, &session_fields);
     plan.modify(schema_path, schema_new);
 
     // ── Auth routes ────────────────────────────────────────────────────────
@@ -544,6 +586,11 @@ pub fn plan_auth_with_providers(
             render_2fa_tests_file(&pascal_name, &snake_name),
         );
     }
+    // Active-session management integration tests (issue #819).
+    plan.create(
+        tests_dir.join("auth_sessions.rs"),
+        render_sessions_tests_file(&pascal_name, &snake_name),
+    );
 
     // ── Documentation ─────────────────────────────────────────────────────
     let docs_dir = project_root.join("docs").join("guide");
@@ -552,6 +599,10 @@ pub fn plan_auth_with_providers(
         render_docs_file(&pascal_name, totp),
     );
     plan.create(docs_dir.join("gdpr-compliance.md"), render_gdpr_docs_file());
+    plan.create(
+        docs_dir.join("session-management.md"),
+        render_sessions_docs_file(&pascal_name, &snake_name, &table),
+    );
 
     // ── src/main.rs — module declarations + route registration ────────────
     let main_path = project_root.join("src").join("main.rs");
@@ -1313,7 +1364,13 @@ scope = "openid profile email"
 
 // ── Template rendering ────────────────────────────────────────────────────────
 
-fn render_migration_up(table: &str, totp: bool) -> String {
+/// Name of the per-login session-tracking table (issue #819), derived from
+/// the auth resource: `User` → `user_sessions`, `Account` → `account_sessions`.
+fn sessions_table_name(snake_name: &str) -> String {
+    format!("{snake_name}_sessions")
+}
+
+fn render_migration_up(snake_name: &str, table: &str, totp: bool) -> String {
     // TOTP columns are inserted after password_digest so the column order
     // matches the generated model struct and `schema.rs` block.
     let totp_columns = if totp {
@@ -1360,15 +1417,39 @@ fn render_migration_up(table: &str, totp: bool) -> String {
              CREATE INDEX recovery_codes_user_id_idx ON recovery_codes (user_id);\n",
         );
     }
+    // Active login sessions (issue #819): one row per login, keyed by the
+    // SHA-256 digest of the opaque server-side session id. Only the digest
+    // is stored so a database leak cannot be replayed as a session cookie.
+    let sess_table = sessions_table_name(snake_name);
+    let _ = write!(
+        out,
+        "\n\
+         CREATE TABLE {sess_table} (\n\
+         \x20   id BIGSERIAL PRIMARY KEY,\n\
+         \x20   user_id BIGINT NOT NULL REFERENCES {table}(id) ON DELETE CASCADE,\n\
+         \x20   token_digest TEXT NOT NULL UNIQUE,\n\
+         \x20   ip TEXT NOT NULL DEFAULT '',\n\
+         \x20   user_agent TEXT NOT NULL DEFAULT '',\n\
+         \x20   ua_family TEXT NOT NULL DEFAULT '',\n\
+         \x20   ua_os TEXT NOT NULL DEFAULT '',\n\
+         \x20   ua_device TEXT NOT NULL DEFAULT '',\n\
+         \x20   label TEXT NULL,\n\
+         \x20   last_seen_at TIMESTAMP NOT NULL DEFAULT NOW(),\n\
+         \x20   created_at TIMESTAMP NOT NULL DEFAULT NOW()\n\
+         );\n\
+         \n\
+         CREATE INDEX {sess_table}_user_id_idx ON {sess_table} (user_id);\n",
+    );
     out
 }
 
-fn render_migration_down(table: &str, totp: bool) -> String {
-    // Drop the dependent table first so the FK constraint is satisfied.
+fn render_migration_down(snake_name: &str, table: &str, totp: bool) -> String {
+    // Drop the dependent tables first so the FK constraints are satisfied.
+    let sess_table = sessions_table_name(snake_name);
     if totp {
-        format!("DROP TABLE recovery_codes;\nDROP TABLE {table};\n")
+        format!("DROP TABLE {sess_table};\nDROP TABLE recovery_codes;\nDROP TABLE {table};\n")
     } else {
-        format!("DROP TABLE {table};\n")
+        format!("DROP TABLE {sess_table};\nDROP TABLE {table};\n")
     }
 }
 
@@ -1455,6 +1536,158 @@ pub struct RecoveryCode {{
     )
 }
 
+/// Render `src/models/{snake}_session.rs` — the active-login-session row and
+/// the revocation APIs on the user model (issue #819).
+///
+/// Only the SHA-256 digest of the opaque session id is stored, so a database
+/// leak cannot be replayed as a session cookie. Revocation deletes the row;
+/// the per-request gate in `routes/auth.rs` treats a missing row as a revoked
+/// session and 401s immediately.
+#[allow(clippy::too_many_lines)]
+fn render_session_model_file(user_pascal: &str, user_snake: &str, user_table: &str) -> String {
+    let sess_table = sessions_table_name(user_snake);
+    format!(
+        r#"//! Generated by `autumn generate auth`.
+//!
+//! Active login sessions for {user_pascal} — one row per logged-in device.
+//! Edit freely — once generated, this is ordinary user code.
+//!
+//! Security notes:
+//! - `token_digest` is the SHA-256 of the opaque server-side session id;
+//!   the raw id is never stored, so a database leak cannot be replayed as
+//!   a session cookie.
+//! - Revocation deletes the row. The per-request gate in `routes/auth.rs`
+//!   (`require_tracked_session`) treats a missing row as revoked and
+//!   responds 401 immediately, even if the cookie is replayed.
+
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+
+use crate::models::{user_snake}::{user_pascal};
+use crate::schema::{sess_table};
+
+#[autumn_web::model]
+pub struct {user_pascal}Session {{
+    pub id: i64,
+    // References {user_table}(id).
+    pub user_id: i64,
+    pub token_digest: String,
+    pub ip: String,
+    pub user_agent: String,
+    pub ua_family: String,
+    pub ua_os: String,
+    pub ua_device: String,
+    #[default]
+    pub label: Option<String>,
+    #[default]
+    pub last_seen_at: chrono::NaiveDateTime,
+    #[default]
+    pub created_at: chrono::NaiveDateTime,
+}}
+
+impl {user_pascal}Session {{
+    /// Human-readable device line for the sessions page, preferring the
+    /// user-set label over the parsed User-Agent.
+    #[must_use]
+    pub fn device_description(&self) -> String {{
+        if let Some(label) = self.label.as_deref().filter(|l| !l.trim().is_empty()) {{
+            return label.to_owned();
+        }}
+        match (self.ua_family.as_str(), self.ua_os.as_str()) {{
+            ("" | "Unknown", "" | "Unknown") => "Unknown device".to_owned(),
+            (family, "" | "Unknown") => family.to_owned(),
+            ("" | "Unknown", os) => os.to_owned(),
+            (family, os) => format!("{{family}} on {{os}}"),
+        }}
+    }}
+}}
+
+/// Active-session APIs available from any request handler that has loaded
+/// the current user (issue #819).
+impl {user_pascal} {{
+    /// All active login sessions for this account, most recently seen first.
+    pub async fn sessions(
+        &self,
+        conn: &mut impl diesel_async::AsyncConnection<Backend = diesel::pg::Pg>,
+    ) -> autumn_web::AutumnResult<Vec<{user_pascal}Session>> {{
+        {sess_table}::table
+            .filter({sess_table}::user_id.eq(self.id))
+            .order({sess_table}::last_seen_at.desc())
+            .select({user_pascal}Session::as_select())
+            .load(conn)
+            .await
+            .map_err(|e| {{
+                autumn_web::AutumnError::internal_server_error_msg(format!(
+                    "Failed to load sessions: {{e}}"
+                ))
+            }})
+    }}
+
+    /// Revoke a single session by row id. Scoped to this account — revoking
+    /// another user's session id is a no-op. Returns `true` when a session
+    /// was actually revoked.
+    pub async fn revoke_session(
+        &self,
+        conn: &mut impl diesel_async::AsyncConnection<Backend = diesel::pg::Pg>,
+        session_id: i64,
+    ) -> autumn_web::AutumnResult<bool> {{
+        let rows = diesel::delete(
+            {sess_table}::table
+                .filter({sess_table}::id.eq(session_id))
+                .filter({sess_table}::user_id.eq(self.id)),
+        )
+        .execute(conn)
+        .await
+        .map_err(|e| {{
+            autumn_web::AutumnError::internal_server_error_msg(format!(
+                "Failed to revoke session: {{e}}"
+            ))
+        }})?;
+        Ok(rows == 1)
+    }}
+
+    /// Revoke every session except the one identified by
+    /// `current_token_digest` ("sign out everywhere else"). Returns the
+    /// number of sessions revoked.
+    pub async fn revoke_other_sessions(
+        &self,
+        conn: &mut impl diesel_async::AsyncConnection<Backend = diesel::pg::Pg>,
+        current_token_digest: &str,
+    ) -> autumn_web::AutumnResult<usize> {{
+        diesel::delete(
+            {sess_table}::table
+                .filter({sess_table}::user_id.eq(self.id))
+                .filter({sess_table}::token_digest.ne(current_token_digest)),
+        )
+        .execute(conn)
+        .await
+        .map_err(|e| {{
+            autumn_web::AutumnError::internal_server_error_msg(format!(
+                "Failed to revoke sessions: {{e}}"
+            ))
+        }})
+    }}
+
+    /// Revoke every session for this account, including the current one.
+    /// Used on password change, where all existing sessions are suspect.
+    pub async fn revoke_all_sessions(
+        &self,
+        conn: &mut impl diesel_async::AsyncConnection<Backend = diesel::pg::Pg>,
+    ) -> autumn_web::AutumnResult<usize> {{
+        diesel::delete({sess_table}::table.filter({sess_table}::user_id.eq(self.id)))
+            .execute(conn)
+            .await
+            .map_err(|e| {{
+                autumn_web::AutumnError::internal_server_error_msg(format!(
+                    "Failed to revoke sessions: {{e}}"
+                ))
+            }})
+    }}
+}}
+"#
+    )
+}
+
 #[allow(
     clippy::too_many_lines,
     reason = "Single auth-routes template — splitting fragments makes the template harder to read."
@@ -1466,6 +1699,7 @@ fn render_routes_file(
     providers: &[String],
     totp: bool,
 ) -> String {
+    let sess_table = sessions_table_name(snake_name);
     let oauth_buttons = if providers.is_empty() {
         String::new()
     } else {
@@ -1522,7 +1756,7 @@ fn render_routes_file(
     };
 
     format!(
-        r#"//! Generated by `autumn generate auth`.
+        r##"//! Generated by `autumn generate auth`.
 //!
 //! Complete browser authentication flow. Edit freely — once generated,
 //! this is ordinary user code.
@@ -1533,6 +1767,10 @@ fn render_routes_file(
 //! - Duplicate signup and failed login return identical non-enumerating errors.
 //! - Login and reset-password rotate the session ID to prevent fixation.
 //! - Logout destroys the session so the old session cannot remain authenticated.
+//! - Every login is tracked as a `{sess_table}` row (digest of the opaque
+//!   session id + device attribution); revoking the row signs that device out
+//!   immediately — see `require_tracked_session` and
+//!   docs/guide/session-management.md.
 
 use autumn_web::auth::{{hash_password, verify_password}};
 use autumn_web::extract::Query;
@@ -1544,6 +1782,8 @@ use diesel_async::RunQueryDsl;
 use serde::Deserialize;
 
 use crate::models::{snake_name}::{{New{pascal_name}, {pascal_name}}};
+use crate::models::{snake_name}_session::{{New{pascal_name}Session, {pascal_name}Session}};
+use crate::schema::{sess_table};
 use crate::schema::{table};
 {totp_imports}
 
@@ -1564,6 +1804,305 @@ fn layout(title: &str, content: Markup) -> Markup {{
 
 fn redirect_to(url: &str) -> Response {{
     axum::response::Redirect::to(url).into_response()
+}}
+
+// ── Active session tracking (issue #819) ─────────────────────────────────────
+//
+// Every login persists a `{sess_table}` row keyed by the SHA-256 digest of the
+// opaque session id. Authenticated handlers call `require_tracked_session`,
+// which (1) 401s — and destroys the cookie session — when the row has been
+// revoked, even if the cookie is replayed, and (2) updates `last_seen_at` at
+// most once per `[auth.sessions].last_seen_update_secs` to bound write
+// amplification. See docs/guide/session-management.md.
+
+/// SHA-256 digest of the current opaque session id. Only the digest is ever
+/// stored server-side, so a database leak cannot be replayed as a cookie.
+pub async fn session_token_digest(session: &Session) -> String {{
+    sha256_hex(&session.id().await)
+}}
+
+/// Persist a `{sess_table}` row for a successful login on this device.
+///
+/// To plug in a custom User-Agent parser, replace the
+/// `autumn_web::user_agent::parse_user_agent` call below — this is the only
+/// parse site. See docs/guide/session-management.md.
+pub async fn record_login_session(
+    db: &mut Db,
+    session: &Session,
+    {snake_name}_id: i64,
+    ip: std::net::IpAddr,
+    headers: &axum::http::HeaderMap,
+) -> AutumnResult<()> {{
+    let user_agent = headers
+        .get(axum::http::header::USER_AGENT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .chars()
+        .take(512)
+        .collect::<String>();
+    let parsed = autumn_web::user_agent::parse_user_agent(&user_agent);
+    let token_digest = session_token_digest(session).await;
+    diesel::insert_into({sess_table}::table)
+        .values(&New{pascal_name}Session {{
+            user_id: {snake_name}_id,
+            token_digest,
+            ip: ip.to_string(),
+            user_agent,
+            ua_family: parsed.family,
+            ua_os: parsed.os,
+            ua_device: parsed.device_class.to_string(),
+        }})
+        .execute(&mut **db)
+        .await
+        .map_err(|e| {{
+            AutumnError::internal_server_error_msg(format!(
+                "Failed to record login session: {{e}}"
+            ))
+        }})?;
+    Ok(())
+}}
+
+/// Validate the tracked session row for the authenticated user and return
+/// the current {pascal_name}.
+///
+/// The `{sess_table}` row is the source of truth: deleting it signs the
+/// device out *immediately* — the next request 401s and the cookie session
+/// is destroyed, so a replayed cookie cannot resurrect it. `last_seen_at`
+/// is refreshed at most once per `[auth.sessions].last_seen_update_secs`
+/// per session, bounding write amplification.
+///
+/// Call this at the top of every handler that requires authentication.
+pub async fn require_tracked_session(
+    session: &Session,
+    db: &mut Db,
+    state: &AppState,
+) -> AutumnResult<{pascal_name}> {{
+    let {snake_name}_id: i64 = session
+        .get("{snake_name}_id")
+        .await
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
+
+    let token_digest = session_token_digest(session).await;
+    let tracked: Option<{pascal_name}Session> = {sess_table}::table
+        .filter({sess_table}::token_digest.eq(&token_digest))
+        .filter({sess_table}::user_id.eq({snake_name}_id))
+        .select({pascal_name}Session::as_select())
+        .first(&mut **db)
+        .await
+        .optional()
+        .map_err(|e| {{
+            AutumnError::internal_server_error_msg(format!("Failed to load session: {{e}}"))
+        }})?;
+
+    let Some(tracked) = tracked else {{
+        // Revoked (or never recorded): destroy the cookie session so a
+        // replayed cookie cannot resurrect it, then reject.
+        session.destroy().await;
+        return Err(AutumnError::unauthorized_msg("Session revoked."));
+    }};
+
+    // Bounded write amplification: skip the UPDATE inside the window.
+    let sessions_cfg = state.config().auth.sessions;
+    let now = chrono::Utc::now().naive_utc();
+    let window =
+        chrono::Duration::seconds(i64::try_from(sessions_cfg.last_seen_update_secs).unwrap_or(60));
+    if now.signed_duration_since(tracked.last_seen_at) >= window {{
+        let _ = diesel::update({sess_table}::table.find(tracked.id))
+            .set({sess_table}::last_seen_at.eq(now))
+            .execute(&mut **db)
+            .await;
+    }}
+
+    {table}::table
+        .find({snake_name}_id)
+        .select({pascal_name}::as_select())
+        .first(&mut **db)
+        .await
+        .map_err(|_| AutumnError::unauthorized_msg("Account not found."))
+}}
+
+/// Render the device list. Shared by the full page and the htmx partial.
+fn sessions_list_fragment(
+    sessions: &[{pascal_name}Session],
+    current_digest: &str,
+    csrf: Option<&CsrfToken>,
+    csrf_field: Option<&CsrfFormField>,
+) -> Markup {{
+    let csrf_name = csrf_field.map_or("_csrf", |f| f.0.as_str());
+    html! {{
+        div id="session-list" {{
+            @if sessions.is_empty() {{
+                p {{ "No active sessions." }}
+            }}
+            ul style="list-style:none;padding:0;" {{
+                @for s in sessions {{
+                    @let current = s.token_digest == current_digest;
+                    li style="border:1px solid #ccc;padding:0.75rem;margin-bottom:0.5rem;" {{
+                        p {{
+                            strong {{ (s.device_description()) }}
+                            @if current {{ " — this device" }}
+                        }}
+                        p {{
+                            "Signed in " (s.created_at.format("%Y-%m-%d %H:%M UTC").to_string())
+                            " from " (s.ip)
+                            " · last seen " (s.last_seen_at.format("%Y-%m-%d %H:%M UTC").to_string())
+                        }}
+                        @if !current {{
+                            button hx-post={{ "/account/sessions/" (s.id) "/revoke" }}
+                                hx-target="#session-list" hx-swap="outerHTML" {{
+                                "Revoke"
+                            }}
+                        }}
+                        form action={{ "/account/sessions/" (s.id) "/label" }} method="post"
+                            style="margin-top:0.25rem;" {{
+                            @if let Some(csrf) = csrf {{
+                                input type="hidden" name=(csrf_name) value=(csrf.token());
+                            }}
+                            input type="text" name="label" placeholder="Device label"
+                                value=[s.label.as_deref()];
+                            button type="submit" {{ "Save label" }}
+                        }}
+                    }}
+                }}
+            }}
+            button hx-post="/account/sessions/revoke-others"
+                hx-target="#session-list" hx-swap="outerHTML" {{
+                "Sign out everywhere else"
+            }}
+        }}
+    }}
+}}
+
+/// Re-render after a mutation: htmx requests get the refreshed partial,
+/// plain form posts get a redirect back to the page.
+async fn sessions_after_mutation(
+    session: &Session,
+    db: &mut Db,
+    state: &AppState,
+    hx: HxRequest,
+    csrf: Option<CsrfToken>,
+    csrf_field: Option<CsrfFormField>,
+) -> AutumnResult<Response> {{
+    if !hx.is_htmx {{
+        return Ok(redirect_to("/account/sessions"));
+    }}
+    let {snake_name} = require_tracked_session(session, db, state).await?;
+    let current_digest = session_token_digest(session).await;
+    let sessions = {snake_name}.sessions(&mut **db).await?;
+    Ok(
+        sessions_list_fragment(&sessions, &current_digest, csrf.as_ref(), csrf_field.as_ref())
+            .into_response(),
+    )
+}}
+
+/// `GET /account/sessions` — list active sessions with revocation controls.
+/// Requires authentication.
+#[secured]
+#[get("/account/sessions")]
+pub async fn sessions_page(
+    session: Session,
+    State(state): State<AppState>,
+    mut db: Db,
+    hx: HxRequest,
+    csrf: Option<CsrfToken>,
+    csrf_field: Option<CsrfFormField>,
+) -> AutumnResult<Response> {{
+    let {snake_name} = require_tracked_session(&session, &mut db, &state).await?;
+    let current_digest = session_token_digest(&session).await;
+    let sessions = {snake_name}.sessions(&mut *db).await?;
+    let fragment =
+        sessions_list_fragment(&sessions, &current_digest, csrf.as_ref(), csrf_field.as_ref());
+    if hx.is_htmx {{
+        return Ok(fragment.into_response());
+    }}
+    Ok(layout("Active Sessions", html! {{
+        @if let Some(ref csrf) = csrf {{ meta name="csrf-token" content=(csrf.token()); }}
+        script src=(HTMX_JS_PATH) {{}}
+        script src=(HTMX_CSRF_JS_PATH) {{}}
+        h1 {{ "Active Sessions" }}
+        p {{
+            "These are the devices currently signed in to your account. \
+             Revoke any session you don't recognise — that device is signed \
+             out immediately."
+        }}
+        (fragment)
+        p {{ a href="/account" {{ "← Back to account" }} }}
+    }}).into_response())
+}}
+
+/// `POST /account/sessions/{{id}}/revoke` — sign a single device out.
+/// The revoked device's next request 401s. Requires authentication.
+#[secured]
+#[post("/account/sessions/{{id}}/revoke")]
+pub async fn sessions_revoke(
+    session: Session,
+    State(state): State<AppState>,
+    mut db: Db,
+    hx: HxRequest,
+    csrf: Option<CsrfToken>,
+    csrf_field: Option<CsrfFormField>,
+    Path(id): Path<i64>,
+) -> AutumnResult<Response> {{
+    let {snake_name} = require_tracked_session(&session, &mut db, &state).await?;
+    {snake_name}.revoke_session(&mut *db, id).await?;
+    sessions_after_mutation(&session, &mut db, &state, hx, csrf, csrf_field).await
+}}
+
+/// `POST /account/sessions/revoke-others` — "Sign out everywhere else":
+/// revoke every session except the current one. Requires authentication.
+#[secured]
+#[post("/account/sessions/revoke-others")]
+pub async fn sessions_revoke_others(
+    session: Session,
+    State(state): State<AppState>,
+    mut db: Db,
+    hx: HxRequest,
+    csrf: Option<CsrfToken>,
+    csrf_field: Option<CsrfFormField>,
+) -> AutumnResult<Response> {{
+    let {snake_name} = require_tracked_session(&session, &mut db, &state).await?;
+    let current_digest = session_token_digest(&session).await;
+    {snake_name}
+        .revoke_other_sessions(&mut *db, &current_digest)
+        .await?;
+    sessions_after_mutation(&session, &mut db, &state, hx, csrf, csrf_field).await
+}}
+
+#[derive(Deserialize)]
+pub struct SessionLabelForm {{
+    pub label: String,
+}}
+
+/// `POST /account/sessions/{{id}}/label` — set a human-readable device label
+/// (e.g. "Work laptop"). An empty label clears it. Requires authentication.
+#[secured]
+#[post("/account/sessions/{{id}}/label")]
+pub async fn sessions_label(
+    session: Session,
+    State(state): State<AppState>,
+    mut db: Db,
+    hx: HxRequest,
+    csrf: Option<CsrfToken>,
+    csrf_field: Option<CsrfFormField>,
+    Path(id): Path<i64>,
+    Form(form): Form<SessionLabelForm>,
+) -> AutumnResult<Response> {{
+    let {snake_name} = require_tracked_session(&session, &mut db, &state).await?;
+    let label = form.label.trim().chars().take(100).collect::<String>();
+    let label = if label.is_empty() {{ None }} else {{ Some(label) }};
+    diesel::update(
+        {sess_table}::table
+            .filter({sess_table}::id.eq(id))
+            .filter({sess_table}::user_id.eq({snake_name}.id)),
+    )
+    .set({sess_table}::label.eq(label))
+    .execute(&mut *db)
+    .await
+    .map_err(|e| {{
+        AutumnError::internal_server_error_msg(format!("Failed to set label: {{e}}"))
+    }})?;
+    sessions_after_mutation(&session, &mut db, &state, hx, csrf, csrf_field).await
 }}
 
 // ── Signup ────────────────────────────────────────────────────────────────────
@@ -1720,7 +2259,7 @@ pub struct LoginForm {{
 /// `UNSPECIFIED` so the handler compiles and runs correctly in both production
 /// (where `into_make_service_with_connect_info` injects the extension) and
 /// in test environments where it is absent.
-pub struct MaybeClientIp(std::net::IpAddr);
+pub struct MaybeClientIp(pub std::net::IpAddr);
 
 impl<S: Send + Sync> axum::extract::FromRequestParts<S> for MaybeClientIp {{
     type Rejection = std::convert::Infallible;
@@ -1752,6 +2291,7 @@ pub async fn login(
     State(state): State<AppState>,
     session: Session,
     MaybeClientIp(addr_ip): MaybeClientIp,
+    headers: axum::http::HeaderMap,
     Form(form): Form<LoginForm>,
 ) -> AutumnResult<Response> {{
     let email = form.email.trim().to_lowercase();
@@ -1943,6 +2483,8 @@ pub async fn login(
     session.insert(state.auth_session_key(), {snake_name}.id.to_string()).await;
     // Stamp the step-up claim so `#[step_up]` routes are immediately accessible.
     autumn_web::step_up::set_last_strong_auth_at(&session).await;
+    // Track this login as an active session (device list + revocation).
+    record_login_session(&mut db, &session, {snake_name}.id, addr_ip, &headers).await?;
     Ok(redirect_to("/account"))
 }}
 
@@ -1951,9 +2493,16 @@ pub async fn login(
 /// `POST /logout` — destroy the session and redirect to the login page.
 ///
 /// Destroying (not just clearing) the session ensures an old session cookie
-/// cannot be replayed after logout.
+/// cannot be replayed after logout. The tracked `{sess_table}` row is removed
+/// too so the device disappears from the active-sessions list.
 #[post("/logout")]
-pub async fn logout(session: Session) -> AutumnResult<Response> {{
+pub async fn logout(session: Session, mut db: Db) -> AutumnResult<Response> {{
+    let token_digest = session_token_digest(&session).await;
+    let _ = diesel::delete(
+        {sess_table}::table.filter({sess_table}::token_digest.eq(&token_digest)),
+    )
+    .execute(&mut *db)
+    .await;
     session.destroy().await;
     Ok(redirect_to("/login"))
 }}
@@ -2026,19 +2575,10 @@ pub async fn unlock_account(
 /// anonymous requests before the handler body runs.
 #[secured]
 #[get("/account")]
-pub async fn account(session: Session, mut db: Db, csrf: Option<CsrfToken>, csrf_field: Option<CsrfFormField>) -> AutumnResult<Response> {{
-    let {snake_name}_id: i64 = session
-        .get("{snake_name}_id")
-        .await
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
-
-    let {snake_name}: {pascal_name} = {table}::table
-        .find({snake_name}_id)
-        .select({pascal_name}::as_select())
-        .first(&mut *db)
-        .await
-        .map_err(|_| AutumnError::not_found_msg("Account not found."))?;
+pub async fn account(session: Session, State(state): State<AppState>, mut db: Db, csrf: Option<CsrfToken>, csrf_field: Option<CsrfFormField>) -> AutumnResult<Response> {{
+    // Validates the tracked session row (401s immediately if revoked) and
+    // refreshes `last_seen_at` with bounded write amplification.
+    let {snake_name} = require_tracked_session(&session, &mut db, &state).await?;
 
     // Email-confirmed gate: demonstrates how to require a confirmed address on
     // any route. Remove this block to allow unconfirmed users to access the
@@ -2076,6 +2616,7 @@ pub async fn account(session: Session, mut db: Db, csrf: Option<CsrfToken>, csrf
             @if let Some(ref csrf) = csrf {{ input type="hidden" name=(csrf_field.as_ref().map_or("_csrf", |f| f.0.as_str())) value=(csrf.token()); }}
             button type="submit" {{ "Log Out" }}
         }}
+        p {{ a href="/account/sessions" {{ "Manage active sessions" }} }}
         p {{
             a href="/account/delete" {{ "Delete my account" }}
             " (30-day grace period — GDPR Article 17)"
@@ -2095,14 +2636,13 @@ pub async fn account(session: Session, mut db: Db, csrf: Option<CsrfToken>, csrf
 #[post("/account/destroy")]
 pub async fn account_destroy(
     session: Session,
+    State(state): State<AppState>,
     mut db: Db,
 ) -> AutumnResult<Response> {{
-    let {snake_name}_id: i64 = session
-        .get("{snake_name}_id")
-        .await
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
+    let {snake_name}_id: i64 = require_tracked_session(&session, &mut db, &state).await?.id;
 
+    // Deleting the account cascades to {sess_table} (FK ON DELETE CASCADE),
+    // signing every device out immediately.
     diesel::delete({table}::table.find({snake_name}_id))
         .execute(&mut *db)
         .await
@@ -2176,18 +2716,8 @@ pub async fn reauth(
         return Ok(redirect_to("/login").into_response());
     }}
 
-    let {snake_name}_id: i64 = session
-        .get("{snake_name}_id")
-        .await
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
-
-    let {snake_name}: {pascal_name} = {table}::table
-        .find({snake_name}_id)
-        .select({pascal_name}::as_select())
-        .first(&mut *db)
-        .await
-        .map_err(|_| AutumnError::not_found_msg("Account not found."))?;
+    // Validates the tracked session row (401s immediately if revoked).
+    let {snake_name} = require_tracked_session(&session, &mut db, &state).await?;
 
     // In the TOTP multi-step flow, the password is verified in one request and the
     // TOTP code in the next. Rather than echoing the password into a hidden DOM
@@ -2494,6 +3024,8 @@ pub async fn reset_password(
     mut db: Db,
     State(state): State<AppState>,
     session: Session,
+    MaybeClientIp(addr_ip): MaybeClientIp,
+    headers: axum::http::HeaderMap,
     Form(form): Form<ResetPasswordForm>,
 ) -> AutumnResult<Response> {{
     if form.password.len() < 8 {{
@@ -2535,6 +3067,15 @@ pub async fn reset_password(
         .execute(&mut *db)
         .await?;
 
+    // Credential changed: revoke every existing session (defaulted on,
+    // configurable via [auth.sessions].revoke_on_credential_change). The
+    // standard response to credential theft — a stolen session on another
+    // device must not survive the password rotation. This brand-new login
+    // is recorded below.
+    if state.config().auth.sessions.revoke_on_credential_change {{
+        let _ = {snake_name}.revoke_all_sessions(&mut *db).await?;
+    }}
+
     // Rotate session to invalidate any previous authenticated state.
     session.rotate_id().await;
 {totp_clear_pending}    session.insert("{snake_name}_id", {snake_name}.id.to_string()).await;
@@ -2543,6 +3084,8 @@ pub async fn reset_password(
     session.insert(state.auth_session_key(), {snake_name}.id.to_string()).await;
     // Stamp the step-up claim so `#[step_up]` routes are immediately accessible.
     autumn_web::step_up::set_last_strong_auth_at(&session).await;
+    // Track this fresh login as an active session.
+    record_login_session(&mut db, &session, {snake_name}.id, addr_ip, &headers).await?;
     Ok(redirect_to("/account"))
 }}
 
@@ -2643,6 +3186,8 @@ pub async fn confirm_email(
     mut db: Db,
     State(state): State<AppState>,
     session: Session,
+    MaybeClientIp(addr_ip): MaybeClientIp,
+    headers: axum::http::HeaderMap,
     Path(params): Path<ConfirmEmailPath>,
 ) -> AutumnResult<Response> {{
     let token_digest = sha256_hex(&params.token);
@@ -2683,6 +3228,8 @@ pub async fn confirm_email(
     session.insert("{snake_name}_email", &{snake_name}.email).await;
     // Use the same session key checked by `#[secured]` / `#[authorize]`.
     session.insert(state.auth_session_key(), {snake_name}.id.to_string()).await;
+    // Track this login as an active session (device list + revocation).
+    record_login_session(&mut db, &session, {snake_name}.id, addr_ip, &headers).await?;
     // Step-up protected routes will redirect to /reauth as designed.
     Ok(redirect_to("/account"))
 }}
@@ -2892,11 +3439,7 @@ pub async fn data_export(
     mut db: Db,
     State(state): State<AppState>,
 ) -> AutumnResult<Response> {{
-    let {snake_name}_id: i64 = session
-        .get("{snake_name}_id")
-        .await
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
+    let {snake_name}_id: i64 = require_tracked_session(&session, &mut db, &state).await?.id;
 
     let mailer = state.extension::<Mailer>();
     let now = chrono::Utc::now().naive_utc();
@@ -3034,11 +3577,7 @@ pub async fn delete_account(
     State(state): State<AppState>,
     axum::Form(form): axum::Form<DeleteAccountForm>,
 ) -> AutumnResult<Response> {{
-    let {snake_name}_id: i64 = session
-        .get("{snake_name}_id")
-        .await
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
+    let {snake_name}_id: i64 = require_tracked_session(&session, &mut db, &state).await?.id;
 
     // Require the user to type DELETE as a confirmation step.
     if form.confirmation.trim() != "DELETE" {{
@@ -3101,11 +3640,7 @@ pub async fn cancel_delete_account(
     mut db: Db,
     State(state): State<AppState>,
 ) -> AutumnResult<Response> {{
-    let {snake_name}_id: i64 = session
-        .get("{snake_name}_id")
-        .await
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
+    let {snake_name}_id: i64 = require_tracked_session(&session, &mut db, &state).await?.id;
 
     // Only cancel if a future deletion is scheduled; reject once the deadline has passed.
     let rows = diesel::update({table}::table.find({snake_name}_id))
@@ -3258,7 +3793,7 @@ pub async fn admin_delete_account(
 
     Ok(redirect_to(&format!("/admin/{table}/{{user_id}}")).into_response())
 }}
-{totp_section}"#
+{totp_section}"##
     )
 }
 
@@ -3668,6 +4203,361 @@ fn email_change_reenters_unconfirmed() {{
         "GET /auth/confirm/resend must return 200:\n{{resp}}"
     );
 }}
+"#
+    )
+}
+
+#[allow(clippy::too_many_lines)]
+/// Render `tests/auth_sessions.rs` — integration tests for active-session
+/// management (issue #819), including the two-client revocation flow.
+fn render_sessions_tests_file(pascal_name: &str, _snake_name: &str) -> String {
+    format!(
+        r#"//! Active-session management integration tests for {pascal_name},
+//! generated by `autumn generate auth` (issue #819).
+//!
+//! These tests run against a live server started with `AUTUMN_TEST_BASE_URL`.
+//! They skip when the env var is unset, so they compile and pass out of the box.
+//!
+//! The revocation tests additionally need a *confirmed* account because login
+//! is gated on email confirmation. Provide one via:
+//!
+//! ```sh
+//! export AUTUMN_TEST_CONFIRMED_EMAIL=tester@example.com
+//! export AUTUMN_TEST_CONFIRMED_PASSWORD=some-password-123
+//! ```
+//!
+//! Seed it directly if needed (replace `users` with your table name):
+//!
+//! ```sql
+//! UPDATE users SET email_confirmed_at = NOW() WHERE email = 'tester@example.com';
+//! ```
+
+use std::io::{{Read, Write}};
+use std::net::TcpStream;
+
+fn base_url() -> Option<String> {{
+    std::env::var("AUTUMN_TEST_BASE_URL").ok()
+}}
+
+fn confirmed_account() -> Option<(String, String)> {{
+    let email = std::env::var("AUTUMN_TEST_CONFIRMED_EMAIL").ok()?;
+    let password = std::env::var("AUTUMN_TEST_CONFIRMED_PASSWORD").ok()?;
+    Some((email, password))
+}}
+
+fn host_port(base: &str) -> String {{
+    base.trim_start_matches("http://")
+        .trim_start_matches("https://")
+        .to_owned()
+}}
+
+fn request(base: &str, method: &str, path: &str, body: &str, cookie: &str) -> String {{
+    let hp = host_port(base);
+    let mut stream =
+        TcpStream::connect(&hp).unwrap_or_else(|_| panic!("cannot connect to {{base}}"));
+    let req = format!(
+        "{{method}} {{path}} HTTP/1.1\r\n\
+         Host: {{hp}}\r\n\
+         Content-Type: application/x-www-form-urlencoded\r\n\
+         Content-Length: {{}}\r\n\
+         Cookie: {{cookie}}\r\n\
+         User-Agent: auth-sessions-integration-test\r\n\
+         Connection: close\r\n\r\n\
+         {{body}}",
+        body.len()
+    );
+    stream.write_all(req.as_bytes()).expect("write failed");
+    let mut resp = String::new();
+    stream.read_to_string(&mut resp).expect("read failed");
+    resp
+}}
+
+fn get(base: &str, path: &str, cookie: &str) -> String {{
+    request(base, "GET", path, "", cookie)
+}}
+
+fn post_form(base: &str, path: &str, body: &str, cookie: &str) -> String {{
+    request(base, "POST", path, body, cookie)
+}}
+
+/// Extract the session cookie (`name=value`) from a `Set-Cookie` header.
+fn session_cookie(resp: &str) -> Option<String> {{
+    resp.lines()
+        .filter(|l| l.to_ascii_lowercase().starts_with("set-cookie:"))
+        .filter_map(|l| l.splitn(2, ':').nth(1))
+        .map(|v| v.split(';').next().unwrap_or("").trim().to_owned())
+        .find(|c| !c.is_empty())
+}}
+
+/// Log in and return the authenticated session cookie. Panics on failure.
+fn login(base: &str, email: &str, password: &str) -> String {{
+    let body = format!("email={{email}}&password={{password}}");
+    let resp = post_form(base, "/login", &body, "");
+    assert!(
+        resp.contains("HTTP/1.1 30") || resp.contains("HTTP/1.0 30"),
+        "login did not redirect — is the account confirmed?\n{{resp}}"
+    );
+    session_cookie(&resp).expect("login response missing Set-Cookie")
+}}
+
+/// The revocation tests share one confirmed account, so a concurrent
+/// `revoke-others` from one test would tear down another test's sessions.
+/// Serialize them.
+static REVOKE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[test]
+fn sessions_page_rejects_anonymous() {{
+    let Some(base) = base_url() else {{
+        eprintln!("skipping: AUTUMN_TEST_BASE_URL not set");
+        return;
+    }};
+    let resp = get(&base, "/account/sessions", "");
+    let is_rejected = resp.contains("HTTP/1.1 401")
+        || resp.contains("HTTP/1.0 401")
+        || resp.contains("HTTP/1.1 30")
+        || resp.contains("HTTP/1.0 30");
+    assert!(
+        is_rejected,
+        "GET /account/sessions should reject anonymous requests:\n{{resp}}"
+    );
+}}
+
+/// AC — log in on two clients, revoke from one, and the revoked client's
+/// next request 401s even though it replays the same (still-valid-looking)
+/// cookie. No reliance on cookie expiry.
+#[test]
+fn revoked_session_next_request_401s() {{
+    let Some(base) = base_url() else {{
+        eprintln!("skipping: AUTUMN_TEST_BASE_URL not set");
+        return;
+    }};
+    let Some((email, password)) = confirmed_account() else {{
+        eprintln!("skipping: AUTUMN_TEST_CONFIRMED_EMAIL/PASSWORD not set");
+        return;
+    }};
+    let _serial = REVOKE_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    // Two independent clients (e.g. laptop + phone).
+    let cookie_a = login(&base, &email, &password);
+    let cookie_b = login(&base, &email, &password);
+
+    // Both sessions work.
+    assert!(
+        get(&base, "/account", &cookie_a).contains(" 200"),
+        "client A should be signed in"
+    );
+    assert!(
+        get(&base, "/account", &cookie_b).contains(" 200"),
+        "client B should be signed in"
+    );
+
+    // Client A signs everything else out — one click.
+    let resp = post_form(&base, "/account/sessions/revoke-others", "", &cookie_a);
+    assert!(
+        resp.contains(" 200") || resp.contains(" 30"),
+        "revoke-others failed:\n{{resp}}"
+    );
+
+    // Client B's replayed cookie must 401 on its very next request.
+    let resp_b = get(&base, "/account", &cookie_b);
+    assert!(
+        resp_b.contains("HTTP/1.1 401") || resp_b.contains("HTTP/1.0 401"),
+        "revoked client's next request must 401:\n{{resp_b}}"
+    );
+}}
+
+/// "Sign out everywhere else" must never revoke the session that asked.
+#[test]
+fn revoke_other_sessions_keeps_current_session_alive() {{
+    let Some(base) = base_url() else {{
+        eprintln!("skipping: AUTUMN_TEST_BASE_URL not set");
+        return;
+    }};
+    let Some((email, password)) = confirmed_account() else {{
+        eprintln!("skipping: AUTUMN_TEST_CONFIRMED_EMAIL/PASSWORD not set");
+        return;
+    }};
+    let _serial = REVOKE_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    let cookie_a = login(&base, &email, &password);
+    let _cookie_b = login(&base, &email, &password);
+
+    post_form(&base, "/account/sessions/revoke-others", "", &cookie_a);
+
+    let resp_a = get(&base, "/account", &cookie_a);
+    assert!(
+        resp_a.contains(" 200"),
+        "current session must survive revoke-others:\n{{resp_a}}"
+    );
+    let resp_page = get(&base, "/account/sessions", &cookie_a);
+    assert!(
+        resp_page.contains(" 200"),
+        "sessions page must render for the surviving session:\n{{resp_page}}"
+    );
+}}
+"#
+    )
+}
+
+/// Render `docs/guide/session-management.md` — covers the data model, the
+/// handler APIs, the auto-revocation policy, the privacy posture for stored
+/// IP / User-Agent data, and how to plug in a custom UA parser (issue #819).
+#[allow(clippy::too_many_lines)]
+fn render_sessions_docs_file(pascal_name: &str, snake_name: &str, user_table: &str) -> String {
+    let sess_table = sessions_table_name(snake_name);
+    format!(
+        r#"# Active Session Management
+
+Generated by `autumn generate auth`. Every login persists a `{sess_table}`
+row so users can answer "where am I signed in?" and revoke any device —
+per-session or all-at-once — from `/account/sessions`.
+
+## How it works
+
+- **One row per login.** A successful login (password, email confirmation,
+  TOTP verify, or passkey) inserts a `{sess_table}` row holding the SHA-256
+  digest of the opaque server-side session id, the {pascal_name} id, the IP
+  at login, the raw and parsed User-Agent, an optional user-set device
+  label, `created_at`, and `last_seen_at`.
+- **The row is the source of truth.** Authenticated handlers call
+  `require_tracked_session(&session, &mut db, &state)`, which loads the row
+  by digest. If the row is gone the request is rejected with `401` and the
+  cookie session is destroyed — a revoked session dies on its *next*
+  request, even if the cookie is replayed. There is no reliance on cookie
+  expiry.
+- **Bounded write amplification.** `last_seen_at` is refreshed at most once
+  per `[auth.sessions].last_seen_update_secs` (default 60 s) per session,
+  so a busy session costs one `UPDATE` per window, not one per request.
+- **Only the digest is stored.** The raw session id never touches the
+  database, so a database leak cannot be replayed as a session cookie.
+
+## Handler APIs
+
+From any request handler that has loaded the current {pascal_name}:
+
+```rust
+// List active sessions, most recently seen first.
+let sessions = current_{snake_name}.sessions(&mut *db).await?;
+
+// Revoke one session by row id (scoped to this account).
+current_{snake_name}.revoke_session(&mut *db, session_id).await?;
+
+// "Sign out everywhere else."
+let digest = session_token_digest(&session).await;
+current_{snake_name}.revoke_other_sessions(&mut *db, &digest).await?;
+
+// Revoke everything, including the current session (password change).
+current_{snake_name}.revoke_all_sessions(&mut *db).await?;
+```
+
+Protect your own routes the same way the generated ones are protected:
+
+```rust
+let current_{snake_name} = require_tracked_session(&session, &mut db, &state).await?;
+```
+
+## The /account/sessions page
+
+`GET /account/sessions` lists every active session with device description
+(parsed from the User-Agent), IP, sign-in and last-seen times, a per-row
+**Revoke** button, a device-label form, and a one-click **Sign out
+everywhere else** button. The page is Maud + htmx: revocations swap the
+list in place without a full reload, and fall back to normal form posts
+when JavaScript is unavailable.
+
+## Automatic revocation on credential change
+
+Password change (reset flow), TOTP enrollment, TOTP disable, and passkey
+add/remove revoke all *other* sessions by default — the standard response
+to credential theft. Disable or tune it in `autumn.toml`:
+
+```toml
+[auth.sessions]
+revoke_on_credential_change = true  # default
+last_seen_update_secs = 60          # default
+```
+
+## Privacy posture for stored IP and User-Agent
+
+The session row stores the login IP and User-Agent so a person can
+recognise their own devices. Treat both as personal data:
+
+- **Purpose limitation.** The data exists for device recognition and
+  incident response only. Don't repurpose it for analytics.
+- **Retention.** Rows are deleted on logout, revocation, and account
+  deletion (`ON DELETE CASCADE`). Sessions that simply go stale keep their
+  rows until revoked — pick a retention window and scrub on a schedule:
+
+  ```sql
+  DELETE FROM {sess_table} WHERE last_seen_at < NOW() - INTERVAL '90 days';
+  ```
+
+  Pair this with your session cookie `max_age_secs` so rows do not outlive
+  the cookies that reference them.
+- **Scrubbing/minimisation.** If full IPs are more than you need, truncate
+  before storing (e.g. zero the last IPv4 octet) in `record_login_session`,
+  or store only the parsed UA fields and set `user_agent` to `""`.
+- **No geolocation.** The framework stores the IP only; GeoIP lookups are
+  deliberately left to userland.
+- **Data export.** Include `{sess_table}` in your GDPR export job — see
+  docs/guide/gdpr-compliance.md.
+
+## Plugging in a custom User-Agent parser
+
+The default parser (`autumn_web::user_agent::parse_user_agent`) is a small
+heuristic covering the major browser/OS families. Every parse goes through
+one call site — `record_login_session` in `src/routes/auth.rs` — so
+swapping in a dedicated crate is a one-line change:
+
+```rust
+// In record_login_session, replace:
+let parsed = autumn_web::user_agent::parse_user_agent(&user_agent);
+// with your parser of choice, mapping into the same three fields:
+let ua = my_ua_crate::parse(&user_agent);
+let parsed = autumn_web::user_agent::ParsedUserAgent {{
+    family: ua.browser_name,
+    os: ua.os_name,
+    device_class: autumn_web::user_agent::DeviceClass::Unknown,
+}};
+```
+
+The parsed fields are stored denormalised (`ua_family`, `ua_os`,
+`ua_device`), so changing the parser only affects *new* sessions.
+
+## Migration path for existing apps
+
+Already generated the auth starter before session management existed? The
+upgrade is one additive table:
+
+```sql
+CREATE TABLE {sess_table} (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES {user_table}(id) ON DELETE CASCADE,
+    token_digest TEXT NOT NULL UNIQUE,
+    ip TEXT NOT NULL DEFAULT '',
+    user_agent TEXT NOT NULL DEFAULT '',
+    ua_family TEXT NOT NULL DEFAULT '',
+    ua_os TEXT NOT NULL DEFAULT '',
+    ua_device TEXT NOT NULL DEFAULT '',
+    label TEXT NULL,
+    last_seen_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX {sess_table}_user_id_idx ON {sess_table} (user_id);
+```
+
+Existing logged-in sessions have no row, so `require_tracked_session`
+treats them as revoked: every user re-authenticates once after the
+deploy. That is the safe default after introducing revocation.
+
+## Integration tests
+
+`tests/auth_sessions.rs` covers the two-client flow: log in on two
+clients, revoke from one, and assert the revoked client's next request
+401s while the surviving client keeps working. Set `AUTUMN_TEST_BASE_URL`
+plus `AUTUMN_TEST_CONFIRMED_EMAIL`/`AUTUMN_TEST_CONFIRMED_PASSWORD` to run
+them against a live server.
 "#
     )
 }
@@ -4172,6 +5062,10 @@ fn auth_route_entries(totp: bool) -> Vec<String> {
         "routes::auth::unlock_account".to_owned(),
         "routes::auth::account".to_owned(),
         "routes::auth::account_destroy".to_owned(),
+        "routes::auth::sessions_page".to_owned(),
+        "routes::auth::sessions_revoke".to_owned(),
+        "routes::auth::sessions_revoke_others".to_owned(),
+        "routes::auth::sessions_label".to_owned(),
         "routes::auth::reauth_form".to_owned(),
         "routes::auth::reauth".to_owned(),
         "routes::auth::forgot_password_form".to_owned(),
@@ -5034,21 +5928,13 @@ fn generate_recovery_code() -> String {
 #[get("/account/2fa")]
 pub async fn two_factor_status(
     session: Session,
+    State(state): State<AppState>,
     mut db: Db,
     csrf: Option<CsrfToken>,
     csrf_field: Option<CsrfFormField>,
 ) -> AutumnResult<Markup> {
-    let __SNAKE___id: i64 = session
-        .get("__SNAKE___id")
-        .await
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
-    let __SNAKE__: __PASCAL__ = __TABLE__::table
-        .find(__SNAKE___id)
-        .select(__PASCAL__::as_select())
-        .first(&mut *db)
-        .await
-        .map_err(|_| AutumnError::not_found_msg("Account not found."))?;
+    // Validates the tracked session row (401s immediately if revoked).
+    let __SNAKE__ = require_tracked_session(&session, &mut db, &state).await?;
 
     let remaining: i64 = if __SNAKE__.totp_enabled {
         recovery_codes::table
@@ -5117,17 +6003,8 @@ pub async fn two_factor_enable(
              Choose a different [auth].session_key.",
         ));
     }
-    let __SNAKE___id: i64 = session
-        .get("__SNAKE___id")
-        .await
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
-    let __SNAKE__: __PASCAL__ = __TABLE__::table
-        .find(__SNAKE___id)
-        .select(__PASCAL__::as_select())
-        .first(&mut *db)
-        .await
-        .map_err(|_| AutumnError::not_found_msg("Account not found."))?;
+    // Validates the tracked session row (401s immediately if revoked).
+    let __SNAKE__ = require_tracked_session(&session, &mut db, &state).await?;
 
     // Step-up re-auth: a logged-in but unattended/hijacked session must not be
     // able to enroll an attacker's authenticator. Require the account password
@@ -5191,20 +6068,12 @@ pub async fn two_factor_enable(
 #[post("/account/2fa/confirm")]
 pub async fn two_factor_confirm(
     session: Session,
+    State(state): State<AppState>,
     mut db: Db,
     Form(form): Form<TotpCodeForm>,
 ) -> AutumnResult<Markup> {
-    let __SNAKE___id: i64 = session
-        .get("__SNAKE___id")
-        .await
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
-    let __SNAKE__: __PASCAL__ = __TABLE__::table
-        .find(__SNAKE___id)
-        .select(__PASCAL__::as_select())
-        .first(&mut *db)
-        .await
-        .map_err(|_| AutumnError::not_found_msg("Account not found."))?;
+    // Validates the tracked session row (401s immediately if revoked).
+    let __SNAKE__ = require_tracked_session(&session, &mut db, &state).await?;
 
     // Re-enrollment guard (defense in depth — `two_factor_enable` blocks this too):
     // never replace an active factor without first disabling (which re-authenticates).
@@ -5301,6 +6170,17 @@ pub async fn two_factor_confirm(
 
     session.remove("totp_pending_secret").await;
 
+    // Credential change (second factor enrolled): sign out every *other*
+    // device (defaulted on, configurable via
+    // [auth.sessions].revoke_on_credential_change). A stolen session on
+    // another device must not survive a 2FA enrollment.
+    if state.config().auth.sessions.revoke_on_credential_change {
+        let current_digest = session_token_digest(&session).await;
+        let _ = __SNAKE__
+            .revoke_other_sessions(&mut *db, &current_digest)
+            .await?;
+    }
+
     Ok(layout("Save Your Recovery Codes", html! {
         h1 { "Two-factor authentication enabled" }
         p { strong { "Save these recovery codes now." } " Each can be used once if you lose your device. They will not be shown again." }
@@ -5323,20 +6203,12 @@ pub async fn two_factor_confirm(
 #[post("/account/2fa/disable")]
 pub async fn two_factor_disable(
     session: Session,
+    State(state): State<AppState>,
     mut db: Db,
     Form(form): Form<TotpDisableForm>,
 ) -> AutumnResult<Response> {
-    let __SNAKE___id: i64 = session
-        .get("__SNAKE___id")
-        .await
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
-    let __SNAKE__: __PASCAL__ = __TABLE__::table
-        .find(__SNAKE___id)
-        .select(__PASCAL__::as_select())
-        .first(&mut *db)
-        .await
-        .map_err(|_| AutumnError::not_found_msg("Account not found."))?;
+    // Validates the tracked session row (401s immediately if revoked).
+    let __SNAKE__ = require_tracked_session(&session, &mut db, &state).await?;
 
     // Re-authenticate: accept a current TOTP code or the account password.
     // A TOTP code used here is consumed with the same atomic replay guard as
@@ -5403,6 +6275,16 @@ pub async fn two_factor_disable(
         .await
         .map_err(|_| AutumnError::internal_server_error_msg("Failed to disable two-factor."))?;
 
+    // Credential change (second factor removed): sign out every *other*
+    // device (defaulted on, configurable via
+    // [auth.sessions].revoke_on_credential_change).
+    if state.config().auth.sessions.revoke_on_credential_change {
+        let current_digest = session_token_digest(&session).await;
+        let _ = __SNAKE__
+            .revoke_other_sessions(&mut *db, &current_digest)
+            .await?;
+    }
+
     Ok(redirect_to("/account/2fa"))
 }
 
@@ -5440,6 +6322,8 @@ pub async fn login_verify(
     mut db: Db,
     State(state): State<AppState>,
     session: Session,
+    MaybeClientIp(addr_ip): MaybeClientIp,
+    headers: axum::http::HeaderMap,
     Form(form): Form<TotpCodeForm>,
 ) -> AutumnResult<Response> {
     let pending_id: i64 = session
@@ -5561,6 +6445,12 @@ pub async fn login_verify(
                 "Reset link expired or already used. Please restart the password reset.",
             ));
         }
+        // Password changed: revoke every existing session (defaulted on,
+        // configurable via [auth.sessions].revoke_on_credential_change).
+        // The fresh login is recorded below.
+        if state.config().auth.sessions.revoke_on_credential_change {
+            let _ = __SNAKE__.revoke_all_sessions(&mut *db).await?;
+        }
     }
 
     // Promote the pending session to a fully authenticated one.
@@ -5578,6 +6468,8 @@ pub async fn login_verify(
     if !from_confirmation {
         autumn_web::step_up::set_last_strong_auth_at(&session).await;
     }
+    // Track this login as an active session (device list + revocation).
+    record_login_session(&mut db, &session, __SNAKE__.id, addr_ip, &headers).await?;
 
     let remaining: i64 = recovery_codes::table
         .filter(recovery_codes::user_id.eq(__SNAKE__.id))
@@ -5984,11 +6876,10 @@ pub async fn passkey_register_finish(
     mut db: Db,
     axum::Json(body): axum::Json<PasskeyRegisterFinishBody>,
 ) -> AutumnResult<axum::Json<serde_json::Value>> {
-    let current_id: i64 = session
-        .get(state.auth_session_key())
-        .await
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
+    // Validates the tracked session row (401s immediately if revoked).
+    let current =
+        crate::routes::auth::require_tracked_session(&session, &mut db, &state).await?;
+    let current_id: i64 = current.id;
     let envelope_str: String = session
         .get("passkey_reg_state")
         .await
@@ -6031,6 +6922,15 @@ pub async fn passkey_register_finish(
         .execute(&mut *db)
         .await
         .map_err(|_| AutumnError::internal_server_error_msg("Failed to store passkey."))?;
+    // Credential change (passkey added): sign out every *other* device
+    // (defaulted on, configurable via
+    // [auth.sessions].revoke_on_credential_change).
+    if state.config().auth.sessions.revoke_on_credential_change {
+        let current_digest = crate::routes::auth::session_token_digest(&session).await;
+        let _ = current
+            .revoke_other_sessions(&mut *db, &current_digest)
+            .await?;
+    }
     Ok(axum::Json(serde_json::json!({ "ok": true })))
 }
 
@@ -6122,6 +7022,8 @@ pub async fn passkey_login_finish(
     session: Session,
     State(state): State<AppState>,
     mut db: Db,
+    crate::routes::auth::MaybeClientIp(addr_ip): crate::routes::auth::MaybeClientIp,
+    headers: axum::http::HeaderMap,
     axum::Json(body): axum::Json<PasskeyLoginFinishBody>,
 ) -> AutumnResult<axum::Json<serde_json::Value>> {
     let auth_state_str: String = session
@@ -6215,6 +7117,9 @@ pub async fn passkey_login_finish(
     session
         .insert(state.auth_session_key(), __SNAKE___id.to_string())
         .await;
+    // Track this login as an active session (device list + revocation).
+    crate::routes::auth::record_login_session(&mut db, &session, __SNAKE___id, addr_ip, &headers)
+        .await?;
     Ok(axum::Json(serde_json::json!({ "ok": true })))
 }
 
@@ -6230,11 +7135,10 @@ pub async fn passkey_list(
     csrf: Option<CsrfToken>,
     csrf_field: Option<CsrfFormField>,
 ) -> AutumnResult<Markup> {
-    let __SNAKE___id: i64 = session
-        .get(state.auth_session_key())
-        .await
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
+    // Validates the tracked session row (401s immediately if revoked).
+    let __SNAKE___id: i64 = crate::routes::auth::require_tracked_session(&session, &mut db, &state)
+        .await?
+        .id;
     let rows: Vec<(i64, String, chrono::NaiveDateTime)> = {
         use crate::schema::webauthn_credentials;
         webauthn_credentials::table
@@ -6289,19 +7193,26 @@ pub async fn passkey_revoke(
     mut db: Db,
     Form(form): Form<PasskeyRevokeForm>,
 ) -> AutumnResult<impl IntoResponse> {
-    let __SNAKE___id: i64 = session
-        .get(state.auth_session_key())
-        .await
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| AutumnError::unauthorized_msg("Not authenticated."))?;
+    // Validates the tracked session row (401s immediately if revoked).
+    let current =
+        crate::routes::auth::require_tracked_session(&session, &mut db, &state).await?;
     diesel::delete(
         crate::schema::webauthn_credentials::table
             .filter(crate::schema::webauthn_credentials::id.eq(form.id))
-            .filter(crate::schema::webauthn_credentials::user_id.eq(__SNAKE___id)),
+            .filter(crate::schema::webauthn_credentials::user_id.eq(current.id)),
     )
     .execute(&mut *db)
     .await
     .map_err(|_| AutumnError::internal_server_error_msg("Failed to revoke passkey."))?;
+    // Credential change (passkey removed): sign out every *other* device
+    // (defaulted on, configurable via
+    // [auth.sessions].revoke_on_credential_change).
+    if state.config().auth.sessions.revoke_on_credential_change {
+        let current_digest = crate::routes::auth::session_token_digest(&session).await;
+        let _ = current
+            .revoke_other_sessions(&mut *db, &current_digest)
+            .await?;
+    }
     Ok(redirect_to("/passkeys"))
 }
 "##;

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -2252,8 +2252,8 @@ fn generate_auth_reset_password_revokes_sessions() {
         "session revocation on password change must be configurable"
     );
     assert!(
-        reset_body.contains("record_login_session"),
-        "reset_password logs the user in and must record the new session"
+        reset_body.contains("insert_into(user_sessions::table)"),
+        "reset_password logs the user in and must record the new session in its transaction"
     );
 }
 
@@ -2312,7 +2312,7 @@ fn generate_auth_passkeys_changes_revoke_other_sessions() {
         let body = &routes[start..];
         let body = &body[..body.find("\n/// `").unwrap_or(body.len())];
         assert!(
-            body.contains("revoke_other_sessions"),
+            body.contains("token_digest.ne(") || body.contains("revoke_other_sessions"),
             "{handler} must revoke other sessions"
         );
         assert!(
@@ -2562,4 +2562,95 @@ fn generate_auth_totp_revocation_is_atomic() {
         verify.contains(".transaction"),
         "login_verify's deferred password-reset commit must be atomic with revocation"
     );
+}
+
+/// PR #1176 Codex round 3: signup must survive an already-authenticated
+/// browser (rebind the tracked row across its rotation), the password-reset
+/// transaction must include the new session-row insert (no 500 after the
+/// reset link is consumed), and passkey changes must revoke other sessions
+/// in the same transaction as the credential change.
+#[test]
+fn generate_auth_sessions_codex_round3() {
+    let (_tmp, project) = fresh_project("auth-sess-codex3");
+    run_autumn(&project, &["generate", "auth", "User"]);
+    let routes = fs::read_to_string(project.join("src/routes/auth.rs")).unwrap();
+
+    let body_of = |handler: &str| {
+        let start = routes
+            .find(handler)
+            .unwrap_or_else(|| panic!("missing {handler}"));
+        let body = &routes[start..];
+        &body[..body.find("\n/// `").unwrap_or(body.len())]
+    };
+
+    // signup: rotation preserves a previous login's keys, so the tracked row
+    // must be re-pointed at the new session id.
+    let signup = body_of("pub async fn signup(");
+    let rotate_at = signup
+        .find("session.rotate_id()")
+        .expect("signup must rotate");
+    let rebind_at = signup
+        .find("rebind_tracked_session")
+        .expect("signup must rebind the tracked row across its rotation");
+    assert!(
+        rotate_at < rebind_at,
+        "signup must rebind AFTER rotating the session id"
+    );
+
+    // reset_password: the new session row is inserted inside the same
+    // transaction as the password change + token consumption, so a failure
+    // rolls everything back and the link stays usable.
+    let reset = body_of("pub async fn reset_password(");
+    assert!(
+        reset.contains("insert_into(user_sessions::table)"),
+        "reset_password must insert the new session row inside its transaction"
+    );
+    assert!(
+        !reset.contains("record_login_session"),
+        "reset_password must not record the session outside the transaction"
+    );
+
+    // The UA parse stays funneled through one documented helper.
+    assert!(
+        routes.contains("pub async fn build_session_row"),
+        "session-row construction must be a shared helper"
+    );
+}
+
+/// PR #1176 Codex round 3 (`--passkeys`): the credential change and the
+/// other-sessions revocation commit atomically — the documented
+/// revoke-on-credential-change guarantee can never be silently skipped, and
+/// a failure rolls back the credential change instead of 500ing after it.
+#[test]
+fn generate_auth_passkeys_revocation_is_atomic() {
+    let (_tmp, project) = fresh_project("auth-sess-pk-atomic");
+    run_autumn(&project, &["generate", "auth", "User", "--passkeys"]);
+    let routes = fs::read_to_string(project.join("src/routes/passkeys.rs")).unwrap();
+
+    let body_of = |handler: &str| {
+        let start = routes
+            .find(handler)
+            .unwrap_or_else(|| panic!("missing {handler}"));
+        let body = &routes[start..];
+        &body[..body.find("\n/// `").unwrap_or(body.len())]
+    };
+
+    for handler in [
+        "pub async fn passkey_register_finish(",
+        "pub async fn passkey_revoke(",
+    ] {
+        let body = body_of(handler);
+        assert!(
+            body.contains(".transaction"),
+            "{handler} must commit the credential change and revocation atomically"
+        );
+        assert!(
+            body.contains("token_digest.ne("),
+            "{handler} must revoke other sessions inside the transaction"
+        );
+        assert!(
+            body.contains("revoke_on_credential_change"),
+            "{handler} revocation must stay config-gated"
+        );
+    }
 }

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -2068,3 +2068,304 @@ fn generate_auth_confirmation_routes_registered_in_main() {
         "main.rs must register resend_confirmation route"
     );
 }
+
+// ── Active session management (issue #819) ────────────────────────────────────
+//
+// `autumn generate auth` must emit first-class login-session tracking: a
+// per-login session row (token digest, IP, parsed User-Agent, label), per-request
+// validation with throttled `last_seen_at` updates, revocation APIs on the user
+// model, an `/account/sessions` Maud+htmx page, auto-revocation on
+// credential-changing events, integration tests, and privacy documentation.
+
+/// AC1 — a session row is persisted per login with token digest, user id,
+/// timestamps, IP, parsed User-Agent fields, and an optional device label.
+#[test]
+fn generate_auth_sessions_migration_schema_and_model() {
+    let (_tmp, project) = fresh_project("auth-sess-app");
+    run_autumn(&project, &["generate", "auth", "User"]);
+
+    let migrations: Vec<_> = fs::read_dir(project.join("migrations"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_name().to_string_lossy().ends_with("_create_users"))
+        .collect();
+    assert_eq!(migrations.len(), 1, "expected one create_users migration");
+    let up = fs::read_to_string(migrations[0].path().join("up.sql")).unwrap();
+    assert!(
+        up.contains("CREATE TABLE user_sessions"),
+        "up.sql missing CREATE TABLE user_sessions:\n{up}"
+    );
+    for column in [
+        "user_id BIGINT NOT NULL REFERENCES users",
+        "token_digest TEXT NOT NULL UNIQUE",
+        "ip TEXT NOT NULL",
+        "user_agent TEXT NOT NULL",
+        "ua_family TEXT NOT NULL",
+        "ua_os TEXT NOT NULL",
+        "ua_device TEXT NOT NULL",
+        "label TEXT NULL",
+        "last_seen_at TIMESTAMP NOT NULL",
+    ] {
+        assert!(up.contains(column), "up.sql missing column: {column}\n{up}");
+    }
+    let down = fs::read_to_string(migrations[0].path().join("down.sql")).unwrap();
+    assert!(
+        down.contains("DROP TABLE user_sessions"),
+        "down.sql must drop user_sessions"
+    );
+    // Dependent table must drop before the referenced users table.
+    assert!(
+        down.find("DROP TABLE user_sessions").unwrap() < down.find("DROP TABLE users").unwrap(),
+        "user_sessions must be dropped before users"
+    );
+
+    // schema.rs gains the table block.
+    let schema = fs::read_to_string(project.join("src/schema.rs")).unwrap();
+    assert!(
+        schema.contains("user_sessions (id)"),
+        "schema.rs missing user_sessions block"
+    );
+    assert!(
+        schema.contains("token_digest -> Text"),
+        "schema.rs missing token_digest column"
+    );
+
+    // Model file: session row + revocation APIs on the user model (AC3).
+    let model = fs::read_to_string(project.join("src/models/user_session.rs")).unwrap();
+    assert!(
+        model.contains("pub struct UserSession"),
+        "model missing UserSession struct"
+    );
+    for needle in [
+        "pub token_digest: String",
+        "pub last_seen_at: chrono::NaiveDateTime",
+        "pub label: Option<String>",
+        "pub async fn sessions(",
+        "pub async fn revoke_session(",
+        "pub async fn revoke_other_sessions(",
+        "pub async fn revoke_all_sessions(",
+    ] {
+        assert!(model.contains(needle), "user_session.rs missing: {needle}");
+    }
+    // The raw session id must never be stored — only its digest.
+    assert!(
+        !model.contains("pub token: String"),
+        "raw session token must not be stored"
+    );
+
+    let mod_rs = fs::read_to_string(project.join("src/models/mod.rs")).unwrap();
+    assert!(
+        mod_rs.contains("pub mod user_session;"),
+        "models/mod.rs missing pub mod user_session"
+    );
+}
+
+/// AC2 + AC4 + AC6 — routes record the session on login, validate it on
+/// authenticated requests (with bounded last_seen_at writes), destroy
+/// revoked sessions immediately, and serve the /account/sessions page.
+#[test]
+fn generate_auth_sessions_routes_and_page() {
+    let (_tmp, project) = fresh_project("auth-sess-routes");
+    run_autumn(&project, &["generate", "auth", "User"]);
+
+    let routes = fs::read_to_string(project.join("src/routes/auth.rs")).unwrap();
+
+    // Login + logout lifecycle.
+    assert!(
+        routes.contains("pub async fn record_login_session"),
+        "routes missing record_login_session helper"
+    );
+    assert!(
+        routes.contains("pub async fn session_token_digest"),
+        "routes missing session_token_digest helper"
+    );
+    assert!(
+        routes.contains("autumn_web::user_agent::parse_user_agent"),
+        "login must parse the User-Agent via autumn_web::user_agent"
+    );
+    // The tracked-session gate: row lookup + throttled last_seen_at update.
+    assert!(
+        routes.contains("pub async fn require_tracked_session"),
+        "routes missing require_tracked_session gate"
+    );
+    assert!(
+        routes.contains("last_seen_update_secs"),
+        "last_seen_at updates must be throttled via config"
+    );
+    // Revoked sessions are destroyed so a replayed cookie cannot resurrect them.
+    assert!(
+        routes.contains("session.destroy()"),
+        "require_tracked_session must destroy revoked sessions"
+    );
+
+    // The sessions page + revocation handlers (AC6).
+    for needle in [
+        "pub async fn sessions_page",
+        "pub async fn sessions_revoke",
+        "pub async fn sessions_revoke_others",
+        "pub async fn sessions_label",
+        "#[get(\"/account/sessions\")]",
+        "#[post(\"/account/sessions/{id}/revoke\")]",
+        "#[post(\"/account/sessions/revoke-others\")]",
+        "#[post(\"/account/sessions/{id}/label\")]",
+    ] {
+        assert!(routes.contains(needle), "routes/auth.rs missing: {needle}");
+    }
+    // htmx-powered page with a one-click "sign out everywhere else".
+    assert!(
+        routes.contains("hx-post"),
+        "sessions page must use htmx for revocation"
+    );
+    assert!(
+        routes.to_lowercase().contains("sign out everywhere else"),
+        "sessions page must offer one-click bulk revocation"
+    );
+
+    // main.rs registers the new handlers.
+    let main = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    for entry in [
+        "routes::auth::sessions_page",
+        "routes::auth::sessions_revoke",
+        "routes::auth::sessions_revoke_others",
+        "routes::auth::sessions_label",
+    ] {
+        assert!(main.contains(entry), "main.rs missing route: {entry}");
+    }
+}
+
+/// AC5 (password change) — resetting the password revokes existing sessions
+/// by default, gated on the `[auth.sessions]` config flag.
+#[test]
+fn generate_auth_reset_password_revokes_sessions() {
+    let (_tmp, project) = fresh_project("auth-sess-reset");
+    run_autumn(&project, &["generate", "auth", "User"]);
+
+    let routes = fs::read_to_string(project.join("src/routes/auth.rs")).unwrap();
+    let reset_body = &routes[routes.find("pub async fn reset_password(").unwrap()..];
+    let reset_body = &reset_body[..reset_body.find("\n// ──").unwrap_or(reset_body.len())];
+    assert!(
+        reset_body.contains("revoke_all_sessions"),
+        "reset_password must revoke existing sessions"
+    );
+    assert!(
+        reset_body.contains("revoke_on_credential_change"),
+        "session revocation on password change must be configurable"
+    );
+    assert!(
+        reset_body.contains("record_login_session"),
+        "reset_password logs the user in and must record the new session"
+    );
+}
+
+/// AC5 (TOTP) — enrollment and disable revoke all *other* sessions by default.
+#[test]
+fn generate_auth_totp_changes_revoke_other_sessions() {
+    let (_tmp, project) = fresh_project("auth-sess-totp");
+    run_autumn(&project, &["generate", "auth", "User", "--totp"]);
+
+    let routes = fs::read_to_string(project.join("src/routes/auth.rs")).unwrap();
+    for handler in [
+        "pub async fn two_factor_confirm",
+        "pub async fn two_factor_disable",
+    ] {
+        let start = routes
+            .find(handler)
+            .unwrap_or_else(|| panic!("missing {handler}"));
+        let body = &routes[start..];
+        let body = &body[..body.find("\n/// `").unwrap_or(body.len())];
+        assert!(
+            body.contains("revoke_other_sessions"),
+            "{handler} must revoke other sessions"
+        );
+        assert!(
+            body.contains("revoke_on_credential_change"),
+            "{handler} revocation must be configurable"
+        );
+    }
+    // Completing a TOTP login also records the session row.
+    assert!(
+        routes.contains("pub async fn login_verify"),
+        "missing login_verify"
+    );
+    let verify = &routes[routes.find("pub async fn login_verify(").unwrap()..];
+    assert!(
+        verify.contains("record_login_session"),
+        "login_verify completes a login and must record the session row"
+    );
+}
+
+/// AC5 (WebAuthn) — passkey add/remove revoke all *other* sessions by default,
+/// and passkey login records a session row.
+#[test]
+fn generate_auth_passkeys_changes_revoke_other_sessions() {
+    let (_tmp, project) = fresh_project("auth-sess-passkeys");
+    run_autumn(&project, &["generate", "auth", "User", "--passkeys"]);
+
+    let routes = fs::read_to_string(project.join("src/routes/passkeys.rs")).unwrap();
+    for handler in [
+        "pub async fn passkey_register_finish",
+        "pub async fn passkey_revoke",
+    ] {
+        let start = routes
+            .find(handler)
+            .unwrap_or_else(|| panic!("missing {handler}"));
+        let body = &routes[start..];
+        let body = &body[..body.find("\n/// `").unwrap_or(body.len())];
+        assert!(
+            body.contains("revoke_other_sessions"),
+            "{handler} must revoke other sessions"
+        );
+        assert!(
+            body.contains("revoke_on_credential_change"),
+            "{handler} revocation must be configurable"
+        );
+    }
+    let login_finish = &routes[routes.find("pub async fn passkey_login_finish(").unwrap()..];
+    assert!(
+        login_finish.contains("record_login_session"),
+        "passkey_login_finish completes a login and must record the session row"
+    );
+}
+
+/// AC7 — the generated integration tests cover the two-client revocation flow.
+#[test]
+fn generate_auth_sessions_tests_emitted() {
+    let (_tmp, project) = fresh_project("auth-sess-tests");
+    run_autumn(&project, &["generate", "auth", "User"]);
+
+    let tests = fs::read_to_string(project.join("tests/auth_sessions.rs")).unwrap();
+    for needle in [
+        "fn sessions_page_rejects_anonymous",
+        "fn revoked_session_next_request_401s",
+        "fn revoke_other_sessions_keeps_current_session_alive",
+        "/account/sessions",
+    ] {
+        assert!(
+            tests.contains(needle),
+            "tests/auth_sessions.rs missing: {needle}"
+        );
+    }
+}
+
+/// AC8 — documentation covers privacy posture for stored IP/UA and how to
+/// plug in a custom User-Agent parser.
+#[test]
+fn generate_auth_sessions_docs_emitted() {
+    let (_tmp, project) = fresh_project("auth-sess-docs");
+    run_autumn(&project, &["generate", "auth", "User"]);
+
+    let docs = fs::read_to_string(project.join("docs/guide/session-management.md")).unwrap();
+    for needle in [
+        "## Privacy",
+        "retention",
+        "parse_user_agent",
+        "revoke_on_credential_change",
+        "/account/sessions",
+        "CREATE TABLE user_sessions",
+    ] {
+        assert!(
+            docs.contains(needle),
+            "session-management.md missing: {needle}"
+        );
+    }
+}

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -2161,7 +2161,7 @@ fn generate_auth_sessions_migration_schema_and_model() {
 }
 
 /// AC2 + AC4 + AC6 — routes record the session on login, validate it on
-/// authenticated requests (with bounded last_seen_at writes), destroy
+/// authenticated requests (with bounded `last_seen_at` writes), destroy
 /// revoked sessions immediately, and serve the /account/sessions page.
 #[test]
 fn generate_auth_sessions_routes_and_page() {
@@ -2294,7 +2294,7 @@ fn generate_auth_totp_changes_revoke_other_sessions() {
     );
 }
 
-/// AC5 (WebAuthn) — passkey add/remove revoke all *other* sessions by default,
+/// AC5 (`WebAuthn`) — passkey add/remove revoke all *other* sessions by default,
 /// and passkey login records a session row.
 #[test]
 fn generate_auth_passkeys_changes_revoke_other_sessions() {
@@ -2366,6 +2366,93 @@ fn generate_auth_sessions_docs_emitted() {
         assert!(
             docs.contains(needle),
             "session-management.md missing: {needle}"
+        );
+    }
+}
+
+/// PR #1176 review hardening: reauth must re-point the tracked session row
+/// after rotating the session id (otherwise step-up locks the user out),
+/// every protected handler — including GET form pages — must go through the
+/// tracked-session gate, and the revocation controls must work without
+/// JavaScript (real forms, htmx as progressive enhancement).
+#[test]
+fn generate_auth_sessions_review_hardening() {
+    let (_tmp, project) = fresh_project("auth-sess-hardening");
+    run_autumn(&project, &["generate", "auth", "User"]);
+    let routes = fs::read_to_string(project.join("src/routes/auth.rs")).unwrap();
+
+    // P1: reauth rotates the session id and must rebind the tracked row to
+    // the new digest, after the rotation.
+    let reauth_start = routes
+        .find("pub async fn reauth(")
+        .expect("missing reauth handler");
+    let reauth = &routes[reauth_start..];
+    let reauth = &reauth[..reauth.find("\n// ──").unwrap_or(reauth.len())];
+    let rotate_at = reauth
+        .find("session.rotate_id()")
+        .expect("reauth must rotate");
+    let rebind_at = reauth
+        .find("rebind_tracked_session")
+        .expect("reauth must rebind the tracked session row after rotation");
+    assert!(
+        rotate_at < rebind_at,
+        "reauth must rebind AFTER rotating the session id"
+    );
+
+    // P2: protected GET form pages validate the tracked row too, so a revoked
+    // device's next request 401s no matter which authenticated route it hits.
+    for handler in [
+        "pub async fn data_export_form",
+        "pub async fn delete_account_form",
+        "pub async fn reauth_form",
+    ] {
+        let start = routes
+            .find(handler)
+            .unwrap_or_else(|| panic!("missing {handler}"));
+        let body = &routes[start..];
+        let body = &body[..body.find("\n/// `").unwrap_or(body.len())];
+        assert!(
+            body.contains("require_tracked_session"),
+            "{handler} must validate the tracked session row"
+        );
+    }
+
+    // P2: revocation controls are real POST forms (usable without JS), with
+    // htmx attributes for in-place swaps when JS is available.
+    assert!(
+        routes.contains("form method=\"post\" action=\"/account/sessions/revoke-others\""),
+        "bulk revoke must be a real form for non-JS fallback"
+    );
+    assert!(
+        routes.contains("action={ \"/account/sessions/\" (s.id) \"/revoke\" }"),
+        "per-session revoke must be a real form for non-JS fallback"
+    );
+    assert!(
+        routes.contains("hx-post=\"/account/sessions/revoke-others\""),
+        "bulk revoke keeps htmx enhancement"
+    );
+}
+
+/// PR #1176 review hardening for `--passkeys`: the registration page and
+/// challenge endpoint must also validate the tracked session row.
+#[test]
+fn generate_auth_passkeys_pages_gated_on_tracked_session() {
+    let (_tmp, project) = fresh_project("auth-sess-pk-gate");
+    run_autumn(&project, &["generate", "auth", "User", "--passkeys"]);
+    let routes = fs::read_to_string(project.join("src/routes/passkeys.rs")).unwrap();
+
+    for handler in [
+        "pub async fn passkey_register_page",
+        "pub async fn passkey_register_begin",
+    ] {
+        let start = routes
+            .find(handler)
+            .unwrap_or_else(|| panic!("missing {handler}"));
+        let body = &routes[start..];
+        let body = &body[..body.find("\n/// `").unwrap_or(body.len())];
+        assert!(
+            body.contains("require_tracked_session"),
+            "{handler} must validate the tracked session row"
         );
     }
 }

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -2244,7 +2244,7 @@ fn generate_auth_reset_password_revokes_sessions() {
     let reset_body = &routes[routes.find("pub async fn reset_password(").unwrap()..];
     let reset_body = &reset_body[..reset_body.find("\n// ──").unwrap_or(reset_body.len())];
     assert!(
-        reset_body.contains("revoke_all_sessions"),
+        reset_body.contains("revoke_existing_sessions") || reset_body.contains("user_sessions"),
         "reset_password must revoke existing sessions"
     );
     assert!(
@@ -2274,7 +2274,7 @@ fn generate_auth_totp_changes_revoke_other_sessions() {
         let body = &routes[start..];
         let body = &body[..body.find("\n/// `").unwrap_or(body.len())];
         assert!(
-            body.contains("revoke_other_sessions"),
+            body.contains("token_digest.ne(") || body.contains("revoke_other_sessions"),
             "{handler} must revoke other sessions"
         );
         assert!(
@@ -2455,4 +2455,111 @@ fn generate_auth_passkeys_pages_gated_on_tracked_session() {
             "{handler} must validate the tracked session row"
         );
     }
+}
+
+/// PR #1176 Codex round 2: login flows must delete the consumed session's
+/// tracked row before rotating (no phantom devices), the password-reset
+/// commit must be atomic with its session revocation (no consumed-token 500
+/// limbo), and the TOTP reset-commit path gets the same treatment.
+#[test]
+fn generate_auth_sessions_codex_round2() {
+    let (_tmp, project) = fresh_project("auth-sess-codex2");
+    run_autumn(&project, &["generate", "auth", "User"]);
+    let routes = fs::read_to_string(project.join("src/routes/auth.rs")).unwrap();
+
+    let body_of = |handler: &str| {
+        let start = routes
+            .find(handler)
+            .unwrap_or_else(|| panic!("missing {handler}"));
+        let body = &routes[start..];
+        &body[..body.find("\n/// `").unwrap_or(body.len())]
+    };
+
+    // Re-login from an already-tracked browser: the old row must be removed
+    // BEFORE the rotation that destroys its session id.
+    let login = body_of("pub async fn login(");
+    let untrack_at = login
+        .find("untrack_current_session")
+        .expect("login must untrack the consumed session row");
+    let rotate_at = login
+        .find("session.rotate_id()")
+        .expect("login must rotate");
+    assert!(
+        untrack_at < rotate_at,
+        "login must untrack BEFORE rotating the session id"
+    );
+    for handler in [
+        "pub async fn confirm_email(",
+        "pub async fn reset_password(",
+    ] {
+        assert!(
+            body_of(handler).contains("untrack_current_session"),
+            "{handler} rotates while logging in and must untrack the old row"
+        );
+    }
+    assert!(
+        body_of("pub async fn logout(").contains("untrack_current_session"),
+        "logout shares the untrack helper"
+    );
+
+    // Password change + session revocation + token consumption are one
+    // transaction: a failure rolls everything back so the reset link
+    // remains usable, and no path leaves sessions unrevoked after the
+    // password actually changed.
+    let reset = body_of("pub async fn reset_password(");
+    assert!(
+        reset.contains(".transaction"),
+        "reset_password must commit password + revocation atomically"
+    );
+    assert!(
+        reset.contains("revoke_on_credential_change") && reset.contains("user_sessions"),
+        "reset_password revocation must stay config-gated and target user_sessions"
+    );
+}
+
+/// PR #1176 Codex round 2 (`--totp`): the post-enrollment/disable revocation
+/// happens inside the existing transactions so a revocation failure can
+/// never 500 after the credential change committed (which would hide the
+/// one-time recovery codes), and the deferred-reset commit in `login_verify`
+/// is atomic with its revocation.
+#[test]
+fn generate_auth_totp_revocation_is_atomic() {
+    let (_tmp, project) = fresh_project("auth-sess-totp-atomic");
+    run_autumn(&project, &["generate", "auth", "User", "--totp"]);
+    let routes = fs::read_to_string(project.join("src/routes/auth.rs")).unwrap();
+
+    let body_of = |handler: &str| {
+        let start = routes
+            .find(handler)
+            .unwrap_or_else(|| panic!("missing {handler}"));
+        let body = &routes[start..];
+        &body[..body.find("\n/// `").unwrap_or(body.len())]
+    };
+
+    for handler in [
+        "pub async fn two_factor_confirm(",
+        "pub async fn two_factor_disable(",
+    ] {
+        let body = body_of(handler);
+        assert!(
+            body.contains("revoke_on_credential_change"),
+            "{handler} revocation must stay config-gated"
+        );
+        // The other-sessions delete lives inside the credential txn.
+        assert!(
+            body.contains("token_digest.ne("),
+            "{handler} must revoke other sessions inside its transaction"
+        );
+        assert!(
+            !body.contains("revoke_other_sessions(&mut *db"),
+            "{handler} must not revoke outside the transaction (a post-commit \
+             failure would 500 after the credential change)"
+        );
+    }
+
+    let verify = body_of("pub async fn login_verify(");
+    assert!(
+        verify.contains(".transaction"),
+        "login_verify's deferred password-reset commit must be atomic with revocation"
+    );
 }

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -466,6 +466,23 @@ pub struct AuthConfig {
     /// ```
     #[serde(default)]
     pub step_up: StepUpConfig,
+
+    /// Active-session tracking and revocation policy (issue #819).
+    ///
+    /// Controls whether credential-changing events (password change, TOTP
+    /// enrollment/disable, `WebAuthn` key add/remove) revoke all *other*
+    /// login sessions (default: on), and how often `last_seen_at` is
+    /// written per session.
+    ///
+    /// Configure in `autumn.toml`:
+    ///
+    /// ```toml
+    /// [auth.sessions]
+    /// revoke_on_credential_change = true
+    /// last_seen_update_secs = 60
+    /// ```
+    #[serde(default)]
+    pub sessions: SessionTrackingConfig,
 }
 
 /// Account lockout policy configuration.
@@ -547,6 +564,56 @@ impl Default for StepUpConfig {
     fn default() -> Self {
         Self {
             default_max_age_secs: crate::step_up::DEFAULT_MAX_AGE_SECS,
+        }
+    }
+}
+
+/// Active-session tracking configuration (issue #819).
+///
+/// Read from the `[auth.sessions]` section of `autumn.toml`. Used by the
+/// session-management machinery emitted by `autumn generate auth`: a
+/// persisted row per login session, a device list at `/account/sessions`,
+/// and per-session / bulk revocation.
+///
+/// ```toml
+/// [auth.sessions]
+/// revoke_on_credential_change = true  # default
+/// last_seen_update_secs = 60          # default
+/// ```
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+pub struct SessionTrackingConfig {
+    /// Revoke all *other* login sessions when credentials change —
+    /// password change/reset, TOTP enrollment or disable, and `WebAuthn`
+    /// key add/remove (default: `true`).
+    ///
+    /// Leave this on unless an external policy handles credential-change
+    /// hygiene: it is the standard response to credential theft.
+    #[serde(default = "default_true_flag")]
+    pub revoke_on_credential_change: bool,
+
+    /// Minimum number of seconds between `last_seen_at` writes for a given
+    /// session (default: `60`).
+    ///
+    /// Bounds write amplification: authenticated requests inside the window
+    /// skip the `UPDATE`, so a busy session costs at most one write per
+    /// window rather than one per request.
+    #[serde(default = "default_last_seen_update_secs")]
+    pub last_seen_update_secs: u64,
+}
+
+const fn default_true_flag() -> bool {
+    true
+}
+
+const fn default_last_seen_update_secs() -> u64 {
+    60
+}
+
+impl Default for SessionTrackingConfig {
+    fn default() -> Self {
+        Self {
+            revoke_on_credential_change: true,
+            last_seen_update_secs: default_last_seen_update_secs(),
         }
     }
 }
@@ -1368,6 +1435,7 @@ impl Default for AuthConfig {
             webauthn: WebAuthnConfig::default(),
             lockout: LockoutConfig::default(),
             step_up: StepUpConfig::default(),
+            sessions: SessionTrackingConfig::default(),
         }
     }
 }
@@ -1988,6 +2056,30 @@ mod tests {
         assert_eq!(config.session_key, "user_id");
         #[cfg(feature = "oauth2")]
         assert!(config.oauth2.providers.is_empty());
+    }
+
+    /// Issue #819 — credential-changing events revoke other sessions by
+    /// default, and `last_seen_at` writes are throttled to one per minute.
+    #[test]
+    fn session_tracking_config_defaults_to_revoke_on_credential_change() {
+        let config = AuthConfig::default();
+        assert!(config.sessions.revoke_on_credential_change);
+        assert_eq!(config.sessions.last_seen_update_secs, 60);
+    }
+
+    /// `[auth.sessions]` can be disabled / tuned from `autumn.toml`.
+    #[test]
+    fn session_tracking_config_deserializes_from_toml() {
+        let cfg: crate::config::AutumnConfig = toml::from_str(
+            r"
+            [auth.sessions]
+            revoke_on_credential_change = false
+            last_seen_update_secs = 5
+            ",
+        )
+        .expect("config must parse");
+        assert!(!cfg.auth.sessions.revoke_on_credential_change);
+        assert_eq!(cfg.auth.sessions.last_seen_update_secs, 5);
     }
 
     #[cfg(feature = "oauth2")]

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -203,6 +203,7 @@ pub mod step_up;
 pub mod storage;
 pub mod tenancy;
 pub mod time;
+pub mod user_agent;
 
 pub mod experiments;
 pub mod feature_flags;

--- a/autumn/src/user_agent.rs
+++ b/autumn/src/user_agent.rs
@@ -93,9 +93,12 @@ pub fn parse_user_agent(ua: &str) -> ParsedUserAgent {
         };
     }
 
-    let family = parse_family(&lower);
+    // Scan for bot markers once; the result feeds both the family and the
+    // device class so the string is not re-scanned per field.
+    let bot = bot_family(&lower);
+    let family = bot.unwrap_or_else(|| parse_family(&lower));
     let os = parse_os(&lower);
-    let device_class = parse_device_class(&lower, family);
+    let device_class = parse_device_class(&lower, family, os, bot.is_some());
 
     ParsedUserAgent {
         family: family.to_owned(),
@@ -137,10 +140,8 @@ fn bot_family(lower: &str) -> Option<&'static str> {
         })
 }
 
+/// Browser family for non-bot agents; `bot_family` is checked by the caller.
 fn parse_family(lower: &str) -> &'static str {
-    if let Some(bot) = bot_family(lower) {
-        return bot;
-    }
     // Order matters: Edge/Opera/Samsung Internet embed "chrome", and
     // Chrome embeds "safari", so check the most specific tokens first.
     if lower.contains("edg/") || lower.contains("edge/") {
@@ -179,8 +180,8 @@ fn parse_os(lower: &str) -> &'static str {
     }
 }
 
-fn parse_device_class(lower: &str, family: &'static str) -> DeviceClass {
-    if bot_family(lower).is_some() {
+fn parse_device_class(lower: &str, family: &str, os: &str, is_bot: bool) -> DeviceClass {
+    if is_bot {
         return DeviceClass::Bot;
     }
     if lower.contains("ipad") || lower.contains("tablet") {
@@ -197,7 +198,7 @@ fn parse_device_class(lower: &str, family: &'static str) -> DeviceClass {
     if lower.contains("iphone") || lower.contains("ipod") || lower.contains("mobile") {
         return DeviceClass::Mobile;
     }
-    if family == "Unknown" && parse_os(lower) == "Unknown" {
+    if family == "Unknown" && os == "Unknown" {
         return DeviceClass::Unknown;
     }
     DeviceClass::Desktop

--- a/autumn/src/user_agent.rs
+++ b/autumn/src/user_agent.rs
@@ -1,0 +1,342 @@
+//! Lightweight `User-Agent` parsing for login-session device attribution.
+//!
+//! Powers the device list emitted by `autumn generate auth` (issue #819):
+//! each login session stores the raw `User-Agent` plus the parsed browser
+//! family, operating system, and device class so a "where am I signed in?"
+//! page can render a human-readable device line without re-parsing on read.
+//!
+//! This is a deliberately small heuristic parser — no regex tables, no
+//! external database — tuned for the major browser/OS families. Apps that
+//! need exhaustive coverage (exotic devices, bot taxonomies) can swap in a
+//! dedicated crate: the generated auth starter funnels every parse through
+//! one call site, so replacing the parser is a one-line change. See the
+//! generated `docs/guide/session-management.md` for the recipe.
+//!
+//! ## Example
+//!
+//! ```rust
+//! use autumn_web::user_agent::{parse_user_agent, DeviceClass};
+//!
+//! let ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
+//!           (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+//! let parsed = parse_user_agent(ua);
+//! assert_eq!(parsed.family, "Chrome");
+//! assert_eq!(parsed.os, "macOS");
+//! assert_eq!(parsed.device_class, DeviceClass::Desktop);
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+/// Coarse device classification derived from a `User-Agent` string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum DeviceClass {
+    /// Desktop or laptop browser.
+    Desktop,
+    /// Phone-class device.
+    Mobile,
+    /// Tablet-class device.
+    Tablet,
+    /// Crawler, monitoring agent, or scripted client.
+    Bot,
+    /// Could not be classified.
+    #[default]
+    Unknown,
+}
+
+impl DeviceClass {
+    /// Stable lowercase label, suitable for storing in a TEXT column.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Desktop => "desktop",
+            Self::Mobile => "mobile",
+            Self::Tablet => "tablet",
+            Self::Bot => "bot",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for DeviceClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The result of parsing a `User-Agent` header.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ParsedUserAgent {
+    /// Browser or client family, e.g. `"Firefox"`, `"Chrome"`, `"curl"`.
+    /// `"Unknown"` when unrecognised.
+    pub family: String,
+    /// Operating system, e.g. `"Windows"`, `"macOS"`, `"iOS"`.
+    /// `"Unknown"` when unrecognised.
+    pub os: String,
+    /// Coarse device class.
+    pub device_class: DeviceClass,
+}
+
+/// Parse a `User-Agent` header value into family / OS / device class.
+///
+/// Heuristic, allocation-light, and total: never fails, returning
+/// `Unknown` fields for anything it cannot classify (including the empty
+/// string).
+#[must_use]
+pub fn parse_user_agent(ua: &str) -> ParsedUserAgent {
+    let lower = ua.to_ascii_lowercase();
+    if lower.trim().is_empty() {
+        return ParsedUserAgent {
+            family: "Unknown".to_owned(),
+            os: "Unknown".to_owned(),
+            device_class: DeviceClass::Unknown,
+        };
+    }
+
+    let family = parse_family(&lower);
+    let os = parse_os(&lower);
+    let device_class = parse_device_class(&lower, family);
+
+    ParsedUserAgent {
+        family: family.to_owned(),
+        os: os.to_owned(),
+        device_class,
+    }
+}
+
+/// Scripted clients and crawlers, matched before browser families because
+/// many bots embed browser tokens (`"compatible; Googlebot/2.1"`).
+const BOT_MARKERS: &[(&str, &str)] = &[
+    ("googlebot", "Googlebot"),
+    ("bingbot", "Bingbot"),
+    ("duckduckbot", "DuckDuckBot"),
+    ("yandexbot", "YandexBot"),
+    ("baiduspider", "Baiduspider"),
+    ("curl/", "curl"),
+    ("wget/", "Wget"),
+    ("python-requests", "python-requests"),
+    ("python-urllib", "python-urllib"),
+    ("go-http-client", "Go-http-client"),
+    ("okhttp", "okhttp"),
+    ("postmanruntime", "PostmanRuntime"),
+    ("headlesschrome", "HeadlessChrome"),
+];
+
+fn bot_family(lower: &str) -> Option<&'static str> {
+    BOT_MARKERS
+        .iter()
+        .find(|(marker, _)| lower.contains(marker))
+        .map(|&(_, family)| family)
+        .or_else(|| {
+            // Generic crawler markers without a well-known name.
+            (lower.contains("bot/")
+                || lower.contains("bot;")
+                || lower.contains("crawler")
+                || lower.contains("spider"))
+            .then_some("Bot")
+        })
+}
+
+fn parse_family(lower: &str) -> &'static str {
+    if let Some(bot) = bot_family(lower) {
+        return bot;
+    }
+    // Order matters: Edge/Opera/Samsung Internet embed "chrome", and
+    // Chrome embeds "safari", so check the most specific tokens first.
+    if lower.contains("edg/") || lower.contains("edge/") {
+        "Edge"
+    } else if lower.contains("opr/") || lower.contains("opera") {
+        "Opera"
+    } else if lower.contains("samsungbrowser") {
+        "Samsung Internet"
+    } else if lower.contains("firefox/") || lower.contains("fxios/") {
+        "Firefox"
+    } else if lower.contains("crios/") || lower.contains("chrome/") || lower.contains("chromium/") {
+        "Chrome"
+    } else if lower.contains("safari/") {
+        "Safari"
+    } else {
+        "Unknown"
+    }
+}
+
+fn parse_os(lower: &str) -> &'static str {
+    // iOS before macOS: iPhone UAs contain "like mac os x".
+    if lower.contains("iphone") || lower.contains("ipad") || lower.contains("ipod") {
+        "iOS"
+    } else if lower.contains("android") {
+        "Android"
+    } else if lower.contains("windows") {
+        "Windows"
+    } else if lower.contains("mac os x") || lower.contains("macintosh") {
+        "macOS"
+    } else if lower.contains("cros") {
+        "ChromeOS"
+    } else if lower.contains("linux") || lower.contains("x11") {
+        "Linux"
+    } else {
+        "Unknown"
+    }
+}
+
+fn parse_device_class(lower: &str, family: &'static str) -> DeviceClass {
+    if bot_family(lower).is_some() {
+        return DeviceClass::Bot;
+    }
+    if lower.contains("ipad") || lower.contains("tablet") {
+        return DeviceClass::Tablet;
+    }
+    if lower.contains("android") {
+        // Android phones carry an explicit "mobile" token; tablets do not.
+        return if lower.contains("mobile") {
+            DeviceClass::Mobile
+        } else {
+            DeviceClass::Tablet
+        };
+    }
+    if lower.contains("iphone") || lower.contains("ipod") || lower.contains("mobile") {
+        return DeviceClass::Mobile;
+    }
+    if family == "Unknown" && parse_os(lower) == "Unknown" {
+        return DeviceClass::Unknown;
+    }
+    DeviceClass::Desktop
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parsed(ua: &str) -> (String, String, DeviceClass) {
+        let p = parse_user_agent(ua);
+        (p.family, p.os, p.device_class)
+    }
+
+    #[test]
+    fn chrome_on_macos_desktop() {
+        let ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+        assert_eq!(
+            parsed(ua),
+            ("Chrome".into(), "macOS".into(), DeviceClass::Desktop)
+        );
+    }
+
+    #[test]
+    fn firefox_on_windows_desktop() {
+        let ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0";
+        assert_eq!(
+            parsed(ua),
+            ("Firefox".into(), "Windows".into(), DeviceClass::Desktop)
+        );
+    }
+
+    #[test]
+    fn safari_on_iphone_is_mobile() {
+        let ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 \
+                  (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1";
+        assert_eq!(
+            parsed(ua),
+            ("Safari".into(), "iOS".into(), DeviceClass::Mobile)
+        );
+    }
+
+    #[test]
+    fn chrome_on_android_phone_is_mobile() {
+        let ua = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/123.0.0.0 Mobile Safari/537.36";
+        assert_eq!(
+            parsed(ua),
+            ("Chrome".into(), "Android".into(), DeviceClass::Mobile)
+        );
+    }
+
+    #[test]
+    fn android_without_mobile_token_is_tablet() {
+        let ua = "Mozilla/5.0 (Linux; Android 13; SM-X906C) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36";
+        assert_eq!(
+            parsed(ua),
+            ("Chrome".into(), "Android".into(), DeviceClass::Tablet)
+        );
+    }
+
+    #[test]
+    fn ipad_is_tablet() {
+        let ua = "Mozilla/5.0 (iPad; CPU OS 17_4 like Mac OS X) AppleWebKit/605.1.15 \
+                  (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1";
+        assert_eq!(
+            parsed(ua),
+            ("Safari".into(), "iOS".into(), DeviceClass::Tablet)
+        );
+    }
+
+    #[test]
+    fn edge_is_not_misread_as_chrome() {
+        let ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.2365.92";
+        assert_eq!(
+            parsed(ua),
+            ("Edge".into(), "Windows".into(), DeviceClass::Desktop)
+        );
+    }
+
+    #[test]
+    fn desktop_safari_is_not_misread_as_chrome() {
+        let ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 \
+                  (KHTML, like Gecko) Version/17.4 Safari/605.1.15";
+        assert_eq!(
+            parsed(ua),
+            ("Safari".into(), "macOS".into(), DeviceClass::Desktop)
+        );
+    }
+
+    #[test]
+    fn linux_firefox_desktop() {
+        let ua = "Mozilla/5.0 (X11; Linux x86_64; rv:124.0) Gecko/20100101 Firefox/124.0";
+        assert_eq!(
+            parsed(ua),
+            ("Firefox".into(), "Linux".into(), DeviceClass::Desktop)
+        );
+    }
+
+    #[test]
+    fn curl_is_a_bot_class_client() {
+        assert_eq!(
+            parsed("curl/8.4.0"),
+            ("curl".into(), "Unknown".into(), DeviceClass::Bot)
+        );
+    }
+
+    #[test]
+    fn googlebot_is_bot() {
+        let ua = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
+        let p = parse_user_agent(ua);
+        assert_eq!(p.device_class, DeviceClass::Bot);
+    }
+
+    #[test]
+    fn empty_string_is_unknown() {
+        assert_eq!(
+            parsed(""),
+            ("Unknown".into(), "Unknown".into(), DeviceClass::Unknown)
+        );
+    }
+
+    #[test]
+    fn garbage_is_unknown_not_panicking() {
+        assert_eq!(
+            parsed("\u{0} \u{ffff} ~~~///"),
+            ("Unknown".into(), "Unknown".into(), DeviceClass::Unknown)
+        );
+    }
+
+    #[test]
+    fn device_class_labels_are_stable() {
+        assert_eq!(DeviceClass::Desktop.as_str(), "desktop");
+        assert_eq!(DeviceClass::Mobile.as_str(), "mobile");
+        assert_eq!(DeviceClass::Tablet.as_str(), "tablet");
+        assert_eq!(DeviceClass::Bot.as_str(), "bot");
+        assert_eq!(DeviceClass::Unknown.as_str(), "unknown");
+    }
+}


### PR DESCRIPTION
## Summary

Implements comprehensive login session tracking and management for the auth starter generated by `autumn generate auth`. Users can now view all active login sessions across devices, revoke individual sessions or all others at once, and label devices for easy identification. Sessions are automatically revoked when credentials change (password reset, TOTP enrollment/disable).

## Key Changes

- **Session persistence**: Each login creates a `{user}_sessions` table row containing:
  - SHA-256 digest of the opaque session ID (never the raw ID, preventing database-leak replay attacks)
  - User ID, IP address, raw User-Agent, and parsed device attribution (browser family, OS, device class)
  - Optional user-set device label and `last_seen_at` timestamp
  - Automatic cleanup on logout and credential-change events

- **User-Agent parsing**: New `autumn_web::user_agent` module provides lightweight, allocation-light parsing for browser family, OS, and device class (desktop/mobile/tablet/bot) without external dependencies or regex tables. Single call site in generated code allows easy swapping for exhaustive parsers.

- **Per-request validation**: Generated `require_tracked_session()` gate validates the session row exists (401s immediately if revoked, even if cookie is replayed) and throttles `last_seen_at` updates via configurable `last_seen_update_secs` to bound write amplification.

- **Session management UI**: New `/account/sessions` page (Maud + htmx) displays active sessions with:
  - Device description (user label or parsed User-Agent)
  - Sign-in timestamp, IP, and last-seen time
  - Per-session revocation buttons
  - One-click "sign out everywhere else" bulk revocation

- **Model APIs**: Generated `{User}Session` model and revocation methods on the user model:
  - `sessions()` — list all active sessions
  - `revoke_session(id)` — revoke a single session
  - `revoke_other_sessions(current_digest)` — sign out all other devices
  - `revoke_all_sessions()` — sign out everywhere (used on password change)

- **Configuration**: New `[auth.sessions]` section in `autumn.toml`:
  - `revoke_on_credential_change` (default: true) — auto-revoke other sessions on password/TOTP/passkey changes
  - `last_seen_update_secs` (default: 60) — throttle window for `last_seen_at` writes

- **Migration and schema**: Generated migrations create `{user}_sessions` table with proper foreign key constraints and indexes; schema.rs updated with table definition.

- **Integration tests**: New `auth_sessions.rs` test file covering session lifecycle, revocation, and device attribution.

- **Documentation**: New `session-management.md` guide explaining the security model, configuration, and how to swap the User-Agent parser.

## Implementation Details

- Session token digest is computed via SHA-256 of the opaque session ID; only the digest is stored, so a compromised database cannot be replayed as a valid session cookie.
- Revocation is immediate: deleting the row causes the next request to 401 and destroy the cookie session, preventing resurrection via replay.
- `last_seen_at` updates are throttled to prevent write amplification on busy sessions (configurable window, default 60 seconds).
- The User-Agent parser is intentionally simple and single-call-site to allow apps to swap in specialized parsers (e.g., `uaparser`) without modifying generated code.
- All session-related routes are marked `#[secured]` and use `require_tracked_session()` to validate the session row before proceeding.

https://claude.ai/code/session_01Wu7dA9ofjvZCL1ZM6Q1vBS