### PR TITLE
Add structured per-request access log (#999)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **log:** Structured per-request access log, on by default (#999)
+  - Every served HTTP request now emits **exactly one** structured access-log
+    event (`tracing` target `autumn::access`, level `INFO`) at the response
+    boundary, carrying `method`, `route` (the matched low-cardinality template,
+    e.g. `/users/{id}` — never the raw path), `status`, `duration_ms`, and the
+    `request_id` that matches the `x-request-id` header and error pages.
+  - Rendered by the standard subscriber, so it honors `log.format`: a readable
+    line under `pretty`, a single JSON object per line under `json`. Works with
+    **no** `telemetry-otlp` feature and no OTLP collector — operators on
+    `docker logs` / platform log drains get request-level visibility for free.
+  - Steady-state probe/asset noise is excluded by default (`/health`,
+    `/actuator/*`, `/static/*`); the set is configurable via
+    `log.access_log_exclude` (whole-segment prefix matching). Unmatched
+    requests log the low-cardinality `_unmatched` route label.
+  - On by default; turn off with `log.access_log = false` in `autumn.toml` —
+    no recompile needed.
+  - The line never includes query strings, headers, or bodies, preserving the
+    log-scrubbing posture established for logs (#697) by construction.
+  - Additive `LogConfig` fields only (`access_log`, `access_log_exclude`);
+    non-breaking, minor version bump.
+
 - **log:** Request-scoped log context that auto-tags every log line (#1169)
   - An always-on `LogContextLayer` establishes a fresh `tokio::task_local`
     `log::context::LogContext` for **every** HTTP request, seeded with the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     **no** `telemetry-otlp` feature and no OTLP collector — operators on
     `docker logs` / platform log drains get request-level visibility for free.
   - Steady-state probe/asset noise is excluded by default (`/health`,
-    `/actuator/*`, `/static/*`); the set is configurable via
-    `log.access_log_exclude` (whole-segment prefix matching). Unmatched
-    requests log the low-cardinality `_unmatched` route label.
-  - On by default; turn off with `log.access_log = false` in `autumn.toml` —
-    no recompile needed.
+    `/live`, `/ready`, `/startup`, `/actuator/*`, `/static/*`); the set is
+    configurable via `log.access_log_exclude` (whole-segment prefix matching)
+    or `AUTUMN_LOG__ACCESS_LOG_EXCLUDE` (comma-separated). Unmatched requests
+    log the low-cardinality `_unmatched` route label.
+  - On by default; turn off with `log.access_log = false` in `autumn.toml`
+    or `AUTUMN_LOG__ACCESS_LOG=false` — no recompile needed.
   - The line never includes query strings, headers, or bodies, preserving the
     log-scrubbing posture established for logs (#697) by construction.
   - Additive `LogConfig` fields only (`access_log`, `access_log_exclude`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     boundary, carrying `method`, `route` (the matched low-cardinality template,
     e.g. `/users/{id}` — never the raw path), `status`, `duration_ms`, and the
     `request_id` that matches the `x-request-id` header and error pages.
-  - Emitted from the **outermost** router boundary — outside the startup
-    barrier, the static-first (SSG/ISR) middleware, the session layer, the
-    exception-filter chain, and the late-mounted MCP endpoint merge — so the
-    logged status is always the status the client receives (startup 503s,
-    pre-built static page hits, session-store outage 503s, and
-    filter-rewritten error responses included).
+  - Dual placement: the **primary** layer emits inside the request
+    span/log context (correlated, request id from the request extension) and
+    marks the response; an **outermost fallback** at the router assembly
+    boundary logs only responses the primary never saw — startup 503s,
+    pre-built static (SSG/ISR) page hits, session-store outage 503s, and
+    requests to the late-mounted MCP endpoint — with the wire status and no
+    request id (those paths never run `RequestIdLayer`).
   - Rendered by the standard subscriber, so it honors `log.format`: a readable
     line under `pretty`, a single JSON object per line under `json`. Works with
     **no** `telemetry-otlp` feature and no OTLP collector — operators on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     boundary, carrying `method`, `route` (the matched low-cardinality template,
     e.g. `/users/{id}` — never the raw path), `status`, `duration_ms`, and the
     `request_id` that matches the `x-request-id` header and error pages.
+  - Emitted from the **outermost** router boundary — outside the startup
+    barrier, the static-first (SSG/ISR) middleware, the session layer, the
+    exception-filter chain, and the late-mounted MCP endpoint merge — so the
+    logged status is always the status the client receives (startup 503s,
+    pre-built static page hits, session-store outage 503s, and
+    filter-rewritten error responses included).
   - Rendered by the standard subscriber, so it honors `log.format`: a readable
     line under `pretty`, a single JSON object per line under `json`. Works with
     **no** `telemetry-otlp` feature and no OTLP collector — operators on

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2016,6 +2016,12 @@ impl AutumnConfig {
 
     fn apply_log_env_overrides_with_env(&mut self, env: &dyn Env) {
         parse_env_string(env, "AUTUMN_LOG__LEVEL", &mut self.log.level);
+        parse_env_bool(env, "AUTUMN_LOG__ACCESS_LOG", &mut self.log.access_log);
+        parse_env_csv(
+            env,
+            "AUTUMN_LOG__ACCESS_LOG_EXCLUDE",
+            &mut self.log.access_log_exclude,
+        );
         if let Ok(val) = env.var("AUTUMN_LOG__FORMAT") {
             match val.as_str() {
                 "Auto" => self.log.format = LogFormat::Auto,
@@ -3037,12 +3043,14 @@ pub struct LogConfig {
     pub access_log: bool,
 
     /// Path prefixes excluded from access logging so steady-state probe and
-    /// asset traffic does not drown application signal.
-    /// Default: `["/health", "/actuator", "/static"]`.
+    /// asset traffic does not drown application signal. Default:
+    /// `["/health", "/live", "/ready", "/startup", "/actuator", "/static"]`
+    /// (the built-in probe, actuator, and static-asset mounts).
     ///
     /// Prefixes match whole path segments: `"/actuator"` excludes
     /// `/actuator/health` but not `/actuators`. Setting this replaces the
-    /// default set entirely.
+    /// default set entirely — and if you move the probe endpoints
+    /// (`health.path` etc.), mirror the new paths here.
     #[serde(default = "default_access_log_exclude")]
     pub access_log_exclude: Vec<String>,
 }
@@ -3505,6 +3513,9 @@ const fn default_access_log() -> bool {
 fn default_access_log_exclude() -> Vec<String> {
     vec![
         "/health".to_owned(),
+        "/live".to_owned(),
+        "/ready".to_owned(),
+        "/startup".to_owned(),
         "/actuator".to_owned(),
         "/static".to_owned(),
     ]
@@ -4314,8 +4325,31 @@ path = "/healthz"
         assert!(log.access_log);
         assert_eq!(
             log.access_log_exclude,
-            vec!["/health", "/actuator", "/static"]
+            vec![
+                "/health",
+                "/live",
+                "/ready",
+                "/startup",
+                "/actuator",
+                "/static"
+            ]
         );
+    }
+
+    #[test]
+    fn env_override_access_log_off() {
+        let env = MockEnv::new().with("AUTUMN_LOG__ACCESS_LOG", "false");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert!(!config.log.access_log);
+    }
+
+    #[test]
+    fn env_override_access_log_exclude_csv() {
+        let env = MockEnv::new().with("AUTUMN_LOG__ACCESS_LOG_EXCLUDE", "/internal, /probes");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.log.access_log_exclude, vec!["/internal", "/probes"]);
     }
 
     #[test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -3002,6 +3002,7 @@ impl DatabaseConfig {
 /// let log = LogConfig::default();
 /// assert_eq!(log.level, "info");
 /// assert_eq!(log.format, LogFormat::Auto);
+/// assert!(log.access_log);
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 pub struct LogConfig {
@@ -3023,6 +3024,27 @@ pub struct LogConfig {
     /// Explicitly remove default sensitive keys from the built-in deny-list.
     #[serde(default)]
     pub unfilter_parameters: Vec<String>,
+
+    /// Emit one structured access-log event per served HTTP request.
+    /// Default: `true`.
+    ///
+    /// The event (target `autumn::access`, level `INFO`) carries `method`,
+    /// `route` (the matched low-cardinality template), `status`,
+    /// `duration_ms`, and `request_id`, and is rendered by the standard
+    /// subscriber according to [`format`](Self::format). It requires no
+    /// telemetry feature or collector.
+    #[serde(default = "default_access_log")]
+    pub access_log: bool,
+
+    /// Path prefixes excluded from access logging so steady-state probe and
+    /// asset traffic does not drown application signal.
+    /// Default: `["/health", "/actuator", "/static"]`.
+    ///
+    /// Prefixes match whole path segments: `"/actuator"` excludes
+    /// `/actuator/health` but not `/actuators`. Setting this replaces the
+    /// default set entirely.
+    #[serde(default = "default_access_log_exclude")]
+    pub access_log_exclude: Vec<String>,
 }
 
 /// Log output format.
@@ -3476,6 +3498,18 @@ fn default_log_level() -> String {
     "info".to_owned()
 }
 
+const fn default_access_log() -> bool {
+    true
+}
+
+fn default_access_log_exclude() -> Vec<String> {
+    vec![
+        "/health".to_owned(),
+        "/actuator".to_owned(),
+        "/static".to_owned(),
+    ]
+}
+
 fn default_telemetry_service_name() -> String {
     "autumn-app".to_owned()
 }
@@ -3543,6 +3577,8 @@ impl Default for LogConfig {
             format: LogFormat::default(),
             filter_parameters: Vec::new(),
             unfilter_parameters: Vec::new(),
+            access_log: default_access_log(),
+            access_log_exclude: default_access_log_exclude(),
         }
     }
 }
@@ -4270,6 +4306,31 @@ path = "/healthz"
         assert_eq!(config.server.host, "127.0.0.1");
         assert_eq!(config.database.pool_size, 10);
         assert_eq!(config.log.level, "info");
+    }
+
+    #[test]
+    fn access_log_defaults_on_with_probe_and_asset_exclusions() {
+        let log = LogConfig::default();
+        assert!(log.access_log);
+        assert_eq!(
+            log.access_log_exclude,
+            vec!["/health", "/actuator", "/static"]
+        );
+    }
+
+    #[test]
+    fn access_log_is_configurable_from_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("autumn.toml");
+        std::fs::write(
+            &path,
+            "[log]\naccess_log = false\naccess_log_exclude = [\"/internal\"]\n",
+        )
+        .unwrap();
+
+        let config = AutumnConfig::load_from(&path).unwrap();
+        assert!(!config.log.access_log);
+        assert_eq!(config.log.access_log_exclude, vec!["/internal"]);
     }
 
     #[test]

--- a/autumn/src/log/context.rs
+++ b/autumn/src/log/context.rs
@@ -6,8 +6,9 @@
 //! tenant id. Handler and service code can attach additional fields with
 //! [`with_log_field`]; those fields are then observable by every
 //! context-aware consumer for the remainder of the request — the actuator log
-//! buffer (#1168), the per-request access line (#999), and any custom
-//! [`tracing`] layer.
+//! buffer (#1168) and any custom [`tracing`] layer. (The per-request access
+//! line (#999) is emitted at the outermost router boundary, outside this
+//! context, and carries its own `request_id` field.)
 //!
 //! The context lives in a [`tokio::task_local`], mirroring the pattern already
 //! used by tenancy and the database connection scope. It is **always-on** and
@@ -24,9 +25,8 @@
 //! The well-known correlation ids (`request_id`/`user_id`/`tenant_id`) ride the
 //! request span, so they appear in ordinary `tracing` output for every event.
 //! Custom fields added via [`with_log_field`] live in the request context and
-//! are surfaced by **structured** consumers — the actuator log buffer (#1168),
-//! the access line (#999), or any context-aware layer — rather than the default
-//! stdout formatter.
+//! are surfaced by **structured** consumers — the actuator log buffer (#1168)
+//! or any context-aware layer — rather than the default stdout formatter.
 //!
 //! # Example
 //!

--- a/autumn/src/log/context.rs
+++ b/autumn/src/log/context.rs
@@ -6,9 +6,8 @@
 //! tenant id. Handler and service code can attach additional fields with
 //! [`with_log_field`]; those fields are then observable by every
 //! context-aware consumer for the remainder of the request — the actuator log
-//! buffer (#1168) and any custom [`tracing`] layer. (The per-request access
-//! line (#999) is emitted at the outermost router boundary, outside this
-//! context, and carries its own `request_id` field.)
+//! buffer (#1168), the per-request access line (#999), and any custom
+//! [`tracing`] layer.
 //!
 //! The context lives in a [`tokio::task_local`], mirroring the pattern already
 //! used by tenancy and the database connection scope. It is **always-on** and
@@ -25,8 +24,9 @@
 //! The well-known correlation ids (`request_id`/`user_id`/`tenant_id`) ride the
 //! request span, so they appear in ordinary `tracing` output for every event.
 //! Custom fields added via [`with_log_field`] live in the request context and
-//! are surfaced by **structured** consumers — the actuator log buffer (#1168)
-//! or any context-aware layer — rather than the default stdout formatter.
+//! are surfaced by **structured** consumers — the actuator log buffer (#1168),
+//! the access line (#999), or any context-aware layer — rather than the default
+//! stdout formatter.
 //!
 //! # Example
 //!

--- a/autumn/src/middleware/access_log.rs
+++ b/autumn/src/middleware/access_log.rs
@@ -13,10 +13,11 @@
 //! bodies, preserving the log scrubbing posture established for logs (#697) by
 //! construction.
 //!
-//! Access logging is on by default (`log.access_log = true`). Steady-state
-//! probe and asset noise is excluded via `log.access_log_exclude`
-//! (default: `/health`, `/actuator`, `/static`), matched on whole path
-//! segments so `/healthz` is still logged while `/actuator/health` is not.
+//! Access logging is on by default (`log.access_log = true`; overridable via
+//! `AUTUMN_LOG__ACCESS_LOG`). Steady-state probe and asset noise is excluded
+//! via `log.access_log_exclude` (default: `/health`, `/live`, `/ready`,
+//! `/startup`, `/actuator`, `/static`), matched on whole path segments so
+//! `/healthz` is still logged while `/actuator/health` is not.
 //!
 //! Applied automatically by the framework router, inner to
 //! [`RequestIdLayer`](crate::middleware::RequestIdLayer) (so the request id is

--- a/autumn/src/middleware/access_log.rs
+++ b/autumn/src/middleware/access_log.rs
@@ -58,9 +58,27 @@ impl AccessLogLayer {
     #[must_use]
     pub fn new(exclude: Vec<String>) -> Self {
         Self {
-            exclude: exclude.into(),
+            exclude: normalize_exclusions(exclude),
         }
     }
+}
+
+/// Normalize configured exclusion prefixes once at construction so the
+/// per-request check is a plain prefix match: trailing slashes are stripped
+/// and empty / slash-only entries are dropped.
+fn normalize_exclusions(exclude: Vec<String>) -> Arc<[String]> {
+    exclude
+        .into_iter()
+        .map(|prefix| {
+            let trimmed = prefix.trim_end_matches('/');
+            if trimmed.len() == prefix.len() {
+                prefix
+            } else {
+                trimmed.to_owned()
+            }
+        })
+        .filter(|prefix| !prefix.is_empty())
+        .collect()
 }
 
 impl<S> Layer<S> for AccessLogLayer {
@@ -125,14 +143,11 @@ where
 
 /// Returns `true` when `path` equals an exclusion prefix or lives under it as
 /// a whole path segment (`/actuator` excludes `/actuator/health`, not
-/// `/actuators`). Trailing slashes on configured prefixes are ignored.
+/// `/actuators`). Prefixes are pre-normalized by [`normalize_exclusions`].
 fn is_excluded(path: &str, exclude: &[String]) -> bool {
     exclude.iter().any(|prefix| {
-        let prefix = prefix.trim_end_matches('/');
-        !prefix.is_empty()
-            && path
-                .strip_prefix(prefix)
-                .is_some_and(|rest| rest.is_empty() || rest.starts_with('/'))
+        path.strip_prefix(prefix.as_str())
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with('/'))
     })
 }
 
@@ -180,8 +195,8 @@ where
 mod tests {
     use super::*;
 
-    fn exclude(prefixes: &[&str]) -> Vec<String> {
-        prefixes.iter().map(|p| (*p).to_owned()).collect()
+    fn exclude(prefixes: &[&str]) -> Arc<[String]> {
+        normalize_exclusions(prefixes.iter().map(|p| (*p).to_owned()).collect())
     }
 
     #[test]

--- a/autumn/src/middleware/access_log.rs
+++ b/autumn/src/middleware/access_log.rs
@@ -20,14 +20,28 @@
 //! `/startup`, `/actuator`, `/static`), matched on whole path segments so
 //! `/healthz` is still logged while `/actuator/health` is not.
 //!
-//! Applied automatically by the framework router at the **outermost** assembly
-//! point — outside the startup barrier, the static-first (SSG/ISR) middleware,
-//! the session layer, and the exception-filter chain — so the logged `status`
-//! is always the status the client receives, including startup 503s,
-//! pre-built static page hits, session-store outage 503s, and
-//! filter-rewritten error responses. Short-circuit responses produced before
-//! `RequestIdLayer` runs carry no `x-request-id` and log without a
-//! `request_id` field.
+//! Applied automatically by the framework router in **two** positions:
+//!
+//! - The **primary** layer ([`AccessLogLayer::new`]) sits inner to
+//!   [`RequestIdLayer`](crate::middleware::RequestIdLayer) and the log-context
+//!   layer, so the event is emitted inside the request span with the request
+//!   id taken from the request extension. Once it emits, it flips the
+//!   [`AccessLogEmitted`] sentinel the fallback planted in the request
+//!   extensions, keeping the fallback silent.
+//! - A **fallback** layer ([`AccessLogLayer::fallback`]) sits at the outermost
+//!   router assembly point — outside the startup barrier, the static-first
+//!   (SSG/ISR) middleware, the session layer, and the late MCP endpoint
+//!   merge — and emits only for responses the primary never saw: startup
+//!   503s, pre-built static page hits, session-store outage 503s, and MCP
+//!   endpoint requests. Those short-circuits never ran `RequestIdLayer`, so
+//!   the fallback reads `request_id` from the `x-request-id` response header
+//!   when present and omits it otherwise.
+//!
+//! Known accepted tradeoff of the in-context primary placement: a custom
+//! exception filter (or a session-store save failure) that *rewrites* an
+//! already-produced response does so after the line was emitted, so the
+//! logged `status` reflects the handler's response in that narrow case. The
+//! built-in filters preserve status.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -50,21 +64,55 @@ pub const ACCESS_LOG_TARGET: &str = "autumn::access";
 /// `route` field low-cardinality. Mirrors the metrics layer.
 pub const UNMATCHED_ROUTE: &str = "_unmatched";
 
+/// Shared sentinel coordinating the primary and fallback access-log layers.
+///
+/// The fallback inserts it into the **request** extensions on the way in, and
+/// the primary flips it once it emits, so the fallback only logs requests
+/// that short-circuited before reaching the primary. It rides the request
+/// (not the response) because error-page/exception filters may rebuild the
+/// response entirely, which would drop a response-side marker.
+#[derive(Clone, Debug, Default)]
+pub struct AccessLogEmitted(Arc<std::sync::atomic::AtomicBool>);
+
+impl AccessLogEmitted {
+    fn mark(&self) {
+        self.0.store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    fn is_marked(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Acquire)
+    }
+}
+
 /// Tower [`Layer`] that emits one structured access-log event per served
 /// request. Applied automatically by the framework router when
 /// `log.access_log` is enabled (the default).
 #[derive(Clone, Debug)]
 pub struct AccessLogLayer {
     exclude: Arc<[String]>,
+    fallback: bool,
 }
 
 impl AccessLogLayer {
-    /// Create a new layer. Requests whose path falls under one of the
-    /// `exclude` prefixes (whole-segment match) are not logged.
+    /// Create the primary layer. Requests whose path falls under one of the
+    /// `exclude` prefixes (whole-segment match) are not logged. Emitted
+    /// responses are stamped with [`AccessLogEmitted`].
     #[must_use]
     pub fn new(exclude: Vec<String>) -> Self {
         Self {
             exclude: normalize_exclusions(exclude),
+            fallback: false,
+        }
+    }
+
+    /// Create the outermost fallback layer: it emits only for responses that
+    /// do **not** carry the [`AccessLogEmitted`] marker — i.e. requests that
+    /// short-circuited before the primary layer ran.
+    #[must_use]
+    pub fn fallback(exclude: Vec<String>) -> Self {
+        Self {
+            exclude: normalize_exclusions(exclude),
+            fallback: true,
         }
     }
 }
@@ -94,6 +142,7 @@ impl<S> Layer<S> for AccessLogLayer {
         AccessLogService {
             inner,
             exclude: Arc::clone(&self.exclude),
+            fallback: self.fallback,
         }
     }
 }
@@ -103,6 +152,7 @@ impl<S> Layer<S> for AccessLogLayer {
 pub struct AccessLogService<S> {
     inner: S,
     exclude: Arc<[String]>,
+    fallback: bool,
 }
 
 /// Request facts captured before the inner service consumes the request.
@@ -110,6 +160,7 @@ pub struct AccessLogService<S> {
 struct RequestMeta {
     method: Method,
     route: Option<String>,
+    request_id: Option<String>,
 }
 
 impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for AccessLogService<S>
@@ -125,6 +176,7 @@ where
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let mut req = req;
         let meta = if is_excluded(req.uri().path(), &self.exclude) {
             None
         } else {
@@ -134,13 +186,32 @@ where
                     .extensions()
                     .get::<MatchedPath>()
                     .map(|matched| matched.as_str().to_owned()),
+                // Set by RequestIdLayer, which sits outer to the primary
+                // layer. Absent at the outermost fallback position.
+                request_id: req
+                    .extensions()
+                    .get::<crate::middleware::RequestId>()
+                    .map(ToString::to_string),
             })
+        };
+
+        // The fallback plants the sentinel for the primary to flip; the
+        // primary picks it up when present (it is absent in bare setups
+        // that apply only the primary layer).
+        let sentinel = if self.fallback {
+            let sentinel = AccessLogEmitted::default();
+            req.extensions_mut().insert(sentinel.clone());
+            Some(sentinel)
+        } else {
+            req.extensions().get::<AccessLogEmitted>().cloned()
         };
 
         AccessLogFuture {
             inner: self.inner.call(req),
             meta,
             start: Instant::now(),
+            fallback: self.fallback,
+            sentinel,
         }
     }
 }
@@ -163,6 +234,8 @@ pin_project! {
         inner: F,
         meta: Option<RequestMeta>,
         start: Instant,
+        fallback: bool,
+        sentinel: Option<AccessLogEmitted>,
     }
 }
 
@@ -176,16 +249,25 @@ where
         let this = self.project();
         match this.inner.poll(cx) {
             Poll::Ready(Ok(response)) => {
-                if let Some(meta) = this.meta.take() {
+                let already_emitted = *this.fallback
+                    && this
+                        .sentinel
+                        .as_ref()
+                        .is_some_and(AccessLogEmitted::is_marked);
+                if let Some(meta) = this.meta.take()
+                    && !already_emitted
+                {
                     let duration_ms = this.start.elapsed().as_secs_f64() * 1000.0;
-                    // Read the request id off the response: the header is
-                    // stamped by RequestIdLayer, which sits inner to this
-                    // layer. Responses short-circuited before it (startup
-                    // 503s, static-first hits) have none and log without it.
-                    let request_id = response
+                    // The primary layer reads the id from the request
+                    // extension; the fallback covers short-circuits that may
+                    // never have run RequestIdLayer, so it falls back to the
+                    // `x-request-id` response header and omits the field when
+                    // neither is present.
+                    let header_id = response
                         .headers()
                         .get(&X_REQUEST_ID)
                         .and_then(|value| value.to_str().ok());
+                    let request_id = meta.request_id.as_deref().or(header_id);
                     tracing::info!(
                         target: ACCESS_LOG_TARGET,
                         method = %meta.method,
@@ -195,6 +277,11 @@ where
                         request_id,
                         "request served"
                     );
+                    if !*this.fallback
+                        && let Some(sentinel) = this.sentinel.as_ref()
+                    {
+                        sentinel.mark();
+                    }
                 }
                 Poll::Ready(Ok(response))
             }

--- a/autumn/src/middleware/access_log.rs
+++ b/autumn/src/middleware/access_log.rs
@@ -1,0 +1,216 @@
+//! Structured per-request access log (#999).
+//!
+//! Emits exactly one `tracing` event (target [`ACCESS_LOG_TARGET`], level
+//! `INFO`) at the point each response is returned, carrying the HTTP method,
+//! the matched low-cardinality route template (never the raw path), the
+//! response status code, the request duration in milliseconds, and the
+//! request's `request_id` (the same value used by the `x-request-id` header
+//! and error pages).
+//!
+//! The event flows through the already-installed subscriber, so it honors
+//! `LogConfig.format` (`pretty` / `json`) and works with **no** telemetry
+//! feature and no OTLP collector. It never includes query strings, headers, or
+//! bodies, preserving the log scrubbing posture established for logs (#697) by
+//! construction.
+//!
+//! Access logging is on by default (`log.access_log = true`). Steady-state
+//! probe and asset noise is excluded via `log.access_log_exclude`
+//! (default: `/health`, `/actuator`, `/static`), matched on whole path
+//! segments so `/healthz` is still logged while `/actuator/health` is not.
+//!
+//! Applied automatically by the framework router, inner to
+//! [`RequestIdLayer`](crate::middleware::RequestIdLayer) (so the request id is
+//! available) and to the log-context layer (so the event is emitted inside the
+//! request span).
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use axum::extract::MatchedPath;
+use axum::http::{Method, Request, Response};
+use pin_project_lite::pin_project;
+use tower::{Layer, Service};
+
+use crate::middleware::RequestId;
+
+/// `tracing` target carried by every access-log event, e.g. for filtering
+/// (`autumn::access=off`) or routing in a custom layer.
+pub const ACCESS_LOG_TARGET: &str = "autumn::access";
+
+/// Route label used when no route matched the request (e.g. 404s), keeping the
+/// `route` field low-cardinality. Mirrors the metrics layer.
+pub const UNMATCHED_ROUTE: &str = "_unmatched";
+
+/// Tower [`Layer`] that emits one structured access-log event per served
+/// request. Applied automatically by the framework router when
+/// `log.access_log` is enabled (the default).
+#[derive(Clone, Debug)]
+pub struct AccessLogLayer {
+    exclude: Arc<[String]>,
+}
+
+impl AccessLogLayer {
+    /// Create a new layer. Requests whose path falls under one of the
+    /// `exclude` prefixes (whole-segment match) are not logged.
+    #[must_use]
+    pub fn new(exclude: Vec<String>) -> Self {
+        Self {
+            exclude: exclude.into(),
+        }
+    }
+}
+
+impl<S> Layer<S> for AccessLogLayer {
+    type Service = AccessLogService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AccessLogService {
+            inner,
+            exclude: Arc::clone(&self.exclude),
+        }
+    }
+}
+
+/// Tower [`Service`] produced by [`AccessLogLayer`].
+#[derive(Clone, Debug)]
+pub struct AccessLogService<S> {
+    inner: S,
+    exclude: Arc<[String]>,
+}
+
+/// Request facts captured before the inner service consumes the request.
+/// `None` when the request path is excluded from access logging.
+struct RequestMeta {
+    method: Method,
+    route: Option<String>,
+    request_id: Option<String>,
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for AccessLogService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = AccessLogFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let meta = if is_excluded(req.uri().path(), &self.exclude) {
+            None
+        } else {
+            Some(RequestMeta {
+                method: req.method().clone(),
+                route: req
+                    .extensions()
+                    .get::<MatchedPath>()
+                    .map(|matched| matched.as_str().to_owned()),
+                request_id: req.extensions().get::<RequestId>().map(ToString::to_string),
+            })
+        };
+
+        AccessLogFuture {
+            inner: self.inner.call(req),
+            meta,
+            start: Instant::now(),
+        }
+    }
+}
+
+/// Returns `true` when `path` equals an exclusion prefix or lives under it as
+/// a whole path segment (`/actuator` excludes `/actuator/health`, not
+/// `/actuators`). Trailing slashes on configured prefixes are ignored.
+fn is_excluded(path: &str, exclude: &[String]) -> bool {
+    exclude.iter().any(|prefix| {
+        let prefix = prefix.trim_end_matches('/');
+        !prefix.is_empty()
+            && path
+                .strip_prefix(prefix)
+                .is_some_and(|rest| rest.is_empty() || rest.starts_with('/'))
+    })
+}
+
+pin_project! {
+    /// Future that emits the access-log event once the inner service produces
+    /// its response.
+    pub struct AccessLogFuture<F> {
+        #[pin]
+        inner: F,
+        meta: Option<RequestMeta>,
+        start: Instant,
+    }
+}
+
+impl<F, ResBody, E> Future for AccessLogFuture<F>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+{
+    type Output = Result<Response<ResBody>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.inner.poll(cx) {
+            Poll::Ready(Ok(response)) => {
+                if let Some(meta) = this.meta.take() {
+                    let duration_ms = this.start.elapsed().as_secs_f64() * 1000.0;
+                    tracing::info!(
+                        target: ACCESS_LOG_TARGET,
+                        method = %meta.method,
+                        route = meta.route.as_deref().unwrap_or(UNMATCHED_ROUTE),
+                        status = response.status().as_u16(),
+                        duration_ms,
+                        request_id = meta.request_id.as_deref(),
+                        "request served"
+                    );
+                }
+                Poll::Ready(Ok(response))
+            }
+            other => other,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exclude(prefixes: &[&str]) -> Vec<String> {
+        prefixes.iter().map(|p| (*p).to_owned()).collect()
+    }
+
+    #[test]
+    fn excludes_exact_path_and_sub_segments() {
+        let prefixes = exclude(&["/health", "/actuator", "/static"]);
+        assert!(is_excluded("/health", &prefixes));
+        assert!(is_excluded("/actuator/health", &prefixes));
+        assert!(is_excluded("/static/css/app.css", &prefixes));
+    }
+
+    #[test]
+    fn does_not_exclude_lookalike_prefixes() {
+        let prefixes = exclude(&["/health", "/static"]);
+        assert!(!is_excluded("/healthz", &prefixes));
+        assert!(!is_excluded("/staticfiles", &prefixes));
+        assert!(!is_excluded("/users/1", &prefixes));
+    }
+
+    #[test]
+    fn trailing_slashes_in_config_are_tolerated() {
+        let prefixes = exclude(&["/actuator/"]);
+        assert!(is_excluded("/actuator", &prefixes));
+        assert!(is_excluded("/actuator/metrics", &prefixes));
+    }
+
+    #[test]
+    fn empty_or_slash_only_prefixes_exclude_nothing() {
+        assert!(!is_excluded("/users/1", &exclude(&[""])));
+        assert!(!is_excluded("/users/1", &exclude(&["/"])));
+        assert!(!is_excluded("/users/1", &[]));
+    }
+}

--- a/autumn/src/middleware/access_log.rs
+++ b/autumn/src/middleware/access_log.rs
@@ -4,8 +4,9 @@
 //! `INFO`) at the point each response is returned, carrying the HTTP method,
 //! the matched low-cardinality route template (never the raw path), the
 //! response status code, the request duration in milliseconds, and the
-//! request's `request_id` (the same value used by the `x-request-id` header
-//! and error pages).
+//! request's `request_id` (read from the `x-request-id` response header
+//! stamped by [`RequestIdLayer`](crate::middleware::RequestIdLayer), so it
+//! matches error pages and the header clients see).
 //!
 //! The event flows through the already-installed subscriber, so it honors
 //! `LogConfig.format` (`pretty` / `json`) and works with **no** telemetry
@@ -19,10 +20,14 @@
 //! `/startup`, `/actuator`, `/static`), matched on whole path segments so
 //! `/healthz` is still logged while `/actuator/health` is not.
 //!
-//! Applied automatically by the framework router, inner to
-//! [`RequestIdLayer`](crate::middleware::RequestIdLayer) (so the request id is
-//! available) and to the log-context layer (so the event is emitted inside the
-//! request span).
+//! Applied automatically by the framework router at the **outermost** assembly
+//! point — outside the startup barrier, the static-first (SSG/ISR) middleware,
+//! the session layer, and the exception-filter chain — so the logged `status`
+//! is always the status the client receives, including startup 503s,
+//! pre-built static page hits, session-store outage 503s, and
+//! filter-rewritten error responses. Short-circuit responses produced before
+//! `RequestIdLayer` runs carry no `x-request-id` and log without a
+//! `request_id` field.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -31,11 +36,11 @@ use std::task::{Context, Poll};
 use std::time::Instant;
 
 use axum::extract::MatchedPath;
-use axum::http::{Method, Request, Response};
+use axum::http::{HeaderName, Method, Request, Response};
 use pin_project_lite::pin_project;
 use tower::{Layer, Service};
 
-use crate::middleware::RequestId;
+static X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
 
 /// `tracing` target carried by every access-log event, e.g. for filtering
 /// (`autumn::access=off`) or routing in a custom layer.
@@ -105,7 +110,6 @@ pub struct AccessLogService<S> {
 struct RequestMeta {
     method: Method,
     route: Option<String>,
-    request_id: Option<String>,
 }
 
 impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for AccessLogService<S>
@@ -130,7 +134,6 @@ where
                     .extensions()
                     .get::<MatchedPath>()
                     .map(|matched| matched.as_str().to_owned()),
-                request_id: req.extensions().get::<RequestId>().map(ToString::to_string),
             })
         };
 
@@ -175,13 +178,21 @@ where
             Poll::Ready(Ok(response)) => {
                 if let Some(meta) = this.meta.take() {
                     let duration_ms = this.start.elapsed().as_secs_f64() * 1000.0;
+                    // Read the request id off the response: the header is
+                    // stamped by RequestIdLayer, which sits inner to this
+                    // layer. Responses short-circuited before it (startup
+                    // 503s, static-first hits) have none and log without it.
+                    let request_id = response
+                        .headers()
+                        .get(&X_REQUEST_ID)
+                        .and_then(|value| value.to_str().ok());
                     tracing::info!(
                         target: ACCESS_LOG_TARGET,
                         method = %meta.method,
                         route = meta.route.as_deref().unwrap_or(UNMATCHED_ROUTE),
                         status = response.status().as_u16(),
                         duration_ms,
-                        request_id = meta.request_id.as_deref(),
+                        request_id,
                         "request served"
                     );
                 }

--- a/autumn/src/middleware/metrics.rs
+++ b/autumn/src/middleware/metrics.rs
@@ -602,10 +602,10 @@ where
                     let latency_ms =
                         u64::try_from(this.start.elapsed().as_millis()).unwrap_or(u64::MAX);
                     let method_str = this.method.as_str();
-                    let route_str = this
-                        .route
-                        .as_ref()
-                        .map_or("_unmatched", axum::extract::MatchedPath::as_str);
+                    let route_str = this.route.as_ref().map_or(
+                        super::access_log::UNMATCHED_ROUTE,
+                        axum::extract::MatchedPath::as_str,
+                    );
                     let status = response.status().as_u16();
                     collector.record(method_str, route_str, status, latency_ms);
                     collector.decrement_active();

--- a/autumn/src/middleware/mod.rs
+++ b/autumn/src/middleware/mod.rs
@@ -30,7 +30,9 @@ pub(crate) mod request_id;
 #[cfg(feature = "telemetry-otlp")]
 pub(crate) mod trace_context;
 
-pub use access_log::{ACCESS_LOG_TARGET, AccessLogLayer, AccessLogService, UNMATCHED_ROUTE};
+pub use access_log::{
+    ACCESS_LOG_TARGET, AccessLogEmitted, AccessLogLayer, AccessLogService, UNMATCHED_ROUTE,
+};
 pub use exception_filter::{AutumnErrorInfo, ExceptionFilter, ExceptionFilterLayer};
 pub use log_context::{LogContextLayer, LogContextService};
 pub use maintenance::{DEFAULT_HEALTH_PREFIX, MaintenanceLayer, MaintenanceService};

--- a/autumn/src/middleware/mod.rs
+++ b/autumn/src/middleware/mod.rs
@@ -5,6 +5,8 @@
 //! - [`RequestIdLayer`] / [`RequestId`] -- assigns a unique UUID v4 to every
 //!   incoming HTTP request, available in handler extensions and the
 //!   `X-Request-Id` response header.
+//! - [`AccessLogLayer`] -- emits one structured access-log event per served
+//!   request (method, route template, status, `duration_ms`, `request_id`).
 //! - [`ExceptionFilterLayer`] / [`ExceptionFilter`] -- intercepts error
 //!   responses and runs a user-registered filter chain for logging,
 //!   transformation, or replacement.
@@ -16,6 +18,7 @@
 //! when at least one exception filter is registered via
 //! [`AppBuilder::exception_filter`](crate::app::AppBuilder::exception_filter).
 
+pub(crate) mod access_log;
 pub(crate) mod dev;
 pub(crate) mod error_page_filter;
 pub(crate) mod exception_filter;
@@ -27,6 +30,7 @@ pub(crate) mod request_id;
 #[cfg(feature = "telemetry-otlp")]
 pub(crate) mod trace_context;
 
+pub use access_log::{ACCESS_LOG_TARGET, AccessLogLayer, AccessLogService, UNMATCHED_ROUTE};
 pub use exception_filter::{AutumnErrorInfo, ExceptionFilter, ExceptionFilterLayer};
 pub use log_context::{LogContextLayer, LogContextService};
 pub use maintenance::{DEFAULT_HEALTH_PREFIX, MaintenanceLayer, MaintenanceService};

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1895,8 +1895,9 @@ fn apply_middleware(
     // layer is available when the timeout fires — see request_timeout_handler).
     //
     // Full ingress layer order (outermost → innermost):
-    //   TraceContext → Compression → Metrics → ExceptionFilter → ErrorPageContext → Session →
-    //   SecurityHeaders → RequestId → LogContext → AccessLog → Timeout → [user layers] →
+    //   TraceContext → AccessLog (applied in apply_startup_barrier) → StartupBarrier →
+    //   Compression → Metrics → ExceptionFilter → ErrorPageContext → Session →
+    //   SecurityHeaders → RequestId → LogContext → Timeout → [user layers] →
     //   Tenancy → BodyLimit/UploadConfig → MethodOverride → RateLimit → CSRF → CORS → handler
     router = apply_request_timeout_middleware(router, config, state.metrics.clone());
 
@@ -1911,18 +1912,6 @@ fn apply_middleware(
             state.error_reporters(),
             config.reporting.enabled,
             config.reporting.sample_rate,
-        ));
-    }
-
-    // Structured per-request access log (#999): one INFO event (target
-    // `autumn::access`) per served request, emitted at the response boundary.
-    // Inner to RequestId (so the request id is available) and to LogContext
-    // (so the event is emitted inside the request span); outer to the
-    // reporting and timeout layers so panics-turned-500s and timeout
-    // responses are logged with the status the client receives.
-    if config.log.access_log {
-        router = router.layer(crate::middleware::AccessLogLayer::new(
-            config.log.access_log_exclude.clone(),
         ));
     }
 
@@ -1996,9 +1985,10 @@ fn apply_middleware(
     //   [user layers, when SSG/ISG dist dir active] ->
     //   StaticFileMiddleware (when SSG/ISG enabled) ->
     //   Metrics -> ExceptionFilter -> ErrorPageContext -> Session ->
-    //   SecurityHeaders -> RequestId -> LogContext -> AccessLog ->
+    //   SecurityHeaders -> RequestId -> LogContext ->
     //   [user layers, non-static build] ->
     //   Tenancy -> RateLimit -> CSRF -> CORS -> handler
+    //   (AccessLog sits outermost, applied in apply_startup_barrier.)
     let router = router
         .layer(crate::middleware::error_page_filter::ErrorPageContextLayer { is_dev })
         .layer(ExceptionFilterLayer::new(all_filters))
@@ -2385,13 +2375,30 @@ fn apply_startup_barrier(
         barrier_state,
         startup_barrier,
     ));
+    // Structured per-request access log (#999), applied OUTSIDE the startup
+    // barrier, the static-first (SSG/ISR) middleware, the session layer, and
+    // the exception-filter chain — every production build path funnels
+    // through this function, including after the late MCP endpoint merge —
+    // so the logged status is always the status the client receives:
+    // startup 503s, pre-built static page hits, session-store outage 503s,
+    // and filter-rewritten error responses included. The request id is read
+    // from the `x-request-id` response header stamped by RequestIdLayer;
+    // short-circuit responses produced before that layer log without one.
+    let router = if config.log.access_log {
+        router.layer(crate::middleware::AccessLogLayer::new(
+            config.log.access_log_exclude.clone(),
+        ))
+    } else {
+        router
+    };
     // W3C Trace Context propagation wraps the startup barrier (and the
     // static-first middleware above it) so short-circuit responses —
     // startup 503s and pre-built static file hits — still extract the
     // incoming `traceparent` and inject the current context into the
     // outgoing response. Applied here rather than inside `apply_middleware`
     // because those outer wrappers can return without ever invoking the
-    // inner router.
+    // inner router. Outer to AccessLog so the access event is emitted while
+    // the trace context is current.
     #[cfg(feature = "telemetry-otlp")]
     let router = router.layer(crate::middleware::TraceContextLayer);
     router

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1895,10 +1895,11 @@ fn apply_middleware(
     // layer is available when the timeout fires — see request_timeout_handler).
     //
     // Full ingress layer order (outermost → innermost):
-    //   TraceContext → AccessLog (applied in apply_startup_barrier) → StartupBarrier →
-    //   Compression → Metrics → ExceptionFilter → ErrorPageContext → Session →
-    //   SecurityHeaders → RequestId → LogContext → Timeout → [user layers] →
-    //   Tenancy → BodyLimit/UploadConfig → MethodOverride → RateLimit → CSRF → CORS → handler
+    //   TraceContext → AccessLog-fallback (applied in apply_startup_barrier) →
+    //   StartupBarrier → Compression → Metrics → ExceptionFilter → ErrorPageContext →
+    //   Session → SecurityHeaders → RequestId → LogContext → AccessLog-primary →
+    //   Timeout → [user layers] → Tenancy → BodyLimit/UploadConfig →
+    //   MethodOverride → RateLimit → CSRF → CORS → handler
     router = apply_request_timeout_middleware(router, config, state.metrics.clone());
 
     // Error-reporting + panic-catch layer. Placed inner to `RequestIdLayer`
@@ -1912,6 +1913,21 @@ fn apply_middleware(
             state.error_reporters(),
             config.reporting.enabled,
             config.reporting.sample_rate,
+        ));
+    }
+
+    // Structured per-request access log (#999), primary emitter: one INFO
+    // event (target `autumn::access`) per served request at the response
+    // boundary. Inner to RequestId (so the request id is available) and to
+    // LogContext (so the event is emitted inside the request span); outer to
+    // the reporting and timeout layers so panics-turned-500s and timeout
+    // responses are logged with the status the client receives. Emitted
+    // responses are marked so the outermost fallback (apply_startup_barrier)
+    // does not double-log; that fallback covers requests that short-circuit
+    // before this layer runs.
+    if config.log.access_log {
+        router = router.layer(crate::middleware::AccessLogLayer::new(
+            config.log.access_log_exclude.clone(),
         ));
     }
 
@@ -1985,10 +2001,10 @@ fn apply_middleware(
     //   [user layers, when SSG/ISG dist dir active] ->
     //   StaticFileMiddleware (when SSG/ISG enabled) ->
     //   Metrics -> ExceptionFilter -> ErrorPageContext -> Session ->
-    //   SecurityHeaders -> RequestId -> LogContext ->
+    //   SecurityHeaders -> RequestId -> LogContext -> AccessLog-primary ->
     //   [user layers, non-static build] ->
     //   Tenancy -> RateLimit -> CSRF -> CORS -> handler
-    //   (AccessLog sits outermost, applied in apply_startup_barrier.)
+    //   (An AccessLog fallback sits outermost, applied in apply_startup_barrier.)
     let router = router
         .layer(crate::middleware::error_page_filter::ErrorPageContextLayer { is_dev })
         .layer(ExceptionFilterLayer::new(all_filters))
@@ -2375,17 +2391,18 @@ fn apply_startup_barrier(
         barrier_state,
         startup_barrier,
     ));
-    // Structured per-request access log (#999), applied OUTSIDE the startup
-    // barrier, the static-first (SSG/ISR) middleware, the session layer, and
-    // the exception-filter chain — every production build path funnels
-    // through this function, including after the late MCP endpoint merge —
-    // so the logged status is always the status the client receives:
-    // startup 503s, pre-built static page hits, session-store outage 503s,
-    // and filter-rewritten error responses included. The request id is read
-    // from the `x-request-id` response header stamped by RequestIdLayer;
-    // short-circuit responses produced before that layer log without one.
+    // Access-log fallback (#999), applied OUTSIDE the startup barrier, the
+    // static-first (SSG/ISR) middleware, the session layer, and the
+    // exception-filter chain — every production build path funnels through
+    // this function, including after the late MCP endpoint merge. It emits
+    // only for responses the primary in-stack layer never saw (it checks the
+    // AccessLogEmitted response marker), giving startup 503s, pre-built
+    // static page hits, session-store outage 503s, and MCP endpoint requests
+    // an access line too. Those short-circuits never ran RequestIdLayer, so
+    // the fallback reads `x-request-id` from the response when present and
+    // logs without a request id otherwise.
     let router = if config.log.access_log {
-        router.layer(crate::middleware::AccessLogLayer::new(
+        router.layer(crate::middleware::AccessLogLayer::fallback(
             config.log.access_log_exclude.clone(),
         ))
     } else {

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1896,8 +1896,8 @@ fn apply_middleware(
     //
     // Full ingress layer order (outermost → innermost):
     //   TraceContext → Compression → Metrics → ExceptionFilter → ErrorPageContext → Session →
-    //   SecurityHeaders → RequestId → Timeout → [user layers] → Tenancy →
-    //   BodyLimit/UploadConfig → MethodOverride → RateLimit → CSRF → CORS → handler
+    //   SecurityHeaders → RequestId → LogContext → AccessLog → Timeout → [user layers] →
+    //   Tenancy → BodyLimit/UploadConfig → MethodOverride → RateLimit → CSRF → CORS → handler
     router = apply_request_timeout_middleware(router, config, state.metrics.clone());
 
     // Error-reporting + panic-catch layer. Placed inner to `RequestIdLayer`
@@ -1911,6 +1911,18 @@ fn apply_middleware(
             state.error_reporters(),
             config.reporting.enabled,
             config.reporting.sample_rate,
+        ));
+    }
+
+    // Structured per-request access log (#999): one INFO event (target
+    // `autumn::access`) per served request, emitted at the response boundary.
+    // Inner to RequestId (so the request id is available) and to LogContext
+    // (so the event is emitted inside the request span); outer to the
+    // reporting and timeout layers so panics-turned-500s and timeout
+    // responses are logged with the status the client receives.
+    if config.log.access_log {
+        router = router.layer(crate::middleware::AccessLogLayer::new(
+            config.log.access_log_exclude.clone(),
         ));
     }
 
@@ -1984,7 +1996,8 @@ fn apply_middleware(
     //   [user layers, when SSG/ISG dist dir active] ->
     //   StaticFileMiddleware (when SSG/ISG enabled) ->
     //   Metrics -> ExceptionFilter -> ErrorPageContext -> Session ->
-    //   SecurityHeaders -> RequestId -> [user layers, non-static build] ->
+    //   SecurityHeaders -> RequestId -> LogContext -> AccessLog ->
+    //   [user layers, non-static build] ->
     //   Tenancy -> RateLimit -> CSRF -> CORS -> handler
     let router = router
         .layer(crate::middleware::error_page_filter::ErrorPageContextLayer { is_dev })

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -2790,6 +2790,83 @@ mod tests {
         assert_eq!(legacy.status(), StatusCode::NOT_FOUND);
     }
 
+    /// Pins the production access-log wiring (#999): the layer is applied in
+    /// `apply_startup_barrier`, outside the barrier itself, so even requests
+    /// rejected with 503 before the app router runs emit one access event
+    /// carrying the status the client receives.
+    #[test]
+    fn startup_barrier_503s_are_access_logged() {
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        #[derive(Clone, Default)]
+        struct Capture {
+            events: Arc<std::sync::Mutex<Vec<std::collections::BTreeMap<String, String>>>>,
+        }
+        struct Visitor<'a>(&'a mut std::collections::BTreeMap<String, String>);
+        impl tracing::field::Visit for Visitor<'_> {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                self.0.insert(field.name().to_owned(), format!("{value:?}"));
+            }
+            fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+                self.0.insert(field.name().to_owned(), value.to_string());
+            }
+        }
+        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for Capture {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                if event.metadata().target() != crate::middleware::ACCESS_LOG_TARGET {
+                    return;
+                }
+                let mut fields = std::collections::BTreeMap::new();
+                event.record(&mut Visitor(&mut fields));
+                self.events.lock().unwrap().push(fields);
+            }
+        }
+
+        let capture = Capture::default();
+        let events = Arc::clone(&capture.events);
+        let subscriber = tracing_subscriber::registry().with(capture);
+
+        tracing::subscriber::with_default(subscriber, || {
+            // With startup incomplete, the barrier rejects non-probe requests
+            // with 503 before the app router runs.
+            let state = AppState::for_test()
+                .with_profile("test")
+                .with_startup_complete(false);
+            let app = build_router(Vec::new(), &AutumnConfig::default(), state);
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let response = rt.block_on(async {
+                app.oneshot(
+                    Request::builder()
+                        .uri("/not-a-probe")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+            });
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        });
+
+        let events = events.lock().unwrap().clone();
+        assert_eq!(
+            events.len(),
+            1,
+            "a barrier-rejected request should emit one access event: {events:?}"
+        );
+        assert_eq!(events[0].get("status").map(String::as_str), Some("503"));
+        assert!(
+            !events[0].contains_key("request_id"),
+            "barrier short-circuits before RequestIdLayer, so no request id"
+        );
+    }
+
     #[test]
     fn try_build_router_rejects_invalid_session_backend_config() {
         let mut config = AutumnConfig::default();

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -1086,12 +1086,14 @@ impl TestApp {
             },
         )
         .expect("failed to build test router");
-        // Mirror production's outermost access-log placement (#999): in
-        // production the layer is applied in `apply_startup_barrier`, outside
-        // the session and exception-filter layers, so tests observe the same
-        // final-response statuses an operator would see in the access log.
+        // Mirror production's outermost access-log fallback (#999): in
+        // production it is applied in `apply_startup_barrier`, outside the
+        // session and exception-filter layers, and emits only for responses
+        // the primary in-stack layer never saw (e.g. session-store outage
+        // 503s), so tests observe the same access-log behavior an operator
+        // would.
         let router = if self.config.log.access_log {
-            router.layer(crate::middleware::AccessLogLayer::new(
+            router.layer(crate::middleware::AccessLogLayer::fallback(
                 self.config.log.access_log_exclude.clone(),
             ))
         } else {

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -1086,6 +1086,17 @@ impl TestApp {
             },
         )
         .expect("failed to build test router");
+        // Mirror production's outermost access-log placement (#999): in
+        // production the layer is applied in `apply_startup_barrier`, outside
+        // the session and exception-filter layers, so tests observe the same
+        // final-response statuses an operator would see in the access log.
+        let router = if self.config.log.access_log {
+            router.layer(crate::middleware::AccessLogLayer::new(
+                self.config.log.access_log_exclude.clone(),
+            ))
+        } else {
+            router
+        };
         TestClient {
             router,
             probes,

--- a/autumn/tests/access_log.rs
+++ b/autumn/tests/access_log.rs
@@ -1,0 +1,395 @@
+//! Integration tests for the default structured per-request access log (#999).
+//!
+//! Acceptance criteria covered:
+//! - exactly one structured access-log event per served request, emitted at
+//!   the response boundary with default configuration and no telemetry feature
+//! - the event carries method, the matched low-cardinality route template,
+//!   status, `duration_ms`, and the `request_id` that matches `x-request-id`
+//! - `/health`, `/actuator/*`, and `/static/*` are excluded by default and the
+//!   exclusion set is configurable
+//! - access logging is on by default and can be disabled via `log.access_log`
+//! - query strings never leak into the event
+//! - under `LogFormat::Json` the event renders as a single JSON object line
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use autumn_web::config::AutumnConfig;
+use autumn_web::test::TestApp;
+use autumn_web::{get, routes};
+use tracing_subscriber::layer::SubscriberExt as _;
+
+/// `tracing` target carried by every access-log event.
+const ACCESS_TARGET: &str = "autumn::access";
+
+// ── Capture infrastructure ─────────────────────────────────────
+
+#[derive(Debug, Clone, Default)]
+struct CapturedEvent {
+    fields: BTreeMap<String, String>,
+}
+
+impl CapturedEvent {
+    fn field(&self, name: &str) -> Option<&str> {
+        self.fields.get(name).map(String::as_str)
+    }
+}
+
+/// Test tracing layer that records every access-log event's fields.
+#[derive(Clone, Default)]
+struct AccessLogCapture {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl AccessLogCapture {
+    fn captured(&self) -> Vec<CapturedEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+struct FieldVisitor<'a>(&'a mut BTreeMap<String, String>);
+
+impl tracing::field::Visit for FieldVisitor<'_> {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.0.insert(field.name().to_owned(), format!("{value:?}"));
+    }
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.0.insert(field.name().to_owned(), value.to_owned());
+    }
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.0.insert(field.name().to_owned(), value.to_string());
+    }
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.0.insert(field.name().to_owned(), value.to_string());
+    }
+    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+        self.0.insert(field.name().to_owned(), value.to_string());
+    }
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for AccessLogCapture {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if event.metadata().target() != ACCESS_TARGET {
+            return;
+        }
+        let mut fields = BTreeMap::new();
+        event.record(&mut FieldVisitor(&mut fields));
+        self.events.lock().unwrap().push(CapturedEvent { fields });
+    }
+}
+
+/// Install a capture layer as the thread-default subscriber. Tests run on a
+/// current-thread tokio runtime, so everything the request emits is observed.
+fn install_capture() -> (AccessLogCapture, tracing::subscriber::DefaultGuard) {
+    let capture = AccessLogCapture::default();
+    let subscriber = tracing_subscriber::registry().with(capture.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    (capture, guard)
+}
+
+fn test_config() -> AutumnConfig {
+    // Mirror TestApp::new() defaults so `.config()` overrides stay additive.
+    let mut config = AutumnConfig {
+        profile: Some("test".into()),
+        ..Default::default()
+    };
+    config.security.csrf.enabled = false;
+    config
+}
+
+// ── Sample handlers ────────────────────────────────────────────
+
+#[get("/users/{id}")]
+async fn show_user(axum::extract::Path(id): axum::extract::Path<i64>) -> String {
+    format!("user {id}")
+}
+
+#[get("/boom")]
+async fn boom() -> Result<String, autumn_web::error::AutumnError> {
+    Err(autumn_web::error::AutumnError::not_found_msg("gone"))
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn emits_exactly_one_access_event_with_status_request_id_and_duration() {
+    let (capture, _guard) = install_capture();
+    let client = TestApp::new().routes(routes![show_user]).build();
+
+    let response = client.get("/users/123").send().await;
+    response.assert_ok();
+    let request_id = response
+        .header("x-request-id")
+        .expect("x-request-id header should be set")
+        .to_owned();
+
+    let events = capture.captured();
+    assert_eq!(
+        events.len(),
+        1,
+        "expected exactly one access-log event, got {events:?}"
+    );
+    let event = &events[0];
+    assert_eq!(event.field("method"), Some("GET"));
+    assert_eq!(
+        event.field("route"),
+        Some("/users/{id}"),
+        "route must be the matched low-cardinality template"
+    );
+    assert_eq!(event.field("status"), Some("200"));
+    assert_eq!(
+        event.field("request_id"),
+        Some(request_id.as_str()),
+        "access line must correlate with the x-request-id header"
+    );
+    let duration: f64 = event
+        .field("duration_ms")
+        .expect("duration_ms field should be present")
+        .parse()
+        .expect("duration_ms should be numeric");
+    assert!(duration >= 0.0);
+}
+
+#[tokio::test]
+async fn error_responses_are_logged_with_their_status() {
+    let (capture, _guard) = install_capture();
+    let client = TestApp::new().routes(routes![boom]).build();
+
+    client.get("/boom").send().await;
+
+    let events = capture.captured();
+    assert_eq!(events.len(), 1, "got {events:?}");
+    assert_eq!(events[0].field("status"), Some("404"));
+    assert_eq!(events[0].field("route"), Some("/boom"));
+}
+
+#[tokio::test]
+async fn route_field_never_contains_the_raw_path() {
+    let (capture, _guard) = install_capture();
+    let client = TestApp::new().routes(routes![show_user]).build();
+
+    client.get("/users/4242").send().await.assert_ok();
+
+    let events = capture.captured();
+    assert_eq!(events.len(), 1);
+    for (key, value) in &events[0].fields {
+        assert!(
+            !value.contains("4242"),
+            "field {key} leaked the raw path parameter: {value}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn unmatched_requests_log_a_low_cardinality_placeholder() {
+    let (capture, _guard) = install_capture();
+    let client = TestApp::new().routes(routes![show_user]).build();
+
+    client.get("/no/such/route").send().await;
+
+    let events = capture.captured();
+    assert_eq!(events.len(), 1, "got {events:?}");
+    assert_eq!(events[0].field("status"), Some("404"));
+    assert_eq!(events[0].field("route"), Some("_unmatched"));
+}
+
+#[tokio::test]
+async fn health_actuator_and_static_are_excluded_by_default() {
+    let (capture, _guard) = install_capture();
+    let client = TestApp::new().routes(routes![show_user]).build();
+
+    client.get("/health").send().await.assert_ok();
+    client.get("/actuator/health").send().await;
+    client.get("/static/app.css").send().await;
+    assert!(
+        capture.captured().is_empty(),
+        "probe/asset traffic should not be access-logged by default: {:?}",
+        capture.captured()
+    );
+
+    // Ordinary application traffic is still logged.
+    client.get("/users/1").send().await.assert_ok();
+    assert_eq!(capture.captured().len(), 1);
+}
+
+#[tokio::test]
+async fn exclusion_set_is_configurable() {
+    let (capture, _guard) = install_capture();
+    let mut config = test_config();
+    config.log.access_log_exclude = vec!["/users".to_owned()];
+    let client = TestApp::new()
+        .config(config)
+        .routes(routes![show_user])
+        .build();
+
+    // The configured exclusion replaces the default set entirely.
+    client.get("/users/1").send().await.assert_ok();
+    assert!(capture.captured().is_empty());
+
+    client.get("/health").send().await.assert_ok();
+    assert_eq!(
+        capture.captured().len(),
+        1,
+        "/health should be logged once the default exclusions are replaced"
+    );
+}
+
+#[tokio::test]
+async fn access_log_can_be_disabled_via_config() {
+    let (capture, _guard) = install_capture();
+    let mut config = test_config();
+    config.log.access_log = false;
+    let client = TestApp::new()
+        .config(config)
+        .routes(routes![show_user])
+        .build();
+
+    client.get("/users/1").send().await.assert_ok();
+    assert!(
+        capture.captured().is_empty(),
+        "log.access_log = false must silence the access log"
+    );
+}
+
+#[tokio::test]
+async fn query_strings_never_appear_in_the_access_event() {
+    let (capture, _guard) = install_capture();
+    let client = TestApp::new().routes(routes![show_user]).build();
+
+    client
+        .get("/users/1?token=supersecret&password=hunter2")
+        .send()
+        .await
+        .assert_ok();
+
+    let events = capture.captured();
+    assert_eq!(events.len(), 1);
+    for (key, value) in &events[0].fields {
+        assert!(
+            !value.contains("supersecret") && !value.contains("hunter2"),
+            "field {key} leaked query-string data: {value}"
+        );
+    }
+}
+
+/// Success-metric probe (#999): added per-request overhead < 50 µs p99.
+///
+/// Ignored by default because wall-clock assertions are environment-sensitive;
+/// run manually with `cargo test --test access_log --release -- --ignored`.
+#[tokio::test]
+#[ignore = "timing-sensitive; run manually in release mode"]
+async fn per_request_overhead_is_under_50_microseconds_p99() {
+    use autumn_web::middleware::AccessLogLayer;
+    use tower::ServiceExt as _;
+
+    async fn handler() -> &'static str {
+        "ok"
+    }
+
+    async fn p99_nanos(router: &axum::Router) -> u128 {
+        const N: usize = 5_000;
+        let mut samples = Vec::with_capacity(N);
+        // Warm-up.
+        for _ in 0..500 {
+            let req = axum::http::Request::builder()
+                .uri("/ping")
+                .body(axum::body::Body::empty())
+                .unwrap();
+            router.clone().oneshot(req).await.unwrap();
+        }
+        for _ in 0..N {
+            let req = axum::http::Request::builder()
+                .uri("/ping")
+                .body(axum::body::Body::empty())
+                .unwrap();
+            let start = std::time::Instant::now();
+            router.clone().oneshot(req).await.unwrap();
+            samples.push(start.elapsed().as_nanos());
+        }
+        samples.sort_unstable();
+        samples[N * 99 / 100]
+    }
+
+    // Discard formatted output so we measure emission, not test-buffer growth.
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .json()
+            .with_writer(std::io::sink),
+    );
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let bare = axum::Router::new().route("/ping", axum::routing::get(handler));
+    let logged = bare
+        .clone()
+        .layer(AccessLogLayer::new(vec!["/health".to_owned()]));
+
+    let baseline = p99_nanos(&bare).await;
+    let with_access_log = p99_nanos(&logged).await;
+    let overhead_ns = with_access_log.saturating_sub(baseline);
+    println!(
+        "p99 baseline: {baseline} ns, with access log: {with_access_log} ns, \
+         overhead: {overhead_ns} ns"
+    );
+    assert!(
+        overhead_ns < 50_000,
+        "access-log p99 overhead {overhead_ns} ns exceeds the 50 µs budget"
+    );
+}
+
+#[tokio::test]
+async fn json_format_renders_the_event_as_a_single_json_object_line() {
+    #[derive(Clone)]
+    struct BufWriter(Arc<Mutex<Vec<u8>>>);
+    struct BufGuard(Arc<Mutex<Vec<u8>>>);
+    impl std::io::Write for BufGuard {
+        fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(b);
+            Ok(b.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufWriter {
+        type Writer = BufGuard;
+        fn make_writer(&'a self) -> Self::Writer {
+            BufGuard(Arc::clone(&self.0))
+        }
+    }
+
+    let buf = Arc::new(Mutex::new(Vec::new()));
+    // Same shape as the framework's LogFormat::Json subscriber.
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .json()
+            .with_writer(BufWriter(Arc::clone(&buf))),
+    );
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let client = TestApp::new().routes(routes![show_user]).build();
+    client.get("/users/7").send().await.assert_ok();
+
+    let out = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    let access_lines: Vec<&str> = out
+        .lines()
+        .filter(|line| line.contains(ACCESS_TARGET))
+        .collect();
+    assert_eq!(
+        access_lines.len(),
+        1,
+        "expected one access-log line, got: {out}"
+    );
+    let value: serde_json::Value =
+        serde_json::from_str(access_lines[0]).expect("access line should be one JSON object");
+    assert_eq!(value["target"], ACCESS_TARGET);
+    let fields = &value["fields"];
+    assert_eq!(fields["method"], "GET");
+    assert_eq!(fields["route"], "/users/{id}");
+    assert_eq!(fields["status"], 200);
+    assert!(fields["duration_ms"].is_number());
+    assert!(fields["request_id"].is_string());
+}

--- a/autumn/tests/access_log.rs
+++ b/autumn/tests/access_log.rs
@@ -396,3 +396,18 @@ async fn json_format_renders_the_event_as_a_single_json_object_line() {
     assert!(fields["duration_ms"].is_number());
     assert!(fields["request_id"].is_string());
 }
+
+#[tokio::test]
+async fn method_mismatch_405_is_access_logged() {
+    let (capture, _guard) = install_capture();
+    let client = TestApp::new().routes(routes![show_user]).build();
+
+    // show_user is GET-only; POST to the same path should 405.
+    let resp = client.post("/users/1").send().await;
+    resp.assert_status(405);
+
+    let events = capture.captured();
+    assert_eq!(events.len(), 1, "got {events:?}");
+    assert_eq!(events[0].field("status"), Some("405"));
+    assert_eq!(events[0].field("method"), Some("POST"));
+}

--- a/autumn/tests/access_log.rs
+++ b/autumn/tests/access_log.rs
@@ -398,6 +398,63 @@ async fn json_format_renders_the_event_as_a_single_json_object_line() {
 }
 
 #[tokio::test]
+async fn exception_filter_rewrites_are_visible_to_the_access_log() {
+    use autumn_web::middleware::{
+        AccessLogLayer, AutumnErrorInfo, ExceptionFilter, ExceptionFilterLayer,
+    };
+    use axum::response::IntoResponse as _;
+    use tower::ServiceExt as _;
+
+    // A filter that replaces the handler's error response entirely, like the
+    // documented `filter_can_replace_response` capability.
+    struct Rewrite;
+    impl ExceptionFilter for Rewrite {
+        fn filter(
+            &self,
+            _error: &AutumnErrorInfo,
+            _response: axum::response::Response,
+        ) -> axum::response::Response {
+            (axum::http::StatusCode::SERVICE_UNAVAILABLE, "down").into_response()
+        }
+    }
+
+    let (capture, _guard) = install_capture();
+    // Production ordering: AccessLog is OUTER to the exception-filter chain,
+    // so the logged status must be the rewritten one the client receives.
+    let app = axum::Router::new()
+        .route(
+            "/boom",
+            axum::routing::get(|| async {
+                Err::<String, _>(autumn_web::error::AutumnError::not_found_msg("gone"))
+            }),
+        )
+        .layer(ExceptionFilterLayer::new(vec![Arc::new(Rewrite)]))
+        .layer(AccessLogLayer::new(Vec::new()));
+
+    let response = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/boom")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        axum::http::StatusCode::SERVICE_UNAVAILABLE
+    );
+
+    let events = capture.captured();
+    assert_eq!(events.len(), 1, "got {events:?}");
+    assert_eq!(
+        events[0].field("status"),
+        Some("503"),
+        "access log must record the filter-rewritten status the client receives"
+    );
+}
+
+#[tokio::test]
 async fn method_mismatch_405_is_access_logged() {
     let (capture, _guard) = install_capture();
     let client = TestApp::new().routes(routes![show_user]).build();

--- a/autumn/tests/access_log.rs
+++ b/autumn/tests/access_log.rs
@@ -398,7 +398,7 @@ async fn json_format_renders_the_event_as_a_single_json_object_line() {
 }
 
 #[tokio::test]
-async fn exception_filter_rewrites_are_visible_to_the_access_log() {
+async fn filter_rewrites_log_handler_status_without_double_logging() {
     use autumn_web::middleware::{
         AccessLogLayer, AutumnErrorInfo, ExceptionFilter, ExceptionFilterLayer,
     };
@@ -419,8 +419,11 @@ async fn exception_filter_rewrites_are_visible_to_the_access_log() {
     }
 
     let (capture, _guard) = install_capture();
-    // Production ordering: AccessLog is OUTER to the exception-filter chain,
-    // so the logged status must be the rewritten one the client receives.
+    // Production ordering: the primary access log is INNER to the
+    // exception-filter chain (in-span, correlated), with the fallback
+    // outermost. The `AccessLogEmitted` marker must keep the fallback silent,
+    // and the logged status is the handler's response — the documented,
+    // accepted tradeoff of the in-context primary placement.
     let app = axum::Router::new()
         .route(
             "/boom",
@@ -428,8 +431,9 @@ async fn exception_filter_rewrites_are_visible_to_the_access_log() {
                 Err::<String, _>(autumn_web::error::AutumnError::not_found_msg("gone"))
             }),
         )
+        .layer(AccessLogLayer::new(Vec::new()))
         .layer(ExceptionFilterLayer::new(vec![Arc::new(Rewrite)]))
-        .layer(AccessLogLayer::new(Vec::new()));
+        .layer(AccessLogLayer::fallback(Vec::new()));
 
     let response = app
         .oneshot(
@@ -446,11 +450,60 @@ async fn exception_filter_rewrites_are_visible_to_the_access_log() {
     );
 
     let events = capture.captured();
-    assert_eq!(events.len(), 1, "got {events:?}");
+    assert_eq!(
+        events.len(),
+        1,
+        "the marker must keep the fallback silent: {events:?}"
+    );
     assert_eq!(
         events[0].field("status"),
-        Some("503"),
-        "access log must record the filter-rewritten status the client receives"
+        Some("404"),
+        "primary placement logs the handler status (accepted tradeoff)"
+    );
+}
+
+/// A response produced by a layer OUTER to the primary access log (here: a
+/// short-circuiting middleware standing in for a session-store outage 503)
+/// carries no `AccessLogEmitted` marker, so the outermost fallback logs it.
+#[tokio::test]
+async fn short_circuits_above_the_primary_are_logged_by_the_fallback() {
+    use autumn_web::middleware::AccessLogLayer;
+    use axum::response::IntoResponse as _;
+    use tower::ServiceExt as _;
+
+    let (capture, _guard) = install_capture();
+    let app = axum::Router::new()
+        .route("/ok", axum::routing::get(|| async { "ok" }))
+        .layer(AccessLogLayer::new(Vec::new()))
+        // Stands in for SessionLayer's store.load failure path: rejects
+        // without calling the inner service (and the primary layer).
+        .layer(axum::middleware::from_fn(
+            |_req: axum::extract::Request, _next: axum::middleware::Next| async {
+                (axum::http::StatusCode::SERVICE_UNAVAILABLE, "store down").into_response()
+            },
+        ))
+        .layer(AccessLogLayer::fallback(Vec::new()));
+
+    let response = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/ok")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        axum::http::StatusCode::SERVICE_UNAVAILABLE
+    );
+
+    let events = capture.captured();
+    assert_eq!(events.len(), 1, "got {events:?}");
+    assert_eq!(events[0].field("status"), Some("503"));
+    assert!(
+        events[0].field("request_id").is_none(),
+        "short-circuit never ran RequestIdLayer, so no request id"
     );
 }
 

--- a/autumn/tests/access_log.rs
+++ b/autumn/tests/access_log.rs
@@ -203,6 +203,9 @@ async fn health_actuator_and_static_are_excluded_by_default() {
     let client = TestApp::new().routes(routes![show_user]).build();
 
     client.get("/health").send().await.assert_ok();
+    client.get("/live").send().await.assert_ok();
+    client.get("/ready").send().await.assert_ok();
+    client.get("/startup").send().await.assert_ok();
     client.get("/actuator/health").send().await;
     client.get("/static/app.css").send().await;
     assert!(

--- a/docs/guide/logging-pii.md
+++ b/docs/guide/logging-pii.md
@@ -63,9 +63,13 @@ Probe and asset noise is excluded by default; both knobs live in `[log]`:
 access_log = true
 
 # Path prefixes to skip (whole-segment match; replaces the default set:
-# "/health", "/actuator", "/static").
+# "/health", "/live", "/ready", "/startup", "/actuator", "/static").
 access_log_exclude = ["/health", "/actuator", "/static", "/uptime-probe"]
 ```
+
+Both knobs also honor environment overrides for TOML-less deployments:
+`AUTUMN_LOG__ACCESS_LOG=false` and
+`AUTUMN_LOG__ACCESS_LOG_EXCLUDE=/health,/internal` (comma-separated).
 
 ## Startup warnings
 

--- a/docs/guide/logging-pii.md
+++ b/docs/guide/logging-pii.md
@@ -42,6 +42,31 @@ unfilter_parameters = ["password"]
   `API-KEY`, `apikey` are treated equivalently).
 - Empty custom keys are ignored to avoid accidental “scrub everything”.
 
+## Access log
+
+Every served HTTP request emits one structured access-log line by default
+(`tracing` target `autumn::access`, level `INFO`) carrying `method`, `route`
+(the matched low-cardinality template, e.g. `/users/{id}` — never the raw
+path), `status`, `duration_ms`, and `request_id` (the same id as the
+`x-request-id` header and error pages). It renders through the standard
+subscriber, so `log.format` controls its shape, and it requires no telemetry
+feature or collector.
+
+The line never includes query strings, headers, or bodies, so it cannot leak
+the sensitive values this scrubber protects.
+
+Probe and asset noise is excluded by default; both knobs live in `[log]`:
+
+```toml
+[log]
+# On by default; set to false to silence the access log without recompiling.
+access_log = true
+
+# Path prefixes to skip (whole-segment match; replaces the default set:
+# "/health", "/actuator", "/static").
+access_log_exclude = ["/health", "/actuator", "/static", "/uptime-probe"]
+```
+
 ## Startup warnings
 
 If you opt out of built-in sensitive defaults via `unfilter_parameters`, Autumn

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -56,14 +56,14 @@ On a request's **ingress** path (outermost → innermost), layers run in this
 order:
 
 ```
-  Metrics
-    └─ ExceptionFilter
-         └─ ErrorPageContext
-              └─ Session
-                   └─ SecurityHeaders
-                        └─ RequestId
-                             └─ LogContext
-                                  └─ AccessLog
+  AccessLog
+    └─ Metrics
+         └─ ExceptionFilter
+              └─ ErrorPageContext
+                   └─ Session
+                        └─ SecurityHeaders
+                             └─ RequestId
+                                  └─ LogContext
                                        └─ [your .layer() calls, first = outermost]
                                             └─ CSRF
                                                  └─ CORS
@@ -71,10 +71,13 @@ order:
 ```
 
 `LogContext` establishes the request-scoped log context (request id
-correlation for every log line), and `AccessLog` emits the structured
-per-request access line (`autumn::access`) when the response comes back out —
-both sit inside `RequestId` so the id is always available, and outside your
-layers so short-circuit responses you produce are still logged.
+correlation for every log line); it sits inside `RequestId` so the id is
+always available, and outside your layers so events they emit are correlated.
+`AccessLog` emits the structured per-request access line (`autumn::access`)
+from the **outermost** position — outside the session and exception-filter
+layers (and, in production, outside the startup barrier and static-first
+middleware) — so the logged status is always the status the client receives;
+it reads the request id off the `x-request-id` response header.
 
 The ordering guarantee that matters most: **user layers run inside
 `RequestIdLayer` on ingress**, so every `.layer()` you register can read the

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -62,11 +62,19 @@ order:
               └─ Session
                    └─ SecurityHeaders
                         └─ RequestId
-                             └─ [your .layer() calls, first = outermost]
-                                  └─ CSRF
-                                       └─ CORS
-                                            └─ route handler
+                             └─ LogContext
+                                  └─ AccessLog
+                                       └─ [your .layer() calls, first = outermost]
+                                            └─ CSRF
+                                                 └─ CORS
+                                                      └─ route handler
 ```
+
+`LogContext` establishes the request-scoped log context (request id
+correlation for every log line), and `AccessLog` emits the structured
+per-request access line (`autumn::access`) when the response comes back out —
+both sit inside `RequestId` so the id is always available, and outside your
+layers so short-circuit responses you produce are still logged.
 
 The ordering guarantee that matters most: **user layers run inside
 `RequestIdLayer` on ingress**, so every `.layer()` you register can read the

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -56,7 +56,7 @@ On a request's **ingress** path (outermost → innermost), layers run in this
 order:
 
 ```
-  AccessLog
+  AccessLog (fallback)
     └─ Metrics
          └─ ExceptionFilter
               └─ ErrorPageContext
@@ -64,20 +64,23 @@ order:
                         └─ SecurityHeaders
                              └─ RequestId
                                   └─ LogContext
-                                       └─ [your .layer() calls, first = outermost]
-                                            └─ CSRF
-                                                 └─ CORS
-                                                      └─ route handler
+                                       └─ AccessLog (primary)
+                                            └─ [your .layer() calls, first = outermost]
+                                                 └─ CSRF
+                                                      └─ CORS
+                                                           └─ route handler
 ```
 
 `LogContext` establishes the request-scoped log context (request id
 correlation for every log line); it sits inside `RequestId` so the id is
 always available, and outside your layers so events they emit are correlated.
-`AccessLog` emits the structured per-request access line (`autumn::access`)
-from the **outermost** position — outside the session and exception-filter
-layers (and, in production, outside the startup barrier and static-first
-middleware) — so the logged status is always the status the client receives;
-it reads the request id off the `x-request-id` response header.
+The structured per-request access line (`autumn::access`) is emitted by the
+**primary** `AccessLog` layer just inside `LogContext`, so the line is
+correlated to the request span and carries the request id. Responses that
+short-circuit above it — session-store outages, and in production startup
+503s, pre-built static page hits, and the MCP endpoint — are caught by the
+outermost **fallback** `AccessLog`, which logs them with the wire status (and
+without a request id, since `RequestIdLayer` never ran for them).
 
 The ordering guarantee that matters most: **user layers run inside
 `RequestIdLayer` on ingress**, so every `.layer()` you register can read the


### PR DESCRIPTION
## Summary

Implements a structured per-request access log that emits exactly one `tracing` event per served HTTP request, carrying method, matched route template, status code, duration, and request ID. The feature is on by default and requires no telemetry feature or OTLP collector.

## Key Changes

- **New middleware layer** (`AccessLogLayer`): Emits one `INFO` event (target `autumn::access`) at the response boundary for each request, capturing:
  - HTTP method
  - Matched low-cardinality route template (e.g., `/users/{id}`, never raw paths)
  - Response status code
  - Request duration in milliseconds
  - Request ID (correlates with `x-request-id` header)

- **Configuration** (`LogConfig`):
  - `access_log: bool` — Enable/disable access logging (default: `true`)
  - `access_log_exclude: Vec<String>` — Path prefixes to skip (default: `/health`, `/actuator`, `/static`)
  - Exclusion matching is whole-segment based: `/actuator` excludes `/actuator/health` but not `/actuators`

- **Integration**:
  - Applied automatically in the router middleware stack, positioned inner to `RequestId` (so the ID is available) and `LogContext` (so events are emitted inside the request span)
  - Renders through the standard subscriber, respecting `log.format` (pretty/json)
  - Never includes query strings, headers, or bodies — preserves log scrubbing posture

- **Comprehensive test suite** (`access_log.rs`):
  - Validates exactly one event per request with correct fields
  - Verifies error responses are logged with their status
  - Confirms raw paths and query strings never leak into events
  - Tests default exclusions and configurability
  - Validates JSON formatting
  - Includes performance benchmark (p99 overhead < 50 µs)

- **Documentation**:
  - Updated middleware guide with layer ordering
  - Added access log section to logging/PII guide
  - Updated CHANGELOG with feature details

## Implementation Details

- Uses `pin_project_lite` for the response future to emit the event once the inner service completes
- Captures request metadata before the inner service consumes the request
- Unmatched requests use the low-cardinality `_unmatched` route label (mirrors metrics layer)
- Exclusion logic handles trailing slashes and empty prefixes gracefully
- No overhead when access logging is disabled via config

https://claude.ai/code/session_01GB5TqxAdSXTuzRjEGayk2A