### PR TITLE
🗣️ Echo: [DX Audit] Suppress optional tailwind warnings and provide primitive response wrapper

### DIFF
--- a/autumn-cli/src/templates/build.rs.tmpl
+++ b/autumn-cli/src/templates/build.rs.tmpl
@@ -25,11 +25,8 @@ fn main() {
             panic!("Tailwind CSS compilation failed");
         }
     } else {
-        // Output a warning ONLY if this is not part of a documentation build
-        // or a test where we don't care about CSS.
-        // Usually, `autumn dev` will complain if it is actually required.
-        // As per DX audit, removing the warning or making it quieter is better,
-        // we'll just not emit a warning for missing tailwind when it's optional.
+        // Tailwind CSS CLI not found.
+        // It is optional, so we do not emit a cargo warning.
     }
 }
 
@@ -45,7 +42,6 @@ fn find_tailwind_cli() -> Option<std::path::PathBuf> {
         return Some(path);
     }
 
-    // 3. Return None to treat this as optional.
     None
 }
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -119,6 +119,8 @@ pub mod probe;
 pub mod system_info;
 pub use plugin::{Plugin, Plugins};
 
+pub use primitives::Primitive;
+
 pub mod route_listing;
 
 #[cfg(feature = "db")]
@@ -1068,3 +1070,4 @@ mod tests {
         let _builder = builder.routes(vec![]);
     }
 }
+pub mod primitives;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -46,6 +46,8 @@ pub use crate::assets::asset_url;
 pub use maud::{Markup, PreEscaped, html};
 
 // ── Extractors ───────────────────────────────────────────────────
+/// Primitive response wrapper for returning raw numbers or booleans from handlers.
+pub use crate::Primitive;
 /// Canary traffic-routing extractor (reads the `X-Canary` header).
 pub use crate::canary::CanaryRoute;
 /// Database connection extractor.
@@ -97,6 +99,7 @@ pub use crate::{Presence, PresenceEntry, PresenceEvent, PresenceHandle};
 pub use axum::extract::State;
 /// Trait for types that can be converted into an HTTP response.
 pub use axum::response::IntoResponse;
+
 /// HTTP status codes.
 pub use http::StatusCode;
 

--- a/autumn/src/primitives.rs
+++ b/autumn/src/primitives.rs
@@ -1,0 +1,52 @@
+use axum::response::{IntoResponse, Response};
+use http::StatusCode;
+
+/// A newtype wrapper for returning plain primitive types from route handlers.
+///
+/// Out of the box, returning an `i32` or `f64` from an `async fn` handler
+/// will fail to compile with trait bound errors because Axum does not implement
+/// `IntoResponse` for numeric primitives. Wrapping the value in `Primitive`
+/// ensures it responds with `200 OK` and a stringified `text/plain` body.
+pub struct Primitive<T>(pub T);
+
+macro_rules! impl_into_response_for_primitive {
+    ($($ty:ty),*) => {
+        $(
+            impl IntoResponse for Primitive<$ty> {
+                fn into_response(self) -> Response {
+                    let body = self.0.to_string();
+                    let mut response = (StatusCode::OK, body).into_response();
+                    response.headers_mut().insert(
+                        axum::http::header::CONTENT_TYPE,
+                        axum::http::HeaderValue::from_static("text/plain; charset=utf-8"),
+                    );
+                    response
+                }
+            }
+        )*
+    };
+}
+
+impl_into_response_for_primitive!(
+    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, f32, f64, bool
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::response::IntoResponse;
+
+    #[tokio::test]
+    async fn primitive_i32_into_response() {
+        let resp = Primitive(42i32).into_response();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get("content-type").unwrap(),
+            "text/plain; charset=utf-8"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(body.as_ref(), b"42");
+    }
+}

--- a/examples/blog/build.rs
+++ b/examples/blog/build.rs
@@ -4,10 +4,6 @@ fn main() {
     println!("cargo:rerun-if-changed=tailwind.config.js");
 
     let Some(tailwind) = find_tailwind_cli() else {
-        println!(
-            "cargo:warning=Tailwind CSS CLI not found — CSS will not be compiled. \
-             Run `autumn setup` or install tailwindcss manually."
-        );
         return;
     };
 

--- a/examples/bookmarks-distributed/build.rs
+++ b/examples/bookmarks-distributed/build.rs
@@ -46,7 +46,7 @@ fn handle_tailwind_unavailable(reason: &str) {
             panic!("{reason}; AUTUMN_REQUIRE_TAILWIND is set");
         }
         build_support::TailwindFailureAction::SkipRegeneration => {
-            println!("cargo:warning={reason}; skipping static/css/autumn.css regeneration");
+            // println!("cargo:warning={reason}; skipping static/css/autumn.css regeneration");
         }
     }
 }

--- a/examples/bookmarks/build.rs
+++ b/examples/bookmarks/build.rs
@@ -4,10 +4,6 @@ fn main() {
     println!("cargo:rerun-if-changed=tailwind.config.js");
 
     let Some(tailwind) = find_tailwind_cli() else {
-        println!(
-            "cargo:warning=Tailwind CSS CLI not found — CSS will not be compiled. \
-             Run `autumn setup` or install tailwindcss manually."
-        );
         return;
     };
 

--- a/examples/reddit-clone/build.rs
+++ b/examples/reddit-clone/build.rs
@@ -4,10 +4,6 @@ fn main() {
     println!("cargo:rerun-if-changed=tailwind.config.js");
 
     let Some(tailwind) = find_tailwind_cli() else {
-        println!(
-            "cargo:warning=Tailwind CSS CLI not found — CSS will not be compiled. \
-             Run `autumn setup` or install tailwindcss manually."
-        );
         return;
     };
 

--- a/examples/todo-app/build.rs
+++ b/examples/todo-app/build.rs
@@ -4,10 +4,6 @@ fn main() {
     println!("cargo:rerun-if-changed=tailwind.config.js");
 
     let Some(tailwind) = find_tailwind_cli() else {
-        println!(
-            "cargo:warning=Tailwind CSS CLI not found — CSS will not be compiled. \
-             Run `autumn setup` or install tailwindcss manually."
-        );
         return;
     };
 

--- a/examples/wiki/build.rs
+++ b/examples/wiki/build.rs
@@ -4,10 +4,6 @@ fn main() {
     println!("cargo:rerun-if-changed=tailwind.config.js");
 
     let Some(tailwind) = find_tailwind_cli() else {
-        println!(
-            "cargo:warning=Tailwind CSS CLI not found — CSS will not be compiled. \
-             Run `autumn setup` or install tailwindcss manually."
-        );
         return;
     };
 

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,11 @@
+1. **Remove unused code and suppress tailwind warning on `examples/*/build.rs` and `autumn-cli/src/templates/build.rs.tmpl`**:
+    - Removed `println!("cargo:warning=Tailwind CSS CLI not found...")` output in templates and examples to prevent unnecessary cargo warnings.
+2. **Add primitive type response wrapper (`Primitive`)**:
+    - Created `autumn_web::primitives` containing a `Primitive<T>` wrapper.
+    - Implemented `IntoResponse` for `Primitive` with numeric and boolean types.
+    - Added tests for `Primitive`.
+3. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done**:
+    - I have already successfully run tests locally for `autumn_web` via `cargo test -p autumn-web --lib primitives::`.
+    - I'll call `pre_commit_instructions` tool to run and double check other necessary steps before creating a pull request.
+4. **Submit PR**:
+    - Commit and PR with title `🎸 Echo: [DX Audit] Suppress optional tailwind warnings and provide primitive response wrapper`.


### PR DESCRIPTION
## 🔍 EXPERIENCE
- Read the documentation for `autumn_web::app()`.
- Wrote a basic test application using `.routes()`.
- Copied example code and modified it to return a plain `i32` instead of `&'static str`.
- Encountered a warning about Tailwind CSS missing on newly scaffolded projects.

## 🚧 STUMBLE
- Returning `i32` from a handler fails to compile with an unintelligible trait bound error (`Handler<_, _> is not satisfied`).
- CLI `cargo run` yields annoying warnings about Tailwind CSS missing, despite the README claiming it's optional.
- (Empty 404 response body and macro error leakage were also reported but found to either be already fixed or documented as necessary tradeoffs).

## 📢 REPORT
- "Why can I return a String but not an integer? If I return 42, the compiler dumps 20 lines of trait bound errors about Axum internals."
- "Why does the CLI yell at me about Tailwind CSS every time I run the app if the README says it's optional?"

## 🧪 VERIFY
- Verified that `Axum`'s `IntoResponse` is not implemented for primitives natively.
- Added `Primitive<T>` wrapper in `autumn_web::primitives` to fix this DX gap, allowing easy wrapping like `Primitive(42)`.
- Suppressed `cargo:warning` output for optional missing tailwind configuration in example and template `build.rs` files.

---
*PR created automatically by Jules for task [7414437344560469715](https://jules.google.com/task/7414437344560469715) started by @madmax983*