### PR TITLE
🔒 Warden: [security fix] Fix timing side channels in constant-time comparisons

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -983,10 +983,7 @@ async fn validate_callback_state(
     let expected_state = session.get(&state_key).await.ok_or_else(|| {
         crate::AutumnError::unauthorized_msg("oauth2 state missing; restart login")
     })?;
-    if subtle::ConstantTimeEq::ct_eq(expected_state.as_bytes(), callback.state.as_bytes())
-        .unwrap_u8()
-        != 1
-    {
+    if !crate::security::constant_time::constant_time_eq_str(&expected_state, &callback.state) {
         return Err(crate::AutumnError::unauthorized_msg(
             "oauth2 state mismatch",
         ));
@@ -1092,10 +1089,7 @@ async fn validate_oidc_nonce(
             .get("nonce")
             .and_then(serde_json::Value::as_str)
             .ok_or_else(|| crate::AutumnError::unauthorized_msg("missing oidc nonce claim"))?;
-        if subtle::ConstantTimeEq::ct_eq(expected_nonce.as_bytes(), actual_nonce.as_bytes())
-            .unwrap_u8()
-            != 1
-        {
+        if !crate::security::constant_time::constant_time_eq_str(&expected_nonce, actual_nonce) {
             return Err(crate::AutumnError::unauthorized_msg("oidc nonce mismatch"));
         }
     }

--- a/autumn/src/inbound_mail.rs
+++ b/autumn/src/inbound_mail.rs
@@ -831,11 +831,6 @@ impl InboundMailRouter {
 
 // ── Provider parsing ──────────────────────────────────────────────────────────
 
-fn subtle_eq(a: &[u8], b: &[u8]) -> bool {
-    use subtle::ConstantTimeEq as _;
-    a.ct_eq(b).into()
-}
-
 /// Strip a display-name from an RFC 5322 address, returning only the addr-spec.
 ///
 /// `"Support <support@company.com>"` → `"support@company.com"`
@@ -896,7 +891,8 @@ pub(crate) fn parse_mailgun(
     }
 
     let expected = compute_mailgun_signature(timestamp, token, signing_key);
-    if !subtle_eq(expected.as_bytes(), signature.as_bytes()) {
+    if !crate::security::constant_time::constant_time_eq(expected.as_bytes(), signature.as_bytes())
+    {
         tracing::warn!("inbound_mail.mailgun: invalid signature — request rejected");
         return Err(StatusCode::UNAUTHORIZED);
     }
@@ -1113,7 +1109,10 @@ pub(crate) fn parse_generic(
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
         let expected = crate::security::config::hmac_sha256_hex(key.as_bytes(), &raw_body);
-        if !subtle_eq(expected.as_bytes(), provided.as_bytes()) {
+        if !crate::security::constant_time::constant_time_eq(
+            expected.as_bytes(),
+            provided.as_bytes(),
+        ) {
             tracing::warn!("inbound_mail.generic: invalid signature — request rejected");
             return Err(StatusCode::UNAUTHORIZED);
         }

--- a/autumn/src/pagination.rs
+++ b/autumn/src/pagination.rs
@@ -578,7 +578,7 @@ impl Cursor {
         let (payload_b64, sig_b64) = token.split_once('.')?;
         let expected_sig = base64url_decode(sig_b64)?;
         let actual_sig = hmac_sha256(key, payload_b64.as_bytes());
-        if !constant_time_eq(&expected_sig, &actual_sig) {
+        if !crate::security::constant_time::constant_time_eq(&expected_sig, &actual_sig) {
             return None;
         }
         let payload = base64url_decode(payload_b64)?;
@@ -593,11 +593,6 @@ fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; 32] {
     let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(key).expect("HMAC accepts any key length");
     mac.update(message);
     mac.finalize().into_bytes().into()
-}
-
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    use subtle::ConstantTimeEq;
-    a.ct_eq(b).into()
 }
 
 // ── CursorRequest ───────────────────────────────────────────────────

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -253,12 +253,6 @@ pub fn hmac_sha256_hex(key: &[u8], message: &[u8]) -> String {
     })
 }
 
-/// Constant-time string comparison for HMAC verification.
-fn ct_eq_str(a: &str, b: &str) -> bool {
-    use subtle::ConstantTimeEq;
-    a.as_bytes().ct_eq(b.as_bytes()).into()
-}
-
 /// Generate a random 32-byte ephemeral key from two UUID v4 values.
 fn generate_ephemeral_key() -> Vec<u8> {
     let a = uuid::Uuid::new_v4();
@@ -303,11 +297,17 @@ impl ResolvedSigningKeys {
     /// Returns `true` when `hex_sig` is a valid HMAC-SHA256 of `message` under
     /// any key (current first, then previous). All comparisons are constant-time.
     pub fn verify(&self, message: &[u8], hex_sig: &str) -> bool {
-        if ct_eq_str(&hmac_sha256_hex(&self.current, message), hex_sig) {
+        if crate::security::constant_time::constant_time_eq_str(
+            &hmac_sha256_hex(&self.current, message),
+            hex_sig,
+        ) {
             return true;
         }
         for prev in &self.previous {
-            if ct_eq_str(&hmac_sha256_hex(prev, message), hex_sig) {
+            if crate::security::constant_time::constant_time_eq_str(
+                &hmac_sha256_hex(prev, message),
+                hex_sig,
+            ) {
                 return true;
             }
         }

--- a/autumn/src/security/constant_time.rs
+++ b/autumn/src/security/constant_time.rs
@@ -1,0 +1,69 @@
+//! Constant-time comparison functions to prevent timing attacks.
+
+use subtle::{Choice, ConstantTimeEq};
+
+/// Constant-time string comparison to prevent timing attacks when verifying tokens.
+///
+/// The comparison always processes exactly `b.len()` bytes so that execution
+/// time is independent of the length of the submitted token `a`. Neither a
+/// length mismatch nor a short input causes an early exit.
+#[inline(never)]
+#[must_use]
+pub fn constant_time_eq_str(a: &str, b: &str) -> bool {
+    constant_time_eq(a.as_bytes(), b.as_bytes())
+}
+
+/// Constant-time byte slice comparison to prevent timing attacks when verifying tokens.
+///
+/// The comparison always processes exactly `b.len()` bytes so that execution
+/// time is independent of the length of the submitted token `a`. Neither a
+/// length mismatch nor a short input causes an early exit.
+#[inline(never)]
+#[must_use]
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    // Constant-time length check — no early exit.
+    let len_eq = a.len().ct_eq(&b.len());
+
+    // Iterate over `a` (the trusted stored token) so the loop count is fixed
+    // at the server-side token length, regardless of what the caller submits
+    // as `b`. Callers pass the attacker-controlled value as `b`, so iterating
+    // over `a` ensures every submission — short or long — executes the same
+    // amount of work. Out-of-range positions in `b` use the inverse of
+    // `a_byte` to guarantee a constant-time mismatch without branching.
+    let mut bytes_eq = Choice::from(1u8);
+    for (i, &a_byte) in a.iter().enumerate() {
+        let b_byte = *b.get(i).unwrap_or(&!a_byte);
+        bytes_eq &= a_byte.ct_eq(&b_byte);
+    }
+
+    (len_eq & bytes_eq).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"ab"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(constant_time_eq(b"", b""));
+        assert!(!constant_time_eq(b"a", b"b"));
+        assert!(!constant_time_eq(b"a", b"A"));
+
+        // Edge case: matching the inverse of a byte
+        assert!(!constant_time_eq(b"\x00\x00\x00", b"\x00\x00"));
+        assert!(!constant_time_eq(b"\xff\xff\xff", b"\xff\xff"));
+    }
+
+    #[test]
+    fn test_constant_time_eq_str() {
+        assert!(constant_time_eq_str("abc", "abc"));
+        assert!(!constant_time_eq_str("abc", "ab"));
+        assert!(!constant_time_eq_str("abc", "abd"));
+        assert!(constant_time_eq_str("", ""));
+        assert!(!constant_time_eq_str("a", "b"));
+        assert!(!constant_time_eq_str("a", "A"));
+    }
+}

--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -312,36 +312,6 @@ pub struct CsrfService<S> {
     settings: Arc<CsrfSettings>,
 }
 
-use subtle::{Choice, ConstantTimeEq};
-
-/// Constant-time string comparison to prevent timing attacks when verifying CSRF tokens.
-///
-/// The comparison always processes exactly `b.len()` bytes so that execution
-/// time is independent of the length of the submitted token `a`.  Neither a
-/// length mismatch nor a short input causes an early exit.
-#[inline(never)]
-fn constant_time_eq(a: &str, b: &str) -> bool {
-    let a = a.as_bytes();
-    let b = b.as_bytes();
-
-    // Constant-time length check — no early exit.
-    let len_eq = a.len().ct_eq(&b.len());
-
-    // Iterate over `a` (the trusted stored token) so the loop count is fixed
-    // at the server-side token length, regardless of what the caller submits
-    // as `b`.  Callers pass the attacker-controlled value as `b`, so iterating
-    // over `a` ensures every submission — short or long — executes the same
-    // amount of work.  Out-of-range positions in `b` use the sentinel 0xFF,
-    // which can never match a valid ASCII/UTF-8 token byte.
-    let mut bytes_eq = Choice::from(1u8);
-    for (i, &a_byte) in a.iter().enumerate() {
-        let b_byte = *b.get(i).unwrap_or(&0xFF);
-        bytes_eq &= a_byte.ct_eq(&b_byte);
-    }
-
-    (len_eq & bytes_eq).into()
-}
-
 /// Extract the CSRF cookie value from the Cookie header.
 fn extract_cookie_token(req_headers: &http::HeaderMap, cookie_name: &str) -> Option<String> {
     let mut found_token = None;
@@ -616,7 +586,7 @@ async fn verify_csrf_token(
         && !c.is_empty()
         && !h.is_empty()
         && validate_cookie_token_hmac(c, settings)
-        && constant_time_eq(c, h)
+        && crate::security::constant_time::constant_time_eq_str(c, h)
     {
         token_found = true;
     }
@@ -636,7 +606,7 @@ async fn verify_csrf_token(
         && !c.is_empty()
         && !q.is_empty()
         && validate_cookie_token_hmac(c, settings)
-        && constant_time_eq(c, q)
+        && crate::security::constant_time::constant_time_eq_str(c, q)
     {
         token_found = true;
     }
@@ -679,7 +649,7 @@ async fn verify_csrf_token(
                     && !c.is_empty()
                     && !value.is_empty()
                     && validate_cookie_token_hmac(c, settings)
-                    && constant_time_eq(c, value.as_ref())
+                    && crate::security::constant_time::constant_time_eq_str(c, value.as_ref())
                 {
                     token_found = true;
                 }
@@ -693,7 +663,7 @@ async fn verify_csrf_token(
                 && !c.is_empty()
                 && !value.is_empty()
                 && validate_cookie_token_hmac(c, settings)
-                && constant_time_eq(c, value)
+                && crate::security::constant_time::constant_time_eq_str(c, value)
             {
                 token_found = true;
             }
@@ -1097,12 +1067,22 @@ mod tests {
 
     #[test]
     fn test_constant_time_eq() {
-        assert!(super::constant_time_eq("abc", "abc"));
-        assert!(!super::constant_time_eq("abc", "ab"));
-        assert!(!super::constant_time_eq("abc", "abd"));
-        assert!(super::constant_time_eq("", ""));
-        assert!(!super::constant_time_eq("a", "b"));
-        assert!(!super::constant_time_eq("a", "A"));
+        assert!(crate::security::constant_time::constant_time_eq_str(
+            "abc", "abc"
+        ));
+        assert!(!crate::security::constant_time::constant_time_eq_str(
+            "abc", "ab"
+        ));
+        assert!(!crate::security::constant_time::constant_time_eq_str(
+            "abc", "abd"
+        ));
+        assert!(crate::security::constant_time::constant_time_eq_str("", ""));
+        assert!(!crate::security::constant_time::constant_time_eq_str(
+            "a", "b"
+        ));
+        assert!(!crate::security::constant_time::constant_time_eq_str(
+            "a", "A"
+        ));
     }
 
     #[tokio::test]

--- a/autumn/src/security/mod.rs
+++ b/autumn/src/security/mod.rs
@@ -139,6 +139,7 @@
 
 pub mod captcha;
 pub(crate) mod config;
+pub mod constant_time;
 pub(crate) mod csrf;
 pub(crate) mod headers;
 pub mod proxy;

--- a/autumn/src/storage/local.rs
+++ b/autumn/src/storage/local.rs
@@ -579,11 +579,14 @@ pub fn verify_upload_with_now(
         return Err(BlobStoreError::Signature("upload token expired".into()));
     }
     let expected = sign_upload(signing_key, blob_key, content_type, expires_at);
-    if constant_time_eq(expected.as_bytes(), signature.as_bytes()) {
+    if crate::security::constant_time::constant_time_eq(expected.as_bytes(), signature.as_bytes()) {
         return Ok(());
     }
     let expected_legacy = sign_upload_legacy(signing_key, blob_key, content_type, expires_at);
-    if constant_time_eq(expected_legacy.as_bytes(), signature.as_bytes()) {
+    if crate::security::constant_time::constant_time_eq(
+        expected_legacy.as_bytes(),
+        signature.as_bytes(),
+    ) {
         return Ok(());
     }
     Err(BlobStoreError::Signature(
@@ -654,22 +657,34 @@ pub(crate) fn verify_upload_rotation_with_now(
         return Err(BlobStoreError::Signature("upload token expired".into()));
     }
     let expected_current = sign_upload(current.as_bytes(), blob_key, content_type, expires_at);
-    if constant_time_eq(expected_current.as_bytes(), signature.as_bytes()) {
+    if crate::security::constant_time::constant_time_eq(
+        expected_current.as_bytes(),
+        signature.as_bytes(),
+    ) {
         return Ok(());
     }
     let expected_current_legacy =
         sign_upload_legacy(current.as_bytes(), blob_key, content_type, expires_at);
-    if constant_time_eq(expected_current_legacy.as_bytes(), signature.as_bytes()) {
+    if crate::security::constant_time::constant_time_eq(
+        expected_current_legacy.as_bytes(),
+        signature.as_bytes(),
+    ) {
         return Ok(());
     }
     for prev in previous {
         let expected = sign_upload(prev.as_bytes(), blob_key, content_type, expires_at);
-        if constant_time_eq(expected.as_bytes(), signature.as_bytes()) {
+        if crate::security::constant_time::constant_time_eq(
+            expected.as_bytes(),
+            signature.as_bytes(),
+        ) {
             return Ok(());
         }
         let expected_legacy =
             sign_upload_legacy(prev.as_bytes(), blob_key, content_type, expires_at);
-        if constant_time_eq(expected_legacy.as_bytes(), signature.as_bytes()) {
+        if crate::security::constant_time::constant_time_eq(
+            expected_legacy.as_bytes(),
+            signature.as_bytes(),
+        ) {
             return Ok(());
         }
     }
@@ -764,7 +779,8 @@ pub fn verify_with_now(
     now_unix: u64,
 ) -> Result<(), BlobStoreError> {
     let expected = sign(signing_key, blob_key, expires_at);
-    if !constant_time_eq(expected.as_bytes(), signature.as_bytes()) {
+    if !crate::security::constant_time::constant_time_eq(expected.as_bytes(), signature.as_bytes())
+    {
         return Err(BlobStoreError::Signature("signature mismatch".into()));
     }
     if expires_at < now_unix {
@@ -1021,11 +1037,6 @@ fn hex<B: AsRef<[u8]>>(bytes: B) -> String {
     s
 }
 
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    use subtle::ConstantTimeEq;
-    a.ct_eq(b).into()
-}
-
 /// Verify a signed blob URL against `current` and each `previous` key.
 ///
 /// Expiry is checked first (same for all keys). The signature is then compared
@@ -1059,12 +1070,18 @@ pub(crate) fn verify_with_rotation_with_now(
         return Err(BlobStoreError::Signature("signed url expired".into()));
     }
     let expected_current = sign(current.as_bytes(), blob_key, expires_at);
-    if constant_time_eq(expected_current.as_bytes(), signature.as_bytes()) {
+    if crate::security::constant_time::constant_time_eq(
+        expected_current.as_bytes(),
+        signature.as_bytes(),
+    ) {
         return Ok(());
     }
     for prev in previous {
         let expected = sign(prev.as_bytes(), blob_key, expires_at);
-        if constant_time_eq(expected.as_bytes(), signature.as_bytes()) {
+        if crate::security::constant_time::constant_time_eq(
+            expected.as_bytes(),
+            signature.as_bytes(),
+        ) {
             return Ok(());
         }
     }


### PR DESCRIPTION
🦠 Threat: Timing side channels in slice comparison. Multiple implementations used `subtle::ConstantTimeEq::ct_eq` directly on `&str` or `&[u8]`, which short-circuits on length mismatches and leaks lengths.
🛡️ Defense: Centralized constant-time comparison in `crate::security::constant_time` that uses bitwise AND without short-circuiting to check lengths in constant time, and compares the full expected string length to a padded buffer.
💥 Severity: Medium - could leak token lengths or other secrets if the attacker can discern the execution time difference of early return vs processing identical length slices.
🧪 Verification: Ensure all tests pass. Tested via `cargo test -p autumn-web`.

---
*PR created automatically by Jules for task [38495319995022365](https://jules.google.com/task/38495319995022365) started by @madmax983*