### PR TITLE
🤖 Sentinel: Add tests for time clock extractor and duration to kill mutants

### DIFF
--- a/autumn/src/time.rs
+++ b/autumn/src/time.rs
@@ -307,4 +307,21 @@ mod tests {
         let clock = FixedClock::at(pre_epoch);
         assert_eq!(clock_unix_duration(&clock), std::time::Duration::ZERO);
     }
+
+    #[test]
+    fn clock_unix_duration_correct_for_post_epoch() {
+        let post_epoch = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+        let clock = FixedClock::at(post_epoch);
+        let duration = clock_unix_duration(&clock);
+        assert_eq!(duration.as_secs(), post_epoch.timestamp().cast_unsigned());
+        assert_eq!(duration.subsec_nanos(), post_epoch.timestamp_subsec_nanos());
+    }
+
+    #[test]
+    fn clock_extractor_deref_and_now() {
+        let dt = Utc.with_ymd_and_hms(2025, 1, 1, 12, 0, 0).unwrap();
+        let clock = Clock(dt);
+        assert_eq!(clock.now(), dt);
+        assert_eq!(*clock, dt);
+    }
 }


### PR DESCRIPTION
**🤖 Sentinel: Add tests for time clock extractor and duration to kill mutants**

**🦠 Mutants Found:** 8 surviving mutants identified via manual diff review in `autumn/src/time.rs` (cargo-mutants timing out).

**🎯 Tests Added/Strengthened:** 
- Added `clock_unix_duration_correct_for_post_epoch` to test post-epoch behaviour and kill >= 0 logic mutation gap.
- Added `clock_extractor_deref_and_now` to test the missing `now()` and `deref()` behavior of `Clock`.

**⚠️ Suspected Bugs:** 0

**📊 Kill Rate:** Target tests added manually to increase kill rate for these branches/functions.

**🔗 Havoc Interaction:** None.

---
*PR created automatically by Jules for task [17511007746366876619](https://jules.google.com/task/17511007746366876619) started by @madmax983*