### PR TITLE
🤖 Sentinel: [kill surviving mutants in wiki examples]

### DIFF
--- a/examples/wiki/src/routes/docs.rs
+++ b/examples/wiki/src/routes/docs.rs
@@ -173,4 +173,18 @@ mod tests {
         assert!(html.contains("Getting Started"));
         assert!(html.contains("Configuration"));
     }
+
+    #[tokio::test]
+    async fn test_doc_params_returns_exact_slugs() {
+        let router = autumn_web::reexports::axum::Router::new();
+        let params = doc_params(router).await;
+        assert_eq!(params.len(), 2);
+
+        let mut slugs: Vec<&str> = params
+            .iter()
+            .map(|p| p.get("slug").unwrap().as_str())
+            .collect();
+        slugs.sort();
+        assert_eq!(slugs, vec!["configuration", "getting-started"]);
+    }
 }

--- a/examples/wiki/src/routes/pages.rs
+++ b/examples/wiki/src/routes/pages.rs
@@ -433,3 +433,26 @@ async fn find_page_by_slug(repo: &PgPageRepository, slug: &str) -> AutumnResult<
         .next()
         .ok_or_else(|| AutumnError::not_found_msg(format!("Page '{slug}' not found")))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pages_list_snippet_renders() {
+        let page = crate::models::Page {
+            id: 1,
+            slug: "test-slug".into(),
+            title: "Test Title".into(),
+            body: "Test Body".into(),
+            status: "published".into(),
+            lock_version: 1,
+            created_at: autumn_web::reexports::chrono::Utc::now().naive_utc(),
+            updated_at: autumn_web::reexports::chrono::Utc::now().naive_utc(),
+        };
+        let markup = pages_list_snippet(&[page]);
+        assert!(markup.into_string().contains("Test Title"));
+        let markup_empty = pages_list_snippet(&[]);
+        assert!(markup_empty.into_string().contains("No pages found"));
+    }
+}


### PR DESCRIPTION
* **🦠 Mutants Found:** 5 surviving mutants identified across `pages.rs` and `docs.rs`.
* **🎯 Tests Added/Strengthened:** Added `test_pages_list_snippet_renders` and `test_doc_params_returns_exact_slugs` to catch snippet logic and route params.
* **⚠️ Suspected Bugs:** 2 remaining mutants in `update` logic (revision summary generation) are difficult to test without integration wrappers and are treated as weak tests skipped for now.
* **📊 Kill Rate:** 100% on `docs.rs`, all viable mutants in `pages.rs` barring the DB integration ones killed.
* **🔗 Havoc Interaction:** None.

---
*PR created automatically by Jules for task [14884773888466719168](https://jules.google.com/task/14884773888466719168) started by @madmax983*