### PR TITLE
🗣️ Echo: [DX Audit fixes for content-length and Tailwind]

### DIFF
--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -802,9 +802,11 @@ fn restart_server(
 
 fn tailwind_build() -> bool {
     let Some(mut cmd) = build_tailwind_command() else {
-        eprintln!(
-            "  \u{2717} Tailwind CSS CLI not found. Run `autumn setup` or install `tailwindcss`."
-        );
+        if crate::doctor::tailwind_enabled() {
+            eprintln!(
+                "  \u{2717} Tailwind CSS CLI not found. Run `autumn setup` or install `tailwindcss`."
+            );
+        }
         return false;
     };
 

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1717,7 +1717,7 @@ fn resolve_is_production() -> bool {
 ///
 /// Falls back to a heuristic: if `build.rs` exists the project is assumed to
 /// use the Tailwind build pipeline.
-pub(crate) fn tailwind_enabled() -> bool {
+pub fn tailwind_enabled() -> bool {
     std::fs::read_to_string("autumn.toml")
         .ok()
         .and_then(|c| toml::from_str::<toml::Table>(&c).ok())

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1717,7 +1717,7 @@ fn resolve_is_production() -> bool {
 ///
 /// Falls back to a heuristic: if `build.rs` exists the project is assumed to
 /// use the Tailwind build pipeline.
-fn tailwind_enabled() -> bool {
+pub(crate) fn tailwind_enabled() -> bool {
     std::fs::read_to_string("autumn.toml")
         .ok()
         .and_then(|c| toml::from_str::<toml::Table>(&c).ok())

--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -934,11 +934,17 @@ impl IntoResponse for AutumnError {
 
         let mut builder = Response::builder()
             .status(status)
-            .header(header::CONTENT_TYPE, HeaderValue::from_static("application/problem+json"))
+            .header(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/problem+json"),
+            )
             .header(header::CONTENT_LENGTH, content_length.to_string());
 
         if status == StatusCode::CONFLICT {
-            builder = builder.header("HX-Trigger", HeaderValue::from_static(r#"{"autumn:conflict":true}"#));
+            builder = builder.header(
+                "HX-Trigger",
+                HeaderValue::from_static(r#"{"autumn:conflict":true}"#),
+            );
         }
 
         let mut response = builder.body(axum::body::Body::from(body_bytes)).unwrap();

--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -928,17 +928,21 @@ impl IntoResponse for AutumnError {
             None,
             true,
         );
-        let mut response = (status, axum::Json(body)).into_response();
-        response.headers_mut().insert(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/problem+json"),
-        );
+
+        let body_bytes = serde_json::to_vec(&body).unwrap_or_default();
+        let content_length = body_bytes.len();
+
+        let mut builder = Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, HeaderValue::from_static("application/problem+json"))
+            .header(header::CONTENT_LENGTH, content_length.to_string());
+
         if status == StatusCode::CONFLICT {
-            response.headers_mut().insert(
-                "HX-Trigger",
-                HeaderValue::from_static(r#"{"autumn:conflict":true}"#),
-            );
+            builder = builder.header("HX-Trigger", HeaderValue::from_static(r#"{"autumn:conflict":true}"#));
         }
+
+        let mut response = builder.body(axum::body::Body::from(body_bytes)).unwrap();
+
         if cache_idempotency_response {
             response
                 .extensions_mut()


### PR DESCRIPTION
🗣️ Echo: [DX Audit fixes for content-length and Tailwind]

1. EXPERIENCE
- Ran the README Run and setup a basic project, hit missing routes, and observed CLI warnings without Tailwind setup.

2. STUMBLE
- Requesting a missing route (404) returned `content-length: 0` despite having a JSON payload format, breaking client expectations.
- Running `autumn dev` logged a warning "Tailwind CSS CLI not found" even when Tailwind wasn't actually enabled for the project.

3. REPORT
- The `AutumnError::into_response` construction using `axum::Json(body)` silently dropped headers (including `content-length`) inside fallback handlers.
- The dev CLI indiscriminately warned about Tailwind without checking `tailwind_enabled()`.

4. VERIFY
- Switched to `axum::response::Response::builder()` to manually assign `content-length`.
- Exposed `tailwind_enabled()` as `pub(crate)` and wrapped the dev warning condition.
- Verified fixes using `curl` and `cargo test`.

---
*PR created automatically by Jules for task [6335466616155333680](https://jules.google.com/task/6335466616155333680) started by @madmax983*