### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/autumn/src/authorization.rs
+++ b/autumn/src/authorization.rs
@@ -63,6 +63,15 @@ use crate::session::Session;
 /// Boxed future returned by [`Policy`] and [`Scope`] methods so the
 /// traits remain object-safe (`dyn Policy<R>` works regardless of
 /// rust edition).
+pub trait ProvideAuthorizationState: Send + Sync {
+    fn auth_session_key(&self) -> &str;
+    fn policy_registry(&self) -> &PolicyRegistry;
+    fn forbidden_response(&self) -> ForbiddenResponse;
+
+    #[cfg(feature = "db")]
+    fn pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>;
+}
+
 pub type BoxFuture<'a, T> = Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
 
 // ── PolicyContext ────────────────────────────────────────────────
@@ -130,7 +139,7 @@ impl PolicyContext {
     /// Build a fully-populated [`PolicyContext`] from `AppState` +
     /// `Session`. Used by the `#[authorize]` macro and
     /// `#[repository(policy = ...)]`-generated handlers.
-    pub async fn from_request(state: &crate::AppState, session: &Session) -> Self {
+    pub async fn from_request(state: &dyn ProvideAuthorizationState, session: &Session) -> Self {
         let mut ctx = Self::from_session(session, state.auth_session_key()).await;
         ctx.policy_registry = state.policy_registry().clone();
         #[cfg(feature = "db")]
@@ -621,7 +630,7 @@ impl<'de> serde::Deserialize<'de> for ForbiddenResponse {
 /// }
 /// ```
 pub async fn authorize<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
     action: &str,
     resource: &R,
@@ -651,7 +660,7 @@ where
 /// the public API** — call [`authorize`] from user code.
 #[doc(hidden)]
 pub async fn __check_policy<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
     action: &str,
     resource: &R,
@@ -673,7 +682,7 @@ where
 /// alias for older macro output.
 #[doc(hidden)]
 pub async fn __check_policy_create<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
 ) -> crate::AutumnResult<()>
 where
@@ -692,7 +701,7 @@ where
 /// only `autumn-web` is upgraded.
 #[doc(hidden)]
 pub async fn __check_policy_create_payload<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
     payload: &serde_json::Value,
 ) -> crate::AutumnResult<()>
@@ -713,7 +722,7 @@ where
 /// Returns the configured deny response when the policy denies.
 /// Returns `500` when no policy is registered for `R`.
 pub async fn authorize_create<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
 ) -> crate::AutumnResult<()>
 where
@@ -749,7 +758,7 @@ where
 /// Returns the configured deny response when the policy denies.
 /// Returns `500` when no policy is registered for `R`.
 pub async fn authorize_create_payload<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
     payload: &serde_json::Value,
 ) -> crate::AutumnResult<()>

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -1071,3 +1071,22 @@ mod tests {
         assert_eq!(stored.as_str(), "haunted");
     }
 }
+
+impl crate::authorization::ProvideAuthorizationState for AppState {
+    fn auth_session_key(&self) -> &str {
+        self.auth_session_key()
+    }
+
+    fn policy_registry(&self) -> &crate::authorization::PolicyRegistry {
+        self.policy_registry()
+    }
+
+    fn forbidden_response(&self) -> crate::authorization::ForbiddenResponse {
+        self.forbidden_response()
+    }
+
+    #[cfg(feature = "db")]
+    fn pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>> {
+        self.pool()
+    }
+}


### PR DESCRIPTION
🕸️ Tangle: The `authorization` module functions currently take `&crate::AppState` directly, heavily coupling them to the God Struct `AppState`.

📏 Blueprint: Created a new trait `ProvideAuthorizationState` in the `authorization` module that exposes the required components of state (`auth_session_key`, `policy_registry`, `forbidden_response`, `pool`). Updated all `authorization` module functions to take a trait object `&dyn ProvideAuthorizationState` instead of `&crate::AppState`. Implemented the new trait for `AppState` in `state.rs`.

🧱 Stability: This reduces coupling by decoupling the core `authorization` module logic from the specific framework implementation details of `AppState`.

🔭 Verification: The code compiles successfully using `cargo check` and passes linting using `cargo clippy`. Unit tests in `authorization` module pass (`cargo test`).

---
*PR created automatically by Jules for task [4236464529959448468](https://jules.google.com/task/4236464529959448468) started by @madmax983*