### PR TITLE
⚡ Bolt: Remove heap allocation in scrub_sql dollar-quoted strings

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -289,21 +289,35 @@ fn consume_estring_body(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
 ///
 /// Called after the opening `$tag$` delimiter has already been consumed.
 /// Uses a simple sliding-window match — sufficient for valid SQL.
+///
+/// ⚡ Bolt: This function uses a composed zero-allocation iterator chain
+/// (`std::iter::once`) to avoid heap allocating a `String` and `Vec<char>`
+/// for the closing tag on every dollar-quoted string parsed.
 fn consume_dollar_quoted_body(chars: &mut std::iter::Peekable<std::str::Chars<'_>>, tag: &str) {
-    let closing: Vec<char> = format!("${tag}$").chars().collect();
-    let clen = closing.len();
+    let get_closing_chars = || {
+        std::iter::once('$')
+            .chain(tag.chars())
+            .chain(std::iter::once('$'))
+    };
+    let mut closing_chars = get_closing_chars();
+    let clen = tag.chars().count() + 2;
     let mut match_count = 0usize;
+    let mut current_target = closing_chars.next().unwrap();
     for sc in chars.by_ref() {
-        if sc == closing[match_count] {
+        if sc == current_target {
             match_count += 1;
             if match_count == clen {
                 break; // Found the closing delimiter.
             }
+            current_target = closing_chars.next().unwrap();
         } else {
             match_count = 0;
+            closing_chars = get_closing_chars();
+            current_target = closing_chars.next().unwrap();
             // The current char may start a new partial match.
-            if sc == closing[0] {
+            if sc == '$' {
                 match_count = 1;
+                current_target = closing_chars.next().unwrap();
             }
         }
     }


### PR DESCRIPTION
💡 What: Replaced a `String` and `Vec<char>` allocation in `consume_dollar_quoted_body` with a composed, zero-allocation iterator chain.
🎯 Why: The original implementation heap-allocated the closing dollar tag string and then collected its characters into a `Vec` for every dollar-quoted string processed during SQL scrubbing. This caused unnecessary allocations on a potentially hot parsing path.
📊 Impact: Eliminates two heap allocations per dollar-quoted string body parsed in `scrub_sql`.
🔬 Measurement: Run `cargo bench` or `cargo test -p autumn-web --lib db::` to verify.

---
*PR created automatically by Jules for task [3066812342975988406](https://jules.google.com/task/3066812342975988406) started by @madmax983*