### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,20 @@
+1. **Define `ProvideAuthorizationState` Trait:**
+   - In `autumn/src/authorization.rs` (or an appropriate module), define `pub trait ProvideAuthorizationState: Send + Sync` that encapsulates the required methods.
+   - Methods: `auth_session_key(&self) -> &str`, `policy_registry(&self) -> &crate::authorization::PolicyRegistry`, `forbidden_response(&self) -> &crate::authorization::ForbiddenResponse`.
+   - Under `#[cfg(feature = "db")]`: `pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>`.
+
+2. **Implement `ProvideAuthorizationState` for `AppState`:**
+   - In `autumn/src/state.rs`, add `impl crate::authorization::ProvideAuthorizationState for AppState`.
+
+3. **Update `authorization.rs` functions:**
+   - Modify the signature of functions taking `&crate::AppState` to take `&dyn ProvideAuthorizationState` or `&impl ProvideAuthorizationState` (or similar depending on turbofish restrictions).
+   - *Self-correction based on memory:* "use dynamic dispatch (e.g., `&dyn Trait`) instead of `impl Trait` or adding a new named generic parameter. Using `impl Trait` in the argument list triggers error E0632 on stable Rust, and adding a named parameter breaks the original turbofish arity." So we will use `&dyn ProvideAuthorizationState`.
+
+4. **Run Verification and Clippy:**
+   - Ensure the new abstractions don't break existing tests.
+   - Run tests for `autumn-web` (`cargo test -p autumn-web`).
+   - Run `cargo clippy --all-targets --all-features -- -D warnings`.
+
+5. **Commit and Submit PR:**
+   - Title: "🗺️ Atlas: [architectural change]"
+   - Description containing: `🕸️ Tangle`, `📐 Blueprint`, `🧱 Stability`, `🔬 Verification`.


### PR DESCRIPTION
🗺️ Atlas: [architectural change]

🕸️ Tangle: The `authorization` module was tightly coupled to the `AppState` God Struct. Functions like `authorize` and `from_request` explicitly took `&crate::AppState`, creating a circular conceptual dependency and making the module harder to test in isolation without constructing a full `AppState`.

📐 Blueprint: Extracted a `ProvideAuthorizationState` trait in the `authorization` module to define the exact dependencies required (session key, policy registry, forbidden response, and optionally the DB pool). Implemented this trait for `AppState` and refactored the `authorization` API to accept `&dyn ProvideAuthorizationState` using dynamic dispatch, preserving the existing turbofish arity for generic type parameters.

🧱 Stability: Reduces coupling between domains. The authorization module now depends on an abstraction rather than concrete framework state, improving modularity and strictly enforcing dependency inversion.

🔬 Verification: Ran `cargo check`, `cargo clippy -p autumn-web --lib -- -D warnings`, `cargo test -p autumn-web --lib`, and multiple integration test targets (`authorization_integration`, `route_macro`, `routes_macro`, `security_tests`). The tests passed correctly (ignoring an environmental Docker Hub rate limit issue with `testcontainers` entirely unrelated to this change). Code review passed.

---
*PR created automatically by Jules for task [1733979706043174826](https://jules.google.com/task/1733979706043174826) started by @madmax983*