### PR TITLE
Add sharding support to scaffold generator

### DIFF
--- a/autumn-cli/src/generate/config.rs
+++ b/autumn-cli/src/generate/config.rs
@@ -50,6 +50,10 @@ pub struct ScaffoldConfigEntry {
     pub soft_delete: bool,
     #[serde(default)]
     pub api: bool,
+    #[serde(default)]
+    pub sharded: bool,
+    #[serde(default)]
+    pub shard_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -96,6 +100,8 @@ pub fn merge_config_with_cli(
     cli_queries: &[String],
     cli_soft_delete: bool,
     cli_api: bool,
+    cli_sharded: bool,
+    cli_shard_key: Option<&str>,
 ) -> (Vec<String>, ScaffoldOptions) {
     let pick = |cli: &[String], toml: Vec<String>| -> Vec<String> {
         if cli.is_empty() { toml } else { cli.to_vec() }
@@ -108,6 +114,8 @@ pub fn merge_config_with_cli(
     // CLI flag wins; TOML config enables it when present.
     let soft_delete = cli_soft_delete || config.soft_delete;
     let api = cli_api || config.api;
+    let sharded = cli_sharded || config.sharded;
+    let shard_key = cli_shard_key.map(str::to_owned).or(config.shard_key);
     (
         fields,
         ScaffoldOptions {
@@ -116,6 +124,8 @@ pub fn merge_config_with_cli(
                 validations,
                 defaults,
                 soft_delete,
+                sharded,
+                shard_key,
             },
             queries,
             api,
@@ -262,13 +272,25 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             queries: vec!["find_by_url:url".into()],
             soft_delete: false,
             api: false,
+            sharded: false,
+            shard_key: None,
         }
     }
 
     #[test]
     fn merge_uses_toml_when_all_cli_empty() {
-        let (fields, opts) =
-            merge_config_with_cli(bookmark_entry(), &[], &[], &[], &[], &[], false, false);
+        let (fields, opts) = merge_config_with_cli(
+            bookmark_entry(),
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            false,
+            None,
+        );
         assert_eq!(fields, vec!["url:String", "tag:String"]);
         assert_eq!(opts.model.indexes, vec!["url"]);
         assert_eq!(opts.model.validations, vec!["url=url"]);
@@ -287,6 +309,8 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             &[],
             false,
             false,
+            false,
+            None,
         );
         assert_eq!(fields, vec!["title:String", "body:Text"]);
     }
@@ -302,6 +326,8 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             &[],
             false,
             false,
+            false,
+            None,
         );
         assert_eq!(opts.model.indexes, vec!["tag"]);
     }
@@ -317,6 +343,8 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             &[],
             false,
             false,
+            false,
+            None,
         );
         assert_eq!(opts.model.validations, vec!["url=email"]);
     }
@@ -334,6 +362,8 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             &[],
             false,
             false,
+            false,
+            None,
         );
         assert_eq!(opts.model.defaults, vec!["tag=general"]);
     }
@@ -349,6 +379,8 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             &["find_by_tag:tag".into()],
             false,
             false,
+            false,
+            None,
         );
         assert_eq!(opts.queries, vec!["find_by_tag:tag"]);
     }
@@ -356,7 +388,8 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
     #[test]
     fn merge_empty_cli_keeps_empty_toml() {
         let entry = ScaffoldConfigEntry::default();
-        let (fields, opts) = merge_config_with_cli(entry, &[], &[], &[], &[], &[], false, false);
+        let (fields, opts) =
+            merge_config_with_cli(entry, &[], &[], &[], &[], &[], false, false, false, None);
         assert!(fields.is_empty());
         assert!(opts.model.indexes.is_empty());
         assert!(opts.model.validations.is_empty());
@@ -366,8 +399,18 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
 
     #[test]
     fn merge_cli_soft_delete_flag_wins() {
-        let (_, opts) =
-            merge_config_with_cli(bookmark_entry(), &[], &[], &[], &[], &[], true, false);
+        let (_, opts) = merge_config_with_cli(
+            bookmark_entry(),
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            true,
+            false,
+            false,
+            None,
+        );
         assert!(
             opts.model.soft_delete,
             "cli_soft_delete=true must set soft_delete on the merged options"
@@ -378,7 +421,8 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
     fn merge_toml_soft_delete_propagates() {
         let mut entry = bookmark_entry();
         entry.soft_delete = true;
-        let (_, opts) = merge_config_with_cli(entry, &[], &[], &[], &[], &[], false, false);
+        let (_, opts) =
+            merge_config_with_cli(entry, &[], &[], &[], &[], &[], false, false, false, None);
         assert!(
             opts.model.soft_delete,
             "soft_delete=true in TOML config must propagate when CLI flag is false"
@@ -387,8 +431,18 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
 
     #[test]
     fn merge_soft_delete_false_when_both_unset() {
-        let (_, opts) =
-            merge_config_with_cli(bookmark_entry(), &[], &[], &[], &[], &[], false, false);
+        let (_, opts) = merge_config_with_cli(
+            bookmark_entry(),
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            false,
+            None,
+        );
         assert!(
             !opts.model.soft_delete,
             "soft_delete must be false when neither CLI nor TOML sets it"
@@ -413,8 +467,18 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
 
     #[test]
     fn merge_cli_api_flag_wins() {
-        let (_, opts) =
-            merge_config_with_cli(bookmark_entry(), &[], &[], &[], &[], &[], false, true);
+        let (_, opts) = merge_config_with_cli(
+            bookmark_entry(),
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            true,
+            false,
+            None,
+        );
         assert!(opts.api);
     }
 
@@ -422,7 +486,8 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
     fn merge_toml_api_propagates() {
         let mut entry = bookmark_entry();
         entry.api = true;
-        let (_, opts) = merge_config_with_cli(entry, &[], &[], &[], &[], &[], false, false);
+        let (_, opts) =
+            merge_config_with_cli(entry, &[], &[], &[], &[], &[], false, false, false, None);
         assert!(opts.api);
     }
 
@@ -439,6 +504,95 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
         assert!(
             entry.api,
             "api = true in TOML must be parsed into ScaffoldConfigEntry"
+        );
+    }
+
+    #[test]
+    fn merge_cli_sharded_flag_wins() {
+        let (_, opts) = merge_config_with_cli(
+            bookmark_entry(),
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            true,
+            None,
+        );
+        assert!(
+            opts.model.sharded,
+            "cli_sharded=true must set sharded on the merged options"
+        );
+    }
+
+    #[test]
+    fn merge_toml_sharded_propagates() {
+        let mut entry = bookmark_entry();
+        entry.sharded = true;
+        let (_, opts) =
+            merge_config_with_cli(entry, &[], &[], &[], &[], &[], false, false, false, None);
+        assert!(
+            opts.model.sharded,
+            "sharded=true in TOML config must propagate when CLI flag is false"
+        );
+    }
+
+    #[test]
+    fn merge_shard_key_cli_overrides_toml() {
+        let mut entry = bookmark_entry();
+        entry.shard_key = Some("tenant_id".into());
+        let (_, opts) = merge_config_with_cli(
+            entry,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            false,
+            Some("user_id"),
+        );
+        assert_eq!(
+            opts.model.shard_key.as_deref(),
+            Some("user_id"),
+            "CLI shard_key must override TOML shard_key"
+        );
+    }
+
+    #[test]
+    fn merge_shard_key_toml_used_when_no_cli() {
+        let mut entry = bookmark_entry();
+        entry.shard_key = Some("org_id".into());
+        let (_, opts) =
+            merge_config_with_cli(entry, &[], &[], &[], &[], &[], false, false, false, None);
+        assert_eq!(
+            opts.model.shard_key.as_deref(),
+            Some("org_id"),
+            "TOML shard_key must propagate when no CLI shard_key is given"
+        );
+    }
+
+    #[test]
+    fn parse_scaffold_config_with_sharded() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_config(
+            &tmp,
+            "[scaffold.Account]\nfields = [\"tenant_id:i64\"]\nsharded = true\nshard_key = \"tenant_id\"\n",
+        );
+        let entry = read_scaffold_config(&path, "Account")
+            .unwrap()
+            .expect("Account section must be present");
+        assert!(
+            entry.sharded,
+            "sharded = true in TOML must be parsed into ScaffoldConfigEntry"
+        );
+        assert_eq!(
+            entry.shard_key.as_deref(),
+            Some("tenant_id"),
+            "shard_key in TOML must be parsed into ScaffoldConfigEntry"
         );
     }
 }

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -24,6 +24,11 @@ pub struct ModelOptions {
     /// Emit a `deleted_at: Option<NaiveDateTime>` field and a nullable
     /// `deleted_at TIMESTAMP NULL` column for soft-delete support.
     pub soft_delete: bool,
+    /// Generate shard-aware handlers (`ShardedDb` instead of `Db`).
+    pub sharded: bool,
+    /// The field used as the sharding key (validated against model fields).
+    /// Defaults to `tenant_id` if present, otherwise `id`.
+    pub shard_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -129,6 +134,11 @@ pub fn plan_model_with_options(
             &fields,
             &metadata,
             options.soft_delete,
+            if options.sharded {
+                options.shard_key.as_deref()
+            } else {
+                None
+            },
         ),
     );
 
@@ -139,12 +149,22 @@ pub fn plan_model_with_options(
     // (b) Diesel migration
     let migration_dir_name = format!("{timestamp}_create_{table}");
     let migration_dir = project_root.join("migrations").join(&migration_dir_name);
-    let up_sql = create_table_sql_with_metadata(
+    let table_sql = create_table_sql_with_metadata(
         &table,
         &schema_fields,
         metadata.indexes(),
         metadata.defaults(),
     );
+    let up_sql = if options.sharded {
+        format!(
+            "-- Sharded model: this migration runs against the control DB by default.\n\
+             -- To apply to shards, run: autumn migrate --shard <name>\n\
+             -- See: autumn migrate --help\n\
+             {table_sql}"
+        )
+    } else {
+        table_sql
+    };
     plan.create(migration_dir.join("up.sql"), up_sql);
     plan.create(migration_dir.join("down.sql"), drop_table_sql(&table));
 
@@ -641,6 +661,7 @@ fn render_model_file(
     fields: &[Field],
     metadata: &ModelMetadata,
     soft_delete: bool,
+    shard_key: Option<&str>,
 ) -> String {
     use std::fmt::Write as _;
     let mut out = String::with_capacity(fields.len() * 128 + 256);
@@ -651,6 +672,9 @@ fn render_model_file(
     let _ = writeln!(out, "use crate::schema::{table};");
     out.push('\n');
     out.push_str("#[autumn_web::model]\n");
+    if let Some(key) = shard_key {
+        let _ = writeln!(out, "#[shard_key = \"{key}\"]");
+    }
     let _ = writeln!(out, "pub struct {name} {{");
     out.push_str("    #[id]\n");
     out.push_str("    pub id: i64,\n");
@@ -1261,6 +1285,106 @@ autumn-web = \"0.3\"\n";
         assert!(
             schema.contains("deleted_at"),
             "schema.rs must include deleted_at column when soft_delete is enabled: {schema}"
+        );
+    }
+
+    // ── sharding tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn model_emits_shard_key_attr() {
+        let tmp = project();
+        let plan = plan_model_with_options(
+            tmp.path(),
+            "Account",
+            &["tenant_id:i64".into(), "name:String".into()],
+            "20260427000000",
+            &ModelOptions {
+                sharded: true,
+                shard_key: Some("tenant_id".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let model = fs::read_to_string(tmp.path().join("src/models/account.rs")).unwrap();
+        assert!(
+            model.contains("#[shard_key = \"tenant_id\"]"),
+            "sharded model must emit #[shard_key] attribute: {model}"
+        );
+    }
+
+    #[test]
+    fn model_no_shard_key_attr_when_not_sharded() {
+        let tmp = project();
+        let plan = plan_model(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let model = fs::read_to_string(tmp.path().join("src/models/post.rs")).unwrap();
+        assert!(
+            !model.contains("shard_key"),
+            "non-sharded model must not emit shard_key: {model}"
+        );
+    }
+
+    #[test]
+    fn migration_notes_shard_target_when_sharded() {
+        let tmp = project();
+        let plan = plan_model_with_options(
+            tmp.path(),
+            "Account",
+            &["tenant_id:i64".into()],
+            "20260427000000",
+            &ModelOptions {
+                sharded: true,
+                shard_key: Some("tenant_id".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let up_sql = fs::read_to_string(
+            tmp.path()
+                .join("migrations/20260427000000_create_accounts/up.sql"),
+        )
+        .unwrap();
+        assert!(
+            up_sql.contains("autumn migrate --shard"),
+            "sharded migration up.sql must note autumn migrate --shard: {up_sql}"
+        );
+        assert!(
+            up_sql.contains("control DB"),
+            "sharded migration up.sql must note control DB default: {up_sql}"
+        );
+    }
+
+    #[test]
+    fn migration_no_shard_comment_when_not_sharded() {
+        let tmp = project();
+        let plan = plan_model(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let up_sql = fs::read_to_string(
+            tmp.path()
+                .join("migrations/20260427000000_create_posts/up.sql"),
+        )
+        .unwrap();
+        assert!(
+            !up_sql.contains("autumn migrate --shard"),
+            "non-sharded migration must not have shard comment: {up_sql}"
         );
     }
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -85,7 +85,7 @@ pub fn plan_scaffold_with_options(
     // Resolve shard key before planning the model (propagates to model render).
     let resolved_shard_key = resolve_shard_key(&fields, &options.model)?;
     let model_options_with_key = ModelOptions {
-        shard_key: resolved_shard_key.clone(),
+        shard_key: resolved_shard_key,
         ..options.model.clone()
     };
     let options_with_key = ScaffoldOptions {
@@ -322,12 +322,14 @@ fn render_repository_file(
     let query_body = render_repository_queries(pascal_name, queries);
     let soft_delete_attr = if soft_delete { ", soft_delete" } else { "" };
     let sharded_note = if sharded {
-        "//!\n\
-         //! This is a shard-aware repository. Handlers construct it via\n\
-         //! `Pg{pascal_name}Repository::from_shard(&db)` where `db` is a `ShardedDb` extractor;\n\
-         //! the extractor routes the request to the correct shard automatically.\n"
+        format!(
+            "//!\n\
+             //! This is a shard-aware repository. Handlers construct it via\n\
+             //! `Pg{pascal_name}Repository::from_shard(&db)` where `db` is a `ShardedDb` extractor;\n\
+             //! the extractor routes the request to the correct shard automatically.\n"
+        )
     } else {
-        ""
+        String::new()
     };
     let api_sharded_note = if sharded && api {
         "//!\n\
@@ -361,9 +363,6 @@ fn render_repository_file(
              {sharded_note}"
         )
     };
-    let pascal_name_str = pascal_name;
-    // Replace placeholder {pascal_name} in sharded_note with actual name.
-    let doc_comment = doc_comment.replace("{pascal_name}", pascal_name_str);
     format!(
         "{doc_comment}\n\
          use crate::models::{snake_name}::{{{pascal_name}, New{pascal_name}, Update{pascal_name}}};\n\
@@ -558,10 +557,9 @@ pub async fn index(
 
     // Imports: when sharded, drop Db from brace-import and add ShardedDb separately.
     let db_import = if sharded {
-        format!(
-            "use autumn_web::sharding::ShardedDb;\n\
-             use autumn_web::{{AutumnError, AutumnResult, Markup, get, html, post, secured}};"
-        )
+        "use autumn_web::sharding::ShardedDb;\n\
+         use autumn_web::{AutumnError, AutumnResult, Markup, get, html, post, secured};"
+            .to_owned()
     } else {
         "use autumn_web::{AutumnError, AutumnResult, Db, Markup, get, html, post, secured};"
             .to_owned()

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -81,11 +81,27 @@ pub fn plan_scaffold_with_options(
     options: &ScaffoldOptions,
 ) -> Result<Plan, GenerateError> {
     ensure_project_root(project_root)?;
-    let mut plan =
-        plan_model_with_options(project_root, name, field_tokens, timestamp, &options.model)?;
     let fields = parse_fields(field_tokens)?;
-    let metadata = parse_model_metadata(&fields, &options.model)?;
-    let queries = parse_query_specs(&fields, &options.queries)?;
+    // Resolve shard key before planning the model (propagates to model render).
+    let resolved_shard_key = resolve_shard_key(&fields, &options.model)?;
+    let model_options_with_key = ModelOptions {
+        shard_key: resolved_shard_key.clone(),
+        ..options.model.clone()
+    };
+    let options_with_key = ScaffoldOptions {
+        model: model_options_with_key,
+        queries: options.queries.clone(),
+        api: options.api,
+    };
+    let mut plan = plan_model_with_options(
+        project_root,
+        name,
+        field_tokens,
+        timestamp,
+        &options_with_key.model,
+    )?;
+    let metadata = parse_model_metadata(&fields, &options_with_key.model)?;
+    let queries = parse_query_specs(&fields, &options_with_key.queries)?;
     let form_fields = fields
         .iter()
         .filter(|field| !metadata.defaults().contains_key(&field.name))
@@ -103,8 +119,9 @@ pub fn plan_scaffold_with_options(
             &pascal_name,
             &snake_name,
             &queries,
-            options.model.soft_delete,
-            options.api,
+            options_with_key.model.soft_delete,
+            options_with_key.api,
+            options_with_key.model.sharded,
         ),
     );
     let repo_mod_path = repos_dir.join("mod.rs");
@@ -114,11 +131,17 @@ pub fn plan_scaffold_with_options(
     );
 
     // Route file under `src/routes/<plural>.rs`
-    if !options.api {
+    if !options_with_key.api {
         let routes_dir = project_root.join("src").join("routes");
         plan.create(
             routes_dir.join(format!("{plural}.rs")),
-            render_routes_file(&pascal_name, &snake_name, &plural, &form_fields),
+            render_routes_file(
+                &pascal_name,
+                &snake_name,
+                &plural,
+                &form_fields,
+                options_with_key.model.sharded,
+            ),
         );
         let route_mod_path = routes_dir.join("mod.rs");
         plan.modify(
@@ -130,7 +153,7 @@ pub fn plan_scaffold_with_options(
     // Smoke test under `tests/<snake>.rs`
     plan.create(
         project_root.join("tests").join(format!("{snake_name}.rs")),
-        render_smoke_test(&pascal_name, &plural, options.api, &fields),
+        render_smoke_test(&pascal_name, &plural, options_with_key.api, &fields),
     );
 
     // `src/main.rs` updates: declare modules + register all new routes.
@@ -141,9 +164,9 @@ pub fn plan_scaffold_with_options(
             format!("missing {}", main_path.display()),
         ))
     })?;
-    let route_entries = main_route_entries(&plural, &snake_name, options.api);
+    let route_entries = main_route_entries(&plural, &snake_name, options_with_key.api);
     let mut mods = vec!["models", "schema", "repositories"];
-    if !options.api {
+    if !options_with_key.api {
         mods.push("routes");
     }
     let updated = update_main_rs(&main_existing, &mods, &route_entries);
@@ -256,35 +279,93 @@ fn is_valid_fn_name(name: &str) -> bool {
         && chars.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
 }
 
+/// Resolve the sharding key field from options and field list.
+///
+/// Returns `None` when sharding is not enabled. When sharding is enabled,
+/// returns the explicitly requested key (validated against model fields and
+/// `id`), or falls back to `tenant_id` if present, then `id`.
+fn resolve_shard_key(
+    fields: &[Field],
+    options: &ModelOptions,
+) -> Result<Option<String>, GenerateError> {
+    if !options.sharded {
+        return Ok(None);
+    }
+    if let Some(ref key) = options.shard_key {
+        let valid = key == "id" || field_by_name(fields, key).is_some();
+        if !valid {
+            return Err(GenerateError::InvalidField {
+                token: key.clone(),
+                reason: format!(
+                    "shard_key field `{key}` does not exist on this model; \
+                     pass an existing field name or `id`"
+                ),
+            });
+        }
+        return Ok(Some(key.clone()));
+    }
+    if field_by_name(fields, "tenant_id").is_some() {
+        return Ok(Some("tenant_id".to_owned()));
+    }
+    Ok(Some("id".to_owned()))
+}
+
 fn render_repository_file(
     pascal_name: &str,
     snake_name: &str,
     queries: &[QuerySpec],
     soft_delete: bool,
     api: bool,
+    sharded: bool,
 ) -> String {
     let plural = pluralize(snake_name);
     let query_body = render_repository_queries(pascal_name, queries);
     let soft_delete_attr = if soft_delete { ", soft_delete" } else { "" };
-    let doc_comment = if api {
-        "//! Generated by `autumn generate scaffold --api`.\n\
-         //!\n\
-         //! `#[repository]` auto-generates CRUD methods and JSON REST handlers.\n\
-         //! When using `--api`, all 5 JSON CRUD endpoints are mounted in `src/main.rs`.\n\
-         //! Note: To start the application in a production profile, you must either\n\
-         //! add a policy (e.g. `policy = SomePolicy`) to this repository or explicitly\n\
-         //! allow unguarded writes by setting `allow_unauthorized_repository_api = true`\n\
-         //! under `[security]` in `autumn.toml`."
+    let sharded_note = if sharded {
+        "//!\n\
+         //! This is a shard-aware repository. Handlers construct it via\n\
+         //! `Pg{pascal_name}Repository::from_shard(&db)` where `db` is a `ShardedDb` extractor;\n\
+         //! the extractor routes the request to the correct shard automatically.\n"
     } else {
-        "//! Generated by `autumn generate scaffold`.\n\
-         //!\n\
-         //! `#[repository]` auto-generates CRUD methods and JSON REST handlers.\n\
-         //! The scaffold registers only read handlers in `src/main.rs` by\n\
-         //! default. Mount mutating API handlers only after adding a policy."
+        ""
     };
+    let api_sharded_note = if sharded && api {
+        "//!\n\
+         //! Note: auto-generated REST handlers (mounted via `api = ...`) route through\n\
+         //! the control pool, not individual shards. Shard-aware REST is planned for a\n\
+         //! future release. Use the HTML handlers or build custom shard-aware endpoints\n\
+         //! with `ShardedDb` in the meantime.\n"
+    } else {
+        ""
+    };
+    let doc_comment = if api {
+        format!(
+            "//! Generated by `autumn generate scaffold --api`.\n\
+             //!\n\
+             //! `#[repository]` auto-generates CRUD methods and JSON REST handlers.\n\
+             //! When using `--api`, all 5 JSON CRUD endpoints are mounted in `src/main.rs`.\n\
+             //! Note: To start the application in a production profile, you must either\n\
+             //! add a policy (e.g. `policy = SomePolicy`) to this repository or explicitly\n\
+             //! allow unguarded writes by setting `allow_unauthorized_repository_api = true`\n\
+             //! under `[security]` in `autumn.toml`.\n\
+             {api_sharded_note}\
+             {sharded_note}"
+        )
+    } else {
+        format!(
+            "//! Generated by `autumn generate scaffold`.\n\
+             //!\n\
+             //! `#[repository]` auto-generates CRUD methods and JSON REST handlers.\n\
+             //! The scaffold registers only read handlers in `src/main.rs` by\n\
+             //! default. Mount mutating API handlers only after adding a policy.\n\
+             {sharded_note}"
+        )
+    };
+    let pascal_name_str = pascal_name;
+    // Replace placeholder {pascal_name} in sharded_note with actual name.
+    let doc_comment = doc_comment.replace("{pascal_name}", pascal_name_str);
     format!(
         "{doc_comment}\n\
-         \n\
          use crate::models::{snake_name}::{{{pascal_name}, New{pascal_name}, Update{pascal_name}}};\n\
          use crate::schema::{plural};\n\
          \n\
@@ -370,11 +451,13 @@ fn render_decoded_form(_pascal_name: &str, fields: &[Field]) -> (String, String)
     reason = "This is a single template — splitting it produces less readable output, \
               not more. The whole point is one place that prints one file."
 )]
+#[allow(clippy::too_many_arguments)]
 fn render_routes_file(
     pascal_name: &str,
     snake_name: &str,
     plural: &str,
     fields: &[Field],
+    sharded: bool,
 ) -> String {
     let create_inputs = render_create_form_inputs(fields);
     let edit_inputs = render_edit_form_inputs(fields);
@@ -387,6 +470,7 @@ fn render_routes_file(
     // a CSRF-protected endpoint (see docs/guide/storage.md#direct-uploads).
     let form_enctype = "";
 
+    let db_ty = if sharded { "ShardedDb" } else { "Db" };
     let (
         create_signature,
         decode_create_call,
@@ -395,21 +479,94 @@ fn render_routes_file(
         decode_form_sig,
     ) = if has_attachments {
         (
-            "state: autumn_web::extract::State<autumn_web::AppState>, mut db: Db, body: Bytes".to_owned(),
+            format!(
+                "state: autumn_web::extract::State<autumn_web::AppState>, mut db: {db_ty}, body: Bytes"
+            ),
             "decode_form(&state, body).await?".to_owned(),
-            "state: autumn_web::extract::State<autumn_web::AppState>,\n    id: Path<i64>,\n    mut db: Db,\n    body: Bytes,".to_owned(),
+            format!(
+                "state: autumn_web::extract::State<autumn_web::AppState>,\n    id: Path<i64>,\n    mut db: {db_ty},\n    body: Bytes,"
+            ),
             "decode_form(&state, body).await?".to_owned(),
-            format!("async fn decode_form(state: &autumn_web::AppState, body: Bytes) -> AutumnResult<New{pascal_name}>"),
+            format!(
+                "async fn decode_form(state: &autumn_web::AppState, body: Bytes) -> AutumnResult<New{pascal_name}>"
+            ),
         )
     } else {
         (
-            "mut db: Db, body: Bytes".to_owned(),
+            format!("mut db: {db_ty}, body: Bytes"),
             "decode_form(body)?".to_owned(),
-            "id: Path<i64>,\n    mut db: Db,\n    body: Bytes,".to_owned(),
+            format!("id: Path<i64>,\n    mut db: {db_ty},\n    body: Bytes,"),
             "decode_form(body)?".to_owned(),
             format!("fn decode_form(body: Bytes) -> AutumnResult<New{pascal_name}>"),
         )
     };
+
+    // The `index` handler: when sharded, use from_shard explicitly so the
+    // generated code shows the canonical sharding pattern.
+    let index_handler = if sharded {
+        format!(
+            r#"/// `GET /{plural}` — paginated list of {snake_name}s.
+///
+/// Accepts `?page=N&size=M` query parameters via the [`PageRequest`] extractor.
+/// Out-of-range or missing values are clamped silently — list endpoints never
+/// return HTTP 400 for bad paging parameters.
+#[get("/{plural}")]
+pub async fn index(
+    page_req: PageRequest,
+    db: ShardedDb,
+) -> AutumnResult<Markup> {{
+    let repo = Pg{pascal_name}Repository::from_shard(&db);
+    let page_data: Page<{pascal_name}> = repo.page(&page_req).await?;
+    Ok(layout("{pascal_name} index", html! {{
+        h1 {{ "{pascal_name}s" }}
+        a href="/{plural}/new" {{ "New {pascal_name}" }}
+        ul {{
+            @for row in &page_data.content {{
+                li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}
+            }}
+        }}
+        (pagination_nav(&page_data, "/{plural}"))
+    }}))
+}}"#
+        )
+    } else {
+        format!(
+            r#"/// `GET /{plural}` — paginated list of {snake_name}s.
+///
+/// Accepts `?page=N&size=M` query parameters via the [`PageRequest`] extractor.
+/// Out-of-range or missing values are clamped silently — list endpoints never
+/// return HTTP 400 for bad paging parameters.
+#[get("/{plural}")]
+pub async fn index(
+    page_req: PageRequest,
+    repo: Pg{pascal_name}Repository,
+) -> AutumnResult<Markup> {{
+    let page_data: Page<{pascal_name}> = repo.page(&page_req).await?;
+    Ok(layout("{pascal_name} index", html! {{
+        h1 {{ "{pascal_name}s" }}
+        a href="/{plural}/new" {{ "New {pascal_name}" }}
+        ul {{
+            @for row in &page_data.content {{
+                li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}
+            }}
+        }}
+        (pagination_nav(&page_data, "/{plural}"))
+    }}))
+}}"#
+        )
+    };
+
+    // Imports: when sharded, drop Db from brace-import and add ShardedDb separately.
+    let db_import = if sharded {
+        format!(
+            "use autumn_web::sharding::ShardedDb;\n\
+             use autumn_web::{{AutumnError, AutumnResult, Markup, get, html, post, secured}};"
+        )
+    } else {
+        "use autumn_web::{AutumnError, AutumnResult, Db, Markup, get, html, post, secured};"
+            .to_owned()
+    };
+
     format!(
         r"//! Generated by `autumn generate scaffold`.
 //!
@@ -421,7 +578,7 @@ use autumn_web::pagination::{{Page, PageRequest}};
 use autumn_web::reexports::axum::body::Bytes;
 use autumn_web::reexports::serde_json;
 use autumn_web::security::{{CsrfFormField, CsrfToken}};
-use autumn_web::{{AutumnError, AutumnResult, Db, Markup, get, html, post, secured}};
+{db_import}
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
@@ -502,32 +659,11 @@ fn pagination_nav<T>(page: &Page<T>, base_url: &str) -> Markup {{
     }}
 }}
 
-/// `GET /{plural}` — paginated list of {snake_name}s.
-///
-/// Accepts `?page=N&size=M` query parameters via the [`PageRequest`] extractor.
-/// Out-of-range or missing values are clamped silently — list endpoints never
-/// return HTTP 400 for bad paging parameters.
-#[get("/{plural}")]
-pub async fn index(
-    page_req: PageRequest,
-    repo: Pg{pascal_name}Repository,
-) -> AutumnResult<Markup> {{
-    let page_data: Page<{pascal_name}> = repo.page(&page_req).await?;
-    Ok(layout("{pascal_name} index", html! {{
-        h1 {{ "{pascal_name}s" }}
-        a href="/{plural}/new" {{ "New {pascal_name}" }}
-        ul {{
-            @for row in &page_data.content {{
-                li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}
-            }}
-        }}
-        (pagination_nav(&page_data, "/{plural}"))
-    }}))
-}}
+{index_handler}
 
 /// `GET /{plural}/{{id}}` — show one {snake_name}.
 #[get("/{plural}/{{id}}")]
-pub async fn show(id: Path<i64>, mut db: Db) -> AutumnResult<Markup> {{
+pub async fn show(id: Path<i64>, mut db: {db_ty}) -> AutumnResult<Markup> {{
     let row: {pascal_name} = {plural}::table
         .find(*id)
         .select({pascal_name}::as_select())
@@ -576,7 +712,7 @@ pub async fn create({create_signature}) -> AutumnResult<Markup> {{
 #[get("/{plural}/{{id}}/edit")]
 pub async fn edit_form(
     id: Path<i64>,
-    mut db: Db,
+    mut db: {db_ty},
     csrf: Option<CsrfToken>,
     csrf_field: Option<CsrfFormField>,
 ) -> AutumnResult<Markup> {{
@@ -1440,6 +1576,183 @@ async fn main() {
         assert!(main.contains("repositories::post::post_api_list"));
         assert!(main.contains("repositories::post::post_api_get"));
         assert!(!main.contains("routes::posts::index"));
+    }
+
+    // ── sharding tests ─────────────────────────────────────────────────────
+
+    fn sharded_options_with_key(key: &str) -> ScaffoldOptions {
+        ScaffoldOptions {
+            model: ModelOptions {
+                sharded: true,
+                shard_key: Some(key.into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resolves_shard_key_explicit_field() {
+        let fields = parse_fields(&["tenant_id:i64".into(), "name:String".into()]).unwrap();
+        let opts = ModelOptions {
+            sharded: true,
+            shard_key: Some("tenant_id".into()),
+            ..Default::default()
+        };
+        let key = resolve_shard_key(&fields, &opts).unwrap();
+        assert_eq!(key, Some("tenant_id".to_owned()));
+    }
+
+    #[test]
+    fn resolves_shard_key_explicit_id() {
+        let fields = parse_fields(&["name:String".into()]).unwrap();
+        let opts = ModelOptions {
+            sharded: true,
+            shard_key: Some("id".into()),
+            ..Default::default()
+        };
+        let key = resolve_shard_key(&fields, &opts).unwrap();
+        assert_eq!(key, Some("id".to_owned()));
+    }
+
+    #[test]
+    fn resolves_shard_key_invalid_field_errors() {
+        let fields = parse_fields(&["name:String".into()]).unwrap();
+        let opts = ModelOptions {
+            sharded: true,
+            shard_key: Some("bogus".into()),
+            ..Default::default()
+        };
+        assert!(
+            resolve_shard_key(&fields, &opts).is_err(),
+            "unknown shard_key field must return an error"
+        );
+    }
+
+    #[test]
+    fn resolves_shard_key_defaults_to_tenant_id_when_present() {
+        let fields = parse_fields(&["tenant_id:i64".into(), "name:String".into()]).unwrap();
+        let opts = ModelOptions {
+            sharded: true,
+            shard_key: None,
+            ..Default::default()
+        };
+        let key = resolve_shard_key(&fields, &opts).unwrap();
+        assert_eq!(key, Some("tenant_id".to_owned()));
+    }
+
+    #[test]
+    fn resolves_shard_key_defaults_to_id_when_no_tenant_id() {
+        let fields = parse_fields(&["name:String".into()]).unwrap();
+        let opts = ModelOptions {
+            sharded: true,
+            shard_key: None,
+            ..Default::default()
+        };
+        let key = resolve_shard_key(&fields, &opts).unwrap();
+        assert_eq!(key, Some("id".to_owned()));
+    }
+
+    #[test]
+    fn resolves_shard_key_none_when_not_sharded() {
+        let fields = parse_fields(&["tenant_id:i64".into()]).unwrap();
+        let opts = ModelOptions {
+            sharded: false,
+            shard_key: None,
+            ..Default::default()
+        };
+        let key = resolve_shard_key(&fields, &opts).unwrap();
+        assert!(key.is_none());
+    }
+
+    #[test]
+    fn routes_use_sharded_db_when_sharded() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Account",
+            &["tenant_id:i64".into(), "name:String".into()],
+            "20260427000000",
+            &sharded_options_with_key("tenant_id"),
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/accounts.rs")).unwrap();
+        // ShardedDb must be imported from the correct path (not crate root).
+        assert!(
+            routes.contains("use autumn_web::sharding::ShardedDb;"),
+            "sharded routes must import ShardedDb from autumn_web::sharding: {routes}"
+        );
+        // Db must NOT appear in the brace-import or as a handler param type.
+        assert!(
+            !routes.contains("mut db: Db"),
+            "sharded routes must not use Db extractor: {routes}"
+        );
+        // ShardedDb must be used in handler signatures.
+        assert!(
+            routes.contains("mut db: ShardedDb"),
+            "sharded routes must use ShardedDb in handler signatures: {routes}"
+        );
+        // index must call from_shard explicitly for a literal proof.
+        assert!(
+            routes.contains("from_shard(&db)"),
+            "sharded index handler must call from_shard(&db): {routes}"
+        );
+    }
+
+    #[test]
+    fn routes_use_db_when_not_sharded() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(
+            routes.contains("mut db: Db"),
+            "non-sharded routes must still use Db"
+        );
+        assert!(
+            !routes.contains("ShardedDb"),
+            "non-sharded routes must not reference ShardedDb"
+        );
+    }
+
+    #[test]
+    fn repository_notes_sharded() {
+        let rendered = render_repository_file("Account", "account", &[], false, false, true);
+        assert!(
+            rendered.contains("shard-aware"),
+            "sharded repository doc must mention shard-aware: {rendered}"
+        );
+        assert!(
+            rendered.contains("from_shard"),
+            "sharded repository doc must mention from_shard: {rendered}"
+        );
+    }
+
+    #[test]
+    fn repository_notes_api_sharded_caveat() {
+        let rendered = render_repository_file("Account", "account", &[], false, true, true);
+        assert!(
+            rendered.contains("control pool"),
+            "sharded api repository doc must note control pool: {rendered}"
+        );
+    }
+
+    #[test]
+    fn repository_no_sharded_note_when_not_sharded() {
+        let rendered = render_repository_file("Post", "post", &[], false, false, false);
+        assert!(
+            !rendered.contains("shard-aware"),
+            "non-sharded repository must not mention shard-aware: {rendered}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1308,6 +1308,14 @@ enum GenerateCommands {
         /// Scaffold a JSON-only API resource (no HTML/Maud views, mount CRUD endpoints).
         #[arg(long)]
         api: bool,
+        /// Generate shard-aware handlers: uses `ShardedDb` instead of `Db` and
+        /// calls `from_shard(&db)` on generated repositories.
+        #[arg(long)]
+        sharded: bool,
+        /// The model field used as the sharding key (e.g. `tenant_id`).
+        /// Defaults to `tenant_id` if that field is present, otherwise `id`.
+        #[arg(long, value_name = "FIELD")]
+        shard_key: Option<String>,
         /// Print the file plan and exit without writing anything.
         #[arg(long)]
         dry_run: bool,
@@ -1952,6 +1960,8 @@ fn run_generate_command(cmd: GenerateCommands) {
             config,
             soft_delete,
             api,
+            sharded,
+            shard_key,
             dry_run,
             force,
         } => {
@@ -1982,6 +1992,8 @@ fn run_generate_command(cmd: GenerateCommands) {
                 &query,
                 soft_delete,
                 api,
+                sharded,
+                shard_key.as_deref(),
             );
             generate::scaffold::run(&name, &fields, generate::Flags { dry_run, force }, &options);
         }
@@ -4061,5 +4073,60 @@ mod tests {
         };
         assert!(!dry_run);
         assert!(force);
+    }
+
+    #[test]
+    fn parse_scaffold_sharded_flags() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "generate",
+            "scaffold",
+            "Post",
+            "title:String",
+            "--sharded",
+            "--shard-key",
+            "tenant_id",
+        ])
+        .unwrap();
+        let Commands::Generate(GenerateCommands::Scaffold {
+            name,
+            sharded,
+            shard_key,
+            ..
+        }) = cli.command
+        else {
+            panic!("expected Scaffold variant");
+        };
+        assert_eq!(name, "Post");
+        assert!(sharded, "--sharded flag must set sharded=true");
+        assert_eq!(
+            shard_key.as_deref(),
+            Some("tenant_id"),
+            "--shard-key must capture the field name"
+        );
+    }
+
+    #[test]
+    fn parse_scaffold_sharded_without_shard_key() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "generate",
+            "scaffold",
+            "Post",
+            "name:String",
+            "--sharded",
+        ])
+        .unwrap();
+        let Commands::Generate(GenerateCommands::Scaffold {
+            sharded, shard_key, ..
+        }) = cli.command
+        else {
+            panic!("expected Scaffold variant");
+        };
+        assert!(sharded);
+        assert!(
+            shard_key.is_none(),
+            "shard_key should be None when not specified"
+        );
     }
 }

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -3051,3 +3051,197 @@ fn generate_wizard_rejects_gen_keyword() {
         "error must mention the keyword issue; got: {stderr}"
     );
 }
+
+// ── autumn generate scaffold --sharded integration tests ─────────────────────
+
+#[test]
+fn generate_sharded_scaffold_in_fresh_project() {
+    let (_tmp, project) = fresh_project("sharded-scaffold-app");
+
+    run_autumn(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Account",
+            "shard_id:i64",
+            "name:String",
+            "--sharded",
+        ],
+    );
+
+    // Model file: must have #[shard_key = "tenant_id"] or #[shard_key = "shard_id"]
+    // (shard_id present, tenant_id absent → fallback to id; but shard_id is not tenant_id,
+    //  so no tenant_id field → default key is "id")
+    // With shard_id but no tenant_id field, default key is "id"
+    let model = fs::read_to_string(project.join("src/models/account.rs")).unwrap();
+    assert!(
+        model.contains("#[shard_key = \"id\"]"),
+        "model must have #[shard_key = \"id\"] (default when no tenant_id field):\n{model}"
+    );
+    assert!(
+        model.contains("#[autumn_web::model]"),
+        "model must have #[autumn_web::model] attr:\n{model}"
+    );
+
+    // Routes file: must use ShardedDb not Db
+    let routes = fs::read_to_string(project.join("src/routes/accounts.rs")).unwrap();
+    assert!(
+        routes.contains("use autumn_web::sharding::ShardedDb"),
+        "routes must import ShardedDb:\n{routes}"
+    );
+    assert!(
+        routes.contains("mut db: ShardedDb"),
+        "routes must use ShardedDb in handler signatures:\n{routes}"
+    );
+    assert!(
+        routes.contains("from_shard(&db)"),
+        "routes index must use from_shard(&db):\n{routes}"
+    );
+    assert!(
+        !routes.contains("mut db: Db"),
+        "routes must not use bare Db extractor when sharded:\n{routes}"
+    );
+
+    // Repository file: must have shard-aware doc note
+    let repo = fs::read_to_string(project.join("src/repositories/account.rs")).unwrap();
+    assert!(
+        repo.contains("from_shard"),
+        "repository must mention from_shard in doc comment:\n{repo}"
+    );
+
+    // Migration: must have shard target comment
+    let migrations: Vec<_> = fs::read_dir(project.join("migrations"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .ends_with("_create_accounts")
+        })
+        .collect();
+    assert_eq!(
+        migrations.len(),
+        1,
+        "expected one create_accounts migration"
+    );
+    let up = fs::read_to_string(migrations[0].path().join("up.sql")).unwrap();
+    assert!(
+        up.contains("autumn migrate --shard"),
+        "up.sql must mention `autumn migrate --shard`:\n{up}"
+    );
+}
+
+#[test]
+fn generate_sharded_scaffold_with_tenant_id_field_uses_tenant_id_as_default_key() {
+    let (_tmp, project) = fresh_project("sharded-tenant-app");
+
+    run_autumn(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Booking",
+            "tenant_id:i64",
+            "title:String",
+            "--sharded",
+        ],
+    );
+
+    let model = fs::read_to_string(project.join("src/models/booking.rs")).unwrap();
+    assert!(
+        model.contains("#[shard_key = \"tenant_id\"]"),
+        "model must default shard_key to tenant_id when that field is present:\n{model}"
+    );
+}
+
+#[test]
+fn generate_sharded_scaffold_with_explicit_shard_key() {
+    let (_tmp, project) = fresh_project("sharded-explicit-app");
+
+    run_autumn(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Widget",
+            "org_id:i64",
+            "label:String",
+            "--sharded",
+            "--shard-key",
+            "org_id",
+        ],
+    );
+
+    let model = fs::read_to_string(project.join("src/models/widget.rs")).unwrap();
+    assert!(
+        model.contains("#[shard_key = \"org_id\"]"),
+        "model must use explicitly supplied --shard-key:\n{model}"
+    );
+}
+
+#[test]
+fn generate_sharded_scaffold_rejects_bogus_shard_key() {
+    let (_tmp, project) = fresh_project("sharded-bogus-app");
+
+    let (_, stderr, code) = run_autumn_failing(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Widget",
+            "label:String",
+            "--sharded",
+            "--shard-key",
+            "bogus",
+        ],
+    );
+    assert_eq!(
+        code,
+        Some(1),
+        "--shard-key with non-existent field must fail"
+    );
+    assert!(
+        stderr.contains("bogus"),
+        "error must mention the invalid field name; got: {stderr}"
+    );
+}
+
+/// Slow end-to-end check: scaffold a sharded project, patch Cargo.toml to the
+/// local autumn-web, and `cargo check --tests` the result. Verifies that
+/// `use autumn_web::sharding::ShardedDb` resolves, `#[shard_key]` compiles
+/// (requires Track A), and `from_shard` typechecks.
+///
+/// Requires Track A (`#[shard_key]` in `#[model]` macro) to be merged first.
+/// Run with: `cargo test -p autumn-cli -- --ignored generated_sharded_scaffold_cargo_checks`
+#[test]
+#[ignore = "slow: cargo-checks a fresh sharded project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn generated_sharded_scaffold_cargo_checks() {
+    let (_tmp, project) = fresh_project("sharded-build");
+
+    patch_generated_cargo_toml(&project);
+
+    run_autumn(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Account",
+            "shard_id:i64",
+            "name:String",
+            "--sharded",
+        ],
+    );
+
+    let check = Command::new("cargo")
+        .args(["check", "--tests"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "cargo check on generated sharded scaffold failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -1364,7 +1364,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         let field_exists = key == "id"
             || all_fields
                 .iter()
-                .any(|f| f.ident.as_ref().map_or(false, |i| i == key));
+                .any(|f| f.ident.as_ref().is_some_and(|i| i == key));
         if !field_exists {
             let attr = outer_attrs
                 .iter()

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -749,6 +749,36 @@ fn parse_model_searchable_lang(attrs: &[syn::Attribute]) -> syn::Result<Option<S
     Ok(None)
 }
 
+/// Parse `#[shard_key = "field_name"]` from struct-level outer attributes.
+///
+/// Returns `Some(field_name)` when the attribute is present, `None` otherwise.
+/// The named field must exist on the model struct; validation happens after
+/// `all_fields` is constructed in `model_macro`.
+fn parse_model_shard_key(attrs: &[syn::Attribute]) -> syn::Result<Option<String>> {
+    for attr in attrs {
+        if attr.path().is_ident("shard_key") {
+            let syn::Meta::NameValue(ref nv) = attr.meta else {
+                return Err(syn::Error::new_spanned(
+                    attr,
+                    "shard_key attribute requires a string value: #[shard_key = \"field\"]",
+                ));
+            };
+            let syn::Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Str(ref lit_str),
+                ..
+            }) = nv.value
+            else {
+                return Err(syn::Error::new_spanned(
+                    &nv.value,
+                    "shard_key value must be a string literal",
+                ));
+            };
+            return Ok(Some(lit_str.value()));
+        }
+    }
+    Ok(None)
+}
+
 enum FieldSearchable {
     NotSearchable,
     SearchableDefault,
@@ -1302,6 +1332,11 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let is_searchable = searchable_lang.is_some();
     let search_language = searchable_lang.unwrap_or_else(|| "simple".to_string());
 
+    let shard_key_field = match parse_model_shard_key(outer_attrs) {
+        Ok(key) => key,
+        Err(err) => return err.to_compile_error(),
+    };
+
     let associations = match resolve_associations(name, outer_attrs) {
         Ok(assocs) => assocs,
         Err(err) => return err.to_compile_error(),
@@ -1310,7 +1345,11 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let filtered_outer_attrs: Vec<&syn::Attribute> = outer_attrs
         .iter()
-        .filter(|a| !a.path().is_ident("searchable") && !is_association_attr(a))
+        .filter(|a| {
+            !a.path().is_ident("searchable")
+                && !is_association_attr(a)
+                && !a.path().is_ident("shard_key")
+        })
         .collect();
 
     let new_name = format_ident!("New{name}");
@@ -1319,6 +1358,25 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     // Classify fields
     let all_fields: Vec<&Field> = fields.named.iter().collect();
+
+    // Validate that the declared shard_key names an existing field (or "id").
+    if let Some(ref key) = shard_key_field {
+        let field_exists = key == "id"
+            || all_fields
+                .iter()
+                .any(|f| f.ident.as_ref().map_or(false, |i| i == key));
+        if !field_exists {
+            let attr = outer_attrs
+                .iter()
+                .find(|a| a.path().is_ident("shard_key"))
+                .expect("attribute was parsed above");
+            return syn::Error::new_spanned(
+                attr,
+                format!("shard_key field `{key}` not found on model"),
+            )
+            .to_compile_error();
+        }
+    }
 
     // Collect state machine specs from all fields (RED → GREEN: declarative SM support).
     let mut state_machine_impls: Vec<TokenStream> = Vec::new();

--- a/autumn/tests/compile-fail/model_shard_key_unknown.rs
+++ b/autumn/tests/compile-fail/model_shard_key_unknown.rs
@@ -1,0 +1,18 @@
+use autumn_web::model;
+
+diesel::table! {
+    posts (id) {
+        id -> BigInt,
+        title -> Text,
+    }
+}
+
+#[model]
+#[shard_key = "nope"]
+pub struct Post {
+    #[id]
+    pub id: i64,
+    pub title: String,
+}
+
+fn main() {}

--- a/autumn/tests/compile-fail/model_shard_key_unknown.stderr
+++ b/autumn/tests/compile-fail/model_shard_key_unknown.stderr
@@ -1,0 +1,5 @@
+error: shard_key field `nope` not found on model
+  --> tests/compile-fail/model_shard_key_unknown.rs:11:1
+   |
+11 | #[shard_key = "nope"]
+   | ^^^^^^^^^^^^^^^^^^^^^

--- a/autumn/tests/compile-pass/model_shard_key.rs
+++ b/autumn/tests/compile-pass/model_shard_key.rs
@@ -1,0 +1,36 @@
+use autumn_web::model;
+
+diesel::table! {
+    accounts (id) {
+        id -> BigInt,
+        shard_id -> BigInt,
+        name -> Text,
+    }
+}
+
+#[model]
+#[shard_key = "shard_id"]
+pub struct Account {
+    #[id]
+    pub id: i64,
+    pub shard_id: i64,
+    pub name: String,
+}
+
+diesel::table! {
+    widgets (id) {
+        id -> BigInt,
+        name -> Text,
+    }
+}
+
+// #[shard_key = "id"] — the primary key itself is always valid
+#[model]
+#[shard_key = "id"]
+pub struct Widget {
+    #[id]
+    pub id: i64,
+    pub name: String,
+}
+
+fn main() {}

--- a/autumn/tests/compile_fail.rs
+++ b/autumn/tests/compile_fail.rs
@@ -21,6 +21,8 @@ fn compile_fail_tests() {
     // Model macro failures (require db feature)
     #[cfg(feature = "db")]
     t.compile_fail("tests/compile-fail/model_on_enum.rs");
+    #[cfg(feature = "db")]
+    t.compile_fail("tests/compile-fail/model_shard_key_unknown.rs");
 
     // Repository hooks failures (require db feature)
     #[cfg(feature = "db")]
@@ -136,6 +138,10 @@ fn compile_pass_tests() {
     // Soft delete (requires db feature)
     #[cfg(feature = "db")]
     t.pass("tests/compile-pass/repository_soft_delete.rs");
+
+    // shard_key model attribute (requires db feature)
+    #[cfg(feature = "db")]
+    t.pass("tests/compile-pass/model_shard_key.rs");
 }
 
 #[cfg(feature = "db")]


### PR DESCRIPTION
## Summary
This PR adds comprehensive sharding support to the `autumn generate scaffold` command, enabling developers to generate shard-aware models, repositories, and handlers that use `ShardedDb` instead of `Db` and follow the canonical sharding pattern with `from_shard(&db)`.

## Key Changes

- **CLI flags**: Added `--sharded` and `--shard-key FIELD` options to `autumn generate scaffold`
- **Shard key resolution**: Implemented `resolve_shard_key()` function that:
  - Validates explicitly provided shard keys against model fields
  - Defaults to `tenant_id` if present, otherwise `id`
  - Returns `None` when sharding is not enabled
- **Model generation**: 
  - Added `sharded` and `shard_key` fields to `ModelOptions`
  - Emits `#[shard_key = "field_name"]` attribute on generated model structs
  - Updated migration comments to note `autumn migrate --shard` requirement for sharded models
- **Repository generation**: 
  - Added doc comments explaining shard-aware pattern (`from_shard(&db)`)
  - Includes warnings about REST API limitations with sharding (control pool routing)
- **Routes generation**:
  - Conditionally imports `ShardedDb` instead of `Db` when sharded
  - Updates handler signatures to use `ShardedDb` parameter
  - Index handler explicitly calls `from_shard(&db)` to demonstrate canonical pattern
  - Other handlers use `mut db: ShardedDb` parameter
- **Config support**: Extended `ScaffoldConfigEntry` and `merge_config_with_cli()` to support `sharded` and `shard_key` from `autumn.toml`
- **Macro validation**: Added `parse_model_shard_key()` to `autumn-macros` that:
  - Parses `#[shard_key = "field"]` attribute syntax
  - Validates the named field exists on the model struct
  - Filters the attribute from downstream processing

## Testing
- Added 8 unit tests for shard key resolution logic
- Added 5 integration tests covering:
  - Fresh project scaffolding with `--sharded`
  - Default key selection (tenant_id vs id)
  - Explicit `--shard-key` override
  - Error handling for invalid shard keys
  - Full cargo check validation (ignored by default, slow)
- Added compile-pass and compile-fail tests for macro validation
- Updated existing config merge tests to include new parameters

## Implementation Details
- Shard key resolution happens early in `plan_scaffold_with_options()` before model planning, ensuring the resolved key propagates to all generated files
- Options are wrapped in a new `options_with_key` struct to thread the resolved shard key through all rendering functions
- Generated code uses `ShardedDb` as a type parameter in handler signatures, with conditional imports based on the `sharded` flag
- Migration files include a comment block explaining the control DB default and `--shard` flag usage

https://claude.ai/code/session_01TGxScSRRzWbB3pQRLfF8aL