### PR TITLE
🗺️ Atlas: [architectural change] Extract ProvideAuthorizationState trait

### DIFF
--- a/autumn/src/authorization.rs
+++ b/autumn/src/authorization.rs
@@ -56,6 +56,27 @@ use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
 
+/// State interface for authorization features.
+///
+/// Implemented by `AppState` and test doubles to provide the framework
+/// components required by `authorize` and `PolicyContext::from_request`.
+pub trait ProvideAuthorizationState {
+    /// Returns a reference to the `PolicyRegistry`.
+    fn policy_registry(&self) -> &PolicyRegistry;
+
+    /// Configured deny-response shape (`403` vs `404`).
+    fn forbidden_response(&self) -> ForbiddenResponse;
+
+    /// Session key used to resolve the authenticated user id.
+    fn auth_session_key(&self) -> &str;
+
+    /// Returns the database connection pool, if enabled.
+    #[cfg(feature = "db")]
+    fn pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>;
+}
+
 use http::StatusCode;
 
 use crate::session::Session;
@@ -130,7 +151,10 @@ impl PolicyContext {
     /// Build a fully-populated [`PolicyContext`] from `AppState` +
     /// `Session`. Used by the `#[authorize]` macro and
     /// `#[repository(policy = ...)]`-generated handlers.
-    pub async fn from_request(state: &crate::AppState, session: &Session) -> Self {
+    pub async fn from_request(
+        state: &(dyn ProvideAuthorizationState + Send + Sync),
+        session: &Session,
+    ) -> Self {
         let mut ctx = Self::from_session(session, state.auth_session_key()).await;
         ctx.policy_registry = state.policy_registry().clone();
         #[cfg(feature = "db")]
@@ -621,7 +645,7 @@ impl<'de> serde::Deserialize<'de> for ForbiddenResponse {
 /// }
 /// ```
 pub async fn authorize<R>(
-    state: &crate::AppState,
+    state: &(dyn ProvideAuthorizationState + Send + Sync),
     session: &Session,
     action: &str,
     resource: &R,
@@ -651,7 +675,7 @@ where
 /// the public API** — call [`authorize`] from user code.
 #[doc(hidden)]
 pub async fn __check_policy<R>(
-    state: &crate::AppState,
+    state: &(dyn ProvideAuthorizationState + Send + Sync),
     session: &Session,
     action: &str,
     resource: &R,
@@ -673,7 +697,7 @@ where
 /// alias for older macro output.
 #[doc(hidden)]
 pub async fn __check_policy_create<R>(
-    state: &crate::AppState,
+    state: &(dyn ProvideAuthorizationState + Send + Sync),
     session: &Session,
 ) -> crate::AutumnResult<()>
 where
@@ -692,7 +716,7 @@ where
 /// only `autumn-web` is upgraded.
 #[doc(hidden)]
 pub async fn __check_policy_create_payload<R>(
-    state: &crate::AppState,
+    state: &(dyn ProvideAuthorizationState + Send + Sync),
     session: &Session,
     payload: &serde_json::Value,
 ) -> crate::AutumnResult<()>
@@ -713,7 +737,7 @@ where
 /// Returns the configured deny response when the policy denies.
 /// Returns `500` when no policy is registered for `R`.
 pub async fn authorize_create<R>(
-    state: &crate::AppState,
+    state: &(dyn ProvideAuthorizationState + Send + Sync),
     session: &Session,
 ) -> crate::AutumnResult<()>
 where
@@ -749,7 +773,7 @@ where
 /// Returns the configured deny response when the policy denies.
 /// Returns `500` when no policy is registered for `R`.
 pub async fn authorize_create_payload<R>(
-    state: &crate::AppState,
+    state: &(dyn ProvideAuthorizationState + Send + Sync),
     session: &Session,
     payload: &serde_json::Value,
 ) -> crate::AutumnResult<()>

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -644,6 +644,28 @@ impl DbState for AppState {
     }
 }
 
+impl crate::authorization::ProvideAuthorizationState for AppState {
+    fn policy_registry(&self) -> &crate::authorization::PolicyRegistry {
+        self.policy_registry()
+    }
+
+    fn forbidden_response(&self) -> crate::authorization::ForbiddenResponse {
+        self.forbidden_response()
+    }
+
+    fn auth_session_key(&self) -> &str {
+        self.auth_session_key()
+    }
+
+    #[cfg(feature = "db")]
+    fn pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
+        self.pool()
+    }
+}
+
 impl crate::probe::ProvideProbeState for AppState {
     fn probes(&self) -> &crate::probe::ProbeState {
         &self.probes


### PR DESCRIPTION
🗺️ Atlas: [architectural change] Extract ProvideAuthorizationState trait

🕸️ Tangle: The authorization module depended concretely on AppState, unnecessarily coupling core framework policy logic to the monolithic application state struct.
📏 Blueprint: Created ProvideAuthorizationState trait and implemented it for AppState, allowing authorization functions to take &dyn ProvideAuthorizationState via Dependency Inversion.
🧱 Stability: Reduced coupling, enforcing a cleaner domain boundary without circular dependencies.
🔭 Verification: Passed cargo check and cargo test for related modules.

---
*PR created automatically by Jules for task [16394016239484113421](https://jules.google.com/task/16394016239484113421) started by @madmax983*