### PR TITLE
⚡ Bolt: [optimize escape_html with Cow]

### DIFF
--- a/autumn/src/inspector.rs
+++ b/autumn/src/inspector.rs
@@ -714,9 +714,28 @@ fn render_layout(title: &str, _inspector_path: &str, body: &str) -> String {
     )
 }
 
-fn escape_html(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for ch in s.chars() {
+/// Escapes HTML special characters in the provided string.
+/// ⚡ Bolt optimization: Returns a `Cow<'_, str>` to avoid allocating a new
+/// `String` when the input does not contain any characters requiring escaping.
+/// This saves memory allocations in the hot path for request rendering,
+/// especially for inputs like simple paths, integers, or regular text.
+fn escape_html(s: &str) -> std::borrow::Cow<'_, str> {
+    let mut first_escape = None;
+    for (i, b) in s.bytes().enumerate() {
+        if matches!(b, b'&' | b'<' | b'>' | b'"' | b'\'') {
+            first_escape = Some(i);
+            break;
+        }
+    }
+
+    let Some(first) = first_escape else {
+        return std::borrow::Cow::Borrowed(s);
+    };
+
+    let mut out = String::with_capacity(s.len() + 8);
+    out.push_str(&s[..first]);
+
+    for ch in s[first..].chars() {
         match ch {
             '&' => out.push_str("&amp;"),
             '<' => out.push_str("&lt;"),
@@ -726,7 +745,7 @@ fn escape_html(s: &str) -> String {
             c => out.push(c),
         }
     }
-    out
+    std::borrow::Cow::Owned(out)
 }
 
 const INSPECTOR_CSS: &str = r"


### PR DESCRIPTION
💡 What: Switched the return type of `escape_html` in the inspector from `String` to `std::borrow::Cow<'_, str>`, allowing it to borrow strings directly if they require no HTML escaping.
🎯 Why: The previous implementation unconditionally allocated a new `String` for every rendered label, method name, or ID in the inspector view, causing a large number of unnecessary heap allocations during UI rendering, since things like integers and routes rarely contain HTML special characters.
📊 Impact: Reduces heap allocations during request inspector UI rendering linearly with the number of table rows and fields displayed, reducing memory overhead per page load.
🔬 Measurement: Run `cargo test -p autumn-web --test inspector_integration` to verify inspector remains functional and renders correctly.

---
*PR created automatically by Jules for task [14107539434139278027](https://jules.google.com/task/14107539434139278027) started by @madmax983*