### PR TITLE
Implement automatic read replica routing for generated repositories

### DIFF
--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -328,6 +328,16 @@ pub fn model(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Generates a `PgXxxRepository` struct implementing the annotated trait,
 /// with auto-generated CRUD methods and query-by-name derived methods.
 ///
+/// # Read replica routing
+///
+/// When `database.replica_url` is configured, generated read-only methods
+/// (`find_by_id`, `find_all`, `count`, `paginate`, `cursor_page`, derived
+/// `find_by_*`, search reads) acquire their connection from the replica
+/// pool; mutating methods always use the primary. Add `primary_reads` to
+/// pin a read-after-write-sensitive repository's reads to the primary, or
+/// call the generated `on_primary()` method to pin a single call chain
+/// (read-your-writes).
+///
 /// # Examples
 ///
 /// ```ignore
@@ -337,6 +347,10 @@ pub fn model(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// trait PostRepository {
 ///     fn find_by_published(published: bool) -> Vec<Post>;
 /// }
+///
+/// // Reads pinned to the primary even when a replica is configured.
+/// #[repository(LedgerEntry, primary_reads)]
+/// trait LedgerEntryRepository {}
 /// ```
 #[proc_macro_attribute]
 pub fn repository(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -104,6 +104,10 @@ struct RepoConfig {
     /// implementation (custom serialization, non-`i64` primary key, etc.) to
     /// avoid the duplicate-impl compile error (E0119).
     no_versioned_record_impl: bool,
+    /// Pin generated read-only methods to the primary pool even when a read
+    /// replica is configured (#971). Use for read-after-write-sensitive
+    /// aggregates that cannot tolerate replication lag.
+    primary_reads: bool,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -123,6 +127,7 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
     let mut searchable = false;
     let mut versioned = false;
     let mut no_versioned_record_impl = false;
+    let mut primary_reads = false;
 
     syn::meta::parser(|meta| {
         // `hooks = Ident` must be checked before the catch-all model_name case,
@@ -178,12 +183,15 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
         } else if meta.path.is_ident("no_versioned_record_impl") {
             no_versioned_record_impl = true;
             Ok(())
+        } else if meta.path.is_ident("primary_reads") {
+            primary_reads = true;
+            Ok(())
         } else if meta.path.get_ident().is_some() && model_name.is_none() {
             model_name = Some(meta.path.get_ident().unwrap().clone());
             Ok(())
         } else {
             Err(meta.error(
-                "expected model name, table = \"...\", hooks = Type, commit_hooks = true, api = \"/path\", policy = Type, scope = Type, cursor_key = field, cursor_key_type = Type, soft_delete, tenant_scoped, no_upsert_trait, searchable, versioned = true, or no_versioned_record_impl",
+                "expected model name, table = \"...\", hooks = Type, commit_hooks = true, api = \"/path\", policy = Type, scope = Type, cursor_key = field, cursor_key_type = Type, soft_delete, tenant_scoped, no_upsert_trait, searchable, versioned = true, no_versioned_record_impl, or primary_reads",
             ))
         }
     })
@@ -219,6 +227,7 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
         searchable,
         versioned,
         no_versioned_record_impl,
+        primary_reads,
     })
 }
 
@@ -312,7 +321,7 @@ fn generate_derived_query_for_source(
         "find" => {
             quote! {
                 #(#encode_lets)*
-                let mut conn = self.__autumn_acquire_conn().await?;
+                let mut conn = self.__autumn_acquire_read_conn().await?;
                 #query_source
                     #(#filters)*
                     #soft_delete_filter
@@ -324,7 +333,7 @@ fn generate_derived_query_for_source(
         "count" => {
             quote! {
                 #(#encode_lets)*
-                let mut conn = self.__autumn_acquire_conn().await?;
+                let mut conn = self.__autumn_acquire_read_conn().await?;
                 #query_source
                     #(#filters)*
                     #soft_delete_filter
@@ -364,7 +373,7 @@ fn generate_derived_query_for_source(
         "exists" => {
             quote! {
                 #(#encode_lets)*
-                let mut conn = self.__autumn_acquire_conn().await?;
+                let mut conn = self.__autumn_acquire_read_conn().await?;
                 ::autumn_web::reexports::diesel::select(
                     ::autumn_web::reexports::diesel::dsl::exists(
                         #query_source #(#filters)* #soft_delete_filter
@@ -718,6 +727,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         hooks: <#hooks_ident as ::autumn_web::hooks::RepositoryHooksClone>::autumn_clone(&self.hooks),
                         #idempotency_clone_field
                         across_tenants: true,
+                        __autumn_read_route: self.__autumn_read_route.clone(),
                         __autumn_statement_timeout_ms: self.__autumn_statement_timeout_ms,
                         __autumn_slow_threshold: self.__autumn_slow_threshold,
                         __autumn_route: self.__autumn_route.clone(),
@@ -733,6 +743,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     Self {
                         pool: self.pool.clone(),
                         across_tenants: true,
+                        __autumn_read_route: self.__autumn_read_route.clone(),
                         __autumn_statement_timeout_ms: self.__autumn_statement_timeout_ms,
                         __autumn_slow_threshold: self.__autumn_slow_threshold,
                         __autumn_route: self.__autumn_route.clone(),
@@ -742,6 +753,22 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     } else {
         quote! {}
+    };
+
+    // #971: snapshot the read-routing decision once per extraction. The
+    // `primary_reads` attribute pins read-after-write-sensitive aggregates
+    // to the primary at compile time; otherwise the route follows
+    // `AppState::read_pool` semantics (replica when healthy, primary
+    // fallback or fail-fast per the configured `replica_fallback` policy).
+    let read_route_init = if config.primary_reads {
+        quote! {
+            let __autumn_read_route = ::autumn_web::repository::ReadRoute::Primary;
+        }
+    } else {
+        quote! {
+            let __autumn_read_route =
+                ::autumn_web::repository::ReadRoute::from_state(state);
+        }
     };
 
     let (
@@ -782,6 +809,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             hooks: #hooks_ident,
             #idempotency_struct_field
             #tenant_struct_field
+            /// Read-routing snapshot for generated read-only methods (#971).
+            __autumn_read_route: ::autumn_web::repository::ReadRoute,
             /// Statement timeout to apply on every connection checkout (ms). 0 = no limit.
             __autumn_statement_timeout_ms: u64,
             /// Slow-query logging threshold.
@@ -798,6 +827,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         hooks: <#hooks_ident as ::autumn_web::hooks::RepositoryHooksClone>::autumn_clone(&self.hooks),
                         #idempotency_clone_field
                         #tenant_clone_field
+                        __autumn_read_route: self.__autumn_read_route.clone(),
                         __autumn_statement_timeout_ms: self.__autumn_statement_timeout_ms,
                         __autumn_slow_threshold: self.__autumn_slow_threshold,
                         __autumn_route: self.__autumn_route.clone(),
@@ -822,6 +852,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 .extensions
                 .get::<::autumn_web::reexports::axum::extract::MatchedPath>()
                 .map(|p| p.as_str().to_owned());
+            #read_route_init
         };
 
         let extractor_init = if commit_hooks_enabled {
@@ -836,6 +867,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         .get::<::autumn_web::idempotency::IdempotencyContext>()
                         .cloned(),
                     #tenant_init_field
+                    __autumn_read_route,
                     __autumn_statement_timeout_ms: __autumn_timeout_ms,
                     __autumn_slow_threshold,
                     __autumn_route,
@@ -848,6 +880,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     pool,
                     hooks: <#hooks_ident as ::autumn_web::hooks::RepositoryHooksDefault>::autumn_default(),
                     #tenant_init_field
+                    __autumn_read_route,
                     __autumn_statement_timeout_ms: __autumn_timeout_ms,
                     __autumn_slow_threshold,
                     __autumn_route,
@@ -3888,6 +3921,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 ::autumn_web::reexports::diesel_async::AsyncPgConnection,
             >,
             #tenant_struct_field
+            /// Read-routing snapshot for generated read-only methods (#971).
+            __autumn_read_route: ::autumn_web::repository::ReadRoute,
             /// Statement timeout to apply on every connection checkout (ms). 0 = no limit.
             __autumn_statement_timeout_ms: u64,
             /// Slow-query logging threshold.
@@ -3902,6 +3937,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     Self {
                         pool: self.pool.clone(),
                         #tenant_clone_field
+                        __autumn_read_route: self.__autumn_read_route.clone(),
                         __autumn_statement_timeout_ms: self.__autumn_statement_timeout_ms,
                         __autumn_slow_threshold: self.__autumn_slow_threshold,
                         __autumn_route: self.__autumn_route.clone(),
@@ -3926,6 +3962,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 .extensions
                 .get::<::autumn_web::reexports::axum::extract::MatchedPath>()
                 .map(|p| p.as_str().to_owned());
+            #read_route_init
         };
 
         let extractor_init = quote! {
@@ -3933,6 +3970,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             Ok(#pg_name {
                 pool,
                 #tenant_init_field
+                __autumn_read_route,
                 __autumn_statement_timeout_ms: __autumn_timeout_ms,
                 __autumn_slow_threshold,
                 __autumn_route,
@@ -5757,7 +5795,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
                     ::core::option::Option::Some(t)
                 };
-                let mut conn = self.__autumn_acquire_conn().await?;
+                let mut conn = self.__autumn_acquire_read_conn().await?;
 
                 let query = #table_ident::table;
                 if let ::core::option::Option::Some(ref t) = tenant_id {
@@ -5807,7 +5845,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             ) -> ::autumn_web::AutumnResult<::autumn_web::pagination::Page<#model_name>> {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                let mut conn = self.__autumn_acquire_conn().await?;
+                let mut conn = self.__autumn_acquire_read_conn().await?;
                 let total: i64 = #table_ident::table
                     #sd_filter
                     .count()
@@ -5884,7 +5922,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 ) -> ::autumn_web::AutumnResult<::autumn_web::pagination::CursorPage<#model_name>> {
                     use ::autumn_web::reexports::diesel::prelude::*;
                     use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                    let mut conn = self.__autumn_acquire_conn().await?;
+                    let mut conn = self.__autumn_acquire_read_conn().await?;
                     let mut query = #table_ident::table.into_boxed();
                     #tenant_query_filter
                     if let ::core::option::Option::Some((after_k, after_id)) =
@@ -5927,7 +5965,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 ) -> ::autumn_web::AutumnResult<::autumn_web::pagination::CursorPage<#model_name>> {
                     use ::autumn_web::reexports::diesel::prelude::*;
                     use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                    let mut conn = self.__autumn_acquire_conn().await?;
+                    let mut conn = self.__autumn_acquire_read_conn().await?;
                     let mut query = #table_ident::table.into_boxed();
                     #tenant_query_filter
                     if let ::core::option::Option::Some(after_id) = req.decode::<i64>() {
@@ -6141,7 +6179,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     &__autumn_state,
                     &__autumn_session,
                 ).await;
-                let mut __conn = repo.__autumn_acquire_conn().await?;
+                let mut __conn = repo.__autumn_acquire_read_conn().await?;
                 let records = __scope.list(&__ctx, &mut __conn).await?;
                 Ok(::autumn_web::prelude::Json(records))
             }
@@ -6866,7 +6904,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     use ::autumn_web::reexports::diesel::prelude::*;
                     use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                     #tenant_id_setup
-                    let mut conn = self.__autumn_acquire_conn().await?;
+                    let mut conn = self.__autumn_acquire_read_conn().await?;
                     let query = #table_ident::table;
                     if let ::core::option::Option::Some(ref t) = tenant_id {
                         query.filter(#table_ident::tenant_id.eq(t))
@@ -6884,7 +6922,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     use ::autumn_web::reexports::diesel::prelude::*;
                     use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                     #tenant_id_setup
-                    let mut conn = self.__autumn_acquire_conn().await?;
+                    let mut conn = self.__autumn_acquire_read_conn().await?;
                     let query = #table_ident::table.filter(#table_ident::deleted_at.is_not_null());
                     if let ::core::option::Option::Some(ref t) = tenant_id {
                         query.filter(#table_ident::tenant_id.eq(t))
@@ -6905,7 +6943,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     use ::autumn_web::reexports::diesel::prelude::*;
                     use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                     #tenant_id_setup
-                    let mut conn = self.__autumn_acquire_conn().await?;
+                    let mut conn = self.__autumn_acquire_read_conn().await?;
                     let query = #table_ident::table.filter(#table_ident::deleted_at.is_not_null());
                     if let ::core::option::Option::Some(ref t) = tenant_id {
                         let total: i64 = query
@@ -6982,7 +7020,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 async fn with_deleted(&self) -> ::autumn_web::AutumnResult<Vec<#model_name>> {
                     use ::autumn_web::reexports::diesel::prelude::*;
                     use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                    let mut conn = self.__autumn_acquire_conn().await?;
+                    let mut conn = self.__autumn_acquire_read_conn().await?;
                     let query = #table_ident::table;
                     query
                         .load::<#model_name>(&mut conn)
@@ -6993,7 +7031,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 async fn only_deleted(&self) -> ::autumn_web::AutumnResult<Vec<#model_name>> {
                     use ::autumn_web::reexports::diesel::prelude::*;
                     use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                    let mut conn = self.__autumn_acquire_conn().await?;
+                    let mut conn = self.__autumn_acquire_read_conn().await?;
                     let query = #table_ident::table.filter(#table_ident::deleted_at.is_not_null());
                     query
                         .load::<#model_name>(&mut conn)
@@ -7007,7 +7045,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 ) -> ::autumn_web::AutumnResult<::autumn_web::pagination::Page<#model_name>> {
                     use ::autumn_web::reexports::diesel::prelude::*;
                     use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                    let mut conn = self.__autumn_acquire_conn().await?;
+                    let mut conn = self.__autumn_acquire_read_conn().await?;
                     let query = #table_ident::table.filter(#table_ident::deleted_at.is_not_null());
                     let total: i64 = query
                         .count()
@@ -7297,7 +7335,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
 
                 #tenant_id_setup
-                let mut conn = self.__autumn_acquire_conn().await?;
+                let mut conn = self.__autumn_acquire_read_conn().await?;
                 let language = <#model_name as ::autumn_web::repository::AutumnSearchableModel>::SEARCH_LANGUAGE;
 
                 let mut sql = format!(
@@ -7387,7 +7425,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
 
                 #tenant_id_setup
-                let mut conn = self.__autumn_acquire_conn().await?;
+                let mut conn = self.__autumn_acquire_read_conn().await?;
                 let language = <#model_name as ::autumn_web::repository::AutumnSearchableModel>::SEARCH_LANGUAGE;
                 let limit = req.limit();
                 let offset = req.offset();
@@ -7647,7 +7685,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     let per_page = filter.per_page();
                     #version_history_tenant_setup
 
-                    let mut conn = self.__autumn_acquire_conn().await?;
+                    let mut conn = self.__autumn_acquire_read_conn().await?;
 
                     // Execute count query, optionally filtered by timestamp range.
                     let total: u64 = if filter.from.is_some() || filter.to.is_some() {
@@ -7817,14 +7855,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             async fn find_by_id(&self, id: i64) -> ::autumn_web::AutumnResult<Option<#model_name>> {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                let mut conn = self.__autumn_acquire_conn().await?;
+                let mut conn = self.__autumn_acquire_read_conn().await?;
                 #find_by_id_impl
             }
 
             async fn find_all(&self) -> ::autumn_web::AutumnResult<Vec<#model_name>> {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                let mut conn = self.__autumn_acquire_conn().await?;
+                let mut conn = self.__autumn_acquire_read_conn().await?;
                 #find_all_impl
             }
 
@@ -7843,14 +7881,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             async fn count(&self) -> ::autumn_web::AutumnResult<i64> {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                let mut conn = self.__autumn_acquire_conn().await?;
+                let mut conn = self.__autumn_acquire_read_conn().await?;
                 #count_impl
             }
 
             async fn exists_by_id(&self, id: i64) -> ::autumn_web::AutumnResult<bool> {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                let mut conn = self.__autumn_acquire_conn().await?;
+                let mut conn = self.__autumn_acquire_read_conn().await?;
                 #exists_by_id_impl
             }
 
@@ -7883,9 +7921,47 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             #across_tenants_method
             #hook_support_methods
 
-            /// Acquire a database connection from the repository's
-            /// pool. Used by `#[repository(scope = ...)]`-generated
-            /// list endpoints; not part of the public surface.
+            /// Returns a clone of this repository whose generated read
+            /// methods are pinned to the primary pool for the rest of the
+            /// call chain — the read-your-writes escape hatch (#971).
+            ///
+            /// Use immediately after a write when replication lag would
+            /// make a replica read stale:
+            ///
+            /// ```rust,ignore
+            /// let created = repo.save(&new).await?;
+            /// let fresh = repo.on_primary().find_by_id(created.id).await?;
+            /// ```
+            ///
+            /// Mutating methods are unaffected — they always run on the
+            /// primary.
+            #[must_use]
+            pub fn on_primary(&self) -> Self {
+                let mut repo = ::core::clone::Clone::clone(self);
+                repo.__autumn_read_route = ::autumn_web::repository::ReadRoute::Primary;
+                repo
+            }
+
+            /// The read route this repository snapshot uses for generated
+            /// read-only methods. Exposed for tests; not a public API.
+            #[doc(hidden)]
+            pub fn __autumn_read_route(&self) -> &::autumn_web::repository::ReadRoute {
+                &self.__autumn_read_route
+            }
+
+            /// The primary/write pool. Exposed for tests; not a public API.
+            #[doc(hidden)]
+            pub fn __autumn_write_pool(
+                &self,
+            ) -> &::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
+                ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+            > {
+                &self.pool
+            }
+
+            /// Acquire a primary-pool connection for mutating methods and
+            /// pessimistic locks. Also used by `#[repository(scope = ...)]`
+            /// generated endpoints; not part of the public surface.
             #[doc(hidden)]
             pub async fn __autumn_acquire_conn(
                 &self,
@@ -7894,8 +7970,50 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     ::autumn_web::reexports::diesel_async::AsyncPgConnection,
                 >,
             > {
+                self.__autumn_acquire_from(&self.pool).await
+            }
+
+            /// Acquire a connection for a generated read-only method,
+            /// following the repository's read route: the replica pool when
+            /// one is configured and healthy, otherwise the primary (#971).
+            #[doc(hidden)]
+            pub async fn __autumn_acquire_read_conn(
+                &self,
+            ) -> ::autumn_web::AutumnResult<
+                ::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Object<
+                    ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                >,
+            > {
+                match &self.__autumn_read_route {
+                    ::autumn_web::repository::ReadRoute::Primary => {
+                        self.__autumn_acquire_from(&self.pool).await
+                    }
+                    ::autumn_web::repository::ReadRoute::ReadPool(pool) => {
+                        self.__autumn_acquire_from(pool).await
+                    }
+                    ::autumn_web::repository::ReadRoute::Unavailable => {
+                        ::core::result::Result::Err(
+                            ::autumn_web::AutumnError::service_unavailable_msg(
+                                "read replica is configured but not ready, and the \
+                                 replica_fallback policy forbids primary reads",
+                            ),
+                        )
+                    }
+                }
+            }
+
+            async fn __autumn_acquire_from(
+                &self,
+                pool: &::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
+                    ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                >,
+            ) -> ::autumn_web::AutumnResult<
+                ::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Object<
+                    ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                >,
+            > {
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl as _;
-                let mut conn = self.pool.get().await.map_err(|e| {
+                let mut conn = pool.get().await.map_err(|e| {
                     ::autumn_web::reexports::tracing::error!(
                         "repository: failed to acquire database connection: {e}"
                     );
@@ -8078,6 +8196,27 @@ mod tests {
         assert!(
             err.to_string().contains("requires hooks"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_repo_args_with_primary_reads() {
+        let tokens: proc_macro2::TokenStream = "Post, primary_reads".parse().unwrap();
+        let config = parse_repo_args(tokens).unwrap();
+        assert_eq!(config.model_name.to_string(), "Post");
+        assert!(
+            config.primary_reads,
+            "primary_reads must pin generated reads to the primary pool"
+        );
+    }
+
+    #[test]
+    fn parse_repo_args_primary_reads_defaults_off() {
+        let tokens: proc_macro2::TokenStream = "Post".parse().unwrap();
+        let config = parse_repo_args(tokens).unwrap();
+        assert!(
+            !config.primary_reads,
+            "reads route to the replica by default"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -6114,7 +6114,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         };
         let policy_check_update_pre = if has_policy {
             quote! {
-                let __existing = repo.find_by_id(id).await?
+                let __existing = repo.on_primary().find_by_id(id).await?
                     .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg("not found"))?;
                 ::autumn_web::authorization::__check_policy::<#model_name>(
                     &__autumn_state,
@@ -6129,7 +6129,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         };
         let policy_check_delete_pre = if has_policy {
             quote! {
-                let __existing = repo.find_by_id(id).await?
+                let __existing = repo.on_primary().find_by_id(id).await?
                     .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg("not found"))?;
                 ::autumn_web::authorization::__check_policy::<#model_name>(
                     &__autumn_state,
@@ -6370,7 +6370,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         };
         let update_body = if has_policy {
             quote! {
-                let __existing = match repo.find_by_id(id).await {
+                let __existing = match repo.on_primary().find_by_id(id).await {
                     ::core::result::Result::Ok(::core::option::Option::Some(existing)) => existing,
                     ::core::result::Result::Ok(::core::option::Option::None) => {
                         return ::autumn_web::idempotency::IdempotencyReplayOr::Inner(
@@ -6440,7 +6440,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         &__autumn_idempotency_replay,
                         "repository.delete.record",
                     );
-                let __existing = match repo.find_by_id(id).await {
+                let __existing = match repo.on_primary().find_by_id(id).await {
                     ::core::result::Result::Ok(::core::option::Option::Some(existing)) => existing,
                     ::core::result::Result::Ok(::core::option::Option::None) => {
                         if let ::core::option::Option::Some(bytes) = __autumn_replay_deleted_record {
@@ -8196,6 +8196,45 @@ mod tests {
         assert!(
             err.to_string().contains("requires hooks"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_api_mutation_prechecks_pin_reads_to_primary() {
+        let generated = repository_macro(
+            quote! { Post, api = "/api/posts", policy = PostPolicy },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+
+        // The PUT/DELETE handlers load the row before writing (404 + policy
+        // decision). Under replication lag a replica read could 404 or
+        // authorize against a stale row even though the write itself runs on
+        // the primary — mutation prechecks must be read-your-writes safe.
+        assert_eq!(
+            generated
+                .matches("repo . on_primary () . find_by_id")
+                .count(),
+            2,
+            "update/delete prechecks must pin find_by_id to the primary"
+        );
+
+        // The plain GET endpoint is an ordinary read and stays on the
+        // replica route.
+        let get_fn = generated
+            .find("async fn post_api_get")
+            .expect("get handler must be generated");
+        let get_end = generated[get_fn..]
+            .find("async fn post_api_create")
+            .map_or(generated.len(), |offset| get_fn + offset);
+        let section = &generated[get_fn..get_end];
+        assert!(
+            section.contains("repo . find_by_id"),
+            "get handler must read through the repository: {section}"
+        );
+        assert!(
+            !section.contains("on_primary"),
+            "get handler reads must stay replica-eligible: {section}"
         );
     }
 

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -1,10 +1,15 @@
-//! Repository error types for framework-generated CRUD operations.
+//! Repository support types for framework-generated CRUD operations.
 //!
-//! Framework-generated repositories use the [`Db`](crate::Db) extractor, which
-//! is bound to the primary/write database role. If an application wants a
-//! primary/replica read split, use an explicit repository seam and route reads
-//! through [`crate::AppState::read_pool`] while keeping writes on
-//! [`crate::AppState::pool`].
+//! Generated `#[repository]` read-only methods (`find_by_id`, `find_all`,
+//! `count`, `paginate`, `cursor_page`, derived `find_by_*`, full-text-search
+//! reads) route to the configured read replica automatically: set
+//! `database.replica_url` and the extractor snapshots a [`ReadRoute`] per
+//! request via [`crate::AppState::read_pool`]. Mutating methods (`save`,
+//! `update`, `delete_by_id`, bulk writes) always run on the primary pool.
+//! Pin a read-after-write-sensitive repository to the primary with
+//! `#[repository(Model, primary_reads)]`, or pin a single call chain with
+//! the generated `on_primary()` method. When no replica is configured, all
+//! methods use the primary — nothing changes for single-pool apps.
 //!
 //! [`RepositoryError`] surfaces typed errors that arise during repository
 //! operations — most notably optimistic-lock conflicts when two replicas
@@ -12,6 +17,65 @@
 
 use sha2::{Digest, Sha256};
 use thiserror::Error;
+
+/// Where a generated repository routes its read-only methods (`find_by_id`,
+/// `find_all`, `count`, `paginate`, `cursor_page`, derived `find_by_*`,
+/// full-text-search reads, …).
+///
+/// The route is snapshotted from [`crate::AppState`] when the repository is
+/// extracted, so every read within a request sees one consistent decision.
+/// Mutating methods (`save`, `update`, `delete_by_id`, bulk writes) always
+/// use the primary pool regardless of this route, as do pessimistic-lock
+/// reads (`with_lock`) and reads running on an explicit transaction
+/// connection.
+#[cfg(feature = "db")]
+#[derive(Clone)]
+pub enum ReadRoute {
+    /// Reads use the primary/write pool: no replica is configured, the
+    /// repository was declared with `#[repository(..., primary_reads)]`, or
+    /// the caller pinned this instance with `on_primary()`.
+    Primary,
+    /// Reads use this read-role pool snapshot — the replica when healthy,
+    /// or the primary when the replica is unready and the
+    /// [`ReplicaFallback::Primary`](crate::config::ReplicaFallback) policy
+    /// applies.
+    ReadPool(diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>),
+    /// A replica is configured but currently unready, and the
+    /// [`ReplicaFallback::FailReadiness`](crate::config::ReplicaFallback)
+    /// policy forbids falling back to the primary. Generated reads fail
+    /// fast with `503 Service Unavailable` instead of silently serving
+    /// from the wrong role.
+    Unavailable,
+}
+
+#[cfg(feature = "db")]
+impl ReadRoute {
+    /// Snapshot the read-routing decision for one request from the app
+    /// state, mirroring [`crate::AppState::read_pool`] semantics.
+    #[must_use]
+    pub fn from_state(state: &crate::AppState) -> Self {
+        if state.replica_pool().is_some() {
+            state
+                .read_pool()
+                .map_or(Self::Unavailable, |pool| Self::ReadPool(pool.clone()))
+        } else {
+            Self::Primary
+        }
+    }
+}
+
+#[cfg(feature = "db")]
+impl std::fmt::Debug for ReadRoute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Primary => f.write_str("ReadRoute::Primary"),
+            Self::ReadPool(pool) => {
+                write!(f, "ReadRoute::ReadPool(max={})", pool.status().max_size)
+            }
+            Self::Unavailable => f.write_str("ReadRoute::Unavailable"),
+        }
+    }
+}
 
 /// Typed errors returned by generated repository methods.
 ///

--- a/autumn/tests/compile-pass/repository_replica_reads.rs
+++ b/autumn/tests/compile-pass/repository_replica_reads.rs
@@ -1,0 +1,58 @@
+// Compile-pass: replica-aware read routing (#971) — the `primary_reads`
+// per-repository opt-out and the per-call `on_primary()` escape hatch.
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        articles (id) {
+            id -> Int8,
+            title -> Text,
+        }
+    }
+
+    autumn_web::reexports::diesel::table! {
+        ledgers (id) {
+            id -> Int8,
+            title -> Text,
+        }
+    }
+}
+
+use schema::{articles, ledgers};
+
+#[autumn_web::model(table = "articles")]
+pub struct Article {
+    #[id]
+    pub id: i64,
+    pub title: String,
+}
+
+// Default: generated reads route to the replica pool when configured.
+#[autumn_web::repository(Article, table = "articles")]
+pub trait ArticleRepository {
+    fn find_by_title(title: String) -> Vec<Article>;
+}
+
+#[autumn_web::model(table = "ledgers")]
+pub struct Ledger {
+    #[id]
+    pub id: i64,
+    pub title: String,
+}
+
+// Opt-out: a read-after-write-sensitive aggregate pins all reads to primary.
+#[autumn_web::repository(Ledger, table = "ledgers", primary_reads)]
+pub trait LedgerRepository {}
+
+// Per-call escape hatch: read-your-writes immediately after a save, without
+// dropping to raw Diesel.
+#[allow(dead_code)]
+async fn read_your_writes(
+    repo: PgArticleRepository,
+    new: NewArticle,
+) -> autumn_web::AutumnResult<Vec<Article>> {
+    let saved = repo.save(&new).await?;
+    let _on_primary = repo.on_primary().find_by_id(saved.id).await?;
+    repo.on_primary().find_all().await
+}
+
+fn main() {}

--- a/autumn/tests/compile_fail.rs
+++ b/autumn/tests/compile_fail.rs
@@ -89,6 +89,8 @@ fn compile_pass_tests() {
     #[cfg(feature = "db")]
     t.pass("tests/compile-pass/repository_no_hooks.rs");
     #[cfg(feature = "db")]
+    t.pass("tests/compile-pass/repository_replica_reads.rs");
+    #[cfg(feature = "db")]
     t.pass("tests/compile-pass/repository_with_hooks.rs");
     #[cfg(feature = "db")]
     t.pass("tests/compile-pass/repository_hooks_serde_skipped_model.rs");

--- a/autumn/tests/repository_bulk_operations.rs
+++ b/autumn/tests/repository_bulk_operations.rs
@@ -341,6 +341,7 @@ async fn setup_pool() -> (
 const fn build_lock_repo(pool: Pool<AsyncPgConnection>) -> PgLockRecordRepository {
     PgLockRecordRepository {
         pool,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: std::time::Duration::from_millis(500),
         __autumn_route: None,
@@ -350,6 +351,7 @@ const fn build_lock_repo(pool: Pool<AsyncPgConnection>) -> PgLockRecordRepositor
 const fn build_bulk_repo(pool: Pool<AsyncPgConnection>) -> PgBulkRecordRepository {
     PgBulkRecordRepository {
         pool,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: std::time::Duration::from_millis(500),
         __autumn_route: None,
@@ -360,6 +362,7 @@ const fn build_hooked_repo(pool: Pool<AsyncPgConnection>) -> PgHookedRecordRepos
     PgHookedRecordRepository {
         pool,
         hooks: HookedRecordHooks,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: std::time::Duration::from_millis(500),
         __autumn_route: None,
@@ -369,6 +372,7 @@ const fn build_hooked_repo(pool: Pool<AsyncPgConnection>) -> PgHookedRecordRepos
 const fn build_zero_col_repo(pool: Pool<AsyncPgConnection>) -> PgZeroColRecordRepository {
     PgZeroColRecordRepository {
         pool,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: std::time::Duration::from_millis(500),
         __autumn_route: None,
@@ -379,6 +383,7 @@ const fn build_tenant_bulk_repo(pool: Pool<AsyncPgConnection>) -> PgTenantBulkRe
     PgTenantBulkRecordRepository {
         pool,
         across_tenants: false,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: std::time::Duration::from_millis(500),
         __autumn_route: None,
@@ -391,6 +396,7 @@ const fn build_hooked_versioned_repo(
     PgHookedVersionedRecordRepository {
         pool,
         hooks: HookedVersionedRecordHooks,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: std::time::Duration::from_millis(500),
         __autumn_route: None,

--- a/autumn/tests/repository_replica_routing.rs
+++ b/autumn/tests/repository_replica_routing.rs
@@ -1,0 +1,208 @@
+//! Issue #971: generated `#[repository]` read methods route to the replica
+//! pool automatically when `database.replica_url` is configured, while
+//! mutating methods stay on the primary.
+//!
+//! Uses the existing two-pool test topology: pools are created lazily (no
+//! live database needed) and distinguished by `status().max_size`, the same
+//! technique as the `AppState::read_pool` tests in `src/state.rs`.
+
+#![cfg(feature = "db")]
+
+use autumn_web::AppState;
+use autumn_web::config::{DatabaseConfig, ReplicaFallback};
+use autumn_web::db;
+use autumn_web::reexports::axum::extract::FromRequestParts;
+use autumn_web::reexports::diesel_async::AsyncPgConnection;
+use autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool;
+use autumn_web::reexports::http::Request;
+use autumn_web::repository::ReadRoute;
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        replica_notes (id) {
+            id -> Int8,
+            content -> Text,
+        }
+    }
+
+    autumn_web::reexports::diesel::table! {
+        pinned_notes (id) {
+            id -> Int8,
+            content -> Text,
+        }
+    }
+}
+
+use schema::{pinned_notes, replica_notes};
+
+#[autumn_web::model(table = "replica_notes")]
+pub struct ReplicaNote {
+    #[id]
+    pub id: i64,
+    pub content: String,
+}
+
+#[autumn_web::model(table = "pinned_notes")]
+pub struct PinnedNote {
+    #[id]
+    pub id: i64,
+    pub content: String,
+}
+
+/// Default routing: reads go to the replica when one is configured.
+#[autumn_web::repository(ReplicaNote, table = "replica_notes")]
+pub trait ReplicaNoteRepository {
+    fn find_by_content(content: String) -> Vec<ReplicaNote>;
+}
+
+/// Per-repository opt-out: reads pinned to the primary.
+#[autumn_web::repository(PinnedNote, table = "pinned_notes", primary_reads)]
+pub trait PinnedNoteRepository {}
+
+const PRIMARY_POOL_SIZE: usize = 5;
+const REPLICA_POOL_SIZE: usize = 2;
+
+fn make_pool(database: &str, pool_size: usize) -> Pool<AsyncPgConnection> {
+    let config = DatabaseConfig {
+        url: Some(format!("postgres://localhost/{database}")),
+        pool_size,
+        ..Default::default()
+    };
+    db::create_pool(&config)
+        .expect("pool config is valid")
+        .expect("url is set")
+}
+
+fn two_pool_state() -> AppState {
+    AppState::for_test()
+        .with_pool(make_pool("primary", PRIMARY_POOL_SIZE))
+        .with_replica_pool(make_pool("replica", REPLICA_POOL_SIZE))
+}
+
+async fn extract<R>(state: &AppState) -> R
+where
+    R: FromRequestParts<AppState, Rejection = autumn_web::AutumnError>,
+{
+    let (mut parts, ()) = Request::builder().body(()).unwrap().into_parts();
+    R::from_request_parts(&mut parts, state)
+        .await
+        .expect("repository extraction succeeds")
+}
+
+/// Resolves the pool a generated read method would acquire from, or `None`
+/// when reads are pinned to the primary / unavailable.
+fn read_pool_size(route: &ReadRoute) -> Option<usize> {
+    match route {
+        ReadRoute::ReadPool(pool) => Some(pool.status().max_size),
+        ReadRoute::Primary | ReadRoute::Unavailable => None,
+    }
+}
+
+#[tokio::test]
+async fn generated_reads_target_replica_and_writes_target_primary() {
+    let state = two_pool_state();
+    let repo: PgReplicaNoteRepository = extract(&state).await;
+
+    // Generated read-only methods acquire from the replica pool…
+    assert_eq!(
+        read_pool_size(repo.__autumn_read_route()),
+        Some(REPLICA_POOL_SIZE),
+        "read route must snapshot the replica pool"
+    );
+    // …while mutating methods stay on the primary pool.
+    assert_eq!(
+        repo.__autumn_write_pool().status().max_size,
+        PRIMARY_POOL_SIZE,
+        "write pool must remain the primary"
+    );
+}
+
+#[tokio::test]
+async fn reads_use_primary_when_no_replica_is_configured() {
+    let state = AppState::for_test().with_pool(make_pool("primary", PRIMARY_POOL_SIZE));
+    let repo: PgReplicaNoteRepository = extract(&state).await;
+
+    assert!(
+        matches!(repo.__autumn_read_route(), ReadRoute::Primary),
+        "single-pool apps must keep current behavior (reads on primary)"
+    );
+}
+
+#[tokio::test]
+async fn primary_reads_attribute_pins_reads_to_primary() {
+    let state = two_pool_state();
+    let repo: PgPinnedNoteRepository = extract(&state).await;
+
+    assert!(
+        matches!(repo.__autumn_read_route(), ReadRoute::Primary),
+        "primary_reads repositories must never read from the replica"
+    );
+    assert_eq!(
+        repo.__autumn_write_pool().status().max_size,
+        PRIMARY_POOL_SIZE
+    );
+}
+
+#[tokio::test]
+async fn on_primary_escape_hatch_pins_reads_per_call() {
+    let state = two_pool_state();
+    let repo: PgReplicaNoteRepository = extract(&state).await;
+
+    let pinned = repo.on_primary();
+    assert!(
+        matches!(pinned.__autumn_read_route(), ReadRoute::Primary),
+        "on_primary() must force reads onto the primary pool"
+    );
+    // The original repository keeps routing reads to the replica.
+    assert_eq!(
+        read_pool_size(repo.__autumn_read_route()),
+        Some(REPLICA_POOL_SIZE),
+        "on_primary() returns a pinned clone without mutating the original"
+    );
+}
+
+#[tokio::test]
+async fn reads_fall_back_to_primary_when_replica_unready_and_policy_allows() {
+    let state = two_pool_state();
+    state
+        .probes()
+        .configure_replica_dependency(ReplicaFallback::Primary);
+    state
+        .probes()
+        .mark_replica_unready("replica migrations lag primary");
+
+    let repo: PgReplicaNoteRepository = extract(&state).await;
+    assert_eq!(
+        read_pool_size(repo.__autumn_read_route()),
+        Some(PRIMARY_POOL_SIZE),
+        "fallback policy routes reads to the primary pool"
+    );
+}
+
+#[tokio::test]
+async fn reads_error_when_replica_unready_and_fallback_forbidden() {
+    let state = two_pool_state();
+    state
+        .probes()
+        .configure_replica_dependency(ReplicaFallback::FailReadiness);
+    state
+        .probes()
+        .mark_replica_unready("replica connection failed");
+
+    let repo: PgReplicaNoteRepository = extract(&state).await;
+    assert!(
+        matches!(repo.__autumn_read_route(), ReadRoute::Unavailable),
+        "FailReadiness policy must not silently fall back to the primary"
+    );
+
+    // A generated read method fails fast — before touching any pool — so this
+    // runs without a live database.
+    let err = repo
+        .find_all()
+        .await
+        .expect_err("reads must be unavailable");
+    assert!(
+        err.to_string().to_lowercase().contains("replica"),
+        "error should explain the replica is unavailable, got: {err}"
+    );
+}

--- a/autumn/tests/repository_search.rs
+++ b/autumn/tests/repository_search.rs
@@ -89,6 +89,7 @@ async fn setup_pool() -> (
 const fn build_repo(pool: Pool<AsyncPgConnection>) -> PgSearchRecordRepository {
     PgSearchRecordRepository {
         pool,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: std::time::Duration::from_millis(500),
         __autumn_route: None,

--- a/autumn/tests/seo.rs
+++ b/autumn/tests/seo.rs
@@ -131,23 +131,35 @@ fn sitemap_xml_escapes_special_chars_in_url() {
 }
 
 #[test]
-fn sitemap_xml_generates_sitemapindex_for_large_sites() {
-    // Generate more than 50,000 entries to trigger sitemapindex
+fn sitemap_xml_caps_entries_at_protocol_limit() {
+    // The sitemap-index feature was removed in favor of a hard cap: when
+    // more than 50,000 entries (the Sitemap protocol per-file limit) are
+    // supplied, only the first 50,000 are served and a warning is logged.
+    // Sites beyond the limit register a custom /sitemap.xml handler.
     let entries: Vec<SitemapEntry> = (0..50_001)
         .map(|i| SitemapEntry::new(format!("https://example.com/page/{i}")))
         .collect();
     let xml = sitemap_xml(&entries, Some("https://example.com"));
     assert!(
-        xml.contains("<sitemapindex"),
-        "should use sitemapindex for large sites"
+        xml.contains("<urlset"),
+        "capped output is still a plain urlset document"
     );
     assert!(
-        xml.contains("<sitemap>"),
-        "should have sitemap entries in index"
+        !xml.contains("<sitemapindex"),
+        "sitemap-index generation was intentionally removed"
+    );
+    assert_eq!(
+        xml.matches("<url>").count(),
+        50_000,
+        "should serve exactly the first 50,000 entries"
     );
     assert!(
-        xml.contains("https://example.com/sitemap-1.xml"),
-        "should reference sub-sitemaps"
+        xml.contains("https://example.com/page/49999"),
+        "last entry within the cap is included"
+    );
+    assert!(
+        !xml.contains("https://example.com/page/50000<"),
+        "entries beyond the cap are dropped"
     );
 }
 

--- a/autumn/tests/tenancy.rs
+++ b/autumn/tests/tenancy.rs
@@ -112,6 +112,7 @@ async fn test_tenant_scoping_isolation() {
     let repo = PgTenantPostRepository {
         pool,
         across_tenants: false,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: ::std::time::Duration::from_millis(100),
         __autumn_route: ::core::option::Option::None,
@@ -186,6 +187,7 @@ async fn test_unscoped_query_without_context_fails() {
     let repo = PgTenantPostRepository {
         pool,
         across_tenants: false,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: ::std::time::Duration::from_millis(100),
         __autumn_route: ::core::option::Option::None,
@@ -225,6 +227,7 @@ async fn test_escape_hatch_across_tenants() {
     let repo = PgTenantPostRepository {
         pool,
         across_tenants: false,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: ::std::time::Duration::from_millis(100),
         __autumn_route: ::core::option::Option::None,
@@ -277,6 +280,7 @@ async fn test_immutable_tenant_id_on_update() {
     let repo = PgTenantPostRepository {
         pool,
         across_tenants: false,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: ::std::time::Duration::from_millis(100),
         __autumn_route: ::core::option::Option::None,
@@ -347,6 +351,7 @@ async fn test_across_tenants_save_without_tenant_id_on_new_struct_works() {
     let repo = PgTenantPostRepository {
         pool,
         across_tenants: false,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: ::std::time::Duration::from_millis(100),
         __autumn_route: ::core::option::Option::None,
@@ -393,6 +398,7 @@ async fn test_bulk_ops_tenant_scoping() {
     let repo = PgTenantPostRepository {
         pool,
         across_tenants: false,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: ::std::time::Duration::from_millis(100),
         __autumn_route: ::core::option::Option::None,

--- a/docs/guide/repositories.md
+++ b/docs/guide/repositories.md
@@ -124,6 +124,43 @@ RETURNING *;
 
 ---
 
+## Read Replicas: Automatic Read Routing
+
+When `database.replica_url` is configured, every generated **read-only** method — `find_by_id`, `find_all`, `count`, `exists_by_id`, `paginate`, `cursor_page`, derived `find_by_*` / `count_by_*` / `exists_by_*` queries, and full-text `search` / `search_page` — automatically acquires its connection from the replica pool. Mutating methods (`save`, `update`, `delete_by_id`, the bulk operations, hook-driven writes, `with_lock`) always run on the primary. Provisioning a replica therefore offloads your primary with **zero application code changes**.
+
+When no replica is configured, all methods use the primary — single-pool apps are unaffected.
+
+The routing decision is snapshotted per request from `AppState::read_pool()`, so it honors the `database.replica_fallback` policy: when the replica is unready, reads either fall back to the primary (`replica_fallback = "primary"`) or fail fast with `503 Service Unavailable` (`replica_fallback = "fail_readiness"`) rather than silently serving from the wrong role.
+
+### Opting Out: `primary_reads`
+
+Replica reads can be **stale** by up to your replication lag. For aggregates where a stale read is worse than extra primary load (e.g. account balances, inventory counters), pin the whole repository to the primary:
+
+```rust
+#[autumn_web::repository(AccountBalance, primary_reads)]
+pub trait AccountBalanceRepository {}
+```
+
+All generated reads on this repository use the primary pool, even when a replica is configured. Prefer the per-call escape hatch below when only *some* call sites are read-after-write-sensitive — a repository-wide opt-out gives up replica offloading everywhere.
+
+### Read-Your-Writes: `on_primary()`
+
+After a handler performs a write, an immediate read may land on a replica that has not replayed it yet. The generated `on_primary()` method returns a clone of the repository whose reads are pinned to the primary, so you can read-your-writes without dropping to raw Diesel:
+
+```rust
+let created = repo.save(&new_post).await?;
+// The replica may not have seen this row yet — read it from the primary.
+let fresh = repo.on_primary().find_by_id(created.id).await?;
+```
+
+The original `repo` keeps routing reads to the replica; only the pinned clone (and call chains on it) use the primary.
+
+### Transactions
+
+Reads executed inside an explicit transaction (`db.tx(...)` or `repo.with_lock(...)`) run on the transaction's own primary connection — a transaction never splits reads onto a replica.
+
+---
+
 ## Performance & Scaling Guidelines
 
 Bulk operations are built for maximum performance, with the following built-in safeguards:

--- a/docs/guide/transactions.md
+++ b/docs/guide/transactions.md
@@ -254,3 +254,13 @@ All generated bulk methods (`save_many`, `update_many`, `delete_many`, `upsert_m
 - **Atomic Execution**: On repositories with hooks configured, the entire batch query and hook execution are wrapped in an atomic database transaction. If any individual record hook fails or if the database returns an error, the entire operation is automatically rolled back.
 - **Participation in `db.tx`**: If a bulk operation is called inside a `db.tx` block, it automatically participates in that outer transaction. No new nested transaction is started, conforming to Autumn's nesting policy.
 - **Durable Commit Hooks**: If commit hooks are enabled (`commit_hooks = true`), post-commit hooks like `after_create_commit` will be staged during bulk writes and executed sequentially only when the surrounding database transaction successfully commits.
+
+## Transactions and Read Replicas
+
+When `database.replica_url` is configured, generated repository read methods normally route to the replica pool (see the [repositories guide](repositories.md#read-replicas-automatic-read-routing)). Transactions are the exception: **everything inside a transaction stays on the single primary connection that owns it**.
+
+- `db.tx(|conn| ...)` hands your closure the transaction's primary connection; every query you run on `conn` — reads included — executes on the primary. There is no split-brain where a transaction writes to the primary but reads stale data from a replica.
+- `repo.with_lock(id, |record, conn| ...)` performs its `SELECT ... FOR UPDATE` and runs your closure on a primary transaction connection, since locking reads are only meaningful on the writer.
+- The internal transactions opened by generated write methods (`save`, `update`, bulk operations, hook lifecycles) acquire from the primary pool, so hook-driven reads-during-write also see the primary.
+
+For read-your-writes *outside* a transaction — e.g. a handler that saves and then re-fetches — use the repository's `on_primary()` escape hatch instead of opening a transaction just to pin the connection.


### PR DESCRIPTION
## Summary

Implements automatic read replica routing for generated `#[repository]` methods (issue #971). When `database.replica_url` is configured, all generated read-only methods (`find_by_id`, `find_all`, `count`, `paginate`, `cursor_page`, derived `find_by_*`, full-text search reads) automatically acquire connections from the replica pool, while mutating methods continue to use the primary. Single-pool applications are unaffected.

## Key Changes

- **New `ReadRoute` enum** (`autumn/src/repository.rs`): Represents the routing decision for read-only methods with three variants:
  - `Primary`: reads use the primary pool (no replica configured, `primary_reads` attribute, or `on_primary()` called)
  - `ReadPool`: reads use the replica pool snapshot
  - `Unavailable`: replica is unready and `FailReadiness` policy forbids fallback

- **Repository macro enhancements** (`autumn-macros/src/repository.rs`):
  - Added `primary_reads` attribute to opt out of replica routing per-repository
  - Snapshot `ReadRoute` during repository extraction via `ReadRoute::from_state(state)`
  - Changed all generated read methods to call `__autumn_acquire_read_conn()` instead of `__autumn_acquire_conn()`
  - Added `on_primary()` method to return a clone with reads pinned to the primary (read-your-writes escape hatch)
  - Updated `across_tenants()` and other cloning methods to preserve the read route

- **Connection acquisition**: Generated read methods now route through the snapshotted `ReadRoute` to acquire connections from either the replica or primary pool based on the routing decision

- **Comprehensive test coverage** (`autumn/tests/repository_replica_routing.rs`):
  - Verifies reads route to replica when configured
  - Confirms writes always use primary
  - Tests `primary_reads` attribute pins reads to primary
  - Validates `on_primary()` escape hatch
  - Tests replica fallback policies (`ReplicaFallback::Primary` and `ReplicaFallback::FailReadiness`)
  - Includes compile-pass test for the new syntax

- **Documentation updates** (`docs/guide/repositories.md`):
  - New "Read Replicas: Automatic Read Routing" section
  - Explains `primary_reads` opt-out for read-after-write-sensitive aggregates
  - Documents `on_primary()` method for per-call pinning
  - Notes that transactions always use primary connections

## Implementation Details

- The read route is snapshotted per request during repository extraction, ensuring consistent routing decisions throughout a single request
- Respects `database.replica_fallback` policy: falls back to primary or fails fast based on configuration
- Backward compatible: existing single-pool applications see no changes
- The routing decision is cloned when repositories are cloned (e.g., via `across_tenants()`)
- Pessimistic-lock reads and explicit transaction connections always use the primary regardless of routing

https://claude.ai/code/session_01L8wThsUWQz6DZwF1N9LqnA