### PR TITLE
Add transparent read-replica routing for sharded repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           cargo test -p autumn-web --test db_hooks_lifecycle -- --ignored
+          cargo test -p autumn-web --test repository_shard_replica_routing -- --ignored
           cargo test -p autumn-web --all-features --test feature_flags_pg_integration -- --ignored
 
   coverage:
@@ -67,6 +68,8 @@ jobs:
           cargo llvm-cov --workspace --all-features --no-report
           cargo llvm-cov --no-report -p autumn-web --all-features \
             --test db_hooks_lifecycle -- --ignored
+          cargo llvm-cov --no-report -p autumn-web --all-features \
+            --test repository_shard_replica_routing -- --ignored
           cargo llvm-cov --no-report -p autumn-web --all-features \
             --test feature_flags_pg_integration -- --ignored
           cargo llvm-cov report --lcov --output-path lcov.info

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -820,6 +820,24 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         } else {
             quote! {}
         };
+        // #1274: snapshot the shard's read route so read-only methods reach
+        // the shard's replica when one is healthy, mirroring the non-shard
+        // `read_route_init` below. `primary_reads` still pins reads to the
+        // shard primary at compile time.
+        let from_shard_read_route = if config.primary_reads {
+            quote! { ::autumn_web::repository::ReadRoute::Primary }
+        } else {
+            quote! { ::core::clone::Clone::clone(&__seed.read_route) }
+        };
+        let from_shard_reads_doc = if config.primary_reads {
+            quote! {
+                #[doc = "This repository is declared `primary_reads`, so reads stay on the shard's primary pool."]
+            }
+        } else {
+            quote! {
+                #[doc = "Read-only methods route to the shard's read replica when one is configured and healthy (honoring the shard's `replica_fallback` policy); mutating methods always use the shard's primary. Pin a single call chain to the primary with [`on_primary`](Self::on_primary)."]
+            }
+        };
         quote! {
             /// Construct this repository from a [`ShardedDb`](::autumn_web::sharding::ShardedDb)
             /// extractor, preserving the full request instrumentation — statement
@@ -836,10 +854,11 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             /// }
             /// ```
             ///
-            /// Reads are pinned to the shard's primary pool.  Use this constructor
-            /// as the standard way to build a repository on a shard; prefer
-            /// [`with_pool_untracked`](Self::with_pool_untracked) only when you
-            /// intentionally want to bypass request instrumentation.
+            #from_shard_reads_doc
+            ///
+            /// Use this constructor as the standard way to build a repository on
+            /// a shard; prefer [`with_pool_untracked`](Self::with_pool_untracked)
+            /// only when you intentionally want to bypass request instrumentation.
             #[must_use]
             pub fn from_shard(db: &::autumn_web::sharding::ShardedDb) -> Self {
                 #register_hooks
@@ -849,7 +868,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     #hooks_field
                     #idempotency_field
                     #tenant_init_field
-                    __autumn_read_route: ::autumn_web::repository::ReadRoute::Primary,
+                    __autumn_read_route: #from_shard_read_route,
                     __autumn_statement_timeout_ms: __seed.statement_timeout_ms,
                     __autumn_slow_threshold: __seed.slow_query_threshold,
                     __autumn_route: ::core::clone::Clone::clone(&__seed.route),

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -11,6 +11,15 @@
 //! the generated `on_primary()` method. When no replica is configured, all
 //! methods use the primary — nothing changes for single-pool apps.
 //!
+//! Sharded repositories built from a
+//! [`ShardedDb`](crate::sharding::ShardedDb) via the generated `from_shard`
+//! constructor get the same treatment **per shard**: reads route to the
+//! shard's replica when one is configured and healthy (honoring the shard's
+//! `replica_fallback` policy via
+//! [`Shard::read_route`](crate::sharding::Shard::read_route)), writes stay on
+//! the shard primary, and `primary_reads` / `on_primary()` pin reads back to
+//! the shard primary.
+//!
 //! [`RepositoryError`] surfaces typed errors that arise during repository
 //! operations — most notably optimistic-lock conflicts when two replicas
 //! write the same row concurrently.

--- a/autumn/src/sharding.rs
+++ b/autumn/src/sharding.rs
@@ -391,6 +391,33 @@ impl Shard {
         self.read_pool_with_role().map(|(pool, _)| pool)
     }
 
+    /// Snapshot this shard's read-routing decision as a
+    /// [`ReadRoute`](crate::repository::ReadRoute), the per-shard analogue of
+    /// [`ReadRoute::from_state`](crate::repository::ReadRoute::from_state).
+    ///
+    /// [`ShardedDb`] captures this at extraction time so a generated
+    /// `#[repository]` built with `from_shard` routes its read-only methods
+    /// to the shard's replica automatically — mirroring [`read_pool`] and
+    /// honoring the shard's `replica_fallback` policy and replica readiness:
+    ///
+    /// - no replica configured → [`Primary`](crate::repository::ReadRoute::Primary);
+    /// - replica ready → [`ReadPool`](crate::repository::ReadRoute::ReadPool) over the replica;
+    /// - replica unready, fallback `primary` → `ReadPool` over the primary;
+    /// - replica unready, fallback `fail_readiness` →
+    ///   [`Unavailable`](crate::repository::ReadRoute::Unavailable).
+    ///
+    /// [`read_pool`]: Self::read_pool
+    #[must_use]
+    pub fn read_route(&self) -> crate::repository::ReadRoute {
+        use crate::repository::ReadRoute;
+        if !self.runtime.replica_configured {
+            return ReadRoute::Primary;
+        }
+        self.read_pool().map_or(ReadRoute::Unavailable, |pool| {
+            ReadRoute::ReadPool(pool.clone())
+        })
+    }
+
     /// [`read_pool`](Self::read_pool) plus the role label of the returned
     /// pool, for interceptor/metric naming.
     pub(crate) fn read_pool_with_role(&self) -> Option<(&Pool<AsyncPgConnection>, &'static str)> {
@@ -1049,6 +1076,11 @@ pub struct ShardRepositorySeed {
     /// Shard-tagged route label (e.g. `"GET /bookmarks shard=shard0"`),
     /// or `None` when no `MatchedPath` was present in the request.
     pub route: Option<String>,
+    /// The shard's read-routing decision, snapshotted at extraction time so
+    /// `from_shard` repositories send read-only methods to the shard's
+    /// replica when one is healthy (issue #1274). Built via
+    /// [`Shard::read_route`].
+    pub read_route: crate::repository::ReadRoute,
 }
 
 impl ShardRepositorySeed {
@@ -1056,6 +1088,7 @@ impl ShardRepositorySeed {
         pool: &Pool<AsyncPgConnection>,
         ctx: &crate::db::RequestDbContext,
         shard_name: &str,
+        read_route: crate::repository::ReadRoute,
     ) -> Self {
         // Postgres `statement_timeout` is a signed 32-bit integer (ms); cap
         // to `i32::MAX` so the cast back to a `u64` field is always lossless.
@@ -1072,6 +1105,7 @@ impl ShardRepositorySeed {
                 .route_key
                 .as_ref()
                 .map(|key| format!("{key} shard={shard_name}")),
+            read_route,
         }
     }
 }
@@ -1197,8 +1231,12 @@ impl axum::extract::FromRequestParts<crate::AppState> for ShardedDb {
         let shard = shards.set.route(&key).await?;
         let shard_name = Arc::clone(&shard.name);
         let shard_id = shard.id();
-        let repo_seed =
-            ShardRepositorySeed::from_ctx(shard.primary_pool(), &shards.ctx, &shard_name);
+        let repo_seed = ShardRepositorySeed::from_ctx(
+            shard.primary_pool(),
+            &shards.ctx,
+            &shard_name,
+            shard.read_route(),
+        );
         let db = shards.checkout_primary(shard).await?;
         Ok(Self {
             db,
@@ -1558,6 +1596,105 @@ mod tests {
         assert!(shard.runtime().detail().expect("detail").contains("lags"));
     }
 
+    // ── read_route: per-shard ReadRoute snapshot (issue #1274) ───────────
+
+    const PRIMARY_SIZE: usize = 7;
+    const REPLICA_SIZE: usize = 3;
+
+    /// A one-shard set whose primary and replica pools have *distinct*
+    /// `max_size` so `read_route()` reveals which pool it selected.
+    fn shard_with_sized_replica(fallback: ReplicaFallback) -> Shard {
+        let mut config = sharded_config(&["a"]);
+        config.shards[0].replica_url = Some("postgres://localhost/a_ro".to_owned());
+        config.shards[0].replica_fallback = Some(fallback);
+        config.shards[0].primary_pool_size = Some(PRIMARY_SIZE);
+        config.shards[0].replica_pool_size = Some(REPLICA_SIZE);
+        let set = create_shard_set(&config, Arc::new(HashShardRouter))
+            .expect("build")
+            .expect("configured");
+        set.get(ShardId(0)).expect("shard").clone()
+    }
+
+    /// `max_size` of the pool a `ReadPool` route would acquire from, or
+    /// `None` for the `Primary` / `Unavailable` variants.
+    fn read_pool_size(route: &crate::repository::ReadRoute) -> Option<usize> {
+        match route {
+            crate::repository::ReadRoute::ReadPool(pool) => Some(pool.status().max_size),
+            crate::repository::ReadRoute::Primary | crate::repository::ReadRoute::Unavailable => {
+                None
+            }
+        }
+    }
+
+    #[test]
+    fn read_route_is_primary_without_replica() {
+        let set = shard_set(&["a"]);
+        let shard = set.get(ShardId(0)).expect("shard");
+        assert!(
+            matches!(shard.read_route(), crate::repository::ReadRoute::Primary),
+            "a shard with no replica must keep reads on the primary"
+        );
+    }
+
+    #[test]
+    fn read_route_targets_replica_when_ready() {
+        let shard = shard_with_sized_replica(ReplicaFallback::Primary);
+        shard.runtime().mark_replica_connection_ready();
+        assert!(shard.runtime().replica_ready());
+        assert_eq!(
+            read_pool_size(&shard.read_route()),
+            Some(REPLICA_SIZE),
+            "a ready replica must route reads to the replica pool"
+        );
+    }
+
+    #[test]
+    fn read_route_falls_back_to_primary_when_unready_and_policy_allows() {
+        // Replica configured but never checked → fallback policy applies.
+        let shard = shard_with_sized_replica(ReplicaFallback::Primary);
+        assert_eq!(
+            read_pool_size(&shard.read_route()),
+            Some(PRIMARY_SIZE),
+            "primary fallback must route reads to the primary pool"
+        );
+    }
+
+    #[test]
+    fn read_route_is_unavailable_when_unready_and_fallback_forbidden() {
+        let shard = shard_with_sized_replica(ReplicaFallback::FailReadiness);
+        assert!(
+            matches!(
+                shard.read_route(),
+                crate::repository::ReadRoute::Unavailable
+            ),
+            "fail_readiness must not silently fall back to the primary"
+        );
+    }
+
+    #[test]
+    fn repository_seed_snapshots_the_shard_read_route() {
+        let shard = shard_with_sized_replica(ReplicaFallback::Primary);
+        shard.runtime().mark_replica_connection_ready();
+        let ctx = crate::db::RequestDbContext {
+            statement_timeout: None,
+            route_key: Some("GET /notes".to_owned()),
+            metrics: None,
+            slow_query_threshold: std::time::Duration::from_millis(500),
+            interceptors: Vec::new(),
+        };
+        let seed = ShardRepositorySeed::from_ctx(
+            shard.primary_pool(),
+            &ctx,
+            shard.name(),
+            shard.read_route(),
+        );
+        assert_eq!(
+            read_pool_size(&seed.read_route),
+            Some(REPLICA_SIZE),
+            "the seed must carry the shard's read route for from_shard"
+        );
+    }
+
     // ── Shards routing surface ──────────────────────────────────────────
 
     fn shards_handle(names: &[&str]) -> Shards {
@@ -1778,7 +1915,8 @@ mod tests {
             slow_query_threshold: std::time::Duration::from_millis(200),
             interceptors: Vec::new(),
         };
-        let seed = ShardRepositorySeed::from_ctx(shard.primary_pool(), &ctx, "shard0");
+        let seed =
+            ShardRepositorySeed::from_ctx(shard.primary_pool(), &ctx, "shard0", shard.read_route());
         assert_eq!(seed.statement_timeout_ms, 3_000, "timeout preserved as ms");
         assert_eq!(
             seed.slow_query_threshold,
@@ -1803,7 +1941,8 @@ mod tests {
             slow_query_threshold: std::time::Duration::from_millis(500),
             interceptors: Vec::new(),
         };
-        let seed = ShardRepositorySeed::from_ctx(shard.primary_pool(), &ctx, "shard0");
+        let seed =
+            ShardRepositorySeed::from_ctx(shard.primary_pool(), &ctx, "shard0", shard.read_route());
         assert_eq!(seed.statement_timeout_ms, 0, "None timeout maps to 0");
         assert!(seed.route.is_none(), "None route_key propagates as None");
     }
@@ -1819,7 +1958,8 @@ mod tests {
             slow_query_threshold: std::time::Duration::from_millis(500),
             interceptors: Vec::new(),
         };
-        let seed = ShardRepositorySeed::from_ctx(shard.primary_pool(), &ctx, "shard0");
+        let seed =
+            ShardRepositorySeed::from_ctx(shard.primary_pool(), &ctx, "shard0", shard.read_route());
         assert_eq!(
             seed.statement_timeout_ms,
             i32::MAX as u64,

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -1150,6 +1150,18 @@ impl TestApp {
             }
         }
 
+        // Mirror production `AppBuilder` wiring: surface each configured shard's
+        // replica readiness as a `db:shard:<name>` indicator so `/ready`
+        // refreshes shard replica health (gating `fail_readiness` shards and
+        // marking healthy replicas ready for `ShardedDb` read routing).
+        #[cfg(feature = "db")]
+        if let Some(set) = state.shards() {
+            crate::sharding::register_shard_health_indicators(
+                set,
+                &state.health_indicator_registry,
+            );
+        }
+
         for initializer in self.state_initializers {
             initializer(&state);
         }

--- a/autumn/tests/repository_shard_replica_routing.rs
+++ b/autumn/tests/repository_shard_replica_routing.rs
@@ -1,0 +1,256 @@
+//! Issue #1274: `ShardedDb` transparent read-replica routing for SELECT methods.
+//!
+//! A repository built with the generated `from_shard(&ShardedDb)` constructor
+//! routes its read-only methods to the shard's read replica when one is
+//! configured and healthy, while mutating methods stay on the shard primary —
+//! transparently, with no handler changes. This mirrors the non-sharded
+//! replica routing (#971) but per-shard.
+//!
+//! This is a live-DB test: it needs a reachable Postgres so the `ShardedDb`
+//! extractor can check out a primary connection and the per-shard health
+//! indicator can probe the replica pool to mark it ready. Both the shard
+//! primary and replica point at the same testcontainer (distinguished only by
+//! pool `max_size`), so no real replication is required — only the routing
+//! decision is under test, surfaced via `ReadRoute`'s `Debug` output.
+//!
+//! **Requires Docker** to be running. Run with:
+//! `cargo test -p autumn-web --test repository_shard_replica_routing -- --ignored`
+
+#![cfg(feature = "db")]
+
+use autumn_web::config::{AutumnConfig, DatabaseConfig, ReplicaFallback, ShardConfig};
+use autumn_web::reexports::axum;
+use autumn_web::sharding::{ShardKeyOverride, ShardedDb};
+use autumn_web::test::{TestApp, TestClient};
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+use tokio::sync::OnceCell;
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        shard_replica_notes (id) {
+            id -> Int8,
+            content -> Text,
+        }
+    }
+
+    autumn_web::reexports::diesel::table! {
+        shard_pinned_notes (id) {
+            id -> Int8,
+            content -> Text,
+        }
+    }
+}
+
+use schema::{shard_pinned_notes, shard_replica_notes};
+
+#[autumn_web::model(table = "shard_replica_notes")]
+pub struct ShardReplicaNote {
+    #[id]
+    pub id: i64,
+    pub content: String,
+}
+
+#[autumn_web::model(table = "shard_pinned_notes")]
+pub struct ShardPinnedNote {
+    #[id]
+    pub id: i64,
+    pub content: String,
+}
+
+/// Default routing: reads follow the shard's read route (replica when ready).
+#[autumn_web::repository(ShardReplicaNote, table = "shard_replica_notes")]
+pub trait ShardReplicaNoteRepository {}
+
+/// Opt-out: `primary_reads` pins reads to the shard primary.
+#[autumn_web::repository(ShardPinnedNote, table = "shard_pinned_notes", primary_reads)]
+pub trait ShardPinnedNoteRepository {}
+
+const PRIMARY_SIZE: usize = 5;
+const REPLICA_SIZE: usize = 2;
+
+// ── Handlers exercising the real ShardedDb + from_shard path ────────────────
+
+/// Reports the read route a `from_shard` repository snapshots for this shard.
+#[autumn_web::get("/read-route")]
+async fn read_route(db: ShardedDb) -> String {
+    let repo = PgShardReplicaNoteRepository::from_shard(&db);
+    format!("{:?}", repo.__autumn_read_route())
+}
+
+/// Reports the write pool — must always be the shard primary.
+#[autumn_web::get("/write-pool")]
+async fn write_pool(db: ShardedDb) -> String {
+    let repo = PgShardReplicaNoteRepository::from_shard(&db);
+    repo.__autumn_write_pool().status().max_size.to_string()
+}
+
+/// `primary_reads` repository must never adopt the replica route.
+#[autumn_web::get("/pinned-route")]
+async fn pinned_route(db: ShardedDb) -> String {
+    let repo = PgShardPinnedNoteRepository::from_shard(&db);
+    format!("{:?}", repo.__autumn_read_route())
+}
+
+/// A real read method: fails fast when the read route is `Unavailable`.
+#[autumn_web::get("/find-all")]
+async fn find_all(db: ShardedDb) -> String {
+    let repo = PgShardReplicaNoteRepository::from_shard(&db);
+    match repo.find_all().await {
+        Ok(rows) => format!("ok:{}", rows.len()),
+        Err(error) => format!("err:{error}"),
+    }
+}
+
+// ── Test harness ────────────────────────────────────────────────────────────
+
+/// One shared Postgres container reused across the (ignored) tests in this file.
+static CONTAINER: OnceCell<(ContainerAsync<Postgres>, String)> = OnceCell::const_new();
+
+async fn db_url() -> &'static str {
+    let (_container, url) = CONTAINER
+        .get_or_init(|| async {
+            let container = Postgres::default()
+                .start()
+                .await
+                .expect("failed to start postgres container");
+            let host = container.get_host().await.expect("failed to get host");
+            let port = container
+                .get_host_port_ipv4(5432)
+                .await
+                .expect("failed to get port");
+            let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+            (container, url)
+        })
+        .await;
+    url
+}
+
+/// Resolve every request to a fixed shard key so `ShardedDb` extracts without
+/// needing tenancy middleware configured.
+async fn inject_shard_key(
+    mut req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    req.extensions_mut()
+        .insert(ShardKeyOverride("tenant-1".to_owned()));
+    next.run(req).await
+}
+
+fn config(url: &str, fallback: ReplicaFallback) -> AutumnConfig {
+    AutumnConfig {
+        database: DatabaseConfig {
+            connect_timeout_secs: 5,
+            shards: vec![ShardConfig {
+                name: "shard0".to_owned(),
+                primary_url: url.to_owned(),
+                // Same physical DB; only pool sizes distinguish the roles.
+                replica_url: Some(url.to_owned()),
+                slots: None,
+                primary_pool_size: Some(PRIMARY_SIZE),
+                replica_pool_size: Some(REPLICA_SIZE),
+                replica_fallback: Some(fallback),
+            }],
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn app(url: &str, fallback: ReplicaFallback) -> TestClient {
+    TestApp::new()
+        .routes(autumn_web::routes![
+            read_route,
+            write_pool,
+            pinned_route,
+            find_all
+        ])
+        .layer(axum::middleware::from_fn(inject_shard_key))
+        .config(config(url, fallback))
+        .build()
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn sharded_reads_switch_to_replica_once_it_is_ready() {
+    let url = db_url().await;
+    let client = app(url, ReplicaFallback::Primary);
+
+    // Before any readiness probe the replica is unchecked, so the `primary`
+    // fallback policy keeps reads on the shard primary pool.
+    let before = client.get("/read-route").send().await;
+    before.assert_ok();
+    assert_eq!(
+        before.text(),
+        format!("ReadRoute::ReadPool(max={PRIMARY_SIZE})"),
+        "an unchecked replica under primary fallback must keep reads on the primary"
+    );
+
+    // Hitting /ready runs the per-shard health indicator, which probes the
+    // replica pool and marks it ready — no handler change required.
+    client.get("/ready").send().await.assert_ok();
+
+    let after = client.get("/read-route").send().await;
+    after.assert_ok();
+    assert_eq!(
+        after.text(),
+        format!("ReadRoute::ReadPool(max={REPLICA_SIZE})"),
+        "reads must transparently route to the shard replica once it is ready"
+    );
+
+    // Writes always target the shard primary regardless of replica readiness.
+    let write = client.get("/write-pool").send().await;
+    write.assert_ok();
+    assert_eq!(
+        write.text(),
+        PRIMARY_SIZE.to_string(),
+        "mutating methods must always use the shard primary pool"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn primary_reads_repository_never_routes_to_the_replica() {
+    let url = db_url().await;
+    let client = app(url, ReplicaFallback::Primary);
+
+    // Mark the replica ready; a `primary_reads` repo must still ignore it.
+    client.get("/ready").send().await.assert_ok();
+
+    let route = client.get("/pinned-route").send().await;
+    route.assert_ok();
+    assert_eq!(
+        route.text(),
+        "ReadRoute::Primary",
+        "primary_reads repositories must keep reads on the shard primary"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn fail_readiness_reads_are_unavailable_until_the_replica_is_ready() {
+    let url = db_url().await;
+    let client = app(url, ReplicaFallback::FailReadiness);
+
+    // The replica has not passed a readiness check and the policy forbids
+    // falling back to the primary, so reads are unavailable.
+    let route = client.get("/read-route").send().await;
+    route.assert_ok();
+    assert_eq!(
+        route.text(),
+        "ReadRoute::Unavailable",
+        "fail_readiness must not silently fall back to the primary"
+    );
+
+    // A real read method fails fast with a replica-specific error.
+    let find = client.get("/find-all").send().await;
+    find.assert_ok();
+    let body = find.text();
+    assert!(
+        body.starts_with("err:") && body.to_lowercase().contains("replica"),
+        "read must fail fast explaining the replica is unavailable, got: {body}"
+    );
+}

--- a/docs/guide/sharding.md
+++ b/docs/guide/sharding.md
@@ -153,6 +153,16 @@ async fn create(db: ShardedDb, Json(body): Json<Body>) -> AutumnResult<Json<Book
 }
 ```
 
+A `from_shard` repository routes its read-only methods (`find_*`, `count`,
+`paginate`, …) to the shard's **read replica** automatically when one is
+configured and healthy — the same transparent read scale-out as the
+control replica, now per shard. Mutating methods always run on the shard
+primary. The decision honors that shard's `replica_fallback` policy and
+replica readiness, so adding a `replica_url` to a shard doubles its read
+capacity with no handler changes. Pin a read-after-write-sensitive
+repository to the shard primary with `#[repository(Model, primary_reads)]`,
+or a single call chain with `repo.on_primary()`.
+
 If you need a repository over an explicit pool **without** request context
 (e.g. a background job that resolved a shard pool from state), use
 `with_pool_untracked`. Statement timeout, slow-query threshold, and route


### PR DESCRIPTION
## Summary

Implement transparent read-replica routing for sharded repositories, mirroring the existing per-pool replica routing (#971) but applied per-shard. Repositories built with the generated `from_shard(&ShardedDb)` constructor now automatically route read-only methods to the shard's read replica when one is configured and healthy, while mutating methods stay on the shard primary.

## Key Changes

- **`Shard::read_route()`**: New method that snapshots a shard's read-routing decision as a `ReadRoute`, respecting the shard's `replica_fallback` policy and replica readiness. Returns:
  - `Primary` if no replica is configured
  - `ReadPool` over the replica if it's ready
  - `ReadPool` over the primary if replica is unready and fallback policy allows
  - `Unavailable` if replica is unready and `fail_readiness` policy forbids fallback

- **`ShardRepositorySeed`**: Extended to carry the shard's `read_route` snapshot at extraction time, enabling `from_shard` repositories to route reads transparently

- **Repository macro (`from_shard`)**: Updated to initialize `__autumn_read_route` from the shard's read route instead of always using `Primary`. The `primary_reads` attribute still pins reads to the shard primary at compile time

- **`TestApp`**: Enhanced to register per-shard health indicators so `/ready` refreshes shard replica readiness, enabling integration tests to verify routing behavior

- **Documentation**: Updated guide and module docs to explain per-shard replica routing and its interaction with `primary_reads` and `on_primary()`

## Implementation Details

- The read route decision is captured at `ShardedDb` extraction time (in `FromRequestParts`), ensuring consistent routing throughout a request
- Shard replica readiness is checked via the same health indicator mechanism as the control replica, integrated into the `/ready` endpoint
- The feature is fully backward compatible: shards without a configured replica continue to route all reads to the primary
- Comprehensive test coverage includes a live-DB integration test (`repository_shard_replica_routing`) that verifies routing decisions with distinct pool sizes and all fallback policies

https://claude.ai/code/session_01PdxS6SeGPtMBjyqjRXH4Fd