### PR TITLE
👺 Havoc: [Fix Idempotency Panic on Large TTL]

### DIFF
--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -464,10 +464,11 @@ impl IdempotencyStore for MemoryIdempotencyStore {
     }
 
     fn set(&self, key: &str, record: IdempotencyRecord, body_hash: Vec<u8>, ttl: Duration) {
+        let now = Instant::now();
         let entry = IdempotencyEntry {
             record,
             body_hash,
-            expires_at: Instant::now() + ttl,
+            expires_at: now.checked_add(ttl).unwrap_or_else(|| now + Duration::from_secs(365 * 24 * 3600 * 10)),
         };
         let mut entries = self.entries.write().unwrap();
         entries.insert(key.to_owned(), entry);
@@ -504,7 +505,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
             key.to_owned(),
             MemoryInFlightLock {
                 owner: owner.to_owned(),
-                expires_at: now + ttl,
+                expires_at: now.checked_add(ttl).unwrap_or_else(|| now + Duration::from_secs(365 * 24 * 3600 * 10)),
             },
         );
         true
@@ -2133,5 +2134,22 @@ mod tests {
             observed.1,
             expected_storage_key("POST", "/payments", None, "pay-once")
         );
+    }
+}
+
+#[cfg(test)]
+mod havoc_proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn test_idempotency_fuzz_try_lock(key in "\\PC*", ttl_secs in any::<u64>()) {
+            let store = MemoryIdempotencyStore::new(Duration::from_secs(60));
+            let locked = store.try_lock(&key, Duration::from_secs(ttl_secs));
+            prop_assert!(locked);
+            let locked_again = store.try_lock(&key, Duration::from_secs(ttl_secs));
+            prop_assert!(!locked_again);
+        }
     }
 }


### PR DESCRIPTION
🧨 **The Trigger:**
A client or developer provides an excessively large `Duration` (e.g., `Duration::MAX` or generated fuzz values) as a `lock_ttl` or cache `ttl` when using `MemoryIdempotencyStore`.

📉 **The Stack Trace:**
```
thread 'test_idempotency_fuzz_try_lock' panicked at /rustc/.../library/std/src/time.rs:429:33:
overflow when adding duration to instant
```

🧪 **Reproduction:**
Run `cargo test -p autumn-web --lib idempotency::havoc_proptests` which fuzzes the `try_lock` method using `proptest`. An unpatched version crashes immediately.

😈 **Comment:**
"You assumed duration arithmetic was infallible because time is infinite. You were wrong. A maliciously large TTL will panic the thread during the `+` operation. Replaced with `checked_add` and bounded fallback."

---
*PR created automatically by Jules for task [14263475472199245389](https://jules.google.com/task/14263475472199245389) started by @madmax983*