### PR TITLE
Add `autumn assets` command for pinning and vendoring JS dependencies

### DIFF
--- a/autumn-cli/Cargo.toml
+++ b/autumn-cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 autumn-web = { version = "0.5.0", path = "../autumn", default-features = false, features = ["db", "htmx", "maud"] }
+base64 = "0.22"
 clap = { version = "4", features = ["derive", "env"] }
 diesel = { workspace = true }
 crossterm = "0.29"

--- a/autumn-cli/src/assets.rs
+++ b/autumn-cli/src/assets.rs
@@ -50,6 +50,9 @@ pub enum AssetsError {
 
     #[error("manifest parse error: {0}")]
     Parse(String),
+
+    #[error("update failed: {0}")]
+    UpdateFailed(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -216,11 +219,18 @@ impl Default for VendorManifest {
     }
 }
 
-pub fn load_manifest(path: &Path) -> VendorManifest {
-    fs::read_to_string(path)
-        .ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_default()
+/// Load the vendor manifest from `path`.
+///
+/// Returns a default (empty) manifest when the file does not exist, but
+/// propagates a parse error when the file exists with invalid JSON — otherwise
+/// a corrupt manifest (e.g. from a merge conflict) would silently become empty
+/// and the next `save_manifest` would overwrite every other pinned asset.
+pub fn load_manifest(path: &Path) -> Result<VendorManifest, AssetsError> {
+    if !path.exists() {
+        return Ok(VendorManifest::default());
+    }
+    let s = fs::read_to_string(path)?;
+    serde_json::from_str(&s).map_err(|e| AssetsError::Parse(e.to_string()))
 }
 
 pub fn save_manifest(path: &Path, manifest: &VendorManifest) -> Result<(), AssetsError> {
@@ -275,7 +285,7 @@ pub fn run_verify(manifest_path: &Path, static_dir: &Path) {
 }
 
 pub fn verify_all(manifest_path: &Path, static_dir: &Path) -> Result<(), AssetsError> {
-    let manifest = load_manifest(manifest_path);
+    let manifest = load_manifest(manifest_path)?;
     if manifest.assets.is_empty() {
         println!("No vendored assets recorded in {}", manifest_path.display());
         return Ok(());
@@ -335,7 +345,7 @@ fn execute_add(spec: &str, url_override: Option<&str>) -> Result<(), AssetsError
     write_atomic(&bytes, &dest)?;
 
     let manifest_path = PathBuf::from(VENDOR_MANIFEST_PATH);
-    let mut manifest = load_manifest(&manifest_path);
+    let mut manifest = load_manifest(&manifest_path)?;
     manifest.assets.insert(
         name.clone(),
         VendorAsset {
@@ -355,7 +365,13 @@ fn execute_add(spec: &str, url_override: Option<&str>) -> Result<(), AssetsError
 
 pub fn run_list() {
     let manifest_path = PathBuf::from(VENDOR_MANIFEST_PATH);
-    let manifest = load_manifest(&manifest_path);
+    let manifest = match load_manifest(&manifest_path) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("Error loading manifest: {e}");
+            std::process::exit(1);
+        }
+    };
     if manifest.assets.is_empty() {
         println!("No vendored assets. Run `autumn assets add <name>@<version>` to add one.");
         return;
@@ -388,7 +404,7 @@ fn execute_update_with_manifest(
     manifest_path: &Path,
     static_dir: &Path,
 ) -> Result<(), AssetsError> {
-    let mut manifest = load_manifest(manifest_path);
+    let mut manifest = load_manifest(manifest_path)?;
 
     let to_update: Vec<(String, String, String, String)> = match name_spec {
         None => {
@@ -416,7 +432,7 @@ fn execute_update_with_manifest(
                 } else {
                     // Package was added with `--url`; we cannot derive the new
                     // version's URL automatically.  The user must re-add it:
-                    return Err(AssetsError::UnknownPackage(format!(
+                    return Err(AssetsError::UpdateFailed(format!(
                         "{name} was added with --url and is not in the built-in registry; \
                          re-pin with `autumn assets add {name}@{version} --url <url>`"
                     )));
@@ -580,11 +596,47 @@ mod tests {
             },
         );
         save_manifest(tmp.path(), &manifest).unwrap();
-        let loaded = load_manifest(tmp.path());
+        let loaded = load_manifest(tmp.path()).unwrap();
         assert_eq!(loaded.assets.len(), 1);
         let htmx = loaded.assets.get("htmx").unwrap();
         assert_eq!(htmx.version, "2.0.4");
         assert_eq!(htmx.integrity, "sha384-abc");
+    }
+
+    #[test]
+    fn load_manifest_missing_file_returns_default() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let missing = tmp_dir.path().join("does-not-exist.json");
+        let manifest = load_manifest(&missing).unwrap();
+        assert!(manifest.assets.is_empty());
+        assert_eq!(manifest.version, "1");
+    }
+
+    #[test]
+    fn load_manifest_corrupt_json_propagates_error() {
+        // A corrupt manifest (e.g. from a merge conflict) must NOT silently
+        // become an empty manifest — otherwise a subsequent save would wipe
+        // every other pinned asset.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        fs::write(tmp.path(), b"{ this is not valid json <<<<<<< HEAD").unwrap();
+        let err = load_manifest(tmp.path()).unwrap_err();
+        assert!(
+            matches!(err, AssetsError::Parse(_)),
+            "expected Parse error for corrupt manifest, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_all_errors_on_corrupt_manifest() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let static_dir = tmp_dir.path().to_path_buf();
+        let manifest_path = static_dir.join(".autumn-assets.json");
+        fs::write(&manifest_path, b"not json").unwrap();
+        let result = verify_all(&manifest_path, &static_dir);
+        assert!(
+            matches!(result, Err(AssetsError::Parse(_))),
+            "verify must surface a parse error rather than report an empty manifest"
+        );
     }
 
     // --- verify detects tampering ---
@@ -685,8 +737,12 @@ mod tests {
         // Attempting to re-pin with @version should fail with a clear message.
         let result =
             execute_update_with_manifest(Some("my-custom-lib@2.0.0"), &manifest_path, &static_dir);
-        assert!(result.is_err(), "expected error for --url package re-pin");
-        let msg = result.unwrap_err().to_string();
+        let err = result.expect_err("expected error for --url package re-pin");
+        assert!(
+            matches!(err, AssetsError::UpdateFailed(_)),
+            "expected UpdateFailed variant, got: {err:?}"
+        );
+        let msg = err.to_string();
         assert!(msg.contains("--url"), "error should mention --url: {msg}");
         assert!(
             msg.contains("my-custom-lib"),

--- a/autumn-cli/src/assets.rs
+++ b/autumn-cli/src/assets.rs
@@ -1,0 +1,654 @@
+//! `autumn assets` — pin, vendor, and integrity-verify JS dependencies.
+//!
+//! Downloads JS files into `static/js/`, computes a sha384 SRI hash, and
+//! records `name → version → source URL → integrity` in
+//! `static/.autumn-assets.json`. No Node/npm required; vendored files are
+//! committed so release builds never touch the network.
+//!
+//! # Commands
+//!
+//! - `autumn assets add htmx@2.0.4` — download, hash, record.
+//! - `autumn assets list`            — print pinned deps.
+//! - `autumn assets update [name]`   — re-pin to recorded or new version.
+//! - `autumn assets verify`          — recompute hashes and compare.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use base64::Engine as _;
+use indicatif::{ProgressBar, ProgressStyle};
+use sha2::{Digest, Sha384};
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, thiserror::Error)]
+pub enum AssetsError {
+    #[error("download failed: {0}")]
+    Download(#[from] reqwest::Error),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("integrity mismatch for {name}: expected {expected}, got {actual}")]
+    IntegrityMismatch {
+        name: String,
+        expected: String,
+        actual: String,
+    },
+
+    #[error(
+        "unknown package `{0}`; use `--url` to specify a download URL, \
+         or choose from the built-in registry: htmx, alpinejs, htmx-ext-sse, htmx-ext-ws"
+    )]
+    UnknownPackage(String),
+
+    #[error("bad spec `{0}`: expected `<name>@<version>` (e.g. `htmx@2.0.4`)")]
+    BadSpec(String),
+
+    #[error("manifest parse error: {0}")]
+    Parse(String),
+}
+
+// ---------------------------------------------------------------------------
+// Built-in package registry
+// ---------------------------------------------------------------------------
+
+/// A known package entry: npm package name, dist-relative path, output filename.
+struct RegistryEntry {
+    /// npm package name on jsdelivr.
+    npm_pkg: &'static str,
+    /// Path within the npm package to the dist file.
+    dist_path: &'static str,
+    /// Filename written to `static/js/`.
+    output_file: &'static str,
+}
+
+const fn registry() -> &'static [(&'static str, RegistryEntry)] {
+    &[
+        (
+            "htmx",
+            RegistryEntry {
+                npm_pkg: "htmx.org",
+                dist_path: "dist/htmx.min.js",
+                output_file: "htmx.min.js",
+            },
+        ),
+        (
+            "alpinejs",
+            RegistryEntry {
+                npm_pkg: "alpinejs",
+                dist_path: "dist/cdn.min.js",
+                output_file: "alpine.min.js",
+            },
+        ),
+        (
+            "htmx-ext-sse",
+            RegistryEntry {
+                npm_pkg: "htmx-ext-sse",
+                dist_path: "dist/sse.min.js",
+                output_file: "htmx-ext-sse.min.js",
+            },
+        ),
+        (
+            "htmx-ext-ws",
+            RegistryEntry {
+                npm_pkg: "htmx-ext-ws",
+                dist_path: "dist/ws.min.js",
+                output_file: "htmx-ext-ws.min.js",
+            },
+        ),
+    ]
+}
+
+/// Resolve name+version to a download URL and output file path relative to `static/`.
+///
+/// If `url_override` is `Some`, it is used directly as the source; the output
+/// file is derived from the registry when the name is known, or from the URL
+/// basename otherwise.
+pub fn resolve_source(
+    name: &str,
+    version: &str,
+    url_override: Option<&str>,
+) -> Result<(String, String), AssetsError> {
+    let entry = registry().iter().find(|(k, _)| *k == name).map(|(_, e)| e);
+    url_override.map_or_else(
+        || {
+            entry.map_or_else(
+                || Err(AssetsError::UnknownPackage(name.to_owned())),
+                |e| {
+                    let url = format!(
+                        "https://cdn.jsdelivr.net/npm/{}@{}/{}",
+                        e.npm_pkg, version, e.dist_path
+                    );
+                    Ok((url, format!("js/{}", e.output_file)))
+                },
+            )
+        },
+        |url| {
+            let file_rel = entry.map_or_else(
+                || {
+                    let basename = url.rsplit('/').next().unwrap_or("asset.js");
+                    format!("js/{basename}")
+                },
+                |e| format!("js/{}", e.output_file),
+            );
+            Ok((url.to_owned(), file_rel))
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Spec parsing
+// ---------------------------------------------------------------------------
+
+/// Parse `"htmx@2.0.4"` into `("htmx", "2.0.4")`.
+pub fn parse_spec(spec: &str) -> Result<(String, String), AssetsError> {
+    let mut parts = spec.splitn(2, '@');
+    let name = parts.next().unwrap_or_default().trim().to_owned();
+    let version = parts
+        .next()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| AssetsError::BadSpec(spec.to_owned()))?
+        .to_owned();
+    if name.is_empty() {
+        return Err(AssetsError::BadSpec(spec.to_owned()));
+    }
+    Ok((name, version))
+}
+
+// ---------------------------------------------------------------------------
+// SRI computation
+// ---------------------------------------------------------------------------
+
+/// Compute a `sha384-<base64>` SRI hash for `bytes`.
+pub fn compute_sri(bytes: &[u8]) -> String {
+    let digest = Sha384::digest(bytes);
+    let b64 = base64::engine::general_purpose::STANDARD.encode(digest);
+    format!("sha384-{b64}")
+}
+
+// ---------------------------------------------------------------------------
+// Manifest
+// ---------------------------------------------------------------------------
+
+/// Path of the vendor manifest relative to the project root.
+pub const VENDOR_MANIFEST_PATH: &str = "static/.autumn-assets.json";
+
+/// In-memory vendor manifest — mirrors the framework's `VendorManifest`.
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct VendorManifest {
+    pub version: String,
+    pub assets: BTreeMap<String, VendorAsset>,
+}
+
+/// Metadata for one vendored asset — mirrors the framework's `VendorAsset`.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct VendorAsset {
+    pub version: String,
+    pub source: String,
+    pub file: String,
+    pub integrity: String,
+}
+
+impl Default for VendorManifest {
+    fn default() -> Self {
+        Self {
+            version: "1".into(),
+            assets: BTreeMap::new(),
+        }
+    }
+}
+
+pub fn load_manifest(path: &Path) -> VendorManifest {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+pub fn save_manifest(path: &Path, manifest: &VendorManifest) -> Result<(), AssetsError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let json =
+        serde_json::to_string_pretty(manifest).map_err(|e| AssetsError::Parse(e.to_string()))?;
+    fs::write(path, json + "\n")?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Download helper
+// ---------------------------------------------------------------------------
+
+pub fn download_bytes(url: &str) -> Result<Vec<u8>, AssetsError> {
+    let response = reqwest::blocking::Client::new()
+        .get(url)
+        .send()?
+        .error_for_status()?;
+
+    let total = response.content_length().unwrap_or(0);
+    let pb = ProgressBar::new(total);
+    pb.set_style(
+        ProgressStyle::with_template("  [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+            .expect("valid progress template")
+            .progress_chars("=> "),
+    );
+
+    let bytes = response.bytes()?;
+    pb.set_length(bytes.len() as u64);
+    pb.finish_and_clear();
+    Ok(bytes.to_vec())
+}
+
+/// Write `bytes` to `dest` atomically via a temp file so a failed write never
+/// leaves a corrupt or partial file in place.
+pub fn write_atomic(bytes: &[u8], dest: &Path) -> Result<(), AssetsError> {
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = dest.with_extension("tmp");
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(bytes)?;
+        f.flush()?;
+    }
+    fs::rename(&tmp, dest)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Verify
+// ---------------------------------------------------------------------------
+
+/// Verify all vendored files in the manifest against their recorded integrity.
+///
+/// Exits non-zero on the first mismatch; reports all mismatches before
+/// exiting so the user can see every broken file at once.
+pub fn run_verify(manifest_path: &Path, static_dir: &Path) {
+    if let Err(e) = verify_all(manifest_path, static_dir) {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+}
+
+pub fn verify_all(manifest_path: &Path, static_dir: &Path) -> Result<(), AssetsError> {
+    let manifest = load_manifest(manifest_path);
+    if manifest.assets.is_empty() {
+        println!("No vendored assets recorded in {}", manifest_path.display());
+        return Ok(());
+    }
+    let mut ok = true;
+    for (name, asset) in &manifest.assets {
+        let file_path = static_dir.join(&asset.file);
+        match fs::read(&file_path) {
+            Err(e) => {
+                eprintln!("  MISSING  {name} — {}: {e}", file_path.display());
+                ok = false;
+            }
+            Ok(bytes) => {
+                let actual = compute_sri(&bytes);
+                if actual == asset.integrity {
+                    println!("  OK       {name}  {}", asset.integrity);
+                } else {
+                    eprintln!("  TAMPERED {name}");
+                    eprintln!("    expected: {}", asset.integrity);
+                    eprintln!("    actual:   {actual}");
+                    ok = false;
+                }
+            }
+        }
+    }
+    if ok {
+        Ok(())
+    } else {
+        Err(AssetsError::IntegrityMismatch {
+            name: "one or more assets".into(),
+            expected: "(see above)".into(),
+            actual: "(see above)".into(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public command runners
+// ---------------------------------------------------------------------------
+
+pub fn run_add(spec: &str, url_override: Option<&str>) {
+    if let Err(e) = execute_add(spec, url_override) {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn execute_add(spec: &str, url_override: Option<&str>) -> Result<(), AssetsError> {
+    let (name, version) = parse_spec(spec)?;
+    let (source_url, file_rel) = resolve_source(&name, &version, url_override)?;
+
+    println!("Downloading {name} {version}...");
+    let bytes = download_bytes(&source_url)?;
+    let sri = compute_sri(&bytes);
+
+    let dest = PathBuf::from("static").join(&file_rel);
+    write_atomic(&bytes, &dest)?;
+
+    let manifest_path = PathBuf::from(VENDOR_MANIFEST_PATH);
+    let mut manifest = load_manifest(&manifest_path);
+    manifest.assets.insert(
+        name.clone(),
+        VendorAsset {
+            version: version.clone(),
+            source: source_url,
+            file: file_rel,
+            integrity: sri.clone(),
+        },
+    );
+    save_manifest(&manifest_path, &manifest)?;
+
+    println!("  Added {name} {version}");
+    println!("  Integrity: {sri}");
+    println!("  Manifest:  {}", manifest_path.display());
+    Ok(())
+}
+
+pub fn run_list() {
+    let manifest_path = PathBuf::from(VENDOR_MANIFEST_PATH);
+    let manifest = load_manifest(&manifest_path);
+    if manifest.assets.is_empty() {
+        println!("No vendored assets. Run `autumn assets add <name>@<version>` to add one.");
+        return;
+    }
+    println!("{:<20} {:<12} INTEGRITY", "NAME", "VERSION");
+    println!("{}", "-".repeat(80));
+    for (name, asset) in &manifest.assets {
+        println!("{:<20} {:<12} {}", name, asset.version, asset.integrity);
+    }
+}
+
+pub fn run_update(name: Option<&str>) {
+    if let Err(e) = execute_update(name) {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn execute_update(name_spec: Option<&str>) -> Result<(), AssetsError> {
+    let manifest_path = PathBuf::from(VENDOR_MANIFEST_PATH);
+    let mut manifest = load_manifest(&manifest_path);
+
+    let to_update: Vec<(String, String, String, String)> = match name_spec {
+        None => {
+            // Update all.
+            manifest
+                .assets
+                .iter()
+                .map(|(n, a)| {
+                    (
+                        n.clone(),
+                        a.version.clone(),
+                        a.source.clone(),
+                        a.file.clone(),
+                    )
+                })
+                .collect()
+        }
+        Some(spec) => {
+            if spec.contains('@') {
+                // Re-pin to a different version.
+                let (name, version) = parse_spec(spec)?;
+                let existing = manifest
+                    .assets
+                    .get(&name)
+                    .map(|a| a.file.clone())
+                    .ok_or_else(|| AssetsError::UnknownPackage(name.clone()));
+                let (source_url, file_rel) = resolve_source(&name, &version, None)?;
+                // If the name isn't in registry but is in manifest, use existing file path.
+                let file_rel = match existing {
+                    Ok(f) if source_url.contains(&name) => f,
+                    _ => file_rel,
+                };
+                vec![(name, version, source_url, file_rel)]
+            } else {
+                // Refresh the existing pinned version.
+                let asset = manifest
+                    .assets
+                    .get(spec)
+                    .ok_or_else(|| AssetsError::UnknownPackage(spec.to_owned()))?;
+                vec![(
+                    spec.to_owned(),
+                    asset.version.clone(),
+                    asset.source.clone(),
+                    asset.file.clone(),
+                )]
+            }
+        }
+    };
+
+    for (name, version, source_url, file_rel) in to_update {
+        println!("Updating {name} → {version}...");
+        let bytes = download_bytes(&source_url)?;
+        let sri = compute_sri(&bytes);
+        let dest = PathBuf::from("static").join(&file_rel);
+        write_atomic(&bytes, &dest)?;
+        manifest.assets.insert(
+            name.clone(),
+            VendorAsset {
+                version: version.clone(),
+                source: source_url,
+                file: file_rel,
+                integrity: sri.clone(),
+            },
+        );
+        println!("  Updated {name} {version}  {sri}");
+    }
+
+    save_manifest(&manifest_path, &manifest)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    // --- parse_spec ---
+
+    #[test]
+    fn parse_spec_happy_path() {
+        let (name, version) = parse_spec("htmx@2.0.4").unwrap();
+        assert_eq!(name, "htmx");
+        assert_eq!(version, "2.0.4");
+    }
+
+    #[test]
+    fn parse_spec_with_prerelease() {
+        let (name, version) = parse_spec("alpinejs@3.14.1").unwrap();
+        assert_eq!(name, "alpinejs");
+        assert_eq!(version, "3.14.1");
+    }
+
+    #[test]
+    fn parse_spec_missing_version_errors() {
+        let err = parse_spec("htmx").unwrap_err();
+        assert!(matches!(err, AssetsError::BadSpec(_)));
+        assert!(err.to_string().contains("htmx"));
+    }
+
+    #[test]
+    fn parse_spec_empty_string_errors() {
+        assert!(parse_spec("").is_err());
+        assert!(parse_spec("@").is_err());
+    }
+
+    // --- resolve_source ---
+
+    #[test]
+    fn resolve_htmx_builds_jsdelivr_url() {
+        let (url, file) = resolve_source("htmx", "2.0.4", None).unwrap();
+        assert!(
+            url.contains("htmx.org@2.0.4"),
+            "URL should contain package@version: {url}"
+        );
+        assert!(
+            url.contains("jsdelivr"),
+            "URL should be from jsdelivr: {url}"
+        );
+        assert_eq!(file, "js/htmx.min.js");
+    }
+
+    #[test]
+    fn resolve_alpinejs_builds_jsdelivr_url() {
+        let (url, file) = resolve_source("alpinejs", "3.14.1", None).unwrap();
+        assert!(url.contains("alpinejs@3.14.1"), "{url}");
+        assert_eq!(file, "js/alpine.min.js");
+    }
+
+    #[test]
+    fn resolve_unknown_without_url_errors() {
+        let err = resolve_source("__not_in_registry__", "1.0.0", None).unwrap_err();
+        assert!(matches!(err, AssetsError::UnknownPackage(_)));
+    }
+
+    #[test]
+    fn resolve_url_override_for_known_package() {
+        let custom = "https://example.com/htmx.custom.js";
+        let (url, file) = resolve_source("htmx", "2.0.4", Some(custom)).unwrap();
+        assert_eq!(url, custom);
+        assert_eq!(file, "js/htmx.min.js"); // still uses the registry output name
+    }
+
+    #[test]
+    fn resolve_url_override_for_unknown_package() {
+        let custom = "https://example.com/my-lib.min.js";
+        let (url, file) = resolve_source("my-lib", "1.0.0", Some(custom)).unwrap();
+        assert_eq!(url, custom);
+        assert_eq!(file, "js/my-lib.min.js");
+    }
+
+    // --- compute_sri ---
+
+    #[test]
+    fn compute_sri_empty_input_known_value() {
+        // SHA-384 of empty string, base64-encoded.
+        let sri = compute_sri(b"");
+        assert_eq!(
+            sri,
+            "sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"
+        );
+    }
+
+    #[test]
+    fn compute_sri_prefix() {
+        assert!(compute_sri(b"hello").starts_with("sha384-"));
+    }
+
+    #[test]
+    fn compute_sri_deterministic() {
+        assert_eq!(compute_sri(b"data"), compute_sri(b"data"));
+    }
+
+    // --- manifest round-trip ---
+
+    #[test]
+    fn manifest_json_round_trip() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let mut manifest = VendorManifest::default();
+        manifest.assets.insert(
+            "htmx".into(),
+            VendorAsset {
+                version: "2.0.4".into(),
+                source: "https://cdn.jsdelivr.net/npm/htmx.org@2.0.4/dist/htmx.min.js".into(),
+                file: "js/htmx.min.js".into(),
+                integrity: "sha384-abc".into(),
+            },
+        );
+        save_manifest(tmp.path(), &manifest).unwrap();
+        let loaded = load_manifest(tmp.path());
+        assert_eq!(loaded.assets.len(), 1);
+        let htmx = loaded.assets.get("htmx").unwrap();
+        assert_eq!(htmx.version, "2.0.4");
+        assert_eq!(htmx.integrity, "sha384-abc");
+    }
+
+    // --- verify detects tampering ---
+
+    #[test]
+    fn verify_detects_tampered_file() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let static_dir = tmp_dir.path().to_path_buf();
+        let js_dir = static_dir.join("js");
+        fs::create_dir_all(&js_dir).unwrap();
+
+        // Write a file with known content.
+        let original = b"console.log('htmx');";
+        let good_sri = compute_sri(original);
+        fs::write(js_dir.join("htmx.min.js"), original).unwrap();
+
+        // Record the good hash in the manifest.
+        let manifest_path = static_dir.join(".autumn-assets.json");
+        let mut manifest = VendorManifest::default();
+        manifest.assets.insert(
+            "htmx".into(),
+            VendorAsset {
+                version: "2.0.4".into(),
+                source: "https://example.com".into(),
+                file: "js/htmx.min.js".into(),
+                integrity: good_sri,
+            },
+        );
+        save_manifest(&manifest_path, &manifest).unwrap();
+
+        // Tamper the file.
+        fs::write(js_dir.join("htmx.min.js"), b"console.log('evil');").unwrap();
+
+        // Verify should fail.
+        let result = verify_all(&manifest_path, &static_dir);
+        assert!(result.is_err(), "expected verify to fail after tampering");
+    }
+
+    #[test]
+    fn verify_passes_for_good_file() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let static_dir = tmp_dir.path().to_path_buf();
+        let js_dir = static_dir.join("js");
+        fs::create_dir_all(&js_dir).unwrap();
+
+        let content = b"console.log('htmx');";
+        let sri = compute_sri(content);
+        fs::write(js_dir.join("htmx.min.js"), content).unwrap();
+
+        let manifest_path = static_dir.join(".autumn-assets.json");
+        let mut manifest = VendorManifest::default();
+        manifest.assets.insert(
+            "htmx".into(),
+            VendorAsset {
+                version: "2.0.4".into(),
+                source: "https://example.com".into(),
+                file: "js/htmx.min.js".into(),
+                integrity: sri,
+            },
+        );
+        save_manifest(&manifest_path, &manifest).unwrap();
+
+        let result = verify_all(&manifest_path, &static_dir);
+        assert!(result.is_ok(), "expected verify to pass");
+    }
+
+    #[test]
+    fn write_atomic_does_not_leave_partial_on_rename() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let dest = tmp_dir.path().join("out.js");
+        write_atomic(b"data", &dest).unwrap();
+        assert_eq!(fs::read(&dest).unwrap(), b"data");
+        // No leftover .tmp file.
+        assert!(!dest.with_extension("tmp").exists());
+    }
+}

--- a/autumn-cli/src/assets.rs
+++ b/autumn-cli/src/assets.rs
@@ -18,7 +18,6 @@ use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use base64::Engine as _;
-use indicatif::{ProgressBar, ProgressStyle};
 use sha2::{Digest, Sha384};
 
 // ---------------------------------------------------------------------------
@@ -131,11 +130,24 @@ pub fn resolve_source(
         |url| {
             let file_rel = entry.map_or_else(
                 || {
-                    let basename = url.rsplit('/').next().unwrap_or("asset.js");
-                    format!("js/{basename}")
+                    // Parse the URL properly so query strings and fragments are
+                    // stripped before deriving the output filename.
+                    let basename = ::url::Url::parse(url)
+                        .ok()
+                        .and_then(|u| {
+                            u.path_segments()
+                                .and_then(|mut segs| segs.next_back().map(str::to_owned))
+                        })
+                        .filter(|s| !s.is_empty() && !s.contains(".."))
+                        .ok_or_else(|| {
+                            AssetsError::BadSpec(format!(
+                                "cannot derive a safe filename from URL: {url}"
+                            ))
+                        })?;
+                    Ok::<String, AssetsError>(format!("js/{basename}"))
                 },
-                |e| format!("js/{}", e.output_file),
-            );
+                |e| Ok(format!("js/{}", e.output_file)),
+            )?;
             Ok((url.to_owned(), file_rel))
         },
     )
@@ -225,24 +237,10 @@ pub fn save_manifest(path: &Path, manifest: &VendorManifest) -> Result<(), Asset
 // Download helper
 // ---------------------------------------------------------------------------
 
+/// Download `url` and return the bytes.  Delegates to [`crate::http::fetch_bytes`]
+/// so progress-bar logic is shared with `autumn setup`.
 pub fn download_bytes(url: &str) -> Result<Vec<u8>, AssetsError> {
-    let response = reqwest::blocking::Client::new()
-        .get(url)
-        .send()?
-        .error_for_status()?;
-
-    let total = response.content_length().unwrap_or(0);
-    let pb = ProgressBar::new(total);
-    pb.set_style(
-        ProgressStyle::with_template("  [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")
-            .expect("valid progress template")
-            .progress_chars("=> "),
-    );
-
-    let bytes = response.bytes()?;
-    pb.set_length(bytes.len() as u64);
-    pb.finish_and_clear();
-    Ok(bytes.to_vec())
+    Ok(crate::http::fetch_bytes(url)?)
 }
 
 /// Write `bytes` to `dest` atomically via a temp file so a failed write never
@@ -378,7 +376,19 @@ pub fn run_update(name: Option<&str>) {
 
 fn execute_update(name_spec: Option<&str>) -> Result<(), AssetsError> {
     let manifest_path = PathBuf::from(VENDOR_MANIFEST_PATH);
-    let mut manifest = load_manifest(&manifest_path);
+    execute_update_with_manifest(name_spec, &manifest_path, Path::new("static"))
+}
+
+/// Testable core of `run_update`: resolves, downloads, and re-pins assets.
+///
+/// Separated from [`execute_update`] so tests can point at a temp directory
+/// without touching the real `static/` tree.
+fn execute_update_with_manifest(
+    name_spec: Option<&str>,
+    manifest_path: &Path,
+    static_dir: &Path,
+) -> Result<(), AssetsError> {
+    let mut manifest = load_manifest(manifest_path);
 
     let to_update: Vec<(String, String, String, String)> = match name_spec {
         None => {
@@ -400,16 +410,16 @@ fn execute_update(name_spec: Option<&str>) -> Result<(), AssetsError> {
             if spec.contains('@') {
                 // Re-pin to a different version.
                 let (name, version) = parse_spec(spec)?;
-                let existing = manifest
-                    .assets
-                    .get(&name)
-                    .map(|a| a.file.clone())
-                    .ok_or_else(|| AssetsError::UnknownPackage(name.clone()));
-                let (source_url, file_rel) = resolve_source(&name, &version, None)?;
-                // If the name isn't in registry but is in manifest, use existing file path.
-                let file_rel = match existing {
-                    Ok(f) if source_url.contains(&name) => f,
-                    _ => file_rel,
+                let in_registry = registry().iter().any(|(k, _)| *k == name.as_str());
+                let (source_url, file_rel) = if in_registry {
+                    resolve_source(&name, &version, None)?
+                } else {
+                    // Package was added with `--url`; we cannot derive the new
+                    // version's URL automatically.  The user must re-add it:
+                    return Err(AssetsError::UnknownPackage(format!(
+                        "{name} was added with --url and is not in the built-in registry; \
+                         re-pin with `autumn assets add {name}@{version} --url <url>`"
+                    )));
                 };
                 vec![(name, version, source_url, file_rel)]
             } else {
@@ -432,7 +442,7 @@ fn execute_update(name_spec: Option<&str>) -> Result<(), AssetsError> {
         println!("Updating {name} → {version}...");
         let bytes = download_bytes(&source_url)?;
         let sri = compute_sri(&bytes);
-        let dest = PathBuf::from("static").join(&file_rel);
+        let dest = static_dir.join(&file_rel);
         write_atomic(&bytes, &dest)?;
         manifest.assets.insert(
             name.clone(),
@@ -446,7 +456,7 @@ fn execute_update(name_spec: Option<&str>) -> Result<(), AssetsError> {
         println!("  Updated {name} {version}  {sri}");
     }
 
-    save_manifest(&manifest_path, &manifest)?;
+    save_manifest(manifest_path, &manifest)?;
     Ok(())
 }
 
@@ -457,7 +467,6 @@ fn execute_update(name_spec: Option<&str>) -> Result<(), AssetsError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write as _;
 
     // --- parse_spec ---
 
@@ -650,5 +659,93 @@ mod tests {
         assert_eq!(fs::read(&dest).unwrap(), b"data");
         // No leftover .tmp file.
         assert!(!dest.with_extension("tmp").exists());
+    }
+
+    // --- Fix #2: execute_update for --url packages ---
+
+    #[test]
+    fn execute_update_with_version_for_url_package_errors_with_hint() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let static_dir = tmp_dir.path().to_path_buf();
+        let manifest_path = static_dir.join(".autumn-assets.json");
+
+        // Simulate a package added with --url (not in the built-in registry).
+        let mut manifest = VendorManifest::default();
+        manifest.assets.insert(
+            "my-custom-lib".into(),
+            VendorAsset {
+                version: "1.0.0".into(),
+                source: "https://example.com/my-custom-lib.min.js".into(),
+                file: "js/my-custom-lib.min.js".into(),
+                integrity: "sha384-abc".into(),
+            },
+        );
+        save_manifest(&manifest_path, &manifest).unwrap();
+
+        // Attempting to re-pin with @version should fail with a clear message.
+        let result =
+            execute_update_with_manifest(Some("my-custom-lib@2.0.0"), &manifest_path, &static_dir);
+        assert!(result.is_err(), "expected error for --url package re-pin");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("--url"), "error should mention --url: {msg}");
+        assert!(
+            msg.contains("my-custom-lib"),
+            "error should mention the package name: {msg}"
+        );
+    }
+
+    // --- Fix #3: URL→filename sanitization ---
+
+    #[test]
+    fn resolve_url_with_query_string_strips_it() {
+        // A URL with ?v= query: the derived filename must NOT include the query string.
+        let custom = "https://example.com/lib.min.js?v=1.2.3";
+        let (url, file) = resolve_source("unknown-pkg", "1.0.0", Some(custom)).unwrap();
+        assert_eq!(url, custom);
+        assert_eq!(file, "js/lib.min.js", "query string must be stripped");
+    }
+
+    #[test]
+    fn resolve_url_with_trailing_slash_errors() {
+        // A URL ending in / has an empty last path segment — cannot derive filename.
+        let custom = "https://example.com/path/";
+        let err = resolve_source("unknown-pkg", "1.0.0", Some(custom)).unwrap_err();
+        assert!(
+            matches!(err, AssetsError::BadSpec(_)),
+            "expected BadSpec for trailing-slash URL"
+        );
+    }
+
+    // --- Fix #4: Schema-identity test (CLI types ↔ framework types) ---
+
+    #[test]
+    fn cli_and_web_vendor_manifest_schemas_are_compatible() {
+        let json = r#"{
+            "version": "1",
+            "assets": {
+                "htmx": {
+                    "version": "2.0.4",
+                    "source": "https://example.com",
+                    "file": "js/htmx.min.js",
+                    "integrity": "sha384-abc"
+                }
+            }
+        }"#;
+
+        // Must parse as CLI type.
+        let cli: VendorManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(cli.assets["htmx"].version, "2.0.4");
+        assert_eq!(cli.assets["htmx"].integrity, "sha384-abc");
+
+        // Must also parse as the framework type.
+        let fw: autumn_web::assets::VendorManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(fw.assets["htmx"].version, "2.0.4");
+        assert_eq!(fw.assets["htmx"].file, "js/htmx.min.js");
+
+        // CLI → JSON → framework round-trip must preserve all fields.
+        let serialized = serde_json::to_string(&cli).unwrap();
+        let fw2: autumn_web::assets::VendorManifest = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(fw2.assets["htmx"].integrity, "sha384-abc");
+        assert_eq!(fw2.assets["htmx"].source, "https://example.com");
     }
 }

--- a/autumn-cli/src/http.rs
+++ b/autumn-cli/src/http.rs
@@ -1,0 +1,28 @@
+//! Shared HTTP download helper used by `autumn setup` and `autumn assets`.
+
+use indicatif::{ProgressBar, ProgressStyle};
+
+/// Download `url` with a progress bar and return the response body as bytes.
+///
+/// Returns `Err(reqwest::Error)` so callers can convert with `?` into their
+/// own error type (both [`crate::setup::SetupError`] and
+/// [`crate::assets::AssetsError`] wrap `reqwest::Error` via `#[from]`).
+pub fn fetch_bytes(url: &str) -> Result<Vec<u8>, reqwest::Error> {
+    let response = reqwest::blocking::Client::new()
+        .get(url)
+        .send()?
+        .error_for_status()?;
+
+    let total = response.content_length().unwrap_or(0);
+    let pb = ProgressBar::new(total);
+    pb.set_style(
+        ProgressStyle::with_template("  [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+            .expect("valid progress template")
+            .progress_chars("=> "),
+    );
+
+    let bytes = response.bytes()?;
+    pb.set_length(bytes.len() as u64);
+    pb.finish_and_clear();
+    Ok(bytes.to_vec())
+}

--- a/autumn-cli/src/http.rs
+++ b/autumn-cli/src/http.rs
@@ -8,7 +8,9 @@ use indicatif::{ProgressBar, ProgressStyle};
 /// own error type (both [`crate::setup::SetupError`] and
 /// [`crate::assets::AssetsError`] wrap `reqwest::Error` via `#[from]`).
 pub fn fetch_bytes(url: &str) -> Result<Vec<u8>, reqwest::Error> {
-    let response = reqwest::blocking::Client::new()
+    let response = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?
         .get(url)
         .send()?
         .error_for_status()?;

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand};
 
+mod assets;
 mod build;
 mod canary;
 mod check;
@@ -130,6 +131,11 @@ enum Commands {
         /// Re-download even if the binary already exists
         #[arg(long)]
         force: bool,
+    },
+    /// Pin, vendor, and integrity-verify JS dependencies
+    Assets {
+        #[command(subcommand)]
+        action: AssetsCommands,
     },
     /// Run or inspect database migrations
     Migrate {
@@ -569,6 +575,35 @@ enum Commands {
         #[arg(long)]
         include_db: bool,
     },
+}
+
+/// Subcommands for `autumn assets`.
+#[derive(Subcommand)]
+enum AssetsCommands {
+    /// Download a JS dependency, compute a sha384 SRI hash, and record it in the manifest.
+    ///
+    /// Example: `autumn assets add htmx@2.0.4`
+    Add {
+        /// Package spec in `<name>@<version>` format (e.g. `htmx@2.0.4`).
+        spec: String,
+        /// Override the download URL (required for packages not in the built-in registry).
+        #[arg(long)]
+        url: Option<String>,
+    },
+    /// Print all pinned JS dependencies with their version and integrity hash.
+    List,
+    /// Re-download and re-pin a dependency (or all if no name given).
+    ///
+    /// Examples:
+    ///   `autumn assets update htmx`         — re-pin the recorded version
+    ///   `autumn assets update htmx@2.0.5`   — re-pin to a new version
+    ///   `autumn assets update`               — refresh all vendored assets
+    Update {
+        /// Name or `<name>@<version>` spec to update. Omit to update all.
+        name: Option<String>,
+    },
+    /// Recompute sha384 hashes for all vendored files and compare to the manifest.
+    Verify,
 }
 
 /// Subcommands for `autumn config`.
@@ -1772,6 +1807,16 @@ fn run_command(command: Commands) {
             &args,
         ),
         Commands::Setup { force } => setup::run(force),
+        Commands::Assets { action } => match action {
+            AssetsCommands::Add { spec, url } => assets::run_add(&spec, url.as_deref()),
+            AssetsCommands::List => assets::run_list(),
+            AssetsCommands::Update { name } => assets::run_update(name.as_deref()),
+            AssetsCommands::Verify => {
+                let manifest_path = std::path::PathBuf::from(assets::VENDOR_MANIFEST_PATH);
+                let static_dir = std::path::PathBuf::from("static");
+                assets::run_verify(&manifest_path, &static_dir);
+            }
+        },
         Commands::Routes {
             package,
             bin,

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -17,6 +17,7 @@ mod experiments;
 mod export;
 mod flags;
 mod generate;
+mod http;
 mod maintenance;
 mod migrate;
 mod monitor;

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -154,6 +154,7 @@ fn generate_inner(
 
     fs::create_dir_all(project_dir.join("src"))?;
     fs::create_dir_all(project_dir.join("static/css"))?;
+    fs::create_dir_all(project_dir.join("static/js"))?;
     fs::create_dir_all(project_dir.join("migrations"))?;
     fs::create_dir_all(project_dir.join("tests"))?;
     fs::create_dir_all(project_dir.join("config/credentials"))?;
@@ -247,6 +248,7 @@ fn generate_inner(
     fs::write(project_dir.join(".gitignore"), render(templates::GITIGNORE))?;
     fs::write(project_dir.join("migrations/.gitkeep"), "")?;
 
+    scaffold_vendor_assets(&project_dir)?;
     scaffold_credentials(&project_dir, name)?;
     fs::write(
         project_dir.join("tests/integration_test.rs"),
@@ -258,6 +260,37 @@ fn generate_inner(
     if !quiet {
         print_scaffold_summary(name, opts);
     }
+
+    Ok(())
+}
+
+fn scaffold_vendor_assets(project_dir: &Path) -> Result<(), NewError> {
+    let htmx_bytes = autumn_web::HTMX_JS;
+    let htmx_version = autumn_web::HTMX_VERSION;
+    let htmx_source =
+        format!("https://cdn.jsdelivr.net/npm/htmx.org@{htmx_version}/dist/htmx.min.js");
+    let htmx_file = "js/htmx.min.js";
+    let integrity = crate::assets::compute_sri(htmx_bytes);
+
+    fs::write(project_dir.join("static").join(htmx_file), htmx_bytes)?;
+
+    let mut assets = std::collections::BTreeMap::new();
+    assets.insert(
+        "htmx".to_owned(),
+        crate::assets::VendorAsset {
+            version: htmx_version.to_owned(),
+            source: htmx_source,
+            file: htmx_file.to_owned(),
+            integrity,
+        },
+    );
+    let manifest = crate::assets::VendorManifest {
+        version: "1".to_owned(),
+        assets,
+    };
+    let manifest_path = project_dir.join("static").join(".autumn-assets.json");
+    crate::assets::save_manifest(&manifest_path, &manifest)
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
 
     Ok(())
 }
@@ -1284,6 +1317,89 @@ mod tests {
         assert_eq!(
             mode, 0o600,
             "master.key permissions must be 0o600, got {mode:#o}"
+        );
+    }
+
+    // ── Vendor asset scaffolding ─────────────────────────────────────────────
+
+    #[test]
+    fn scaffold_writes_htmx_js_file() {
+        let tmp = TempDir::new().unwrap();
+        generate("asset-app", tmp.path()).unwrap();
+        let htmx = tmp.path().join("asset-app/static/js/htmx.min.js");
+        assert!(
+            htmx.is_file(),
+            "static/js/htmx.min.js must be created by `autumn new`"
+        );
+        let bytes = fs::read(&htmx).unwrap();
+        assert!(!bytes.is_empty(), "htmx.min.js must not be empty");
+    }
+
+    #[test]
+    fn scaffold_writes_vendor_manifest() {
+        let tmp = TempDir::new().unwrap();
+        generate("manifest-app", tmp.path()).unwrap();
+        let manifest_path = tmp.path().join("manifest-app/static/.autumn-assets.json");
+        assert!(
+            manifest_path.is_file(),
+            "static/.autumn-assets.json must be created by `autumn new`"
+        );
+        let content = fs::read_to_string(&manifest_path).unwrap();
+        let manifest: serde_json::Value =
+            serde_json::from_str(&content).expect("manifest must be valid JSON");
+        assert_eq!(manifest["version"], "1", "manifest must have version=1");
+        let htmx = &manifest["assets"]["htmx"];
+        assert!(!htmx.is_null(), "manifest must contain an htmx entry");
+        assert!(
+            htmx["version"].as_str().unwrap_or("").contains('.'),
+            "htmx version must look like a semver: {}",
+            htmx["version"]
+        );
+        let integrity = htmx["integrity"].as_str().unwrap_or("");
+        assert!(
+            integrity.starts_with("sha384-"),
+            "htmx integrity must be a sha384 SRI hash: {integrity}"
+        );
+    }
+
+    #[test]
+    fn manifest_integrity_matches_vendored_file() {
+        let tmp = TempDir::new().unwrap();
+        generate("sri-app", tmp.path()).unwrap();
+        let p = tmp.path().join("sri-app");
+
+        let htmx_bytes = fs::read(p.join("static/js/htmx.min.js")).unwrap();
+        let computed = crate::assets::compute_sri(&htmx_bytes);
+
+        let manifest_raw = fs::read_to_string(p.join("static/.autumn-assets.json")).unwrap();
+        let manifest: serde_json::Value = serde_json::from_str(&manifest_raw).unwrap();
+        let recorded = manifest["assets"]["htmx"]["integrity"].as_str().unwrap();
+
+        assert_eq!(
+            computed, recorded,
+            "SRI hash in manifest must match the vendored htmx.min.js"
+        );
+    }
+
+    #[test]
+    fn generated_main_rs_uses_javascript_include_tag() {
+        let tmp = TempDir::new().unwrap();
+        generate("helper-app", tmp.path()).unwrap();
+        let content = fs::read_to_string(tmp.path().join("helper-app/src/main.rs")).unwrap();
+        assert!(
+            content.contains("javascript_include_tag(\"htmx\")"),
+            "generated main.rs must use javascript_include_tag(\"htmx\"), got:\n{content}"
+        );
+    }
+
+    #[test]
+    fn generated_main_rs_has_no_hardcoded_htmx_script_src() {
+        let tmp = TempDir::new().unwrap();
+        generate("no-hardcode-app", tmp.path()).unwrap();
+        let content = fs::read_to_string(tmp.path().join("no-hardcode-app/src/main.rs")).unwrap();
+        assert!(
+            !content.contains("/static/js/htmx.min.js"),
+            "generated main.rs must not hardcode /static/js/htmx.min.js, got:\n{content}"
         );
     }
 }

--- a/autumn-cli/src/setup.rs
+++ b/autumn-cli/src/setup.rs
@@ -8,7 +8,6 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use indicatif::{ProgressBar, ProgressStyle};
 use sha2::{Digest, Sha256};
 
 /// Pinned Tailwind CSS release version.
@@ -170,24 +169,9 @@ pub fn verify_checksum(expected: &str, actual: &str) -> Result<(), SetupError> {
 }
 
 fn download_with_progress(url: &str, dest: &Path) -> Result<(), SetupError> {
-    let response = reqwest::blocking::Client::new()
-        .get(url)
-        .send()?
-        .error_for_status()?;
-
-    let total = response.content_length().unwrap_or(0);
-    let pb = ProgressBar::new(total);
-    pb.set_style(
-        ProgressStyle::with_template("  [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")
-            .expect("valid progress template")
-            .progress_chars("=> "),
-    );
-
+    let bytes = crate::http::fetch_bytes(url)?;
     let mut file = fs::File::create(dest)?;
-    let bytes = response.bytes()?;
-    pb.set_length(bytes.len() as u64);
     file.write_all(&bytes)?;
-    pb.finish_and_clear();
     Ok(())
 }
 

--- a/autumn-cli/src/templates/main.rs.tmpl
+++ b/autumn-cli/src/templates/main.rs.tmpl
@@ -19,6 +19,7 @@ pub fn layout(title: &str, content: maud::Markup) -> maud::Markup {
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { (title) }
                 link rel="stylesheet" href="/static/css/app.css";
+                (javascript_include_tag("htmx"))
             }
             body {
                 (skip_link("#main-content", "Skip to main content"))

--- a/autumn/src/assets.rs
+++ b/autumn/src/assets.rs
@@ -32,9 +32,7 @@
 //! }
 //! ```
 
-#[cfg(any(not(debug_assertions), feature = "embed-assets"))]
 use std::collections::HashMap;
-#[cfg(any(not(debug_assertions), feature = "embed-assets"))]
 use std::sync::OnceLock;
 
 /// Filename of the fingerprint manifest within the `static/` tree.
@@ -59,6 +57,115 @@ fn load_manifest() -> &'static Option<AssetManifest> {
         let contents = std::fs::read_to_string(manifest_path).ok()?;
         serde_json::from_str(&contents).ok()
     })
+}
+
+// ── Vendor asset manifest (.autumn-assets.json) ──────────────────────────────
+
+/// Filename of the vendor asset manifest within the `static/` tree.
+pub(crate) const VENDOR_MANIFEST_FILE: &str = ".autumn-assets.json";
+
+/// A single vendored JS dependency recorded in the vendor manifest.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct VendorAsset {
+    /// Pinned version string (e.g. `"2.0.4"`).
+    pub version: String,
+    /// Original download URL.
+    pub source: String,
+    /// Path relative to `static/` where the file is vendored (e.g. `"js/htmx.min.js"`).
+    pub file: String,
+    /// `sha384-<base64>` Subresource Integrity hash.
+    pub integrity: String,
+}
+
+/// On-disk format of `static/.autumn-assets.json`.
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct VendorManifest {
+    /// Format version; currently `"1"`.
+    pub version: String,
+    /// Map from logical name (e.g. `"htmx"`) to asset metadata.
+    pub assets: HashMap<String, VendorAsset>,
+}
+
+static VENDOR_MANIFEST: OnceLock<Option<VendorManifest>> = OnceLock::new();
+
+fn load_vendor_manifest() -> Option<&'static VendorManifest> {
+    VENDOR_MANIFEST
+        .get_or_init(|| {
+            // In single-binary builds the embedded dir is the sole source of truth.
+            #[cfg(feature = "embed-assets")]
+            if embedded_static_dir().is_some() {
+                return load_embedded_vendor_manifest();
+            }
+            let manifest_path =
+                crate::app::project_dir("static", &crate::config::OsEnv).join(VENDOR_MANIFEST_FILE);
+            let contents = std::fs::read_to_string(manifest_path).ok()?;
+            serde_json::from_str(&contents).ok()
+        })
+        .as_ref()
+}
+
+#[cfg(feature = "embed-assets")]
+fn load_embedded_vendor_manifest() -> Option<VendorManifest> {
+    EMBEDDED_STATIC
+        .get()?
+        .0
+        .get_file(VENDOR_MANIFEST_FILE)
+        .and_then(include_dir::File::contents_utf8)
+        .and_then(|s| serde_json::from_str(s).ok())
+}
+
+/// Render a `<script>` tag for a vendored JS dependency.
+///
+/// Resolves the asset URL through [`asset_url`] (fingerprinted in release,
+/// plain in dev) and emits `integrity` + `crossorigin="anonymous"` for SRI.
+#[cfg(feature = "maud")]
+fn render_javascript_tag(asset: &VendorAsset) -> maud::Markup {
+    maud::html! {
+        script
+            src=(asset_url(&asset.file))
+            integrity=(asset.integrity)
+            crossorigin="anonymous"
+            {}
+    }
+}
+
+/// Render a `<script>` tag for a named vendored JS dependency.
+///
+/// Looks up `name` in `static/.autumn-assets.json` and emits:
+/// ```html
+/// <script src="{url}" integrity="{sri}" crossorigin="anonymous"></script>
+/// ```
+/// where `{url}` is fingerprinted in release builds and plain in dev.
+///
+/// Returns empty markup (with a `tracing::warn!`) when `name` is not found in
+/// the manifest, so a missing entry is a soft error that never breaks rendering.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::prelude::*;
+///
+/// html! {
+///     head {
+///         (javascript_include_tag("htmx"))
+///     }
+/// }
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+#[allow(clippy::option_if_let_else)] // side-effecting else branch makes map_or_else harder to read
+pub fn javascript_include_tag(name: &str) -> maud::Markup {
+    if let Some(asset) = load_vendor_manifest().and_then(|m| m.assets.get(name)) {
+        render_javascript_tag(asset)
+    } else {
+        tracing::warn!(
+            asset = name,
+            "javascript_include_tag: asset not found in {}; \
+             run `autumn assets add {name}@<version>` to pin it",
+            VENDOR_MANIFEST_FILE,
+        );
+        maud::html! {}
+    }
 }
 
 // ── Embedded assets (feature = "embed-assets") ──────────────────────────────
@@ -408,6 +515,63 @@ mod tests {
         assert!(!is_fingerprinted_path("/static/css/autumn.A1B2C3D4.css"));
         // No extension
         assert!(!is_fingerprinted_path("/static/file.a1b2c3d4"));
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn vendor_manifest_parses_json() {
+        let json = r#"{
+            "version": "1",
+            "assets": {
+                "htmx": {
+                    "version": "2.0.4",
+                    "source": "https://cdn.jsdelivr.net/npm/htmx.org@2.0.4/dist/htmx.min.js",
+                    "file": "js/htmx.min.js",
+                    "integrity": "sha384-testintegrityhash"
+                }
+            }
+        }"#;
+        let manifest: VendorManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(manifest.version, "1");
+        let htmx = manifest.assets.get("htmx").unwrap();
+        assert_eq!(htmx.version, "2.0.4");
+        assert_eq!(htmx.file, "js/htmx.min.js");
+        assert_eq!(htmx.integrity, "sha384-testintegrityhash");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn render_javascript_tag_has_src_integrity_crossorigin() {
+        let asset = VendorAsset {
+            version: "2.0.4".into(),
+            source: "https://cdn.jsdelivr.net/npm/htmx.org@2.0.4/dist/htmx.min.js".into(),
+            file: "js/htmx.min.js".into(),
+            integrity: "sha384-abc123".into(),
+        };
+        let markup = render_javascript_tag(&asset);
+        let html = markup.into_string();
+        assert!(
+            html.contains("src=\"/static/js/htmx.min.js\""),
+            "missing src: {html}"
+        );
+        assert!(
+            html.contains("integrity=\"sha384-abc123\""),
+            "missing integrity: {html}"
+        );
+        assert!(
+            html.contains("crossorigin=\"anonymous\""),
+            "missing crossorigin: {html}"
+        );
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn javascript_include_tag_unknown_name_returns_empty() {
+        let markup = javascript_include_tag("__nonexistent_pkg__");
+        assert!(
+            markup.into_string().is_empty(),
+            "expected empty markup for unknown asset"
+        );
     }
 
     #[cfg(feature = "embed-assets")]

--- a/autumn/src/assets.rs
+++ b/autumn/src/assets.rs
@@ -104,6 +104,14 @@ fn load_vendor_manifest() -> Option<&'static VendorManifest> {
         .as_ref()
 }
 
+/// Returns `true` when htmx has been pinned via `autumn assets add htmx@…`.
+///
+/// The router uses this to skip the built-in embedded htmx handler so the
+/// vendored file (and its pinned integrity hash) is served by `ServeDir` instead.
+pub(crate) fn htmx_is_vendored() -> bool {
+    load_vendor_manifest().is_some_and(|m| m.assets.contains_key("htmx"))
+}
+
 #[cfg(feature = "embed-assets")]
 fn load_embedded_vendor_manifest() -> Option<VendorManifest> {
     EMBEDDED_STATIC
@@ -137,8 +145,10 @@ fn render_javascript_tag(asset: &VendorAsset) -> maud::Markup {
 /// ```
 /// where `{url}` is fingerprinted in release builds and plain in dev.
 ///
-/// Returns empty markup (with a `tracing::warn!`) when `name` is not found in
-/// the manifest, so a missing entry is a soft error that never breaks rendering.
+/// When `name` is not found in the manifest the helper logs a `tracing::warn!`
+/// and returns a visible HTML comment so the gap is discoverable in View Source.
+/// In debug builds a `<script>console.error(…)</script>` is also emitted so the
+/// error appears in the browser `DevTools` console.
 ///
 /// # Example
 ///
@@ -164,7 +174,30 @@ pub fn javascript_include_tag(name: &str) -> maud::Markup {
              run `autumn assets add {name}@<version>` to pin it",
             VENDOR_MANIFEST_FILE,
         );
-        maud::html! {}
+        missing_asset_markup(name)
+    }
+}
+
+/// Diagnostic markup returned when [`javascript_include_tag`] cannot find a
+/// named asset.  Always contains an HTML comment visible in View Source; in
+/// debug builds also fires `console.error` so `DevTools` catches the gap early.
+#[cfg(feature = "maud")]
+fn missing_asset_markup(name: &str) -> maud::Markup {
+    let comment = format!(
+        "<!-- autumn: asset '{name}' not found in {VENDOR_MANIFEST_FILE}; \
+         run `autumn assets add {name}@<version>` -->"
+    );
+    if cfg!(debug_assertions) {
+        let console_err = format!(
+            "console.error('[autumn] asset not found: {name} \
+             \u{2014} run autumn assets add {name}@<version>');"
+        );
+        maud::html! {
+            (maud::PreEscaped(comment))
+            script { (maud::PreEscaped(console_err)) }
+        }
+    } else {
+        maud::html! { (maud::PreEscaped(comment)) }
     }
 }
 
@@ -437,7 +470,7 @@ fn embedded_response(rel_path: &str) -> axum::response::Response {
     let is_manifest = rel_path
         .rsplit('/')
         .next()
-        .is_some_and(|name| name == ASSET_MANIFEST_FILE);
+        .is_some_and(|name| name == ASSET_MANIFEST_FILE || name == VENDOR_MANIFEST_FILE);
     if is_traversal || is_manifest {
         return http::StatusCode::NOT_FOUND.into_response();
     }
@@ -566,11 +599,12 @@ mod tests {
 
     #[cfg(feature = "maud")]
     #[test]
-    fn javascript_include_tag_unknown_name_returns_empty() {
+    fn javascript_include_tag_unknown_name_returns_diagnostic_comment() {
         let markup = javascript_include_tag("__nonexistent_pkg__");
+        let html = markup.into_string();
         assert!(
-            markup.into_string().is_empty(),
-            "expected empty markup for unknown asset"
+            html.contains("<!-- autumn: asset '__nonexistent_pkg__' not found"),
+            "expected HTML comment diagnostic for unknown asset, got: {html}"
         );
     }
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -435,7 +435,7 @@ pub use validation::Validated;
 /// Useful for cache-busting or diagnostic logging. The corresponding
 /// minified JS is served automatically at `/static/js/htmx.min.js`.
 #[cfg(feature = "htmx")]
-pub use htmx::{AUTUMN_WIDGETS_JS_PATH, HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HTMX_VERSION};
+pub use htmx::{AUTUMN_WIDGETS_JS_PATH, HTMX_CSRF_JS_PATH, HTMX_JS, HTMX_JS_PATH, HTMX_VERSION};
 #[cfg(feature = "mail")]
 pub use mail::{
     Mail, MailConfig, MailDeliveryQueue, MailDeliveryQueueHandle, MailError, MailTransport, Mailer,

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -41,6 +41,9 @@ pub use autumn_macros::{mail_previews, mailer, mailer_preview};
 // ── Rendering ────────────────────────────────────────────────────
 /// Resolve a logical static asset path to a fingerprinted URL in release builds.
 pub use crate::assets::asset_url;
+/// Render a `<script>` tag with SRI integrity for a named vendored JS dependency.
+#[cfg(feature = "maud")]
+pub use crate::assets::javascript_include_tag;
 /// Maud HTML templating types.
 #[cfg(feature = "maud")]
 pub use maud::{Markup, PreEscaped, html};

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1032,7 +1032,12 @@ fn collect_claimed_get_paths(
     }
     #[cfg(feature = "htmx")]
     {
-        claimed.insert(crate::htmx::HTMX_JS_PATH.to_owned());
+        // Only claim the htmx path when the built-in handler is actually
+        // mounted; when htmx is vendored via `autumn assets`, ServeDir serves
+        // the file and the path must not appear in the claimed-routes set.
+        if !crate::assets::htmx_is_vendored() {
+            claimed.insert(crate::htmx::HTMX_JS_PATH.to_owned());
+        }
         claimed.insert(crate::htmx::HTMX_CSRF_JS_PATH.to_owned());
         claimed.insert(crate::htmx::AUTUMN_WIDGETS_JS_PATH.to_owned());
     }
@@ -1384,7 +1389,24 @@ fn mount_framework_routes(
     // Framework-provided routes
     #[cfg(feature = "htmx")]
     {
-        router = router.route(crate::htmx::HTMX_JS_PATH, axum::routing::get(htmx_handler));
+        // When htmx is vendored via `autumn assets add htmx@…`, skip the
+        // built-in handler so ServeDir serves the correctly-pinned file.
+        // Axum explicit routes beat `nest_service`, so without this guard the
+        // embedded 2.0.4 bytes would shadow any updated vendored version.
+        if crate::assets::htmx_is_vendored() {
+            tracing::debug!(
+                path = crate::htmx::HTMX_JS_PATH,
+                "htmx vendored via `autumn assets`; built-in handler skipped, ServeDir serves it"
+            );
+        } else {
+            router = router.route(crate::htmx::HTMX_JS_PATH, axum::routing::get(htmx_handler));
+            tracing::debug!(
+                method = "GET",
+                path = crate::htmx::HTMX_JS_PATH,
+                name = format!("htmx {}", crate::htmx::HTMX_VERSION),
+                "Mounted route"
+            );
+        }
         router = router.route(
             crate::htmx::HTMX_CSRF_JS_PATH,
             axum::routing::get(htmx_csrf_handler),
@@ -1392,12 +1414,6 @@ fn mount_framework_routes(
         router = router.route(
             crate::htmx::AUTUMN_WIDGETS_JS_PATH,
             axum::routing::get(autumn_widgets_handler),
-        );
-        tracing::debug!(
-            method = "GET",
-            path = crate::htmx::HTMX_JS_PATH,
-            name = format!("htmx {}", crate::htmx::HTMX_VERSION),
-            "Mounted route"
         );
         tracing::debug!(
             method = "GET",


### PR DESCRIPTION
## Summary

Introduces a new `autumn assets` CLI command that enables developers to pin, vendor, and integrity-verify JavaScript dependencies without requiring Node/npm. Downloaded files are committed to the repository with SHA-384 SRI hashes recorded in a manifest, ensuring release builds never touch the network and dependencies remain reproducible.

## Key Changes

- **New `autumn-cli/src/assets.rs` module** (751 lines)
  - Implements the complete asset management system with four subcommands:
    - `autumn assets add <name>@<version>` — download, hash, and record a dependency
    - `autumn assets list` — display all pinned dependencies
    - `autumn assets update [name]` — refresh one or all vendored assets
    - `autumn assets verify` — validate file integrity against recorded hashes
  - Built-in registry for common packages (htmx, alpinejs, htmx-ext-sse, htmx-ext-ws) that resolve to jsdelivr CDN URLs
  - Support for custom URLs via `--url` flag for packages outside the registry
  - Atomic file writes to prevent corruption on failed downloads
  - Comprehensive test coverage including tampering detection and URL sanitization

- **New `autumn-cli/src/http.rs` module** (28 lines)
  - Extracted shared HTTP download logic with progress bar
  - Used by both `autumn setup` and `autumn assets` commands
  - Delegates to `reqwest::blocking` with indicatif progress visualization

- **Framework-side vendor asset support in `autumn/src/assets.rs`**
  - Added `VendorManifest` and `VendorAsset` types mirroring CLI definitions
  - New `javascript_include_tag(name)` helper function for rendering `<script>` tags with SRI integrity attributes
  - Automatic fallback to diagnostic HTML comments when assets are missing
  - `htmx_is_vendored()` function to detect when htmx has been pinned via CLI

- **Router integration in `autumn/src/router.rs`**
  - Modified htmx route mounting to skip the built-in handler when htmx is vendored
  - Ensures `ServeDir` serves the pinned version instead of the embedded fallback
  - Prevents route shadowing that would ignore updated vendored files

- **Project scaffolding in `autumn-cli/src/new.rs`**
  - `autumn new` now creates `static/js/` directory
  - Pre-seeds new projects with htmx vendored and recorded in manifest
  - Ensures all new projects start with a valid vendor manifest

- **CLI integration in `autumn-cli/src/main.rs`**
  - Added `Assets` command with `AssetsCommands` subcommand enum
  - Wired up all four asset management operations

- **Template updates**
  - Updated `main.rs.tmpl` to use `javascript_include_tag("htmx")` instead of hardcoded script tag

## Notable Implementation Details

- **Schema compatibility**: CLI and framework `VendorManifest`/`VendorAsset` types are identical and tested for round-trip JSON serialization
- **URL safety**: Custom URLs are parsed and validated to strip query strings and fragments before deriving filenames
- **Error messages**: Clear guidance for users attempting to re-pin packages added with `--url` (which lack automatic version resolution)
- **Manifest format**: Uses `BTreeMap` in CLI for deterministic JSON output; `HashMap` in framework for runtime efficiency
- **Embedded assets**: Vendor manifest is excluded from embedded static trees (like the fingerprint manifest) to allow dynamic updates
- **Backward compatibility**: Existing projects without a vendor manifest continue to work; the built-in htmx handler remains active until explicitly vendored

https://claude.ai/code/session_016H19wy5miJGL3jRcGTV77n