### PR TITLE
Add single-binary deployment via embedded assets and locales

### DIFF
--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -40,19 +40,59 @@ fn build_cargo_command(debug: bool, embed: bool, package: Option<&str>) -> Comma
     cargo
 }
 
+/// Run a cargo command, exiting the process on failure.
+fn run_cargo_or_exit(mut cargo: Command) {
+    let status = cargo.status().expect("failed to run cargo build");
+    if !status.success() {
+        eprintln!("\u{2717} Compilation failed");
+        std::process::exit(1);
+    }
+}
+
+/// Build a self-contained release binary with `static/` (and its fingerprint
+/// manifest) plus i18n locales embedded.
+///
+/// Three phases so the embedded tree is complete and consistent:
+/// 1. Compile **without** the embed feature so the app's build scripts (e.g.
+///    Tailwind CSS generation) populate `static/` first.
+/// 2. Fingerprint the now-complete `static/` tree of the **selected package**
+///    (not the CLI cwd), writing the manifest + hashed copies.
+/// 3. Recompile **with** the embed feature so `include_dir!` bakes the
+///    fingerprinted tree into the binary.
+fn build_embedded(debug: bool, profile: &str, package: Option<&str>) {
+    // Resolve the selected package's directory so `-p <pkg>` fingerprints that
+    // package's `static/` (which `embed_static!` reads via $CARGO_MANIFEST_DIR),
+    // not whatever `static/` happens to sit next to the CLI's cwd.
+    let (_, manifest_dir) = find_binary(debug, package);
+    let static_dir = manifest_dir
+        .unwrap_or_else(|| std::env::current_dir().expect("current dir"))
+        .join("static");
+
+    eprintln!("Compiling ({profile} profile)...");
+    run_cargo_or_exit(build_cargo_command(debug, false, package));
+
+    eprintln!("\nFingerprinting static assets for embedding...");
+    fingerprint_assets_in(&static_dir);
+
+    eprintln!("\nEmbedding assets and locales into the binary...");
+    run_cargo_or_exit(build_cargo_command(debug, true, package));
+
+    eprintln!("\n\u{1F342} Build complete! Assets and locales embedded into the binary.");
+}
+
 /// Run the static build pipeline.
 pub fn run(debug: bool, embed: bool, package: Option<&str>) {
     eprintln!("\u{1F342} autumn build\n");
 
     let profile = if debug { "dev" } else { "release" };
 
-    // For embedded builds the fingerprint manifest and the hashed asset copies
-    // must exist on disk *before* the compile, because `include_dir!` bakes the
-    // `static/` tree into the binary at compile time. Fingerprint first so the
-    // embedded manifest and the embedded files come from the same build.
-    if embed && !debug {
-        eprintln!("Fingerprinting static assets (pre-compile, for embedding)...");
-        fingerprint_static_assets();
+    // Embedding produces a self-contained release binary; it is not static-site
+    // generation, so it skips the static renderer (which requires `#[static_get]`
+    // routes and the app's runtime state) and lets dynamic-server apps build a
+    // single binary without a database or pre-render step.
+    if embed {
+        build_embedded(debug, profile, package);
+        return;
     }
 
     let mut cargo = build_cargo_command(debug, embed, package);
@@ -64,21 +104,12 @@ pub fn run(debug: bool, embed: bool, package: Option<&str>) {
         std::process::exit(1);
     }
 
-    // Non-embedded release builds fingerprint *after* the compile (the runtime
-    // reads the manifest from disk, so order doesn't matter for them, and the
-    // static renderer below then resolves the new hashed URLs).
-    if !debug && !embed {
+    // Release builds fingerprint *after* the compile (the runtime reads the
+    // manifest from disk, so order doesn't matter, and the static renderer below
+    // then resolves the new hashed URLs).
+    if !debug {
         eprintln!("\nFingerprinting static assets...");
         fingerprint_static_assets();
-    }
-
-    // Embedding produces a self-contained release binary; it is not static-site
-    // generation. Skip the static renderer (which requires `#[static_get]`
-    // routes and the app's runtime state) so dynamic-server apps can build a
-    // single binary without a database or pre-render step.
-    if embed {
-        eprintln!("\n\u{1F342} Build complete! Assets and locales embedded into the binary.");
-        return;
     }
 
     let (binary, manifest_dir) = find_binary(debug, package);

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -15,11 +15,12 @@ use std::process::Command;
 
 use sha2::{Digest, Sha256};
 
-/// Run the static build pipeline.
-pub fn run(debug: bool, package: Option<&str>) {
-    eprintln!("\u{1F342} autumn build\n");
-
-    let profile = if debug { "dev" } else { "release" };
+/// Build the `cargo build` command for the static pipeline.
+///
+/// Factored out so the flags are unit-testable. With `embed`, the
+/// `autumn-web/embed-assets` feature is enabled so the binary bakes in the
+/// `static/` tree (and its manifest) plus i18n locales.
+fn build_cargo_command(debug: bool, embed: bool, package: Option<&str>) -> Command {
     let mut cargo = Command::new("cargo");
     cargo.arg("build");
     if !debug {
@@ -28,6 +29,33 @@ pub fn run(debug: bool, package: Option<&str>) {
     if let Some(pkg) = package {
         cargo.args(["-p", pkg]);
     }
+    if embed {
+        // Enable the app crate's `embed-assets` feature, which the scaffold
+        // defines as `["autumn-web/embed-assets"]`. Using the app-crate feature
+        // (rather than `autumn-web/embed-assets` directly) lets app code gate the
+        // `.embedded_static()` / `.embedded_locales()` wiring on
+        // `#[cfg(feature = "embed-assets")]`.
+        cargo.args(["--features", "embed-assets"]);
+    }
+    cargo
+}
+
+/// Run the static build pipeline.
+pub fn run(debug: bool, embed: bool, package: Option<&str>) {
+    eprintln!("\u{1F342} autumn build\n");
+
+    let profile = if debug { "dev" } else { "release" };
+
+    // For embedded builds the fingerprint manifest and the hashed asset copies
+    // must exist on disk *before* the compile, because `include_dir!` bakes the
+    // `static/` tree into the binary at compile time. Fingerprint first so the
+    // embedded manifest and the embedded files come from the same build.
+    if embed && !debug {
+        eprintln!("Fingerprinting static assets (pre-compile, for embedding)...");
+        fingerprint_static_assets();
+    }
+
+    let mut cargo = build_cargo_command(debug, embed, package);
 
     eprintln!("Compiling ({profile} profile)...");
     let status = cargo.status().expect("failed to run cargo build");
@@ -36,12 +64,21 @@ pub fn run(debug: bool, package: Option<&str>) {
         std::process::exit(1);
     }
 
-    // Fingerprint before the static renderer so that `asset_url()` inside
-    // pre-rendered templates resolves to the new hashed URLs rather than
-    // plain paths or stale hashes from a previous build.
-    if !debug {
+    // Non-embedded release builds fingerprint *after* the compile (the runtime
+    // reads the manifest from disk, so order doesn't matter for them, and the
+    // static renderer below then resolves the new hashed URLs).
+    if !debug && !embed {
         eprintln!("\nFingerprinting static assets...");
         fingerprint_static_assets();
+    }
+
+    // Embedding produces a self-contained release binary; it is not static-site
+    // generation. Skip the static renderer (which requires `#[static_get]`
+    // routes and the app's runtime state) so dynamic-server apps can build a
+    // single binary without a database or pre-render step.
+    if embed {
+        eprintln!("\n\u{1F342} Build complete! Assets and locales embedded into the binary.");
+        return;
     }
 
     let (binary, manifest_dir) = find_binary(debug, package);
@@ -384,6 +421,33 @@ fn resolve_binary_from_metadata(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn cargo_args(debug: bool, embed: bool, package: Option<&str>) -> Vec<String> {
+        build_cargo_command(debug, embed, package)
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn embed_build_enables_feature_in_release() {
+        let args = cargo_args(false, true, None);
+        assert!(args.contains(&"--release".to_string()));
+        assert!(
+            args.windows(2).any(|w| w == ["--features", "embed-assets"]),
+            "embed build must enable the embed-assets feature: {args:?}"
+        );
+    }
+
+    #[test]
+    fn non_embed_build_omits_embed_feature() {
+        let args = cargo_args(false, false, Some("blog"));
+        assert!(
+            !args.iter().any(|a| a.contains("embed-assets")),
+            "non-embed build must not enable embed-assets: {args:?}"
+        );
+        assert!(args.windows(2).any(|w| w == ["-p", "blog"]));
+    }
 
     fn expected_binary(path: &str) -> PathBuf {
         let mut p = PathBuf::from(path);

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -95,14 +95,8 @@ pub fn run(debug: bool, embed: bool, package: Option<&str>) {
         return;
     }
 
-    let mut cargo = build_cargo_command(debug, embed, package);
-
     eprintln!("Compiling ({profile} profile)...");
-    let status = cargo.status().expect("failed to run cargo build");
-    if !status.success() {
-        eprintln!("\u{2717} Compilation failed");
-        std::process::exit(1);
-    }
+    run_cargo_or_exit(build_cargo_command(debug, embed, package));
 
     // Release builds fingerprint *after* the compile (the runtime reads the
     // manifest from disk, so order doesn't matter, and the static renderer below

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -84,6 +84,11 @@ enum Commands {
         /// Package to build (for workspaces)
         #[arg(short, long)]
         package: Option<String>,
+        /// Embed static assets + i18n locales into the binary for a true
+        /// single-binary deploy (enables the `autumn-web/embed-assets` feature
+        /// and fingerprints before compiling so the manifest is baked in).
+        #[arg(long)]
+        embed: bool,
     },
     /// Start the dev server with hot reload (watch mode)
     Dev {
@@ -1512,7 +1517,11 @@ fn main() {
 #[allow(clippy::too_many_lines)]
 fn run_command(command: Commands) {
     match command {
-        Commands::Build { debug, package } => build::run(debug, package.as_deref()),
+        Commands::Build {
+            debug,
+            package,
+            embed,
+        } => build::run(debug, embed, package.as_deref()),
         Commands::Dev {
             package,
             show_config,
@@ -2349,7 +2358,8 @@ mod tests {
             cli.command,
             Commands::Build {
                 debug: false,
-                package: None
+                package: None,
+                embed: false
             }
         ));
     }
@@ -2361,7 +2371,8 @@ mod tests {
             cli.command,
             Commands::Build {
                 debug: true,
-                package: None
+                package: None,
+                embed: false
             }
         ));
     }
@@ -2370,9 +2381,26 @@ mod tests {
     fn parse_build_with_package() {
         let cli = Cli::try_parse_from(["autumn", "build", "-p", "blog"]).unwrap();
         match cli.command {
-            Commands::Build { debug, package } => {
+            Commands::Build {
+                debug,
+                package,
+                embed,
+            } => {
                 assert!(!debug);
+                assert!(!embed);
                 assert_eq!(package.as_deref(), Some("blog"));
+            }
+            _ => panic!("expected Build command"),
+        }
+    }
+
+    #[test]
+    fn parse_build_with_embed() {
+        let cli = Cli::try_parse_from(["autumn", "build", "--embed"]).unwrap();
+        match cli.command {
+            Commands::Build { embed, debug, .. } => {
+                assert!(embed, "--embed must set the embed flag");
+                assert!(!debug);
             }
             _ => panic!("expected Build command"),
         }
@@ -2382,7 +2410,7 @@ mod tests {
     fn parse_build_with_long_package() {
         let cli = Cli::try_parse_from(["autumn", "build", "--package", "blog", "--debug"]).unwrap();
         match cli.command {
-            Commands::Build { debug, package } => {
+            Commands::Build { debug, package, .. } => {
                 assert!(debug);
                 assert_eq!(package.as_deref(), Some("blog"));
             }

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -160,10 +160,7 @@ pub fn generate_with(name: &str, parent_dir: &Path, opts: GenerateOptions) -> Re
     fs::write(project_dir.join("Cargo.toml"), cargo_toml)?;
 
     let mut main_rs = if opts.with_i18n {
-        render(templates::MAIN_RS).replace(
-            "        .routes(routes![index, hello, hello_name])",
-            "        .i18n_auto()\n        .routes(routes![index, hello, hello_name])",
-        )
+        inject_i18n(&render(templates::MAIN_RS))
     } else {
         render(templates::MAIN_RS)
     };
@@ -313,14 +310,36 @@ fn print_scaffold_summary(name: &str, opts: GenerateOptions) {
     }
 }
 
+/// Enable i18n in a generated `main.rs`: call `.i18n_auto()` and embed the
+/// `i18n/` locale bundles alongside the static assets for single-binary deploys.
+fn inject_i18n(main_rs: &str) -> String {
+    main_rs
+        .replace(
+            "        .routes(routes![index, hello, hello_name])",
+            "        .i18n_auto()\n        .routes(routes![index, hello, hello_name])",
+        )
+        .replace(
+            "static EMBEDDED_STATIC: autumn_web::include_dir::Dir = autumn_web::embed_static!();",
+            "static EMBEDDED_STATIC: autumn_web::include_dir::Dir = autumn_web::embed_static!();\n\
+             #[cfg(feature = \"embed-assets\")]\n\
+             static EMBEDDED_LOCALES: autumn_web::include_dir::Dir = autumn_web::embed_locales!();",
+        )
+        .replace(
+            "    let app = app.embedded_static(&EMBEDDED_STATIC);\n",
+            "    let app = app.embedded_static(&EMBEDDED_STATIC);\n\
+             \x20   #[cfg(feature = \"embed-assets\")]\n\
+             \x20   let app = app.embedded_locales(&EMBEDDED_LOCALES);\n",
+        )
+}
+
 /// Inject a managed-Postgres pool provider plus a shutdown hook into a
 /// generated `main.rs` so the bundled cluster is supervised by the daemon.
 fn inject_managed_pg(main_rs: &str) -> String {
     main_rs.replace(
-        "    autumn_web::app()\n",
+        "    let app = autumn_web::app()\n",
         "    let pg = autumn_web::managed_pg::ManagedPostgresPoolProvider::new();\n\
          \x20   let pg_shutdown = pg.clone();\n\
-         \x20   autumn_web::app()\n\
+         \x20   let app = autumn_web::app()\n\
          \x20       .with_pool_provider(pg)\n\
          \x20       .on_shutdown(move || {\n\
          \x20           let pg = pg_shutdown.clone();\n\

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -310,32 +310,51 @@ fn print_scaffold_summary(name: &str, opts: GenerateOptions) {
     }
 }
 
+/// Replace `from` with `to`, asserting the anchor exists first.
+///
+/// The scaffold generators below patch the generated `main.rs` by string
+/// replacement against anchors in `main.rs.tmpl`. If the template and an anchor
+/// drift out of sync, a plain `.replace()` silently no-ops and produces a
+/// broken scaffold (this exact class of bug has bitten the mailer wiring once
+/// already). Asserting the anchor turns that into a loud, test-caught failure.
+fn replace_anchor(src: &str, from: &str, to: &str) -> String {
+    assert!(
+        src.contains(from),
+        "scaffold template anchor not found: {from:?} — src/templates/main.rs.tmpl and the \
+         inject_* helpers in new.rs have drifted out of sync"
+    );
+    src.replace(from, to)
+}
+
 /// Enable i18n in a generated `main.rs`: call `.i18n_auto()` and embed the
 /// `i18n/` locale bundles alongside the static assets for single-binary deploys.
 fn inject_i18n(main_rs: &str) -> String {
-    main_rs
-        .replace(
-            "        .routes(routes![index, hello, hello_name])",
-            "        .i18n_auto()\n        .routes(routes![index, hello, hello_name])",
-        )
-        .replace(
-            "static EMBEDDED_STATIC: autumn_web::include_dir::Dir = autumn_web::embed_static!();",
-            "static EMBEDDED_STATIC: autumn_web::include_dir::Dir = autumn_web::embed_static!();\n\
-             #[cfg(feature = \"embed-assets\")]\n\
-             static EMBEDDED_LOCALES: autumn_web::include_dir::Dir = autumn_web::embed_locales!();",
-        )
-        .replace(
-            "    let app = app.embedded_static(&EMBEDDED_STATIC);\n",
-            "    let app = app.embedded_static(&EMBEDDED_STATIC);\n\
-             \x20   #[cfg(feature = \"embed-assets\")]\n\
-             \x20   let app = app.embedded_locales(&EMBEDDED_LOCALES);\n",
-        )
+    let with_locale = replace_anchor(
+        main_rs,
+        "        .routes(routes![index, hello, hello_name])",
+        "        .i18n_auto()\n        .routes(routes![index, hello, hello_name])",
+    );
+    let with_static = replace_anchor(
+        &with_locale,
+        "static EMBEDDED_STATIC: autumn_web::include_dir::Dir = autumn_web::embed_static!();",
+        "static EMBEDDED_STATIC: autumn_web::include_dir::Dir = autumn_web::embed_static!();\n\
+         #[cfg(feature = \"embed-assets\")]\n\
+         static EMBEDDED_LOCALES: autumn_web::include_dir::Dir = autumn_web::embed_locales!();",
+    );
+    replace_anchor(
+        &with_static,
+        "    let app = app.embedded_static(&EMBEDDED_STATIC);\n",
+        "    let app = app.embedded_static(&EMBEDDED_STATIC);\n\
+         \x20   #[cfg(feature = \"embed-assets\")]\n\
+         \x20   let app = app.embedded_locales(&EMBEDDED_LOCALES);\n",
+    )
 }
 
 /// Inject a managed-Postgres pool provider plus a shutdown hook into a
 /// generated `main.rs` so the bundled cluster is supervised by the daemon.
 fn inject_managed_pg(main_rs: &str) -> String {
-    main_rs.replace(
+    replace_anchor(
+        main_rs,
         "    let app = autumn_web::app()\n",
         "    let pg = autumn_web::managed_pg::ManagedPostgresPoolProvider::new();\n\
          \x20   let pg_shutdown = pg.clone();\n\
@@ -353,16 +372,17 @@ fn inject_managed_pg(main_rs: &str) -> String {
 /// Remove the diesel-migrations wiring from a generated `main.rs` so a DB-free
 /// app compiles without the db-gated `migrate` module.
 fn strip_migrations(main_rs: &str) -> String {
-    main_rs
-        .replace(
-            "use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};\n",
-            "",
-        )
-        .replace(
-            "const MIGRATIONS: EmbeddedMigrations = embed_migrations!();\n\n",
-            "",
-        )
-        .replace("\n        .migrations(MIGRATIONS)", "")
+    let no_use = replace_anchor(
+        main_rs,
+        "use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};\n",
+        "",
+    );
+    let no_const = replace_anchor(
+        &no_use,
+        "const MIGRATIONS: EmbeddedMigrations = embed_migrations!();\n\n",
+        "",
+    );
+    replace_anchor(&no_const, "\n        .migrations(MIGRATIONS)", "")
 }
 
 /// Default `autumn-web` features minus `db` — the DB-free daemon feature set.

--- a/autumn-cli/src/release.rs
+++ b/autumn-cli/src/release.rs
@@ -227,8 +227,22 @@ pub fn init(
 
 /// Whether the project at `dir` defines an `embed-assets` Cargo feature, i.e.
 /// it is wired for single-binary embedded builds (`autumn build --embed`).
+///
+/// Parses the `[features]` table rather than substring-matching the file, so a
+/// comment or unrelated text mentioning "embed-assets" doesn't cause
+/// `autumn build --embed` (which would then fail for a project that lacks the
+/// feature) to be baked into the generated Dockerfile.
 fn project_has_embed_assets(dir: &Path) -> bool {
-    fs::read_to_string(dir.join("Cargo.toml")).is_ok_and(|toml| toml.contains("embed-assets"))
+    let Ok(contents) = fs::read_to_string(dir.join("Cargo.toml")) else {
+        return false;
+    };
+    let Ok(parsed) = toml::from_str::<toml::Table>(&contents) else {
+        return false;
+    };
+    parsed
+        .get("features")
+        .and_then(toml::Value::as_table)
+        .is_some_and(|features| features.contains_key("embed-assets"))
 }
 
 fn render(template: &str, project_name: &str, embed: bool) -> String {

--- a/autumn-cli/src/release.rs
+++ b/autumn-cli/src/release.rs
@@ -209,9 +209,15 @@ pub fn init(
         }
     }
 
+    // Embed assets into the binary only when the project opts in via the
+    // `embed-assets` feature (as `autumn new` generates). Pre-existing apps
+    // without that feature get the disk-based build (`cargo build --release`
+    // plus `COPY static`), so their Docker builds keep working.
+    let embed = project_has_embed_assets(dir);
+
     let mut created = Vec::new();
     for (name, template) in files {
-        fs::write(dir.join(name), render(template, project_name))?;
+        fs::write(dir.join(name), render(template, project_name, embed))?;
         created.push(name.to_string());
     }
     Ok(created)
@@ -219,7 +225,30 @@ pub fn init(
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-fn render(template: &str, project_name: &str) -> String {
+/// Whether the project at `dir` defines an `embed-assets` Cargo feature, i.e.
+/// it is wired for single-binary embedded builds (`autumn build --embed`).
+fn project_has_embed_assets(dir: &Path) -> bool {
+    fs::read_to_string(dir.join("Cargo.toml")).is_ok_and(|toml| toml.contains("embed-assets"))
+}
+
+fn render(template: &str, project_name: &str, embed: bool) -> String {
+    let (build_step, static_copy) = if embed {
+        (
+            "# Single-binary build: fingerprint static assets, then compile with the\n\
+             # embed-assets feature so the binary serves static/ (incl. the fingerprint\n\
+             # manifest) and i18n locales from itself — no sidecar directories. The app\n\
+             # opts in via `.embedded_static()` / `.embedded_locales()` (see src/main.rs).\n\
+             RUN autumn build --embed",
+            // Assets/locales are embedded; only migrations/ is staged below.
+            "# Assets and locales are embedded in the binary (`autumn build --embed`);\n\
+             # only migrations/ is staged, for the one-shot `autumn migrate` job.\n",
+        )
+    } else {
+        (
+            "RUN cargo build --release",
+            "COPY --chown=autumn:autumn --from=builder /app/static /app/static\n",
+        )
+    };
     template
         .replace("{{project_name}}", project_name)
         .replace(
@@ -228,6 +257,8 @@ fn render(template: &str, project_name: &str) -> String {
         )
         .replace("{{autumn_cli_version}}", env!("CARGO_PKG_VERSION"))
         .replace("{{diesel_cli_version}}", "2.3.8")
+        .replace("{{build_step}}", build_step)
+        .replace("{{static_copy}}", static_copy)
 }
 
 fn planned_files(target: Target) -> Vec<(&'static str, &'static str)> {
@@ -405,16 +436,45 @@ mod tests {
     }
 
     #[test]
-    fn dockerfile_embeds_assets_instead_of_copying_static() {
+    fn dockerfile_uses_disk_build_without_embed_feature() {
+        // A project that doesn't define the `embed-assets` feature (e.g. one
+        // scaffolded before embedding existed) must get the disk-based build so
+        // its Docker build keeps working.
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
         init(&dir, "my-app", false, Target::Default).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
-        // Single-binary deploy: assets are embedded via `autumn build --embed`,
-        // so the runtime image must NOT stage a `static/` sidecar directory.
+        assert!(
+            content.contains("RUN cargo build --release"),
+            "non-embed project must use the disk-based build: {content}"
+        );
+        assert!(
+            !content.contains("autumn build --embed"),
+            "non-embed project must not require the embed-assets feature"
+        );
+        assert!(
+            content.contains("/app/static"),
+            "non-embed build must COPY the static/ sidecar into the runtime image"
+        );
+    }
+
+    #[test]
+    fn dockerfile_embeds_when_project_has_embed_feature() {
+        // A project that opts into the `embed-assets` feature gets a
+        // single-binary build with no static/ sidecar.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_path_buf();
+        fs::write(
+            dir.join("Cargo.toml"),
+            "[package]\nname = \"my-app\"\nversion = \"0.1.0\"\n\n\
+             [features]\nembed-assets = [\"autumn-web/embed-assets\"]\n",
+        )
+        .unwrap();
+        init(&dir, "my-app", false, Target::Default).unwrap();
+        let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
             content.contains("autumn build --embed"),
-            "release Dockerfile must build the embedded single binary"
+            "embed-feature project must build the embedded single binary: {content}"
         );
         assert!(
             !content.contains("/app/static"),

--- a/autumn-cli/src/release.rs
+++ b/autumn-cli/src/release.rs
@@ -405,14 +405,20 @@ mod tests {
     }
 
     #[test]
-    fn dockerfile_copies_static_assets() {
+    fn dockerfile_embeds_assets_instead_of_copying_static() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
         init(&dir, "my-app", false, Target::Default).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
+        // Single-binary deploy: assets are embedded via `autumn build --embed`,
+        // so the runtime image must NOT stage a `static/` sidecar directory.
         assert!(
-            content.contains("static"),
-            "Dockerfile must COPY static/ assets into runtime image"
+            content.contains("autumn build --embed"),
+            "release Dockerfile must build the embedded single binary"
+        );
+        assert!(
+            !content.contains("/app/static"),
+            "embedded build must not COPY a static/ sidecar into the runtime image"
         );
     }
 

--- a/autumn-cli/src/templates/Cargo.toml.tmpl
+++ b/autumn-cli/src/templates/Cargo.toml.tmpl
@@ -10,6 +10,11 @@ autumn-web = "{{autumn_version}}"
 maud = { version = "0.27", features = ["axum"] }
 diesel_migrations = "2"
 
+[features]
+# Bake static/ (incl. the fingerprint manifest) and i18n locales into the
+# release binary for single-binary deploys. Enable with `autumn build --embed`.
+embed-assets = ["autumn-web/embed-assets"]
+
 [dev-dependencies]
 # tokio runtime macros are needed for #[tokio::test] in integration tests.
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/autumn-cli/src/templates/main.rs.tmpl
+++ b/autumn-cli/src/templates/main.rs.tmpl
@@ -67,5 +67,7 @@ async fn main() {
     #[cfg(feature = "embed-assets")]
     let app = app.embedded_static(&EMBEDDED_STATIC);
 
-    app.run().await;
+    app
+        .run()
+        .await;
 }

--- a/autumn-cli/src/templates/main.rs.tmpl
+++ b/autumn-cli/src/templates/main.rs.tmpl
@@ -4,6 +4,12 @@ use autumn_web::prelude::*;
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
+// Embed the `static/` tree (and its fingerprint manifest) into the binary for
+// single-binary deploys. Active only when built with the `embed-assets` feature
+// (`autumn build --embed`); in dev the app serves from disk for hot-reload.
+#[cfg(feature = "embed-assets")]
+static EMBEDDED_STATIC: autumn_web::include_dir::Dir = autumn_web::embed_static!();
+
 pub fn layout(title: &str, content: maud::Markup) -> maud::Markup {
     maud::html! {
         (maud::DOCTYPE)
@@ -52,9 +58,14 @@ async fn hello_name(name: autumn_web::extract::Path<String>) -> String {
 
 #[autumn_web::main]
 async fn main() {
-    autumn_web::app()
+    let app = autumn_web::app()
         .routes(routes![index, hello, hello_name])
-        .migrations(MIGRATIONS)
-        .run()
-        .await;
+        .migrations(MIGRATIONS);
+
+    // Single-binary deploys: serve static assets (and i18n locales) from the
+    // binary when built with `autumn build --embed`.
+    #[cfg(feature = "embed-assets")]
+    let app = app.embedded_static(&EMBEDDED_STATIC);
+
+    app.run().await;
 }

--- a/autumn-cli/src/templates/release/Dockerfile.tmpl
+++ b/autumn-cli/src/templates/release/Dockerfile.tmpl
@@ -34,10 +34,9 @@ RUN mkdir -p target/autumn \
         "https://github.com/tailwindlabs/tailwindcss/releases/download/${TAILWIND_VERSION}/tailwindcss-${suffix}" \
     && chmod +x target/autumn/tailwindcss
 
-# Install the Autumn + Diesel CLIs before the build. The Autumn CLI is needed
-# at build time so `autumn build --embed` can fingerprint the static/ tree and
-# bake it (plus i18n locales) into the binary; Diesel CLI ships in the runtime
-# for the one-shot migration job.
+# Install the Autumn + Diesel CLIs. The Autumn CLI is used at build time for
+# embedded single-binary builds and in the runtime for the one-shot migration
+# job; Diesel CLI is used by that migration job.
 RUN cargo install --locked autumn-cli --version "${AUTUMN_CLI_VERSION}"
 RUN cargo install diesel_cli \
     --version "${DIESEL_CLI_VERSION}" \
@@ -45,11 +44,7 @@ RUN cargo install diesel_cli \
     --features postgres
 
 COPY . .
-# Single-binary build: fingerprint static assets, then compile with the
-# `embed-assets` feature so the binary serves static/ (incl. the fingerprint
-# manifest) and i18n locales from itself — no sidecar directories. The generated
-# app opts in via `.embedded_static()` / `.embedded_locales()` (see src/main.rs).
-RUN autumn build --embed
+{{build_step}}
 
 # ── Stage 3: runtime ──────────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -69,10 +64,7 @@ WORKDIR /app
 COPY --chown=autumn:autumn --from=builder /app/target/release/{{project_name}} /usr/local/bin/{{project_name}}
 COPY --chown=autumn:autumn --from=builder /usr/local/cargo/bin/autumn /usr/local/bin/autumn
 COPY --chown=autumn:autumn --from=builder /usr/local/cargo/bin/diesel /usr/local/bin/diesel
-# No `COPY static` / `COPY i18n`: assets and locales are embedded in the binary
-# (`autumn build --embed`). Only `migrations/` is staged, for the one-shot
-# `autumn migrate` job (the running server does not read it).
-COPY --chown=autumn:autumn --from=builder /app/migrations /app/migrations
+{{static_copy}}COPY --chown=autumn:autumn --from=builder /app/migrations /app/migrations
 # Use the production config example as the runtime autumn.toml.
 # It sets host = "0.0.0.0" and leaves migration ownership to an explicit
 # one-shot primary-role job.

--- a/autumn-cli/src/templates/release/Dockerfile.tmpl
+++ b/autumn-cli/src/templates/release/Dockerfile.tmpl
@@ -34,13 +34,22 @@ RUN mkdir -p target/autumn \
         "https://github.com/tailwindlabs/tailwindcss/releases/download/${TAILWIND_VERSION}/tailwindcss-${suffix}" \
     && chmod +x target/autumn/tailwindcss
 
-COPY . .
-RUN cargo build --release
+# Install the Autumn + Diesel CLIs before the build. The Autumn CLI is needed
+# at build time so `autumn build --embed` can fingerprint the static/ tree and
+# bake it (plus i18n locales) into the binary; Diesel CLI ships in the runtime
+# for the one-shot migration job.
 RUN cargo install --locked autumn-cli --version "${AUTUMN_CLI_VERSION}"
 RUN cargo install diesel_cli \
     --version "${DIESEL_CLI_VERSION}" \
     --no-default-features \
     --features postgres
+
+COPY . .
+# Single-binary build: fingerprint static assets, then compile with the
+# `embed-assets` feature so the binary serves static/ (incl. the fingerprint
+# manifest) and i18n locales from itself — no sidecar directories. The generated
+# app opts in via `.embedded_static()` / `.embedded_locales()` (see src/main.rs).
+RUN autumn build --embed
 
 # ── Stage 3: runtime ──────────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -60,7 +69,9 @@ WORKDIR /app
 COPY --chown=autumn:autumn --from=builder /app/target/release/{{project_name}} /usr/local/bin/{{project_name}}
 COPY --chown=autumn:autumn --from=builder /usr/local/cargo/bin/autumn /usr/local/bin/autumn
 COPY --chown=autumn:autumn --from=builder /usr/local/cargo/bin/diesel /usr/local/bin/diesel
-COPY --chown=autumn:autumn --from=builder /app/static /app/static
+# No `COPY static` / `COPY i18n`: assets and locales are embedded in the binary
+# (`autumn build --embed`). Only `migrations/` is staged, for the one-shot
+# `autumn migrate` job (the running server does not read it).
 COPY --chown=autumn:autumn --from=builder /app/migrations /app/migrations
 # Use the production config example as the runtime autumn.toml.
 # It sets host = "0.0.0.0" and leaves migration ownership to an explicit

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -52,6 +52,12 @@ telemetry-otlp = [
 ]
 redis = ["dep:redis"]
 i18n = []
+# Embed the app's `static/` tree (incl. the fingerprint manifest) and i18n
+# `locales`/`i18n` bundles into the release binary at compile time, so a single
+# binary serves styled, localized pages with zero sidecar files. Opt-in: dev
+# builds (or this feature off) still serve from disk for hot-reload. Mirrors the
+# `embed_migrations!` precedent. See `embed_static!`/`embed_locales!`.
+embed-assets = ["dep:include_dir"]
 # Pluggable file storage backends. Off by default; enabling adds the
 # `BlobStore` trait, the `Blob` value type, and a Local backend.
 # For S3-compatible storage add `autumn-storage-s3` as a separate
@@ -175,6 +181,7 @@ rsa = { version = "0.9", default-features = false, features = ["std", "pem"], op
 aes-gcm = "0.10"
 getrandom = "0.2"
 hex = "0.4"
+include_dir = { version = "0.7", optional = true }
 csv = { workspace = true, optional = true }
 lettre = { version = "0.11.21", default-features = false, features = ["builder", "smtp-transport", "tokio1-rustls-tls"], optional = true }
 chromiumoxide = { workspace = true, optional = true }
@@ -216,7 +223,7 @@ features = [
   "maud", "htmx", "tailwind", "db", "cache-moka",
   "ws", "flash", "multipart", "http-client", "oauth2", "openapi", "mcp",
   "redis", "i18n", "storage", "variants", "mail", "seed", "system-info", "markdown",
-  "reporting", "csv",
+  "reporting", "csv", "embed-assets",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2617,23 +2617,13 @@ impl AppBuilder {
 
         // Register the embedded `static/` tree (if any) before the router is
         // built so `/static/*` serves from the binary and `asset_url()` resolves
-        // against the embedded manifest.
+        // against the embedded manifest, then prefer embedded locales over disk
+        // auto-loading when no explicit bundle was provided.
         #[cfg(feature = "embed-assets")]
-        if let Some(dir) = embedded_static {
-            crate::assets::register_embedded_static(dir);
-        }
+        register_embedded_static_dir(embedded_static);
 
-        // Embedded locales win over disk auto-loading when no explicit bundle
-        // was provided; resolve_i18n_bundle then returns this bundle as-is.
         #[cfg(all(feature = "embed-assets", feature = "i18n"))]
-        let i18n_bundle = i18n_bundle.or_else(|| {
-            embedded_locales.map(|dir| {
-                std::sync::Arc::new(
-                    crate::i18n::Bundle::load_from_embedded(dir, &config.i18n)
-                        .unwrap_or_else(|e| panic!("embedded_locales: {e}")),
-                )
-            })
-        });
+        let i18n_bundle = embedded_i18n_bundle(i18n_bundle, embedded_locales, &config);
 
         #[cfg(feature = "i18n")]
         let i18n_bundle =
@@ -3662,23 +3652,13 @@ impl AppBuilder {
 
         // Register the embedded `static/` tree (if any) before the router is
         // built so `/static/*` serves from the binary and `asset_url()` resolves
-        // against the embedded manifest.
+        // against the embedded manifest, then prefer embedded locales over disk
+        // auto-loading when no explicit bundle was provided.
         #[cfg(feature = "embed-assets")]
-        if let Some(dir) = embedded_static {
-            crate::assets::register_embedded_static(dir);
-        }
+        register_embedded_static_dir(embedded_static);
 
-        // Embedded locales win over disk auto-loading when no explicit bundle
-        // was provided; resolve_i18n_bundle then returns this bundle as-is.
         #[cfg(all(feature = "embed-assets", feature = "i18n"))]
-        let i18n_bundle = i18n_bundle.or_else(|| {
-            embedded_locales.map(|dir| {
-                std::sync::Arc::new(
-                    crate::i18n::Bundle::load_from_embedded(dir, &config.i18n)
-                        .unwrap_or_else(|e| panic!("embedded_locales: {e}")),
-                )
-            })
-        });
+        let i18n_bundle = embedded_i18n_bundle(i18n_bundle, embedded_locales, &config);
 
         #[cfg(feature = "i18n")]
         let i18n_bundle =
@@ -4234,23 +4214,13 @@ impl AppBuilder {
 
         // Register the embedded `static/` tree (if any) before the router is
         // built so `/static/*` serves from the binary and `asset_url()` resolves
-        // against the embedded manifest.
+        // against the embedded manifest, then prefer embedded locales over disk
+        // auto-loading when no explicit bundle was provided.
         #[cfg(feature = "embed-assets")]
-        if let Some(dir) = embedded_static {
-            crate::assets::register_embedded_static(dir);
-        }
+        register_embedded_static_dir(embedded_static);
 
-        // Embedded locales win over disk auto-loading when no explicit bundle
-        // was provided; resolve_i18n_bundle then returns this bundle as-is.
         #[cfg(all(feature = "embed-assets", feature = "i18n"))]
-        let i18n_bundle = i18n_bundle.or_else(|| {
-            embedded_locales.map(|dir| {
-                std::sync::Arc::new(
-                    crate::i18n::Bundle::load_from_embedded(dir, &config.i18n)
-                        .unwrap_or_else(|e| panic!("embedded_locales: {e}")),
-                )
-            })
-        });
+        let i18n_bundle = embedded_i18n_bundle(i18n_bundle, embedded_locales, &config);
 
         #[cfg(feature = "i18n")]
         let i18n_bundle =
@@ -5714,6 +5684,36 @@ async fn load_config_and_telemetry(
         });
 
     (config, telemetry_guard)
+}
+
+/// Register the embedded `static/` tree (if any) as the process-wide asset
+/// source. Called by each `run` path before the router is built so `/static/*`
+/// serves from the binary and `asset_url()` resolves against the embedded
+/// manifest.
+#[cfg(feature = "embed-assets")]
+fn register_embedded_static_dir(embedded_static: Option<crate::assets::EmbeddedStaticDir>) {
+    if let Some(dir) = embedded_static {
+        crate::assets::register_embedded_static(dir);
+    }
+}
+
+/// Prefer an embedded locale bundle over disk auto-loading when no explicit
+/// bundle was provided. Returns `explicit` unchanged when it is `Some` or when
+/// no embedded locales were registered.
+#[cfg(all(feature = "embed-assets", feature = "i18n"))]
+fn embedded_i18n_bundle(
+    explicit: Option<Arc<crate::i18n::Bundle>>,
+    embedded_locales: Option<&'static include_dir::Dir<'static>>,
+    config: &AutumnConfig,
+) -> Option<Arc<crate::i18n::Bundle>> {
+    explicit.or_else(|| {
+        embedded_locales.map(|dir| {
+            Arc::new(
+                crate::i18n::Bundle::load_from_embedded(dir, &config.i18n)
+                    .unwrap_or_else(|e| panic!("embedded_locales: {e}")),
+            )
+        })
+    })
 }
 
 #[cfg(feature = "i18n")]

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -116,6 +116,10 @@ pub fn app() -> AppBuilder {
         i18n_bundle: None,
         #[cfg(feature = "i18n")]
         i18n_auto_load: false,
+        #[cfg(feature = "embed-assets")]
+        embedded_static: None,
+        #[cfg(all(feature = "embed-assets", feature = "i18n"))]
+        embedded_locales: None,
         policy_registrations: Vec::new(),
         #[cfg(feature = "mail")]
         mail_delivery_queue_factory: None,
@@ -349,6 +353,18 @@ pub struct AppBuilder {
     /// `.with_config_loader(...)`.
     #[cfg(feature = "i18n")]
     i18n_auto_load: bool,
+    /// Embedded `static/` tree (incl. the fingerprint manifest) registered via
+    /// [`embedded_static`](AppBuilder::embedded_static). When set, `/static/*`
+    /// is served from the binary and `asset_url()` resolves against the embedded
+    /// manifest — no `static/` sidecar directory is read at runtime.
+    #[cfg(feature = "embed-assets")]
+    embedded_static: Option<crate::assets::EmbeddedStaticDir>,
+    /// Embedded i18n locale bundles registered via
+    /// [`embedded_locales`](AppBuilder::embedded_locales). When set (and no
+    /// explicit bundle was provided), the bundle is loaded from the binary
+    /// instead of the `i18n/` directory on disk.
+    #[cfg(all(feature = "embed-assets", feature = "i18n"))]
+    embedded_locales: Option<&'static include_dir::Dir<'static>>,
     /// Deferred [`Policy`](crate::authorization::Policy) and
     /// [`Scope`](crate::authorization::Scope) registrations applied
     /// to [`AppState::policy_registry`] just before the router is
@@ -2392,6 +2408,56 @@ impl AppBuilder {
         self
     }
 
+    /// Embed the app's `static/` tree into the binary for single-binary deploys.
+    ///
+    /// Pass the directory produced by [`embed_static!`](crate::embed_static)
+    /// (requires the `embed-assets` feature). When set, `/static/*` is served
+    /// from the binary and `asset_url()` resolves against the embedded
+    /// fingerprint manifest — copying only the release binary into an empty
+    /// directory serves every referenced asset with no `static/` sidecar.
+    /// Because the manifest and the files are baked from the same build,
+    /// fingerprint-vs-manifest drift is impossible.
+    ///
+    /// This is a release-time concern: leave it unset in development so CSS/JS
+    /// hot-reload keeps serving from disk.
+    ///
+    /// ```rust,ignore
+    /// static STATIC: autumn_web::include_dir::Dir = autumn_web::embed_static!();
+    ///
+    /// #[autumn_web::main]
+    /// async fn main() {
+    ///     autumn_web::app().embedded_static(&STATIC).run().await;
+    /// }
+    /// ```
+    #[cfg(feature = "embed-assets")]
+    #[must_use]
+    pub const fn embedded_static(mut self, dir: &'static include_dir::Dir<'static>) -> Self {
+        self.embedded_static = Some(crate::assets::EmbeddedStaticDir(dir));
+        self
+    }
+
+    /// Embed the app's i18n locale bundles into the binary.
+    ///
+    /// Pass the directory produced by [`embed_locales!`](crate::embed_locales)
+    /// (requires the `embed-assets` and `i18n` features). When set (and no
+    /// explicit [`i18n`](AppBuilder::i18n) bundle was provided), all configured
+    /// locales render from the binary with no `i18n/` sidecar directory.
+    ///
+    /// ```rust,ignore
+    /// static LOCALES: autumn_web::include_dir::Dir = autumn_web::embed_locales!();
+    ///
+    /// #[autumn_web::main]
+    /// async fn main() {
+    ///     autumn_web::app().embedded_locales(&LOCALES).run().await;
+    /// }
+    /// ```
+    #[cfg(all(feature = "embed-assets", feature = "i18n"))]
+    #[must_use]
+    pub const fn embedded_locales(mut self, dir: &'static include_dir::Dir<'static>) -> Self {
+        self.embedded_locales = Some(dir);
+        self
+    }
+
     /// Start the HTTP server.
     ///
     /// This method performs the full application lifecycle:
@@ -2492,6 +2558,10 @@ impl AppBuilder {
             i18n_bundle,
             #[cfg(feature = "i18n")]
             i18n_auto_load,
+            #[cfg(feature = "embed-assets")]
+            embedded_static,
+            #[cfg(all(feature = "embed-assets", feature = "i18n"))]
+            embedded_locales,
             policy_registrations,
             #[cfg(feature = "mail")]
             mail_delivery_queue_factory,
@@ -2544,6 +2614,26 @@ impl AppBuilder {
                 config.idempotency.enabled = Some(true);
             }
         }
+
+        // Register the embedded `static/` tree (if any) before the router is
+        // built so `/static/*` serves from the binary and `asset_url()` resolves
+        // against the embedded manifest.
+        #[cfg(feature = "embed-assets")]
+        if let Some(dir) = embedded_static {
+            crate::assets::register_embedded_static(dir);
+        }
+
+        // Embedded locales win over disk auto-loading when no explicit bundle
+        // was provided; resolve_i18n_bundle then returns this bundle as-is.
+        #[cfg(all(feature = "embed-assets", feature = "i18n"))]
+        let i18n_bundle = i18n_bundle.or_else(|| {
+            embedded_locales.map(|dir| {
+                std::sync::Arc::new(
+                    crate::i18n::Bundle::load_from_embedded(dir, &config.i18n)
+                        .unwrap_or_else(|e| panic!("embedded_locales: {e}")),
+                )
+            })
+        });
 
         #[cfg(feature = "i18n")]
         let i18n_bundle =
@@ -3516,6 +3606,10 @@ impl AppBuilder {
             i18n_bundle,
             #[cfg(feature = "i18n")]
             i18n_auto_load,
+            #[cfg(feature = "embed-assets")]
+            embedded_static,
+            #[cfg(all(feature = "embed-assets", feature = "i18n"))]
+            embedded_locales,
             policy_registrations,
             #[cfg(feature = "mail")]
             mail_delivery_queue_factory,
@@ -3565,6 +3659,26 @@ impl AppBuilder {
                 config.idempotency.enabled = Some(true);
             }
         }
+
+        // Register the embedded `static/` tree (if any) before the router is
+        // built so `/static/*` serves from the binary and `asset_url()` resolves
+        // against the embedded manifest.
+        #[cfg(feature = "embed-assets")]
+        if let Some(dir) = embedded_static {
+            crate::assets::register_embedded_static(dir);
+        }
+
+        // Embedded locales win over disk auto-loading when no explicit bundle
+        // was provided; resolve_i18n_bundle then returns this bundle as-is.
+        #[cfg(all(feature = "embed-assets", feature = "i18n"))]
+        let i18n_bundle = i18n_bundle.or_else(|| {
+            embedded_locales.map(|dir| {
+                std::sync::Arc::new(
+                    crate::i18n::Bundle::load_from_embedded(dir, &config.i18n)
+                        .unwrap_or_else(|e| panic!("embedded_locales: {e}")),
+                )
+            })
+        });
 
         #[cfg(feature = "i18n")]
         let i18n_bundle =
@@ -4071,6 +4185,10 @@ impl AppBuilder {
             i18n_bundle,
             #[cfg(feature = "i18n")]
             i18n_auto_load,
+            #[cfg(feature = "embed-assets")]
+            embedded_static,
+            #[cfg(all(feature = "embed-assets", feature = "i18n"))]
+            embedded_locales,
             policy_registrations,
             cache_backend,
             #[cfg(feature = "mail")]
@@ -4113,6 +4231,26 @@ impl AppBuilder {
 
         let (config, telemetry_guard) =
             load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
+
+        // Register the embedded `static/` tree (if any) before the router is
+        // built so `/static/*` serves from the binary and `asset_url()` resolves
+        // against the embedded manifest.
+        #[cfg(feature = "embed-assets")]
+        if let Some(dir) = embedded_static {
+            crate::assets::register_embedded_static(dir);
+        }
+
+        // Embedded locales win over disk auto-loading when no explicit bundle
+        // was provided; resolve_i18n_bundle then returns this bundle as-is.
+        #[cfg(all(feature = "embed-assets", feature = "i18n"))]
+        let i18n_bundle = i18n_bundle.or_else(|| {
+            embedded_locales.map(|dir| {
+                std::sync::Arc::new(
+                    crate::i18n::Bundle::load_from_embedded(dir, &config.i18n)
+                        .unwrap_or_else(|e| panic!("embedded_locales: {e}")),
+                )
+            })
+        });
 
         #[cfg(feature = "i18n")]
         let i18n_bundle =

--- a/autumn/src/assets.rs
+++ b/autumn/src/assets.rs
@@ -32,13 +32,13 @@
 //! }
 //! ```
 
-#[cfg(not(debug_assertions))]
+#[cfg(any(not(debug_assertions), feature = "embed-assets"))]
 use std::collections::HashMap;
-#[cfg(not(debug_assertions))]
+#[cfg(any(not(debug_assertions), feature = "embed-assets"))]
 use std::sync::OnceLock;
 
 /// On-disk format of `static/.autumn-manifest.json`.
-#[cfg(not(debug_assertions))]
+#[cfg(any(not(debug_assertions), feature = "embed-assets"))]
 #[derive(Debug, serde::Deserialize)]
 struct AssetManifest {
     files: HashMap<String, String>,
@@ -55,6 +55,82 @@ fn load_manifest() -> &'static Option<AssetManifest> {
         let contents = std::fs::read_to_string(manifest_path).ok()?;
         serde_json::from_str(&contents).ok()
     })
+}
+
+// ── Embedded assets (feature = "embed-assets") ──────────────────────────────
+//
+// When the app registers an embedded `static/` tree via
+// [`AppBuilder::embedded_static`](crate::app::AppBuilder::embedded_static),
+// the binary is fully self-contained: `asset_url`/`is_manifest_asset` resolve
+// against the manifest baked into the binary (no disk read) and `/static/*`
+// is served from the embedded bytes. Both the manifest and the files come from
+// the *same* build, so fingerprint-vs-manifest drift is impossible.
+//
+// The embedded path is active regardless of `debug_assertions`: it engages only
+// once a dir is registered, so dev builds (which never register one) are
+// unaffected and keep serving from disk for hot-reload.
+
+/// A `static/` directory embedded into the binary at compile time.
+///
+/// Produced by [`embed_static!`](crate::embed_static) and handed to
+/// [`AppBuilder::embedded_static`](crate::app::AppBuilder::embedded_static).
+#[cfg(feature = "embed-assets")]
+#[derive(Clone, Copy)]
+pub struct EmbeddedStaticDir(pub &'static include_dir::Dir<'static>);
+
+#[cfg(feature = "embed-assets")]
+impl std::fmt::Debug for EmbeddedStaticDir {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EmbeddedStaticDir")
+            .field("path", &self.0.path())
+            .finish()
+    }
+}
+
+#[cfg(feature = "embed-assets")]
+static EMBEDDED_STATIC: OnceLock<EmbeddedStaticDir> = OnceLock::new();
+
+#[cfg(feature = "embed-assets")]
+static EMBEDDED_MANIFEST: OnceLock<Option<AssetManifest>> = OnceLock::new();
+
+/// Register the embedded `static/` tree as the process-wide asset source.
+///
+/// Parses the embedded `.autumn-manifest.json` so [`asset_url`] and
+/// [`is_manifest_asset`] resolve against it. Called by the framework during
+/// `AppBuilder::run` before the router is built; calling it more than once is a
+/// no-op (the first registration wins).
+#[cfg(feature = "embed-assets")]
+pub fn register_embedded_static(dir: EmbeddedStaticDir) {
+    let _ = EMBEDDED_STATIC.set(dir);
+    let _ = EMBEDDED_MANIFEST.set(
+        dir.0
+            .get_file(".autumn-manifest.json")
+            .and_then(include_dir::File::contents_utf8)
+            .and_then(|s| serde_json::from_str::<AssetManifest>(s).ok()),
+    );
+}
+
+/// The registered embedded `static/` dir, if [`register_embedded_static`] ran.
+#[cfg(feature = "embed-assets")]
+#[must_use]
+pub fn embedded_static_dir() -> Option<EmbeddedStaticDir> {
+    EMBEDDED_STATIC.get().copied()
+}
+
+/// Look up a logical asset path in the embedded manifest, returning the
+/// fingerprinted path when present.
+#[cfg(feature = "embed-assets")]
+fn embedded_manifest_lookup(path: &str) -> Option<String> {
+    EMBEDDED_MANIFEST.get()?.as_ref()?.files.get(path).cloned()
+}
+
+/// `true` if `rel_path` is a fingerprinted value in the embedded manifest.
+#[cfg(feature = "embed-assets")]
+fn embedded_is_manifest_asset(rel_path: &str) -> bool {
+    EMBEDDED_MANIFEST
+        .get()
+        .and_then(Option::as_ref)
+        .is_some_and(|m| m.files.values().any(|v| v == rel_path))
 }
 
 /// Return the URL for a static asset, fingerprinted in release builds.
@@ -76,6 +152,15 @@ fn load_manifest() -> &'static Option<AssetManifest> {
 /// ```
 #[must_use]
 pub fn asset_url(path: &str) -> String {
+    // When an embedded manifest is registered (release single-binary builds),
+    // it is authoritative regardless of build profile — both the manifest and
+    // the served files come from the same build, so there is no drift.
+    #[cfg(feature = "embed-assets")]
+    {
+        if let Some(fingerprinted) = embedded_manifest_lookup(path) {
+            return format!("/static/{fingerprinted}");
+        }
+    }
     #[cfg(debug_assertions)]
     {
         format!("/static/{path}")
@@ -100,16 +185,30 @@ pub fn asset_url(path: &str) -> String {
 /// never given a year-long cache lifetime.
 ///
 /// Always returns `false` in debug builds — the manifest does not exist there.
-#[cfg(not(debug_assertions))]
+// Not `const fn`: the body branches on build profile/feature, and the
+// release/embedded arms perform non-const lookups.
+#[allow(clippy::missing_const_for_fn)]
 pub(crate) fn is_manifest_asset(rel_path: &str) -> bool {
-    load_manifest()
-        .as_ref()
-        .is_some_and(|m| m.files.values().any(|v| v == rel_path))
-}
-
-#[cfg(debug_assertions)]
-pub(crate) const fn is_manifest_asset(_rel_path: &str) -> bool {
-    false
+    // An embedded manifest (release single-binary build) is consulted first and
+    // is reachable in debug builds too, so the cache policy is correct whenever
+    // assets are embedded — not only in `--release`.
+    #[cfg(feature = "embed-assets")]
+    {
+        if embedded_is_manifest_asset(rel_path) {
+            return true;
+        }
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        load_manifest()
+            .as_ref()
+            .is_some_and(|m| m.files.values().any(|v| v == rel_path))
+    }
+    #[cfg(debug_assertions)]
+    {
+        let _ = rel_path;
+        false
+    }
 }
 
 /// Returns `true` if the URI path segment looks like a fingerprinted asset
@@ -129,6 +228,124 @@ pub(crate) fn is_fingerprinted_path(uri_path: &str) -> bool {
         && hash_candidate
             .bytes()
             .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+/// Cache-control policy for `/static/*` responses.
+///
+/// Fingerprinted assets (members of the manifest, embedded or on-disk) get a
+/// year-long `immutable` lifetime; everything else gets `must-revalidate` so
+/// returning visitors always pick up the latest file after a deploy. Manifest
+/// membership — rather than filename pattern — gates the `immutable` policy so a
+/// user-authored `vendor.deadbeef.js` is never frozen for a year.
+///
+/// Applied as a middleware layer over both the on-disk (`ServeDir`) and the
+/// embedded static-serving paths so the policy is identical regardless of where
+/// the bytes come from.
+pub async fn asset_cache_control(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let path = req.uri().path().to_owned();
+    let mut resp = next.run(req).await;
+    if path.starts_with("/static/") && resp.status().is_success() {
+        let is_immutable = path.strip_prefix("/static/").is_some_and(is_manifest_asset);
+        let header = if is_immutable {
+            "public, max-age=31536000, immutable"
+        } else {
+            "public, max-age=0, must-revalidate"
+        };
+        resp.headers_mut().insert(
+            http::header::CACHE_CONTROL,
+            http::HeaderValue::from_static(header),
+        );
+    }
+    resp
+}
+
+/// Best-effort `Content-Type` for an embedded asset, derived from its
+/// extension. Covers the closed set of asset types Autumn apps ship; unknown
+/// extensions fall back to `application/octet-stream`.
+#[cfg(feature = "embed-assets")]
+#[must_use]
+pub(crate) fn content_type_for(path: &str) -> &'static str {
+    let ext = path
+        .rsplit('/')
+        .next()
+        .unwrap_or("")
+        .rsplit_once('.')
+        .map_or(String::new(), |(_, e)| e.to_ascii_lowercase());
+    match ext.as_str() {
+        "css" => "text/css; charset=utf-8",
+        "js" | "mjs" => "text/javascript; charset=utf-8",
+        "json" | "map" => "application/json",
+        "html" | "htm" => "text/html; charset=utf-8",
+        "txt" => "text/plain; charset=utf-8",
+        "xml" => "application/xml",
+        "svg" => "image/svg+xml",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "avif" => "image/avif",
+        "ico" => "image/x-icon",
+        "woff" => "font/woff",
+        "woff2" => "font/woff2",
+        "ttf" => "font/ttf",
+        "otf" => "font/otf",
+        "wasm" => "application/wasm",
+        _ => "application/octet-stream",
+    }
+}
+
+/// Serve a single file from the registered embedded `static/` tree.
+///
+/// Returns `404` for traversal attempts, dotfiles (so the embedded
+/// `.autumn-manifest.json` is never exposed), missing files, or when no
+/// embedded dir is registered.
+#[cfg(feature = "embed-assets")]
+fn embedded_response(rel_path: &str) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    if rel_path
+        .split('/')
+        .any(|seg| seg.is_empty() || seg == ".." || seg.starts_with('.'))
+    {
+        return http::StatusCode::NOT_FOUND.into_response();
+    }
+    let Some(dir) = embedded_static_dir() else {
+        return http::StatusCode::NOT_FOUND.into_response();
+    };
+    dir.0.get_file(rel_path).map_or_else(
+        || http::StatusCode::NOT_FOUND.into_response(),
+        |file| {
+            (
+                [(http::header::CONTENT_TYPE, content_type_for(rel_path))],
+                file.contents().to_vec(),
+            )
+                .into_response()
+        },
+    )
+}
+
+/// Axum handler serving `/static/{*path}` from the embedded tree.
+#[cfg(feature = "embed-assets")]
+pub(crate) async fn serve_embedded(
+    axum::extract::Path(path): axum::extract::Path<String>,
+) -> axum::response::Response {
+    embedded_response(&path)
+}
+
+/// A standalone router that serves `/static/*` from the registered embedded
+/// tree with the [`asset_cache_control`] policy applied.
+///
+/// The framework wires the embedded handler directly into the typed
+/// application router; this helper exposes the same serving behavior as a
+/// self-contained `Router` for tests and embedding into custom setups.
+#[cfg(feature = "embed-assets")]
+pub fn embedded_static_router() -> axum::Router {
+    axum::Router::new()
+        .route("/static/{*path}", axum::routing::get(serve_embedded))
+        .layer(axum::middleware::from_fn(asset_cache_control))
 }
 
 #[cfg(test)]
@@ -168,5 +385,22 @@ mod tests {
         assert!(!is_fingerprinted_path("/static/css/autumn.A1B2C3D4.css"));
         // No extension
         assert!(!is_fingerprinted_path("/static/file.a1b2c3d4"));
+    }
+
+    #[cfg(feature = "embed-assets")]
+    #[test]
+    fn content_type_covers_common_assets() {
+        assert_eq!(content_type_for("css/app.css"), "text/css; charset=utf-8");
+        assert_eq!(
+            content_type_for("js/app.js"),
+            "text/javascript; charset=utf-8"
+        );
+        assert_eq!(content_type_for("img/logo.svg"), "image/svg+xml");
+        assert_eq!(content_type_for("img/logo.png"), "image/png");
+        assert_eq!(content_type_for("fonts/inter.woff2"), "font/woff2");
+        assert_eq!(content_type_for("favicon.ico"), "image/x-icon");
+        // Unknown / extensionless fall back to octet-stream.
+        assert_eq!(content_type_for("data.bin"), "application/octet-stream");
+        assert_eq!(content_type_for("LICENSE"), "application/octet-stream");
     }
 }

--- a/autumn/src/assets.rs
+++ b/autumn/src/assets.rs
@@ -37,6 +37,10 @@ use std::collections::HashMap;
 #[cfg(any(not(debug_assertions), feature = "embed-assets"))]
 use std::sync::OnceLock;
 
+/// Filename of the fingerprint manifest within the `static/` tree.
+#[cfg(any(not(debug_assertions), feature = "embed-assets"))]
+const ASSET_MANIFEST_FILE: &str = ".autumn-manifest.json";
+
 /// On-disk format of `static/.autumn-manifest.json`.
 #[cfg(any(not(debug_assertions), feature = "embed-assets"))]
 #[derive(Debug, serde::Deserialize)]
@@ -51,7 +55,7 @@ static ASSET_MANIFEST: OnceLock<Option<AssetManifest>> = OnceLock::new();
 fn load_manifest() -> &'static Option<AssetManifest> {
     ASSET_MANIFEST.get_or_init(|| {
         let manifest_path =
-            crate::app::project_dir("static", &crate::config::OsEnv).join(".autumn-manifest.json");
+            crate::app::project_dir("static", &crate::config::OsEnv).join(ASSET_MANIFEST_FILE);
         let contents = std::fs::read_to_string(manifest_path).ok()?;
         serde_json::from_str(&contents).ok()
     })
@@ -104,7 +108,7 @@ pub fn register_embedded_static(dir: EmbeddedStaticDir) {
     let _ = EMBEDDED_STATIC.set(dir);
     let _ = EMBEDDED_MANIFEST.set(
         dir.0
-            .get_file(".autumn-manifest.json")
+            .get_file(ASSET_MANIFEST_FILE)
             .and_then(include_dir::File::contents_utf8)
             .and_then(|s| serde_json::from_str::<AssetManifest>(s).ok()),
     );
@@ -271,13 +275,23 @@ pub async fn asset_cache_control(
 #[cfg(feature = "embed-assets")]
 #[must_use]
 pub(crate) fn content_type_for(path: &str) -> &'static str {
-    let ext = path
+    // Lowercase the extension into a small stack buffer (extensions are short
+    // and ASCII) to avoid a per-request heap allocation on the serving path.
+    let raw = path
         .rsplit('/')
         .next()
         .unwrap_or("")
         .rsplit_once('.')
-        .map_or(String::new(), |(_, e)| e.to_ascii_lowercase());
-    match ext.as_str() {
+        .map_or("", |(_, e)| e);
+    let mut buf = [0u8; 8];
+    let ext = if raw.is_ascii() && raw.len() <= buf.len() {
+        buf[..raw.len()].copy_from_slice(raw.as_bytes());
+        buf[..raw.len()].make_ascii_lowercase();
+        std::str::from_utf8(&buf[..raw.len()]).unwrap_or("")
+    } else {
+        "" // unknown long/non-ASCII extension → octet-stream
+    };
+    match ext {
         "css" => "text/css; charset=utf-8",
         "js" | "mjs" => "text/javascript; charset=utf-8",
         "json" | "map" => "application/json",
@@ -302,17 +316,22 @@ pub(crate) fn content_type_for(path: &str) -> &'static str {
 
 /// Serve a single file from the registered embedded `static/` tree.
 ///
-/// Returns `404` for traversal attempts, dotfiles (so the embedded
-/// `.autumn-manifest.json` is never exposed), missing files, or when no
-/// embedded dir is registered.
+/// Returns `404` for path-traversal attempts, the framework manifest
+/// (`.autumn-manifest.json`, which must never be exposed), missing files, or
+/// when no embedded dir is registered. Other files — including legitimate
+/// dotfile assets — are served, matching the on-disk `ServeDir` behavior.
 #[cfg(feature = "embed-assets")]
 fn embedded_response(rel_path: &str) -> axum::response::Response {
     use axum::response::IntoResponse;
 
-    if rel_path
+    let is_traversal = rel_path
         .split('/')
-        .any(|seg| seg.is_empty() || seg == ".." || seg.starts_with('.'))
-    {
+        .any(|seg| seg.is_empty() || seg == "." || seg == "..");
+    let is_manifest = rel_path
+        .rsplit('/')
+        .next()
+        .is_some_and(|name| name == ASSET_MANIFEST_FILE);
+    if is_traversal || is_manifest {
         return http::StatusCode::NOT_FOUND.into_response();
     }
     let Some(dir) = embedded_static_dir() else {
@@ -321,9 +340,10 @@ fn embedded_response(rel_path: &str) -> axum::response::Response {
     dir.0.get_file(rel_path).map_or_else(
         || http::StatusCode::NOT_FOUND.into_response(),
         |file| {
+            // `contents()` is `&'static [u8]`; serve it directly (no per-request copy).
             (
                 [(http::header::CONTENT_TYPE, content_type_for(rel_path))],
-                file.contents().to_vec(),
+                file.contents(),
             )
                 .into_response()
         },

--- a/autumn/src/assets.rs
+++ b/autumn/src/assets.rs
@@ -152,13 +152,16 @@ fn embedded_is_manifest_asset(rel_path: &str) -> bool {
 /// ```
 #[must_use]
 pub fn asset_url(path: &str) -> String {
-    // When an embedded manifest is registered (release single-binary builds),
-    // it is authoritative regardless of build profile — both the manifest and
-    // the served files come from the same build, so there is no drift.
+    // When an embedded `static/` tree is registered (single-binary build), the
+    // embedded manifest is the *only* source of truth — assets are served from
+    // the binary, so a miss means the asset isn't fingerprinted and should use
+    // the plain embedded path. Never fall through to a disk sidecar manifest,
+    // which could otherwise point at a hashed file that was never baked in.
     #[cfg(feature = "embed-assets")]
     {
-        if let Some(fingerprinted) = embedded_manifest_lookup(path) {
-            return format!("/static/{fingerprinted}");
+        if embedded_static_dir().is_some() {
+            return embedded_manifest_lookup(path)
+                .map_or_else(|| format!("/static/{path}"), |fp| format!("/static/{fp}"));
         }
     }
     #[cfg(debug_assertions)]
@@ -189,13 +192,13 @@ pub fn asset_url(path: &str) -> String {
 // release/embedded arms perform non-const lookups.
 #[allow(clippy::missing_const_for_fn)]
 pub(crate) fn is_manifest_asset(rel_path: &str) -> bool {
-    // An embedded manifest (release single-binary build) is consulted first and
-    // is reachable in debug builds too, so the cache policy is correct whenever
-    // assets are embedded — not only in `--release`.
+    // When an embedded `static/` tree is registered, its manifest is the sole
+    // authority for the immutable-cache decision (and is reachable in debug
+    // builds too); never consult a disk sidecar manifest in that case.
     #[cfg(feature = "embed-assets")]
     {
-        if embedded_is_manifest_asset(rel_path) {
-            return true;
+        if embedded_static_dir().is_some() {
+            return embedded_is_manifest_asset(rel_path);
         }
     }
     #[cfg(not(debug_assertions))]

--- a/autumn/src/i18n.rs
+++ b/autumn/src/i18n.rs
@@ -373,11 +373,28 @@ impl Bundle {
             messages.insert(stem, parsed);
         }
 
-        let default_path = dir.join(format!("{}.ftl", config.default_locale));
+        Self::from_locale_messages(
+            messages,
+            config,
+            dir.join(format!("{}.ftl", config.default_locale)),
+        )
+    }
+
+    /// Validate that the default locale is present and assemble the bundle.
+    ///
+    /// Shared tail of [`load_from_dir`](Self::load_from_dir) and
+    /// [`load_from_embedded`](Self::load_from_embedded): only their file-source
+    /// loops differ. `missing_default_path` is the path reported when the
+    /// default locale's file is absent.
+    fn from_locale_messages(
+        messages: HashMap<String, HashMap<String, String>>,
+        config: &I18nConfig,
+        missing_default_path: PathBuf,
+    ) -> Result<Self, LoadError> {
         if !messages.contains_key(&config.default_locale) {
             return Err(LoadError::MissingDefaultLocale {
                 locale: config.default_locale.clone(),
-                path: default_path,
+                path: missing_default_path,
             });
         }
 
@@ -433,22 +450,11 @@ impl Bundle {
             messages.insert(stem, parsed);
         }
 
-        if !messages.contains_key(&config.default_locale) {
-            return Err(LoadError::MissingDefaultLocale {
-                locale: config.default_locale.clone(),
-                path: PathBuf::from(format!("{}.ftl", config.default_locale)),
-            });
-        }
-
-        Ok(Self {
+        Self::from_locale_messages(
             messages,
-            fallback_chain: config.resolved_fallback_chain(),
-            default_locale: config.default_locale.clone(),
-            supported_locales: config.supported_locales.clone(),
-            miss_warnings: std::sync::Mutex::new(HashMap::new()),
-            warn_dedup_window: Duration::from_secs(60),
-            miss_count: AtomicU64::new(0),
-        })
+            config,
+            PathBuf::from(format!("{}.ftl", config.default_locale)),
+        )
     }
 
     /// Construct a bundle directly from in-memory translations (test helper).

--- a/autumn/src/i18n.rs
+++ b/autumn/src/i18n.rs
@@ -392,6 +392,65 @@ impl Bundle {
         })
     }
 
+    /// Load all `<locale>.ftl` files from a directory embedded into the binary
+    /// at compile time (via [`embed_locales!`](crate::embed_locales)).
+    ///
+    /// The embedded counterpart to [`load_from_dir`](Self::load_from_dir): same
+    /// `.ftl` discovery, same [`parse_ftl`] parsing, and the same fail-fast on a
+    /// missing default locale — but every byte comes from the binary, so no
+    /// `i18n/` sidecar directory is required at runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LoadError::MissingDefaultLocale`] if the default locale's file
+    /// is absent, [`LoadError::InvalidLocaleFilename`] if a file name or its
+    /// contents are not valid UTF-8, or [`LoadError::Parse`] on a syntax error.
+    #[cfg(feature = "embed-assets")]
+    pub fn load_from_embedded(
+        dir: &include_dir::Dir,
+        config: &I18nConfig,
+    ) -> Result<Self, LoadError> {
+        let mut messages: HashMap<String, HashMap<String, String>> = HashMap::new();
+
+        for file in dir.files() {
+            let path = file.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("ftl") {
+                continue;
+            }
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .ok_or_else(|| LoadError::InvalidLocaleFilename {
+                    path: path.to_path_buf(),
+                })?
+                .to_owned();
+            let raw = file
+                .contents_utf8()
+                .ok_or_else(|| LoadError::InvalidLocaleFilename {
+                    path: path.to_path_buf(),
+                })?;
+            let parsed = parse_ftl(raw, path)?;
+            messages.insert(stem, parsed);
+        }
+
+        if !messages.contains_key(&config.default_locale) {
+            return Err(LoadError::MissingDefaultLocale {
+                locale: config.default_locale.clone(),
+                path: PathBuf::from(format!("{}.ftl", config.default_locale)),
+            });
+        }
+
+        Ok(Self {
+            messages,
+            fallback_chain: config.resolved_fallback_chain(),
+            default_locale: config.default_locale.clone(),
+            supported_locales: config.supported_locales.clone(),
+            miss_warnings: std::sync::Mutex::new(HashMap::new()),
+            warn_dedup_window: Duration::from_secs(60),
+            miss_count: AtomicU64::new(0),
+        })
+    }
+
     /// Construct a bundle directly from in-memory translations (test helper).
     #[must_use]
     pub fn from_messages(

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -117,6 +117,72 @@ pub mod migrate;
 pub mod plugin;
 pub mod plugin_conformance;
 pub mod probe;
+
+/// Re-export of the [`include_dir`](https://docs.rs/include_dir) crate.
+///
+/// Lets apps embed their `static/` and `i18n/` trees without adding `include_dir`
+/// as a direct dependency. Used by the [`embed_static!`] and [`embed_locales!`]
+/// macros. Nested in a module (rather than a crate-root `pub use`) so the
+/// re-export resolves for external consumers, mirroring [`reexports`].
+#[cfg(feature = "embed-assets")]
+pub mod include_dir {
+    pub use ::include_dir::*;
+}
+
+/// Embed the app's `static/` directory (including the `.autumn-manifest.json`
+/// written by `autumn build --embed`) into the binary at compile time.
+///
+/// Expands to an [`include_dir::Dir`] rooted at the **calling crate's**
+/// `static/` directory (resolved via `$CARGO_MANIFEST_DIR`, exactly like
+/// `embed_migrations!`). Pass the result to
+/// [`AppBuilder::embedded_static`](crate::app::AppBuilder::embedded_static):
+///
+/// ```rust,ignore
+/// static STATIC: autumn_web::include_dir::Dir = autumn_web::embed_static!();
+///
+/// #[autumn_web::main]
+/// async fn main() {
+///     autumn_web::app().embedded_static(&STATIC).run().await;
+/// }
+/// ```
+#[cfg(feature = "embed-assets")]
+#[macro_export]
+macro_rules! embed_static {
+    () => {{
+        // `include_dir!` emits `include_dir::{Dir, File, ...}` paths resolved at
+        // the call site, so bring our re-export into scope under that name. This
+        // lets apps embed without depending on the `include_dir` crate directly.
+        #[allow(unused_imports)]
+        use $crate::include_dir;
+        $crate::include_dir::include_dir!("$CARGO_MANIFEST_DIR/static")
+    }};
+}
+
+/// Embed the app's i18n locale bundles (the `i18n/` directory, or a custom
+/// directory) into the binary at compile time.
+///
+/// Pass the result to
+/// [`AppBuilder::embedded_locales`](crate::app::AppBuilder::embedded_locales).
+///
+/// ```rust,ignore
+/// static LOCALES: autumn_web::include_dir::Dir = autumn_web::embed_locales!();
+/// // or a custom directory:
+/// static LOCALES: autumn_web::include_dir::Dir = autumn_web::embed_locales!("translations");
+/// ```
+#[cfg(all(feature = "embed-assets", feature = "i18n"))]
+#[macro_export]
+macro_rules! embed_locales {
+    () => {{
+        #[allow(unused_imports)]
+        use $crate::include_dir;
+        $crate::include_dir::include_dir!("$CARGO_MANIFEST_DIR/i18n")
+    }};
+    ($dir:literal) => {{
+        #[allow(unused_imports)]
+        use $crate::include_dir;
+        $crate::include_dir::include_dir!(concat!("$CARGO_MANIFEST_DIR/", $dir))
+    }};
+}
 #[cfg(feature = "system-info")]
 pub mod system_info;
 pub use plugin::{Plugin, Plugins};

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -471,14 +471,35 @@ fn build_router_pre_state(
         router = router.merge(openapi_router);
     }
 
-    // Static file serving from project's static/ directory.
-    // Fingerprinted assets (e.g. `autumn.a1b2c3d4.css`) are served with
-    // `Cache-Control: public, max-age=31536000, immutable`; all other static
-    // files use the default browser policy.
-    let env = crate::config::OsEnv;
-    let static_dir = crate::app::project_dir("static", &env);
-    router = router.nest_service("/static", tower_http::services::ServeDir::new(&static_dir));
-    router = router.layer(axum::middleware::from_fn(asset_cache_control));
+    // Static file serving. Fingerprinted assets (e.g. `autumn.a1b2c3d4.css`)
+    // are served with `Cache-Control: public, max-age=31536000, immutable`; all
+    // other static files use the default browser policy.
+    //
+    // When the app embedded its `static/` tree (feature = "embed-assets" plus a
+    // registered dir), serve `/static/*` from the binary — no disk read, no
+    // sidecar directory. Otherwise serve from the project's `static/` directory
+    // on disk (the dev default, preserving hot-reload).
+    #[cfg(feature = "embed-assets")]
+    let embedded_static = crate::assets::embedded_static_dir().is_some();
+    #[cfg(not(feature = "embed-assets"))]
+    let embedded_static = false;
+
+    if embedded_static {
+        #[cfg(feature = "embed-assets")]
+        {
+            router = router.route(
+                "/static/{*path}",
+                axum::routing::get(crate::assets::serve_embedded),
+            );
+        }
+    } else {
+        let env = crate::config::OsEnv;
+        let static_dir = crate::app::project_dir("static", &env);
+        router = router.nest_service("/static", tower_http::services::ServeDir::new(&static_dir));
+    }
+    router = router.layer(axum::middleware::from_fn(
+        crate::assets::asset_cache_control,
+    ));
 
     router = mount_scoped_groups(
         router,
@@ -3069,45 +3090,6 @@ fn apply_cors_headers_to_timeout_response(
             http::HeaderValue::from_static("true"),
         );
     }
-}
-
-/// Set `Cache-Control` headers for static assets based on whether the path is
-/// fingerprinted.
-///
-/// | Path | Header |
-/// |------|--------|
-/// | `/static/**.<8hex>.*` | `public, max-age=31536000, immutable` |
-/// | `/static/**` (other) | `public, max-age=0, must-revalidate` |
-/// | Everything else | unchanged |
-///
-/// The short `must-revalidate` policy for plain static paths ensures that
-/// returning visitors always fetch the latest file after a deploy, while the
-/// long `immutable` policy for fingerprinted files lets browsers skip the
-/// network entirely for assets whose content will never change.
-pub async fn asset_cache_control(
-    req: axum::extract::Request,
-    next: axum::middleware::Next,
-) -> axum::response::Response {
-    let path = req.uri().path().to_owned();
-    let mut resp = next.run(req).await;
-    if path.starts_with("/static/") && resp.status().is_success() {
-        // Use manifest membership rather than filename pattern so that
-        // user-authored assets like `vendor.deadbeef.js` are never given an
-        // immutable cache lifetime.
-        let is_immutable = path
-            .strip_prefix("/static/")
-            .is_some_and(crate::assets::is_manifest_asset);
-        let header = if is_immutable {
-            "public, max-age=31536000, immutable"
-        } else {
-            "public, max-age=0, must-revalidate"
-        };
-        resp.headers_mut().insert(
-            http::header::CACHE_CONTROL,
-            http::HeaderValue::from_static(header),
-        );
-    }
-    resp
 }
 
 #[cfg(feature = "htmx")]

--- a/autumn/tests/embed_assets_integration.rs
+++ b/autumn/tests/embed_assets_integration.rs
@@ -1,0 +1,149 @@
+//! Single-binary deploy proof for the `embed-assets` feature (issue #1004).
+//!
+//! Embeds a fixture `static/` tree (with its fingerprint manifest) and an
+//! `i18n/` bundle into this test binary, then drives a router **from an empty
+//! working directory** — proving that copying only the binary serves styled,
+//! localized pages with zero sidecar files.
+
+#![cfg(all(feature = "embed-assets", feature = "i18n"))]
+
+use std::sync::Arc;
+
+use autumn_web::i18n::{Bundle, I18nConfig, Locale};
+use autumn_web::include_dir::{Dir, include_dir};
+use axum::Extension;
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+use axum::response::Html;
+use axum::routing::get;
+use tower::ServiceExt;
+
+static STATIC: Dir = include_dir!("$CARGO_MANIFEST_DIR/tests/fixtures/embed/static");
+static LOCALES: Dir = include_dir!("$CARGO_MANIFEST_DIR/tests/fixtures/embed/i18n");
+
+/// Fingerprint of `body{color:#0a0}\n` — the first 8 hex of its SHA-256, exactly
+/// as `autumn build --embed` would compute. Kept in sync with the committed
+/// fixture `static/css/app.<hash>.css` and `.autumn-manifest.json`.
+const FINGERPRINTED: &str = "/static/css/app.79edc02e.css";
+
+fn config() -> I18nConfig {
+    I18nConfig {
+        default_locale: "en".to_owned(),
+        supported_locales: vec!["en".to_owned(), "es".to_owned()],
+        fallback_chain: vec![],
+        dir: "i18n".to_owned(),
+    }
+}
+
+async fn home(locale: Locale) -> Html<String> {
+    // `asset_url` must resolve against the embedded manifest (no disk read).
+    let css = autumn_web::assets::asset_url("css/app.css");
+    let greet = autumn_web::t!(locale, "greet");
+    Html(format!(
+        "<link rel=\"stylesheet\" href=\"{css}\"><p>{greet}</p>"
+    ))
+}
+
+fn app() -> axum::Router {
+    let bundle =
+        Arc::new(Bundle::load_from_embedded(&LOCALES, &config()).expect("embedded bundle"));
+    axum::Router::new()
+        .route("/", get(home))
+        .merge(autumn_web::assets::embedded_static_router())
+        .layer(Extension(bundle))
+}
+
+async fn body_string(resp: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+async fn get_path(app: &axum::Router, uri: &str) -> axum::response::Response {
+    app.clone()
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn single_binary_serves_styled_localized_pages_from_empty_dir() {
+    // Register the embedded static tree as the process-wide asset source.
+    autumn_web::assets::register_embedded_static(autumn_web::assets::EmbeddedStaticDir(&STATIC));
+
+    // Run from an empty directory: zero sidecar files present. Everything served
+    // below must come from the binary.
+    let empty = tempfile::tempdir().unwrap();
+    std::env::set_current_dir(empty.path()).unwrap();
+    assert_eq!(
+        std::fs::read_dir(empty.path()).unwrap().count(),
+        0,
+        "working directory must be empty — no static/ or i18n/ sidecars"
+    );
+
+    let app = app();
+
+    // 1. Home page renders the fingerprinted asset URL from the embedded manifest.
+    let resp = get_path(&app, "/").await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let html = body_string(resp).await;
+    assert!(
+        html.contains(FINGERPRINTED),
+        "home page must reference the embedded fingerprinted asset; got: {html}"
+    );
+    assert!(html.contains("Hello"), "default locale must render: {html}");
+
+    // 2. The fingerprinted asset itself serves 200 with the right content-type
+    //    and a year-long immutable cache lifetime (manifest membership).
+    let resp = get_path(&app, FINGERPRINTED).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "fingerprinted asset must 200"
+    );
+    assert_eq!(
+        resp.headers().get(header::CONTENT_TYPE).unwrap(),
+        "text/css; charset=utf-8"
+    );
+    assert!(
+        resp.headers()
+            .get(header::CACHE_CONTROL)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains("immutable"),
+        "fingerprinted asset must be immutable"
+    );
+    let expected_css = concat!("body{color:#0a0}", "\n");
+    assert_eq!(body_string(resp).await, expected_css);
+
+    // 3. The logical (non-fingerprinted) path also serves, but must-revalidate.
+    let resp = get_path(&app, "/static/css/app.css").await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(
+        resp.headers()
+            .get(header::CACHE_CONTROL)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains("must-revalidate"),
+        "non-fingerprinted asset must revalidate"
+    );
+
+    // 4. The embedded manifest itself must never be served to clients.
+    let resp = get_path(&app, "/static/.autumn-manifest.json").await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    // 5. A missing asset 404s rather than panicking.
+    let resp = get_path(&app, "/static/css/missing.css").await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    // 6. The non-default locale renders from the embedded bundle.
+    let resp = get_path(&app, "/?locale=es").await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(
+        body_string(resp).await.contains("Hola"),
+        "non-default locale must render from the embedded bundle"
+    );
+}

--- a/autumn/tests/fixtures/embed/i18n/en.ftl
+++ b/autumn/tests/fixtures/embed/i18n/en.ftl
@@ -1,0 +1,1 @@
+greet = Hello

--- a/autumn/tests/fixtures/embed/i18n/es.ftl
+++ b/autumn/tests/fixtures/embed/i18n/es.ftl
@@ -1,0 +1,1 @@
+greet = Hola

--- a/autumn/tests/fixtures/embed/static/.autumn-manifest.json
+++ b/autumn/tests/fixtures/embed/static/.autumn-manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "files": {
+    "css/app.css": "css/app.79edc02e.css"
+  }
+}

--- a/autumn/tests/fixtures/embed/static/css/app.79edc02e.css
+++ b/autumn/tests/fixtures/embed/static/css/app.79edc02e.css
@@ -1,0 +1,1 @@
+body{color:#0a0}

--- a/autumn/tests/fixtures/embed/static/css/app.css
+++ b/autumn/tests/fixtures/embed/static/css/app.css
@@ -1,0 +1,1 @@
+body{color:#0a0}

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -123,12 +123,11 @@ response looks like:
 rust:1.88.0-bookworm (chef stage)
   └─ cargo chef prepare          # snapshot dependency graph
        └─ cargo chef cook        # build all dependencies (cached layer)
-            └─ cargo build --release
+            └─ autumn build --embed         # fingerprint + embed assets
                  └─ debian:bookworm-slim (runtime stage)
                        libpq5, tini, ca-certificates, curl
-                       /usr/local/bin/myapp     ← your binary
-                       /app/static/             ← compiled Tailwind + assets
-                       /app/migrations/         ← SQL migration files
+                       /usr/local/bin/myapp     ← your binary (assets + locales embedded)
+                       /app/migrations/         ← SQL migration files (one-shot migrate job)
                        /app/autumn.toml         ← production config (host=0.0.0.0)
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
@@ -148,6 +147,71 @@ Key design decisions:
   binary binds to `0.0.0.0` (all interfaces) instead of the dev default
   `127.0.0.1`. Override any value at runtime via `AUTUMN_*` environment
   variables (see the [config reference](getting-started.md#configuration)).
+
+---
+
+## Single-binary deploys (embedded assets)
+
+Autumn's design pillar is **single binary deployment**: copy one file, run it, no
+sidecar directories. The generated release image delivers on this by **embedding**
+the app's `static/` tree (CSS/JS/fonts **and** the fingerprint manifest) and its
+i18n `i18n/` locale bundles into the binary at compile time — the same way Diesel
+migrations are embedded with `embed_migrations!`. With assets embedded:
+
+- `scp ./myapp host && ./myapp` serves styled, localized pages from an empty
+  directory — every referenced asset returns `200`, no `static/`/`i18n/` to stage.
+- `asset_url()` resolves against the embedded manifest (no disk read). The manifest
+  and the files are baked from the **same** build, so fingerprint-vs-manifest drift
+  is impossible.
+
+### How it works
+
+Embedding is an **opt-in, release-time** concern (a Cargo feature). In development
+— or whenever the feature is off — the app serves from disk so CSS/JS/translation
+hot-reload is unaffected.
+
+Generated apps are wired for it out of the box:
+
+```rust
+// src/main.rs (generated)
+#[cfg(feature = "embed-assets")]
+static EMBEDDED_STATIC: autumn_web::include_dir::Dir = autumn_web::embed_static!();
+
+#[autumn_web::main]
+async fn main() {
+    let app = autumn_web::app().routes(routes![/* … */]).migrations(MIGRATIONS);
+
+    #[cfg(feature = "embed-assets")]
+    let app = app.embedded_static(&EMBEDDED_STATIC);
+
+    app.run().await;
+}
+```
+
+```toml
+# Cargo.toml (generated)
+[features]
+embed-assets = ["autumn-web/embed-assets"]
+```
+
+i18n apps additionally embed locales via `embed_locales!()` /
+`.embedded_locales(&EMBEDDED_LOCALES)`.
+
+### Building
+
+```bash
+autumn build --embed
+```
+
+This fingerprints `static/` **before** compiling (so the manifest is baked in) and
+enables the `embed-assets` feature. The release `Dockerfile` runs exactly this and
+therefore **does not** `COPY static`/`i18n` into the runtime image — only
+`migrations/` is staged, for the one-shot `autumn migrate` job (the running server
+never reads it).
+
+> Adding embedding to an existing app: add the `[features]` block above, wire
+> `.embedded_static()` (and `.embedded_locales()` if you use i18n) behind
+> `#[cfg(feature = "embed-assets")]`, then build with `autumn build --embed`.
 
 ---
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -123,7 +123,7 @@ response looks like:
 rust:1.88.0-bookworm (chef stage)
   └─ cargo chef prepare          # snapshot dependency graph
        └─ cargo chef cook        # build all dependencies (cached layer)
-            └─ autumn build --embed         # fingerprint + embed assets
+            └─ autumn build --embed         # fingerprint + embed assets (embed-assets feature)
                  └─ debian:bookworm-slim (runtime stage)
                        libpq5, tini, ca-certificates, curl
                        /usr/local/bin/myapp     ← your binary (assets + locales embedded)
@@ -133,6 +133,9 @@ rust:1.88.0-bookworm (chef stage)
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/usr/local/bin/myapp"]
 ```
+
+> Projects without the `embed-assets` feature instead build with `cargo build
+> --release` and stage `/app/static/` — see [Single-binary deploys](#single-binary-deploys-embedded-assets).
 
 Key design decisions:
 
@@ -203,15 +206,19 @@ i18n apps additionally embed locales via `embed_locales!()` /
 autumn build --embed
 ```
 
-This fingerprints `static/` **before** compiling (so the manifest is baked in) and
-enables the `embed-assets` feature. The release `Dockerfile` runs exactly this and
-therefore **does not** `COPY static`/`i18n` into the runtime image — only
-`migrations/` is staged, for the one-shot `autumn migrate` job (the running server
-never reads it).
+This compiles your build scripts (e.g. Tailwind), fingerprints `static/`, then
+recompiles with the `embed-assets` feature so the manifest and assets are baked in.
+
+`autumn release init` detects the `embed-assets` feature in your `Cargo.toml`: when
+present it emits a release `Dockerfile` that runs `autumn build --embed` and **does
+not** `COPY static`/`i18n` into the runtime image (only `migrations/` is staged, for
+the one-shot `autumn migrate` job). Projects without the feature get the disk-based
+build (`cargo build --release` + `COPY static`) so their Docker builds keep working.
 
 > Adding embedding to an existing app: add the `[features]` block above, wire
 > `.embedded_static()` (and `.embedded_locales()` if you use i18n) behind
-> `#[cfg(feature = "embed-assets")]`, then build with `autumn build --embed`.
+> `#[cfg(feature = "embed-assets")]`, then re-run `autumn release init --force` and
+> build with `autumn build --embed`.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR implements single-binary deployment for Autumn apps by embedding the `static/` directory (including the fingerprint manifest) and i18n locale bundles directly into the release binary at compile time. Apps can now be deployed by copying a single executable with zero sidecar files.

## Key Changes

**Core Asset Embedding (`autumn/src/assets.rs`)**
- Added `EmbeddedStaticDir` wrapper type for compile-time embedded directories
- Implemented `register_embedded_static()` to register the embedded tree as the process-wide asset source
- Added `embedded_manifest_lookup()` and `embedded_is_manifest_asset()` for manifest resolution against embedded files
- Implemented `serve_embedded()` handler and `embedded_static_router()` for serving `/static/*` from the binary
- Added `content_type_for()` to derive MIME types from file extensions
- Moved `asset_cache_control` middleware from `router.rs` to `assets.rs` for reuse by both disk and embedded serving paths
- Updated `asset_url()` and `is_manifest_asset()` to consult the embedded manifest first when available

**App Builder Integration (`autumn/src/app.rs`)**
- Added `embedded_static()` builder method to register an embedded `static/` directory
- Added `embedded_locales()` builder method to register embedded i18n bundles
- Integrated embedded asset registration into the `run()` lifecycle before router construction
- Embedded locales take precedence over disk auto-loading when no explicit bundle is provided

**i18n Support (`autumn/src/i18n.rs`)**
- Implemented `Bundle::load_from_embedded()` to load locale files from an embedded directory
- Mirrors the behavior of `load_from_dir()` but reads from binary instead of disk

**Macros and Re-exports (`autumn/src/lib.rs`)**
- Added `embed_static!()` macro to embed the `static/` directory at compile time
- Added `embed_locales!()` macro to embed i18n locale bundles (with optional custom directory)
- Re-exported `include_dir` crate under `autumn_web::include_dir` for macro expansion

**Build System (`autumn-cli/src/build.rs`)**
- Added `--embed` flag to `autumn build` command
- Implemented pre-compile fingerprinting for embedded builds (so manifest is baked into binary)
- Skips static renderer for embedded builds (single-binary, not static site generation)
- Factored `build_cargo_command()` to enable `embed-assets` feature when `--embed` is used

**CLI Updates (`autumn-cli/src/main.rs`)**
- Added `--embed` flag to the `build` subcommand
- Updated tests to account for the new flag

**Code Generation (`autumn-cli/src/new.rs`, `autumn-cli/src/templates/`)**
- Updated generated `main.rs` to include `embed_static!()` and conditionally `embed_locales!()`
- Wired `.embedded_static()` and `.embedded_locales()` calls behind `#[cfg(feature = "embed-assets")]`
- Updated generated `Cargo.toml` with `embed-assets` feature definition
- Updated `Dockerfile` to use `autumn build --embed` instead of `cargo build --release`
- Removed `COPY static` and `i18n` from runtime image (assets now embedded)

**Router Integration (`autumn/src/router.rs`)**
- Updated static file serving to use embedded handler when available, falling back to disk serving
- Removed duplicate `asset_cache_control` definition (now in `assets.rs`)

**Documentation (`docs/guide/deployment.md`)**
- Added comprehensive "Single-binary deploys (embedded assets)" section
- Documented how embedding works, build process, and integration steps
- Updated deployment architecture diagrams to reflect embedded assets

**Testing**
- Added `embed_assets_integration.rs` test demonstrating single-binary deployment
- Test embeds fixture `static/` and `i18n/` trees, runs from empty directory, verifies all assets serve correctly
- Added `content_type_covers_common_assets()` unit test

https://claude.ai/code/session_01FKisMRpfd3orR4JKcCbeoc