### PR TITLE
Add macro-scaling benchmark gate for warm incremental rebuild latency

### DIFF
--- a/.github/workflows/dev-loop-scaling.yml
+++ b/.github/workflows/dev-loop-scaling.yml
@@ -1,0 +1,163 @@
+name: Macro-Scaling Benchmark Gate
+
+# Gates that the warm incremental rebuild stays near-flat as an Autumn app
+# grows (issue #983). A synthetic app is generated at N ∈ {1,25,50,100}
+# #[get] handlers + #[model]/#[repository] pairs; a single-handler edit is
+# timed N_runs times at each size; the gate asserts:
+#   • p95 ≤ 8 s at every size (absolute ceiling)
+#   • slope (p95@N=100 / p95@N=1) ≤ 2× (near-flat growth)
+#   • slope regression vs accepted baseline ≤ 20% (once baseline established)
+#
+# Per-PR: only the dry-run budget table and unit tests run (no compilation of
+# synthetic apps; that takes minutes per size point). Scheduled / manual: the
+# full sweep runs.
+on:
+  schedule:
+    # Every Monday at 08:00 UTC (after dev-loop 06:00 and cold-start 07:00).
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+    inputs:
+      sizes:
+        description: "Comma-separated app sizes to sweep (e.g. 1,25,50,100)"
+        required: false
+        default: "1,25,50,100"
+      runs:
+        description: "Number of timed incremental builds per size"
+        required: false
+        default: "5"
+      fail_on_regression:
+        description: "Exit 1 if any budget is exceeded"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+  pull_request:
+    branches: [trunk, trunk-dev]
+    paths:
+      - "autumn-cli/src/dev_loop_scaling.rs"
+      - "autumn-cli/src/scaling_driver.rs"
+      - "autumn-cli/src/main.rs"
+      - "benchmarks/dev-loop-scaling/baseline.json"
+      - "docs/guide/dev-loop-latency.md"
+      - ".github/workflows/dev-loop-scaling.yml"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Budget table smoke-check (runs on every PR, no build needed) ───────────
+  budget-table:
+    name: Scaling budget table (dry-run)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2.7.8
+
+      - name: Build CLI
+        run: cargo build -p autumn-cli
+
+      - name: Print scaling budget table
+        run: |
+          AUTUMN_BENCH_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+          AUTUMN_BENCH_RUST_VERSION="$(rustc --version)" \
+          ./target/debug/autumn dev-loop-bench --scaling --dry-run
+
+  # ── Unit tests for scaling module ─────────────────────────────────────────
+  unit-tests:
+    name: Scaling unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2.7.8
+
+      - name: Run scaling unit tests
+        shell: bash
+        run: |
+          cargo test -p autumn-cli \
+            -- dev_loop_scaling scaling_driver \
+            2>&1 | tee test-output.txt
+          grep -E "^test result:" test-output.txt
+          # Guard against a stale filter matching zero tests.
+          for module in dev_loop_scaling scaling_driver; do
+            if ! grep -qE "^test ${module}::tests::.* \.\.\. ok" test-output.txt; then
+              echo "::error::No ${module} unit tests ran — the test filter may be stale."
+              exit 1
+            fi
+          done
+
+  # ── Live scaling sweep (scheduled / manual only) ───────────────────────────
+  measure:
+    name: Measure macro-scaling sweep (${{ inputs.sizes || '1,25,50,100' }})
+    runs-on: ubuntu-latest
+    # Only run the live sweep on schedule or manual dispatch.
+    if: github.event_name != 'pull_request'
+    # Compiling the synthetic app at N=100 takes several minutes; allow up to
+    # 120 minutes total for the full 4-size sweep.
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2.7.8
+
+      - name: Build CLI
+        run: cargo build -p autumn-cli
+
+      - name: Run scaling sweep
+        id: bench
+        shell: bash
+        run: |
+          export AUTUMN_BENCH_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          export AUTUMN_BENCH_RUST_VERSION="$(rustc --version)"
+          SIZES="${{ inputs.sizes || '1,25,50,100' }}"
+          RUNS="${{ inputs.runs || '5' }}"
+          FAIL="${{ inputs.fail_on_regression || 'true' }}"
+          FAIL_FLAG=""
+          if [ "$FAIL" = "true" ]; then FAIL_FLAG="--fail-on-regression"; fi
+          ./target/debug/autumn dev-loop-bench --scaling \
+            --sizes "$SIZES" \
+            --runs "$RUNS" \
+            --baseline benchmarks/dev-loop-scaling/baseline.json \
+            --output scaling-report.json \
+            $FAIL_FLAG | tee scaling-summary.txt
+
+      - name: Upload JSON report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: scaling-report-${{ github.run_id }}
+          path: |
+            scaling-report.json
+            scaling-summary.txt
+          retention-days: 90
+
+      - name: Post summary
+        if: always()
+        run: |
+          echo "## Macro-Scaling Benchmark Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          cat scaling-summary.txt >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Full JSON report archived as workflow artifact \`scaling-report-${{ github.run_id }}\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "See [dev-loop-latency.md](https://github.com/${{ github.repository }}/blob/${{ github.sha }}/docs/guide/dev-loop-latency.md#scaling-macro-tax-budget) for the budget matrix and methodology." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Regression gate
+        if: ${{ inputs.fail_on_regression == 'true' || inputs.fail_on_regression == '' }}
+        run: |
+          # Fail closed: a missing or unparseable report must NOT pass the gate.
+          ALL_PASSED=$(jq -r '.all_passed' scaling-report.json 2>/dev/null || echo "false")
+          if [ "$ALL_PASSED" != "true" ]; then
+            echo "::error::Macro-scaling benchmark failed: p95 ceiling or slope budget exceeded."
+            echo "::error::See the report artifact for per-size diagnostics."
+            exit 1
+          fi

--- a/autumn-cli/src/cold_start_driver.rs
+++ b/autumn-cli/src/cold_start_driver.rs
@@ -46,7 +46,7 @@ const fn class_for(shape: ColdStartShape) -> ChangeClass {
 /// Honours the `AUTUMN_BENCH_AUTUMN_WEB_PATH` override, otherwise walks up from
 /// the current directory looking for an `autumn/Cargo.toml` whose package is
 /// `autumn-web`.
-fn locate_autumn_web() -> Option<PathBuf> {
+pub fn locate_autumn_web() -> Option<PathBuf> {
     if let Ok(p) = std::env::var("AUTUMN_BENCH_AUTUMN_WEB_PATH") {
         let pb = PathBuf::from(p);
         if pb.join("Cargo.toml").is_file() {
@@ -71,7 +71,7 @@ fn locate_autumn_web() -> Option<PathBuf> {
 ///
 /// The repo location is invariant across samples, so the ancestor walk + file
 /// reads + canonicalize run only on the first sample and are cached for the rest.
-fn cached_autumn_web() -> Option<PathBuf> {
+pub fn cached_autumn_web() -> Option<PathBuf> {
     static AUTUMN_WEB: OnceLock<Option<PathBuf>> = OnceLock::new();
     AUTUMN_WEB
         .get_or_init(|| locate_autumn_web().and_then(|p| std::fs::canonicalize(p).ok()))
@@ -84,7 +84,7 @@ fn cached_autumn_web() -> Option<PathBuf> {
 /// table, so it is a standalone workspace root and a `[patch]` section is valid
 /// there. The patch applies regardless of whether the dependency is the plain
 /// `autumn-web = "x"` form or the daemon/`features` table form.
-fn repoint_autumn_web(project_dir: &Path, autumn_web: &Path) -> Result<(), String> {
+pub fn repoint_autumn_web(project_dir: &Path, autumn_web: &Path) -> Result<(), String> {
     let manifest = project_dir.join("Cargo.toml");
     let mut content =
         std::fs::read_to_string(&manifest).map_err(|e| format!("read Cargo.toml: {e}"))?;

--- a/autumn-cli/src/dev_loop_bench.rs
+++ b/autumn-cli/src/dev_loop_bench.rs
@@ -603,11 +603,11 @@ fn build_placeholder_results(example: &str) -> Vec<BudgetCheckResult> {
         .collect()
 }
 
-fn chrono_utc_now() -> String {
+pub fn chrono_utc_now() -> String {
     std::env::var("AUTUMN_BENCH_TIMESTAMP").unwrap_or_else(|_| "unknown".to_string())
 }
 
-fn rust_version_string() -> String {
+pub fn rust_version_string() -> String {
     std::env::var("AUTUMN_BENCH_RUST_VERSION").unwrap_or_else(|_| "unknown".to_string())
 }
 

--- a/autumn-cli/src/dev_loop_scaling.rs
+++ b/autumn-cli/src/dev_loop_scaling.rs
@@ -184,7 +184,9 @@ fn generate_schema(n: usize) -> String {
 }
 
 fn generate_models(n: usize) -> String {
-    let mut out = String::from("// Bring all diesel table DSLs into scope for derive macros.\nuse crate::schema::*;\n\n");
+    let mut out = String::from(
+        "// Bring all diesel table DSLs into scope for derive macros.\nuse crate::schema::*;\n\n",
+    );
     for k in 0..n {
         writeln!(
             out,
@@ -277,13 +279,8 @@ pub fn apply_handler_edit(handlers_src: &str, revision: u32) -> String {
     handlers_src
         .split('\n')
         .map(|line| {
-            if line
-                .trim_start()
-                .starts_with("const BENCH_EDIT_SENTINEL:")
-            {
-                format!(
-                    "const BENCH_EDIT_SENTINEL: &str = \"bench_edit_rev_{revision}\";"
-                )
+            if line.trim_start().starts_with("const BENCH_EDIT_SENTINEL:") {
+                format!("const BENCH_EDIT_SENTINEL: &str = \"bench_edit_rev_{revision}\";")
             } else {
                 line.to_string()
             }
@@ -368,14 +365,14 @@ pub fn build_scaling_report(
     // N rather than by input position. `parse_sizes` preserves caller order, so
     // a sweep passed out of order (e.g. `--sizes 100,50,1`) must not invert the
     // ratio and let a real regression pass the gate.
-    let p95_by_n = |sel: fn(&ScalingPoint, &ScalingPoint) -> bool| {
-        points
-            .iter()
-            .reduce(|a, b| if sel(a, b) { a } else { b })
-            .map_or(0, |p| p.stats.p95_ms)
-    };
-    let min_n_p95 = p95_by_n(|a, b| a.n <= b.n);
-    let max_n_p95 = p95_by_n(|a, b| a.n >= b.n);
+    let min_n_p95 = points
+        .iter()
+        .min_by_key(|p| p.n)
+        .map_or(0, |p| p.stats.p95_ms);
+    let max_n_p95 = points
+        .iter()
+        .max_by_key(|p| p.n)
+        .map_or(0, |p| p.stats.p95_ms);
     let slope = if points.len() < 2 {
         1.0
     } else {
@@ -501,17 +498,8 @@ pub fn format_scaling_human(report: &ScalingReport) -> String {
 /// Render the scaling budget table for `--dry-run` (no build needed).
 pub fn format_scaling_budget_table() -> String {
     let mut out = String::new();
-    writeln!(
-        out,
-        "Autumn macro-scaling budget (issue #983)\n"
-    )
-    .unwrap();
-    writeln!(
-        out,
-        "{:<12}  {:>12}  Notes",
-        "Metric", "Budget",
-    )
-    .unwrap();
+    writeln!(out, "Autumn macro-scaling budget (issue #983)\n").unwrap();
+    writeln!(out, "{:<12}  {:>12}  Notes", "Metric", "Budget",).unwrap();
     writeln!(out, "{}", "-".repeat(50)).unwrap();
     writeln!(
         out,
@@ -528,10 +516,15 @@ pub fn format_scaling_budget_table() -> String {
     writeln!(
         out,
         "{:<12}  {:>10.0}%   vs accepted baseline slope (skipped until baseline established)",
-        "Regression", SCALING_BASELINE_REGRESSION.mul_add(100.0, -100.0),
+        "Regression",
+        SCALING_BASELINE_REGRESSION.mul_add(100.0, -100.0),
     )
     .unwrap();
-    writeln!(out, "\nSee docs/guide/dev-loop-latency.md (§ Scaling) for methodology.").unwrap();
+    writeln!(
+        out,
+        "\nSee docs/guide/dev-loop-latency.md (§ Scaling) for methodology."
+    )
+    .unwrap();
     out
 }
 
@@ -566,9 +559,7 @@ pub fn emit_scaling_report(
     }
 
     if fail_on_regression && !report.all_passed {
-        eprintln!(
-            "Scaling benchmark failed: p95 ceiling or slope budget exceeded. Exiting 1."
-        );
+        eprintln!("Scaling benchmark failed: p95 ceiling or slope budget exceeded. Exiting 1.");
         exit = 1;
     }
 
@@ -588,11 +579,20 @@ pub fn run_scaling_dry_run() -> i32 {
     0
 }
 
-/// Load a `ScalingBaseline` from a JSON file, returning `None` on any error.
-pub fn load_baseline(path: Option<&str>) -> Option<ScalingBaseline> {
-    let path = path?;
-    let content = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&content).ok()
+/// Load a `ScalingBaseline` from a JSON file.
+///
+/// Returns `Ok(None)` when no path is given, and `Err` when the file cannot be
+/// read or parsed — surfacing the error rather than silently skipping the
+/// regression gate on a corrupt baseline.
+pub fn load_baseline(path: Option<&str>) -> Result<Option<ScalingBaseline>, String> {
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read baseline file {path:?}: {e}"))?;
+    let baseline = serde_json::from_str(&content)
+        .map_err(|e| format!("failed to parse baseline file {path:?}: {e}"))?;
+    Ok(Some(baseline))
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -626,7 +626,10 @@ mod tests {
         let paths: Vec<&str> = app.files.iter().map(|(p, _)| p.as_str()).collect();
         assert!(paths.contains(&"src/schema.rs"), "missing schema.rs");
         assert!(paths.contains(&"src/models.rs"), "missing models.rs");
-        assert!(paths.contains(&"src/repositories.rs"), "missing repositories.rs");
+        assert!(
+            paths.contains(&"src/repositories.rs"),
+            "missing repositories.rs"
+        );
         assert!(paths.contains(&"src/handlers.rs"), "missing handlers.rs");
         assert!(paths.contains(&"src/main.rs"), "missing main.rs");
         assert_eq!(paths.len(), 5, "expected exactly 5 source files");
@@ -709,7 +712,10 @@ mod tests {
     fn generate_app_is_deterministic() {
         let a = generate_synthetic_app(10);
         let b = generate_synthetic_app(10);
-        assert_eq!(a.cargo_toml, b.cargo_toml, "Cargo.toml must be deterministic");
+        assert_eq!(
+            a.cargo_toml, b.cargo_toml,
+            "Cargo.toml must be deterministic"
+        );
         assert_eq!(a.files.len(), b.files.len());
         for ((pa, ca), (pb, cb)) in a.files.iter().zip(b.files.iter()) {
             assert_eq!(pa, pb, "file paths must be deterministic");
@@ -783,7 +789,11 @@ mod tests {
         // Lines other than the sentinel line are unchanged.
         let orig_lines: Vec<&str> = handlers.lines().collect();
         let edit_lines: Vec<&str> = edited.lines().collect();
-        assert_eq!(orig_lines.len(), edit_lines.len(), "line count must not change");
+        assert_eq!(
+            orig_lines.len(),
+            edit_lines.len(),
+            "line count must not change"
+        );
         let changed: Vec<usize> = orig_lines
             .iter()
             .zip(edit_lines.iter())
@@ -791,7 +801,11 @@ mod tests {
             .filter(|(_, (a, b))| a != b)
             .map(|(i, _)| i)
             .collect();
-        assert_eq!(changed.len(), 1, "exactly one line must change, changed: {changed:?}");
+        assert_eq!(
+            changed.len(),
+            1,
+            "exactly one line must change, changed: {changed:?}"
+        );
     }
 
     #[test]
@@ -828,28 +842,37 @@ mod tests {
 
     #[test]
     fn parse_sizes_rejects_zero() {
-        assert!(
-            parse_sizes("1,0,100").is_err(),
-            "size 0 must be rejected"
-        );
+        assert!(parse_sizes("1,0,100").is_err(), "size 0 must be rejected");
     }
 
     #[test]
     fn parse_sizes_rejects_empty_string() {
         assert!(parse_sizes("").is_err(), "empty string must be rejected");
-        assert!(parse_sizes("  ").is_err(), "whitespace-only must be rejected");
+        assert!(
+            parse_sizes("  ").is_err(),
+            "whitespace-only must be rejected"
+        );
     }
 
     #[test]
     fn parse_sizes_rejects_non_numeric() {
-        assert!(parse_sizes("1,abc,100").is_err(), "non-numeric token must be rejected");
-        assert!(parse_sizes("foo").is_err(), "all-non-numeric must be rejected");
+        assert!(
+            parse_sizes("1,abc,100").is_err(),
+            "non-numeric token must be rejected"
+        );
+        assert!(
+            parse_sizes("foo").is_err(),
+            "all-non-numeric must be rejected"
+        );
     }
 
     #[test]
     fn parse_sizes_rejects_negative() {
         // usize parse rejects leading "-" so this is an Err.
-        assert!(parse_sizes("1,-5,100").is_err(), "negative must be rejected");
+        assert!(
+            parse_sizes("1,-5,100").is_err(),
+            "negative must be rejected"
+        );
     }
 
     // ── compute_slope ─────────────────────────────────────────────────────
@@ -870,9 +893,15 @@ mod tests {
     fn compute_slope_zero_baseline_returns_one() {
         // Placeholder / empty-sample baseline must not cause divide-by-zero.
         let s = compute_slope(0, 0);
-        assert!((s - 1.0).abs() < 1e-9, "zero baseline → slope 1.0 (flat), got {s}");
+        assert!(
+            (s - 1.0).abs() < 1e-9,
+            "zero baseline → slope 1.0 (flat), got {s}"
+        );
         let s2 = compute_slope(0, 5000);
-        assert!((s2 - 1.0).abs() < 1e-9, "zero baseline (any max) → slope 1.0, got {s2}");
+        assert!(
+            (s2 - 1.0).abs() < 1e-9,
+            "zero baseline (any max) → slope 1.0, got {s2}"
+        );
     }
 
     #[test]
@@ -936,7 +965,10 @@ mod tests {
             note: None,
         };
         let r = build_scaling_report(&m, Some(&baseline));
-        assert!(r.baseline_regression_passed, "non-established baseline must always pass regression");
+        assert!(
+            r.baseline_regression_passed,
+            "non-established baseline must always pass regression"
+        );
         // slope = 3.0 still > 2× so all_passed should be false due to slope gate
         assert!(!r.all_passed, "slope 3× still fails 2× absolute slope gate");
     }
@@ -951,7 +983,10 @@ mod tests {
             note: None,
         };
         let r = build_scaling_report(&m, Some(&baseline));
-        assert!(!r.baseline_regression_passed, "slope 3× vs accepted 1.2 must fail regression");
+        assert!(
+            !r.baseline_regression_passed,
+            "slope 3× vs accepted 1.2 must fail regression"
+        );
         assert!(!r.all_passed);
     }
 
@@ -965,8 +1000,14 @@ mod tests {
             note: None,
         };
         let r = build_scaling_report(&m, Some(&baseline));
-        assert!(r.baseline_regression_passed, "1.6 within 1.5×1.2=1.80 must pass");
-        assert!(r.all_passed, "within abs, slope, and regression → all_passed");
+        assert!(
+            r.baseline_regression_passed,
+            "1.6 within 1.5×1.2=1.80 must pass"
+        );
+        assert!(
+            r.all_passed,
+            "within abs, slope, and regression → all_passed"
+        );
     }
 
     #[test]
@@ -974,7 +1015,10 @@ mod tests {
         // Single size → no meaningful slope → defaults to 1.0 (flat).
         let m = make_measurements(&[50], &[4000]);
         let r = build_scaling_report(&m, None);
-        assert!((r.slope - 1.0).abs() < 1e-9, "single-size slope must be 1.0");
+        assert!(
+            (r.slope - 1.0).abs() < 1e-9,
+            "single-size slope must be 1.0"
+        );
         assert!(r.slope_passed);
         assert!(r.all_passed);
     }
@@ -982,7 +1026,10 @@ mod tests {
     #[test]
     fn build_report_empty_measurements_passes() {
         let r = build_scaling_report(&[], None);
-        assert!(r.all_passed, "empty measurement set must pass (nothing to fail)");
+        assert!(
+            r.all_passed,
+            "empty measurement set must pass (nothing to fail)"
+        );
     }
 
     #[test]
@@ -1002,9 +1049,18 @@ mod tests {
         let ra = build_scaling_report(&ascending, None);
         let rr = build_scaling_report(&reversed, None);
         assert!((ra.slope - 5.0).abs() < 1e-9, "ascending slope must be 5.0");
-        assert!((rr.slope - 5.0).abs() < 1e-9, "reversed-input slope must also be 5.0");
-        assert!(!ra.slope_passed && !rr.slope_passed, "slope 5× must fail either way");
-        assert!(!ra.all_passed && !rr.all_passed, "reversed sweep must not pass the gate");
+        assert!(
+            (rr.slope - 5.0).abs() < 1e-9,
+            "reversed-input slope must also be 5.0"
+        );
+        assert!(
+            !ra.slope_passed && !rr.slope_passed,
+            "slope 5× must fail either way"
+        );
+        assert!(
+            !ra.all_passed && !rr.all_passed,
+            "reversed sweep must not pass the gate"
+        );
     }
 
     #[test]
@@ -1014,8 +1070,14 @@ mod tests {
         let m: Vec<(usize, Vec<u64>)> = vec![(1, vec![2000]), (100, vec![])];
         let r = build_scaling_report(&m, None);
         assert!(r.points[0].abs_passed, "the measured size still passes");
-        assert!(!r.points[1].abs_passed, "an empty-sample size must fail the abs gate");
-        assert!(!r.all_passed, "a missing measurement must fail the overall gate");
+        assert!(
+            !r.points[1].abs_passed,
+            "an empty-sample size must fail the abs gate"
+        );
+        assert!(
+            !r.all_passed,
+            "a missing measurement must fail the overall gate"
+        );
     }
 
     // ── format_scaling_json ───────────────────────────────────────────────
@@ -1037,7 +1099,10 @@ mod tests {
         assert!(v.get("timestamp_utc").is_some(), "must have timestamp_utc");
         assert!(v.get("runner_os").is_some(), "must have runner_os");
         assert!(v.get("rust_version").is_some(), "must have rust_version");
-        assert!(v.get("autumn_version").is_some(), "must have autumn_version");
+        assert!(
+            v.get("autumn_version").is_some(),
+            "must have autumn_version"
+        );
         assert!(v.get("all_passed").is_some(), "must have all_passed");
         assert!(v.get("slope").is_some(), "must have slope");
         assert!(v.get("points").is_some(), "must have points array");
@@ -1159,7 +1224,10 @@ mod tests {
         let r = build_scaling_report(&m, None);
         assert!(r.all_passed);
         let exit = emit_scaling_report(&r, false, None, true);
-        assert_eq!(exit, 0, "--fail-on-regression must not trip on a passing report");
+        assert_eq!(
+            exit, 0,
+            "--fail-on-regression must not trip on a passing report"
+        );
     }
 
     #[test]
@@ -1168,7 +1236,10 @@ mod tests {
         let r = build_scaling_report(&m, None);
         assert!(!r.all_passed);
         let exit = emit_scaling_report(&r, false, None, true);
-        assert_eq!(exit, 1, "--fail-on-regression must return 1 for a failing report");
+        assert_eq!(
+            exit, 1,
+            "--fail-on-regression must return 1 for a failing report"
+        );
     }
 
     // ── run_scaling_dry_run ───────────────────────────────────────────────
@@ -1182,12 +1253,12 @@ mod tests {
 
     #[test]
     fn load_baseline_none_path_returns_none() {
-        assert!(load_baseline(None).is_none());
+        assert!(load_baseline(None).unwrap().is_none());
     }
 
     #[test]
-    fn load_baseline_missing_file_returns_none() {
-        assert!(load_baseline(Some("/nonexistent/path/baseline.json")).is_none());
+    fn load_baseline_missing_file_errors() {
+        assert!(load_baseline(Some("/nonexistent/path/baseline.json")).is_err());
     }
 
     #[test]
@@ -1198,7 +1269,9 @@ mod tests {
             r#"{"established":false,"accepted_slope":null,"note":"initial"}"#,
         )
         .expect("write baseline");
-        let b = load_baseline(Some(tmp.path().to_str().unwrap())).expect("must parse");
+        let b = load_baseline(Some(tmp.path().to_str().unwrap()))
+            .expect("must parse")
+            .expect("must be Some");
         assert!(!b.established);
         assert!(b.accepted_slope.is_none());
     }
@@ -1208,7 +1281,9 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().expect("tempfile");
         std::fs::write(tmp.path(), r#"{"established":true,"accepted_slope":1.5}"#)
             .expect("write baseline");
-        let b = load_baseline(Some(tmp.path().to_str().unwrap())).expect("must parse");
+        let b = load_baseline(Some(tmp.path().to_str().unwrap()))
+            .expect("must parse")
+            .expect("must be Some");
         assert!(b.established);
         assert!((b.accepted_slope.unwrap() - 1.5).abs() < 1e-9);
     }
@@ -1216,11 +1291,9 @@ mod tests {
     // ── helper ────────────────────────────────────────────────────────────
 
     fn file_content<'a>(app: &'a GeneratedApp, relpath: &str) -> &'a str {
-        app.files
-            .iter()
-            .find(|(p, _)| p == relpath)
-            .map_or_else(|| panic!("file {relpath:?} not found in GeneratedApp"), |(_, c)| {
-                c.as_str()
-            })
+        app.files.iter().find(|(p, _)| p == relpath).map_or_else(
+            || panic!("file {relpath:?} not found in GeneratedApp"),
+            |(_, c)| c.as_str(),
+        )
     }
 }

--- a/autumn-cli/src/dev_loop_scaling.rs
+++ b/autumn-cli/src/dev_loop_scaling.rs
@@ -499,7 +499,7 @@ pub fn format_scaling_human(report: &ScalingReport) -> String {
 pub fn format_scaling_budget_table() -> String {
     let mut out = String::new();
     writeln!(out, "Autumn macro-scaling budget (issue #983)\n").unwrap();
-    writeln!(out, "{:<12}  {:>12}  Notes", "Metric", "Budget",).unwrap();
+    writeln!(out, "{:<12}  {:>12}  Notes", "Metric", "Budget").unwrap();
     writeln!(out, "{}", "-".repeat(50)).unwrap();
     writeln!(
         out,

--- a/autumn-cli/src/dev_loop_scaling.rs
+++ b/autumn-cli/src/dev_loop_scaling.rs
@@ -24,7 +24,7 @@ use std::fmt::Write as FmtWrite;
 
 use serde::{Deserialize, Serialize};
 
-use crate::dev_loop_bench::{ClassStats, compute_stats};
+use crate::dev_loop_bench::{ClassStats, chrono_utc_now, compute_stats, rust_version_string};
 
 // ── Budget constants ─────────────────────────────────────────────────────────
 
@@ -138,6 +138,11 @@ pub struct ScalingReport {
 /// in `handler_0` whose value can be changed by [`apply_handler_edit`] to
 /// force a warm incremental recompile of exactly one file.
 pub fn generate_synthetic_app(n: usize) -> GeneratedApp {
+    // `autumn-web = "*"`: the live driver always appends a `[patch.crates-io]`
+    // pointing this dependency at the workspace's local `autumn-web` source, so
+    // the resolved version is whatever the repo currently is. A wildcard avoids
+    // a hardcoded version that would silently break `[patch]` resolution after a
+    // workspace version bump; `publish = false` makes the wildcard valid.
     let cargo_toml = "[package]\n\
          name = \"scaling_bench_app\"\n\
          version = \"0.1.0\"\n\
@@ -147,7 +152,7 @@ pub fn generate_synthetic_app(n: usize) -> GeneratedApp {
          [workspace]\n\
          \n\
          [dependencies]\n\
-         autumn-web = \"0.5.0\"\n"
+         autumn-web = \"*\"\n"
         .to_string();
 
     let files = vec![
@@ -347,7 +352,11 @@ pub fn build_scaling_report(
     let mut points = Vec::new();
     for (n, samples) in measurements {
         let stats = compute_stats(samples);
-        let abs_passed = stats.p95_ms <= SCALING_ABS_P95_MS;
+        // An empty sample vector means the measurement for this size failed:
+        // `compute_stats` yields p95 = 0, which would otherwise sail under the
+        // absolute ceiling and silently report a missing measurement as a pass.
+        // Treat a sample-less point as a hard fail.
+        let abs_passed = !samples.is_empty() && stats.p95_ms <= SCALING_ABS_P95_MS;
         points.push(ScalingPoint {
             n: *n,
             stats,
@@ -355,12 +364,22 @@ pub fn build_scaling_report(
         });
     }
 
-    let first_p95 = points.first().map_or(0, |p| p.stats.p95_ms);
-    let last_p95 = points.last().map_or(0, |p| p.stats.p95_ms);
+    // Compute the slope from the smallest-N to the largest-N point, ordered by
+    // N rather than by input position. `parse_sizes` preserves caller order, so
+    // a sweep passed out of order (e.g. `--sizes 100,50,1`) must not invert the
+    // ratio and let a real regression pass the gate.
+    let p95_by_n = |sel: fn(&ScalingPoint, &ScalingPoint) -> bool| {
+        points
+            .iter()
+            .reduce(|a, b| if sel(a, b) { a } else { b })
+            .map_or(0, |p| p.stats.p95_ms)
+    };
+    let min_n_p95 = p95_by_n(|a, b| a.n <= b.n);
+    let max_n_p95 = p95_by_n(|a, b| a.n >= b.n);
     let slope = if points.len() < 2 {
         1.0
     } else {
-        compute_slope(first_p95, last_p95)
+        compute_slope(min_n_p95, max_n_p95)
     };
     let slope_passed = slope <= SCALING_SLOPE_MAX;
 
@@ -574,16 +593,6 @@ pub fn load_baseline(path: Option<&str>) -> Option<ScalingBaseline> {
     let path = path?;
     let content = std::fs::read_to_string(path).ok()?;
     serde_json::from_str(&content).ok()
-}
-
-// ── Env-var helpers (same vars as dev_loop_bench) ────────────────────────────
-
-fn chrono_utc_now() -> String {
-    std::env::var("AUTUMN_BENCH_TIMESTAMP").unwrap_or_else(|_| "unknown".to_string())
-}
-
-fn rust_version_string() -> String {
-    std::env::var("AUTUMN_BENCH_RUST_VERSION").unwrap_or_else(|_| "unknown".to_string())
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -981,6 +990,32 @@ mod tests {
         let m = make_measurements(&[1, 25, 50, 100], &[1000, 1200, 1500, 2000]);
         let r = build_scaling_report(&m, None);
         assert_eq!(r.sizes, vec![1, 25, 50, 100]);
+    }
+
+    #[test]
+    fn build_report_slope_is_size_ordered_not_input_ordered() {
+        // Same data, ascending vs. reversed input order. The slope must be
+        // p95@N_max / p95@N_min (5000/1000 = 5.0) regardless of input order —
+        // a reversed sweep must not invert the ratio and pass the gate.
+        let ascending = make_measurements(&[1, 100], &[1000, 5000]);
+        let reversed = make_measurements(&[100, 1], &[5000, 1000]);
+        let ra = build_scaling_report(&ascending, None);
+        let rr = build_scaling_report(&reversed, None);
+        assert!((ra.slope - 5.0).abs() < 1e-9, "ascending slope must be 5.0");
+        assert!((rr.slope - 5.0).abs() < 1e-9, "reversed-input slope must also be 5.0");
+        assert!(!ra.slope_passed && !rr.slope_passed, "slope 5× must fail either way");
+        assert!(!ra.all_passed && !rr.all_passed, "reversed sweep must not pass the gate");
+    }
+
+    #[test]
+    fn build_report_empty_samples_point_fails() {
+        // A size whose measurement produced no samples (build failure) must not
+        // be reported as a pass via compute_stats' zero p95.
+        let m: Vec<(usize, Vec<u64>)> = vec![(1, vec![2000]), (100, vec![])];
+        let r = build_scaling_report(&m, None);
+        assert!(r.points[0].abs_passed, "the measured size still passes");
+        assert!(!r.points[1].abs_passed, "an empty-sample size must fail the abs gate");
+        assert!(!r.all_passed, "a missing measurement must fail the overall gate");
     }
 
     // ── format_scaling_json ───────────────────────────────────────────────

--- a/autumn-cli/src/dev_loop_scaling.rs
+++ b/autumn-cli/src/dev_loop_scaling.rs
@@ -1,0 +1,1191 @@
+//! Macro-scaling benchmark: measures how warm incremental rebuild p95 grows
+//! as an Autumn app adds routes and models (issue #983).
+//!
+//! This module is the **pure, unit-tested** half of the scaling sweep:
+//! - A deterministic synthetic-app generator (N `#[get]` handlers + N
+//!   `#[model]`/`#[repository]` pairs) used by the live driver to scaffold
+//!   compile targets without checking in fixtures.
+//! - Budget constants: p95 ≤ **8 s** absolute per size; slope
+//!   (p95\@N\_max / p95\@N\_min) ≤ **2×**.
+//! - `ScalingReport` with per-size `ScalingPoint`s, slope, and baseline-
+//!   regression check (skipped until an accepted baseline is established,
+//!   mirroring the cold-start policy).
+//! - Formatters and emitters reusing the `dev_loop_bench` plumbing so the
+//!   output shape is identical to every other Autumn latency report.
+//!
+//! The **live driver** (tempdir scaffold → warm cargo build → single-file edit
+//! → timed incremental rebuild) lives in [`crate::scaling_driver`], which is
+//! excluded from coverage like `cold_start_driver.rs`.
+//!
+//! See `docs/guide/dev-loop-latency.md` (§ Scaling) for the budget table and
+//! methodology.
+
+use std::fmt::Write as FmtWrite;
+
+use serde::{Deserialize, Serialize};
+
+use crate::dev_loop_bench::{ClassStats, compute_stats};
+
+// ── Budget constants ─────────────────────────────────────────────────────────
+
+/// Absolute p95 ceiling per size point (ms). Any N whose p95 exceeds this
+/// fails the gate regardless of slope.
+pub const SCALING_ABS_P95_MS: u64 = 8_000;
+
+/// Maximum allowed slope: p95\@N\_max / p95\@N\_min must be ≤ this value.
+/// Enforces that the edit-refresh loop at 100 routes is no more than 2× slower
+/// than at 1 route.
+pub const SCALING_SLOPE_MAX: f64 = 2.0;
+
+/// Baseline regression allowance: if an accepted slope baseline is on record,
+/// the measured slope may not exceed `accepted × SCALING_BASELINE_REGRESSION`
+/// before the run is considered a regression.
+pub const SCALING_BASELINE_REGRESSION: f64 = 1.20;
+
+/// Default size sweep (CSV) used by `--sizes` when the flag is omitted.
+pub const DEFAULT_SIZES: &str = "1,25,50,100";
+
+// ── Generated-app types ──────────────────────────────────────────────────────
+
+/// A complete synthetic Autumn app ready to be written to disk and compiled.
+///
+/// `files` contains `(relative_path, content)` pairs; `cargo_toml` is the
+/// root manifest. Both are byte-for-byte deterministic for a given `n`.
+#[derive(Debug, Clone)]
+pub struct GeneratedApp {
+    /// Content of `Cargo.toml` at the project root.
+    pub cargo_toml: String,
+    /// All source files: `(relpath_from_project_root, content)`.
+    pub files: Vec<(String, String)>,
+}
+
+// ── Baseline ─────────────────────────────────────────────────────────────────
+
+/// Accepted slope baseline, loaded from `benchmarks/dev-loop-scaling/baseline.json`.
+///
+/// When `established` is `false` (the initial committed state), the
+/// `> 20%-over-baseline` regression check is skipped entirely so the first CI
+/// run can record a baseline number without failing. The absolute (8 s) and 2×
+/// slope gates always apply.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScalingBaseline {
+    pub established: bool,
+    pub accepted_slope: Option<f64>,
+    #[serde(default)]
+    pub note: Option<String>,
+}
+
+// ── Report types ─────────────────────────────────────────────────────────────
+
+/// Measured result for a single app size N.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScalingPoint {
+    /// Number of handlers / model+repository pairs in this synthetic app.
+    pub n: usize,
+    /// p50/p95/max timing statistics (ms) across `--runs` incremental rebuild samples.
+    pub stats: ClassStats,
+    /// Whether this size's p95 is within the 8 s absolute ceiling.
+    pub abs_passed: bool,
+}
+
+/// Complete scaling benchmark report.
+#[derive(Debug, Serialize)]
+pub struct ScalingReport {
+    // ── Environment metadata ──
+    pub timestamp_utc: String,
+    pub runner_os: String,
+    pub rust_version: String,
+    pub autumn_version: String,
+    // ── Sweep configuration ──
+    /// Sizes that were swept, in the order measured.
+    pub sizes: Vec<usize>,
+    // ── Per-size results ──
+    pub points: Vec<ScalingPoint>,
+    // ── Slope gate ──
+    /// p95\@N\_max / p95\@N\_min (1.0 when flat or only one size measured).
+    pub slope: f64,
+    /// Budget ceiling for the slope (always `SCALING_SLOPE_MAX`).
+    pub slope_max: f64,
+    pub slope_passed: bool,
+    // ── Baseline regression gate ──
+    /// The accepted slope from the baseline file, when established.
+    pub baseline_slope: Option<f64>,
+    /// `true` when no baseline is established OR regression is within allowance.
+    pub baseline_regression_passed: bool,
+    // ── Overall ──
+    /// `true` iff every per-size p95 ≤ 8 s AND slope ≤ 2× AND (baseline
+    /// regression ≤ 20% when an accepted baseline exists).
+    pub all_passed: bool,
+}
+
+// ── Generator ────────────────────────────────────────────────────────────────
+
+/// Generate a deterministic synthetic Autumn app with `n` handlers and `n`
+/// model/repository pairs.
+///
+/// The generated app:
+/// - Is a **standalone workspace root** (contains `[workspace]`) so that the
+///   `[patch.crates-io]` section appended by the live driver is valid.
+/// - Depends only on `autumn-web` at default features (which include `db`,
+///   bringing in diesel and diesel-async).
+/// - Uses `autumn_web::reexports::diesel::table!` (no separate diesel dep)
+///   and `#[autumn_web::model]` / `#[autumn_web::repository]`, exactly
+///   mirroring `autumn/tests/compile-pass/repository_no_hooks.rs`.
+/// - Is **compile-only** — no Postgres is required because we never boot the
+///   binary, only `cargo build` it.
+///
+/// The file named `src/handlers.rs` contains a `BENCH_EDIT_SENTINEL` constant
+/// in `handler_0` whose value can be changed by [`apply_handler_edit`] to
+/// force a warm incremental recompile of exactly one file.
+pub fn generate_synthetic_app(n: usize) -> GeneratedApp {
+    let cargo_toml = "[package]\n\
+         name = \"scaling_bench_app\"\n\
+         version = \"0.1.0\"\n\
+         edition = \"2024\"\n\
+         publish = false\n\
+         \n\
+         [workspace]\n\
+         \n\
+         [dependencies]\n\
+         autumn-web = \"0.5.0\"\n"
+        .to_string();
+
+    let files = vec![
+        ("src/schema.rs".to_string(), generate_schema(n)),
+        ("src/models.rs".to_string(), generate_models(n)),
+        ("src/repositories.rs".to_string(), generate_repositories(n)),
+        ("src/handlers.rs".to_string(), generate_handlers(n, 0)),
+        ("src/main.rs".to_string(), generate_main(n)),
+    ];
+
+    GeneratedApp { cargo_toml, files }
+}
+
+fn generate_schema(n: usize) -> String {
+    let mut out = String::new();
+    for k in 0..n {
+        writeln!(
+            out,
+            "autumn_web::reexports::diesel::table! {{\n\
+             \tentity_{k} (id) {{\n\
+             \t\tid -> Int8,\n\
+             \t\tcontent -> Text,\n\
+             \t}}\n\
+             }}\n"
+        )
+        .unwrap();
+    }
+    out
+}
+
+fn generate_models(n: usize) -> String {
+    let mut out = String::from("// Bring all diesel table DSLs into scope for derive macros.\nuse crate::schema::*;\n\n");
+    for k in 0..n {
+        writeln!(
+            out,
+            "#[autumn_web::model(table = \"entity_{k}\")]\npub struct Entity{k} {{\n\
+             \t#[id]\n\
+             \tpub id: i64,\n\
+             \tpub content: String,\n\
+             }}\n"
+        )
+        .unwrap();
+    }
+    out
+}
+
+fn generate_repositories(n: usize) -> String {
+    let mut out = String::from("use crate::models::*;\nuse crate::schema::*;\n\n");
+    for k in 0..n {
+        writeln!(
+            out,
+            "#[autumn_web::repository(Entity{k})]\npub trait Entity{k}Repository {{\n\
+             \tfn find_by_content(content: String) -> Vec<Entity{k}>;\n\
+             }}\n"
+        )
+        .unwrap();
+    }
+    out
+}
+
+/// Generate `src/handlers.rs` with `n` route handlers.
+///
+/// `handler_0` contains the `BENCH_EDIT_SENTINEL` constant, which
+/// [`apply_handler_edit`] bumps to force a warm incremental recompile of
+/// exactly this one file. All other handlers are static strings.
+fn generate_handlers(n: usize, revision: u32) -> String {
+    let mut out = String::from("use autumn_web::prelude::*;\n\n");
+    // handler_0 — the editable handler whose BENCH_EDIT_SENTINEL is bumped
+    // each time the live driver wants to trigger a warm incremental rebuild.
+    writeln!(
+        out,
+        "const BENCH_EDIT_SENTINEL: &str = \"bench_edit_rev_{revision}\";\n\n\
+         #[get(\"/entity_0\")]\npub async fn handler_0() -> String {{ \
+         BENCH_EDIT_SENTINEL.to_string() }}\n"
+    )
+    .unwrap();
+    for k in 1..n {
+        writeln!(
+            out,
+            "#[get(\"/entity_{k}\")]\npub async fn handler_{k}() -> String {{ \
+             \"handler_{k}\".to_string() }}\n"
+        )
+        .unwrap();
+    }
+    out
+}
+
+fn generate_main(n: usize) -> String {
+    let handler_list = (0..n)
+        .map(|k| format!("handler_{k}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    format!(
+        "use autumn_web::prelude::*;\n\
+         mod schema;\n\
+         mod models;\n\
+         mod repositories;\n\
+         mod handlers;\n\
+         use handlers::*;\n\n\
+         #[autumn_web::main]\nasync fn main() {{\n\
+         \tautumn_web::app()\n\
+         \t\t.routes(routes![{handler_list}])\n\
+         \t\t.run()\n\
+         \t\t.await;\n\
+         }}\n"
+    )
+}
+
+// ── Editing ──────────────────────────────────────────────────────────────────
+
+/// Return a copy of `handlers_src` with the `BENCH_EDIT_SENTINEL` constant
+/// bumped to `revision`.
+///
+/// This changes exactly one line in one file, causing `cargo build` to
+/// recompile only `handlers.rs` — a genuine warm incremental rebuild that
+/// exercises macro re-expansion without touching any other module.
+pub fn apply_handler_edit(handlers_src: &str, revision: u32) -> String {
+    // Use split('\n') instead of lines() so trailing newlines are preserved
+    // when the result is rejoined: lines() silently drops trailing \n, which
+    // would cause the output to have a different line count than the input.
+    handlers_src
+        .split('\n')
+        .map(|line| {
+            if line
+                .trim_start()
+                .starts_with("const BENCH_EDIT_SENTINEL:")
+            {
+                format!(
+                    "const BENCH_EDIT_SENTINEL: &str = \"bench_edit_rev_{revision}\";"
+                )
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// ── Size parsing ─────────────────────────────────────────────────────────────
+
+/// Parse a comma-separated list of positive integers (e.g. `"1,25,50,100"`).
+///
+/// Returns `Err` if the string is empty, any token is not a positive integer,
+/// or any token is `0` (zero-size apps would yield meaningless slope data).
+pub fn parse_sizes(csv: &str) -> Result<Vec<usize>, String> {
+    if csv.trim().is_empty() {
+        return Err("--sizes must not be empty".to_string());
+    }
+    let mut sizes = Vec::new();
+    for part in csv.split(',') {
+        let tok = part.trim();
+        match tok.parse::<usize>() {
+            Ok(0) => return Err("app size must be ≥ 1 (got 0)".to_string()),
+            Ok(n) => sizes.push(n),
+            Err(_) => return Err(format!("invalid size {tok:?}: not a positive integer")),
+        }
+    }
+    if sizes.is_empty() {
+        return Err("no valid sizes found".to_string());
+    }
+    Ok(sizes)
+}
+
+// ── Slope ────────────────────────────────────────────────────────────────────
+
+/// Compute the slope: `p95_max_n / p95_min_n`.
+///
+/// Returns `1.0` (flat / no regression) when `p95_min_n` is `0` to avoid
+/// division-by-zero from placeholder or empty samples.
+pub fn compute_slope(p95_min_n: u64, p95_max_n: u64) -> f64 {
+    if p95_min_n == 0 {
+        return 1.0;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let result = p95_max_n as f64 / p95_min_n as f64;
+    result
+}
+
+// ── Report builder ───────────────────────────────────────────────────────────
+
+/// Assemble a `ScalingReport` from raw per-size timing samples.
+///
+/// `measurements` is `[(N, samples_ms), …]` in size order. The slope is
+/// computed from the first point's p95 to the last point's p95.
+///
+/// When fewer than two sizes are present the slope defaults to `1.0` (flat).
+///
+/// The baseline-regression check is **skipped** (passes) when `baseline` is
+/// `None` or `baseline.established` is `false`, mirroring the cold-start
+/// policy: the first weekly run records the number; until then only the
+/// absolute and 2× slope gates apply.
+pub fn build_scaling_report(
+    measurements: &[(usize, Vec<u64>)],
+    baseline: Option<&ScalingBaseline>,
+) -> ScalingReport {
+    let mut points = Vec::new();
+    for (n, samples) in measurements {
+        let stats = compute_stats(samples);
+        let abs_passed = stats.p95_ms <= SCALING_ABS_P95_MS;
+        points.push(ScalingPoint {
+            n: *n,
+            stats,
+            abs_passed,
+        });
+    }
+
+    let first_p95 = points.first().map_or(0, |p| p.stats.p95_ms);
+    let last_p95 = points.last().map_or(0, |p| p.stats.p95_ms);
+    let slope = if points.len() < 2 {
+        1.0
+    } else {
+        compute_slope(first_p95, last_p95)
+    };
+    let slope_passed = slope <= SCALING_SLOPE_MAX;
+
+    let (baseline_slope, baseline_regression_passed) = match baseline {
+        Some(b) if b.established => b.accepted_slope.map_or((None, true), |accepted| {
+            let passes = slope <= accepted * SCALING_BASELINE_REGRESSION;
+            (Some(accepted), passes)
+        }),
+        _ => (None, true),
+    };
+
+    let all_abs_passed = points.is_empty() || points.iter().all(|p| p.abs_passed);
+    let all_passed = all_abs_passed && slope_passed && baseline_regression_passed;
+
+    ScalingReport {
+        timestamp_utc: chrono_utc_now(),
+        runner_os: std::env::consts::OS.to_string(),
+        rust_version: rust_version_string(),
+        autumn_version: env!("CARGO_PKG_VERSION").to_string(),
+        sizes: measurements.iter().map(|(n, _)| *n).collect(),
+        points,
+        slope,
+        slope_max: SCALING_SLOPE_MAX,
+        slope_passed,
+        baseline_slope,
+        baseline_regression_passed,
+        all_passed,
+    }
+}
+
+// ── Formatters ───────────────────────────────────────────────────────────────
+
+/// Serialise a `ScalingReport` as a machine-readable JSON string.
+pub fn format_scaling_json(report: &ScalingReport) -> String {
+    serde_json::to_string_pretty(report)
+        .unwrap_or_else(|e| format!("{{\"error\": \"serialisation failed: {e}\"}}"))
+}
+
+/// Format a `ScalingReport` as a human-readable summary table.
+pub fn format_scaling_human(report: &ScalingReport) -> String {
+    let mut out = String::new();
+
+    writeln!(
+        out,
+        "Autumn macro-scaling benchmark — {}",
+        report.timestamp_utc
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "Runner: {runner}  Rust: {rust}  autumn-web: {av}",
+        runner = report.runner_os,
+        rust = report.rust_version,
+        av = report.autumn_version,
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "Budget: p95 ≤ {SCALING_ABS_P95_MS} ms absolute; slope ≤ {SCALING_SLOPE_MAX}×",
+    )
+    .unwrap();
+    out.push('\n');
+
+    writeln!(
+        out,
+        "{:>6}  {:>8}  {:>8}  {:>8}  Abs",
+        "N", "p50 ms", "p95 ms", "max ms",
+    )
+    .unwrap();
+    writeln!(out, "{}", "-".repeat(44)).unwrap();
+
+    for p in &report.points {
+        let abs = if p.abs_passed { "PASS" } else { "FAIL" };
+        writeln!(
+            out,
+            "{:>6}  {:>8}  {:>8}  {:>8}  {abs}",
+            p.n, p.stats.p50_ms, p.stats.p95_ms, p.stats.max_ms,
+        )
+        .unwrap();
+    }
+
+    out.push('\n');
+    let slope_status = if report.slope_passed { "PASS" } else { "FAIL" };
+    writeln!(
+        out,
+        "Slope (p95@Nmax / p95@Nmin): {:.2}× ≤ {:.1}× → {slope_status}",
+        report.slope, report.slope_max,
+    )
+    .unwrap();
+
+    match report.baseline_slope {
+        Some(accepted) => {
+            let reg_status = if report.baseline_regression_passed {
+                "PASS"
+            } else {
+                "FAIL"
+            };
+            writeln!(
+                out,
+                "Baseline regression: slope {:.2}× vs accepted {:.2}× (≤ {:.0}%) → {reg_status}",
+                report.slope,
+                accepted,
+                SCALING_BASELINE_REGRESSION.mul_add(100.0, -100.0),
+            )
+            .unwrap();
+        }
+        None => {
+            writeln!(out, "Baseline regression: N/A (no established baseline)").unwrap();
+        }
+    }
+
+    out.push('\n');
+    let overall = if report.all_passed { "PASS" } else { "FAIL" };
+    writeln!(out, "Overall: {overall}").unwrap();
+
+    out
+}
+
+/// Render the scaling budget table for `--dry-run` (no build needed).
+pub fn format_scaling_budget_table() -> String {
+    let mut out = String::new();
+    writeln!(
+        out,
+        "Autumn macro-scaling budget (issue #983)\n"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "{:<12}  {:>12}  Notes",
+        "Metric", "Budget",
+    )
+    .unwrap();
+    writeln!(out, "{}", "-".repeat(50)).unwrap();
+    writeln!(
+        out,
+        "{:<12}  {:>11} ms  p95 warm incremental rebuild at any N ∈ {{1,25,50,100}}",
+        "Abs p95", SCALING_ABS_P95_MS,
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "{:<12}  {:>11.1}×  p95@N=100 / p95@N=1 (near-flat growth)",
+        "Slope max", SCALING_SLOPE_MAX,
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "{:<12}  {:>10.0}%   vs accepted baseline slope (skipped until baseline established)",
+        "Regression", SCALING_BASELINE_REGRESSION.mul_add(100.0, -100.0),
+    )
+    .unwrap();
+    writeln!(out, "\nSee docs/guide/dev-loop-latency.md (§ Scaling) for methodology.").unwrap();
+    out
+}
+
+// ── Emitter ──────────────────────────────────────────────────────────────────
+
+/// Print a `ScalingReport` (human or JSON), optionally write to `output`, and
+/// return the process exit code. Mirrors `dev_loop_bench::emit_report`.
+pub fn emit_scaling_report(
+    report: &ScalingReport,
+    json: bool,
+    output: Option<&str>,
+    fail_on_regression: bool,
+) -> i32 {
+    let human = format_scaling_human(report);
+    let machine = format_scaling_json(report);
+
+    if json {
+        println!("{machine}");
+    } else {
+        println!("{human}");
+    }
+
+    let mut exit = 0;
+
+    if let Some(path) = output {
+        if let Err(e) = std::fs::write(path, &machine) {
+            eprintln!("Error: could not write scaling report to {path}: {e}");
+            exit = 1;
+        } else {
+            eprintln!("Scaling report written to {path}");
+        }
+    }
+
+    if fail_on_regression && !report.all_passed {
+        eprintln!(
+            "Scaling benchmark failed: p95 ceiling or slope budget exceeded. Exiting 1."
+        );
+        exit = 1;
+    }
+
+    exit
+}
+
+// ── CLI entry point (placeholder / dry-run) ───────────────────────────────────
+
+/// Run `autumn dev-loop-bench --scaling`.
+///
+/// In `--dry-run` mode prints the budget table and exits. Otherwise the live
+/// measurement driver in [`crate::scaling_driver`] is invoked; this function
+/// is used only for the dry-run path and for tests (placeholder all-zero
+/// samples always pass the budget).
+pub fn run_scaling_dry_run() -> i32 {
+    print!("{}", format_scaling_budget_table());
+    0
+}
+
+/// Load a `ScalingBaseline` from a JSON file, returning `None` on any error.
+pub fn load_baseline(path: Option<&str>) -> Option<ScalingBaseline> {
+    let path = path?;
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+// ── Env-var helpers (same vars as dev_loop_bench) ────────────────────────────
+
+fn chrono_utc_now() -> String {
+    std::env::var("AUTUMN_BENCH_TIMESTAMP").unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn rust_version_string() -> String {
+    std::env::var("AUTUMN_BENCH_RUST_VERSION").unwrap_or_else(|_| "unknown".to_string())
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── generate_synthetic_app ────────────────────────────────────────────
+
+    #[test]
+    fn generate_app_cargo_toml_contains_package_and_workspace() {
+        let app = generate_synthetic_app(3);
+        assert!(
+            app.cargo_toml.contains("[package]"),
+            "Cargo.toml must have [package]"
+        );
+        assert!(
+            app.cargo_toml.contains("[workspace]"),
+            "Cargo.toml must declare a standalone [workspace] so [patch] is valid"
+        );
+        assert!(
+            app.cargo_toml.contains("autumn-web"),
+            "Cargo.toml must depend on autumn-web"
+        );
+    }
+
+    #[test]
+    fn generate_app_has_five_source_files() {
+        let app = generate_synthetic_app(2);
+        let paths: Vec<&str> = app.files.iter().map(|(p, _)| p.as_str()).collect();
+        assert!(paths.contains(&"src/schema.rs"), "missing schema.rs");
+        assert!(paths.contains(&"src/models.rs"), "missing models.rs");
+        assert!(paths.contains(&"src/repositories.rs"), "missing repositories.rs");
+        assert!(paths.contains(&"src/handlers.rs"), "missing handlers.rs");
+        assert!(paths.contains(&"src/main.rs"), "missing main.rs");
+        assert_eq!(paths.len(), 5, "expected exactly 5 source files");
+    }
+
+    #[test]
+    fn generate_app_schema_has_n_tables() {
+        let n = 5;
+        let app = generate_synthetic_app(n);
+        let schema = file_content(&app, "src/schema.rs");
+        for k in 0..n {
+            assert!(
+                schema.contains(&format!("entity_{k} (id)")),
+                "schema must define table entity_{k}"
+            );
+        }
+    }
+
+    #[test]
+    fn generate_app_models_has_n_structs() {
+        let n = 4;
+        let app = generate_synthetic_app(n);
+        let models = file_content(&app, "src/models.rs");
+        for k in 0..n {
+            assert!(
+                models.contains(&format!("pub struct Entity{k}")),
+                "models must define Entity{k}"
+            );
+        }
+    }
+
+    #[test]
+    fn generate_app_repositories_has_n_traits() {
+        let n = 3;
+        let app = generate_synthetic_app(n);
+        let repos = file_content(&app, "src/repositories.rs");
+        for k in 0..n {
+            assert!(
+                repos.contains(&format!("pub trait Entity{k}Repository")),
+                "repositories must define Entity{k}Repository"
+            );
+        }
+    }
+
+    #[test]
+    fn generate_app_handlers_has_n_handlers() {
+        let n = 4;
+        let app = generate_synthetic_app(n);
+        let handlers = file_content(&app, "src/handlers.rs");
+        for k in 0..n {
+            assert!(
+                handlers.contains(&format!("async fn handler_{k}()")),
+                "handlers must define handler_{k}"
+            );
+        }
+    }
+
+    #[test]
+    fn generate_app_main_routes_list_all_handlers() {
+        let n = 3;
+        let app = generate_synthetic_app(n);
+        let main_src = file_content(&app, "src/main.rs");
+        assert!(
+            main_src.contains("routes![handler_0, handler_1, handler_2]"),
+            "main.rs must register all {n} handlers in routes![], got:\n{main_src}"
+        );
+    }
+
+    #[test]
+    fn generate_app_n1_routes_list_just_handler_0() {
+        let app = generate_synthetic_app(1);
+        let main_src = file_content(&app, "src/main.rs");
+        assert!(
+            main_src.contains("routes![handler_0]"),
+            "n=1 must have routes![handler_0], got:\n{main_src}"
+        );
+    }
+
+    #[test]
+    fn generate_app_is_deterministic() {
+        let a = generate_synthetic_app(10);
+        let b = generate_synthetic_app(10);
+        assert_eq!(a.cargo_toml, b.cargo_toml, "Cargo.toml must be deterministic");
+        assert_eq!(a.files.len(), b.files.len());
+        for ((pa, ca), (pb, cb)) in a.files.iter().zip(b.files.iter()) {
+            assert_eq!(pa, pb, "file paths must be deterministic");
+            assert_eq!(ca, cb, "file content must be deterministic for {pa}");
+        }
+    }
+
+    #[test]
+    fn generate_app_handlers_contain_bench_edit_sentinel() {
+        let app = generate_synthetic_app(2);
+        let handlers = file_content(&app, "src/handlers.rs");
+        assert!(
+            handlers.contains("BENCH_EDIT_SENTINEL"),
+            "handlers.rs must contain the BENCH_EDIT_SENTINEL constant"
+        );
+        assert!(
+            handlers.contains("bench_edit_rev_0"),
+            "initial revision must be 0"
+        );
+    }
+
+    #[test]
+    fn generate_app_models_use_explicit_table_attr() {
+        let app = generate_synthetic_app(2);
+        let models = file_content(&app, "src/models.rs");
+        assert!(
+            models.contains("table = \"entity_0\""),
+            "model macro must use explicit table attribute to avoid pluralization guessing"
+        );
+        assert!(
+            models.contains("table = \"entity_1\""),
+            "every model must have its own explicit table attribute"
+        );
+    }
+
+    #[test]
+    fn generate_app_schema_uses_reexport_path() {
+        // The generated app only depends on autumn-web, not a separate diesel
+        // dep. It must use autumn_web::reexports::diesel::table! to declare
+        // schema, mirroring the compile-pass test pattern.
+        let app = generate_synthetic_app(1);
+        let schema = file_content(&app, "src/schema.rs");
+        assert!(
+            schema.contains("autumn_web::reexports::diesel::table!"),
+            "schema must use autumn_web::reexports::diesel::table! (no direct diesel dep)"
+        );
+    }
+
+    // ── apply_handler_edit ────────────────────────────────────────────────
+
+    #[test]
+    fn apply_handler_edit_bumps_sentinel() {
+        let app = generate_synthetic_app(2);
+        let handlers = file_content(&app, "src/handlers.rs");
+        let edited = apply_handler_edit(handlers, 1);
+        assert!(
+            edited.contains("bench_edit_rev_1"),
+            "edited handlers must contain rev 1"
+        );
+        assert!(
+            !edited.contains("bench_edit_rev_0"),
+            "old sentinel must be gone after edit"
+        );
+    }
+
+    #[test]
+    fn apply_handler_edit_only_changes_sentinel_line() {
+        let app = generate_synthetic_app(3);
+        let handlers = file_content(&app, "src/handlers.rs");
+        let edited = apply_handler_edit(handlers, 5);
+        // Lines other than the sentinel line are unchanged.
+        let orig_lines: Vec<&str> = handlers.lines().collect();
+        let edit_lines: Vec<&str> = edited.lines().collect();
+        assert_eq!(orig_lines.len(), edit_lines.len(), "line count must not change");
+        let changed: Vec<usize> = orig_lines
+            .iter()
+            .zip(edit_lines.iter())
+            .enumerate()
+            .filter(|(_, (a, b))| a != b)
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(changed.len(), 1, "exactly one line must change, changed: {changed:?}");
+    }
+
+    #[test]
+    fn apply_handler_edit_stable_across_multiple_revisions() {
+        let app = generate_synthetic_app(2);
+        let handlers = file_content(&app, "src/handlers.rs");
+        let r1 = apply_handler_edit(handlers, 1);
+        let r2 = apply_handler_edit(&r1, 2);
+        let r3 = apply_handler_edit(&r2, 3);
+        assert!(r3.contains("bench_edit_rev_3"), "final revision must be 3");
+        assert!(!r3.contains("bench_edit_rev_1"), "old rev 1 must be gone");
+        assert!(!r3.contains("bench_edit_rev_2"), "old rev 2 must be gone");
+    }
+
+    // ── parse_sizes ───────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_sizes_valid_csv() {
+        let sizes = parse_sizes("1,25,50,100").expect("valid CSV must parse");
+        assert_eq!(sizes, vec![1, 25, 50, 100]);
+    }
+
+    #[test]
+    fn parse_sizes_single_value() {
+        let sizes = parse_sizes("42").expect("single value must parse");
+        assert_eq!(sizes, vec![42]);
+    }
+
+    #[test]
+    fn parse_sizes_ignores_surrounding_whitespace() {
+        let sizes = parse_sizes(" 1 , 10 , 100 ").expect("whitespace-padded CSV must parse");
+        assert_eq!(sizes, vec![1, 10, 100]);
+    }
+
+    #[test]
+    fn parse_sizes_rejects_zero() {
+        assert!(
+            parse_sizes("1,0,100").is_err(),
+            "size 0 must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_sizes_rejects_empty_string() {
+        assert!(parse_sizes("").is_err(), "empty string must be rejected");
+        assert!(parse_sizes("  ").is_err(), "whitespace-only must be rejected");
+    }
+
+    #[test]
+    fn parse_sizes_rejects_non_numeric() {
+        assert!(parse_sizes("1,abc,100").is_err(), "non-numeric token must be rejected");
+        assert!(parse_sizes("foo").is_err(), "all-non-numeric must be rejected");
+    }
+
+    #[test]
+    fn parse_sizes_rejects_negative() {
+        // usize parse rejects leading "-" so this is an Err.
+        assert!(parse_sizes("1,-5,100").is_err(), "negative must be rejected");
+    }
+
+    // ── compute_slope ─────────────────────────────────────────────────────
+
+    #[test]
+    fn compute_slope_flat() {
+        let s = compute_slope(500, 500);
+        assert!((s - 1.0).abs() < 1e-9, "equal p95s → slope 1.0, got {s}");
+    }
+
+    #[test]
+    fn compute_slope_doubled() {
+        let s = compute_slope(1000, 2000);
+        assert!((s - 2.0).abs() < 1e-9, "doubled p95 → slope 2.0, got {s}");
+    }
+
+    #[test]
+    fn compute_slope_zero_baseline_returns_one() {
+        // Placeholder / empty-sample baseline must not cause divide-by-zero.
+        let s = compute_slope(0, 0);
+        assert!((s - 1.0).abs() < 1e-9, "zero baseline → slope 1.0 (flat), got {s}");
+        let s2 = compute_slope(0, 5000);
+        assert!((s2 - 1.0).abs() < 1e-9, "zero baseline (any max) → slope 1.0, got {s2}");
+    }
+
+    #[test]
+    fn compute_slope_below_two_passes_gate() {
+        let s = compute_slope(1000, 1900);
+        assert!(s <= SCALING_SLOPE_MAX, "1.9× must be within the 2× budget");
+    }
+
+    #[test]
+    fn compute_slope_above_two_fails_gate() {
+        let s = compute_slope(1000, 2100);
+        assert!(s > SCALING_SLOPE_MAX, "2.1× must exceed the 2× budget");
+    }
+
+    // ── build_scaling_report ──────────────────────────────────────────────
+
+    fn make_measurements(sizes: &[usize], p95s: &[u64]) -> Vec<(usize, Vec<u64>)> {
+        sizes
+            .iter()
+            .zip(p95s.iter())
+            .map(|(&n, &p95)| (n, vec![p95]))
+            .collect()
+    }
+
+    #[test]
+    fn build_report_all_pass_under_budget() {
+        let m = make_measurements(&[1, 100], &[2000, 3000]);
+        let r = build_scaling_report(&m, None);
+        assert!(r.points[0].abs_passed, "2000 ms must pass 8000 ms ceiling");
+        assert!(r.points[1].abs_passed, "3000 ms must pass 8000 ms ceiling");
+        assert!(r.slope_passed, "slope 1.5× must pass 2× budget");
+        assert!(r.baseline_regression_passed);
+        assert!(r.all_passed);
+    }
+
+    #[test]
+    fn build_report_fails_abs_p95_exceeded() {
+        let m = make_measurements(&[1, 100], &[2000, 9000]);
+        let r = build_scaling_report(&m, None);
+        assert!(!r.points[1].abs_passed, "9000 ms must fail 8000 ms ceiling");
+        assert!(!r.all_passed, "abs failure must fail overall gate");
+    }
+
+    #[test]
+    fn build_report_fails_slope_exceeded() {
+        // slope = 7000 / 1000 = 7.0 > 2.0
+        let m = make_measurements(&[1, 100], &[1000, 7000]);
+        let r = build_scaling_report(&m, None);
+        assert!(!r.slope_passed, "slope 7× must fail 2× budget");
+        assert!(!r.all_passed);
+    }
+
+    #[test]
+    fn build_report_baseline_not_established_always_passes() {
+        // slope = 5.0 (violates 2× budget, but baseline not established → reg check skipped)
+        // The 2× slope gate still applies regardless of baseline.
+        let m = make_measurements(&[1, 100], &[1000, 3000]);
+        let baseline = ScalingBaseline {
+            established: false,
+            accepted_slope: Some(1.2), // won't matter — not established
+            note: None,
+        };
+        let r = build_scaling_report(&m, Some(&baseline));
+        assert!(r.baseline_regression_passed, "non-established baseline must always pass regression");
+        // slope = 3.0 still > 2× so all_passed should be false due to slope gate
+        assert!(!r.all_passed, "slope 3× still fails 2× absolute slope gate");
+    }
+
+    #[test]
+    fn build_report_baseline_established_regression_fails() {
+        // accepted = 1.2; current slope = 3.0 > 1.2 * 1.2 = 1.44 → regression
+        let m = make_measurements(&[1, 100], &[1000, 3000]);
+        let baseline = ScalingBaseline {
+            established: true,
+            accepted_slope: Some(1.2),
+            note: None,
+        };
+        let r = build_scaling_report(&m, Some(&baseline));
+        assert!(!r.baseline_regression_passed, "slope 3× vs accepted 1.2 must fail regression");
+        assert!(!r.all_passed);
+    }
+
+    #[test]
+    fn build_report_baseline_established_regression_passes() {
+        // accepted = 1.5; current slope = 1.6 ≤ 1.5 * 1.2 = 1.80 → passes
+        let m = make_measurements(&[1, 100], &[1000, 1600]);
+        let baseline = ScalingBaseline {
+            established: true,
+            accepted_slope: Some(1.5),
+            note: None,
+        };
+        let r = build_scaling_report(&m, Some(&baseline));
+        assert!(r.baseline_regression_passed, "1.6 within 1.5×1.2=1.80 must pass");
+        assert!(r.all_passed, "within abs, slope, and regression → all_passed");
+    }
+
+    #[test]
+    fn build_report_single_size_slope_is_one() {
+        // Single size → no meaningful slope → defaults to 1.0 (flat).
+        let m = make_measurements(&[50], &[4000]);
+        let r = build_scaling_report(&m, None);
+        assert!((r.slope - 1.0).abs() < 1e-9, "single-size slope must be 1.0");
+        assert!(r.slope_passed);
+        assert!(r.all_passed);
+    }
+
+    #[test]
+    fn build_report_empty_measurements_passes() {
+        let r = build_scaling_report(&[], None);
+        assert!(r.all_passed, "empty measurement set must pass (nothing to fail)");
+    }
+
+    #[test]
+    fn build_report_sizes_preserved_in_output() {
+        let m = make_measurements(&[1, 25, 50, 100], &[1000, 1200, 1500, 2000]);
+        let r = build_scaling_report(&m, None);
+        assert_eq!(r.sizes, vec![1, 25, 50, 100]);
+    }
+
+    // ── format_scaling_json ───────────────────────────────────────────────
+
+    #[test]
+    fn format_json_produces_valid_json() {
+        let m = make_measurements(&[1, 100], &[2000, 3000]);
+        let r = build_scaling_report(&m, None);
+        let s = format_scaling_json(&r);
+        serde_json::from_str::<serde_json::Value>(&s).expect("must be valid JSON");
+    }
+
+    #[test]
+    fn format_json_contains_env_metadata() {
+        let m = make_measurements(&[1, 100], &[2000, 3000]);
+        let r = build_scaling_report(&m, None);
+        let s = format_scaling_json(&r);
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert!(v.get("timestamp_utc").is_some(), "must have timestamp_utc");
+        assert!(v.get("runner_os").is_some(), "must have runner_os");
+        assert!(v.get("rust_version").is_some(), "must have rust_version");
+        assert!(v.get("autumn_version").is_some(), "must have autumn_version");
+        assert!(v.get("all_passed").is_some(), "must have all_passed");
+        assert!(v.get("slope").is_some(), "must have slope");
+        assert!(v.get("points").is_some(), "must have points array");
+    }
+
+    #[test]
+    fn format_json_no_path_leak() {
+        let m = make_measurements(&[1, 100], &[2000, 3000]);
+        let r = build_scaling_report(&m, None);
+        let s = format_scaling_json(&r);
+        assert!(!s.contains("/home/"), "must not leak /home/ paths");
+        assert!(!s.contains("C:\\Users\\"), "must not leak Windows paths");
+    }
+
+    // ── format_scaling_human ──────────────────────────────────────────────
+
+    #[test]
+    fn format_human_shows_slope_and_overall() {
+        let m = make_measurements(&[1, 100], &[2000, 3000]);
+        let r = build_scaling_report(&m, None);
+        let s = format_scaling_human(&r);
+        assert!(s.contains("Slope"), "must mention slope");
+        assert!(
+            s.contains("PASS") || s.contains("FAIL"),
+            "must show PASS or FAIL"
+        );
+        assert!(s.contains("Overall"), "must show Overall");
+    }
+
+    #[test]
+    fn format_human_passing_shows_pass() {
+        let m = make_measurements(&[1, 100], &[2000, 3000]);
+        let r = build_scaling_report(&m, None);
+        let s = format_scaling_human(&r);
+        assert!(s.contains("Overall: PASS"), "passing report must show PASS");
+    }
+
+    #[test]
+    fn format_human_failing_shows_fail() {
+        let m = make_measurements(&[1, 100], &[2000, 9000]);
+        let r = build_scaling_report(&m, None);
+        let s = format_scaling_human(&r);
+        assert!(
+            s.contains("FAIL"),
+            "failing report must show FAIL, got:\n{s}"
+        );
+    }
+
+    #[test]
+    fn format_human_shows_n_values() {
+        let m = make_measurements(&[1, 25, 100], &[1000, 1500, 2000]);
+        let r = build_scaling_report(&m, None);
+        let s = format_scaling_human(&r);
+        assert!(s.contains('1'), "must show N=1");
+        assert!(s.contains("25"), "must show N=25");
+        assert!(s.contains("100"), "must show N=100");
+    }
+
+    // ── format_scaling_budget_table ───────────────────────────────────────
+
+    #[test]
+    fn budget_table_shows_abs_ceiling() {
+        let t = format_scaling_budget_table();
+        assert!(
+            t.contains("8000") || t.contains("8 000"),
+            "budget table must show 8000 ms ceiling, got:\n{t}"
+        );
+    }
+
+    #[test]
+    fn budget_table_shows_slope_max() {
+        let t = format_scaling_budget_table();
+        assert!(
+            t.contains("2.0") || t.contains("2×"),
+            "budget table must mention 2× slope max, got:\n{t}"
+        );
+    }
+
+    #[test]
+    fn budget_table_references_docs() {
+        let t = format_scaling_budget_table();
+        assert!(
+            t.contains("dev-loop-latency.md"),
+            "budget table must reference docs, got:\n{t}"
+        );
+    }
+
+    // ── emit_scaling_report ───────────────────────────────────────────────
+
+    #[test]
+    fn emit_report_output_writes_valid_json() {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        let path = tmp.path().to_str().unwrap().to_string();
+        let m = make_measurements(&[1, 100], &[2000, 3000]);
+        let r = build_scaling_report(&m, None);
+        let exit = emit_scaling_report(&r, false, Some(&path), false);
+        assert_eq!(exit, 0);
+        let content = std::fs::read_to_string(&path).expect("report file");
+        serde_json::from_str::<serde_json::Value>(&content)
+            .expect("output file must be valid JSON");
+    }
+
+    #[test]
+    fn emit_report_output_write_failure_returns_nonzero() {
+        let m = make_measurements(&[1, 100], &[2000, 3000]);
+        let r = build_scaling_report(&m, None);
+        let exit = emit_scaling_report(
+            &r,
+            false,
+            Some("/dev/full/nonexistent/path/report.json"),
+            false,
+        );
+        assert_eq!(exit, 1, "failed output write must return 1");
+    }
+
+    #[test]
+    fn emit_report_fail_on_regression_passing_report_returns_zero() {
+        let m = make_measurements(&[1, 100], &[2000, 3000]);
+        let r = build_scaling_report(&m, None);
+        assert!(r.all_passed);
+        let exit = emit_scaling_report(&r, false, None, true);
+        assert_eq!(exit, 0, "--fail-on-regression must not trip on a passing report");
+    }
+
+    #[test]
+    fn emit_report_fail_on_regression_failing_report_returns_nonzero() {
+        let m = make_measurements(&[1, 100], &[2000, 9000]);
+        let r = build_scaling_report(&m, None);
+        assert!(!r.all_passed);
+        let exit = emit_scaling_report(&r, false, None, true);
+        assert_eq!(exit, 1, "--fail-on-regression must return 1 for a failing report");
+    }
+
+    // ── run_scaling_dry_run ───────────────────────────────────────────────
+
+    #[test]
+    fn run_scaling_dry_run_returns_zero() {
+        assert_eq!(run_scaling_dry_run(), 0);
+    }
+
+    // ── load_baseline ─────────────────────────────────────────────────────
+
+    #[test]
+    fn load_baseline_none_path_returns_none() {
+        assert!(load_baseline(None).is_none());
+    }
+
+    #[test]
+    fn load_baseline_missing_file_returns_none() {
+        assert!(load_baseline(Some("/nonexistent/path/baseline.json")).is_none());
+    }
+
+    #[test]
+    fn load_baseline_valid_json_parses() {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(
+            tmp.path(),
+            r#"{"established":false,"accepted_slope":null,"note":"initial"}"#,
+        )
+        .expect("write baseline");
+        let b = load_baseline(Some(tmp.path().to_str().unwrap())).expect("must parse");
+        assert!(!b.established);
+        assert!(b.accepted_slope.is_none());
+    }
+
+    #[test]
+    fn load_baseline_established_with_slope_parses() {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(tmp.path(), r#"{"established":true,"accepted_slope":1.5}"#)
+            .expect("write baseline");
+        let b = load_baseline(Some(tmp.path().to_str().unwrap())).expect("must parse");
+        assert!(b.established);
+        assert!((b.accepted_slope.unwrap() - 1.5).abs() < 1e-9);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────
+
+    fn file_content<'a>(app: &'a GeneratedApp, relpath: &str) -> &'a str {
+        app.files
+            .iter()
+            .find(|(p, _)| p == relpath)
+            .map_or_else(|| panic!("file {relpath:?} not found in GeneratedApp"), |(_, c)| {
+                c.as_str()
+            })
+    }
+}

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -13,7 +13,6 @@ mod db_pull;
 mod dev;
 mod dev_loop_bench;
 mod dev_loop_scaling;
-mod scaling_driver;
 mod doctor;
 mod experiments;
 mod export;
@@ -29,6 +28,7 @@ mod plugin_check;
 mod process;
 mod release;
 mod routes;
+mod scaling_driver;
 mod seed;
 mod serve;
 mod setup;
@@ -4502,8 +4502,7 @@ mod tests {
 
     #[test]
     fn parse_dev_loop_bench_scaling_flag() {
-        let cli =
-            Cli::try_parse_from(["autumn", "dev-loop-bench", "--scaling"]).unwrap();
+        let cli = Cli::try_parse_from(["autumn", "dev-loop-bench", "--scaling"]).unwrap();
         let Commands::DevLoopBench { scaling, .. } = cli.command else {
             panic!("expected dev-loop-bench");
         };
@@ -4512,9 +4511,14 @@ mod tests {
 
     #[test]
     fn parse_dev_loop_bench_scaling_custom_sizes() {
-        let cli =
-            Cli::try_parse_from(["autumn", "dev-loop-bench", "--scaling", "--sizes", "1,10,50"])
-                .unwrap();
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "dev-loop-bench",
+            "--scaling",
+            "--sizes",
+            "1,10,50",
+        ])
+        .unwrap();
         let Commands::DevLoopBench { scaling, sizes, .. } = cli.command else {
             panic!("expected dev-loop-bench");
         };
@@ -4532,7 +4536,10 @@ mod tests {
             "benchmarks/dev-loop-scaling/baseline.json",
         ])
         .unwrap();
-        let Commands::DevLoopBench { scaling, baseline, .. } = cli.command else {
+        let Commands::DevLoopBench {
+            scaling, baseline, ..
+        } = cli.command
+        else {
             panic!("expected dev-loop-bench");
         };
         assert!(scaling);

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -12,6 +12,8 @@ mod db;
 mod db_pull;
 mod dev;
 mod dev_loop_bench;
+mod dev_loop_scaling;
+mod scaling_driver;
 mod doctor;
 mod experiments;
 mod export;
@@ -578,6 +580,20 @@ enum Commands {
         /// informational (non-gating) result.
         #[arg(long)]
         include_db: bool,
+        /// Run the macro-scaling sweep: measure warm incremental rebuild at
+        /// multiple app sizes (N handlers + model/repository pairs) to gate
+        /// that the edit-refresh loop stays near-flat as the app grows.
+        #[arg(long)]
+        scaling: bool,
+        /// Comma-separated list of app sizes to sweep (e.g. `1,25,50,100`).
+        /// Only used with `--scaling`.
+        #[arg(long, default_value = crate::dev_loop_scaling::DEFAULT_SIZES)]
+        sizes: String,
+        /// Path to `benchmarks/dev-loop-scaling/baseline.json` for the
+        /// `>20%`-slope-regression check. Omit to skip baseline gating.
+        /// Only used with `--scaling`.
+        #[arg(long, value_name = "PATH")]
+        baseline: Option<String>,
     },
 }
 
@@ -2011,8 +2027,21 @@ fn run_command(command: Commands) {
             dry_run,
             cold_start,
             include_db,
+            scaling,
+            sizes,
+            baseline,
         } => {
-            let exit_code = if cold_start {
+            let exit_code = if scaling {
+                scaling_driver::run_scaling(
+                    &sizes,
+                    runs,
+                    output.as_deref(),
+                    json,
+                    fail_on_regression,
+                    dry_run,
+                    baseline.as_deref(),
+                )
+            } else if cold_start {
                 cold_start_driver::run_cold_start(
                     runs,
                     output.as_deref(),
@@ -4376,6 +4405,9 @@ mod tests {
             dry_run,
             cold_start,
             include_db,
+            scaling,
+            sizes,
+            baseline,
         } = cli.command
         else {
             panic!("expected dev-loop-bench");
@@ -4388,6 +4420,9 @@ mod tests {
         assert!(!dry_run);
         assert!(!cold_start);
         assert!(!include_db);
+        assert!(!scaling);
+        assert_eq!(sizes, crate::dev_loop_scaling::DEFAULT_SIZES);
+        assert!(baseline.is_none());
     }
 
     #[test]
@@ -4463,6 +4498,48 @@ mod tests {
             panic!("expected dev-loop-bench");
         };
         assert_eq!(output.as_deref(), Some("report.json"));
+    }
+
+    #[test]
+    fn parse_dev_loop_bench_scaling_flag() {
+        let cli =
+            Cli::try_parse_from(["autumn", "dev-loop-bench", "--scaling"]).unwrap();
+        let Commands::DevLoopBench { scaling, .. } = cli.command else {
+            panic!("expected dev-loop-bench");
+        };
+        assert!(scaling);
+    }
+
+    #[test]
+    fn parse_dev_loop_bench_scaling_custom_sizes() {
+        let cli =
+            Cli::try_parse_from(["autumn", "dev-loop-bench", "--scaling", "--sizes", "1,10,50"])
+                .unwrap();
+        let Commands::DevLoopBench { scaling, sizes, .. } = cli.command else {
+            panic!("expected dev-loop-bench");
+        };
+        assert!(scaling);
+        assert_eq!(sizes, "1,10,50");
+    }
+
+    #[test]
+    fn parse_dev_loop_bench_scaling_baseline_path() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "dev-loop-bench",
+            "--scaling",
+            "--baseline",
+            "benchmarks/dev-loop-scaling/baseline.json",
+        ])
+        .unwrap();
+        let Commands::DevLoopBench { scaling, baseline, .. } = cli.command else {
+            panic!("expected dev-loop-bench");
+        };
+        assert!(scaling);
+        assert_eq!(
+            baseline.as_deref(),
+            Some("benchmarks/dev-loop-scaling/baseline.json")
+        );
     }
 
     // ── autumn config tests ────────────────────────────────────────────────────

--- a/autumn-cli/src/scaling_driver.rs
+++ b/autumn-cli/src/scaling_driver.rs
@@ -11,60 +11,28 @@
 //! report logic is unit-tested in `dev_loop_scaling.rs`. This file is
 //! excluded from coverage like `cold_start_driver.rs`.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Command, Stdio};
-use std::sync::OnceLock;
 use std::time::Instant;
 
+use crate::cold_start_driver::{cached_autumn_web, repoint_autumn_web};
 use crate::dev_loop_scaling::{
     GeneratedApp, apply_handler_edit, build_scaling_report, emit_scaling_report,
     generate_synthetic_app, load_baseline, parse_sizes, run_scaling_dry_run,
 };
 
-// ── Workspace location ───────────────────────────────────────────────────────
-
-/// Locate the workspace `autumn-web` crate — reuses the same ancestor-walk
-/// logic as `cold_start_driver`, made `pub(crate)` there for sharing.
-fn locate_autumn_web() -> Option<PathBuf> {
-    if let Ok(p) = std::env::var("AUTUMN_BENCH_AUTUMN_WEB_PATH") {
-        let pb = PathBuf::from(p);
-        if pb.join("Cargo.toml").is_file() {
-            return Some(pb);
-        }
-    }
-    let cwd = std::env::current_dir().ok()?;
-    for ancestor in cwd.ancestors() {
-        let candidate = ancestor.join("autumn");
-        let manifest = candidate.join("Cargo.toml");
-        if manifest.is_file()
-            && let Ok(s) = std::fs::read_to_string(&manifest)
-            && s.contains("name = \"autumn-web\"")
-        {
-            return Some(candidate);
-        }
-    }
-    None
-}
-
-fn cached_autumn_web() -> Option<PathBuf> {
-    static AUTUMN_WEB: OnceLock<Option<PathBuf>> = OnceLock::new();
-    AUTUMN_WEB
-        .get_or_init(|| locate_autumn_web().and_then(|p| std::fs::canonicalize(p).ok()))
-        .clone()
-}
-
 // ── App scaffold ─────────────────────────────────────────────────────────────
 
 /// Write a `GeneratedApp` to `project_dir` and append a
 /// `[patch.crates-io] autumn-web` section pointing at local source.
+///
+/// The `[patch]` append reuses `cold_start_driver::repoint_autumn_web` so both
+/// benchmarks generate byte-identical patch sections.
 fn scaffold_app(app: &GeneratedApp, project_dir: &Path, autumn_web: &Path) -> Result<(), String> {
-    // Write Cargo.toml + [patch]
-    let patch = format!(
-        "\n[patch.crates-io]\nautumn-web = {{ path = {:?} }}\n",
-        autumn_web.display().to_string()
-    );
-    std::fs::write(project_dir.join("Cargo.toml"), format!("{}{patch}", app.cargo_toml))
+    // Write the generated manifest, then repoint autumn-web at local source.
+    std::fs::write(project_dir.join("Cargo.toml"), &app.cargo_toml)
         .map_err(|e| format!("write Cargo.toml: {e}"))?;
+    repoint_autumn_web(project_dir, autumn_web)?;
 
     // Write source files
     for (relpath, content) in &app.files {
@@ -160,16 +128,36 @@ fn measure_size(n: usize, runs: u32, autumn_web: &Path) -> Result<Vec<u64>, Stri
 
 /// Run the full scaling sweep: for each size in `sizes`, measure `runs`
 /// incremental rebuild samples and return `(n, samples)` pairs.
+///
+/// A single size that fails to build (transient OOM, flaky proc-macro, disk
+/// pressure) is logged and skipped rather than aborting the whole sweep, so the
+/// other sizes' samples are still reported. Returns `Err` only if **every** size
+/// failed, leaving no data to build a report from.
 fn measure_scaling(
     sizes: &[usize],
     runs: u32,
     autumn_web: &Path,
 ) -> Result<Vec<(usize, Vec<u64>)>, String> {
     let mut results = Vec::with_capacity(sizes.len());
+    let mut failures = Vec::new();
     for &n in sizes {
         eprintln!("Measuring N={n}…");
-        let samples = measure_size(n, runs, autumn_web)?;
-        results.push((n, samples));
+        match measure_size(n, runs, autumn_web) {
+            Ok(samples) => results.push((n, samples)),
+            Err(e) => {
+                eprintln!("  N={n}: measurement failed, skipping this size: {e}");
+                failures.push(n);
+            }
+        }
+    }
+    if results.is_empty() {
+        return Err(format!(
+            "every size failed to measure ({} attempted: {failures:?})",
+            sizes.len()
+        ));
+    }
+    if !failures.is_empty() {
+        eprintln!("Warning: {} size(s) failed and were skipped: {failures:?}", failures.len());
     }
     Ok(results)
 }
@@ -245,18 +233,9 @@ pub fn run_scaling(
 mod tests {
     use super::*;
 
-    #[test]
-    fn locate_autumn_web_honours_env_override() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        std::fs::write(tmp.path().join("Cargo.toml"), "name = \"autumn-web\"\n")
-            .expect("write manifest");
-        let found = temp_env::with_var(
-            "AUTUMN_BENCH_AUTUMN_WEB_PATH",
-            Some(tmp.path().as_os_str()),
-            locate_autumn_web,
-        );
-        assert_eq!(found.as_deref(), Some(tmp.path()));
-    }
+    // `locate_autumn_web` / `cached_autumn_web` are owned and tested by
+    // `cold_start_driver` (see its `locate_autumn_web_honours_env_override`);
+    // this module reuses them rather than duplicating the logic or its test.
 
     #[test]
     fn scaffold_app_writes_cargo_toml_and_sources() {

--- a/autumn-cli/src/scaling_driver.rs
+++ b/autumn-cli/src/scaling_driver.rs
@@ -1,0 +1,310 @@
+//! Live warm-incremental scaling measurement driver for
+//! `autumn dev-loop-bench --scaling` (issue #983).
+//!
+//! This module scaffolds a synthetic Autumn app at each requested size N,
+//! performs a warm build (untimed), then runs `--runs` timed incremental
+//! rebuilds after a single-file edit (`src/handlers.rs` `BENCH_EDIT_SENTINEL`
+//! bump), and feeds the timing samples to the pure report logic in
+//! [`crate::dev_loop_scaling`].
+//!
+//! All subprocess / filesystem / timing I/O is here; the pure budget and
+//! report logic is unit-tested in `dev_loop_scaling.rs`. This file is
+//! excluded from coverage like `cold_start_driver.rs`.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use crate::dev_loop_scaling::{
+    GeneratedApp, apply_handler_edit, build_scaling_report, emit_scaling_report,
+    generate_synthetic_app, load_baseline, parse_sizes, run_scaling_dry_run,
+};
+
+// ── Workspace location ───────────────────────────────────────────────────────
+
+/// Locate the workspace `autumn-web` crate — reuses the same ancestor-walk
+/// logic as `cold_start_driver`, made `pub(crate)` there for sharing.
+fn locate_autumn_web() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("AUTUMN_BENCH_AUTUMN_WEB_PATH") {
+        let pb = PathBuf::from(p);
+        if pb.join("Cargo.toml").is_file() {
+            return Some(pb);
+        }
+    }
+    let cwd = std::env::current_dir().ok()?;
+    for ancestor in cwd.ancestors() {
+        let candidate = ancestor.join("autumn");
+        let manifest = candidate.join("Cargo.toml");
+        if manifest.is_file()
+            && let Ok(s) = std::fs::read_to_string(&manifest)
+            && s.contains("name = \"autumn-web\"")
+        {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn cached_autumn_web() -> Option<PathBuf> {
+    static AUTUMN_WEB: OnceLock<Option<PathBuf>> = OnceLock::new();
+    AUTUMN_WEB
+        .get_or_init(|| locate_autumn_web().and_then(|p| std::fs::canonicalize(p).ok()))
+        .clone()
+}
+
+// ── App scaffold ─────────────────────────────────────────────────────────────
+
+/// Write a `GeneratedApp` to `project_dir` and append a
+/// `[patch.crates-io] autumn-web` section pointing at local source.
+fn scaffold_app(app: &GeneratedApp, project_dir: &Path, autumn_web: &Path) -> Result<(), String> {
+    // Write Cargo.toml + [patch]
+    let patch = format!(
+        "\n[patch.crates-io]\nautumn-web = {{ path = {:?} }}\n",
+        autumn_web.display().to_string()
+    );
+    std::fs::write(project_dir.join("Cargo.toml"), format!("{}{patch}", app.cargo_toml))
+        .map_err(|e| format!("write Cargo.toml: {e}"))?;
+
+    // Write source files
+    for (relpath, content) in &app.files {
+        let dest = project_dir.join(relpath);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
+        }
+        std::fs::write(&dest, content).map_err(|e| format!("write {}: {e}", dest.display()))?;
+    }
+
+    Ok(())
+}
+
+// ── Build helpers ────────────────────────────────────────────────────────────
+
+/// Run `cargo build` in `project_dir`, capturing stderr for diagnostics.
+///
+/// Pass `timed = true` to wrap the call in an `Instant` and return elapsed ms;
+/// `timed = false` returns `0` (warm-up build that is not measured).
+fn run_cargo_build(project_dir: &Path, timed: bool) -> Result<u64, String> {
+    let target_dir = project_dir.join("target");
+    let mut cmd = Command::new("cargo");
+    cmd.args(["build", "--target-dir"])
+        .arg(&target_dir)
+        .current_dir(project_dir)
+        // Remove inherited target-dir overrides so the warm cache for THIS
+        // project accumulates in its own dedicated directory.
+        .env_remove("CARGO_TARGET_DIR")
+        .env_remove("CARGO_BUILD_TARGET_DIR")
+        .env_remove("CARGO_BUILD_TARGET")
+        // Suppress output so bench stderr is clean.
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    let start = Instant::now();
+    let status = cmd
+        .status()
+        .map_err(|e| format!("cargo build spawn failed: {e}"))?;
+    let elapsed = if timed {
+        u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX)
+    } else {
+        0
+    };
+
+    if !status.success() {
+        return Err(format!("cargo build failed (exit: {status})"));
+    }
+    Ok(elapsed)
+}
+
+// ── Per-size measurement ─────────────────────────────────────────────────────
+
+/// Measure warm incremental rebuild latency for a synthetic app of size `n`.
+///
+/// 1. Scaffolds the app in a fresh tempdir.
+/// 2. Runs one **warm build** (untimed) to populate the incremental cache.
+/// 3. Runs `runs` **timed builds**, each preceded by bumping the
+///    `BENCH_EDIT_SENTINEL` in `src/handlers.rs` to force recompilation of
+///    exactly that one file.
+///
+/// Returns a `Vec<u64>` of `runs` timing samples in milliseconds.
+fn measure_size(n: usize, runs: u32, autumn_web: &Path) -> Result<Vec<u64>, String> {
+    let tmp = tempfile::tempdir().map_err(|e| format!("create temp dir: {e}"))?;
+    let project_dir = tmp.path().to_path_buf();
+
+    let app = generate_synthetic_app(n);
+    scaffold_app(&app, &project_dir, autumn_web)?;
+
+    eprintln!("  N={n}: warm build (untimed)…");
+    run_cargo_build(&project_dir, false)?;
+
+    let handlers_path = project_dir.join("src/handlers.rs");
+    let mut samples = Vec::with_capacity(runs as usize);
+
+    for run in 1..=runs {
+        // Bump the sentinel to trigger a one-file incremental recompile.
+        let handlers_src = std::fs::read_to_string(&handlers_path)
+            .map_err(|e| format!("read handlers.rs: {e}"))?;
+        let edited = apply_handler_edit(&handlers_src, run);
+        std::fs::write(&handlers_path, &edited)
+            .map_err(|e| format!("write handlers.rs: {e}"))?;
+
+        eprintln!("  N={n} run {run}/{runs}: timed incremental build…");
+        let ms = run_cargo_build(&project_dir, true)?;
+        eprintln!("    → {ms} ms");
+        samples.push(ms);
+    }
+
+    Ok(samples)
+}
+
+// ── Sweep ────────────────────────────────────────────────────────────────────
+
+/// Run the full scaling sweep: for each size in `sizes`, measure `runs`
+/// incremental rebuild samples and return `(n, samples)` pairs.
+fn measure_scaling(
+    sizes: &[usize],
+    runs: u32,
+    autumn_web: &Path,
+) -> Result<Vec<(usize, Vec<u64>)>, String> {
+    let mut results = Vec::with_capacity(sizes.len());
+    for &n in sizes {
+        eprintln!("Measuring N={n}…");
+        let samples = measure_size(n, runs, autumn_web)?;
+        results.push((n, samples));
+    }
+    Ok(results)
+}
+
+// ── CLI entry point ──────────────────────────────────────────────────────────
+
+/// Run the `autumn dev-loop-bench --scaling` command.
+///
+/// In `--dry-run` mode prints the budget table without building anything.
+/// Otherwise locates the workspace `autumn-web`, runs the sizing sweep, and
+/// emits a scaling report.
+#[allow(clippy::fn_params_excessive_bools)]
+pub fn run_scaling(
+    sizes_csv: &str,
+    runs: u32,
+    output: Option<&str>,
+    json: bool,
+    fail_on_regression: bool,
+    dry_run: bool,
+    baseline_path: Option<&str>,
+) -> i32 {
+    if dry_run {
+        return run_scaling_dry_run();
+    }
+
+    if runs == 0 {
+        eprintln!("Error: --runs must be at least 1 for a scaling measurement.");
+        return 1;
+    }
+
+    let sizes = match parse_sizes(sizes_csv) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Error: invalid --sizes: {e}");
+            return 1;
+        }
+    };
+
+    let Some(autumn_web) = cached_autumn_web() else {
+        eprintln!(
+            "Error: could not locate the workspace autumn-web crate; \
+             set AUTUMN_BENCH_AUTUMN_WEB_PATH to its directory."
+        );
+        return 1;
+    };
+
+    eprintln!(
+        "autumn dev-loop-bench --scaling: warming and measuring {} size(s), {} run(s) each",
+        sizes.len(),
+        runs
+    );
+    eprintln!(
+        "This scaffolds a synthetic Autumn app for each N and runs timed incremental builds — \
+         expect several minutes total.\n"
+    );
+
+    let measurements = match measure_scaling(&sizes, runs, &autumn_web) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("Error: scaling measurement failed: {e}");
+            return 1;
+        }
+    };
+
+    let baseline = load_baseline(baseline_path);
+    let report = build_scaling_report(&measurements, baseline.as_ref());
+    emit_scaling_report(&report, json, output, fail_on_regression)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locate_autumn_web_honours_env_override() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("Cargo.toml"), "name = \"autumn-web\"\n")
+            .expect("write manifest");
+        let found = temp_env::with_var(
+            "AUTUMN_BENCH_AUTUMN_WEB_PATH",
+            Some(tmp.path().as_os_str()),
+            locate_autumn_web,
+        );
+        assert_eq!(found.as_deref(), Some(tmp.path()));
+    }
+
+    #[test]
+    fn scaffold_app_writes_cargo_toml_and_sources() {
+        use crate::dev_loop_scaling::generate_synthetic_app;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let autumn_web = tmp.path().join("autumn-web");
+        std::fs::create_dir_all(&autumn_web).expect("mkdir");
+
+        let app = generate_synthetic_app(2);
+        scaffold_app(&app, tmp.path(), &autumn_web).expect("scaffold must succeed");
+
+        assert!(tmp.path().join("Cargo.toml").is_file(), "Cargo.toml must exist");
+        let manifest =
+            std::fs::read_to_string(tmp.path().join("Cargo.toml")).expect("read manifest");
+        assert!(manifest.contains("[patch.crates-io]"), "patch section must be appended");
+
+        for (relpath, _) in &app.files {
+            assert!(
+                tmp.path().join(relpath).is_file(),
+                "{relpath} must be written"
+            );
+        }
+    }
+
+    #[test]
+    fn run_scaling_dry_run_returns_zero() {
+        assert_eq!(run_scaling("1,25,50,100", 3, None, false, false, true, None), 0);
+    }
+
+    #[test]
+    fn run_scaling_rejects_zero_runs() {
+        let exit = run_scaling("1,100", 0, None, false, false, false, None);
+        assert_eq!(exit, 1, "zero runs must be rejected");
+    }
+
+    #[test]
+    fn run_scaling_rejects_invalid_sizes() {
+        let exit = run_scaling("abc", 1, None, false, false, false, None);
+        assert_eq!(exit, 1, "invalid sizes must be rejected");
+    }
+
+    // Live test — compiles a real n=1 synthetic app; gated behind --ignored.
+    #[test]
+    #[ignore = "compiles a synthetic app from scratch; run with --ignored"]
+    fn scaling_live_n1_measures_positive_duration() {
+        let autumn_web = cached_autumn_web().expect("must locate autumn-web");
+        let samples = measure_size(1, 1, &autumn_web).expect("must succeed");
+        assert_eq!(samples.len(), 1);
+        assert!(samples[0] > 0, "measured duration must be positive");
+    }
+}

--- a/autumn-cli/src/scaling_driver.rs
+++ b/autumn-cli/src/scaling_driver.rs
@@ -12,7 +12,7 @@
 //! excluded from coverage like `cold_start_driver.rs`.
 
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::time::Instant;
 
 use crate::cold_start_driver::{cached_autumn_web, repoint_autumn_web};
@@ -38,7 +38,8 @@ fn scaffold_app(app: &GeneratedApp, project_dir: &Path, autumn_web: &Path) -> Re
     for (relpath, content) in &app.files {
         let dest = project_dir.join(relpath);
         if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
         }
         std::fs::write(&dest, content).map_err(|e| format!("write {}: {e}", dest.display()))?;
     }
@@ -62,14 +63,14 @@ fn run_cargo_build(project_dir: &Path, timed: bool) -> Result<u64, String> {
         // project accumulates in its own dedicated directory.
         .env_remove("CARGO_TARGET_DIR")
         .env_remove("CARGO_BUILD_TARGET_DIR")
-        .env_remove("CARGO_BUILD_TARGET")
-        // Suppress output so bench stderr is clean.
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .env_remove("CARGO_BUILD_TARGET");
 
+    // Capture output rather than inheriting it: keeps the benchmark's own
+    // stderr clean on success, but preserves the compiler's diagnostics so a
+    // build failure mid-sweep is actually debuggable.
     let start = Instant::now();
-    let status = cmd
-        .status()
+    let output = cmd
+        .output()
         .map_err(|e| format!("cargo build spawn failed: {e}"))?;
     let elapsed = if timed {
         u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX)
@@ -77,8 +78,12 @@ fn run_cargo_build(project_dir: &Path, timed: bool) -> Result<u64, String> {
         0
     };
 
-    if !status.success() {
-        return Err(format!("cargo build failed (exit: {status})"));
+    if !output.status.success() {
+        return Err(format!(
+            "cargo build failed (exit: {}):\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
     Ok(elapsed)
 }
@@ -112,8 +117,7 @@ fn measure_size(n: usize, runs: u32, autumn_web: &Path) -> Result<Vec<u64>, Stri
         let handlers_src = std::fs::read_to_string(&handlers_path)
             .map_err(|e| format!("read handlers.rs: {e}"))?;
         let edited = apply_handler_edit(&handlers_src, run);
-        std::fs::write(&handlers_path, &edited)
-            .map_err(|e| format!("write handlers.rs: {e}"))?;
+        std::fs::write(&handlers_path, &edited).map_err(|e| format!("write handlers.rs: {e}"))?;
 
         eprintln!("  N={n} run {run}/{runs}: timed incremental build…");
         let ms = run_cargo_build(&project_dir, true)?;
@@ -157,7 +161,10 @@ fn measure_scaling(
         ));
     }
     if !failures.is_empty() {
-        eprintln!("Warning: {} size(s) failed and were skipped: {failures:?}", failures.len());
+        eprintln!(
+            "Warning: {} size(s) failed and were skipped: {failures:?}",
+            failures.len()
+        );
     }
     Ok(results)
 }
@@ -222,7 +229,13 @@ pub fn run_scaling(
         }
     };
 
-    let baseline = load_baseline(baseline_path);
+    let baseline = match load_baseline(baseline_path) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            return 1;
+        }
+    };
     let report = build_scaling_report(&measurements, baseline.as_ref());
     emit_scaling_report(&report, json, output, fail_on_regression)
 }
@@ -247,10 +260,16 @@ mod tests {
         let app = generate_synthetic_app(2);
         scaffold_app(&app, tmp.path(), &autumn_web).expect("scaffold must succeed");
 
-        assert!(tmp.path().join("Cargo.toml").is_file(), "Cargo.toml must exist");
+        assert!(
+            tmp.path().join("Cargo.toml").is_file(),
+            "Cargo.toml must exist"
+        );
         let manifest =
             std::fs::read_to_string(tmp.path().join("Cargo.toml")).expect("read manifest");
-        assert!(manifest.contains("[patch.crates-io]"), "patch section must be appended");
+        assert!(
+            manifest.contains("[patch.crates-io]"),
+            "patch section must be appended"
+        );
 
         for (relpath, _) in &app.files {
             assert!(
@@ -262,7 +281,10 @@ mod tests {
 
     #[test]
     fn run_scaling_dry_run_returns_zero() {
-        assert_eq!(run_scaling("1,25,50,100", 3, None, false, false, true, None), 0);
+        assert_eq!(
+            run_scaling("1,25,50,100", 3, None, false, false, true, None),
+            0
+        );
     }
 
     #[test]

--- a/benchmarks/dev-loop-scaling/baseline.json
+++ b/benchmarks/dev-loop-scaling/baseline.json
@@ -1,0 +1,5 @@
+{
+  "established": false,
+  "accepted_slope": null,
+  "note": "First weekly CI run records the measured slope as the accepted baseline. Until established, the >20% slope-regression check is skipped; the absolute (p95 ≤ 8 s) and 2× slope budgets are always enforced. To re-baseline after an intentional regression: run the scaling sweep on the reference runner, compute the measured slope, set established=true and accepted_slope=<value>, and document the change in RELEASE_NOTES.md."
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,6 +19,7 @@ ignore:
   - "autumn-cli/src/build.rs"   # CLI subprocess orchestration — untestable in unit tests
   - "autumn-cli/src/dev.rs"     # CLI subprocess orchestration — untestable in unit tests
   - "autumn-cli/src/cold_start_driver.rs"  # Cold-start onboarding measurement driver: scaffold + cold cargo build + server spawn + HTTP poll — subprocess/TCP/filesystem orchestration, untestable in unit tests (like dev.rs/build.rs). Pure budget/report logic lives in dev_loop_bench.rs and is unit-tested there.
+  - "autumn-cli/src/scaling_driver.rs"   # Macro-scaling measurement driver: synthetic app scaffold + warm/incremental cargo build timing — subprocess/filesystem/timing orchestration, untestable in unit tests (same pattern as cold_start_driver.rs). Pure budget/report/generator logic lives in dev_loop_scaling.rs and is unit-tested there.
   - "autumn-cli/src/doctor.rs"  # Mix of pure-function unit tests and IO-bound orchestration; IO paths (process spawning, TCP, filesystem) excluded like build.rs/dev.rs
   - "autumn-cli/src/config.rs"  # psql subprocess orchestration (run_set/unset/list/history/check_psql) — untestable in unit tests; URL-resolution logic is covered in separate tests
   - "autumn-cli/src/flags.rs"  # psql subprocess orchestration (enable/disable/set-rollout/allow) — same pattern as config.rs

--- a/docs/guide/dev-loop-latency.md
+++ b/docs/guide/dev-loop-latency.md
@@ -325,6 +325,111 @@ CSS/Tailwind edit to refreshed stylesheet  1 234  1 450  2 100  FAIL
 
 ---
 
+## Scaling: Macro-Tax Budget
+
+The budget matrix above measures the **warm incremental** loop at a single,
+small app size. Autumn leans heavily on proc-macros (`#[get]`, `#[model]`,
+`#[repository]`, `#[secured]`, `#[scheduled]`). If a one-line handler edit
+forces re-expansion or re-monomorphization proportional to the total
+route/model count, edit-refresh latency rots silently as real apps reach
+50–200 routes — invisible in CI because no example is large enough to surface
+it (issue #983).
+
+### Scaling budget
+
+| Metric | Budget | Notes |
+|---|---|---|
+| p95 per size | ≤ **8 000 ms** | At every N ∈ {1, 25, 50, 100} |
+| Slope (p95@N=100 / p95@N=1) | ≤ **2×** | Near-flat growth guarantee |
+| Slope regression vs baseline | ≤ **20%** | Once a baseline is established; skipped until then |
+
+**Success metric (issue #983):** single-file handler-edit warm incremental
+rebuild p95 grows ≤ 2× from N=1 to N=100 routes **and** stays under 8 s
+absolute on the reference runner.
+
+### Regression allowance
+
+Any release that **exceeds the absolute 8 s ceiling at any size**, or
+**exceeds the 2× slope**, or **regresses an accepted slope baseline by more
+than 20%**, must either fail the documented gate or carry an explicit
+release-note exception — the same escape hatch as the
+[warm-loop regression allowance](#regression-allowance).
+
+### Synthetic-app methodology
+
+`autumn dev-loop-bench --scaling` generates a **deterministic synthetic
+Autumn app** at each requested size N (default: `{1, 25, 50, 100}`) from a
+built-in code generator — not a hand-checked-in fixture. For each N the
+generator produces:
+
+- `Cargo.toml` — standalone workspace root (same `[patch.crates-io]` trick
+  as `--cold-start` to point at local `autumn-web`).
+- `src/schema.rs` — N `autumn_web::reexports::diesel::table!` declarations.
+- `src/models.rs` — N `#[autumn_web::model]` structs.
+- `src/repositories.rs` — N `#[autumn_web::repository]` traits.
+- `src/handlers.rs` — N `#[get]` handlers; `handler_0` contains a
+  `BENCH_EDIT_SENTINEL` constant that is bumped each run to force a
+  single-file warm incremental recompile.
+- `src/main.rs` — `routes![handler_0 … handler_{n-1}]`.
+
+The generated app depends only on `autumn-web` (default features, which
+include `db` + diesel-async). **No Postgres is required** — we `cargo build`
+only; the binary is never started.
+
+**Measurement procedure per size N:**
+
+1. Write the generated app to a fresh `tempdir`.
+2. Run one **warm build** (untimed) to populate the incremental cache with
+   all N routes, models, and repositories compiled.
+3. Repeat `--runs` times (default 5):
+   a. Bump the `BENCH_EDIT_SENTINEL` in `src/handlers.rs` (exactly one
+      line changed in exactly one file).
+   b. Time `cargo build` end-to-end.
+4. Compute p50/p95/max over the `--runs` samples.
+5. Move on to the next N.
+
+The **slope** is `p95@N_max / p95@N_min` (last vs first size in the sweep).
+
+### Running the scaling benchmark
+
+```bash
+# Print the budget table (no build):
+autumn dev-loop-bench --scaling --dry-run
+
+# Run a fast local sweep (2 sizes, 2 runs):
+AUTUMN_BENCH_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+AUTUMN_BENCH_RUST_VERSION="$(rustc --version)" \
+autumn dev-loop-bench --scaling \
+  --sizes 1,25 \
+  --runs 2 \
+  --output scaling-report.json
+
+# Full sweep with CI regression gate:
+autumn dev-loop-bench --scaling \
+  --baseline benchmarks/dev-loop-scaling/baseline.json \
+  --fail-on-regression
+
+# JSON output:
+autumn dev-loop-bench --scaling --json
+```
+
+### Scaling CI gate
+
+`.github/workflows/dev-loop-scaling.yml` runs weekly (Monday 08:00 UTC,
+after the warm dev-loop and cold-start gates) and on `workflow_dispatch`.
+Per-PR runs are limited to the dry-run budget table and the module unit tests.
+The `measure` job writes `scaling-report.json`, uploads it as a 90-day
+artifact, and fails closed when `all_passed` is `false`.
+
+The accepted slope baseline lives in
+`benchmarks/dev-loop-scaling/baseline.json`. Until `"established": true` is
+set, the > 20%-regression check is skipped and only the absolute (8 s) and 2×
+slope gates apply. To establish the baseline after the first successful run:
+set `established: true` and `accepted_slope: <measured_slope>` and document
+the decision in `RELEASE_NOTES.md`.
+
+---
+
 ## CI Gate
 
 ### Scheduled job (`.github/workflows/dev-loop-latency.yml`)


### PR DESCRIPTION
## Summary

Implements a new macro-scaling benchmark (issue #983) that gates warm incremental rebuild latency as an Autumn app grows from 1 to 100 routes and model/repository pairs. This ensures the edit-refresh loop stays near-flat despite heavy proc-macro usage.

## Key Changes

- **New `dev_loop_scaling.rs` module** (1226 lines): Pure, unit-tested scaling benchmark logic
  - Deterministic synthetic-app generator producing N `#[get]` handlers + N `#[model]`/`#[repository]` pairs
  - Budget constants: p95 ≤ 8 s absolute per size; slope (p95@N=100 / p95@N=1) ≤ 2×
  - `ScalingReport` with per-size `ScalingPoint`s, slope computation, and baseline-regression checking
  - Formatters and emitters reusing `dev_loop_bench` plumbing for consistent output shape
  - 40+ unit tests covering app generation, editing, size parsing, slope computation, and report building

- **New `scaling_driver.rs` module** (289 lines): Live measurement driver
  - Scaffolds synthetic apps in tempdirs with local `autumn-web` patching
  - Runs warm build (untimed) then N timed incremental rebuilds per size
  - Single-file edit via `BENCH_EDIT_SENTINEL` bump in `src/handlers.rs`
  - Graceful per-size failure handling (skip failed sizes, report others)

- **New GitHub Actions workflow** (`.github/workflows/dev-loop-scaling.yml`)
  - Budget table smoke-check on every PR (no build needed)
  - Unit tests on every PR
  - Full scaling sweep on schedule (Monday 08:00 UTC) and manual dispatch
  - 120-minute timeout for 4-size sweep

- **CLI integration** (`main.rs`)
  - `--scaling` flag to run the macro-scaling benchmark
  - `--sizes` CSV parameter (default: `1,25,50,100`)
  - `--baseline` path for slope-regression gating
  - Reuses existing `--runs`, `--output`, `--json`, `--fail-on-regression`, `--dry-run` flags

- **Documentation** (`docs/guide/dev-loop-latency.md`)
  - New "Scaling: Macro-Tax Budget" section with budget table, methodology, and synthetic-app details
  - Explains regression allowance (20% over baseline, same escape hatch as warm-loop)

- **Baseline file** (`benchmarks/dev-loop-scaling/baseline.json`)
  - Initial state: `established: false`, no regression check until first CI run records baseline

- **Coverage exclusion** (`codecov.yml`)
  - Excludes `scaling_driver.rs` (subprocess/filesystem I/O, like `cold_start_driver.rs`)

## Implementation Details

- **Deterministic generation**: All generated files are byte-for-byte identical for a given N, enabling reproducible benchmarks
- **Workspace root**: Generated apps declare `[workspace]` so the live driver's `[patch.crates-io]` section is valid
- **No Postgres required**: Synthetic apps are compile-only; the binary is never started
- **Single-file edits**: `BENCH_EDIT_SENTINEL` bumps force warm incremental recompiles of exactly `src/handlers.rs`
- **Slope computation**: Computed from smallest-N to largest-N p95 (not input order) to catch real regressions even if sizes are swept out of order
- **Baseline policy**: Mirrors cold-start: first run records baseline; regression check skipped until `established: true`
- **Graceful degradation**: If one size fails to build, others are still measured and reported; only fails if all sizes fail

https://claude.ai/code/session_01SHKMyW8gatCfiV2sQQxK9C