### PR TITLE
👺 Havoc: [Fix Idempotency TTL Overflow]

### DIFF
--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -467,7 +467,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
         let entry = IdempotencyEntry {
             record,
             body_hash,
-            expires_at: Instant::now() + ttl,
+            expires_at: Instant::now().checked_add(ttl).unwrap_or_else(Instant::now),
         };
         let mut entries = self.entries.write().unwrap();
         entries.insert(key.to_owned(), entry);
@@ -504,7 +504,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
             key.to_owned(),
             MemoryInFlightLock {
                 owner: owner.to_owned(),
-                expires_at: now + ttl,
+                expires_at: now.checked_add(ttl).unwrap_or_else(|| now),
             },
         );
         true

--- a/autumn/tests/security/havoc_ttl_overflow.rs
+++ b/autumn/tests/security/havoc_ttl_overflow.rs
@@ -1,0 +1,24 @@
+use autumn_web::idempotency::{IdempotencyRecord, IdempotencyStore, MemoryIdempotencyStore};
+use std::time::Duration;
+
+#[test]
+fn test_idempotency_ttl_overflow() {
+    let store = MemoryIdempotencyStore::new(Duration::from_secs(60));
+    let ttl = Duration::MAX;
+
+    // Test `try_lock_owned`
+    let locked = store.try_lock_owned("key", "owner-a", ttl);
+    assert!(
+        locked,
+        "Lock should be acquired successfully, failing closed the TTL instead of panicking"
+    );
+
+    // Test `set`
+    let record = IdempotencyRecord {
+        status: 200,
+        headers: Default::default(),
+        body: vec![],
+        metadata: vec![],
+    };
+    store.set("key", record, vec![], ttl);
+}

--- a/autumn/tests/security/mod.rs
+++ b/autumn/tests/security/mod.rs
@@ -10,6 +10,7 @@ pub mod csrf_path_traversal;
 pub mod csrf_timing;
 pub mod ctf;
 pub mod fallback_middleware_bypass;
+pub mod havoc_ttl_overflow;
 pub mod maintenance;
 pub mod rate_limit_xff_bypass;
 pub mod session_exhaustion;


### PR DESCRIPTION
🧨 **The Trigger:** Passing a very large `ttl` Duration, such as `Duration::MAX`, to `MemoryIdempotencyStore::try_lock_owned` or `set`.
📉 **The Stack Trace:**
```
thread 'security::havoc_ttl_overflow::test_idempotency_ttl_overflow' panicked at library/std/src/time.rs:429:33:
overflow when adding duration to instant
```
🧪 **Reproduction:** Run `cargo test -p autumn-web --test security_tests test_idempotency_ttl_overflow` from the regression test suite.
😈 **Comment:** You assumed duration addition wouldn't overflow. You were wrong.

---
*PR created automatically by Jules for task [15823248320842067536](https://jules.google.com/task/15823248320842067536) started by @madmax983*