### PR TITLE
Add TimeZone extractor for per-user time zone resolution

### DIFF
--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -480,8 +480,11 @@ pub fn plan_auth_with_providers(
     //   password_digest  String   → Text      NOT NULL
     //   reset_token_digest         Option<String>         → Nullable<Text>
     //   reset_token_expires_at     Option<NaiveDateTime>  → Nullable<Timestamp>
-    let mut user_field_tokens: Vec<&str> =
-        vec!["email:String", "time_zone:Option<String>", "password_digest:String"];
+    let mut user_field_tokens: Vec<&str> = vec![
+        "email:String",
+        "time_zone:Option<String>",
+        "password_digest:String",
+    ];
     if totp {
         user_field_tokens.push("totp_secret_encrypted:Option<String>");
         user_field_tokens.push("totp_enabled:bool");

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -480,7 +480,8 @@ pub fn plan_auth_with_providers(
     //   password_digest  String   → Text      NOT NULL
     //   reset_token_digest         Option<String>         → Nullable<Text>
     //   reset_token_expires_at     Option<NaiveDateTime>  → Nullable<Timestamp>
-    let mut user_field_tokens: Vec<&str> = vec!["email:String", "password_digest:String"];
+    let mut user_field_tokens: Vec<&str> =
+        vec!["email:String", "time_zone:Option<String>", "password_digest:String"];
     if totp {
         user_field_tokens.push("totp_secret_encrypted:Option<String>");
         user_field_tokens.push("totp_enabled:bool");
@@ -1384,6 +1385,7 @@ fn render_migration_up(snake_name: &str, table: &str, totp: bool) -> String {
         "CREATE TABLE {table} (\n\
          \x20   id BIGSERIAL PRIMARY KEY,\n\
          \x20   email TEXT NOT NULL UNIQUE,\n\
+         \x20   time_zone TEXT NULL,\n\
          \x20   password_digest TEXT NOT NULL,\n\
          {totp_columns}\
          \x20   failed_attempts INT NOT NULL DEFAULT 0,\n\
@@ -1483,6 +1485,7 @@ use crate::schema::{table};
 pub struct {pascal_name} {{
     pub id: i64,
     pub email: String,
+    pub time_zone: Option<String>,
     pub password_digest: String,
 {totp_fields}    #[default]
     pub failed_attempts: i32,

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -1488,7 +1488,6 @@ use crate::schema::{table};
 pub struct {pascal_name} {{
     pub id: i64,
     pub email: String,
-    #[default]
     pub time_zone: Option<String>,
     pub password_digest: String,
 {totp_fields}    #[default]
@@ -2262,6 +2261,7 @@ pub async fn signup(
     let password_digest = hash_password(&form.password).await?;
     let new_{snake_name} = New{pascal_name} {{
         email: email.clone(),
+        time_zone: None,
         password_digest,
         reset_token_digest: None,
         reset_token_expires_at: None,

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -1488,6 +1488,7 @@ use crate::schema::{table};
 pub struct {pascal_name} {{
     pub id: i64,
     pub email: String,
+    #[default]
     pub time_zone: Option<String>,
     pub password_digest: String,
 {totp_fields}    #[default]

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -839,6 +839,10 @@ fn generate_auth_in_fresh_project_creates_expected_files() {
     );
     assert!(up.contains("email"), "up.sql missing email column");
     assert!(
+        up.contains("time_zone TEXT NULL"),
+        "up.sql missing time_zone column"
+    );
+    assert!(
         up.contains("password_digest"),
         "up.sql missing password_digest"
     );
@@ -859,6 +863,10 @@ fn generate_auth_in_fresh_project_creates_expected_files() {
     assert!(
         model.contains("pub email: String"),
         "model missing email field"
+    );
+    assert!(
+        model.contains("pub time_zone: Option<String>"),
+        "model missing time_zone field"
     );
     assert!(
         model.contains("pub password_digest: String"),
@@ -885,6 +893,10 @@ fn generate_auth_in_fresh_project_creates_expected_files() {
     assert!(
         schema.contains("email -> Text"),
         "schema.rs missing email column"
+    );
+    assert!(
+        schema.contains("time_zone -> Nullable<Text>"),
+        "schema.rs missing time_zone column"
     );
     assert!(
         schema.contains("reset_token_digest -> Nullable<Text>"),

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -125,6 +125,7 @@
 //! | `AUTUMN_AUTH__LOCKOUT__THRESHOLD` | `auth.lockout.threshold` | `i32` |
 //! | `AUTUMN_AUTH__LOCKOUT__WINDOW_SECS` | `auth.lockout.window_secs` | `u64` |
 //! | `AUTUMN_AUTH__LOCKOUT__COOLOFF_SECS` | `auth.lockout.cooloff_secs` | `u64` |
+//! | `AUTUMN_TIME_ZONE__IDENTIFIER` | `time_zone.identifier` | IANA id `String` |
 
 use std::path::{Path, PathBuf};
 
@@ -1932,6 +1933,15 @@ impl AutumnConfig {
         #[cfg(feature = "mail")]
         self.apply_mail_env_overrides_with_env(env);
         self.apply_resilience_env_overrides_with_env(env);
+        self.apply_time_zone_env_overrides_with_env(env);
+    }
+
+    fn apply_time_zone_env_overrides_with_env(&mut self, env: &dyn Env) {
+        parse_env_string(
+            env,
+            "AUTUMN_TIME_ZONE__IDENTIFIER",
+            &mut self.time_zone.identifier,
+        );
     }
 
     #[cfg(feature = "reporting")]
@@ -4269,6 +4279,18 @@ pool_size = 7
         };
         assert!(message.contains("database.replica_url"));
         assert!(message.contains("database.primary_url"));
+    }
+
+    #[test]
+    fn time_zone_identifier_env_override_applies() {
+        let env = MockEnv::new().with("AUTUMN_TIME_ZONE__IDENTIFIER", "America/New_York");
+        let mut config = AutumnConfig::default();
+        assert_eq!(config.time_zone.identifier, "UTC");
+
+        config.apply_env_overrides_with_env(&env);
+
+        assert_eq!(config.time_zone.identifier, "America/New_York");
+        assert!(config.time_zone.validate().is_ok());
     }
 
     #[test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -732,6 +732,20 @@ pub struct AutumnConfig {
     #[cfg(feature = "i18n")]
     #[serde(default)]
     pub i18n: crate::i18n::I18nConfig,
+
+    /// Per-user time zone settings (`[time_zone]` block in `autumn.toml`).
+    ///
+    /// Controls the default IANA zone and the source resolution chain for the
+    /// [`TimeZone`](crate::time_zone::TimeZone) extractor.
+    ///
+    /// # Example
+    ///
+    /// ```toml
+    /// [time_zone]
+    /// identifier = "America/New_York"
+    /// ```
+    #[serde(default)]
+    pub time_zone: crate::time_zone::TimeZoneConfig,
     /// Pluggable file storage configuration. Honored only when the
     /// `storage` cargo feature is enabled.
     #[cfg(feature = "storage")]
@@ -1817,6 +1831,7 @@ impl AutumnConfig {
             .map_err(|error| ConfigError::Validation(error.to_string()))?;
         #[cfg(feature = "mail")]
         self.mail.validate(self.profile.as_deref())?;
+        self.time_zone.validate()?;
         // Session backend validation deliberately lives in
         // `crate::session::apply_session_layer`, not here. That function
         // short-circuits when a custom `SessionStore` was installed via

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -205,6 +205,7 @@ pub mod step_up;
 pub mod storage;
 pub mod tenancy;
 pub mod time;
+pub mod time_zone;
 pub mod user_agent;
 
 pub mod experiments;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -247,6 +247,27 @@ pub use crate::i18n::Locale;
 #[cfg(feature = "i18n")]
 pub use crate::i18n::t;
 
+// ── Time zones ────────────────────────────────────────────────────
+/// Request-scoped time zone extractor (resolves from user extension,
+/// session, cookie, and query parameter — see [`crate::time_zone`]).
+pub use crate::time_zone::TimeZone;
+/// Newtype for auth middleware to publish the authenticated user's zone
+/// into request extensions.
+pub use crate::time_zone::UserTimeZone;
+/// Render a UTC timestamp as a `<time>` element in the given zone.
+#[cfg(feature = "maud")]
+pub use crate::time_zone::local_datetime;
+/// Render only the date portion in the given zone.
+#[cfg(feature = "maud")]
+pub use crate::time_zone::local_date;
+/// Render a relative time string (e.g. "3 minutes ago") as a `<time>` element.
+#[cfg(feature = "maud")]
+pub use crate::time_zone::time_ago;
+/// Parse a browser `datetime-local` value as a local time in `tz` → UTC.
+pub use crate::time_zone::parse_local_datetime;
+/// Format a UTC timestamp as a `datetime-local` input value in `tz`.
+pub use crate::time_zone::to_local_input_value;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -254,17 +254,17 @@ pub use crate::time_zone::TimeZone;
 /// Newtype for auth middleware to publish the authenticated user's zone
 /// into request extensions.
 pub use crate::time_zone::UserTimeZone;
-/// Render a UTC timestamp as a `<time>` element in the given zone.
-#[cfg(feature = "maud")]
-pub use crate::time_zone::local_datetime;
 /// Render only the date portion in the given zone.
 #[cfg(feature = "maud")]
 pub use crate::time_zone::local_date;
+/// Render a UTC timestamp as a `<time>` element in the given zone.
+#[cfg(feature = "maud")]
+pub use crate::time_zone::local_datetime;
+/// Parse a browser `datetime-local` value as a local time in `tz` → UTC.
+pub use crate::time_zone::parse_local_datetime;
 /// Render a relative time string (e.g. "3 minutes ago") as a `<time>` element.
 #[cfg(feature = "maud")]
 pub use crate::time_zone::time_ago;
-/// Parse a browser `datetime-local` value as a local time in `tz` → UTC.
-pub use crate::time_zone::parse_local_datetime;
 /// Format a UTC timestamp as a `datetime-local` input value in `tz`.
 pub use crate::time_zone::to_local_input_value;
 

--- a/autumn/src/time_zone.rs
+++ b/autumn/src/time_zone.rs
@@ -56,10 +56,18 @@ pub enum Source {
 /// Configuration for the time zone subsystem.
 ///
 /// Populated from the `[time_zone]` block in `autumn.toml`, or left at
-/// defaults (`UTC`, all sources). `time_zone = "America/New_York"` is also
-/// accepted as a shorthand for just the identifier.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(default)]
+/// defaults (`UTC`, all sources). Both the table form and the scalar
+/// shorthand are accepted:
+///
+/// ```toml
+/// # Scalar shorthand — sets `identifier`, keeps default sources:
+/// time_zone = "America/New_York"
+///
+/// # Table form — also lets you reorder the resolution sources:
+/// [time_zone]
+/// identifier = "America/New_York"
+/// ```
+#[derive(Debug, Clone)]
 pub struct TimeZoneConfig {
     /// IANA time zone identifier used when no source resolves.
     /// Defaults to `"UTC"`.
@@ -68,18 +76,63 @@ pub struct TimeZoneConfig {
     pub sources: Vec<Source>,
 }
 
+fn default_time_zone_identifier() -> String {
+    "UTC".to_owned()
+}
+
+fn default_time_zone_sources() -> Vec<Source> {
+    vec![Source::User, Source::Session, Source::Cookie, Source::Query]
+}
+
 impl Default for TimeZoneConfig {
     fn default() -> Self {
         Self {
-            identifier: "UTC".to_owned(),
-            sources: vec![Source::User, Source::Session, Source::Cookie, Source::Query],
+            identifier: default_time_zone_identifier(),
+            sources: default_time_zone_sources(),
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for TimeZoneConfig {
+    /// Accept either a scalar identifier (`time_zone = "America/New_York"`) or
+    /// a full table (`[time_zone] identifier = "…"`), so the documented
+    /// shorthand in issue #836 loads correctly.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Scalar(String),
+            Table {
+                #[serde(default = "default_time_zone_identifier")]
+                identifier: String,
+                #[serde(default = "default_time_zone_sources")]
+                sources: Vec<Source>,
+            },
+        }
+
+        Ok(match Repr::deserialize(deserializer)? {
+            Repr::Scalar(identifier) => Self {
+                identifier,
+                sources: default_time_zone_sources(),
+            },
+            Repr::Table {
+                identifier,
+                sources,
+            } => Self {
+                identifier,
+                sources,
+            },
+        })
     }
 }
 
 impl TimeZoneConfig {
     /// Validate the config, returning an error if the identifier is not a
-    /// recognised IANA zone. Called by [`AutumnConfig::validate`] at startup.
+    /// recognised IANA zone. Called by
+    /// [`AutumnConfig::validate`](crate::config::AutumnConfig::validate) at startup.
     ///
     /// # Errors
     ///
@@ -214,7 +267,7 @@ fn resolve_from_query(parts: &axum::http::request::Parts) -> Option<Tz> {
     let query = parts.uri.query()?;
     for pair in query.split('&') {
         if let Some(value) = pair.strip_prefix("tz=")
-            && let Some(tz) = parse_iana(value)
+            && let Some(tz) = parse_iana(&percent_decode(value))
         {
             return Some(tz);
         }
@@ -230,12 +283,54 @@ fn resolve_from_cookie(parts: &axum::http::request::Parts) -> Option<Tz> {
     for cookie in cookie_header.split(';') {
         let cookie = cookie.trim();
         if let Some(value) = cookie.strip_prefix("autumn_time_zone=")
-            && let Some(tz) = parse_iana(value)
+            && let Some(tz) = parse_iana(&percent_decode(value))
         {
             return Some(tz);
         }
     }
     None
+}
+
+/// Resolve `%XX` percent-escapes in a query/cookie value so that
+/// pre-encoded IANA identifiers (e.g. `America%2FNew_York`,
+/// `Etc%2FGMT%2B5`) still parse.
+///
+/// `+` is left literal rather than decoded to a space: IANA identifiers can
+/// contain `+` (e.g. `Etc/GMT+5`) and never contain spaces, so treating `+`
+/// as a literal is the correct choice here.
+fn percent_decode(value: &str) -> std::borrow::Cow<'_, str> {
+    if !value.contains('%') {
+        return std::borrow::Cow::Borrowed(value);
+    }
+    let bytes = value.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let Some(byte) = decode_hex_pair(bytes[i + 1], bytes[i + 2])
+        {
+            out.push(byte);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    // Fall back to the original string if decoding produced invalid UTF-8.
+    String::from_utf8(out).map_or_else(
+        |_| std::borrow::Cow::Owned(value.to_owned()),
+        std::borrow::Cow::Owned,
+    )
+}
+
+/// Decode two ASCII hex digits into the byte they represent, or `None` if
+/// either character is not a hex digit.
+fn decode_hex_pair(hi: u8, lo: u8) -> Option<u8> {
+    let hi = (hi as char).to_digit(16)?;
+    let lo = (lo as char).to_digit(16)?;
+    // `hi` and `lo` are each in `0..16`, so the result is always `<= 255`.
+    u8::try_from(hi * 16 + lo).ok()
 }
 
 // ── IANA parsing ──────────────────────────────────────────────────────────────
@@ -348,7 +443,7 @@ pub fn time_ago(dt: DateTime<Utc>, now: DateTime<Utc>, tz: Tz) -> maud::Markup {
 fn format_relative(diff: chrono::Duration) -> String {
     let secs = diff.num_seconds();
     if secs < 0 {
-        let future = -secs;
+        let future = secs.unsigned_abs();
         return if future < 60 {
             format!("in {future} seconds")
         } else if future < 3600 {
@@ -560,6 +655,53 @@ mod tests {
         );
     }
 
+    #[derive(serde::Deserialize)]
+    struct Wrapper {
+        #[serde(default)]
+        time_zone: TimeZoneConfig,
+    }
+
+    #[test]
+    fn config_deserializes_scalar_shorthand() {
+        let w: Wrapper = toml::from_str(r#"time_zone = "America/New_York""#).unwrap();
+        assert_eq!(w.time_zone.identifier, "America/New_York");
+        // Scalar form keeps the default source chain.
+        assert_eq!(w.time_zone.sources, default_time_zone_sources());
+    }
+
+    #[test]
+    fn config_deserializes_table_form() {
+        let w: Wrapper = toml::from_str(
+            r#"
+            [time_zone]
+            identifier = "Asia/Tokyo"
+            sources = ["query", "cookie"]
+            "#,
+        )
+        .unwrap();
+        assert_eq!(w.time_zone.identifier, "Asia/Tokyo");
+        assert_eq!(w.time_zone.sources, vec![Source::Query, Source::Cookie]);
+    }
+
+    #[test]
+    fn config_table_form_defaults_missing_fields() {
+        let w: Wrapper = toml::from_str(
+            r#"
+            [time_zone]
+            identifier = "Europe/London"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(w.time_zone.identifier, "Europe/London");
+        assert_eq!(w.time_zone.sources, default_time_zone_sources());
+    }
+
+    #[test]
+    fn config_absent_uses_default() {
+        let w: Wrapper = toml::from_str("").unwrap();
+        assert_eq!(w.time_zone.identifier, "UTC");
+    }
+
     // ── Query resolution ──────────────────────────────────────────────────────
 
     #[test]
@@ -579,6 +721,46 @@ mod tests {
     fn query_param_absent_returns_none() {
         let p = parts("/", &[]);
         assert!(resolve_from_query(&p).is_none());
+    }
+
+    #[test]
+    fn query_param_percent_encoded_slash() {
+        let p = parts("/?tz=America%2FNew_York", &[]);
+        assert_eq!(resolve_from_query(&p), Some(Tz::America__New_York));
+    }
+
+    #[test]
+    fn query_param_percent_encoded_plus() {
+        // Etc/GMT+5 contains a literal '+'; fully percent-encoded form must parse.
+        let p = parts("/?tz=Etc%2FGMT%2B5", &[]);
+        assert_eq!(resolve_from_query(&p), Some(Tz::Etc__GMTPlus5));
+    }
+
+    #[test]
+    fn percent_decode_passthrough_when_no_escapes() {
+        assert_eq!(percent_decode("America/New_York"), "America/New_York");
+        assert!(matches!(
+            percent_decode("UTC"),
+            std::borrow::Cow::Borrowed("UTC")
+        ));
+    }
+
+    #[test]
+    fn percent_decode_resolves_escapes() {
+        assert_eq!(percent_decode("America%2FNew_York"), "America/New_York");
+        assert_eq!(percent_decode("Etc%2FGMT%2B5"), "Etc/GMT+5");
+    }
+
+    #[test]
+    fn percent_decode_leaves_plus_literal() {
+        assert_eq!(percent_decode("Etc/GMT+5"), "Etc/GMT+5");
+    }
+
+    #[test]
+    fn percent_decode_keeps_trailing_partial_escape_literal() {
+        // A stray '%' with too few hex digits is preserved verbatim.
+        assert_eq!(percent_decode("UTC%2"), "UTC%2");
+        assert_eq!(percent_decode("UTC%"), "UTC%");
     }
 
     // ── Cookie resolution ─────────────────────────────────────────────────────
@@ -610,6 +792,13 @@ mod tests {
     fn cookie_absent_returns_none() {
         let p = parts("/", &[]);
         assert!(resolve_from_cookie(&p).is_none());
+    }
+
+    #[test]
+    fn cookie_percent_encoded_value() {
+        // Frontend libraries often encodeURIComponent cookie values.
+        let p = parts("/", &[("Cookie", "autumn_time_zone=America%2FNew_York")]);
+        assert_eq!(resolve_from_cookie(&p), Some(Tz::America__New_York));
     }
 
     // ── Cookie helper ─────────────────────────────────────────────────────────

--- a/autumn/src/time_zone.rs
+++ b/autumn/src/time_zone.rs
@@ -32,8 +32,8 @@
 //! }
 //! ```
 
-use chrono::{DateTime, Utc};
 use chrono::TimeZone as _;
+use chrono::{DateTime, Utc};
 use chrono_tz::Tz;
 use serde::Deserialize;
 
@@ -197,15 +197,9 @@ impl axum::extract::FromRequestParts<crate::state::AppState> for TimeZone {
     }
 }
 
-async fn resolve_source(
-    parts: &axum::http::request::Parts,
-    source: &Source,
-) -> Option<Tz> {
+async fn resolve_source(parts: &axum::http::request::Parts, source: &Source) -> Option<Tz> {
     match source {
-        Source::User => parts
-            .extensions
-            .get::<UserTimeZone>()
-            .map(|utz| utz.0),
+        Source::User => parts.extensions.get::<UserTimeZone>().map(|utz| utz.0),
         Source::Session => {
             let session = parts.extensions.get::<crate::session::Session>().cloned()?;
             let value: String = session.get(TIME_ZONE_SESSION_KEY).await?;
@@ -442,9 +436,7 @@ pub fn datetime_local_input(
     dt: Option<DateTime<Utc>>,
     tz: Tz,
 ) -> maud::Markup {
-    let value = dt
-        .map(|d| to_local_input_value(d, tz))
-        .unwrap_or_default();
+    let value = dt.map(|d| to_local_input_value(d, tz)).unwrap_or_default();
     maud::html! {
         div.field {
             label for=(name) { (label) }
@@ -600,7 +592,10 @@ mod tests {
 
     #[test]
     fn cookie_ignores_other_cookies() {
-        let p = parts("/", &[("Cookie", "session=abc; autumn_time_zone=UTC; other=x")]);
+        let p = parts(
+            "/",
+            &[("Cookie", "session=abc; autumn_time_zone=UTC; other=x")],
+        );
         let result = resolve_from_cookie(&p);
         assert_eq!(result, Some(Tz::UTC));
     }
@@ -707,7 +702,10 @@ mod tests {
     fn to_local_input_value_formats_correctly() {
         use chrono::TimeZone as ChrTz;
         let utc = chrono::Utc.with_ymd_and_hms(2025, 6, 14, 6, 30, 0).unwrap();
-        assert_eq!(to_local_input_value(utc, Tz::Asia__Tokyo), "2025-06-14T15:30");
+        assert_eq!(
+            to_local_input_value(utc, Tz::Asia__Tokyo),
+            "2025-06-14T15:30"
+        );
         assert_eq!(to_local_input_value(utc, Tz::UTC), "2025-06-14T06:30");
     }
 
@@ -815,20 +813,15 @@ mod tests {
 
     #[tokio::test]
     async fn with_request_time_zone_sets_ambient() {
-        let result = with_request_time_zone(Tz::Asia__Tokyo, async {
-            ambient_time_zone()
-        })
-        .await;
+        let result = with_request_time_zone(Tz::Asia__Tokyo, async { ambient_time_zone() }).await;
         assert_eq!(result, Tz::Asia__Tokyo);
     }
 
     #[tokio::test]
     async fn ambient_returns_utc_outside_scope() {
         // Inside scope
-        let inside = with_request_time_zone(Tz::America__New_York, async {
-            ambient_time_zone()
-        })
-        .await;
+        let inside =
+            with_request_time_zone(Tz::America__New_York, async { ambient_time_zone() }).await;
         // Outside scope
         let outside = ambient_time_zone();
         assert_eq!(inside, Tz::America__New_York);

--- a/autumn/src/time_zone.rs
+++ b/autumn/src/time_zone.rs
@@ -1,0 +1,837 @@
+//! Per-user time zone resolution and locale-aware date/time rendering.
+//!
+//! Autumn exposes a [`TimeZone`] extractor so handlers can render timestamps in the
+//! requesting user's local time instead of always serving UTC. It mirrors the
+//! [`Clock`](crate::time::Clock) extractor pattern — deterministic, injected,
+//! testable — and reuses the existing `chrono-tz` dependency (already required by
+//! the scheduler).
+//!
+//! # Resolution order
+//!
+//! The extractor walks the request in this order, returning the first valid IANA
+//! zone found, or falling back to the configured app default (`UTC` when omitted):
+//!
+//! 1. `UserTimeZone` extension (set by your auth middleware for the logged-in user).
+//! 2. `autumn_time_zone` key in the signed session.
+//! 3. Plain `autumn_time_zone` cookie (unsigned, for apps without sessions).
+//! 4. `?tz=<iana>` query parameter (dev/test convenience).
+//!
+//! The order is configurable via [`TimeZoneConfig::sources`].
+//!
+//! # Quick example
+//!
+//! ```rust,ignore
+//! use autumn_web::prelude::*;
+//! use autumn_web::time_zone::{TimeZone, local_datetime};
+//! use autumn_web::time::Clock;
+//!
+//! #[get("/events")]
+//! async fn index(clock: Clock, tz: TimeZone) -> Markup {
+//!     let now = clock.now();
+//!     html! { p { (local_datetime(now, *tz)) } }
+//! }
+//! ```
+
+use chrono::{DateTime, Utc};
+use chrono::TimeZone as _;
+use chrono_tz::Tz;
+use serde::Deserialize;
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+/// Source of the time zone in the resolution chain.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Source {
+    /// `UserTimeZone` extension inserted by the app's auth middleware.
+    User,
+    /// `autumn_time_zone` key in the framework's signed session cookie.
+    Session,
+    /// Plain (unsigned) `autumn_time_zone` cookie.
+    Cookie,
+    /// `?tz=<iana>` query parameter override.
+    Query,
+}
+
+/// Configuration for the time zone subsystem.
+///
+/// Populated from the `[time_zone]` block in `autumn.toml`, or left at
+/// defaults (`UTC`, all sources). `time_zone = "America/New_York"` is also
+/// accepted as a shorthand for just the identifier.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct TimeZoneConfig {
+    /// IANA time zone identifier used when no source resolves.
+    /// Defaults to `"UTC"`.
+    pub identifier: String,
+    /// Ordered list of sources tried during resolution.
+    pub sources: Vec<Source>,
+}
+
+impl Default for TimeZoneConfig {
+    fn default() -> Self {
+        Self {
+            identifier: "UTC".to_owned(),
+            sources: vec![Source::User, Source::Session, Source::Cookie, Source::Query],
+        }
+    }
+}
+
+impl TimeZoneConfig {
+    /// Validate the config, returning an error if the identifier is not a
+    /// recognised IANA zone. Called by [`AutumnConfig::validate`] at startup.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::config::ConfigError::Validation`] when the identifier
+    /// is not a known IANA time zone.
+    pub fn validate(&self) -> Result<(), crate::config::ConfigError> {
+        parse_iana(&self.identifier).ok_or_else(|| {
+            crate::config::ConfigError::Validation(format!(
+                "time_zone identifier `{}` is not a valid IANA time zone",
+                self.identifier
+            ))
+        })?;
+        Ok(())
+    }
+
+    /// Returns the configured default [`Tz`], or `UTC` if the identifier is
+    /// somehow invalid (should not happen after validation).
+    #[must_use]
+    pub fn default_tz(&self) -> Tz {
+        parse_iana(&self.identifier).unwrap_or(Tz::UTC)
+    }
+}
+
+// ── UserTimeZone extension ───────────────────────────────────────────────────
+
+/// Newtype placed into request extensions by the app's auth middleware when
+/// an authenticated user with a known time zone is present.
+///
+/// The [`TimeZone`] extractor reads this as the highest-priority source (when
+/// `Source::User` is in the resolution chain, which it is by default).
+///
+/// ```rust,ignore
+/// // In your auth / current-user middleware:
+/// parts.extensions.insert(UserTimeZone(user.time_zone.parse::<Tz>().unwrap()));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UserTimeZone(pub Tz);
+
+// ── Session key ───────────────────────────────────────────────────────────────
+
+/// Session key used to persist the chosen time zone in the signed session.
+pub const TIME_ZONE_SESSION_KEY: &str = "autumn_time_zone";
+
+// ── TimeZone extractor ────────────────────────────────────────────────────────
+
+/// Axum extractor that resolves the per-request time zone.
+///
+/// Declare it as a handler parameter to get the zone without any manual
+/// resolution. Compose it with [`Clock`](crate::time::Clock) for fully
+/// deterministic, test-injectable time handling:
+///
+/// ```rust,ignore
+/// use autumn_web::time_zone::TimeZone;
+/// use autumn_web::time::Clock;
+///
+/// async fn handler(clock: Clock, tz: TimeZone) -> String {
+///     let local = tz.convert(clock.now());
+///     local.format("%Y-%m-%d %H:%M %Z").to_string()
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TimeZone(pub Tz);
+
+impl TimeZone {
+    /// Construct a `TimeZone` for testing without going through extraction.
+    #[must_use]
+    pub const fn new(tz: Tz) -> Self {
+        Self(tz)
+    }
+
+    /// Returns the wrapped [`Tz`].
+    #[must_use]
+    pub const fn tz(&self) -> Tz {
+        self.0
+    }
+
+    /// Returns the IANA identifier string (e.g. `"America/New_York"`).
+    #[must_use]
+    pub fn iana(&self) -> &'static str {
+        self.0.name()
+    }
+
+    /// Convert a UTC timestamp into this zone's local time.
+    #[must_use]
+    pub fn convert(&self, dt: DateTime<Utc>) -> chrono::DateTime<Tz> {
+        use chrono::TimeZone as _;
+        self.0.from_utc_datetime(&dt.naive_utc())
+    }
+}
+
+impl std::ops::Deref for TimeZone {
+    type Target = Tz;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl axum::extract::FromRequestParts<crate::state::AppState> for TimeZone {
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &crate::state::AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let cfg = state.config().time_zone;
+        let sources = cfg.sources.clone();
+        let default_tz = cfg.default_tz();
+
+        for source in &sources {
+            if let Some(tz) = resolve_source(parts, source).await {
+                return Ok(Self(tz));
+            }
+        }
+        Ok(Self(default_tz))
+    }
+}
+
+async fn resolve_source(
+    parts: &axum::http::request::Parts,
+    source: &Source,
+) -> Option<Tz> {
+    match source {
+        Source::User => parts
+            .extensions
+            .get::<UserTimeZone>()
+            .map(|utz| utz.0),
+        Source::Session => {
+            let session = parts.extensions.get::<crate::session::Session>().cloned()?;
+            let value: String = session.get(TIME_ZONE_SESSION_KEY).await?;
+            parse_iana(&value)
+        }
+        Source::Cookie => resolve_from_cookie(parts),
+        Source::Query => resolve_from_query(parts),
+    }
+}
+
+fn resolve_from_query(parts: &axum::http::request::Parts) -> Option<Tz> {
+    let query = parts.uri.query()?;
+    for pair in query.split('&') {
+        if let Some(value) = pair.strip_prefix("tz=")
+            && let Some(tz) = parse_iana(value)
+        {
+            return Some(tz);
+        }
+    }
+    None
+}
+
+fn resolve_from_cookie(parts: &axum::http::request::Parts) -> Option<Tz> {
+    let cookie_header = parts
+        .headers
+        .get(axum::http::header::COOKIE)
+        .and_then(|h| h.to_str().ok())?;
+    for cookie in cookie_header.split(';') {
+        let cookie = cookie.trim();
+        if let Some(value) = cookie.strip_prefix("autumn_time_zone=")
+            && let Some(tz) = parse_iana(value)
+        {
+            return Some(tz);
+        }
+    }
+    None
+}
+
+// ── IANA parsing ──────────────────────────────────────────────────────────────
+
+/// Parse and validate an IANA time zone identifier.
+///
+/// Returns `None` for unknown or malformed identifiers so callers can fall
+/// through to the next resolution source.
+#[must_use]
+pub fn parse_iana(s: &str) -> Option<Tz> {
+    s.trim().parse::<Tz>().ok()
+}
+
+// ── Session & cookie helpers ──────────────────────────────────────────────────
+
+/// Persist a time zone choice into the framework's signed session cookie.
+///
+/// The value is the IANA identifier string (e.g. `"America/New_York"`).
+pub async fn set_time_zone_in_session(session: &crate::session::Session, iana: &str) {
+    session.insert(TIME_ZONE_SESSION_KEY, iana).await;
+}
+
+/// Produce a `Set-Cookie` header value that persists the chosen zone.
+///
+/// The cookie is unsigned — for signed persistence use
+/// [`set_time_zone_in_session`] instead.
+#[must_use]
+pub fn set_time_zone_cookie(iana: &str) -> String {
+    let safe = encode_tz_cookie_value(iana);
+    format!("autumn_time_zone={safe}; Path=/; Max-Age=31536000; SameSite=Lax")
+}
+
+fn encode_tz_cookie_value(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for b in value.bytes() {
+        if is_tz_cookie_byte(b) {
+            out.push(char::from(b));
+        } else {
+            push_pct_encoded(&mut out, b);
+        }
+    }
+    out
+}
+
+const fn is_tz_cookie_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'+' | b'/')
+}
+
+fn push_pct_encoded(out: &mut String, byte: u8) {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    out.push('%');
+    out.push(char::from(HEX[(byte >> 4) as usize]));
+    out.push(char::from(HEX[(byte & 0x0f) as usize]));
+}
+
+// ── Maud view helpers ─────────────────────────────────────────────────────────
+
+/// A semantic `<time>` element showing the local date and time.
+///
+/// The `datetime` attribute is always UTC RFC3339 for machine readers; the
+/// visible text uses the given zone.
+///
+/// ```rust,ignore
+/// let markup = local_datetime(clock.now(), *tz);
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn local_datetime(dt: DateTime<Utc>, tz: Tz) -> maud::Markup {
+    let local = tz.from_utc_datetime(&dt.naive_utc());
+    let display = local.format("%Y-%m-%d %H:%M %Z").to_string();
+    let rfc = dt.to_rfc3339();
+    maud::html! {
+        time datetime=(rfc) { (display) }
+    }
+}
+
+/// A semantic `<time>` element showing the local date (no time component).
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn local_date(dt: DateTime<Utc>, tz: Tz) -> maud::Markup {
+    let local = tz.from_utc_datetime(&dt.naive_utc());
+    let display = local.format("%Y-%m-%d").to_string();
+    let rfc = dt.to_rfc3339();
+    maud::html! {
+        time datetime=(rfc) { (display) }
+    }
+}
+
+/// A semantic `<time>` element with a human-readable relative time string.
+///
+/// `now` should come from the [`Clock`](crate::time::Clock) extractor so
+/// tests can control it deterministically.
+///
+/// ```rust,ignore
+/// let markup = time_ago(event.created_at, clock.now(), *tz);
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn time_ago(dt: DateTime<Utc>, now: DateTime<Utc>, tz: Tz) -> maud::Markup {
+    let diff = now.signed_duration_since(dt);
+    let relative = format_relative(diff);
+    let rfc = dt.to_rfc3339();
+    let local = tz.from_utc_datetime(&dt.naive_utc());
+    let display = local.format("%Y-%m-%d %H:%M %Z").to_string();
+    maud::html! {
+        time datetime=(rfc) title=(display) { (relative) }
+    }
+}
+
+fn format_relative(diff: chrono::Duration) -> String {
+    let secs = diff.num_seconds();
+    if secs < 0 {
+        let future = -secs;
+        return if future < 60 {
+            format!("in {future} seconds")
+        } else if future < 3600 {
+            format!("in {} minutes", future / 60)
+        } else if future < 86400 {
+            format!("in {} hours", future / 3600)
+        } else {
+            format!("in {} days", future / 86400)
+        };
+    }
+    if secs < 60 {
+        format!("{secs} seconds ago")
+    } else if secs < 3600 {
+        format!("{} minutes ago", secs / 60)
+    } else if secs < 86400 {
+        format!("{} hours ago", secs / 3600)
+    } else {
+        format!("{} days ago", secs / 86400)
+    }
+}
+
+// ── Form parsing helpers ──────────────────────────────────────────────────────
+
+/// Error returned by [`parse_local_datetime`].
+#[derive(Debug, thiserror::Error)]
+pub enum TimeZoneError {
+    /// The input string did not match `YYYY-MM-DDTHH:MM`.
+    #[error("invalid datetime-local input `{input}`: expected YYYY-MM-DDTHH:MM")]
+    InvalidFormat {
+        /// The string that failed to parse.
+        input: String,
+    },
+    /// The input represents an ambiguous or non-existent local time (DST gap).
+    #[error("local time `{input}` is ambiguous or non-existent in `{zone}`")]
+    AmbiguousLocalTime {
+        /// Original input string.
+        input: String,
+        /// Zone name for the error message.
+        zone: String,
+    },
+}
+
+/// Parse a browser `datetime-local` input value (`YYYY-MM-DDTHH:MM`) as a
+/// time in `tz` and convert it to UTC.
+///
+/// DST ambiguity is resolved by choosing the **earlier** (pre-transition)
+/// interpretation.
+///
+/// # Errors
+///
+/// Returns [`TimeZoneError::InvalidFormat`] for unparseable input and
+/// [`TimeZoneError::AmbiguousLocalTime`] for a non-existent local time
+/// (e.g. a DST gap when clocks spring forward).
+pub fn parse_local_datetime(input: &str, tz: Tz) -> Result<DateTime<Utc>, TimeZoneError> {
+    use chrono::NaiveDateTime;
+    let naive = NaiveDateTime::parse_from_str(input.trim(), "%Y-%m-%dT%H:%M").map_err(|_| {
+        TimeZoneError::InvalidFormat {
+            input: input.to_owned(),
+        }
+    })?;
+    tz.from_local_datetime(&naive)
+        .earliest()
+        .ok_or_else(|| TimeZoneError::AmbiguousLocalTime {
+            input: input.to_owned(),
+            zone: tz.name().to_owned(),
+        })
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+/// Format a UTC timestamp as a `datetime-local` input value (`YYYY-MM-DDTHH:MM`)
+/// in the given zone. Suitable for populating an `<input type="datetime-local">`.
+#[must_use]
+pub fn to_local_input_value(dt: DateTime<Utc>, tz: Tz) -> String {
+    let local = tz.from_utc_datetime(&dt.naive_utc());
+    local.format("%Y-%m-%dT%H:%M").to_string()
+}
+
+/// Maud helper that renders a `<input type="datetime-local">` pre-filled with
+/// the UTC value converted to `tz`.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn datetime_local_input(
+    name: &str,
+    label: &str,
+    dt: Option<DateTime<Utc>>,
+    tz: Tz,
+) -> maud::Markup {
+    let value = dt
+        .map(|d| to_local_input_value(d, tz))
+        .unwrap_or_default();
+    maud::html! {
+        div.field {
+            label for=(name) { (label) }
+            input type="datetime-local" id=(name) name=(name) value=(value);
+        }
+    }
+}
+
+// ── Ambient request zone (task-local) ─────────────────────────────────────────
+
+tokio::task_local! {
+    static AMBIENT_TZ: Tz;
+}
+
+/// Run `fut` with `tz` set as the ambient request-scoped time zone.
+///
+/// Use in mailer templates and job workers to render timestamps in the zone
+/// that was active when the request was handled:
+///
+/// ```rust,ignore
+/// with_request_time_zone(tz.tz(), async move {
+///     mail.deliver_later(&state).await;
+/// })
+/// .await;
+/// ```
+pub async fn with_request_time_zone<F, R>(tz: Tz, fut: F) -> R
+where
+    F: std::future::Future<Output = R>,
+{
+    AMBIENT_TZ.scope(tz, fut).await
+}
+
+/// Read the ambient time zone set by [`with_request_time_zone`], or `UTC` if
+/// none is set.
+#[must_use]
+pub fn ambient_time_zone() -> Tz {
+    AMBIENT_TZ.try_with(|tz| *tz).unwrap_or(Tz::UTC)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use chrono::Timelike;
+
+    fn parts(uri: &str, headers: &[(&str, &str)]) -> axum::http::request::Parts {
+        let mut req = Request::builder().uri(uri);
+        for (k, v) in headers {
+            req = req.header(*k, *v);
+        }
+        let (parts, _) = req.body(Body::empty()).unwrap().into_parts();
+        parts
+    }
+
+    // ── IANA parsing ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_iana_valid_zones() {
+        assert!(parse_iana("UTC").is_some());
+        assert!(parse_iana("America/New_York").is_some());
+        assert!(parse_iana("Asia/Tokyo").is_some());
+        assert!(parse_iana("Europe/London").is_some());
+        assert!(parse_iana("America/Sao_Paulo").is_some());
+    }
+
+    #[test]
+    fn parse_iana_invalid_zones() {
+        assert!(parse_iana("Mars/Phobos").is_none());
+        assert!(parse_iana("").is_none());
+        assert!(parse_iana("garbage").is_none());
+        assert!(parse_iana("Not/A/Zone").is_none());
+    }
+
+    #[test]
+    fn parse_iana_trims_whitespace() {
+        assert!(parse_iana("  UTC  ").is_some());
+        assert!(parse_iana("  America/New_York  ").is_some());
+    }
+
+    // ── Config ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn config_default_is_utc() {
+        let cfg = TimeZoneConfig::default();
+        assert_eq!(cfg.identifier, "UTC");
+        assert_eq!(cfg.default_tz(), Tz::UTC);
+    }
+
+    #[test]
+    fn config_validate_accepts_valid_identifier() {
+        let cfg = TimeZoneConfig {
+            identifier: "America/New_York".to_owned(),
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn config_validate_rejects_unknown_identifier() {
+        let cfg = TimeZoneConfig {
+            identifier: "Mars/Phobos".to_owned(),
+            ..Default::default()
+        };
+        let err = cfg.validate().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Mars/Phobos"),
+            "error should mention the bad identifier: {msg}"
+        );
+    }
+
+    #[test]
+    fn config_default_sources_order() {
+        let cfg = TimeZoneConfig::default();
+        assert_eq!(
+            cfg.sources,
+            vec![Source::User, Source::Session, Source::Cookie, Source::Query]
+        );
+    }
+
+    // ── Query resolution ──────────────────────────────────────────────────────
+
+    #[test]
+    fn query_param_resolves_valid_zone() {
+        let p = parts("/?tz=Asia/Tokyo", &[]);
+        let result = resolve_from_query(&p);
+        assert_eq!(result, Some(Tz::Asia__Tokyo));
+    }
+
+    #[test]
+    fn query_param_ignores_invalid_zone() {
+        let p = parts("/?tz=Mars/Phobos", &[]);
+        assert!(resolve_from_query(&p).is_none());
+    }
+
+    #[test]
+    fn query_param_absent_returns_none() {
+        let p = parts("/", &[]);
+        assert!(resolve_from_query(&p).is_none());
+    }
+
+    // ── Cookie resolution ─────────────────────────────────────────────────────
+
+    #[test]
+    fn cookie_resolves_valid_zone() {
+        let p = parts("/", &[("Cookie", "autumn_time_zone=America/Chicago")]);
+        let result = resolve_from_cookie(&p);
+        assert_eq!(result, Some(Tz::America__Chicago));
+    }
+
+    #[test]
+    fn cookie_ignores_other_cookies() {
+        let p = parts("/", &[("Cookie", "session=abc; autumn_time_zone=UTC; other=x")]);
+        let result = resolve_from_cookie(&p);
+        assert_eq!(result, Some(Tz::UTC));
+    }
+
+    #[test]
+    fn cookie_invalid_zone_returns_none() {
+        let p = parts("/", &[("Cookie", "autumn_time_zone=garbage")]);
+        assert!(resolve_from_cookie(&p).is_none());
+    }
+
+    #[test]
+    fn cookie_absent_returns_none() {
+        let p = parts("/", &[]);
+        assert!(resolve_from_cookie(&p).is_none());
+    }
+
+    // ── Cookie helper ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn set_time_zone_cookie_produces_correct_header() {
+        let header = set_time_zone_cookie("America/New_York");
+        assert!(header.starts_with("autumn_time_zone=America/New_York"));
+        assert!(header.contains("Path=/"));
+        assert!(header.contains("Max-Age=31536000"));
+        assert!(header.contains("SameSite=Lax"));
+    }
+
+    #[test]
+    fn set_time_zone_cookie_encodes_special_chars() {
+        // '+' is safe per our allow-list; space should be encoded
+        let header = set_time_zone_cookie("Etc/UTC");
+        assert!(header.contains("Etc/UTC"));
+    }
+
+    // ── UserTimeZone extractor ────────────────────────────────────────────────
+
+    #[test]
+    fn user_time_zone_newtype_roundtrips() {
+        let utz = UserTimeZone(Tz::Asia__Tokyo);
+        assert_eq!(utz.0, Tz::Asia__Tokyo);
+    }
+
+    // ── TimeZone struct ───────────────────────────────────────────────────────
+
+    #[test]
+    fn time_zone_new_constructor() {
+        let tz = TimeZone::new(Tz::UTC);
+        assert_eq!(tz.tz(), Tz::UTC);
+        assert_eq!(*tz, Tz::UTC);
+    }
+
+    #[test]
+    fn time_zone_iana_returns_name() {
+        let tz = TimeZone::new(Tz::America__New_York);
+        assert_eq!(tz.iana(), "America/New_York");
+    }
+
+    #[test]
+    fn time_zone_convert_uses_given_zone() {
+        use chrono::TimeZone as ChrTz;
+        let utc = chrono::Utc.with_ymd_and_hms(2025, 6, 14, 12, 0, 0).unwrap();
+        let tz = TimeZone::new(Tz::America__New_York);
+        let local = tz.convert(utc);
+        // New York is UTC-4 in June (EDT)
+        assert_eq!(local.hour(), 8);
+    }
+
+    // ── Form parsing ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_local_datetime_tokyo() {
+        // 15:30 in Tokyo (UTC+9) → 06:30 UTC
+        let result = parse_local_datetime("2025-06-14T15:30", Tz::Asia__Tokyo).unwrap();
+        assert_eq!(result.hour(), 6);
+        assert_eq!(result.minute(), 30);
+    }
+
+    #[test]
+    fn parse_local_datetime_new_york_summer() {
+        // 12:00 in New York (UTC-4 in summer) → 16:00 UTC
+        let result = parse_local_datetime("2025-06-14T12:00", Tz::America__New_York).unwrap();
+        assert_eq!(result.hour(), 16);
+        assert_eq!(result.minute(), 0);
+    }
+
+    #[test]
+    fn parse_local_datetime_invalid_format() {
+        let err = parse_local_datetime("not-a-date", Tz::UTC).unwrap_err();
+        assert!(matches!(err, TimeZoneError::InvalidFormat { .. }));
+    }
+
+    #[test]
+    fn to_local_input_value_roundtrip() {
+        let zones = [Tz::UTC, Tz::America__New_York, Tz::Asia__Tokyo];
+        for tz in zones {
+            let original = "2025-06-14T15:30";
+            let utc = parse_local_datetime(original, tz).unwrap();
+            let back = to_local_input_value(utc, tz);
+            assert_eq!(back, original, "roundtrip failed for {}", tz.name());
+        }
+    }
+
+    #[test]
+    fn to_local_input_value_formats_correctly() {
+        use chrono::TimeZone as ChrTz;
+        let utc = chrono::Utc.with_ymd_and_hms(2025, 6, 14, 6, 30, 0).unwrap();
+        assert_eq!(to_local_input_value(utc, Tz::Asia__Tokyo), "2025-06-14T15:30");
+        assert_eq!(to_local_input_value(utc, Tz::UTC), "2025-06-14T06:30");
+    }
+
+    // ── Maud view helpers ─────────────────────────────────────────────────────
+
+    #[cfg(feature = "maud")]
+    mod maud_tests {
+        use super::*;
+        use chrono::TimeZone as ChrTz;
+
+        #[allow(clippy::many_single_char_names)]
+        fn utc(y: i32, mo: u32, d: u32, h: u32, m: u32, s: u32) -> DateTime<Utc> {
+            chrono::Utc.with_ymd_and_hms(y, mo, d, h, m, s).unwrap()
+        }
+
+        #[test]
+        fn local_datetime_uses_zone() {
+            let dt = utc(2025, 6, 14, 12, 0, 0);
+            let utc_html = local_datetime(dt, Tz::UTC).into_string();
+            let tokyo_html = local_datetime(dt, Tz::Asia__Tokyo).into_string();
+            let ny_html = local_datetime(dt, Tz::America__New_York).into_string();
+            // Each zone yields a different visible time
+            assert!(utc_html.contains("12:00"), "UTC: {utc_html}");
+            assert!(tokyo_html.contains("21:00"), "Tokyo: {tokyo_html}");
+            assert!(ny_html.contains("08:00"), "New York: {ny_html}");
+        }
+
+        #[test]
+        fn local_datetime_datetime_attr_is_utc() {
+            let dt = utc(2025, 6, 14, 12, 0, 0);
+            let html = local_datetime(dt, Tz::Asia__Tokyo).into_string();
+            // The machine-readable datetime attr should include the UTC timestamp
+            assert!(
+                html.contains("2025-06-14T12:00:00"),
+                "datetime attr must be UTC: {html}"
+            );
+        }
+
+        #[test]
+        fn local_date_uses_zone() {
+            // Close to midnight UTC — the date differs by zone
+            let dt = utc(2025, 6, 14, 23, 30, 0); // Jun 14 23:30 UTC = Jun 15 08:30 Tokyo
+            let utc_html = local_date(dt, Tz::UTC).into_string();
+            let tokyo_html = local_date(dt, Tz::Asia__Tokyo).into_string();
+            assert!(utc_html.contains("2025-06-14"), "UTC: {utc_html}");
+            assert!(tokyo_html.contains("2025-06-15"), "Tokyo: {tokyo_html}");
+        }
+
+        #[test]
+        fn time_ago_seconds() {
+            let now = utc(2025, 6, 14, 12, 0, 30);
+            let dt = utc(2025, 6, 14, 12, 0, 0);
+            let html = time_ago(dt, now, Tz::UTC).into_string();
+            assert!(html.contains("seconds ago"), "{html}");
+        }
+
+        #[test]
+        fn time_ago_minutes() {
+            let now = utc(2025, 6, 14, 12, 5, 0);
+            let dt = utc(2025, 6, 14, 12, 0, 0);
+            let html = time_ago(dt, now, Tz::UTC).into_string();
+            assert!(html.contains("minutes ago"), "{html}");
+        }
+
+        #[test]
+        fn time_ago_hours() {
+            let now = utc(2025, 6, 14, 14, 0, 0);
+            let dt = utc(2025, 6, 14, 12, 0, 0);
+            let html = time_ago(dt, now, Tz::UTC).into_string();
+            assert!(html.contains("hours ago"), "{html}");
+        }
+
+        #[test]
+        fn time_ago_days() {
+            let now = utc(2025, 6, 16, 12, 0, 0);
+            let dt = utc(2025, 6, 14, 12, 0, 0);
+            let html = time_ago(dt, now, Tz::UTC).into_string();
+            assert!(html.contains("days ago"), "{html}");
+        }
+
+        #[test]
+        fn time_ago_future_minutes() {
+            let now = utc(2025, 6, 14, 12, 0, 0);
+            let dt = utc(2025, 6, 14, 12, 5, 0);
+            let html = time_ago(dt, now, Tz::UTC).into_string();
+            assert!(html.contains("in "), "{html}");
+            assert!(html.contains("minutes"), "{html}");
+        }
+
+        #[test]
+        fn time_ago_preserves_utc_datetime_attr() {
+            let now = utc(2025, 6, 14, 12, 5, 0);
+            let dt = utc(2025, 6, 14, 12, 0, 0);
+            let html = time_ago(dt, now, Tz::UTC).into_string();
+            assert!(html.contains("datetime="), "{html}");
+        }
+    }
+
+    // ── Ambient TZ ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn ambient_time_zone_defaults_to_utc() {
+        assert_eq!(ambient_time_zone(), Tz::UTC);
+    }
+
+    #[tokio::test]
+    async fn with_request_time_zone_sets_ambient() {
+        let result = with_request_time_zone(Tz::Asia__Tokyo, async {
+            ambient_time_zone()
+        })
+        .await;
+        assert_eq!(result, Tz::Asia__Tokyo);
+    }
+
+    #[tokio::test]
+    async fn ambient_returns_utc_outside_scope() {
+        // Inside scope
+        let inside = with_request_time_zone(Tz::America__New_York, async {
+            ambient_time_zone()
+        })
+        .await;
+        // Outside scope
+        let outside = ambient_time_zone();
+        assert_eq!(inside, Tz::America__New_York);
+        assert_eq!(outside, Tz::UTC);
+    }
+}

--- a/autumn/tests/time_zone_integration.rs
+++ b/autumn/tests/time_zone_integration.rs
@@ -1,0 +1,90 @@
+//! Integration tests for the `TimeZone` extractor and Maud view helpers.
+//!
+//! Demonstrates that `Clock` and `TimeZone` compose deterministically in
+//! `TestApp`, letting tests drive three zones with zero sleeps.
+
+use autumn_web::prelude::*;
+use autumn_web::test::TestApp;
+use autumn_web::time::FixedClock;
+use autumn_web::time_zone::{TimeZone, local_datetime};
+use chrono::{TimeZone as ChrTz, Utc};
+
+// ── Handler under test ────────────────────────────────────────────────────────
+
+/// Renders a fixed UTC timestamp as local time in the request's zone.
+#[get("/local")]
+async fn show_local(clock: Clock, tz: TimeZone) -> Markup {
+    html! { p { (local_datetime(clock.now(), *tz)) } }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Three zones → three distinct, correctly formatted bodies from one handler.
+#[tokio::test]
+async fn three_zones_produce_distinct_local_times() {
+    let pinned = Utc.with_ymd_and_hms(2025, 6, 14, 12, 0, 0).unwrap();
+    let client = TestApp::new()
+        .routes(routes![show_local])
+        .with_clock(FixedClock::at(pinned))
+        .build();
+
+    let utc_body = client.get("/local?tz=UTC").send().await.assert_ok().text();
+    let ny_body = client
+        .get("/local?tz=America/New_York")
+        .send()
+        .await
+        .assert_ok()
+        .text();
+    let tok_body = client
+        .get("/local?tz=Asia/Tokyo")
+        .send()
+        .await
+        .assert_ok()
+        .text();
+
+    // UTC: 12:00 UTC
+    assert!(utc_body.contains("12:00"), "UTC body: {utc_body}");
+    // New York: UTC-4 in June (EDT) → 08:00
+    assert!(ny_body.contains("08:00"), "New York body: {ny_body}");
+    // Tokyo: UTC+9 → 21:00
+    assert!(tok_body.contains("21:00"), "Tokyo body: {tok_body}");
+
+    // All three bodies differ
+    assert_ne!(utc_body, ny_body);
+    assert_ne!(utc_body, tok_body);
+    assert_ne!(ny_body, tok_body);
+}
+
+/// `Clock` and `TimeZone` compose: both are deterministic and independent.
+#[tokio::test]
+async fn clock_and_time_zone_compose_deterministically() {
+    let pinned = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+    let client = TestApp::new()
+        .routes(routes![show_local])
+        .with_clock(FixedClock::at(pinned))
+        .build();
+
+    // Tokyo is UTC+9, so midnight UTC = 09:00 Tokyo on Jan 1
+    let body = client
+        .get("/local?tz=Asia/Tokyo")
+        .send()
+        .await
+        .assert_ok()
+        .text();
+    assert!(body.contains("09:00"), "body: {body}");
+    // Machine-readable attr must still be UTC
+    assert!(body.contains("2025-01-01T00:00:00"), "body: {body}");
+}
+
+/// Without any zone override, the extractor falls back to UTC (default config).
+#[tokio::test]
+async fn falls_back_to_utc_when_no_zone_provided() {
+    let pinned = Utc.with_ymd_and_hms(2025, 6, 14, 15, 30, 0).unwrap();
+    let client = TestApp::new()
+        .routes(routes![show_local])
+        .with_clock(FixedClock::at(pinned))
+        .build();
+
+    let body = client.get("/local").send().await.assert_ok().text();
+    assert!(body.contains("15:30"), "UTC fallback body: {body}");
+}

--- a/docs/guide/time-zones.md
+++ b/docs/guide/time-zones.md
@@ -179,7 +179,9 @@ job::send_report(user.id, tz.iana()).enqueue(&state).await?;
 async fn send_report(user_id: i64, tz_name: String, state: AppState) {
     let tz = autumn_web::time_zone::parse_iana(&tz_name).unwrap_or(Tz::UTC);
     with_request_time_zone(tz, async move {
-        // local_datetime helpers automatically pick up the ambient zone
+        // Pass the captured zone to the view helpers explicitly; the ambient
+        // zone set above is available via `ambient_time_zone()` if you'd rather
+        // read it inside a deeply-nested renderer.
         let body = render_report(user_id, &state, tz).await;
         // ...
     }).await;

--- a/docs/guide/time-zones.md
+++ b/docs/guide/time-zones.md
@@ -1,0 +1,249 @@
+# Per-user time zones
+
+Autumn ships a `TimeZone` extractor that resolves the requesting user's IANA
+time zone and makes it available in handlers as a first-class parameter. Pair
+it with the `Clock` extractor for fully deterministic, test-injectable date/time
+rendering — no globals, no `Utc::now()` calls in templates.
+
+> **Status:** ships in `v0.5.x` always-on (no Cargo feature needed). `chrono`
+> and `chrono-tz` are unconditional dependencies, so the extractor adds zero
+> overhead to apps that don't use it.
+
+---
+
+## Quick start
+
+### 1. (Optional) Configure the app default
+
+```toml
+# autumn.toml
+[time_zone]
+identifier = "America/New_York"   # IANA id; defaults to "UTC"
+```
+
+If the block is omitted, the default falls back to `UTC`.
+
+### 2. Use `TimeZone` in a handler
+
+```rust,ignore
+use autumn_web::prelude::*;
+use autumn_web::time_zone::local_datetime;
+
+#[get("/events")]
+async fn events_index(clock: Clock, tz: TimeZone) -> Markup {
+    let now = clock.now();
+    html! {
+        p { "Current time: " (local_datetime(now, *tz)) }
+    }
+}
+```
+
+That's it. No TZ-conversion code inside the handler — `TimeZone` resolves the
+zone for you and `local_datetime` renders a semantic `<time>` element.
+
+### 3. Wire your auth middleware to set the user's zone
+
+When a user has a stored `time_zone` preference, insert it into request
+extensions so the resolver picks it up automatically:
+
+```rust,ignore
+// In your current-user middleware:
+if let Some(tz_str) = &user.time_zone {
+    if let Some(tz) = autumn_web::time_zone::parse_iana(tz_str) {
+        parts.extensions.insert(UserTimeZone(tz));
+    }
+}
+```
+
+The `time_zone` column is generated automatically for you if you scaffold your
+auth with `autumn generate auth` (see §User model below).
+
+---
+
+## Resolution order
+
+The `TimeZone` extractor walks the request in this order, returning the first
+valid IANA zone found:
+
+1. **`UserTimeZone` extension** — inserted by your auth middleware for the
+   authenticated user's stored preference (highest priority).
+2. **Signed session** — `autumn_time_zone` key in the HMAC-signed session
+   cookie, set via `autumn_web::time_zone::set_time_zone_in_session`.
+3. **Plain cookie** — unsigned `autumn_time_zone=<iana>` cookie, set via
+   `set_time_zone_cookie`. Useful when sessions are not enabled.
+4. **`?tz=<iana>` query parameter** — developer/test override.
+
+If none of the above yields a valid zone, the configured `default_locale`
+(from `[time_zone]` in `autumn.toml`) is used. If no config is present,
+`UTC` is the ultimate fallback.
+
+The order is stable. Applications can rely on it.
+
+### Implementing a zone switcher
+
+```rust,ignore
+use autumn_web::time_zone::set_time_zone_in_session;
+
+#[post("/tz/{tz}")]
+async fn switch_tz(session: Session, Path(tz): Path<String>) -> impl IntoResponse {
+    set_time_zone_in_session(&session, &tz).await;
+    Redirect::to("/")
+}
+```
+
+---
+
+## View helpers
+
+All helpers live in `autumn_web::time_zone` and are re-exported from
+`autumn_web::prelude` (gated on the `maud` feature).
+
+### `local_datetime(dt, tz)`
+
+Renders a `<time datetime="<rfc3339-utc>">YYYY-MM-DD HH:MM TZ</time>` element.
+The `datetime` attribute is always UTC for machine readers.
+
+```rust,ignore
+(local_datetime(clock.now(), *tz))
+```
+
+### `local_date(dt, tz)`
+
+Same but shows only the date (`YYYY-MM-DD`). Useful when the time-of-day is
+irrelevant.
+
+### `time_ago(dt, now, tz)`
+
+Renders a relative string ("3 minutes ago", "in 2 hours"). Pass `clock.now()`
+as `now` so tests can freeze it.
+
+```rust,ignore
+(time_ago(post.created_at, clock.now(), *tz))
+```
+
+---
+
+## Form round-trip: `datetime-local` inputs
+
+Browser `<input type="datetime-local">` values have no offset — they are
+interpreted as local time in the user's zone. Autumn provides two helpers for a
+lossless round-trip:
+
+```rust,ignore
+use autumn_web::time_zone::{parse_local_datetime, to_local_input_value};
+
+// Incoming form POST: parse "2025-06-14T15:30" as Tokyo time → UTC
+let utc: DateTime<Utc> = parse_local_datetime(&form.starts_at, Tz::Asia__Tokyo)?;
+
+// Repopulating the form: UTC → Tokyo local string
+let input_value = to_local_input_value(stored_utc, *tz);
+```
+
+Round-trip is lossless to minute granularity (the resolution of
+`datetime-local`).
+
+---
+
+## User model: the `time_zone` column
+
+`autumn generate auth` automatically adds a `time_zone TEXT NULL` column to the
+generated users table, a `pub time_zone: Option<String>` field on the model,
+and the corresponding Diesel schema entry. No extra flags needed.
+
+```sql
+-- Generated migration (excerpt)
+CREATE TABLE users (
+    id BIGSERIAL PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    time_zone TEXT NULL,        -- IANA id, e.g. "America/New_York"
+    password_digest TEXT NOT NULL,
+    ...
+);
+```
+
+---
+
+## Using in `#[mailer]` and `#[job]`
+
+Capture the zone at enqueue time and re-establish it when the background
+task renders:
+
+```rust,ignore
+use autumn_web::time_zone::{with_request_time_zone, ambient_time_zone};
+
+// In your handler — capture the zone and pass it into the job:
+job::send_report(user.id, tz.iana()).enqueue(&state).await?;
+
+// In the job handler — re-enter the zone:
+#[job]
+async fn send_report(user_id: i64, tz_name: String, state: AppState) {
+    let tz = autumn_web::time_zone::parse_iana(&tz_name).unwrap_or(Tz::UTC);
+    with_request_time_zone(tz, async move {
+        // local_datetime helpers automatically pick up the ambient zone
+        let body = render_report(user_id, &state, tz).await;
+        // ...
+    }).await;
+}
+```
+
+---
+
+## Testing
+
+Pin both clock and zone for fully deterministic tests:
+
+```rust,ignore
+use autumn_web::test::TestApp;
+use autumn_web::time::FixedClock;
+use chrono::{TimeZone as _, Utc};
+
+#[tokio::test]
+async fn report_shows_tokyo_time() {
+    let pinned = Utc.with_ymd_and_hms(2025, 6, 14, 12, 0, 0).unwrap();
+    let client = TestApp::new()
+        .routes(routes![my_handler])
+        .with_clock(FixedClock::at(pinned))
+        .build();
+
+    // Drive with ?tz= to override the zone without any DB user
+    let body = client.get("/report?tz=Asia/Tokyo").send().await.text();
+    assert!(body.contains("21:00")); // 12:00 UTC = 21:00 Tokyo
+}
+```
+
+---
+
+## Config fail-fast
+
+An invalid `identifier` in `autumn.toml` causes the app to fail at startup
+rather than at the first request:
+
+```toml
+[time_zone]
+identifier = "Mars/Phobos"  # → ConfigError::Validation at load time
+```
+
+```text
+error: time_zone identifier `Mars/Phobos` is not a valid IANA time zone
+```
+
+---
+
+## Out of scope
+
+- DST-aware scheduling ("fire at 9 AM local time every weekday"). Use a
+  cron-with-tz library for that; the extractor only handles rendering.
+- Right-to-left date ordering. Configure your locale's date format in the
+  template layer.
+- `datetime-local` inputs with seconds precision. The browser format is
+  `HH:MM`; sub-minute offsets are dropped.
+- Hot-reloading the `[time_zone]` config. Restart the app to pick up changes.
+
+---
+
+## See also
+
+- [`autumn_web::time_zone`](https://docs.rs/autumn-web/latest/autumn_web/time_zone/index.html) — full API reference.
+- [`autumn_web::time::Clock`](https://docs.rs/autumn-web/latest/autumn_web/time/struct.Clock.html) — injectable clock, compose with `TimeZone`.
+- [docs/guide/i18n.md](./i18n.md) — locale-aware text rendering.
+- [Project chrono-tz](https://docs.rs/chrono-tz) — the IANA database backing `parse_iana`.


### PR DESCRIPTION
## Summary

Introduces a new `TimeZone` extractor that resolves the requesting user's IANA time zone and makes it available as a first-class handler parameter. The extractor walks a configurable resolution chain (user extension → session → cookie → query parameter) and falls back to a configured default (UTC by default). Pairs seamlessly with the existing `Clock` extractor for fully deterministic, test-injectable date/time rendering.

## Key Changes

- **New `time_zone` module** (`autumn/src/time_zone.rs`): 
  - `TimeZone` extractor implementing `FromRequestParts` for Axum
  - `UserTimeZone` newtype for auth middleware to publish authenticated user zones
  - `TimeZoneConfig` struct with validation and configurable resolution sources
  - IANA parsing via `parse_iana()` with `chrono-tz`
  - Session/cookie persistence helpers: `set_time_zone_in_session()`, `set_time_zone_cookie()`
  - Form round-trip helpers: `parse_local_datetime()`, `to_local_input_value()`
  - Maud view helpers (gated on `maud` feature): `local_datetime()`, `local_date()`, `time_ago()`, `datetime_local_input()`
  - Task-local ambient zone support for mailers/jobs: `with_request_time_zone()`, `ambient_time_zone()`
  - Comprehensive unit tests covering IANA parsing, config validation, query/cookie resolution, form parsing, and view rendering

- **Config integration** (`autumn/src/config.rs`):
  - Added `time_zone: TimeZoneConfig` field to `AutumnConfig`
  - Supports `[time_zone]` block in `autumn.toml` with `identifier` and `sources` keys
  - Shorthand syntax: `time_zone = "America/New_York"` for just the identifier

- **Prelude exports** (`autumn/src/prelude.rs`):
  - Re-exported `TimeZone`, `UserTimeZone`, and Maud view helpers for ergonomic access

- **Auth scaffolding** (`autumn-cli/src/generate/auth.rs`, `autumn-cli/tests/generate.rs`):
  - Generated users table now includes `time_zone TEXT NULL` column
  - Generated user model includes `pub time_zone: Option<String>` field
  - Diesel schema updated automatically

- **Module registration** (`autumn/src/lib.rs`):
  - Added `pub mod time_zone` to library exports

- **Documentation** (`docs/guide/time-zones.md`):
  - Comprehensive guide covering quick start, resolution order, view helpers, form round-trips, user model integration, background job usage, testing patterns, and config validation

- **Integration tests** (`autumn/tests/time_zone_integration.rs`):
  - Demonstrates `Clock` and `TimeZone` composing deterministically in `TestApp`
  - Tests three zones producing distinct local times from one handler
  - Validates fallback to UTC when no zone is provided

## Notable Implementation Details

- **Resolution chain is stable and configurable**: Default order is User → Session → Cookie → Query, but can be customized via `TimeZoneConfig::sources`
- **DST handling**: `parse_local_datetime()` resolves ambiguous times (DST gaps) by choosing the earlier interpretation
- **Deterministic testing**: Both `Clock` and `TimeZone` are injectable, allowing tests to pin both time and zone without sleeps
- **Zero overhead for non-users**: `chrono` and `chrono-tz` are unconditional dependencies (already required by scheduler), so the extractor adds no new transitive deps
- **Fail-fast config validation**: Invalid IANA identifiers in `autumn.toml` cause startup errors, not runtime failures
- **Task-local ambient zone**: Allows mailers and background jobs to capture and re-establish the zone that was active during request handling

https://claude.ai/code/session_019GuYPK77qxXeEnHWXiTNRd