### PR TITLE
🔒 Warden: Hardening unsafe unwraps in locks and auth

### DIFF
--- a/autumn/src/experiments.rs
+++ b/autumn/src/experiments.rs
@@ -627,12 +627,18 @@ impl InMemoryExperimentStore {
 
 impl ExperimentStore for InMemoryExperimentStore {
     fn get(&self, name: &str) -> Result<Option<ExperimentConfig>, ExperimentStoreError> {
-        Ok(self.inner.read().unwrap().experiments.get(name).cloned())
+        Ok(self
+            .inner
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .experiments
+            .get(name)
+            .cloned())
     }
 
     fn list(&self) -> Result<Vec<ExperimentConfig>, ExperimentStoreError> {
         let mut exps: Vec<ExperimentConfig> = {
-            let inner = self.inner.read().unwrap();
+            let inner = self.inner.read().unwrap_or_else(std::sync::PoisonError::into_inner);
             inner.experiments.values().cloned().collect()
         };
         exps.sort_by(|a, b| a.name.cmp(&b.name));
@@ -642,7 +648,7 @@ impl ExperimentStore for InMemoryExperimentStore {
     fn upsert(&self, config: ExperimentConfig) -> Result<(), ExperimentStoreError> {
         let name = config.name.clone();
         {
-            let mut inner = self.inner.write().unwrap();
+            let mut inner = self.inner.write().unwrap_or_else(std::sync::PoisonError::into_inner);
             let active_variants: std::collections::HashSet<String> = inner
                 .assignments
                 .values()
@@ -680,7 +686,7 @@ impl ExperimentStore for InMemoryExperimentStore {
         winner: Option<&str>,
     ) -> Result<(), ExperimentStoreError> {
         {
-            let mut inner = self.inner.write().unwrap();
+            let mut inner = self.inner.write().unwrap_or_else(std::sync::PoisonError::into_inner);
             if let Some(exp) = inner.experiments.get_mut(name) {
                 exp.state = state;
                 if let Some(w) = winner {
@@ -708,7 +714,7 @@ impl ExperimentStore for InMemoryExperimentStore {
         actor: Option<&str>,
     ) -> Result<(), ExperimentStoreError> {
         {
-            let mut inner = self.inner.write().unwrap();
+            let mut inner = self.inner.write().unwrap_or_else(std::sync::PoisonError::into_inner);
             let active_variants: std::collections::HashSet<String> = inner
                 .assignments
                 .values()
@@ -745,7 +751,7 @@ impl ExperimentStore for InMemoryExperimentStore {
         experiment: &str,
         actor: &str,
     ) -> Result<Option<Assignment>, ExperimentStoreError> {
-        let inner = self.inner.read().unwrap();
+        let inner = self.inner.read().unwrap_or_else(std::sync::PoisonError::into_inner);
         Ok(inner
             .assignments
             .get(&(experiment.to_owned(), actor.to_owned()))
@@ -753,7 +759,7 @@ impl ExperimentStore for InMemoryExperimentStore {
     }
 
     fn record_assignment(&self, assignment: Assignment) -> Result<String, ExperimentStoreError> {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.inner.write().unwrap_or_else(std::sync::PoisonError::into_inner);
 
         if !assignment.is_override {
             // Find the exclusion group for this experiment.
@@ -792,7 +798,7 @@ impl ExperimentStore for InMemoryExperimentStore {
         experiment: &str,
         actor: &str,
     ) -> Result<Option<String>, ExperimentStoreError> {
-        let inner = self.inner.read().unwrap();
+        let inner = self.inner.read().unwrap_or_else(std::sync::PoisonError::into_inner);
         Ok(inner
             .overrides
             .get(&(experiment.to_owned(), actor.to_owned()))
@@ -808,7 +814,7 @@ impl ExperimentStore for InMemoryExperimentStore {
         let key = (experiment.to_owned(), actor.to_owned());
         self.inner
             .write()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .overrides
             .insert(key, variant.to_owned());
         Ok(())
@@ -820,7 +826,7 @@ impl ExperimentStore for InMemoryExperimentStore {
         group: &str,
         exclude_experiment: &str,
     ) -> Result<bool, ExperimentStoreError> {
-        let inner = self.inner.read().unwrap();
+        let inner = self.inner.read().unwrap_or_else(std::sync::PoisonError::into_inner);
         for (exp_name, config) in &inner.experiments {
             if exp_name == exclude_experiment {
                 continue;
@@ -844,7 +850,7 @@ impl ExperimentStore for InMemoryExperimentStore {
         limit: usize,
     ) -> Result<Vec<ChangeRecord>, ExperimentStoreError> {
         let records = {
-            let inner = self.inner.read().unwrap();
+            let inner = self.inner.read().unwrap_or_else(std::sync::PoisonError::into_inner);
             inner
                 .changes
                 .get(experiment)

--- a/autumn/src/feature_flags.rs
+++ b/autumn/src/feature_flags.rs
@@ -317,7 +317,7 @@ impl InMemoryFlagStore {
     }
 
     fn upsert(&self, key: &str, f: impl FnOnce(&mut FlagConfig)) {
-        let mut flags = self.flags.write().unwrap();
+        let mut flags = self.flags.write().unwrap_or_else(std::sync::PoisonError::into_inner);
         let flag = flags
             .entry(key.to_owned())
             .or_insert_with(|| FlagConfig::new(key));
@@ -328,7 +328,7 @@ impl InMemoryFlagStore {
     fn record(&self, record: FlagChangeRecord) {
         self.history
             .write()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .entry(record.key.clone())
             .or_default()
             .push(record);
@@ -337,11 +337,22 @@ impl InMemoryFlagStore {
 
 impl FlagStore for InMemoryFlagStore {
     fn get(&self, key: &str) -> Result<Option<FlagConfig>, FlagStoreError> {
-        Ok(self.flags.read().unwrap().get(key).cloned())
+        Ok(self
+            .flags
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(key)
+            .cloned())
     }
 
     fn list(&self) -> Result<Vec<FlagConfig>, FlagStoreError> {
-        let mut flags: Vec<FlagConfig> = self.flags.read().unwrap().values().cloned().collect();
+        let mut flags: Vec<FlagConfig> = self
+            .flags
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .values()
+            .cloned()
+            .collect();
         flags.sort_by(|a, b| a.key.cmp(&b.key));
         Ok(flags)
     }
@@ -422,7 +433,7 @@ impl FlagStore for InMemoryFlagStore {
         Ok(self
             .history
             .read()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .get(key)
             .map(|records| records.iter().rev().take(limit).cloned().collect())
             .unwrap_or_default())

--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -459,7 +459,12 @@ impl MemoryIdempotencyStore {
 impl IdempotencyStore for MemoryIdempotencyStore {
     fn get(&self, key: &str) -> Option<IdempotencyEntry> {
         // Release the read lock immediately after cloning.
-        let entry = self.entries.read().unwrap().get(key).cloned();
+        let entry = self
+            .entries
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(key)
+            .cloned();
         entry.filter(|e| e.expires_at > Instant::now())
     }
 
@@ -469,7 +474,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
             body_hash,
             expires_at: Instant::now() + ttl,
         };
-        let mut entries = self.entries.write().unwrap();
+        let mut entries = self.entries.write().unwrap_or_else(std::sync::PoisonError::into_inner);
         entries.insert(key.to_owned(), entry);
         // Periodically evict expired entries to bound memory growth for
         // long-running processes. O(N) scan is amortised over every 128 writes.
@@ -486,7 +491,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
 
     fn try_lock_owned(&self, key: &str, owner: &str, lock_ttl: Duration) -> bool {
         let now = Instant::now();
-        let mut in_flight = self.in_flight.write().unwrap();
+        let mut in_flight = self.in_flight.write().unwrap_or_else(std::sync::PoisonError::into_inner);
         // Check only the requested key's active in-flight marker.
         if let Some(lock) = in_flight.get(key)
             && lock.expires_at > now

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -4792,7 +4792,11 @@ async fn api_versioning_middleware(
                 ));
             }
             if auth_failed {
-                return auth_error.unwrap().into_response();
+                return auth_error
+                    .unwrap_or_else(|| {
+                        crate::error::AutumnError::unauthorized_msg("authentication required")
+                    })
+                    .into_response();
             }
         }
 

--- a/autumn/src/runtime_config.rs
+++ b/autumn/src/runtime_config.rs
@@ -845,7 +845,12 @@ impl InMemoryConfigStore {
 
 impl ConfigStore for InMemoryConfigStore {
     fn get_raw(&self, key: &str) -> Result<Option<String>, ConfigStoreError> {
-        Ok(self.values.read().unwrap().get(key).cloned())
+        Ok(self
+            .values
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(key)
+            .cloned())
     }
 
     fn set_raw(
@@ -858,10 +863,13 @@ impl ConfigStore for InMemoryConfigStore {
         let old_value = old_raw.map(ConfigValue::Text);
         let new_value = Some(ConfigValue::Text(new_raw.clone()));
         let record = ConfigChangeRecord::now(key, old_value, new_value, actor);
-        self.values.write().unwrap().insert(key.to_owned(), new_raw);
+        self.values
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(key.to_owned(), new_raw);
         self.history
             .write()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .entry(key.to_owned())
             .or_default()
             .push(record);
@@ -876,10 +884,13 @@ impl ConfigStore for InMemoryConfigStore {
     ) -> Result<(), ConfigStoreError> {
         let old_value = old_raw.map(ConfigValue::Text);
         let record = ConfigChangeRecord::now(key, old_value, None, actor);
-        self.values.write().unwrap().remove(key);
+        self.values
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(key);
         self.history
             .write()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .entry(key.to_owned())
             .or_default()
             .push(record);
@@ -890,7 +901,7 @@ impl ConfigStore for InMemoryConfigStore {
         let mut pairs: Vec<(String, String)> = self
             .values
             .read()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
@@ -903,7 +914,7 @@ impl ConfigStore for InMemoryConfigStore {
         key: &str,
         limit: usize,
     ) -> Result<Vec<ConfigChangeRecord>, ConfigStoreError> {
-        let guard = self.history.read().unwrap();
+        let guard = self.history.read().unwrap_or_else(std::sync::PoisonError::into_inner);
         Ok(guard
             .get(key)
             .map(|records| records.iter().rev().take(limit).cloned().collect())


### PR DESCRIPTION
🔒 Warden: Hardening unsafe unwraps in locks and auth

🦠 Threat: A single thread panic while holding an application-wide `Mutex` or `RwLock` (e.g. in the Idempotency, Experiments, Feature Flags, or Config stores) would permanently poison the lock. Subsequent threads blindly `.unwrap()`ing these locks would also panic, leading to a cascading failure and a denial-of-service (DoS) across the entire application. Additionally, an unsafe unwrap in the routing layer could cause an unhandled panic during authorization failures.
🛡️ Defense: Replaced all `.unwrap()` calls on `Mutex` and `RwLock` acquisitions with `.unwrap_or_else(std::sync::PoisonError::into_inner)` across all core concurrent stores. This allows the application to gracefully recover from thread panics without taking down other requests. Fixed the routing unwrap to supply a default unauthorized message gracefully.
💥 Severity: High - A single thread crash could take down the entire application by poisoning central config or feature flag state.
🧪 Verification: `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all` completed cleanly with no regressions in the core libraries.

---
*PR created automatically by Jules for task [1082252798553251746](https://jules.google.com/task/1082252798553251746) started by @madmax983*