### PR TITLE
⚒️ Forge: Extract handle_failed_local_job helper from execute_local_job

### DIFF
--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -2407,72 +2407,22 @@ async fn execute_local_job(
             );
         }
         JobExecutionOutcome::Failed(error) => {
-            if job.attempt < max_attempts {
-                // Running-window keys stay held across retries (the job is
-                // still in flight until it settles). A pending-window key was
-                // released when execution started, so re-acquire it now to
-                // keep duplicates coalescing while the retry waits out its
-                // backoff as a pending job again. If a duplicate was accepted
-                // while this job ran it now owns the key; in that case drop
-                // the retry (coalesce into the duplicate) rather than letting
-                // both run unprotected.
-                if let Some(unique) = &uniqueness
-                    && unique.window == JobUniquenessWindow::Pending
-                {
-                    let key = job_unique_key(unique, &job.payload);
-                    if !coordination.try_acquire_unique(&job.name, &key, &job.id, unique.window) {
-                        state.job_registry.record_deduplicated(&job.name);
-                        job_admin.record_deduplicated(&job.id);
-                        finish_local_slot(coordination, concurrency_group.as_ref(), tx, state);
-                        return;
-                    }
-                }
-                state
-                    .job_registry
-                    .record_retry(&job.name, &error, job.attempt);
-                job_admin.record_retrying(&job.id, &error);
-                let sender = tx.clone();
-                let registry = state.job_registry.clone();
-                let job_admin = job_admin.clone();
-                let id = job.id.clone();
-                let name = job.name.clone();
-                let payload = job.payload;
-                #[cfg(feature = "telemetry-otlp")]
-                let traceparent = job.traceparent;
-                #[cfg(feature = "telemetry-otlp")]
-                let tracestate = job.tracestate;
-                let delay = backoff_ms.saturating_mul(2_u64.saturating_pow(job.attempt - 1));
-                tokio::spawn(async move {
-                    tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
-                    registry.record_enqueue(&name);
-                    job_admin.record_requeued(&id, job.attempt + 1);
-                    let _ = sender
-                        .send(QueuedJob {
-                            id,
-                            name,
-                            payload,
-                            attempt: job.attempt + 1,
-                            max_attempts,
-                            initial_backoff_ms: backoff_ms,
-                            #[cfg(feature = "telemetry-otlp")]
-                            traceparent,
-                            #[cfg(feature = "telemetry-otlp")]
-                            tracestate,
-                        })
-                        .await;
-                });
-            } else {
-                state
-                    .job_registry
-                    .record_failure(&job.name, error.clone(), true);
-                job_admin.record_failure(&job.id, error);
-                release_local_unique_hold(
+            let retry_handled = handle_failed_local_job(
+                job,
+                error,
+                &LocalJobContext {
+                    max_attempts,
+                    backoff_ms,
+                    state,
+                    job_admin,
                     coordination,
-                    uniqueness.as_ref(),
-                    &job.name,
-                    &job.payload,
-                    &job.id,
-                );
+                    uniqueness: uniqueness.as_ref(),
+                    tx,
+                },
+            );
+            if retry_handled {
+                finish_local_slot(coordination, concurrency_group.as_ref(), tx, state);
+                return;
             }
         }
         JobExecutionOutcome::Panicked(error) => {
@@ -2494,6 +2444,94 @@ async fn execute_local_job(
     // The concurrency slot frees as soon as the handler is no longer running,
     // including while a retry waits out its backoff.
     finish_local_slot(coordination, concurrency_group.as_ref(), tx, state);
+}
+
+struct LocalJobContext<'a> {
+    max_attempts: u32,
+    backoff_ms: u64,
+    state: &'a AppState,
+    job_admin: &'a JobAdminMemoryBackend,
+    coordination: &'a Arc<LocalJobCoordination>,
+    uniqueness: Option<&'a JobUniqueness>,
+    tx: &'a tokio::sync::mpsc::Sender<QueuedJob>,
+}
+
+fn handle_failed_local_job(job: QueuedJob, error: String, ctx: &LocalJobContext<'_>) -> bool {
+    if job.attempt < ctx.max_attempts {
+        // Running-window keys stay held across retries (the job is
+        // still in flight until it settles). A pending-window key was
+        // released when execution started, so re-acquire it now to
+        // keep duplicates coalescing while the retry waits out its
+        // backoff as a pending job again. If a duplicate was accepted
+        // while this job ran it now owns the key; in that case drop
+        // the retry (coalesce into the duplicate) rather than letting
+        // both run unprotected.
+        if let Some(unique) = ctx.uniqueness
+            && unique.window == JobUniquenessWindow::Pending
+        {
+            let key = job_unique_key(unique, &job.payload);
+            if !ctx
+                .coordination
+                .try_acquire_unique(&job.name, &key, &job.id, unique.window)
+            {
+                ctx.state.job_registry.record_deduplicated(&job.name);
+                ctx.job_admin.record_deduplicated(&job.id);
+                return true; // Indicate that execution should return early
+            }
+        }
+        ctx.state
+            .job_registry
+            .record_retry(&job.name, &error, job.attempt);
+        ctx.job_admin.record_retrying(&job.id, &error);
+        let sender = ctx.tx.clone();
+        let registry = ctx.state.job_registry.clone();
+        let job_admin = ctx.job_admin.clone();
+        let id = job.id;
+        let name = job.name;
+        let payload = job.payload;
+        #[cfg(feature = "telemetry-otlp")]
+        let traceparent = job.traceparent;
+        #[cfg(feature = "telemetry-otlp")]
+        let tracestate = job.tracestate;
+        let attempt = job.attempt;
+        let delay = ctx
+            .backoff_ms
+            .saturating_mul(2_u64.saturating_pow(attempt - 1));
+        let max_attempts = ctx.max_attempts;
+        let backoff_ms = ctx.backoff_ms;
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+            registry.record_enqueue(&name);
+            job_admin.record_requeued(&id, attempt + 1);
+            let _ = sender
+                .send(QueuedJob {
+                    id,
+                    name,
+                    payload,
+                    attempt: attempt + 1,
+                    max_attempts,
+                    initial_backoff_ms: backoff_ms,
+                    #[cfg(feature = "telemetry-otlp")]
+                    traceparent,
+                    #[cfg(feature = "telemetry-otlp")]
+                    tracestate,
+                })
+                .await;
+        });
+    } else {
+        ctx.state
+            .job_registry
+            .record_failure(&job.name, error.clone(), true);
+        ctx.job_admin.record_failure(&job.id, error);
+        release_local_unique_hold(
+            ctx.coordination,
+            ctx.uniqueness,
+            &job.name,
+            &job.payload,
+            &job.id,
+        );
+    }
+    false
 }
 
 /// Release a unique hold after a job settles. No-op for TTL-window holds

--- a/execute_local_job.txt
+++ b/execute_local_job.txt
@@ -1,0 +1,209 @@
+async fn execute_local_job(
+    job: QueuedJob,
+    jobs_by_name: &Arc<RwLock<HashMap<String, JobInfo>>>,
+    tx: &tokio::sync::mpsc::Sender<QueuedJob>,
+    state: &AppState,
+    job_admin: &JobAdminMemoryBackend,
+    coordination: &Arc<LocalJobCoordination>,
+) {
+    let maybe_info = jobs_by_name
+        .read()
+        .expect("job registry lock poisoned")
+        .get(&job.name)
+        .map(|info| {
+            (
+                info.handler,
+                info.max_attempts,
+                info.initial_backoff_ms,
+                info.uniqueness.clone(),
+                info.concurrency.clone(),
+            )
+        });
+    let Some((handler, info_max_attempts, info_backoff_ms, uniqueness, concurrency)) = maybe_info
+    else {
+        if job_admin.try_record_start(&job.id, job.attempt) == JobAdminStartDecision::Canceled {
+            state.job_registry.record_cancel(&job.name);
+            job_admin.record_cancelled(&job.id);
+            return;
+        }
+        state.job_registry.record_start(&job.name);
+        state
+            .job_registry
+            .record_failure(&job.name, format!("unknown job '{}'", job.name), true);
+        job_admin.record_failure(&job.id, format!("unknown job '{}'", job.name));
+        return;
+    };
+
+    // Concurrency gate: park the job when its group is saturated. Parked jobs
+    // keep their enqueued status and resume when release_slot pops them.
+    let job_name = job.name.clone();
+    let concurrency_group = concurrency.as_ref().map(|conc| {
+        let scope = job_concurrency_scope(conc, &job.payload);
+        (
+            local_concurrency_group(&job.name, scope.as_deref()),
+            conc.limit,
+        )
+    });
+    let job = if let Some((group, limit)) = &concurrency_group {
+        match coordination.acquire_slot_or_park(group, *limit, job) {
+            LocalSlotDecision::Acquired(job) => job,
+            LocalSlotDecision::Parked => {
+                state.job_registry.record_concurrency_blocked(&job_name);
+                return;
+            }
+        }
+    } else {
+        job
+    };
+
+    if job_admin.try_record_start(&job.id, job.attempt) == JobAdminStartDecision::Canceled {
+        state.job_registry.record_cancel(&job.name);
+        job_admin.record_cancelled(&job.id);
+        release_local_unique_hold(
+            coordination,
+            uniqueness.as_ref(),
+            &job.name,
+            &job.payload,
+            &job.id,
+        );
+        finish_local_slot(coordination, concurrency_group.as_ref(), tx, state);
+        return;
+    }
+    state.job_registry.record_start(&job.name);
+
+    // A pending-window unique key is held only until execution starts.
+    if let Some(unique) = &uniqueness
+        && unique.window == JobUniquenessWindow::Pending
+    {
+        let key = job_unique_key(unique, &job.payload);
+        coordination.release_unique(&job.name, &key, &job.id);
+    }
+
+    let max_attempts = if job.max_attempts != 0 {
+        job.max_attempts
+    } else if info_max_attempts != 0 {
+        info_max_attempts
+    } else {
+        5
+    };
+    let backoff_ms = if job.initial_backoff_ms != 0 {
+        job.initial_backoff_ms
+    } else if info_backoff_ms != 0 {
+        info_backoff_ms
+    } else {
+        250
+    };
+
+    let job_span = build_job_consumer_span(&job.name, job.attempt);
+    #[cfg(feature = "telemetry-otlp")]
+    if let Some(cx) =
+        restore_job_trace_context(job.traceparent.as_deref(), job.tracestate.as_deref())
+    {
+        use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+        let _ = job_span.set_parent(cx);
+    }
+    let f = run_job_handler(&job.name, handler, state.clone(), job.payload.clone());
+    let outcome = tracing::Instrument::instrument(f, job_span).await;
+    match outcome {
+        JobExecutionOutcome::Succeeded => {
+            state.job_registry.record_success(&job.name);
+            job_admin.record_success(&job.id);
+            release_local_unique_hold(
+                coordination,
+                uniqueness.as_ref(),
+                &job.name,
+                &job.payload,
+                &job.id,
+            );
+        }
+        JobExecutionOutcome::Failed(error) => {
+            if job.attempt < max_attempts {
+                // Running-window keys stay held across retries (the job is
+                // still in flight until it settles). A pending-window key was
+                // released when execution started, so re-acquire it now to
+                // keep duplicates coalescing while the retry waits out its
+                // backoff as a pending job again. If a duplicate was accepted
+                // while this job ran it now owns the key; in that case drop
+                // the retry (coalesce into the duplicate) rather than letting
+                // both run unprotected.
+                if let Some(unique) = &uniqueness
+                    && unique.window == JobUniquenessWindow::Pending
+                {
+                    let key = job_unique_key(unique, &job.payload);
+                    if !coordination.try_acquire_unique(&job.name, &key, &job.id, unique.window) {
+                        state.job_registry.record_deduplicated(&job.name);
+                        job_admin.record_deduplicated(&job.id);
+                        finish_local_slot(coordination, concurrency_group.as_ref(), tx, state);
+                        return;
+                    }
+                }
+                state
+                    .job_registry
+                    .record_retry(&job.name, &error, job.attempt);
+                job_admin.record_retrying(&job.id, &error);
+                let sender = tx.clone();
+                let registry = state.job_registry.clone();
+                let job_admin = job_admin.clone();
+                let id = job.id.clone();
+                let name = job.name.clone();
+                let payload = job.payload;
+                #[cfg(feature = "telemetry-otlp")]
+                let traceparent = job.traceparent;
+                #[cfg(feature = "telemetry-otlp")]
+                let tracestate = job.tracestate;
+                let delay = backoff_ms.saturating_mul(2_u64.saturating_pow(job.attempt - 1));
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                    registry.record_enqueue(&name);
+                    job_admin.record_requeued(&id, job.attempt + 1);
+                    let _ = sender
+                        .send(QueuedJob {
+                            id,
+                            name,
+                            payload,
+                            attempt: job.attempt + 1,
+                            max_attempts,
+                            initial_backoff_ms: backoff_ms,
+                            #[cfg(feature = "telemetry-otlp")]
+                            traceparent,
+                            #[cfg(feature = "telemetry-otlp")]
+                            tracestate,
+                        })
+                        .await;
+                });
+            } else {
+                state
+                    .job_registry
+                    .record_failure(&job.name, error.clone(), true);
+                job_admin.record_failure(&job.id, error);
+                release_local_unique_hold(
+                    coordination,
+                    uniqueness.as_ref(),
+                    &job.name,
+                    &job.payload,
+                    &job.id,
+                );
+            }
+        }
+        JobExecutionOutcome::Panicked(error) => {
+            tracing::error!(job = %job.name, error = %error, "local job handler panicked");
+            state
+                .job_registry
+                .record_failure(&job.name, error.clone(), true);
+            job_admin.record_failure(&job.id, error);
+            release_local_unique_hold(
+                coordination,
+                uniqueness.as_ref(),
+                &job.name,
+                &job.payload,
+                &job.id,
+            );
+        }
+    }
+
+    // The concurrency slot frees as soon as the handler is no longer running,
+    // including while a retry waits out its backoff.
+    finish_local_slot(coordination, concurrency_group.as_ref(), tx, state);
+}
+
+/// Release a unique hold after a job settles. No-op for TTL-window holds

--- a/patch_job.rs
+++ b/patch_job.rs
@@ -1,0 +1,176 @@
+<<<<<<< SEARCH
+        JobExecutionOutcome::Failed(error) => {
+            if job.attempt < max_attempts {
+                // Running-window keys stay held across retries (the job is
+                // still in flight until it settles). A pending-window key was
+                // released when execution started, so re-acquire it now to
+                // keep duplicates coalescing while the retry waits out its
+                // backoff as a pending job again. If a duplicate was accepted
+                // while this job ran it now owns the key; in that case drop
+                // the retry (coalesce into the duplicate) rather than letting
+                // both run unprotected.
+                if let Some(unique) = &uniqueness
+                    && unique.window == JobUniquenessWindow::Pending
+                {
+                    let key = job_unique_key(unique, &job.payload);
+                    if !coordination.try_acquire_unique(&job.name, &key, &job.id, unique.window) {
+                        state.job_registry.record_deduplicated(&job.name);
+                        job_admin.record_deduplicated(&job.id);
+                        finish_local_slot(coordination, concurrency_group.as_ref(), tx, state);
+                        return;
+                    }
+                }
+                state
+                    .job_registry
+                    .record_retry(&job.name, &error, job.attempt);
+                job_admin.record_retrying(&job.id, &error);
+                let sender = tx.clone();
+                let registry = state.job_registry.clone();
+                let job_admin = job_admin.clone();
+                let id = job.id.clone();
+                let name = job.name.clone();
+                let payload = job.payload;
+                #[cfg(feature = "telemetry-otlp")]
+                let traceparent = job.traceparent;
+                #[cfg(feature = "telemetry-otlp")]
+                let tracestate = job.tracestate;
+                let delay = backoff_ms.saturating_mul(2_u64.saturating_pow(job.attempt - 1));
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                    registry.record_enqueue(&name);
+                    job_admin.record_requeued(&id, job.attempt + 1);
+                    let _ = sender
+                        .send(QueuedJob {
+                            id,
+                            name,
+                            payload,
+                            attempt: job.attempt + 1,
+                            max_attempts,
+                            initial_backoff_ms: backoff_ms,
+                            #[cfg(feature = "telemetry-otlp")]
+                            traceparent,
+                            #[cfg(feature = "telemetry-otlp")]
+                            tracestate,
+                        })
+                        .await;
+                });
+            } else {
+                state
+                    .job_registry
+                    .record_failure(&job.name, error.clone(), true);
+                job_admin.record_failure(&job.id, error);
+                release_local_unique_hold(
+                    coordination,
+                    uniqueness.as_ref(),
+                    &job.name,
+                    &job.payload,
+                    &job.id,
+                );
+            }
+        }
+=======
+        JobExecutionOutcome::Failed(error) => {
+            let retry_handled = handle_failed_local_job(
+                &job,
+                &error,
+                max_attempts,
+                backoff_ms,
+                state,
+                job_admin,
+                coordination,
+                uniqueness.as_ref(),
+                tx,
+            );
+            if retry_handled {
+                finish_local_slot(coordination, concurrency_group.as_ref(), tx, state);
+                return;
+            }
+        }
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+/// Release a unique hold after a job settles. No-op for TTL-window holds
+=======
+#[allow(clippy::too_many_arguments)]
+fn handle_failed_local_job(
+    job: &QueuedJob,
+    error: &str,
+    max_attempts: u32,
+    backoff_ms: u64,
+    state: &AppState,
+    job_admin: &JobAdminMemoryBackend,
+    coordination: &Arc<LocalJobCoordination>,
+    uniqueness: Option<&JobUniqueness>,
+    tx: &tokio::sync::mpsc::Sender<QueuedJob>,
+) -> bool {
+    if job.attempt < max_attempts {
+        // Running-window keys stay held across retries (the job is
+        // still in flight until it settles). A pending-window key was
+        // released when execution started, so re-acquire it now to
+        // keep duplicates coalescing while the retry waits out its
+        // backoff as a pending job again. If a duplicate was accepted
+        // while this job ran it now owns the key; in that case drop
+        // the retry (coalesce into the duplicate) rather than letting
+        // both run unprotected.
+        if let Some(unique) = uniqueness
+            && unique.window == JobUniquenessWindow::Pending
+        {
+            let key = job_unique_key(unique, &job.payload);
+            if !coordination.try_acquire_unique(&job.name, &key, &job.id, unique.window) {
+                state.job_registry.record_deduplicated(&job.name);
+                job_admin.record_deduplicated(&job.id);
+                return true; // Indicate that execution should return early
+            }
+        }
+        state
+            .job_registry
+            .record_retry(&job.name, error, job.attempt);
+        job_admin.record_retrying(&job.id, error);
+        let sender = tx.clone();
+        let registry = state.job_registry.clone();
+        let job_admin = job_admin.clone();
+        let id = job.id.clone();
+        let name = job.name.clone();
+        let payload = job.payload.clone();
+        #[cfg(feature = "telemetry-otlp")]
+        let traceparent = job.traceparent.clone();
+        #[cfg(feature = "telemetry-otlp")]
+        let tracestate = job.tracestate.clone();
+        let attempt = job.attempt;
+        let delay = backoff_ms.saturating_mul(2_u64.saturating_pow(attempt - 1));
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+            registry.record_enqueue(&name);
+            job_admin.record_requeued(&id, attempt + 1);
+            let _ = sender
+                .send(QueuedJob {
+                    id,
+                    name,
+                    payload,
+                    attempt: attempt + 1,
+                    max_attempts,
+                    initial_backoff_ms: backoff_ms,
+                    #[cfg(feature = "telemetry-otlp")]
+                    traceparent,
+                    #[cfg(feature = "telemetry-otlp")]
+                    tracestate,
+                })
+                .await;
+        });
+    } else {
+        state
+            .job_registry
+            .record_failure(&job.name, error.to_owned(), true);
+        job_admin.record_failure(&job.id, error.to_owned());
+        release_local_unique_hold(
+            coordination,
+            uniqueness,
+            &job.name,
+            &job.payload,
+            &job.id,
+        );
+    }
+    false
+}
+
+/// Release a unique hold after a job settles. No-op for TTL-window holds
+>>>>>>> REPLACE

--- a/patch_job_cleanup.rs
+++ b/patch_job_cleanup.rs
@@ -1,0 +1,205 @@
+<<<<<<< SEARCH
+#[allow(clippy::too_many_arguments)]
+fn handle_failed_local_job(
+    job: &QueuedJob,
+    error: &str,
+    max_attempts: u32,
+    backoff_ms: u64,
+    state: &AppState,
+    job_admin: &JobAdminMemoryBackend,
+    coordination: &Arc<LocalJobCoordination>,
+    uniqueness: Option<&JobUniqueness>,
+    tx: &tokio::sync::mpsc::Sender<QueuedJob>,
+) -> bool {
+    if job.attempt < max_attempts {
+        // Running-window keys stay held across retries (the job is
+        // still in flight until it settles). A pending-window key was
+        // released when execution started, so re-acquire it now to
+        // keep duplicates coalescing while the retry waits out its
+        // backoff as a pending job again. If a duplicate was accepted
+        // while this job ran it now owns the key; in that case drop
+        // the retry (coalesce into the duplicate) rather than letting
+        // both run unprotected.
+        if let Some(unique) = uniqueness
+            && unique.window == JobUniquenessWindow::Pending
+        {
+            let key = job_unique_key(unique, &job.payload);
+            if !coordination.try_acquire_unique(&job.name, &key, &job.id, unique.window) {
+                state.job_registry.record_deduplicated(&job.name);
+                job_admin.record_deduplicated(&job.id);
+                return true; // Indicate that execution should return early
+            }
+        }
+        state
+            .job_registry
+            .record_retry(&job.name, error, job.attempt);
+        job_admin.record_retrying(&job.id, error);
+        let sender = tx.clone();
+        let registry = state.job_registry.clone();
+        let job_admin = job_admin.clone();
+        let id = job.id.clone();
+        let name = job.name.clone();
+        let payload = job.payload.clone();
+        #[cfg(feature = "telemetry-otlp")]
+        let traceparent = job.traceparent.clone();
+        #[cfg(feature = "telemetry-otlp")]
+        let tracestate = job.tracestate.clone();
+        let attempt = job.attempt;
+        let delay = backoff_ms.saturating_mul(2_u64.saturating_pow(attempt - 1));
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+            registry.record_enqueue(&name);
+            job_admin.record_requeued(&id, attempt + 1);
+            let _ = sender
+                .send(QueuedJob {
+                    id,
+                    name,
+                    payload,
+                    attempt: attempt + 1,
+                    max_attempts,
+                    initial_backoff_ms: backoff_ms,
+                    #[cfg(feature = "telemetry-otlp")]
+                    traceparent,
+                    #[cfg(feature = "telemetry-otlp")]
+                    tracestate,
+                })
+                .await;
+        });
+    } else {
+        state
+            .job_registry
+            .record_failure(&job.name, error.to_owned(), true);
+        job_admin.record_failure(&job.id, error.to_owned());
+        release_local_unique_hold(
+            coordination,
+            uniqueness,
+            &job.name,
+            &job.payload,
+            &job.id,
+        );
+    }
+    false
+}
+=======
+struct LocalJobContext<'a> {
+    max_attempts: u32,
+    backoff_ms: u64,
+    state: &'a AppState,
+    job_admin: &'a JobAdminMemoryBackend,
+    coordination: &'a Arc<LocalJobCoordination>,
+    uniqueness: Option<&'a JobUniqueness>,
+    tx: &'a tokio::sync::mpsc::Sender<QueuedJob>,
+}
+
+fn handle_failed_local_job(job: QueuedJob, error: String, ctx: LocalJobContext<'_>) -> bool {
+    if job.attempt < ctx.max_attempts {
+        // Running-window keys stay held across retries (the job is
+        // still in flight until it settles). A pending-window key was
+        // released when execution started, so re-acquire it now to
+        // keep duplicates coalescing while the retry waits out its
+        // backoff as a pending job again. If a duplicate was accepted
+        // while this job ran it now owns the key; in that case drop
+        // the retry (coalesce into the duplicate) rather than letting
+        // both run unprotected.
+        if let Some(unique) = ctx.uniqueness
+            && unique.window == JobUniquenessWindow::Pending
+        {
+            let key = job_unique_key(unique, &job.payload);
+            if !ctx.coordination.try_acquire_unique(&job.name, &key, &job.id, unique.window) {
+                ctx.state.job_registry.record_deduplicated(&job.name);
+                ctx.job_admin.record_deduplicated(&job.id);
+                return true; // Indicate that execution should return early
+            }
+        }
+        ctx.state
+            .job_registry
+            .record_retry(&job.name, &error, job.attempt);
+        ctx.job_admin.record_retrying(&job.id, &error);
+        let sender = ctx.tx.clone();
+        let registry = ctx.state.job_registry.clone();
+        let job_admin = ctx.job_admin.clone();
+        let id = job.id;
+        let name = job.name;
+        let payload = job.payload;
+        #[cfg(feature = "telemetry-otlp")]
+        let traceparent = job.traceparent;
+        #[cfg(feature = "telemetry-otlp")]
+        let tracestate = job.tracestate;
+        let attempt = job.attempt;
+        let delay = ctx.backoff_ms.saturating_mul(2_u64.saturating_pow(attempt - 1));
+        let max_attempts = ctx.max_attempts;
+        let backoff_ms = ctx.backoff_ms;
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+            registry.record_enqueue(&name);
+            job_admin.record_requeued(&id, attempt + 1);
+            let _ = sender
+                .send(QueuedJob {
+                    id,
+                    name,
+                    payload,
+                    attempt: attempt + 1,
+                    max_attempts,
+                    initial_backoff_ms: backoff_ms,
+                    #[cfg(feature = "telemetry-otlp")]
+                    traceparent,
+                    #[cfg(feature = "telemetry-otlp")]
+                    tracestate,
+                })
+                .await;
+        });
+    } else {
+        ctx.state
+            .job_registry
+            .record_failure(&job.name, error.clone(), true);
+        ctx.job_admin.record_failure(&job.id, error);
+        release_local_unique_hold(
+            ctx.coordination,
+            ctx.uniqueness,
+            &job.name,
+            &job.payload,
+            &job.id,
+        );
+    }
+    false
+}
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+        JobExecutionOutcome::Failed(error) => {
+            let retry_handled = handle_failed_local_job(
+                &job,
+                &error,
+                max_attempts,
+                backoff_ms,
+                state,
+                job_admin,
+                coordination,
+                uniqueness.as_ref(),
+                tx,
+            );
+            if retry_handled {
+                finish_local_slot(coordination, concurrency_group.as_ref(), tx, state);
+                return;
+            }
+        }
+=======
+        JobExecutionOutcome::Failed(error) => {
+            let retry_handled = handle_failed_local_job(
+                job,
+                error,
+                LocalJobContext {
+                    max_attempts,
+                    backoff_ms,
+                    state,
+                    job_admin,
+                    coordination,
+                    uniqueness: uniqueness.as_ref(),
+                    tx,
+                },
+            );
+            if retry_handled {
+                finish_local_slot(coordination, concurrency_group.as_ref(), tx, state);
+                return;
+            }
+        }
+>>>>>>> REPLACE


### PR DESCRIPTION
🚮 Smell: The `execute_local_job` function in `autumn/src/job.rs` was a "God Function" with deep nesting and multiple responsibilities, specifically related to the complex error handling and retry logic for local background jobs.
✨ Solution: Extracted the failure-handling logic (`JobExecutionOutcome::Failed` block) from `execute_local_job` into a dedicated helper function called `handle_failed_local_job`. Created a `LocalJobContext` struct to pass the numerous configuration and runtime dependencies neatly.
🧼 Benefit: Reduces cognitive load and flattens nesting in the main `execute_local_job` routine, making the top-level orchestration much easier to trace.
🛡️ Verification: Tests passed (`cargo test -p autumn-web --lib job::`). No logic or runtime behavior was changed. Clippy and rustfmt pass with zero new warnings.

---
*PR created automatically by Jules for task [10637191086590220754](https://jules.google.com/task/10637191086590220754) started by @madmax983*