### PR TITLE
👺 Havoc: [Pagination DoS]

### DIFF
--- a/autumn/src/ui/pagination.rs
+++ b/autumn/src/ui/pagination.rs
@@ -217,10 +217,11 @@ impl<'a> PagerOptions<'a> {
 /// Always includes page `1` and `total`, the `radius` pages on either side of
 /// `current`, and inserts a [`PageItem::Ellipsis`] wherever a run of pages is
 /// skipped. Returns a compact sequence like `1 … 4 5 6 … 20`.
-fn page_window(current: u32, total: u32, radius: u32) -> Vec<PageItem> {
+fn page_window(current: u32, total: u32, mut radius: u32) -> Vec<PageItem> {
     if total <= 1 {
         return vec![PageItem::Page(1)];
     }
+    radius = radius.min(1000);
     let current = current.clamp(1, total);
     let lo = current.saturating_sub(radius).max(1);
     let hi = current.saturating_add(radius).min(total);
@@ -720,5 +721,15 @@ mod tests {
         let opts = PagerOptions::new("/feed").prev_cursor("PREVTOK");
         let html = cursor_pagination_nav(&page, &opts).into_string();
         assert!(html.contains("PREVTOK"), "{html}");
+    }
+}
+
+#[cfg(test)]
+mod havoc_tests {
+    use super::*;
+
+    #[test]
+    fn havoc_pagination_radius_oom() {
+        let _ = page_window(1, u32::MAX, u32::MAX);
     }
 }

--- a/autumn/tests/chaos_page_window_oom.rs
+++ b/autumn/tests/chaos_page_window_oom.rs
@@ -1,0 +1,9 @@
+use autumn_web::pagination::Page;
+use autumn_web::ui::pagination::*;
+
+#[test]
+fn havoc_page_window_oom() {
+    let opts = PagerOptions::new("/test").window(2_000_000_000);
+    let page: Page<u32> = Page::from_raw(2_000_000_000, 10, 4_000_000_000_000, 400_000_000);
+    let _ = pagination_nav(&page, &opts);
+}


### PR DESCRIPTION
🧨 **The Trigger:** Pagination options with a massive radius causes OOM buffer allocation.
📉 **The Stack Trace:** memory allocation of 16000000016 bytes failed\nAborted (core dumped)
🧪 **Reproduction:** Run `cargo test --test chaos_page_window_oom`.
😈 **Comment:** You assumed users would only ask for 5 pages of context. They asked for 2 billion.

---
*PR created automatically by Jules for task [16921705468459263433](https://jules.google.com/task/16921705468459263433) started by @madmax983*