### PR TITLE
🗺️ Atlas: [architectural change] decouple authorization from AppState

### DIFF
--- a/autumn/src/authorization.rs
+++ b/autumn/src/authorization.rs
@@ -65,6 +65,27 @@ use crate::session::Session;
 /// rust edition).
 pub type BoxFuture<'a, T> = Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
 
+// ── Provider Trait ───────────────────────────────────────────────
+
+/// Provider trait that abstracts the state required for authorization operations.
+/// This prevents tight coupling to `AppState` and prevents circular dependencies.
+pub trait ProvideAuthorizationState: Send + Sync {
+    /// Returns the registered policies and scopes.
+    fn policy_registry(&self) -> &PolicyRegistry;
+
+    /// Returns the configured response when authorization is denied.
+    fn forbidden_response(&self) -> ForbiddenResponse;
+
+    /// Returns the session key used to retrieve the authenticated user's ID.
+    fn auth_session_key(&self) -> &str;
+
+    /// Returns the database pool, if available.
+    #[cfg(feature = "db")]
+    fn pool(
+        &self,
+    ) -> Option<diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>;
+}
+
 // ── PolicyContext ────────────────────────────────────────────────
 
 /// Per-request context handed to every policy and scope check.
@@ -130,13 +151,13 @@ impl PolicyContext {
     /// Build a fully-populated [`PolicyContext`] from `AppState` +
     /// `Session`. Used by the `#[authorize]` macro and
     /// `#[repository(policy = ...)]`-generated handlers.
-    pub async fn from_request(state: &crate::AppState, session: &Session) -> Self {
+    pub async fn from_request(state: &dyn ProvideAuthorizationState, session: &Session) -> Self {
         let mut ctx = Self::from_session(session, state.auth_session_key()).await;
         ctx.policy_registry = state.policy_registry().clone();
         #[cfg(feature = "db")]
         {
             if let Some(pool) = state.pool() {
-                ctx.pool = Some(pool.clone());
+                ctx.pool = Some(pool);
             }
         }
         ctx
@@ -621,7 +642,7 @@ impl<'de> serde::Deserialize<'de> for ForbiddenResponse {
 /// }
 /// ```
 pub async fn authorize<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
     action: &str,
     resource: &R,
@@ -651,7 +672,7 @@ where
 /// the public API** — call [`authorize`] from user code.
 #[doc(hidden)]
 pub async fn __check_policy<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
     action: &str,
     resource: &R,
@@ -673,7 +694,7 @@ where
 /// alias for older macro output.
 #[doc(hidden)]
 pub async fn __check_policy_create<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
 ) -> crate::AutumnResult<()>
 where
@@ -692,7 +713,7 @@ where
 /// only `autumn-web` is upgraded.
 #[doc(hidden)]
 pub async fn __check_policy_create_payload<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
     payload: &serde_json::Value,
 ) -> crate::AutumnResult<()>
@@ -713,7 +734,7 @@ where
 /// Returns the configured deny response when the policy denies.
 /// Returns `500` when no policy is registered for `R`.
 pub async fn authorize_create<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
 ) -> crate::AutumnResult<()>
 where
@@ -749,7 +770,7 @@ where
 /// Returns the configured deny response when the policy denies.
 /// Returns `500` when no policy is registered for `R`.
 pub async fn authorize_create_payload<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
     payload: &serde_json::Value,
 ) -> crate::AutumnResult<()>

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -150,6 +150,28 @@ pub struct AppState {
     pub(crate) clock: Arc<dyn ClockSource>,
 }
 
+impl crate::authorization::ProvideAuthorizationState for AppState {
+    fn policy_registry(&self) -> &crate::authorization::PolicyRegistry {
+        &self.policy_registry
+    }
+
+    fn forbidden_response(&self) -> crate::authorization::ForbiddenResponse {
+        self.forbidden_response
+    }
+
+    fn auth_session_key(&self) -> &str {
+        &self.auth_session_key
+    }
+
+    #[cfg(feature = "db")]
+    fn pool(
+        &self,
+    ) -> Option<diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
+        self.pool().cloned()
+    }
+}
+
 impl AppState {
     /// Install or replace a typed runtime extension.
     ///


### PR DESCRIPTION
🕸️ Tangle: The `authorization` module functions (`authorize`, `authorize_create`, etc.) were tightly coupled to the concrete "God Struct" `AppState`, which creates circular dependencies when other domain components need authorization features but can't easily construct or reference the entire application state.

📐 Blueprint: Extracted a `ProvideAuthorizationState` trait in the `authorization` module and implemented it for `AppState`. Updated authorization functions to accept `&dyn ProvideAuthorizationState` to achieve inversion of control without breaking turbofish syntax or causing monomorphization bloat.

🧱 Stability: Enforces module boundaries, removes the tight coupling to `AppState`, and enables easier unit testing for domain components that require authorization.

🔭 Verification: The `ProvideAuthorizationState` trait successfully implemented for `AppState`, and `cargo check`, `cargo fmt`, `cargo clippy`, and `cargo test` pass successfully.

---
*PR created automatically by Jules for task [16844086138728124361](https://jules.google.com/task/16844086138728124361) started by @madmax983*