### PR TITLE
👺 Havoc: [Fix subtle::ConstantTimeEq short-circuit and Instant overflow]

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -983,10 +983,7 @@ async fn validate_callback_state(
     let expected_state = session.get(&state_key).await.ok_or_else(|| {
         crate::AutumnError::unauthorized_msg("oauth2 state missing; restart login")
     })?;
-    if subtle::ConstantTimeEq::ct_eq(expected_state.as_bytes(), callback.state.as_bytes())
-        .unwrap_u8()
-        != 1
-    {
+    if !crate::security::config::ct_eq_str(&expected_state, &callback.state) {
         return Err(crate::AutumnError::unauthorized_msg(
             "oauth2 state mismatch",
         ));
@@ -1092,10 +1089,7 @@ async fn validate_oidc_nonce(
             .get("nonce")
             .and_then(serde_json::Value::as_str)
             .ok_or_else(|| crate::AutumnError::unauthorized_msg("missing oidc nonce claim"))?;
-        if subtle::ConstantTimeEq::ct_eq(expected_nonce.as_bytes(), actual_nonce.as_bytes())
-            .unwrap_u8()
-            != 1
-        {
+        if !crate::security::config::ct_eq_str(&expected_nonce, actual_nonce) {
             return Err(crate::AutumnError::unauthorized_msg("oidc nonce mismatch"));
         }
     }

--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -467,7 +467,9 @@ impl IdempotencyStore for MemoryIdempotencyStore {
         let entry = IdempotencyEntry {
             record,
             body_hash,
-            expires_at: Instant::now() + ttl,
+            expires_at: Instant::now()
+                .checked_add(ttl)
+                .unwrap_or_else(|| Instant::now() + Duration::from_secs(315_360_000)),
         };
         let mut entries = self.entries.write().unwrap();
         entries.insert(key.to_owned(), entry);

--- a/autumn/src/inbound_mail.rs
+++ b/autumn/src/inbound_mail.rs
@@ -833,7 +833,13 @@ impl InboundMailRouter {
 
 fn subtle_eq(a: &[u8], b: &[u8]) -> bool {
     use subtle::ConstantTimeEq as _;
-    a.ct_eq(b).into()
+    let len_eq = a.len().ct_eq(&b.len());
+    let mut bytes_eq = subtle::Choice::from(1u8);
+    for (i, &a_byte) in a.iter().enumerate() {
+        let b_byte = *b.get(i).unwrap_or(&0xFF);
+        bytes_eq &= a_byte.ct_eq(&b_byte);
+    }
+    (len_eq & bytes_eq).into()
 }
 
 /// Strip a display-name from an RFC 5322 address, returning only the addr-spec.

--- a/autumn/src/pagination.rs
+++ b/autumn/src/pagination.rs
@@ -597,7 +597,13 @@ fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; 32] {
 
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     use subtle::ConstantTimeEq;
-    a.ct_eq(b).into()
+    let len_eq = a.len().ct_eq(&b.len());
+    let mut bytes_eq = subtle::Choice::from(1u8);
+    for (i, &a_byte) in a.iter().enumerate() {
+        let b_byte = *b.get(i).unwrap_or(&0xFF);
+        bytes_eq &= a_byte.ct_eq(&b_byte);
+    }
+    (len_eq & bytes_eq).into()
 }
 
 // ── CursorRequest ───────────────────────────────────────────────────

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -254,9 +254,17 @@ pub fn hmac_sha256_hex(key: &[u8], message: &[u8]) -> String {
 }
 
 /// Constant-time string comparison for HMAC verification.
-fn ct_eq_str(a: &str, b: &str) -> bool {
+pub fn ct_eq_str(a: &str, b: &str) -> bool {
     use subtle::ConstantTimeEq;
-    a.as_bytes().ct_eq(b.as_bytes()).into()
+    let a_bytes = a.as_bytes();
+    let b_bytes = b.as_bytes();
+    let len_eq = a_bytes.len().ct_eq(&b_bytes.len());
+    let mut bytes_eq = subtle::Choice::from(1u8);
+    for (i, &a_byte) in a_bytes.iter().enumerate() {
+        let b_byte = *b_bytes.get(i).unwrap_or(&0xFF);
+        bytes_eq &= a_byte.ct_eq(&b_byte);
+    }
+    (len_eq & bytes_eq).into()
 }
 
 /// Generate a random 32-byte ephemeral key from two UUID v4 values.

--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -312,8 +312,6 @@ pub struct CsrfService<S> {
     settings: Arc<CsrfSettings>,
 }
 
-use subtle::{Choice, ConstantTimeEq};
-
 /// Constant-time string comparison to prevent timing attacks when verifying CSRF tokens.
 ///
 /// The comparison always processes exactly `b.len()` bytes so that execution
@@ -321,25 +319,7 @@ use subtle::{Choice, ConstantTimeEq};
 /// length mismatch nor a short input causes an early exit.
 #[inline(never)]
 fn constant_time_eq(a: &str, b: &str) -> bool {
-    let a = a.as_bytes();
-    let b = b.as_bytes();
-
-    // Constant-time length check — no early exit.
-    let len_eq = a.len().ct_eq(&b.len());
-
-    // Iterate over `a` (the trusted stored token) so the loop count is fixed
-    // at the server-side token length, regardless of what the caller submits
-    // as `b`.  Callers pass the attacker-controlled value as `b`, so iterating
-    // over `a` ensures every submission — short or long — executes the same
-    // amount of work.  Out-of-range positions in `b` use the sentinel 0xFF,
-    // which can never match a valid ASCII/UTF-8 token byte.
-    let mut bytes_eq = Choice::from(1u8);
-    for (i, &a_byte) in a.iter().enumerate() {
-        let b_byte = *b.get(i).unwrap_or(&0xFF);
-        bytes_eq &= a_byte.ct_eq(&b_byte);
-    }
-
-    (len_eq & bytes_eq).into()
+    crate::security::config::ct_eq_str(a, b)
 }
 
 /// Extract the CSRF cookie value from the Cookie header.

--- a/autumn/src/storage/local.rs
+++ b/autumn/src/storage/local.rs
@@ -1023,7 +1023,13 @@ fn hex<B: AsRef<[u8]>>(bytes: B) -> String {
 
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     use subtle::ConstantTimeEq;
-    a.ct_eq(b).into()
+    let len_eq = a.len().ct_eq(&b.len());
+    let mut bytes_eq = subtle::Choice::from(1u8);
+    for (i, &a_byte) in a.iter().enumerate() {
+        let b_byte = *b.get(i).unwrap_or(&0xFF);
+        bytes_eq &= a_byte.ct_eq(&b_byte);
+    }
+    (len_eq & bytes_eq).into()
 }
 
 /// Verify a signed blob URL against `current` and each `previous` key.

--- a/autumn/tests/chaos_idempotency_fuzz.rs
+++ b/autumn/tests/chaos_idempotency_fuzz.rs
@@ -1,0 +1,18 @@
+use autumn_web::idempotency::{IdempotencyRecord, IdempotencyStore, MemoryIdempotencyStore};
+use proptest::prelude::*;
+use std::time::Duration;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10))]
+    #[test]
+    fn idempotency_memory_store_ttl_overflow(ttl_secs in (u64::MAX - 1000)..u64::MAX) {
+        let store = MemoryIdempotencyStore::new(Duration::from_secs(60));
+        let record = IdempotencyRecord {
+            status: 200,
+            headers: vec![],
+            body: vec![],
+            metadata: vec![],
+        };
+        store.set("test-key", record, vec![], Duration::from_secs(ttl_secs));
+    }
+}


### PR DESCRIPTION
👺 Havoc: [Fix subtle::ConstantTimeEq short-circuit and Instant overflow]

🧨 **The Trigger:**
1. Using `ct_eq` on slices directly short circuits on length mismatch.
2. `Instant::now() + Duration` panics if the addition overflows, causing a crash.

📉 **The Stack Trace:**
```
thread idempotency_memory_store_ttl_overflow panicked at library/std/src/time.rs:429:33:
overflow when adding duration to instant
```

🧪 **Reproduction:** Run `cargo test -p autumn-web --test chaos_idempotency_fuzz`

😈 **Comment:** You assumed the ttl buffer would never be larger than time. You were wrong.

---
*PR created automatically by Jules for task [2879754589571405568](https://jules.google.com/task/2879754589571405568) started by @madmax983*