### PR TITLE
Add ShardedReadDb extractor for explicit replica-only reads

### DIFF
--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -79,7 +79,7 @@ pub use crate::mail::{
 };
 /// Shard routing extractors and types for `[[database.shards]]` apps.
 #[cfg(feature = "db")]
-pub use crate::sharding::{ShardKey, ShardKeyOverride, ShardedDb, Shards};
+pub use crate::sharding::{ShardKey, ShardKeyOverride, ShardedDb, ShardedReadDb, Shards};
 /// Server-Sent Events (SSE) support.
 pub use crate::sse::{Event, Sse};
 /// Structured CLI argument extractor for one-off `#[task]` handlers.

--- a/autumn/src/sharding.rs
+++ b/autumn/src/sharding.rs
@@ -418,6 +418,27 @@ impl Shard {
         })
     }
 
+    /// The shard's replica pool for **explicit replica-only** reads.
+    ///
+    /// Returns the replica pool only when a replica is configured *and* has
+    /// passed its readiness checks. Never returns the primary pool — this is
+    /// the `replica_fallback`-independent counterpart to [`read_pool`]:
+    ///
+    /// - no replica configured → `None`;
+    /// - replica configured but unready (regardless of `replica_fallback`) → `None`;
+    /// - replica configured and ready → `Some(replica_pool)`.
+    ///
+    /// Backs [`ShardedReadDb`], which always requires a healthy replica.
+    ///
+    /// [`read_pool`]: Self::read_pool
+    pub(crate) fn replica_read_pool(&self) -> Option<&Pool<AsyncPgConnection>> {
+        if self.runtime.replica_configured && self.runtime.replica_ready() {
+            self.topology.replica()
+        } else {
+            None
+        }
+    }
+
     /// [`read_pool`](Self::read_pool) plus the role label of the returned
     /// pool, for interceptor/metric naming.
     pub(crate) fn read_pool_with_role(&self) -> Option<(&Pool<AsyncPgConnection>, &'static str)> {
@@ -930,6 +951,37 @@ impl Shards {
         self.checkout(shard, pool, role).await
     }
 
+    /// Check out a **replica-only** connection to the shard that owns `key`.
+    ///
+    /// Unlike [`read_for`], this method ignores the shard's `replica_fallback`
+    /// policy and **never** falls back to the primary. It returns `503 Service
+    /// Unavailable` whenever a healthy, ready replica is unavailable — whether
+    /// no replica is configured, or the replica has not yet passed its
+    /// readiness checks. Use this for analytics/reporting paths that must
+    /// guarantee replica-only semantics.
+    ///
+    /// # Errors
+    ///
+    /// Returns the router's error, a checkout failure, or
+    /// `503 Service Unavailable` when no healthy replica is available for the
+    /// resolved shard.
+    ///
+    /// [`read_for`]: Self::read_for
+    pub async fn read_replica_for<'k>(
+        &self,
+        key: impl Into<ShardKey<'k>>,
+    ) -> Result<crate::db::Db, AutumnError> {
+        let shard = self.set.route(key).await?;
+        let pool = shard.replica_read_pool().ok_or_else(|| {
+            AutumnError::service_unavailable_msg(format!(
+                "shard {:?} has no healthy replica; ShardedReadDb requires a \
+                 configured, ready replica (no primary fallback)",
+                shard.name()
+            ))
+        })?;
+        self.checkout(shard, pool, "replica").await
+    }
+
     /// Check out a connection to a shard's primary **by name** —
     /// intended for admin/operational paths, not request routing.
     ///
@@ -1243,6 +1295,111 @@ impl axum::extract::FromRequestParts<crate::AppState> for ShardedDb {
             shard_name,
             shard_id,
             repo_seed,
+        })
+    }
+}
+
+/// Explicit replica-only shard connection extractor.
+///
+/// Resolves the routing key exactly like [`ShardedDb`] and checks out a
+/// connection to the **replica** of the owning shard. Unlike [`ShardedDb`]'s
+/// transparent read-routing (which follows the shard's `replica_fallback`
+/// policy), `ShardedReadDb` **always** requires a healthy replica and returns
+/// `503 Service Unavailable` immediately if one is not available — it never
+/// silently falls back to the primary.
+///
+/// Use this extractor for analytics, reporting, or admin scatter-gather
+/// handlers where replica-only semantics must be guaranteed:
+///
+/// ```rust,no_run
+/// use autumn_web::prelude::*;
+///
+/// #[get("/analytics")]
+/// async fn analytics(db: ShardedReadDb) -> impl IntoResponse {
+///     // guaranteed replica connection; 503 if none is configured or healthy
+///     "ok"
+/// }
+/// ```
+///
+/// Pairs with the transparent default routing provided by [`ShardedDb`]:
+/// that is the opt-out-free default; `ShardedReadDb` is the explicit
+/// replica-only override (see issue #1275).
+pub struct ShardedReadDb {
+    db: crate::db::Db,
+    shard_name: Arc<str>,
+    shard_id: ShardId,
+}
+
+impl ShardedReadDb {
+    /// Name of the shard this connection belongs to.
+    #[must_use]
+    pub fn shard(&self) -> &str {
+        &self.shard_name
+    }
+
+    /// Id of the shard this connection belongs to.
+    #[must_use]
+    pub const fn shard_id(&self) -> ShardId {
+        self.shard_id
+    }
+
+    /// Connection-scoped tracing span (see [`Db::span`](crate::db::Db::span)).
+    #[must_use]
+    pub const fn span(&self) -> &tracing::Span {
+        self.db.span()
+    }
+
+    /// Borrow the underlying [`Db`](crate::db::Db) (e.g. to pass to
+    /// helpers written against the unsharded extractor).
+    pub const fn db_mut(&mut self) -> &mut crate::db::Db {
+        &mut self.db
+    }
+}
+
+impl std::ops::Deref for ShardedReadDb {
+    type Target = AsyncPgConnection;
+    fn deref(&self) -> &Self::Target {
+        &self.db
+    }
+}
+
+impl std::ops::DerefMut for ShardedReadDb {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.db
+    }
+}
+
+impl AsMut<crate::db::Db> for ShardedReadDb {
+    fn as_mut(&mut self) -> &mut crate::db::Db {
+        &mut self.db
+    }
+}
+
+impl axum::extract::FromRequestParts<crate::AppState> for ShardedReadDb {
+    type Rejection = AutumnError;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &crate::AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let shards = Shards::from_request_parts(parts, state).await?;
+        let key = resolve_shard_key(parts, state).await?;
+
+        let shard = shards.set.route(&key).await?;
+        let shard_name = Arc::clone(&shard.name);
+        let shard_id = shard.id();
+        let pool = shard.replica_read_pool().ok_or_else(|| {
+            AutumnError::service_unavailable_msg(format!(
+                "shard {:?} has no healthy replica; ShardedReadDb requires a \
+                 configured, ready replica (no primary fallback)",
+                shard.name()
+            ))
+        })?;
+        let db = shards.checkout(shard, pool, "replica").await?;
+        Ok(Self {
+            db,
+            shard_name,
+            shard_id,
         })
     }
 }
@@ -1964,6 +2121,96 @@ mod tests {
             seed.statement_timeout_ms,
             i32::MAX as u64,
             "timeout capped at i32::MAX ms"
+        );
+    }
+
+    // ── ShardedReadDb / replica_read_pool (issue #1275) ─────────────────
+
+    #[test]
+    fn replica_read_pool_is_none_without_replica() {
+        let set = shard_set(&["a"]);
+        let shard = set.get(ShardId(0)).expect("shard");
+        assert!(
+            shard.replica_read_pool().is_none(),
+            "no replica configured → replica_read_pool must be None"
+        );
+    }
+
+    #[test]
+    fn replica_read_pool_is_none_when_unready_even_under_primary_fallback() {
+        // The key difference from read_pool(): even with ReplicaFallback::Primary,
+        // replica_read_pool never falls back to the primary — returns None.
+        let shard = shard_with_sized_replica(ReplicaFallback::Primary);
+        assert!(
+            shard.replica_read_pool().is_none(),
+            "unready replica under primary fallback must still return None for replica_read_pool"
+        );
+    }
+
+    #[test]
+    fn replica_read_pool_is_none_when_unready_under_fail_readiness() {
+        let shard = shard_with_sized_replica(ReplicaFallback::FailReadiness);
+        assert!(
+            shard.replica_read_pool().is_none(),
+            "unready replica under fail_readiness must return None"
+        );
+    }
+
+    #[test]
+    fn replica_read_pool_targets_replica_when_ready() {
+        let shard = shard_with_sized_replica(ReplicaFallback::Primary);
+        shard.runtime().mark_replica_connection_ready();
+        assert!(shard.runtime().replica_ready());
+        assert_eq!(
+            shard.replica_read_pool().map(|p| p.status().max_size),
+            Some(REPLICA_SIZE),
+            "a ready replica must be returned by replica_read_pool"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_replica_for_fails_when_no_replica_configured() {
+        let shards = shards_handle(&["a"]);
+        let Err(error) = shards.read_replica_for("tenant-1").await else {
+            panic!("no replica configured must be rejected");
+        };
+        // Error must mention replica (not checkout failure) and must not
+        // mention fail_readiness (this path is policy-independent).
+        let msg = error.to_string();
+        assert!(
+            msg.contains("replica"),
+            "error must name the missing replica: {msg}"
+        );
+        assert!(
+            !msg.contains("fail_readiness"),
+            "error must not mention fallback policy: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_replica_for_fails_when_replica_unready_under_primary_fallback() {
+        // Unlike read_for, read_replica_for must NOT fall back to the primary.
+        let mut config = sharded_config(&["a"]);
+        config.shards[0].replica_url = Some("postgres://localhost/a_ro".to_owned());
+        config.shards[0].replica_fallback = Some(ReplicaFallback::Primary);
+        let shards = Shards {
+            set: create_shard_set(&config, Arc::new(HashShardRouter))
+                .expect("build")
+                .expect("configured"),
+            ctx: crate::db::RequestDbContext {
+                statement_timeout: None,
+                route_key: None,
+                metrics: None,
+                slow_query_threshold: std::time::Duration::from_millis(500),
+                interceptors: Vec::new(),
+            },
+        };
+        let Err(error) = shards.read_replica_for("tenant-1").await else {
+            panic!("unready replica must be rejected even under primary fallback");
+        };
+        assert!(
+            error.to_string().contains("replica"),
+            "must name the replica: {error}"
         );
     }
 }

--- a/autumn/src/sharding.rs
+++ b/autumn/src/sharding.rs
@@ -974,7 +974,7 @@ impl Shards {
         let shard = self.set.route(key).await?;
         let pool = shard.replica_read_pool().ok_or_else(|| {
             AutumnError::service_unavailable_msg(format!(
-                "shard {:?} has no healthy replica; ShardedReadDb requires a \
+                "shard {:?} has no healthy replica; read_replica_for requires a \
                  configured, ready replica (no primary fallback)",
                 shard.name()
             ))

--- a/autumn/tests/compile-pass/sharded_handlers.rs
+++ b/autumn/tests/compile-pass/sharded_handlers.rs
@@ -57,9 +57,16 @@ async fn repo_from_shard(db: &ShardedDb) -> PgNoteRepository {
     PgNoteRepository::from_shard(db)
 }
 
+// Explicit replica-only extractor: 503 if no replica is configured/healthy.
+#[get("/analytics")]
+async fn analytics(db: ShardedReadDb) -> AutumnResult<String> {
+    Ok(format!("replica of shard {}", db.shard()))
+}
+
 fn main() {
     let _ = list_notes;
     let _ = user_notes;
     let _ = repo_on_shard_untracked;
     let _ = repo_from_shard;
+    let _ = analytics;
 }

--- a/autumn/tests/repository_shard_replica_routing.rs
+++ b/autumn/tests/repository_shard_replica_routing.rs
@@ -20,7 +20,7 @@
 
 use autumn_web::config::{AutumnConfig, DatabaseConfig, ReplicaFallback, ShardConfig};
 use autumn_web::reexports::axum;
-use autumn_web::sharding::{ShardKeyOverride, ShardedDb};
+use autumn_web::sharding::{ShardKeyOverride, ShardedDb, ShardedReadDb};
 use autumn_web::test::{TestApp, TestClient};
 use testcontainers::ContainerAsync;
 use testcontainers::runners::AsyncRunner;
@@ -103,6 +103,30 @@ async fn find_all(db: ShardedDb) -> String {
     }
 }
 
+/// Explicit replica-only extractor (issue #1275): exercises the
+/// `ShardedReadDb` success path — a real replica checkout — plus its full
+/// accessor surface (`shard`, `shard_id`, `span`, `db_mut`, `AsMut`) and the
+/// `Deref`/`DerefMut` to `AsyncPgConnection` by running a query on the replica
+/// connection. Reachable only once the replica has passed its readiness check.
+#[autumn_web::get("/replica-only")]
+async fn replica_only(mut db: ShardedReadDb) -> String {
+    use autumn_web::reexports::diesel;
+    use autumn_web::reexports::diesel_async::RunQueryDsl as _;
+
+    let shard = db.shard().to_owned();
+    let shard_id = db.shard_id();
+    let _span = db.span();
+    // AsMut<Db> and db_mut() both borrow the inner Db.
+    let _as_mut: &mut autumn_web::db::Db = db.as_mut();
+    let _db_mut: &mut autumn_web::db::Db = db.db_mut();
+    // Deref/DerefMut to AsyncPgConnection: run a real query on the replica.
+    let rows = diesel::sql_query("SELECT 1")
+        .execute(&mut *db)
+        .await
+        .expect("replica query runs");
+    format!("replica shard={shard} id={} rows={rows}", shard_id.0)
+}
+
 // ── Test harness ────────────────────────────────────────────────────────────
 
 /// One shared Postgres container reused across the (ignored) tests in this file.
@@ -164,7 +188,8 @@ fn app(url: &str, fallback: ReplicaFallback) -> TestClient {
             read_route,
             write_pool,
             pinned_route,
-            find_all
+            find_all,
+            replica_only
         ])
         .layer(axum::middleware::from_fn(inject_shard_key))
         .config(config(url, fallback))
@@ -226,6 +251,35 @@ async fn primary_reads_repository_never_routes_to_the_replica() {
         route.text(),
         "ReadRoute::Primary",
         "primary_reads repositories must keep reads on the shard primary"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn sharded_read_db_serves_only_a_ready_replica() {
+    let url = db_url().await;
+    // fail_readiness so an unchecked replica is genuinely unavailable, not a
+    // silent primary fallback — ShardedReadDb must 503 either way.
+    let client = app(url, ReplicaFallback::FailReadiness);
+
+    // Before the readiness probe there is no healthy replica → 503.
+    let before = client.get("/replica-only").send().await;
+    assert_eq!(
+        before.status,
+        axum::http::StatusCode::SERVICE_UNAVAILABLE,
+        "ShardedReadDb must fail fast with 503 until the replica is ready"
+    );
+
+    // The readiness probe marks the replica ready; the extractor now checks
+    // out the replica and the handler exercises its accessor surface.
+    client.get("/ready").send().await.assert_ok();
+
+    let after = client.get("/replica-only").send().await;
+    after.assert_ok();
+    let body = after.text();
+    assert!(
+        body.starts_with("replica shard=shard0") && body.contains("rows="),
+        "replica-only handler must serve the ready replica, got: {body}"
     );
 }
 

--- a/autumn/tests/sharding_integration.rs
+++ b/autumn/tests/sharding_integration.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use autumn_web::AppState;
 use autumn_web::config::{AutumnConfig, DatabaseConfig, ShardConfig};
 use autumn_web::sharding::{
-    HashShardRouter, ShardKeyOverride, ShardedDb, Shards, create_shard_set,
+    HashShardRouter, ShardKeyOverride, ShardedDb, ShardedReadDb, Shards, create_shard_set,
 };
 use axum::extract::FromRequestParts;
 use axum::http::Request;
@@ -183,6 +183,32 @@ async fn sharded_db_resolves_key_from_tenancy_task_local() {
     assert!(
         !rejection.to_string().contains("ShardKeyOverride"),
         "tenant context must resolve the key: {rejection}"
+    );
+}
+
+#[tokio::test]
+async fn sharded_read_db_without_replica_rejects_with_503() {
+    // A state whose shard has no replica must reject with a 503 that names
+    // the missing replica, not a ShardKeyOverride-guidance message.
+    let state = sharded_state(&["alpha"]);
+    state.insert_extension(AutumnConfig::default());
+    let mut parts = request_parts("/");
+    parts
+        .extensions
+        .insert(ShardKeyOverride("tenant-1".to_owned()));
+
+    let rejection = ShardedReadDb::from_request_parts(&mut parts, &state)
+        .await
+        .err()
+        .expect("no replica → must reject");
+    let msg = rejection.to_string();
+    assert!(
+        msg.contains("replica"),
+        "rejection must name the missing replica: {msg}"
+    );
+    assert!(
+        !msg.contains("ShardKeyOverride"),
+        "must get past key resolution: {msg}"
     );
 }
 


### PR DESCRIPTION
## Summary

Introduces `ShardedReadDb`, a new Axum extractor that enforces replica-only semantics for shard connections. Unlike `ShardedDb` which transparently follows the shard's `replica_fallback` policy, `ShardedReadDb` always requires a healthy, ready replica and returns `503 Service Unavailable` if one is unavailable — it never falls back to the primary.

## Key Changes

- **New `replica_read_pool()` method on `Shard`**: Returns the replica pool only when a replica is configured AND has passed readiness checks, independent of the `replica_fallback` policy. Never returns the primary pool.

- **New `read_replica_for()` method on `Shards`**: Checks out a replica-only connection to the shard owning a given key. Returns `503 Service Unavailable` if no healthy replica is available, with no primary fallback regardless of policy.

- **New `ShardedReadDb` extractor**: Resolves the routing key like `ShardedDb` but always requires a healthy replica. Implements `Deref`/`DerefMut` to `AsyncPgConnection` and provides `shard()`, `shard_id()`, `span()`, and `db_mut()` accessors matching `ShardedDb`'s interface.

- **Comprehensive test coverage**: Added unit tests for `replica_read_pool()` behavior under various configurations (no replica, unready replica with/without primary fallback, ready replica) and integration tests verifying `read_replica_for()` and `ShardedReadDb` rejection behavior.

- **Documentation and examples**: Added detailed doc comments explaining the replica-only guarantee and use cases (analytics, reporting, admin scatter-gather). Included compile-pass example showing `ShardedReadDb` in a handler.

- **Public API export**: Added `ShardedReadDb` to the prelude for convenient use in handler signatures.

## Implementation Details

- `replica_read_pool()` checks both `replica_configured` and `replica_ready()` before returning the replica pool, ensuring the replica has passed all readiness checks.
- Error messages clearly indicate the missing/unhealthy replica rather than generic checkout failures, aiding debugging.
- The extractor follows the same request parts extraction pattern as `ShardedDb`, reusing `resolve_shard_key()` for consistent routing key resolution.
- Addresses issue #1275 by providing an explicit opt-in mechanism for replica-only semantics.

https://claude.ai/code/session_01CEEUrHfXFPEsT4zpN9Uibm