### PR TITLE
Add startup wait loop for database cold-start scenarios

### DIFF
--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -182,6 +182,13 @@ enum Commands {
         /// app's runtime precedence — so env vars are not overridden by this flag.
         #[arg(long, value_name = "PROFILE")]
         profile: Option<String>,
+        /// Wait up to SECS seconds for the database to become reachable before
+        /// failing, retrying with capped exponential backoff. Overrides
+        /// `database.startup_wait_secs` from the config file and
+        /// `AUTUMN_DATABASE__STARTUP_WAIT_SECS` from the environment.
+        /// When omitted, the config value is used (default `0` = fail fast).
+        #[arg(long, value_name = "SECS")]
+        wait: Option<u64>,
     },
     /// Create, drop, or reset the database itself.
     ///
@@ -1677,6 +1684,7 @@ fn run_command(command: Commands) {
             shard,
             control_only,
             profile,
+            wait,
         } => {
             let action = match action {
                 Some(MigrateCommands::Status) => migrate::MigrateAction::Status,
@@ -1697,7 +1705,7 @@ fn run_command(command: Commands) {
                 (None, true) => migrate::MigrateTarget::ControlOnly,
                 (None, false) => migrate::MigrateTarget::All,
             };
-            migrate::run(&action, with_maintenance, &target, profile.as_deref());
+            migrate::run(&action, with_maintenance, &target, profile.as_deref(), wait);
         }
         Commands::Db(cmd) => match cmd {
             DbCommands::Pull {
@@ -4540,6 +4548,24 @@ mod tests {
             Cli::try_parse_from(["autumn", "migrate", "--shard", "shard1", "--control-only"])
                 .is_err()
         );
+    }
+
+    #[test]
+    fn parse_migrate_wait_flag() {
+        let cli = Cli::try_parse_from(["autumn", "migrate", "--wait", "60"]).unwrap();
+        let Commands::Migrate { wait, .. } = cli.command else {
+            panic!("expected migrate");
+        };
+        assert_eq!(wait, Some(60u64));
+    }
+
+    #[test]
+    fn parse_migrate_wait_defaults_none() {
+        let cli = Cli::try_parse_from(["autumn", "migrate"]).unwrap();
+        let Commands::Migrate { wait, .. } = cli.command else {
+            panic!("expected migrate");
+        };
+        assert_eq!(wait, None);
     }
 
     #[test]

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -115,8 +115,9 @@ pub fn run(
     }
 
     // 1. Resolve migration target databases from autumn.toml (+ profile
-    //    overlay) + env
-    let targets = resolve_targets(target, profile);
+    //    overlay) + env.  The merged config table is returned so that
+    //    resolve_startup_wait can reuse it without a second filesystem read.
+    let (targets, config_table) = resolve_targets(target, profile);
 
     // 2. Resolve migrations directory
     let migrations_dir = resolve_migrations_dir();
@@ -133,7 +134,7 @@ pub fn run(
     match action {
         MigrateAction::Run => {
             // Resolve the effective startup wait (--wait flag > config > 0).
-            let wait = resolve_startup_wait(wait_override, profile);
+            let wait = resolve_startup_wait(wait_override, config_table.as_ref());
             run_all_targets(&targets, &migrations_dir, with_maintenance, wait);
         }
         MigrateAction::Status => {
@@ -153,7 +154,13 @@ pub fn run(
 
 /// Resolve the `(label, database_url)` pairs the command operates on,
 /// in apply order (control first, then shards in declaration order).
-fn resolve_targets(target: &MigrateTarget, profile: Option<&str>) -> Vec<(String, String)> {
+///
+/// Also returns the merged config table so callers can reuse it (e.g. for
+/// `resolve_startup_wait_secs_from_sources`) without a second filesystem read.
+fn resolve_targets(
+    target: &MigrateTarget,
+    profile: Option<&str>,
+) -> (Vec<(String, String)>, Option<toml::Table>) {
     // Read autumn.toml once, deep-merging the `autumn-<profile>.toml` overlay
     // when a profile is selected, so control and shard URLs both resolve from
     // the same effective configuration. Environment overrides still win over
@@ -169,7 +176,7 @@ fn resolve_targets(target: &MigrateTarget, profile: Option<&str>) -> Vec<(String
     let shards =
         resolve_shard_database_urls_from_sources(|key| std::env::var(key), config_table.as_ref());
     match build_targets(control, shards, target) {
-        Ok(targets) => targets,
+        Ok(targets) => (targets, config_table),
         Err(message) => {
             eprintln!("{message}");
             if matches!(target, MigrateTarget::All | MigrateTarget::ControlOnly) {
@@ -955,8 +962,15 @@ where
     F: Fn(&str) -> Result<String, std::env::VarError>,
 {
     if let Ok(val) = env_var("AUTUMN_DATABASE__STARTUP_WAIT_SECS") {
-        if let Ok(n) = val.trim().parse::<u64>() {
-            return n;
+        match val.trim().parse::<u64>() {
+            Ok(n) => return n,
+            Err(_) => {
+                eprintln!(
+                    "  Warning: AUTUMN_DATABASE__STARTUP_WAIT_SECS={:?} is not a valid \
+                     non-negative integer; falling back to config file / default (0).",
+                    val.trim()
+                );
+            }
         }
     }
 
@@ -965,25 +979,31 @@ where
         .and_then(toml::Value::as_table)
         .and_then(|db| db.get("startup_wait_secs"))
         .and_then(toml::Value::as_integer)
-        .map(|n| u64::try_from(n).unwrap_or(0))
+        .map(|n| {
+            u64::try_from(n).unwrap_or_else(|_| {
+                eprintln!(
+                    "  Warning: `database.startup_wait_secs = {n}` in autumn.toml is not a \
+                     valid non-negative integer; falling back to 0 (fail-fast)."
+                );
+                0
+            })
+        })
         .unwrap_or(0)
 }
 
 /// Resolve the effective startup wait: the `--wait` CLI flag (if given) wins;
-/// otherwise fall back to the merged config (env > toml > 0).
+/// otherwise fall back to the merged config table (env > toml > 0).
+///
+/// `config_table` should be the already-merged table returned by
+/// `resolve_targets` so this function does not need a second filesystem read.
 fn resolve_startup_wait(
     flag: Option<u64>,
-    profile: Option<&str>,
+    config_table: Option<&toml::Table>,
 ) -> std::time::Duration {
     let secs = if let Some(n) = flag {
         n
     } else {
-        let effective = effective_profile(profile);
-        let config_table = read_autumn_toml_table_with_profile(Some(&effective));
-        resolve_startup_wait_secs_from_sources(
-            |key| std::env::var(key),
-            config_table.as_ref(),
-        )
+        resolve_startup_wait_secs_from_sources(|key| std::env::var(key), config_table)
     };
     std::time::Duration::from_secs(secs)
 }
@@ -1194,7 +1214,7 @@ fn run_down(
     // 2. Resolve target databases (control + shards / a single shard /
     //    control-only) and the migrations dir. `down` honors --shard /
     //    --control-only exactly like `migrate run`.
-    let targets = resolve_targets(target, profile);
+    let (targets, _) = resolve_targets(target, profile);
     let migrations_dir = resolve_migrations_dir();
     let dir = Path::new(&migrations_dir);
 

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -350,7 +350,10 @@ fn run_single_target(
     // When wait == Duration::ZERO we skip entirely so the existing fail-fast
     // path is preserved byte-for-byte (AC #6).
     if wait > std::time::Duration::ZERO {
-        eprintln!("  Waiting up to {}s for database to become reachable…", wait.as_secs());
+        eprintln!(
+            "  Waiting up to {}s for database to become reachable…",
+            wait.as_secs()
+        );
         match wait_for_database(database_url, wait, |attempt, delay| {
             eprintln!(
                 "  Database not reachable yet (attempt {attempt}); \
@@ -954,10 +957,7 @@ where
 /// 1. `AUTUMN_DATABASE__STARTUP_WAIT_SECS` env var (highest)
 /// 2. `database.startup_wait_secs` in the merged `autumn.toml` table
 /// 3. `0` (default, fail-fast — no wait)
-pub fn resolve_startup_wait_secs_from_sources<F>(
-    env_var: F,
-    table: Option<&toml::Table>,
-) -> u64
+pub fn resolve_startup_wait_secs_from_sources<F>(env_var: F, table: Option<&toml::Table>) -> u64
 where
     F: Fn(&str) -> Result<String, std::env::VarError>,
 {
@@ -3031,10 +3031,8 @@ primary_url = "postgres://prod-s0:5432/app"
 
     #[test]
     fn resolve_startup_wait_secs_defaults_to_zero() {
-        let secs = resolve_startup_wait_secs_from_sources(
-            |_| Err(std::env::VarError::NotPresent),
-            None,
-        );
+        let secs =
+            resolve_startup_wait_secs_from_sources(|_| Err(std::env::VarError::NotPresent), None);
         assert_eq!(secs, 0);
     }
 
@@ -3042,10 +3040,7 @@ primary_url = "postgres://prod-s0:5432/app"
     fn resolve_startup_wait_secs_from_toml() {
         let mut table = toml::Table::new();
         let mut db = toml::Table::new();
-        db.insert(
-            "startup_wait_secs".to_owned(),
-            toml::Value::Integer(45),
-        );
+        db.insert("startup_wait_secs".to_owned(), toml::Value::Integer(45));
         table.insert("database".to_owned(), toml::Value::Table(db));
         let secs = resolve_startup_wait_secs_from_sources(
             |_| Err(std::env::VarError::NotPresent),
@@ -3058,10 +3053,7 @@ primary_url = "postgres://prod-s0:5432/app"
     fn resolve_startup_wait_secs_env_overrides_toml() {
         let mut table = toml::Table::new();
         let mut db = toml::Table::new();
-        db.insert(
-            "startup_wait_secs".to_owned(),
-            toml::Value::Integer(10),
-        );
+        db.insert("startup_wait_secs".to_owned(), toml::Value::Integer(10));
         table.insert("database".to_owned(), toml::Value::Table(db));
         let secs = resolve_startup_wait_secs_from_sources(
             |key| {
@@ -3080,10 +3072,7 @@ primary_url = "postgres://prod-s0:5432/app"
     fn resolve_startup_wait_secs_bad_env_falls_back_to_toml() {
         let mut table = toml::Table::new();
         let mut db = toml::Table::new();
-        db.insert(
-            "startup_wait_secs".to_owned(),
-            toml::Value::Integer(30),
-        );
+        db.insert("startup_wait_secs".to_owned(), toml::Value::Integer(30));
         table.insert("database".to_owned(), toml::Value::Table(db));
         let secs = resolve_startup_wait_secs_from_sources(
             |key| {

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -89,11 +89,15 @@ pub enum MigrateTarget {
 }
 
 /// Run the migrate command.
+///
+/// `wait_override` comes from the `--wait` CLI flag and, when `Some`, takes
+/// precedence over `database.startup_wait_secs` from the config / environment.
 pub fn run(
     action: &MigrateAction,
     with_maintenance: bool,
     target: &MigrateTarget,
     profile: Option<&str>,
+    wait_override: Option<u64>,
 ) {
     eprintln!("\u{1F342} autumn migrate\n");
 
@@ -128,7 +132,9 @@ pub fn run(
     // 5. Execute the appropriate diesel command per target
     match action {
         MigrateAction::Run => {
-            run_all_targets(&targets, &migrations_dir, with_maintenance);
+            // Resolve the effective startup wait (--wait flag > config > 0).
+            let wait = resolve_startup_wait(wait_override, profile);
+            run_all_targets(&targets, &migrations_dir, with_maintenance, wait);
         }
         MigrateAction::Status => {
             for (label, url) in &targets {
@@ -236,7 +242,12 @@ fn reject_duplicate_target_urls(targets: &[(String, String)]) -> Result<(), Stri
 
 /// Apply migrations to every target in order, failing fast with a
 /// per-target summary.
-fn run_all_targets(targets: &[(String, String)], migrations_dir: &str, with_maintenance: bool) {
+fn run_all_targets(
+    targets: &[(String, String)],
+    migrations_dir: &str,
+    with_maintenance: bool,
+    wait: std::time::Duration,
+) {
     let mut completed: Vec<&str> = Vec::new();
     for (label, url) in targets {
         eprintln!("\u{2500}\u{2500} Migrating {label} \u{2500}\u{2500}");
@@ -244,7 +255,7 @@ fn run_all_targets(targets: &[(String, String)], migrations_dir: &str, with_main
         // the shard-required framework migrations (version history + commit
         // hook queue), not the full control-plane schema.
         let is_shard = label.starts_with("shard:");
-        if run_single_target(url, migrations_dir, is_shard) {
+        if run_single_target(url, migrations_dir, is_shard, wait) {
             completed.push(label);
             eprintln!();
         } else {
@@ -315,8 +326,38 @@ fn disable_maintenance_after_migrate() {
 /// When `is_shard` is `true`, applies only the shard-required framework
 /// migrations (version history + commit-hook queue) instead of the full
 /// control-plane `FRAMEWORK_MIGRATIONS` set.
-fn run_single_target(database_url: &str, migrations_dir: &str, is_shard: bool) -> bool {
-    use autumn_web::migrate::{DEFAULT_LOCK_WAIT_TIMEOUT, hold_migration_lock};
+///
+/// `wait` controls the startup connectivity wait (AC #2/#6):
+///   * `Duration::ZERO` → skip; behaviour is byte-for-byte identical to today.
+///   * `> Duration::ZERO` → retry with capped exponential backoff until the DB
+///     accepts connections or the window elapses.
+fn run_single_target(
+    database_url: &str,
+    migrations_dir: &str,
+    is_shard: bool,
+    wait: std::time::Duration,
+) -> bool {
+    use autumn_web::migrate::{DEFAULT_LOCK_WAIT_TIMEOUT, hold_migration_lock, wait_for_database};
+
+    // Startup wait — only when enabled (startup_wait_secs > 0 or --wait N).
+    // When wait == Duration::ZERO we skip entirely so the existing fail-fast
+    // path is preserved byte-for-byte (AC #6).
+    if wait > std::time::Duration::ZERO {
+        eprintln!("  Waiting up to {}s for database to become reachable…", wait.as_secs());
+        match wait_for_database(database_url, wait, |attempt, delay| {
+            eprintln!(
+                "  Database not reachable yet (attempt {attempt}); \
+                 retrying in {}ms\u{2026}",
+                delay.as_millis(),
+            );
+        }) {
+            Ok(()) => eprintln!("  Database reachable."),
+            Err(e) => {
+                eprintln!("\u{274C} {e}");
+                return false;
+            }
+        }
+    }
 
     // Acquire this target database's Postgres advisory lock before reading
     // the pending-migration list. This serializes concurrent callers
@@ -898,6 +939,53 @@ where
     }
 
     shards
+}
+
+/// Resolve `database.startup_wait_secs` from env and config, mirroring the
+/// same source precedence as other database config knobs:
+///
+/// 1. `AUTUMN_DATABASE__STARTUP_WAIT_SECS` env var (highest)
+/// 2. `database.startup_wait_secs` in the merged `autumn.toml` table
+/// 3. `0` (default, fail-fast — no wait)
+pub fn resolve_startup_wait_secs_from_sources<F>(
+    env_var: F,
+    table: Option<&toml::Table>,
+) -> u64
+where
+    F: Fn(&str) -> Result<String, std::env::VarError>,
+{
+    if let Ok(val) = env_var("AUTUMN_DATABASE__STARTUP_WAIT_SECS") {
+        if let Ok(n) = val.trim().parse::<u64>() {
+            return n;
+        }
+    }
+
+    table
+        .and_then(|t| t.get("database"))
+        .and_then(toml::Value::as_table)
+        .and_then(|db| db.get("startup_wait_secs"))
+        .and_then(toml::Value::as_integer)
+        .map(|n| u64::try_from(n).unwrap_or(0))
+        .unwrap_or(0)
+}
+
+/// Resolve the effective startup wait: the `--wait` CLI flag (if given) wins;
+/// otherwise fall back to the merged config (env > toml > 0).
+fn resolve_startup_wait(
+    flag: Option<u64>,
+    profile: Option<&str>,
+) -> std::time::Duration {
+    let secs = if let Some(n) = flag {
+        n
+    } else {
+        let effective = effective_profile(profile);
+        let config_table = read_autumn_toml_table_with_profile(Some(&effective));
+        resolve_startup_wait_secs_from_sources(
+            |key| std::env::var(key),
+            config_table.as_ref(),
+        )
+    };
+    std::time::Duration::from_secs(secs)
 }
 
 /// Resolve the migrations directory (default: `./migrations/`).
@@ -2917,6 +3005,77 @@ primary_url = "postgres://prod-s0:5432/app"
             findings[0].operation.contains("CONCURRENTLY"),
             "finding should mention CONCURRENTLY"
         );
+    }
+
+    // ── startup wait resolver (red phase) ────────────────────────────────────
+
+    #[test]
+    fn resolve_startup_wait_secs_defaults_to_zero() {
+        let secs = resolve_startup_wait_secs_from_sources(
+            |_| Err(std::env::VarError::NotPresent),
+            None,
+        );
+        assert_eq!(secs, 0);
+    }
+
+    #[test]
+    fn resolve_startup_wait_secs_from_toml() {
+        let mut table = toml::Table::new();
+        let mut db = toml::Table::new();
+        db.insert(
+            "startup_wait_secs".to_owned(),
+            toml::Value::Integer(45),
+        );
+        table.insert("database".to_owned(), toml::Value::Table(db));
+        let secs = resolve_startup_wait_secs_from_sources(
+            |_| Err(std::env::VarError::NotPresent),
+            Some(&table),
+        );
+        assert_eq!(secs, 45);
+    }
+
+    #[test]
+    fn resolve_startup_wait_secs_env_overrides_toml() {
+        let mut table = toml::Table::new();
+        let mut db = toml::Table::new();
+        db.insert(
+            "startup_wait_secs".to_owned(),
+            toml::Value::Integer(10),
+        );
+        table.insert("database".to_owned(), toml::Value::Table(db));
+        let secs = resolve_startup_wait_secs_from_sources(
+            |key| {
+                if key == "AUTUMN_DATABASE__STARTUP_WAIT_SECS" {
+                    Ok("90".to_owned())
+                } else {
+                    Err(std::env::VarError::NotPresent)
+                }
+            },
+            Some(&table),
+        );
+        assert_eq!(secs, 90);
+    }
+
+    #[test]
+    fn resolve_startup_wait_secs_bad_env_falls_back_to_toml() {
+        let mut table = toml::Table::new();
+        let mut db = toml::Table::new();
+        db.insert(
+            "startup_wait_secs".to_owned(),
+            toml::Value::Integer(30),
+        );
+        table.insert("database".to_owned(), toml::Value::Table(db));
+        let secs = resolve_startup_wait_secs_from_sources(
+            |key| {
+                if key == "AUTUMN_DATABASE__STARTUP_WAIT_SECS" {
+                    Ok("not_a_number".to_owned())
+                } else {
+                    Err(std::env::VarError::NotPresent)
+                }
+            },
+            Some(&table),
+        );
+        assert_eq!(secs, 30, "bad env value should fall back to toml");
     }
 
     #[test]

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -979,7 +979,7 @@ where
         .and_then(toml::Value::as_table)
         .and_then(|db| db.get("startup_wait_secs"))
         .and_then(toml::Value::as_integer)
-        .map(|n| {
+        .map_or(0, |n| {
             u64::try_from(n).unwrap_or_else(|_| {
                 eprintln!(
                     "  Warning: `database.startup_wait_secs = {n}` in autumn.toml is not a \
@@ -988,7 +988,6 @@ where
                 0
             })
         })
-        .unwrap_or(0)
 }
 
 /// Resolve the effective startup wait: the `--wait` CLI flag (if given) wins;
@@ -1000,11 +999,10 @@ fn resolve_startup_wait(
     flag: Option<u64>,
     config_table: Option<&toml::Table>,
 ) -> std::time::Duration {
-    let secs = if let Some(n) = flag {
-        n
-    } else {
-        resolve_startup_wait_secs_from_sources(|key| std::env::var(key), config_table)
-    };
+    let secs = flag.map_or_else(
+        || resolve_startup_wait_secs_from_sources(|key| std::env::var(key), config_table),
+        |n| n,
+    );
     std::time::Duration::from_secs(secs)
 }
 

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -999,10 +999,9 @@ fn resolve_startup_wait(
     flag: Option<u64>,
     config_table: Option<&toml::Table>,
 ) -> std::time::Duration {
-    let secs = flag.map_or_else(
-        || resolve_startup_wait_secs_from_sources(|key| std::env::var(key), config_table),
-        |n| n,
-    );
+    let secs = flag.unwrap_or_else(|| {
+        resolve_startup_wait_secs_from_sources(|key| std::env::var(key), config_table)
+    });
     std::time::Duration::from_secs(secs)
 }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -50,6 +50,7 @@
 //! | `AUTUMN_DATABASE__REPLICA_POOL_SIZE` | `database.replica_pool_size` | `usize` |
 //! | `AUTUMN_DATABASE__REPLICA_FALLBACK` | `database.replica_fallback` | `fail_readiness` / `primary` |
 //! | `AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS` | `database.connect_timeout_secs` | `u64` |
+//! | `AUTUMN_DATABASE__STARTUP_WAIT_SECS` | `database.startup_wait_secs` | `u64` |
 //! | `AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION` | `database.auto_migrate_in_production` | `bool` |
 //! | `AUTUMN_DATABASE__SHARDS__{i}__NAME` | `database.shards[i].name` | `String` |
 //! | `AUTUMN_DATABASE__SHARDS__{i}__PRIMARY_URL` | `database.shards[i].primary_url` | `String` |
@@ -2060,6 +2061,7 @@ impl AutumnConfig {
     /// - `AUTUMN_DATABASE__URL` → `database.url` (String)
     /// - `AUTUMN_DATABASE__POOL_SIZE` → `database.pool_size` (usize)
     /// - `AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS` → `database.connect_timeout_secs` (u64)
+    /// - `AUTUMN_DATABASE__STARTUP_WAIT_SECS` → `database.startup_wait_secs` (u64)
     /// - `AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION` -> `database.auto_migrate_in_production` (bool)
     ///
     /// # Log
@@ -2301,6 +2303,11 @@ impl AutumnConfig {
             env,
             "AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS",
             &mut self.database.connect_timeout_secs,
+        );
+        parse_env(
+            env,
+            "AUTUMN_DATABASE__STARTUP_WAIT_SECS",
+            &mut self.database.startup_wait_secs,
         );
         parse_env_bool(
             env,
@@ -3483,6 +3490,17 @@ pub struct DatabaseConfig {
     #[serde(default = "default_connect_timeout")]
     pub connect_timeout_secs: u64,
 
+    /// Bounded startup wait (seconds) for the database to become reachable
+    /// before the migrator fails. `0` (the default) disables the wait and
+    /// preserves the current fail-fast behaviour — a single connection attempt,
+    /// no retry.  Set a non-zero value (e.g. `60`) to have `autumn migrate`
+    /// retry with capped exponential backoff until either the database accepts
+    /// connections or the window elapses.
+    ///
+    /// Override via `AUTUMN_DATABASE__STARTUP_WAIT_SECS`.
+    #[serde(default)]
+    pub startup_wait_secs: u64,
+
     /// When true, permits automatic migration application while running with
     /// `prod`/`production` profile. Default: `false`.
     ///
@@ -4368,6 +4386,7 @@ impl Default for DatabaseConfig {
             replica_pool_size: None,
             replica_fallback: ReplicaFallback::default(),
             connect_timeout_secs: default_connect_timeout(),
+            startup_wait_secs: 0,
             auto_migrate_in_production: false,
             statement_timeout: None,
             slow_query_threshold: default_slow_query_threshold(),
@@ -6315,6 +6334,28 @@ path = "/healthz"
         let mut config = AutumnConfig::default();
         config.apply_env_overrides_with_env(&env);
         assert_eq!(config.database.pool_size, 10);
+    }
+
+    // ── startup_wait_secs ─────────────────────────────────────────────────────
+
+    #[test]
+    fn startup_wait_secs_default_is_zero() {
+        assert_eq!(DatabaseConfig::default().startup_wait_secs, 0);
+    }
+
+    #[test]
+    fn env_override_startup_wait_secs() {
+        let env = MockEnv::new().with("AUTUMN_DATABASE__STARTUP_WAIT_SECS", "60");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.database.startup_wait_secs, 60);
+    }
+
+    #[test]
+    fn startup_wait_secs_parses_from_toml() {
+        let config: AutumnConfig =
+            toml::from_str("[database]\nstartup_wait_secs = 30").unwrap();
+        assert_eq!(config.database.startup_wait_secs, 30);
     }
 
     #[cfg(feature = "storage")]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -6353,8 +6353,7 @@ path = "/healthz"
 
     #[test]
     fn startup_wait_secs_parses_from_toml() {
-        let config: AutumnConfig =
-            toml::from_str("[database]\nstartup_wait_secs = 30").unwrap();
+        let config: AutumnConfig = toml::from_str("[database]\nstartup_wait_secs = 30").unwrap();
         assert_eq!(config.database.startup_wait_secs, 30);
     }
 

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -679,7 +679,7 @@ where
 pub(crate) enum AttemptError {
     /// The server is not yet reachable (connection refused, starting up, …).
     /// The caller will retry after a backoff delay.
-    Retryable(String),
+    Retryable,
     /// A non-transient failure (auth error, bad URL, missing database, …).
     /// The caller must surface the error immediately without retrying.
     Fatal(String),
@@ -702,6 +702,13 @@ pub(crate) fn is_retryable_connection_error(msg: &str) -> bool {
         || lower.contains("network is unreachable")
         || lower.contains("timed out")
         || lower.contains("connection closed")
+        // DNS resolution failures — common in Docker Compose / Kubernetes
+        // cold-start where the 'db' hostname resolves only after the DNS
+        // service is ready (Linux/glibc, macOS, and generic forms).
+        || lower.contains("name or service not known")
+        || lower.contains("nodename nor servname provided")
+        || lower.contains("failed to lookup")
+        || lower.contains("temporary failure in name resolution")
 }
 
 /// Capped exponential backoff for the startup wait loop.
@@ -712,33 +719,44 @@ pub(crate) fn backoff_delay(attempt: u32) -> std::time::Duration {
     std::time::Duration::from_millis(ms.min(5_000))
 }
 
-/// Redact the password from any `postgres://` URL embedded in `msg`.
+/// Redact the password from any `postgres://` or `postgresql://` URL embedded
+/// in `msg`.
 ///
-/// Mirrors `mask_database_url` in `autumn/src/app.rs`: replaces the password
-/// component with `****`.  Leaves the rest of the message unchanged.
+/// Replaces the password component with `****`, mirroring the approach used
+/// by `mask_database_url` in `autumn/src/app.rs`.  When the URL token cannot
+/// be parsed, the entire token is replaced with `****` as a safe fallback so
+/// a malformed-but-credential-bearing string is never surfaced (also matches
+/// `mask_database_url`'s parse-failure behaviour).  Leaves the rest of the
+/// message unchanged.
 pub(crate) fn redact_db_url_credentials(msg: &str) -> String {
-    // Find all postgres:// substrings and replace their password component.
-    // We do a simple pass that parses each occurrence as a URL and substitutes.
     let mut out = msg.to_owned();
-    // Collect start-positions of `postgres://` in the string (reverse order so
-    // replacements don't shift earlier positions).
-    let positions: Vec<usize> = msg
+    // Collect start positions of both recognised postgres URL schemes.
+    // Reverse order so replacements (which may change token length) don't
+    // invalidate earlier positions.
+    let mut positions: Vec<usize> = msg
         .match_indices("postgres://")
+        .chain(msg.match_indices("postgresql://"))
         .map(|(i, _)| i)
         .collect();
+    positions.sort_unstable();
+    positions.dedup();
     for &start in positions.iter().rev() {
         // Extract the URL-shaped token (everything until the first whitespace
-        // or end of string) and try to parse it.
+        // or end of string).
         let token: &str = msg[start..]
             .split(|c: char| c.is_ascii_whitespace())
             .next()
             .unwrap_or(&msg[start..]);
+        let end = start + token.len();
         if let Ok(mut parsed) = url::Url::parse(token) {
             if parsed.password().is_some() {
                 let _ = parsed.set_password(Some("****"));
-                let end = start + token.len();
                 out.replace_range(start..end, parsed.as_str());
             }
+        } else {
+            // Parse failed — mask the whole token rather than risk leaking a
+            // malformed credential-bearing URL.
+            out.replace_range(start..end, "****");
         }
     }
     out
@@ -753,7 +771,7 @@ pub(crate) fn redact_db_url_credentials(msg: &str) -> String {
 ///
 /// * `max_wait` — maximum total time to spend waiting (> 0 enforced by callers)
 /// * `try_connect` — attempts one connection; returns `Ok(())` on success,
-///   `Err(AttemptError::Retryable(_))` for transient errors, or
+///   `Err(AttemptError::Retryable)` for transient errors, or
 ///   `Err(AttemptError::Fatal(_))` for non-transient failures
 /// * `sleep` — called with the computed backoff delay; may be a no-op in tests
 /// * `elapsed` — returns the total time elapsed since the wait started
@@ -774,7 +792,7 @@ pub(crate) fn wait_for_database_inner(
             Err(AttemptError::Fatal(msg)) => {
                 return Err(MigrationError::Connection(redact_db_url_credentials(&msg)));
             }
-            Err(AttemptError::Retryable(_msg)) => {
+            Err(AttemptError::Retryable) => {
                 let elapsed_now = elapsed();
                 if elapsed_now >= max_wait {
                     return Err(MigrationError::Connection(format!(
@@ -808,19 +826,54 @@ pub(crate) fn wait_for_database_inner(
 /// # Errors
 ///
 /// Returns [`MigrationError::Connection`] on either a fatal error or a timeout.
+/// Append (or replace) a `connect_timeout` query parameter in a libpq
+/// connection URI so that a single `establish` call cannot block longer than
+/// `timeout_secs` seconds.  This bounds each attempt within the startup wait
+/// loop independently of the loop's own elapsed-time check.
+///
+/// Falls back to the original URL unchanged when parsing fails (the `establish`
+/// call will then produce a `Fatal` error).
+fn with_connect_timeout(url: &str, timeout_secs: u64) -> String {
+    if let Ok(mut parsed) = url::Url::parse(url) {
+        let params: Vec<(String, String)> = parsed
+            .query_pairs()
+            .filter(|(k, _)| k != "connect_timeout")
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        {
+            let mut qs = parsed.query_pairs_mut();
+            qs.clear();
+            for (k, v) in &params {
+                qs.append_pair(k, v);
+            }
+            qs.append_pair("connect_timeout", &timeout_secs.to_string());
+        }
+        parsed.to_string()
+    } else {
+        url.to_owned()
+    }
+}
+
 pub fn wait_for_database(
     database_url: &str,
     max_wait: std::time::Duration,
     mut on_retry: impl FnMut(u32, std::time::Duration),
 ) -> Result<(), MigrationError> {
+    // Set a per-attempt connect_timeout so a single hung establish() call
+    // cannot block longer than max_wait (e.g. a DROP-firewalled host that
+    // accepts the SYN but never completes the handshake).  libpq's
+    // connect_timeout is in whole seconds; clamp to at least 1.
+    let connect_timeout_secs = max_wait.as_secs().max(1);
+    let timed_url = with_connect_timeout(database_url, connect_timeout_secs);
+
     let start = std::time::Instant::now();
     wait_for_database_inner(
         max_wait,
         || {
-            diesel::PgConnection::establish(database_url).map(|_conn| ()).map_err(|e| {
+            diesel::PgConnection::establish(&timed_url).map(|_conn| ()).map_err(|e| {
                 let msg = e.to_string();
                 if is_retryable_connection_error(&msg) {
-                    AttemptError::Retryable(msg)
+                    AttemptError::Retryable
                 } else {
                     AttemptError::Fatal(msg)
                 }
@@ -1568,6 +1621,29 @@ mod tests {
     }
 
     #[test]
+    fn is_retryable_dns_linux() {
+        assert!(is_retryable_connection_error(
+            "could not translate host name \"db\" to address: \
+             Name or service not known"
+        ));
+    }
+
+    #[test]
+    fn is_retryable_dns_macos() {
+        assert!(is_retryable_connection_error(
+            "could not translate host name \"db\" to address: \
+             nodename nor servname provided, or not known"
+        ));
+    }
+
+    #[test]
+    fn is_retryable_dns_temporary_failure() {
+        assert!(is_retryable_connection_error(
+            "Temporary failure in name resolution"
+        ));
+    }
+
+    #[test]
     fn backoff_delay_grows_and_caps() {
         let d = |n| backoff_delay(n).as_millis();
         assert_eq!(d(1), 500);
@@ -1597,6 +1673,26 @@ mod tests {
             "no-cred url should not be mangled: {out}"
         );
         assert!(out.contains("host:5432"), "host should still be present: {out}");
+    }
+
+    #[test]
+    fn redact_removes_password_from_postgresql_scheme() {
+        let msg = "failed: postgresql://user:s3cret@host:5432/db";
+        let out = redact_db_url_credentials(msg);
+        assert!(
+            !out.contains("s3cret"),
+            "password must not appear when scheme is postgresql://: {out}"
+        );
+        assert!(out.contains("****"), "masked marker missing: {out}");
+    }
+
+    #[test]
+    fn redact_masks_whole_token_on_parse_failure() {
+        // A URL with a bare @ in the password fails url::Url::parse; the whole
+        // token must be replaced with **** rather than passed through unredacted.
+        let msg = "error: postgres://user:p@ss@host/db";
+        let out = redact_db_url_credentials(msg);
+        assert!(!out.contains("p@ss"), "unparseable password must not leak: {out}");
     }
 
     #[test]
@@ -1655,7 +1751,7 @@ mod tests {
                 let n = attempts.get() + 1;
                 attempts.set(n);
                 if n < 3 {
-                    Err(AttemptError::Retryable("connection refused".to_string()))
+                    Err(AttemptError::Retryable)
                 } else {
                     Ok(())
                 }
@@ -1681,7 +1777,7 @@ mod tests {
             std::time::Duration::from_secs(5),
             || {
                 attempts.set(attempts.get() + 1);
-                Err(AttemptError::Retryable("connection refused".to_string()))
+                Err(AttemptError::Retryable)
             },
             |_| {},
             || std::time::Duration::from_secs(10), // fake: already past the budget

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -688,6 +688,10 @@ pub(crate) fn is_retryable_connection_error(msg: &str) -> bool {
         || lower.contains("host is unreachable")
         || lower.contains("network is unreachable")
         || lower.contains("timed out")
+        // libpq reports a connect_timeout expiry as "timeout expired" (not
+        // "timed out"), so firewalled hosts that silently drop packets are
+        // also retryable rather than being mis-classified as fatal.
+        || lower.contains("timeout expired")
         || lower.contains("connection closed")
         // DNS resolution failures — common in Docker Compose / Kubernetes
         // cold-start where the 'db' hostname resolves only after the DNS
@@ -1607,6 +1611,11 @@ mod tests {
         assert!(is_retryable_connection_error("connection timed out"));
         assert!(is_retryable_connection_error(
             "timed out waiting for server"
+        ));
+        // libpq reports connect_timeout expiry as "timeout expired"
+        assert!(is_retryable_connection_error("timeout expired"));
+        assert!(is_retryable_connection_error(
+            "ERROR: SSL connection: timeout expired"
         ));
     }
 

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -672,6 +672,173 @@ where
 /// Returns [`MigrationError::Connection`] if the database is unreachable, or
 /// [`MigrationError::LockTimeout`] if the lock cannot be acquired within
 /// `wait_timeout`.
+// ── Startup wait-for-database ─────────────────────────────────────────────────
+
+/// A single connect attempt returned by the injected `try_connect` closure.
+#[derive(Debug)]
+pub(crate) enum AttemptError {
+    /// The server is not yet reachable (connection refused, starting up, …).
+    /// The caller will retry after a backoff delay.
+    Retryable(String),
+    /// A non-transient failure (auth error, bad URL, missing database, …).
+    /// The caller must surface the error immediately without retrying.
+    Fatal(String),
+}
+
+/// Classify an error message from `PgConnection::establish` as retryable or
+/// fatal so the startup wait loop can decide whether to keep waiting.
+///
+/// The default is **fatal** (deny-list for retry) so that unknown errors always
+/// fail fast rather than silently burning the whole startup-wait window.
+/// Only "server not yet reachable" patterns are allowed to retry (AC #5).
+pub(crate) fn is_retryable_connection_error(msg: &str) -> bool {
+    let lower = msg.to_ascii_lowercase();
+    lower.contains("connection refused")
+        || lower.contains("could not connect to server")
+        || lower.contains("the database system is starting up")
+        || lower.contains("connection reset")
+        || lower.contains("no route to host")
+        || lower.contains("host is unreachable")
+        || lower.contains("network is unreachable")
+        || lower.contains("timed out")
+        || lower.contains("connection closed")
+}
+
+/// Capped exponential backoff for the startup wait loop.
+///
+/// Returns `500ms * 2^(attempt - 1)`, capped at `5s`.
+pub(crate) fn backoff_delay(attempt: u32) -> std::time::Duration {
+    let ms = 500u64.saturating_mul(1u64 << (attempt.saturating_sub(1).min(10)));
+    std::time::Duration::from_millis(ms.min(5_000))
+}
+
+/// Redact the password from any `postgres://` URL embedded in `msg`.
+///
+/// Mirrors `mask_database_url` in `autumn/src/app.rs`: replaces the password
+/// component with `****`.  Leaves the rest of the message unchanged.
+pub(crate) fn redact_db_url_credentials(msg: &str) -> String {
+    // Find all postgres:// substrings and replace their password component.
+    // We do a simple pass that parses each occurrence as a URL and substitutes.
+    let mut out = msg.to_owned();
+    // Collect start-positions of `postgres://` in the string (reverse order so
+    // replacements don't shift earlier positions).
+    let positions: Vec<usize> = msg
+        .match_indices("postgres://")
+        .map(|(i, _)| i)
+        .collect();
+    for &start in positions.iter().rev() {
+        // Extract the URL-shaped token (everything until the first whitespace
+        // or end of string) and try to parse it.
+        let token: &str = msg[start..]
+            .split(|c: char| c.is_ascii_whitespace())
+            .next()
+            .unwrap_or(&msg[start..]);
+        if let Ok(mut parsed) = url::Url::parse(token) {
+            if parsed.password().is_some() {
+                let _ = parsed.set_password(Some("****"));
+                let end = start + token.len();
+                out.replace_range(start..end, parsed.as_str());
+            }
+        }
+    }
+    out
+}
+
+/// Inner (dependency-injected) startup wait loop.
+///
+/// All I/O is supplied via closures so the logic is unit-testable without a
+/// real Postgres instance or wall-clock sleeps (AC #2).
+///
+/// # Arguments
+///
+/// * `max_wait` — maximum total time to spend waiting (> 0 enforced by callers)
+/// * `try_connect` — attempts one connection; returns `Ok(())` on success,
+///   `Err(AttemptError::Retryable(_))` for transient errors, or
+///   `Err(AttemptError::Fatal(_))` for non-transient failures
+/// * `sleep` — called with the computed backoff delay; may be a no-op in tests
+/// * `elapsed` — returns the total time elapsed since the wait started
+/// * `on_retry` — called **before** sleeping with `(attempt, next_delay)` so
+///   the caller can print a user-visible retry message (AC #4)
+pub(crate) fn wait_for_database_inner(
+    max_wait: std::time::Duration,
+    mut try_connect: impl FnMut() -> Result<(), AttemptError>,
+    mut sleep: impl FnMut(std::time::Duration),
+    elapsed: impl Fn() -> std::time::Duration,
+    mut on_retry: impl FnMut(u32, std::time::Duration),
+) -> Result<(), MigrationError> {
+    let mut attempt: u32 = 0;
+    loop {
+        attempt += 1;
+        match try_connect() {
+            Ok(()) => return Ok(()),
+            Err(AttemptError::Fatal(msg)) => {
+                return Err(MigrationError::Connection(redact_db_url_credentials(&msg)));
+            }
+            Err(AttemptError::Retryable(_msg)) => {
+                let elapsed_now = elapsed();
+                if elapsed_now >= max_wait {
+                    return Err(MigrationError::Connection(format!(
+                        "database did not become reachable within {}s \
+                         after {} attempt(s); timed out waiting for startup",
+                        max_wait.as_secs(),
+                        attempt,
+                    )));
+                }
+                let delay = backoff_delay(attempt).min(max_wait.saturating_sub(elapsed_now));
+                on_retry(attempt, delay);
+                sleep(delay);
+            }
+        }
+    }
+}
+
+/// Wait for the database at `database_url` to accept connections, retrying
+/// with capped exponential backoff until either success or `max_wait` elapses.
+///
+/// * `max_wait == Duration::ZERO` — callers **must not** call this function;
+///   skip it and connect directly (preserves today's fail-fast behaviour,
+///   AC #6).
+/// * Non-retryable errors (auth failures, bad URL, missing database) are
+///   surfaced immediately regardless of `max_wait`.
+/// * Connection credentials are never included in retry log output (AC #4).
+///
+/// `on_retry` is invoked **before** each sleep so the CLI can print a visible
+/// `eprintln!` message with attempt count and next delay.
+///
+/// # Errors
+///
+/// Returns [`MigrationError::Connection`] on either a fatal error or a timeout.
+pub fn wait_for_database(
+    database_url: &str,
+    max_wait: std::time::Duration,
+    mut on_retry: impl FnMut(u32, std::time::Duration),
+) -> Result<(), MigrationError> {
+    let start = std::time::Instant::now();
+    wait_for_database_inner(
+        max_wait,
+        || {
+            diesel::PgConnection::establish(database_url).map(|_conn| ()).map_err(|e| {
+                let msg = e.to_string();
+                if is_retryable_connection_error(&msg) {
+                    AttemptError::Retryable(msg)
+                } else {
+                    AttemptError::Fatal(msg)
+                }
+            })
+        },
+        std::thread::sleep,
+        move || start.elapsed(),
+        |attempt, delay| {
+            tracing::warn!(
+                attempt,
+                next_delay_ms = delay.as_millis(),
+                "Database not reachable; retrying after backoff",
+            );
+            on_retry(attempt, delay);
+        },
+    )
+}
+
 pub fn hold_migration_lock(
     database_url: &str,
     wait_timeout: std::time::Duration,
@@ -1342,5 +1509,191 @@ mod tests {
     fn should_auto_apply_returns_false_for_none_profile() {
         assert!(!should_auto_apply(None, false));
         assert!(!should_auto_apply(None, true));
+    }
+
+    // ── startup wait-for-DB (red phase) ───────────────────────────────────────
+
+    #[test]
+    fn is_retryable_connection_refused() {
+        assert!(is_retryable_connection_error("connection refused"));
+        assert!(is_retryable_connection_error("FATAL: connection refused (os error 111)"));
+    }
+
+    #[test]
+    fn is_retryable_server_starting_up() {
+        assert!(is_retryable_connection_error(
+            "the database system is starting up"
+        ));
+    }
+
+    #[test]
+    fn is_retryable_timed_out() {
+        assert!(is_retryable_connection_error("connection timed out"));
+        assert!(is_retryable_connection_error("timed out waiting for server"));
+    }
+
+    #[test]
+    fn is_retryable_could_not_connect() {
+        assert!(is_retryable_connection_error(
+            "could not connect to server: Connection refused"
+        ));
+    }
+
+    #[test]
+    fn is_not_retryable_auth_failure() {
+        assert!(!is_retryable_connection_error(
+            "password authentication failed for user \"app\""
+        ));
+    }
+
+    #[test]
+    fn is_not_retryable_database_does_not_exist() {
+        assert!(!is_retryable_connection_error(
+            "database \"mydb\" does not exist"
+        ));
+    }
+
+    #[test]
+    fn is_not_retryable_invalid_url() {
+        assert!(!is_retryable_connection_error(
+            "invalid connection string syntax"
+        ));
+    }
+
+    #[test]
+    fn is_not_retryable_role_does_not_exist() {
+        assert!(!is_retryable_connection_error(
+            "role \"app\" does not exist"
+        ));
+    }
+
+    #[test]
+    fn backoff_delay_grows_and_caps() {
+        let d = |n| backoff_delay(n).as_millis();
+        assert_eq!(d(1), 500);
+        assert_eq!(d(2), 1000);
+        assert_eq!(d(3), 2000);
+        assert_eq!(d(4), 4000);
+        assert_eq!(d(5), 5000); // capped
+        assert_eq!(d(10), 5000); // still capped
+    }
+
+    #[test]
+    fn redact_removes_password_from_url() {
+        let msg = "failed: postgres://user:secret@host:5432/db";
+        let out = redact_db_url_credentials(msg);
+        assert!(
+            !out.contains("secret"),
+            "password must not appear in output: {out}"
+        );
+    }
+
+    #[test]
+    fn redact_no_creds_url_unchanged_format() {
+        let msg = "connection refused at postgres://host:5432/db";
+        let out = redact_db_url_credentials(msg);
+        assert!(
+            !out.contains("****"),
+            "no-cred url should not be mangled: {out}"
+        );
+        assert!(out.contains("host:5432"), "host should still be present: {out}");
+    }
+
+    #[test]
+    fn wait_for_database_inner_success_first_attempt() {
+        use std::cell::Cell;
+        let attempts = Cell::new(0u32);
+        let sleeps = Cell::new(0u32);
+
+        let result = wait_for_database_inner(
+            std::time::Duration::from_secs(30),
+            || {
+                attempts.set(attempts.get() + 1);
+                Ok(())
+            },
+            |_| sleeps.set(sleeps.get() + 1),
+            || std::time::Duration::ZERO,
+            |_, _| {},
+        );
+        assert!(result.is_ok());
+        assert_eq!(attempts.get(), 1);
+        assert_eq!(sleeps.get(), 0);
+    }
+
+    #[test]
+    fn wait_for_database_inner_fatal_error_no_retry() {
+        use std::cell::Cell;
+        let attempts = Cell::new(0u32);
+        let retried = Cell::new(false);
+
+        let result = wait_for_database_inner(
+            std::time::Duration::from_secs(30),
+            || {
+                attempts.set(attempts.get() + 1);
+                Err(AttemptError::Fatal(
+                    "password authentication failed".to_string(),
+                ))
+            },
+            |_| {},
+            || std::time::Duration::ZERO,
+            |_, _| retried.set(true),
+        );
+        assert!(result.is_err());
+        assert_eq!(attempts.get(), 1, "fatal error must not retry");
+        assert!(!retried.get(), "on_retry must not fire for fatal errors");
+    }
+
+    #[test]
+    fn wait_for_database_inner_success_on_third_attempt() {
+        use std::cell::Cell;
+        let attempts = Cell::new(0u32);
+        let mut sleep_delays = Vec::new();
+
+        let result = wait_for_database_inner(
+            std::time::Duration::from_secs(30),
+            || {
+                let n = attempts.get() + 1;
+                attempts.set(n);
+                if n < 3 {
+                    Err(AttemptError::Retryable("connection refused".to_string()))
+                } else {
+                    Ok(())
+                }
+            },
+            |d| sleep_delays.push(d),
+            || std::time::Duration::ZERO, // always within budget
+            |_, _| {},
+        );
+        assert!(result.is_ok());
+        assert_eq!(attempts.get(), 3);
+        assert_eq!(sleep_delays.len(), 2);
+        // Delays grow with capped exponential backoff
+        assert_eq!(sleep_delays[0], std::time::Duration::from_millis(500));
+        assert_eq!(sleep_delays[1], std::time::Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn wait_for_database_inner_timeout_returns_error() {
+        use std::cell::Cell;
+        let attempts = Cell::new(0u32);
+
+        let result = wait_for_database_inner(
+            std::time::Duration::from_secs(5),
+            || {
+                attempts.set(attempts.get() + 1);
+                Err(AttemptError::Retryable("connection refused".to_string()))
+            },
+            |_| {},
+            || std::time::Duration::from_secs(10), // fake: already past the budget
+            |_, _| {},
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.to_lowercase().contains("wait")
+                || msg.to_lowercase().contains("timeout")
+                || msg.to_lowercase().contains("timed out"),
+            "error must describe the timeout: {msg}"
+        );
     }
 }

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -678,8 +678,9 @@ where
 #[derive(Debug)]
 pub(crate) enum AttemptError {
     /// The server is not yet reachable (connection refused, starting up, …).
+    /// Carries the raw error message so a timeout can include the last error.
     /// The caller will retry after a backoff delay.
-    Retryable,
+    Retryable(String),
     /// A non-transient failure (auth error, bad URL, missing database, …).
     /// The caller must surface the error immediately without retrying.
     Fatal(String),
@@ -729,35 +730,42 @@ pub(crate) fn backoff_delay(attempt: u32) -> std::time::Duration {
 /// `mask_database_url`'s parse-failure behaviour).  Leaves the rest of the
 /// message unchanged.
 pub(crate) fn redact_db_url_credentials(msg: &str) -> String {
-    let mut out = msg.to_owned();
-    // Collect start positions of both recognised postgres URL schemes.
-    // Reverse order so replacements (which may change token length) don't
-    // invalidate earlier positions.
-    let mut positions: Vec<usize> = msg
-        .match_indices("postgres://")
-        .chain(msg.match_indices("postgresql://"))
-        .map(|(i, _)| i)
-        .collect();
-    positions.sort_unstable();
-    positions.dedup();
-    for &start in positions.iter().rev() {
-        // Extract the URL-shaped token (everything until the first whitespace
-        // or end of string).
-        let token: &str = msg[start..]
-            .split(|c: char| c.is_ascii_whitespace())
-            .next()
-            .unwrap_or(&msg[start..]);
-        let end = start + token.len();
+    let mut out = String::with_capacity(msg.len());
+    let mut rest = msg;
+    loop {
+        // Find the leftmost postgres:// or postgresql:// occurrence.
+        let pg = rest.find("postgres://");
+        let pgl = rest.find("postgresql://");
+        let start = match (pg, pgl) {
+            (None, None) => {
+                out.push_str(rest);
+                break;
+            }
+            (Some(a), None) => a,
+            (None, Some(b)) => b,
+            (Some(a), Some(b)) => a.min(b),
+        };
+        // Push everything before the URL token unchanged.
+        out.push_str(&rest[..start]);
+        rest = &rest[start..];
+        // Extract the URL-shaped token (everything until first whitespace or EOS).
+        let token_end = rest
+            .find(|c: char| c.is_ascii_whitespace())
+            .unwrap_or(rest.len());
+        let token = &rest[..token_end];
         if let Ok(mut parsed) = url::Url::parse(token) {
             if parsed.password().is_some() {
                 let _ = parsed.set_password(Some("****"));
-                out.replace_range(start..end, parsed.as_str());
+                out.push_str(parsed.as_str());
+            } else {
+                out.push_str(token);
             }
         } else {
             // Parse failed — mask the whole token rather than risk leaking a
             // malformed credential-bearing URL.
-            out.replace_range(start..end, "****");
+            out.push_str("****");
         }
+        rest = &rest[token_end..];
     }
     out
 }
@@ -771,8 +779,9 @@ pub(crate) fn redact_db_url_credentials(msg: &str) -> String {
 ///
 /// * `max_wait` — maximum total time to spend waiting (> 0 enforced by callers)
 /// * `try_connect` — attempts one connection; returns `Ok(())` on success,
-///   `Err(AttemptError::Retryable)` for transient errors, or
-///   `Err(AttemptError::Fatal(_))` for non-transient failures
+///   `Err(AttemptError::Retryable(msg))` for transient errors (the message is
+///   included in the timeout error), or `Err(AttemptError::Fatal(_))` for
+///   non-transient failures
 /// * `sleep` — called with the computed backoff delay; may be a no-op in tests
 /// * `elapsed` — returns the total time elapsed since the wait started
 /// * `on_retry` — called **before** sleeping with `(attempt, next_delay)` so
@@ -787,25 +796,38 @@ pub(crate) fn wait_for_database_inner(
     let mut attempt: u32 = 0;
     loop {
         attempt += 1;
-        match try_connect() {
+        // Extract the transient error message or return immediately for Ok/Fatal.
+        let retryable_msg = match try_connect() {
             Ok(()) => return Ok(()),
             Err(AttemptError::Fatal(msg)) => {
                 return Err(MigrationError::Connection(redact_db_url_credentials(&msg)));
             }
-            Err(AttemptError::Retryable) => {
-                let elapsed_now = elapsed();
-                if elapsed_now >= max_wait {
-                    return Err(MigrationError::Connection(format!(
-                        "database did not become reachable within {}s \
-                         after {} attempt(s); timed out waiting for startup",
-                        max_wait.as_secs(),
-                        attempt,
-                    )));
-                }
-                let delay = backoff_delay(attempt).min(max_wait.saturating_sub(elapsed_now));
-                on_retry(attempt, delay);
-                sleep(delay);
-            }
+            Err(AttemptError::Retryable(msg)) => msg,
+        };
+        let elapsed_now = elapsed();
+        if elapsed_now >= max_wait {
+            return Err(MigrationError::Connection(format!(
+                "database did not become reachable within {}s after {} attempt(s); \
+                 timed out waiting for startup (last error: {})",
+                max_wait.as_secs(),
+                attempt,
+                redact_db_url_credentials(&retryable_msg),
+            )));
+        }
+        let delay = backoff_delay(attempt).min(max_wait.saturating_sub(elapsed_now));
+        on_retry(attempt, delay);
+        sleep(delay);
+        // Guard against sleep overshoot: if the deadline has now passed, don't
+        // start another connection attempt (which could block for a full
+        // per-attempt connect_timeout before detecting the expiry).
+        if elapsed() >= max_wait {
+            return Err(MigrationError::Connection(format!(
+                "database did not become reachable within {}s after {} attempt(s); \
+                 timed out waiting for startup (last error: {})",
+                max_wait.as_secs(),
+                attempt,
+                redact_db_url_credentials(&retryable_msg),
+            )));
         }
     }
 }
@@ -859,25 +881,28 @@ pub fn wait_for_database(
     max_wait: std::time::Duration,
     mut on_retry: impl FnMut(u32, std::time::Duration),
 ) -> Result<(), MigrationError> {
-    // Set a per-attempt connect_timeout so a single hung establish() call
-    // cannot block longer than max_wait (e.g. a DROP-firewalled host that
-    // accepts the SYN but never completes the handshake).  libpq's
-    // connect_timeout is in whole seconds; clamp to at least 1.
-    let connect_timeout_secs = max_wait.as_secs().max(1);
-    let timed_url = with_connect_timeout(database_url, connect_timeout_secs);
-
     let start = std::time::Instant::now();
     wait_for_database_inner(
         max_wait,
         || {
-            diesel::PgConnection::establish(&timed_url).map(|_conn| ()).map_err(|e| {
-                let msg = e.to_string();
-                if is_retryable_connection_error(&msg) {
-                    AttemptError::Retryable
-                } else {
-                    AttemptError::Fatal(msg)
-                }
-            })
+            // Cap the per-attempt connect_timeout to the remaining budget so
+            // a single hung establish() call cannot extend the total wait beyond
+            // max_wait (e.g. a DROP-firewalled host that accepts the SYN but
+            // never completes the handshake).  libpq's connect_timeout is in
+            // whole seconds; clamp to at least 1.
+            let remaining = max_wait.saturating_sub(start.elapsed());
+            let connect_timeout_secs = remaining.as_secs().max(1);
+            let timed_url = with_connect_timeout(database_url, connect_timeout_secs);
+            diesel::PgConnection::establish(&timed_url)
+                .map(|_conn| ())
+                .map_err(|e| {
+                    let msg = e.to_string();
+                    if is_retryable_connection_error(&msg) {
+                        AttemptError::Retryable(msg)
+                    } else {
+                        AttemptError::Fatal(msg)
+                    }
+                })
         },
         std::thread::sleep,
         move || start.elapsed(),
@@ -1569,7 +1594,9 @@ mod tests {
     #[test]
     fn is_retryable_connection_refused() {
         assert!(is_retryable_connection_error("connection refused"));
-        assert!(is_retryable_connection_error("FATAL: connection refused (os error 111)"));
+        assert!(is_retryable_connection_error(
+            "FATAL: connection refused (os error 111)"
+        ));
     }
 
     #[test]
@@ -1582,7 +1609,9 @@ mod tests {
     #[test]
     fn is_retryable_timed_out() {
         assert!(is_retryable_connection_error("connection timed out"));
-        assert!(is_retryable_connection_error("timed out waiting for server"));
+        assert!(is_retryable_connection_error(
+            "timed out waiting for server"
+        ));
     }
 
     #[test]
@@ -1672,7 +1701,10 @@ mod tests {
             !out.contains("****"),
             "no-cred url should not be mangled: {out}"
         );
-        assert!(out.contains("host:5432"), "host should still be present: {out}");
+        assert!(
+            out.contains("host:5432"),
+            "host should still be present: {out}"
+        );
     }
 
     #[test]
@@ -1692,7 +1724,10 @@ mod tests {
         // token must be replaced with **** rather than passed through unredacted.
         let msg = "error: postgres://user:p@ss@host/db";
         let out = redact_db_url_credentials(msg);
-        assert!(!out.contains("p@ss"), "unparseable password must not leak: {out}");
+        assert!(
+            !out.contains("p@ss"),
+            "unparseable password must not leak: {out}"
+        );
     }
 
     #[test]
@@ -1751,7 +1786,7 @@ mod tests {
                 let n = attempts.get() + 1;
                 attempts.set(n);
                 if n < 3 {
-                    Err(AttemptError::Retryable)
+                    Err(AttemptError::Retryable("connection refused".to_string()))
                 } else {
                     Ok(())
                 }
@@ -1777,7 +1812,7 @@ mod tests {
             std::time::Duration::from_secs(5),
             || {
                 attempts.set(attempts.get() + 1);
-                Err(AttemptError::Retryable)
+                Err(AttemptError::Retryable("connection refused".to_string()))
             },
             |_| {},
             || std::time::Duration::from_secs(10), // fake: already past the budget

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -658,20 +658,6 @@ where
     result
 }
 
-/// Open a new Postgres connection and acquire the migration advisory lock,
-/// returning a [`MigrationLockGuard`] that releases it on drop.
-///
-/// This is the right primitive when migrations are run by an external process
-/// (e.g. the `diesel` CLI subprocess in `autumn migrate run`): the guard keeps
-/// the lock connection alive for the duration of the external run.
-///
-/// Use [`run_pending_locked`] when the Rust harness runs migrations directly.
-///
-/// # Errors
-///
-/// Returns [`MigrationError::Connection`] if the database is unreachable, or
-/// [`MigrationError::LockTimeout`] if the lock cannot be acquired within
-/// `wait_timeout`.
 // ── Startup wait-for-database ─────────────────────────────────────────────────
 
 /// A single connect attempt returned by the injected `try_connect` closure.
@@ -832,50 +818,46 @@ pub(crate) fn wait_for_database_inner(
     }
 }
 
+fn with_connect_timeout(url: &str, timeout_secs: u64) -> String {
+    // Splice `connect_timeout` directly into the raw percent-encoded query
+    // string so existing parameters (e.g. `options=-c%20search_path%3Dapp`)
+    // are preserved byte-for-byte.  Using query_pairs() / append_pair() would
+    // decode and re-encode them via form encoding (spaces → `+`), which libpq
+    // does not accept.
+    url::Url::parse(url).map_or_else(
+        |_| url.to_owned(),
+        |mut parsed| {
+            let pair = format!("connect_timeout={timeout_secs}");
+            let raw = parsed
+                .query()
+                .unwrap_or("")
+                .split('&')
+                .filter(|p| !p.is_empty() && !p.starts_with("connect_timeout="))
+                .chain(std::iter::once(pair.as_str()))
+                .collect::<Vec<_>>()
+                .join("&");
+            parsed.set_query(Some(&raw));
+            parsed.to_string()
+        },
+    )
+}
+
 /// Wait for the database at `database_url` to accept connections, retrying
 /// with capped exponential backoff until either success or `max_wait` elapses.
 ///
 /// * `max_wait == Duration::ZERO` — callers **must not** call this function;
-///   skip it and connect directly (preserves today's fail-fast behaviour,
-///   AC #6).
+///   skip it and connect directly (preserves today's fail-fast behaviour).
 /// * Non-retryable errors (auth failures, bad URL, missing database) are
 ///   surfaced immediately regardless of `max_wait`.
-/// * Connection credentials are never included in retry log output (AC #4).
+/// * Connection credentials are never included in retry log output.
 ///
-/// `on_retry` is invoked **before** each sleep so the CLI can print a visible
-/// `eprintln!` message with attempt count and next delay.
+/// `on_retry` is called **before** each sleep with `(attempt, next_delay)` so
+/// the CLI can print a visible message with attempt count and next delay.
 ///
 /// # Errors
 ///
-/// Returns [`MigrationError::Connection`] on either a fatal error or a timeout.
-/// Append (or replace) a `connect_timeout` query parameter in a libpq
-/// connection URI so that a single `establish` call cannot block longer than
-/// `timeout_secs` seconds.  This bounds each attempt within the startup wait
-/// loop independently of the loop's own elapsed-time check.
-///
-/// Falls back to the original URL unchanged when parsing fails (the `establish`
-/// call will then produce a `Fatal` error).
-fn with_connect_timeout(url: &str, timeout_secs: u64) -> String {
-    if let Ok(mut parsed) = url::Url::parse(url) {
-        let params: Vec<(String, String)> = parsed
-            .query_pairs()
-            .filter(|(k, _)| k != "connect_timeout")
-            .map(|(k, v)| (k.into_owned(), v.into_owned()))
-            .collect();
-        {
-            let mut qs = parsed.query_pairs_mut();
-            qs.clear();
-            for (k, v) in &params {
-                qs.append_pair(k, v);
-            }
-            qs.append_pair("connect_timeout", &timeout_secs.to_string());
-        }
-        parsed.to_string()
-    } else {
-        url.to_owned()
-    }
-}
-
+/// Returns [`MigrationError::Connection`] when a fatal (non-retryable) error
+/// is encountered or when `max_wait` elapses without a successful connection.
 pub fn wait_for_database(
     database_url: &str,
     max_wait: std::time::Duration,
@@ -917,6 +899,20 @@ pub fn wait_for_database(
     )
 }
 
+/// Open a new Postgres connection and acquire the migration advisory lock,
+/// returning a [`MigrationLockGuard`] that releases it on drop.
+///
+/// This is the right primitive when migrations are run by an external process
+/// (e.g. the `diesel` CLI subprocess in `autumn migrate run`): the guard keeps
+/// the lock connection alive for the duration of the external run.
+///
+/// Use [`run_pending_locked`] when the Rust harness runs migrations directly.
+///
+/// # Errors
+///
+/// Returns [`MigrationError::Connection`] if the database is unreachable, or
+/// [`MigrationError::LockTimeout`] if the lock cannot be acquired within
+/// `wait_timeout`.
 pub fn hold_migration_lock(
     database_url: &str,
     wait_timeout: std::time::Duration,
@@ -1800,7 +1796,7 @@ mod tests {
         assert_eq!(sleep_delays.len(), 2);
         // Delays grow with capped exponential backoff
         assert_eq!(sleep_delays[0], std::time::Duration::from_millis(500));
-        assert_eq!(sleep_delays[1], std::time::Duration::from_millis(1000));
+        assert_eq!(sleep_delays[1], std::time::Duration::from_secs(1));
     }
 
     #[test]

--- a/docs/guide/cloud-native.md
+++ b/docs/guide/cloud-native.md
@@ -274,6 +274,69 @@ AUTUMN_DATABASE__PRIMARY_URL="postgres://user:pass@primary:5432/app" autumn migr
 `auto_migrate_in_production = false` on web replicas unless you are deliberately
 running a single-process deployment.
 
+### Waiting for the Database at Cold Start
+
+On a fresh Compose stack, a cold managed Postgres, or a Kubernetes pod that
+races ahead of its database, `autumn migrate` may be called before the database
+is accepting connections. Instead of crashing and requiring a bespoke
+`wait-for-it.sh` wrapper, you can tell `autumn migrate` to wait:
+
+```bash
+# Via environment variable (recommended for container deployments):
+AUTUMN_DATABASE__STARTUP_WAIT_SECS=60 autumn migrate
+
+# Via CLI flag (overrides the environment variable and config file):
+autumn migrate --wait 60
+
+# Via autumn.toml:
+# [database]
+# startup_wait_secs = 60
+```
+
+When `startup_wait_secs` is set to a non-zero value, `autumn migrate` retries
+the initial connection with capped exponential backoff (starting at 500 ms,
+doubling each attempt, capped at 5 s) until the database responds or the total
+wait exceeds the configured limit. On each retry, the attempt number and delay
+are printed so you can see progress in container logs.
+
+Only transient "server not yet reachable" errors are retried (connection
+refused, network unreachable, database system starting up, etc.). Authentication
+failures, missing databases, and malformed URLs fail immediately so you do not
+burn the entire wait window on a configuration mistake.
+
+The default is `0`, which preserves today's fail-fast behavior with no
+behavioral change for existing deployments.
+
+**Docker Compose example** — no `depends_on: condition: service_healthy` or
+`wait-for-it.sh` required:
+
+```yaml
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: app
+
+  migrate:
+    image: my-app:latest
+    command: autumn migrate
+    environment:
+      AUTUMN_DATABASE__PRIMARY_URL: postgres://app:secret@db:5432/app
+      AUTUMN_DATABASE__STARTUP_WAIT_SECS: "60"
+    depends_on:
+      - db
+
+  web:
+    image: my-app:latest
+    environment:
+      AUTUMN_DATABASE__PRIMARY_URL: postgres://app:secret@db:5432/app
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+```
+
 ## Migration Safety Preflight
 
 Before applying migrations in production, run the safety check in CI or locally:


### PR DESCRIPTION
## Summary

Adds a configurable startup wait mechanism to `autumn migrate` that retries database connections with capped exponential backoff when the database is not yet reachable. This eliminates the need for external `wait-for-it.sh` scripts in containerized deployments where the database may still be starting up.

## Key Changes

- **New `wait_for_database` function** in `autumn/src/migrate.rs`:
  - Retries connection attempts with capped exponential backoff (500ms → 5s)
  - Classifies errors as retryable (connection refused, DNS failures, startup) or fatal (auth, missing DB)
  - Redacts credentials from error messages before surfacing them
  - Fully testable via dependency injection (`try_connect`, `sleep`, `elapsed` closures)

- **Configuration support** across three sources (in precedence order):
  - `--wait SECS` CLI flag (highest priority)
  - `AUTUMN_DATABASE__STARTUP_WAIT_SECS` environment variable
  - `database.startup_wait_secs` in `autumn.toml` (default: `0`)
  - Updated `autumn/src/config.rs` to parse and document the new config knob

- **CLI integration** in `autumn-cli/src/main.rs`:
  - Added `--wait SECS` flag to `migrate` command
  - Passes wait duration through to migration execution

- **Migration execution** in `autumn-cli/src/migrate.rs`:
  - Calls `wait_for_database` before acquiring migration lock when wait > 0
  - Prints user-visible retry messages with attempt count and backoff delay
  - Preserves byte-for-byte fail-fast behavior when `startup_wait_secs = 0`

- **Comprehensive test coverage**:
  - Error classification tests (retryable vs. fatal patterns)
  - Backoff delay calculation and capping
  - Credential redaction from URLs
  - Inner loop behavior (success, fatal errors, retries, timeouts)
  - Config resolution from env/toml with proper precedence

- **Documentation** in `docs/guide/cloud-native.md`:
  - Usage examples for env var, CLI flag, and config file
  - Docker Compose example showing cold-start without `wait-for-it.sh`
  - Explanation of retry behavior and error classification

## Implementation Details

- **Retryable error patterns** (deny-list approach for safety):
  - Connection refused, could not connect, database starting up
  - Network errors (reset, unreachable, timed out)
  - DNS resolution failures (Linux, macOS, temporary)

- **Fatal errors** (fail immediately):
  - Authentication failures, missing databases, invalid URLs, missing roles

- **Backoff formula**: `500ms * 2^(attempt-1)`, capped at 5s
  - Attempt 1: 500ms, Attempt 2: 1s, Attempt 3: 2s, Attempt 4: 4s, Attempt 5+: 5s

- **Per-attempt timeout**: Sets `connect_timeout` query parameter to prevent a single hung connection from blocking longer than the total wait window

- **Credential safety**: Redacts passwords from `postgres://` and `postgresql://` URLs in error messages; masks unparseable URLs entirely as a fallback

https://claude.ai/code/session_01HmLDYtuuZNf2UHkeimZgdc