### PR TITLE
🛡️ Sentry: [test coverage improvement] Fix TickingClock::advance panic on large delta

### DIFF
--- a/autumn/src/time.rs
+++ b/autumn/src/time.rs
@@ -318,7 +318,7 @@ mod tests {
         let clock = TickingClock::starting_at(start);
 
         // This duration is large enough to overflow the chrono::Duration if directly added
-        let max_dur = std::time::Duration::from_secs(10000000000000);
+        let max_dur = std::time::Duration::from_secs(10_000_000_000_000);
         clock.advance(max_dur);
         assert_eq!(clock.now(), DateTime::<Utc>::MAX_UTC);
     }

--- a/autumn/src/time.rs
+++ b/autumn/src/time.rs
@@ -204,7 +204,11 @@ impl TickingClock {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if let Ok(delta) = chrono::Duration::from_std(duration) {
-            *guard += delta;
+            if let Some(new_time) = guard.checked_add_signed(delta) {
+                *guard = new_time;
+            } else {
+                *guard = DateTime::<Utc>::MAX_UTC;
+            }
         }
     }
 }
@@ -306,5 +310,16 @@ mod tests {
         let pre_epoch = Utc.with_ymd_and_hms(1969, 12, 31, 23, 59, 59).unwrap();
         let clock = FixedClock::at(pre_epoch);
         assert_eq!(clock_unix_duration(&clock), std::time::Duration::ZERO);
+    }
+
+    #[test]
+    fn ticking_clock_advance_overflow_saturates_to_max() {
+        let start = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+        let clock = TickingClock::starting_at(start);
+
+        // This duration is large enough to overflow the chrono::Duration if directly added
+        let max_dur = std::time::Duration::from_secs(10000000000000);
+        clock.advance(max_dur);
+        assert_eq!(clock.now(), DateTime::<Utc>::MAX_UTC);
     }
 }


### PR DESCRIPTION
🎯 Target: `autumn_web::time::TickingClock::advance`
💣 Risk: Adding exceptionally large time deltas panics the thread because `chrono`'s `AddAssign` checks for overflow and calls `expect()`. This is particularly dangerous in testing or fuzzing scenarios with mock clocks.
🧪 Strategy: Replaced the `+=` operator with `checked_add_signed` and saturated the overflow result to `DateTime::<Utc>::MAX_UTC`. Created a dedicated unit test `ticking_clock_advance_overflow_saturates_to_max` that explicitly exercises this failure state and ensures no panic occurs.
🔬 Verification: `cargo test -p autumn-web --lib time::tests`

---
*PR created automatically by Jules for task [2083479440181476650](https://jules.google.com/task/2083479440181476650) started by @madmax983*