### PR TITLE
fix(serve): bind unix socket under an owner-only umask

### DIFF
--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -49,6 +49,15 @@ pub fn run(debug: bool, package: Option<&str>) {
 
     let mut cmd = Command::new(&binary);
     cmd.env("AUTUMN_BUILD_STATIC", "1");
+    // Share the serve daemon's managed-Postgres cluster (and attach to it when
+    // live) so the static renderer doesn't try to start a second postmaster on
+    // the daemon's locked data dir. A no-op for apps that don't use managed PG.
+    if let Some(pg) = crate::serve::managed_pg_env(package) {
+        cmd.env(crate::serve::MANAGED_PG_DATA_DIR_ENV, &pg.data_dir);
+        if let Some(url) = pg.attach_url {
+            cmd.env(crate::serve::MANAGED_PG_ATTACH_URL_ENV, url);
+        }
+    }
     // Mirror cargo's profile selection: dev builds use the dev Autumn profile
     // (skips production-only validation), release builds use prod so that
     // prod config overrides (robots.txt, SEO settings, etc.) are applied.

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -52,17 +52,16 @@ pub fn run(debug: bool, package: Option<&str>) {
     // Share the serve daemon's managed-Postgres cluster (and attach to it when
     // live) so the static renderer doesn't try to start a second postmaster on
     // the daemon's locked data dir. A no-op for apps that don't use managed PG.
+    // The attach URL is CLI→child plumbing, not an operator knob. Clear any
+    // inherited value up front (even when an explicit AUTUMN_MANAGED_PG_DATA_DIR
+    // override makes `managed_pg_env` return None) so a stale/foreign value can't
+    // redirect the static renderer to the wrong database; re-set it only when a
+    // live cluster is discovered.
+    cmd.env_remove(crate::serve::MANAGED_PG_ATTACH_URL_ENV);
     if let Some(pg) = crate::serve::managed_pg_env(package) {
         cmd.env(crate::serve::MANAGED_PG_DATA_DIR_ENV, &pg.data_dir);
-        match pg.attach_url {
-            Some(url) => {
-                cmd.env(crate::serve::MANAGED_PG_ATTACH_URL_ENV, url);
-            }
-            // No live cluster: clear any inherited attach URL so a stale/foreign
-            // value can't redirect the static renderer to the wrong database.
-            None => {
-                cmd.env_remove(crate::serve::MANAGED_PG_ATTACH_URL_ENV);
-            }
+        if let Some(url) = pg.attach_url {
+            cmd.env(crate::serve::MANAGED_PG_ATTACH_URL_ENV, url);
         }
     }
     // Mirror cargo's profile selection: dev builds use the dev Autumn profile

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -54,8 +54,15 @@ pub fn run(debug: bool, package: Option<&str>) {
     // the daemon's locked data dir. A no-op for apps that don't use managed PG.
     if let Some(pg) = crate::serve::managed_pg_env(package) {
         cmd.env(crate::serve::MANAGED_PG_DATA_DIR_ENV, &pg.data_dir);
-        if let Some(url) = pg.attach_url {
-            cmd.env(crate::serve::MANAGED_PG_ATTACH_URL_ENV, url);
+        match pg.attach_url {
+            Some(url) => {
+                cmd.env(crate::serve::MANAGED_PG_ATTACH_URL_ENV, url);
+            }
+            // No live cluster: clear any inherited attach URL so a stale/foreign
+            // value can't redirect the static renderer to the wrong database.
+            None => {
+                cmd.env_remove(crate::serve::MANAGED_PG_ATTACH_URL_ENV);
+            }
         }
     }
     // Mirror cargo's profile selection: dev builds use the dev Autumn profile

--- a/autumn-cli/src/paths.rs
+++ b/autumn-cli/src/paths.rs
@@ -161,6 +161,14 @@ impl RuntimePaths {
         self.runtime.join("serve.addr")
     }
 
+    /// Mode-marker file (`<runtime>/serve.mode`): the daemon's `release`/`profile`
+    /// recorded separately from `serve.addr` so `restart` can recover them even
+    /// if the address file is deleted/corrupted while the daemon runs.
+    #[must_use]
+    pub fn mode_file(&self) -> PathBuf {
+        self.runtime.join("serve.mode")
+    }
+
     /// Readiness-signal file (`<runtime>/serve.ready`). The daemon creates it
     /// after `mark_startup_complete()`; the supervisor polls for it to detect
     /// true startup completion without probing HTTP.

--- a/autumn-cli/src/process.rs
+++ b/autumn-cli/src/process.rs
@@ -364,13 +364,21 @@ pub fn wait_for_record_exit(record: &PidRecord, timeout: Duration) -> bool {
 /// signal instead — if it no longer has a live listener, the daemon has exited
 /// and the still-"alive" PID belongs to an unrelated reuser, so the
 /// `SIGKILL`/`killpg` escalation is skipped rather than aimed at a stranger.
+/// `startup_in_progress` guards that socket check: a daemon still starting hasn't
+/// bound its socket yet, so without it a stop racing startup would mistake our
+/// own starting daemon for a dead one and orphan it.
 ///
 /// A `false` return means the daemon could **not** be stopped — e.g. it is owned
 /// by another user and `kill` returns `EPERM` — so the caller must not delete
 /// its state or report success.
 #[cfg(unix)]
 #[must_use]
-pub fn stop_record(record: &PidRecord, timeout: Duration, socket: &Path) -> bool {
+pub fn stop_record(
+    record: &PidRecord,
+    timeout: Duration,
+    socket: &Path,
+    startup_in_progress: bool,
+) -> bool {
     let _ = signal_terminate(record.pid);
     if wait_for_record_exit(record, timeout) {
         return true;
@@ -379,8 +387,10 @@ pub fn stop_record(record: &PidRecord, timeout: Duration, socket: &Path) -> bool
     // recorded start time, `is_record_alive` is a bare liveness check that can't
     // tell our daemon from a process that reused its PID after it exited. Use the
     // daemon's socket as the identity check: only our daemon listens there, so a
-    // dead socket means it's gone — don't escalate against the reused PID.
-    if record.start_time.is_none() && !socket_has_live_listener(socket) {
+    // dead socket means it's gone — don't escalate against the reused PID. But a
+    // start still in progress hasn't bound the socket yet, and that live PID *is*
+    // our starting daemon, so don't skip escalation in that window.
+    if record.start_time.is_none() && !startup_in_progress && !socket_has_live_listener(socket) {
         return true;
     }
     if !is_record_alive(record) {
@@ -440,7 +450,12 @@ pub fn stop_postmaster(_pid: u32, _timeout: Duration) {}
 /// Non-Unix fallback: no graceful-signal mechanism in this MVP.
 #[cfg(not(unix))]
 #[must_use]
-pub fn stop_record(_record: &PidRecord, _timeout: Duration, _socket: &Path) -> bool {
+pub fn stop_record(
+    _record: &PidRecord,
+    _timeout: Duration,
+    _socket: &Path,
+    _startup_in_progress: bool,
+) -> bool {
     false
 }
 

--- a/autumn-cli/src/process.rs
+++ b/autumn-cli/src/process.rs
@@ -358,44 +358,35 @@ pub fn wait_for_record_exit(record: &PidRecord, timeout: Duration) -> bool {
 /// `timeout` for it to drain and exit, then force-kill if it is still alive.
 /// Returns `true` only if the recorded process is gone afterwards.
 ///
-/// The wait and the pre-escalation check are identity-aware: a recorded start
-/// time (Linux) detects a PID reused mid-drain, and where that's unavailable
-/// (macOS/BSD, or legacy pidfiles) the daemon's `socket` is used as the identity
-/// signal instead — if it no longer has a live listener, the daemon has exited
-/// and the still-"alive" PID belongs to an unrelated reuser, so the
-/// `SIGKILL`/`killpg` escalation is skipped rather than aimed at a stranger.
-/// `startup_in_progress` guards that socket check: a daemon still starting hasn't
-/// bound its socket yet, so without it a stop racing startup would mistake our
-/// own starting daemon for a dead one and orphan it.
+/// On Linux the wait is identity-aware: a recorded start time detects a PID
+/// reused mid-drain, so the `SIGKILL`/`killpg` escalation never aims at a
+/// stranger. Where a start time is unavailable (macOS/BSD, or legacy pidfiles)
+/// we can't distinguish our stuck daemon from a reused PID, so we enforce the
+/// timeout and escalate against the still-live PID rather than risk reporting a
+/// false "stopped" and orphaning a daemon that merely closed its listener while
+/// still draining. (The residual risk of signalling a reused PID is bounded: the
+/// wait returns the instant the original exits, so reaching here with a live PID
+/// almost always means our own daemon never exited.)
 ///
 /// A `false` return means the daemon could **not** be stopped — e.g. it is owned
 /// by another user and `kill` returns `EPERM` — so the caller must not delete
 /// its state or report success.
 #[cfg(unix)]
 #[must_use]
-pub fn stop_record(
-    record: &PidRecord,
-    timeout: Duration,
-    socket: &Path,
-    startup_in_progress: bool,
-) -> bool {
+pub fn stop_record(record: &PidRecord, timeout: Duration, socket: &Path) -> bool {
     let _ = signal_terminate(record.pid);
     if wait_for_record_exit(record, timeout) {
-        return true;
-    }
-    // Timed out with the PID still apparently alive. On platforms without a
-    // recorded start time, `is_record_alive` is a bare liveness check that can't
-    // tell our daemon from a process that reused its PID after it exited. Use the
-    // daemon's socket as the identity check: only our daemon listens there, so a
-    // dead socket means it's gone — don't escalate against the reused PID. But a
-    // start still in progress hasn't bound the socket yet, and that live PID *is*
-    // our starting daemon, so don't skip escalation in that window.
-    if record.start_time.is_none() && !startup_in_progress && !socket_has_live_listener(socket) {
         return true;
     }
     if !is_record_alive(record) {
         return true;
     }
+    // Timed out with the PID still alive. A daemon can close its control socket
+    // before its `on_shutdown` hooks finish (or hang outright), so a dead socket
+    // is *not* proof of exit — enforce the budget with a `SIGKILL`. `socket` is
+    // retained for symmetry with the non-Unix stub and possible future identity
+    // checks, but is intentionally not used as an exit signal here.
+    let _ = socket;
     // The app missed its graceful-drain budget and is still our daemon, so its
     // `on_shutdown` hooks (which stop a managed Postgres child) may not have run.
     // Kill the whole daemon process group, not just the app PID, so supervised
@@ -403,15 +394,6 @@ pub fn stop_record(
     force_kill(record.pid);
     force_kill_group(record.pid);
     wait_for_record_exit(record, Duration::from_secs(5))
-}
-
-/// Whether a Unix socket at `path` currently has a live listener (a `connect`
-/// succeeds). Used as an identity signal where a process start time isn't
-/// available, since only our daemon listens on its control socket.
-#[cfg(unix)]
-#[must_use]
-fn socket_has_live_listener(path: &Path) -> bool {
-    std::os::unix::net::UnixStream::connect(path).is_ok()
 }
 
 /// Stop a managed Postgres postmaster `pid`: request a "fast" shutdown (SIGINT —
@@ -450,12 +432,7 @@ pub fn stop_postmaster(_pid: u32, _timeout: Duration) {}
 /// Non-Unix fallback: no graceful-signal mechanism in this MVP.
 #[cfg(not(unix))]
 #[must_use]
-pub fn stop_record(
-    _record: &PidRecord,
-    _timeout: Duration,
-    _socket: &Path,
-    _startup_in_progress: bool,
-) -> bool {
+pub fn stop_record(_record: &PidRecord, _timeout: Duration, _socket: &Path) -> bool {
     false
 }
 

--- a/autumn-cli/src/process.rs
+++ b/autumn-cli/src/process.rs
@@ -358,20 +358,29 @@ pub fn wait_for_record_exit(record: &PidRecord, timeout: Duration) -> bool {
 /// `timeout` for it to drain and exit, then force-kill if it is still alive.
 /// Returns `true` only if the recorded process is gone afterwards.
 ///
-/// The wait and the pre-escalation check are identity-aware (start time, when
-/// the platform records it): if the daemon exits and its PID is reused before
-/// the loop observes the exit, the reused process has a different start time and
-/// is treated as already-gone, so the `SIGKILL`/`killpg` escalation is skipped
-/// rather than aimed at an unrelated process.
+/// The wait and the pre-escalation check are identity-aware: a recorded start
+/// time (Linux) detects a PID reused mid-drain, and where that's unavailable
+/// (macOS/BSD, or legacy pidfiles) the daemon's `socket` is used as the identity
+/// signal instead — if it no longer has a live listener, the daemon has exited
+/// and the still-"alive" PID belongs to an unrelated reuser, so the
+/// `SIGKILL`/`killpg` escalation is skipped rather than aimed at a stranger.
 ///
 /// A `false` return means the daemon could **not** be stopped — e.g. it is owned
 /// by another user and `kill` returns `EPERM` — so the caller must not delete
 /// its state or report success.
 #[cfg(unix)]
 #[must_use]
-pub fn stop_record(record: &PidRecord, timeout: Duration) -> bool {
+pub fn stop_record(record: &PidRecord, timeout: Duration, socket: &Path) -> bool {
     let _ = signal_terminate(record.pid);
     if wait_for_record_exit(record, timeout) {
+        return true;
+    }
+    // Timed out with the PID still apparently alive. On platforms without a
+    // recorded start time, `is_record_alive` is a bare liveness check that can't
+    // tell our daemon from a process that reused its PID after it exited. Use the
+    // daemon's socket as the identity check: only our daemon listens there, so a
+    // dead socket means it's gone — don't escalate against the reused PID.
+    if record.start_time.is_none() && !socket_has_live_listener(socket) {
         return true;
     }
     if !is_record_alive(record) {
@@ -384,6 +393,15 @@ pub fn stop_record(record: &PidRecord, timeout: Duration) -> bool {
     force_kill(record.pid);
     force_kill_group(record.pid);
     wait_for_record_exit(record, Duration::from_secs(5))
+}
+
+/// Whether a Unix socket at `path` currently has a live listener (a `connect`
+/// succeeds). Used as an identity signal where a process start time isn't
+/// available, since only our daemon listens on its control socket.
+#[cfg(unix)]
+#[must_use]
+fn socket_has_live_listener(path: &Path) -> bool {
+    std::os::unix::net::UnixStream::connect(path).is_ok()
 }
 
 /// Stop a managed Postgres postmaster `pid`: request a "fast" shutdown (SIGINT —
@@ -422,7 +440,7 @@ pub fn stop_postmaster(_pid: u32, _timeout: Duration) {}
 /// Non-Unix fallback: no graceful-signal mechanism in this MVP.
 #[cfg(not(unix))]
 #[must_use]
-pub fn stop_record(_record: &PidRecord, _timeout: Duration) -> bool {
+pub fn stop_record(_record: &PidRecord, _timeout: Duration, _socket: &Path) -> bool {
     false
 }
 

--- a/autumn-cli/src/serve.rs
+++ b/autumn-cli/src/serve.rs
@@ -165,12 +165,19 @@ fn run_unix(action: Option<ServeAction>, opts: &ServeOptions) -> i32 {
                     || managed_cluster_present(opts.package.as_deref()),
                     |a| a.managed_pg,
                 );
-            let keep_release = opts.release || running.as_ref().is_some_and(|a| a.release);
+            // Fall back to the `serve.mode` marker for release/profile when the
+            // address file is missing/corrupt (it persists them independently).
+            let recorded_mode = running_daemon_mode(opts.package.as_deref());
+            let keep_release = opts.release
+                || running.as_ref().is_some_and(|a| a.release)
+                || recorded_mode.as_ref().is_some_and(|m| m.release);
             // Preserve the original daemon's profile: prefer one set on *this*
             // restart's environment, else restore what the running daemon
-            // recorded, so a bare `restart` doesn't silently fall back to `dev`.
-            let keep_profile =
-                env_profile().or_else(|| running.as_ref().and_then(|a| a.profile.clone()));
+            // recorded (address file, then mode marker), so a bare `restart`
+            // doesn't silently fall back to `dev`.
+            let keep_profile = env_profile()
+                .or_else(|| running.as_ref().and_then(|a| a.profile.clone()))
+                .or_else(|| recorded_mode.and_then(|m| m.profile));
             let _ = stop(opts);
             let daemon_opts = ServeOptions {
                 daemon: true,
@@ -932,7 +939,50 @@ fn write_addr_file(
         use std::os::unix::fs::PermissionsExt;
         let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
     }
+    // Persist release/profile in a separate marker too, so a later `restart` can
+    // recover them even if `serve.addr` is deleted/corrupted while the daemon is
+    // running. Best-effort: the address file is the primary record, so a failure
+    // here doesn't fail the start.
+    write_mode_file(paths, opts);
     Ok(())
+}
+
+/// The daemon's build/profile mode, recorded alongside `serve.addr` (see
+/// [`RuntimePaths::mode_file`]) as a resilient fallback for `restart`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct ModeFile {
+    /// Whether the daemon was built/started in release mode.
+    #[serde(default)]
+    release: bool,
+    /// The explicit profile (`AUTUMN_ENV`/`AUTUMN_PROFILE`) the daemon used.
+    #[serde(default)]
+    profile: Option<String>,
+}
+
+/// Write the `serve.mode` marker (`0600`). Best-effort.
+fn write_mode_file(paths: &RuntimePaths, opts: &ServeOptions) {
+    let mode = ModeFile {
+        release: opts.release,
+        profile: opts.profile.clone().or_else(env_profile),
+    };
+    let Ok(toml) = toml::to_string(&mode) else {
+        return;
+    };
+    let path = paths.mode_file();
+    if std::fs::write(&path, toml).is_ok() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+        }
+    }
+}
+
+/// The recorded `serve.mode` for this project, if present and parseable.
+fn running_daemon_mode(package: Option<&str>) -> Option<ModeFile> {
+    let paths = RuntimePaths::resolve(&project_identity(package)).ok()?;
+    let contents = std::fs::read_to_string(paths.mode_file()).ok()?;
+    toml::from_str(&contents).ok()
 }
 
 /// Stop the running daemon. Returns the exit code.
@@ -1247,10 +1297,12 @@ fn status(opts: &ServeOptions) -> i32 {
     }
 }
 
-/// Best-effort removal of the pidfile, address file, readiness file, and socket.
+/// Best-effort removal of the pidfile, address file, mode marker, readiness
+/// file, and socket.
 fn cleanup(paths: &RuntimePaths, socket: &Path) {
     let _ = std::fs::remove_file(paths.pid_file());
     let _ = std::fs::remove_file(paths.addr_file());
+    let _ = std::fs::remove_file(paths.mode_file());
     let _ = std::fs::remove_file(paths.ready_file());
     remove_socket_if_not_live(socket);
 }

--- a/autumn-cli/src/serve.rs
+++ b/autumn-cli/src/serve.rs
@@ -1207,23 +1207,20 @@ pub fn managed_pg_env(package: Option<&str>) -> Option<ManagedPgEnv> {
     let paths = RuntimePaths::resolve(&project_identity(package)).ok()?;
     let data_dir = paths.pg_data_dir();
 
-    // Attach only to a cluster we can actually reach: a published URL whose
-    // endpoint accepts a connection. This confirms liveness portably — covering
-    // macOS/BSD PID reuse, where the postmaster-pid check can only test bare
-    // liveness — and never hands the child a stale/dead endpoint.
-    if let Some(url) = reachable_published_url(&data_dir) {
-        return Some(ManagedPgEnv {
+    // Only attach when a live postmaster actually owns this data dir. The identity
+    // guard in `live_postmaster_pid` (PID alive + process is `postgres` + its cwd
+    // is this data dir, where observable) prevents trusting a stale `.autumn-pg-url`
+    // whose old random port was reused by a foreign listener — a bare TCP probe
+    // can't tell our cluster from a stranger.
+    if live_postmaster_pid(&data_dir).is_some() {
+        // A live postmaster holds the dir. Attach only when its published URL is
+        // actually reachable; otherwise don't point the child at the *locked* dir
+        // (URL missing/unpublished, or a best-effort publish failure) — starting a
+        // second postmaster there would deadlock. Let it use its own default.
+        return reachable_published_url(&data_dir).map(|url| ManagedPgEnv {
             data_dir,
             attach_url: Some(url),
         });
-    }
-
-    // No reachable cluster. But if a live postmaster still holds this data dir
-    // (URL missing/unpublished, a best-effort publish failure, or a task racing
-    // the daemon's startup), don't point the child at the *locked* dir — it would
-    // deadlock starting a second postmaster. Let it use its own default cluster.
-    if live_postmaster_pid(&data_dir).is_some() {
-        return None;
     }
 
     // A daemon start is in flight (the startup lock is held by a live launcher)

--- a/autumn-cli/src/serve.rs
+++ b/autumn-cli/src/serve.rs
@@ -174,19 +174,26 @@ fn run_unix(action: Option<ServeAction>, opts: &ServeOptions) -> i32 {
                     || managed_cluster_present(opts.package.as_deref()),
                     |a| a.managed_pg,
                 );
-            // Fall back to the `serve.mode` marker for release/profile when the
-            // address file is missing/corrupt (it persists them independently).
+            // The address file is authoritative when present; only fall back to
+            // the `serve.mode` marker for release/profile when it is
+            // missing/corrupt. A best-effort marker left over from an older
+            // release run must not force a parseable dev daemon back to release.
             let recorded_mode = running_daemon_mode(opts.package.as_deref());
             let keep_release = opts.release
-                || running.as_ref().is_some_and(|a| a.release)
-                || recorded_mode.as_ref().is_some_and(|m| m.release);
+                || running.as_ref().map_or_else(
+                    || recorded_mode.as_ref().is_some_and(|m| m.release),
+                    |a| a.release,
+                );
             // Preserve the original daemon's profile: prefer one set on *this*
-            // restart's environment, else restore what the running daemon
-            // recorded (address file, then mode marker), so a bare `restart`
-            // doesn't silently fall back to `dev`.
-            let keep_profile = env_profile()
-                .or_else(|| running.as_ref().and_then(|a| a.profile.clone()))
-                .or_else(|| recorded_mode.and_then(|m| m.profile));
+            // restart's environment, else what the running daemon recorded —
+            // address file first, the mode marker only when there is no address
+            // file — so a bare `restart` doesn't silently fall back to `dev`.
+            let keep_profile = env_profile().or_else(|| {
+                running.as_ref().map_or_else(
+                    || recorded_mode.as_ref().and_then(|m| m.profile.clone()),
+                    |a| a.profile.clone(),
+                )
+            });
             let daemon_opts = ServeOptions {
                 daemon: true,
                 bundled_pg: keep_managed,
@@ -1068,7 +1075,6 @@ fn stop(opts: &ServeOptions) -> i32 {
         &rec,
         stop_timeout(opts, recorded_release, recorded_budget),
         &socket,
-        startup_in_progress(&paths),
     ) {
         // The daemon is still alive and we couldn't signal it (e.g. it is owned
         // by another user — `kill` returned `EPERM`). Do NOT remove its state or
@@ -1158,10 +1164,11 @@ pub struct ManagedPgEnv {
 }
 
 /// Resolve the managed-Postgres environment for a one-off run of `package` so it
-/// shares the serve daemon's cluster. Returns the daemon's data dir (always) and
-/// the live cluster's published URL (only when a postmaster is actually running
-/// for this project). `None` when the project's runtime paths can't be resolved,
-/// in which case the run falls back to the provider's own per-project default.
+/// shares the serve daemon's cluster. `None` when the project's runtime paths
+/// can't be resolved (the run then uses the provider's own per-project default),
+/// or when a live postmaster holds the data dir but we can't attach to it (so the
+/// child must not be pointed at the locked dir). Otherwise returns the data dir
+/// and, when a reachable cluster is published, its attach URL.
 #[must_use]
 pub fn managed_pg_env(package: Option<&str>) -> Option<ManagedPgEnv> {
     // Respect an explicit operator override: if the environment already pins the
@@ -1172,46 +1179,80 @@ pub fn managed_pg_env(package: Option<&str>) -> Option<ManagedPgEnv> {
         return None;
     }
     let paths = RuntimePaths::resolve(&project_identity(package)).ok()?;
-    let attach_url = live_managed_pg_url(&paths);
+    let data_dir = paths.pg_data_dir();
+
+    // Attach only to a cluster we can actually reach: a published URL whose
+    // endpoint accepts a connection. This confirms liveness portably — covering
+    // macOS/BSD PID reuse, where the postmaster-pid check can only test bare
+    // liveness — and never hands the child a stale/dead endpoint.
+    if let Some(url) = reachable_published_url(&data_dir) {
+        return Some(ManagedPgEnv {
+            data_dir,
+            attach_url: Some(url),
+        });
+    }
+
+    // No reachable cluster. But if a live postmaster still holds this data dir
+    // (URL missing/unpublished, a best-effort publish failure, or a task racing
+    // the daemon's startup), don't point the child at the *locked* dir — it would
+    // deadlock starting a second postmaster. Let it use its own default cluster.
+    if live_postmaster_pid(&data_dir).is_some() {
+        return None;
+    }
+
+    // Nothing holds the data dir: safe to share its location so this run and a
+    // future `serve` use the same cluster.
     Some(ManagedPgEnv {
-        data_dir: paths.pg_data_dir(),
-        attach_url,
+        data_dir,
+        attach_url: None,
     })
 }
 
-/// The published connection URL of this project's managed cluster, but only when
-/// the cluster is currently running. Combines the live-postmaster check with the
-/// URL file the provider writes next to the data dir.
-fn live_managed_pg_url(paths: &RuntimePaths) -> Option<String> {
-    // Restrict attach discovery to Unix. Off Unix, `process::is_process_alive` is
-    // a conservative `true` (the daemon lock's fail-safe), so a stale
-    // `postmaster.pid` + URL file left by a crash would make `task`/`build`
-    // attach to a *dead* cluster instead of starting their own. The daemon is
-    // Unix-only anyway, so there's nothing live to share off Unix.
-    #[cfg(not(unix))]
-    {
-        let _ = paths;
-        None
+/// The published connection URL for this project's managed cluster, returned only
+/// when its endpoint is reachable. Reads the URL file the provider writes next to
+/// the data dir, then confirms a live postmaster answers there so a stale
+/// `.autumn-pg-url` (crash / PID reuse) can't make a run attach to a dead cluster.
+fn reachable_published_url(data_dir: &Path) -> Option<String> {
+    // The provider publishes the URL beside the data dir. Keep this filename in
+    // sync with `autumn_web::managed_pg::PUBLISHED_URL_FILE` (the CLI doesn't
+    // build the `managed-pg` feature, so it can't reference the const).
+    let url_file = data_dir.parent().unwrap_or(data_dir).join(".autumn-pg-url");
+    let contents = std::fs::read_to_string(url_file).ok()?;
+    let url = contents.trim();
+    if url.is_empty() || !published_url_reachable(url) {
+        return None;
     }
-    #[cfg(unix)]
-    {
-        let data_dir = paths.pg_data_dir();
-        live_postmaster_pid(&data_dir)?;
-        // The provider publishes the URL beside the data dir. Keep this filename
-        // in sync with `autumn_web::managed_pg::PUBLISHED_URL_FILE` (the CLI
-        // doesn't build the `managed-pg` feature, so it can't reference the const).
-        let url_file = data_dir
-            .parent()
-            .unwrap_or(&data_dir)
-            .join(".autumn-pg-url");
-        let contents = std::fs::read_to_string(url_file).ok()?;
-        let trimmed = contents.trim();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_owned())
-        }
+    Some(url.to_owned())
+}
+
+/// Whether the `host:port` in a `postgresql://…` URL accepts a TCP connection
+/// within a short timeout — a portable, definitive "the cluster is up" probe.
+fn published_url_reachable(url: &str) -> bool {
+    use std::net::ToSocketAddrs;
+    let Some(hostport) = pg_url_host_port(url) else {
+        return false;
+    };
+    let Ok(addrs) = hostport.to_socket_addrs() else {
+        return false;
+    };
+    addrs
+        .take(4)
+        .any(|sa| std::net::TcpStream::connect_timeout(&sa, Duration::from_millis(500)).is_ok())
+}
+
+/// Extract `host:port` from a `postgresql://[user[:pass]@]host:port/db` URL.
+/// Returns `None` unless an explicit numeric port is present (the managed
+/// provider always emits one; a unix-socket URL has none and isn't TCP-probable).
+fn pg_url_host_port(url: &str) -> Option<String> {
+    let after_scheme = url.split_once("://")?.1;
+    let authority = after_scheme.split(['/', '?']).next()?;
+    // Drop any `user:pass@` userinfo (split at the last '@' before the host).
+    let hostport = authority.rsplit_once('@').map_or(authority, |(_, hp)| hp);
+    let (_, port) = hostport.rsplit_once(':')?;
+    if port.parse::<u16>().is_err() {
+        return None;
     }
+    Some(hostport.to_owned())
 }
 
 /// Graceful-stop budget before escalating to `SIGKILL`.
@@ -1577,6 +1618,24 @@ mod tests {
         let nested = root.join("src");
         std::fs::create_dir_all(&nested).expect("create nested dir");
         assert_eq!(workspace_anchor_from(&nested), Some(root));
+    }
+
+    #[test]
+    fn pg_url_host_port_extracts_authority() {
+        assert_eq!(
+            pg_url_host_port("postgresql://postgres:secret@localhost:54213/autumn"),
+            Some("localhost:54213".to_owned())
+        );
+        // No userinfo.
+        assert_eq!(
+            pg_url_host_port("postgres://127.0.0.1:5432/db"),
+            Some("127.0.0.1:5432".to_owned())
+        );
+        // Missing/invalid port → not TCP-probable.
+        assert_eq!(pg_url_host_port("postgresql://localhost/autumn"), None);
+        assert_eq!(pg_url_host_port("postgresql://localhost:notaport/db"), None);
+        // Not a URL.
+        assert_eq!(pg_url_host_port("/var/run/pg.sock"), None);
     }
 
     #[test]

--- a/autumn-cli/src/serve.rs
+++ b/autumn-cli/src/serve.rs
@@ -434,8 +434,17 @@ fn identity_root() -> PathBuf {
 /// ancestor whose `Cargo.toml` has a `[workspace]` table), else the nearest
 /// ancestor containing any `Cargo.toml`, else `None`. Separated from CWD lookup
 /// so it can be unit-tested against a fixture tree.
+///
+/// If a `Cargo.toml` above us exists but fails to parse, we can't confirm its
+/// `[workspace]` table, so fall back to the **topmost** manifest dir (the most
+/// likely workspace root) rather than the nearest. This keeps the namespace
+/// stable when the root manifest is *transiently* unparsable while a `-p`
+/// lifecycle command runs from a member — otherwise the anchor would flip from
+/// the root to the member and `status`/`stop` would target a different dir.
 fn workspace_anchor_from(start: &Path) -> Option<PathBuf> {
     let mut nearest_manifest: Option<PathBuf> = None;
+    let mut topmost_manifest: Option<PathBuf> = None;
+    let mut saw_unparsable = false;
     for dir in start.ancestors() {
         let Ok(contents) = std::fs::read_to_string(dir.join("Cargo.toml")) else {
             continue;
@@ -443,11 +452,18 @@ fn workspace_anchor_from(start: &Path) -> Option<PathBuf> {
         if nearest_manifest.is_none() {
             nearest_manifest = Some(dir.to_path_buf());
         }
-        if toml::from_str::<toml::Table>(&contents).is_ok_and(|t| t.contains_key("workspace")) {
-            return Some(dir.to_path_buf());
+        topmost_manifest = Some(dir.to_path_buf());
+        match toml::from_str::<toml::Table>(&contents) {
+            Ok(table) if table.contains_key("workspace") => return Some(dir.to_path_buf()),
+            Ok(_) => {}
+            Err(_) => saw_unparsable = true,
         }
     }
-    nearest_manifest
+    if saw_unparsable {
+        topmost_manifest
+    } else {
+        nearest_manifest
+    }
 }
 
 /// Build, then start the server (foreground or daemon). Returns the exit code.
@@ -1030,7 +1046,11 @@ fn stop(opts: &ServeOptions) -> i32 {
     // daemons started before that field was recorded.
     let recorded_release = addr.as_ref().is_some_and(|a| a.release);
     let recorded_budget = addr.as_ref().and_then(|a| a.stop_budget_secs);
-    if !process::stop_record(&rec, stop_timeout(opts, recorded_release, recorded_budget)) {
+    if !process::stop_record(
+        &rec,
+        stop_timeout(opts, recorded_release, recorded_budget),
+        &socket,
+    ) {
         // The daemon is still alive and we couldn't signal it (e.g. it is owned
         // by another user — `kill` returned `EPERM`). Do NOT remove its state or
         // report success: that would orphan a running daemon and lie to scripts.
@@ -1469,6 +1489,28 @@ mod tests {
         let nested = root.join("src");
         std::fs::create_dir_all(&nested).expect("create nested dir");
         assert_eq!(workspace_anchor_from(&nested), Some(root));
+    }
+
+    #[test]
+    fn workspace_anchor_stable_when_root_manifest_unparsable() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize root");
+        // The workspace root manifest is temporarily broken (mid-edit).
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[workspace\nthis is not valid toml",
+        )
+        .expect("write broken root manifest");
+        let member = root.join("crates/api");
+        std::fs::create_dir_all(&member).expect("create member dir");
+        std::fs::write(
+            member.join("Cargo.toml"),
+            "[package]\nname = \"api\"\nversion = \"0.1.0\"\n",
+        )
+        .expect("write member manifest");
+        // The anchor must still be the root (topmost manifest), not the member,
+        // so the namespace doesn't flip while the root manifest is unparsable.
+        assert_eq!(workspace_anchor_from(&member), Some(root));
     }
 
     // Env vars touched by these tests; cleared so a polluted outer environment

--- a/autumn-cli/src/serve.rs
+++ b/autumn-cli/src/serve.rs
@@ -474,7 +474,13 @@ fn workspace_anchor_from(start: &Path) -> Option<PathBuf> {
             nearest_manifest = Some(dir.to_path_buf());
         }
         match toml::from_str::<toml::Table>(&contents) {
-            Ok(table) if table.contains_key("workspace") => return Some(dir.to_path_buf()),
+            // A nearer transiently-broken workspace root (the one being edited)
+            // takes precedence over an outer valid `[workspace]`: in a nested
+            // checkout the daemon was started under the inner root, so anchoring
+            // to the outer one would make lifecycle commands miss it.
+            Ok(table) if table.contains_key("workspace") => {
+                return broken_workspace_dir.or_else(|| Some(dir.to_path_buf()));
+            }
             // A *transiently-broken* workspace root: unparsable but still carrying
             // the `[workspace]` header. Anchor to this exact dir (the nearest such
             // root), not the topmost manifest in the ancestry — a higher unrelated
@@ -1155,7 +1161,18 @@ fn live_postmaster_pid(data_dir: &Path) -> Option<u32> {
 /// postmaster owns the data dir, requests a fast shutdown and escalates. No-op
 /// when the cluster already stopped cleanly (pidfile absent or postmaster gone).
 fn reap_managed_postgres(paths: &RuntimePaths) {
-    let Some(pid) = live_postmaster_pid(&paths.pg_data_dir()) else {
+    let data_dir = paths.pg_data_dir();
+    // Whether or not a postmaster is still up, drop the published URL: this
+    // reaper bypasses `ManagedPostgresPoolProvider::stop()` (the only path that
+    // normally removes it), so a leftover `.autumn-pg-url` could make a later
+    // `task`/`build` attach to a dead — or, if the port was reused, foreign —
+    // endpoint instead of starting its own cluster.
+    let url_file = data_dir
+        .parent()
+        .unwrap_or(&data_dir)
+        .join(".autumn-pg-url");
+    let _ = std::fs::remove_file(&url_file);
+    let Some(pid) = live_postmaster_pid(&data_dir) else {
         return;
     };
     process::stop_postmaster(pid, Duration::from_secs(10));
@@ -1726,6 +1743,34 @@ mod tests {
         // Anchor must be the broken workspace dir, not the outer manifest above it,
         // or lifecycle commands would target the wrong runtime dir.
         assert_eq!(workspace_anchor_from(&member), Some(ws));
+    }
+
+    #[test]
+    fn workspace_anchor_inner_broken_root_wins_over_outer_valid_workspace() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let outer = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        // A *valid* outer workspace sits above a transiently-broken inner one.
+        std::fs::write(
+            outer.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"inner\"]\n",
+        )
+        .expect("write outer ws manifest");
+        let inner = outer.join("inner");
+        let member = inner.join("crates/api");
+        std::fs::create_dir_all(&member).expect("create dirs");
+        std::fs::write(
+            inner.join("Cargo.toml"),
+            "[workspace]\nmembers = [\n  \"crates/api\"",
+        )
+        .expect("write broken inner ws manifest");
+        std::fs::write(
+            member.join("Cargo.toml"),
+            "[package]\nname = \"api\"\nversion = \"0.1.0\"\n",
+        )
+        .expect("write member manifest");
+        // The inner (broken) workspace root the daemon was started under wins; the
+        // walk must not return the outer valid workspace.
+        assert_eq!(workspace_anchor_from(&member), Some(inner));
     }
 
     // Env vars touched by these tests; cleared so a polluted outer environment

--- a/autumn-cli/src/serve.rs
+++ b/autumn-cli/src/serve.rs
@@ -456,16 +456,16 @@ fn identity_root() -> PathBuf {
 /// ancestor containing any `Cargo.toml`, else `None`. Separated from CWD lookup
 /// so it can be unit-tested against a fixture tree.
 ///
-/// If a `Cargo.toml` above us exists but fails to parse, we can't confirm its
-/// `[workspace]` table, so fall back to the **topmost** manifest dir (the most
-/// likely workspace root) rather than the nearest. This keeps the namespace
-/// stable when the root manifest is *transiently* unparsable while a `-p`
-/// lifecycle command runs from a member — otherwise the anchor would flip from
-/// the root to the member and `status`/`stop` would target a different dir.
+/// If a `Cargo.toml` above us is unparsable but still contains the `[workspace]`
+/// header, we treat it as a *transiently-broken workspace root* and anchor to
+/// that exact dir (the nearest such one). This keeps the namespace stable while
+/// the root manifest is mid-edit during a `-p` lifecycle command from a member —
+/// otherwise the anchor would flip to the member and `status`/`stop` would target
+/// a different dir. A broken manifest *without* `[workspace]` is ignored so an
+/// unrelated stray file up the tree can't hijack a standalone project's anchor.
 fn workspace_anchor_from(start: &Path) -> Option<PathBuf> {
     let mut nearest_manifest: Option<PathBuf> = None;
-    let mut topmost_manifest: Option<PathBuf> = None;
-    let mut saw_unparsable = false;
+    let mut broken_workspace_dir: Option<PathBuf> = None;
     for dir in start.ancestors() {
         let Ok(contents) = std::fs::read_to_string(dir.join("Cargo.toml")) else {
             continue;
@@ -473,22 +473,24 @@ fn workspace_anchor_from(start: &Path) -> Option<PathBuf> {
         if nearest_manifest.is_none() {
             nearest_manifest = Some(dir.to_path_buf());
         }
-        topmost_manifest = Some(dir.to_path_buf());
         match toml::from_str::<toml::Table>(&contents) {
             Ok(table) if table.contains_key("workspace") => return Some(dir.to_path_buf()),
-            // Only a manifest that *looks* like a workspace root counts as a
-            // transiently-broken root worth anchoring to. An unrelated broken
-            // `Cargo.toml` up the tree (e.g. one in the user's home dir) must not
-            // hijack a standalone project's anchor and corrupt its identity.
-            Err(_) if contents.contains("[workspace]") => saw_unparsable = true,
+            // A *transiently-broken* workspace root: unparsable but still carrying
+            // the `[workspace]` header. Anchor to this exact dir (the nearest such
+            // root), not the topmost manifest in the ancestry — a higher unrelated
+            // `Cargo.toml` above it must not pull the anchor up to the outer
+            // project, or lifecycle commands would target a different runtime dir.
+            // An unrelated broken `Cargo.toml` (no `[workspace]`) is ignored so it
+            // can't hijack a standalone project's anchor.
+            Err(_) if contents.contains("[workspace]") => {
+                if broken_workspace_dir.is_none() {
+                    broken_workspace_dir = Some(dir.to_path_buf());
+                }
+            }
             Ok(_) | Err(_) => {}
         }
     }
-    if saw_unparsable {
-        topmost_manifest
-    } else {
-        nearest_manifest
-    }
+    broken_workspace_dir.or(nearest_manifest)
 }
 
 /// Build, then start the server (foreground or daemon). Returns the exit code.
@@ -1200,6 +1202,15 @@ pub fn managed_pg_env(package: Option<&str>) -> Option<ManagedPgEnv> {
         return None;
     }
 
+    // A daemon start is in flight (the startup lock is held by a live launcher)
+    // but it hasn't started its postmaster or published a URL yet — there's no
+    // `postmaster.pid` to catch above. Sharing the data dir now would let this
+    // run `initdb`/start against the directory the daemon is provisioning and
+    // corrupt or deadlock it, so fall back to the child's own default cluster.
+    if startup_in_progress(&paths) {
+        return None;
+    }
+
     // Nothing holds the data dir: safe to share its location so this run and a
     // future `serve` use the same cluster.
     Some(ManagedPgEnv {
@@ -1676,9 +1687,38 @@ mod tests {
             "[package]\nname = \"api\"\nversion = \"0.1.0\"\n",
         )
         .expect("write member manifest");
-        // The anchor must still be the root (topmost manifest), not the member,
+        // The anchor must still be the broken workspace root, not the member,
         // so the namespace doesn't flip while the root manifest is unparsable.
         assert_eq!(workspace_anchor_from(&member), Some(root));
+    }
+
+    #[test]
+    fn workspace_anchor_broken_root_not_pulled_up_to_outer_manifest() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let outer = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        // An unrelated outer crate sits *above* the (broken) workspace root.
+        std::fs::write(
+            outer.join("Cargo.toml"),
+            "[package]\nname = \"outer\"\nversion = \"0.1.0\"\n",
+        )
+        .expect("write outer manifest");
+        let ws = outer.join("ws");
+        let member = ws.join("crates/api");
+        std::fs::create_dir_all(&member).expect("create dirs");
+        // The intended workspace root is transiently broken (mid-edit).
+        std::fs::write(
+            ws.join("Cargo.toml"),
+            "[workspace]\nmembers = [\n  \"crates/api\"",
+        )
+        .expect("write broken ws manifest");
+        std::fs::write(
+            member.join("Cargo.toml"),
+            "[package]\nname = \"api\"\nversion = \"0.1.0\"\n",
+        )
+        .expect("write member manifest");
+        // Anchor must be the broken workspace dir, not the outer manifest above it,
+        // or lifecycle commands would target the wrong runtime dir.
+        assert_eq!(workspace_anchor_from(&member), Some(ws));
     }
 
     // Env vars touched by these tests; cleared so a polluted outer environment

--- a/autumn-cli/src/serve.rs
+++ b/autumn-cli/src/serve.rs
@@ -15,6 +15,15 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
+/// Env var the managed-Postgres provider reads to locate its data dir. Mirrors
+/// `autumn_web::managed_pg::MANAGED_PG_DATA_DIR_ENV`; redefined here because the
+/// CLI doesn't build the `managed-pg` feature and so can't reference the const.
+pub const MANAGED_PG_DATA_DIR_ENV: &str = "AUTUMN_MANAGED_PG_DATA_DIR";
+/// Env var that makes the provider *attach* to an already-running cluster at the
+/// given URL instead of starting its own. Mirrors
+/// `autumn_web::managed_pg::MANAGED_PG_ATTACH_URL_ENV`.
+pub const MANAGED_PG_ATTACH_URL_ENV: &str = "AUTUMN_MANAGED_PG_ATTACH_URL";
+
 /// Lifecycle subcommand for `autumn serve`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ServeAction {
@@ -592,7 +601,7 @@ fn base_command(binary: &Path, paths: Option<&RuntimePaths>, opts: &ServeOptions
     if opts.bundled_pg
         && let Some(paths) = paths
     {
-        cmd.env("AUTUMN_MANAGED_PG_DATA_DIR", paths.pg_data_dir());
+        cmd.env(MANAGED_PG_DATA_DIR_ENV, paths.pg_data_dir());
     }
     // Restore an explicit profile (set by `restart`) so the relaunched daemon
     // loads the same config as the original even when the restart shell didn't
@@ -1086,44 +1095,93 @@ fn stop(opts: &ServeOptions) -> i32 {
     0
 }
 
-/// Reap a managed Postgres cluster the daemon may have left running. Reads the
-/// postmaster pid from the data dir's `postmaster.pid` and, if it's still alive,
-/// requests a fast shutdown and escalates. No-op when the cluster already
-/// stopped cleanly (pidfile absent or the postmaster is gone).
-fn reap_managed_postgres(paths: &RuntimePaths) {
-    let data_dir = paths.pg_data_dir();
+/// The PID of this cluster's live postmaster, or `None` when none is running.
+///
+/// Reads the data dir's `postmaster.pid` and applies PID-reuse guards: the live
+/// process must actually be `postgres` and (where the platform exposes it) be
+/// `chdir`'d into *this* data dir, since a postmaster `chdir`s to its data dir.
+/// A `postmaster.pid` left by a crashed/`SIGKILL`ed cluster keeps its old PID,
+/// which the OS may have recycled — these checks stop us from mistaking an
+/// unrelated process (or a *different* cluster) for this one.
+fn live_postmaster_pid(data_dir: &Path) -> Option<u32> {
     let pidfile = data_dir.join("postmaster.pid");
-    let Some(pid) = std::fs::read_to_string(&pidfile)
+    let pid = std::fs::read_to_string(&pidfile)
         .ok()
-        .and_then(|s| s.lines().next()?.trim().parse::<u32>().ok())
-    else {
-        return;
-    };
+        .and_then(|s| s.lines().next()?.trim().parse::<u32>().ok())?;
     if !process::is_process_alive(pid) {
-        return;
+        return None;
     }
-    // Guard against PID reuse: a `postmaster.pid` left behind by a crashed or
-    // `SIGKILL`ed cluster keeps its old PID, which the OS may have recycled.
-    // Where the platform reports it, require the live process to actually be
-    // `postgres` before signalling it; if we can't tell (non-Linux), fall back
-    // to liveness alone.
     if process::process_command_name(pid).is_some_and(|name| name != "postgres") {
-        return;
+        return None;
     }
-    // ...and, since the reused PID could be *another* `postgres` cluster, require
-    // its working directory to be this cluster's data dir (a postmaster `chdir`s
-    // to its data dir). Only enforced where `cwd` is observable (Linux); a
-    // mismatch means a different cluster owns the PID, so leave it alone.
     if let Some(cwd) = process::process_cwd(pid) {
         let same_dir = std::fs::canonicalize(&cwd)
             .ok()
-            .zip(std::fs::canonicalize(&data_dir).ok())
+            .zip(std::fs::canonicalize(data_dir).ok())
             .is_some_and(|(live, ours)| live == ours);
         if !same_dir {
-            return;
+            return None;
         }
     }
+    Some(pid)
+}
+
+/// Reap a managed Postgres cluster the daemon may have left running. If a live
+/// postmaster owns the data dir, requests a fast shutdown and escalates. No-op
+/// when the cluster already stopped cleanly (pidfile absent or postmaster gone).
+fn reap_managed_postgres(paths: &RuntimePaths) {
+    let Some(pid) = live_postmaster_pid(&paths.pg_data_dir()) else {
+        return;
+    };
     process::stop_postmaster(pid, Duration::from_secs(10));
+}
+
+/// Managed-Postgres environment for a one-off `autumn task`/`autumn build` run
+/// (see [`managed_pg_env`]).
+pub struct ManagedPgEnv {
+    /// The daemon's cluster data dir, always set so a one-off run and the daemon
+    /// agree on the cluster location.
+    pub data_dir: PathBuf,
+    /// The running cluster's connection URL, set only when a live cluster is
+    /// detected — the run then *attaches* instead of starting its own.
+    pub attach_url: Option<String>,
+}
+
+/// Resolve the managed-Postgres environment for a one-off run of `package` so it
+/// shares the serve daemon's cluster. Returns the daemon's data dir (always) and
+/// the live cluster's published URL (only when a postmaster is actually running
+/// for this project). `None` when the project's runtime paths can't be resolved,
+/// in which case the run falls back to the provider's own per-project default.
+#[must_use]
+pub fn managed_pg_env(package: Option<&str>) -> Option<ManagedPgEnv> {
+    let paths = RuntimePaths::resolve(&project_identity(package)).ok()?;
+    let attach_url = live_managed_pg_url(&paths);
+    Some(ManagedPgEnv {
+        data_dir: paths.pg_data_dir(),
+        attach_url,
+    })
+}
+
+/// The published connection URL of this project's managed cluster, but only when
+/// the cluster is currently running. Combines the live-postmaster check with the
+/// URL file the provider writes next to the data dir.
+fn live_managed_pg_url(paths: &RuntimePaths) -> Option<String> {
+    let data_dir = paths.pg_data_dir();
+    live_postmaster_pid(&data_dir)?;
+    // The provider publishes the URL beside the data dir. Keep this filename in
+    // sync with `autumn_web::managed_pg::PUBLISHED_URL_FILE` (the CLI doesn't
+    // build the `managed-pg` feature, so it can't reference the const).
+    let url_file = data_dir
+        .parent()
+        .unwrap_or(&data_dir)
+        .join(".autumn-pg-url");
+    let contents = std::fs::read_to_string(url_file).ok()?;
+    let trimmed = contents.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
 }
 
 /// Graceful-stop budget before escalating to `SIGKILL`.

--- a/autumn-cli/src/serve.rs
+++ b/autumn-cli/src/serve.rs
@@ -187,7 +187,6 @@ fn run_unix(action: Option<ServeAction>, opts: &ServeOptions) -> i32 {
             let keep_profile = env_profile()
                 .or_else(|| running.as_ref().and_then(|a| a.profile.clone()))
                 .or_else(|| recorded_mode.and_then(|m| m.profile));
-            let _ = stop(opts);
             let daemon_opts = ServeOptions {
                 daemon: true,
                 bundled_pg: keep_managed,
@@ -195,6 +194,12 @@ fn run_unix(action: Option<ServeAction>, opts: &ServeOptions) -> i32 {
                 profile: keep_profile,
                 ..opts.clone()
             };
+            // Stop using the *recovered* mode, not the bare restart flags: when
+            // `serve.addr` is missing/corrupt, `stop`'s budget falls back to
+            // recomputing from release/profile, and the restart shell's defaults
+            // would otherwise derive a short `dev` budget and SIGKILL a release
+            // daemon before it finishes draining.
+            let _ = stop(&daemon_opts);
             start(&daemon_opts)
         }
     }
@@ -464,8 +469,12 @@ fn workspace_anchor_from(start: &Path) -> Option<PathBuf> {
         topmost_manifest = Some(dir.to_path_buf());
         match toml::from_str::<toml::Table>(&contents) {
             Ok(table) if table.contains_key("workspace") => return Some(dir.to_path_buf()),
-            Ok(_) => {}
-            Err(_) => saw_unparsable = true,
+            // Only a manifest that *looks* like a workspace root counts as a
+            // transiently-broken root worth anchoring to. An unrelated broken
+            // `Cargo.toml` up the tree (e.g. one in the user's home dir) must not
+            // hijack a standalone project's anchor and corrupt its identity.
+            Err(_) if contents.contains("[workspace]") => saw_unparsable = true,
+            Ok(_) | Err(_) => {}
         }
     }
     if saw_unparsable {
@@ -1059,6 +1068,7 @@ fn stop(opts: &ServeOptions) -> i32 {
         &rec,
         stop_timeout(opts, recorded_release, recorded_budget),
         &socket,
+        startup_in_progress(&paths),
     ) {
         // The daemon is still alive and we couldn't signal it (e.g. it is owned
         // by another user — `kill` returned `EPERM`). Do NOT remove its state or
@@ -1154,6 +1164,13 @@ pub struct ManagedPgEnv {
 /// in which case the run falls back to the provider's own per-project default.
 #[must_use]
 pub fn managed_pg_env(package: Option<&str>) -> Option<ManagedPgEnv> {
+    // Respect an explicit operator override: if the environment already pins the
+    // managed-PG data dir (e.g. a CI/ops run targeting an isolated cluster), don't
+    // clobber it or redirect the run to the CLI's platform cluster. Returning
+    // `None` leaves the child to inherit the caller's `AUTUMN_MANAGED_PG_DATA_DIR`.
+    if std::env::var_os(MANAGED_PG_DATA_DIR_ENV).is_some() {
+        return None;
+    }
     let paths = RuntimePaths::resolve(&project_identity(package)).ok()?;
     let attach_url = live_managed_pg_url(&paths);
     Some(ManagedPgEnv {
@@ -1166,21 +1183,34 @@ pub fn managed_pg_env(package: Option<&str>) -> Option<ManagedPgEnv> {
 /// the cluster is currently running. Combines the live-postmaster check with the
 /// URL file the provider writes next to the data dir.
 fn live_managed_pg_url(paths: &RuntimePaths) -> Option<String> {
-    let data_dir = paths.pg_data_dir();
-    live_postmaster_pid(&data_dir)?;
-    // The provider publishes the URL beside the data dir. Keep this filename in
-    // sync with `autumn_web::managed_pg::PUBLISHED_URL_FILE` (the CLI doesn't
-    // build the `managed-pg` feature, so it can't reference the const).
-    let url_file = data_dir
-        .parent()
-        .unwrap_or(&data_dir)
-        .join(".autumn-pg-url");
-    let contents = std::fs::read_to_string(url_file).ok()?;
-    let trimmed = contents.trim();
-    if trimmed.is_empty() {
+    // Restrict attach discovery to Unix. Off Unix, `process::is_process_alive` is
+    // a conservative `true` (the daemon lock's fail-safe), so a stale
+    // `postmaster.pid` + URL file left by a crash would make `task`/`build`
+    // attach to a *dead* cluster instead of starting their own. The daemon is
+    // Unix-only anyway, so there's nothing live to share off Unix.
+    #[cfg(not(unix))]
+    {
+        let _ = paths;
         None
-    } else {
-        Some(trimmed.to_owned())
+    }
+    #[cfg(unix)]
+    {
+        let data_dir = paths.pg_data_dir();
+        live_postmaster_pid(&data_dir)?;
+        // The provider publishes the URL beside the data dir. Keep this filename
+        // in sync with `autumn_web::managed_pg::PUBLISHED_URL_FILE` (the CLI
+        // doesn't build the `managed-pg` feature, so it can't reference the const).
+        let url_file = data_dir
+            .parent()
+            .unwrap_or(&data_dir)
+            .join(".autumn-pg-url");
+        let contents = std::fs::read_to_string(url_file).ok()?;
+        let trimmed = contents.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_owned())
+        }
     }
 }
 
@@ -1550,13 +1580,34 @@ mod tests {
     }
 
     #[test]
+    fn workspace_anchor_ignores_unrelated_broken_parent_manifest() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize root");
+        // A broken `Cargo.toml` up the tree that is NOT a workspace root (e.g. a
+        // stray/half-written file in a parent dir) must not hijack the anchor.
+        std::fs::write(root.join("Cargo.toml"), "this is = not [ valid toml")
+            .expect("write broken parent manifest");
+        let project = root.join("proj");
+        std::fs::create_dir_all(&project).expect("create project dir");
+        std::fs::write(
+            project.join("Cargo.toml"),
+            "[package]\nname = \"proj\"\nversion = \"0.1.0\"\n",
+        )
+        .expect("write project manifest");
+        // The anchor is the standalone project, not the broken parent.
+        assert_eq!(workspace_anchor_from(&project), Some(project));
+    }
+
+    #[test]
     fn workspace_anchor_stable_when_root_manifest_unparsable() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = std::fs::canonicalize(tmp.path()).expect("canonicalize root");
-        // The workspace root manifest is temporarily broken (mid-edit).
+        // The workspace root manifest is temporarily broken (mid-edit) but still
+        // carries the recognizable `[workspace]` header, so it's treated as a
+        // transiently-broken root rather than an unrelated broken manifest.
         std::fs::write(
             root.join("Cargo.toml"),
-            "[workspace\nthis is not valid toml",
+            "[workspace]\nmembers = [\n  \"crates/api\"",
         )
         .expect("write broken root manifest");
         let member = root.join("crates/api");

--- a/autumn-cli/src/serve.rs
+++ b/autumn-cli/src/serve.rs
@@ -586,6 +586,13 @@ fn start_foreground(opts: &ServeOptions) -> i32 {
 /// runtime directories.
 fn base_command(binary: &Path, paths: Option<&RuntimePaths>, opts: &ServeOptions) -> Command {
     let mut cmd = Command::new(binary);
+    // `autumn serve` is the cluster *owner*: it must provision and supervise its
+    // own managed Postgres, never attach to someone else's. Clear any inherited
+    // `AUTUMN_MANAGED_PG_ATTACH_URL` (e.g. leaked from the launching shell or a
+    // prior task/build run) so the provider can't take the attach branch and
+    // leave the daemon recorded as managed-PG while it never starts/stops a
+    // cluster (and `stop()` no-ops because `attached` is set).
+    cmd.env_remove(MANAGED_PG_ATTACH_URL_ENV);
     // For a workspace member selected with `-p`, run the child from the member's
     // manifest dir so its `autumn.toml`/profile and asset dirs resolve correctly
     // instead of the workspace-root CWD. Set both `current_dir` (covers CWD-

--- a/autumn-cli/src/task.rs
+++ b/autumn-cli/src/task.rs
@@ -43,8 +43,16 @@ fn apply_managed_pg_env(cmd: &mut Command, package: Option<&str>) {
         return;
     };
     cmd.env(crate::serve::MANAGED_PG_DATA_DIR_ENV, &env.data_dir);
-    if let Some(url) = env.attach_url {
-        cmd.env(crate::serve::MANAGED_PG_ATTACH_URL_ENV, url);
+    match env.attach_url {
+        Some(url) => {
+            cmd.env(crate::serve::MANAGED_PG_ATTACH_URL_ENV, url);
+        }
+        // No live cluster to attach to: clear any inherited attach URL so a stale
+        // or foreign value from the parent environment can't make the child
+        // connect to the wrong (or a dead) database instead of starting its own.
+        None => {
+            cmd.env_remove(crate::serve::MANAGED_PG_ATTACH_URL_ENV);
+        }
     }
 }
 

--- a/autumn-cli/src/task.rs
+++ b/autumn-cli/src/task.rs
@@ -39,20 +39,18 @@ pub fn run(opts: &TaskOptions<'_>) {
 /// starting a second postmaster on the daemon's locked data dir. A no-op for
 /// apps that don't use managed Postgres (the env vars are simply unread).
 fn apply_managed_pg_env(cmd: &mut Command, package: Option<&str>) {
+    // The attach URL is CLI→child plumbing, not an operator knob. Clear any
+    // inherited value up front so a stale/foreign one can't override the data dir
+    // (the provider checks the attach URL first) — including when an explicit
+    // `AUTUMN_MANAGED_PG_DATA_DIR` override makes `managed_pg_env` return `None`.
+    // We re-set it only when we discover a live cluster to attach to.
+    cmd.env_remove(crate::serve::MANAGED_PG_ATTACH_URL_ENV);
     let Some(env) = crate::serve::managed_pg_env(package) else {
         return;
     };
     cmd.env(crate::serve::MANAGED_PG_DATA_DIR_ENV, &env.data_dir);
-    match env.attach_url {
-        Some(url) => {
-            cmd.env(crate::serve::MANAGED_PG_ATTACH_URL_ENV, url);
-        }
-        // No live cluster to attach to: clear any inherited attach URL so a stale
-        // or foreign value from the parent environment can't make the child
-        // connect to the wrong (or a dead) database instead of starting its own.
-        None => {
-            cmd.env_remove(crate::serve::MANAGED_PG_ATTACH_URL_ENV);
-        }
+    if let Some(url) = env.attach_url {
+        cmd.env(crate::serve::MANAGED_PG_ATTACH_URL_ENV, url);
     }
 }
 

--- a/autumn-cli/src/task.rs
+++ b/autumn-cli/src/task.rs
@@ -34,18 +34,33 @@ pub fn run(opts: &TaskOptions<'_>) {
     }
 }
 
+/// Point a one-off task run at the serve daemon's managed-Postgres cluster:
+/// share its data dir and, when the cluster is live, attach to it instead of
+/// starting a second postmaster on the daemon's locked data dir. A no-op for
+/// apps that don't use managed Postgres (the env vars are simply unread).
+fn apply_managed_pg_env(cmd: &mut Command, package: Option<&str>) {
+    let Some(env) = crate::serve::managed_pg_env(package) else {
+        return;
+    };
+    cmd.env(crate::serve::MANAGED_PG_DATA_DIR_ENV, &env.data_dir);
+    if let Some(url) = env.attach_url {
+        cmd.env(crate::serve::MANAGED_PG_ATTACH_URL_ENV, url);
+    }
+}
+
 fn list_tasks(binary: &std::path::Path, opts: &TaskOptions<'_>) {
-    let output = Command::new(binary)
+    let mut command = Command::new(binary);
+    command
         .env("AUTUMN_LIST_TASKS", "1")
         .env("AUTUMN_ENV", opts.profile)
         .env("AUTUMN_PROFILE", opts.profile)
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .output()
-        .unwrap_or_else(|error| {
-            eprintln!("Failed to run {}: {error}", binary.display());
-            std::process::exit(1);
-        });
+        .stderr(Stdio::inherit());
+    apply_managed_pg_env(&mut command, opts.package);
+    let output = command.output().unwrap_or_else(|error| {
+        eprintln!("Failed to run {}: {error}", binary.display());
+        std::process::exit(1);
+    });
 
     if !output.status.success() {
         eprintln!(
@@ -77,19 +92,20 @@ fn run_task(binary: &std::path::Path, opts: &TaskOptions<'_>) {
         std::process::exit(1);
     });
 
-    let status = Command::new(binary)
+    let mut command = Command::new(binary);
+    command
         .env("AUTUMN_RUN_TASK", name)
         .env("AUTUMN_TASK_ARGS_JSON", args_json)
         .env("AUTUMN_ENV", opts.profile)
         .env("AUTUMN_PROFILE", opts.profile)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
-        .unwrap_or_else(|error| {
-            eprintln!("Failed to run {}: {error}", binary.display());
-            std::process::exit(1);
-        });
+        .stderr(Stdio::inherit());
+    apply_managed_pg_env(&mut command, opts.package);
+    let status = command.status().unwrap_or_else(|error| {
+        eprintln!("Failed to run {}: {error}", binary.display());
+        std::process::exit(1);
+    });
 
     if !status.success() {
         std::process::exit(status.code().unwrap_or(1));

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -180,6 +180,12 @@ lettre = { version = "0.11.21", default-features = false, features = ["builder",
 chromiumoxide = { workspace = true, optional = true }
 image = { workspace = true, optional = true }
 
+[target.'cfg(unix)'.dependencies]
+# `umask` (via the safe `nix` wrapper) for binding `server.unix_socket` with
+# owner-only permissions from creation, closing the bind→chmod race on
+# user-configured socket paths in shared directories.
+nix = { version = "0.31.2", features = ["fs"] }
+
 [dev-dependencies]
 diesel = { version = "2", features = ["chrono", "postgres"] }
 filetime = "0.2"

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -3028,10 +3028,23 @@ impl AppBuilder {
                 // does not revoke a connection already established in that window.
                 // This matters for a user-configured `server.unix_socket` in a
                 // shared dir; the CLI's own socket also sits in a `0700` parent.
-                let prev_umask =
-                    nix::sys::stat::umask(nix::sys::stat::Mode::from_bits_truncate(0o177));
-                let bind_result = tokio::net::UnixListener::bind(path);
-                nix::sys::stat::umask(prev_umask);
+                // `umask` is process-wide, so serialize the save/bind/restore: a
+                // concurrent UDS bind in the same process (integration tests, or an
+                // app running several servers) could otherwise interleave these
+                // pairs and either bind under the wrong umask — reopening the
+                // bind→chmod window this closes — or leave `0177` set permanently.
+                // The guard is released before the `.await` in the error arm below.
+                let bind_result = {
+                    static UMASK_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+                    let _umask_guard = UMASK_LOCK
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    let prev_umask =
+                        nix::sys::stat::umask(nix::sys::stat::Mode::from_bits_truncate(0o177));
+                    let result = tokio::net::UnixListener::bind(path);
+                    nix::sys::stat::umask(prev_umask);
+                    result
+                };
                 let listener = match bind_result {
                     Ok(listener) => listener,
                     Err(e) => {

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -3022,7 +3022,17 @@ impl AppBuilder {
                     crate::managed_pg::emergency_stop_async().await;
                     std::process::exit(1);
                 }
-                let listener = match tokio::net::UnixListener::bind(path) {
+                // Bind under an owner-only umask so the socket is created `0600`
+                // from the start — a plain bind would briefly leave it
+                // group/other-connectable (umask-dependent), and `chmod` afterward
+                // does not revoke a connection already established in that window.
+                // This matters for a user-configured `server.unix_socket` in a
+                // shared dir; the CLI's own socket also sits in a `0700` parent.
+                let prev_umask =
+                    nix::sys::stat::umask(nix::sys::stat::Mode::from_bits_truncate(0o177));
+                let bind_result = tokio::net::UnixListener::bind(path);
+                nix::sys::stat::umask(prev_umask);
+                let listener = match bind_result {
                     Ok(listener) => listener,
                     Err(e) => {
                         tracing::error!(socket = %socket_path, "Failed to bind unix socket: {e}");
@@ -3031,12 +3041,11 @@ impl AppBuilder {
                         std::process::exit(1);
                     }
                 };
-                // Local-daemon socket: owner-only access. Fail *closed* — a
-                // user-configured `server.unix_socket` may sit in a shared
-                // directory, so if we cannot enforce `0600` (chmod error, an ACL
-                // /filesystem that rejects it), refuse to serve rather than
-                // expose a world-reachable control socket. Remove the socket we
-                // just bound so nothing keeps listening on it.
+                // Owner-only access, belt-and-suspenders after the umask bind.
+                // Fail *closed* — if we cannot enforce `0600` (chmod error, an ACL
+                // /filesystem that rejects it), refuse to serve rather than expose
+                // a reachable control socket. Remove the socket we just bound so
+                // nothing keeps listening on it.
                 if let Err(e) =
                     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
                 {

--- a/autumn/src/managed_pg.rs
+++ b/autumn/src/managed_pg.rs
@@ -295,8 +295,15 @@ impl ManagedPostgresPoolProvider {
                 use std::io::Write;
                 // `mode(0o600)` only applies on create; tighten an existing
                 // (older-build / manually-created) file before writing the URL,
-                // which embeds the cluster superuser password.
-                enforce_password_file_mode_or_exit(&path);
+                // which embeds the cluster superuser password. Best-effort: unlike
+                // the superuser password file (whose mode gates boot), this
+                // published copy is an optimization, so a `chmod` failure (e.g. a
+                // mount without Unix permissions) must not fail the boot.
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+                }
                 if let Err(e) = f.write_all(url.as_bytes()) {
                     tracing::warn!(error = %e, path = %path.display(),
                         "managed Postgres: failed to publish cluster URL for task/build attach");

--- a/autumn/src/managed_pg.rs
+++ b/autumn/src/managed_pg.rs
@@ -21,6 +21,7 @@
 //! ```
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -38,6 +39,23 @@ const MANAGED_DB_NAME: &str = "autumn";
 /// `autumn serve` sets this to a platform data dir; falls back to a per-user
 /// default otherwise.
 pub const MANAGED_PG_DATA_DIR_ENV: &str = "AUTUMN_MANAGED_PG_DATA_DIR";
+
+/// Makes the provider *attach* to an already-running cluster instead of starting
+/// its own.
+///
+/// When set, the value is the connection URL to use. `autumn task`/`autumn build`
+/// set this (to the URL the running daemon published, see [`PUBLISHED_URL_FILE`])
+/// so a one-off command shares the daemon's live cluster rather than failing to
+/// start a second postmaster on the daemon's locked data dir.
+pub const MANAGED_PG_ATTACH_URL_ENV: &str = "AUTUMN_MANAGED_PG_ATTACH_URL";
+
+/// File the provider writes with the running cluster's connection URL.
+///
+/// Written next to the data dir at mode `0600` so `autumn task`/`autumn build`
+/// can discover it and attach via [`MANAGED_PG_ATTACH_URL_ENV`]. Lives in the
+/// data dir's parent alongside `.autumn-pg-superuser` (the secret it embeds is
+/// the same one).
+pub const PUBLISHED_URL_FILE: &str = ".autumn-pg-url";
 
 /// How long to allow each `initdb`/`start` step before surfacing a diagnostic.
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
@@ -193,6 +211,15 @@ pub struct ManagedPostgresPoolProvider {
     /// when an archive is compiled into the binary.
     version: Option<VersionReq>,
     instance: Arc<Mutex<Option<PostgreSQL>>>,
+    /// The cluster's connection URL once resolved — set whether we *started* the
+    /// cluster or *attached* to an externally-owned one. `create_topology` reads
+    /// it for the migration URL, which is the only path that needs the URL when
+    /// attached (there is no local `instance` to read it from).
+    resolved_url: Arc<Mutex<Option<String>>>,
+    /// Whether we attached to a cluster owned by another process (the daemon)
+    /// rather than starting our own. When set, [`stop`](Self::stop) is a no-op:
+    /// the cluster's lifecycle belongs to whoever started it.
+    attached: Arc<AtomicBool>,
 }
 
 impl std::fmt::Debug for ManagedPostgresPoolProvider {
@@ -227,6 +254,8 @@ impl ManagedPostgresPoolProvider {
             // embedded archive version (offline, exact) instead of `*`.
             version: None,
             instance: Arc::new(Mutex::new(None)),
+            resolved_url: Arc::new(Mutex::new(None)),
+            attached: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -240,6 +269,44 @@ impl ManagedPostgresPoolProvider {
             .join("postgresql")
     }
 
+    /// Path of the published connection-URL file (data dir's parent, alongside
+    /// the superuser password file).
+    fn published_url_path(&self) -> PathBuf {
+        self.data_dir
+            .parent()
+            .unwrap_or(&self.data_dir)
+            .join(PUBLISHED_URL_FILE)
+    }
+
+    /// Publish the running cluster's URL (mode `0600`) so `autumn task`/`autumn
+    /// build` can attach to it. Best-effort: a failure only means those one-off
+    /// commands fall back to their own resolution; it must not fail the boot.
+    fn publish_url(&self, url: &str) {
+        let path = self.published_url_path();
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        match options.open(&path) {
+            Ok(mut f) => {
+                use std::io::Write;
+                // `mode(0o600)` only applies on create; tighten an existing
+                // (older-build / manually-created) file before writing the URL,
+                // which embeds the cluster superuser password.
+                enforce_password_file_mode_or_exit(&path);
+                if let Err(e) = f.write_all(url.as_bytes()) {
+                    tracing::warn!(error = %e, path = %path.display(),
+                        "managed Postgres: failed to publish cluster URL for task/build attach");
+                }
+            }
+            Err(e) => tracing::warn!(error = %e, path = %path.display(),
+                "managed Postgres: failed to open cluster URL file for publishing"),
+        }
+    }
+
     /// Provision (if needed) and start the cluster, returning its connection URL.
     async fn ensure_running(&self) -> Result<String, postgresql_embedded::Error> {
         // Already started (e.g. a second pool, or repeated calls): reuse the
@@ -249,6 +316,22 @@ impl ManagedPostgresPoolProvider {
             && let Some(pg) = guard.as_ref()
         {
             return Ok(pg.settings().url(MANAGED_DB_NAME));
+        }
+
+        // Attach mode: a cluster is already running (started by `autumn serve`)
+        // and `autumn task`/`autumn build` set `AUTUMN_MANAGED_PG_ATTACH_URL` to
+        // its published URL. Connect to it instead of starting a second
+        // postmaster on the daemon's locked data dir — and never `stop()` it,
+        // since its lifecycle belongs to the daemon.
+        if let Some(url) = std::env::var_os(MANAGED_PG_ATTACH_URL_ENV)
+            .and_then(|v| v.into_string().ok())
+            .filter(|s| !s.trim().is_empty())
+        {
+            self.attached.store(true, Ordering::SeqCst);
+            if let Ok(mut g) = self.resolved_url.lock() {
+                *g = Some(url.clone());
+            }
+            return Ok(url);
         }
 
         let mut settings = Settings::new();
@@ -295,6 +378,13 @@ impl ManagedPostgresPoolProvider {
         if let Ok(mut guard) = self.instance.lock() {
             *guard = Some(pg);
         }
+        if let Ok(mut g) = self.resolved_url.lock() {
+            *g = Some(url.clone());
+        }
+
+        // Publish the URL so `autumn task`/`autumn build` can attach to this
+        // running cluster instead of contending for its locked data dir.
+        self.publish_url(&url);
 
         // Register for emergency shutdown so an abnormal boot exit (which
         // bypasses `on_shutdown`) still stops the supervised child instead of
@@ -371,6 +461,12 @@ impl ManagedPostgresPoolProvider {
     /// Stop the supervised Postgres child. Wire this to the daemon's
     /// `on_shutdown` so the cluster shuts down with the app.
     pub async fn stop(&self) {
+        // Attached to a cluster owned by another process (the daemon): never stop
+        // it or remove its published URL — `autumn task`/`autumn build` only
+        // borrowed the running cluster.
+        if self.attached.load(Ordering::SeqCst) {
+            return;
+        }
         let taken = self.instance.lock().ok().and_then(|mut guard| guard.take());
         let Some(pg) = taken else {
             // Nothing running (or already stopped): clear the emergency registration.
@@ -394,6 +490,9 @@ impl ManagedPostgresPoolProvider {
         // handle. The resolved URL is carried on the per-app topology, so there is
         // no process-global URL to clear.
         clear_emergency_registration();
+        // Remove the published URL file so a later `autumn task`/`autumn build`
+        // doesn't try to attach to a cluster that is now down.
+        let _ = std::fs::remove_file(self.published_url_path());
     }
 }
 
@@ -445,14 +544,20 @@ impl DatabasePoolProvider for ManagedPostgresPoolProvider {
         let Some(primary) = self.create_pool(config).await? else {
             return Ok(None);
         };
-        // After `create_pool`, the cluster is running; read its URL from the
-        // retained handle and carry it on the topology so startup migrations
-        // target this managed cluster — per-app, with no process-global.
-        let migration_url = self
-            .instance
-            .lock()
-            .ok()
-            .and_then(|guard| guard.as_ref().map(|pg| pg.settings().url(MANAGED_DB_NAME)));
+        // After `create_pool`, the cluster is running; carry its URL on the
+        // topology so startup migrations target this managed cluster — per-app,
+        // with no process-global. Prefer the resolved URL (set whether we started
+        // the cluster or attached to one), falling back to the retained handle.
+        let migration_url =
+            self.resolved_url
+                .lock()
+                .ok()
+                .and_then(|g| g.clone())
+                .or_else(|| {
+                    self.instance.lock().ok().and_then(|guard| {
+                        guard.as_ref().map(|pg| pg.settings().url(MANAGED_DB_NAME))
+                    })
+                });
         Ok(Some(
             crate::db::DatabaseTopology::from_pools(primary, None)
                 .with_migration_url(migration_url),
@@ -561,5 +666,37 @@ mod tests {
     fn with_data_dir_is_used() {
         let p = ManagedPostgresPoolProvider::with_data_dir(PathBuf::from("/var/lib/x"));
         assert_eq!(p.data_dir, PathBuf::from("/var/lib/x"));
+    }
+
+    #[test]
+    fn attach_mode_uses_env_url_without_starting() {
+        // With the attach env set, `ensure_running` must return that URL without
+        // touching the (nonexistent) data dir, and `stop` must be a no-op.
+        temp_env::with_var(
+            MANAGED_PG_ATTACH_URL_ENV,
+            Some("postgresql://u:p@localhost:5499/autumn"),
+            || {
+                let provider =
+                    ManagedPostgresPoolProvider::with_data_dir(PathBuf::from("/nonexistent/pg"));
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                let url = rt.block_on(provider.ensure_running()).unwrap();
+                assert_eq!(url, "postgresql://u:p@localhost:5499/autumn");
+                assert!(provider.attached.load(Ordering::SeqCst));
+                // No-op in attach mode: must not panic or strand state.
+                rt.block_on(provider.stop());
+            },
+        );
+    }
+
+    #[test]
+    fn published_url_path_is_beside_data_dir() {
+        let p = ManagedPostgresPoolProvider::with_data_dir(PathBuf::from("/var/lib/app/pg"));
+        assert_eq!(
+            p.published_url_path(),
+            PathBuf::from("/var/lib/app").join(PUBLISHED_URL_FILE)
+        );
     }
 }

--- a/autumn/src/managed_pg.rs
+++ b/autumn/src/managed_pg.rs
@@ -293,16 +293,23 @@ impl ManagedPostgresPoolProvider {
         match options.open(&path) {
             Ok(mut f) => {
                 use std::io::Write;
-                // `mode(0o600)` only applies on create; tighten an existing
-                // (older-build / manually-created) file before writing the URL,
-                // which embeds the cluster superuser password. Best-effort: unlike
-                // the superuser password file (whose mode gates boot), this
-                // published copy is an optimization, so a `chmod` failure (e.g. a
-                // mount without Unix permissions) must not fail the boot.
+                // `mode(0o600)` only applies on create; an existing (older-build /
+                // manually-created / symlinked) file keeps its old, possibly
+                // permissive mode. The URL embeds the cluster superuser password,
+                // so if we can't enforce owner-only we must NOT write it — skip
+                // publishing (it's only an optimization for task/build attach) and
+                // drop the truncated file rather than expose credentials.
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::PermissionsExt;
-                    let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+                    if std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                        .is_err()
+                    {
+                        tracing::warn!(path = %path.display(),
+                            "managed Postgres: cannot enforce owner-only mode on the cluster URL file; not publishing");
+                        let _ = std::fs::remove_file(&path);
+                        return;
+                    }
                 }
                 if let Err(e) = f.write_all(url.as_bytes()) {
                     tracing::warn!(error = %e, path = %path.display(),


### PR DESCRIPTION
Close the bind->chmod window on user-configured server.unix_socket paths: a
plain bind creates the socket with umask-dependent permissions, briefly
group/other-connectable, and a later chmod does not revoke a connection already
established in that window. Bind under a 0o177 umask so the socket is 0600 from
creation (keeping the fail-closed chmod as belt-and-suspenders). Adds nix (fs)
to autumn-web for the safe umask wrapper; the unsafe lives in nix, not here.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EtcPej5wb3uYyLh21ZU9tr