### PR TITLE
🗣️ Echo: [DX audit fixes for autumn dev and README]

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ async fn index() -> &'static str {
 }
 
 #[get("/hello/{name}")]
-async fn hello_name(name: autumn_web::extract::Path<String>) -> String {
+async fn hello_name(name: Path<String>) -> String {
     format!("Hello, {}!", *name)
 }
 

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -221,7 +221,35 @@ pub fn run(package: Option<&str>, show_config: bool) {
 
     let normalized_dirs = sanitize_custom_watch_dirs(load_dev_config(Path::new(AUTUMN_TOML)));
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let custom_watch_dirs = resolve_custom_watch_dirs(&normalized_dirs, &cwd);
+    let mut custom_watch_dirs = resolve_custom_watch_dirs(&normalized_dirs, &cwd);
+
+    // Dynamically discover all top-level directories except target and hidden directories
+    // so we can watch them and correctly classify their changes.
+    if let Ok(entries) = std::fs::read_dir(&cwd) {
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if name.starts_with('.') || name == "target" {
+                continue;
+            }
+            // Avoid duplicates if already explicitly configured
+            if !custom_watch_dirs
+                .iter()
+                .any(|d| d.relative.to_string_lossy() == name)
+            {
+                let absolute = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+                custom_watch_dirs.push(CustomWatchDir {
+                    relative: PathBuf::from(name),
+                    absolute,
+                });
+            }
+        }
+    }
 
     // Set up file watcher
     let (tx, rx) = mpsc::channel();
@@ -230,23 +258,15 @@ pub fn run(package: Option<&str>, show_config: bool) {
 
     let watcher = debouncer.watcher();
 
-    // Watch the default directories.
-    for dir in DEFAULT_WATCH_DIRS {
-        let path = Path::new(dir);
-        if path.exists()
-            && let Err(e) = watcher.watch(path, notify::RecursiveMode::Recursive)
-        {
-            eprintln!("  Warning: could not watch {dir}/: {e}");
-        }
-    }
-
-    // Watch any additional directories from `[dev] watch_dirs` in autumn.toml.
     for dir in &custom_watch_dirs {
         let display = dir.relative.display();
         if let Err(e) = watcher.watch(&dir.relative, notify::RecursiveMode::Recursive) {
             eprintln!("  Warning: could not watch {display}/: {e}");
         } else {
-            eprintln!("  Watching custom directory: {display}/");
+            // Only print for explicitly configured custom dirs, otherwise it's too noisy
+            if normalized_dirs.contains(&display.to_string()) {
+                eprintln!("  Watching custom directory: {display}/");
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes friction points identified during a Developer Experience (DX) audit:

1. **`autumn dev` Hot Reloading:** Previously, `autumn dev` relied on a hardcoded list of directories (`src`, `static`, `templates`, `migrations`), silently ignoring changes in other common structural choices like `views`. The logic has been modified to dynamically discover and recursively watch all top-level directories in the project root, safely explicitly excluding hidden directories (like `.git`) and the `target` folder.
2. **README Example:** The README quickstart used the fully qualified `autumn_web::extract::Path<String>`, which cluttered code and confused developers when `Path` was already available via `autumn_web::prelude::*`. The example has been simplified to `Path<String>`.

Testing, formatting (`cargo fmt`), and linting (`cargo clippy`) checks all passed successfully without introducing bugs or regressions.

---
*PR created automatically by Jules for task [4695720822813210688](https://jules.google.com/task/4695720822813210688) started by @madmax983*