### PR TITLE
⚡ Bolt: [performance improvement] Optimize string allocations

### DIFF
--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -1590,17 +1590,32 @@ fn collapse_sse_body(bytes: &[u8]) -> String {
     let mut parser = SseWireParser::new();
     let mut events = parser.push(bytes);
     events.extend(parser.finish());
-    let (results, progress): (Vec<_>, Vec<_>) = events
-        .into_iter()
-        .partition(|e| e.event.as_deref() == Some("result"));
-    if results.is_empty() {
-        progress
-            .into_iter()
-            .map(|e| e.data)
-            .collect::<Vec<_>>()
-            .join("\n")
+
+    let mut has_result = false;
+    for e in &events {
+        if e.event.as_deref() == Some("result") {
+            has_result = true;
+            break;
+        }
+    }
+
+    if has_result {
+        let mut out = String::new();
+        for e in events {
+            if e.event.as_deref() == Some("result") {
+                out.push_str(&e.data);
+            }
+        }
+        out
     } else {
-        results.into_iter().map(|e| e.data).collect()
+        let mut out = String::new();
+        for (i, e) in events.into_iter().enumerate() {
+            if i > 0 {
+                out.push('\n');
+            }
+            out.push_str(&e.data);
+        }
+        out
     }
 }
 

--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -351,16 +351,18 @@ pub fn check_route_prefix(
 /// `{}`. matchit (Axum's router) treats a named param and a catch-all at the
 /// same path position as a conflict, so they must map to the same key.
 fn normalize_path_for_collision(path: &str) -> String {
-    path.split('/')
-        .map(|seg| {
-            if seg.starts_with('{') && seg.ends_with('}') {
-                "{}"
-            } else {
-                seg
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
+    let mut out = String::with_capacity(path.len());
+    for (i, seg) in path.split('/').enumerate() {
+        if i > 0 {
+            out.push('/');
+        }
+        if seg.starts_with('{') && seg.ends_with('}') {
+            out.push_str("{}");
+        } else {
+            out.push_str(seg);
+        }
+    }
+    out
 }
 
 /// Detect route collisions: any two routes sharing the same (method, path) pair.


### PR DESCRIPTION
💡 What:
Replaced `.collect::<Vec<_>>().join(sep)` with pre-allocated `String` buffers built via `.push_str()` in two hot paths (`collapse_sse_body` and `normalize_path_for_collision`).

🎯 Why:
The original approach caused intermediate heap allocations for vectors that were only used temporarily to join strings, reducing performance and increasing GC pressure on the allocator.

📊 Impact:
Reduces heap allocations during both MCP SSE body fallback processing and during route collision normalization mapping.

🔬 Measurement:
Run `cargo bench` or profile memory allocations. The unit tests `cargo test -p autumn-web --lib plugin_conformance` and `cargo test -p autumn-web --lib mcp` continue to pass identically to ensure logic correctness.

---
*PR created automatically by Jules for task [17390080544074675119](https://jules.google.com/task/17390080544074675119) started by @madmax983*