### PR TITLE
Add Maud fragment caching keyed by (identity, version)

### DIFF
--- a/autumn/src/cache/fragment.rs
+++ b/autumn/src/cache/fragment.rs
@@ -364,7 +364,7 @@ mod tests {
         clear_global_cache();
 
         let moka = Arc::new(MokaCache::new(100, None));
-        set_global_cache(moka.clone() as Arc<dyn Cache>);
+        set_global_cache(moka as Arc<dyn Cache>);
 
         let counter = Arc::new(AtomicUsize::new(0));
 

--- a/autumn/src/cache/fragment.rs
+++ b/autumn/src/cache/fragment.rs
@@ -42,7 +42,8 @@ use super::{Cache, get_cached, insert_cached};
 /// - **Miss**: calls `render()`, stores the result, and returns it.
 /// - **No cache** (`cache = None`): calls `render()` on every call — no panic.
 ///
-/// The cache key is `"fragment:{identity}:{version}"`. Storing the rendered
+/// The cache key combines `identity` and `version` (the identity is
+/// length-prefixed so a `:` inside it can't alias two fragments). Storing the rendered
 /// `String` via [`insert_cached`] means the fragment works with both the
 /// moka in-process backend and the Redis shared backend (which serializes via
 /// serde JSON), and honours an optional TTL.
@@ -67,7 +68,12 @@ pub fn cache_fragment(
         return render();
     };
 
-    let key = format!("fragment:{identity}:{version}");
+    // Length-prefix the identity so a `:` inside it cannot shift the
+    // identity/version boundary and alias two distinct fragments — e.g.
+    // (identity="a:b", version="c") must not collide with (identity="a",
+    // version="b:c"). The byte length pins where the identity ends.
+    let identity = identity.to_string();
+    let key = format!("fragment:{}:{identity}:{version}", identity.len());
 
     if let Some(html) = get_cached::<String>(cache, &key) {
         // Hit: reconstruct Markup from the cached String without re-escaping.
@@ -425,5 +431,41 @@ mod tests {
             2,
             "each identity must be cached independently"
         );
+    }
+
+    // ── Key boundary is unambiguous even when identity contains `:` ───────
+
+    #[test]
+    fn colon_in_identity_does_not_alias_distinct_fragments() {
+        let cache = make_cache(100);
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        // These two pairs join to the same naive "fragment:{id}:{ver}" string
+        // ("fragment:a:b:c") but are semantically distinct fragments. The
+        // length prefix must keep them apart.
+        let first = {
+            let counter = counter.clone();
+            cache_fragment(Some(&cache), "a:b", "c", None, move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                html! { p { "left" } }
+            })
+        };
+        assert_eq!(counter.load(Ordering::SeqCst), 1, "first pair is a miss");
+        assert!(first.into_string().contains("left"));
+
+        let second = {
+            let counter = counter.clone();
+            cache_fragment(Some(&cache), "a", "b:c", None, move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                html! { p { "right" } }
+            })
+        };
+        // Must be a MISS (distinct key), not a hit serving "left".
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            2,
+            "a `:` in the identity must not collide with a different (identity, version) split"
+        );
+        assert!(second.into_string().contains("right"));
     }
 }

--- a/autumn/src/cache/fragment.rs
+++ b/autumn/src/cache/fragment.rs
@@ -149,7 +149,11 @@ mod tests {
                 html! { p { "rendered" } }
             })
         };
-        assert_eq!(counter.load(Ordering::SeqCst), 1, "miss must run closure once");
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "miss must run closure once"
+        );
         assert!(first.into_string().contains("rendered"));
 
         // Second call (same identity + version) → hit; closure must NOT run.
@@ -319,7 +323,11 @@ mod tests {
         // hits its own cache so the closures don't run. The outer itself hits.
         assert_eq!(inner_a.load(Ordering::SeqCst), 1, "inner-a stays cached");
         assert_eq!(inner_b.load(Ordering::SeqCst), 1, "inner-b stays cached");
-        assert_eq!(outer.load(Ordering::SeqCst), 1, "outer hit: not re-rendered");
+        assert_eq!(
+            outer.load(Ordering::SeqCst),
+            1,
+            "outer hit: not re-rendered"
+        );
 
         // --- Pass 3: inner-a changes (v2), outer version bumps. ---
         // inner-a re-renders, inner-b sibling stays cached, outer re-renders.
@@ -332,9 +340,21 @@ mod tests {
                 html! { ul { (a) (b) } }
             });
         }
-        assert_eq!(inner_a.load(Ordering::SeqCst), 2, "inner-a re-renders on version bump");
-        assert_eq!(inner_b.load(Ordering::SeqCst), 1, "inner-b sibling stays cached");
-        assert_eq!(outer.load(Ordering::SeqCst), 2, "outer re-renders when its version bumped");
+        assert_eq!(
+            inner_a.load(Ordering::SeqCst),
+            2,
+            "inner-a re-renders on version bump"
+        );
+        assert_eq!(
+            inner_b.load(Ordering::SeqCst),
+            1,
+            "inner-b sibling stays cached"
+        );
+        assert_eq!(
+            outer.load(Ordering::SeqCst),
+            2,
+            "outer re-renders when its version bumped"
+        );
     }
 
     // ── cache_fragment_global: uses process-global cache ─────────────────
@@ -375,8 +395,7 @@ mod tests {
     fn global_variant_no_global_cache_renders_fallback() {
         clear_global_cache();
 
-        let result =
-            cache_fragment_global("post:fallback", "v1", None, || html! { span { "ok" } });
+        let result = cache_fragment_global("post:fallback", "v1", None, || html! { span { "ok" } });
         assert!(
             result.into_string().contains("ok"),
             "must render when no global cache"

--- a/autumn/src/cache/fragment.rs
+++ b/autumn/src/cache/fragment.rs
@@ -1,0 +1,429 @@
+//! Maud fragment caching keyed by (identity, version).
+//!
+//! [`cache_fragment`] returns cached markup on a hit and renders + stores it
+//! on a miss. Bumping the `version` token (e.g. `record.updated_at`) causes
+//! a miss so writes auto-invalidate without manual eviction.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use autumn_web::cache::{cache_fragment, MokaCache};
+//! use std::sync::Arc;
+//!
+//! let cache: Arc<dyn autumn_web::cache::Cache> = Arc::new(MokaCache::new(1_000, None));
+//!
+//! let markup = cache_fragment(
+//!     Some(cache.as_ref()),
+//!     format_args!("post:{}", post.id),
+//!     post.updated_at.timestamp(),
+//!     None,
+//!     || html! { h1 { (post.title) } },
+//! );
+//! ```
+//!
+//! Pass `None` for the cache (e.g. in dev without Redis/moka) and the helper
+//! renders directly without panicking.
+//!
+//! # Russian-doll nesting
+//!
+//! Inner fragments cached by their own `(identity, version)` are reused when
+//! an outer fragment re-renders. Only the changed inner record's closure runs;
+//! unchanged siblings are served from cache. Derive the outer fragment's
+//! version from its children (e.g. `max(child.updated_at)`) so the outer
+//! re-renders whenever any child changes.
+
+use maud::{Markup, PreEscaped};
+
+use super::{Cache, get_cached, insert_cached};
+
+/// Cache a rendered Maud fragment keyed by `(identity, version)`.
+///
+/// - **Hit**: returns the cached `Markup` without running `render`.
+/// - **Miss**: calls `render()`, stores the result, and returns it.
+/// - **No cache** (`cache = None`): calls `render()` on every call — no panic.
+///
+/// The cache key is `"fragment:{identity}:{version}"`. Storing the rendered
+/// `String` via [`insert_cached`] means the fragment works with both the
+/// moka in-process backend and the Redis shared backend (which serializes via
+/// serde JSON), and honours an optional TTL.
+///
+/// # Arguments
+///
+/// * `cache`    — the backing store; `None` → fallback render (dev / no cache configured)
+/// * `identity` — uniquely identifies *which* fragment (e.g. `"post:42"`)
+/// * `version`  — a token that changes when the underlying record changes
+///   (e.g. `record.updated_at.timestamp()` or a sequence number)
+/// * `ttl`      — optional time-to-live forwarded to the backend (Redis etc.)
+/// * `render`   — closure that produces the `Markup`; **not called on a hit**
+pub fn cache_fragment(
+    cache: Option<&dyn Cache>,
+    identity: impl std::fmt::Display,
+    version: impl std::fmt::Display,
+    ttl: Option<std::time::Duration>,
+    render: impl FnOnce() -> Markup,
+) -> Markup {
+    let Some(cache) = cache else {
+        // Graceful fallback: no cache configured → render every time, no panic.
+        return render();
+    };
+
+    let key = format!("fragment:{identity}:{version}");
+
+    if let Some(html) = get_cached::<String>(cache, &key) {
+        // Hit: reconstruct Markup from the cached String without re-escaping.
+        return PreEscaped(html);
+    }
+
+    // Miss: render once, store the inner String (serde-transparent for Redis).
+    let markup = render();
+    insert_cached(cache, &key, markup.0.clone(), ttl);
+    markup
+}
+
+/// Cache a Maud fragment using the **process-global** cache backend.
+///
+/// Resolves the cache registered via
+/// [`AppBuilder::with_cache_backend`](crate::app::AppBuilder) or
+/// [`AppState::set_cache`](crate::state::AppState::set_cache). When no global
+/// cache is registered (e.g. during local dev without Redis/moka) the helper
+/// renders directly and never panics.
+///
+/// This is the ergonomic variant for use inside handler/component functions
+/// where you don't hold an `Arc<dyn Cache>` directly:
+///
+/// ```rust,ignore
+/// fn post_card(post: &Post) -> Markup {
+///     cache_fragment_global(
+///         format_args!("post:{}", post.id),
+///         post.updated_at.timestamp(),
+///         None,
+///         || html! { article { h2 { (post.title) } } },
+///     )
+/// }
+/// ```
+pub fn cache_fragment_global(
+    identity: impl std::fmt::Display,
+    version: impl std::fmt::Display,
+    ttl: Option<std::time::Duration>,
+    render: impl FnOnce() -> Markup,
+) -> Markup {
+    let global = super::global_cache();
+    cache_fragment(global.as_deref(), identity, version, ttl, render)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "cache-moka"))]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use maud::{Markup, html};
+
+    use super::{cache_fragment, cache_fragment_global};
+    use crate::cache::{Cache, MokaCache, clear_global_cache, set_global_cache};
+
+    fn make_cache(capacity: u64) -> MokaCache {
+        MokaCache::new(capacity, None)
+    }
+
+    // ── AC1 + AC5: miss renders+stores; closure NOT executed on a hit ──────
+
+    #[test]
+    fn hit_does_not_run_closure() {
+        let cache = make_cache(100);
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        // First call → miss; closure runs once.
+        let first = {
+            let counter = counter.clone();
+            cache_fragment(Some(&cache), "post:1", "v1", None, move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                html! { p { "rendered" } }
+            })
+        };
+        assert_eq!(counter.load(Ordering::SeqCst), 1, "miss must run closure once");
+        assert!(first.into_string().contains("rendered"));
+
+        // Second call (same identity + version) → hit; closure must NOT run.
+        let second = {
+            let counter = counter.clone();
+            cache_fragment(Some(&cache), "post:1", "v1", None, move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                html! { p { "SHOULD NOT APPEAR" } }
+            })
+        };
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "hit must not run the render closure"
+        );
+        assert!(second.into_string().contains("rendered"));
+    }
+
+    // ── AC2: version bump → miss → re-render ──────────────────────────────
+
+    #[test]
+    fn version_bump_causes_miss() {
+        let cache = make_cache(100);
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let v1 = {
+            let counter = counter.clone();
+            cache_fragment(Some(&cache), "post:7", "2024-01-01", None, move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                html! { p { "version-one" } }
+            })
+        };
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert!(v1.into_string().contains("version-one"));
+
+        // Same identity, NEW version → must miss and re-render.
+        let v2 = {
+            let counter = counter.clone();
+            cache_fragment(Some(&cache), "post:7", "2024-06-01", None, move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                html! { p { "version-two" } }
+            })
+        };
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            2,
+            "version bump must produce a miss"
+        );
+        assert!(v2.into_string().contains("version-two"));
+    }
+
+    // ── AC6: no cache → renders directly, never panics ────────────────────
+
+    #[test]
+    fn no_cache_renders_directly_without_panic() {
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..3 {
+            let counter = counter.clone();
+            let result = cache_fragment(None, "post:99", "v1", None, move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                html! { span { "fallback" } }
+            });
+            assert!(result.into_string().contains("fallback"));
+        }
+
+        // No cache → every call renders.
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            3,
+            "no cache must render on every call"
+        );
+    }
+
+    // ── AC3: TTL forwarded to backend (insert_cached honours ttl arg) ─────
+
+    #[test]
+    fn ttl_parameter_accepted_and_hit_still_works() {
+        let cache = make_cache(100);
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        // Store with a TTL (in-process moka ignores per-call TTL, but must not panic).
+        {
+            let counter = counter.clone();
+            cache_fragment(
+                Some(&cache),
+                "post:2",
+                "v1",
+                Some(Duration::from_secs(60)),
+                move || {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    html! { em { "ttl-test" } }
+                },
+            );
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+        // Hit must still work immediately after.
+        {
+            let counter = counter.clone();
+            cache_fragment(
+                Some(&cache),
+                "post:2",
+                "v1",
+                Some(Duration::from_secs(60)),
+                move || {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    html! { em { "ttl-test" } }
+                },
+            );
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 1, "hit must not re-render");
+    }
+
+    // ── AC4: Russian-doll nesting ─────────────────────────────────────────
+    //
+    // Two inner fragments live inside an outer fragment. We derive the outer
+    // version from its children. When one inner record changes:
+    //   - the outer re-renders (its version bumped),
+    //   - the changed inner re-renders,
+    //   - the *unchanged sibling* is served from cache (closure not run).
+
+    /// Render inner fragment `id` at `version`, counting closure invocations.
+    fn inner(cache: &dyn Cache, id: &str, version: &str, counter: &Arc<AtomicUsize>) -> Markup {
+        let counter = counter.clone();
+        let version_owned = version.to_owned();
+        cache_fragment(Some(cache), id, version, None, move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+            html! { li { "fragment " (version_owned) } }
+        })
+    }
+
+    #[test]
+    fn russian_doll_nesting_sibling_hit_unchanged_inner() {
+        let cache = make_cache(100);
+        let cache_ref: &dyn Cache = &cache;
+
+        let inner_a = Arc::new(AtomicUsize::new(0));
+        let inner_b = Arc::new(AtomicUsize::new(0));
+        let outer = Arc::new(AtomicUsize::new(0));
+
+        // --- Pass 1: warm everything (outer v1, a v1, b v1) ---
+        {
+            let a = inner(cache_ref, "inner:a", "v1", &inner_a);
+            let b = inner(cache_ref, "inner:b", "v1", &inner_b);
+            let outer_c = outer.clone();
+            cache_fragment(Some(cache_ref), "outer:list", "outer-v1", None, move || {
+                outer_c.fetch_add(1, Ordering::SeqCst);
+                html! { ul { (a) (b) } }
+            });
+        }
+        assert_eq!(inner_a.load(Ordering::SeqCst), 1, "inner-a warmed once");
+        assert_eq!(inner_b.load(Ordering::SeqCst), 1, "inner-b warmed once");
+        assert_eq!(outer.load(Ordering::SeqCst), 1, "outer warmed once");
+
+        // --- Pass 2: identical → outer hit, inner closures never invoked ---
+        {
+            let a = inner(cache_ref, "inner:a", "v1", &inner_a);
+            let b = inner(cache_ref, "inner:b", "v1", &inner_b);
+            let outer_c = outer.clone();
+            cache_fragment(Some(cache_ref), "outer:list", "outer-v1", None, move || {
+                outer_c.fetch_add(1, Ordering::SeqCst);
+                html! { ul { (a) (b) } }
+            });
+        }
+        // The inner() helper above *does* run when the outer is a hit, but it
+        // hits its own cache so the closures don't run. The outer itself hits.
+        assert_eq!(inner_a.load(Ordering::SeqCst), 1, "inner-a stays cached");
+        assert_eq!(inner_b.load(Ordering::SeqCst), 1, "inner-b stays cached");
+        assert_eq!(outer.load(Ordering::SeqCst), 1, "outer hit: not re-rendered");
+
+        // --- Pass 3: inner-a changes (v2), outer version bumps. ---
+        // inner-a re-renders, inner-b sibling stays cached, outer re-renders.
+        {
+            let a = inner(cache_ref, "inner:a", "v2", &inner_a); // bumped
+            let b = inner(cache_ref, "inner:b", "v1", &inner_b); // unchanged
+            let outer_c = outer.clone();
+            cache_fragment(Some(cache_ref), "outer:list", "outer-v2", None, move || {
+                outer_c.fetch_add(1, Ordering::SeqCst);
+                html! { ul { (a) (b) } }
+            });
+        }
+        assert_eq!(inner_a.load(Ordering::SeqCst), 2, "inner-a re-renders on version bump");
+        assert_eq!(inner_b.load(Ordering::SeqCst), 1, "inner-b sibling stays cached");
+        assert_eq!(outer.load(Ordering::SeqCst), 2, "outer re-renders when its version bumped");
+    }
+
+    // ── cache_fragment_global: uses process-global cache ─────────────────
+
+    #[test]
+    fn global_variant_hits_process_global_cache() {
+        clear_global_cache();
+
+        let moka = Arc::new(MokaCache::new(100, None));
+        set_global_cache(moka.clone() as Arc<dyn Cache>);
+
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        {
+            let counter = counter.clone();
+            cache_fragment_global("post:global", "v1", None, move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                html! { div { "global" } }
+            });
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 1, "first call must miss");
+
+        {
+            let counter = counter.clone();
+            cache_fragment_global("post:global", "v1", None, move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                html! { div { "global" } }
+            });
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 1, "second call must hit");
+
+        clear_global_cache();
+    }
+
+    // ── cache_fragment_global: no global → renders without panicking ──────
+
+    #[test]
+    fn global_variant_no_global_cache_renders_fallback() {
+        clear_global_cache();
+
+        let result =
+            cache_fragment_global("post:fallback", "v1", None, || html! { span { "ok" } });
+        assert!(
+            result.into_string().contains("ok"),
+            "must render when no global cache"
+        );
+    }
+
+    // ── Returned Markup is byte-identical to the rendered Markup ──────────
+
+    #[test]
+    fn cached_markup_matches_rendered_markup() {
+        let cache = make_cache(10);
+
+        let first: Markup = cache_fragment(Some(&cache), "post:html", "v1", None, || {
+            html! { article { h1 { "Hello" } p { "World" } } }
+        });
+        let first_html = first.into_string();
+
+        // Retrieve from cache; the alternate closure must be ignored.
+        let second: Markup = cache_fragment(Some(&cache), "post:html", "v1", None, || {
+            html! { span { "WRONG" } }
+        });
+        let second_html = second.into_string();
+
+        assert_eq!(first_html, second_html, "cached markup must equal original");
+        assert!(second_html.contains("Hello"));
+        assert!(second_html.contains("World"));
+        assert!(!second_html.contains("WRONG"));
+    }
+
+    // ── Different identities are cached independently ─────────────────────
+
+    #[test]
+    fn different_identities_are_independent() {
+        let cache = make_cache(100);
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let render = |id: &str| {
+            let counter = counter.clone();
+            cache_fragment(Some(&cache), id, "v1", None, move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                html! { span { "x" } }
+            });
+        };
+
+        render("post:A");
+        render("post:B");
+        render("post:A"); // hit
+        render("post:B"); // hit
+
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            2,
+            "each identity must be cached independently"
+        );
+    }
+}

--- a/autumn/src/cache/mod.rs
+++ b/autumn/src/cache/mod.rs
@@ -33,10 +33,14 @@
 //! }
 //! ```
 
+#[cfg(feature = "maud")]
+mod fragment;
 mod layer;
 #[cfg(feature = "cache-moka")]
 mod moka_impl;
 
+#[cfg(feature = "maud")]
+pub use fragment::{cache_fragment, cache_fragment_global};
 pub use layer::{CacheResponseLayer, CacheResponseService};
 #[cfg(feature = "cache-moka")]
 pub use moka_impl::MokaCache;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -47,6 +47,9 @@ pub use crate::assets::javascript_include_tag;
 /// Maud HTML templating types.
 #[cfg(feature = "maud")]
 pub use maud::{Markup, PreEscaped, html};
+/// Cache a rendered Maud fragment keyed by `(identity, version)`.
+#[cfg(feature = "maud")]
+pub use crate::cache::{cache_fragment, cache_fragment_global};
 
 // ── Extractors ───────────────────────────────────────────────────
 /// Canary traffic-routing extractor (reads the `X-Canary` header).

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -44,12 +44,12 @@ pub use crate::assets::asset_url;
 /// Render a `<script>` tag with SRI integrity for a named vendored JS dependency.
 #[cfg(feature = "maud")]
 pub use crate::assets::javascript_include_tag;
-/// Maud HTML templating types.
-#[cfg(feature = "maud")]
-pub use maud::{Markup, PreEscaped, html};
 /// Cache a rendered Maud fragment keyed by `(identity, version)`.
 #[cfg(feature = "maud")]
 pub use crate::cache::{cache_fragment, cache_fragment_global};
+/// Maud HTML templating types.
+#[cfg(feature = "maud")]
+pub use maud::{Markup, PreEscaped, html};
 
 // ── Extractors ───────────────────────────────────────────────────
 /// Canary traffic-routing extractor (reads the `X-Canary` header).

--- a/autumn/tests/fragment_cache_integration.rs
+++ b/autumn/tests/fragment_cache_integration.rs
@@ -1,0 +1,154 @@
+//! Integration tests for Maud fragment caching (issue #1040).
+//!
+//! Verifies the end-to-end story:
+//! - a fragment cached via the registered `AppState` backend is reused on a hit,
+//! - a "write" (version-token bump, e.g. `record.updated_at`) re-renders the
+//!   fragment on the very next read — **0 stale renders** (the Success Metric).
+
+#![cfg(all(feature = "maud", feature = "cache-moka"))]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use autumn_web::AppState;
+use autumn_web::cache::{Cache, MokaCache, cache_fragment};
+use maud::html;
+
+/// A toy record with an `updated_at`-style version token.
+struct Post {
+    id: i64,
+    title: &'static str,
+    version: i64, // stands in for `updated_at.timestamp()`
+}
+
+/// Render a post card, caching it keyed by `(post.id, post.version)`.
+/// `counter` increments only when the render closure actually runs (a miss).
+fn render_post_card(cache: &dyn Cache, post: &Post, counter: &Arc<AtomicUsize>) -> String {
+    let counter = counter.clone();
+    let title = post.title;
+    cache_fragment(
+        Some(cache),
+        format_args!("post:{}", post.id),
+        post.version,
+        None,
+        move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+            html! { article { h2 { (title) } } }
+        },
+    )
+    .into_string()
+}
+
+#[test]
+fn fragment_served_from_app_state_cache_on_hit() {
+    let moka = Arc::new(MokaCache::new(100, None));
+    let state = AppState::for_test().with_cache(moka as Arc<dyn Cache>);
+    let cache = state.cache().expect("cache registered");
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let post = Post { id: 1, title: "Hello", version: 1 };
+
+    // First read → miss → render once.
+    let first = render_post_card(cache.as_ref(), &post, &counter);
+    assert_eq!(counter.load(Ordering::SeqCst), 1, "first read is a miss");
+    assert!(first.contains("Hello"));
+
+    // Second read of the same version → hit → no re-render.
+    let second = render_post_card(cache.as_ref(), &post, &counter);
+    assert_eq!(counter.load(Ordering::SeqCst), 1, "second read is a cache hit");
+    assert_eq!(first, second, "cached markup is identical");
+}
+
+#[test]
+fn write_then_read_produces_zero_stale_renders() {
+    let moka = Arc::new(MokaCache::new(100, None));
+    let state = AppState::for_test().with_cache(moka as Arc<dyn Cache>);
+    let cache = state.cache().expect("cache registered");
+
+    let counter = Arc::new(AtomicUsize::new(0));
+
+    // v1 of the record, warmed into the cache.
+    let v1 = Post { id: 42, title: "Original title", version: 1 };
+    let rendered_v1 = render_post_card(cache.as_ref(), &v1, &counter);
+    assert!(rendered_v1.contains("Original title"));
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+    // A write bumps the version token (updated_at changes) and the title.
+    let v2 = Post { id: 42, title: "Edited title", version: 2 };
+
+    // The very next read must reflect the new content — no stale render.
+    let rendered_v2 = render_post_card(cache.as_ref(), &v2, &counter);
+    assert_eq!(counter.load(Ordering::SeqCst), 2, "write must force a re-render");
+    assert!(
+        rendered_v2.contains("Edited title"),
+        "next read after a write must show fresh content, not the stale cached fragment"
+    );
+    assert!(
+        !rendered_v2.contains("Original title"),
+        "0 stale renders: the old fragment must never be served after a write"
+    );
+}
+
+#[test]
+fn list_view_reuses_unchanged_rows() {
+    // A 3-row list. Re-rendering the whole list a second time should hit the
+    // cache for every unchanged row (closures never re-run).
+    let moka = Arc::new(MokaCache::new(100, None));
+    let state = AppState::for_test().with_cache(moka as Arc<dyn Cache>);
+    let cache = state.cache().expect("cache registered");
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let posts = [
+        Post { id: 1, title: "One", version: 1 },
+        Post { id: 2, title: "Two", version: 1 },
+        Post { id: 3, title: "Three", version: 1 },
+    ];
+
+    // Cold render of the list: 3 misses.
+    for p in &posts {
+        render_post_card(cache.as_ref(), p, &counter);
+    }
+    assert_eq!(counter.load(Ordering::SeqCst), 3, "cold list renders every row");
+
+    // Warm render of the same list: 0 additional renders.
+    for p in &posts {
+        render_post_card(cache.as_ref(), p, &counter);
+    }
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        3,
+        "warm list serves every unchanged row from cache"
+    );
+}
+
+#[test]
+fn no_cache_configured_falls_back_gracefully() {
+    // AppState with no cache backend → cache() is None → render directly.
+    let state = AppState::for_test();
+    assert!(state.cache().is_none());
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let post = Post { id: 1, title: "Dev", version: 1 };
+
+    for _ in 0..2 {
+        let rendered = render_post_card_optional(state.cache().as_deref(), &post, &counter);
+        assert!(rendered.contains("Dev"));
+    }
+    // No cache → renders every time, never panics.
+    assert_eq!(counter.load(Ordering::SeqCst), 2);
+}
+
+/// Variant that accepts an optional cache, mirroring `AppState::cache()`.
+fn render_post_card_optional(
+    cache: Option<&dyn Cache>,
+    post: &Post,
+    counter: &Arc<AtomicUsize>,
+) -> String {
+    let counter = counter.clone();
+    let title = post.title;
+    cache_fragment(cache, format_args!("post:{}", post.id), post.version, None, move || {
+        counter.fetch_add(1, Ordering::SeqCst);
+        html! { article { h2 { (title) } } }
+    })
+    .into_string()
+}

--- a/autumn/tests/fragment_cache_integration.rs
+++ b/autumn/tests/fragment_cache_integration.rs
@@ -46,7 +46,11 @@ fn fragment_served_from_app_state_cache_on_hit() {
     let cache = state.cache().expect("cache registered");
 
     let counter = Arc::new(AtomicUsize::new(0));
-    let post = Post { id: 1, title: "Hello", version: 1 };
+    let post = Post {
+        id: 1,
+        title: "Hello",
+        version: 1,
+    };
 
     // First read → miss → render once.
     let first = render_post_card(cache.as_ref(), &post, &counter);
@@ -55,7 +59,11 @@ fn fragment_served_from_app_state_cache_on_hit() {
 
     // Second read of the same version → hit → no re-render.
     let second = render_post_card(cache.as_ref(), &post, &counter);
-    assert_eq!(counter.load(Ordering::SeqCst), 1, "second read is a cache hit");
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "second read is a cache hit"
+    );
     assert_eq!(first, second, "cached markup is identical");
 }
 
@@ -68,17 +76,29 @@ fn write_then_read_produces_zero_stale_renders() {
     let counter = Arc::new(AtomicUsize::new(0));
 
     // v1 of the record, warmed into the cache.
-    let v1 = Post { id: 42, title: "Original title", version: 1 };
+    let v1 = Post {
+        id: 42,
+        title: "Original title",
+        version: 1,
+    };
     let rendered_v1 = render_post_card(cache.as_ref(), &v1, &counter);
     assert!(rendered_v1.contains("Original title"));
     assert_eq!(counter.load(Ordering::SeqCst), 1);
 
     // A write bumps the version token (updated_at changes) and the title.
-    let v2 = Post { id: 42, title: "Edited title", version: 2 };
+    let v2 = Post {
+        id: 42,
+        title: "Edited title",
+        version: 2,
+    };
 
     // The very next read must reflect the new content — no stale render.
     let rendered_v2 = render_post_card(cache.as_ref(), &v2, &counter);
-    assert_eq!(counter.load(Ordering::SeqCst), 2, "write must force a re-render");
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        2,
+        "write must force a re-render"
+    );
     assert!(
         rendered_v2.contains("Edited title"),
         "next read after a write must show fresh content, not the stale cached fragment"
@@ -99,16 +119,32 @@ fn list_view_reuses_unchanged_rows() {
 
     let counter = Arc::new(AtomicUsize::new(0));
     let posts = [
-        Post { id: 1, title: "One", version: 1 },
-        Post { id: 2, title: "Two", version: 1 },
-        Post { id: 3, title: "Three", version: 1 },
+        Post {
+            id: 1,
+            title: "One",
+            version: 1,
+        },
+        Post {
+            id: 2,
+            title: "Two",
+            version: 1,
+        },
+        Post {
+            id: 3,
+            title: "Three",
+            version: 1,
+        },
     ];
 
     // Cold render of the list: 3 misses.
     for p in &posts {
         render_post_card(cache.as_ref(), p, &counter);
     }
-    assert_eq!(counter.load(Ordering::SeqCst), 3, "cold list renders every row");
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        3,
+        "cold list renders every row"
+    );
 
     // Warm render of the same list: 0 additional renders.
     for p in &posts {
@@ -128,7 +164,11 @@ fn no_cache_configured_falls_back_gracefully() {
     assert!(state.cache().is_none());
 
     let counter = Arc::new(AtomicUsize::new(0));
-    let post = Post { id: 1, title: "Dev", version: 1 };
+    let post = Post {
+        id: 1,
+        title: "Dev",
+        version: 1,
+    };
 
     for _ in 0..2 {
         let rendered = render_post_card_optional(state.cache().as_deref(), &post, &counter);
@@ -146,9 +186,15 @@ fn render_post_card_optional(
 ) -> String {
     let counter = counter.clone();
     let title = post.title;
-    cache_fragment(cache, format_args!("post:{}", post.id), post.version, None, move || {
-        counter.fetch_add(1, Ordering::SeqCst);
-        html! { article { h2 { (title) } } }
-    })
+    cache_fragment(
+        cache,
+        format_args!("post:{}", post.id),
+        post.version,
+        None,
+        move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+            html! { article { h2 { (title) } } }
+        },
+    )
     .into_string()
 }

--- a/docs/guide/fragment-caching.md
+++ b/docs/guide/fragment-caching.md
@@ -147,8 +147,9 @@ fn comment_thread(thread: &Thread) -> Markup {
         format_args!("thread:{}", thread.id),
         // outer version derived from the children, so the outer re-renders
         // whenever *any* child changes
-        thread.comments.iter().map(|c| c.updated_at).max().unwrap_or_default()
-            .and_utc().timestamp_micros(),
+        thread.comments.iter().map(|c| c.updated_at).max()
+            .map(|t| t.and_utc().timestamp_micros())
+            .unwrap_or(0),
         None,
         || html! {
             ul {

--- a/docs/guide/fragment-caching.md
+++ b/docs/guide/fragment-caching.md
@@ -1,0 +1,219 @@
+# Maud fragment caching
+
+Autumn can cache a **rendered Maud fragment** keyed by a record's identity and
+version, so unchanged rows are served from cache and re-render automatically the
+moment the record is written — without you hand-rolling cache keys or
+invalidation.
+
+This is the view-layer companion to Autumn's other caching primitives:
+
+| Primitive | Caches | Granularity |
+|-----------|--------|-------------|
+| `#[cached]` | repository / function results | data |
+| `CacheResponseLayer` | whole HTTP responses | per-URL |
+| **`cache_fragment`** | **rendered `Markup`** | **per-fragment** |
+
+Whole-response caching is too coarse — any per-user chrome (a CSRF token, a
+"signed in as…" banner) busts the entire page. Data caching skips the query but
+still re-runs the `html!{}` work. `cache_fragment` sits in between: it caches the
+expensive render of an individual row, card, or feed item.
+
+## Why it matters
+
+For Autumn's Maud + htmx hybrid-rendering model, server-side render time *is* the
+latency budget. A list or feed view re-renders dozens of identical partials per
+request. Caching each fragment by `(identity, version)` means:
+
+- a warm list of unchanged rows skips the render entirely, and
+- a write to any record produces a freshly rendered fragment on the *very next*
+  request — zero stale renders, no manual eviction.
+
+## Quick start
+
+```rust
+use autumn_web::prelude::*;
+
+fn post_card(post: &Post) -> Markup {
+    cache_fragment_global(
+        // identity: which fragment is this?
+        format_args!("post_card:{}", post.id),
+        // version: bump this whenever the record changes
+        post.updated_at.and_utc().timestamp(),
+        // optional TTL (None = no expiry)
+        None,
+        // render closure: only runs on a cache miss
+        || html! {
+            article {
+                h2 { (post.title) }
+                p { (post.body) }
+            }
+        },
+    )
+}
+```
+
+On the first request the closure runs and the markup is stored. On every
+subsequent request — until `post.updated_at` changes — the cached markup is
+returned and the closure is **not** executed. Editing the post bumps
+`updated_at`, which changes the key, and the card re-renders once.
+
+Use it in a list view exactly as you would any Maud component:
+
+```rust
+#[get("/")]
+pub async fn index(mut db: Db) -> AutumnResult<Markup> {
+    let posts = Post::published(&mut db).await?;
+    Ok(html! {
+        div class="space-y-4" {
+            @for post in &posts {
+                (post_card(post))   // each row cached independently
+            }
+        }
+    })
+}
+```
+
+## The two helpers
+
+```rust
+use autumn_web::cache::{cache_fragment, cache_fragment_global};
+```
+
+### `cache_fragment_global`
+
+Resolves the **process-global** cache backend — the one registered with
+[`AppBuilder::with_cache_backend`](#wiring-a-backend) or `AppState::set_cache`.
+This is the ergonomic choice inside component functions that don't hold a cache
+handle.
+
+### `cache_fragment`
+
+Takes an explicit `Option<&dyn Cache>`. Use it when you already have the cache in
+hand — for example from `AppState::cache()` in a handler:
+
+```rust
+#[get("/")]
+pub async fn index(state: AppState, mut db: Db) -> AutumnResult<Markup> {
+    let cache = state.cache();           // Option<Arc<dyn Cache>>
+    let posts = Post::published(&mut db).await?;
+    Ok(html! {
+        @for post in &posts {
+            (cache_fragment(
+                cache.as_deref(),
+                format_args!("post_card:{}", post.id),
+                post.updated_at.and_utc().timestamp(),
+                None,
+                || render_post_card(post),
+            ))
+        }
+    })
+}
+```
+
+## Choosing the identity and version
+
+The cache key is `"fragment:{identity}:{version}"`. You supply both halves:
+
+- **identity** — anything `Display` that uniquely names the fragment. Include the
+  record type and primary key (`format_args!("post_card:{}", post.id)`), and any
+  variant that changes the markup (locale, compact-vs-card layout, viewer role):
+  `format_args!("post_card:{}:{}", post.id, locale.tag())`.
+- **version** — a token that changes whenever the record changes. The natural
+  choices are the record's `updated_at` timestamp or a version-history sequence
+  number (see [version history](version-history.md)). Bumping it yields a cache
+  miss, so a write naturally re-renders the fragment.
+
+> **Important:** if the fragment's appearance depends on data *outside* the
+> record (e.g. the current user's vote state), fold that into the identity or
+> version, or don't cache it — otherwise stale variants can be served.
+
+## Russian-doll nesting
+
+Fragments compose. An outer fragment whose render closure calls
+`cache_fragment` for its children reuses the children's cached markup:
+
+```rust
+fn comment_thread(thread: &Thread) -> Markup {
+    cache_fragment_global(
+        format_args!("thread:{}", thread.id),
+        // outer version derived from the children, so the outer re-renders
+        // whenever *any* child changes
+        thread.comments.iter().map(|c| c.updated_at).max().unwrap_or_default()
+            .and_utc().timestamp(),
+        None,
+        || html! {
+            ul {
+                @for comment in &thread.comments {
+                    (comment_card(comment))   // each inner fragment cached too
+                }
+            }
+        },
+    )
+}
+
+fn comment_card(comment: &Comment) -> Markup {
+    cache_fragment_global(
+        format_args!("comment:{}", comment.id),
+        comment.updated_at.and_utc().timestamp(),
+        None,
+        || html! { li { (comment.body) } },
+    )
+}
+```
+
+When one comment is edited:
+
+1. that comment's `updated_at` bumps → its inner fragment re-renders,
+2. the thread's derived version bumps → the outer fragment re-renders,
+3. but the **unchanged sibling** comments are served straight from cache — their
+   render closures never run.
+
+Deriving the outer version from `max(child.updated_at)` is what wires the
+invalidation together; Autumn does not track cross-fragment dependencies for you.
+
+## TTL
+
+The fourth argument is an optional `Duration`. It is forwarded to backends that
+support native expiry (e.g. Redis `PSETEX`):
+
+```rust
+cache_fragment_global(
+    format_args!("trending:{}", id),
+    version,
+    Some(std::time::Duration::from_secs(300)),  // expire after 5 min
+    || html! { /* … */ },
+);
+```
+
+The in-process moka backend manages TTL at the store level (configured when the
+`MokaCache` is built), so the per-call TTL is most useful with Redis.
+
+## Wiring a backend
+
+Fragment caching uses the same pluggable [`Cache`] store as the rest of Autumn.
+Register one when building the app:
+
+```rust
+autumn_web::app()
+    // in-process, single node:
+    .with_cache_backend(autumn_web::cache::MokaCache::new(1_000, None))
+    // …or the Redis plugin for a cache shared across replicas.
+    .run()
+    .await;
+```
+
+Because rendered fragments are stored as their HTML `String`, they round-trip
+through both the moka in-process store and the Redis shared store transparently.
+
+## Graceful fallback
+
+If **no** cache backend is configured — common in local dev without Redis or
+moka — `cache_fragment_global` (and `cache_fragment(None, …)`) render the
+fragment directly and never panic. Caching is a transparent optimization: code
+written against these helpers works identically with or without a cache.
+
+## See also
+
+- [`#[cached]` and data caching](cloud-native.md) — cache query/function results
+- [Conditional GET and ETags](conditional-get.md) — skip the *network* path
+- [Version history](version-history.md) — per-record version tokens

--- a/docs/guide/fragment-caching.md
+++ b/docs/guide/fragment-caching.md
@@ -114,11 +114,11 @@ pub async fn index(state: AppState, mut db: Db) -> AutumnResult<Markup> {
 
 ## Choosing the identity and version
 
-The cache key is `"fragment:{identity}:{version}"`. You supply both halves.
-Keep the `version` token unambiguous (a number or other colon-free value): the
-key is a plain `:`-joined string, so a colon *inside* the version could shift
-the identity/version boundary and alias two distinct fragments. Numeric tokens
-like `timestamp_micros()` or a sequence number are always safe.
+The cache key is built from both halves you supply. The identity is
+length-prefixed internally, so a `:` (or any other character) inside it can
+never shift the identity/version boundary or alias two distinct fragments —
+`(identity="a:b", version="c")` and `(identity="a", version="b:c")` stay
+separate. You can put whatever you like in either half.
 
 - **identity** — anything `Display` that uniquely names the fragment. Include the
   record type and primary key (`format_args!("post_card:{}", post.id)`), and any

--- a/docs/guide/fragment-caching.md
+++ b/docs/guide/fragment-caching.md
@@ -37,8 +37,10 @@ fn post_card(post: &Post) -> Markup {
     cache_fragment_global(
         // identity: which fragment is this?
         format_args!("post_card:{}", post.id),
-        // version: bump this whenever the record changes
-        post.updated_at.and_utc().timestamp(),
+        // version: bump this whenever the record changes. Use a sub-second
+        // resolution token (micros) so two edits in the same second still
+        // produce distinct keys.
+        post.updated_at.and_utc().timestamp_micros(),
         // optional TTL (None = no expiry)
         None,
         // render closure: only runs on a cache miss
@@ -101,7 +103,7 @@ pub async fn index(state: AppState, mut db: Db) -> AutumnResult<Markup> {
             (cache_fragment(
                 cache.as_deref(),
                 format_args!("post_card:{}", post.id),
-                post.updated_at.and_utc().timestamp(),
+                post.updated_at.and_utc().timestamp_micros(),
                 None,
                 || render_post_card(post),
             ))
@@ -112,7 +114,11 @@ pub async fn index(state: AppState, mut db: Db) -> AutumnResult<Markup> {
 
 ## Choosing the identity and version
 
-The cache key is `"fragment:{identity}:{version}"`. You supply both halves:
+The cache key is `"fragment:{identity}:{version}"`. You supply both halves.
+Keep the `version` token unambiguous (a number or other colon-free value): the
+key is a plain `:`-joined string, so a colon *inside* the version could shift
+the identity/version boundary and alias two distinct fragments. Numeric tokens
+like `timestamp_micros()` or a sequence number are always safe.
 
 - **identity** — anything `Display` that uniquely names the fragment. Include the
   record type and primary key (`format_args!("post_card:{}", post.id)`), and any
@@ -121,7 +127,10 @@ The cache key is `"fragment:{identity}:{version}"`. You supply both halves:
 - **version** — a token that changes whenever the record changes. The natural
   choices are the record's `updated_at` timestamp or a version-history sequence
   number (see [version history](version-history.md)). Bumping it yields a cache
-  miss, so a write naturally re-renders the fragment.
+  miss, so a write naturally re-renders the fragment. Prefer a **sub-second**
+  token — `timestamp_micros()` rather than `timestamp()` — so two writes within
+  the same wall-clock second still produce distinct keys (a sequence number
+  sidesteps this entirely).
 
 > **Important:** if the fragment's appearance depends on data *outside* the
 > record (e.g. the current user's vote state), fold that into the identity or
@@ -139,7 +148,7 @@ fn comment_thread(thread: &Thread) -> Markup {
         // outer version derived from the children, so the outer re-renders
         // whenever *any* child changes
         thread.comments.iter().map(|c| c.updated_at).max().unwrap_or_default()
-            .and_utc().timestamp(),
+            .and_utc().timestamp_micros(),
         None,
         || html! {
             ul {
@@ -154,7 +163,7 @@ fn comment_thread(thread: &Thread) -> Markup {
 fn comment_card(comment: &Comment) -> Markup {
     cache_fragment_global(
         format_args!("comment:{}", comment.id),
-        comment.updated_at.and_utc().timestamp(),
+        comment.updated_at.and_utc().timestamp_micros(),
         None,
         || html! { li { (comment.body) } },
     )

--- a/examples/blog/src/admin.rs
+++ b/examples/blog/src/admin.rs
@@ -217,6 +217,9 @@ impl AdminModel for PostAdmin {
                 slug: Some(new_post.slug),
                 body: Some(new_post.body),
                 published: Some(new_post.published),
+                // Bump the version token so the cached post card re-renders on
+                // the next request (Postgres has no ON UPDATE trigger).
+                updated_at: Some(chrono::Utc::now().naive_utc()),
             };
             let mut conn = pool.get().await.map_err(Self::pool_error)?;
 

--- a/examples/blog/src/main.rs
+++ b/examples/blog/src/main.rs
@@ -36,6 +36,12 @@ impl SitemapSource for BlogSitemapSource {
 async fn main() {
     autumn_web::app()
         .migrations(MIGRATIONS)
+        // In-process fragment cache for the post-list view. Rendered post
+        // cards are cached by `(post.id, post.updated_at)` (see
+        // `routes::posts::post_card`), so unchanged rows skip the `html!{}`
+        // work and editing a post re-renders only that card. Swap in the
+        // Redis backend to share the cache across replicas.
+        .with_cache_backend(autumn_web::cache::MokaCache::new(1_000, None))
         // Auto-load i18n bundle from `i18n/<locale>.ftl` according to the
         // `[i18n]` block in `autumn.toml`. Visit `/greet` to see it work
         // end-to-end with a locale switcher.

--- a/examples/blog/src/models.rs
+++ b/examples/blog/src/models.rs
@@ -116,6 +116,13 @@ pub struct UpdatePost {
     /// unchecking the checkbox actually unpublishes the post.
     #[serde(default)]
     pub published: Option<bool>,
+    /// Bumped to the current time on every save. Postgres has no `ON UPDATE`
+    /// trigger, so without this the `updated_at` column would keep its
+    /// insert-time value — which would freeze the `post_card` fragment-cache
+    /// key (see `routes::posts::post_card`) and serve a stale card forever.
+    /// Never deserialized from form/JSON input; the handler always sets it.
+    #[serde(skip)]
+    pub updated_at: Option<chrono::NaiveDateTime>,
 }
 
 /// Convert a string into a URL-safe slug.

--- a/examples/blog/src/routes/posts.rs
+++ b/examples/blog/src/routes/posts.rs
@@ -485,6 +485,9 @@ pub async fn update(id: Path<i64>, mut db: Db, form: Form<NewPost>) -> AutumnRes
         slug: Some(validated.slug),
         body: Some(validated.body),
         published: Some(validated.published),
+        // Bump the version token so the cached post card re-renders on the
+        // next request (Postgres has no ON UPDATE trigger for `updated_at`).
+        updated_at: Some(chrono::Utc::now().naive_utc()),
     };
 
     let updated = diesel::update(posts::table.find(*id))

--- a/examples/blog/src/routes/posts.rs
+++ b/examples/blog/src/routes/posts.rs
@@ -107,7 +107,10 @@ pub fn layout_with_seo(locale: &Locale, seo: SeoMeta, content: Markup) -> Markup
 fn post_card(post: &Post) -> Markup {
     cache_fragment_global(
         format_args!("blog:post_card:{}", post.id),
-        post.updated_at.and_utc().timestamp(),
+        // Microsecond resolution so two edits in the same wall-clock second
+        // still produce distinct cache keys (a plain `timestamp()` would
+        // collide and serve the first edit's stale markup).
+        post.updated_at.and_utc().timestamp_micros(),
         None,
         || render_post_card(post),
     )

--- a/examples/blog/src/routes/posts.rs
+++ b/examples/blog/src/routes/posts.rs
@@ -4,10 +4,10 @@
 //! use htmx attributes for interactive publish/delete behaviour.
 
 use autumn_web::assets::asset_url;
+use autumn_web::cache::cache_fragment_global;
 use autumn_web::extract::{Form, Path};
 use autumn_web::i18n::Locale;
 use autumn_web::seo::SeoMeta;
-use autumn_web::cache::cache_fragment_global;
 use autumn_web::{AutumnError, AutumnResult, Db, Markup, Redirect, delete, get, html, post, t};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;

--- a/examples/blog/src/routes/posts.rs
+++ b/examples/blog/src/routes/posts.rs
@@ -7,6 +7,7 @@ use autumn_web::assets::asset_url;
 use autumn_web::extract::{Form, Path};
 use autumn_web::i18n::Locale;
 use autumn_web::seo::SeoMeta;
+use autumn_web::cache::cache_fragment_global;
 use autumn_web::{AutumnError, AutumnResult, Db, Markup, Redirect, delete, get, html, post, t};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
@@ -96,7 +97,24 @@ pub fn layout_with_seo(locale: &Locale, seo: SeoMeta, content: Markup) -> Markup
 // ── Components ──────────────────────────────────────────────────
 
 /// Render a single post card for the listing page.
+///
+/// The rendered markup is cached with [`cache_fragment_global`], keyed by the
+/// post's id **plus** its `updated_at` timestamp. On a warm cache an unchanged
+/// row is served without re-running the `html!{}` work; editing the post bumps
+/// `updated_at`, which changes the cache key and re-renders the card on the
+/// very next request — no manual eviction. When no cache backend is configured
+/// the helper renders directly, so this is safe in any environment.
 fn post_card(post: &Post) -> Markup {
+    cache_fragment_global(
+        format_args!("blog:post_card:{}", post.id),
+        post.updated_at.and_utc().timestamp(),
+        None,
+        || render_post_card(post),
+    )
+}
+
+/// The actual Maud render for a post card (executed only on a cache miss).
+fn render_post_card(post: &Post) -> Markup {
     let date = post.created_at.format("%b %d, %Y");
     let preview: String = post.body.chars().take(200).collect::<String>();
     let preview = if post.body.len() > 200 {


### PR DESCRIPTION
## Summary

Adds a new fragment caching system for Maud templates that automatically invalidates on record updates. Rendered HTML fragments are cached by a composite key of `(identity, version)`, where the version token (e.g., `updated_at` timestamp) changes whenever the underlying record is modified. This enables efficient view-layer caching without manual cache invalidation.

## Key Changes

- **New `cache_fragment` module** (`autumn/src/cache/fragment.rs`):
  - `cache_fragment()` — explicit cache variant accepting `Option<&dyn Cache>`
  - `cache_fragment_global()` — ergonomic variant using the process-global cache backend
  - Length-prefixed cache keys prevent collisions when identity contains `:` characters
  - Graceful fallback: renders directly when no cache is configured (dev environments)
  - Comprehensive test suite covering hits, misses, version bumps, Russian-doll nesting, and edge cases

- **Documentation** (`docs/guide/fragment-caching.md`):
  - Quick-start examples and usage patterns
  - Guidance on choosing identity and version tokens
  - Russian-doll nesting patterns for composed fragments
  - TTL configuration and backend wiring

- **Integration tests** (`autumn/tests/fragment_cache_integration.rs`):
  - End-to-end verification with `AppState` cache backend
  - Validates zero stale renders after writes (the success metric)
  - List view reuse of unchanged rows
  - Graceful fallback when no cache is configured

- **Example integration** (`examples/blog/src/routes/posts.rs`):
  - Demonstrates caching post cards in the listing view
  - Shows version token derivation from `updated_at`

- **Module exports**:
  - Added to `autumn/src/cache/mod.rs` (gated by `maud` feature)
  - Re-exported in `autumn/src/prelude.rs` for convenience

## Implementation Details

- Cache keys use format: `fragment:{identity_len}:{identity}:{version}` to unambiguously separate identity and version boundaries
- Rendered `Markup` is stored as its inner `String` for transparent serialization across moka (in-process) and Redis (shared) backends
- Render closures are only invoked on cache misses; hits return `PreEscaped` markup without re-rendering
- Supports optional per-call TTL forwarding to backends that implement native expiry (Redis)
- Works seamlessly with nested fragments where outer version is derived from children (e.g., `max(child.updated_at)`)

https://claude.ai/code/session_014rXwCiQRe4zJftvjRMBf4f