### PR TITLE
🗺️ Atlas: [architectural change] Apply Dependency Inversion in Authorization

### DIFF
--- a/autumn/src/authorization.rs
+++ b/autumn/src/authorization.rs
@@ -75,6 +75,16 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn std::future::Future<Output = T> + Send +
 /// re-threading state), and a clone of the database pool so
 /// policies can consult related rows. `Clone + Send + Sync` — flows
 /// freely across `.await` points.
+pub trait ProvideAuthorizationState: Send + Sync {
+    fn policy_registry(&self) -> &PolicyRegistry;
+    fn forbidden_response(&self) -> ForbiddenResponse;
+    fn auth_session_key(&self) -> &str;
+    #[cfg(feature = "db")]
+    fn pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>;
+}
+
 #[derive(Clone)]
 pub struct PolicyContext {
     /// The full per-request [`Session`]. Read raw values via
@@ -130,7 +140,7 @@ impl PolicyContext {
     /// Build a fully-populated [`PolicyContext`] from `AppState` +
     /// `Session`. Used by the `#[authorize]` macro and
     /// `#[repository(policy = ...)]`-generated handlers.
-    pub async fn from_request(state: &crate::AppState, session: &Session) -> Self {
+    pub async fn from_request(state: &dyn ProvideAuthorizationState, session: &Session) -> Self {
         let mut ctx = Self::from_session(session, state.auth_session_key()).await;
         ctx.policy_registry = state.policy_registry().clone();
         #[cfg(feature = "db")]
@@ -621,7 +631,7 @@ impl<'de> serde::Deserialize<'de> for ForbiddenResponse {
 /// }
 /// ```
 pub async fn authorize<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
     action: &str,
     resource: &R,
@@ -651,7 +661,7 @@ where
 /// the public API** — call [`authorize`] from user code.
 #[doc(hidden)]
 pub async fn __check_policy<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
     action: &str,
     resource: &R,
@@ -673,7 +683,7 @@ where
 /// alias for older macro output.
 #[doc(hidden)]
 pub async fn __check_policy_create<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
 ) -> crate::AutumnResult<()>
 where
@@ -692,7 +702,7 @@ where
 /// only `autumn-web` is upgraded.
 #[doc(hidden)]
 pub async fn __check_policy_create_payload<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
     payload: &serde_json::Value,
 ) -> crate::AutumnResult<()>
@@ -713,7 +723,7 @@ where
 /// Returns the configured deny response when the policy denies.
 /// Returns `500` when no policy is registered for `R`.
 pub async fn authorize_create<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
 ) -> crate::AutumnResult<()>
 where
@@ -749,7 +759,7 @@ where
 /// Returns the configured deny response when the policy denies.
 /// Returns `500` when no policy is registered for `R`.
 pub async fn authorize_create_payload<R>(
-    state: &crate::AppState,
+    state: &dyn ProvideAuthorizationState,
     session: &Session,
     payload: &serde_json::Value,
 ) -> crate::AutumnResult<()>

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -624,6 +624,28 @@ impl AppState {
     }
 }
 
+impl crate::authorization::ProvideAuthorizationState for AppState {
+    fn policy_registry(&self) -> &crate::authorization::PolicyRegistry {
+        &self.policy_registry
+    }
+
+    fn forbidden_response(&self) -> crate::authorization::ForbiddenResponse {
+        self.forbidden_response
+    }
+
+    fn auth_session_key(&self) -> &str {
+        &self.auth_session_key
+    }
+
+    #[cfg(feature = "db")]
+    fn pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
+        self.pool.as_ref()
+    }
+}
+
 #[cfg(feature = "db")]
 impl DbState for AppState {
     fn metrics(&self) -> Option<&crate::middleware::MetricsCollector> {


### PR DESCRIPTION
🕸️ Tangle: `authorization.rs` was tightly coupled to `crate::AppState`, directly referencing it for policies, forbidden responses, and auth session keys. This created a potential circular dependency and leaked internal state representation.

📐 Blueprint: Introduced a `ProvideAuthorizationState` trait in `authorization.rs` defining the required methods (`policy_registry`, `forbidden_response`, `auth_session_key`, `pool`). Updated all `authorize` and `PolicyContext` builder functions to accept `&dyn ProvideAuthorizationState`. Implemented this trait for `AppState` in `state.rs`.

🧱 Stability: Reduced coupling by depending on an abstraction (a trait) rather than a concrete struct. `authorization.rs` is now agnostic to the global application state representation, making it easier to test and maintain. The use of dynamic dispatch (`&dyn`) ensures turbofish syntax isn't broken.

🔬 Verification: The project successfully builds (`cargo check -p autumn-web --lib`). All tests pass without regressions (`cargo test -p autumn-web --lib`). Linting passes (`cargo clippy`). Visual inspection of `git diff` confirmed the trait abstraction and trait impl.

---
*PR created automatically by Jules for task [206088721128381748](https://jules.google.com/task/206088721128381748) started by @madmax983*