### PR TITLE
⚒️ Forge: [Refactoring config and idempotency]

### DIFF
--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -274,20 +274,16 @@ pub(crate) fn resolve_profile(env: &dyn Env) -> String {
 
 /// Resolve the raw profile selector value (before normalization).
 fn resolve_profile_input(env: &dyn Env) -> String {
+    let check_env = |var| env.var(var).ok().map(|s| s.trim().to_owned()).filter(|s| !s.is_empty());
+
     // 1. Preferred env var
-    if let Ok(profile) = env.var("AUTUMN_ENV") {
-        let trimmed = profile.trim();
-        if !trimmed.is_empty() {
-            return trimmed.to_owned();
-        }
+    if let Some(profile) = check_env("AUTUMN_ENV") {
+        return profile;
     }
 
     // 2. Legacy env var
-    if let Ok(profile) = env.var("AUTUMN_PROFILE") {
-        let trimmed = profile.trim();
-        if !trimmed.is_empty() {
-            return trimmed.to_owned();
-        }
+    if let Some(profile) = check_env("AUTUMN_PROFILE") {
+        return profile;
     }
 
     // 3. CLI flag

--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -1268,18 +1268,15 @@ pub(crate) fn add_deferred_session_replay_key(
     session_id: Option<&str>,
     primary_replay_after_guard_denial: bool,
 ) {
-    if let Some(commit) = response.extensions().get::<DeferredIdempotencyCommit>() {
-        commit.add_session_alias(session_id, primary_replay_after_guard_denial);
-    }
+    let Some(commit) = response.extensions().get::<DeferredIdempotencyCommit>() else { return; };
+    commit.add_session_alias(session_id, primary_replay_after_guard_denial);
 }
 
 pub(crate) fn keep_deferred_session_commit_locked(response: &mut Response<Body>) {
-    if let Some(commit) = response
+    let Some(commit) = response
         .extensions_mut()
-        .remove::<DeferredIdempotencyCommit>()
-    {
-        commit.keep_locked_until_ttl();
-    }
+        .remove::<DeferredIdempotencyCommit>() else { return; };
+    commit.keep_locked_until_ttl();
 }
 
 fn request_idempotency_key(req: &Request<Body>) -> Option<String> {


### PR DESCRIPTION
🚮 Smell: Code contained repetitive structures like nested `if let` statements and unnecessary variables that could be simplified and flattened for readability.
✨ Solution: Extracted repetitive closures and used guard clauses `let Some(...) = ... else { return; }` across `config.rs` and `idempotency.rs`.
🧼 Benefit: Reduces cognitive load by flattening code and removing verbose patterns without changing logic.
🛡️ Verification: All tests passed, zero logic change.

---
*PR created automatically by Jules for task [10560421536613212750](https://jules.google.com/task/10560421536613212750) started by @madmax983*