### PR TITLE
Add first-class SEO toolkit: sitemap, robots.txt, and meta tags

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2557,54 +2557,24 @@ impl AppBuilder {
 
         // Register SEO routes (/robots.txt and /sitemap.xml) when any SEO
         // configuration is present or dynamic sources are registered.
-        // Entries are collected from all registered sources and baked into
-        // the response at startup.
-        {
+        if !seo_sources.is_empty() || crate::seo::has_seo_config(&config.seo) {
             let seo_cfg = &config.seo;
-            let has_seo_config = seo_cfg.base_url.is_some()
-                || !seo_cfg.robots.additional_rules.is_empty()
-                || seo_cfg.robots.allow_all.is_some()
-                || seo_cfg.robots.sitemap_url.is_some();
-            if !seo_sources.is_empty() || has_seo_config {
-                let raw_profile = config.profile.as_deref().unwrap_or("dev");
-                // Honour the explicit allow_all override from [seo.robots].
-                let profile = match seo_cfg.robots.allow_all {
-                    Some(true) => "prod",
-                    Some(false) => "dev",
-                    None => raw_profile,
-                };
-                // Trim trailing slash so base_url = "https://example.com/" works.
-                let base_url = seo_cfg.base_url.as_deref().map(|u| u.trim_end_matches('/'));
-                let additional_rules = &seo_cfg.robots.additional_rules;
-                let mut sitemap_entries = Vec::new();
-                for source in &seo_sources {
-                    let mut entries = source.entries().await;
-                    sitemap_entries.append(&mut entries);
-                }
-                // Auto-include simple static routes (no path params) in the sitemap.
-                if let Some(bu) = base_url {
-                    for meta in &static_metas {
-                        if !meta.path.contains('{') {
-                            sitemap_entries
-                                .push(crate::seo::SitemapEntry::new(format!("{bu}{}", meta.path)));
-                        }
-                    }
-                }
-                // Derive the sitemap URL for robots.txt, preferring an explicit
-                // [seo.robots] sitemap_url when configured.
-                let derived_sitemap_url = base_url.map(|b| format!("{b}/sitemap.xml"));
-                let sitemap_url_for_robots = seo_cfg
-                    .robots
-                    .sitemap_url
-                    .as_deref()
-                    .or(derived_sitemap_url.as_deref());
-                let robots_body =
-                    crate::seo::robots_txt(profile, sitemap_url_for_robots, additional_rules);
-                let sitemap_body = crate::seo::sitemap_xml(&sitemap_entries, base_url);
-                let seo_router =
-                    crate::seo::build_seo_router_from_bodies(robots_body, sitemap_body);
-                merge_routers.push(seo_router);
-            }
+            let raw_profile = config.profile.as_deref().unwrap_or("dev");
+            let profile =
+                crate::seo::effective_seo_profile(raw_profile, seo_cfg.robots.allow_all);
+            let static_paths: Vec<&str> = static_metas.iter().map(|m| m.path).collect();
+            let (robots_body, sitemap_body) = crate::seo::assemble_seo_bodies(
+                profile,
+                seo_cfg.base_url.as_deref(),
+                seo_cfg.robots.sitemap_url.as_deref(),
+                &seo_cfg.robots.additional_rules,
+                &seo_sources,
+                &static_paths,
+            )
+            .await;
+            let seo_router =
+                crate::seo::build_seo_router_from_bodies(robots_body, sitemap_body);
+            merge_routers.push(seo_router);
         }
 
         #[cfg(feature = "inbound-mail")]
@@ -3299,74 +3269,49 @@ impl AppBuilder {
         // Write robots.txt and sitemap.xml to dist/ — only when SEO is explicitly
         // configured or dynamic sources are registered, and never overwrite files
         // already produced by a custom #[static_get("/robots.txt")] route.
-        {
+        if !seo_sources.is_empty() || crate::seo::has_seo_config(&config.seo) {
             let seo_cfg = &config.seo;
-            let has_seo_config = seo_cfg.base_url.is_some()
-                || !seo_cfg.robots.additional_rules.is_empty()
-                || seo_cfg.robots.allow_all.is_some()
-                || seo_cfg.robots.sitemap_url.is_some();
-            if !seo_sources.is_empty() || has_seo_config {
-                let raw_profile = config.profile.as_deref().unwrap_or("dev");
-                let profile = match seo_cfg.robots.allow_all {
-                    Some(true) => "prod",
-                    Some(false) => "dev",
-                    None => raw_profile,
-                };
-                let base_url = seo_cfg.base_url.as_deref().map(|u| u.trim_end_matches('/'));
-                let additional_rules = &seo_cfg.robots.additional_rules;
-                let mut sitemap_entries = Vec::new();
-                for source in &seo_sources {
-                    let mut entries = source.entries().await;
-                    sitemap_entries.append(&mut entries);
+            let raw_profile = config.profile.as_deref().unwrap_or("dev");
+            let profile =
+                crate::seo::effective_seo_profile(raw_profile, seo_cfg.robots.allow_all);
+            let static_paths: Vec<&str> = static_metas.iter().map(|m| m.path).collect();
+            let (robots_body, sitemap_body) = crate::seo::assemble_seo_bodies(
+                profile,
+                seo_cfg.base_url.as_deref(),
+                seo_cfg.robots.sitemap_url.as_deref(),
+                &seo_cfg.robots.additional_rules,
+                &seo_sources,
+                &static_paths,
+            )
+            .await;
+            // Write each file only if it wasn't already produced by a
+            // custom #[static_get] route.
+            let robots_path = dist_dir.join("robots.txt");
+            let sitemap_path = dist_dir.join("sitemap.xml");
+            if robots_path.exists() {
+                eprintln!(
+                    "  \u{2713} SEO: robots.txt already present (custom static route), skipping"
+                );
+            } else {
+                match tokio::fs::write(&robots_path, robots_body).await {
+                    Ok(()) => eprintln!(
+                        "  \u{2713} SEO: robots.txt written \u{2192} {}",
+                        robots_path.display()
+                    ),
+                    Err(e) => eprintln!("  \u{26A0} Failed to write robots.txt: {e}"),
                 }
-                // Build entries from static route metas (auto-include static pages)
-                if let Some(bu) = base_url {
-                    for meta in &static_metas {
-                        if !meta.path.contains('{') {
-                            sitemap_entries
-                                .push(crate::seo::SitemapEntry::new(format!("{bu}{}", meta.path)));
-                        }
-                    }
-                }
-                let derived_sitemap_url = base_url.map(|b| format!("{b}/sitemap.xml"));
-                let sitemap_url_for_robots = seo_cfg
-                    .robots
-                    .sitemap_url
-                    .as_deref()
-                    .or(derived_sitemap_url.as_deref());
-                // Write each file only if it wasn't already produced by a
-                // custom #[static_get] route.
-                let robots_path = dist_dir.join("robots.txt");
-                let sitemap_path = dist_dir.join("sitemap.xml");
-                if robots_path.exists() {
-                    eprintln!(
-                        "  \u{2713} SEO: robots.txt already present (custom static route), skipping"
-                    );
-                } else {
-                    let derived_sitemap_url2 = base_url.map(|b| format!("{b}/sitemap.xml"));
-                    let surl = sitemap_url_for_robots.or(derived_sitemap_url2.as_deref());
-                    let content = crate::seo::robots_txt(profile, surl, additional_rules);
-                    match tokio::fs::write(&robots_path, content).await {
-                        Ok(()) => eprintln!(
-                            "  \u{2713} SEO: robots.txt written \u{2192} {}",
-                            robots_path.display()
-                        ),
-                        Err(e) => eprintln!("  \u{26A0} Failed to write robots.txt: {e}"),
-                    }
-                }
-                if sitemap_path.exists() {
-                    eprintln!(
-                        "  \u{2713} SEO: sitemap.xml already present (custom static route), skipping"
-                    );
-                } else {
-                    let content = crate::seo::sitemap_xml(&sitemap_entries, base_url);
-                    match tokio::fs::write(&sitemap_path, content).await {
-                        Ok(()) => eprintln!(
-                            "  \u{2713} SEO: sitemap.xml written \u{2192} {}",
-                            sitemap_path.display()
-                        ),
-                        Err(e) => eprintln!("  \u{26A0} Failed to write sitemap.xml: {e}"),
-                    }
+            }
+            if sitemap_path.exists() {
+                eprintln!(
+                    "  \u{2713} SEO: sitemap.xml already present (custom static route), skipping"
+                );
+            } else {
+                match tokio::fs::write(&sitemap_path, sitemap_body).await {
+                    Ok(()) => eprintln!(
+                        "  \u{2713} SEO: sitemap.xml written \u{2192} {}",
+                        sitemap_path.display()
+                    ),
+                    Err(e) => eprintln!("  \u{26A0} Failed to write sitemap.xml: {e}"),
                 }
             }
         }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -124,6 +124,7 @@ pub fn app() -> AppBuilder {
         channels_interceptor: None,
         #[cfg(feature = "oauth2")]
         http_interceptor: None,
+        seo_sources: Vec::new(),
         metrics_sources: Vec::new(),
         health_indicators: Vec::new(),
         #[cfg(feature = "inbound-mail")]
@@ -332,6 +333,10 @@ pub struct AppBuilder {
     channels_interceptor: Option<Arc<dyn crate::interceptor::ChannelsInterceptor>>,
     #[cfg(feature = "oauth2")]
     http_interceptor: Option<Arc<dyn crate::interceptor::HttpInterceptor>>,
+    /// Sitemap sources registered via [`AppBuilder::seo_source`].
+    /// Each source provides dynamic URL entries for `/sitemap.xml`.
+    seo_sources: Vec<Arc<dyn crate::seo::SitemapSource>>,
+
     /// Plugin-contributed metrics sources registered via [`AppBuilder::metrics_source`].
     pub(crate) metrics_sources: Vec<(String, Arc<dyn crate::actuator::MetricsSource>)>,
     /// Custom health indicators registered via [`AppBuilder::health_indicator`].
@@ -520,6 +525,49 @@ impl AppBuilder {
     #[must_use]
     pub fn static_routes(mut self, metas: Vec<crate::static_gen::StaticRouteMeta>) -> Self {
         self.static_metas.extend(metas);
+        self
+    }
+
+    /// Register a [`SitemapSource`](crate::seo::SitemapSource) for dynamic sitemap entries.
+    ///
+    /// When called at least once, the framework automatically serves `/sitemap.xml` and
+    /// `/robots.txt`. Dynamic sources (e.g. blog posts from a database) produce entries
+    /// collected at request time.
+    ///
+    /// Combine with `[seo] base_url` in `autumn.toml` to auto-inject the `Sitemap:`
+    /// directive in `robots.txt` and compute canonical URLs.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use autumn_web::prelude::*;
+    /// use autumn_web::seo::{SitemapEntry, SitemapSource};
+    /// use std::pin::Pin;
+    /// use std::future::Future;
+    ///
+    /// struct PostsSitemap;
+    ///
+    /// impl SitemapSource for PostsSitemap {
+    ///     fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send>> {
+    ///         Box::pin(async {
+    ///             vec![SitemapEntry::new("https://example.com/posts/hello")]
+    ///         })
+    ///     }
+    /// }
+    ///
+    /// # #[autumn_web::main]
+    /// # async fn main() {
+    /// # #[get("/")] async fn index() -> &'static str { "" }
+    /// autumn_web::app()
+    ///     .routes(routes![index])
+    ///     .seo_source(PostsSitemap)
+    ///     .run()
+    ///     .await;
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn seo_source<S: crate::seo::SitemapSource + 'static>(mut self, source: S) -> Self {
+        self.seo_sources.push(Arc::new(source));
         self
     }
 
@@ -2176,6 +2224,7 @@ impl AppBuilder {
             channels_interceptor,
             #[cfg(feature = "oauth2")]
             http_interceptor,
+            seo_sources,
             metrics_sources,
             health_indicators,
             #[cfg(feature = "inbound-mail")]
@@ -2505,6 +2554,29 @@ impl AppBuilder {
         if let Some(router) = storage_router {
             merge_routers.push(router);
         }
+
+        // Register SEO routes (/robots.txt and /sitemap.xml) when sitemap
+        // sources are configured. Entries are collected from all registered
+        // sources and baked into the response at startup.
+        if !seo_sources.is_empty() {
+            let seo_cfg = &config.seo;
+            let profile = config.profile.as_deref().unwrap_or("dev");
+            let base_url = seo_cfg.base_url.as_deref();
+            let additional_rules = seo_cfg.robots.additional_rules.clone();
+            let mut sitemap_entries = Vec::new();
+            for source in &seo_sources {
+                let mut entries = source.entries().await;
+                sitemap_entries.append(&mut entries);
+            }
+            let seo_router = crate::seo::build_seo_router_with_entries(
+                profile,
+                base_url,
+                &additional_rules,
+                sitemap_entries,
+            );
+            merge_routers.push(seo_router);
+        }
+
         #[cfg(feature = "inbound-mail")]
         if let Some(ref im_router) = inbound_mail_router {
             let mut registered_inbound: std::collections::HashSet<String> =
@@ -2902,6 +2974,7 @@ impl AppBuilder {
             channels_interceptor,
             #[cfg(feature = "oauth2")]
             http_interceptor,
+            seo_sources,
             metrics_sources,
             health_indicators,
             #[cfg(feature = "inbound-mail")]
@@ -3189,6 +3262,49 @@ impl AppBuilder {
                 }
                 Err(e) => {
                     eprintln!("  \u{26A0} Failed to write OpenAPI spec: {e}");
+                }
+            }
+        }
+
+        // Write robots.txt and sitemap.xml to dist/
+        {
+            let profile = config.profile.as_deref().unwrap_or("dev");
+            let seo_cfg = &config.seo;
+            let base_url = seo_cfg.base_url.as_deref();
+            let additional_rules = &seo_cfg.robots.additional_rules;
+            let mut sitemap_entries = Vec::new();
+            for source in &seo_sources {
+                let mut entries = source.entries().await;
+                sitemap_entries.append(&mut entries);
+            }
+            // Build entries from static route metas (auto-include static pages)
+            if let Some(bu) = base_url {
+                for meta in &static_metas {
+                    if !meta.path.contains('{') {
+                        sitemap_entries.push(crate::seo::SitemapEntry::new(
+                            format!("{bu}{}", meta.path),
+                        ));
+                    }
+                }
+            }
+            match crate::seo::write_seo_files(
+                &dist_dir,
+                profile,
+                base_url,
+                additional_rules,
+                &sitemap_entries,
+            )
+            .await
+            {
+                Ok(()) => {
+                    eprintln!(
+                        "  \u{2713} SEO files written \u{2192} {}/robots.txt, {}/sitemap.xml",
+                        dist_dir.display(),
+                        dist_dir.display()
+                    );
+                }
+                Err(e) => {
+                    eprintln!("  \u{26A0} Failed to write SEO files: {e}");
                 }
             }
         }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -3281,9 +3281,8 @@ impl AppBuilder {
             if let Some(bu) = base_url {
                 for meta in &static_metas {
                     if !meta.path.contains('{') {
-                        sitemap_entries.push(crate::seo::SitemapEntry::new(
-                            format!("{bu}{}", meta.path),
-                        ));
+                        sitemap_entries
+                            .push(crate::seo::SitemapEntry::new(format!("{bu}{}", meta.path)));
                     }
                 }
             }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2555,26 +2555,46 @@ impl AppBuilder {
             merge_routers.push(router);
         }
 
-        // Register SEO routes (/robots.txt and /sitemap.xml) when sitemap
-        // sources are configured. Entries are collected from all registered
-        // sources and baked into the response at startup.
-        if !seo_sources.is_empty() {
+        // Register SEO routes (/robots.txt and /sitemap.xml) when any SEO
+        // configuration is present or dynamic sources are registered.
+        // Entries are collected from all registered sources and baked into
+        // the response at startup.
+        {
             let seo_cfg = &config.seo;
-            let profile = config.profile.as_deref().unwrap_or("dev");
-            let base_url = seo_cfg.base_url.as_deref();
-            let additional_rules = seo_cfg.robots.additional_rules.clone();
-            let mut sitemap_entries = Vec::new();
-            for source in &seo_sources {
-                let mut entries = source.entries().await;
-                sitemap_entries.append(&mut entries);
+            let has_seo_config = seo_cfg.base_url.is_some()
+                || !seo_cfg.robots.additional_rules.is_empty()
+                || seo_cfg.robots.allow_all.is_some()
+                || seo_cfg.robots.sitemap_url.is_some();
+            if !seo_sources.is_empty() || has_seo_config {
+                let raw_profile = config.profile.as_deref().unwrap_or("dev");
+                // Honour the explicit allow_all override from [seo.robots].
+                let profile = match seo_cfg.robots.allow_all {
+                    Some(true) => "prod",
+                    Some(false) => "dev",
+                    None => raw_profile,
+                };
+                // Trim trailing slash so base_url = "https://example.com/" works.
+                let base_url = seo_cfg.base_url.as_deref().map(|u| u.trim_end_matches('/'));
+                let additional_rules = &seo_cfg.robots.additional_rules;
+                let mut sitemap_entries = Vec::new();
+                for source in &seo_sources {
+                    let mut entries = source.entries().await;
+                    sitemap_entries.append(&mut entries);
+                }
+                // Derive the sitemap URL for robots.txt, preferring an explicit
+                // [seo.robots] sitemap_url when configured.
+                let derived_sitemap_url = base_url.map(|b| format!("{b}/sitemap.xml"));
+                let sitemap_url_for_robots = seo_cfg
+                    .robots
+                    .sitemap_url
+                    .as_deref()
+                    .or(derived_sitemap_url.as_deref());
+                let robots_body =
+                    crate::seo::robots_txt(profile, sitemap_url_for_robots, additional_rules);
+                let sitemap_body = crate::seo::sitemap_xml(&sitemap_entries, base_url);
+                let seo_router = crate::seo::build_seo_router_from_bodies(robots_body, sitemap_body);
+                merge_routers.push(seo_router);
             }
-            let seo_router = crate::seo::build_seo_router_with_entries(
-                profile,
-                base_url,
-                &additional_rules,
-                sitemap_entries,
-            );
-            merge_routers.push(seo_router);
         }
 
         #[cfg(feature = "inbound-mail")]
@@ -3268,9 +3288,14 @@ impl AppBuilder {
 
         // Write robots.txt and sitemap.xml to dist/
         {
-            let profile = config.profile.as_deref().unwrap_or("dev");
             let seo_cfg = &config.seo;
-            let base_url = seo_cfg.base_url.as_deref();
+            let raw_profile = config.profile.as_deref().unwrap_or("dev");
+            let profile = match seo_cfg.robots.allow_all {
+                Some(true) => "prod",
+                Some(false) => "dev",
+                None => raw_profile,
+            };
+            let base_url = seo_cfg.base_url.as_deref().map(|u| u.trim_end_matches('/'));
             let additional_rules = &seo_cfg.robots.additional_rules;
             let mut sitemap_entries = Vec::new();
             for source in &seo_sources {
@@ -3281,15 +3306,23 @@ impl AppBuilder {
             if let Some(bu) = base_url {
                 for meta in &static_metas {
                     if !meta.path.contains('{') {
-                        sitemap_entries
-                            .push(crate::seo::SitemapEntry::new(format!("{bu}{}", meta.path)));
+                        sitemap_entries.push(crate::seo::SitemapEntry::new(
+                            format!("{bu}{}", meta.path),
+                        ));
                     }
                 }
             }
+            let derived_sitemap_url = base_url.map(|b| format!("{b}/sitemap.xml"));
+            let sitemap_url_for_robots = seo_cfg
+                .robots
+                .sitemap_url
+                .as_deref()
+                .or(derived_sitemap_url.as_deref());
             match crate::seo::write_seo_files(
                 &dist_dir,
                 profile,
                 base_url,
+                sitemap_url_for_robots,
                 additional_rules,
                 &sitemap_entries,
             )

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2592,7 +2592,8 @@ impl AppBuilder {
                 let robots_body =
                     crate::seo::robots_txt(profile, sitemap_url_for_robots, additional_rules);
                 let sitemap_body = crate::seo::sitemap_xml(&sitemap_entries, base_url);
-                let seo_router = crate::seo::build_seo_router_from_bodies(robots_body, sitemap_body);
+                let seo_router =
+                    crate::seo::build_seo_router_from_bodies(robots_body, sitemap_body);
                 merge_routers.push(seo_router);
             }
         }
@@ -3306,9 +3307,8 @@ impl AppBuilder {
             if let Some(bu) = base_url {
                 for meta in &static_metas {
                     if !meta.path.contains('{') {
-                        sitemap_entries.push(crate::seo::SitemapEntry::new(
-                            format!("{bu}{}", meta.path),
-                        ));
+                        sitemap_entries
+                            .push(crate::seo::SitemapEntry::new(format!("{bu}{}", meta.path)));
                     }
                 }
             }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2560,8 +2560,7 @@ impl AppBuilder {
         if !seo_sources.is_empty() || crate::seo::has_seo_config(&config.seo) {
             let seo_cfg = &config.seo;
             let raw_profile = config.profile.as_deref().unwrap_or("dev");
-            let profile =
-                crate::seo::effective_seo_profile(raw_profile, seo_cfg.robots.allow_all);
+            let profile = crate::seo::effective_seo_profile(raw_profile, seo_cfg.robots.allow_all);
             let static_paths: Vec<&str> = static_metas.iter().map(|m| m.path).collect();
             let (robots_body, sitemap_body) = crate::seo::assemble_seo_bodies(
                 profile,
@@ -2572,8 +2571,7 @@ impl AppBuilder {
                 &static_paths,
             )
             .await;
-            let seo_router =
-                crate::seo::build_seo_router_from_bodies(robots_body, sitemap_body);
+            let seo_router = crate::seo::build_seo_router_from_bodies(robots_body, sitemap_body);
             merge_routers.push(seo_router);
         }
 
@@ -3272,8 +3270,7 @@ impl AppBuilder {
         if !seo_sources.is_empty() || crate::seo::has_seo_config(&config.seo) {
             let seo_cfg = &config.seo;
             let raw_profile = config.profile.as_deref().unwrap_or("dev");
-            let profile =
-                crate::seo::effective_seo_profile(raw_profile, seo_cfg.robots.allow_all);
+            let profile = crate::seo::effective_seo_profile(raw_profile, seo_cfg.robots.allow_all);
             let static_paths: Vec<&str> = static_metas.iter().map(|m| m.path).collect();
             let (robots_body, sitemap_body) = crate::seo::assemble_seo_bodies(
                 profile,

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2585,10 +2585,8 @@ impl AppBuilder {
                 if let Some(bu) = base_url {
                     for meta in &static_metas {
                         if !meta.path.contains('{') {
-                            sitemap_entries.push(crate::seo::SitemapEntry::new(format!(
-                                "{bu}{}",
-                                meta.path
-                            )));
+                            sitemap_entries
+                                .push(crate::seo::SitemapEntry::new(format!("{bu}{}", meta.path)));
                         }
                     }
                 }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2173,7 +2173,7 @@ impl AppBuilder {
             tasks,
             one_off_tasks: _,
             jobs,
-            static_metas: _,
+            static_metas,
             exception_filters,
             scoped_groups,
             merge_routers,
@@ -2580,6 +2580,17 @@ impl AppBuilder {
                 for source in &seo_sources {
                     let mut entries = source.entries().await;
                     sitemap_entries.append(&mut entries);
+                }
+                // Auto-include simple static routes (no path params) in the sitemap.
+                if let Some(bu) = base_url {
+                    for meta in &static_metas {
+                        if !meta.path.contains('{') {
+                            sitemap_entries.push(crate::seo::SitemapEntry::new(format!(
+                                "{bu}{}",
+                                meta.path
+                            )));
+                        }
+                    }
                 }
                 // Derive the sitemap URL for robots.txt, preferring an explicit
                 // [seo.robots] sitemap_url when configured.
@@ -3287,56 +3298,77 @@ impl AppBuilder {
             }
         }
 
-        // Write robots.txt and sitemap.xml to dist/
+        // Write robots.txt and sitemap.xml to dist/ — only when SEO is explicitly
+        // configured or dynamic sources are registered, and never overwrite files
+        // already produced by a custom #[static_get("/robots.txt")] route.
         {
             let seo_cfg = &config.seo;
-            let raw_profile = config.profile.as_deref().unwrap_or("dev");
-            let profile = match seo_cfg.robots.allow_all {
-                Some(true) => "prod",
-                Some(false) => "dev",
-                None => raw_profile,
-            };
-            let base_url = seo_cfg.base_url.as_deref().map(|u| u.trim_end_matches('/'));
-            let additional_rules = &seo_cfg.robots.additional_rules;
-            let mut sitemap_entries = Vec::new();
-            for source in &seo_sources {
-                let mut entries = source.entries().await;
-                sitemap_entries.append(&mut entries);
-            }
-            // Build entries from static route metas (auto-include static pages)
-            if let Some(bu) = base_url {
-                for meta in &static_metas {
-                    if !meta.path.contains('{') {
-                        sitemap_entries
-                            .push(crate::seo::SitemapEntry::new(format!("{bu}{}", meta.path)));
+            let has_seo_config = seo_cfg.base_url.is_some()
+                || !seo_cfg.robots.additional_rules.is_empty()
+                || seo_cfg.robots.allow_all.is_some()
+                || seo_cfg.robots.sitemap_url.is_some();
+            if !seo_sources.is_empty() || has_seo_config {
+                let raw_profile = config.profile.as_deref().unwrap_or("dev");
+                let profile = match seo_cfg.robots.allow_all {
+                    Some(true) => "prod",
+                    Some(false) => "dev",
+                    None => raw_profile,
+                };
+                let base_url = seo_cfg.base_url.as_deref().map(|u| u.trim_end_matches('/'));
+                let additional_rules = &seo_cfg.robots.additional_rules;
+                let mut sitemap_entries = Vec::new();
+                for source in &seo_sources {
+                    let mut entries = source.entries().await;
+                    sitemap_entries.append(&mut entries);
+                }
+                // Build entries from static route metas (auto-include static pages)
+                if let Some(bu) = base_url {
+                    for meta in &static_metas {
+                        if !meta.path.contains('{') {
+                            sitemap_entries
+                                .push(crate::seo::SitemapEntry::new(format!("{bu}{}", meta.path)));
+                        }
                     }
                 }
-            }
-            let derived_sitemap_url = base_url.map(|b| format!("{b}/sitemap.xml"));
-            let sitemap_url_for_robots = seo_cfg
-                .robots
-                .sitemap_url
-                .as_deref()
-                .or(derived_sitemap_url.as_deref());
-            match crate::seo::write_seo_files(
-                &dist_dir,
-                profile,
-                base_url,
-                sitemap_url_for_robots,
-                additional_rules,
-                &sitemap_entries,
-            )
-            .await
-            {
-                Ok(()) => {
+                let derived_sitemap_url = base_url.map(|b| format!("{b}/sitemap.xml"));
+                let sitemap_url_for_robots = seo_cfg
+                    .robots
+                    .sitemap_url
+                    .as_deref()
+                    .or(derived_sitemap_url.as_deref());
+                // Write each file only if it wasn't already produced by a
+                // custom #[static_get] route.
+                let robots_path = dist_dir.join("robots.txt");
+                let sitemap_path = dist_dir.join("sitemap.xml");
+                if robots_path.exists() {
                     eprintln!(
-                        "  \u{2713} SEO files written \u{2192} {}/robots.txt, {}/sitemap.xml",
-                        dist_dir.display(),
-                        dist_dir.display()
+                        "  \u{2713} SEO: robots.txt already present (custom static route), skipping"
                     );
+                } else {
+                    let derived_sitemap_url2 = base_url.map(|b| format!("{b}/sitemap.xml"));
+                    let surl = sitemap_url_for_robots.or(derived_sitemap_url2.as_deref());
+                    let content = crate::seo::robots_txt(profile, surl, additional_rules);
+                    match tokio::fs::write(&robots_path, content).await {
+                        Ok(()) => eprintln!(
+                            "  \u{2713} SEO: robots.txt written \u{2192} {}",
+                            robots_path.display()
+                        ),
+                        Err(e) => eprintln!("  \u{26A0} Failed to write robots.txt: {e}"),
+                    }
                 }
-                Err(e) => {
-                    eprintln!("  \u{26A0} Failed to write SEO files: {e}");
+                if sitemap_path.exists() {
+                    eprintln!(
+                        "  \u{2713} SEO: sitemap.xml already present (custom static route), skipping"
+                    );
+                } else {
+                    let content = crate::seo::sitemap_xml(&sitemap_entries, base_url);
+                    match tokio::fs::write(&sitemap_path, content).await {
+                        Ok(()) => eprintln!(
+                            "  \u{2713} SEO: sitemap.xml written \u{2192} {}",
+                            sitemap_path.display()
+                        ),
+                        Err(e) => eprintln!("  \u{26A0} Failed to write sitemap.xml: {e}"),
+                    }
                 }
             }
         }

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -807,6 +807,71 @@ pub struct AutumnConfig {
     /// ```
     #[serde(default)]
     pub bot_protection: crate::security::captcha::BotProtectionConfig,
+
+    /// SEO settings (`[seo]` section in `autumn.toml`).
+    ///
+    /// Controls sitemap generation, robots.txt behavior, and canonical URL
+    /// computation. See [`crate::seo`] for the full surface.
+    ///
+    /// # Example `autumn.toml`
+    ///
+    /// ```toml
+    /// [seo]
+    /// base_url = "https://example.com"
+    ///
+    /// [seo.robots]
+    /// additional_rules = ["Disallow: /admin"]
+    /// ```
+    #[serde(default)]
+    pub seo: SeoConfig,
+}
+
+/// SEO configuration (`[seo]` section in `autumn.toml`).
+///
+/// # Example
+///
+/// ```toml
+/// [seo]
+/// base_url = "https://example.com"
+///
+/// [seo.robots]
+/// additional_rules = ["Disallow: /admin"]
+/// ```
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SeoConfig {
+    /// Base URL used for canonical URL computation and sitemap auto-injection.
+    ///
+    /// E.g. `"https://example.com"`. When set, the `Sitemap:` directive is
+    /// automatically injected into `robots.txt`.
+    pub base_url: Option<String>,
+
+    /// Robots.txt overrides.
+    #[serde(default)]
+    pub robots: RobotsConfig,
+}
+
+/// Per-profile `robots.txt` overrides (`[seo.robots]` in `autumn.toml`).
+///
+/// The framework default behavior (dev/test → disallow all; prod → allow all)
+/// can be overridden here.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct RobotsConfig {
+    /// Override the profile-driven allow/disallow default.
+    ///
+    /// `None` means: use the profile default (dev → disallow, prod → allow).
+    /// `Some(true)` forces `Allow: /`; `Some(false)` forces `Disallow: /`.
+    pub allow_all: Option<bool>,
+
+    /// Additional directives appended after the main `User-agent` block.
+    ///
+    /// Example: `["Disallow: /admin", "Crawl-delay: 5"]`
+    #[serde(default)]
+    pub additional_rules: Vec<String>,
+
+    /// Explicit `Sitemap:` URL.
+    ///
+    /// When `None`, the URL is auto-computed from `[seo] base_url` if set.
+    pub sitemap_url: Option<String>,
 }
 
 /// Error-reporting settings (`[reporting]` section in `autumn.toml`).

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -83,7 +83,6 @@ pub use channels::{
 pub mod canary;
 pub mod config;
 pub mod credentials;
-pub mod seo;
 #[cfg(feature = "db")]
 pub mod db;
 pub mod encryption;
@@ -96,6 +95,7 @@ pub mod hooks;
 #[cfg(feature = "i18n")]
 pub mod i18n;
 pub mod idempotency;
+pub mod seo;
 /// Translation lookup macro with compile-time key validation.
 ///
 /// Re-exported from [`crate::i18n::t`] for ergonomic

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -83,6 +83,7 @@ pub use channels::{
 pub mod canary;
 pub mod config;
 pub mod credentials;
+pub mod seo;
 #[cfg(feature = "db")]
 pub mod db;
 pub mod encryption;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -201,6 +201,16 @@ pub use crate::webhook::{
 #[cfg(feature = "http-client")]
 pub use crate::http_client::Client;
 
+// ── SEO helpers ──────────────────────────────────────────────────
+/// Per-page SEO meta tag builder (title, description, canonical, OG, Twitter).
+pub use crate::seo::SeoMeta;
+/// A single sitemap entry (URL, lastmod, changefreq, priority).
+pub use crate::seo::SitemapEntry;
+/// Sitemap change frequency values.
+pub use crate::seo::SitemapChangefreq;
+/// Trait for dynamic sitemap URL providers (e.g. database-driven blog posts).
+pub use crate::seo::SitemapSource;
+
 // ── Application state ────────────────────────────────────────────
 /// Shared application state (for custom extractors).
 pub use crate::state::AppState;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -204,10 +204,10 @@ pub use crate::http_client::Client;
 // ── SEO helpers ──────────────────────────────────────────────────
 /// Per-page SEO meta tag builder (title, description, canonical, OG, Twitter).
 pub use crate::seo::SeoMeta;
-/// A single sitemap entry (URL, lastmod, changefreq, priority).
-pub use crate::seo::SitemapEntry;
 /// Sitemap change frequency values.
 pub use crate::seo::SitemapChangefreq;
+/// A single sitemap entry (URL, lastmod, changefreq, priority).
+pub use crate::seo::SitemapEntry;
 /// Trait for dynamic sitemap URL providers (e.g. database-driven blog posts).
 pub use crate::seo::SitemapSource;
 

--- a/autumn/src/seo.rs
+++ b/autumn/src/seo.rs
@@ -812,9 +812,8 @@ mod tests {
     impl SitemapSource for SimpleSitemapSource {
         fn entries(
             &self,
-        ) -> std::pin::Pin<
-            Box<dyn std::future::Future<Output = Vec<SitemapEntry>> + Send + '_>,
-        > {
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Vec<SitemapEntry>> + Send + '_>>
+        {
             let entries = self.entries.clone();
             Box::pin(async move { entries })
         }
@@ -822,8 +821,7 @@ mod tests {
 
     #[tokio::test]
     async fn assemble_seo_bodies_empty() {
-        let (robots, sitemap) =
-            assemble_seo_bodies("prod", None, None, &[], &[], &[]).await;
+        let (robots, sitemap) = assemble_seo_bodies("prod", None, None, &[], &[], &[]).await;
         assert!(robots.contains("Allow: /"));
         assert!(sitemap.contains("<urlset"));
     }

--- a/autumn/src/seo.rs
+++ b/autumn/src/seo.rs
@@ -625,7 +625,7 @@ where
 // ── App-level SEO helpers (shared by run() and run_build_mode()) ──────────────
 
 /// Return `true` when the `[seo]` config section contains any non-default value.
-pub(crate) fn has_seo_config(seo_cfg: &crate::config::SeoConfig) -> bool {
+pub(crate) const fn has_seo_config(seo_cfg: &crate::config::SeoConfig) -> bool {
     seo_cfg.base_url.is_some()
         || !seo_cfg.robots.additional_rules.is_empty()
         || seo_cfg.robots.allow_all.is_some()
@@ -634,7 +634,7 @@ pub(crate) fn has_seo_config(seo_cfg: &crate::config::SeoConfig) -> bool {
 
 /// Resolve the effective robots.txt profile from `raw_profile` and the
 /// optional `allow_all` override in `[seo.robots]`.
-pub(crate) fn effective_seo_profile<'a>(raw_profile: &'a str, allow_all: Option<bool>) -> &'a str {
+pub(crate) const fn effective_seo_profile(raw_profile: &str, allow_all: Option<bool>) -> &str {
     match allow_all {
         Some(true) => "prod",
         Some(false) => "dev",
@@ -764,29 +764,46 @@ mod tests {
 
     #[test]
     fn has_seo_config_true_when_base_url_set() {
-        let mut cfg = crate::config::SeoConfig::default();
-        cfg.base_url = Some("https://example.com".to_string());
+        let cfg = crate::config::SeoConfig {
+            base_url: Some("https://example.com".to_string()),
+            ..Default::default()
+        };
         assert!(has_seo_config(&cfg));
     }
 
     #[test]
     fn has_seo_config_true_when_allow_all_set() {
-        let mut cfg = crate::config::SeoConfig::default();
-        cfg.robots.allow_all = Some(true);
+        let cfg = crate::config::SeoConfig {
+            robots: crate::config::RobotsConfig {
+                allow_all: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
         assert!(has_seo_config(&cfg));
     }
 
     #[test]
     fn has_seo_config_true_when_sitemap_url_set() {
-        let mut cfg = crate::config::SeoConfig::default();
-        cfg.robots.sitemap_url = Some("https://example.com/sitemap.xml".to_string());
+        let cfg = crate::config::SeoConfig {
+            robots: crate::config::RobotsConfig {
+                sitemap_url: Some("https://example.com/sitemap.xml".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
         assert!(has_seo_config(&cfg));
     }
 
     #[test]
     fn has_seo_config_true_when_additional_rules_set() {
-        let mut cfg = crate::config::SeoConfig::default();
-        cfg.robots.additional_rules = vec!["Disallow: /admin".to_string()];
+        let cfg = crate::config::SeoConfig {
+            robots: crate::config::RobotsConfig {
+                additional_rules: vec!["Disallow: /admin".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
         assert!(has_seo_config(&cfg));
     }
 

--- a/autumn/src/seo.rs
+++ b/autumn/src/seo.rs
@@ -1,0 +1,634 @@
+//! First-class SEO toolkit: sitemap.xml, robots.txt, and meta tag helpers.
+//!
+//! Autumn content apps need three artifacts for full crawl coverage:
+//! a `sitemap.xml`, a `robots.txt`, and per-page meta tags. This module
+//! provides builders and helpers for all three with sensible defaults.
+//!
+//! # Quick start
+//!
+//! ## Meta tags
+//!
+//! ```rust,ignore
+//! use autumn_web::seo::SeoMeta;
+//! use autumn_web::prelude::*;
+//!
+//! #[get("/posts/{slug}")]
+//! async fn show(slug: Path<String>) -> Markup {
+//!     let meta = SeoMeta::new()
+//!         .title("My Blog Post")
+//!         .description("A fascinating exploration of things")
+//!         .canonical(format!("https://example.com/posts/{}", *slug))
+//!         .og_image("https://example.com/og.jpg");
+//!     html! {
+//!         head { (meta.render()) }
+//!     }
+//! }
+//! ```
+//!
+//! ## Sitemap
+//!
+//! Register a [`SitemapSource`] on the app builder for dynamic routes:
+//!
+//! ```rust,ignore
+//! use autumn_web::seo::{SitemapEntry, SitemapSource};
+//! use std::future::Future;
+//! use std::pin::Pin;
+//!
+//! struct BlogSitemapSource;
+//!
+//! impl SitemapSource for BlogSitemapSource {
+//!     fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send>> {
+//!         Box::pin(async {
+//!             vec![SitemapEntry::new("https://example.com/posts/hello")]
+//!         })
+//!     }
+//! }
+//!
+//! // In main():
+//! // autumn_web::app()
+//! //     .routes(routes![...])
+//! //     .seo_source(BlogSitemapSource)
+//! //     .run()
+//! //     .await;
+//! ```
+//!
+//! ## Robots.txt
+//!
+//! Configure in `autumn.toml`:
+//!
+//! ```toml
+//! [seo]
+//! base_url = "https://example.com"
+//!
+//! [seo.robots]
+//! additional_rules = ["Disallow: /admin"]
+//! ```
+//!
+//! The framework defaults: `dev`/`test` → disallow all; `prod` → allow all.
+
+use std::future::Future;
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::Response;
+use axum::routing::get;
+
+#[cfg(feature = "maud")]
+use maud::{Markup, html};
+
+// ── SitemapEntry ─────────────────────────────────────────────────────────────
+
+/// A single URL entry in a sitemap.
+#[derive(Debug, Clone)]
+pub struct SitemapEntry {
+    /// The fully-qualified URL of the page.
+    pub loc: String,
+    /// Last modified date in `YYYY-MM-DD` format.
+    pub lastmod: Option<String>,
+    /// Suggested crawl frequency.
+    pub changefreq: Option<SitemapChangefreq>,
+    /// Relative priority (0.0–1.0). Clamped on construction.
+    pub priority: Option<f32>,
+}
+
+impl SitemapEntry {
+    /// Create a new entry with the given URL.
+    pub fn new(loc: impl Into<String>) -> Self {
+        Self {
+            loc: loc.into(),
+            lastmod: None,
+            changefreq: None,
+            priority: None,
+        }
+    }
+
+    /// Set the last modified date (ISO 8601, e.g. `"2026-01-15"`).
+    pub fn lastmod(mut self, lastmod: impl Into<String>) -> Self {
+        self.lastmod = Some(lastmod.into());
+        self
+    }
+
+    /// Set the suggested change frequency.
+    pub fn changefreq(mut self, changefreq: SitemapChangefreq) -> Self {
+        self.changefreq = Some(changefreq);
+        self
+    }
+
+    /// Set the priority (clamped to 0.0–1.0).
+    pub fn priority(mut self, priority: f32) -> Self {
+        self.priority = Some(priority.clamp(0.0, 1.0));
+        self
+    }
+}
+
+// ── SitemapChangefreq ─────────────────────────────────────────────────────────
+
+/// Suggested update frequency for a sitemap entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SitemapChangefreq {
+    Always,
+    Hourly,
+    Daily,
+    Weekly,
+    Monthly,
+    Yearly,
+    Never,
+}
+
+impl SitemapChangefreq {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Always => "always",
+            Self::Hourly => "hourly",
+            Self::Daily => "daily",
+            Self::Weekly => "weekly",
+            Self::Monthly => "monthly",
+            Self::Yearly => "yearly",
+            Self::Never => "never",
+        }
+    }
+}
+
+// ── SitemapSource ─────────────────────────────────────────────────────────────
+
+/// Trait for providing dynamic sitemap entries (e.g. blog posts from a database).
+///
+/// Implement this trait and register the source with
+/// [`AppBuilder::seo_source`](crate::app::AppBuilder::seo_source).
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::seo::{SitemapEntry, SitemapSource};
+/// use std::pin::Pin;
+/// use std::future::Future;
+///
+/// struct PostSitemapSource;
+///
+/// impl SitemapSource for PostSitemapSource {
+///     fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send>> {
+///         Box::pin(async {
+///             vec![
+///                 SitemapEntry::new("https://example.com/posts/hello-world")
+///                     .lastmod("2026-01-15")
+///                     .changefreq(autumn_web::seo::SitemapChangefreq::Weekly),
+///             ]
+///         })
+///     }
+/// }
+/// ```
+pub trait SitemapSource: Send + Sync {
+    /// Return the sitemap entries for this source.
+    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send>>;
+}
+
+// ── Internal AppState extension newtypes ──────────────────────────────────────
+
+/// Registered sitemap sources stored in AppState extensions.
+#[doc(hidden)]
+pub struct RegisteredSitemapSources(pub Vec<Arc<dyn SitemapSource>>);
+
+/// Registered SEO config stored in AppState extensions.
+#[doc(hidden)]
+pub struct RegisteredSeoConfig(pub crate::config::SeoConfig);
+
+// ── robots_txt() ──────────────────────────────────────────────────────────────
+
+/// Generate an environment-aware `robots.txt` string.
+///
+/// - `dev`/`test` profiles → `Disallow: /` (blocks all crawlers)
+/// - `prod`/`production` profiles → `Allow: /` (permits all crawlers)
+///
+/// # Arguments
+///
+/// * `profile` — The active profile (`"dev"`, `"test"`, or `"prod"`).
+/// * `sitemap_url` — Optional sitemap URL to inject as a `Sitemap:` directive.
+/// * `additional_rules` — Extra lines to append (e.g. `"Disallow: /admin"`).
+pub fn robots_txt(profile: &str, sitemap_url: Option<&str>, additional_rules: &[String]) -> String {
+    let mut txt = String::new();
+
+    let is_prod = matches!(profile, "prod" | "production");
+    if is_prod {
+        txt.push_str("User-agent: *\nAllow: /\n");
+    } else {
+        txt.push_str("User-agent: *\nDisallow: /\n");
+    }
+
+    for rule in additional_rules {
+        txt.push_str(rule);
+        txt.push('\n');
+    }
+
+    if let Some(url) = sitemap_url {
+        txt.push_str(&format!("\nSitemap: {url}\n"));
+    }
+
+    txt
+}
+
+// ── sitemap_xml() ─────────────────────────────────────────────────────────────
+
+/// Generate a valid `sitemap.xml` string.
+///
+/// For sites with more than 50,000 URLs, generates a
+/// `<sitemapindex>` document that references numbered sub-sitemaps
+/// (`/sitemap-1.xml`, `/sitemap-2.xml`, …).
+///
+/// # Arguments
+///
+/// * `entries` — The sitemap entries to include.
+/// * `base_url` — The site base URL (e.g. `"https://example.com"`), used to
+///   build sub-sitemap URLs in sitemapindex mode.
+pub fn sitemap_xml(entries: &[SitemapEntry], base_url: Option<&str>) -> String {
+    const CHUNK_SIZE: usize = 50_000;
+
+    if entries.len() > CHUNK_SIZE {
+        sitemap_index_xml(entries, base_url.unwrap_or(""), CHUNK_SIZE)
+    } else {
+        sitemap_urlset_xml(entries)
+    }
+}
+
+/// Build a `<urlset>` sitemap.
+pub(crate) fn sitemap_urlset_xml(entries: &[SitemapEntry]) -> String {
+    let mut xml = String::from(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">",
+    );
+    for entry in entries {
+        xml.push_str("\n  <url>");
+        xml.push_str(&format!("\n    <loc>{}</loc>", xml_escape(&entry.loc)));
+        if let Some(lastmod) = &entry.lastmod {
+            xml.push_str(&format!("\n    <lastmod>{lastmod}</lastmod>"));
+        }
+        if let Some(freq) = entry.changefreq {
+            xml.push_str(&format!("\n    <changefreq>{}</changefreq>", freq.as_str()));
+        }
+        if let Some(prio) = entry.priority {
+            xml.push_str(&format!("\n    <priority>{prio:.1}</priority>"));
+        }
+        xml.push_str("\n  </url>");
+    }
+    xml.push_str("\n</urlset>");
+    xml
+}
+
+/// Build a `<sitemapindex>` for sites with more than `chunk_size` URLs.
+fn sitemap_index_xml(entries: &[SitemapEntry], base_url: &str, chunk_size: usize) -> String {
+    let chunk_count = entries.len().div_ceil(chunk_size);
+    let mut xml = String::from(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">",
+    );
+    for i in 0..chunk_count {
+        let idx = i + 1;
+        xml.push_str(&format!(
+            "\n  <sitemap>\n    <loc>{base_url}/sitemap-{idx}.xml</loc>\n  </sitemap>"
+        ));
+    }
+    xml.push_str("\n</sitemapindex>");
+    xml
+}
+
+/// Escape XML special characters.
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+// ── SeoMeta builder ───────────────────────────────────────────────────────────
+
+/// Builder for per-page SEO meta tags.
+///
+/// Generates `<title>`, `<meta>`, `<link rel="canonical">`, Open Graph,
+/// and Twitter card tags from a fluent builder API.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// # #[cfg(feature = "maud")]
+/// # {
+/// use autumn_web::seo::SeoMeta;
+///
+/// let meta = SeoMeta::new()
+///     .title("My Post")
+///     .description("A great post")
+///     .canonical("https://example.com/posts/my-post")
+///     .og_image("https://example.com/og.jpg")
+///     .twitter_card("summary_large_image");
+///
+/// // Embed in a Maud template:
+/// // html! { head { (meta.render()) } }
+/// # }
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct SeoMeta {
+    title: Option<String>,
+    description: Option<String>,
+    canonical: Option<String>,
+    og_title: Option<String>,
+    og_description: Option<String>,
+    og_image: Option<String>,
+    og_type: Option<String>,
+    og_url: Option<String>,
+    twitter_card: Option<String>,
+    twitter_title: Option<String>,
+    twitter_description: Option<String>,
+    twitter_image: Option<String>,
+    robots_directive: Option<String>,
+}
+
+impl SeoMeta {
+    /// Create a new, empty builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the page `<title>` (also used as the default OG/Twitter title).
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Set the `<meta name="description">` content.
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the `<link rel="canonical">` URL.
+    ///
+    /// Also used as the `og:url` fallback.
+    pub fn canonical(mut self, url: impl Into<String>) -> Self {
+        self.canonical = Some(url.into());
+        self
+    }
+
+    /// Set the `og:image` URL.
+    pub fn og_image(mut self, url: impl Into<String>) -> Self {
+        self.og_image = Some(url.into());
+        self
+    }
+
+    /// Set the `og:type` value (default: omitted; common: `"website"`, `"article"`).
+    pub fn og_type(mut self, og_type: impl Into<String>) -> Self {
+        self.og_type = Some(og_type.into());
+        self
+    }
+
+    /// Override the `og:title` (defaults to `title()`).
+    pub fn og_title(mut self, title: impl Into<String>) -> Self {
+        self.og_title = Some(title.into());
+        self
+    }
+
+    /// Override the `og:description` (defaults to `description()`).
+    pub fn og_description(mut self, desc: impl Into<String>) -> Self {
+        self.og_description = Some(desc.into());
+        self
+    }
+
+    /// Set the `og:url` (defaults to `canonical()` if not set).
+    pub fn og_url(mut self, url: impl Into<String>) -> Self {
+        self.og_url = Some(url.into());
+        self
+    }
+
+    /// Set the `twitter:card` type (e.g. `"summary_large_image"`).
+    ///
+    /// When set, `twitter:title` and `twitter:description` are also emitted.
+    pub fn twitter_card(mut self, card_type: impl Into<String>) -> Self {
+        self.twitter_card = Some(card_type.into());
+        self
+    }
+
+    /// Override the `twitter:title` (defaults to `title()`).
+    pub fn twitter_title(mut self, title: impl Into<String>) -> Self {
+        self.twitter_title = Some(title.into());
+        self
+    }
+
+    /// Override the `twitter:description` (defaults to `description()`).
+    pub fn twitter_description(mut self, desc: impl Into<String>) -> Self {
+        self.twitter_description = Some(desc.into());
+        self
+    }
+
+    /// Set the `twitter:image` URL.
+    pub fn twitter_image(mut self, url: impl Into<String>) -> Self {
+        self.twitter_image = Some(url.into());
+        self
+    }
+
+    /// Set the `<meta name="robots">` directive (e.g. `"noindex"`, `"nofollow"`).
+    pub fn robots(mut self, directive: impl Into<String>) -> Self {
+        self.robots_directive = Some(directive.into());
+        self
+    }
+
+    /// Render all configured meta tags as Maud [`Markup`].
+    ///
+    /// Emits only the tags that have been configured. Empty builders produce
+    /// no output.
+    #[cfg(feature = "maud")]
+    pub fn render(&self) -> Markup {
+        let og_title = self.og_title.as_ref().or(self.title.as_ref());
+        let og_desc = self.og_description.as_ref().or(self.description.as_ref());
+        let twitter_title = self.twitter_title.as_ref().or(self.title.as_ref());
+        let twitter_desc = self.twitter_description.as_ref().or(self.description.as_ref());
+        let og_url = self.og_url.as_ref().or(self.canonical.as_ref());
+        let has_twitter = self.twitter_card.is_some();
+
+        html! {
+            @if let Some(title) = &self.title {
+                title { (title) }
+            }
+            @if let Some(desc) = &self.description {
+                meta name="description" content=(desc);
+            }
+            @if let Some(dir) = &self.robots_directive {
+                meta name="robots" content=(dir);
+            }
+            @if let Some(url) = &self.canonical {
+                link rel="canonical" href=(url);
+            }
+            @if let Some(t) = og_title {
+                meta property="og:title" content=(t);
+            }
+            @if let Some(d) = og_desc {
+                meta property="og:description" content=(d);
+            }
+            @if let Some(img) = &self.og_image {
+                meta property="og:image" content=(img);
+            }
+            @if let Some(ot) = &self.og_type {
+                meta property="og:type" content=(ot);
+            }
+            @if let Some(url) = og_url {
+                meta property="og:url" content=(url);
+            }
+            @if let Some(card) = &self.twitter_card {
+                meta name="twitter:card" content=(card);
+            }
+            @if has_twitter {
+                @if let Some(t) = twitter_title {
+                    meta name="twitter:title" content=(t);
+                }
+                @if let Some(d) = twitter_desc {
+                    meta name="twitter:description" content=(d);
+                }
+            }
+            @if let Some(img) = &self.twitter_image {
+                meta name="twitter:image" content=(img);
+            }
+        }
+    }
+}
+
+// ── HTTP route builders (used by AppBuilder::run) ─────────────────────────────
+
+/// Build an axum [`Router`] serving `/robots.txt` and `/sitemap.xml`.
+///
+/// The router is generic over the application state `S`, making it compatible
+/// with both bare test routers and full `AppState`-powered production routers.
+///
+/// Used by [`AppBuilder::seo_source`](crate::app::AppBuilder::seo_source) when
+/// assembling the server. The `entries` parameter provides the initial set of
+/// URLs to include in the sitemap; dynamic sources registered via `seo_source()`
+/// can supply additional entries at request time.
+pub fn build_seo_router<S>(
+    profile: &str,
+    base_url: Option<&str>,
+    additional_rules: &[String],
+) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    build_seo_router_with_entries(profile, base_url, additional_rules, Vec::new())
+}
+
+/// Build a SEO router with a pre-populated list of sitemap entries.
+pub fn build_seo_router_with_entries<S>(
+    profile: &str,
+    base_url: Option<&str>,
+    additional_rules: &[String],
+    entries: Vec<SitemapEntry>,
+) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    let sitemap_url = base_url.map(|b| format!("{b}/sitemap.xml"));
+    let robots_body = robots_txt(profile, sitemap_url.as_deref(), additional_rules);
+    let sitemap_body = sitemap_xml(&entries, base_url);
+
+    Router::<S>::new()
+        .route(
+            "/robots.txt",
+            get({
+                let robots_body = robots_body.clone();
+                move || {
+                    let body = robots_body.clone();
+                    async move {
+                        Response::builder()
+                            .header("Content-Type", "text/plain; charset=utf-8")
+                            .body(Body::from(body))
+                            .unwrap()
+                    }
+                }
+            }),
+        )
+        .route(
+            "/sitemap.xml",
+            get({
+                let sitemap_body = sitemap_body.clone();
+                move || {
+                    let body = sitemap_body.clone();
+                    async move {
+                        Response::builder()
+                            .header("Content-Type", "application/xml; charset=utf-8")
+                            .body(Body::from(body))
+                            .unwrap()
+                    }
+                }
+            }),
+        )
+}
+
+// ── Static build helpers ──────────────────────────────────────────────────────
+
+/// Write `robots.txt` and `sitemap.xml` to `dist_dir` as part of `autumn build`.
+///
+/// Called by [`AppBuilder::run_build_mode`] after static routes are rendered.
+///
+/// # Arguments
+///
+/// * `dist_dir` — The output directory (e.g. `dist/`).
+/// * `profile` — The active profile.
+/// * `base_url` — The site base URL (auto-injects the `Sitemap:` directive).
+/// * `additional_rules` — Extra robots.txt rules.
+/// * `entries` — Sitemap entries to include (from registered sources + static metas).
+///
+/// # Errors
+///
+/// Returns `std::io::Error` if writing fails.
+pub async fn write_seo_files(
+    dist_dir: &Path,
+    profile: &str,
+    base_url: Option<&str>,
+    additional_rules: &[String],
+    entries: &[SitemapEntry],
+) -> Result<(), std::io::Error> {
+    let sitemap_url = base_url.map(|b| format!("{b}/sitemap.xml"));
+    let robots = robots_txt(profile, sitemap_url.as_deref(), additional_rules);
+    let sitemap = sitemap_xml(entries, base_url);
+
+    tokio::fs::write(dist_dir.join("robots.txt"), robots).await?;
+    tokio::fs::write(dist_dir.join("sitemap.xml"), sitemap).await?;
+
+    Ok(())
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sitemap_entry_builder() {
+        let e = SitemapEntry::new("https://example.com/")
+            .lastmod("2026-01-01")
+            .changefreq(SitemapChangefreq::Weekly)
+            .priority(0.9);
+        assert_eq!(e.loc, "https://example.com/");
+        assert_eq!(e.lastmod.as_deref(), Some("2026-01-01"));
+        assert_eq!(e.changefreq, Some(SitemapChangefreq::Weekly));
+        assert!((e.priority.unwrap() - 0.9).abs() < 0.001);
+    }
+
+    #[test]
+    fn sitemap_entry_priority_clamped() {
+        let hi = SitemapEntry::new("https://example.com/").priority(1.5);
+        let lo = SitemapEntry::new("https://example.com/").priority(-0.5);
+        assert!((hi.priority.unwrap() - 1.0).abs() < 0.001);
+        assert!((lo.priority.unwrap() - 0.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn xml_escape_replaces_special_chars() {
+        assert_eq!(xml_escape("a&b<c>d\"e'f"), "a&amp;b&lt;c&gt;d&quot;e&apos;f");
+    }
+
+    #[test]
+    fn robots_txt_staging_profile_disallows() {
+        let txt = robots_txt("staging", None, &[]);
+        assert!(txt.contains("Disallow: /"));
+        assert!(!txt.contains("Allow: /"));
+    }
+}

--- a/autumn/src/seo.rs
+++ b/autumn/src/seo.rs
@@ -37,7 +37,7 @@
 //! struct BlogSitemapSource;
 //!
 //! impl SitemapSource for BlogSitemapSource {
-//!     fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send>> {
+//!     fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send + '_>> {
 //!         Box::pin(async {
 //!             vec![SitemapEntry::new("https://example.com/posts/hello")]
 //!         })
@@ -174,7 +174,7 @@ impl SitemapChangefreq {
 /// struct PostSitemapSource;
 ///
 /// impl SitemapSource for PostSitemapSource {
-///     fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send>> {
+///     fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send + '_>> {
 ///         Box::pin(async {
 ///             vec![
 ///                 SitemapEntry::new("https://example.com/posts/hello-world")
@@ -187,7 +187,7 @@ impl SitemapChangefreq {
 /// ```
 pub trait SitemapSource: Send + Sync {
     /// Return the sitemap entries for this source.
-    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send>>;
+    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send + '_>>;
 }
 
 // ── Internal AppState extension newtypes ──────────────────────────────────────

--- a/autumn/src/seo.rs
+++ b/autumn/src/seo.rs
@@ -441,7 +441,10 @@ impl SeoMeta {
         let og_title = self.og_title.as_ref().or(self.title.as_ref());
         let og_desc = self.og_description.as_ref().or(self.description.as_ref());
         let twitter_title = self.twitter_title.as_ref().or(self.title.as_ref());
-        let twitter_desc = self.twitter_description.as_ref().or(self.description.as_ref());
+        let twitter_desc = self
+            .twitter_description
+            .as_ref()
+            .or(self.description.as_ref());
         let og_url = self.og_url.as_ref().or(self.canonical.as_ref());
         let has_twitter = self.twitter_card.is_some();
 
@@ -564,7 +567,7 @@ where
 
 /// Write `robots.txt` and `sitemap.xml` to `dist_dir` as part of `autumn build`.
 ///
-/// Called by [`AppBuilder::run_build_mode`] after static routes are rendered.
+/// Called by `AppBuilder::run_build_mode` after static routes are rendered.
 ///
 /// # Arguments
 ///
@@ -622,7 +625,10 @@ mod tests {
 
     #[test]
     fn xml_escape_replaces_special_chars() {
-        assert_eq!(xml_escape("a&b<c>d\"e'f"), "a&amp;b&lt;c&gt;d&quot;e&apos;f");
+        assert_eq!(
+            xml_escape("a&b<c>d\"e'f"),
+            "a&amp;b&lt;c&gt;d&quot;e&apos;f"
+        );
     }
 
     #[test]

--- a/autumn/src/seo.rs
+++ b/autumn/src/seo.rs
@@ -66,6 +66,7 @@
 //!
 //! The framework defaults: `dev`/`test` → disallow all; `prod` → allow all.
 
+use std::fmt::Write as _;
 use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
@@ -106,19 +107,22 @@ impl SitemapEntry {
     }
 
     /// Set the last modified date (ISO 8601, e.g. `"2026-01-15"`).
+    #[must_use]
     pub fn lastmod(mut self, lastmod: impl Into<String>) -> Self {
         self.lastmod = Some(lastmod.into());
         self
     }
 
     /// Set the suggested change frequency.
-    pub fn changefreq(mut self, changefreq: SitemapChangefreq) -> Self {
+    #[must_use]
+    pub const fn changefreq(mut self, changefreq: SitemapChangefreq) -> Self {
         self.changefreq = Some(changefreq);
         self
     }
 
     /// Set the priority (clamped to 0.0–1.0).
-    pub fn priority(mut self, priority: f32) -> Self {
+    #[must_use]
+    pub const fn priority(mut self, priority: f32) -> Self {
         self.priority = Some(priority.clamp(0.0, 1.0));
         self
     }
@@ -139,7 +143,8 @@ pub enum SitemapChangefreq {
 }
 
 impl SitemapChangefreq {
-    fn as_str(self) -> &'static str {
+    #[must_use]
+    pub(crate) const fn as_str(self) -> &'static str {
         match self {
             Self::Always => "always",
             Self::Hourly => "hourly",
@@ -207,6 +212,7 @@ pub struct RegisteredSeoConfig(pub crate::config::SeoConfig);
 /// * `profile` — The active profile (`"dev"`, `"test"`, or `"prod"`).
 /// * `sitemap_url` — Optional sitemap URL to inject as a `Sitemap:` directive.
 /// * `additional_rules` — Extra lines to append (e.g. `"Disallow: /admin"`).
+#[must_use]
 pub fn robots_txt(profile: &str, sitemap_url: Option<&str>, additional_rules: &[String]) -> String {
     let mut txt = String::new();
 
@@ -223,7 +229,10 @@ pub fn robots_txt(profile: &str, sitemap_url: Option<&str>, additional_rules: &[
     }
 
     if let Some(url) = sitemap_url {
-        txt.push_str(&format!("\nSitemap: {url}\n"));
+        txt.push('\n');
+        txt.push_str("Sitemap: ");
+        txt.push_str(url);
+        txt.push('\n');
     }
 
     txt
@@ -242,6 +251,7 @@ pub fn robots_txt(profile: &str, sitemap_url: Option<&str>, additional_rules: &[
 /// * `entries` — The sitemap entries to include.
 /// * `base_url` — The site base URL (e.g. `"https://example.com"`), used to
 ///   build sub-sitemap URLs in sitemapindex mode.
+#[must_use]
 pub fn sitemap_xml(entries: &[SitemapEntry], base_url: Option<&str>) -> String {
     const CHUNK_SIZE: usize = 50_000;
 
@@ -253,6 +263,7 @@ pub fn sitemap_xml(entries: &[SitemapEntry], base_url: Option<&str>) -> String {
 }
 
 /// Build a `<urlset>` sitemap.
+#[must_use]
 pub(crate) fn sitemap_urlset_xml(entries: &[SitemapEntry]) -> String {
     let mut xml = String::from(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
@@ -260,15 +271,23 @@ pub(crate) fn sitemap_urlset_xml(entries: &[SitemapEntry]) -> String {
     );
     for entry in entries {
         xml.push_str("\n  <url>");
-        xml.push_str(&format!("\n    <loc>{}</loc>", xml_escape(&entry.loc)));
+        xml.push_str("\n    <loc>");
+        xml.push_str(&xml_escape(&entry.loc));
+        xml.push_str("</loc>");
         if let Some(lastmod) = &entry.lastmod {
-            xml.push_str(&format!("\n    <lastmod>{lastmod}</lastmod>"));
+            xml.push_str("\n    <lastmod>");
+            xml.push_str(lastmod);
+            xml.push_str("</lastmod>");
         }
         if let Some(freq) = entry.changefreq {
-            xml.push_str(&format!("\n    <changefreq>{}</changefreq>", freq.as_str()));
+            xml.push_str("\n    <changefreq>");
+            xml.push_str(freq.as_str());
+            xml.push_str("</changefreq>");
         }
         if let Some(prio) = entry.priority {
-            xml.push_str(&format!("\n    <priority>{prio:.1}</priority>"));
+            xml.push_str("\n    <priority>");
+            write!(xml, "{prio:.1}").ok();
+            xml.push_str("</priority>");
         }
         xml.push_str("\n  </url>");
     }
@@ -285,21 +304,30 @@ fn sitemap_index_xml(entries: &[SitemapEntry], base_url: &str, chunk_size: usize
     );
     for i in 0..chunk_count {
         let idx = i + 1;
-        xml.push_str(&format!(
-            "\n  <sitemap>\n    <loc>{base_url}/sitemap-{idx}.xml</loc>\n  </sitemap>"
-        ));
+        xml.push_str("\n  <sitemap>\n    <loc>");
+        xml.push_str(base_url);
+        xml.push_str("/sitemap-");
+        write!(xml, "{idx}").ok();
+        xml.push_str(".xml</loc>\n  </sitemap>");
     }
     xml.push_str("\n</sitemapindex>");
     xml
 }
 
-/// Escape XML special characters.
+/// Escape XML special characters in a single pass over the input.
 fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
+    let mut escaped = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            _ => escaped.push(c),
+        }
+    }
+    escaped
 }
 
 // ── SeoMeta builder ───────────────────────────────────────────────────────────
@@ -346,17 +374,20 @@ pub struct SeoMeta {
 
 impl SeoMeta {
     /// Create a new, empty builder.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Set the page `<title>` (also used as the default OG/Twitter title).
+    #[must_use]
     pub fn title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
     }
 
     /// Set the `<meta name="description">` content.
+    #[must_use]
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
         self
@@ -365,36 +396,42 @@ impl SeoMeta {
     /// Set the `<link rel="canonical">` URL.
     ///
     /// Also used as the `og:url` fallback.
+    #[must_use]
     pub fn canonical(mut self, url: impl Into<String>) -> Self {
         self.canonical = Some(url.into());
         self
     }
 
     /// Set the `og:image` URL.
+    #[must_use]
     pub fn og_image(mut self, url: impl Into<String>) -> Self {
         self.og_image = Some(url.into());
         self
     }
 
     /// Set the `og:type` value (default: omitted; common: `"website"`, `"article"`).
+    #[must_use]
     pub fn og_type(mut self, og_type: impl Into<String>) -> Self {
         self.og_type = Some(og_type.into());
         self
     }
 
     /// Override the `og:title` (defaults to `title()`).
+    #[must_use]
     pub fn og_title(mut self, title: impl Into<String>) -> Self {
         self.og_title = Some(title.into());
         self
     }
 
     /// Override the `og:description` (defaults to `description()`).
+    #[must_use]
     pub fn og_description(mut self, desc: impl Into<String>) -> Self {
         self.og_description = Some(desc.into());
         self
     }
 
     /// Set the `og:url` (defaults to `canonical()` if not set).
+    #[must_use]
     pub fn og_url(mut self, url: impl Into<String>) -> Self {
         self.og_url = Some(url.into());
         self
@@ -403,30 +440,35 @@ impl SeoMeta {
     /// Set the `twitter:card` type (e.g. `"summary_large_image"`).
     ///
     /// When set, `twitter:title` and `twitter:description` are also emitted.
+    #[must_use]
     pub fn twitter_card(mut self, card_type: impl Into<String>) -> Self {
         self.twitter_card = Some(card_type.into());
         self
     }
 
     /// Override the `twitter:title` (defaults to `title()`).
+    #[must_use]
     pub fn twitter_title(mut self, title: impl Into<String>) -> Self {
         self.twitter_title = Some(title.into());
         self
     }
 
     /// Override the `twitter:description` (defaults to `description()`).
+    #[must_use]
     pub fn twitter_description(mut self, desc: impl Into<String>) -> Self {
         self.twitter_description = Some(desc.into());
         self
     }
 
     /// Set the `twitter:image` URL.
+    #[must_use]
     pub fn twitter_image(mut self, url: impl Into<String>) -> Self {
         self.twitter_image = Some(url.into());
         self
     }
 
     /// Set the `<meta name="robots">` directive (e.g. `"noindex"`, `"nofollow"`).
+    #[must_use]
     pub fn robots(mut self, directive: impl Into<String>) -> Self {
         self.robots_directive = Some(directive.into());
         self
@@ -437,6 +479,7 @@ impl SeoMeta {
     /// Emits only the tags that have been configured. Empty builders produce
     /// no output.
     #[cfg(feature = "maud")]
+    #[must_use]
     pub fn render(&self) -> Markup {
         let og_title = self.og_title.as_ref().or(self.title.as_ref());
         let og_desc = self.og_description.as_ref().or(self.description.as_ref());
@@ -513,51 +556,67 @@ pub fn build_seo_router<S>(
 where
     S: Clone + Send + Sync + 'static,
 {
-    build_seo_router_with_entries(profile, base_url, additional_rules, Vec::new())
+    build_seo_router_with_entries(profile, base_url, additional_rules, &[])
 }
 
 /// Build a SEO router with a pre-populated list of sitemap entries.
+///
+/// # Panics
+///
+/// This function will not panic in practice. The `Response::builder()` calls
+/// inside the route handlers use hard-coded, well-formed `Content-Type` header
+/// values that can never produce an error.
 pub fn build_seo_router_with_entries<S>(
     profile: &str,
     base_url: Option<&str>,
     additional_rules: &[String],
-    entries: Vec<SitemapEntry>,
+    entries: &[SitemapEntry],
 ) -> Router<S>
 where
     S: Clone + Send + Sync + 'static,
 {
+    let base_url = base_url.map(|u| u.trim_end_matches('/'));
     let sitemap_url = base_url.map(|b| format!("{b}/sitemap.xml"));
     let robots_body = robots_txt(profile, sitemap_url.as_deref(), additional_rules);
-    let sitemap_body = sitemap_xml(&entries, base_url);
+    let sitemap_body = sitemap_xml(entries, base_url);
+    build_seo_router_from_bodies(robots_body, sitemap_body)
+}
 
+/// Build a SEO router from pre-rendered `robots.txt` and `sitemap.xml` bodies.
+///
+/// Use this when you need full control over how the bodies are generated
+/// (e.g. to honour `[seo.robots] sitemap_url` or `allow_all` overrides).
+///
+/// # Panics
+///
+/// In practice this function cannot panic. The hard-coded `Content-Type`
+/// header values are always valid.
+pub fn build_seo_router_from_bodies<S>(robots_body: String, sitemap_body: String) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
     Router::<S>::new()
         .route(
             "/robots.txt",
-            get({
-                let robots_body = robots_body.clone();
-                move || {
-                    let body = robots_body.clone();
-                    async move {
-                        Response::builder()
-                            .header("Content-Type", "text/plain; charset=utf-8")
-                            .body(Body::from(body))
-                            .unwrap()
-                    }
+            get(move || {
+                let body = robots_body.clone();
+                async move {
+                    Response::builder()
+                        .header("Content-Type", "text/plain; charset=utf-8")
+                        .body(Body::from(body))
+                        .unwrap()
                 }
             }),
         )
         .route(
             "/sitemap.xml",
-            get({
-                let sitemap_body = sitemap_body.clone();
-                move || {
-                    let body = sitemap_body.clone();
-                    async move {
-                        Response::builder()
-                            .header("Content-Type", "application/xml; charset=utf-8")
-                            .body(Body::from(body))
-                            .unwrap()
-                    }
+            get(move || {
+                let body = sitemap_body.clone();
+                async move {
+                    Response::builder()
+                        .header("Content-Type", "application/xml; charset=utf-8")
+                        .body(Body::from(body))
+                        .unwrap()
                 }
             }),
         )
@@ -584,11 +643,14 @@ pub async fn write_seo_files(
     dist_dir: &Path,
     profile: &str,
     base_url: Option<&str>,
+    sitemap_url_override: Option<&str>,
     additional_rules: &[String],
     entries: &[SitemapEntry],
 ) -> Result<(), std::io::Error> {
-    let sitemap_url = base_url.map(|b| format!("{b}/sitemap.xml"));
-    let robots = robots_txt(profile, sitemap_url.as_deref(), additional_rules);
+    let base_url = base_url.map(|u| u.trim_end_matches('/'));
+    let derived_sitemap_url = base_url.map(|b| format!("{b}/sitemap.xml"));
+    let sitemap_url = sitemap_url_override.or(derived_sitemap_url.as_deref());
+    let robots = robots_txt(profile, sitemap_url, additional_rules);
     let sitemap = sitemap_xml(entries, base_url);
 
     tokio::fs::write(dist_dir.join("robots.txt"), robots).await?;

--- a/autumn/src/seo.rs
+++ b/autumn/src/seo.rs
@@ -622,6 +622,62 @@ where
         )
 }
 
+// ── App-level SEO helpers (shared by run() and run_build_mode()) ──────────────
+
+/// Return `true` when the `[seo]` config section contains any non-default value.
+pub(crate) fn has_seo_config(seo_cfg: &crate::config::SeoConfig) -> bool {
+    seo_cfg.base_url.is_some()
+        || !seo_cfg.robots.additional_rules.is_empty()
+        || seo_cfg.robots.allow_all.is_some()
+        || seo_cfg.robots.sitemap_url.is_some()
+}
+
+/// Resolve the effective robots.txt profile from `raw_profile` and the
+/// optional `allow_all` override in `[seo.robots]`.
+pub(crate) fn effective_seo_profile<'a>(raw_profile: &'a str, allow_all: Option<bool>) -> &'a str {
+    match allow_all {
+        Some(true) => "prod",
+        Some(false) => "dev",
+        None => raw_profile,
+    }
+}
+
+/// Collect sitemap entries from dynamic sources and static path hints, then
+/// build the `robots.txt` and `sitemap.xml` bodies.
+///
+/// Called by both `AppBuilder::run` (server mode) and
+/// `AppBuilder::run_build_mode` (static build mode).
+pub(crate) async fn assemble_seo_bodies(
+    profile: &str,
+    base_url: Option<&str>,
+    sitemap_url_override: Option<&str>,
+    additional_rules: &[String],
+    sources: &[Arc<dyn SitemapSource>],
+    static_paths: &[&str],
+) -> (String, String) {
+    let base_url = base_url.map(|u| u.trim_end_matches('/'));
+
+    let mut sitemap_entries = Vec::new();
+    for source in sources {
+        let mut entries = source.entries().await;
+        sitemap_entries.append(&mut entries);
+    }
+
+    if let Some(bu) = base_url {
+        for path in static_paths {
+            if !path.contains('{') {
+                sitemap_entries.push(SitemapEntry::new(format!("{bu}{path}")));
+            }
+        }
+    }
+
+    let derived_sitemap_url = base_url.map(|b| format!("{b}/sitemap.xml"));
+    let sitemap_url = sitemap_url_override.or(derived_sitemap_url.as_deref());
+    let robots_body = robots_txt(profile, sitemap_url, additional_rules);
+    let sitemap_body = sitemap_xml(&sitemap_entries, base_url);
+    (robots_body, sitemap_body)
+}
+
 // ── Static build helpers ──────────────────────────────────────────────────────
 
 /// Write `robots.txt` and `sitemap.xml` to `dist_dir` as part of `autumn build`.
@@ -698,5 +754,163 @@ mod tests {
         let txt = robots_txt("staging", None, &[]);
         assert!(txt.contains("Disallow: /"));
         assert!(!txt.contains("Allow: /"));
+    }
+
+    #[test]
+    fn has_seo_config_false_when_empty() {
+        let cfg = crate::config::SeoConfig::default();
+        assert!(!has_seo_config(&cfg));
+    }
+
+    #[test]
+    fn has_seo_config_true_when_base_url_set() {
+        let mut cfg = crate::config::SeoConfig::default();
+        cfg.base_url = Some("https://example.com".to_string());
+        assert!(has_seo_config(&cfg));
+    }
+
+    #[test]
+    fn has_seo_config_true_when_allow_all_set() {
+        let mut cfg = crate::config::SeoConfig::default();
+        cfg.robots.allow_all = Some(true);
+        assert!(has_seo_config(&cfg));
+    }
+
+    #[test]
+    fn has_seo_config_true_when_sitemap_url_set() {
+        let mut cfg = crate::config::SeoConfig::default();
+        cfg.robots.sitemap_url = Some("https://example.com/sitemap.xml".to_string());
+        assert!(has_seo_config(&cfg));
+    }
+
+    #[test]
+    fn has_seo_config_true_when_additional_rules_set() {
+        let mut cfg = crate::config::SeoConfig::default();
+        cfg.robots.additional_rules = vec!["Disallow: /admin".to_string()];
+        assert!(has_seo_config(&cfg));
+    }
+
+    #[test]
+    fn effective_seo_profile_respects_allow_all_true() {
+        assert_eq!(effective_seo_profile("dev", Some(true)), "prod");
+    }
+
+    #[test]
+    fn effective_seo_profile_respects_allow_all_false() {
+        assert_eq!(effective_seo_profile("prod", Some(false)), "dev");
+    }
+
+    #[test]
+    fn effective_seo_profile_falls_back_to_raw_when_none() {
+        assert_eq!(effective_seo_profile("staging", None), "staging");
+    }
+
+    struct SimpleSitemapSource {
+        entries: Vec<SitemapEntry>,
+    }
+
+    impl SitemapSource for SimpleSitemapSource {
+        fn entries(
+            &self,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Vec<SitemapEntry>> + Send + '_>,
+        > {
+            let entries = self.entries.clone();
+            Box::pin(async move { entries })
+        }
+    }
+
+    #[tokio::test]
+    async fn assemble_seo_bodies_empty() {
+        let (robots, sitemap) =
+            assemble_seo_bodies("prod", None, None, &[], &[], &[]).await;
+        assert!(robots.contains("Allow: /"));
+        assert!(sitemap.contains("<urlset"));
+    }
+
+    #[tokio::test]
+    async fn assemble_seo_bodies_collects_source_entries() {
+        let source = Arc::new(SimpleSitemapSource {
+            entries: vec![SitemapEntry::new("https://example.com/post/1")],
+        }) as Arc<dyn SitemapSource>;
+        let (_, sitemap) = assemble_seo_bodies(
+            "prod",
+            Some("https://example.com"),
+            None,
+            &[],
+            &[source],
+            &[],
+        )
+        .await;
+        assert!(
+            sitemap.contains("https://example.com/post/1"),
+            "should include source entry; got:\n{sitemap}"
+        );
+    }
+
+    #[tokio::test]
+    async fn assemble_seo_bodies_includes_static_paths() {
+        let (_, sitemap) = assemble_seo_bodies(
+            "prod",
+            Some("https://example.com"),
+            None,
+            &[],
+            &[],
+            &["/about", "/contact"],
+        )
+        .await;
+        assert!(sitemap.contains("https://example.com/about"));
+        assert!(sitemap.contains("https://example.com/contact"));
+    }
+
+    #[tokio::test]
+    async fn assemble_seo_bodies_skips_dynamic_paths() {
+        let (_, sitemap) = assemble_seo_bodies(
+            "prod",
+            Some("https://example.com"),
+            None,
+            &[],
+            &[],
+            &["/posts/{slug}"],
+        )
+        .await;
+        assert!(
+            !sitemap.contains("/posts/"),
+            "should skip paths with params; got:\n{sitemap}"
+        );
+    }
+
+    #[tokio::test]
+    async fn assemble_seo_bodies_uses_sitemap_url_override() {
+        let (robots, _) = assemble_seo_bodies(
+            "prod",
+            Some("https://example.com"),
+            Some("https://cdn.example.com/sitemap.xml"),
+            &[],
+            &[],
+            &[],
+        )
+        .await;
+        assert!(
+            robots.contains("Sitemap: https://cdn.example.com/sitemap.xml"),
+            "should use override url; got:\n{robots}"
+        );
+    }
+
+    #[tokio::test]
+    async fn assemble_seo_bodies_trims_trailing_slash() {
+        let (_, sitemap) = assemble_seo_bodies(
+            "prod",
+            Some("https://example.com/"),
+            None,
+            &[],
+            &[],
+            &["/about"],
+        )
+        .await;
+        assert!(
+            sitemap.contains("https://example.com/about"),
+            "base_url trailing slash should be trimmed; got:\n{sitemap}"
+        );
     }
 }

--- a/autumn/tests/seo.rs
+++ b/autumn/tests/seo.rs
@@ -320,7 +320,7 @@ struct TestSitemapSource {
 }
 
 impl SitemapSource for TestSitemapSource {
-    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send>> {
+    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send + '_>> {
         let entries = self.entries.clone();
         Box::pin(async move { entries })
     }

--- a/autumn/tests/seo.rs
+++ b/autumn/tests/seo.rs
@@ -520,9 +520,16 @@ async fn write_seo_files_injects_sitemap_url_in_robots() {
     use autumn_web::seo::write_seo_files;
 
     let dir = tempfile::tempdir().unwrap();
-    write_seo_files(dir.path(), "prod", Some("https://example.com"), None, &[], &[])
-        .await
-        .unwrap();
+    write_seo_files(
+        dir.path(),
+        "prod",
+        Some("https://example.com"),
+        None,
+        &[],
+        &[],
+    )
+    .await
+    .unwrap();
 
     let robots = std::fs::read_to_string(dir.path().join("robots.txt")).unwrap();
     assert!(

--- a/autumn/tests/seo.rs
+++ b/autumn/tests/seo.rs
@@ -537,3 +537,187 @@ async fn write_seo_files_injects_sitemap_url_in_robots() {
         "robots.txt should auto-inject sitemap URL; got:\n{robots}"
     );
 }
+
+#[tokio::test]
+async fn write_seo_files_respects_sitemap_url_override() {
+    use autumn_web::seo::write_seo_files;
+
+    let dir = tempfile::tempdir().unwrap();
+    write_seo_files(
+        dir.path(),
+        "prod",
+        Some("https://example.com"),
+        Some("https://cdn.example.com/sitemap.xml"),
+        &[],
+        &[],
+    )
+    .await
+    .unwrap();
+
+    let robots = std::fs::read_to_string(dir.path().join("robots.txt")).unwrap();
+    assert!(
+        robots.contains("Sitemap: https://cdn.example.com/sitemap.xml"),
+        "should use sitemap_url_override; got:\n{robots}"
+    );
+    assert!(
+        !robots.contains("Sitemap: https://example.com/sitemap.xml"),
+        "should not use derived sitemap url; got:\n{robots}"
+    );
+}
+
+// ── SitemapChangefreq coverage ────────────────────────────────────────────────
+
+#[test]
+fn sitemap_changefreq_all_variants_render() {
+    let variants = [
+        (SitemapChangefreq::Always, "always"),
+        (SitemapChangefreq::Hourly, "hourly"),
+        (SitemapChangefreq::Daily, "daily"),
+        (SitemapChangefreq::Weekly, "weekly"),
+        (SitemapChangefreq::Monthly, "monthly"),
+        (SitemapChangefreq::Yearly, "yearly"),
+        (SitemapChangefreq::Never, "never"),
+    ];
+    for (freq, expected) in variants {
+        let entries = vec![SitemapEntry::new("https://example.com/").changefreq(freq)];
+        let xml = sitemap_xml(&entries, None);
+        assert!(
+            xml.contains(&format!("<changefreq>{expected}</changefreq>")),
+            "should render {expected}; got:\n{xml}"
+        );
+    }
+}
+
+// ── build_seo_router_from_bodies endpoint tests ───────────────────────────────
+
+mod router_from_bodies_tests {
+    use autumn_web::seo::build_seo_router_from_bodies;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn serves_robots_body() {
+        let router: Router =
+            build_seo_router_from_bodies("User-agent: *\nAllow: /\n".to_string(), String::new());
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/robots.txt")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn serves_sitemap_body() {
+        let router: Router = build_seo_router_from_bodies(
+            String::new(),
+            "<?xml version=\"1.0\"?><urlset/>".to_string(),
+        );
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/sitemap.xml")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}
+
+// ── SeoMeta additional field coverage ────────────────────────────────────────
+
+#[cfg(feature = "maud")]
+mod meta_extra_tests {
+    use super::*;
+
+    #[test]
+    fn seometa_og_type_renders() {
+        let meta = SeoMeta::new().og_type("article");
+        let rendered = meta.render().into_string();
+        assert!(
+            rendered.contains(r#"property="og:type""#),
+            "should have og:type; got:\n{rendered}"
+        );
+        assert!(rendered.contains("article"), "should have og:type value");
+    }
+
+    #[test]
+    fn seometa_og_description_overrides_description() {
+        let meta = SeoMeta::new()
+            .description("Generic desc")
+            .og_description("OG specific desc");
+        let rendered = meta.render().into_string();
+        assert!(
+            rendered.contains("OG specific desc"),
+            "og_description should override description for OG; got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn seometa_og_url_explicit_override() {
+        let meta = SeoMeta::new().og_url("https://example.com/canonical-og");
+        let rendered = meta.render().into_string();
+        assert!(
+            rendered.contains(r#"property="og:url""#),
+            "should have og:url; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("https://example.com/canonical-og"),
+            "should have explicit og:url; got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn seometa_twitter_image_renders() {
+        let meta = SeoMeta::new()
+            .twitter_card("summary_large_image")
+            .twitter_image("https://example.com/og.jpg");
+        let rendered = meta.render().into_string();
+        assert!(
+            rendered.contains(r#"name="twitter:image""#),
+            "should have twitter:image; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("https://example.com/og.jpg"),
+            "should have twitter:image url; got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn seometa_twitter_title_override() {
+        let meta = SeoMeta::new()
+            .title("Generic Title")
+            .twitter_card("summary")
+            .twitter_title("Twitter-specific Title");
+        let rendered = meta.render().into_string();
+        assert!(
+            rendered.contains("Twitter-specific Title"),
+            "twitter_title should override for twitter:title; got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn seometa_twitter_description_override() {
+        let meta = SeoMeta::new()
+            .description("Generic desc")
+            .twitter_card("summary")
+            .twitter_description("Twitter-specific desc");
+        let rendered = meta.render().into_string();
+        assert!(
+            rendered.contains("Twitter-specific desc"),
+            "twitter_description should override for twitter:description; got:\n{rendered}"
+        );
+    }
+}

--- a/autumn/tests/seo.rs
+++ b/autumn/tests/seo.rs
@@ -1,6 +1,8 @@
 // SEO toolkit integration tests.
 
-use autumn_web::seo::{SeoMeta, SitemapChangefreq, SitemapEntry, SitemapSource, robots_txt, sitemap_xml};
+use autumn_web::seo::{
+    SeoMeta, SitemapChangefreq, SitemapEntry, SitemapSource, robots_txt, sitemap_xml,
+};
 use std::future::Future;
 use std::pin::Pin;
 
@@ -48,10 +50,19 @@ fn robots_txt_no_sitemap_when_not_provided() {
 
 #[test]
 fn robots_txt_includes_additional_rules() {
-    let rules = vec!["Disallow: /admin".to_string(), "Crawl-delay: 10".to_string()];
+    let rules = vec![
+        "Disallow: /admin".to_string(),
+        "Crawl-delay: 10".to_string(),
+    ];
     let txt = robots_txt("prod", None, &rules);
-    assert!(txt.contains("Disallow: /admin"), "should include additional rules");
-    assert!(txt.contains("Crawl-delay: 10"), "should include crawl delay rule");
+    assert!(
+        txt.contains("Disallow: /admin"),
+        "should include additional rules"
+    );
+    assert!(
+        txt.contains("Crawl-delay: 10"),
+        "should include crawl delay rule"
+    );
 }
 
 // ── sitemap_xml() unit tests ─────────────────────────────────────────────────
@@ -60,10 +71,19 @@ fn robots_txt_includes_additional_rules() {
 fn sitemap_xml_valid_urlset_structure() {
     let entries = vec![SitemapEntry::new("https://example.com/about")];
     let xml = sitemap_xml(&entries, None);
-    assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"), "should start with XML declaration");
+    assert!(
+        xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"),
+        "should start with XML declaration"
+    );
     assert!(xml.contains("<urlset"), "should have urlset element");
-    assert!(xml.contains("http://www.sitemaps.org/schemas/sitemap/0.9"), "should have sitemap namespace");
-    assert!(xml.contains("<loc>https://example.com/about</loc>"), "should have location URL");
+    assert!(
+        xml.contains("http://www.sitemaps.org/schemas/sitemap/0.9"),
+        "should have sitemap namespace"
+    );
+    assert!(
+        xml.contains("<loc>https://example.com/about</loc>"),
+        "should have location URL"
+    );
     assert!(xml.contains("</urlset>"), "should close urlset");
 }
 
@@ -71,23 +91,31 @@ fn sitemap_xml_valid_urlset_structure() {
 fn sitemap_xml_includes_lastmod() {
     let entries = vec![SitemapEntry::new("https://example.com/").lastmod("2026-01-15")];
     let xml = sitemap_xml(&entries, None);
-    assert!(xml.contains("<lastmod>2026-01-15</lastmod>"), "should include lastmod");
+    assert!(
+        xml.contains("<lastmod>2026-01-15</lastmod>"),
+        "should include lastmod"
+    );
 }
 
 #[test]
 fn sitemap_xml_includes_changefreq() {
-    let entries = vec![
-        SitemapEntry::new("https://example.com/").changefreq(SitemapChangefreq::Weekly),
-    ];
+    let entries =
+        vec![SitemapEntry::new("https://example.com/").changefreq(SitemapChangefreq::Weekly)];
     let xml = sitemap_xml(&entries, None);
-    assert!(xml.contains("<changefreq>weekly</changefreq>"), "should include changefreq");
+    assert!(
+        xml.contains("<changefreq>weekly</changefreq>"),
+        "should include changefreq"
+    );
 }
 
 #[test]
 fn sitemap_xml_includes_priority() {
     let entries = vec![SitemapEntry::new("https://example.com/").priority(0.8)];
     let xml = sitemap_xml(&entries, None);
-    assert!(xml.contains("<priority>0.8</priority>"), "should include priority");
+    assert!(
+        xml.contains("<priority>0.8</priority>"),
+        "should include priority"
+    );
 }
 
 #[test]
@@ -109,9 +137,18 @@ fn sitemap_xml_generates_sitemapindex_for_large_sites() {
         .map(|i| SitemapEntry::new(format!("https://example.com/page/{i}")))
         .collect();
     let xml = sitemap_xml(&entries, Some("https://example.com"));
-    assert!(xml.contains("<sitemapindex"), "should use sitemapindex for large sites");
-    assert!(xml.contains("<sitemap>"), "should have sitemap entries in index");
-    assert!(xml.contains("https://example.com/sitemap-1.xml"), "should reference sub-sitemaps");
+    assert!(
+        xml.contains("<sitemapindex"),
+        "should use sitemapindex for large sites"
+    );
+    assert!(
+        xml.contains("<sitemap>"),
+        "should have sitemap entries in index"
+    );
+    assert!(
+        xml.contains("https://example.com/sitemap-1.xml"),
+        "should reference sub-sitemaps"
+    );
 }
 
 #[test]
@@ -135,7 +172,10 @@ mod meta_tag_tests {
     fn seometa_renders_title() {
         let meta = SeoMeta::new().title("My Blog Post");
         let rendered = meta.render().into_string();
-        assert!(rendered.contains("<title>My Blog Post</title>"), "should render title; got:\n{rendered}");
+        assert!(
+            rendered.contains("<title>My Blog Post</title>"),
+            "should render title; got:\n{rendered}"
+        );
     }
 
     #[test]
@@ -173,9 +213,18 @@ mod meta_tag_tests {
             .description("Post Description")
             .og_image("https://example.com/og.jpg");
         let rendered = meta.render().into_string();
-        assert!(rendered.contains(r#"property="og:title""#), "should have og:title; got:\n{rendered}");
-        assert!(rendered.contains(r#"property="og:description""#), "should have og:description; got:\n{rendered}");
-        assert!(rendered.contains(r#"property="og:image""#), "should have og:image; got:\n{rendered}");
+        assert!(
+            rendered.contains(r#"property="og:title""#),
+            "should have og:title; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains(r#"property="og:description""#),
+            "should have og:description; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains(r#"property="og:image""#),
+            "should have og:image; got:\n{rendered}"
+        );
     }
 
     #[test]
@@ -184,8 +233,14 @@ mod meta_tag_tests {
             .title("Generic Title")
             .og_title("OG Specific Title");
         let rendered = meta.render().into_string();
-        assert!(rendered.contains("OG Specific Title"), "og_title should override title for OG; got:\n{rendered}");
-        assert!(rendered.contains("<title>Generic Title</title>"), "page title should remain unchanged");
+        assert!(
+            rendered.contains("OG Specific Title"),
+            "og_title should override title for OG; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("<title>Generic Title</title>"),
+            "page title should remain unchanged"
+        );
     }
 
     #[test]
@@ -194,9 +249,18 @@ mod meta_tag_tests {
             .title("Post Title")
             .twitter_card("summary_large_image");
         let rendered = meta.render().into_string();
-        assert!(rendered.contains(r#"name="twitter:card""#), "should have twitter:card; got:\n{rendered}");
-        assert!(rendered.contains("summary_large_image"), "should have card type; got:\n{rendered}");
-        assert!(rendered.contains(r#"name="twitter:title""#), "should have twitter:title when card set; got:\n{rendered}");
+        assert!(
+            rendered.contains(r#"name="twitter:card""#),
+            "should have twitter:card; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("summary_large_image"),
+            "should have card type; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains(r#"name="twitter:title""#),
+            "should have twitter:title when card set; got:\n{rendered}"
+        );
     }
 
     #[test]
@@ -213,8 +277,14 @@ mod meta_tag_tests {
     fn seometa_renders_robots_directive() {
         let meta = SeoMeta::new().robots("noindex");
         let rendered = meta.render().into_string();
-        assert!(rendered.contains(r#"name="robots""#), "should have robots meta; got:\n{rendered}");
-        assert!(rendered.contains("noindex"), "should have noindex directive; got:\n{rendered}");
+        assert!(
+            rendered.contains(r#"name="robots""#),
+            "should have robots meta; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("noindex"),
+            "should have noindex directive; got:\n{rendered}"
+        );
     }
 
     #[test]
@@ -232,8 +302,14 @@ mod meta_tag_tests {
         let meta = SeoMeta::new();
         let rendered = meta.render().into_string();
         // Empty meta should produce empty/minimal markup - no spurious tags
-        assert!(!rendered.contains("<title>"), "empty meta should not render title");
-        assert!(!rendered.contains(r#"name="description""#), "empty meta should not render description");
+        assert!(
+            !rendered.contains("<title>"),
+            "empty meta should not render title"
+        );
+        assert!(
+            !rendered.contains(r#"name="description""#),
+            "empty meta should not render description"
+        );
     }
 }
 
@@ -292,11 +368,11 @@ fn seo_config_defaults_are_empty() {
 // ── HTTP endpoint tests ──────────────────────────────────────────────────────
 
 mod endpoint_tests {
+    use autumn_web::seo::{SitemapEntry, build_seo_router, build_seo_router_with_entries};
     use axum::Router;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
-    use autumn_web::seo::{SitemapEntry, build_seo_router, build_seo_router_with_entries};
 
     /// Verifies that when SEO routes are enabled, /robots.txt returns 200.
     #[tokio::test]
@@ -345,7 +421,8 @@ mod endpoint_tests {
     #[tokio::test]
     async fn sitemap_xml_endpoint_returns_200() {
         let entries = vec![SitemapEntry::new("https://example.com/")];
-        let router: Router = build_seo_router_with_entries("prod", Some("https://example.com"), &[], entries);
+        let router: Router =
+            build_seo_router_with_entries("prod", Some("https://example.com"), &[], entries);
 
         let response = router
             .oneshot(
@@ -363,7 +440,8 @@ mod endpoint_tests {
     #[tokio::test]
     async fn sitemap_xml_endpoint_returns_application_xml() {
         let entries = vec![SitemapEntry::new("https://example.com/")];
-        let router: Router = build_seo_router_with_entries("prod", Some("https://example.com"), &[], entries);
+        let router: Router =
+            build_seo_router_with_entries("prod", Some("https://example.com"), &[], entries);
 
         let response = router
             .oneshot(
@@ -395,11 +473,16 @@ async fn write_seo_files_creates_robots_txt() {
     use autumn_web::seo::write_seo_files;
 
     let dir = tempfile::tempdir().unwrap();
-    write_seo_files(dir.path(), "prod", None, &[], &[]).await.unwrap();
+    write_seo_files(dir.path(), "prod", None, &[], &[])
+        .await
+        .unwrap();
     let robots_path = dir.path().join("robots.txt");
     assert!(robots_path.exists(), "dist/robots.txt should be written");
     let content = std::fs::read_to_string(&robots_path).unwrap();
-    assert!(content.contains("Allow: /"), "prod robots.txt should allow all");
+    assert!(
+        content.contains("Allow: /"),
+        "prod robots.txt should allow all"
+    );
 }
 
 #[tokio::test]
@@ -408,13 +491,27 @@ async fn write_seo_files_creates_sitemap_xml() {
 
     let dir = tempfile::tempdir().unwrap();
     let entries = vec![SitemapEntry::new("https://example.com/about")];
-    write_seo_files(dir.path(), "prod", Some("https://example.com"), &[], &entries).await.unwrap();
+    write_seo_files(
+        dir.path(),
+        "prod",
+        Some("https://example.com"),
+        &[],
+        &entries,
+    )
+    .await
+    .unwrap();
 
     let sitemap_path = dir.path().join("sitemap.xml");
     assert!(sitemap_path.exists(), "dist/sitemap.xml should be written");
     let content = std::fs::read_to_string(&sitemap_path).unwrap();
-    assert!(content.contains("<urlset"), "sitemap.xml should have urlset");
-    assert!(content.contains("https://example.com/about"), "sitemap should include provided entries");
+    assert!(
+        content.contains("<urlset"),
+        "sitemap.xml should have urlset"
+    );
+    assert!(
+        content.contains("https://example.com/about"),
+        "sitemap should include provided entries"
+    );
 }
 
 #[tokio::test]
@@ -422,7 +519,9 @@ async fn write_seo_files_injects_sitemap_url_in_robots() {
     use autumn_web::seo::write_seo_files;
 
     let dir = tempfile::tempdir().unwrap();
-    write_seo_files(dir.path(), "prod", Some("https://example.com"), &[], &[]).await.unwrap();
+    write_seo_files(dir.path(), "prod", Some("https://example.com"), &[], &[])
+        .await
+        .unwrap();
 
     let robots = std::fs::read_to_string(dir.path().join("robots.txt")).unwrap();
     assert!(

--- a/autumn/tests/seo.rs
+++ b/autumn/tests/seo.rs
@@ -1,0 +1,432 @@
+// SEO toolkit integration tests.
+
+use autumn_web::seo::{SeoMeta, SitemapChangefreq, SitemapEntry, SitemapSource, robots_txt, sitemap_xml};
+use std::future::Future;
+use std::pin::Pin;
+
+// ── robots_txt() unit tests ──────────────────────────────────────────────────
+
+#[test]
+fn robots_txt_dev_disallows_all() {
+    let txt = robots_txt("dev", None, &[]);
+    assert!(txt.contains("User-agent: *"), "missing User-agent");
+    assert!(txt.contains("Disallow: /"), "dev should disallow all");
+    assert!(!txt.contains("Allow: /"), "dev must not allow all");
+}
+
+#[test]
+fn robots_txt_test_disallows_all() {
+    let txt = robots_txt("test", None, &[]);
+    assert!(txt.contains("Disallow: /"), "test should disallow all");
+}
+
+#[test]
+fn robots_txt_prod_allows_all() {
+    let txt = robots_txt("prod", None, &[]);
+    assert!(txt.contains("User-agent: *"), "missing User-agent");
+    assert!(txt.contains("Allow: /"), "prod should allow all");
+    assert!(!txt.contains("Disallow: /"), "prod must not disallow all");
+}
+
+#[test]
+fn robots_txt_injects_sitemap_url() {
+    let txt = robots_txt("prod", Some("https://example.com/sitemap.xml"), &[]);
+    assert!(
+        txt.contains("Sitemap: https://example.com/sitemap.xml"),
+        "should inject sitemap URL; got:\n{txt}"
+    );
+}
+
+#[test]
+fn robots_txt_no_sitemap_when_not_provided() {
+    let txt = robots_txt("prod", None, &[]);
+    assert!(
+        !txt.contains("Sitemap:"),
+        "should not emit Sitemap: when None"
+    );
+}
+
+#[test]
+fn robots_txt_includes_additional_rules() {
+    let rules = vec!["Disallow: /admin".to_string(), "Crawl-delay: 10".to_string()];
+    let txt = robots_txt("prod", None, &rules);
+    assert!(txt.contains("Disallow: /admin"), "should include additional rules");
+    assert!(txt.contains("Crawl-delay: 10"), "should include crawl delay rule");
+}
+
+// ── sitemap_xml() unit tests ─────────────────────────────────────────────────
+
+#[test]
+fn sitemap_xml_valid_urlset_structure() {
+    let entries = vec![SitemapEntry::new("https://example.com/about")];
+    let xml = sitemap_xml(&entries, None);
+    assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"), "should start with XML declaration");
+    assert!(xml.contains("<urlset"), "should have urlset element");
+    assert!(xml.contains("http://www.sitemaps.org/schemas/sitemap/0.9"), "should have sitemap namespace");
+    assert!(xml.contains("<loc>https://example.com/about</loc>"), "should have location URL");
+    assert!(xml.contains("</urlset>"), "should close urlset");
+}
+
+#[test]
+fn sitemap_xml_includes_lastmod() {
+    let entries = vec![SitemapEntry::new("https://example.com/").lastmod("2026-01-15")];
+    let xml = sitemap_xml(&entries, None);
+    assert!(xml.contains("<lastmod>2026-01-15</lastmod>"), "should include lastmod");
+}
+
+#[test]
+fn sitemap_xml_includes_changefreq() {
+    let entries = vec![
+        SitemapEntry::new("https://example.com/").changefreq(SitemapChangefreq::Weekly),
+    ];
+    let xml = sitemap_xml(&entries, None);
+    assert!(xml.contains("<changefreq>weekly</changefreq>"), "should include changefreq");
+}
+
+#[test]
+fn sitemap_xml_includes_priority() {
+    let entries = vec![SitemapEntry::new("https://example.com/").priority(0.8)];
+    let xml = sitemap_xml(&entries, None);
+    assert!(xml.contains("<priority>0.8</priority>"), "should include priority");
+}
+
+#[test]
+fn sitemap_xml_escapes_special_chars_in_url() {
+    let entries = vec![SitemapEntry::new("https://example.com/?q=hello&amp;world")];
+    let xml = sitemap_xml(&entries, None);
+    // The URL itself doesn't need & escaping if it's already well-formed,
+    // but raw & in URLs should be escaped in XML
+    let entries2 = vec![SitemapEntry::new("https://example.com/?q=hello&world")];
+    let xml2 = sitemap_xml(&entries2, None);
+    assert!(xml2.contains("&amp;"), "should escape & in URL");
+    let _ = xml;
+}
+
+#[test]
+fn sitemap_xml_generates_sitemapindex_for_large_sites() {
+    // Generate more than 50,000 entries to trigger sitemapindex
+    let entries: Vec<SitemapEntry> = (0..50_001)
+        .map(|i| SitemapEntry::new(format!("https://example.com/page/{i}")))
+        .collect();
+    let xml = sitemap_xml(&entries, Some("https://example.com"));
+    assert!(xml.contains("<sitemapindex"), "should use sitemapindex for large sites");
+    assert!(xml.contains("<sitemap>"), "should have sitemap entries in index");
+    assert!(xml.contains("https://example.com/sitemap-1.xml"), "should reference sub-sitemaps");
+}
+
+#[test]
+fn sitemap_xml_multiple_entries() {
+    let entries = vec![
+        SitemapEntry::new("https://example.com/"),
+        SitemapEntry::new("https://example.com/about"),
+        SitemapEntry::new("https://example.com/contact"),
+    ];
+    let xml = sitemap_xml(&entries, None);
+    assert_eq!(xml.matches("<url>").count(), 3, "should have 3 url entries");
+}
+
+// ── SeoMeta::render() unit tests ─────────────────────────────────────────────
+
+#[cfg(feature = "maud")]
+mod meta_tag_tests {
+    use super::*;
+
+    #[test]
+    fn seometa_renders_title() {
+        let meta = SeoMeta::new().title("My Blog Post");
+        let rendered = meta.render().into_string();
+        assert!(rendered.contains("<title>My Blog Post</title>"), "should render title; got:\n{rendered}");
+    }
+
+    #[test]
+    fn seometa_renders_description() {
+        let meta = SeoMeta::new().description("A great post about things");
+        let rendered = meta.render().into_string();
+        assert!(
+            rendered.contains(r#"name="description""#),
+            "should have name=description; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("A great post about things"),
+            "should have description content; got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn seometa_renders_canonical() {
+        let meta = SeoMeta::new().canonical("https://example.com/posts/my-post");
+        let rendered = meta.render().into_string();
+        assert!(
+            rendered.contains(r#"rel="canonical""#),
+            "should have rel=canonical; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("https://example.com/posts/my-post"),
+            "should have canonical URL; got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn seometa_renders_og_tags() {
+        let meta = SeoMeta::new()
+            .title("Post Title")
+            .description("Post Description")
+            .og_image("https://example.com/og.jpg");
+        let rendered = meta.render().into_string();
+        assert!(rendered.contains(r#"property="og:title""#), "should have og:title; got:\n{rendered}");
+        assert!(rendered.contains(r#"property="og:description""#), "should have og:description; got:\n{rendered}");
+        assert!(rendered.contains(r#"property="og:image""#), "should have og:image; got:\n{rendered}");
+    }
+
+    #[test]
+    fn seometa_og_title_overrides_title() {
+        let meta = SeoMeta::new()
+            .title("Generic Title")
+            .og_title("OG Specific Title");
+        let rendered = meta.render().into_string();
+        assert!(rendered.contains("OG Specific Title"), "og_title should override title for OG; got:\n{rendered}");
+        assert!(rendered.contains("<title>Generic Title</title>"), "page title should remain unchanged");
+    }
+
+    #[test]
+    fn seometa_renders_twitter_card() {
+        let meta = SeoMeta::new()
+            .title("Post Title")
+            .twitter_card("summary_large_image");
+        let rendered = meta.render().into_string();
+        assert!(rendered.contains(r#"name="twitter:card""#), "should have twitter:card; got:\n{rendered}");
+        assert!(rendered.contains("summary_large_image"), "should have card type; got:\n{rendered}");
+        assert!(rendered.contains(r#"name="twitter:title""#), "should have twitter:title when card set; got:\n{rendered}");
+    }
+
+    #[test]
+    fn seometa_no_twitter_title_without_card() {
+        let meta = SeoMeta::new().title("Post Title");
+        let rendered = meta.render().into_string();
+        assert!(
+            !rendered.contains(r#"name="twitter:title""#),
+            "should not emit twitter:title without twitter:card"
+        );
+    }
+
+    #[test]
+    fn seometa_renders_robots_directive() {
+        let meta = SeoMeta::new().robots("noindex");
+        let rendered = meta.render().into_string();
+        assert!(rendered.contains(r#"name="robots""#), "should have robots meta; got:\n{rendered}");
+        assert!(rendered.contains("noindex"), "should have noindex directive; got:\n{rendered}");
+    }
+
+    #[test]
+    fn seometa_og_url_defaults_to_canonical() {
+        let meta = SeoMeta::new().canonical("https://example.com/post");
+        let rendered = meta.render().into_string();
+        assert!(
+            rendered.contains(r#"property="og:url""#),
+            "og:url should use canonical as fallback; got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn seometa_empty_renders_nothing() {
+        let meta = SeoMeta::new();
+        let rendered = meta.render().into_string();
+        // Empty meta should produce empty/minimal markup - no spurious tags
+        assert!(!rendered.contains("<title>"), "empty meta should not render title");
+        assert!(!rendered.contains(r#"name="description""#), "empty meta should not render description");
+    }
+}
+
+// ── SitemapSource trait tests ────────────────────────────────────────────────
+
+struct TestSitemapSource {
+    entries: Vec<SitemapEntry>,
+}
+
+impl SitemapSource for TestSitemapSource {
+    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send>> {
+        let entries = self.entries.clone();
+        Box::pin(async move { entries })
+    }
+}
+
+#[tokio::test]
+async fn sitemap_source_provides_entries() {
+    let source = TestSitemapSource {
+        entries: vec![
+            SitemapEntry::new("https://example.com/post/1"),
+            SitemapEntry::new("https://example.com/post/2"),
+        ],
+    };
+
+    let entries = source.entries().await;
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].loc, "https://example.com/post/1");
+    assert_eq!(entries[1].loc, "https://example.com/post/2");
+}
+
+// ── SeoConfig deserialization tests ─────────────────────────────────────────
+
+#[test]
+fn seo_config_deserializes_from_toml() {
+    let toml = r#"
+[seo]
+base_url = "https://example.com"
+
+[seo.robots]
+additional_rules = ["Disallow: /admin"]
+"#;
+    let config: autumn_web::config::AutumnConfig = toml::from_str(toml).unwrap();
+    assert_eq!(config.seo.base_url.as_deref(), Some("https://example.com"));
+    assert_eq!(config.seo.robots.additional_rules, vec!["Disallow: /admin"]);
+}
+
+#[test]
+fn seo_config_defaults_are_empty() {
+    let config = autumn_web::config::AutumnConfig::default();
+    assert!(config.seo.base_url.is_none());
+    assert!(config.seo.robots.additional_rules.is_empty());
+    assert!(config.seo.robots.allow_all.is_none());
+}
+
+// ── HTTP endpoint tests ──────────────────────────────────────────────────────
+
+mod endpoint_tests {
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+    use autumn_web::seo::{SitemapEntry, build_seo_router, build_seo_router_with_entries};
+
+    /// Verifies that when SEO routes are enabled, /robots.txt returns 200.
+    #[tokio::test]
+    async fn robots_txt_endpoint_returns_200() {
+        let router: Router = build_seo_router("dev", None, &[]);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/robots.txt")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn robots_txt_endpoint_returns_text_plain() {
+        let router: Router = build_seo_router("prod", None, &[]);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/robots.txt")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            content_type.contains("text/plain"),
+            "robots.txt should have text/plain content-type; got: {content_type}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sitemap_xml_endpoint_returns_200() {
+        let entries = vec![SitemapEntry::new("https://example.com/")];
+        let router: Router = build_seo_router_with_entries("prod", Some("https://example.com"), &[], entries);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/sitemap.xml")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn sitemap_xml_endpoint_returns_application_xml() {
+        let entries = vec![SitemapEntry::new("https://example.com/")];
+        let router: Router = build_seo_router_with_entries("prod", Some("https://example.com"), &[], entries);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/sitemap.xml")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            content_type.contains("application/xml") || content_type.contains("text/xml"),
+            "sitemap.xml should have XML content-type; got: {content_type}"
+        );
+    }
+}
+
+// ── Static build SEO output tests ────────────────────────────────────────────
+
+#[tokio::test]
+async fn write_seo_files_creates_robots_txt() {
+    use autumn_web::seo::write_seo_files;
+
+    let dir = tempfile::tempdir().unwrap();
+    write_seo_files(dir.path(), "prod", None, &[], &[]).await.unwrap();
+    let robots_path = dir.path().join("robots.txt");
+    assert!(robots_path.exists(), "dist/robots.txt should be written");
+    let content = std::fs::read_to_string(&robots_path).unwrap();
+    assert!(content.contains("Allow: /"), "prod robots.txt should allow all");
+}
+
+#[tokio::test]
+async fn write_seo_files_creates_sitemap_xml() {
+    use autumn_web::seo::{SitemapEntry, write_seo_files};
+
+    let dir = tempfile::tempdir().unwrap();
+    let entries = vec![SitemapEntry::new("https://example.com/about")];
+    write_seo_files(dir.path(), "prod", Some("https://example.com"), &[], &entries).await.unwrap();
+
+    let sitemap_path = dir.path().join("sitemap.xml");
+    assert!(sitemap_path.exists(), "dist/sitemap.xml should be written");
+    let content = std::fs::read_to_string(&sitemap_path).unwrap();
+    assert!(content.contains("<urlset"), "sitemap.xml should have urlset");
+    assert!(content.contains("https://example.com/about"), "sitemap should include provided entries");
+}
+
+#[tokio::test]
+async fn write_seo_files_injects_sitemap_url_in_robots() {
+    use autumn_web::seo::write_seo_files;
+
+    let dir = tempfile::tempdir().unwrap();
+    write_seo_files(dir.path(), "prod", Some("https://example.com"), &[], &[]).await.unwrap();
+
+    let robots = std::fs::read_to_string(dir.path().join("robots.txt")).unwrap();
+    assert!(
+        robots.contains("Sitemap: https://example.com/sitemap.xml"),
+        "robots.txt should auto-inject sitemap URL; got:\n{robots}"
+    );
+}

--- a/autumn/tests/seo.rs
+++ b/autumn/tests/seo.rs
@@ -422,7 +422,7 @@ mod endpoint_tests {
     async fn sitemap_xml_endpoint_returns_200() {
         let entries = vec![SitemapEntry::new("https://example.com/")];
         let router: Router =
-            build_seo_router_with_entries("prod", Some("https://example.com"), &[], entries);
+            build_seo_router_with_entries("prod", Some("https://example.com"), &[], &entries);
 
         let response = router
             .oneshot(
@@ -441,7 +441,7 @@ mod endpoint_tests {
     async fn sitemap_xml_endpoint_returns_application_xml() {
         let entries = vec![SitemapEntry::new("https://example.com/")];
         let router: Router =
-            build_seo_router_with_entries("prod", Some("https://example.com"), &[], entries);
+            build_seo_router_with_entries("prod", Some("https://example.com"), &[], &entries);
 
         let response = router
             .oneshot(
@@ -473,7 +473,7 @@ async fn write_seo_files_creates_robots_txt() {
     use autumn_web::seo::write_seo_files;
 
     let dir = tempfile::tempdir().unwrap();
-    write_seo_files(dir.path(), "prod", None, &[], &[])
+    write_seo_files(dir.path(), "prod", None, None, &[], &[])
         .await
         .unwrap();
     let robots_path = dir.path().join("robots.txt");
@@ -495,6 +495,7 @@ async fn write_seo_files_creates_sitemap_xml() {
         dir.path(),
         "prod",
         Some("https://example.com"),
+        None,
         &[],
         &entries,
     )
@@ -519,7 +520,7 @@ async fn write_seo_files_injects_sitemap_url_in_robots() {
     use autumn_web::seo::write_seo_files;
 
     let dir = tempfile::tempdir().unwrap();
-    write_seo_files(dir.path(), "prod", Some("https://example.com"), &[], &[])
+    write_seo_files(dir.path(), "prod", Some("https://example.com"), None, &[], &[])
         .await
         .unwrap();
 

--- a/examples/blog/src/main.rs
+++ b/examples/blog/src/main.rs
@@ -24,9 +24,8 @@ impl SitemapSource for BlogSitemapSource {
     fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send>> {
         Box::pin(async {
             vec![
-                SitemapEntry::new("https://autumn-demo.example.com/").changefreq(
-                    autumn_web::seo::SitemapChangefreq::Weekly,
-                ),
+                SitemapEntry::new("https://autumn-demo.example.com/")
+                    .changefreq(autumn_web::seo::SitemapChangefreq::Weekly),
                 SitemapEntry::new("https://autumn-demo.example.com/about"),
             ]
         })

--- a/examples/blog/src/main.rs
+++ b/examples/blog/src/main.rs
@@ -6,9 +6,32 @@ mod tasks;
 
 use autumn_admin_plugin::AdminPlugin;
 use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
+use autumn_web::seo::{SitemapEntry, SitemapSource};
 use autumn_web::{jobs, one_off_tasks, routes, static_routes};
+use std::future::Future;
+use std::pin::Pin;
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
+
+/// Dynamic sitemap source: provides a URL for every published blog post.
+///
+/// In a real app this would query the database; here we return a
+/// representative static list so `autumn build` and the running server
+/// produce a valid `/sitemap.xml` without requiring a live database.
+struct BlogSitemapSource;
+
+impl SitemapSource for BlogSitemapSource {
+    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send>> {
+        Box::pin(async {
+            vec![
+                SitemapEntry::new("https://autumn-demo.example.com/").changefreq(
+                    autumn_web::seo::SitemapChangefreq::Weekly,
+                ),
+                SitemapEntry::new("https://autumn-demo.example.com/about"),
+            ]
+        })
+    }
+}
 
 #[autumn_web::main]
 async fn main() {
@@ -24,6 +47,9 @@ async fn main() {
                 .require_role(None::<String>)
                 .register(admin::PostAdmin),
         )
+        // Register the sitemap source: mounts /robots.txt and /sitemap.xml.
+        // Configure [seo] base_url in autumn.toml for canonical URL injection.
+        .seo_source(BlogSitemapSource)
         .routes(routes![
             // Public routes
             routes::about::about, // #[static_get] — pre-rendered

--- a/examples/blog/src/main.rs
+++ b/examples/blog/src/main.rs
@@ -21,7 +21,7 @@ const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 struct BlogSitemapSource;
 
 impl SitemapSource for BlogSitemapSource {
-    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send>> {
+    fn entries(&self) -> Pin<Box<dyn Future<Output = Vec<SitemapEntry>> + Send + '_>> {
         Box::pin(async {
             vec![
                 SitemapEntry::new("https://autumn-demo.example.com/")

--- a/examples/blog/src/routes/posts.rs
+++ b/examples/blog/src/routes/posts.rs
@@ -6,6 +6,7 @@
 use autumn_web::assets::asset_url;
 use autumn_web::extract::{Form, Path};
 use autumn_web::i18n::Locale;
+use autumn_web::seo::SeoMeta;
 use autumn_web::{AutumnError, AutumnResult, Db, Markup, Redirect, delete, get, html, post, t};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
@@ -21,15 +22,22 @@ use crate::schema::posts;
 /// are translated through the [`t!`] macro. Pages reachable via
 /// `#[static_get]` (e.g. `about.rs`) use the same extractor during static
 /// rendering, so pre-rendered HTML receives the configured bundle too.
+///
+/// Accepts an optional [`SeoMeta`] to inject per-page meta tags. Falls back
+/// to a sensible site-wide description when omitted.
 pub fn layout(locale: &Locale, title: &str, content: Markup) -> Markup {
+    layout_with_seo(locale, SeoMeta::new().title(title).description("A blog built with the Autumn web framework for Rust."), content)
+}
+
+/// Layout variant accepting an explicit [`SeoMeta`] builder.
+pub fn layout_with_seo(locale: &Locale, seo: SeoMeta, content: Markup) -> Markup {
     html! {
         (autumn_web::PreEscaped("<!DOCTYPE html>"))
         html lang=(locale.tag()) {
             head {
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
-                title { (title) }
-                meta name="description" content="A blog built with the Autumn web framework for Rust.";
+                (seo.render())
                 link rel="stylesheet" href=(asset_url("css/autumn.css"));
                 script src=(asset_url("js/htmx.min.js")) {}
             }
@@ -244,9 +252,22 @@ pub async fn show(locale: Locale, slug: Path<String>, mut db: Db) -> AutumnResul
     // Simple paragraph rendering — split on double newlines
     let paragraphs: Vec<&str> = p.body.split("\n\n").collect();
 
-    Ok(layout(
+    let seo = SeoMeta::new()
+        .title(format!("{} • Autumn Blog", p.title))
+        .description(
+            p.body
+                .split('\n')
+                .next()
+                .unwrap_or(&p.title)
+                .chars()
+                .take(160)
+                .collect::<String>(),
+        )
+        .og_type("article");
+
+    Ok(layout_with_seo(
         &locale,
-        &p.title,
+        seo,
         html! {
             article {
                 // Back link

--- a/examples/blog/src/routes/posts.rs
+++ b/examples/blog/src/routes/posts.rs
@@ -26,7 +26,13 @@ use crate::schema::posts;
 /// Accepts an optional [`SeoMeta`] to inject per-page meta tags. Falls back
 /// to a sensible site-wide description when omitted.
 pub fn layout(locale: &Locale, title: &str, content: Markup) -> Markup {
-    layout_with_seo(locale, SeoMeta::new().title(title).description("A blog built with the Autumn web framework for Rust."), content)
+    layout_with_seo(
+        locale,
+        SeoMeta::new()
+            .title(title)
+            .description("A blog built with the Autumn web framework for Rust."),
+        content,
+    )
 }
 
 /// Layout variant accepting an explicit [`SeoMeta`] builder.


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive SEO toolkit to Autumn, providing first-class support for sitemap generation, robots.txt configuration, and per-page meta tag helpers. The implementation includes dynamic sitemap sources, environment-aware robots.txt generation, and a fluent builder API for SEO meta tags.

## Key Changes

- **New `seo` module** (`autumn/src/seo.rs`): Complete SEO toolkit with 634 lines of well-documented code
  - `SitemapEntry` builder for individual URL entries with lastmod, changefreq, and priority
  - `SitemapSource` trait for dynamic sitemap entry generation (e.g., from database queries)
  - `SeoMeta` builder for per-page meta tags (title, description, canonical, OG, Twitter cards)
  - `robots_txt()` function with environment-aware defaults (dev/test → disallow all; prod → allow all)
  - `sitemap_xml()` function with automatic sitemapindex generation for sites >50k URLs
  - HTTP route builders (`build_seo_router`, `build_seo_router_with_entries`) for serving `/robots.txt` and `/sitemap.xml`
  - Static build helper (`write_seo_files`) for pre-rendering SEO artifacts during `autumn build`

- **Configuration support** (`autumn/src/config.rs`):
  - New `SeoConfig` struct for `[seo]` section in `autumn.toml`
  - `RobotsConfig` for robots.txt customization (allow_all override, additional_rules, sitemap_url)
  - Base URL configuration for canonical URL computation and sitemap auto-injection

- **AppBuilder integration** (`autumn/src/app.rs`):
  - New `seo_source()` method to register `SitemapSource` implementations
  - Automatic SEO router mounting when sources are registered
  - Collects entries from all registered sources at startup and bakes them into responses

- **Prelude exports** (`autumn/src/prelude.rs`):
  - Exports `SeoMeta`, `SitemapEntry`, `SitemapChangefreq`, and `SitemapSource` for convenient access

- **Comprehensive test coverage** (`autumn/tests/seo.rs`):
  - 432 lines of integration tests covering robots.txt generation, sitemap XML structure, meta tag rendering, HTTP endpoints, and static build output
  - Tests for environment-aware behavior, XML escaping, sitemapindex generation, and configuration deserialization

- **Example integration** (`examples/blog/`):
  - Updated blog example to demonstrate `SeoMeta` usage in route handlers
  - Implements `BlogSitemapSource` to show dynamic sitemap generation pattern
  - Registers source with `app().seo_source(BlogSitemapSource)`

## Notable Implementation Details

- **XML generation**: Hand-rolled XML builders with proper escaping for special characters
- **Sitemapindex support**: Automatically switches to sitemapindex format for sites with >50,000 URLs
- **Environment-aware defaults**: Profile-driven robots.txt behavior (dev/test disallow, prod allow) with override capability
- **Maud integration**: `SeoMeta::render()` generates proper HTML markup when `maud` feature is enabled
- **Async sitemap sources**: Sources use `Pin<Box<dyn Future>>` for flexible async implementations
- **Static build support**: SEO files can be pre-rendered during `autumn build` for static site generation

https://claude.ai/code/session_01YJkpfC4Vu8hSo8HzuQQ6fV