### PR TITLE
👺 Havoc: [Fix circuit breaker mutex poisoning]

### DIFF
--- a/autumn/src/circuit_breaker.rs
+++ b/autumn/src/circuit_breaker.rs
@@ -169,7 +169,7 @@ impl CircuitBreaker {
     }
 
     pub fn state(&self) -> CircuitState {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let now = Instant::now();
         if inner.state == CircuitState::Open {
             if let Some(until) = inner.open_until {
@@ -186,18 +186,18 @@ impl CircuitBreaker {
     }
 
     pub fn config(&self) -> CircuitBreakerPolicy {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         inner.config.clone()
     }
 
     pub fn update_config(&self, mut config: CircuitBreakerPolicy) {
         config.failure_ratio_threshold = config.failure_ratio_threshold.clamp(0.000_1, 1.0);
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         inner.config = config;
     }
 
     pub fn failure_ratio(&self) -> f64 {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let window = inner.config.sample_window;
         inner.clean_history(window, Instant::now());
         inner.failure_ratio()
@@ -205,7 +205,7 @@ impl CircuitBreaker {
 
     #[allow(clippy::significant_drop_tightening)]
     pub(crate) fn before_call(&self) -> Result<(), CircuitBreakerError<()>> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let now = Instant::now();
 
         if inner.state == CircuitState::Open {
@@ -236,7 +236,7 @@ impl CircuitBreaker {
     }
 
     pub(crate) fn after_call(&self, success: bool) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let now = Instant::now();
         let window = inner.config.sample_window;
         inner.clean_history(window, now);
@@ -336,7 +336,7 @@ impl CircuitBreakerGuard {
 impl Drop for CircuitBreakerGuard {
     fn drop(&mut self) {
         if !self.completed {
-            let mut inner = self.breaker.inner.lock().unwrap();
+            let mut inner = self.breaker.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             if inner.state == CircuitState::HalfOpen {
                 if inner.half_open_in_flight > 0 {
                     inner.half_open_in_flight -= 1;
@@ -358,7 +358,7 @@ impl CircuitBreakerRegistry {
     }
 
     pub fn get_or_create(&self, name: &str, config: CircuitBreakerPolicy) -> CircuitBreaker {
-        let mut breakers = self.breakers.lock().unwrap();
+        let mut breakers = self.breakers.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         breakers
             .entry(name.to_owned())
             .or_insert_with(|| CircuitBreaker::new(name, config))
@@ -370,7 +370,7 @@ impl CircuitBreakerRegistry {
         name: &str,
         config: CircuitBreakerPolicy,
     ) -> CircuitBreaker {
-        let mut breakers = self.breakers.lock().unwrap();
+        let mut breakers = self.breakers.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         if let Some(breaker) = breakers.get(name) {
             breaker.update_config(config);
             breaker.clone()
@@ -385,9 +385,9 @@ impl CircuitBreakerRegistry {
     ///
     /// # Panics
     ///
-    /// Panics if the internal registry lock is poisoned.
+
     pub fn all_breakers(&self) -> Vec<CircuitBreaker> {
-        let breakers = self.breakers.lock().unwrap();
+        let breakers = self.breakers.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         breakers.values().cloned().collect()
     }
 
@@ -395,9 +395,9 @@ impl CircuitBreakerRegistry {
     ///
     /// # Panics
     ///
-    /// Panics if the internal registry lock is poisoned.
+
     pub fn clear(&self) {
-        let mut breakers = self.breakers.lock().unwrap();
+        let mut breakers = self.breakers.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         breakers.clear();
     }
 }
@@ -653,7 +653,7 @@ mod tests {
 
         // Put the breaker in HalfOpen state
         {
-            let mut inner = breaker.inner.lock().unwrap();
+            let mut inner = breaker.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             inner.state = CircuitState::HalfOpen;
             inner.half_open_in_flight = 0;
         }
@@ -680,14 +680,14 @@ mod tests {
 
         // Call the service: this will increment half_open_in_flight since it's HalfOpen
         let fut = svc.call("ok");
-        let in_flight_before = breaker.inner.lock().unwrap().half_open_in_flight;
+        let in_flight_before = breaker.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner).half_open_in_flight;
         assert_eq!(in_flight_before, 1);
 
         // Drop the future (cancellation)
         drop(fut);
 
         // half_open_in_flight should be decremented back to 0!
-        let in_flight_after = breaker.inner.lock().unwrap().half_open_in_flight;
+        let in_flight_after = breaker.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner).half_open_in_flight;
         assert_eq!(in_flight_after, 0);
     }
 
@@ -712,5 +712,27 @@ mod tests {
             assert!(res.is_ok());
         }
         assert_eq!(breaker.state(), CircuitState::Closed);
+    }
+}
+
+#[cfg(test)]
+mod poison_tests {
+    use super::*;
+    use std::thread;
+
+    #[test]
+    fn test_circuit_breaker_poison() {
+        let cb = Arc::new(CircuitBreaker::new("test", CircuitBreakerPolicy::default()));
+        let cb2 = cb.clone();
+
+        let handle = thread::spawn(move || {
+            let _guard = cb2.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            panic!("poisoning lock");
+        });
+
+        let _ = handle.join();
+
+        // This should not panic since `unwrap_or_else` is used
+        assert_eq!(cb.state(), CircuitState::Closed);
     }
 }


### PR DESCRIPTION
🧨 **The Trigger:** Panicking while holding the lock poisons the mutex, cascading the failure to all subsequent requests.
📉 **The Stack Trace:** Panic at `called Result::unwrap() on an Err value: PoisonError`
🧪 **Reproduction:** Run the included unit test `test_circuit_breaker_poison` inside `autumn/src/circuit_breaker.rs`.
😈 **Comment:** You assumed a thread would never panic while holding the lock. You were wrong.

---
*PR created automatically by Jules for task [5937538768140398713](https://jules.google.com/task/5937538768140398713) started by @madmax983*