### PR TITLE
Share reqwest::Client connection pool across requests

### DIFF
--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -7038,9 +7038,10 @@ fn build_state(
         default_max_age_secs: config.auth.step_up.default_max_age_secs,
     });
     #[cfg(feature = "http-client")]
-    state.insert_extension(crate::http_client::SharedReqwestClient(
-        crate::http_client::Client::build_inner(&config.http.client),
-    ));
+    state.insert_extension(crate::http_client::SharedReqwestClient {
+        client: crate::http_client::Client::build_inner(&config.http.client),
+        timeout_secs: config.http.client.timeout_secs,
+    });
     state
 }
 

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -7037,6 +7037,10 @@ fn build_state(
     state.insert_extension(crate::step_up::StepUpGlobalConfig {
         default_max_age_secs: config.auth.step_up.default_max_age_secs,
     });
+    #[cfg(feature = "http-client")]
+    state.insert_extension(crate::http_client::SharedReqwestClient(
+        crate::http_client::Client::build_inner(&config.http.client),
+    ));
     state
 }
 
@@ -10622,6 +10626,29 @@ mod tests {
         assert!(
             fast_ran.load(Ordering::SeqCst),
             "fast hook must still run even after slow hook overruns its per-hook budget"
+        );
+    }
+
+    // Verify that build_state registers a SharedReqwestClient so that
+    // Client::from_state can reuse the shared connection pool on every request.
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn build_state_registers_shared_reqwest_client() {
+        let config = AutumnConfig::default();
+        let state = build_state(
+            &config,
+            #[cfg(feature = "db")]
+            None,
+            #[cfg(feature = "db")]
+            None,
+            #[cfg(feature = "ws")]
+            None,
+        );
+        assert!(
+            state
+                .extension::<crate::http_client::SharedReqwestClient>()
+                .is_some(),
+            "build_state must register a SharedReqwestClient for connection-pool sharing"
         );
     }
 }

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -515,7 +515,10 @@ impl Client {
     /// Assemble a `Client` around an already-built `reqwest::Client` using the
     /// policy fields from `config`.  The caller supplies the inner client so
     /// the connection pool can be shared across requests.
-    fn from_config_with_inner(inner: reqwest::Client, config: &crate::config::HttpClientConfig) -> Self {
+    fn from_config_with_inner(
+        inner: reqwest::Client,
+        config: &crate::config::HttpClientConfig,
+    ) -> Self {
         let timeout = Duration::from_secs(config.timeout_secs);
         Self {
             inner,
@@ -577,12 +580,12 @@ impl Client {
     /// carry a shared client.
     pub fn from_state(state: &crate::AppState) -> Self {
         let autumn_config = state.extension::<crate::config::AutumnConfig>();
-        let config = state.extension::<crate::config::HttpConfig>().or_else(|| {
-            autumn_config
-                .as_ref()
-                .map(|c| Arc::new(c.http.clone()))
-        });
-        let shared = state.extension::<SharedReqwestClient>().map(|s| s.0.clone());
+        let config = state
+            .extension::<crate::config::HttpConfig>()
+            .or_else(|| autumn_config.as_ref().map(|c| Arc::new(c.http.clone())));
+        let shared = state
+            .extension::<SharedReqwestClient>()
+            .map(|s| s.0.clone());
 
         let mut client = match (config, shared) {
             (Some(cfg), Some(inner)) => Self::from_config_with_inner(inner, &cfg.client),

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -1976,4 +1976,47 @@ mod tests {
         assert_eq!(resp.text(), "autumn-shared-pool-test");
         crate::circuit_breaker::global_registry().clear();
     }
+
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn from_state_falls_back_when_timeout_mismatches_shared_client() {
+        // SharedReqwestClient was built with 5s; config says 10s → mismatch
+        // → from_state must not reuse the shared inner (falls through to
+        //   from_config which builds a fresh reqwest::Client).
+        use crate::config::{AutumnConfig, HttpClientConfig};
+        use std::sync::Arc;
+
+        let mut config = AutumnConfig::default();
+        config.http.client = HttpClientConfig {
+            timeout_secs: 10,
+            ..Default::default()
+        };
+
+        let state = crate::AppState::for_test();
+        state.insert_extension(SharedReqwestClient {
+            client: reqwest::Client::new(),
+            timeout_secs: 5, // deliberately different from config
+        });
+        state.insert_extension(Arc::new(config));
+
+        // Should not panic — falls back to building a fresh client.
+        let _client = Client::from_state(&state);
+    }
+
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn from_state_reuses_shared_client_when_no_config() {
+        // No HttpConfig/AutumnConfig in state, but SharedReqwestClient is
+        // present → hits the (None, Some(inner)) arm → with_inner.
+        let state = crate::AppState::for_test();
+        // Default timeout_secs from HttpClientConfig matches the default used
+        // in effective_timeout_secs, so the shared client is reused.
+        let default_timeout = crate::config::HttpClientConfig::default().timeout_secs;
+        state.insert_extension(SharedReqwestClient {
+            client: reqwest::Client::new(),
+            timeout_secs: default_timeout,
+        });
+
+        let _client = Client::from_state(&state);
+    }
 }

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -365,6 +365,14 @@ impl MockSetupBuilder {
         self
     }
 
+    /// Match `HEAD <path>`.
+    #[must_use]
+    pub fn head(mut self, path: &str) -> Self {
+        self.method = Some(Method::HEAD);
+        self.path = Some(path.to_owned());
+        self
+    }
+
     /// Register the mock entry and return a [`MockHandle`] for assertions.
     ///
     /// `status` is the HTTP status code to return.

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -537,7 +537,15 @@ impl Client {
     /// `reqwest::Client`.  Used when a shared inner client is available but
     /// no explicit `[http.client]` config is registered.
     fn with_inner(inner: reqwest::Client) -> Self {
-        Self { inner, ..Self::new() }
+        Self {
+            inner,
+            alias: None,
+            base_url: None,
+            base_urls: HashMap::new(),
+            retry_policy: RetryPolicy::default(),
+            mock: None,
+            resilience_config: None,
+        }
     }
 
     /// Create a client from `[http.client]` framework configuration.

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -273,8 +273,17 @@ pub struct HttpMockRegistryExt(pub Arc<MockRegistry>);
 /// Shared, process-wide `reqwest::Client` registered in [`AppState`] at server
 /// boot. Cloning is O(1) because `reqwest::Client` is internally `Arc`-backed,
 /// and the connection pool is preserved across the clone.
+///
+/// `timeout_secs` records the per-request timeout the inner client was built
+/// with.  [`Client::from_state`] compares this against the currently installed
+/// config so that a `state_initializer` that replaces `AutumnConfig` with a
+/// different timeout causes the stale inner to be discarded and a fresh client
+/// to be built from the new config instead.
 #[derive(Clone)]
-pub(crate) struct SharedReqwestClient(pub(crate) reqwest::Client);
+pub(crate) struct SharedReqwestClient {
+    pub(crate) client: reqwest::Client,
+    pub(crate) timeout_secs: u64,
+}
 
 /// Handle returned by
 /// [`MockSetupBuilder::respond_with`] that lets tests assert call counts.
@@ -584,9 +593,23 @@ impl Client {
         let config = state
             .extension::<crate::config::HttpConfig>()
             .or_else(|| autumn_config.as_ref().map(|c| Arc::new(c.http.clone())));
-        let shared = state
-            .extension::<SharedReqwestClient>()
-            .map(|s| s.0.clone());
+
+        // Only reuse the shared inner client when its baked-in timeout still
+        // matches the effective config timeout.  A state_initializer that
+        // replaces AutumnConfig/HttpConfig with a different timeout_secs runs
+        // after build_state, so without this check the stale inner would
+        // silently override the new config's per-request timeout.
+        let effective_timeout_secs = config.as_ref().map_or(
+            crate::config::HttpClientConfig::default().timeout_secs,
+            |c| c.client.timeout_secs,
+        );
+        let shared = state.extension::<SharedReqwestClient>().and_then(|s| {
+            if s.timeout_secs == effective_timeout_secs {
+                Some(s.client.clone())
+            } else {
+                None
+            }
+        });
 
         let mut client = match (config, shared) {
             (Some(cfg), Some(inner)) => Self::from_config_with_inner(inner, &cfg.client),
@@ -1879,8 +1902,10 @@ mod tests {
     // RED-PHASE TEST 41: SharedReqwestClient round-trips through AppState extensions.
     #[test]
     fn shared_reqwest_client_ext_round_trips() {
-        let inner = reqwest::Client::new();
-        let ext = SharedReqwestClient(inner);
+        let ext = SharedReqwestClient {
+            client: reqwest::Client::new(),
+            timeout_secs: 30,
+        };
         let state = crate::AppState::for_test();
         state.insert_extension(ext);
         let retrieved = state.extension::<SharedReqwestClient>();
@@ -1928,7 +1953,10 @@ mod tests {
             .build()
             .expect("failed to build inner client");
         let state = crate::AppState::for_test();
-        state.insert_extension(SharedReqwestClient(distinctive_inner));
+        state.insert_extension(SharedReqwestClient {
+            client: distinctive_inner,
+            timeout_secs: 30,
+        });
 
         let client = Client::from_state(&state);
         let resp = client

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -599,8 +599,8 @@ impl Client {
         // replaces AutumnConfig/HttpConfig with a different timeout_secs runs
         // after build_state, so without this check the stale inner would
         // silently override the new config's per-request timeout.
-        let effective_timeout_secs = config.as_ref().map_or(
-            crate::config::HttpClientConfig::default().timeout_secs,
+        let effective_timeout_secs = config.as_ref().map_or_else(
+            || crate::config::HttpClientConfig::default().timeout_secs,
             |c| c.client.timeout_secs,
         );
         let shared = state.extension::<SharedReqwestClient>().and_then(|s| {

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -270,6 +270,12 @@ impl Default for MockRegistry {
 /// `MockRegistry` `Arc` survives a `build()` without double-wrapping.
 pub struct HttpMockRegistryExt(pub Arc<MockRegistry>);
 
+/// Shared, process-wide `reqwest::Client` registered in [`AppState`] at server
+/// boot. Cloning is O(1) because `reqwest::Client` is internally `Arc`-backed,
+/// and the connection pool is preserved across the clone.
+#[derive(Clone)]
+pub(crate) struct SharedReqwestClient(pub(crate) reqwest::Client);
+
 /// Handle returned by
 /// [`MockSetupBuilder::respond_with`] that lets tests assert call counts.
 pub struct MockHandle {
@@ -490,19 +496,27 @@ impl Client {
         }
     }
 
-    /// Create a client from `[http.client]` framework configuration.
+    /// Build a bare `reqwest::Client` from `[http.client]` config.
+    ///
+    /// Used by `build_state` to create the single shared instance registered
+    /// in `AppState` at server boot, and as the fallback when no shared client
+    /// is available.
     ///
     /// # Panics
     ///
-    /// Panics if the underlying TLS backend cannot be initialised (should not
-    /// happen with the default `rustls-tls` feature).
-    #[must_use]
-    pub fn from_config(config: &crate::config::HttpClientConfig) -> Self {
-        let timeout = Duration::from_secs(config.timeout_secs);
-        let inner = reqwest::ClientBuilder::new()
-            .timeout(timeout)
+    /// Panics if the underlying TLS backend cannot be initialised.
+    pub(crate) fn build_inner(config: &crate::config::HttpClientConfig) -> reqwest::Client {
+        reqwest::ClientBuilder::new()
+            .timeout(Duration::from_secs(config.timeout_secs))
             .build()
-            .expect("failed to build reqwest client");
+            .expect("failed to build reqwest client")
+    }
+
+    /// Assemble a `Client` around an already-built `reqwest::Client` using the
+    /// policy fields from `config`.  The caller supplies the inner client so
+    /// the connection pool can be shared across requests.
+    fn from_config_with_inner(inner: reqwest::Client, config: &crate::config::HttpClientConfig) -> Self {
+        let timeout = Duration::from_secs(config.timeout_secs);
         Self {
             inner,
             alias: None,
@@ -519,6 +533,38 @@ impl Client {
         }
     }
 
+    /// Assemble a `Client` with default policy around an already-built
+    /// `reqwest::Client`.  Used when a shared inner client is available but
+    /// no explicit `[http.client]` config is registered.
+    fn with_inner(inner: reqwest::Client) -> Self {
+        let timeout = Duration::from_secs(30);
+        Self {
+            inner,
+            alias: None,
+            base_url: None,
+            base_urls: HashMap::new(),
+            retry_policy: RetryPolicy {
+                max_retries: 3,
+                retry_idempotent_only: true,
+                max_retry_after: Duration::from_secs(10),
+                request_timeout: Some(timeout),
+            },
+            mock: None,
+            resilience_config: None,
+        }
+    }
+
+    /// Create a client from `[http.client]` framework configuration.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the underlying TLS backend cannot be initialised (should not
+    /// happen with the default `rustls-tls` feature).
+    #[must_use]
+    pub fn from_config(config: &crate::config::HttpClientConfig) -> Self {
+        Self::from_config_with_inner(Self::build_inner(config), config)
+    }
+
     /// Attach a mock registry (used by the test harness).
     pub(crate) fn with_mock(mut self, registry: Arc<MockRegistry>) -> Self {
         self.mock = Some(registry);
@@ -526,13 +572,29 @@ impl Client {
     }
 
     /// Build a client from runtime application state.
-    pub(crate) fn from_state(state: &crate::AppState) -> Self {
+    ///
+    /// When the server was started via `AppBuilder`, a single `reqwest::Client`
+    /// is registered in `AppState` at boot as a `SharedReqwestClient`.  This
+    /// method clones that shared instance (O(1), preserves the connection pool)
+    /// instead of constructing a new one, eliminating per-request TCP/TLS
+    /// handshakes and DNS-resolver-spawn overhead.
+    ///
+    /// Falls back to `Self::new()` for detached or test state that does not
+    /// carry a shared client.
+    pub fn from_state(state: &crate::AppState) -> Self {
         let config = state.extension::<crate::config::HttpConfig>().or_else(|| {
             state
                 .extension::<crate::config::AutumnConfig>()
                 .map(|c| Arc::new(c.http.clone()))
         });
-        let mut client = config.map_or_else(Self::new, |cfg| Self::from_config(&cfg.client));
+        let shared = state.extension::<SharedReqwestClient>().map(|s| s.0.clone());
+
+        let mut client = match (config, shared) {
+            (Some(cfg), Some(inner)) => Self::from_config_with_inner(inner, &cfg.client),
+            (Some(cfg), None) => Self::from_config(&cfg.client),
+            (None, Some(inner)) => Self::with_inner(inner),
+            (None, None) => Self::new(),
+        };
 
         let resilience = state
             .extension::<crate::config::AutumnConfig>()
@@ -636,6 +698,12 @@ impl Client {
     #[must_use]
     pub fn delete(&self, url: impl AsRef<str>) -> RequestBuilder {
         self.build_request(Method::DELETE, url)
+    }
+
+    /// Build a `HEAD` request.
+    #[must_use]
+    pub fn head(&self, url: impl AsRef<str>) -> RequestBuilder {
+        self.build_request(Method::HEAD, url)
     }
 }
 
@@ -1809,6 +1877,71 @@ mod tests {
 
         // Assert that the server was only hit 3 times
         assert_eq!(hit.load(SeqOrdering::SeqCst), 3);
+        crate::circuit_breaker::global_registry().clear();
+    }
+
+    // RED-PHASE TEST 41: SharedReqwestClient round-trips through AppState extensions.
+    #[test]
+    fn shared_reqwest_client_ext_round_trips() {
+        let inner = reqwest::Client::new();
+        let ext = SharedReqwestClient(inner);
+        let state = crate::AppState::for_test();
+        state.insert_extension(ext);
+        let retrieved = state.extension::<SharedReqwestClient>();
+        assert!(retrieved.is_some());
+    }
+
+    // RED-PHASE TEST 42: Client::head() compiles and builds a HEAD RequestBuilder.
+    #[test]
+    fn client_head_method_builds_request_builder() {
+        let client = Client::new();
+        let _builder = client.head("https://example.com/resource");
+    }
+
+    // RED-PHASE TEST 43: from_state reuses the SharedReqwestClient when registered.
+    // Spins up a local echo server that returns the User-Agent header as the body,
+    // then asserts the extracted Client carries the distinctive user-agent we set
+    // on the shared inner client — proving from_state cloned it rather than
+    // building a fresh default.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn from_state_reuses_shared_client() {
+        use axum::{Router, routing::get};
+
+        let _lock = crate::circuit_breaker::TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        crate::circuit_breaker::global_registry().clear();
+
+        let app = Router::new().route(
+            "/ua",
+            get(|req: axum::http::Request<axum::body::Body>| async move {
+                req.headers()
+                    .get("user-agent")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("")
+                    .to_owned()
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let distinctive_inner = reqwest::ClientBuilder::new()
+            .user_agent("autumn-shared-pool-test")
+            .build()
+            .expect("failed to build inner client");
+        let state = crate::AppState::for_test();
+        state.insert_extension(SharedReqwestClient(distinctive_inner));
+
+        let client = Client::from_state(&state);
+        let resp = client
+            .get(format!("http://127.0.0.1:{}/ua", addr.port()))
+            .send()
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(resp.text(), "autumn-shared-pool-test");
         crate::circuit_breaker::global_registry().clear();
     }
 }

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -578,6 +578,7 @@ impl Client {
     ///
     /// Falls back to `Self::new()` for detached or test state that does not
     /// carry a shared client.
+    #[must_use]
     pub fn from_state(state: &crate::AppState) -> Self {
         let autumn_config = state.extension::<crate::config::AutumnConfig>();
         let config = state

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -537,21 +537,7 @@ impl Client {
     /// `reqwest::Client`.  Used when a shared inner client is available but
     /// no explicit `[http.client]` config is registered.
     fn with_inner(inner: reqwest::Client) -> Self {
-        let timeout = Duration::from_secs(30);
-        Self {
-            inner,
-            alias: None,
-            base_url: None,
-            base_urls: HashMap::new(),
-            retry_policy: RetryPolicy {
-                max_retries: 3,
-                retry_idempotent_only: true,
-                max_retry_after: Duration::from_secs(10),
-                request_timeout: Some(timeout),
-            },
-            mock: None,
-            resilience_config: None,
-        }
+        Self { inner, ..Self::new() }
     }
 
     /// Create a client from `[http.client]` framework configuration.
@@ -582,9 +568,10 @@ impl Client {
     /// Falls back to `Self::new()` for detached or test state that does not
     /// carry a shared client.
     pub fn from_state(state: &crate::AppState) -> Self {
+        let autumn_config = state.extension::<crate::config::AutumnConfig>();
         let config = state.extension::<crate::config::HttpConfig>().or_else(|| {
-            state
-                .extension::<crate::config::AutumnConfig>()
+            autumn_config
+                .as_ref()
                 .map(|c| Arc::new(c.http.clone()))
         });
         let shared = state.extension::<SharedReqwestClient>().map(|s| s.0.clone());
@@ -596,10 +583,7 @@ impl Client {
             (None, None) => Self::new(),
         };
 
-        let resilience = state
-            .extension::<crate::config::AutumnConfig>()
-            .map(|c| Arc::new(c.resilience.clone()));
-        client.resilience_config = resilience;
+        client.resilience_config = autumn_config.map(|c| Arc::new(c.resilience.clone()));
 
         if let Some(ext) = state.extension::<HttpMockRegistryExt>() {
             client = client.with_mock(ext.0.clone());

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -1214,6 +1214,13 @@ impl TestApp {
         #[cfg(feature = "http-client")]
         state.insert_extension(self.config.http.clone());
 
+        // Register the shared reqwest::Client so Client::from_state reuses the
+        // connection pool in tests, mirroring the production build_state path.
+        #[cfg(feature = "http-client")]
+        state.insert_extension(crate::http_client::SharedReqwestClient(
+            crate::http_client::Client::build_inner(&self.config.http.client),
+        ));
+
         // Install mock registry when http_mock() was called.
         #[cfg(feature = "http-client")]
         if let Some(registry) = self.http_mock_registry {

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -1217,9 +1217,10 @@ impl TestApp {
         // Register the shared reqwest::Client so Client::from_state reuses the
         // connection pool in tests, mirroring the production build_state path.
         #[cfg(feature = "http-client")]
-        state.insert_extension(crate::http_client::SharedReqwestClient(
-            crate::http_client::Client::build_inner(&self.config.http.client),
-        ));
+        state.insert_extension(crate::http_client::SharedReqwestClient {
+            client: crate::http_client::Client::build_inner(&self.config.http.client),
+            timeout_secs: self.config.http.client.timeout_secs,
+        });
 
         // Install mock registry when http_mock() was called.
         #[cfg(feature = "http-client")]

--- a/docs/guide/outbound-http.md
+++ b/docs/guide/outbound-http.md
@@ -178,8 +178,29 @@ than hitting the network — so unregistered calls are caught immediately.
 
 ## Standalone usage (outside handlers)
 
-You can construct a `Client` directly when you need it outside of a handler
-(e.g. in a `#[job]`, a startup hook, or a CLI task):
+### In `#[scheduled]` and `#[job]` tasks
+
+Tasks that receive `AppState` should call `Client::from_state` to borrow the shared
+connection pool built once at server startup.  This avoids creating a new TCP/TLS
+connection on every task invocation:
+
+```rust
+use autumn_web::http::Client;
+use autumn_web::prelude::*;
+
+#[scheduled(every = "1h", name = "link-checker")]
+pub async fn check_links(state: AppState) -> AutumnResult<()> {
+    let client = Client::from_state(&state);
+    // client reuses the shared connection pool — no cold handshake
+    client.get("https://api.example.com/status").send().await?;
+    Ok(())
+}
+```
+
+### Outside the framework
+
+For truly standalone use (CLI utilities, benchmarks, tests that run without an
+`AppState`), construct a client directly:
 
 ```rust
 use autumn_web::http::Client;

--- a/examples/bookmarks-distributed/autumn.toml
+++ b/examples/bookmarks-distributed/autumn.toml
@@ -7,6 +7,9 @@ level = "info"
 [health]
 path = "/health"
 
+[http.client]
+timeout_secs = 10
+
 [database]
 primary_url = "postgres://autumn:autumn@localhost:5432/bookmarks_distributed"
 replica_url = "postgres://autumn:autumn@localhost:5433/bookmarks_distributed"

--- a/examples/bookmarks-distributed/src/tasks.rs
+++ b/examples/bookmarks-distributed/src/tasks.rs
@@ -7,6 +7,7 @@
 // Errors are logged at WARN level and the task retries on the
 // next scheduled interval.
 
+use autumn_web::http::Client;
 use autumn_web::prelude::*;
 use futures::FutureExt;
 use reqwest::StatusCode;
@@ -34,7 +35,7 @@ fn probe_outcome(head: Result<StatusCode, ()>, get: Option<Result<StatusCode, ()
     }
 }
 
-async fn probe_reachable(client: &reqwest::Client, url: &str) -> bool {
+async fn probe_reachable(client: &Client, url: &str) -> bool {
     let head = client
         .head(url)
         .send()
@@ -57,7 +58,7 @@ async fn probe_reachable(client: &reqwest::Client, url: &str) -> bool {
 
 async fn process_shard(
     repo: &BookmarkRepository,
-    client: &reqwest::Client,
+    client: &Client,
     shard: u32,
 ) -> AutumnResult<(u32, u32)> {
     let shard_alive = repo.find_alive_in_shard(shard).await?;
@@ -106,12 +107,9 @@ fn process_shard_result(
 }
 
 #[scheduled(every = "1h", name = "link-checker")]
-pub async fn check_links(_state: AppState) -> AutumnResult<()> {
+pub async fn check_links(state: AppState) -> AutumnResult<()> {
     let repo = BookmarkRepository;
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .map_err(|e| AutumnError::from(std::io::Error::other(e.to_string())))?;
+    let client = Client::from_state(&state);
 
     let mut dead_count = 0u32;
     let mut checked_count = 0u32;

--- a/examples/bookmarks-distributed/src/tasks.rs
+++ b/examples/bookmarks-distributed/src/tasks.rs
@@ -7,7 +7,7 @@
 // Errors are logged at WARN level and the task retries on the
 // next scheduled interval.
 
-use autumn_web::http::Client;
+use autumn_web::http::{Client, ClientError};
 use autumn_web::prelude::*;
 use futures::FutureExt;
 use reqwest::StatusCode;
@@ -36,21 +36,19 @@ fn probe_outcome(head: Result<StatusCode, ()>, get: Option<Result<StatusCode, ()
 }
 
 async fn probe_reachable(client: &Client, url: &str) -> bool {
-    let head = client
-        .head(url)
-        .no_retry()
-        .send()
-        .await
-        .map(|response| response.status());
+    let head_result = client.head(url).no_retry().send().await;
+    let head = match head_result {
+        Err(ClientError::CircuitBreakerOpen) => return true, // inconclusive — don't mark dead
+        other => other.map(|r| r.status()),
+    };
     match head {
         Ok(status) if response_is_reachable(status) => true,
         Ok(status) if head_requires_get_fallback(status) => {
-            let get = client
-                .get(url)
-                .no_retry()
-                .send()
-                .await
-                .map(|response| response.status());
+            let get_result = client.get(url).no_retry().send().await;
+            let get = match get_result {
+                Err(ClientError::CircuitBreakerOpen) => return true, // inconclusive
+                other => other.map(|r| r.status()),
+            };
             probe_outcome(Ok(status), Some(get.map_err(|_| ())))
         }
         Ok(status) => probe_outcome(Ok(status), None),

--- a/examples/bookmarks-distributed/src/tasks.rs
+++ b/examples/bookmarks-distributed/src/tasks.rs
@@ -38,6 +38,7 @@ fn probe_outcome(head: Result<StatusCode, ()>, get: Option<Result<StatusCode, ()
 async fn probe_reachable(client: &Client, url: &str) -> bool {
     let head = client
         .head(url)
+        .no_retry()
         .send()
         .await
         .map(|response| response.status());
@@ -46,6 +47,7 @@ async fn probe_reachable(client: &Client, url: &str) -> bool {
         Ok(status) if head_requires_get_fallback(status) => {
             let get = client
                 .get(url)
+                .no_retry()
                 .send()
                 .await
                 .map(|response| response.status());

--- a/examples/bookmarks/autumn.toml
+++ b/examples/bookmarks/autumn.toml
@@ -6,3 +6,6 @@ level = "info"
 
 [health]
 path = "/health"
+
+[http.client]
+timeout_secs = 10

--- a/examples/bookmarks/src/tasks.rs
+++ b/examples/bookmarks/src/tasks.rs
@@ -10,6 +10,7 @@
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
+use autumn_web::http::Client;
 use autumn_web::prelude::*;
 
 use crate::schema::bookmarks;
@@ -37,10 +38,7 @@ pub async fn check_links(state: AppState) -> AutumnResult<()> {
 
     tracing::info!("link-checker: checking {} URLs", alive.len());
 
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .map_err(|e| AutumnError::from(std::io::Error::other(e.to_string())))?;
+    let client = Client::from_state(&state);
 
     let mut dead_ids = Vec::new();
     for (id, url) in &alive {

--- a/examples/bookmarks/src/tasks.rs
+++ b/examples/bookmarks/src/tasks.rs
@@ -10,7 +10,7 @@
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
-use autumn_web::http::Client;
+use autumn_web::http::{Client, ClientError};
 use autumn_web::prelude::*;
 
 use crate::schema::bookmarks;
@@ -42,12 +42,14 @@ pub async fn check_links(state: AppState) -> AutumnResult<()> {
 
     let mut dead_ids = Vec::new();
     for (id, url) in &alive {
-        let reachable = client
-            .head(url)
-            .no_retry()
-            .send()
-            .await
-            .is_ok_and(|r| r.status().is_success() || r.status().is_redirection());
+        let reachable = match client.head(url).no_retry().send().await {
+            Ok(r) => r.status().is_success() || r.status().is_redirection(),
+            Err(ClientError::CircuitBreakerOpen) => {
+                tracing::debug!("link-checker: circuit breaker open for {url}, skipping probe");
+                continue;
+            }
+            Err(_) => false,
+        };
 
         if !reachable {
             tracing::warn!("link-checker: dead link id={id} url={url}");

--- a/examples/bookmarks/src/tasks.rs
+++ b/examples/bookmarks/src/tasks.rs
@@ -44,6 +44,7 @@ pub async fn check_links(state: AppState) -> AutumnResult<()> {
     for (id, url) in &alive {
         let reachable = client
             .head(url)
+            .no_retry()
             .send()
             .await
             .is_ok_and(|r| r.status().is_success() || r.status().is_redirection());


### PR DESCRIPTION
## Summary

This PR introduces connection pool sharing for HTTP clients by registering a single `reqwest::Client` instance in `AppState` at server startup. This eliminates per-request TCP/TLS handshakes and DNS resolver overhead when using `Client::from_state()`.

## Key Changes

- **New `SharedReqwestClient` type**: A wrapper around `reqwest::Client` that can be registered as an `AppState` extension, enabling O(1) cloning while preserving the connection pool.

- **Refactored `Client::from_config()`**: Split into two methods:
  - `build_inner()`: Creates a bare `reqwest::Client` from config (used at server startup)
  - `from_config_with_inner()`: Wraps an existing `reqwest::Client` with policy configuration

- **Enhanced `Client::from_state()`**: Now checks for a registered `SharedReqwestClient` and reuses it when available, falling back to creating a new client only when necessary. This is now public to support scheduled tasks and jobs.

- **New `Client::with_inner()` helper**: Constructs a `Client` with default policy around an existing `reqwest::Client`.

- **Added `Client::head()` method**: Implements HTTP HEAD requests for consistency with other HTTP methods.

- **Server startup integration**: `build_state()` now registers a `SharedReqwestClient` using the configured timeout and TLS settings, ensuring all requests share the same connection pool.

- **Test harness support**: `TestApp` now registers the shared client in test state, mirroring production behavior.

## Notable Implementation Details

- The shared client is built once at server startup with the configured timeout, eliminating per-request initialization overhead.
- `reqwest::Client` is internally `Arc`-backed, so cloning is cheap and preserves the connection pool across all clones.
- The implementation gracefully handles cases where no shared client is available (detached state, legacy code paths).
- Updated documentation and examples (`bookmarks` and `bookmarks-distributed`) to demonstrate using `Client::from_state()` in scheduled tasks instead of creating new clients.

https://claude.ai/code/session_01Hmwi19UmThQT3BPQzoN8Co