### PR TITLE
👺 Havoc: [SQL Scrubber Overlapping Match Bug]

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -307,10 +307,15 @@ fn consume_dollar_quoted_body(chars: &mut std::iter::Peekable<std::str::Chars<'_
                 break; // Found the closing delimiter.
             }
         } else {
+            let mut failed_match = closing[0..match_count].to_vec();
+            failed_match.push(sc);
+
             match_count = 0;
-            // The current char may start a new partial match.
-            if sc == closing[0] {
-                match_count = 1;
+            for i in (1..=failed_match.len()).rev() {
+                if failed_match[failed_match.len() - i..] == closing[0..i] {
+                    match_count = i;
+                    break;
+                }
             }
         }
     }

--- a/autumn/tests/chaos_scrub_sql_fuzz.rs
+++ b/autumn/tests/chaos_scrub_sql_fuzz.rs
@@ -1,0 +1,31 @@
+use autumn_web::db::scrub_sql;
+
+#[test]
+fn test_scrub_sql_fuzz() {
+    proptest::proptest!(|(s in "\\PC*")| {
+        let _ = scrub_sql(&s);
+    });
+}
+
+#[test]
+fn test_scrub_sql_overlapping_dollar_quotes() {
+    // This case will hang or panic (in previous impls) or incorrectly parse
+    // if overlapping matches are not handled correctly.
+    let cases = vec![
+        ("$tag$$t$tag$", "'?'"),
+        ("$tag$$t$$tag$", "'?'"),
+        ("$tag$$t$t$tag$", "'?'"),
+        ("$tag$$ta$tag$", "'?'"),
+        ("$$$$$$$$", "'?''?'"),
+        ("$t$$t$t$", "'?'t$"),
+        (
+            "SELECT * FROM users WHERE note = $tag$$ta$tag$",
+            "SELECT * FROM users WHERE note = '?'",
+        ),
+    ];
+
+    for (input, expected) in cases {
+        let scrubbed = scrub_sql(input);
+        assert_eq!(scrubbed, expected, "Failed for input: {}", input);
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:**
Supplying a string that creates overlapping string matches for the closing dollar-quote tag, such as `"$tag$$ta$tag$"`. When parsing the inner `$ta$tag$` assuming it's the tag, the parser checks `$`, then `t`, then `a`. Since `a` doesn't match `g`, it used to completely abandon the match and reset its count back to 0 (or 1 if the current character matches the start of the pattern). This resulted in ignoring the actual legitimate tag matching boundary, causing it to potentially skip over actual string delimiters and fail to scrub data within strings or incorrectly attempt to parse subsequent valid SQL logic as strings.

📉 **The Stack Trace:**
N/A (No stack trace was directly triggered here, but an assertion failure occurs when expected scrubbing results differ from the actual unscrubbed output)
`assert_eq!(scrubbed, expected, "Failed for input: {}", input);`

🧪 **Reproduction:**
Run `cargo test -p autumn-web --test chaos_scrub_sql_fuzz`

😈 **Comment:**
You assumed your sliding window failure could reset to zero. You were wrong. If a partial match of `"$tag$"` fails on the `g`, the preceding characters might just be the start of a new `"$tag$"`. Handled properly via dynamic longest-suffix-prefix prefix fallback. Always expect overlapping noise.

---
*PR created automatically by Jules for task [17951149188445009268](https://jules.google.com/task/17951149188445009268) started by @madmax983*