### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -1638,11 +1638,16 @@ fn build_request(
         // Use the same full segment encoder the typed path helpers use, so an
         // MCP call accepts the same values a direct HTTP caller could pass.
         let encoded = if is_catch_all {
-            value
-                .split('/')
-                .map(crate::paths::encode_path_segment)
-                .collect::<Vec<_>>()
-                .join("/")
+            value.split('/').enumerate().fold(
+                String::with_capacity(value.len() + 10),
+                |mut acc, (i, s)| {
+                    if i > 0 {
+                        acc.push('/');
+                    }
+                    acc.push_str(&crate::paths::encode_path_segment(s));
+                    acc
+                },
+            )
         } else {
             crate::paths::encode_path_segment(&value)
         };

--- a/autumn/src/test_html.rs
+++ b/autumn/src/test_html.rs
@@ -80,8 +80,16 @@ fn collect_text(nodes: &[Node], out: &mut String) {
 /// Collapse runs of ASCII whitespace into single spaces and trim the ends, so
 /// text/`assert_text` comparisons survive indentation and line-wrapping
 /// changes in templates.
+/// Removes intermediate Vec allocations and pre-allocates String capacity.
 pub fn normalize_ws(s: &str) -> String {
-    s.split_whitespace().collect::<Vec<_>>().join(" ")
+    let mut result = String::with_capacity(s.len());
+    for (i, word) in s.split_whitespace().enumerate() {
+        if i > 0 {
+            result.push(' ');
+        }
+        result.push_str(word);
+    }
+    result
 }
 
 // ── Parser ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
💡 What: Replaced two instances of `.collect::<Vec<_>>().join(...)` with standard iterator manual allocations without `Vec` wrappers (in `autumn/src/test_html.rs` and `autumn/src/mcp.rs`).
🎯 Why: Iterators being collected (`.collect()`) into intermediate vectors unnecessarily just to perform string concatenation is a known anti-pattern in high performance code and creates excess heap allocations.
📊 Impact: Removes redundant intermediate `Vec` allocations, providing zero-cost abstraction building to hot-path functions, improving scaling for longer inputs.
🔭 Measurement: Verify changes via `cargo test -p autumn-web --lib`.

---
*PR created automatically by Jules for task [12313071883961235658](https://jules.google.com/task/12313071883961235658) started by @madmax983*