### PR TITLE
🌟 Nova: [Actuator Routes Endpoint]

### DIFF
--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -2326,11 +2326,10 @@ pub(crate) async fn routes_endpoint<S: ProvideActuatorState + Send + Sync + 'sta
     State(state): State<S>,
 ) -> impl IntoResponse {
     let routes = state.registered_routes();
-    if let Some(r) = routes {
-        Json(r.0.clone()).into_response()
-    } else {
-        Json(Vec::<crate::route_listing::RouteInfo>::new()).into_response()
-    }
+    routes.map_or_else(
+        || Json(Vec::<crate::route_listing::RouteInfo>::new()).into_response(),
+        |r| Json(r.0.clone()).into_response(),
+    )
 }
 
 /// `GET <actuator-prefix>/loggers` -- view current log levels.
@@ -3136,9 +3135,29 @@ mod tests {
         channels: crate::channels::Channels,
         #[cfg(feature = "ws")]
         shutdown: tokio_util::sync::CancellationToken,
+        extensions: axum::extract::Extension<axum::http::Extensions>,
+    }
+
+    impl TestActuatorState {
+        fn insert_extension<T: Clone + Send + Sync + 'static>(&mut self, val: T) {
+            self.extensions.0.insert(val);
+        }
     }
 
     impl ProvideActuatorState for TestActuatorState {
+        fn registered_routes(&self) -> Option<std::sync::Arc<crate::app::RegisteredRoutes>> {
+            self.extensions
+                .0
+                .get::<crate::app::RegisteredRoutes>()
+                .cloned()
+                .map(std::sync::Arc::new)
+        }
+
+        #[cfg(feature = "ws")]
+        fn channels(&self) -> &crate::channels::Channels {
+            &self.channels
+        }
+
         fn metrics(&self) -> &crate::middleware::MetricsCollector {
             &self.metrics
         }
@@ -3176,10 +3195,6 @@ mod tests {
         ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
         {
             self.pool.as_ref()
-        }
-        #[cfg(feature = "ws")]
-        fn channels(&self) -> &crate::channels::Channels {
-            &self.channels
         }
         #[cfg(feature = "ws")]
         fn shutdown_token(&self) -> tokio_util::sync::CancellationToken {
@@ -3221,6 +3236,7 @@ mod tests {
             channels: crate::channels::Channels::new(32),
             #[cfg(feature = "ws")]
             shutdown: tokio_util::sync::CancellationToken::new(),
+            extensions: axum::extract::Extension(axum::http::Extensions::new()),
         }
     }
 
@@ -4414,7 +4430,7 @@ mod tests {
 
     #[tokio::test]
     async fn actuator_routes_returns_json_list() {
-        let state = test_state();
+        let mut state = test_state();
         state.insert_extension(crate::app::RegisteredRoutes(vec![
             crate::route_listing::RouteInfo {
                 method: "GET".to_owned(),
@@ -4451,12 +4467,13 @@ mod tests {
         assert_eq!(routes[0].handler, "test_handler");
     }
 
+    #[cfg(feature = "ws")]
     #[tokio::test]
     async fn actuator_channels_returns_metrics() {
         let state = test_state();
-        let mut rx = state.channels().subscribe("feed");
+        let mut rx = state.channels.subscribe("feed");
         state
-            .channels()
+            .channels
             .broadcast()
             .publish("feed", "hello")
             .expect("publish should succeed");

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -349,6 +349,14 @@ pub trait ProvideActuatorState {
         None
     }
 
+    /// Returns the registered routes if available.
+    ///
+    /// The default returns `None`. [`crate::AppState`] overrides this to return
+    /// the route listing built at application startup.
+    fn registered_routes(&self) -> Option<std::sync::Arc<crate::app::RegisteredRoutes>> {
+        None
+    }
+
     /// Returns the in-memory log capture buffer, if capture is enabled.
     ///
     /// The default returns `None` (capture disabled). [`crate::AppState`]
@@ -2313,6 +2321,18 @@ pub(crate) struct LoggersResponse {
     loggers: HashMap<String, String>,
 }
 
+/// `GET <actuator-prefix>/routes` -- view registered routes.
+pub(crate) async fn routes_endpoint<S: ProvideActuatorState + Send + Sync + 'static>(
+    State(state): State<S>,
+) -> impl IntoResponse {
+    let routes = state.registered_routes();
+    if let Some(r) = routes {
+        Json(r.0.clone()).into_response()
+    } else {
+        Json(Vec::<crate::route_listing::RouteInfo>::new()).into_response()
+    }
+}
+
 /// `GET <actuator-prefix>/loggers` -- view current log levels.
 pub(crate) async fn loggers_get<S: ProvideActuatorState + Send + Sync + 'static>(
     State(state): State<S>,
@@ -2904,6 +2924,10 @@ pub(crate) fn actuator_router_with_prefix<
             .route(
                 &actuator_route_path(prefix, "/configprops"),
                 axum::routing::get(configprops_endpoint::<S>),
+            )
+            .route(
+                &actuator_route_path(prefix, "/routes"),
+                axum::routing::get(routes_endpoint::<S>),
             )
             .route(
                 &actuator_route_path(prefix, "/loggers"),
@@ -4388,7 +4412,45 @@ mod tests {
         assert_eq!(job["total_failures"], 0);
     }
 
-    #[cfg(feature = "ws")]
+    #[tokio::test]
+    async fn actuator_routes_returns_json_list() {
+        let state = test_state();
+        state.insert_extension(crate::app::RegisteredRoutes(vec![
+            crate::route_listing::RouteInfo {
+                method: "GET".to_owned(),
+                path: "/api/test".to_owned(),
+                handler: "test_handler".to_owned(),
+                source: crate::route_listing::RouteSource::User,
+                middleware: vec![],
+                api_version: None,
+                status: None,
+                sunset_opt_out: None,
+            },
+        ]));
+
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/routes")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = http_body_util::BodyExt::collect(resp.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let routes: Vec<crate::route_listing::RouteInfo> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].path, "/api/test");
+        assert_eq!(routes[0].handler, "test_handler");
+    }
+
     #[tokio::test]
     async fn actuator_channels_returns_metrics() {
         let state = test_state();

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -182,6 +182,10 @@ pub struct ApiVersion {
 #[derive(Clone, Debug)]
 pub struct RegisteredApiVersions(pub Vec<ApiVersion>);
 
+/// A wrapper for registered routes in the app state.
+#[derive(Clone, Debug)]
+pub struct RegisteredRoutes(pub Vec<crate::route_listing::RouteInfo>);
+
 /// Builder for configuring and launching an Autumn application.
 ///
 /// Created by [`app()`]. Collect routes with [`.routes()`](Self::routes),
@@ -2495,7 +2499,29 @@ impl AppBuilder {
         } else {
             crate::cache::clear_global_cache();
         }
-        state.insert_extension(RegisteredApiVersions(api_versions));
+        state.insert_extension(RegisteredApiVersions(api_versions.clone()));
+
+        let mut infos = match crate::route_listing::collect_route_infos(
+            &all_routes,
+            &route_sources,
+            &scoped_groups,
+            &api_versions,
+        ) {
+            Ok(infos) => infos,
+            Err(e) => {
+                tracing::error!("Failed to collect route listing: {e}");
+                Vec::new()
+            }
+        };
+        infos.extend(declared_routes);
+        crate::route_listing::append_framework_routes(&mut infos, &config);
+        #[cfg(feature = "openapi")]
+        if let Some(ref oa) = openapi {
+            crate::route_listing::append_openapi_routes(&mut infos, oa);
+        }
+        crate::route_listing::append_dev_reload_routes(&mut infos);
+        crate::route_listing::sort_route_infos(&mut infos);
+        state.insert_extension(RegisteredRoutes(infos));
 
         // Install registered error reporters so the reporting layer (wired in
         // `apply_middleware`) can deliver panic + 5xx events. Empty is fine —

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2503,7 +2503,7 @@ impl AppBuilder {
 
         let mut infos = match crate::route_listing::collect_route_infos(
             &all_routes,
-            &route_sources,
+            &self.route_sources,
             &scoped_groups,
             &api_versions,
         ) {
@@ -2513,14 +2513,12 @@ impl AppBuilder {
                 Vec::new()
             }
         };
-        infos.extend(declared_routes);
+        infos.extend(self.declared_routes);
         crate::route_listing::append_framework_routes(&mut infos, &config);
         #[cfg(feature = "openapi")]
         if let Some(ref oa) = openapi {
             crate::route_listing::append_openapi_routes(&mut infos, oa);
         }
-        crate::route_listing::append_dev_reload_routes(&mut infos);
-        crate::route_listing::sort_route_infos(&mut infos);
         state.insert_extension(RegisteredRoutes(infos));
 
         // Install registered error reporters so the reporting layer (wired in

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -735,6 +735,10 @@ impl crate::actuator::ProvideActuatorState for AppState {
         &self.channels
     }
 
+    fn registered_routes(&self) -> Option<std::sync::Arc<crate::app::RegisteredRoutes>> {
+        self.extension::<crate::app::RegisteredRoutes>()
+    }
+
     #[cfg(feature = "ws")]
     fn shutdown_token(&self) -> tokio_util::sync::CancellationToken {
         self.shutdown_token()


### PR DESCRIPTION
💡 **The Spark:**
The `autumn` framework gathers a list of routes with paths, HTTP methods, and source plugins to print to the console when `autumn routes` is run, but this data is unavailable while the application is live.

🚀 **The Feature:**
Added a dynamic `GET /actuator/routes` endpoint. During `AppBuilder::run`, the route compilation logic aggregates the framework and OpenAPI routes and injects them as a `RegisteredRoutes` extension into `AppState`. The new endpoint makes this registry easily queryable, returning a JSON array of `RouteInfo`.

🔭 **The Potential:**
Developers and security teams can query running production and staging replicas to exactly determine what HTTP boundaries, methods, handlers, and source plugins are exposed without needing to inspect application code or CLI outputs. This can power admin dashboard plugins and dynamic API discovery mechanisms.

⚠️ **Risk:**
Low. The logic repurposes existing `route_listing::collect_route_infos` functions and only exposes the data if the `actuator.sensitive` profile setting allows it. A fallback catches collection errors at startup to prevent crashing the host process.

---
*PR created automatically by Jules for task [17475704575052940691](https://jules.google.com/task/17475704575052940691) started by @madmax983*