### PR TITLE
Integrate RateLimitPrincipal with session and API token auth

### DIFF
--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -2029,6 +2029,45 @@ pub use db_store::DbApiTokenStore;
 mod tests {
     use super::*;
 
+    /// Build a minimal `AppState` for middleware tests, parameterized only by
+    /// the auth session key (the sole field these tests vary). Collapses the
+    /// otherwise-identical struct literal that each test would copy verbatim.
+    fn test_app_state(auth_session_key: &str) -> crate::state::AppState {
+        crate::state::AppState {
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
+            #[cfg(feature = "db")]
+            pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
+            #[cfg(feature = "db")]
+            shards: None,
+            profile: None,
+            started_at: std::time::Instant::now(),
+            health_detailed: false,
+            probes: crate::probe::ProbeState::ready_for_test(),
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            job_registry: crate::actuator::JobRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
+            health_indicator_registry: crate::actuator::HealthIndicatorRegistry::new(),
+            #[cfg(feature = "ws")]
+            channels: crate::channels::Channels::new(32),
+            #[cfg(feature = "presence")]
+            presence: crate::presence::Presence::new(crate::channels::Channels::new(32)),
+            #[cfg(feature = "ws")]
+            shutdown: tokio_util::sync::CancellationToken::new(),
+            policy_registry: crate::authorization::PolicyRegistry::default(),
+            forbidden_response: crate::authorization::ForbiddenResponse::default(),
+            auth_session_key: auth_session_key.to_owned(),
+            shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
+        }
+    }
+
     #[tokio::test]
     async fn hash_and_verify_password() {
         let hash = hash_password("test_password").await.unwrap();
@@ -2278,7 +2317,6 @@ mod tests {
 
     #[tokio::test]
     async fn auth_extractor_returns_401_when_no_user() {
-        use crate::state::AppState;
         use axum::Router;
         use axum::body::Body;
         use axum::routing::get;
@@ -2293,39 +2331,7 @@ mod tests {
             user.name
         }
 
-        let state = AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            #[cfg(feature = "db")]
-            pool: None,
-            #[cfg(feature = "db")]
-            replica_pool: None,
-            #[cfg(feature = "db")]
-            shards: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: false,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            job_registry: crate::actuator::JobRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
-            health_indicator_registry: crate::actuator::HealthIndicatorRegistry::new(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "presence")]
-            presence: crate::presence::Presence::new(crate::channels::Channels::new(32)),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-            policy_registry: crate::authorization::PolicyRegistry::default(),
-            forbidden_response: crate::authorization::ForbiddenResponse::default(),
-            auth_session_key: "user_id".to_owned(),
-            shared_cache: None,
-            clock: std::sync::Arc::new(crate::time::SystemClock),
-        };
+        let state = test_app_state("user_id");
 
         let app = Router::new().route("/", get(handler)).with_state(state);
 
@@ -2344,7 +2350,6 @@ mod tests {
 
     #[tokio::test]
     async fn auth_extractor_returns_user_when_present() {
-        use crate::state::AppState;
         use axum::Router;
         use axum::body::Body;
         use axum::routing::get;
@@ -2359,39 +2364,7 @@ mod tests {
             user.name
         }
 
-        let state = AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            #[cfg(feature = "db")]
-            pool: None,
-            #[cfg(feature = "db")]
-            replica_pool: None,
-            #[cfg(feature = "db")]
-            shards: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: false,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            job_registry: crate::actuator::JobRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
-            health_indicator_registry: crate::actuator::HealthIndicatorRegistry::new(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "presence")]
-            presence: crate::presence::Presence::new(crate::channels::Channels::new(32)),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-            policy_registry: crate::authorization::PolicyRegistry::default(),
-            forbidden_response: crate::authorization::ForbiddenResponse::default(),
-            auth_session_key: "user_id".to_owned(),
-            shared_cache: None,
-            clock: std::sync::Arc::new(crate::time::SystemClock),
-        };
+        let state = test_app_state("user_id");
 
         // Middleware that inserts a user into extensions
         let app = Router::new()
@@ -2431,41 +2404,8 @@ mod tests {
         use tower::ServiceExt;
 
         use crate::session::{MemoryStore, SessionConfig, SessionLayer};
-        use crate::state::AppState;
 
-        let state = AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            #[cfg(feature = "db")]
-            pool: None,
-            #[cfg(feature = "db")]
-            replica_pool: None,
-            #[cfg(feature = "db")]
-            shards: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: false,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            job_registry: crate::actuator::JobRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
-            health_indicator_registry: crate::actuator::HealthIndicatorRegistry::new(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "presence")]
-            presence: crate::presence::Presence::new(crate::channels::Channels::new(32)),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-            policy_registry: crate::authorization::PolicyRegistry::default(),
-            forbidden_response: crate::authorization::ForbiddenResponse::default(),
-            auth_session_key: "user_id".to_owned(),
-            shared_cache: None,
-            clock: std::sync::Arc::new(crate::time::SystemClock),
-        };
+        let state = test_app_state("user_id");
 
         let app = Router::new()
             .route("/protected", get(|| async { "secret" }))
@@ -2556,46 +2496,13 @@ mod tests {
         use tower::ServiceExt;
 
         use crate::session::{MemoryStore, SessionConfig, SessionLayer};
-        use crate::state::AppState;
 
         #[autumn_macros::secured]
         async fn protected_handler() -> crate::AutumnResult<&'static str> {
             Ok("secret")
         }
 
-        let state = AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            #[cfg(feature = "db")]
-            pool: None,
-            #[cfg(feature = "db")]
-            replica_pool: None,
-            #[cfg(feature = "db")]
-            shards: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: false,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            job_registry: crate::actuator::JobRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
-            health_indicator_registry: crate::actuator::HealthIndicatorRegistry::new(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "presence")]
-            presence: crate::presence::Presence::new(crate::channels::Channels::new(32)),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-            policy_registry: crate::authorization::PolicyRegistry::default(),
-            forbidden_response: crate::authorization::ForbiddenResponse::default(),
-            auth_session_key: "user_id".to_owned(),
-            shared_cache: None,
-            clock: std::sync::Arc::new(crate::time::SystemClock),
-        };
+        let state = test_app_state("user_id");
 
         let app = Router::new()
             .route("/", get(protected_handler))
@@ -2627,7 +2534,6 @@ mod tests {
         use tower::ServiceExt;
 
         use crate::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
-        use crate::state::AppState;
 
         #[autumn_macros::secured]
         async fn protected_handler() -> crate::AutumnResult<&'static str> {
@@ -2643,39 +2549,7 @@ mod tests {
             .await
             .unwrap();
 
-        let state = AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            #[cfg(feature = "db")]
-            pool: None,
-            #[cfg(feature = "db")]
-            replica_pool: None,
-            #[cfg(feature = "db")]
-            shards: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: false,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            job_registry: crate::actuator::JobRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
-            health_indicator_registry: crate::actuator::HealthIndicatorRegistry::new(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "presence")]
-            presence: crate::presence::Presence::new(crate::channels::Channels::new(32)),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-            policy_registry: crate::authorization::PolicyRegistry::default(),
-            forbidden_response: crate::authorization::ForbiddenResponse::default(),
-            auth_session_key: "user_id".to_owned(),
-            shared_cache: None,
-            clock: std::sync::Arc::new(crate::time::SystemClock),
-        };
+        let state = test_app_state("user_id");
 
         let app = Router::new()
             .route("/", get(protected_handler))
@@ -2709,7 +2583,6 @@ mod tests {
         use tower::ServiceExt;
 
         use crate::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
-        use crate::state::AppState;
 
         #[autumn_macros::secured]
         async fn account_handler() -> crate::AutumnResult<&'static str> {
@@ -2728,39 +2601,7 @@ mod tests {
             .await
             .unwrap();
 
-        let state = AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            #[cfg(feature = "db")]
-            pool: None,
-            #[cfg(feature = "db")]
-            replica_pool: None,
-            #[cfg(feature = "db")]
-            shards: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: false,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            job_registry: crate::actuator::JobRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
-            health_indicator_registry: crate::actuator::HealthIndicatorRegistry::new(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "presence")]
-            presence: crate::presence::Presence::new(crate::channels::Channels::new(32)),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-            policy_registry: crate::authorization::PolicyRegistry::default(),
-            forbidden_response: crate::authorization::ForbiddenResponse::default(),
-            auth_session_key: "uid".to_owned(),
-            shared_cache: None,
-            clock: std::sync::Arc::new(crate::time::SystemClock),
-        };
+        let state = test_app_state("uid");
 
         let app = Router::new()
             .route("/account", get(account_handler))
@@ -2794,7 +2635,6 @@ mod tests {
         use tower::ServiceExt;
 
         use crate::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
-        use crate::state::AppState;
 
         #[autumn_macros::secured("admin")]
         async fn admin_only() -> crate::AutumnResult<&'static str> {
@@ -2813,39 +2653,7 @@ mod tests {
             .await
             .unwrap();
 
-        let state = AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            #[cfg(feature = "db")]
-            pool: None,
-            #[cfg(feature = "db")]
-            replica_pool: None,
-            #[cfg(feature = "db")]
-            shards: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: false,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            job_registry: crate::actuator::JobRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
-            health_indicator_registry: crate::actuator::HealthIndicatorRegistry::new(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "presence")]
-            presence: crate::presence::Presence::new(crate::channels::Channels::new(32)),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-            policy_registry: crate::authorization::PolicyRegistry::default(),
-            forbidden_response: crate::authorization::ForbiddenResponse::default(),
-            auth_session_key: "user_id".to_owned(),
-            shared_cache: None,
-            clock: std::sync::Arc::new(crate::time::SystemClock),
-        };
+        let state = test_app_state("user_id");
 
         let app = Router::new()
             .route("/", get(admin_only))
@@ -2875,7 +2683,6 @@ mod tests {
         use tower::ServiceExt;
 
         use crate::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
-        use crate::state::AppState;
 
         #[autumn_macros::secured("admin", "editor")]
         async fn content_handler() -> crate::AutumnResult<&'static str> {
@@ -2894,39 +2701,7 @@ mod tests {
             .await
             .unwrap();
 
-        let state = AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            #[cfg(feature = "db")]
-            pool: None,
-            #[cfg(feature = "db")]
-            replica_pool: None,
-            #[cfg(feature = "db")]
-            shards: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: false,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            job_registry: crate::actuator::JobRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
-            health_indicator_registry: crate::actuator::HealthIndicatorRegistry::new(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "presence")]
-            presence: crate::presence::Presence::new(crate::channels::Channels::new(32)),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-            policy_registry: crate::authorization::PolicyRegistry::default(),
-            forbidden_response: crate::authorization::ForbiddenResponse::default(),
-            auth_session_key: "user_id".to_owned(),
-            shared_cache: None,
-            clock: std::sync::Arc::new(crate::time::SystemClock),
-        };
+        let state = test_app_state("user_id");
 
         let app = Router::new()
             .route("/", get(content_handler))
@@ -2960,7 +2735,6 @@ mod tests {
         use tower::ServiceExt;
 
         use crate::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
-        use crate::state::AppState;
 
         let store = MemoryStore::new();
         // Pre-populate a session with user_id
@@ -2968,39 +2742,7 @@ mod tests {
         session_data.insert("user_id".into(), "42".into());
         store.save("valid-session", session_data).await.unwrap();
 
-        let state = AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            #[cfg(feature = "db")]
-            pool: None,
-            #[cfg(feature = "db")]
-            replica_pool: None,
-            #[cfg(feature = "db")]
-            shards: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: false,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            job_registry: crate::actuator::JobRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
-            health_indicator_registry: crate::actuator::HealthIndicatorRegistry::new(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "presence")]
-            presence: crate::presence::Presence::new(crate::channels::Channels::new(32)),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-            policy_registry: crate::authorization::PolicyRegistry::default(),
-            forbidden_response: crate::authorization::ForbiddenResponse::default(),
-            auth_session_key: "user_id".to_owned(),
-            shared_cache: None,
-            clock: std::sync::Arc::new(crate::time::SystemClock),
-        };
+        let state = test_app_state("user_id");
 
         let app = Router::new()
             .route("/protected", get(|| async { "secret" }))
@@ -3036,7 +2778,6 @@ mod tests {
 
         use crate::security::RateLimitPrincipal;
         use crate::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
-        use crate::state::AppState;
 
         async fn handler(
             axum::Extension(principal): axum::Extension<RateLimitPrincipal>,
@@ -3049,39 +2790,7 @@ mod tests {
         session_data.insert("user_id".into(), "42".into());
         store.save("valid-session", session_data).await.unwrap();
 
-        let state = AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            #[cfg(feature = "db")]
-            pool: None,
-            #[cfg(feature = "db")]
-            replica_pool: None,
-            #[cfg(feature = "db")]
-            shards: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: false,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            job_registry: crate::actuator::JobRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
-            health_indicator_registry: crate::actuator::HealthIndicatorRegistry::new(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "presence")]
-            presence: crate::presence::Presence::new(crate::channels::Channels::new(32)),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-            policy_registry: crate::authorization::PolicyRegistry::default(),
-            forbidden_response: crate::authorization::ForbiddenResponse::default(),
-            auth_session_key: "user_id".to_owned(),
-            shared_cache: None,
-            clock: std::sync::Arc::new(crate::time::SystemClock),
-        };
+        let state = test_app_state("user_id");
 
         let app = Router::new()
             .route("/protected", get(handler))
@@ -3120,7 +2829,6 @@ mod tests {
 
         use crate::security::{KeyStrategy, RateLimitConfig, RateLimitLayer};
         use crate::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
-        use crate::state::AppState;
 
         let session_store = MemoryStore::new();
         let mut data_a = std::collections::HashMap::new();
@@ -3138,39 +2846,7 @@ mod tests {
             ..Default::default()
         };
 
-        let state = AppState {
-            extensions: std::sync::Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            #[cfg(feature = "db")]
-            pool: None,
-            #[cfg(feature = "db")]
-            replica_pool: None,
-            #[cfg(feature = "db")]
-            shards: None,
-            profile: None,
-            started_at: std::time::Instant::now(),
-            health_detailed: false,
-            probes: crate::probe::ProbeState::ready_for_test(),
-            metrics: crate::middleware::MetricsCollector::new(),
-            log_levels: crate::actuator::LogLevels::new("info"),
-            task_registry: crate::actuator::TaskRegistry::new(),
-            job_registry: crate::actuator::JobRegistry::new(),
-            config_props: crate::actuator::ConfigProperties::default(),
-            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
-            health_indicator_registry: crate::actuator::HealthIndicatorRegistry::new(),
-            #[cfg(feature = "ws")]
-            channels: crate::channels::Channels::new(32),
-            #[cfg(feature = "presence")]
-            presence: crate::presence::Presence::new(crate::channels::Channels::new(32)),
-            #[cfg(feature = "ws")]
-            shutdown: tokio_util::sync::CancellationToken::new(),
-            policy_registry: crate::authorization::PolicyRegistry::default(),
-            forbidden_response: crate::authorization::ForbiddenResponse::default(),
-            auth_session_key: "user_id".to_owned(),
-            shared_cache: None,
-            clock: std::sync::Arc::new(crate::time::SystemClock),
-        };
+        let state = test_app_state("user_id");
 
         let app = Router::new()
             .route("/protected", get(|| async { "ok" }))

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -276,6 +276,10 @@ impl std::fmt::Display for AuthRejection {
 /// is authenticated. If the key is missing, the request is rejected before
 /// reaching the handler.
 ///
+/// On success, the resolved principal value is also inserted as a
+/// [`crate::security::RateLimitPrincipal`] extension so that
+/// `key_strategy = "authenticated_principal"` works out of the box.
+///
 /// # Examples
 ///
 /// ```rust,no_run
@@ -338,7 +342,7 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, req: axum::extract::Request) -> Self::Future {
+    fn call(&mut self, mut req: axum::extract::Request) -> Self::Future {
         let session_key = Arc::clone(&self.session_key);
         let mut inner = self.inner.clone();
         std::mem::swap(&mut self.inner, &mut inner);
@@ -354,6 +358,10 @@ where
             };
 
             if let Some(user_id) = user_id {
+                // Fulfil the RateLimitPrincipal contract so key_strategy =
+                // "authenticated_principal" works without an extra middleware shim.
+                req.extensions_mut()
+                    .insert(crate::security::RateLimitPrincipal(user_id.clone()));
                 // Tag the request-scoped log context (#1169) so handler logs for
                 // middleware-authenticated requests carry `user_id` too, matching
                 // the `#[secured]` path.
@@ -1668,6 +1676,9 @@ where
 /// `401 Unauthorized` using the same Problem Details contract as
 /// [`AuthRejection`].
 ///
+/// Also inserts [`crate::security::RateLimitPrincipal`] so that
+/// `key_strategy = "authenticated_principal"` works out of the box.
+///
 /// Composes with [`RequireAuth`] and session middleware without conflict.
 ///
 /// # Examples
@@ -1756,6 +1767,10 @@ where
 
             match store.verify(&raw_token).await {
                 Ok(Some(principal_id)) => {
+                    // Fulfil the RateLimitPrincipal contract so key_strategy =
+                    // "authenticated_principal" works without an extra middleware shim.
+                    req.extensions_mut()
+                        .insert(crate::security::RateLimitPrincipal(principal_id.clone()));
                     req.extensions_mut().insert(ApiTokenPrincipal(principal_id));
                     inner.call(req).await
                 }
@@ -3012,6 +3027,87 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn require_auth_sets_rate_limit_principal() {
+        use axum::Router;
+        use axum::body::Body;
+        use axum::routing::get;
+        use http::header::COOKIE;
+        use tower::ServiceExt;
+
+        use crate::security::RateLimitPrincipal;
+        use crate::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
+        use crate::state::AppState;
+
+        async fn handler(
+            axum::Extension(principal): axum::Extension<RateLimitPrincipal>,
+        ) -> String {
+            principal.0
+        }
+
+        let store = MemoryStore::new();
+        let mut session_data = std::collections::HashMap::new();
+        session_data.insert("user_id".into(), "42".into());
+        store.save("valid-session", session_data).await.unwrap();
+
+        let state = AppState {
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
+            #[cfg(feature = "db")]
+            pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
+            #[cfg(feature = "db")]
+            shards: None,
+            profile: None,
+            started_at: std::time::Instant::now(),
+            health_detailed: false,
+            probes: crate::probe::ProbeState::ready_for_test(),
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            job_registry: crate::actuator::JobRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
+            health_indicator_registry: crate::actuator::HealthIndicatorRegistry::new(),
+            #[cfg(feature = "ws")]
+            channels: crate::channels::Channels::new(32),
+            #[cfg(feature = "presence")]
+            presence: crate::presence::Presence::new(crate::channels::Channels::new(32)),
+            #[cfg(feature = "ws")]
+            shutdown: tokio_util::sync::CancellationToken::new(),
+            policy_registry: crate::authorization::PolicyRegistry::default(),
+            forbidden_response: crate::authorization::ForbiddenResponse::default(),
+            auth_session_key: "user_id".to_owned(),
+            shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
+        };
+
+        let app = Router::new()
+            .route("/protected", get(handler))
+            .layer(RequireAuth::new("user_id"))
+            .layer(SessionLayer::new(store, SessionConfig::default()))
+            .with_state(state);
+
+        let response = app
+            .oneshot(
+                http::Request::builder()
+                    .uri("/protected")
+                    .header(COOKIE, "autumn.sid=valid-session")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(std::str::from_utf8(&body).unwrap(), "42");
+    }
+
+    #[tokio::test]
     async fn require_auth_poll_ready_propagates() {
         use std::task::{Context, Poll};
         use tower::{Layer, Service};
@@ -3816,6 +3912,44 @@ mod api_token_tests {
         let layer2 = RequireApiToken::new(store2);
         let mut svc2 = layer2.layer(MockService { ready: true });
         assert!(svc2.poll_ready(&mut cx).is_ready());
+    }
+
+    #[tokio::test]
+    async fn require_api_token_sets_rate_limit_principal() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        use crate::security::RateLimitPrincipal;
+
+        async fn handler(
+            axum::Extension(principal): axum::Extension<RateLimitPrincipal>,
+        ) -> String {
+            principal.0
+        }
+
+        let store = Arc::new(InMemoryApiTokenStore::default());
+        let raw = issue_api_token(&*store, "agent:bot").await.unwrap();
+
+        let app = axum::Router::new()
+            .route("/", axum::routing::get(handler))
+            .layer(RequireApiToken::new(Arc::clone(&store)));
+
+        let response = app
+            .oneshot(
+                http::Request::builder()
+                    .uri("/")
+                    .header("authorization", format!("Bearer {raw}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(std::str::from_utf8(&body).unwrap(), "agent:bot");
     }
 }
 

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -3108,6 +3108,121 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn require_auth_rate_limits_by_session_principal() {
+        // Verifies end-to-end: RequireAuth (outer) sets RateLimitPrincipal so a
+        // route-scoped RateLimitLayer (inner) keys on the principal, not the IP.
+        // Layer composition:  Session → RequireAuth → RateLimitLayer → handler
+        use axum::Router;
+        use axum::body::Body;
+        use axum::routing::get;
+        use http::header::COOKIE;
+        use tower::ServiceExt;
+
+        use crate::security::{KeyStrategy, RateLimitConfig, RateLimitLayer};
+        use crate::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
+        use crate::state::AppState;
+
+        let session_store = MemoryStore::new();
+        let mut data_a = std::collections::HashMap::new();
+        data_a.insert("user_id".into(), "user-1".into());
+        session_store.save("sess-a", data_a).await.unwrap();
+        let mut data_b = std::collections::HashMap::new();
+        data_b.insert("user_id".into(), "user-2".into());
+        session_store.save("sess-b", data_b).await.unwrap();
+
+        let rl_config = RateLimitConfig {
+            enabled: true,
+            requests_per_second: 0.1,
+            burst: 1,
+            key_strategy: KeyStrategy::AuthenticatedPrincipal,
+            ..Default::default()
+        };
+
+        let state = AppState {
+            extensions: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
+            #[cfg(feature = "db")]
+            pool: None,
+            #[cfg(feature = "db")]
+            replica_pool: None,
+            #[cfg(feature = "db")]
+            shards: None,
+            profile: None,
+            started_at: std::time::Instant::now(),
+            health_detailed: false,
+            probes: crate::probe::ProbeState::ready_for_test(),
+            metrics: crate::middleware::MetricsCollector::new(),
+            log_levels: crate::actuator::LogLevels::new("info"),
+            task_registry: crate::actuator::TaskRegistry::new(),
+            job_registry: crate::actuator::JobRegistry::new(),
+            config_props: crate::actuator::ConfigProperties::default(),
+            metrics_source_registry: crate::actuator::MetricsSourceRegistry::new(),
+            health_indicator_registry: crate::actuator::HealthIndicatorRegistry::new(),
+            #[cfg(feature = "ws")]
+            channels: crate::channels::Channels::new(32),
+            #[cfg(feature = "presence")]
+            presence: crate::presence::Presence::new(crate::channels::Channels::new(32)),
+            #[cfg(feature = "ws")]
+            shutdown: tokio_util::sync::CancellationToken::new(),
+            policy_registry: crate::authorization::PolicyRegistry::default(),
+            forbidden_response: crate::authorization::ForbiddenResponse::default(),
+            auth_session_key: "user_id".to_owned(),
+            shared_cache: None,
+            clock: std::sync::Arc::new(crate::time::SystemClock),
+        };
+
+        let app = Router::new()
+            .route("/protected", get(|| async { "ok" }))
+            .layer(RateLimitLayer::from_config(&rl_config)) // inner — reads principal
+            .layer(RequireAuth::new("user_id")) // outer — sets RateLimitPrincipal
+            .layer(SessionLayer::new(session_store, SessionConfig::default()))
+            .with_state(state);
+
+        // user-1 first request: allowed (1 token in bucket).
+        let r = app
+            .clone()
+            .oneshot(
+                http::Request::builder()
+                    .uri("/protected")
+                    .header(COOKIE, "autumn.sid=sess-a")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+
+        // user-1 second request: bucket exhausted → 429.
+        let r = app
+            .clone()
+            .oneshot(
+                http::Request::builder()
+                    .uri("/protected")
+                    .header(COOKIE, "autumn.sid=sess-a")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        // user-2 first request: separate bucket → allowed.
+        let r = app
+            .clone()
+            .oneshot(
+                http::Request::builder()
+                    .uri("/protected")
+                    .header(COOKIE, "autumn.sid=sess-b")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
     async fn require_auth_poll_ready_propagates() {
         use std::task::{Context, Poll};
         use tower::{Layer, Service};
@@ -3912,6 +4027,82 @@ mod api_token_tests {
         let layer2 = RequireApiToken::new(store2);
         let mut svc2 = layer2.layer(MockService { ready: true });
         assert!(svc2.poll_ready(&mut cx).is_ready());
+    }
+
+    #[tokio::test]
+    async fn require_api_token_rate_limits_by_principal() {
+        // Verifies end-to-end: RequireApiToken (outer) sets RateLimitPrincipal
+        // with the VERIFIED principal ID so a route-scoped RateLimitLayer (inner)
+        // keys on the principal — two different tokens for the same principal share
+        // one bucket.  Layer composition: RequireApiToken → RateLimitLayer → handler
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        use crate::security::{KeyStrategy, RateLimitConfig, RateLimitLayer};
+
+        let rl_config = RateLimitConfig {
+            enabled: true,
+            requests_per_second: 0.1,
+            burst: 1,
+            key_strategy: KeyStrategy::AuthenticatedPrincipal,
+            ..Default::default()
+        };
+
+        let store = Arc::new(InMemoryApiTokenStore::default());
+        let token_a1 = issue_api_token(&*store, "principal-1").await.unwrap();
+        let token_a2 = issue_api_token(&*store, "principal-1").await.unwrap(); // second token, same principal
+        let token_b = issue_api_token(&*store, "principal-2").await.unwrap();
+
+        let app = axum::Router::new()
+            .route("/", axum::routing::get(|| async { "ok" }))
+            .layer(RateLimitLayer::from_config(&rl_config)) // inner — reads principal
+            .layer(RequireApiToken::new(Arc::clone(&store))); // outer — sets RateLimitPrincipal
+
+        // principal-1, first token: allowed.
+        let r = app
+            .clone()
+            .oneshot(
+                http::Request::builder()
+                    .uri("/")
+                    .header("authorization", format!("Bearer {token_a1}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+
+        // principal-1, different token: shares the same bucket → 429.
+        let r = app
+            .clone()
+            .oneshot(
+                http::Request::builder()
+                    .uri("/")
+                    .header("authorization", format!("Bearer {token_a2}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            r.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "second token for the same principal must share the rate-limit bucket"
+        );
+
+        // principal-2: separate bucket → allowed.
+        let r = app
+            .clone()
+            .oneshot(
+                http::Request::builder()
+                    .uri("/")
+                    .header("authorization", format!("Bearer {token_b}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1785,33 +1785,25 @@ async fn populate_rate_limit_principal(
     mut req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
-    // Session principal takes priority: key on the verified user identity.
+    // Populate RateLimitPrincipal from the *verified* session identity only.
+    //
+    // We deliberately do NOT fall back to a raw Authorization header here: this
+    // shim runs as a global layer outer to route-scoped auth (RequireApiToken),
+    // so any bearer token visible at this point is still unverified and fully
+    // attacker-controlled. Keying the limiter on it would let a caller rotate
+    // the token to mint unlimited buckets (defeating the per-IP fallback) or
+    // forge another user's principal to exhaust their bucket. When no verified
+    // principal is available, the limiter's extract_key falls back to IP keying,
+    // which is the correct safe default. API-token routes that want
+    // per-principal limiting should place a RateLimitLayer inner to
+    // RequireApiToken, which sets the verified principal ID (see
+    // RequireApiTokenService::call).
     if let Some(session) = req.extensions().get::<crate::session::Session>() {
         let auth_session_key = state.auth_session_key();
         if let Some(user_id) = session.get(auth_session_key).await {
             req.extensions_mut()
                 .insert(crate::security::RateLimitPrincipal(user_id));
-            return next.run(req).await;
         }
-    }
-    // Bearer-token fallback: for API-token-protected routes the global rate
-    // limiter runs outer to RequireApiToken (which sets the verified principal
-    // ID), so the raw token is used as a stable per-token key.  Verification
-    // still happens downstream in RequireApiToken; a route-scoped limiter inner
-    // to that layer will see the verified principal ID instead.
-    if let Some(token) = req
-        .headers()
-        .get(http::header::AUTHORIZATION)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|h| {
-            let (scheme, tok) = h.split_once(' ')?;
-            scheme
-                .eq_ignore_ascii_case("Bearer")
-                .then_some(tok.to_owned())
-        })
-    {
-        req.extensions_mut()
-            .insert(crate::security::RateLimitPrincipal(token));
     }
     next.run(req).await
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1785,12 +1785,33 @@ async fn populate_rate_limit_principal(
     mut req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
+    // Session principal takes priority: key on the verified user identity.
     if let Some(session) = req.extensions().get::<crate::session::Session>() {
         let auth_session_key = state.auth_session_key();
         if let Some(user_id) = session.get(auth_session_key).await {
             req.extensions_mut()
                 .insert(crate::security::RateLimitPrincipal(user_id));
+            return next.run(req).await;
         }
+    }
+    // Bearer-token fallback: for API-token-protected routes the global rate
+    // limiter runs outer to RequireApiToken (which sets the verified principal
+    // ID), so the raw token is used as a stable per-token key.  Verification
+    // still happens downstream in RequireApiToken; a route-scoped limiter inner
+    // to that layer will see the verified principal ID instead.
+    if let Some(token) = req
+        .headers()
+        .get(http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| {
+            let (scheme, tok) = h.split_once(' ')?;
+            scheme
+                .eq_ignore_ascii_case("Bearer")
+                .then_some(tok.to_owned())
+        })
+    {
+        req.extensions_mut()
+            .insert(crate::security::RateLimitPrincipal(token));
     }
     next.run(req).await
 }

--- a/autumn/tests/rate_limit_principal.rs
+++ b/autumn/tests/rate_limit_principal.rs
@@ -677,40 +677,46 @@ async fn principal_strategy_keys_on_session_user_id() {
         .assert_ok();
 }
 
-// ── Global limiter: bearer-token fallback via populate_rate_limit_principal ────
+// ── Global limiter: unverified bearer tokens must NOT key the principal ────────
 
 #[tokio::test]
-async fn principal_strategy_global_limiter_keys_on_bearer_token() {
-    // When key_strategy = "authenticated_principal" is configured globally and
-    // a request carries a bearer token but no session, the framework's
-    // populate_rate_limit_principal shim uses the raw token as the
-    // RateLimitPrincipal so the global limiter applies per-token rather than
-    // per-IP keying.  Two different tokens get separate buckets.
+async fn principal_strategy_global_limiter_ignores_unverified_bearer_token() {
+    // Security regression guard: when key_strategy = "authenticated_principal"
+    // is configured globally, the populate_rate_limit_principal shim runs outer
+    // to any route-scoped auth, so a bearer token seen at that point is still
+    // unverified and attacker-controlled. It must NOT be used as the rate-limit
+    // key — otherwise a caller could rotate the token to mint unlimited buckets
+    // and bypass the IP fallback entirely. Instead, requests without a verified
+    // session principal must fall back to per-IP keying.
     let client = TestApp::new()
         .routes(routes![ping])
         .config(principal_config(0.1, 1))
         .build();
 
-    // Token A first request: allowed.
+    // First request from this IP carrying an arbitrary bearer token: allowed.
     client
         .get("/ping")
+        .header("X-Forwarded-For", "10.1.1.1")
         .header("Authorization", "Bearer token-alpha")
         .send()
         .await
         .assert_status(200);
 
-    // Token A second request: bucket exhausted → 429.
+    // Rotating to a *different* bearer token from the SAME IP must NOT mint a
+    // fresh bucket — the limiter keys on IP, so this is throttled.
     client
         .get("/ping")
-        .header("Authorization", "Bearer token-alpha")
+        .header("X-Forwarded-For", "10.1.1.1")
+        .header("Authorization", "Bearer token-beta")
         .send()
         .await
         .assert_status(429);
 
-    // Token B: separate bucket → allowed.
+    // A different IP gets its own bucket regardless of the token value.
     client
         .get("/ping")
-        .header("Authorization", "Bearer token-beta")
+        .header("X-Forwarded-For", "10.2.2.2")
+        .header("Authorization", "Bearer token-alpha")
         .send()
         .await
         .assert_status(200);

--- a/autumn/tests/rate_limit_principal.rs
+++ b/autumn/tests/rate_limit_principal.rs
@@ -676,3 +676,42 @@ async fn principal_strategy_keys_on_session_user_id() {
         .await
         .assert_ok();
 }
+
+// ── Global limiter: bearer-token fallback via populate_rate_limit_principal ────
+
+#[tokio::test]
+async fn principal_strategy_global_limiter_keys_on_bearer_token() {
+    // When key_strategy = "authenticated_principal" is configured globally and
+    // a request carries a bearer token but no session, the framework's
+    // populate_rate_limit_principal shim uses the raw token as the
+    // RateLimitPrincipal so the global limiter applies per-token rather than
+    // per-IP keying.  Two different tokens get separate buckets.
+    let client = TestApp::new()
+        .routes(routes![ping])
+        .config(principal_config(0.1, 1))
+        .build();
+
+    // Token A first request: allowed.
+    client
+        .get("/ping")
+        .header("Authorization", "Bearer token-alpha")
+        .send()
+        .await
+        .assert_status(200);
+
+    // Token A second request: bucket exhausted → 429.
+    client
+        .get("/ping")
+        .header("Authorization", "Bearer token-alpha")
+        .send()
+        .await
+        .assert_status(429);
+
+    // Token B: separate bucket → allowed.
+    client
+        .get("/ping")
+        .header("Authorization", "Bearer token-beta")
+        .send()
+        .await
+        .assert_status(200);
+}


### PR DESCRIPTION
## Summary

This PR integrates authenticated principal identity with rate limiting by having `RequireAuth` (session-based) and `RequireApiToken` (bearer token) middleware automatically populate the `RateLimitPrincipal` extension. This enables `key_strategy = "authenticated_principal"` to work out-of-the-box without requiring additional middleware shims.

## Key Changes

- **RequireAuth middleware**: Now inserts `RateLimitPrincipal` extension with the authenticated session user ID, allowing route-scoped rate limiters to key on the verified principal instead of IP
- **RequireApiToken middleware**: Similarly inserts `RateLimitPrincipal` with the verified API token's principal ID
- **Global rate limit shim** (`populate_rate_limit_principal`): Explicitly avoids using unverified bearer tokens as rate-limit keys to prevent token rotation attacks; only uses verified session principals and falls back to IP-based keying
- **Test helper**: Extracted `test_app_state()` function to reduce boilerplate in 10+ test cases
- **Comprehensive test coverage**: Added tests verifying:
  - `RateLimitPrincipal` is correctly set by both auth middlewares
  - Rate limiting keys on principal when multiple tokens/sessions exist for the same user
  - Global limiter correctly ignores unverified bearer tokens and falls back to IP keying

## Implementation Details

- The `RateLimitPrincipal` is inserted into request extensions immediately after successful authentication, before the inner handler is called
- This allows inner rate-limit layers to extract the principal without needing to re-authenticate
- Security: The global `populate_rate_limit_principal` middleware explicitly does NOT extract unverified Authorization headers, preventing attackers from minting unlimited rate-limit buckets via token rotation
- Updated documentation comments to clarify the new behavior

https://claude.ai/code/session_01DGW8Ytzc5KbGmvPqUhoiJK