### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -6520,6 +6520,22 @@ mod tests {
 
     #[cfg(feature = "i18n")]
     #[tokio::test]
+    #[should_panic(expected = "i18n_auto: i18n default locale `en` is missing")]
+    async fn i18n_auto_panics_with_path_when_bundle_missing() {
+        let project = tempfile::tempdir().expect("project dir");
+        let mut config = AutumnConfig::default();
+        config.i18n.dir = "nonexistent-i18n".to_owned();
+
+        let env = crate::config::MockEnv::new().with(
+            "AUTUMN_MANIFEST_DIR",
+            project.path().to_str().expect("utf-8 path"),
+        );
+
+        let _ = resolve_i18n_bundle(None, true, &config, &env);
+    }
+
+    #[cfg(feature = "i18n")]
+    #[tokio::test]
     async fn i18n_auto_uses_config_loader_output_for_bundle_dir() {
         let project = tempfile::tempdir().expect("project dir");
         let i18n_dir = project.path().join("custom-i18n");

--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -1227,4 +1227,38 @@ mod tests {
         assert_eq!(hx_trigger, r#"{"autumn:conflict":true}"#);
         Ok(())
     }
+
+    #[test]
+    fn problem_title_for_fallback_uses_canonical_reason() {
+        assert_eq!(super::problem_title_for(StatusCode::from_u16(599).unwrap(), false), "Error");
+        assert_eq!(super::problem_title_for(StatusCode::from_u16(418).unwrap(), false), "I'm a teapot");
+    }
+
+    #[test]
+    fn problem_code_with_explicit_type_infers_slug() {
+        let json = super::problem_details_json_string(
+            StatusCode::BAD_REQUEST,
+            "test",
+            None,
+            Some("https://example.com/custom-error"),
+            None,
+            None,
+            false,
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["code"], "autumn.custom_error");
+
+        // Edge case: when type doesn't contain a slash, it uses the whole thing
+        let json_no_slash = super::problem_details_json_string(
+            StatusCode::BAD_REQUEST,
+            "test",
+            None,
+            Some("custom-error"),
+            None,
+            None,
+            false,
+        );
+        let parsed_no_slash: serde_json::Value = serde_json::from_str(&json_no_slash).unwrap();
+        assert_eq!(parsed_no_slash["code"], "autumn.custom_error");
+    }
 }

--- a/autumn/src/error_pages/source.rs
+++ b/autumn/src/error_pages/source.rs
@@ -271,6 +271,13 @@ mod tests {
     }
 
     #[test]
+    fn parse_location_ignores_invalid_line_number() {
+        let (file, line) = parse_location("src/lib.rs:not_a_number");
+        assert_eq!(file, "src/lib.rs:not_a_number");
+        assert_eq!(line, 0);
+    }
+
+    #[test]
     fn read_source_context_returns_empty_for_zero_line() {
         let lines = read_source_context("src/lib.rs", 0);
         assert!(lines.is_empty());

--- a/autumn/src/test_html.rs
+++ b/autumn/src/test_html.rs
@@ -870,6 +870,24 @@ fn parse_attr_pred(chars: &[char], i: &mut usize, full: &str) -> Result<AttrPred
     Ok(AttrPred { name, op })
 }
 
+#[cfg(test)]
+mod operator_tests {
+    use super::*;
+
+    #[test]
+    fn parse_attr_predicate_rejects_unsupported_operator() {
+        let chars: Vec<char> = "name~='value']".chars().collect();
+        let mut i = 0;
+        let result = parse_attr_pred(&chars, &mut i, "div[name~='value']");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .contains("unsupported attribute operator")
+        );
+    }
+}
+
 fn read_attr_value(chars: &[char], i: &mut usize, full: &str) -> Result<String, String> {
     if let Some(&q @ ('"' | '\'')) = chars.get(*i) {
         *i += 1;


### PR DESCRIPTION
🎯 Target: `test_html::parse_attr_pred`, `error::problem_title_for`, `error::build_problem_details_json`, `error_pages::source::parse_location`, `app::resolve_i18n_bundle`.
💣 Risk: Untested error paths, unwrap_or fallback cases, and missing panic behavior checks that could cause regressions.
🧪 Strategy: Added specific unit tests triggering these fallback modes and invalid paths, particularly focusing on unreachable macro assertions and parsing edge cases.
🔬 Verification: `cargo test -p autumn-web --lib`

---
*PR created automatically by Jules for task [18376428352023633948](https://jules.google.com/task/18376428352023633948) started by @madmax983*