### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn/src/reporting.rs
+++ b/autumn/src/reporting.rs
@@ -632,6 +632,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn panic_in_future_poll_is_caught_as_500() {
+        use axum::body::Body;
+        use std::convert::Infallible;
+        use tower::ServiceExt;
+
+        struct PanicOnPoll;
+        impl Future for PanicOnPoll {
+            type Output = Result<Response, Infallible>;
+            fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+                panic!("boom in poll");
+            }
+        }
+
+        #[derive(Clone)]
+        struct ReturnPanickingFuture;
+        impl Service<Request<Body>> for ReturnPanickingFuture {
+            type Response = Response;
+            type Error = Infallible;
+            type Future = PanicOnPoll;
+
+            fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, _req: Request<Body>) -> Self::Future {
+                PanicOnPoll
+            }
+        }
+
+        let service = ReportingLayer::new(Vec::new(), true, 1.0).layer(ReturnPanickingFuture);
+        let response = service
+            .oneshot(Request::new(Body::empty()))
+            .await
+            .expect("panic in poll must be converted to a response, not propagated");
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
     async fn disabled_chain_does_not_dispatch() {
         #[derive(Clone)]
         struct Counter(Arc<Mutex<u32>>);


### PR DESCRIPTION
🎯 Target: `autumn/src/reporting.rs` (the `ReportingFuture` and `handle_panic` logic).
💣 Risk: The `ReportingFuture` has two panic handling paths (one for `call`, one for `poll`). If `poll` panics, the inner future could abort the worker task if not caught securely. The existing tests covered panics in `call`, but there was no test covering a panic during `poll`.
🧪 Strategy: Added `panic_in_future_poll_is_caught_as_500` inside `mod tests` in `autumn/src/reporting.rs`. This implements a custom `Future` that panics when polled and validates that the `catch_unwind` block catches it and returns a sanitized 500 response.
🔬 Verification: `cargo test -p autumn-web --lib reporting` and `cargo test -p autumn-web --lib`

---
*PR created automatically by Jules for task [12012864620954534210](https://jules.google.com/task/12012864620954534210) started by @madmax983*