### PR TITLE
Add `autumn db` commands for database lifecycle management

### DIFF
--- a/autumn-cli/Cargo.toml
+++ b/autumn-cli/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [dependencies]
 autumn-web = { version = "0.5.0", path = "../autumn", default-features = false, features = ["db", "htmx", "maud"] }
 clap = { version = "4", features = ["derive", "env"] }
+diesel = { workspace = true }
 crossterm = "0.29"
 ctrlc = "3.5.2"
 getrandom = "0.4"

--- a/autumn-cli/src/db.rs
+++ b/autumn-cli/src/db.rs
@@ -1,0 +1,410 @@
+//! `autumn db` — database lifecycle commands: `create`, `drop`, and `reset`.
+//!
+//! These are thin orchestration over Autumn's existing config resolution and the
+//! `migrate` / `seed` runners. They resolve the primary/write database URL the
+//! exact same way `autumn migrate` does (defaults → `autumn.toml` →
+//! `autumn-{profile}.toml` → `AUTUMN_*` / `DATABASE_URL` / `primary_url`) and
+//! operate only on the single primary role. `CREATE`/`DROP DATABASE` are issued
+//! from a connection to the server's maintenance database (`postgres`) because
+//! they cannot run while connected to the target database.
+//!
+//! Production safety: the destructive operations (`drop`, `reset`) refuse to run
+//! against a production profile unless `--force` is passed, and credentials are
+//! never printed in output or error messages.
+
+use std::path::Path;
+use std::process::Command;
+
+use diesel::connection::SimpleConnection as _;
+use diesel::{Connection as _, PgConnection, RunQueryDsl as _, sql_query};
+
+use crate::migrate;
+
+/// The lifecycle subcommands of `autumn db`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DbCommand {
+    /// Create the database named in the resolved connection config (idempotent).
+    Create,
+    /// Drop the database (idempotent; refuses prod without `force`).
+    Drop { force: bool },
+    /// Drop → create → migrate → seed in one shot (refuses prod without `force`).
+    Reset { force: bool },
+}
+
+/// Failure modes for the `db` commands. `Display` is deliberately
+/// credential-safe: no variant ever embeds the resolved URL, only the parsed
+/// host/port and database name, consistent with `autumn doctor --strict`.
+#[derive(Debug)]
+enum DbError {
+    /// No database URL could be resolved from config or environment.
+    NoUrl,
+    /// The resolved URL could not be parsed or names no database.
+    UnparsableUrl,
+    /// Could not connect to the maintenance database. Carries only the parsed
+    /// host/port/db — never the credentials from the URL.
+    Connection { host: String, port: u16, db: String },
+    /// A SQL statement failed. The message comes from the server (statement
+    /// errors like "database is being accessed by other users"), never the URL.
+    Sql(String),
+    /// A destructive op was refused because the active profile is production
+    /// and `--force` was not supplied.
+    ProductionRefused { profile: String },
+}
+
+impl std::fmt::Display for DbError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoUrl => write!(
+                f,
+                "No database URL found.\n  Set database.primary_url (or database.url) in autumn.toml, \
+                 or set AUTUMN_DATABASE__PRIMARY_URL / AUTUMN_DATABASE__URL / DATABASE_URL."
+            ),
+            Self::UnparsableUrl => write!(
+                f,
+                "The resolved database URL could not be parsed or does not name a database."
+            ),
+            Self::Connection { host, port, db } => write!(
+                f,
+                "Could not connect to the Postgres maintenance database for {db:?} at {host}:{port}.\n  \
+                 Is the server running and reachable?"
+            ),
+            Self::Sql(message) => write!(f, "{message}"),
+            Self::ProductionRefused { profile } => write!(
+                f,
+                "Refusing to run a destructive database operation against the {profile:?} profile.\n  \
+                 Re-run with --force if you really mean it."
+            ),
+        }
+    }
+}
+
+/// Entry point dispatched from `main`. Prints a credential-safe message and
+/// exits non-zero on failure.
+pub fn run(command: &DbCommand, profile: Option<&str>) {
+    eprintln!("\u{1F342} autumn db\n");
+    let result = match command {
+        DbCommand::Create => create(profile),
+        DbCommand::Drop { force } => drop(profile, *force),
+        DbCommand::Reset { force } => reset(profile, *force),
+    };
+    if let Err(e) = result {
+        eprintln!("\u{2717} {e}");
+        std::process::exit(1);
+    }
+}
+
+/// `autumn db create` — create the configured database, idempotently.
+fn create(profile: Option<&str>) -> Result<(), DbError> {
+    let url = resolve_url(profile)?;
+    let MaintenanceTarget { db_name, maintenance_url, host, port } = maintenance_target(&url)?;
+    let mut conn = connect(&maintenance_url, &host, port, &db_name)?;
+
+    if database_exists(&mut conn, &db_name)? {
+        eprintln!("  \u{2139} Database {db_name:?} already exists \u{2014} nothing to do.");
+        return Ok(());
+    }
+    conn.batch_execute(&format!("CREATE DATABASE {}", quote_ident(&db_name)))
+        .map_err(|e| DbError::Sql(e.to_string()))?;
+    eprintln!("  \u{2713} Created database {db_name:?}.");
+    Ok(())
+}
+
+/// `autumn db drop` — drop the configured database, idempotently. Refuses to run
+/// outside the `dev`/`test` profile unless `force` is set.
+fn drop(profile: Option<&str>, force: bool) -> Result<(), DbError> {
+    let resolved = migrate::effective_profile(profile);
+    guard_destructive(&resolved, force)?;
+
+    let url = resolve_url(profile)?;
+    let MaintenanceTarget { db_name, maintenance_url, host, port } = maintenance_target(&url)?;
+    let mut conn = connect(&maintenance_url, &host, port, &db_name)?;
+
+    if !database_exists(&mut conn, &db_name)? {
+        eprintln!("  \u{2139} Database {db_name:?} does not exist \u{2014} nothing to do.");
+        return Ok(());
+    }
+    conn.batch_execute(&format!("DROP DATABASE {}", quote_ident(&db_name)))
+        .map_err(|e| DbError::Sql(e.to_string()))?;
+    eprintln!("  \u{2713} Dropped database {db_name:?}.");
+    Ok(())
+}
+
+/// `autumn db reset` — drop → create → migrate → seed, as a single command.
+///
+/// The four steps are run by self-invoking this same binary so each reuses the
+/// existing runners verbatim and reports its own exit status; reset stops at the
+/// first failure and names the step that failed. The seed step is skipped (with
+/// a notice) when `src/bin/seed.rs` is absent.
+fn reset(profile: Option<&str>, force: bool) -> Result<(), DbError> {
+    let resolved = migrate::effective_profile(profile);
+    // Apply the production guard once, up front, before any destructive work.
+    guard_destructive(&resolved, force)?;
+
+    // `db drop` is invoked with --force because reset has already cleared the
+    // production guard above; otherwise the child would re-refuse.
+    run_step("drop", &["db", "drop", "--force"], profile)?;
+    run_step("create", &["db", "create"], profile)?;
+    run_step("migrate", &["migrate"], profile)?;
+
+    if seed_binary_present() {
+        run_step("seed", &["seed"], profile)?;
+    } else {
+        eprintln!("  \u{2139} No src/bin/seed.rs found \u{2014} skipping the seed step.");
+    }
+
+    eprintln!("\n\u{2713} Database reset complete (drop \u{2192} create \u{2192} migrate \u{2192} seed).");
+    Ok(())
+}
+
+/// Run one reset step by self-invoking the `autumn` binary, forwarding the
+/// profile. On a non-zero exit, fail with a message naming the step.
+fn run_step(name: &str, args: &[&str], profile: Option<&str>) -> Result<(), DbError> {
+    eprintln!("\u{2500}\u{2500} reset: {name} \u{2500}\u{2500}");
+    let exe = std::env::current_exe()
+        .map_err(|e| DbError::Sql(format!("could not locate the autumn executable: {e}")))?;
+    let mut command = Command::new(exe);
+    command.args(args);
+    if let Some(profile) = profile {
+        command.args(["--profile", profile]);
+    }
+    let status = command
+        .status()
+        .map_err(|e| DbError::Sql(format!("failed to spawn `autumn {}`: {e}", args.join(" "))))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(DbError::Sql(format!(
+            "reset failed at the {name:?} step (`autumn {}` exited {}).",
+            args.join(" "),
+            status.code().map_or_else(|| "with a signal".to_owned(), |c| format!("with code {c}")),
+        )))
+    }
+}
+
+/// Whether a seed binary exists at the conventional `src/bin/seed.rs` path.
+fn seed_binary_present() -> bool {
+    Path::new("src/bin/seed.rs").is_file()
+}
+
+/// Resolve the primary/write URL, mapping a missing URL to [`DbError::NoUrl`].
+fn resolve_url(profile: Option<&str>) -> Result<String, DbError> {
+    migrate::resolve_primary_url(profile).ok_or(DbError::NoUrl)
+}
+
+/// Refuse destructive operations against a production profile unless forced.
+/// `dev`/`test` (and their aliases) are always allowed; any other profile —
+/// including custom ones — requires `--force`, matching the issue's
+/// "refuse-by-default outside dev/test" posture.
+fn guard_destructive(profile: &str, force: bool) -> Result<(), DbError> {
+    if force || is_safe_destructive_profile(profile) {
+        Ok(())
+    } else {
+        Err(DbError::ProductionRefused { profile: profile.to_owned() })
+    }
+}
+
+/// Whether a profile is one the destructive ops may run against without
+/// `--force` (the local-development profiles `dev`/`test`).
+fn is_safe_destructive_profile(profile: &str) -> bool {
+    matches!(profile.trim().to_ascii_lowercase().as_str(), "dev" | "development" | "test")
+}
+
+/// The parsed pieces needed to issue `CREATE`/`DROP DATABASE` from the server's
+/// maintenance database.
+struct MaintenanceTarget {
+    /// The target database name (decoded).
+    db_name: String,
+    /// A connection URL pointing at the `postgres` maintenance database on the
+    /// same server, carrying the original credentials.
+    maintenance_url: String,
+    /// Parsed host, for credential-safe error reporting.
+    host: String,
+    /// Parsed port, for credential-safe error reporting.
+    port: u16,
+}
+
+/// Derive the maintenance-database connection from a resolved primary URL.
+///
+/// `CREATE DATABASE` / `DROP DATABASE` cannot run while connected to the target
+/// database (or inside a transaction), so we connect to the per-server
+/// maintenance database `postgres` and keep the original credentials/host.
+fn maintenance_target(url: &str) -> Result<MaintenanceTarget, DbError> {
+    let parsed = url::Url::parse(url).map_err(|_| DbError::UnparsableUrl)?;
+
+    // The database name is the first (and only meaningful) path segment.
+    let db_name = parsed
+        .path_segments()
+        .and_then(|mut segments| segments.next())
+        .map(decode_percent)
+        .filter(|name| !name.is_empty())
+        .ok_or(DbError::UnparsableUrl)?;
+
+    let host = parsed.host_str().unwrap_or("localhost").to_owned();
+    let port = parsed.port().unwrap_or(5432);
+
+    let mut maintenance = parsed;
+    maintenance.set_path("/postgres");
+    Ok(MaintenanceTarget { db_name, maintenance_url: maintenance.to_string(), host, port })
+}
+
+/// Establish a synchronous Postgres connection to the maintenance database,
+/// mapping any failure to a [`DbError::Connection`] that omits credentials.
+fn connect(
+    maintenance_url: &str,
+    host: &str,
+    port: u16,
+    db_name: &str,
+) -> Result<PgConnection, DbError> {
+    PgConnection::establish(maintenance_url).map_err(|_| DbError::Connection {
+        host: host.to_owned(),
+        port,
+        db: db_name.to_owned(),
+    })
+}
+
+/// A single boolean column produced by the existence probe.
+#[derive(diesel::QueryableByName)]
+struct ExistsRow {
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    exists: bool,
+}
+
+/// Whether a database with `db_name` exists, via `pg_database`.
+fn database_exists(conn: &mut PgConnection, db_name: &str) -> Result<bool, DbError> {
+    let query = format!(
+        "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = {}) AS exists",
+        quote_literal(db_name)
+    );
+    let row: ExistsRow = sql_query(query)
+        .get_result(conn)
+        .map_err(|e| DbError::Sql(e.to_string()))?;
+    Ok(row.exists)
+}
+
+/// Quote a Postgres identifier (database name) for safe interpolation, doubling
+/// any embedded double quotes.
+fn quote_ident(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+/// Quote a value as a single-quoted SQL string literal, doubling embedded
+/// single quotes.
+fn quote_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+/// Minimal percent-decoding for a URL path segment (database name).
+fn decode_percent(segment: &str) -> String {
+    let bytes = segment.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(hi), Some(lo)) = (hi, lo)
+                && let Ok(byte) = u8::try_from(hi * 16 + lo)
+            {
+                out.push(byte);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maintenance_target_extracts_name_and_rewrites_to_postgres() {
+        let target = maintenance_target("postgres://user:pw@db.example.com:6543/my_app").unwrap();
+        assert_eq!(target.db_name, "my_app");
+        assert_eq!(target.host, "db.example.com");
+        assert_eq!(target.port, 6543);
+        assert!(
+            target.maintenance_url.ends_with("/postgres"),
+            "maintenance url should point at the postgres database: {}",
+            target.maintenance_url
+        );
+    }
+
+    #[test]
+    fn maintenance_target_defaults_port_and_handles_no_credentials() {
+        let target = maintenance_target("postgres://localhost/my_app").unwrap();
+        assert_eq!(target.db_name, "my_app");
+        assert_eq!(target.host, "localhost");
+        assert_eq!(target.port, 5432);
+    }
+
+    #[test]
+    fn maintenance_target_decodes_percent_encoded_name() {
+        let target = maintenance_target("postgres://localhost/my%20app").unwrap();
+        assert_eq!(target.db_name, "my app");
+    }
+
+    #[test]
+    fn maintenance_target_rejects_url_without_database_name() {
+        assert!(matches!(
+            maintenance_target("postgres://localhost/"),
+            Err(DbError::UnparsableUrl)
+        ));
+        assert!(matches!(
+            maintenance_target("not a url"),
+            Err(DbError::UnparsableUrl)
+        ));
+    }
+
+    #[test]
+    fn quote_ident_doubles_embedded_quotes() {
+        assert_eq!(quote_ident("my_app"), "\"my_app\"");
+        assert_eq!(quote_ident("we\"ird"), "\"we\"\"ird\"");
+    }
+
+    #[test]
+    fn quote_literal_doubles_embedded_single_quotes() {
+        assert_eq!(quote_literal("my_app"), "'my_app'");
+        assert_eq!(quote_literal("o'brien"), "'o''brien'");
+    }
+
+    #[test]
+    fn guard_allows_dev_and_test_without_force() {
+        for profile in ["dev", "development", "DEV", "test", "Test"] {
+            assert!(guard_destructive(profile, false).is_ok(), "{profile} should be allowed");
+        }
+    }
+
+    #[test]
+    fn guard_refuses_prod_and_custom_without_force() {
+        for profile in ["prod", "production", "staging", "anything-else"] {
+            assert!(
+                matches!(guard_destructive(profile, false), Err(DbError::ProductionRefused { .. })),
+                "{profile} should be refused without --force"
+            );
+            assert!(guard_destructive(profile, true).is_ok(), "{profile} should pass with --force");
+        }
+    }
+
+    #[test]
+    fn errors_never_leak_credentials() {
+        // The connection error carries only host/port/db, never the password.
+        let err = DbError::Connection {
+            host: "db.example.com".to_owned(),
+            port: 5432,
+            db: "my_app".to_owned(),
+        };
+        let rendered = err.to_string();
+        assert!(!rendered.contains("hunter2"));
+        assert!(rendered.contains("db.example.com"));
+        assert!(rendered.contains("my_app"));
+
+        // The production-refusal message names the profile but no URL.
+        let refused = DbError::ProductionRefused { profile: "prod".to_owned() };
+        assert!(refused.to_string().contains("prod"));
+        assert!(!refused.to_string().contains("postgres://"));
+    }
+}

--- a/autumn-cli/src/db.rs
+++ b/autumn-cli/src/db.rs
@@ -96,7 +96,12 @@ pub fn run(command: &DbCommand, profile: Option<&str>) {
 /// `autumn db create` — create the configured database, idempotently.
 fn create(profile: Option<&str>) -> Result<(), DbError> {
     let url = resolve_url(profile)?;
-    let MaintenanceTarget { db_name, maintenance_url, host, port } = maintenance_target(&url)?;
+    let MaintenanceTarget {
+        db_name,
+        maintenance_url,
+        host,
+        port,
+    } = maintenance_target(&url)?;
     let mut conn = connect(&maintenance_url, &host, port, &db_name)?;
 
     if database_exists(&mut conn, &db_name)? {
@@ -116,7 +121,12 @@ fn drop(profile: Option<&str>, force: bool) -> Result<(), DbError> {
     guard_destructive(&resolved, force)?;
 
     let url = resolve_url(profile)?;
-    let MaintenanceTarget { db_name, maintenance_url, host, port } = maintenance_target(&url)?;
+    let MaintenanceTarget {
+        db_name,
+        maintenance_url,
+        host,
+        port,
+    } = maintenance_target(&url)?;
     let mut conn = connect(&maintenance_url, &host, port, &db_name)?;
 
     if !database_exists(&mut conn, &db_name)? {
@@ -152,7 +162,9 @@ fn reset(profile: Option<&str>, force: bool) -> Result<(), DbError> {
         eprintln!("  \u{2139} No src/bin/seed.rs found \u{2014} skipping the seed step.");
     }
 
-    eprintln!("\n\u{2713} Database reset complete (drop \u{2192} create \u{2192} migrate \u{2192} seed).");
+    eprintln!(
+        "\n\u{2713} Database reset complete (drop \u{2192} create \u{2192} migrate \u{2192} seed)."
+    );
     Ok(())
 }
 
@@ -176,7 +188,9 @@ fn run_step(name: &str, args: &[&str], profile: Option<&str>) -> Result<(), DbEr
         Err(DbError::Sql(format!(
             "reset failed at the {name:?} step (`autumn {}` exited {}).",
             args.join(" "),
-            status.code().map_or_else(|| "with a signal".to_owned(), |c| format!("with code {c}")),
+            status
+                .code()
+                .map_or_else(|| "with a signal".to_owned(), |c| format!("with code {c}")),
         )))
     }
 }
@@ -199,14 +213,19 @@ fn guard_destructive(profile: &str, force: bool) -> Result<(), DbError> {
     if force || is_safe_destructive_profile(profile) {
         Ok(())
     } else {
-        Err(DbError::ProductionRefused { profile: profile.to_owned() })
+        Err(DbError::ProductionRefused {
+            profile: profile.to_owned(),
+        })
     }
 }
 
 /// Whether a profile is one the destructive ops may run against without
 /// `--force` (the local-development profiles `dev`/`test`).
 fn is_safe_destructive_profile(profile: &str) -> bool {
-    matches!(profile.trim().to_ascii_lowercase().as_str(), "dev" | "development" | "test")
+    matches!(
+        profile.trim().to_ascii_lowercase().as_str(),
+        "dev" | "development" | "test"
+    )
 }
 
 /// The parsed pieces needed to issue `CREATE`/`DROP DATABASE` from the server's
@@ -244,7 +263,12 @@ fn maintenance_target(url: &str) -> Result<MaintenanceTarget, DbError> {
 
     let mut maintenance = parsed;
     maintenance.set_path("/postgres");
-    Ok(MaintenanceTarget { db_name, maintenance_url: maintenance.to_string(), host, port })
+    Ok(MaintenanceTarget {
+        db_name,
+        maintenance_url: maintenance.to_string(),
+        host,
+        port,
+    })
 }
 
 /// Establish a synchronous Postgres connection to the maintenance database,
@@ -374,7 +398,10 @@ mod tests {
     #[test]
     fn guard_allows_dev_and_test_without_force() {
         for profile in ["dev", "development", "DEV", "test", "Test"] {
-            assert!(guard_destructive(profile, false).is_ok(), "{profile} should be allowed");
+            assert!(
+                guard_destructive(profile, false).is_ok(),
+                "{profile} should be allowed"
+            );
         }
     }
 
@@ -382,10 +409,16 @@ mod tests {
     fn guard_refuses_prod_and_custom_without_force() {
         for profile in ["prod", "production", "staging", "anything-else"] {
             assert!(
-                matches!(guard_destructive(profile, false), Err(DbError::ProductionRefused { .. })),
+                matches!(
+                    guard_destructive(profile, false),
+                    Err(DbError::ProductionRefused { .. })
+                ),
                 "{profile} should be refused without --force"
             );
-            assert!(guard_destructive(profile, true).is_ok(), "{profile} should pass with --force");
+            assert!(
+                guard_destructive(profile, true).is_ok(),
+                "{profile} should pass with --force"
+            );
         }
     }
 
@@ -403,7 +436,9 @@ mod tests {
         assert!(rendered.contains("my_app"));
 
         // The production-refusal message names the profile but no URL.
-        let refused = DbError::ProductionRefused { profile: "prod".to_owned() };
+        let refused = DbError::ProductionRefused {
+            profile: "prod".to_owned(),
+        };
         assert!(refused.to_string().contains("prod"));
         assert!(!refused.to_string().contains("postgres://"));
     }

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -6,6 +6,7 @@ mod check;
 mod config;
 mod credentials;
 mod data;
+mod db;
 mod dev;
 mod dev_loop_bench;
 mod doctor;
@@ -113,6 +114,19 @@ enum Commands {
         #[arg(long, value_name = "PROFILE")]
         profile: Option<String>,
     },
+    /// Create, drop, or reset the database itself.
+    ///
+    /// These commands resolve the connection the same way `autumn migrate`
+    /// does (defaults → `autumn.toml` → `autumn-{profile}.toml` → `AUTUMN_*`,
+    /// plus `DATABASE_URL` / `primary_url`) and operate only on the primary
+    /// write role, connecting to the server's maintenance database to issue
+    /// `CREATE`/`DROP`.
+    ///
+    ///   autumn db create
+    ///   autumn db drop --force
+    ///   autumn db reset
+    #[command(subcommand, verbatim_doc_comment, name = "db")]
+    Db(DbCommands),
     /// Shard operations (e.g. moving a tenant's data between shards)
     Shard(ShardCommands),
     /// Live monitoring dashboard for a running Autumn application
@@ -585,6 +599,46 @@ enum CredentialsCommands {
         /// Print the decrypted values instead of redacting them.
         #[arg(long)]
         reveal: bool,
+    },
+}
+
+/// Subcommands for `autumn db`.
+#[derive(Subcommand)]
+enum DbCommands {
+    /// Create the configured database (idempotent: a no-op notice if it exists).
+    Create {
+        /// Resolve the connection through a profile overlay. When omitted, the
+        /// profile is selected from `AUTUMN_ENV` (preferred) or the legacy
+        /// `AUTUMN_PROFILE`, matching the app's runtime precedence.
+        #[arg(long, value_name = "PROFILE")]
+        profile: Option<String>,
+    },
+    /// Drop the configured database (idempotent if already absent).
+    ///
+    /// Refuses to run outside the `dev`/`test` profile unless `--force` is
+    /// passed. Credentials are never printed.
+    #[command(verbatim_doc_comment)]
+    Drop {
+        /// Resolve the connection through a profile overlay (see `db create`).
+        #[arg(long, value_name = "PROFILE")]
+        profile: Option<String>,
+        /// Allow the drop against a non-dev/test (e.g. production) profile.
+        #[arg(long)]
+        force: bool,
+    },
+    /// Drop → create → migrate → seed, in that order, as a single command.
+    ///
+    /// Stops and exits non-zero if any step fails, naming the failed step. The
+    /// seed step is skipped (with a notice) when `src/bin/seed.rs` is absent.
+    /// Refuses to run outside the `dev`/`test` profile unless `--force` is set.
+    #[command(verbatim_doc_comment)]
+    Reset {
+        /// Resolve the connection through a profile overlay (see `db create`).
+        #[arg(long, value_name = "PROFILE")]
+        profile: Option<String>,
+        /// Allow the reset against a non-dev/test (e.g. production) profile.
+        #[arg(long)]
+        force: bool,
     },
 }
 
@@ -1432,6 +1486,14 @@ fn run_command(command: Commands) {
                 (None, false) => migrate::MigrateTarget::All,
             };
             migrate::run(&action, with_maintenance, &target, profile.as_deref());
+        }
+        Commands::Db(cmd) => {
+            let (command, profile) = match cmd {
+                DbCommands::Create { profile } => (db::DbCommand::Create, profile),
+                DbCommands::Drop { profile, force } => (db::DbCommand::Drop { force }, profile),
+                DbCommands::Reset { profile, force } => (db::DbCommand::Reset { force }, profile),
+            };
+            db::run(&command, profile.as_deref());
         }
         Commands::Shard(cmd) => match cmd.command {
             ShardSubcommand::MoveSlot {
@@ -2600,6 +2662,67 @@ mod tests {
     #[test]
     fn parse_generate_model_without_name_is_error() {
         assert!(Cli::try_parse_from(["autumn", "generate", "model"]).is_err());
+    }
+
+    // ── autumn db tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_db_create() {
+        let cli = Cli::try_parse_from(["autumn", "db", "create"]).unwrap();
+        match cli.command {
+            Commands::Db(DbCommands::Create { profile }) => assert!(profile.is_none()),
+            _ => panic!("expected Db(Create) command"),
+        }
+    }
+
+    #[test]
+    fn parse_db_create_with_profile() {
+        let cli = Cli::try_parse_from(["autumn", "db", "create", "--profile", "test"]).unwrap();
+        match cli.command {
+            Commands::Db(DbCommands::Create { profile }) => {
+                assert_eq!(profile.as_deref(), Some("test"));
+            }
+            _ => panic!("expected Db(Create) command"),
+        }
+    }
+
+    #[test]
+    fn parse_db_drop_defaults_force_false() {
+        let cli = Cli::try_parse_from(["autumn", "db", "drop"]).unwrap();
+        match cli.command {
+            Commands::Db(DbCommands::Drop { profile, force }) => {
+                assert!(profile.is_none());
+                assert!(!force);
+            }
+            _ => panic!("expected Db(Drop) command"),
+        }
+    }
+
+    #[test]
+    fn parse_db_drop_with_force() {
+        let cli = Cli::try_parse_from(["autumn", "db", "drop", "--force"]).unwrap();
+        match cli.command {
+            Commands::Db(DbCommands::Drop { force, .. }) => assert!(force),
+            _ => panic!("expected Db(Drop) command"),
+        }
+    }
+
+    #[test]
+    fn parse_db_reset_with_profile_and_force() {
+        let cli =
+            Cli::try_parse_from(["autumn", "db", "reset", "--profile", "prod", "--force"]).unwrap();
+        match cli.command {
+            Commands::Db(DbCommands::Reset { profile, force }) => {
+                assert_eq!(profile.as_deref(), Some("prod"));
+                assert!(force);
+            }
+            _ => panic!("expected Db(Reset) command"),
+        }
+    }
+
+    #[test]
+    fn parse_db_without_subcommand_is_error() {
+        assert!(Cli::try_parse_from(["autumn", "db"]).is_err());
     }
 
     // ── autumn seed tests ──────────────────────────────────────────────────

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -642,6 +642,18 @@ enum DbCommands {
     },
 }
 
+impl DbCommands {
+    /// Translate the parsed CLI subcommand into the `db` module's command and
+    /// the optional profile override the connection should be resolved under.
+    fn into_command(self) -> (db::DbCommand, Option<String>) {
+        match self {
+            Self::Create { profile } => (db::DbCommand::Create, profile),
+            Self::Drop { profile, force } => (db::DbCommand::Drop { force }, profile),
+            Self::Reset { profile, force } => (db::DbCommand::Reset { force }, profile),
+        }
+    }
+}
+
 /// Subcommands for `autumn migrate`.
 #[derive(Subcommand)]
 enum MigrateCommands {
@@ -1488,11 +1500,7 @@ fn run_command(command: Commands) {
             migrate::run(&action, with_maintenance, &target, profile.as_deref());
         }
         Commands::Db(cmd) => {
-            let (command, profile) = match cmd {
-                DbCommands::Create { profile } => (db::DbCommand::Create, profile),
-                DbCommands::Drop { profile, force } => (db::DbCommand::Drop { force }, profile),
-                DbCommands::Reset { profile, force } => (db::DbCommand::Reset { force }, profile),
-            };
+            let (command, profile) = cmd.into_command();
             db::run(&command, profile.as_deref());
         }
         Commands::Shard(cmd) => match cmd.command {
@@ -2669,60 +2677,82 @@ mod tests {
     #[test]
     fn parse_db_create() {
         let cli = Cli::try_parse_from(["autumn", "db", "create"]).unwrap();
-        match cli.command {
-            Commands::Db(DbCommands::Create { profile }) => assert!(profile.is_none()),
-            _ => panic!("expected Db(Create) command"),
-        }
+        assert!(matches!(
+            cli.command,
+            Commands::Db(DbCommands::Create { profile: None })
+        ));
     }
 
     #[test]
     fn parse_db_create_with_profile() {
         let cli = Cli::try_parse_from(["autumn", "db", "create", "--profile", "test"]).unwrap();
-        match cli.command {
-            Commands::Db(DbCommands::Create { profile }) => {
-                assert_eq!(profile.as_deref(), Some("test"));
-            }
-            _ => panic!("expected Db(Create) command"),
-        }
+        assert!(matches!(
+            cli.command,
+            Commands::Db(DbCommands::Create { profile: Some(p) }) if p == "test"
+        ));
     }
 
     #[test]
     fn parse_db_drop_defaults_force_false() {
         let cli = Cli::try_parse_from(["autumn", "db", "drop"]).unwrap();
-        match cli.command {
-            Commands::Db(DbCommands::Drop { profile, force }) => {
-                assert!(profile.is_none());
-                assert!(!force);
-            }
-            _ => panic!("expected Db(Drop) command"),
-        }
+        assert!(matches!(
+            cli.command,
+            Commands::Db(DbCommands::Drop {
+                profile: None,
+                force: false
+            })
+        ));
     }
 
     #[test]
     fn parse_db_drop_with_force() {
         let cli = Cli::try_parse_from(["autumn", "db", "drop", "--force"]).unwrap();
-        match cli.command {
-            Commands::Db(DbCommands::Drop { force, .. }) => assert!(force),
-            _ => panic!("expected Db(Drop) command"),
-        }
+        assert!(matches!(
+            cli.command,
+            Commands::Db(DbCommands::Drop { force: true, .. })
+        ));
     }
 
     #[test]
     fn parse_db_reset_with_profile_and_force() {
         let cli =
             Cli::try_parse_from(["autumn", "db", "reset", "--profile", "prod", "--force"]).unwrap();
-        match cli.command {
-            Commands::Db(DbCommands::Reset { profile, force }) => {
-                assert_eq!(profile.as_deref(), Some("prod"));
-                assert!(force);
-            }
-            _ => panic!("expected Db(Reset) command"),
-        }
+        assert!(matches!(
+            cli.command,
+            Commands::Db(DbCommands::Reset {
+                profile: Some(p),
+                force: true
+            }) if p == "prod"
+        ));
     }
 
     #[test]
     fn parse_db_without_subcommand_is_error() {
         assert!(Cli::try_parse_from(["autumn", "db"]).is_err());
+    }
+
+    #[test]
+    fn db_into_command_maps_every_variant() {
+        assert!(matches!(
+            DbCommands::Create { profile: None }.into_command(),
+            (db::DbCommand::Create, None)
+        ));
+        assert!(matches!(
+            DbCommands::Drop {
+                profile: Some("dev".to_owned()),
+                force: true,
+            }
+            .into_command(),
+            (db::DbCommand::Drop { force: true }, Some(p)) if p == "dev"
+        ));
+        assert!(matches!(
+            DbCommands::Reset {
+                profile: None,
+                force: false,
+            }
+            .into_command(),
+            (db::DbCommand::Reset { force: false }, None)
+        ));
     }
 
     // ── autumn seed tests ──────────────────────────────────────────────────

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -616,7 +616,7 @@ pub fn effective_profile(explicit: Option<&str>) -> String {
 }
 
 /// Whether a resolved profile name is production (`prod`/`production`).
-fn is_production_profile_name(profile: &str) -> bool {
+pub fn is_production_profile_name(profile: &str) -> bool {
     let normalized = profile.trim().to_ascii_lowercase();
     normalized == "prod" || normalized == "production"
 }
@@ -762,7 +762,19 @@ fn deep_merge_toml(base: &mut toml::Table, overlay: toml::Table) {
     }
 }
 
-fn resolve_primary_database_url_from_sources<F>(
+/// Resolve the primary/write database URL for the given profile using the
+/// exact same layering as `autumn migrate` (defaults → `autumn.toml` →
+/// `autumn-{profile}.toml` → `AUTUMN_*` / `DATABASE_URL` / `primary_url`).
+///
+/// Returns `None` when no URL can be resolved, leaving the caller to decide how
+/// to report the failure (the `autumn db` commands surface their own message).
+pub fn resolve_primary_url(profile: Option<&str>) -> Option<String> {
+    let effective = effective_profile(profile);
+    let config_table = read_autumn_toml_table_with_profile(Some(&effective));
+    resolve_primary_database_url_from_sources(|key| std::env::var(key), config_table.as_ref())
+}
+
+pub fn resolve_primary_database_url_from_sources<F>(
     env_var: F,
     table: Option<&toml::Table>,
 ) -> Option<String>

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -2328,6 +2328,44 @@ replica_url = "postgres://replica:5432/app"
         assert_eq!(url, "postgres://primary:5432/app");
     }
 
+    #[test]
+    fn resolve_primary_url_reads_env_for_active_profile() {
+        // `resolve_primary_url` is the convenience entry the `autumn db`
+        // commands use; it must resolve the same primary URL `autumn migrate`
+        // would for the active profile. The env var wins over any file layer.
+        temp_env::with_vars(
+            [
+                ("AUTUMN_ENV", Some("dev")),
+                (
+                    "AUTUMN_DATABASE__PRIMARY_URL",
+                    Some("postgres://primary:5432/app"),
+                ),
+            ],
+            || {
+                assert_eq!(
+                    resolve_primary_url(None).as_deref(),
+                    Some("postgres://primary:5432/app")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_primary_url_none_when_unset() {
+        // No env URL and no autumn.toml in the test's working directory → None,
+        // leaving the caller to report the missing-URL error.
+        temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
+                ("AUTUMN_DATABASE__URL", None),
+                ("DATABASE_URL", None),
+            ],
+            || {
+                assert!(resolve_primary_url(Some("dev")).is_none());
+            },
+        );
+    }
+
     // ── build_targets ──────────────────────────────────────────────────────
 
     fn two_shards() -> Vec<(String, String)> {

--- a/autumn-cli/tests/db.rs
+++ b/autumn-cli/tests/db.rs
@@ -1,0 +1,212 @@
+//! Integration tests for `autumn db create | drop | reset`.
+//!
+//! These tests require Docker (via testcontainers) and are marked `#[ignore]`
+//! so they only run when explicitly requested with `-- --ignored`.
+//!
+//! Run with:
+//!   cargo test -p autumn-cli --test db -- --ignored --nocapture
+
+use std::path::Path;
+use std::process::Command;
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+/// A distinctive password so tests can assert it never leaks into output.
+const SECRET_PW: &str = "s3cr3t_pw_do_not_leak";
+
+/// Run the autumn binary with `args` and env overrides; return (stdout, stderr, `exit_code`).
+fn run_autumn(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String, Option<i32>) {
+    let output = Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .envs(envs.iter().copied())
+        .output()
+        .expect("failed to run autumn");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code(),
+    )
+}
+
+fn run_autumn_ok(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String) {
+    let (stdout, stderr, code) = run_autumn(dir, args, envs);
+    assert_eq!(
+        code,
+        Some(0),
+        "autumn {args:?} failed (exit={code:?})\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    (stdout, stderr)
+}
+
+fn run_autumn_fail(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String) {
+    let (stdout, stderr, code) = run_autumn(dir, args, envs);
+    assert_ne!(
+        code,
+        Some(0),
+        "autumn {args:?} should have failed but exited 0\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    (stdout, stderr)
+}
+
+/// Write a minimal migration directory with `up.sql` and `down.sql`.
+fn write_migration(migrations_dir: &Path, name: &str, up_sql: &str, down_sql: &str) {
+    let dir = migrations_dir.join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("up.sql"), up_sql).unwrap();
+    std::fs::write(dir.join("down.sql"), down_sql).unwrap();
+}
+
+/// Start a Postgres container with a distinctive password and return its
+/// `host:port`. The default `postgres` maintenance database is present; the
+/// per-test target database (named in the URL) does **not** yet exist.
+async fn start_postgres() -> (
+    testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>,
+    String,
+    u16,
+) {
+    use testcontainers::runners::AsyncRunner as _;
+    use testcontainers_modules::postgres::Postgres;
+
+    let container = Postgres::default()
+        .with_password(SECRET_PW)
+        .start()
+        .await
+        .expect("failed to start Postgres testcontainer — is Docker running?");
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    (container, host, port)
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn db_create_creates_database_and_is_idempotent() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/created_app");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    // First create: makes the database.
+    let (_, stderr) = run_autumn_ok(dir, &["db", "create"], &envs);
+    assert!(stderr.contains("Created database"), "stderr: {stderr}");
+    assert!(stderr.contains("created_app"), "stderr: {stderr}");
+
+    // Second create: idempotent notice, still exits 0.
+    let (_, stderr) = run_autumn_ok(dir, &["db", "create"], &envs);
+    assert!(stderr.contains("already exists"), "stderr: {stderr}");
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn db_drop_is_idempotent_and_never_leaks_credentials() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/dropped_app");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    run_autumn_ok(dir, &["db", "create"], &envs);
+
+    // Drop under the default (dev) profile: succeeds without --force.
+    let (stdout, stderr) = run_autumn_ok(dir, &["db", "drop"], &envs);
+    assert!(stderr.contains("Dropped database"), "stderr: {stderr}");
+    assert!(
+        !stdout.contains(SECRET_PW) && !stderr.contains(SECRET_PW),
+        "credentials leaked!\nstdout: {stdout}\nstderr: {stderr}",
+    );
+
+    // Drop again: idempotent notice, still exits 0.
+    let (_, stderr) = run_autumn_ok(dir, &["db", "drop"], &envs);
+    assert!(stderr.contains("does not exist"), "stderr: {stderr}");
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn db_drop_refuses_production_without_force() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/prod_app");
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    // Create under prod (creation is non-destructive, always allowed).
+    let prod_envs = [
+        ("AUTUMN_DATABASE__URL", url.as_str()),
+        ("AUTUMN_ENV", "prod"),
+    ];
+    run_autumn_ok(dir, &["db", "create"], &prod_envs);
+
+    // Drop under prod without --force: refused, non-zero, no credential leak.
+    let (stdout, stderr) = run_autumn_fail(dir, &["db", "drop"], &prod_envs);
+    assert!(stderr.contains("Refusing"), "stderr: {stderr}");
+    assert!(stderr.contains("--force"), "stderr: {stderr}");
+    assert!(
+        !stdout.contains(SECRET_PW) && !stderr.contains(SECRET_PW),
+        "credentials leaked!\nstdout: {stdout}\nstderr: {stderr}",
+    );
+
+    // Drop under prod WITH --force: allowed.
+    let (_, stderr) = run_autumn_ok(dir, &["db", "drop", "--force"], &prod_envs);
+    assert!(stderr.contains("Dropped database"), "stderr: {stderr}");
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn db_reset_runs_drop_create_migrate_and_skips_seed() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/reset_app");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    // A valid migration so the migrate step has work to do.
+    let migrations = dir.join("migrations");
+    std::fs::create_dir_all(&migrations).unwrap();
+    write_migration(
+        &migrations,
+        "20260101000000_create_widgets",
+        "CREATE TABLE widgets (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);",
+        "DROP TABLE widgets;",
+    );
+
+    // Reset from scratch: drop (idempotent no-op) → create → migrate → seed (skipped).
+    let (_, stderr) = run_autumn_ok(dir, &["db", "reset"], &envs);
+    assert!(stderr.contains("reset: drop"), "stderr: {stderr}");
+    assert!(stderr.contains("reset: create"), "stderr: {stderr}");
+    assert!(stderr.contains("reset: migrate"), "stderr: {stderr}");
+    assert!(stderr.contains("skipping the seed step"), "stderr: {stderr}");
+    assert!(stderr.contains("Database reset complete"), "stderr: {stderr}");
+
+    // Running it a second time proves the full round-trip is repeatable
+    // (drop now actually drops the populated DB, then re-creates + migrates).
+    let (_, stderr) = run_autumn_ok(dir, &["db", "reset"], &envs);
+    assert!(stderr.contains("Database reset complete"), "stderr: {stderr}");
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn db_reset_stops_and_names_failing_migrate_step() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/reset_fail_app");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    // A deliberately broken migration so the migrate step fails.
+    let migrations = dir.join("migrations");
+    std::fs::create_dir_all(&migrations).unwrap();
+    write_migration(
+        &migrations,
+        "20260101000000_broken",
+        "THIS IS NOT VALID SQL;",
+        "SELECT 1;",
+    );
+
+    let (stdout, stderr) = run_autumn_fail(dir, &["db", "reset"], &envs);
+    assert!(
+        stderr.contains("migrate") && stderr.contains("reset failed"),
+        "expected reset to name the failing migrate step\nstdout: {stdout}\nstderr: {stderr}",
+    );
+}

--- a/autumn-cli/tests/db.rs
+++ b/autumn-cli/tests/db.rs
@@ -176,13 +176,22 @@ async fn db_reset_runs_drop_create_migrate_and_skips_seed() {
     assert!(stderr.contains("reset: drop"), "stderr: {stderr}");
     assert!(stderr.contains("reset: create"), "stderr: {stderr}");
     assert!(stderr.contains("reset: migrate"), "stderr: {stderr}");
-    assert!(stderr.contains("skipping the seed step"), "stderr: {stderr}");
-    assert!(stderr.contains("Database reset complete"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("skipping the seed step"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Database reset complete"),
+        "stderr: {stderr}"
+    );
 
     // Running it a second time proves the full round-trip is repeatable
     // (drop now actually drops the populated DB, then re-creates + migrates).
     let (_, stderr) = run_autumn_ok(dir, &["db", "reset"], &envs);
-    assert!(stderr.contains("Database reset complete"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("Database reset complete"),
+        "stderr: {stderr}"
+    );
 }
 
 #[tokio::test]

--- a/codecov.yml
+++ b/codecov.yml
@@ -22,6 +22,7 @@ ignore:
   - "autumn-cli/src/config.rs"  # psql subprocess orchestration (run_set/unset/list/history/check_psql) — untestable in unit tests; URL-resolution logic is covered in separate tests
   - "autumn-cli/src/flags.rs"  # psql subprocess orchestration (enable/disable/set-rollout/allow) — same pattern as config.rs
   - "autumn-cli/src/shard.rs"  # psql subprocess orchestration (move-slot \copy/verify/delete) — untestable in unit tests; SQL-building, identifier-quoting and URL-resolution logic are covered in separate tests
+  - "autumn-cli/src/db.rs"     # DB lifecycle (create/drop/reset): Postgres connection + subprocess orchestration — untestable in unit tests; URL parsing, identifier quoting, profile guards and error formatting are covered in separate tests, end-to-end paths in Docker-gated tests/db.rs
   - "autumn-cli/src/templates/**"
   - "autumn-cache-redis/**"     # Requires a live Redis server (testcontainers); all tests are #[ignore] for cross-platform CI
   - "**/*_test.rs"

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -319,21 +319,20 @@ async fn list_items(Query(params): Query<Pagination>) -> String {
 
 Autumn uses [Diesel](https://diesel.rs/) with
 [diesel-async](https://github.com/weiznich/diesel_async) and
-[deadpool](https://docs.rs/deadpool) for async Postgres connections.
+[deadpool](https://docs.rs/deadpool) for async Postgres connections. Autumn
+drives Diesel for you — the steps below stand up and migrate the database using
+`autumn` commands end to end.
 
 ### 1. Install the Diesel CLI
+
+`autumn migrate` shells out to the Diesel CLI to apply migrations, so install it
+once:
 
 ```bash
 cargo install diesel_cli --no-default-features --features postgres
 ```
 
-### 2. Create a database
-
-```bash
-createdb my_app
-```
-
-### 3. Configure the connection
+### 2. Configure the connection
 
 Edit `autumn.toml` and uncomment the `[database]` section:
 
@@ -370,14 +369,25 @@ export AUTUMN_DATABASE__PRIMARY_URL="postgres://localhost/my_app"
 
 (Note the double underscore `__` separating section from field.)
 
+### 3. Create the database
+
+```bash
+autumn db create
+```
+
+`autumn db create` reads the connection you just configured and creates the
+database on its server. It is idempotent — run it again and it simply reports
+that the database already exists. (Need a clean slate while iterating on your
+schema? See `autumn db reset` below.)
+
 ### 4. Create a migration
 
 ```bash
-diesel setup --database-url postgres://localhost/my_app
-diesel migration generate create_todos
+autumn generate migration CreateTodos
 ```
 
-Edit the generated `up.sql`:
+This emits a timestamped migration directory under `migrations/` with `up.sql`
+and `down.sql` files. Edit the generated `up.sql`:
 
 ```sql
 CREATE TABLE todos (
@@ -397,11 +407,16 @@ DROP TABLE todos;
 Run it:
 
 ```bash
-diesel migration run --database-url postgres://localhost/my_app
+autumn migrate
 ```
 
-This also generates `src/schema.rs` with Diesel's table macro. If it doesn't
-appear, run `diesel print-schema > src/schema.rs`.
+`autumn migrate` applies every pending migration to the primary database and
+regenerates `src/schema.rs` with Diesel's table macro.
+
+> **Tip — reset the dev database.** While iterating on your schema, run
+> `autumn db reset` to drop, recreate, migrate, and (when a `src/bin/seed.rs`
+> exists) seed the database in a single step. It refuses to run against a
+> production profile unless you pass `--force`.
 
 ---
 


### PR DESCRIPTION
## Summary

Introduces three new `autumn db` subcommands (`create`, `drop`, `reset`) for managing the database lifecycle directly from the CLI, eliminating the need for manual `createdb`/`dropdb` commands or raw SQL.

## Key Changes

- **New `db` module** (`autumn-cli/src/db.rs`): Implements database lifecycle operations
  - `autumn db create`: Creates the configured database (idempotent)
  - `autumn db drop`: Drops the database with production safety guards (refuses non-dev/test profiles without `--force`)
  - `autumn db reset`: Orchestrates drop → create → migrate → seed in a single command
  - All operations resolve the primary database URL using the same layering as `autumn migrate` (defaults → `autumn.toml` → profile overlays → environment variables)
  - Connects to the server's `postgres` maintenance database to issue `CREATE`/`DROP` statements (required since these cannot run while connected to the target database)

- **Credential safety**: Error messages never leak passwords or full connection URLs; only parsed host/port/database name are included in output, consistent with `autumn doctor --strict`

- **Production safety**: Destructive operations (`drop`, `reset`) refuse to run against production profiles (`prod`/`production` or custom profiles) unless `--force` is explicitly passed

- **CLI integration** (`autumn-cli/src/main.rs`):
  - Added `Db(DbCommands)` variant to the `Commands` enum
  - Added `DbCommands` subcommand enum with `Create`, `Drop`, and `Reset` variants
  - Wired dispatch logic to call `db::run()` with the appropriate command

- **URL resolution** (`autumn-cli/src/migrate.rs`):
  - Exposed `resolve_primary_database_url_from_sources()` as public so `db` module can reuse the same URL resolution logic as `migrate`
  - Made `is_production_profile_name()` public for production guard checks

- **Comprehensive tests**:
  - Unit tests in `db.rs` covering URL parsing, identifier quoting, profile guards, and credential safety
  - Integration tests in `tests/db.rs` (marked `#[ignore]`, require Docker/testcontainers) validating end-to-end workflows: idempotency, production refusal, reset orchestration, and error handling

- **Documentation updates** (`docs/guide/getting-started.md`):
  - Replaced manual `createdb` and `diesel` CLI steps with `autumn db create` and `autumn migrate`
  - Added tip about `autumn db reset` for iterative schema development
  - Clarified that `autumn migrate` regenerates `src/schema.rs` automatically

## Notable Implementation Details

- **Reset orchestration**: The `reset` command self-invokes the `autumn` binary for each step (drop, create, migrate, seed) so each reuses its existing runner verbatim and reports its own exit status; reset stops at the first failure and names the failing step
- **Seed step**: Conditionally skipped (with a notice) when `src/bin/seed.rs` is absent
- **Percent-decoding**: Handles URL-encoded database names (e.g., `my%20app` → `my app`)
- **SQL injection prevention**: Uses proper identifier and literal quoting functions (`quote_ident`, `quote_literal`) for all dynamic SQL

https://claude.ai/code/session_01RpudY4QVPUvaHaSbXoKPDf