### PR TITLE
🔒 Warden: Secure JWT secret with Secrecy

### DIFF
--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -164,6 +164,7 @@ csv = { workspace = true, optional = true }
 lettre = { version = "0.11.21", default-features = false, features = ["builder", "smtp-transport", "tokio1-rustls-tls"], optional = true }
 chromiumoxide = { workspace = true, optional = true }
 image = { workspace = true, optional = true }
+secrecy = { version = "0.10.3", features = ["serde"] }
 
 [dev-dependencies]
 diesel = { version = "2", features = ["chrono", "postgres"] }

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -4355,7 +4355,7 @@ pub struct TenancyConfig {
 
     /// JWT secret key used to verify the JWT signature.
     #[serde(default)]
-    pub jwt_secret: Option<String>,
+    pub jwt_secret: Option<secrecy::SecretString>,
 
     /// Expected JWT issuer to validate.
     #[serde(default)]

--- a/autumn/src/tenancy.rs
+++ b/autumn/src/tenancy.rs
@@ -1,3 +1,4 @@
+use secrecy::ExposeSecret;
 use axum::{
     extract::State,
     http::Request,
@@ -243,7 +244,7 @@ pub async fn extract_tenant_from_parts(
 
             let token_data = ::jsonwebtoken::decode::<serde_json::Value>(
                 token,
-                &::jsonwebtoken::DecodingKey::from_secret(secret.as_bytes()),
+                &::jsonwebtoken::DecodingKey::from_secret(secret.expose_secret().as_bytes()),
                 &validation,
             )
             .map_err(|e| {

--- a/autumn/tests/tenancy_unit.rs
+++ b/autumn/tests/tenancy_unit.rs
@@ -57,7 +57,7 @@ async fn test_case_insensitive_bearer_and_valid_jwt() {
     config.tenancy.enabled = true;
     config.tenancy.source = "jwt".to_string();
     config.tenancy.jwt_claim = "company".to_string();
-    config.tenancy.jwt_secret = Some("my-secret".to_string());
+    config.tenancy.jwt_secret = Some("my-secret".to_string().into());
     config.tenancy.jwt_issuer = Some("my-issuer".to_string());
 
     let token = generate_jwt("tenant123", "my-secret", false, Some("my-issuer"));
@@ -103,7 +103,7 @@ async fn test_jwt_verification_signature_and_expiration() {
     config.tenancy.enabled = true;
     config.tenancy.source = "jwt".to_string();
     config.tenancy.jwt_claim = "company".to_string();
-    config.tenancy.jwt_secret = Some("my-secret".to_string());
+    config.tenancy.jwt_secret = Some("my-secret".to_string().into());
     config.tenancy.jwt_issuer = Some("my-issuer".to_string());
 
     // 1. Untrusted signature (forged payload)
@@ -304,7 +304,7 @@ async fn jwt_audience_valid_passes() {
     config.tenancy.enabled = true;
     config.tenancy.source = "jwt".to_string();
     config.tenancy.jwt_claim = "company".to_string();
-    config.tenancy.jwt_secret = Some("secret".to_string());
+    config.tenancy.jwt_secret = Some("secret".to_string().into());
     config.tenancy.jwt_audience = Some("my-api".to_string());
 
     let token = generate_jwt_with_audience("acme", "secret", Some("my-api"));
@@ -327,7 +327,7 @@ async fn jwt_audience_mismatch_fails() {
     config.tenancy.enabled = true;
     config.tenancy.source = "jwt".to_string();
     config.tenancy.jwt_claim = "company".to_string();
-    config.tenancy.jwt_secret = Some("secret".to_string());
+    config.tenancy.jwt_secret = Some("secret".to_string().into());
     config.tenancy.jwt_audience = Some("my-api".to_string());
 
     // Token carries audience "wrong-api" — should be rejected
@@ -357,7 +357,7 @@ async fn jwt_audience_missing_claim_fails() {
     config.tenancy.enabled = true;
     config.tenancy.source = "jwt".to_string();
     config.tenancy.jwt_claim = "company".to_string();
-    config.tenancy.jwt_secret = Some("secret".to_string());
+    config.tenancy.jwt_secret = Some("secret".to_string().into());
     config.tenancy.jwt_audience = Some("my-api".to_string());
 
     // Token has aud: None — skip_serializing_if means the field is absent
@@ -385,7 +385,7 @@ async fn jwt_malformed_bearer_boundary_handling_does_not_panic() {
     config.tenancy.enabled = true;
     config.tenancy.source = "jwt".to_string();
     config.tenancy.jwt_claim = "company".to_string();
-    config.tenancy.jwt_secret = Some("secret".to_string());
+    config.tenancy.jwt_secret = Some("secret".to_string().into());
 
     let req = Request::builder()
         .header("Authorization", "aaaaaaé...")


### PR DESCRIPTION
🦠 Threat: The JWT secret was being stored as a plain `String` in memory. This could allow the secret to be leaked in case of memory dumps or logging.
🛡️ Defense: Wrapped the `jwt_secret` field in the `TenancyConfig` struct with `secrecy::SecretString`. This guarantees that the secret cannot be accidentally logged or printed, and will be zeroized when it goes out of scope.
💥 Severity: Medium. If the server is compromised and a memory dump is taken, or if the config is accidentally logged, the secret would be exposed. With the secret, an attacker could forge JWT tokens and impersonate any tenant.
🧪 Verification: Unit tests have been updated to construct `SecretString`s. Tests still pass.

---
*PR created automatically by Jules for task [11014270712365388824](https://jules.google.com/task/11014270712365388824) started by @madmax983*