### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -41,7 +41,7 @@ use std::time::Duration;
 use tracing::Instrument as _;
 
 use crate::config::DatabaseConfig;
-use crate::error::AutumnError;
+use crate::error::{AutumnError, AutumnResult};
 
 // ── After-commit callback infrastructure ─────────────────────────────────────
 
@@ -79,7 +79,7 @@ pub(crate) fn record_after_commit_failure() -> u64 {
     AFTER_COMMIT_FAILURES_TOTAL.fetch_add(1, Ordering::Relaxed) + 1
 }
 
-pub(crate) fn reject_ambient_after_commit_registry_for_tx() -> Result<(), AutumnError> {
+pub(crate) fn reject_ambient_after_commit_registry_for_tx() -> AutumnResult<()> {
     if AFTER_COMMIT_REGISTRY.try_with(|_| ()).is_ok() {
         return Err(AutumnError::bad_request_msg(
             "Nested Db::tx calls are not supported",
@@ -492,7 +492,7 @@ pub async fn run_instrumented<F, Fut, T>(
     slow_threshold: std::time::Duration,
     metrics: &crate::middleware::metrics::MetricsCollector,
     query: F,
-) -> Result<T, AutumnError>
+) -> AutumnResult<T>
 where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = Result<T, diesel::result::Error>>,
@@ -869,11 +869,11 @@ impl Db {
     ///
     /// Panics if the internal after-commit registry mutex is poisoned (only
     /// possible if a previous thread holding the lock panicked).
-    pub async fn tx<'a, T, E, F>(&'a mut self, f: F) -> Result<T, crate::error::AutumnError>
+    pub async fn tx<'a, T, E, F>(&'a mut self, f: F) -> AutumnResult<T>
     where
         T: Send + 'a,
         E: From<diesel::result::Error> + Send + Sync + 'a,
-        crate::error::AutumnError: From<E>,
+        AutumnError: From<E>,
         F: for<'r> FnOnce(
                 &'r mut PooledConnection,
             ) -> scoped_futures::ScopedBoxFuture<'a, 'r, Result<T, E>>
@@ -883,12 +883,12 @@ impl Db {
         use diesel_async::AsyncConnection as _;
 
         if self.tx_poisoned {
-            return Err(crate::error::AutumnError::service_unavailable_msg(
+            return Err(AutumnError::service_unavailable_msg(
                 "Database connection is in an invalid transaction state",
             ));
         }
         if self.tx_depth > 0 {
-            return Err(crate::error::AutumnError::bad_request_msg(
+            return Err(AutumnError::bad_request_msg(
                 "Nested Db::tx calls are not supported",
             ));
         }
@@ -985,7 +985,7 @@ impl Db {
     /// shard-routed checkouts: span creation, checkout interceptors,
     /// `SET statement_timeout`, and the metrics captured for the
     /// slow-query warning on `Drop`.
-    pub(crate) async fn checkout(params: DbCheckoutParams<'_>) -> Result<Self, AutumnError> {
+    pub(crate) async fn checkout(params: DbCheckoutParams<'_>) -> AutumnResult<Self> {
         const PG_TIMEOUT_MAX_MS: u64 = i32::MAX as u64;
         use diesel_async::RunQueryDsl as _;
 
@@ -1007,9 +1007,7 @@ impl Db {
 
         let pool = params.pool;
         let mut checkout_future: std::pin::Pin<
-            Box<
-                dyn std::future::Future<Output = Result<PooledConnection, AutumnError>> + Send + '_,
-            >,
+            Box<dyn std::future::Future<Output = AutumnResult<PooledConnection>> + Send + '_>,
         > = Box::pin(async move {
             pool.get().await.map_err(|e| {
                 tracing::error!("Failed to acquire database connection: {e}");

--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -63,7 +63,7 @@ impl std::error::Error for StringError {}
 
 /// JSON body for RFC 7807 Problem Details responses.
 #[derive(Clone, Debug, Serialize)]
-pub struct ProblemDetails {
+pub(crate) struct ProblemDetails {
     /// Problem type URI. Autumn uses stable `https://autumn.dev/problems/...`
     /// URIs for framework-generated errors.
     #[serde(rename = "type")]
@@ -86,7 +86,7 @@ pub struct ProblemDetails {
 
 /// Field-level validation detail in the Problem Details `errors` extension.
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
-pub struct ProblemFieldError {
+pub(crate) struct ProblemFieldError {
     /// Field name as seen by the request payload or form.
     pub field: String,
     /// Stable list of validation messages for this field.
@@ -704,18 +704,6 @@ impl std::fmt::Debug for AutumnError {
                 &self.cache_idempotency_response,
             )
             .finish_non_exhaustive()
-    }
-}
-
-impl ProblemDetails {
-    /// Build a Problem Details payload from framework error metadata.
-    #[must_use]
-    pub fn new(
-        status: StatusCode,
-        detail: impl Into<String>,
-        details: Option<&std::collections::HashMap<String, Vec<String>>>,
-    ) -> Self {
-        problem_details(status, detail.into(), details, None, None, None, true)
     }
 }
 

--- a/autumn/src/sharding.rs
+++ b/autumn/src/sharding.rs
@@ -44,7 +44,7 @@ use diesel_async::pooled_connection::deadpool::Pool;
 pub use crate::config::SLOT_COUNT;
 use crate::config::{ConfigError, DatabaseConfig, ReplicaFallback};
 use crate::db::{DatabaseTopology, PoolError};
-use crate::error::AutumnError;
+use crate::error::{AutumnError, AutumnResult};
 
 /// Index of a physical shard within the configured shard set.
 ///
@@ -180,7 +180,7 @@ pub trait ShardRouter: Send + Sync + 'static {
         &'a self,
         key: ShardKey<'a>,
         shards: &'a ShardSet,
-    ) -> futures::future::BoxFuture<'a, Result<ShardId, AutumnError>>;
+    ) -> futures::future::BoxFuture<'a, AutumnResult<ShardId>>;
 }
 
 /// `Arc<R>` routes through its inner router. This lets a caller build a single
@@ -196,7 +196,7 @@ impl<R: ShardRouter + ?Sized> ShardRouter for Arc<R> {
         &'a self,
         key: ShardKey<'a>,
         shards: &'a ShardSet,
-    ) -> futures::future::BoxFuture<'a, Result<ShardId, AutumnError>> {
+    ) -> futures::future::BoxFuture<'a, AutumnResult<ShardId>> {
         (**self).route(key, shards)
     }
 }
@@ -211,7 +211,7 @@ impl ShardRouter for HashShardRouter {
         &'a self,
         key: ShardKey<'a>,
         shards: &'a ShardSet,
-    ) -> futures::future::BoxFuture<'a, Result<ShardId, AutumnError>> {
+    ) -> futures::future::BoxFuture<'a, AutumnResult<ShardId>> {
         let slot = shards.slot_for_key(key);
         Box::pin(std::future::ready(
             shards
@@ -561,7 +561,7 @@ impl ShardRouter for DirectoryShardRouter {
         &'a self,
         key: ShardKey<'a>,
         shards: &'a ShardSet,
-    ) -> futures::future::BoxFuture<'a, Result<ShardId, AutumnError>> {
+    ) -> futures::future::BoxFuture<'a, AutumnResult<ShardId>> {
         Box::pin(async move {
             // Only string keys participate in the directory (tenants are
             // strings); numeric/byte keys route straight through the fallback.
@@ -1493,7 +1493,7 @@ fn no_shards_configured() -> AutumnError {
 fn cross_shard_seed(
     set: &ShardSet,
     ctx: &crate::db::RequestDbContext,
-) -> Result<ShardRepositorySeed, AutumnError> {
+) -> AutumnResult<ShardRepositorySeed> {
     let shard = set.iter().next().ok_or_else(no_shards_configured)?;
     let mut seed =
         ShardRepositorySeed::from_ctx(shard.primary_pool(), ctx, shard.name(), shard.read_route());
@@ -1690,10 +1690,10 @@ impl Shards {
     ///     })
     ///     .await;
     /// ```
-    pub async fn each_shard<T, Fut, F>(&self, f: F) -> Vec<(ShardId, Result<T, AutumnError>)>
+    pub async fn each_shard<T, Fut, F>(&self, f: F) -> Vec<(ShardId, AutumnResult<T>)>
     where
         T: Send,
-        Fut: std::future::Future<Output = Result<T, AutumnError>> + Send,
+        Fut: std::future::Future<Output = AutumnResult<T>> + Send,
         F: Fn(&Shard, crate::db::Db) -> Fut + Send + Sync,
     {
         // FuturesUnordered keeps the pipeline full at FAN_OUT_CONCURRENCY
@@ -1704,12 +1704,11 @@ impl Shards {
         // for Send.
         use futures::StreamExt as _;
 
-        let mut results: Vec<Option<(ShardId, Result<T, AutumnError>)>> =
-            std::iter::repeat_with(|| None)
-                .take(self.set.len())
-                .collect();
+        let mut results: Vec<Option<(ShardId, AutumnResult<T>)>> = std::iter::repeat_with(|| None)
+            .take(self.set.len())
+            .collect();
         let mut in_flight: futures::stream::FuturesUnordered<
-            futures::future::BoxFuture<'_, (ShardId, Result<T, AutumnError>)>,
+            futures::future::BoxFuture<'_, (ShardId, AutumnResult<T>)>,
         > = futures::stream::FuturesUnordered::new();
 
         for shard in self.set.iter() {
@@ -1726,14 +1725,10 @@ impl Shards {
         results.into_iter().flatten().collect()
     }
 
-    async fn run_on_shard<T, Fut, F>(
-        &self,
-        shard: &Shard,
-        f: &F,
-    ) -> (ShardId, Result<T, AutumnError>)
+    async fn run_on_shard<T, Fut, F>(&self, shard: &Shard, f: &F) -> (ShardId, AutumnResult<T>)
     where
         T: Send,
-        Fut: std::future::Future<Output = Result<T, AutumnError>> + Send,
+        Fut: std::future::Future<Output = AutumnResult<T>> + Send,
         F: Fn(&Shard, crate::db::Db) -> Fut + Send + Sync,
     {
         let result = match self.checkout_primary(shard).await {
@@ -1909,7 +1904,7 @@ impl ShardedDb {
     /// # Errors
     ///
     /// See [`Db::tx`](crate::db::Db::tx).
-    pub async fn tx<'a, T, E, F>(&'a mut self, f: F) -> Result<T, AutumnError>
+    pub async fn tx<'a, T, E, F>(&'a mut self, f: F) -> AutumnResult<T>
     where
         T: Send + 'a,
         E: From<diesel::result::Error> + Send + Sync + 'a,
@@ -2135,7 +2130,7 @@ impl axum::extract::FromRequestParts<crate::AppState> for ShardedReadDb {
 async fn resolve_shard_key(
     parts: &mut axum::http::request::Parts,
     state: &crate::AppState,
-) -> Result<String, AutumnError> {
+) -> AutumnResult<String> {
     if let Some(overridden) = parts.extensions.get::<ShardKeyOverride>() {
         return Ok(overridden.0.clone());
     }
@@ -2740,7 +2735,7 @@ mod tests {
                 &'a self,
                 _key: ShardKey<'a>,
                 _shards: &'a ShardSet,
-            ) -> futures::future::BoxFuture<'a, Result<ShardId, AutumnError>> {
+            ) -> futures::future::BoxFuture<'a, AutumnResult<ShardId>> {
                 Box::pin(std::future::ready(Ok(ShardId(99))))
             }
         }


### PR DESCRIPTION
🕸️ Tangle: The codebase had inconsistent internal error type usage across `db.rs` and `sharding.rs` (mixing `Result<T, AutumnError>` and `AutumnResult<T>`), alongside internal Problem Details structs `ProblemDetails` and `ProblemFieldError` inappropriately leaking as `pub struct` in `error.rs`.

📐 Blueprint: Replaced all scattered usages of `Result<T, AutumnError>` with the standardized `AutumnResult<T>` in `db.rs` and `sharding.rs`. Narrowed the visibility of `ProblemDetails` and `ProblemFieldError` to `pub(crate)` to prevent internal state leakage in public APIs, aligning with strict boundary definitions. Addressed a resulting `dead_code` warning by removing the unused `ProblemDetails::new` constructor.

🧱 Stability: Enforces rigorous module boundaries and prevents downstream coupling to internal web framework serialization structures.

🔬 Verification: Clean compilation with `cargo check -p autumn-web --lib`, no regressions during `cargo test -p autumn-web --lib`, and all code is formatted per `cargo fmt`. Lints pass under `cargo clippy -p autumn-web --lib -- -D warnings`.

---
*PR created automatically by Jules for task [5479700689459752300](https://jules.google.com/task/5479700689459752300) started by @madmax983*