### PR TITLE
Add typed domain event bus with sync/durable listeners

### DIFF
--- a/autumn-macros/src/event.rs
+++ b/autumn-macros/src/event.rs
@@ -1,0 +1,116 @@
+//! `#[event]` proc macro implementation.
+//!
+//! Marks a struct as a typed domain event: applies the serde derives the event
+//! bus needs to ship the payload across the durable job queue, and implements
+//! the `Event` trait with a stable `NAME`. Mirrors the ergonomics of `#[model]`
+//! (which applies serde derives directly via `::serde::…`).
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::parse::Parser as _;
+use syn::{DeriveInput, LitStr};
+
+struct EventAttrs {
+    name: Option<String>,
+}
+
+fn parse_event_args(attr: TokenStream) -> syn::Result<EventAttrs> {
+    let mut result = EventAttrs { name: None };
+    if attr.is_empty() {
+        return Ok(result);
+    }
+    syn::meta::parser(|meta| {
+        if meta.path.is_ident("name") {
+            let value: LitStr = meta.value()?.parse()?;
+            result.name = Some(value.value());
+            Ok(())
+        } else {
+            Err(meta.error("unsupported attribute: expected `name`"))
+        }
+    })
+    .parse2(attr)?;
+    Ok(result)
+}
+
+pub fn event_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attrs = match parse_event_args(attr) {
+        Ok(a) => a,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    let input: DeriveInput = match syn::parse2(item) {
+        Ok(input) => input,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    let ident = &input.ident;
+    let event_name = attrs.name.unwrap_or_else(|| ident.to_string());
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    quote! {
+        #[derive(
+            ::serde::Serialize,
+            ::serde::Deserialize,
+            ::std::clone::Clone,
+            ::std::fmt::Debug,
+        )]
+        #input
+
+        impl #impl_generics ::autumn_web::events::Event for #ident #ty_generics #where_clause {
+            const NAME: &'static str = #event_name;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+
+    #[test]
+    fn applies_serde_derives_and_implements_event() {
+        let expanded = event_macro(
+            quote! {},
+            quote! {
+                struct UserSignedUp {
+                    user_id: i64,
+                }
+            },
+        )
+        .to_string();
+        assert!(expanded.contains("serde :: Serialize"), "{expanded}");
+        assert!(expanded.contains("serde :: Deserialize"), "{expanded}");
+        assert!(
+            expanded.contains("impl :: autumn_web :: events :: Event for UserSignedUp"),
+            "{expanded}"
+        );
+        assert!(
+            expanded.contains("const NAME : & 'static str = \"UserSignedUp\""),
+            "{expanded}"
+        );
+    }
+
+    #[test]
+    fn name_attribute_overrides_event_name() {
+        let expanded = event_macro(
+            quote! { name = "user.signed_up" },
+            quote! {
+                struct UserSignedUp {
+                    user_id: i64,
+                }
+            },
+        )
+        .to_string();
+        assert!(
+            expanded.contains("const NAME : & 'static str = \"user.signed_up\""),
+            "{expanded}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_attribute() {
+        let expanded =
+            event_macro(quote! { topic = "x" }, quote! { struct E { a: i64 } }).to_string();
+        assert!(expanded.contains("compile_error"), "{expanded}");
+    }
+}

--- a/autumn-macros/src/event.rs
+++ b/autumn-macros/src/event.rs
@@ -44,20 +44,31 @@ pub fn event_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let ident = &input.ident;
-    let event_name = attrs.name.unwrap_or_else(|| ident.to_string());
+    let ident_str = ident.to_string();
+    // Default the routing name to a module-qualified path so two event types
+    // that share a short name (e.g. `Created`) in different modules never
+    // collide on the registry's string key. An explicit `name = "..."` wins.
+    let name_const = attrs.name.map_or_else(
+        || quote! { ::std::concat!(::std::module_path!(), "::", #ident_str) },
+        |name| quote! { #name },
+    );
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     quote! {
+        // Derive serde through the framework's re-export (and point serde's
+        // generated code at it) so `#[event]` works for apps that depend only
+        // on `autumn-web`, without a direct `serde` dependency.
         #[derive(
-            ::serde::Serialize,
-            ::serde::Deserialize,
+            ::autumn_web::reexports::serde::Serialize,
+            ::autumn_web::reexports::serde::Deserialize,
             ::std::clone::Clone,
             ::std::fmt::Debug,
         )]
+        #[serde(crate = "::autumn_web::reexports::serde")]
         #input
 
         impl #impl_generics ::autumn_web::events::Event for #ident #ty_generics #where_clause {
-            const NAME: &'static str = #event_name;
+            const NAME: &'static str = #name_const;
         }
     }
 }
@@ -78,14 +89,25 @@ mod tests {
             },
         )
         .to_string();
-        assert!(expanded.contains("serde :: Serialize"), "{expanded}");
-        assert!(expanded.contains("serde :: Deserialize"), "{expanded}");
+        assert!(
+            expanded.contains("autumn_web :: reexports :: serde :: Serialize"),
+            "{expanded}"
+        );
+        assert!(
+            expanded.contains("autumn_web :: reexports :: serde :: Deserialize"),
+            "{expanded}"
+        );
+        assert!(
+            expanded.contains("serde (crate = \"::autumn_web::reexports::serde\")"),
+            "{expanded}"
+        );
         assert!(
             expanded.contains("impl :: autumn_web :: events :: Event for UserSignedUp"),
             "{expanded}"
         );
+        // Default name is module-qualified to avoid cross-module collisions.
         assert!(
-            expanded.contains("const NAME : & 'static str = \"UserSignedUp\""),
+            expanded.contains("module_path ! ()") && expanded.contains("\"UserSignedUp\""),
             "{expanded}"
         );
     }

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -16,12 +16,15 @@ mod api_doc;
 mod authorize;
 mod cached;
 mod collect;
+mod event;
 mod feature_flag;
 mod i18n;
 mod idempotency_guard;
 mod inbound_mail;
 mod job;
 mod jobs_macro;
+mod listener;
+mod listeners_macro;
 mod mail_previews_macro;
 mod mailer;
 mod mailer_preview;
@@ -377,6 +380,41 @@ pub fn scheduled(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn job(attr: TokenStream, item: TokenStream) -> TokenStream {
     job::job_macro(attr.into(), item.into()).into()
+}
+
+/// Declare a typed domain event.
+///
+/// Applies the serde + `Clone`/`Debug` derives the event bus needs and
+/// implements `autumn_web::events::Event` with a stable `NAME` (the struct
+/// name by default, or `#[event(name = "...")]`).
+///
+/// ```ignore
+/// #[event]
+/// struct UserSignedUp { user_id: i64 }
+/// ```
+#[proc_macro_attribute]
+pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
+    event::event_macro(attr.into(), item.into()).into()
+}
+
+/// Declare an event listener that reacts to a typed `#[event]`.
+///
+/// Runs **synchronously** (in-request) by default, or **durably** (enqueued on
+/// the `#[job]` queue, surviving restarts with retry + DLQ) with `durable`.
+///
+/// ```ignore
+/// #[listener(UserSignedUp, durable, max_attempts = 5)]
+/// async fn send_welcome_email(state: AppState, event: UserSignedUp) -> AutumnResult<()> { Ok(()) }
+/// ```
+#[proc_macro_attribute]
+pub fn listener(attr: TokenStream, item: TokenStream) -> TokenStream {
+    listener::listener_macro(attr.into(), item.into()).into()
+}
+
+/// Collect `#[listener]` handlers into a `Vec<ListenerInfo>`.
+#[proc_macro]
+pub fn listeners(input: TokenStream) -> TokenStream {
+    listeners_macro::listeners_macro(input.into()).into()
 }
 
 /// Declare a one-off operational task runnable with `autumn task <name>`.

--- a/autumn-macros/src/listener.rs
+++ b/autumn-macros/src/listener.rs
@@ -1,0 +1,244 @@
+//! `#[listener]` proc macro implementation.
+//!
+//! Declares an event listener: an async function reacting to a typed `#[event]`.
+//! Mirrors `#[job]` — it emits a `__autumn_listener_info_{fn}()` companion that
+//! `listeners![]` collects into a `Vec<ListenerInfo>` for `AppBuilder::listeners`.
+//!
+//! A listener runs **synchronously** (in-request, before the response) by
+//! default, or **durably** (`durable`) — enqueued onto the existing `#[job]`
+//! queue so it survives restarts and inherits retry + DLQ semantics.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::parse::{Parse, ParseStream, Parser as _};
+use syn::{FnArg, ItemFn, LitInt, PatType, Token, Type};
+
+struct ListenerAttrs {
+    event_type: Type,
+    durable: bool,
+    max_attempts: Option<u32>,
+    backoff_ms: Option<u64>,
+}
+
+impl Parse for ListenerAttrs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let event_type: Type = input.parse().map_err(|_| {
+            input.error("#[listener] requires an event type, e.g. #[listener(UserSignedUp)]")
+        })?;
+
+        let mut durable = false;
+        let mut max_attempts = None;
+        let mut backoff_ms = None;
+
+        while !input.is_empty() {
+            input.parse::<Token![,]>()?;
+            if input.is_empty() {
+                break;
+            }
+            let ident: syn::Ident = input.parse()?;
+            if ident == "durable" {
+                durable = true;
+            } else if ident == "max_attempts" {
+                input.parse::<Token![=]>()?;
+                let value: LitInt = input.parse()?;
+                max_attempts = Some(value.base10_parse::<u32>()?);
+            } else if ident == "backoff_ms" {
+                input.parse::<Token![=]>()?;
+                let value: LitInt = input.parse()?;
+                backoff_ms = Some(value.base10_parse::<u64>()?);
+            } else {
+                return Err(syn::Error::new(
+                    ident.span(),
+                    "unsupported attribute: expected `durable`, `max_attempts`, or `backoff_ms`",
+                ));
+            }
+        }
+
+        if !durable && (max_attempts.is_some() || backoff_ms.is_some()) {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "`max_attempts`/`backoff_ms` only apply to `durable` listeners",
+            ));
+        }
+
+        Ok(Self {
+            event_type,
+            durable,
+            max_attempts,
+            backoff_ms,
+        })
+    }
+}
+
+pub fn listener_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attrs = match ListenerAttrs::parse.parse2(attr) {
+        Ok(a) => a,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    let input_fn: ItemFn = match syn::parse2(item) {
+        Ok(f) => f,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    if input_fn.sig.asyncness.is_none() {
+        return syn::Error::new_spanned(
+            input_fn.sig.fn_token,
+            "#[listener] functions must be async",
+        )
+        .to_compile_error();
+    }
+
+    if input_fn.sig.inputs.len() != 2 {
+        return syn::Error::new_spanned(
+            &input_fn.sig.ident,
+            "#[listener] function must have signature async fn(AppState, Event)",
+        )
+        .to_compile_error();
+    }
+
+    // Validate the second argument is a typed event struct (mirrors #[job]).
+    let mut inputs = input_fn.sig.inputs.iter();
+    let _state_arg = inputs.next();
+    if !matches!(inputs.next(), Some(FnArg::Typed(PatType { .. }))) {
+        return syn::Error::new_spanned(
+            &input_fn.sig.ident,
+            "#[listener] second argument must be a typed event struct",
+        )
+        .to_compile_error();
+    }
+
+    let event_type = &attrs.event_type;
+    let fn_name = &input_fn.sig.ident;
+    let companion_name = format_ident!("__autumn_listener_info_{fn_name}");
+    let fn_name_str = fn_name.to_string();
+    let max_attempts = attrs.max_attempts.unwrap_or(0);
+    let backoff_ms = attrs.backoff_ms.unwrap_or(0);
+
+    let (mode, job_name_expr) = if attrs.durable {
+        (
+            quote! { ::autumn_web::events::DispatchMode::Durable },
+            quote! { ::std::option::Option::Some(::std::format!("__event_listener::{listener_name}")) },
+        )
+    } else {
+        (
+            quote! { ::autumn_web::events::DispatchMode::Sync },
+            quote! { ::std::option::Option::<::std::string::String>::None },
+        )
+    };
+
+    quote! {
+        #input_fn
+
+        #[doc(hidden)]
+        pub fn #companion_name() -> ::autumn_web::events::ListenerInfo {
+            // Fully-qualified, per-listener identity. `module_path!` expands at
+            // the listener's definition site, so two listeners can never collide.
+            let listener_name = ::std::format!("{}::{}", ::std::module_path!(), #fn_name_str);
+            // Compute `job_name` before moving `listener_name` into the struct.
+            let job_name = #job_name_expr;
+            ::autumn_web::events::ListenerInfo {
+                event_name: <#event_type as ::autumn_web::events::Event>::NAME,
+                listener_name,
+                mode: #mode,
+                job_name,
+                max_attempts: #max_attempts,
+                initial_backoff_ms: #backoff_ms,
+                handler: |state: ::autumn_web::AppState, payload: ::autumn_web::reexports::serde_json::Value| {
+                    ::std::boxed::Box::pin(async move {
+                        let event: #event_type = ::autumn_web::reexports::serde_json::from_value(payload)
+                            .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(format!("event deserialization failed: {e}"))))?;
+                        #fn_name(state, event).await
+                    })
+                },
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+
+    fn expand(attr: TokenStream, item: TokenStream) -> String {
+        listener_macro(attr, item).to_string()
+    }
+
+    #[test]
+    fn sync_listener_emits_companion_with_sync_mode() {
+        let expanded = expand(
+            quote! { UserSignedUp },
+            quote! {
+                async fn send_welcome(state: AppState, event: UserSignedUp) -> AutumnResult<()> {
+                    Ok(())
+                }
+            },
+        );
+        assert!(
+            expanded.contains("pub fn __autumn_listener_info_send_welcome"),
+            "{expanded}"
+        );
+        assert!(expanded.contains("DispatchMode :: Sync"), "{expanded}");
+        assert!(
+            expanded.contains("string :: String > :: None"),
+            "{expanded}"
+        );
+        assert!(
+            expanded.contains("< UserSignedUp as :: autumn_web :: events :: Event > :: NAME"),
+            "{expanded}"
+        );
+    }
+
+    #[test]
+    fn durable_listener_sets_job_name_and_durable_mode() {
+        let expanded = expand(
+            quote! { UserSignedUp, durable, max_attempts = 5, backoff_ms = 1000 },
+            quote! {
+                async fn seed_workspace(state: AppState, event: UserSignedUp) -> AutumnResult<()> {
+                    Ok(())
+                }
+            },
+        );
+        assert!(expanded.contains("DispatchMode :: Durable"), "{expanded}");
+        assert!(expanded.contains("__event_listener::"), "{expanded}");
+        assert!(expanded.contains("max_attempts : 5u32"), "{expanded}");
+        assert!(
+            expanded.contains("initial_backoff_ms : 1000u64"),
+            "{expanded}"
+        );
+    }
+
+    #[test]
+    fn rejects_non_async() {
+        let expanded = expand(
+            quote! { UserSignedUp },
+            quote! {
+                fn handle(state: AppState, event: UserSignedUp) -> AutumnResult<()> { Ok(()) }
+            },
+        );
+        assert!(expanded.contains("must be async"), "{expanded}");
+    }
+
+    #[test]
+    fn rejects_wrong_arity() {
+        let expanded = expand(
+            quote! { UserSignedUp },
+            quote! {
+                async fn handle(state: AppState) -> AutumnResult<()> { Ok(()) }
+            },
+        );
+        assert!(expanded.contains("async fn(AppState, Event)"), "{expanded}");
+    }
+
+    #[test]
+    fn rejects_retry_attrs_on_sync_listener() {
+        let expanded = expand(
+            quote! { UserSignedUp, max_attempts = 3 },
+            quote! {
+                async fn handle(state: AppState, event: UserSignedUp) -> AutumnResult<()> { Ok(()) }
+            },
+        );
+        assert!(expanded.contains("only apply to `durable`"), "{expanded}");
+    }
+}

--- a/autumn-macros/src/listeners_macro.rs
+++ b/autumn-macros/src/listeners_macro.rs
@@ -1,0 +1,7 @@
+//! `listeners![]` collection macro.
+
+use proc_macro2::TokenStream;
+
+pub fn listeners_macro(input: TokenStream) -> TokenStream {
+    crate::collect::collect_companions(input, "__autumn_listener_info_")
+}

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -73,6 +73,7 @@ pub fn app() -> AppBuilder {
         tasks: Vec::new(),
         one_off_tasks: Vec::new(),
         jobs: Vec::new(),
+        listeners: Vec::new(),
         static_metas: Vec::new(),
         exception_filters: Vec::new(),
         scoped_groups: Vec::new(),
@@ -247,6 +248,9 @@ pub struct AppBuilder {
     tasks: Vec<crate::task::TaskInfo>,
     one_off_tasks: Vec<crate::task::OneOffTaskInfo>,
     pub(crate) jobs: Vec<crate::job::JobInfo>,
+    /// Registered event listeners; durable ones are synthesized into jobs at
+    /// build time and the rest dispatch synchronously via the event registry.
+    pub(crate) listeners: Vec<crate::events::ListenerInfo>,
     pub(crate) static_metas: Vec<crate::static_gen::StaticRouteMeta>,
     pub(crate) exception_filters: Vec<Arc<dyn ExceptionFilter>>,
     pub(crate) scoped_groups: Vec<ScopedGroup>,
@@ -562,6 +566,18 @@ impl AppBuilder {
     #[must_use]
     pub fn jobs(mut self, jobs: Vec<crate::job::JobInfo>) -> Self {
         self.jobs.extend(jobs);
+        self
+    }
+
+    /// Register event listeners with the application.
+    ///
+    /// Collect them with `listeners![..]`. Durable listeners are wired onto the
+    /// job runtime automatically (no separate `jobs![..]` entry needed); sync
+    /// listeners run in-request when their event is published. Decoupled from
+    /// emitters: adding a listener never touches the code that publishes.
+    #[must_use]
+    pub fn listeners(mut self, listeners: Vec<crate::events::ListenerInfo>) -> Self {
+        self.listeners.extend(listeners);
         self
     }
 
@@ -2432,7 +2448,8 @@ impl AppBuilder {
             current_plugin: _,
             tasks,
             one_off_tasks: _,
-            jobs,
+            mut jobs,
+            listeners,
             static_metas,
             exception_filters,
             scoped_groups,
@@ -2860,6 +2877,7 @@ impl AppBuilder {
         let storage_router = storage_bootstrap.and_then(|b| b.install(&state));
         install_webhook_registry(&state, &config);
         run_state_initializers(state_initializers, &state);
+        finalize_event_bus(listeners, &mut jobs, &state);
 
         let env = crate::config::OsEnv;
         let dist_dir = project_dir("dist", &env);
@@ -3433,6 +3451,7 @@ impl AppBuilder {
             tasks: _,
             one_off_tasks: _,
             jobs: _,
+            listeners,
             static_metas,
             exception_filters: _,
             scoped_groups,
@@ -3730,6 +3749,9 @@ impl AppBuilder {
         let storage_router = storage_bootstrap.and_then(|b| b.install(&state));
         install_webhook_registry(&state, &config);
         run_state_initializers(state_initializers, &state);
+        // Static generation has no job runtime; sync listeners still dispatch,
+        // so install the registry but drop the durable jobs it would synthesize.
+        finalize_event_bus(listeners, &mut Vec::new(), &state);
 
         // Build the full router (same as production). Use the inner builder
         // so the custom session store installed via with_session_store(...)
@@ -3990,7 +4012,8 @@ impl AppBuilder {
     async fn run_one_off_task_mode(self, requested_name: String) {
         let Self {
             one_off_tasks,
-            jobs,
+            mut jobs,
+            listeners,
             #[cfg(feature = "i18n")]
             custom_layers,
             #[cfg(not(feature = "i18n"))]
@@ -4190,6 +4213,7 @@ impl AppBuilder {
         #[cfg(feature = "storage")]
         let _storage_router = storage_bootstrap.and_then(|bootstrap| bootstrap.install(&state));
         run_state_initializers(state_initializers, &state);
+        finalize_event_bus(listeners, &mut jobs, &state);
 
         let task_shutdown = tokio_util::sync::CancellationToken::new();
         if let Err(error) = initialize_job_runtime(jobs, &state, &task_shutdown, &config.jobs) {
@@ -4873,6 +4897,24 @@ fn run_state_initializers(initializers: Vec<StateInitializer>, state: &AppState)
     for initializer in initializers {
         initializer(state);
     }
+}
+
+/// Wire the typed event bus into the app at build time.
+///
+/// Builds the [`EventRegistry`](crate::events::EventRegistry) from registered
+/// listeners, installs it onto `state` for the [`Events`](crate::events::Events)
+/// extractor, appends a job per durable listener so they ride the job runtime
+/// (retry + DLQ + restart-safety), and initializes the process-global bus used
+/// by the module-level `events::publish`.
+fn finalize_event_bus(
+    listeners: Vec<crate::events::ListenerInfo>,
+    jobs: &mut Vec<crate::job::JobInfo>,
+    state: &AppState,
+) {
+    let registry = crate::events::EventRegistry::from_listeners(listeners);
+    jobs.extend(registry.durable_job_infos());
+    state.insert_extension(registry.clone());
+    crate::events::init_global_event_bus(&registry, state, None);
 }
 
 fn initialize_job_runtime(

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -3749,9 +3749,15 @@ impl AppBuilder {
         let storage_router = storage_bootstrap.and_then(|b| b.install(&state));
         install_webhook_registry(&state, &config);
         run_state_initializers(state_initializers, &state);
-        // Static generation has no job runtime; sync listeners still dispatch,
-        // so install the registry but drop the durable jobs it would synthesize.
-        finalize_event_bus(listeners, &mut Vec::new(), &state);
+        // Static generation has no job runtime, so register only sync listeners.
+        // Durable listeners are dropped entirely (not just their jobs) so a
+        // static route publishing such an event is a clean no-op for the durable
+        // side effect rather than a "job runtime not initialized" error.
+        let sync_listeners: Vec<_> = listeners
+            .into_iter()
+            .filter(|listener| listener.mode == crate::events::DispatchMode::Sync)
+            .collect();
+        finalize_event_bus(sync_listeners, &mut Vec::new(), &state);
 
         // Build the full router (same as production). Use the inner builder
         // so the custom session store installed via with_session_store(...)

--- a/autumn/src/events.rs
+++ b/autumn/src/events.rs
@@ -41,7 +41,7 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex, OnceLock, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -342,7 +342,12 @@ async fn dispatch(
 
 /// Run every sync listener on its own task so a panic or error in one never
 /// blocks the others, then await them all (they finish before the response).
+///
+/// Each task is instrumented with the publishing span so listener logs stay
+/// correlated with the originating request/trace despite the `tokio::spawn`.
 async fn run_sync_listeners(state: &AppState, listeners: &[ListenerInfo], payload: &Value) {
+    use tracing::Instrument as _;
+
     let mut handles = Vec::new();
     for listener in listeners
         .iter()
@@ -352,14 +357,18 @@ async fn run_sync_listeners(state: &AppState, listeners: &[ListenerInfo], payloa
         let payload = payload.clone();
         let run = listener.handler;
         let name = listener.listener_name.clone();
-        handles.push(tokio::spawn(async move {
-            match run(state, payload).await {
-                Ok(()) => {}
-                Err(error) => {
-                    tracing::error!(listener = %name, %error, "sync event listener failed");
+        let span = tracing::Span::current();
+        handles.push(tokio::spawn(
+            async move {
+                match run(state, payload).await {
+                    Ok(()) => {}
+                    Err(error) => {
+                        tracing::error!(listener = %name, %error, "sync event listener failed");
+                    }
                 }
             }
-        }));
+            .instrument(span),
+        ));
     }
     for handle in handles {
         if let Err(join_error) = handle.await {
@@ -374,12 +383,10 @@ struct GlobalBus {
     state: AppState,
 }
 
-static GLOBAL_EVENT_BUS: OnceLock<RwLock<Option<Arc<GlobalBus>>>> = OnceLock::new();
+static GLOBAL_EVENT_BUS: RwLock<Option<Arc<GlobalBus>>> = RwLock::new(None);
 
 fn global_bus() -> Option<Arc<GlobalBus>> {
-    GLOBAL_EVENT_BUS
-        .get()
-        .and_then(|lock| lock.read().ok().and_then(|guard| guard.clone()))
+    GLOBAL_EVENT_BUS.read().ok().and_then(|guard| guard.clone())
 }
 
 /// Install the process-global event bus used by the module-level [`publish`].
@@ -395,23 +402,15 @@ pub(crate) fn init_global_event_bus(
         recorder,
         state: state.clone(),
     });
-    if let Some(lock) = GLOBAL_EVENT_BUS.get() {
-        if let Ok(mut guard) = lock.write() {
-            *guard = Some(bus);
-        }
-        return;
+    if let Ok(mut guard) = GLOBAL_EVENT_BUS.write() {
+        *guard = Some(bus);
     }
-    let _ = GLOBAL_EVENT_BUS.set(RwLock::new(Some(bus)));
 }
 
 /// Reset the process-global event bus (used for test isolation).
 pub fn clear_global_event_bus() {
-    if let Some(lock) = GLOBAL_EVENT_BUS.get() {
-        if let Ok(mut guard) = lock.write() {
-            *guard = None;
-        }
-    } else {
-        let _ = GLOBAL_EVENT_BUS.set(RwLock::new(None));
+    if let Ok(mut guard) = GLOBAL_EVENT_BUS.write() {
+        *guard = None;
     }
 }
 

--- a/autumn/src/events.rs
+++ b/autumn/src/events.rs
@@ -1,0 +1,567 @@
+//! Typed domain event bus with decoupled, durable listeners.
+//!
+//! A *domain event* is a typed value (declared with `#[event]`) describing
+//! something that happened in your application — `UserSignedUp { user_id }`,
+//! `OrderPlaced { .. }`. *Listeners* (declared with `#[listener]`) react to an
+//! event independently of the code that emitted it: adding a new reaction is a
+//! new listener and **zero edits** to the emitter.
+//!
+//! ```ignore
+//! use autumn_web::prelude::*;
+//!
+//! #[event]
+//! struct UserSignedUp { user_id: i64 }
+//!
+//! // Durable: rides the #[job] queue, survives restarts, retried on failure.
+//! #[listener(UserSignedUp, durable)]
+//! async fn send_welcome_email(state: AppState, event: UserSignedUp) -> AutumnResult<()> {
+//!     // ...
+//!     Ok(())
+//! }
+//!
+//! #[post("/signup")]
+//! async fn signup(events: Events) -> AutumnResult<&'static str> {
+//!     events.publish(UserSignedUp { user_id: 42 }).await?;
+//!     Ok("ok")
+//! }
+//! ```
+//!
+//! # Dispatch
+//!
+//! - **Sync** listeners run in-request, before the response is returned — use
+//!   these for invariants the caller depends on. Each runs independently with
+//!   panic/error isolation: one failing listener never blocks the others, and
+//!   never fails the publish.
+//! - **Durable** listeners are enqueued onto the existing `#[job]` queue, so
+//!   they survive a process restart and inherit the queue's retry + DLQ
+//!   semantics (at-least-once delivery).
+//!
+//! A published event with no registered listeners is a **no-op**, not an error.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::{AppState, AutumnError, AutumnResult};
+
+/// A typed domain event.
+///
+/// Implemented by the `#[event]` macro, which also derives the serde +
+/// `Clone`/`Debug` impls the bus needs to carry the payload across the durable
+/// job queue.
+pub trait Event: Serialize + DeserializeOwned + Send + Sync + 'static {
+    /// Stable identifier used to route the event to its listeners and to name
+    /// the durable listener jobs.
+    const NAME: &'static str;
+}
+
+/// How a listener is dispatched when its event is published.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum DispatchMode {
+    /// Runs in-request, before the response, with panic/error isolation.
+    Sync,
+    /// Enqueued onto the `#[job]` queue (retry + DLQ + restart-safe).
+    Durable,
+}
+
+/// The async function signature for an event listener.
+///
+/// Intentionally identical to [`crate::job::JobHandler`] so a durable listener
+/// becomes a [`crate::job::JobInfo`] with no adapter.
+pub type ListenerHandler =
+    fn(AppState, Value) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>>;
+
+/// Metadata describing a registered event listener.
+///
+/// Produced by the `#[listener]` macro's `__autumn_listener_info_*` companion
+/// and collected by `listeners![]`.
+#[derive(Clone)]
+pub struct ListenerInfo {
+    /// The [`Event::NAME`] this listener subscribes to.
+    pub event_name: &'static str,
+    /// Fully-qualified, per-listener identity (`module::fn`).
+    pub listener_name: String,
+    /// Sync (in-request) or Durable (job queue).
+    pub mode: DispatchMode,
+    /// For durable listeners, the registered job name; `None` for sync.
+    pub job_name: Option<String>,
+    /// Durable retry cap (mirrors [`crate::job::JobInfo`]); ignored for sync.
+    pub max_attempts: u32,
+    /// Durable initial backoff in ms; ignored for sync.
+    pub initial_backoff_ms: u64,
+    /// Runs the listener: deserialize the event payload, call the function.
+    pub handler: ListenerHandler,
+}
+
+/// Routes published events to their registered listeners.
+///
+/// Built from the listeners registered with `AppBuilder::listeners` and
+/// installed onto [`AppState`] as a typed extension.
+#[derive(Clone, Default)]
+pub struct EventRegistry {
+    by_event: Arc<HashMap<&'static str, Vec<ListenerInfo>>>,
+}
+
+impl EventRegistry {
+    /// Group listeners by event name, preserving registration order.
+    #[must_use]
+    pub fn from_listeners(listeners: Vec<ListenerInfo>) -> Self {
+        let mut by_event: HashMap<&'static str, Vec<ListenerInfo>> = HashMap::new();
+        for listener in listeners {
+            by_event
+                .entry(listener.event_name)
+                .or_default()
+                .push(listener);
+        }
+        Self {
+            by_event: Arc::new(by_event),
+        }
+    }
+
+    /// Listeners registered for `event_name` (empty slice if none).
+    #[must_use]
+    pub fn listeners_for(&self, event_name: &str) -> &[ListenerInfo] {
+        self.by_event.get(event_name).map_or(&[][..], Vec::as_slice)
+    }
+
+    /// Synthesize a [`crate::job::JobInfo`] for each durable listener so the
+    /// app builder can register them with the job runtime.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a durable listener is missing its `job_name` (the `#[listener]`
+    /// macro always sets one, so this only fires on a hand-built `ListenerInfo`).
+    #[must_use]
+    pub fn durable_job_infos(&self) -> Vec<crate::job::JobInfo> {
+        self.by_event
+            .values()
+            .flatten()
+            .filter(|listener| listener.mode == DispatchMode::Durable)
+            .map(|listener| crate::job::JobInfo {
+                name: listener
+                    .job_name
+                    .clone()
+                    .expect("durable listener must carry a job_name"),
+                max_attempts: listener.max_attempts,
+                initial_backoff_ms: listener.initial_backoff_ms,
+                uniqueness: None,
+                concurrency: None,
+                handler: listener.handler,
+            })
+            .collect()
+    }
+}
+
+/// A single recorded publication, captured by [`EventRecorder`] in tests.
+#[derive(Clone, Debug)]
+pub struct RecordedEvent {
+    /// The [`Event::NAME`] of the published event.
+    pub event_name: &'static str,
+    /// The serialized event payload.
+    pub payload: Value,
+}
+
+/// Records published events so tests can assert on them without standing up the
+/// job runner. Installed onto [`AppState`] by the test client.
+#[derive(Default)]
+pub struct EventRecorder {
+    events: Mutex<Vec<RecordedEvent>>,
+}
+
+impl EventRecorder {
+    fn record(&self, event_name: &'static str, payload: Value) {
+        self.events
+            .lock()
+            .expect("event recorder lock poisoned")
+            .push(RecordedEvent {
+                event_name,
+                payload,
+            });
+    }
+
+    /// Deserialize every recorded publication of event type `E`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the recorder's internal lock is poisoned.
+    #[must_use]
+    pub fn published<E: Event>(&self) -> Vec<E> {
+        self.events
+            .lock()
+            .expect("event recorder lock poisoned")
+            .iter()
+            .filter(|recorded| recorded.event_name == E::NAME)
+            .filter_map(|recorded| serde_json::from_value(recorded.payload.clone()).ok())
+            .collect()
+    }
+
+    /// How many times event type `E` was published.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the recorder's internal lock is poisoned.
+    #[must_use]
+    pub fn count<E: Event>(&self) -> usize {
+        self.events
+            .lock()
+            .expect("event recorder lock poisoned")
+            .iter()
+            .filter(|recorded| recorded.event_name == E::NAME)
+            .count()
+    }
+
+    /// All recorded events, in publication order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the recorder's internal lock is poisoned.
+    #[must_use]
+    pub fn all(&self) -> Vec<RecordedEvent> {
+        self.events
+            .lock()
+            .expect("event recorder lock poisoned")
+            .clone()
+    }
+}
+
+/// Injectable event publisher.
+///
+/// Extracted in handlers/services just like the `Mailer`. Call
+/// [`Events::publish`] to emit a typed event to its listeners.
+#[derive(Clone)]
+pub struct Events {
+    registry: Arc<EventRegistry>,
+    recorder: Option<Arc<EventRecorder>>,
+    state: AppState,
+}
+
+impl Events {
+    /// Publish a typed event to its registered listeners.
+    ///
+    /// Durable listeners are enqueued onto the job queue; sync listeners run
+    /// in-request with panic/error isolation. A missing-listener event is a
+    /// no-op. Returns `Ok(())` even when sync listeners fail (the emitter stays
+    /// decoupled); only a durable **enqueue** failure propagates.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the event cannot be serialized, or if enqueueing a
+    /// durable listener onto the job queue fails.
+    pub async fn publish<E: Event>(&self, event: E) -> AutumnResult<()> {
+        let payload = serialize_event(&event)?;
+        dispatch(
+            &self.registry,
+            self.recorder.as_deref(),
+            &self.state,
+            E::NAME,
+            payload,
+        )
+        .await
+    }
+}
+
+impl axum::extract::FromRequestParts<AppState> for Events {
+    type Rejection = AutumnError;
+
+    async fn from_request_parts(
+        _parts: &mut http::request::Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        // A missing registry is not an error — publishing is then a safe no-op.
+        let registry = state
+            .extension::<EventRegistry>()
+            .unwrap_or_else(|| Arc::new(EventRegistry::default()));
+        let recorder = state.extension::<EventRecorder>();
+        Ok(Self {
+            registry,
+            recorder,
+            state: state.clone(),
+        })
+    }
+}
+
+fn serialize_event<E: Event>(event: &E) -> AutumnResult<Value> {
+    serde_json::to_value(event).map_err(|e| {
+        AutumnError::internal_server_error(std::io::Error::other(format!(
+            "event serialization failed: {e}"
+        )))
+    })
+}
+
+/// Core dispatch shared by [`Events::publish`] and the module-level [`publish`].
+async fn dispatch(
+    registry: &EventRegistry,
+    recorder: Option<&EventRecorder>,
+    state: &AppState,
+    event_name: &'static str,
+    payload: Value,
+) -> AutumnResult<()> {
+    // 1. Record first so tests observe the event even without a job runner.
+    if let Some(recorder) = recorder {
+        recorder.record(event_name, payload.clone());
+    }
+
+    let listeners = registry.listeners_for(event_name);
+    if listeners.is_empty() {
+        return Ok(());
+    }
+
+    // 2. Durable listeners: enqueue onto the job queue (at-least-once).
+    for listener in listeners
+        .iter()
+        .filter(|listener| listener.mode == DispatchMode::Durable)
+    {
+        let job_name = listener
+            .job_name
+            .as_deref()
+            .expect("durable listener must carry a job_name");
+        crate::job::enqueue(job_name, payload.clone()).await?;
+    }
+
+    // 3. Sync listeners: run independently, isolated from each other.
+    run_sync_listeners(state, listeners, &payload).await;
+
+    Ok(())
+}
+
+/// Run every sync listener on its own task so a panic or error in one never
+/// blocks the others, then await them all (they finish before the response).
+async fn run_sync_listeners(state: &AppState, listeners: &[ListenerInfo], payload: &Value) {
+    let mut handles = Vec::new();
+    for listener in listeners
+        .iter()
+        .filter(|listener| listener.mode == DispatchMode::Sync)
+    {
+        let state = state.clone();
+        let payload = payload.clone();
+        let run = listener.handler;
+        let name = listener.listener_name.clone();
+        handles.push(tokio::spawn(async move {
+            match run(state, payload).await {
+                Ok(()) => {}
+                Err(error) => {
+                    tracing::error!(listener = %name, %error, "sync event listener failed");
+                }
+            }
+        }));
+    }
+    for handle in handles {
+        if let Err(join_error) = handle.await {
+            tracing::error!(%join_error, "sync event listener panicked");
+        }
+    }
+}
+
+struct GlobalBus {
+    registry: Arc<EventRegistry>,
+    recorder: Option<Arc<EventRecorder>>,
+    state: AppState,
+}
+
+static GLOBAL_EVENT_BUS: OnceLock<RwLock<Option<Arc<GlobalBus>>>> = OnceLock::new();
+
+fn global_bus() -> Option<Arc<GlobalBus>> {
+    GLOBAL_EVENT_BUS
+        .get()
+        .and_then(|lock| lock.read().ok().and_then(|guard| guard.clone()))
+}
+
+/// Install the process-global event bus used by the module-level [`publish`].
+///
+/// Called by the app builder (and the test client) after the registry is built.
+pub(crate) fn init_global_event_bus(
+    registry: &EventRegistry,
+    state: &AppState,
+    recorder: Option<Arc<EventRecorder>>,
+) {
+    let bus = Arc::new(GlobalBus {
+        registry: Arc::new(registry.clone()),
+        recorder,
+        state: state.clone(),
+    });
+    if let Some(lock) = GLOBAL_EVENT_BUS.get() {
+        if let Ok(mut guard) = lock.write() {
+            *guard = Some(bus);
+        }
+        return;
+    }
+    let _ = GLOBAL_EVENT_BUS.set(RwLock::new(Some(bus)));
+}
+
+/// Reset the process-global event bus (used for test isolation).
+pub fn clear_global_event_bus() {
+    if let Some(lock) = GLOBAL_EVENT_BUS.get() {
+        if let Ok(mut guard) = lock.write() {
+            *guard = None;
+        }
+    } else {
+        let _ = GLOBAL_EVENT_BUS.set(RwLock::new(None));
+    }
+}
+
+/// Publish an event without a request context (services, jobs, scheduled tasks).
+///
+/// Delegates to the process-global bus installed at startup. Inside a request,
+/// prefer the injectable [`Events`] extractor.
+///
+/// # Errors
+///
+/// Returns an error if the event cannot be serialized or if enqueueing a
+/// durable listener fails. If the bus is not initialized the call is a no-op.
+pub async fn publish<E: Event>(event: E) -> AutumnResult<()> {
+    let payload = serialize_event(&event)?;
+    let Some(bus) = global_bus() else {
+        // No app wired the bus (e.g. a bare unit test) — nothing to dispatch to.
+        return Ok(());
+    };
+    dispatch(
+        &bus.registry,
+        bus.recorder.as_deref(),
+        &bus.state,
+        E::NAME,
+        payload,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[derive(Serialize, Deserialize, Clone, Debug)]
+    struct Ping {
+        n: i64,
+    }
+    impl Event for Ping {
+        const NAME: &'static str = "Ping";
+    }
+
+    fn ok_handler() -> ListenerHandler {
+        |_state, _payload| Box::pin(async { Ok(()) })
+    }
+
+    fn sync_listener(name: &str, handler: ListenerHandler) -> ListenerInfo {
+        ListenerInfo {
+            event_name: Ping::NAME,
+            listener_name: name.to_string(),
+            mode: DispatchMode::Sync,
+            job_name: None,
+            max_attempts: 0,
+            initial_backoff_ms: 0,
+            handler,
+        }
+    }
+
+    fn durable_listener(name: &str) -> ListenerInfo {
+        ListenerInfo {
+            event_name: Ping::NAME,
+            listener_name: name.to_string(),
+            mode: DispatchMode::Durable,
+            job_name: Some(format!("__event_listener::{name}")),
+            max_attempts: 4,
+            initial_backoff_ms: 250,
+            handler: ok_handler(),
+        }
+    }
+
+    #[test]
+    fn registry_groups_by_event_name() {
+        let registry = EventRegistry::from_listeners(vec![
+            sync_listener("a", ok_handler()),
+            sync_listener("b", ok_handler()),
+        ]);
+        assert_eq!(registry.listeners_for("Ping").len(), 2);
+        assert!(registry.listeners_for("Other").is_empty());
+    }
+
+    #[test]
+    fn durable_listeners_become_job_infos() {
+        let registry = EventRegistry::from_listeners(vec![
+            sync_listener("a", ok_handler()),
+            durable_listener("seed_workspace"),
+        ]);
+        let jobs = registry.durable_job_infos();
+        assert_eq!(jobs.len(), 1, "only durable listeners become jobs");
+        assert_eq!(jobs[0].name, "__event_listener::seed_workspace");
+        assert_eq!(jobs[0].max_attempts, 4);
+        assert_eq!(jobs[0].initial_backoff_ms, 250);
+    }
+
+    #[tokio::test]
+    async fn sync_listeners_are_isolated_from_panics_and_errors() {
+        static RAN: AtomicU32 = AtomicU32::new(0);
+        RAN.store(0, Ordering::SeqCst);
+
+        let panicking: ListenerHandler = |_state, _payload| Box::pin(async { panic!("boom") });
+        let erroring: ListenerHandler = |_state, _payload| {
+            Box::pin(async {
+                Err(AutumnError::internal_server_error(std::io::Error::other(
+                    "nope",
+                )))
+            })
+        };
+        let counting: ListenerHandler = |_state, _payload| {
+            Box::pin(async {
+                RAN.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+        };
+
+        let registry = EventRegistry::from_listeners(vec![
+            sync_listener("panics", panicking),
+            sync_listener("errors", erroring),
+            sync_listener("counts", counting),
+        ]);
+        let state = AppState::for_test();
+
+        // No recorder, no durable listeners: a panicking/erroring sibling must
+        // not stop the third listener from running, and publish still succeeds.
+        let result = dispatch(
+            &registry,
+            None,
+            &state,
+            Ping::NAME,
+            serde_json::json!({"n": 1}),
+        )
+        .await;
+        assert!(result.is_ok(), "publish stays Ok despite listener failures");
+        assert_eq!(RAN.load(Ordering::SeqCst), 1, "surviving listener ran");
+    }
+
+    #[tokio::test]
+    async fn missing_listener_is_a_noop() {
+        let registry = EventRegistry::default();
+        let state = AppState::for_test();
+        let result = dispatch(
+            &registry,
+            None,
+            &state,
+            Ping::NAME,
+            serde_json::json!({"n": 1}),
+        )
+        .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn recorder_captures_published_events() {
+        let registry = EventRegistry::default();
+        let recorder = EventRecorder::default();
+        let state = AppState::for_test();
+        let payload = serialize_event(&Ping { n: 7 }).unwrap();
+        dispatch(&registry, Some(&recorder), &state, Ping::NAME, payload)
+            .await
+            .unwrap();
+        assert_eq!(recorder.count::<Ping>(), 1);
+        let published = recorder.published::<Ping>();
+        assert_eq!(published.len(), 1);
+        assert_eq!(published[0].n, 7);
+    }
+}

--- a/autumn/src/events.rs
+++ b/autumn/src/events.rs
@@ -424,19 +424,56 @@ pub fn clear_global_event_bus() {
     }
 }
 
+tokio::task_local! {
+    /// The ambient app for the current request or job, used by the free
+    /// [`publish`] so it resolves *this* app rather than the process-global bus.
+    static CURRENT_EVENT_APP: AppState;
+}
+
+/// Run `future` with `state` installed as the ambient app for the free
+/// [`publish`]. Scoped by the request pipeline and the job runtime so a handler,
+/// service, or job that calls `publish` dispatches against its own app —
+/// keeping parallel in-process apps (notably tests) isolated.
+pub(crate) fn scope_event_app<F>(
+    state: AppState,
+    future: F,
+) -> tokio::task::futures::TaskLocalFuture<AppState, F>
+where
+    F: Future,
+{
+    CURRENT_EVENT_APP.scope(state, future)
+}
+
+fn current_event_app() -> Option<AppState> {
+    CURRENT_EVENT_APP.try_with(AppState::clone).ok()
+}
+
 /// Publish an event without a request context (services, jobs, scheduled tasks).
 ///
-/// Delegates to the process-global bus installed at startup. Inside a request,
-/// prefer the injectable [`Events`] extractor.
+/// Resolves the **current app** from the ambient request/job context when one is
+/// set (so parallel apps stay isolated), falling back to the process-global bus
+/// installed at startup. Inside a request, the injectable [`Events`] extractor is
+/// equivalent and slightly more explicit.
 ///
 /// # Errors
 ///
 /// Returns an error if the event cannot be serialized or if enqueueing a
-/// durable listener fails. If the bus is not initialized the call is a no-op.
+/// durable listener fails. If no app context is available the call is a no-op.
 pub async fn publish<E: Event>(event: E) -> AutumnResult<()> {
     let payload = serialize_event(&event)?;
+
+    // Prefer the ambient app context (set per request and per job) for isolation.
+    if let Some(state) = current_event_app() {
+        let registry = state.extension::<EventRegistry>();
+        let empty = EventRegistry::default();
+        let registry_ref = registry.as_deref().unwrap_or(&empty);
+        let recorder = state.extension::<EventRecorder>();
+        return dispatch(registry_ref, recorder.as_deref(), &state, E::NAME, payload).await;
+    }
+
+    // No ambient app (e.g. a startup hook or bare task) — fall back to the
+    // process-global bus, or no-op if nothing wired it.
     let Some(bus) = global_bus() else {
-        // No app wired the bus (e.g. a bare unit test) — nothing to dispatch to.
         return Ok(());
     };
     dispatch(

--- a/autumn/src/events.rs
+++ b/autumn/src/events.rs
@@ -328,10 +328,15 @@ async fn dispatch(
             .job_name
             .as_deref()
             .expect("durable listener must carry a job_name");
+        // Enqueue *after commit* so publishing inside a `Db::tx` defers the
+        // durable reaction until the transaction commits — a rolled-back event
+        // never fires its listeners, and (on Postgres) the job is not claimed on
+        // another connection before the event's data is visible. Outside a
+        // transaction this enqueues immediately.
         let enqueued = if let Some(client) = &app_client {
-            client.enqueue(job_name, payload.clone()).await
+            client.enqueue_after_commit(job_name, payload.clone()).await
         } else {
-            crate::job::enqueue(job_name, payload.clone()).await
+            crate::job::enqueue_after_commit(job_name, payload.clone()).await
         };
         // Don't let one durable enqueue failure skip the in-request sync
         // listeners (or the remaining durable enqueues); remember the first
@@ -350,41 +355,43 @@ async fn dispatch(
     durable_error.map_or(Ok(()), Err)
 }
 
-/// Run every sync listener on its own task so a panic or error in one never
-/// blocks the others, then await them all (they finish before the response).
+/// Run every sync listener concurrently on the caller's task, isolating each
+/// from its siblings with `catch_unwind` (the same panic-isolation the job
+/// runtime uses), then await them all (they finish before the response).
 ///
-/// Each task is instrumented with the publishing span so listener logs stay
-/// correlated with the originating request/trace despite the `tokio::spawn`.
+/// Running directly — rather than `tokio::spawn` — keeps the ambient app context
+/// (`CURRENT_EVENT_APP`) and tracing span in scope, so a listener that itself
+/// calls the free [`publish`] dispatches against the right app and stays
+/// log-correlated. It also ties the listeners to the publish future's lifecycle,
+/// so cancelling the request (timeout, disconnect) cancels the listeners instead
+/// of leaving detached tasks running after the response is abandoned.
 async fn run_sync_listeners(state: &AppState, listeners: &[ListenerInfo], payload: &Value) {
-    use tracing::Instrument as _;
+    use futures::FutureExt as _;
 
-    let mut handles = Vec::new();
-    for listener in listeners
+    let runs = listeners
         .iter()
         .filter(|listener| listener.mode == DispatchMode::Sync)
-    {
-        let state = state.clone();
-        let payload = payload.clone();
-        let run = listener.handler;
-        let name = listener.listener_name.clone();
-        let span = tracing::Span::current();
-        handles.push(tokio::spawn(
+        .map(|listener| {
+            let state = state.clone();
+            let payload = payload.clone();
+            let run = listener.handler;
+            let name = listener.listener_name.clone();
             async move {
-                match run(state, payload).await {
-                    Ok(()) => {}
-                    Err(error) => {
+                match std::panic::AssertUnwindSafe(run(state, payload))
+                    .catch_unwind()
+                    .await
+                {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => {
                         tracing::error!(listener = %name, %error, "sync event listener failed");
+                    }
+                    Err(_panic) => {
+                        tracing::error!(listener = %name, "sync event listener panicked");
                     }
                 }
             }
-            .instrument(span),
-        ));
-    }
-    for handle in handles {
-        if let Err(join_error) = handle.await {
-            tracing::error!(%join_error, "sync event listener panicked");
-        }
-    }
+        });
+    futures::future::join_all(runs).await;
 }
 
 struct GlobalBus {

--- a/autumn/src/events.rs
+++ b/autumn/src/events.rs
@@ -312,6 +312,13 @@ async fn dispatch(
     }
 
     // 2. Durable listeners: enqueue onto the job queue (at-least-once).
+    //
+    // Prefer this app's own `JobClient` (installed onto `AppState` by the job
+    // runtime) over the process-global client, so durable dispatch is scoped to
+    // the publishing app rather than whichever app last started a runtime. This
+    // keeps parallel in-process apps (notably tests) from contending. We fall
+    // back to the global client only if no app-local one is present.
+    let app_client = state.extension::<crate::job::JobClient>();
     for listener in listeners
         .iter()
         .filter(|listener| listener.mode == DispatchMode::Durable)
@@ -320,7 +327,11 @@ async fn dispatch(
             .job_name
             .as_deref()
             .expect("durable listener must carry a job_name");
-        crate::job::enqueue(job_name, payload.clone()).await?;
+        if let Some(client) = &app_client {
+            client.enqueue(job_name, payload.clone()).await?;
+        } else {
+            crate::job::enqueue(job_name, payload.clone()).await?;
+        }
     }
 
     // 3. Sync listeners: run independently, isolated from each other.

--- a/autumn/src/events.rs
+++ b/autumn/src/events.rs
@@ -319,6 +319,7 @@ async fn dispatch(
     // keeps parallel in-process apps (notably tests) from contending. We fall
     // back to the global client only if no app-local one is present.
     let app_client = state.extension::<crate::job::JobClient>();
+    let mut durable_error = None;
     for listener in listeners
         .iter()
         .filter(|listener| listener.mode == DispatchMode::Durable)
@@ -327,17 +328,26 @@ async fn dispatch(
             .job_name
             .as_deref()
             .expect("durable listener must carry a job_name");
-        if let Some(client) = &app_client {
-            client.enqueue(job_name, payload.clone()).await?;
+        let enqueued = if let Some(client) = &app_client {
+            client.enqueue(job_name, payload.clone()).await
         } else {
-            crate::job::enqueue(job_name, payload.clone()).await?;
+            crate::job::enqueue(job_name, payload.clone()).await
+        };
+        // Don't let one durable enqueue failure skip the in-request sync
+        // listeners (or the remaining durable enqueues); remember the first
+        // error and surface it after sync listeners have run.
+        if let Err(error) = enqueued
+            && durable_error.is_none()
+        {
+            durable_error = Some(error);
         }
     }
 
-    // 3. Sync listeners: run independently, isolated from each other.
+    // 3. Sync listeners: run independently, isolated from each other — these run
+    // even if a durable enqueue above failed.
     run_sync_listeners(state, listeners, &payload).await;
 
-    Ok(())
+    durable_error.map_or(Ok(()), Err)
 }
 
 /// Run every sync listener on its own task so a panic or error in one never
@@ -543,6 +553,37 @@ mod tests {
         .await;
         assert!(result.is_ok(), "publish stays Ok despite listener failures");
         assert_eq!(RAN.load(Ordering::SeqCst), 1, "surviving listener ran");
+    }
+
+    #[tokio::test]
+    async fn sync_listeners_run_even_when_a_durable_enqueue_fails() {
+        // With no app-local client and no global job runtime, the durable
+        // enqueue fails — but the sync listener must still run (and the error
+        // is surfaced afterwards rather than short-circuiting dispatch).
+        static RAN: AtomicU32 = AtomicU32::new(0);
+        crate::job::clear_global_job_client();
+        RAN.store(0, Ordering::SeqCst);
+        let counting: ListenerHandler = |_state, _payload| {
+            Box::pin(async {
+                RAN.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+        };
+        let registry = EventRegistry::from_listeners(vec![
+            durable_listener("seed_workspace"),
+            sync_listener("counts", counting),
+        ]);
+        let state = AppState::for_test();
+        let _ = dispatch(
+            &registry,
+            None,
+            &state,
+            Ping::NAME,
+            serde_json::json!({"n": 1}),
+        )
+        .await;
+        // The key guarantee: the durable failure did not skip the sync listener.
+        assert_eq!(RAN.load(Ordering::SeqCst), 1, "sync listener ran anyway");
     }
 
     #[tokio::test]

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -1427,6 +1427,16 @@ pub fn global_job_client() -> Option<Arc<JobClient>> {
         .and_then(|lock| lock.read().ok().and_then(|guard| guard.clone()))
 }
 
+/// Install the runtime's [`JobClient`] both as the process-global client (used
+/// by the free [`enqueue`] functions and `#[job]` handlers) **and** as an
+/// [`AppState`] extension, so callers that hold an `AppState` — notably the
+/// event bus's durable dispatch — can enqueue against *this* app's client
+/// rather than racing on the process-global one.
+pub(crate) fn install_job_client(state: &AppState, client: JobClient) {
+    state.insert_extension(client.clone());
+    init_global_job_client(client);
+}
+
 pub(crate) fn init_global_job_client(client: JobClient) {
     if let Some(lock) = GLOBAL_JOB_CLIENT.get() {
         if let Ok(mut guard) = lock.write() {
@@ -2259,7 +2269,7 @@ pub(crate) fn start_local_runtime(
             .extension::<crate::config::AutumnConfig>()
             .map(|c| Arc::new(c.resilience.clone())),
     };
-    init_global_job_client(client);
+    install_job_client(state, client);
 
     for _ in 0..worker_count {
         let state = state.clone();
@@ -4333,29 +4343,32 @@ fn start_redis_runtime(
         }
     }
 
-    init_global_job_client(JobClient {
-        local_sender: None,
-        local_coordination: None,
-        redis: Some(RedisClient {
-            connection: producer_connection,
-            queue_key: queue_key.clone(),
-            record_prefix: record_prefix.clone(),
-            unique_prefix: unique_prefix.clone(),
-        }),
-        #[cfg(feature = "db")]
-        pg_pool: None,
-        registry: state.job_registry.clone(),
-        job_admin: job_admin.clone(),
-        default_max_attempts: config.max_attempts,
-        default_initial_backoff_ms: config.initial_backoff_ms,
-        per_job_settings,
-        interceptor: state
-            .extension::<Arc<dyn crate::interceptor::JobInterceptor>>()
-            .map(|arc| (*arc).clone()),
-        resilience_config: state
-            .extension::<crate::config::AutumnConfig>()
-            .map(|c| Arc::new(c.resilience.clone())),
-    });
+    install_job_client(
+        state,
+        JobClient {
+            local_sender: None,
+            local_coordination: None,
+            redis: Some(RedisClient {
+                connection: producer_connection,
+                queue_key: queue_key.clone(),
+                record_prefix: record_prefix.clone(),
+                unique_prefix: unique_prefix.clone(),
+            }),
+            #[cfg(feature = "db")]
+            pg_pool: None,
+            registry: state.job_registry.clone(),
+            job_admin: job_admin.clone(),
+            default_max_attempts: config.max_attempts,
+            default_initial_backoff_ms: config.initial_backoff_ms,
+            per_job_settings,
+            interceptor: state
+                .extension::<Arc<dyn crate::interceptor::JobInterceptor>>()
+                .map(|arc| (*arc).clone()),
+            resilience_config: state
+                .extension::<crate::config::AutumnConfig>()
+                .map(|c| Arc::new(c.resilience.clone())),
+        },
+    );
 
     let worker_count = config.workers.max(1);
     for _ in 0..worker_count {
@@ -5642,24 +5655,27 @@ fn start_postgres_runtime(
         })));
     }
 
-    init_global_job_client(JobClient {
-        local_sender: None,
-        local_coordination: None,
-        #[cfg(feature = "redis")]
-        redis: None,
-        pg_pool: Some(pool.clone()),
-        registry: state.job_registry.clone(),
-        job_admin: job_admin.clone(),
-        default_max_attempts: config.max_attempts,
-        default_initial_backoff_ms: config.initial_backoff_ms,
-        per_job_settings,
-        interceptor: state
-            .extension::<Arc<dyn crate::interceptor::JobInterceptor>>()
-            .map(|arc| (*arc).clone()),
-        resilience_config: state
-            .extension::<crate::config::AutumnConfig>()
-            .map(|c| Arc::new(c.resilience.clone())),
-    });
+    install_job_client(
+        state,
+        JobClient {
+            local_sender: None,
+            local_coordination: None,
+            #[cfg(feature = "redis")]
+            redis: None,
+            pg_pool: Some(pool.clone()),
+            registry: state.job_registry.clone(),
+            job_admin: job_admin.clone(),
+            default_max_attempts: config.max_attempts,
+            default_initial_backoff_ms: config.initial_backoff_ms,
+            per_job_settings,
+            interceptor: state
+                .extension::<Arc<dyn crate::interceptor::JobInterceptor>>()
+                .map(|arc| (*arc).clone()),
+            resilience_config: state
+                .extension::<crate::config::AutumnConfig>()
+                .map(|c| Arc::new(c.resilience.clone())),
+        },
+    );
 
     let visibility_timeout_ms = config.postgres.visibility_timeout_ms;
     let worker_count = config.workers.max(1);

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -1335,6 +1335,10 @@ async fn run_job_handler(
     state: AppState,
     payload: Value,
 ) -> JobExecutionOutcome {
+    // Make this job's app the ambient event context so a job (or durable event
+    // listener) that calls the free `events::publish` dispatches against its own
+    // app rather than the process-global bus.
+    let event_app = state.clone();
     let interceptor = state
         .extension::<Arc<dyn crate::interceptor::JobInterceptor>>()
         .map(|arc| (*arc).clone());
@@ -1369,7 +1373,8 @@ async fn run_job_handler(
         Err(panic) => return JobExecutionOutcome::Panicked(format_job_panic(panic.as_ref())),
     };
 
-    match std::panic::AssertUnwindSafe(future).catch_unwind().await {
+    let execution = std::panic::AssertUnwindSafe(future).catch_unwind();
+    match crate::events::scope_event_app(event_app, execution).await {
         Ok(Ok(())) => JobExecutionOutcome::Succeeded,
         Ok(Err(error)) => JobExecutionOutcome::Failed(error.to_string()),
         Err(panic) => JobExecutionOutcome::Panicked(format_job_panic(panic.as_ref())),

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -218,6 +218,7 @@ pub mod time;
 pub mod time_zone;
 pub mod user_agent;
 
+pub mod events;
 pub mod experiments;
 pub mod feature_flags;
 pub mod form;
@@ -699,8 +700,12 @@ pub use autumn_macros::cached;
 #[cfg(feature = "ws")]
 pub use autumn_macros::ws;
 
+/// Declare a typed domain event. See [`mod@events`] module.
+pub use autumn_macros::event;
 /// Declare an on-demand background job. See [`mod@job`] module.
 pub use autumn_macros::job;
+/// Declare an event listener. See [`mod@events`] module.
+pub use autumn_macros::listener;
 /// Declare a scheduled background task. See [`mod@task`] module.
 pub use autumn_macros::scheduled;
 /// Declare a one-off operational task. See [`task::OneOffTaskInfo`].
@@ -849,6 +854,8 @@ pub use autumn_macros::feature_flag;
 pub use autumn_macros::authorize;
 /// Collect `#[job]` handlers into a `Vec<JobInfo>`.
 pub use autumn_macros::jobs;
+/// Collect `#[listener]` handlers into a `Vec<events::ListenerInfo>`.
+pub use autumn_macros::listeners;
 
 /// Collect `#[task]` handlers into a `Vec<task::OneOffTaskInfo>`.
 pub use autumn_macros::one_off_tasks;
@@ -1037,6 +1044,7 @@ pub mod reexports {
     pub use lettre;
     #[cfg(feature = "db")]
     pub use scoped_futures;
+    pub use serde;
     pub use serde_json;
     pub use tokio;
     pub use tokio_util;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -31,9 +31,9 @@ pub use crate::paths::PathExt;
 pub use autumn_macros::ws;
 /// HTTP method route macros, main macro, and route collection.
 pub use autumn_macros::{
-    api_doc, authorize, cached, delete, feature_flag, get, job, jobs, main, oauth2_callback,
-    one_off_tasks, patch, paths, post, put, routes, scheduled, secured, service, static_get,
-    static_routes, step_up, task, tasks,
+    api_doc, authorize, cached, delete, event, feature_flag, get, job, jobs, listener, listeners,
+    main, oauth2_callback, one_off_tasks, patch, paths, post, put, routes, scheduled, secured,
+    service, static_get, static_routes, step_up, task, tasks,
 };
 #[cfg(feature = "mail")]
 pub use autumn_macros::{mail_previews, mailer, mailer_preview};
@@ -51,6 +51,10 @@ pub use crate::canary::CanaryRoute;
 /// Database connection extractor.
 #[cfg(feature = "db")]
 pub use crate::db::Db;
+/// Typed domain event bus publisher extractor. The `Event` trait it works with
+/// lives at [`crate::events::Event`] (kept out of the prelude to avoid clashing
+/// with [`crate::sse::Event`]).
+pub use crate::events::Events;
 /// Form data extractor.
 pub use crate::extract::Form;
 /// JSON request/response type.

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -557,6 +557,15 @@ fn build_router_pre_state(
         http_interceptor_middleware,
     ));
 
+    // Install the request's app as the ambient event-bus context so any code in
+    // the request (handlers, services) that calls the free `events::publish`
+    // dispatches against this app rather than the process-global bus — keeping
+    // parallel in-process apps (notably tests) isolated.
+    let router = router.layer(axum::middleware::from_fn_with_state(
+        state.clone(),
+        event_app_context_middleware,
+    ));
+
     // Mount the MCP endpoint last so its dispatch target — a clone of the
     // fully-assembled router with state applied — traverses the exact same
     // routes, layers, and middleware an HTTP request would. The clone is
@@ -3274,6 +3283,16 @@ fn mount_swagger_ui_routes(
         }),
     );
     router
+}
+
+/// Scope the request's [`AppState`] as the ambient event-bus app for the
+/// duration of the request, so the free `events::publish` resolves this app.
+async fn event_app_context_middleware(
+    state: axum::extract::State<AppState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    crate::events::scope_event_app(state.0.clone(), async move { next.run(req).await }).await
 }
 
 #[cfg(feature = "oauth2")]

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -254,6 +254,7 @@ pub struct TestApp {
     http_mock_registry: Option<std::sync::Arc<crate::http_client::MockRegistry>>,
     state_initializers: Vec<Box<dyn FnOnce(&AppState) + Send>>,
     jobs: Vec<crate::job::JobInfo>,
+    listeners: Vec<crate::events::ListenerInfo>,
     exception_filters: Vec<std::sync::Arc<dyn crate::middleware::ExceptionFilter>>,
     #[cfg(feature = "mail")]
     suppression_store: Option<crate::mail::SuppressionStoreHandle>,
@@ -324,6 +325,7 @@ impl TestApp {
             http_mock_registry: None,
             state_initializers: Vec::new(),
             jobs: Vec::new(),
+            listeners: Vec::new(),
             exception_filters: Vec::new(),
             #[cfg(feature = "mail")]
             suppression_store: None,
@@ -660,6 +662,7 @@ impl TestApp {
         self.static_gate_layers
             .extend(app_builder.static_gate_layers);
         self.jobs.extend(app_builder.jobs);
+        self.listeners.extend(app_builder.listeners);
         self.exception_filters.extend(app_builder.exception_filters);
         self.metrics_sources.extend(app_builder.metrics_sources);
         self.health_indicators.extend(app_builder.health_indicators);
@@ -773,6 +776,18 @@ impl TestApp {
         interceptor: impl crate::interceptor::JobInterceptor,
     ) -> Self {
         self.job_interceptor = Some(std::sync::Arc::new(interceptor));
+        self
+    }
+
+    /// Register event listeners with the test app.
+    ///
+    /// Collect them with `listeners![..]`, exactly as in `AppBuilder::listeners`.
+    /// Durable listeners run under the in-process test job runtime; sync
+    /// listeners run in-request. Published events are always recorded, so
+    /// [`TestClient::assert_event_published`] works without standing up jobs.
+    #[must_use]
+    pub fn listeners(mut self, listeners: Vec<crate::events::ListenerInfo>) -> Self {
+        self.listeners.extend(listeners);
         self
     }
 
@@ -991,6 +1006,9 @@ impl TestApp {
     pub fn build(mut self) -> TestClient {
         // Reset the global cache to prevent cross-test contamination.
         crate::cache::clear_global_cache();
+        // Reset the global event bus so a prior test's listeners/recorder do not
+        // leak into this one (it is re-installed below).
+        crate::events::clear_global_event_bus();
 
         #[cfg(feature = "db")]
         let (pool, replica_pool, db_interceptor) = if self.transactional {
@@ -1234,6 +1252,20 @@ impl TestApp {
             initializer(&state);
         }
 
+        // Wire the event bus: always install a recorder so tests can assert on
+        // published events without a job runner, register the listener registry
+        // for the `Events` extractor, and fold durable listeners into the jobs
+        // started below so they dispatch through the in-process test runtime.
+        state.insert_extension(crate::events::EventRecorder::default());
+        let event_recorder = state
+            .extension::<crate::events::EventRecorder>()
+            .expect("event recorder just installed");
+        let event_registry =
+            crate::events::EventRegistry::from_listeners(std::mem::take(&mut self.listeners));
+        self.jobs.extend(event_registry.durable_job_infos());
+        state.insert_extension(event_registry.clone());
+        crate::events::init_global_event_bus(&event_registry, &state, Some(event_recorder));
+
         for job in &self.jobs {
             state.job_registry.register(&job.name);
         }
@@ -1397,6 +1429,35 @@ impl TestClient {
     #[must_use]
     pub const fn state(&self) -> &AppState {
         &self.state
+    }
+
+    /// Every recorded publication of event type `E`, deserialized.
+    ///
+    /// Events are recorded synchronously at publish time, so this works whether
+    /// or not the listeners (sync or durable) have run.
+    #[must_use]
+    pub fn published_events<E: crate::events::Event>(&self) -> Vec<E> {
+        self.state
+            .extension::<crate::events::EventRecorder>()
+            .map(|recorder| recorder.published::<E>())
+            .unwrap_or_default()
+    }
+
+    /// Assert that at least one event of type `E` was published during the test.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no event of type `E` was recorded.
+    pub fn assert_event_published<E: crate::events::Event>(&self) {
+        let count = self
+            .state
+            .extension::<crate::events::EventRecorder>()
+            .map_or(0, |recorder| recorder.count::<E>());
+        assert!(
+            count > 0,
+            "expected event `{}` to have been published, but none were recorded",
+            E::NAME,
+        );
     }
 
     /// Step the test clock forward by `duration`.

--- a/autumn/tests/events_integration.rs
+++ b/autumn/tests/events_integration.rs
@@ -1,0 +1,187 @@
+//! Integration tests for the typed domain event bus (#1338).
+//!
+//! Acceptance criteria covered end-to-end through the in-process test client:
+//! - a typed `#[event]` is published from a handler via the injectable `Events`
+//!   extractor;
+//! - multiple listeners on the same event each run, and a panicking/erroring
+//!   listener does not stop the others;
+//! - sync listeners run in-request before the response; durable listeners run
+//!   via the in-process job runtime;
+//! - adding a listener requires zero edits to the publishing handler;
+//! - a published event with no listeners is a no-op;
+//! - the test recorder lets `assert_event_published::<T>()` work without
+//!   inspecting listeners.
+//!
+//! Listeners are plain `fn` pointers, so per-test observability lives in an
+//! `AppState` extension (`Counters`) installed via `state_initializer` — this
+//! keeps the tests isolated under parallel execution rather than racing on
+//! process-global statics.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use autumn_web::events::Events;
+use autumn_web::prelude::*;
+use autumn_web::test::TestApp;
+use autumn_web::{event, get, listener, listeners, routes};
+
+#[derive(Default)]
+struct Counters {
+    sync_a: AtomicU32,
+    survivor: AtomicU32,
+    durable: AtomicU32,
+}
+
+fn bump(state: &AppState, pick: fn(&Counters) -> &AtomicU32) {
+    if let Some(counters) = state.extension::<Counters>() {
+        pick(&counters).fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn read(state: &AppState, pick: fn(&Counters) -> &AtomicU32) -> u32 {
+    state
+        .extension::<Counters>()
+        .map_or(0, |counters| pick(&counters).load(Ordering::SeqCst))
+}
+
+// ── A typed domain event ───────────────────────────────────────────
+#[event]
+struct UserSignedUp {
+    user_id: i64,
+}
+
+#[event]
+struct NothingListens {
+    value: i64,
+}
+
+// ── Listeners (decoupled from the emitter) ─────────────────────────
+#[listener(UserSignedUp)]
+async fn sync_a(state: AppState, event: UserSignedUp) -> AutumnResult<()> {
+    assert_eq!(event.user_id, 42);
+    bump(&state, |c| &c.sync_a);
+    Ok(())
+}
+
+#[listener(UserSignedUp)]
+async fn sync_panics(_state: AppState, _event: UserSignedUp) -> AutumnResult<()> {
+    panic!("this listener blows up but must not affect the others");
+}
+
+#[listener(UserSignedUp)]
+async fn sync_survivor(state: AppState, _event: UserSignedUp) -> AutumnResult<()> {
+    bump(&state, |c| &c.survivor);
+    Ok(())
+}
+
+#[listener(UserSignedUp, durable, max_attempts = 3)]
+async fn durable_seed(state: AppState, _event: UserSignedUp) -> AutumnResult<()> {
+    bump(&state, |c| &c.durable);
+    Ok(())
+}
+
+/// Sync-only listeners. The durable path rides the process-global job client
+/// (a job-system constraint), so only the dedicated durable test registers a
+/// durable listener — that keeps these parallel tests from stomping on each
+/// other's job runtime.
+fn sync_listeners() -> Vec<autumn_web::events::ListenerInfo> {
+    listeners![sync_a, sync_panics, sync_survivor]
+}
+
+// ── Emitting handler (never edited when listeners are added) ────────
+#[get("/signup")]
+async fn signup(events: Events) -> AutumnResult<&'static str> {
+    events.publish(UserSignedUp { user_id: 42 }).await?;
+    Ok("ok")
+}
+
+#[get("/quiet")]
+async fn quiet(events: Events) -> AutumnResult<&'static str> {
+    // No listener subscribes to this event — publishing must be a no-op.
+    events.publish(NothingListens { value: 1 }).await?;
+    Ok("ok")
+}
+
+fn app_with(listeners: Vec<autumn_web::events::ListenerInfo>) -> autumn_web::test::TestClient {
+    TestApp::new()
+        .routes(routes![signup, quiet])
+        .state_initializer(|state| state.insert_extension(Counters::default()))
+        .listeners(listeners)
+        .build()
+}
+
+#[tokio::test]
+async fn publishing_runs_sync_listeners_with_panic_isolation() {
+    let client = app_with(sync_listeners());
+
+    client.get("/signup").send().await.assert_ok();
+
+    // Both non-panicking sync listeners ran despite a sibling panicking.
+    assert_eq!(read(client.state(), |c| &c.sync_a), 1, "sync_a ran");
+    assert_eq!(
+        read(client.state(), |c| &c.survivor),
+        1,
+        "sync_survivor ran even though a sibling panicked"
+    );
+}
+
+#[tokio::test]
+async fn durable_listener_runs_via_the_job_runtime() {
+    // This is the only test that registers a durable listener (and thus builds a
+    // job runtime), so the process-global job client it installs is not raced.
+    let client = app_with(listeners![durable_seed]);
+
+    client.get("/signup").send().await.assert_ok();
+
+    // The durable listener is enqueued onto the job queue; under the in-process
+    // local backend it runs shortly after. Poll briefly for it.
+    let mut ran = false;
+    for _ in 0..100 {
+        if read(client.state(), |c| &c.durable) >= 1 {
+            ran = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert!(ran, "durable listener should have run via the job runtime");
+}
+
+#[tokio::test]
+async fn test_recorder_captures_published_events() {
+    let client = app_with(sync_listeners());
+
+    client.get("/signup").send().await.assert_ok();
+
+    client.assert_event_published::<UserSignedUp>();
+    let published = client.published_events::<UserSignedUp>();
+    assert_eq!(published.len(), 1);
+    assert_eq!(published[0].user_id, 42);
+}
+
+#[tokio::test]
+async fn event_with_no_listeners_is_a_noop() {
+    // No listeners registered at all.
+    let client = app_with(Vec::new());
+    // Publishing an event nobody listens to must succeed, not error.
+    client.get("/quiet").send().await.assert_ok();
+    // It is still recorded, so the recorder works regardless of listeners.
+    client.assert_event_published::<NothingListens>();
+}
+
+#[tokio::test]
+async fn adding_a_listener_needs_zero_emitter_edits() {
+    // The emitter (`signup`) is identical here; we register only one listener.
+    // This is the "+1 file, 0 emitter edits" property: registration is the only
+    // thing that changes when a reaction is added.
+    let client = app_with(listeners![sync_a]);
+
+    client.get("/signup").send().await.assert_ok();
+    assert_eq!(read(client.state(), |c| &c.sync_a), 1);
+    // The other listeners were not registered, so they never ran.
+    assert_eq!(read(client.state(), |c| &c.survivor), 0);
+}
+
+// Keep an explicit reference so the unused-import lints stay quiet if the test
+// set shrinks during refactors.
+#[allow(dead_code)]
+fn _type_anchor(_: Arc<Counters>) {}

--- a/autumn/tests/events_integration.rs
+++ b/autumn/tests/events_integration.rs
@@ -55,6 +55,11 @@ struct NothingListens {
     value: i64,
 }
 
+#[event]
+struct ChainedFollowup {
+    source_user: i64,
+}
+
 // ── Listeners (decoupled from the emitter) ─────────────────────────
 #[listener(UserSignedUp)]
 async fn sync_a(state: AppState, event: UserSignedUp) -> AutumnResult<()> {
@@ -78,6 +83,16 @@ async fn sync_survivor(state: AppState, _event: UserSignedUp) -> AutumnResult<()
 async fn durable_seed(state: AppState, _event: UserSignedUp) -> AutumnResult<()> {
     bump(&state, |c| &c.durable);
     Ok(())
+}
+
+// A sync listener that itself publishes a follow-up event via the free
+// publisher — exercising that the ambient app context survives into listeners.
+#[listener(UserSignedUp)]
+async fn republish_followup(_state: AppState, event: UserSignedUp) -> AutumnResult<()> {
+    autumn_web::events::publish(ChainedFollowup {
+        source_user: event.user_id,
+    })
+    .await
 }
 
 /// The full listener set, including the durable one. Durable dispatch is scoped
@@ -203,6 +218,26 @@ async fn free_publisher_dispatches_to_the_current_app() {
         1,
         "sync_a ran via free publish"
     );
+}
+
+#[tokio::test]
+async fn sync_listener_can_publish_a_followup_event() {
+    // The sync listener runs on the request's task and calls the free publisher;
+    // the ambient app context must carry through so the follow-up is recorded
+    // against this app (it would be lost if listeners were detached via spawn).
+    let client = TestApp::new()
+        .routes(routes![signup])
+        .state_initializer(|state| state.insert_extension(Counters::default()))
+        .listeners(listeners![republish_followup])
+        .build();
+
+    client.get("/signup").send().await.assert_ok();
+
+    client.assert_event_published::<UserSignedUp>();
+    client.assert_event_published::<ChainedFollowup>();
+    let followups = client.published_events::<ChainedFollowup>();
+    assert_eq!(followups.len(), 1);
+    assert_eq!(followups[0].source_user, 42);
 }
 
 #[tokio::test]

--- a/autumn/tests/events_integration.rs
+++ b/autumn/tests/events_integration.rs
@@ -80,12 +80,12 @@ async fn durable_seed(state: AppState, _event: UserSignedUp) -> AutumnResult<()>
     Ok(())
 }
 
-/// Sync-only listeners. The durable path rides the process-global job client
-/// (a job-system constraint), so only the dedicated durable test registers a
-/// durable listener — that keeps these parallel tests from stomping on each
-/// other's job runtime.
-fn sync_listeners() -> Vec<autumn_web::events::ListenerInfo> {
-    listeners![sync_a, sync_panics, sync_survivor]
+/// The full listener set, including the durable one. Durable dispatch is scoped
+/// to each app's own `JobClient` (installed on `AppState`), so several of these
+/// tests can register the durable listener and run in parallel without stomping
+/// on each other's job runtime.
+fn all_listeners() -> Vec<autumn_web::events::ListenerInfo> {
+    listeners![sync_a, sync_panics, sync_survivor, durable_seed]
 }
 
 // ── Emitting handler (never edited when listeners are added) ────────
@@ -112,7 +112,7 @@ fn app_with(listeners: Vec<autumn_web::events::ListenerInfo>) -> autumn_web::tes
 
 #[tokio::test]
 async fn publishing_runs_sync_listeners_with_panic_isolation() {
-    let client = app_with(sync_listeners());
+    let client = app_with(all_listeners());
 
     client.get("/signup").send().await.assert_ok();
 
@@ -127,9 +127,9 @@ async fn publishing_runs_sync_listeners_with_panic_isolation() {
 
 #[tokio::test]
 async fn durable_listener_runs_via_the_job_runtime() {
-    // This is the only test that registers a durable listener (and thus builds a
-    // job runtime), so the process-global job client it installs is not raced.
-    let client = app_with(listeners![durable_seed]);
+    // Durable dispatch uses this app's own JobClient, so registering the durable
+    // listener here is safe even though other parallel tests do the same.
+    let client = app_with(all_listeners());
 
     client.get("/signup").send().await.assert_ok();
 
@@ -148,7 +148,7 @@ async fn durable_listener_runs_via_the_job_runtime() {
 
 #[tokio::test]
 async fn test_recorder_captures_published_events() {
-    let client = app_with(sync_listeners());
+    let client = app_with(all_listeners());
 
     client.get("/signup").send().await.assert_ok();
 

--- a/autumn/tests/events_integration.rs
+++ b/autumn/tests/events_integration.rs
@@ -102,9 +102,17 @@ async fn quiet(events: Events) -> AutumnResult<&'static str> {
     Ok("ok")
 }
 
+#[get("/signup-free")]
+async fn signup_free() -> AutumnResult<&'static str> {
+    // Uses the module-level free publisher (no `Events` extractor). It must
+    // resolve *this* request's app via the ambient context, not a global.
+    autumn_web::events::publish(UserSignedUp { user_id: 42 }).await?;
+    Ok("ok")
+}
+
 fn app_with(listeners: Vec<autumn_web::events::ListenerInfo>) -> autumn_web::test::TestClient {
     TestApp::new()
-        .routes(routes![signup, quiet])
+        .routes(routes![signup, quiet, signup_free])
         .state_initializer(|state| state.insert_extension(Counters::default()))
         .listeners(listeners)
         .build()
@@ -179,6 +187,43 @@ async fn adding_a_listener_needs_zero_emitter_edits() {
     assert_eq!(read(client.state(), |c| &c.sync_a), 1);
     // The other listeners were not registered, so they never ran.
     assert_eq!(read(client.state(), |c| &c.survivor), 0);
+}
+
+#[tokio::test]
+async fn free_publisher_dispatches_to_the_current_app() {
+    // A handler using the module-level `events::publish` (not the extractor)
+    // must still reach this app's listeners and recorder via the ambient context.
+    let client = app_with(all_listeners());
+
+    client.get("/signup-free").send().await.assert_ok();
+
+    client.assert_event_published::<UserSignedUp>();
+    assert_eq!(
+        read(client.state(), |c| &c.sync_a),
+        1,
+        "sync_a ran via free publish"
+    );
+}
+
+#[tokio::test]
+async fn free_publisher_is_isolated_across_parallel_apps() {
+    // Two apps live at once. Publishing through the free function on app A must
+    // not leak into app B's recorder — proving the path is app-scoped, not global.
+    let app_a = app_with(all_listeners());
+    let app_b = app_with(all_listeners());
+
+    app_a.get("/signup-free").send().await.assert_ok();
+
+    assert_eq!(
+        app_a.published_events::<UserSignedUp>().len(),
+        1,
+        "app A recorded its own event"
+    );
+    assert_eq!(
+        app_b.published_events::<UserSignedUp>().len(),
+        0,
+        "app B must not see app A's event"
+    );
 }
 
 // Keep an explicit reference so the unused-import lints stay quiet if the test

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -128,6 +128,13 @@ A published event with **no registered listeners is a no-op**, not an error.
   retry can run a listener more than once. **Make durable listeners idempotent**
   (key off the event's domain ids). With the `local` backend, durable listeners
   run in-process and are lost on restart — use `postgres`/`redis` in production.
+- **Durable listeners are transaction-aware.** Publishing inside a
+  [`Db::tx`](transactions.md) block enqueues durable listeners **after the
+  transaction commits** — a rolled-back event never fires them, and the job is
+  not picked up before the event's data is visible. (This after-commit deferral
+  is process-local, mirroring `job::enqueue_after_commit`: a crash between commit
+  and enqueue can drop the reaction.) Publishing outside a transaction enqueues
+  immediately.
 - **No ordering guarantee between independent listeners.** Sync listeners run
   concurrently; durable listeners are independent queue jobs. Do not rely on one
   listener observing another's effects.

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -31,9 +31,12 @@ struct UserSignedUp {
 }
 ```
 
-`#[event]` derives the serde + `Clone`/`Debug` impls the bus needs and implements
-`autumn_web::events::Event` with a stable `NAME` (the struct name by default, or
-`#[event(name = "user.signed_up")]`).
+`#[event]` derives the serde + `Clone`/`Debug` impls the bus needs (through
+`autumn-web`'s re-exported `serde`, so you don't need a direct `serde`
+dependency) and implements `autumn_web::events::Event` with a stable `NAME`. The
+default `NAME` is **module-qualified** (e.g. `my_app::events::UserSignedUp`) so
+two events that share a short name like `Created` in different modules never
+collide on the bus; override it with `#[event(name = "user.signed_up")]`.
 
 ## Publish an event
 

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -1,0 +1,167 @@
+# Events & Listeners (`#[event]` / `#[listener]`)
+
+Autumn provides a **typed domain event bus** so you can react to a business event
+with several decoupled side effects. Instead of one fat handler that does
+everything inline, you publish a typed event and independent *listeners* react to
+it — synchronously in-request, or durably on the background job queue.
+
+The payoff: **adding a new reaction is a new file and zero edits to the code that
+publishes the event.**
+
+## When to use it
+
+- You have a handler that triggers several unrelated side effects ("on signup →
+  send welcome email **and** seed a workspace **and** record analytics") and you
+  want each reaction to live on its own.
+- You want some reactions to be guaranteed-durable (survive a restart, get retry +
+  DLQ) without hand-rolling a queue subscriber.
+
+For a single side effect tied to one model's CRUD, reach for
+[hooks](hooks-and-transactions.md). For client-facing realtime, use
+[channels](realtime.md). The event bus is for **server-side, decoupled reactions**.
+
+## Declare an event
+
+```rust,ignore
+use autumn_web::prelude::*;
+
+#[event]
+struct UserSignedUp {
+    user_id: i64,
+}
+```
+
+`#[event]` derives the serde + `Clone`/`Debug` impls the bus needs and implements
+`autumn_web::events::Event` with a stable `NAME` (the struct name by default, or
+`#[event(name = "user.signed_up")]`).
+
+## Publish an event
+
+Inject the `Events` publisher just like any other extractor and call `publish`:
+
+```rust,ignore
+#[post("/signup")]
+async fn signup(events: Events /* , db: Db, ... */) -> AutumnResult<Redirect> {
+    // ... create the user ...
+    events.publish(UserSignedUp { user_id: 42 }).await?;
+    Ok(Redirect::to("/welcome"))
+}
+```
+
+Outside a request (in a service, job, or scheduled task) use the module-level
+`autumn_web::events::publish(UserSignedUp { .. }).await?` instead.
+
+## Worked example: welcome email on signup
+
+A listener is an async function over `(AppState, YourEvent)`. Declare it with
+`#[listener]`, in **its own file** — the `signup` handler above never changes when
+you add it:
+
+```rust,ignore
+use autumn_web::prelude::*;
+
+// Durable: rides the #[job] queue, so it survives a restart and is retried.
+#[listener(UserSignedUp, durable, max_attempts = 5)]
+async fn send_welcome_email(state: AppState, event: UserSignedUp) -> AutumnResult<()> {
+    let mailer = state.extension::<Mailer>().expect("mailer configured");
+    let mail = Mail::builder()
+        .to(/* look up the user's email by */ format!("user-{}@example.com", event.user_id))
+        .subject("Welcome to Acme!")
+        .text("Thanks for signing up.".to_string())
+        .build()?;
+    mailer.send(mail).await
+}
+```
+
+Want a second reaction? Add another file with another listener — still zero edits
+to `signup`:
+
+```rust,ignore
+// Synchronous: runs in-request, before the response is returned.
+#[listener(UserSignedUp)]
+async fn seed_default_workspace(state: AppState, event: UserSignedUp) -> AutumnResult<()> {
+    // ... create the user's first workspace ...
+    Ok(())
+}
+```
+
+## Register listeners
+
+Collect listeners with `listeners![..]` and register them on the app, consistent
+with how `routes!`/`jobs!`/`tasks!` register today:
+
+```rust,ignore
+autumn_web::app()
+    .routes(routes![signup])
+    .listeners(listeners![send_welcome_email, seed_default_workspace])
+    .run()
+    .await;
+```
+
+**You do not also list durable listeners in `jobs![..]`** — `.listeners(..)` wires
+them onto the job runtime for you. Sync listeners need no job runtime at all.
+
+## Sync vs. durable
+
+| Mode | Declared with | Runs | Use for |
+|---|---|---|---|
+| Sync | `#[listener(Event)]` | in-request, before the response | invariants the caller depends on |
+| Durable | `#[listener(Event, durable)]` | on the `#[job]` queue | reactions that must survive a restart |
+
+- **Sync** listeners run before `publish` returns. Each runs **independently and
+  isolated**: one listener erroring *or panicking* never blocks the others, and
+  never fails the publish. (Their failures are logged.)
+- **Durable** listeners are enqueued onto the existing background job queue, so
+  they inherit its retry, dead-letter, and restart-safety behavior. Durable
+  retry knobs mirror `#[job]`: `max_attempts` and `backoff_ms`.
+
+A published event with **no registered listeners is a no-op**, not an error.
+
+## Delivery & ordering guarantees
+
+- **Durable listeners are at-least-once.** They ride the job queue, so the same
+  guarantees as [background jobs](jobs.md) apply: with the `postgres`/`redis`
+  backends a reaction is **not lost across a process restart**, and a recovered
+  retry can run a listener more than once. **Make durable listeners idempotent**
+  (key off the event's domain ids). With the `local` backend, durable listeners
+  run in-process and are lost on restart — use `postgres`/`redis` in production.
+- **No ordering guarantee between independent listeners.** Sync listeners run
+  concurrently; durable listeners are independent queue jobs. Do not rely on one
+  listener observing another's effects.
+- **No cross-event ordering.** Two published events may have their listeners
+  interleave; the bus is fan-out pub/sub, not an ordered log.
+
+## Testing
+
+The in-process test client records every published event, so you can assert on
+publications without standing up the job runner:
+
+```rust,ignore
+use autumn_web::test::TestApp;
+
+#[tokio::test]
+async fn signup_publishes_event() {
+    let client = TestApp::new()
+        .routes(routes![signup])
+        .listeners(listeners![send_welcome_email])
+        .build();
+
+    client.post("/signup").send().await.assert_ok();
+
+    client.assert_event_published::<UserSignedUp>();
+    let published = client.published_events::<UserSignedUp>();
+    assert_eq!(published[0].user_id, 42);
+}
+```
+
+Recording happens synchronously at publish time, so `assert_event_published`
+works whether or not the listeners have run.
+
+## Out of scope (today)
+
+- Cross-process delivery via an external broker (Kafka/NATS). Durable fan-out
+  rides the existing Postgres/Redis job queue.
+- Event sourcing / an append-only event store. This is in-process pub/sub for
+  side effects, not persistence.
+- Auto-emitting events from model CRUD — that overlaps
+  [hooks](hooks-and-transactions.md).

--- a/examples/reddit-clone/src/events.rs
+++ b/examples/reddit-clone/src/events.rs
@@ -1,0 +1,14 @@
+//! Typed domain events for reddit-clone.
+//!
+//! Events describe *something that happened* in the app. Handlers publish them;
+//! decoupled listeners (see [`crate::listeners`]) react. Adding a new reaction
+//! is a new listener and zero edits to the handler that publishes the event.
+
+use autumn_web::event;
+
+/// Emitted right after a new account is created in the signup handler.
+#[event]
+pub struct UserSignedUp {
+    pub user_id: i64,
+    pub username: String,
+}

--- a/examples/reddit-clone/src/lib.rs
+++ b/examples/reddit-clone/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod config;
 pub mod error_reporter;
+pub mod events;
 pub mod experiments;
 pub mod feature_flags;
 pub mod hooks;
 pub mod jobs;
+pub mod listeners;
 pub mod live_bus;
 pub mod live_events;
 pub mod models;

--- a/examples/reddit-clone/src/listeners.rs
+++ b/examples/reddit-clone/src/listeners.rs
@@ -59,7 +59,12 @@ mod tests {
         assert_eq!(durable, 1, "welcome_new_user is durable");
         assert_eq!(sync, 1, "record_signup_metric is sync");
 
-        // Every listener subscribes to UserSignedUp.
-        assert!(listeners.iter().all(|l| l.event_name == "UserSignedUp"));
+        // Every listener subscribes to UserSignedUp. The default event name is
+        // module-qualified, so match on the suffix rather than the bare type.
+        assert!(
+            listeners
+                .iter()
+                .all(|l| l.event_name.ends_with("::UserSignedUp"))
+        );
     }
 }

--- a/examples/reddit-clone/src/listeners.rs
+++ b/examples/reddit-clone/src/listeners.rs
@@ -1,0 +1,65 @@
+//! Event listeners for reddit-clone.
+//!
+//! Each listener reacts to a typed event independently of the code that emits
+//! it. This file is the *only* thing that changes when a new reaction is added —
+//! the signup handler that publishes `UserSignedUp` is never touched.
+
+use autumn_web::prelude::*;
+use autumn_web::{listener, listeners};
+
+use crate::events::UserSignedUp;
+
+/// Durable reaction: rides the `#[job]` queue, so it survives a process restart
+/// and inherits the queue's retry + DLQ semantics. In a real app this might
+/// seed a default subreddit subscription or send a welcome email.
+#[listener(UserSignedUp, durable, max_attempts = 5, backoff_ms = 500)]
+async fn welcome_new_user(_state: AppState, event: UserSignedUp) -> AutumnResult<()> {
+    tracing::info!(
+        user_id = event.user_id,
+        username = %event.username,
+        "welcoming newly signed-up user (durable listener)"
+    );
+    Ok(())
+}
+
+/// Synchronous reaction: runs in-request, before the response. Use for
+/// invariants the caller depends on. Records a lightweight signup metric.
+#[listener(UserSignedUp)]
+async fn record_signup_metric(_state: AppState, event: UserSignedUp) -> AutumnResult<()> {
+    tracing::debug!(
+        user_id = event.user_id,
+        "recording signup metric (sync listener)"
+    );
+    Ok(())
+}
+
+/// Collected for `AppBuilder::listeners`, mirroring `jobs::registered_jobs`.
+#[must_use]
+pub fn registered_listeners() -> Vec<autumn_web::events::ListenerInfo> {
+    listeners![welcome_new_user, record_signup_metric]
+}
+
+#[cfg(test)]
+mod tests {
+    use autumn_web::events::DispatchMode;
+
+    #[test]
+    fn registers_both_signup_listeners() {
+        let listeners = super::registered_listeners();
+        assert_eq!(listeners.len(), 2);
+
+        let durable = listeners
+            .iter()
+            .filter(|l| l.mode == DispatchMode::Durable)
+            .count();
+        let sync = listeners
+            .iter()
+            .filter(|l| l.mode == DispatchMode::Sync)
+            .count();
+        assert_eq!(durable, 1, "welcome_new_user is durable");
+        assert_eq!(sync, 1, "record_signup_metric is sync");
+
+        // Every listener subscribes to UserSignedUp.
+        assert!(listeners.iter().all(|l| l.event_name == "UserSignedUp"));
+    }
+}

--- a/examples/reddit-clone/src/main.rs
+++ b/examples/reddit-clone/src/main.rs
@@ -152,6 +152,7 @@ async fn main() {
             tasks::prune_live_feed_events
         ])
         .jobs(reddit_clone::jobs::registered_jobs())
+        .listeners(reddit_clone::listeners::registered_listeners())
         .plugin(webhook_plugin)
         .plugin(live_events::LiveFeedPlugin::new())
         // Custom health indicator — visible at GET /actuator/health under "live_feed_relay".

--- a/examples/reddit-clone/src/routes/auth.rs
+++ b/examples/reddit-clone/src/routes/auth.rs
@@ -207,6 +207,14 @@ pub async fn register(
         })
         .await?;
 
+    // Publish a typed domain event. Listeners (see `crate::listeners`) react
+    // independently — adding a new reaction needs zero edits to this handler.
+    autumn_web::events::publish(crate::events::UserSignedUp {
+        user_id: user.id,
+        username: user.username.clone(),
+    })
+    .await?;
+
     // Dispatch the outbound webhook event on "user.created"
     if let Some(manager) = state.extension::<WebhookOutboundManager>() {
         let dispatch_result = manager.dispatch(&state, "user.created", &user).await;

--- a/examples/reddit-clone/src/routes/auth.rs
+++ b/examples/reddit-clone/src/routes/auth.rs
@@ -124,6 +124,7 @@ pub async fn register(
     mut db: Db,
     mailer: Mailer,
     session: Session,
+    events: autumn_web::events::Events,
     form: Form<RegisterForm>,
 ) -> AutumnResult<Redirect> {
     let open = crate::config_svc()
@@ -209,11 +210,13 @@ pub async fn register(
 
     // Publish a typed domain event. Listeners (see `crate::listeners`) react
     // independently — adding a new reaction needs zero edits to this handler.
-    autumn_web::events::publish(crate::events::UserSignedUp {
-        user_id: user.id,
-        username: user.username.clone(),
-    })
-    .await?;
+    // Use the injected `Events` extractor so dispatch is scoped to this app.
+    events
+        .publish(crate::events::UserSignedUp {
+            user_id: user.id,
+            username: user.username.clone(),
+        })
+        .await?;
 
     // Dispatch the outbound webhook event on "user.created"
     if let Some(manager) = state.extension::<WebhookOutboundManager>() {


### PR DESCRIPTION
## Summary

Introduces a **typed domain event bus** that enables decoupled, event-driven architecture. Handlers publish typed events; independent listeners react synchronously (in-request) or durably (via the job queue). Adding a new reaction requires zero edits to the publishing handler.

## Key Changes

- **New `#[event]` macro** (`autumn-macros/src/event.rs`): Marks structs as typed domain events, derives serde + Clone/Debug, implements the `Event` trait with stable `NAME` identifiers.

- **New `#[listener]` macro** (`autumn-macros/src/listener.rs`): Declares async functions that react to events. Supports two dispatch modes:
  - **Sync** (default): Runs in-request before the response, with panic/error isolation
  - **Durable**: Enqueued onto the existing `#[job]` queue for at-least-once delivery with retry + DLQ semantics

- **New `listeners![]` macro** (`autumn-macros/src/listeners_macro.rs`): Collects listener metadata, mirroring `jobs![]` and `routes![]` patterns.

- **Core event bus** (`autumn/src/events.rs`):
  - `Event` trait: Base type for all domain events
  - `EventRegistry`: Routes published events to registered listeners by name
  - `Events` extractor: Injectable publisher for use in handlers
  - `EventRecorder`: Captures published events in tests without requiring a job runner
  - `publish()` function: Module-level publisher for services, jobs, and scheduled tasks
  - Dispatch logic: Durable listeners enqueue to the job queue; sync listeners run isolated on separate tasks

- **AppBuilder integration** (`autumn/src/app.rs`):
  - New `.listeners()` method to register event listeners
  - Durable listeners are automatically synthesized into `JobInfo` entries at build time

- **TestApp support** (`autumn/src/test.rs`):
  - New `.listeners()` method for test apps
  - `EventRecorder` installed by default so tests can assert on published events without standing up the job runner

- **Job runtime integration** (`autumn/src/job.rs`):
  - New `install_job_client()` function that installs the `JobClient` both globally and as an `AppState` extension
  - Durable event dispatch uses the app-local `JobClient` to avoid contention in parallel tests

- **Documentation** (`docs/guide/events.md`): Comprehensive guide covering when to use events, sync vs. durable dispatch, delivery guarantees, and testing patterns.

- **Example integration** (`examples/reddit-clone/`):
  - New `events.rs`: Defines `UserSignedUp` event
  - New `listeners.rs`: Implements durable and sync listeners
  - Updated `auth.rs`: Publishes `UserSignedUp` on signup
  - Updated `main.rs`: Registers listeners with the app

- **Integration tests** (`autumn/tests/events_integration.rs`): End-to-end tests validating sync listener isolation, durable dispatch via job runtime, event recording, and no-op behavior for unlistened events.

## Notable Implementation Details

- **Panic/error isolation**: Sync listeners run on independent tokio tasks; one panicking or erroring listener never blocks others or fails the publish.
- **App-scoped job dispatch**: Durable listeners prefer the app-local `JobClient` (installed on `AppState`) over the process-global one, enabling parallel in-process apps (especially tests) to avoid contention.
- **No-op for missing listeners**: Publishing an event with no registered listeners is safe and returns `Ok(())`.
- **Test-friendly**: `EventRecorder` captures all published events, allowing tests to assert on events without running the full job queue.
- **Mirrors job/route patterns**: `#[listener]` and `listeners![]` follow the same ergonomics as `#[job]`/`jobs![]` and `#[get]`/`routes![]`.

https://claude.ai/code/session_012YgeJFcPpUz5K8UGWH9FJv