### PR TITLE
🌟 Nova: [Markdown Route Exporter]

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -3429,6 +3429,12 @@ impl AppBuilder {
         crate::route_listing::append_dev_reload_routes(&mut infos);
         crate::route_listing::sort_route_infos(&mut infos);
 
+        if std::env::var("AUTUMN_ROUTES_FORMAT").ok().as_deref() == Some("markdown") {
+            let md = crate::route_listing::export_markdown(&infos);
+            println!("{md}");
+            std::process::exit(0);
+        }
+
         let json = serde_json::to_string_pretty(&infos).unwrap_or_else(|e| {
             eprintln!("Failed to serialize route listing: {e}");
             std::process::exit(1);

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -78,6 +78,38 @@ pub struct RouteInfo {
 /// Helper type alias representing version name, status string, and sunset opt-out flag.
 type RouteVersionInfo = (Option<String>, Option<String>, Option<bool>);
 
+// ── export_markdown ────────────────────────────────────────────────────────
+
+/// Serialize the given route listing to Markdown format.
+///
+/// The Markdown contains a table with headers and includes the method, path, handler name,
+/// route source, and joined middleware labels.
+#[must_use]
+pub fn export_markdown(infos: &[RouteInfo]) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    out.push_str("| Method | Path | Handler | Source | Middleware |\n");
+    out.push_str("|---|---|---|---|---|\n");
+    for info in infos {
+        let middleware = info.middleware.join(", ");
+        // Ensure values do not contain unescaped '|' which breaks markdown tables.
+        writeln!(
+            out,
+            "| {} | {} | {} | {} | {} |",
+            info.method.replace('|', "\\|"),
+            info.path.replace('|', "\\|"),
+            info.handler.replace('|', "\\|"),
+            info.source.to_string().replace('|', "\\|"),
+            middleware.replace('|', "\\|")
+        )
+        .expect("writing to a String is infallible");
+    }
+    out
+}
+
+// ── collect_route_infos ────────────────────────────────────────────────────
+
 /// Collect [`RouteInfo`] entries from user routes and scoped groups.
 ///
 /// `route_sources` is a parallel slice to `routes`; each element is the
@@ -834,6 +866,34 @@ mod tests {
         assert_eq!(r.method, "GET");
         assert_eq!(r.handler, "static_files");
         assert_eq!(r.source, RouteSource::Framework);
+    }
+
+    // ── export_markdown ────────────────────────────────────────────────────
+
+    #[test]
+    fn route_info_exports_to_markdown() {
+        let infos = vec![RouteInfo {
+            method: "GET".to_owned(),
+            path: "/posts/{id}".to_owned(),
+            handler: "posts::show".to_owned(),
+            source: RouteSource::User,
+            middleware: vec!["secured".to_owned(), "cached".to_owned()],
+            api_version: None,
+            status: None,
+            sunset_opt_out: None,
+        }];
+        let md = export_markdown(&infos);
+        let lines: Vec<&str> = md.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert_eq!(
+            lines[0],
+            "| Method | Path | Handler | Source | Middleware |"
+        );
+        assert_eq!(lines[1], "|---|---|---|---|---|");
+        assert_eq!(
+            lines[2],
+            "| GET | /posts/{id} | posts::show | user | secured, cached |"
+        );
     }
 
     // ── append_dev_reload_routes ───────────────────────────────────────────


### PR DESCRIPTION
💡 **The Spark:** The framework already dumps route listings as JSON, but developers often need these route listings rendered into human-readable documentation, such as for a Wiki or README.

🚀 **The Feature:** Implemented `export_markdown` in `route_listing.rs` and wired it into `autumn routes` via the `AUTUMN_ROUTES_FORMAT=markdown` environment variable. This allows zero-dependency, instant extraction of the application's route tables into cleanly formatted Markdown tables.

🔭 **The Potential:** Can be used in CI/CD pipelines to automatically generate and commit API route documentation to the repository, keeping the documentation perpetually in-sync with the code.

⚠️ **Risk:** Low. Isolated purely to the route listing and CLI reflection layer, entirely bypassing the actual HTTP runtime. No external dependencies were added.

---
*PR created automatically by Jules for task [17873129272581644627](https://jules.google.com/task/17873129272581644627) started by @madmax983*