### PR TITLE
⚒️ Forge: Extract `ExcludedByGroup` parsing logic

### DIFF
--- a/autumn/src/experiments.rs
+++ b/autumn/src/experiments.rs
@@ -977,6 +977,14 @@ fn validate_variants(variants: &[VariantConfig]) -> Result<(), ExperimentError> 
     Ok(())
 }
 
+fn parse_excluded_by_group(msg: &str) -> Option<String> {
+    if msg.starts_with("ExcludedByGroup:") {
+        Some(msg.strip_prefix("ExcludedByGroup:")?.trim().to_owned())
+    } else {
+        None
+    }
+}
+
 // ── ExperimentService ─────────────────────────────────────────────────────────
 
 /// The main experiment service.
@@ -1108,19 +1116,14 @@ impl ExperimentService {
             let sticky = Assignment::new(experiment, actor, &override_variant, true);
             if let Err(e) = self.store.record_assignment(sticky) {
                 match e {
-                    ExperimentStoreError::Backend(msg) if msg.starts_with("ExcludedByGroup:") => {
-                        let group = msg
-                            .strip_prefix("ExcludedByGroup:")
-                            .unwrap_or("")
-                            .trim()
-                            .to_owned();
-                        return Err(ExperimentError::ExcludedByGroup(
-                            experiment.to_owned(),
-                            group,
-                        ));
-                    }
-                    other @ ExperimentStoreError::Backend(_) => {
-                        return Err(ExperimentError::Store(other));
+                    ExperimentStoreError::Backend(msg) => {
+                        if let Some(group) = parse_excluded_by_group(&msg) {
+                            return Err(ExperimentError::ExcludedByGroup(
+                                experiment.to_owned(),
+                                group,
+                            ));
+                        }
+                        return Err(ExperimentError::Store(ExperimentStoreError::Backend(msg)));
                     }
                 }
             }
@@ -1163,19 +1166,14 @@ impl ExperimentService {
         let assignment = Assignment::new(experiment, actor, &variant_name, false);
         let persisted_variant = match self.store.record_assignment(assignment) {
             Ok(v) => v,
-            Err(ExperimentStoreError::Backend(msg)) if msg.starts_with("ExcludedByGroup:") => {
-                let group = msg
-                    .strip_prefix("ExcludedByGroup:")
-                    .unwrap_or("")
-                    .trim()
-                    .to_owned();
-                return Err(ExperimentError::ExcludedByGroup(
-                    experiment.to_owned(),
-                    group,
-                ));
-            }
-            Err(other @ ExperimentStoreError::Backend(_)) => {
-                return Err(ExperimentError::Store(other));
+            Err(ExperimentStoreError::Backend(msg)) => {
+                if let Some(group) = parse_excluded_by_group(&msg) {
+                    return Err(ExperimentError::ExcludedByGroup(
+                        experiment.to_owned(),
+                        group,
+                    ));
+                }
+                return Err(ExperimentError::Store(ExperimentStoreError::Backend(msg)));
             }
         };
         self.emit_exposure(experiment, &persisted_variant, actor, request_id, false);

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,6 @@
+1. **Identify the smell:** The code in `autumn/src/experiments.rs` repeats the logic for extracting an exclusion group string from `ExperimentStoreError::Backend` messages that start with "ExcludedByGroup:". This duplication creates unnecessary boilerplate and reduces clarity.
+2. **Extract common logic:** Create a helper function `parse_excluded_by_group(msg: &str) -> Option<String>` in `autumn/src/experiments.rs` that checks if the message starts with "ExcludedByGroup:" and extracts the group name.
+3. **Refactor occurrences:** Use this helper function in `assign_with_request_id` (around line 1111 and 1166) to replace the duplicate block of logic.
+4. **Complete pre-commit steps:** Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+5. **Verify changes:** Use `cargo check -p autumn-web --lib`, `cargo clippy -p autumn-web --lib`, `cargo test -p autumn-web --lib experiments::`, and `cargo fmt --all` to verify the refactoring correctly retains the same logic and tests pass.
+6. **Submit PR:** Submit the changes following the Forge persona PR conventions.


### PR DESCRIPTION
🚰 Smell: Duplicated string parsing logic in `autumn/src/experiments.rs` for extracting group names from "ExcludedByGroup:" error messages inside `assign_with_request_id`.
✨ Solution: Extracted the parsing logic into a clean `parse_excluded_by_group` helper function that returns an `Option<String>`, and replaced the duplicated code blocks with a single call to the helper.
🧼 Benefit: Reduces boilerplate, flattens code by removing a nested custom match arm condition, and abstracts string manipulation details away from the core business logic.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [119473046022152629](https://jules.google.com/task/119473046022152629) started by @madmax983*