### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn/src/data/csv.rs
+++ b/autumn/src/data/csv.rs
@@ -178,7 +178,12 @@ pub enum ImportRowResult {
     /// A row-level error occurred.
     RowError(String),
     /// A field-level error occurred (column name + message).
-    FieldError { column: String, message: String },
+    FieldError {
+        /// The name of the CSV column where the error occurred.
+        column: String,
+        /// The error message.
+        message: String,
+    },
 }
 
 // ── CsvSchema trait ───────────────────────────────────────────────────────────

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -418,7 +418,7 @@ pub use autumn_macros::api_doc;
 pub use autumn_macros::get;
 /// Annotate an async function as a first-class inbound mail handler.
 ///
-/// See [`inbound_mail`] for usage documentation.
+/// See [`macro@inbound_mail`] for usage documentation.
 #[cfg(feature = "inbound-mail")]
 pub use autumn_macros::inbound_mail;
 /// Collect mailer preview registrations into an `AppBuilder`.

--- a/autumn/src/reporting.rs
+++ b/autumn/src/reporting.rs
@@ -2,24 +2,24 @@
 //! route them to one or more configured reporters.
 //!
 //! When an Autumn handler panics or returns a server error, the failure is
-//! turned into a structured [`ErrorEvent`] and delivered to every registered
-//! [`ErrorReporter`]. This is the "where do my errors go?" seam: ship events to
+//! turned into a structured [`crate::reporting::ErrorEvent`] and delivered to every registered
+//! [`crate::reporting::ErrorReporter`]. This is the "where do my errors go?" seam: ship events to
 //! Sentry, Honeycomb, Slack, or a custom sink by implementing a single trait
 //! and wiring it once with
 //! [`AppBuilder::with_error_reporter`](crate::app::AppBuilder::with_error_reporter).
 //!
 //! The design mirrors Rails' [Error Reporter] and Autumn's other pluggable
 //! backends ([`BlobStore`](crate::storage::BlobStore),
-//! [`Cache`](crate::cache::Cache)): a built-in [`LogReporter`] (which uses
+//! [`Cache`](crate::cache::Cache)): a built-in [`crate::reporting::LogReporter`] (which uses
 //! `tracing`) ships as the default so the feature is useful with zero extra
 //! dependencies, and one builder call swaps in your own sink.
 //!
 //! # What gets reported
 //!
-//! - **Handler panics.** A [`ReportingLayer`] catches unwinding panics at the
+//! - **Handler panics.** A [`crate::reporting::ReportingLayer`] catches unwinding panics at the
 //!   HTTP layer (so a single panicking handler can never abort the worker
 //!   task), converts them into a sanitized [`AutumnError`](crate::AutumnError)
-//!   `500` Problem Details response, and reports an [`ErrorEvent`] carrying the
+//!   `500` Problem Details response, and reports an [`crate::reporting::ErrorEvent`] carrying the
 //!   panic payload and (when `RUST_BACKTRACE` is set) a backtrace.
 //! - **Server errors.** Any response with a `5xx` status is reported with its
 //!   status, message, and Problem Details type.

--- a/autumn/src/runtime_config.rs
+++ b/autumn/src/runtime_config.rs
@@ -1331,7 +1331,12 @@ pub enum ConfigError {
 
     /// A declared validator rejected the value.
     #[error("config key '{key}': validation failed — {reason}")]
-    ValidationFailed { key: String, reason: String },
+    ValidationFailed {
+        /// The config key that failed validation.
+        key: String,
+        /// The reason the validation failed.
+        reason: String,
+    },
 
     /// The backing store returned an error.
     #[error("config store error: {0}")]
@@ -1343,11 +1348,17 @@ pub enum ConfigError {
 /// A snapshot of a single config key: schema defaults + current override.
 #[derive(Debug, Clone)]
 pub struct ConfigEntry {
+    /// The unique name of the config key.
     pub name: String,
+    /// The expected data type for this configuration value.
     pub value_type: ConfigValueType,
+    /// The currently active value (override if present, otherwise default).
     pub current: ConfigValue,
+    /// The default value as defined in the registry.
     pub default: ConfigValue,
+    /// True if the current value is overriding the default.
     pub is_overridden: bool,
+    /// Optional human-readable description of the config key.
     pub description: Option<String>,
 }
 

--- a/autumn/src/system_test.rs
+++ b/autumn/src/system_test.rs
@@ -292,8 +292,8 @@ impl SystemTest {
         self
     }
 
-    /// Supply a pre-configured [`AppState`] to use instead of
-    /// [`AppState::for_test()`].
+    /// Supply a pre-configured [`crate::AppState`] to use instead of
+    /// [`crate::AppState::for_test()`].
     ///
     /// Use this when the routes under test require a real database pool, API
     /// version registrations, authorization policies, or any other state that

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -692,6 +692,7 @@ impl TestApp {
         self
     }
 
+    /// Adds a mail interceptor for capturing and inspecting outbound emails in tests.
     #[cfg(feature = "mail")]
     #[must_use]
     pub fn with_mail_interceptor(
@@ -702,6 +703,7 @@ impl TestApp {
         self
     }
 
+    /// Adds a job interceptor for observing and validating background job enqueues.
     #[must_use]
     pub fn with_job_interceptor(
         mut self,
@@ -711,6 +713,7 @@ impl TestApp {
         self
     }
 
+    /// Adds a database interceptor to trace database connections during test execution.
     #[cfg(feature = "db")]
     #[must_use]
     pub fn with_db_interceptor(
@@ -721,6 +724,7 @@ impl TestApp {
         self
     }
 
+    /// Adds a WebSocket channels interceptor to inspect real-time channel events.
     #[cfg(feature = "ws")]
     #[must_use]
     pub fn with_channels_interceptor(
@@ -731,6 +735,7 @@ impl TestApp {
         self
     }
 
+    /// Adds an HTTP client interceptor to observe or mock external API requests.
     #[cfg(feature = "oauth2")]
     #[must_use]
     pub fn with_http_interceptor(

--- a/autumn/src/webhook.rs
+++ b/autumn/src/webhook.rs
@@ -1023,6 +1023,10 @@ type ReplayStoreCell =
     std::sync::Arc<std::sync::Mutex<Option<(std::sync::Arc<dyn WebhookReplayStore>, Vec<String>)>>>;
 
 tokio::task_local! {
+    /// A task-local cell holding a thread-safe replay store and a list of recorded events.
+    ///
+    /// This is used internally to track outbound webhook deliveries during a simulated replay,
+    /// preventing them from accidentally being dispatched to live systems during tests.
     pub static WEBHOOK_REPLAY_KEY: ReplayStoreCell;
 }
 

--- a/autumn/src/webhook_outbound.rs
+++ b/autumn/src/webhook_outbound.rs
@@ -22,8 +22,11 @@ const TRUNCATED_RESPONSE_BODY_SUFFIX: &str = "\n[truncated]";
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum WebhookSubscriptionStatus {
+    /// The subscription is active and delivering events.
     Active,
+    /// The subscription was manually disabled.
     Disabled,
+    /// The subscription failed to deliver events too many times and has been suspended.
     Failed,
 }
 
@@ -48,29 +51,48 @@ impl std::fmt::Display for WebhookSubscriptionStatus {
 /// A registered webhook subscription targeting a consumer endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebhookSubscription {
+    /// The unique identifier of the subscription.
     pub id: String,
+    /// The URL endpoint to deliver events to.
     pub target_url: String,
+    /// A list of topics this subscription listens for.
     pub event_topics: Vec<String>,
+    /// The secret used to sign outbound requests.
     pub secret: String,
+    /// The current operational status of the subscription.
     pub status: WebhookSubscriptionStatus,
+    /// The number of consecutive failed delivery attempts.
     pub consecutive_failures: u32,
 }
 
 /// A structured log of an outbound webhook delivery attempt.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebhookDeliveryLog {
+    /// The unique identifier for this delivery attempt.
     pub id: String,
+    /// The associated subscription ID.
     pub subscription_id: String,
+    /// The topic of the event being delivered.
     pub topic: String,
+    /// The JSON payload delivered to the endpoint.
     pub payload: String,
+    /// The headers sent with the outbound request.
     pub request_headers: HashMap<String, String>,
+    /// The HTTP status code returned by the endpoint, if a response was received.
     pub response_status: Option<u16>,
+    /// The body returned by the endpoint, if a response was received.
     pub response_body: Option<String>,
+    /// The duration of the delivery attempt in milliseconds.
     pub elapsed_ms: u64,
+    /// The attempt sequence number (e.g., 1 for the first attempt).
     pub attempt: u32,
+    /// The maximum number of retry attempts configured.
     pub max_attempts: u32,
+    /// True if the payload has been moved to the dead-letter queue.
     pub is_dlq: bool,
+    /// A descriptive error message if the delivery attempt failed.
     pub last_error: Option<String>,
+    /// The UTC timestamp of the delivery attempt.
     pub timestamp: DateTime<Utc>,
 }
 

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,20 @@
+1. **Fix missing documentation for `ConfigError` and `ConfigEntry` fields in `autumn/src/runtime_config.rs`**.
+   - Add comments indicating the purpose of `ValidationFailed` fields `key` and `reason`.
+   - Add comments to `ConfigEntry` fields `name`, `value_type`, `current`, `default`, `is_overridden`, and `description`.
+2. **Fix missing documentation for `FieldError` fields in `autumn/src/data/csv.rs`**.
+   - Add comments indicating the purpose of `FieldError` fields `column` and `message`.
+3. **Fix missing documentation for `WEBHOOK_REPLAY_KEY` in `autumn/src/webhook.rs`**.
+   - Add comments explaining its purpose.
+4. **Fix missing documentation for `WebhookSubscriptionStatus` variants and fields in `autumn/src/webhook_outbound.rs`**.
+   - Add comments for `Active`, `Disabled`, and `Failed` variants.
+   - Add comments for `WebhookSubscription` and `WebhookDeliveryLog` fields.
+5. **Fix missing documentation for interceptor methods in `autumn/src/test.rs`**.
+   - Add comments for `with_mail_interceptor`, `with_job_interceptor`, `with_db_interceptor`, `with_channels_interceptor`, and `with_http_interceptor`.
+6. **Fix unresolved intra-doc links in `autumn/src/reporting.rs`**.
+   - Update unresolved links to `ErrorEvent`, `ErrorReporter`, `LogReporter`, and `ReportingLayer` using absolute paths (e.g. `crate::reporting::ErrorEvent`).
+7. **Fix unresolved intra-doc link in `autumn/src/system_test.rs`**.
+   - Change `AppState::for_test()` to `crate::AppState::for_test()`.
+8. **Fix ambiguous intra-doc link in `autumn/src/lib.rs`**.
+   - Use `macro@inbound_mail` instead of just `inbound_mail`.
+9. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done**.
+10. **Submit PR with Bard styling**.


### PR DESCRIPTION
📖 Chapter: `autumn-web` Missing Documentation and Intra-Doc Links
🔦 Insight: Added missing comments for `RuntimeConfigService`, `FieldError`, `WEBHOOK_REPLAY_KEY`, and `WebhookSubscription` fields. Fixed broken intra-doc links in `reporting`, `system_test`, and `lib.rs`.
🧪 Example: Verified via `cargo rustdoc` and `cargo test --doc` that the added comments are clean, compile correctly, and format perfectly in the generated docs.
🖼️ Preview: (Docs successfully rendered with `cargo doc`)

---
*PR created automatically by Jules for task [12679767208826996232](https://jules.google.com/task/12679767208826996232) started by @madmax983*