### PR TITLE
Add declarative auto-broadcasting for repository mutations

### DIFF
--- a/autumn-cli/src/generate/config.rs
+++ b/autumn-cli/src/generate/config.rs
@@ -40,6 +40,7 @@ use super::scaffold::ScaffoldOptions;
 /// One resource's scaffold metadata from a TOML config file.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct ScaffoldConfigEntry {
     #[serde(default)]
     pub fields: Vec<String>,
@@ -267,7 +268,7 @@ pub fn read_generate_defaults(config_path: &Path) -> Result<IdType, GenerateErro
 ///
 /// # Errors
 /// Returns [`GenerateError::Config`] if any `--id` value is unrecognised.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub fn merge_config_with_cli(
     config: ScaffoldConfigEntry,
     cli_fields: &[String],

--- a/autumn-cli/src/generate/config.rs
+++ b/autumn-cli/src/generate/config.rs
@@ -59,6 +59,8 @@ pub struct ScaffoldConfigEntry {
     pub sharded: bool,
     #[serde(default)]
     pub shard_key: Option<String>,
+    #[serde(default)]
+    pub live: bool,
     /// Primary-key type for this resource (`"uuid"` or `"bigint"`).
     /// Inherits from `[generate] id` when absent.
     #[serde(default)]
@@ -277,6 +279,7 @@ pub fn merge_config_with_cli(
     cli_api: bool,
     cli_sharded: bool,
     cli_shard_key: Option<&str>,
+    cli_live: bool,
     cli_id: Option<&str>,
 ) -> Result<(Vec<String>, ScaffoldOptions), GenerateError> {
     let pick = |cli: &[String], toml: Vec<String>| -> Vec<String> {
@@ -292,6 +295,7 @@ pub fn merge_config_with_cli(
     let api = cli_api || config.api;
     let sharded = cli_sharded || config.sharded;
     let shard_key = cli_shard_key.map(str::to_owned).or(config.shard_key);
+    let live = cli_live || config.live;
     // Precedence: CLI > per-resource TOML > project-default TOML > BigSerial.
     let id_type = if let Some(s) = cli_id {
         IdType::parse(s)?
@@ -314,6 +318,7 @@ pub fn merge_config_with_cli(
             },
             queries,
             api,
+            live,
         },
     ))
 }
@@ -604,6 +609,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             api: false,
             sharded: false,
             shard_key: None,
+            live: false,
             id: None,
         }
     }
@@ -620,6 +626,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
             None,
         )
         .unwrap()
@@ -648,6 +655,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
             None,
         )
         .unwrap();
@@ -667,6 +675,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
             None,
         )
         .unwrap();
@@ -686,6 +695,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
             None,
         )
         .unwrap();
@@ -707,6 +717,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
             None,
         )
         .unwrap();
@@ -726,6 +737,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
             None,
         )
         .unwrap();
@@ -746,6 +758,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
             None,
         )
         .unwrap();
@@ -769,6 +782,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
             None,
         )
         .unwrap();
@@ -827,6 +841,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             true,
             false,
             None,
+            false,
             None,
         )
         .unwrap();
@@ -870,6 +885,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             true,
             None,
+            false,
             None,
         )
         .unwrap();
@@ -905,6 +921,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             Some("user_id"),
+            false,
             None,
         )
         .unwrap();
@@ -963,6 +980,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
             Some("uuid"),
         )
         .unwrap();
@@ -1000,6 +1018,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
             Some("bigint"),
         )
         .unwrap();
@@ -1033,6 +1052,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
             Some("guid"),
         )
         .unwrap_err();

--- a/autumn-cli/src/generate/config.rs
+++ b/autumn-cli/src/generate/config.rs
@@ -54,6 +54,8 @@ pub struct ScaffoldConfigEntry {
     pub sharded: bool,
     #[serde(default)]
     pub shard_key: Option<String>,
+    #[serde(default)]
+    pub live: bool,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -102,6 +104,7 @@ pub fn merge_config_with_cli(
     cli_api: bool,
     cli_sharded: bool,
     cli_shard_key: Option<&str>,
+    cli_live: bool,
 ) -> (Vec<String>, ScaffoldOptions) {
     let pick = |cli: &[String], toml: Vec<String>| -> Vec<String> {
         if cli.is_empty() { toml } else { cli.to_vec() }
@@ -116,6 +119,7 @@ pub fn merge_config_with_cli(
     let api = cli_api || config.api;
     let sharded = cli_sharded || config.sharded;
     let shard_key = cli_shard_key.map(str::to_owned).or(config.shard_key);
+    let live = cli_live || config.live;
     (
         fields,
         ScaffoldOptions {
@@ -129,6 +133,7 @@ pub fn merge_config_with_cli(
             },
             queries,
             api,
+            live,
         },
     )
 }
@@ -274,6 +279,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             api: false,
             sharded: false,
             shard_key: None,
+            live: false,
         }
     }
 
@@ -290,6 +296,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
         );
         assert_eq!(fields, vec!["url:String", "tag:String"]);
         assert_eq!(opts.model.indexes, vec!["url"]);
@@ -311,6 +318,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
         );
         assert_eq!(fields, vec!["title:String", "body:Text"]);
     }
@@ -328,6 +336,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
         );
         assert_eq!(opts.model.indexes, vec!["tag"]);
     }
@@ -345,6 +354,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
         );
         assert_eq!(opts.model.validations, vec!["url=email"]);
     }
@@ -364,6 +374,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
         );
         assert_eq!(opts.model.defaults, vec!["tag=general"]);
     }
@@ -381,6 +392,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
         );
         assert_eq!(opts.queries, vec!["find_by_tag:tag"]);
     }
@@ -388,8 +400,19 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
     #[test]
     fn merge_empty_cli_keeps_empty_toml() {
         let entry = ScaffoldConfigEntry::default();
-        let (fields, opts) =
-            merge_config_with_cli(entry, &[], &[], &[], &[], &[], false, false, false, None);
+        let (fields, opts) = merge_config_with_cli(
+            entry,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            false,
+            None,
+            false,
+        );
         assert!(fields.is_empty());
         assert!(opts.model.indexes.is_empty());
         assert!(opts.model.validations.is_empty());
@@ -410,6 +433,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
         );
         assert!(
             opts.model.soft_delete,
@@ -421,8 +445,19 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
     fn merge_toml_soft_delete_propagates() {
         let mut entry = bookmark_entry();
         entry.soft_delete = true;
-        let (_, opts) =
-            merge_config_with_cli(entry, &[], &[], &[], &[], &[], false, false, false, None);
+        let (_, opts) = merge_config_with_cli(
+            entry,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            false,
+            None,
+            false,
+        );
         assert!(
             opts.model.soft_delete,
             "soft_delete=true in TOML config must propagate when CLI flag is false"
@@ -442,6 +477,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             None,
+            false,
         );
         assert!(
             !opts.model.soft_delete,
@@ -478,6 +514,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             true,
             false,
             None,
+            false,
         );
         assert!(opts.api);
     }
@@ -486,8 +523,19 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
     fn merge_toml_api_propagates() {
         let mut entry = bookmark_entry();
         entry.api = true;
-        let (_, opts) =
-            merge_config_with_cli(entry, &[], &[], &[], &[], &[], false, false, false, None);
+        let (_, opts) = merge_config_with_cli(
+            entry,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            false,
+            None,
+            false,
+        );
         assert!(opts.api);
     }
 
@@ -520,6 +568,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             true,
             None,
+            false,
         );
         assert!(
             opts.model.sharded,
@@ -531,8 +580,19 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
     fn merge_toml_sharded_propagates() {
         let mut entry = bookmark_entry();
         entry.sharded = true;
-        let (_, opts) =
-            merge_config_with_cli(entry, &[], &[], &[], &[], &[], false, false, false, None);
+        let (_, opts) = merge_config_with_cli(
+            entry,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            false,
+            None,
+            false,
+        );
         assert!(
             opts.model.sharded,
             "sharded=true in TOML config must propagate when CLI flag is false"
@@ -554,6 +614,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             false,
             false,
             Some("user_id"),
+            false,
         );
         assert_eq!(
             opts.model.shard_key.as_deref(),
@@ -566,8 +627,19 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
     fn merge_shard_key_toml_used_when_no_cli() {
         let mut entry = bookmark_entry();
         entry.shard_key = Some("org_id".into());
-        let (_, opts) =
-            merge_config_with_cli(entry, &[], &[], &[], &[], &[], false, false, false, None);
+        let (_, opts) = merge_config_with_cli(
+            entry,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            false,
+            None,
+            false,
+        );
         assert_eq!(
             opts.model.shard_key.as_deref(),
             Some("org_id"),
@@ -593,6 +665,60 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             entry.shard_key.as_deref(),
             Some("tenant_id"),
             "shard_key in TOML must be parsed into ScaffoldConfigEntry"
+        );
+    }
+
+    #[test]
+    fn merge_cli_live_flag_wins() {
+        let (_, opts) = merge_config_with_cli(
+            bookmark_entry(),
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            false,
+            None,
+            true,
+        );
+        assert!(opts.live);
+    }
+
+    #[test]
+    fn merge_toml_live_propagates() {
+        let mut entry = bookmark_entry();
+        entry.live = true;
+        let (_, opts) = merge_config_with_cli(
+            entry,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            false,
+            None,
+            false,
+        );
+        assert!(opts.live);
+    }
+
+    #[test]
+    fn parse_scaffold_config_with_live() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_config(
+            &tmp,
+            "[scaffold.Article]\nfields = [\"title:String\"]\nlive = true\n",
+        );
+        let entry = read_scaffold_config(&path, "Article")
+            .unwrap()
+            .expect("Article section must be present");
+        assert!(
+            entry.live,
+            "live = true in TOML must be parsed into ScaffoldConfigEntry"
         );
     }
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -240,13 +240,15 @@ pub fn plan_scaffold_with_options(
         if let Some(contents) = cargo_content {
             let with_ws = ensure_autumn_web_feature(contents, "ws");
             let with_maud = ensure_autumn_web_feature(&with_ws, "maud");
-            *contents = with_maud;
+            let with_htmx = ensure_autumn_web_feature(&with_maud, "htmx");
+            *contents = with_htmx;
         } else {
             let existing = read_or_empty(&cargo_toml_path);
             let with_ws = ensure_autumn_web_feature(&existing, "ws");
             let with_maud = ensure_autumn_web_feature(&with_ws, "maud");
-            if with_maud != existing {
-                plan.modify(cargo_toml_path, with_maud);
+            let with_htmx = ensure_autumn_web_feature(&with_maud, "htmx");
+            if with_htmx != existing {
+                plan.modify(cargo_toml_path, with_htmx);
             }
         }
     }
@@ -2182,5 +2184,6 @@ async fn main() {
         let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
         assert!(cargo.contains("\"ws\""));
         assert!(cargo.contains("\"maud\""));
+        assert!(cargo.contains("\"htmx\""));
     }
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -555,7 +555,7 @@ fn render_routes_file(
 ) -> String {
     let id_rust = id_type.rust_type();
     let layout_head_scripts = if live {
-        "\n                script src=\"/static/js/htmx.min.js\" {}\n                script src=\"/static/js/htmx-ext-sse.min.js\" {}"
+        "\n                script src=\"/static/js/htmx.min.js\" {}\n                script src=\"/static/js/sse.js\" {}"
     } else {
         ""
     };

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -509,7 +509,16 @@ fn render_routes_file(
     // The destroy handler must honour the resource's delete semantics: when the
     // scaffold was generated with `--soft-delete`, mark `deleted_at` (matching
     // the soft-delete repository) instead of issuing a physical `DELETE`.
-    let destroy_stmt = if soft_delete {
+    let destroy_stmt = if live {
+        if sharded {
+            format!(
+                "let repo = Pg{pascal_name}Repository::from_shard(&db);\n    \
+                 let deleted = repo.delete_by_id(*id).await?;"
+            )
+        } else {
+            format!("let deleted = repo.delete_by_id(*id).await?;")
+        }
+    } else if soft_delete {
         // Filter on `deleted_at IS NULL` so deleting an already-soft-deleted row
         // affects zero rows and returns 404, matching the physical-delete path.
         format!(
@@ -523,27 +532,93 @@ fn render_routes_file(
                  .execute(&mut *db)\n        .await?;"
         )
     };
+
+    let create_stmt = if live {
+        if sharded {
+            format!(
+                "let repo = Pg{pascal_name}Repository::from_shard(&db);\n    \
+                 repo.save(&new).await?;"
+            )
+        } else {
+            format!("repo.save(&new).await?;")
+        }
+    } else {
+        format!(
+            "diesel::insert_into({plural}::table)\n        \
+             .values(&new)\n        \
+             .execute(&mut *db)\n        .await?;"
+        )
+    };
+
+    let update_changeset_expr = render_update_changeset_expr(pascal_name, fields);
+    let update_stmt = if live {
+        if sharded {
+            format!(
+                "let repo = Pg{pascal_name}Repository::from_shard(&db);\n    \
+                 let update_changes = {update_changeset_expr};\n    \
+                 repo.update(*id, &update_changes).await?;\n    \
+                 let updated = 1;"
+            )
+        } else {
+            format!(
+                "let update_changes = {update_changeset_expr};\n    \
+                 repo.update(*id, &update_changes).await?;\n    \
+                 let updated = 1;"
+            )
+        }
+    } else {
+        format!(
+            "let updated = diesel::update({plural}::table.find(*id))\n        \
+             .set(({update_columns}))\n        \
+             .execute(&mut *db)\n        .await?;"
+        )
+    };
+
     // Forms remain URL-encoded for compatibility with the generated handlers.
     // File uploads are handled separately via direct-upload URLs generated in
     // a CSRF-protected endpoint (see docs/guide/storage.md#direct-uploads).
     let form_enctype = "";
 
     let db_ty = if sharded { "ShardedDb" } else { "Db" };
+    let create_signature = if live && !sharded {
+        if has_attachments {
+            format!("flash: Flash, state: autumn_web::extract::State<autumn_web::AppState>, repo: Pg{pascal_name}Repository, body: Bytes")
+        } else {
+            format!("flash: Flash, repo: Pg{pascal_name}Repository, body: Bytes")
+        }
+    } else {
+        if has_attachments {
+            format!("flash: Flash, state: autumn_web::extract::State<autumn_web::AppState>, mut db: {db_ty}, body: Bytes")
+        } else {
+            format!("flash: Flash, mut db: {db_ty}, body: Bytes")
+        }
+    };
+
+    let update_signature = if live && !sharded {
+        if has_attachments {
+            format!("flash: Flash,\n    state: autumn_web::extract::State<autumn_web::AppState>,\n    id: Path<i64>,\n    repo: Pg{pascal_name}Repository,\n    body: Bytes,")
+        } else {
+            format!("flash: Flash,\n    id: Path<i64>,\n    repo: Pg{pascal_name}Repository,\n    body: Bytes,")
+        }
+    } else {
+        if has_attachments {
+            format!("flash: Flash,\n    state: autumn_web::extract::State<autumn_web::AppState>,\n    id: Path<i64>,\n    mut db: {db_ty},\n    body: Bytes,")
+        } else {
+            format!("flash: Flash,\n    id: Path<i64>,\n    mut db: {db_ty},\n    body: Bytes,")
+        }
+    };
+
     let (
-        create_signature,
+        _,
         decode_create_call,
-        update_signature,
+        _,
         decode_update_call,
         decode_form_sig,
     ) = if has_attachments {
         (
-            format!(
-                "flash: Flash, state: autumn_web::extract::State<autumn_web::AppState>, mut db: {db_ty}, body: Bytes"
-            ),
+            "",
             "decode_form(&state, body).await?".to_owned(),
-            format!(
-                "flash: Flash,\n    state: autumn_web::extract::State<autumn_web::AppState>,\n    id: Path<i64>,\n    mut db: {db_ty},\n    body: Bytes,"
-            ),
+            "",
             "decode_form(&state, body).await?".to_owned(),
             format!(
                 "async fn decode_form(state: &autumn_web::AppState, body: Bytes) -> AutumnResult<New{pascal_name}>"
@@ -551,12 +626,18 @@ fn render_routes_file(
         )
     } else {
         (
-            format!("flash: Flash, mut db: {db_ty}, body: Bytes"),
+            "",
             "decode_form(body)?".to_owned(),
-            format!("flash: Flash,\n    id: Path<i64>,\n    mut db: {db_ty},\n    body: Bytes,"),
+            "",
             "decode_form(body)?".to_owned(),
             format!("fn decode_form(body: Bytes) -> AutumnResult<New{pascal_name}>"),
         )
+    };
+
+    let destroy_signature_arg = if live && !sharded {
+        format!("repo: Pg{pascal_name}Repository")
+    } else {
+        format!("mut db: {db_ty}")
     };
 
     // The `index` handler: when sharded, use from_shard explicitly so the
@@ -573,7 +654,9 @@ fn render_routes_file(
     } else {
         (
             "ul".to_owned(),
-            r#"li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}"#.to_owned(),
+            format!(
+                r#"li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}"#
+            ),
         )
     };
 
@@ -660,7 +743,7 @@ use autumn_web::ui::pagination::{{PagerOptions, pagination_nav}};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
-use crate::models::{snake_name}::{{{pascal_name}, New{pascal_name}}};
+use crate::models::{snake_name}::{{{pascal_name}, New{pascal_name}, Update{pascal_name}}};
 use crate::repositories::{snake_name}::{{{pascal_name}Repository, Pg{pascal_name}Repository}};
 use crate::schema::{plural};",
         attachment_note = if has_attachments {
@@ -754,10 +837,7 @@ pub async fn new_form(
 #[post("/{plural}")]
 pub async fn create({create_signature}) -> AutumnResult<Markup> {{
     let new = {decode_create_call};
-    diesel::insert_into({plural}::table)
-        .values(&new)
-        .execute(&mut *db)
-        .await?;
+    {create_stmt}
     flash.success("{pascal_name} created").await;
     Ok(redirect_to("/{plural}"))
 }}
@@ -806,10 +886,7 @@ pub async fn update(
     {update_signature}
 ) -> AutumnResult<Markup> {{
     let form = {decode_update_call};
-    let updated = diesel::update({plural}::table.find(*id))
-        .set(({update_columns}))
-        .execute(&mut *db)
-        .await?;
+    {update_stmt}
     if updated == 0 {{
         return Err(AutumnError::not_found_msg(format!(
             "{pascal_name} with id {{}} not found", *id
@@ -828,7 +905,7 @@ pub async fn update(
 #[post("/{plural}/{{id}}/delete")]
 pub async fn destroy(
     id: Path<i64>,
-    mut db: {db_ty},
+    {destroy_signature_arg},
     flash: Flash,
 ) -> AutumnResult<Markup> {{
     {destroy_stmt}
@@ -1009,6 +1086,22 @@ fn render_update_columns(plural: &str, fields: &[Field]) -> String {
         )
         .unwrap();
     }
+    out
+}
+
+fn render_update_changeset_expr(pascal_name: &str, fields: &[Field]) -> String {
+    use std::fmt::Write;
+    let mut out = format!("Update{pascal_name} {{\n");
+    for f in fields {
+        let name = &f.name;
+        writeln!(
+            out,
+            "        {name}: Some(form.{name}.clone()),",
+            name = name
+        )
+        .unwrap();
+    }
+    out.push_str("    }");
     out
 }
 
@@ -1305,7 +1398,7 @@ async fn main() {
         plan.execute(Flags::default()).unwrap();
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
-        assert!(routes.contains("use crate::models::post::{Post, NewPost};"));
+        assert!(routes.contains("use crate::models::post::{Post, NewPost, UpdatePost};"));
         assert!(routes.contains("#[get(\"/posts\")]"));
         assert!(routes.contains("#[get(\"/posts/{id}\")]"));
         assert!(

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -11,12 +11,12 @@
 use std::path::Path;
 
 use super::dsl::{Field, FieldKind, IdType, parse_fields};
-use super::emit::Plan;
+use super::emit::{Action, Plan};
 use super::model::{
     ModelOptions, field_by_name, parse_model_metadata, plan_cargo_deps, plan_model_with_options,
 };
 use super::naming::{pascal, pluralize, snake};
-use super::schema_edit::{add_mod_declaration, update_main_rs};
+use super::schema_edit::{add_mod_declaration, ensure_autumn_web_feature, update_main_rs};
 use super::{Flags, GenerateError, ensure_project_root, timestamp_now};
 
 /// Extra dependencies the *scaffold* generator's output requires on top of
@@ -37,6 +37,8 @@ pub struct ScaffoldOptions {
     pub queries: Vec<String>,
     /// Scaffold a JSON-only API resource.
     pub api: bool,
+    /// Enable live auto-broadcasting using SSE and HTMX extensions.
+    pub live: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -107,6 +109,7 @@ pub fn plan_scaffold_with_options(
         model: model_options_with_key,
         queries: options.queries.clone(),
         api: options.api,
+        live: options.live,
     };
     let mut plan = plan_model_with_options(
         project_root,
@@ -137,6 +140,7 @@ pub fn plan_scaffold_with_options(
             options_with_key.model.soft_delete,
             options_with_key.api,
             options_with_key.model.sharded,
+            options_with_key.live,
         ),
     );
     let repo_mod_path = repos_dir.join("mod.rs");
@@ -157,6 +161,7 @@ pub fn plan_scaffold_with_options(
                 &form_fields,
                 options_with_key.model.sharded,
                 options_with_key.model.soft_delete,
+                options_with_key.live,
                 options_with_key.model.id_type,
             ),
         );
@@ -213,6 +218,33 @@ pub fn plan_scaffold_with_options(
         ));
     }
     plan_cargo_deps(&mut plan, project_root, &combined);
+
+    if options_with_key.live {
+        let cargo_toml_path = project_root.join("Cargo.toml");
+        let mut cargo_content = None;
+        for action in &mut plan.actions {
+            match action {
+                Action::Modify { path, contents } if path == &cargo_toml_path => {
+                    cargo_content = Some(contents);
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(contents) = cargo_content {
+            let with_ws = ensure_autumn_web_feature(contents, "ws");
+            let with_maud = ensure_autumn_web_feature(&with_ws, "maud");
+            *contents = with_maud;
+        } else {
+            let existing = read_or_empty(&cargo_toml_path);
+            let with_ws = ensure_autumn_web_feature(&existing, "ws");
+            let with_maud = ensure_autumn_web_feature(&with_ws, "maud");
+            if with_maud != existing {
+                plan.modify(cargo_toml_path, with_maud);
+            }
+        }
+    }
 
     Ok(plan)
 }
@@ -367,10 +399,12 @@ fn render_repository_file(
     soft_delete: bool,
     api: bool,
     sharded: bool,
+    live: bool,
 ) -> String {
     let plural = pluralize(snake_name);
     let query_body = render_repository_queries(pascal_name, queries);
     let soft_delete_attr = if soft_delete { ", soft_delete" } else { "" };
+    let broadcasts_attr = if live { ", broadcasts = true" } else { "" };
     let sharded_note = if sharded {
         format!(
             "//!\n\
@@ -418,7 +452,7 @@ fn render_repository_file(
          use crate::models::{snake_name}::{{{pascal_name}, New{pascal_name}, Update{pascal_name}}};\n\
          use crate::schema::{plural};\n\
          \n\
-         #[autumn_web::repository({pascal_name}, api = \"/api/{plural}\"{soft_delete_attr})]\n\
+         #[autumn_web::repository({pascal_name}, api = \"/api/{plural}\"{soft_delete_attr}{broadcasts_attr})]\n\
          pub trait {pascal_name}Repository {{\n\
 {query_body}\
          }}\n"
@@ -508,9 +542,15 @@ fn render_routes_file(
     fields: &[Field],
     sharded: bool,
     soft_delete: bool,
+    live: bool,
     id_type: IdType,
 ) -> String {
     let id_rust = id_type.rust_type();
+    let layout_head_scripts = if live {
+        "\n                script src=\"/static/js/htmx.min.js\" {}\n                script src=\"/static/js/sse.js\" {}"
+    } else {
+        ""
+    };
     let create_inputs = render_create_form_inputs(fields);
     let edit_inputs = render_edit_form_inputs(fields);
     let update_columns = render_update_columns(plural, fields);
@@ -520,7 +560,17 @@ fn render_routes_file(
     // The destroy handler must honour the resource's delete semantics: when the
     // scaffold was generated with `--soft-delete`, mark `deleted_at` (matching
     // the soft-delete repository) instead of issuing a physical `DELETE`.
-    let destroy_stmt = if soft_delete {
+    let destroy_stmt = if live {
+        if sharded {
+            format!(
+                "let repo = Pg{pascal_name}Repository::from_shard(&db);\n    \
+                 repo.delete_by_id(*id).await?;\n    \
+                 let deleted = 1;"
+            )
+        } else {
+            "repo.delete_by_id(*id).await?;\n    let deleted = 1;".to_owned()
+        }
+    } else if soft_delete {
         // Filter on `deleted_at IS NULL` so deleting an already-soft-deleted row
         // affects zero rows and returns 404, matching the physical-delete path.
         format!(
@@ -534,27 +584,103 @@ fn render_routes_file(
                  .execute(&mut *db)\n        .await?;"
         )
     };
+
+    let create_stmt = if live {
+        if sharded {
+            format!(
+                "let repo = Pg{pascal_name}Repository::from_shard(&db);\n    \
+                 repo.save(&new).await?;"
+            )
+        } else {
+            "repo.save(&new).await?;".to_owned()
+        }
+    } else {
+        format!(
+            "diesel::insert_into({plural}::table)\n        \
+             .values(&new)\n        \
+             .execute(&mut *db)\n        .await?;"
+        )
+    };
+
+    let update_changeset_expr = render_update_changeset_expr(pascal_name, fields);
+    let update_stmt = if live {
+        if sharded {
+            format!(
+                "let repo = Pg{pascal_name}Repository::from_shard(&db);\n    \
+                 let update_changes = {update_changeset_expr};\n    \
+                 repo.update(*id, &update_changes).await?;\n    \
+                 let updated = 1;"
+            )
+        } else {
+            format!(
+                "let update_changes = {update_changeset_expr};\n    \
+                 repo.update(*id, &update_changes).await?;\n    \
+                 let updated = 1;"
+            )
+        }
+    } else {
+        format!(
+            "let updated = diesel::update({plural}::table.find(*id))\n        \
+             .set(({update_columns}))\n        \
+             .execute(&mut *db)\n        .await?;"
+        )
+    };
+
     // Forms remain URL-encoded for compatibility with the generated handlers.
     // File uploads are handled separately via direct-upload URLs generated in
     // a CSRF-protected endpoint (see docs/guide/storage.md#direct-uploads).
     let form_enctype = "";
 
     let db_ty = if sharded { "ShardedDb" } else { "Db" };
-    let (
-        create_signature,
-        decode_create_call,
-        update_signature,
-        decode_update_call,
-        decode_form_sig,
-    ) = if has_attachments {
-        (
+    let create_signature = if live && !sharded {
+        if has_attachments {
+            format!(
+                "flash: Flash, state: autumn_web::extract::State<autumn_web::AppState>, repo: Pg{pascal_name}Repository, body: Bytes"
+            )
+        } else {
+            format!("flash: Flash, repo: Pg{pascal_name}Repository, body: Bytes")
+        }
+    } else {
+        if has_attachments {
             format!(
                 "flash: Flash, state: autumn_web::extract::State<autumn_web::AppState>, mut db: {db_ty}, body: Bytes"
-            ),
-            "decode_form(&state, body).await?".to_owned(),
+            )
+        } else {
+            format!("flash: Flash, mut db: {db_ty}, body: Bytes")
+        }
+    };
+
+    let update_signature = if live && !sharded {
+        if has_attachments {
+            format!(
+                "flash: Flash,\n    state: autumn_web::extract::State<autumn_web::AppState>,\n    id: Path<{id_rust}>,\n    repo: Pg{pascal_name}Repository,\n    body: Bytes,"
+            )
+        } else {
+            format!(
+                "flash: Flash,\n    id: Path<{id_rust}>,\n    repo: Pg{pascal_name}Repository,\n    body: Bytes,"
+            )
+        }
+    } else {
+        if has_attachments {
             format!(
                 "flash: Flash,\n    state: autumn_web::extract::State<autumn_web::AppState>,\n    id: Path<{id_rust}>,\n    mut db: {db_ty},\n    body: Bytes,"
-            ),
+            )
+        } else {
+            format!(
+                "flash: Flash,\n    id: Path<{id_rust}>,\n    mut db: {db_ty},\n    body: Bytes,"
+            )
+        }
+    };
+
+    let destroy_signature_arg = if live && !sharded {
+        format!("repo: Pg{pascal_name}Repository")
+    } else {
+        format!("mut db: {db_ty}")
+    };
+
+    let (decode_create_call, decode_update_call, decode_form_sig) = if has_attachments {
+        (
+            "decode_form(&state, body).await?".to_owned(),
             "decode_form(&state, body).await?".to_owned(),
             format!(
                 "async fn decode_form(state: &autumn_web::AppState, body: Bytes) -> AutumnResult<New{pascal_name}>"
@@ -562,11 +688,7 @@ fn render_routes_file(
         )
     } else {
         (
-            format!("flash: Flash, mut db: {db_ty}, body: Bytes"),
             "decode_form(body)?".to_owned(),
-            format!(
-                "flash: Flash,\n    id: Path<{id_rust}>,\n    mut db: {db_ty},\n    body: Bytes,"
-            ),
             "decode_form(body)?".to_owned(),
             format!("fn decode_form(body: Bytes) -> AutumnResult<New{pascal_name}>"),
         )
@@ -574,6 +696,22 @@ fn render_routes_file(
 
     // The `index` handler: when sharded, use from_shard explicitly so the
     // generated code shows the canonical sharding pattern.
+    let (ul_tag, li_render) = if live {
+        (
+            format!(
+                r#"ul id="{plural}-list" hx-ext="sse" sse-connect="/{plural}/events" sse-swap="message""#
+            ),
+            format!(
+                r#"li id=(format!("{snake_name}-{{}}", row.id)) {{ a href=(format!("/{plural}/{{}}", row.id)) {{ "{pascal_name} #{{}}" (row.id) }} }}"#
+            ),
+        )
+    } else {
+        (
+            "ul".to_owned(),
+            format!(r#"li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}"#),
+        )
+    };
+
     let index_handler = if sharded {
         format!(
             r#"/// `GET /{plural}` — paginated list of {snake_name}s.
@@ -592,9 +730,9 @@ pub async fn index(
     Ok(layout("{pascal_name} index", flash.render().await, html! {{
         h1 {{ "{pascal_name}s" }}
         a href="/{plural}/new" {{ "New {pascal_name}" }}
-        ul {{
+        {ul_tag} {{
             @for row in &page_data.content {{
-                li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}
+                {li_render}
             }}
         }}
         (pagination_nav(&page_data, &PagerOptions::new("/{plural}")))
@@ -618,9 +756,9 @@ pub async fn index(
     Ok(layout("{pascal_name} index", flash.render().await, html! {{
         h1 {{ "{pascal_name}s" }}
         a href="/{plural}/new" {{ "New {pascal_name}" }}
-        ul {{
+        {ul_tag} {{
             @for row in &page_data.content {{
-                li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}
+                {li_render}
             }}
         }}
         (pagination_nav(&page_data, &PagerOptions::new("/{plural}")))
@@ -657,7 +795,7 @@ use autumn_web::ui::pagination::{{PagerOptions, pagination_nav}};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
-use crate::models::{snake_name}::{{{pascal_name}, New{pascal_name}}};
+use crate::models::{snake_name}::{{{pascal_name}, New{pascal_name}, Update{pascal_name}}};
 use crate::repositories::{snake_name}::{{{pascal_name}Repository, Pg{pascal_name}Repository}};
 use crate::schema::{plural};",
         attachment_note = if has_attachments {
@@ -700,7 +838,7 @@ fn layout(title: &str, flash: Markup, content: Markup) -> Markup {{
             head {{
                 meta charset="utf-8";
                 title {{ (title) }}
-                link rel="stylesheet" href=(autumn_web::flash::FLASH_CSS_PATH);
+                link rel="stylesheet" href=(autumn_web::flash::FLASH_CSS_PATH);{layout_head_scripts}
             }}
             body {{
                 (flash)
@@ -751,10 +889,7 @@ pub async fn new_form(
 #[post("/{plural}")]
 pub async fn create({create_signature}) -> AutumnResult<Markup> {{
     let new = {decode_create_call};
-    diesel::insert_into({plural}::table)
-        .values(&new)
-        .execute(&mut *db)
-        .await?;
+    {create_stmt}
     flash.success("{pascal_name} created").await;
     Ok(redirect_to("/{plural}"))
 }}
@@ -803,10 +938,7 @@ pub async fn update(
     {update_signature}
 ) -> AutumnResult<Markup> {{
     let form = {decode_update_call};
-    let updated = diesel::update({plural}::table.find(*id))
-        .set(({update_columns}))
-        .execute(&mut *db)
-        .await?;
+    {update_stmt}
     if updated == 0 {{
         return Err(AutumnError::not_found_msg(format!(
             "{pascal_name} with id {{}} not found", *id
@@ -825,7 +957,7 @@ pub async fn update(
 #[post("/{plural}/{{id}}/delete")]
 pub async fn destroy(
     id: Path<{id_rust}>,
-    mut db: {db_ty},
+    {destroy_signature_arg},
     flash: Flash,
 ) -> AutumnResult<Markup> {{
     {destroy_stmt}
@@ -868,7 +1000,36 @@ fn redirect_to(url: &str) -> Markup {{
     }}
 }}
 "#
-    )
+    ) + &if live {
+        format!(
+            r#"
+
+/// `GET /{plural}/events` — Server-Sent Events stream for live updates.
+#[get("/{plural}/events")]
+pub async fn events(
+    state: autumn_web::extract::State<autumn_web::AppState>,
+) -> impl autumn_web::reexports::axum::response::IntoResponse {{
+    autumn_web::sse::stream(&state, "{plural}")
+}}"#
+        )
+    } else {
+        String::new()
+    }
+}
+
+fn render_update_changeset_expr(pascal_name: &str, fields: &[Field]) -> String {
+    use std::fmt::Write;
+    let mut out = format!("Update{pascal_name} {{\n");
+    for f in fields {
+        let name = &f.name;
+        writeln!(
+            out,
+            "        {name}: autumn_web::hooks::Patch::Set(form.{name}.clone()),"
+        )
+        .unwrap();
+    }
+    out.push_str("    }");
+    out
 }
 
 /// Whether any field in `fields` is a file attachment.
@@ -1298,7 +1459,7 @@ async fn main() {
         plan.execute(Flags::default()).unwrap();
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
-        assert!(routes.contains("use crate::models::post::{Post, NewPost};"));
+        assert!(routes.contains("use crate::models::post::{Post, NewPost, UpdatePost};"));
         assert!(routes.contains("#[get(\"/posts\")]"));
         assert!(routes.contains("#[get(\"/posts/{id}\")]"));
         assert!(
@@ -1923,7 +2084,7 @@ async fn main() {
 
     #[test]
     fn repository_notes_sharded() {
-        let rendered = render_repository_file("Account", "account", &[], false, false, true);
+        let rendered = render_repository_file("Account", "account", &[], false, false, true, false);
         assert!(
             rendered.contains("shard-aware"),
             "sharded repository doc must mention shard-aware: {rendered}"
@@ -1936,7 +2097,7 @@ async fn main() {
 
     #[test]
     fn repository_notes_api_sharded_caveat() {
-        let rendered = render_repository_file("Account", "account", &[], false, true, true);
+        let rendered = render_repository_file("Account", "account", &[], false, true, true, false);
         assert!(
             rendered.contains("control pool"),
             "sharded api repository doc must note control pool: {rendered}"
@@ -1945,7 +2106,7 @@ async fn main() {
 
     #[test]
     fn repository_no_sharded_note_when_not_sharded() {
-        let rendered = render_repository_file("Post", "post", &[], false, false, false);
+        let rendered = render_repository_file("Post", "post", &[], false, false, false, false);
         assert!(
             !rendered.contains("shard-aware"),
             "non-sharded repository must not mention shard-aware: {rendered}"
@@ -1972,5 +2133,42 @@ async fn main() {
         assert!(test_file.contains("/api/posts"));
         assert!(test_file.contains("DELETE"));
         assert!(!test_file.contains("contains(\"Posts\")"));
+    }
+
+    #[test]
+    fn plan_scaffold_live_views() {
+        let tmp = project_with_main(default_main());
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"x\"\n\n[dependencies]\nautumn-web = \"0.5.0\"\n",
+        )
+        .unwrap();
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260427000000",
+            &ScaffoldOptions {
+                live: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(routes.contains("/posts/events"));
+        assert!(routes.contains("autumn_web::sse::stream"));
+        assert!(routes.contains("hx-ext=\"sse\""));
+        assert!(routes.contains("sse-connect=\"/posts/events\""));
+        assert!(routes.contains("script src=\"/static/js/htmx.min.js\""));
+        assert!(routes.contains("script src=\"/static/js/sse.js\""));
+        assert!(routes.contains("title: autumn_web::hooks::Patch::Set(form.title.clone())"));
+
+        let repo = fs::read_to_string(tmp.path().join("src/repositories/post.rs")).unwrap();
+        assert!(repo.contains("broadcasts = true"));
+
+        let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert!(cargo.contains("\"ws\""));
+        assert!(cargo.contains("\"maud\""));
     }
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -582,13 +582,17 @@ fn render_routes_file(
     let db_ty = if sharded { "ShardedDb" } else { "Db" };
     let create_signature = if live && !sharded {
         if has_attachments {
-            format!("flash: Flash, state: autumn_web::extract::State<autumn_web::AppState>, repo: Pg{pascal_name}Repository, body: Bytes")
+            format!(
+                "flash: Flash, state: autumn_web::extract::State<autumn_web::AppState>, repo: Pg{pascal_name}Repository, body: Bytes"
+            )
         } else {
             format!("flash: Flash, repo: Pg{pascal_name}Repository, body: Bytes")
         }
     } else {
         if has_attachments {
-            format!("flash: Flash, state: autumn_web::extract::State<autumn_web::AppState>, mut db: {db_ty}, body: Bytes")
+            format!(
+                "flash: Flash, state: autumn_web::extract::State<autumn_web::AppState>, mut db: {db_ty}, body: Bytes"
+            )
         } else {
             format!("flash: Flash, mut db: {db_ty}, body: Bytes")
         }
@@ -596,25 +600,25 @@ fn render_routes_file(
 
     let update_signature = if live && !sharded {
         if has_attachments {
-            format!("flash: Flash,\n    state: autumn_web::extract::State<autumn_web::AppState>,\n    id: Path<i64>,\n    repo: Pg{pascal_name}Repository,\n    body: Bytes,")
+            format!(
+                "flash: Flash,\n    state: autumn_web::extract::State<autumn_web::AppState>,\n    id: Path<i64>,\n    repo: Pg{pascal_name}Repository,\n    body: Bytes,"
+            )
         } else {
-            format!("flash: Flash,\n    id: Path<i64>,\n    repo: Pg{pascal_name}Repository,\n    body: Bytes,")
+            format!(
+                "flash: Flash,\n    id: Path<i64>,\n    repo: Pg{pascal_name}Repository,\n    body: Bytes,"
+            )
         }
     } else {
         if has_attachments {
-            format!("flash: Flash,\n    state: autumn_web::extract::State<autumn_web::AppState>,\n    id: Path<i64>,\n    mut db: {db_ty},\n    body: Bytes,")
+            format!(
+                "flash: Flash,\n    state: autumn_web::extract::State<autumn_web::AppState>,\n    id: Path<i64>,\n    mut db: {db_ty},\n    body: Bytes,"
+            )
         } else {
             format!("flash: Flash,\n    id: Path<i64>,\n    mut db: {db_ty},\n    body: Bytes,")
         }
     };
 
-    let (
-        _,
-        decode_create_call,
-        _,
-        decode_update_call,
-        decode_form_sig,
-    ) = if has_attachments {
+    let (_, decode_create_call, _, decode_update_call, decode_form_sig) = if has_attachments {
         (
             "",
             "decode_form(&state, body).await?".to_owned(),
@@ -654,9 +658,7 @@ fn render_routes_file(
     } else {
         (
             "ul".to_owned(),
-            format!(
-                r#"li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}"#
-            ),
+            format!(r#"li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}"#),
         )
     };
 

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2184,7 +2184,7 @@ async fn main() {
         assert!(routes.contains("sse-connect=\"/posts/events\""));
         assert!(routes.contains("hx-swap=\"none\""));
         assert!(routes.contains("script src=\"/static/js/htmx.min.js\""));
-        assert!(routes.contains("script src=\"/static/js/htmx-ext-sse.min.js\""));
+        assert!(routes.contains("script src=\"/static/js/sse.js\""));
         assert!(routes.contains("title: autumn_web::hooks::Patch::Set(form.title.clone())"));
 
         let main_rs = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -555,7 +555,7 @@ fn render_routes_file(
 ) -> String {
     let id_rust = id_type.rust_type();
     let layout_head_scripts = if live {
-        "\n                script src=\"/static/js/htmx.min.js\" {}\n                script src=\"/static/js/sse.js\" {}"
+        "\n                script src=\"/static/js/htmx.min.js\" {}\n                script src=\"/static/js/htmx-ext-sse.min.js\" {}"
     } else {
         ""
     };
@@ -704,19 +704,37 @@ fn render_routes_file(
 
     // The `index` handler: when sharded, use from_shard explicitly so the
     // generated code shows the canonical sharding pattern.
-    let (ul_tag, li_render) = if live {
-        (
-            format!(
-                r#"ul id="{plural}-list" hx-ext="sse" sse-connect="/{plural}/events" sse-swap="message" hx-swap="none""#
-            ),
-            format!(
-                r#"li id=(format!("{snake_name}-{{}}", row.id)) {{ a href=(format!("/{plural}/{{}}", row.id)) {{ "{pascal_name} #{{}}" (row.id) }} }}"#
-            ),
+    let li_render = if live {
+        format!(
+            r#"li id=(format!("{snake_name}-{{}}", row.id)) {{ a href=(format!("/{plural}/{{}}", row.id)) {{ "{pascal_name} #{{}}" (row.id) }} }}"#
         )
     } else {
-        (
-            "ul".to_owned(),
-            format!(r#"li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}"#),
+        format!(r#"li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}"#)
+    };
+
+    let ul_list_render = if live {
+        format!(
+            r#"@if page_req.page() == 1 {{
+            ul id="{plural}-list" hx-ext="sse" sse-connect="/{plural}/events" sse-swap="message" hx-swap="none" {{
+                @for row in &page_data.content {{
+                    {li_render}
+                }}
+            }}
+        }} @else {{
+            ul id="{plural}-list" {{
+                @for row in &page_data.content {{
+                    {li_render}
+                }}
+            }}
+        }}"#
+        )
+    } else {
+        format!(
+            r#"ul id="{plural}-list" {{
+            @for row in &page_data.content {{
+                {li_render}
+            }}
+        }}"#
         )
     };
 
@@ -738,11 +756,7 @@ pub async fn index(
     Ok(layout("{pascal_name} index", flash.render().await, html! {{
         h1 {{ "{pascal_name}s" }}
         a href="/{plural}/new" {{ "New {pascal_name}" }}
-        {ul_tag} {{
-            @for row in &page_data.content {{
-                {li_render}
-            }}
-        }}
+        {ul_list_render}
         (pagination_nav(&page_data, &PagerOptions::new("/{plural}")))
     }}))
 }}"#
@@ -764,11 +778,7 @@ pub async fn index(
     Ok(layout("{pascal_name} index", flash.render().await, html! {{
         h1 {{ "{pascal_name}s" }}
         a href="/{plural}/new" {{ "New {pascal_name}" }}
-        {ul_tag} {{
-            @for row in &page_data.content {{
-                {li_render}
-            }}
-        }}
+        {ul_list_render}
         (pagination_nav(&page_data, &PagerOptions::new("/{plural}")))
     }}))
 }}"#
@@ -2174,7 +2184,7 @@ async fn main() {
         assert!(routes.contains("sse-connect=\"/posts/events\""));
         assert!(routes.contains("hx-swap=\"none\""));
         assert!(routes.contains("script src=\"/static/js/htmx.min.js\""));
-        assert!(routes.contains("script src=\"/static/js/sse.js\""));
+        assert!(routes.contains("script src=\"/static/js/htmx-ext-sse.min.js\""));
         assert!(routes.contains("title: autumn_web::hooks::Patch::Set(form.title.clone())"));
 
         let main_rs = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -399,6 +399,7 @@ pub(super) fn render_repository_for_pull(
     )
 }
 
+#[allow(clippy::fn_params_excessive_bools)]
 fn render_repository_file(
     pascal_name: &str,
     snake_name: &str,

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -706,7 +706,7 @@ fn render_routes_file(
     let (ul_tag, li_render) = if live {
         (
             format!(
-                r#"ul id="{plural}-list" hx-ext="sse" sse-connect="/{plural}/events" sse-swap="message""#
+                r#"ul id="{plural}-list" hx-ext="sse" sse-connect="/{plural}/events" sse-swap="message" hx-swap="none""#
             ),
             format!(
                 r#"li id=(format!("{snake_name}-{{}}", row.id)) {{ a href=(format!("/{plural}/{{}}", row.id)) {{ "{pascal_name} #{{}}" (row.id) }} }}"#
@@ -2171,6 +2171,7 @@ async fn main() {
         assert!(routes.contains("autumn_web::sse::stream"));
         assert!(routes.contains("hx-ext=\"sse\""));
         assert!(routes.contains("sse-connect=\"/posts/events\""));
+        assert!(routes.contains("hx-swap=\"none\""));
         assert!(routes.contains("script src=\"/static/js/htmx.min.js\""));
         assert!(routes.contains("script src=\"/static/js/sse.js\""));
         assert!(routes.contains("title: autumn_web::hooks::Patch::Set(form.title.clone())"));

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -11,12 +11,12 @@
 use std::path::Path;
 
 use super::dsl::{Field, FieldKind, parse_fields};
-use super::emit::Plan;
+use super::emit::{Action, Plan};
 use super::model::{
     ModelOptions, field_by_name, parse_model_metadata, plan_cargo_deps, plan_model_with_options,
 };
 use super::naming::{pascal, pluralize, snake};
-use super::schema_edit::{add_mod_declaration, update_main_rs};
+use super::schema_edit::{add_mod_declaration, ensure_autumn_web_feature, update_main_rs};
 use super::{Flags, GenerateError, ensure_project_root, timestamp_now};
 
 /// Extra dependencies the *scaffold* generator's output requires on top of
@@ -201,6 +201,33 @@ pub fn plan_scaffold_with_options(
         ));
     }
     plan_cargo_deps(&mut plan, project_root, &combined);
+
+    if options_with_key.live {
+        let cargo_toml_path = project_root.join("Cargo.toml");
+        let mut cargo_content = None;
+        for action in &mut plan.actions {
+            match action {
+                Action::Modify { path, contents } if path == &cargo_toml_path => {
+                    cargo_content = Some(contents);
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(contents) = cargo_content {
+            let with_ws = ensure_autumn_web_feature(contents, "ws");
+            let with_maud = ensure_autumn_web_feature(&with_ws, "maud");
+            *contents = with_maud;
+        } else {
+            let existing = read_or_empty(&cargo_toml_path);
+            let with_ws = ensure_autumn_web_feature(&existing, "ws");
+            let with_maud = ensure_autumn_web_feature(&with_ws, "maud");
+            if with_maud != existing {
+                plan.modify(cargo_toml_path, with_maud);
+            }
+        }
+    }
 
     Ok(plan)
 }
@@ -500,6 +527,11 @@ fn render_routes_file(
     soft_delete: bool,
     live: bool,
 ) -> String {
+    let layout_head_scripts = if live {
+        "\n                script src=\"/static/js/htmx.min.js\" {}\n                script src=\"https://unpkg.com/htmx-ext-sse@2.2.2/sse.js\" {}"
+    } else {
+        ""
+    };
     let create_inputs = render_create_form_inputs(fields);
     let edit_inputs = render_edit_form_inputs(fields);
     let update_columns = render_update_columns(plural, fields);
@@ -516,7 +548,7 @@ fn render_routes_file(
                  let deleted = repo.delete_by_id(*id).await?;"
             )
         } else {
-            format!("let deleted = repo.delete_by_id(*id).await?;")
+            "let deleted = repo.delete_by_id(*id).await?;".to_owned()
         }
     } else if soft_delete {
         // Filter on `deleted_at IS NULL` so deleting an already-soft-deleted row
@@ -540,7 +572,7 @@ fn render_routes_file(
                  repo.save(&new).await?;"
             )
         } else {
-            format!("repo.save(&new).await?;")
+            "repo.save(&new).await?;".to_owned()
         }
     } else {
         format!(
@@ -788,7 +820,7 @@ fn layout(title: &str, flash: Markup, content: Markup) -> Markup {{
             head {{
                 meta charset="utf-8";
                 title {{ (title) }}
-                link rel="stylesheet" href=(autumn_web::flash::FLASH_CSS_PATH);
+                link rel="stylesheet" href=(autumn_web::flash::FLASH_CSS_PATH);{layout_head_scripts}
             }}
             body {{
                 (flash)
@@ -1098,8 +1130,7 @@ fn render_update_changeset_expr(pascal_name: &str, fields: &[Field]) -> String {
         let name = &f.name;
         writeln!(
             out,
-            "        {name}: Some(form.{name}.clone()),",
-            name = name
+            "        {name}: autumn_web::hooks::Patch::Set(form.{name}.clone()),"
         )
         .unwrap();
     }
@@ -1310,7 +1341,11 @@ mod tests {
 
     fn project_with_main(template: &str) -> TempDir {
         let tmp = TempDir::new().unwrap();
-        fs::write(tmp.path().join("Cargo.toml"), "[package]\nname=\"x\"\n").unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"x\"\n\n[dependencies]\nautumn-web = \"0.5.0\"\n",
+        )
+        .unwrap();
         fs::create_dir_all(tmp.path().join("src")).unwrap();
         fs::write(tmp.path().join("src/main.rs"), template).unwrap();
         tmp
@@ -2096,8 +2131,15 @@ async fn main() {
         assert!(routes.contains("autumn_web::sse::stream"));
         assert!(routes.contains("hx-ext=\"sse\""));
         assert!(routes.contains("sse-connect=\"/posts/events\""));
+        assert!(routes.contains("script src=\"/static/js/htmx.min.js\""));
+        assert!(routes.contains("script src=\"https://unpkg.com/htmx-ext-sse@2.2.2/sse.js\""));
+        assert!(routes.contains("title: autumn_web::hooks::Patch::Set(form.title.clone())"));
 
         let repo = fs::read_to_string(tmp.path().join("src/repositories/post.rs")).unwrap();
         assert!(repo.contains("broadcasts = true"));
+
+        let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert!(cargo.contains("\"ws\""));
+        assert!(cargo.contains("\"maud\""));
     }
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -37,6 +37,8 @@ pub struct ScaffoldOptions {
     pub queries: Vec<String>,
     /// Scaffold a JSON-only API resource.
     pub api: bool,
+    /// Enable live auto-broadcasting using SSE and HTMX extensions.
+    pub live: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -92,6 +94,7 @@ pub fn plan_scaffold_with_options(
         model: model_options_with_key,
         queries: options.queries.clone(),
         api: options.api,
+        live: options.live,
     };
     let mut plan = plan_model_with_options(
         project_root,
@@ -122,6 +125,7 @@ pub fn plan_scaffold_with_options(
             options_with_key.model.soft_delete,
             options_with_key.api,
             options_with_key.model.sharded,
+            options_with_key.live,
         ),
     );
     let repo_mod_path = repos_dir.join("mod.rs");
@@ -142,6 +146,7 @@ pub fn plan_scaffold_with_options(
                 &form_fields,
                 options_with_key.model.sharded,
                 options_with_key.model.soft_delete,
+                options_with_key.live,
             ),
         );
         let route_mod_path = routes_dir.join("mod.rs");
@@ -165,7 +170,12 @@ pub fn plan_scaffold_with_options(
             format!("missing {}", main_path.display()),
         ))
     })?;
-    let route_entries = main_route_entries(&plural, &snake_name, options_with_key.api);
+    let route_entries = main_route_entries(
+        &plural,
+        &snake_name,
+        options_with_key.api,
+        options_with_key.live,
+    );
     let mut mods = vec!["models", "schema", "repositories"];
     if !options_with_key.api {
         mods.push("routes");
@@ -345,10 +355,12 @@ fn render_repository_file(
     soft_delete: bool,
     api: bool,
     sharded: bool,
+    live: bool,
 ) -> String {
     let plural = pluralize(snake_name);
     let query_body = render_repository_queries(pascal_name, queries);
     let soft_delete_attr = if soft_delete { ", soft_delete" } else { "" };
+    let live_attr = if live { ", broadcasts = true" } else { "" };
     let sharded_note = if sharded {
         format!(
             "//!\n\
@@ -396,7 +408,7 @@ fn render_repository_file(
          use crate::models::{snake_name}::{{{pascal_name}, New{pascal_name}, Update{pascal_name}}};\n\
          use crate::schema::{plural};\n\
          \n\
-         #[autumn_web::repository({pascal_name}, api = \"/api/{plural}\"{soft_delete_attr})]\n\
+         #[autumn_web::repository({pascal_name}, api = \"/api/{plural}\"{soft_delete_attr}{live_attr})]\n\
          pub trait {pascal_name}Repository {{\n\
 {query_body}\
          }}\n"
@@ -486,6 +498,7 @@ fn render_routes_file(
     fields: &[Field],
     sharded: bool,
     soft_delete: bool,
+    live: bool,
 ) -> String {
     let create_inputs = render_create_form_inputs(fields);
     let edit_inputs = render_edit_form_inputs(fields);
@@ -548,6 +561,22 @@ fn render_routes_file(
 
     // The `index` handler: when sharded, use from_shard explicitly so the
     // generated code shows the canonical sharding pattern.
+    let (ul_tag, li_render) = if live {
+        (
+            format!(
+                r#"ul id="{plural}-list" hx-ext="sse" sse-connect="/{plural}/events" sse-swap="message""#
+            ),
+            format!(
+                r#"li id=(format!("{snake_name}-{{}}", row.id)) {{ a href=(format!("/{plural}/{{}}", row.id)) {{ "{pascal_name} #{{}}" (row.id) }} }}"#
+            ),
+        )
+    } else {
+        (
+            "ul".to_owned(),
+            r#"li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}"#.to_owned(),
+        )
+    };
+
     let index_handler = if sharded {
         format!(
             r#"/// `GET /{plural}` — paginated list of {snake_name}s.
@@ -566,9 +595,9 @@ pub async fn index(
     Ok(layout("{pascal_name} index", flash.render().await, html! {{
         h1 {{ "{pascal_name}s" }}
         a href="/{plural}/new" {{ "New {pascal_name}" }}
-        ul {{
+        {ul_tag} {{
             @for row in &page_data.content {{
-                li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}
+                {li_render}
             }}
         }}
         (pagination_nav(&page_data, &PagerOptions::new("/{plural}")))
@@ -592,9 +621,9 @@ pub async fn index(
     Ok(layout("{pascal_name} index", flash.render().await, html! {{
         h1 {{ "{pascal_name}s" }}
         a href="/{plural}/new" {{ "New {pascal_name}" }}
-        ul {{
+        {ul_tag} {{
             @for row in &page_data.content {{
-                li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}
+                {li_render}
             }}
         }}
         (pagination_nav(&page_data, &PagerOptions::new("/{plural}")))
@@ -842,7 +871,21 @@ fn redirect_to(url: &str) -> Markup {{
     }}
 }}
 "#
-    )
+    ) + &if live {
+        format!(
+            r#"
+
+/// `GET /{plural}/events` — Server-Sent Events stream for live updates.
+#[get("/{plural}/events")]
+pub async fn events(
+    state: autumn_web::extract::State<autumn_web::AppState>,
+) -> impl autumn_web::reexports::axum::response::IntoResponse {{
+    autumn_web::sse::stream(&state, "{plural}")
+}}"#
+        )
+    } else {
+        String::new()
+    }
 }
 
 /// Whether any field in `fields` is a file attachment.
@@ -1136,7 +1179,7 @@ fn render_smoke_test(pascal_name: &str, plural: &str, api: bool, fields: &[Field
     }
 }
 
-fn main_route_entries(plural: &str, snake_name: &str, api: bool) -> Vec<String> {
+fn main_route_entries(plural: &str, snake_name: &str, api: bool, live: bool) -> Vec<String> {
     if api {
         vec![
             format!("repositories::{snake_name}::{snake_name}_api_list"),
@@ -1146,7 +1189,7 @@ fn main_route_entries(plural: &str, snake_name: &str, api: bool) -> Vec<String> 
             format!("repositories::{snake_name}::{snake_name}_api_delete"),
         ]
     } else {
-        vec![
+        let mut entries = vec![
             format!("routes::{plural}::index"),
             format!("routes::{plural}::show"),
             format!("routes::{plural}::new_form"),
@@ -1156,7 +1199,11 @@ fn main_route_entries(plural: &str, snake_name: &str, api: bool) -> Vec<String> 
             format!("routes::{plural}::destroy"),
             format!("repositories::{snake_name}::{snake_name}_api_list"),
             format!("repositories::{snake_name}::{snake_name}_api_get"),
-        ]
+        ];
+        if live {
+            entries.push(format!("routes::{plural}::events"));
+        }
+        entries
     }
 }
 
@@ -1883,7 +1930,7 @@ async fn main() {
 
     #[test]
     fn repository_notes_sharded() {
-        let rendered = render_repository_file("Account", "account", &[], false, false, true);
+        let rendered = render_repository_file("Account", "account", &[], false, false, true, false);
         assert!(
             rendered.contains("shard-aware"),
             "sharded repository doc must mention shard-aware: {rendered}"
@@ -1896,7 +1943,7 @@ async fn main() {
 
     #[test]
     fn repository_notes_api_sharded_caveat() {
-        let rendered = render_repository_file("Account", "account", &[], false, true, true);
+        let rendered = render_repository_file("Account", "account", &[], false, true, true, false);
         assert!(
             rendered.contains("control pool"),
             "sharded api repository doc must note control pool: {rendered}"
@@ -1905,7 +1952,7 @@ async fn main() {
 
     #[test]
     fn repository_no_sharded_note_when_not_sharded() {
-        let rendered = render_repository_file("Post", "post", &[], false, false, false);
+        let rendered = render_repository_file("Post", "post", &[], false, false, false, false);
         assert!(
             !rendered.contains("shard-aware"),
             "non-sharded repository must not mention shard-aware: {rendered}"
@@ -1932,5 +1979,30 @@ async fn main() {
         assert!(test_file.contains("/api/posts"));
         assert!(test_file.contains("DELETE"));
         assert!(!test_file.contains("contains(\"Posts\")"));
+    }
+
+    #[test]
+    fn plan_scaffold_live_views() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260427000000",
+            &ScaffoldOptions {
+                live: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(routes.contains("/posts/events"));
+        assert!(routes.contains("autumn_web::sse::stream"));
+        assert!(routes.contains("hx-ext=\"sse\""));
+        assert!(routes.contains("sse-connect=\"/posts/events\""));
+
+        let repo = fs::read_to_string(tmp.path().join("src/repositories/post.rs")).unwrap();
+        assert!(repo.contains("broadcasts = true"));
     }
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -192,7 +192,12 @@ pub fn plan_scaffold_with_options(
             format!("missing {}", main_path.display()),
         ))
     })?;
-    let route_entries = main_route_entries(&plural, &snake_name, options_with_key.api);
+    let route_entries = main_route_entries(
+        &plural,
+        &snake_name,
+        options_with_key.api,
+        options_with_key.live,
+    );
     let mut mods = vec!["models", "schema", "repositories"];
     if !options_with_key.api {
         mods.push("routes");
@@ -1337,7 +1342,7 @@ fn render_smoke_test(
     }
 }
 
-fn main_route_entries(plural: &str, snake_name: &str, api: bool) -> Vec<String> {
+fn main_route_entries(plural: &str, snake_name: &str, api: bool, live: bool) -> Vec<String> {
     if api {
         vec![
             format!("repositories::{snake_name}::{snake_name}_api_list"),
@@ -1347,7 +1352,7 @@ fn main_route_entries(plural: &str, snake_name: &str, api: bool) -> Vec<String> 
             format!("repositories::{snake_name}::{snake_name}_api_delete"),
         ]
     } else {
-        vec![
+        let mut entries = vec![
             format!("routes::{plural}::index"),
             format!("routes::{plural}::show"),
             format!("routes::{plural}::new_form"),
@@ -1355,9 +1360,13 @@ fn main_route_entries(plural: &str, snake_name: &str, api: bool) -> Vec<String> 
             format!("routes::{plural}::edit_form"),
             format!("routes::{plural}::update"),
             format!("routes::{plural}::destroy"),
-            format!("repositories::{snake_name}::{snake_name}_api_list"),
-            format!("repositories::{snake_name}::{snake_name}_api_get"),
-        ]
+        ];
+        if live {
+            entries.push(format!("routes::{plural}::events"));
+        }
+        entries.push(format!("repositories::{snake_name}::{snake_name}_api_list"));
+        entries.push(format!("repositories::{snake_name}::{snake_name}_api_get"));
+        entries
     }
 }
 
@@ -2163,6 +2172,9 @@ async fn main() {
         assert!(routes.contains("script src=\"/static/js/htmx.min.js\""));
         assert!(routes.contains("script src=\"/static/js/sse.js\""));
         assert!(routes.contains("title: autumn_web::hooks::Patch::Set(form.title.clone())"));
+
+        let main_rs = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(main_rs.contains("routes::posts::events"));
 
         let repo = fs::read_to_string(tmp.path().join("src/repositories/post.rs")).unwrap();
         assert!(repo.contains("broadcasts = true"));

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1619,6 +1619,9 @@ enum GenerateCommands {
         /// Defaults to `tenant_id` if that field is present, otherwise `id`.
         #[arg(long, value_name = "FIELD")]
         shard_key: Option<String>,
+        /// Auto-broadcast model mutations to live HTMX views.
+        #[arg(long)]
+        live: bool,
         /// Print the file plan and exit without writing anything.
         #[arg(long)]
         dry_run: bool,
@@ -2427,6 +2430,7 @@ fn run_generate_command(cmd: GenerateCommands) {
             api,
             sharded,
             shard_key,
+            live,
             dry_run,
             force,
         } => {
@@ -2459,6 +2463,7 @@ fn run_generate_command(cmd: GenerateCommands) {
                 api,
                 sharded,
                 shard_key.as_deref(),
+                live,
             );
             generate::scaffold::run(&name, &fields, generate::Flags { dry_run, force }, &options);
         }

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -306,6 +306,13 @@ fn scaffold_vendor_assets(project_dir: &Path) -> Result<(), NewError> {
 
     fs::write(project_dir.join("static").join(htmx_file), htmx_bytes)?;
 
+    let sse_bytes = autumn_web::HTMX_SSE_JS;
+    let sse_source = "https://unpkg.com/htmx-ext-sse@2.2.2/sse.js".to_owned();
+    let sse_file = "js/sse.js";
+    let sse_integrity = crate::assets::compute_sri(sse_bytes);
+
+    fs::write(project_dir.join("static").join(sse_file), sse_bytes)?;
+
     let mut assets = std::collections::BTreeMap::new();
     assets.insert(
         "htmx".to_owned(),
@@ -314,6 +321,15 @@ fn scaffold_vendor_assets(project_dir: &Path) -> Result<(), NewError> {
             source: htmx_source,
             file: htmx_file.to_owned(),
             integrity,
+        },
+    );
+    assets.insert(
+        "sse".to_owned(),
+        crate::assets::VendorAsset {
+            version: "2.2.2".to_owned(),
+            source: sse_source,
+            file: sse_file.to_owned(),
+            integrity: sse_integrity,
         },
     );
     let manifest = crate::assets::VendorManifest {
@@ -1392,6 +1408,19 @@ mod tests {
             integrity.starts_with("sha384-"),
             "htmx integrity must be a sha384 SRI hash: {integrity}"
         );
+
+        let sse = &manifest["assets"]["sse"];
+        assert!(!sse.is_null(), "manifest must contain an sse entry");
+        assert!(
+            sse["version"].as_str().unwrap_or("").contains('.'),
+            "sse version must look like a semver: {}",
+            sse["version"]
+        );
+        let sse_integrity = sse["integrity"].as_str().unwrap_or("");
+        assert!(
+            sse_integrity.starts_with("sha384-"),
+            "sse integrity must be a sha384 SRI hash: {sse_integrity}"
+        );
     }
 
     #[test]
@@ -1410,6 +1439,15 @@ mod tests {
         assert_eq!(
             computed, recorded,
             "SRI hash in manifest must match the vendored htmx.min.js"
+        );
+
+        let sse_bytes = fs::read(p.join("static/js/sse.js")).unwrap();
+        let computed_sse = crate::assets::compute_sri(&sse_bytes);
+        let recorded_sse = manifest["assets"]["sse"]["integrity"].as_str().unwrap();
+
+        assert_eq!(
+            computed_sse, recorded_sse,
+            "SRI hash in manifest must match the vendored sse.js"
         );
     }
 

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -308,7 +308,7 @@ fn scaffold_vendor_assets(project_dir: &Path) -> Result<(), NewError> {
 
     let sse_bytes = autumn_web::HTMX_SSE_JS;
     let sse_source = "https://unpkg.com/htmx-ext-sse@2.2.2/sse.js".to_owned();
-    let sse_file = "js/sse.js";
+    let sse_file = "js/htmx-ext-sse.min.js";
     let sse_integrity = crate::assets::compute_sri(sse_bytes);
 
     fs::write(project_dir.join("static").join(sse_file), sse_bytes)?;
@@ -324,7 +324,7 @@ fn scaffold_vendor_assets(project_dir: &Path) -> Result<(), NewError> {
         },
     );
     assets.insert(
-        "sse".to_owned(),
+        "htmx-ext-sse".to_owned(),
         crate::assets::VendorAsset {
             version: "2.2.2".to_owned(),
             source: sse_source,
@@ -1409,17 +1409,20 @@ mod tests {
             "htmx integrity must be a sha384 SRI hash: {integrity}"
         );
 
-        let sse = &manifest["assets"]["sse"];
-        assert!(!sse.is_null(), "manifest must contain an sse entry");
+        let sse = &manifest["assets"]["htmx-ext-sse"];
+        assert!(
+            !sse.is_null(),
+            "manifest must contain an htmx-ext-sse entry"
+        );
         assert!(
             sse["version"].as_str().unwrap_or("").contains('.'),
-            "sse version must look like a semver: {}",
+            "htmx-ext-sse version must look like a semver: {}",
             sse["version"]
         );
         let sse_integrity = sse["integrity"].as_str().unwrap_or("");
         assert!(
             sse_integrity.starts_with("sha384-"),
-            "sse integrity must be a sha384 SRI hash: {sse_integrity}"
+            "htmx-ext-sse integrity must be a sha384 SRI hash: {sse_integrity}"
         );
     }
 
@@ -1441,13 +1444,15 @@ mod tests {
             "SRI hash in manifest must match the vendored htmx.min.js"
         );
 
-        let sse_bytes = fs::read(p.join("static/js/sse.js")).unwrap();
+        let sse_bytes = fs::read(p.join("static/js/htmx-ext-sse.min.js")).unwrap();
         let computed_sse = crate::assets::compute_sri(&sse_bytes);
-        let recorded_sse = manifest["assets"]["sse"]["integrity"].as_str().unwrap();
+        let recorded_sse = manifest["assets"]["htmx-ext-sse"]["integrity"]
+            .as_str()
+            .unwrap();
 
         assert_eq!(
             computed_sse, recorded_sse,
-            "SRI hash in manifest must match the vendored sse.js"
+            "SRI hash in manifest must match the vendored htmx-ext-sse.min.js"
         );
     }
 

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -2156,6 +2156,15 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         panic!("#[model]: could not detect primary-key field for factory generation")
     });
 
+    let model_primary_key_impl = quote! {
+        impl ::autumn_web::repository::ModelPrimaryKey for #name {
+            type IdType = #pk_ty;
+            fn primary_key_value(&self) -> Self::IdType {
+                ::core::clone::Clone::clone(&self.#pk_id)
+            }
+        }
+    };
+
     // Whether any factory field is an association (drives depth-check generation).
     let has_assoc_fields = fields_for_new
         .iter()
@@ -2823,6 +2832,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         #can_set_tenant_id_impl
         #model_tenant_id_meta_impl
+        #model_primary_key_impl
 
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #vis enum #field_enum_name {

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1453,11 +1453,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             .get("__autumn_previous_id")
                             .and_then(|__v| __v.as_str());
 
+                        let mut __topic_changed = false;
                         if let ::core::option::Option::Some(__prev_topic) = __ctx_val
                             .get("__autumn_previous_topic")
                             .and_then(|__v| __v.as_str())
                         {
                             if __prev_topic != __topic {
+                                __topic_changed = true;
                                 let __delete_id = __prev_id.unwrap_or(&__id);
                                 let __delete_fragment = ::autumn_web::html! {};
                                 if let ::core::result::Result::Err(__err) = __channels
@@ -1469,22 +1471,27 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             }
                         }
 
-                        let __swap_strategy = if let ::core::option::Option::Some(__prev_id_val) = __prev_id {
-                            if __prev_id_val != &__id {
-                                ::autumn_web::htmx::OobSwap::Target(
-                                    ::autumn_web::htmx::OobMethod::OuterHTML,
-                                    ::std::format!("#{}", __prev_id_val),
-                                )
+                        let (__target_id, __swap_strategy) = if __topic_changed {
+                            (#container_expr, ::autumn_web::htmx::OobSwap::BeforeEnd)
+                        } else {
+                            let __strategy = if let ::core::option::Option::Some(__prev_id_val) = __prev_id {
+                                if __prev_id_val != &__id {
+                                    ::autumn_web::htmx::OobSwap::Target(
+                                        ::autumn_web::htmx::OobMethod::OuterHTML,
+                                        ::std::format!("#{}", __prev_id_val),
+                                    )
+                                } else {
+                                    ::autumn_web::htmx::OobSwap::OuterHTML
+                                }
                             } else {
                                 ::autumn_web::htmx::OobSwap::OuterHTML
-                            }
-                        } else {
-                            ::autumn_web::htmx::OobSwap::OuterHTML
+                            };
+                            (__id.as_str(), __strategy)
                         };
 
                         if let ::core::result::Result::Err(__err) = __channels
                             .broadcast()
-                            .publish_oob(&__topic, &__id, __swap_strategy, &__fragment)
+                            .publish_oob(&__topic, __target_id, __swap_strategy, &__fragment)
                         {
                             ::autumn_web::reexports::tracing::warn!(error = %__err, "auto-broadcast failed");
                         }

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1449,8 +1449,21 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             let mut __found_id = ::core::option::Option::None;
                             if let ::core::option::Option::Some(__start_tag_end) = __html.find('>') {
                                 let __start_tag = &__html[..__start_tag_end];
-                                if let ::core::option::Option::Some(__id_idx) = __start_tag.find("id=") {
-                                    let __after_id = &__start_tag[__id_idx + 3..];
+                                let mut __id_idx = ::core::option::Option::None;
+                                let mut __search_start = 0;
+                                while let ::core::option::Option::Some(__offset) = __start_tag[__search_start..].find("id=") {
+                                    let __absolute_idx = __search_start + __offset;
+                                    if __absolute_idx > 0 {
+                                        let __prev_char = __start_tag.as_bytes()[__absolute_idx - 1];
+                                        if __prev_char == b' ' || __prev_char == b'\t' || __prev_char == b'\n' || __prev_char == b'\r' {
+                                            __id_idx = ::core::option::Option::Some(__absolute_idx);
+                                            break;
+                                        }
+                                    }
+                                    __search_start = __absolute_idx + 3;
+                                }
+                                if let ::core::option::Option::Some(__idx) = __id_idx {
+                                    let __after_id = &__start_tag[__idx + 3..];
                                     let mut __chars = __after_id.chars();
                                     if let ::core::option::Option::Some(__quote) = __chars.next() {
                                         if __quote == '"' || __quote == '\'' {
@@ -1488,8 +1501,21 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             let mut __found_id = ::core::option::Option::None;
                             if let ::core::option::Option::Some(__start_tag_end) = __html.find('>') {
                                 let __start_tag = &__html[..__start_tag_end];
-                                if let ::core::option::Option::Some(__id_idx) = __start_tag.find("id=") {
-                                    let __after_id = &__start_tag[__id_idx + 3..];
+                                let mut __id_idx = ::core::option::Option::None;
+                                let mut __search_start = 0;
+                                while let ::core::option::Option::Some(__offset) = __start_tag[__search_start..].find("id=") {
+                                    let __absolute_idx = __search_start + __offset;
+                                    if __absolute_idx > 0 {
+                                        let __prev_char = __start_tag.as_bytes()[__absolute_idx - 1];
+                                        if __prev_char == b' ' || __prev_char == b'\t' || __prev_char == b'\n' || __prev_char == b'\r' {
+                                            __id_idx = ::core::option::Option::Some(__absolute_idx);
+                                            break;
+                                        }
+                                    }
+                                    __search_start = __absolute_idx + 3;
+                                }
+                                if let ::core::option::Option::Some(__idx) = __id_idx {
+                                    let __after_id = &__start_tag[__idx + 3..];
                                     let mut __chars = __after_id.chars();
                                     if let ::core::option::Option::Some(__quote) = __chars.next() {
                                         if __quote == '"' || __quote == '\'' {

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1453,13 +1453,16 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             .get("__autumn_previous_id")
                             .and_then(|__v| __v.as_str());
 
-                        let mut __topic_changed = false;
-                        if let ::core::option::Option::Some(__prev_topic) = __ctx_val
+                        let __topic_changed = __ctx_val
                             .get("__autumn_previous_topic")
                             .and_then(|__v| __v.as_str())
-                        {
-                            if __prev_topic != __topic {
-                                __topic_changed = true;
+                            .map_or(false, |__prev_topic| __prev_topic != __topic);
+
+                        if __topic_changed {
+                            if let ::core::option::Option::Some(__prev_topic) = __ctx_val
+                                .get("__autumn_previous_topic")
+                                .and_then(|__v| __v.as_str())
+                            {
                                 let __delete_id = __prev_id.unwrap_or(&__id);
                                 let __delete_fragment = ::autumn_web::html! {};
                                 if let ::core::result::Result::Err(__err) = __channels
@@ -1600,33 +1603,36 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
             };
 
-            (
+             (
                 quote! {
-                    let mut __autumn_previous_topic: ::core::option::Option<::std::string::String> = ::core::option::Option::None;
-                    let mut __autumn_previous_id: ::core::option::Option<::std::string::String> = ::core::option::Option::None;
-                    let mut __autumn_ctx_val = ::autumn_web::reexports::serde_json::to_value(&ctx)
-                        .map_err(|e| ::autumn_web::AutumnError::internal_server_error_msg(format!("serialize context: {e}")))?;
-                    if let ::core::option::Option::Some(__record_val) = &__vh_before {
+                    let (__autumn_previous_topic, __autumn_previous_id) = if let ::core::option::Option::Some(__record_val) = &__vh_before {
                         let __record_ref = __record_val;
                         let __prev_topic = #topic_expr;
-                        __autumn_previous_topic = ::core::option::Option::Some(__prev_topic.clone());
+                        let __prev_fragment = #render_expr;
+                        let __prev_id = ::autumn_web::htmx::extract_html_id(&__prev_fragment.into_string());
+                        (::core::option::Option::Some(__prev_topic), __prev_id)
+                    } else {
+                        (::core::option::Option::None, ::core::option::Option::None)
+                    };
+
+                    let mut __autumn_ctx_val = ::autumn_web::reexports::serde_json::to_value(&ctx)
+                        .map_err(|e| ::autumn_web::AutumnError::internal_server_error_msg(format!("serialize context: {e}")))?;
+
+                    if let ::core::option::Option::Some(ref __prev_topic) = __autumn_previous_topic {
                         if let ::core::option::Option::Some(__map) = __autumn_ctx_val.as_object_mut() {
                             __map.insert(
                                 "__autumn_previous_topic".to_string(),
-                                ::autumn_web::reexports::serde_json::Value::String(__prev_topic),
+                                ::autumn_web::reexports::serde_json::Value::String(__prev_topic.clone()),
                             );
                         }
+                    }
 
-                        let __prev_fragment = #render_expr;
-                        let __prev_id = ::autumn_web::htmx::extract_html_id(&__prev_fragment.into_string());
-                        __autumn_previous_id = __prev_id.clone();
-                        if let ::core::option::Option::Some(__prev_id_val) = __prev_id {
-                            if let ::core::option::Option::Some(__map) = __autumn_ctx_val.as_object_mut() {
-                                __map.insert(
-                                    "__autumn_previous_id".to_string(),
-                                    ::autumn_web::reexports::serde_json::Value::String(__prev_id_val),
-                                );
-                            }
+                    if let ::core::option::Option::Some(ref __prev_id_val) = __autumn_previous_id {
+                        if let ::core::option::Option::Some(__map) = __autumn_ctx_val.as_object_mut() {
+                            __map.insert(
+                                "__autumn_previous_id".to_string(),
+                                ::autumn_web::reexports::serde_json::Value::String(__prev_id_val.clone()),
+                            );
                         }
                     }
                 },
@@ -9401,6 +9407,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         #clone_impl
 
+        #[allow(clippy::useless_let_if_seq)]
         impl #trait_name for #pg_name {
             async fn find_by_id(&self, id: i64) -> ::autumn_web::AutumnResult<Option<#model_name>> {
                 use ::autumn_web::reexports::diesel::prelude::*;
@@ -9467,6 +9474,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             #search_impl_methods
         }
 
+        #[allow(clippy::useless_let_if_seq)]
         impl #pg_name {
             #across_tenants_method
             #for_shard_method

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1386,7 +1386,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     .broadcast_topic
                     .as_deref()
                     .unwrap_or(&config.table_name),
-                &quote! { __record },
+                &quote! { __record_ref },
             ) {
                 Ok(expr) => expr,
                 Err(err) => {
@@ -1396,7 +1396,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             };
 
             let topic_expr = if config.tenant_scoped {
-                quote! { ::std::format!("tenant:{}:{}", ::autumn_web::tenancy::DisplayTenantId::tenant_id_str(&__record.tenant_id), #base_topic_expr) }
+                quote! { ::std::format!("tenant:{}:{}", ::autumn_web::tenancy::DisplayTenantId::tenant_id_str(&__record_ref.tenant_id), #base_topic_expr) }
             } else {
                 base_topic_expr
             };
@@ -1411,13 +1411,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             let table_name = &config.table_name;
 
             let render_expr = if let Some(ref render_path) = config.broadcast_render {
-                quote! { #render_path(&__record) }
+                quote! { #render_path(__record_ref) }
             } else {
                 quote! {
                     ::autumn_web::html! {
-                        li id=(::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record))) {
-                            a href=(::std::format!("/{}/{}", #table_name, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record))) {
-                                (::std::format!("{} #{}", #model_name_str, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record)))
+                        li id=(::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(__record_ref))) {
+                            a href=(::std::format!("/{}/{}", #table_name, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(__record_ref))) {
+                                (::std::format!("{} #{}", #model_name_str, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(__record_ref)))
                             }
                         }
                     }
@@ -1426,6 +1426,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
             let create = quote! {
                 {
+                    let __record_ref = &__record;
                     if let ::core::option::Option::Some(__channels) = ::autumn_web::__private::get_global_channels() {
                         let __topic = #topic_expr;
                         let __fragment = #render_expr;
@@ -1441,63 +1442,49 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
             let update = quote! {
                 {
+                    let __record_ref = &__record;
                     if let ::core::option::Option::Some(__channels) = ::autumn_web::__private::get_global_channels() {
                         let __topic = #topic_expr;
                         let __fragment = #render_expr;
-                        let __id = {
-                            let __html = __fragment.clone().into_string();
-                            (|| -> ::core::option::Option<::std::string::String> {
-                                let __start_tag_end = __html.find('>')?;
-                                let __start_tag = &__html[..__start_tag_end];
-                                let mut __id_idx = ::core::option::Option::None;
-                                let mut __search_start = 0;
-                                while let ::core::option::Option::Some(__offset) = __start_tag[__search_start..].find("id=") {
-                                    let __absolute_idx = __search_start + __offset;
-                                    if __absolute_idx > 0 {
-                                        let __prev_char = __start_tag.as_bytes()[__absolute_idx - 1];
-                                        if __prev_char == b' ' || __prev_char == b'\t' || __prev_char == b'\n' || __prev_char == b'\r' {
-                                            __id_idx = ::core::option::Option::Some(__absolute_idx);
-                                            break;
-                                        }
-                                    }
-                                    __search_start = __absolute_idx + 3;
-                                }
-                                let __idx = __id_idx?;
-                                let __after_id = &__start_tag[__idx + 3..];
-                                let mut __chars = __after_id.chars();
-                                let __quote = __chars.next()?;
-                                if __quote == '"' || __quote == '\'' {
-                                    let mut __val = ::std::string::String::new();
-                                    for __c in __chars {
-                                        if __c == __quote {
-                                            break;
-                                        }
-                                        __val.push(__c);
-                                    }
-                                    ::core::option::Option::Some(__val)
-                                } else {
-                                    ::core::option::Option::None
-                                }
-                            })().unwrap_or_else(|| ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record)))
-                        };
+                        let __id = ::autumn_web::htmx::extract_html_id(&__fragment.clone().into_string())
+                            .unwrap_or_else(|| ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(__record_ref)));
+
+                        let __prev_id = __ctx_val
+                            .get("__autumn_previous_id")
+                            .and_then(|__v| __v.as_str());
+
                         if let ::core::option::Option::Some(__prev_topic) = __ctx_val
                             .get("__autumn_previous_topic")
                             .and_then(|__v| __v.as_str())
                         {
                             if __prev_topic != __topic {
+                                let __delete_id = __prev_id.unwrap_or(&__id);
                                 let __delete_fragment = ::autumn_web::html! {};
                                 if let ::core::result::Result::Err(__err) = __channels
                                     .broadcast()
-                                    .publish_oob(__prev_topic, &__id, ::autumn_web::htmx::OobSwap::Delete, &__delete_fragment)
+                                    .publish_oob(__prev_topic, __delete_id, ::autumn_web::htmx::OobSwap::Delete, &__delete_fragment)
                                 {
                                     ::autumn_web::reexports::tracing::warn!(error = %__err, "auto-broadcast delete of old topic failed");
                                 }
                             }
                         }
 
+                        let __swap_strategy = if let ::core::option::Option::Some(__prev_id_val) = __prev_id {
+                            if __prev_id_val != &__id {
+                                ::autumn_web::htmx::OobSwap::Target(
+                                    ::autumn_web::htmx::OobMethod::OuterHTML,
+                                    ::std::format!("#{}", __prev_id_val),
+                                )
+                            } else {
+                                ::autumn_web::htmx::OobSwap::OuterHTML
+                            }
+                        } else {
+                            ::autumn_web::htmx::OobSwap::OuterHTML
+                        };
+
                         if let ::core::result::Result::Err(__err) = __channels
                             .broadcast()
-                            .publish_oob(&__topic, &__id, ::autumn_web::htmx::OobSwap::OuterHTML, &__fragment)
+                            .publish_oob(&__topic, &__id, __swap_strategy, &__fragment)
                         {
                             ::autumn_web::reexports::tracing::warn!(error = %__err, "auto-broadcast failed");
                         }
@@ -1507,6 +1494,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
             let delete = quote! {
                 {
+                    let __record_ref = &__record;
                     if let ::core::option::Option::Some(__channels) = ::autumn_web::__private::get_global_channels() {
                         let __topic = #topic_expr;
                         let __id = {
@@ -1544,7 +1532,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 } else {
                                     ::core::option::Option::None
                                 }
-                            })().unwrap_or_else(|| ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record)))
+                            })().unwrap_or_else(|| ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(__record_ref)))
                         };
                         let __fragment = ::autumn_web::html! {};
                         if let ::core::result::Result::Err(__err) = __channels
@@ -1573,7 +1561,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     .broadcast_topic
                     .as_deref()
                     .unwrap_or(&config.table_name),
-                &quote! { __record },
+                &quote! { __record_ref },
             ) {
                 Ok(expr) => expr,
                 Err(err) => {
@@ -1583,17 +1571,36 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             };
 
             let topic_expr = if config.tenant_scoped {
-                quote! { ::std::format!("tenant:{}:{}", ::autumn_web::tenancy::DisplayTenantId::tenant_id_str(&__record.tenant_id), #base_topic_expr) }
+                quote! { ::std::format!("tenant:{}:{}", ::autumn_web::tenancy::DisplayTenantId::tenant_id_str(&__record_ref.tenant_id), #base_topic_expr) }
             } else {
                 base_topic_expr
+            };
+
+            let model_prefix = to_snake_case(&config.model_name.to_string());
+            let model_name_str = config.model_name.to_string();
+            let table_name = &config.table_name;
+            let render_expr = if let Some(ref render_path) = config.broadcast_render {
+                quote! { #render_path(__record_ref) }
+            } else {
+                quote! {
+                    ::autumn_web::html! {
+                        li id=(::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(__record_ref))) {
+                            a href=(::std::format!("/{}/{}", #table_name, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(__record_ref))) {
+                                (::std::format!("{} #{}", #model_name_str, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(__record_ref)))
+                            }
+                        }
+                    }
+                }
             };
 
             (
                 quote! {
                     let mut __autumn_previous_topic: ::core::option::Option<::std::string::String> = ::core::option::Option::None;
+                    let mut __autumn_previous_id: ::core::option::Option<::std::string::String> = ::core::option::Option::None;
                     let mut __autumn_ctx_val = ::autumn_web::reexports::serde_json::to_value(&ctx)
                         .map_err(|e| ::autumn_web::AutumnError::internal_server_error_msg(format!("serialize context: {e}")))?;
-                    if let ::core::option::Option::Some(__record) = &__vh_before {
+                    if let ::core::option::Option::Some(__record_val) = &__vh_before {
+                        let __record_ref = __record_val;
                         let __prev_topic = #topic_expr;
                         __autumn_previous_topic = ::core::option::Option::Some(__prev_topic.clone());
                         if let ::core::option::Option::Some(__map) = __autumn_ctx_val.as_object_mut() {
@@ -1601,6 +1608,18 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 "__autumn_previous_topic".to_string(),
                                 ::autumn_web::reexports::serde_json::Value::String(__prev_topic),
                             );
+                        }
+
+                        let __prev_fragment = #render_expr;
+                        let __prev_id = ::autumn_web::htmx::extract_html_id(&__prev_fragment.into_string());
+                        __autumn_previous_id = __prev_id.clone();
+                        if let ::core::option::Option::Some(__prev_id_val) = __prev_id {
+                            if let ::core::option::Option::Some(__map) = __autumn_ctx_val.as_object_mut() {
+                                __map.insert(
+                                    "__autumn_previous_id".to_string(),
+                                    ::autumn_web::reexports::serde_json::Value::String(__prev_id_val),
+                                );
+                            }
                         }
                     }
                 },
@@ -1616,12 +1635,23 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             );
                         }
                     }
+                    if let ::core::option::Option::Some(ref __prev_id) = __autumn_previous_id {
+                        if let ::core::option::Option::Some(__map) = __autumn_finalized_ctx_val.as_object_mut() {
+                            __map.insert(
+                                "__autumn_previous_id".to_string(),
+                                ::autumn_web::reexports::serde_json::Value::String(__prev_id.clone()),
+                            );
+                        }
+                    }
                 },
                 quote! { &__autumn_finalized_ctx_val },
             )
         } else {
             (
-                quote! { let __autumn_previous_topic: ::core::option::Option<::std::string::String> = ::core::option::Option::None; },
+                quote! {
+                    let __autumn_previous_topic: ::core::option::Option<::std::string::String> = ::core::option::Option::None;
+                    let __autumn_previous_id: ::core::option::Option<::std::string::String> = ::core::option::Option::None;
+                },
                 quote! { &ctx },
                 quote! {},
                 quote! { &ctx },
@@ -2184,8 +2214,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                     Self::__autumn_register_repository_commit_hooks();
                     let mut conn = self.__autumn_acquire_conn().await?;
-                    let (record, mut ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record, __autumn_previous_topic) = conn
-                        .transaction::<(#model_name, MutationContext, ::std::string::String, ::std::string::String, ::autumn_web::reexports::serde_json::Value, ::core::option::Option<::std::string::String>), ::autumn_web::AutumnError, _>(|conn| {
+                    let (record, mut ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record, __autumn_previous_topic, __autumn_previous_id) = conn
+                        .transaction::<(#model_name, MutationContext, ::std::string::String, ::std::string::String, ::autumn_web::reexports::serde_json::Value, ::core::option::Option<::std::string::String>, ::core::option::Option<::std::string::String>), ::autumn_web::AutumnError, _>(|conn| {
                             async move {
                                 let mut ctx = MutationContext::new(MutationOp::Update);
                                 let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
@@ -2306,7 +2336,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 )
                                 .await?;
 
-                                Ok((record, ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record, __autumn_previous_topic))
+                                Ok((record, ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record, __autumn_previous_topic, __autumn_previous_id))
                             }
                             .scope_boxed()
                         })
@@ -2528,8 +2558,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                     Self::__autumn_register_repository_commit_hooks();
                     let mut conn = self.__autumn_acquire_conn().await?;
-                    let (record, mut ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record, __autumn_previous_topic) = conn
-                        .transaction::<(#model_name, MutationContext, ::std::string::String, ::std::string::String, ::autumn_web::reexports::serde_json::Value, ::core::option::Option<::std::string::String>), ::autumn_web::AutumnError, _>(|conn| {
+                    let (record, mut ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record, __autumn_previous_topic, __autumn_previous_id) = conn
+                        .transaction::<(#model_name, MutationContext, ::std::string::String, ::std::string::String, ::autumn_web::reexports::serde_json::Value, ::core::option::Option<::std::string::String>, ::core::option::Option<::std::string::String>), ::autumn_web::AutumnError, _>(|conn| {
                             async move {
                                 let mut ctx = MutationContext::new(MutationOp::Update);
                                 let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
@@ -2624,7 +2654,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 )
                                 .await?;
 
-                                Ok((record, ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record, __autumn_previous_topic))
+                                Ok((record, ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record, __autumn_previous_topic, __autumn_previous_id))
                             }
                             .scope_boxed()
                         })
@@ -4123,7 +4153,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             .broadcast_topic
                             .as_deref()
                             .unwrap_or(&config.table_name),
-                        &quote! { __record },
+                        &quote! { __record_ref },
                     ) {
                         Ok(expr) => expr,
                         Err(err) => {
@@ -4133,9 +4163,26 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     };
 
                     let topic_expr = if config.tenant_scoped {
-                        quote! { ::std::format!("tenant:{}:{}", ::autumn_web::tenancy::DisplayTenantId::tenant_id_str(&__record.tenant_id), #base_topic_expr) }
+                        quote! { ::std::format!("tenant:{}:{}", ::autumn_web::tenancy::DisplayTenantId::tenant_id_str(&__record_ref.tenant_id), #base_topic_expr) }
                     } else {
                         base_topic_expr
+                    };
+
+                    let model_prefix = to_snake_case(&config.model_name.to_string());
+                    let model_name_str = config.model_name.to_string();
+                    let table_name = &config.table_name;
+                    let render_expr = if let Some(ref render_path) = config.broadcast_render {
+                        quote! { #render_path(__record_ref) }
+                    } else {
+                        quote! {
+                            ::autumn_web::html! {
+                                li id=(::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(__record_ref))) {
+                                    a href=(::std::format!("/{}/{}", #table_name, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(__record_ref))) {
+                                        (::std::format!("{} #{}", #model_name_str, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(__record_ref)))
+                                    }
+                                }
+                            }
+                        }
                     };
 
                     quote! {
@@ -4153,15 +4200,31 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                         let mut serialized_contexts = Vec::new();
                         let mut chunk_previous_topics = Vec::new();
+                        let mut chunk_previous_ids = Vec::new();
                         for (idx, _record) in chunk_updated.iter().enumerate() {
                             let global_idx = offset + idx;
                             let ctx = &contexts[global_idx];
                             let mut ctx_val = ::autumn_web::reexports::serde_json::to_value(ctx)
                                 .map_err(|e| ::autumn_web::AutumnError::internal_server_error_msg(format!("serialize context: {e}")))?;
 
-                            let __record = &current_rows[global_idx];
+                            let __record_val = &current_rows[global_idx];
+                            let __record_ref = __record_val;
                             let __prev_topic = #topic_expr;
                             chunk_previous_topics.push(::core::option::Option::Some(__prev_topic.clone()));
+
+                            let __prev_fragment = #render_expr;
+                            let __prev_id = ::autumn_web::htmx::extract_html_id(&__prev_fragment.into_string());
+                            chunk_previous_ids.push(__prev_id.clone());
+
+                            if let ::core::option::Option::Some(__prev_id_val) = __prev_id {
+                                if let ::core::option::Option::Some(__map) = ctx_val.as_object_mut() {
+                                    __map.insert(
+                                        "__autumn_previous_id".to_string(),
+                                        ::autumn_web::reexports::serde_json::Value::String(__prev_id_val),
+                                    );
+                                }
+                            }
+
                             if let ::core::option::Option::Some(__map) = ctx_val.as_object_mut() {
                                 __map.insert(
                                     "__autumn_previous_topic".to_string(),
@@ -4191,7 +4254,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         .await?;
 
                         for (idx, info) in chunk_hook_infos.into_iter().enumerate() {
-                            hook_infos.push((info.0, info.1, hook_records[idx].0.clone(), chunk_previous_topics[idx].clone()));
+                            hook_infos.push((
+                                info.0,
+                                info.1,
+                                hook_records[idx].0.clone(),
+                                chunk_previous_topics[idx].clone(),
+                                chunk_previous_ids[idx].clone(),
+                            ));
                         }
                     }
                 } else {
@@ -4229,7 +4298,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         .await?;
 
                         for (idx, info) in chunk_hook_infos.into_iter().enumerate() {
-                            hook_infos.push((info.0, info.1, hook_records[idx].0.clone(), ::core::option::Option::None));
+                            hook_infos.push((
+                                info.0,
+                                info.1,
+                                hook_records[idx].0.clone(),
+                                ::core::option::Option::None,
+                                ::core::option::Option::None,
+                            ));
                         }
                     }
                 }
@@ -4250,6 +4325,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 );
                             }
                         }
+                        if let ::core::option::Option::Some(__prev_id) = __autumn_previous_id {
+                            if let ::core::option::Option::Some(__map) = __autumn_finalized_ctx_val.as_object_mut() {
+                                __map.insert(
+                                    "__autumn_previous_id".to_string(),
+                                    ::autumn_web::reexports::serde_json::Value::String(__prev_id.clone()),
+                                );
+                            }
+                        }
                     }
                 } else {
                     quote! {}
@@ -4261,7 +4344,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 };
 
                 quote! {
-                    let (hook_id, hook_owner, hook_record, __autumn_previous_topic) = &hook_infos[idx];
+                    let (hook_id, hook_owner, hook_record, __autumn_previous_topic, __autumn_previous_id) = &hook_infos[idx];
                     let __autumn_pending_heartbeat =
                         ::autumn_web::__private::start_repository_commit_hook_pending_finalizer_heartbeat(
                             self.pool.clone(),
@@ -4421,7 +4504,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         }
 
                         let mut updated_records = Vec::new();
-                        let mut hook_infos: ::std::vec::Vec<(::std::string::String, ::std::string::String, ::serde_json::Value, ::core::option::Option<::std::string::String>)> = ::std::vec::Vec::new();
+                        let mut hook_infos: ::std::vec::Vec<(::std::string::String, ::std::string::String, ::serde_json::Value, ::core::option::Option<::std::string::String>, ::core::option::Option<::std::string::String>)> = ::std::vec::Vec::new();
                         let mut offset = 0;
                         for chunk in proposed_rows.chunks(1000) {
                             let mut chunk_updated = Vec::new();

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1396,7 +1396,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             };
 
             let topic_expr = if config.tenant_scoped {
-                quote! { ::std::format!("tenant:{}:{}", __record.tenant_id, #base_topic_expr) }
+                quote! { ::std::format!("tenant:{}:{}", ::autumn_web::tenancy::DisplayTenantId::tenant_id_str(&__record.tenant_id), #base_topic_expr) }
             } else {
                 base_topic_expr
             };

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1480,6 +1480,21 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 }
                             })().unwrap_or_else(|| ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record)))
                         };
+                        if let ::core::option::Option::Some(__prev_topic) = __ctx_val
+                            .get("__autumn_previous_topic")
+                            .and_then(|__v| __v.as_str())
+                        {
+                            if __prev_topic != __topic {
+                                let __delete_fragment = ::autumn_web::html! {};
+                                if let ::core::result::Result::Err(__err) = __channels
+                                    .broadcast()
+                                    .publish_oob(__prev_topic, &__id, ::autumn_web::htmx::OobSwap::Delete, &__delete_fragment)
+                                {
+                                    ::autumn_web::reexports::tracing::warn!(error = %__err, "auto-broadcast delete of old topic failed");
+                                }
+                            }
+                        }
+
                         if let ::core::result::Result::Err(__err) = __channels
                             .broadcast()
                             .publish_oob(&__topic, &__id, ::autumn_web::htmx::OobSwap::OuterHTML, &__fragment)
@@ -1547,6 +1562,72 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             (quote! {}, quote! {}, quote! {})
         };
 
+        let (
+            enqueue_context_setup,
+            enqueue_context_ref,
+            finalize_context_setup,
+            finalize_context_ref,
+        ) = if config.broadcasts {
+            let base_topic_expr = match generate_topic_format(
+                config
+                    .broadcast_topic
+                    .as_deref()
+                    .unwrap_or(&config.table_name),
+                &quote! { __record },
+            ) {
+                Ok(expr) => expr,
+                Err(err) => {
+                    let compile_err = err.to_compile_error();
+                    return quote! { #compile_err };
+                }
+            };
+
+            let topic_expr = if config.tenant_scoped {
+                quote! { ::std::format!("tenant:{}:{}", ::autumn_web::tenancy::DisplayTenantId::tenant_id_str(&__record.tenant_id), #base_topic_expr) }
+            } else {
+                base_topic_expr
+            };
+
+            (
+                quote! {
+                    let mut __autumn_previous_topic: ::core::option::Option<::std::string::String> = ::core::option::Option::None;
+                    let mut __autumn_ctx_val = ::autumn_web::reexports::serde_json::to_value(&ctx)
+                        .map_err(|e| ::autumn_web::AutumnError::internal_server_error_msg(format!("serialize context: {e}")))?;
+                    if let ::core::option::Option::Some(ref __record) = __vh_before {
+                        let __prev_topic = #topic_expr;
+                        __autumn_previous_topic = ::core::option::Option::Some(__prev_topic.clone());
+                        if let ::core::option::Option::Some(__map) = __autumn_ctx_val.as_object_mut() {
+                            __map.insert(
+                                "__autumn_previous_topic".to_string(),
+                                ::autumn_web::reexports::serde_json::Value::String(__prev_topic),
+                            );
+                        }
+                    }
+                },
+                quote! { &__autumn_ctx_val },
+                quote! {
+                    let mut __autumn_finalized_ctx_val = ::autumn_web::reexports::serde_json::to_value(&ctx)
+                        .map_err(|e| ::autumn_web::AutumnError::internal_server_error_msg(format!("serialize finalized context: {e}")))?;
+                    if let ::core::option::Option::Some(ref __prev_topic) = __autumn_previous_topic {
+                        if let ::core::option::Option::Some(__map) = __autumn_finalized_ctx_val.as_object_mut() {
+                            __map.insert(
+                                "__autumn_previous_topic".to_string(),
+                                ::autumn_web::reexports::serde_json::Value::String(__prev_topic.clone()),
+                            );
+                        }
+                    }
+                },
+                quote! { &__autumn_finalized_ctx_val },
+            )
+        } else {
+            (
+                quote! { let __autumn_previous_topic: ::core::option::Option<::std::string::String> = ::core::option::Option::None; },
+                quote! { &ctx },
+                quote! {},
+                quote! { &ctx },
+            )
+        };
+
         let hook_support_methods = if commit_hooks_enabled {
             quote! {
             #[doc(hidden)]
@@ -1591,9 +1672,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             #broadcast_create
                             Ok(())
                         },
-                        |__ctx, __record| async move {
+                        |__ctx_val, __record| async move {
                             let mut __ctx: ::autumn_web::hooks::MutationContext =
-                                ::autumn_web::reexports::serde_json::from_value(__ctx)
+                                ::autumn_web::reexports::serde_json::from_value(__ctx_val.clone())
                                     .map_err(|__error| {
                                         ::autumn_web::AutumnError::internal_server_error_msg(
                                             format!("deserialize repository update hook context: {__error}")
@@ -2103,8 +2184,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                     Self::__autumn_register_repository_commit_hooks();
                     let mut conn = self.__autumn_acquire_conn().await?;
-                    let (record, mut ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record) = conn
-                        .transaction::<(#model_name, MutationContext, ::std::string::String, ::std::string::String, ::autumn_web::reexports::serde_json::Value), ::autumn_web::AutumnError, _>(|conn| {
+                    let (record, mut ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record, __autumn_previous_topic) = conn
+                        .transaction::<(#model_name, MutationContext, ::std::string::String, ::std::string::String, ::autumn_web::reexports::serde_json::Value, ::core::option::Option<::std::string::String>), ::autumn_web::AutumnError, _>(|conn| {
                             async move {
                                 let mut ctx = MutationContext::new(MutationOp::Update);
                                 let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
@@ -2212,6 +2293,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     #vh_update_in_hooks
                                 }
 
+                                #enqueue_context_setup
                                 let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
                                 let (__autumn_commit_hook_id, __autumn_commit_hook_owner) = ::autumn_web::__private::enqueue_repository_commit_hook_pending_on_conn(
                                     conn,
@@ -2219,12 +2301,12 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     "update",
                                     ctx.idempotency_key.as_deref(),
                                     __autumn_commit_hook_discriminator.as_deref(),
-                                    &ctx,
+                                    #enqueue_context_ref,
                                     &__autumn_commit_hook_record,
                                 )
                                 .await?;
 
-                                Ok((record, ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record))
+                                Ok((record, ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record, __autumn_previous_topic))
                             }
                             .scope_boxed()
                         })
@@ -2275,11 +2357,12 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::std::panic::resume_unwind(__autumn_panic);
                         }
                     }
+                    #finalize_context_setup
                     let __autumn_finalize_result = ::autumn_web::__private::finalize_repository_commit_hook_after_hook(
                         &self.pool,
                         &__autumn_commit_hook_id,
                         &__autumn_commit_hook_owner,
-                        &ctx,
+                        #finalize_context_ref,
                         &__autumn_commit_hook_record,
                     )
                     .await;
@@ -2445,8 +2528,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                     Self::__autumn_register_repository_commit_hooks();
                     let mut conn = self.__autumn_acquire_conn().await?;
-                    let (record, mut ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record) = conn
-                        .transaction::<(#model_name, MutationContext, ::std::string::String, ::std::string::String, ::autumn_web::reexports::serde_json::Value), ::autumn_web::AutumnError, _>(|conn| {
+                    let (record, mut ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record, __autumn_previous_topic) = conn
+                        .transaction::<(#model_name, MutationContext, ::std::string::String, ::std::string::String, ::autumn_web::reexports::serde_json::Value, ::core::option::Option<::std::string::String>), ::autumn_web::AutumnError, _>(|conn| {
                             async move {
                                 let mut ctx = MutationContext::new(MutationOp::Update);
                                 let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
@@ -2528,6 +2611,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     #vh_update_in_hooks
                                 }
 
+                                #enqueue_context_setup
                                 let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
                                 let (__autumn_commit_hook_id, __autumn_commit_hook_owner) = ::autumn_web::__private::enqueue_repository_commit_hook_pending_on_conn(
                                     conn,
@@ -2535,12 +2619,12 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     "update",
                                     ctx.idempotency_key.as_deref(),
                                     __autumn_commit_hook_discriminator.as_deref(),
-                                    &ctx,
+                                    #enqueue_context_ref,
                                     &__autumn_commit_hook_record,
                                 )
                                 .await?;
 
-                                Ok((record, ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record))
+                                Ok((record, ctx, __autumn_commit_hook_id, __autumn_commit_hook_owner, __autumn_commit_hook_record, __autumn_previous_topic))
                             }
                             .scope_boxed()
                         })
@@ -2591,11 +2675,12 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::std::panic::resume_unwind(__autumn_panic);
                         }
                     }
+                    #finalize_context_setup
                     let __autumn_finalize_result = ::autumn_web::__private::finalize_repository_commit_hook_after_hook(
                         &self.pool,
                         &__autumn_commit_hook_id,
                         &__autumn_commit_hook_owner,
-                        &ctx,
+                        #finalize_context_ref,
                         &__autumn_commit_hook_record,
                     )
                     .await;
@@ -4032,41 +4117,118 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             };
 
             let commit_hooks_enqueue_block = if commit_hooks_enabled {
-                quote! {
-                    let mut hook_records = Vec::new();
-                    for record in &chunk_updated {
-                        let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
-                            ::core::option::Option::None;
-                        if let ::core::option::Option::Some(__autumn_idempotency) = &self.idempotency {
-                            __autumn_commit_hook_discriminator =
-                                ::core::option::Option::Some(__autumn_idempotency.next_mutation_discriminator());
+                if config.broadcasts {
+                    let base_topic_expr = match generate_topic_format(
+                        config
+                            .broadcast_topic
+                            .as_deref()
+                            .unwrap_or(&config.table_name),
+                        &quote! { __record },
+                    ) {
+                        Ok(expr) => expr,
+                        Err(err) => {
+                            let compile_err = err.to_compile_error();
+                            return quote! { #compile_err };
                         }
-                        let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
-                        hook_records.push((__autumn_commit_hook_record, __autumn_commit_hook_discriminator));
-                    }
+                    };
 
-                    let hook_inputs: Vec<_> = chunk_updated.iter().enumerate().map(|(idx, _)| {
-                        let global_idx = offset + idx;
-                        let ctx = &contexts[global_idx];
-                        let (ref record_val, ref discriminator) = hook_records[idx];
-                        (
-                            ctx.idempotency_key.clone(),
-                            discriminator.clone(),
-                            ctx,
-                            record_val,
+                    let topic_expr = if config.tenant_scoped {
+                        quote! { ::std::format!("tenant:{}:{}", ::autumn_web::tenancy::DisplayTenantId::tenant_id_str(&__record.tenant_id), #base_topic_expr) }
+                    } else {
+                        base_topic_expr
+                    };
+
+                    quote! {
+                        let mut hook_records = Vec::new();
+                        for record in &chunk_updated {
+                            let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
+                                ::core::option::Option::None;
+                            if let ::core::option::Option::Some(__autumn_idempotency) = &self.idempotency {
+                                __autumn_commit_hook_discriminator =
+                                    ::core::option::Option::Some(__autumn_idempotency.next_mutation_discriminator());
+                            }
+                            let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
+                            hook_records.push((__autumn_commit_hook_record, __autumn_commit_hook_discriminator));
+                        }
+
+                        let mut serialized_contexts = Vec::new();
+                        for (idx, _record) in chunk_updated.iter().enumerate() {
+                            let global_idx = offset + idx;
+                            let ctx = &contexts[global_idx];
+                            let mut ctx_val = ::autumn_web::reexports::serde_json::to_value(ctx)
+                                .map_err(|e| ::autumn_web::AutumnError::internal_server_error_msg(format!("serialize context: {e}")))?;
+
+                            let __record = &current_rows[global_idx];
+                            let __prev_topic = #topic_expr;
+                            if let ::core::option::Option::Some(__map) = ctx_val.as_object_mut() {
+                                __map.insert(
+                                    "__autumn_previous_topic".to_string(),
+                                    ::autumn_web::reexports::serde_json::Value::String(__prev_topic),
+                                );
+                            }
+                            serialized_contexts.push(ctx_val);
+                        }
+
+                        let hook_inputs: Vec<_> = chunk_updated.iter().enumerate().map(|(idx, _)| {
+                            let global_idx = offset + idx;
+                            let (ref record_val, ref discriminator) = hook_records[idx];
+                            (
+                                contexts[global_idx].idempotency_key.clone(),
+                                discriminator.clone(),
+                                &serialized_contexts[idx],
+                                record_val,
+                            )
+                        }).collect();
+
+                        let chunk_hook_infos = ::autumn_web::__private::enqueue_repository_commit_hooks_pending_bulk_on_conn(
+                            conn,
+                            Self::__autumn_repository_commit_hook_key(),
+                            "update",
+                            &hook_inputs,
                         )
-                    }).collect();
+                        .await?;
 
-                    let chunk_hook_infos = ::autumn_web::__private::enqueue_repository_commit_hooks_pending_bulk_on_conn(
-                        conn,
-                        Self::__autumn_repository_commit_hook_key(),
-                        "update",
-                        &hook_inputs,
-                    )
-                    .await?;
+                        for (idx, info) in chunk_hook_infos.into_iter().enumerate() {
+                            hook_infos.push((info.0, info.1, hook_records[idx].0.clone()));
+                        }
+                    }
+                } else {
+                    quote! {
+                        let mut hook_records = Vec::new();
+                        for record in &chunk_updated {
+                            let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
+                                ::core::option::Option::None;
+                            if let ::core::option::Option::Some(__autumn_idempotency) = &self.idempotency {
+                                __autumn_commit_hook_discriminator =
+                                    ::core::option::Option::Some(__autumn_idempotency.next_mutation_discriminator());
+                            }
+                            let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
+                            hook_records.push((__autumn_commit_hook_record, __autumn_commit_hook_discriminator));
+                        }
 
-                    for (idx, info) in chunk_hook_infos.into_iter().enumerate() {
-                        hook_infos.push((info.0, info.1, hook_records[idx].0.clone()));
+                        let hook_inputs: Vec<_> = chunk_updated.iter().enumerate().map(|(idx, _)| {
+                            let global_idx = offset + idx;
+                            let ctx = &contexts[global_idx];
+                            let (ref record_val, ref discriminator) = hook_records[idx];
+                            (
+                                ctx.idempotency_key.clone(),
+                                discriminator.clone(),
+                                ctx,
+                                record_val,
+                            )
+                        }).collect();
+
+                        let chunk_hook_infos = ::autumn_web::__private::enqueue_repository_commit_hooks_pending_bulk_on_conn(
+                            conn,
+                            Self::__autumn_repository_commit_hook_key(),
+                            "update",
+                            &hook_inputs,
+                        )
+                        .await?;
+
+                        for (idx, info) in chunk_hook_infos.into_iter().enumerate() {
+                            hook_infos.push((info.0, info.1, hook_records[idx].0.clone()));
+                        }
                     }
                 }
             } else {

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1603,7 +1603,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
             };
 
-             (
+            (
                 quote! {
                     let (__autumn_previous_topic, __autumn_previous_id) = if let ::core::option::Option::Some(__record_val) = &__vh_before {
                         let __record_ref = __record_val;

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1432,7 +1432,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         let __fragment = #render_expr;
                         if let ::core::result::Result::Err(__err) = __channels
                             .broadcast()
-                            .publish_oob(&__topic, #container_expr, ::autumn_web::htmx::OobSwap::BeforeEnd, &__fragment)
+                            .publish_oob(&__topic, #container_expr, &::autumn_web::htmx::OobSwap::BeforeEnd, &__fragment)
                         {
                             ::autumn_web::reexports::tracing::warn!(error = %__err, "auto-broadcast failed");
                         }
@@ -1464,7 +1464,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 let __delete_fragment = ::autumn_web::html! {};
                                 if let ::core::result::Result::Err(__err) = __channels
                                     .broadcast()
-                                    .publish_oob(__prev_topic, __delete_id, ::autumn_web::htmx::OobSwap::Delete, &__delete_fragment)
+                                    .publish_oob(__prev_topic, __delete_id, &::autumn_web::htmx::OobSwap::Delete, &__delete_fragment)
                                 {
                                     ::autumn_web::reexports::tracing::warn!(error = %__err, "auto-broadcast delete of old topic failed");
                                 }
@@ -1491,7 +1491,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                         if let ::core::result::Result::Err(__err) = __channels
                             .broadcast()
-                            .publish_oob(&__topic, __target_id, __swap_strategy, &__fragment)
+                            .publish_oob(&__topic, __target_id, &__swap_strategy, &__fragment)
                         {
                             ::autumn_web::reexports::tracing::warn!(error = %__err, "auto-broadcast failed");
                         }
@@ -1544,7 +1544,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         let __fragment = ::autumn_web::html! {};
                         if let ::core::result::Result::Err(__err) = __channels
                             .broadcast()
-                            .publish_oob(&__topic, &__id, ::autumn_web::htmx::OobSwap::Delete, &__fragment)
+                            .publish_oob(&__topic, &__id, &::autumn_web::htmx::OobSwap::Delete, &__fragment)
                         {
                             ::autumn_web::reexports::tracing::warn!(error = %__err, "auto-broadcast failed");
                         }

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -101,7 +101,7 @@ fn generate_topic_format(topic: &str, record_ident: &TokenStream) -> syn::Result
                     )
                 })?;
                 format_str.push_str("{}");
-                args.push(quote! { #record_ident.#field_ident });
+                args.push(quote! { ::autumn_web::repository::DisplayTopicField::to_topic_string(&#record_ident.#field_ident) });
             } else {
                 format_str.push('{');
                 format_str.push_str(&field);
@@ -1593,7 +1593,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     let mut __autumn_previous_topic: ::core::option::Option<::std::string::String> = ::core::option::Option::None;
                     let mut __autumn_ctx_val = ::autumn_web::reexports::serde_json::to_value(&ctx)
                         .map_err(|e| ::autumn_web::AutumnError::internal_server_error_msg(format!("serialize context: {e}")))?;
-                    if let ::core::option::Option::Some(ref __record) = __vh_before {
+                    if let ::core::option::Option::Some(__record) = &__vh_before {
                         let __prev_topic = #topic_expr;
                         __autumn_previous_topic = ::core::option::Option::Some(__prev_topic.clone());
                         if let ::core::option::Option::Some(__map) = __autumn_ctx_val.as_object_mut() {
@@ -4152,6 +4152,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         }
 
                         let mut serialized_contexts = Vec::new();
+                        let mut chunk_previous_topics = Vec::new();
                         for (idx, _record) in chunk_updated.iter().enumerate() {
                             let global_idx = offset + idx;
                             let ctx = &contexts[global_idx];
@@ -4160,6 +4161,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                             let __record = &current_rows[global_idx];
                             let __prev_topic = #topic_expr;
+                            chunk_previous_topics.push(::core::option::Option::Some(__prev_topic.clone()));
                             if let ::core::option::Option::Some(__map) = ctx_val.as_object_mut() {
                                 __map.insert(
                                     "__autumn_previous_topic".to_string(),
@@ -4189,7 +4191,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         .await?;
 
                         for (idx, info) in chunk_hook_infos.into_iter().enumerate() {
-                            hook_infos.push((info.0, info.1, hook_records[idx].0.clone()));
+                            hook_infos.push((info.0, info.1, hook_records[idx].0.clone(), chunk_previous_topics[idx].clone()));
                         }
                     }
                 } else {
@@ -4227,7 +4229,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         .await?;
 
                         for (idx, info) in chunk_hook_infos.into_iter().enumerate() {
-                            hook_infos.push((info.0, info.1, hook_records[idx].0.clone()));
+                            hook_infos.push((info.0, info.1, hook_records[idx].0.clone(), ::core::option::Option::None));
                         }
                     }
                 }
@@ -4236,8 +4238,30 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             };
 
             let after_update_hook_block = if commit_hooks_enabled {
+                let finalize_setup = if config.broadcasts {
+                    quote! {
+                        let mut __autumn_finalized_ctx_val = ::autumn_web::reexports::serde_json::to_value(&ctx)
+                            .map_err(|e| ::autumn_web::AutumnError::internal_server_error_msg(format!("serialize finalized context: {e}")))?;
+                        if let ::core::option::Option::Some(__prev_topic) = __autumn_previous_topic {
+                            if let ::core::option::Option::Some(__map) = __autumn_finalized_ctx_val.as_object_mut() {
+                                __map.insert(
+                                    "__autumn_previous_topic".to_string(),
+                                    ::autumn_web::reexports::serde_json::Value::String(__prev_topic.clone()),
+                                );
+                            }
+                        }
+                    }
+                } else {
+                    quote! {}
+                };
+                let finalize_ref = if config.broadcasts {
+                    quote! { &__autumn_finalized_ctx_val }
+                } else {
+                    quote! { &ctx }
+                };
+
                 quote! {
-                    let (hook_id, hook_owner, hook_record) = &hook_infos[idx];
+                    let (hook_id, hook_owner, hook_record, __autumn_previous_topic) = &hook_infos[idx];
                     let __autumn_pending_heartbeat =
                         ::autumn_web::__private::start_repository_commit_hook_pending_finalizer_heartbeat(
                             self.pool.clone(),
@@ -4251,11 +4275,12 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                     match __autumn_after_update {
                         ::core::result::Result::Ok(::core::result::Result::Ok(())) => {
+                            #finalize_setup
                             let __autumn_finalize_result = ::autumn_web::__private::finalize_repository_commit_hook_after_hook(
                                 &self.pool,
                                 hook_id,
                                 hook_owner,
-                                &ctx,
+                                #finalize_ref,
                                 hook_record,
                             )
                             .await;
@@ -4396,7 +4421,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         }
 
                         let mut updated_records = Vec::new();
-                        let mut hook_infos: ::std::vec::Vec<(::std::string::String, ::std::string::String, ::serde_json::Value)> = ::std::vec::Vec::new();
+                        let mut hook_infos: ::std::vec::Vec<(::std::string::String, ::std::string::String, ::serde_json::Value, ::core::option::Option<::std::string::String>)> = ::std::vec::Vec::new();
                         let mut offset = 0;
                         for chunk in proposed_rows.chunks(1000) {
                             let mut chunk_updated = Vec::new();

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1446,8 +1446,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         let __fragment = #render_expr;
                         let __id = {
                             let __html = __fragment.clone().into_string();
-                            let mut __found_id = ::core::option::Option::None;
-                            if let ::core::option::Option::Some(__start_tag_end) = __html.find('>') {
+                            (|| -> ::core::option::Option<::std::string::String> {
+                                let __start_tag_end = __html.find('>')?;
                                 let __start_tag = &__html[..__start_tag_end];
                                 let mut __id_idx = ::core::option::Option::None;
                                 let mut __search_start = 0;
@@ -1462,24 +1462,23 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     }
                                     __search_start = __absolute_idx + 3;
                                 }
-                                if let ::core::option::Option::Some(__idx) = __id_idx {
-                                    let __after_id = &__start_tag[__idx + 3..];
-                                    let mut __chars = __after_id.chars();
-                                    if let ::core::option::Option::Some(__quote) = __chars.next() {
-                                        if __quote == '"' || __quote == '\'' {
-                                            let mut __val = ::std::string::String::new();
-                                            for __c in __chars {
-                                                if __c == __quote {
-                                                    break;
-                                                }
-                                                __val.push(__c);
-                                            }
-                                            __found_id = ::core::option::Option::Some(__val);
+                                let __idx = __id_idx?;
+                                let __after_id = &__start_tag[__idx + 3..];
+                                let mut __chars = __after_id.chars();
+                                let __quote = __chars.next()?;
+                                if __quote == '"' || __quote == '\'' {
+                                    let mut __val = ::std::string::String::new();
+                                    for __c in __chars {
+                                        if __c == __quote {
+                                            break;
                                         }
+                                        __val.push(__c);
                                     }
+                                    ::core::option::Option::Some(__val)
+                                } else {
+                                    ::core::option::Option::None
                                 }
-                            }
-                            __found_id.unwrap_or_else(|| ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record)))
+                            })().unwrap_or_else(|| ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record)))
                         };
                         if let ::core::result::Result::Err(__err) = __channels
                             .broadcast()
@@ -1498,8 +1497,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         let __id = {
                             let __fragment = #render_expr;
                             let __html = __fragment.into_string();
-                            let mut __found_id = ::core::option::Option::None;
-                            if let ::core::option::Option::Some(__start_tag_end) = __html.find('>') {
+                            (|| -> ::core::option::Option<::std::string::String> {
+                                let __start_tag_end = __html.find('>')?;
                                 let __start_tag = &__html[..__start_tag_end];
                                 let mut __id_idx = ::core::option::Option::None;
                                 let mut __search_start = 0;
@@ -1514,24 +1513,23 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     }
                                     __search_start = __absolute_idx + 3;
                                 }
-                                if let ::core::option::Option::Some(__idx) = __id_idx {
-                                    let __after_id = &__start_tag[__idx + 3..];
-                                    let mut __chars = __after_id.chars();
-                                    if let ::core::option::Option::Some(__quote) = __chars.next() {
-                                        if __quote == '"' || __quote == '\'' {
-                                            let mut __val = ::std::string::String::new();
-                                            for __c in __chars {
-                                                if __c == __quote {
-                                                    break;
-                                                }
-                                                __val.push(__c);
-                                            }
-                                            __found_id = ::core::option::Option::Some(__val);
+                                let __idx = __id_idx?;
+                                let __after_id = &__start_tag[__idx + 3..];
+                                let mut __chars = __after_id.chars();
+                                let __quote = __chars.next()?;
+                                if __quote == '"' || __quote == '\'' {
+                                    let mut __val = ::std::string::String::new();
+                                    for __c in __chars {
+                                        if __c == __quote {
+                                            break;
                                         }
+                                        __val.push(__c);
                                     }
+                                    ::core::option::Option::Some(__val)
+                                } else {
+                                    ::core::option::Option::None
                                 }
-                            }
-                            __found_id.unwrap_or_else(|| ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record)))
+                            })().unwrap_or_else(|| ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record)))
                         };
                         let __fragment = ::autumn_web::html! {};
                         if let ::core::result::Result::Err(__err) = __channels

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -83,9 +83,8 @@ fn generate_topic_format(topic: &str, record_ident: &TokenStream) -> syn::Result
                     chars.next();
                     closed = true;
                     break;
-                } else {
-                    field.push(chars.next().unwrap());
                 }
+                field.push(chars.next().unwrap());
             }
             if closed {
                 let trimmed = field.trim();
@@ -98,10 +97,7 @@ fn generate_topic_format(topic: &str, record_ident: &TokenStream) -> syn::Result
                 let field_ident = syn::parse_str::<syn::Ident>(trimmed).map_err(|e| {
                     syn::Error::new(
                         proc_macro2::Span::call_site(),
-                        format!(
-                            "invalid field name '{}' in topic placeholder: {}",
-                            trimmed, e
-                        ),
+                        format!("invalid field name '{trimmed}' in topic placeholder: {e}"),
                     )
                 })?;
                 format_str.push_str("{}");
@@ -1395,7 +1391,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 Ok(expr) => expr,
                 Err(err) => {
                     let compile_err = err.to_compile_error();
-                    return quote! { #compile_err }.into();
+                    return quote! { #compile_err };
                 }
             };
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -70,6 +70,58 @@ fn to_snake_case(name: &str) -> String {
     result
 }
 
+fn generate_topic_format(topic: &str, record_ident: &TokenStream) -> syn::Result<TokenStream> {
+    let mut format_str = String::new();
+    let mut args = Vec::new();
+    let mut chars = topic.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '{' {
+            let mut field = String::new();
+            let mut closed = false;
+            while let Some(&next_ch) = chars.peek() {
+                if next_ch == '}' {
+                    chars.next();
+                    closed = true;
+                    break;
+                } else {
+                    field.push(chars.next().unwrap());
+                }
+            }
+            if closed {
+                let trimmed = field.trim();
+                if trimmed.is_empty() {
+                    return Err(syn::Error::new(
+                        proc_macro2::Span::call_site(),
+                        "empty topic placeholder '{}' is not allowed",
+                    ));
+                }
+                let field_ident = syn::parse_str::<syn::Ident>(trimmed).map_err(|e| {
+                    syn::Error::new(
+                        proc_macro2::Span::call_site(),
+                        format!(
+                            "invalid field name '{}' in topic placeholder: {}",
+                            trimmed, e
+                        ),
+                    )
+                })?;
+                format_str.push_str("{}");
+                args.push(quote! { #record_ident.#field_ident });
+            } else {
+                format_str.push('{');
+                format_str.push_str(&field);
+            }
+        } else {
+            format_str.push(ch);
+        }
+    }
+    let output = if args.is_empty() {
+        quote! { ::std::string::ToString::to_string(#format_str) }
+    } else {
+        quote! { ::std::format!(#format_str, #(#args),*) }
+    };
+    Ok(output)
+}
+
 #[allow(clippy::struct_excessive_bools)]
 struct RepoConfig {
     model_name: Ident,
@@ -114,6 +166,11 @@ struct RepoConfig {
     /// Works with `tenant_scoped` for per-tenant routing and `across_tenants` for
     /// cross-shard fan-out reads. (issue #1209)
     sharded: bool,
+    broadcasts: bool,
+    broadcast_topic: Option<String>,
+    broadcast_render: Option<syn::Path>,
+    broadcast_container: Option<String>,
+    generated_internal_hooks: bool,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -135,6 +192,10 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
     let mut no_versioned_record_impl = false;
     let mut primary_reads = false;
     let mut sharded = false;
+    let mut broadcasts = false;
+    let mut broadcast_topic: Option<String> = None;
+    let mut broadcast_render: Option<syn::Path> = None;
+    let mut broadcast_container: Option<String> = None;
 
     syn::meta::parser(|meta| {
         // `hooks = Ident` must be checked before the catch-all model_name case,
@@ -146,6 +207,22 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
         } else if meta.path.is_ident("commit_hooks") {
             let value: syn::LitBool = meta.value()?.parse()?;
             commit_hooks = value.value;
+            Ok(())
+        } else if meta.path.is_ident("broadcasts") {
+            let value: syn::LitBool = meta.value()?.parse()?;
+            broadcasts = value.value;
+            Ok(())
+        } else if meta.path.is_ident("topic") {
+            let value: LitStr = meta.value()?.parse()?;
+            broadcast_topic = Some(value.value());
+            Ok(())
+        } else if meta.path.is_ident("render") {
+            let value: syn::Path = meta.value()?.parse()?;
+            broadcast_render = Some(value);
+            Ok(())
+        } else if meta.path.is_ident("container") {
+            let value: LitStr = meta.value()?.parse()?;
+            broadcast_container = Some(value.value());
             Ok(())
         } else if meta.path.is_ident("table") {
             let value: LitStr = meta.value()?.parse()?;
@@ -213,13 +290,17 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
             "expected model name: #[repository(ModelName)]",
         )
     })?;
-    if commit_hooks && hooks_type.is_none() {
+    if broadcasts {
+        commit_hooks = true;
+    }
+    if commit_hooks && hooks_type.is_none() && !broadcasts {
         return Err(syn::Error::new(
             proc_macro2::Span::call_site(),
             "commit_hooks = true requires hooks = Type",
         ));
     }
     let table = table_name.unwrap_or_else(|| infer_table_name(&model));
+    let generated_internal_hooks = false;
 
     Ok(RepoConfig {
         model_name: model,
@@ -239,6 +320,11 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
         no_versioned_record_impl,
         primary_reads,
         sharded,
+        broadcasts,
+        broadcast_topic,
+        broadcast_render,
+        broadcast_container,
+        generated_internal_hooks,
     })
 }
 
@@ -583,7 +669,7 @@ fn vh_insert_ts(
 )]
 #[allow(clippy::cognitive_complexity)]
 pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let config = match parse_repo_args(attr) {
+    let mut config = match parse_repo_args(attr) {
         Ok(c) => c,
         Err(err) => return err.to_compile_error(),
     };
@@ -592,6 +678,11 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         Ok(t) => t,
         Err(err) => return err.to_compile_error(),
     };
+
+    if config.broadcasts && config.hooks_type.is_none() {
+        config.hooks_type = Some(format_ident!("Pg{}InternalHooks", trait_def.ident));
+        config.generated_internal_hooks = true;
+    }
 
     let model_name = &config.model_name;
     let table_name = &config.table_name;
@@ -1293,6 +1384,105 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         };
 
+        let (broadcast_create, broadcast_update, broadcast_delete) = if config.broadcasts {
+            let base_topic_expr = match generate_topic_format(
+                config
+                    .broadcast_topic
+                    .as_deref()
+                    .unwrap_or(&config.table_name),
+                &quote! { __record },
+            ) {
+                Ok(expr) => expr,
+                Err(err) => {
+                    let compile_err = err.to_compile_error();
+                    return quote! { #compile_err }.into();
+                }
+            };
+
+            let topic_expr = if config.tenant_scoped {
+                quote! { ::std::format!("tenant:{}:{}", __record.tenant_id, #base_topic_expr) }
+            } else {
+                base_topic_expr
+            };
+
+            let default_container = format!("{}-list", config.table_name);
+            let container_expr = config
+                .broadcast_container
+                .as_deref()
+                .unwrap_or(&default_container);
+            let model_prefix = to_snake_case(&config.model_name.to_string());
+            let model_name_str = config.model_name.to_string();
+            let table_name = &config.table_name;
+
+            let render_expr = if let Some(ref render_path) = config.broadcast_render {
+                quote! { #render_path(&__record) }
+            } else {
+                quote! {
+                    ::autumn_web::html! {
+                        li id=(::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record))) {
+                            a href=(::std::format!("/{}/{}", #table_name, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record))) {
+                                (::std::format!("{} #{}", #model_name_str, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record)))
+                            }
+                        }
+                    }
+                }
+            };
+
+            let create = quote! {
+                #[cfg(all(feature = "ws", feature = "maud"))]
+                {
+                    if let ::core::option::Option::Some(__channels) = ::autumn_web::__private::get_global_channels() {
+                        let __topic = #topic_expr;
+                        let __fragment = #render_expr;
+                        if let ::core::result::Result::Err(__err) = __channels
+                            .broadcast()
+                            .publish_oob(&__topic, #container_expr, ::autumn_web::htmx::OobSwap::BeforeEnd, &__fragment)
+                        {
+                            ::autumn_web::reexports::tracing::warn!(error = %__err, "auto-broadcast failed");
+                        }
+                    }
+                }
+            };
+
+            let update = quote! {
+                #[cfg(all(feature = "ws", feature = "maud"))]
+                {
+                    if let ::core::option::Option::Some(__channels) = ::autumn_web::__private::get_global_channels() {
+                        let __topic = #topic_expr;
+                        let __id = ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record));
+                        let __fragment = #render_expr;
+                        if let ::core::result::Result::Err(__err) = __channels
+                            .broadcast()
+                            .publish_oob(&__topic, &__id, ::autumn_web::htmx::OobSwap::OuterHTML, &__fragment)
+                        {
+                            ::autumn_web::reexports::tracing::warn!(error = %__err, "auto-broadcast failed");
+                        }
+                    }
+                }
+            };
+
+            let delete = quote! {
+                #[cfg(all(feature = "ws", feature = "maud"))]
+                {
+                    if let ::core::option::Option::Some(__channels) = ::autumn_web::__private::get_global_channels() {
+                        let __topic = #topic_expr;
+                        let __id = ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record));
+                        let __fragment = ::autumn_web::html! {};
+                        if let ::core::result::Result::Err(__err) = __channels
+                            .broadcast()
+                            .publish_oob(&__topic, &__id, ::autumn_web::htmx::OobSwap::Delete, &__fragment)
+                        {
+                            ::autumn_web::reexports::tracing::warn!(error = %__err, "auto-broadcast failed");
+                        }
+                    }
+                }
+            };
+
+            (create, update, delete)
+        } else {
+            (quote! {}, quote! {}, quote! {})
+        };
+
         let hook_support_methods = if commit_hooks_enabled {
             quote! {
             #[doc(hidden)]
@@ -1326,14 +1516,16 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     })?;
                             let __record: #model_name =
                                 #model_name::__autumn_commit_hook_from_value(__record)?;
-                                let __hooks =
-                                    <#hooks_ident as ::autumn_web::hooks::RepositoryHooksDefault>::autumn_default();
-                                <#hooks_ident as ::autumn_web::hooks::MutationHooks>::after_create_commit(
-                                    &__hooks,
-                                    &mut __ctx,
-                                    &__record,
-                                )
-                                .await
+                            let __hooks =
+                                <#hooks_ident as ::autumn_web::hooks::RepositoryHooksDefault>::autumn_default();
+                            <#hooks_ident as ::autumn_web::hooks::MutationHooks>::after_create_commit(
+                                &__hooks,
+                                &mut __ctx,
+                                &__record,
+                            )
+                            .await?;
+                            #broadcast_create
+                            Ok(())
                         },
                         |__ctx, __record| async move {
                             let mut __ctx: ::autumn_web::hooks::MutationContext =
@@ -1345,14 +1537,16 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     })?;
                             let __record: #model_name =
                                 #model_name::__autumn_commit_hook_from_value(__record)?;
-                                let __hooks =
-                                    <#hooks_ident as ::autumn_web::hooks::RepositoryHooksDefault>::autumn_default();
-                                <#hooks_ident as ::autumn_web::hooks::MutationHooks>::after_update_commit(
-                                    &__hooks,
-                                    &mut __ctx,
-                                    &__record,
-                                )
-                                .await
+                            let __hooks =
+                                <#hooks_ident as ::autumn_web::hooks::RepositoryHooksDefault>::autumn_default();
+                            <#hooks_ident as ::autumn_web::hooks::MutationHooks>::after_update_commit(
+                                &__hooks,
+                                &mut __ctx,
+                                &__record,
+                            )
+                            .await?;
+                            #broadcast_update
+                            Ok(())
                         },
                         |__ctx, __record| async move {
                             let mut __ctx: ::autumn_web::hooks::MutationContext =
@@ -1364,14 +1558,16 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     })?;
                             let __record: #model_name =
                                 #model_name::__autumn_commit_hook_from_value(__record)?;
-                                let __hooks =
-                                    <#hooks_ident as ::autumn_web::hooks::RepositoryHooksDefault>::autumn_default();
-                                <#hooks_ident as ::autumn_web::hooks::MutationHooks>::after_delete_commit(
-                                    &__hooks,
-                                    &mut __ctx,
-                                    &__record,
-                                )
-                                .await
+                            let __hooks =
+                                <#hooks_ident as ::autumn_web::hooks::RepositoryHooksDefault>::autumn_default();
+                            <#hooks_ident as ::autumn_web::hooks::MutationHooks>::after_delete_commit(
+                                &__hooks,
+                                &mut __ctx,
+                                &__record,
+                            )
+                            .await?;
+                            #broadcast_delete
+                            Ok(())
                         },
                     );
                 });
@@ -8074,6 +8270,22 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         quote! {}
     };
 
+    let internal_hooks_defn = if config.generated_internal_hooks {
+        let hooks_ident = config.hooks_type.as_ref().unwrap();
+        quote! {
+            #[derive(Default, Clone)]
+            pub struct #hooks_ident;
+
+            impl ::autumn_web::hooks::MutationHooks for #hooks_ident {
+                type Model = #model_name;
+                type NewModel = #new_name;
+                type UpdateModel = #update_name;
+            }
+        }
+    } else {
+        quote! {}
+    };
+
     let (search_impl_methods, search_one_shard_helpers) = if config.searchable {
         let tenant_id_setup = if config.tenant_scoped {
             quote! {
@@ -9208,6 +9420,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         #versioned_history_impl
 
         #search_compile_check
+
+        #internal_hooks_defn
     }
 }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1425,7 +1425,6 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             };
 
             let create = quote! {
-                #[cfg(all(feature = "ws", feature = "maud"))]
                 {
                     if let ::core::option::Option::Some(__channels) = ::autumn_web::__private::get_global_channels() {
                         let __topic = #topic_expr;
@@ -1441,12 +1440,34 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             };
 
             let update = quote! {
-                #[cfg(all(feature = "ws", feature = "maud"))]
                 {
                     if let ::core::option::Option::Some(__channels) = ::autumn_web::__private::get_global_channels() {
                         let __topic = #topic_expr;
-                        let __id = ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record));
                         let __fragment = #render_expr;
+                        let __id = {
+                            let __html = __fragment.clone().into_string();
+                            let mut __found_id = ::core::option::Option::None;
+                            if let ::core::option::Option::Some(__start_tag_end) = __html.find('>') {
+                                let __start_tag = &__html[..__start_tag_end];
+                                if let ::core::option::Option::Some(__id_idx) = __start_tag.find("id=") {
+                                    let __after_id = &__start_tag[__id_idx + 3..];
+                                    let mut __chars = __after_id.chars();
+                                    if let ::core::option::Option::Some(__quote) = __chars.next() {
+                                        if __quote == '"' || __quote == '\'' {
+                                            let mut __val = ::std::string::String::new();
+                                            for __c in __chars {
+                                                if __c == __quote {
+                                                    break;
+                                                }
+                                                __val.push(__c);
+                                            }
+                                            __found_id = ::core::option::Option::Some(__val);
+                                        }
+                                    }
+                                }
+                            }
+                            __found_id.unwrap_or_else(|| ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record)))
+                        };
                         if let ::core::result::Result::Err(__err) = __channels
                             .broadcast()
                             .publish_oob(&__topic, &__id, ::autumn_web::htmx::OobSwap::OuterHTML, &__fragment)
@@ -1458,11 +1479,34 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             };
 
             let delete = quote! {
-                #[cfg(all(feature = "ws", feature = "maud"))]
                 {
                     if let ::core::option::Option::Some(__channels) = ::autumn_web::__private::get_global_channels() {
                         let __topic = #topic_expr;
-                        let __id = ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record));
+                        let __id = {
+                            let __fragment = #render_expr;
+                            let __html = __fragment.into_string();
+                            let mut __found_id = ::core::option::Option::None;
+                            if let ::core::option::Option::Some(__start_tag_end) = __html.find('>') {
+                                let __start_tag = &__html[..__start_tag_end];
+                                if let ::core::option::Option::Some(__id_idx) = __start_tag.find("id=") {
+                                    let __after_id = &__start_tag[__id_idx + 3..];
+                                    let mut __chars = __after_id.chars();
+                                    if let ::core::option::Option::Some(__quote) = __chars.next() {
+                                        if __quote == '"' || __quote == '\'' {
+                                            let mut __val = ::std::string::String::new();
+                                            for __c in __chars {
+                                                if __c == __quote {
+                                                    break;
+                                                }
+                                                __val.push(__c);
+                                            }
+                                            __found_id = ::core::option::Option::Some(__val);
+                                        }
+                                    }
+                                }
+                            }
+                            __found_id.unwrap_or_else(|| ::std::format!("{}-{}", #model_prefix, ::autumn_web::repository::ModelPrimaryKey::primary_key_value(&__record)))
+                        };
                         let __fragment = ::autumn_web::html! {};
                         if let ::core::result::Result::Err(__err) = __channels
                             .broadcast()

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -3227,6 +3227,17 @@ impl AppBuilder {
 
         #[cfg(feature = "db")]
         if let Some(pool) = state.pool().cloned() {
+            #[cfg(feature = "ws")]
+            {
+                let channels = state.channels().clone();
+                crate::repository_commit_hooks::set_global_channels(channels.clone());
+                crate::repository_commit_hooks::start_repository_commit_hook_worker(
+                    pool,
+                    Some(channels),
+                    server_shutdown.child_token(),
+                );
+            }
+            #[cfg(not(feature = "ws"))]
             crate::repository_commit_hooks::start_repository_commit_hook_worker(
                 pool,
                 server_shutdown.child_token(),
@@ -3237,6 +3248,13 @@ impl AppBuilder {
         #[cfg(feature = "db")]
         if let Some(shards) = state.shards() {
             for shard in shards.iter() {
+                #[cfg(feature = "ws")]
+                crate::repository_commit_hooks::start_repository_commit_hook_worker(
+                    shard.primary_pool().clone(),
+                    Some(state.channels().clone()),
+                    server_shutdown.child_token(),
+                );
+                #[cfg(not(feature = "ws"))]
                 crate::repository_commit_hooks::start_repository_commit_hook_worker(
                     shard.primary_pool().clone(),
                     server_shutdown.child_token(),
@@ -4373,6 +4391,17 @@ impl AppBuilder {
 
         #[cfg(feature = "db")]
         if let Some(pool) = state.pool().cloned() {
+            #[cfg(feature = "ws")]
+            {
+                let channels = state.channels().clone();
+                crate::repository_commit_hooks::set_global_channels(channels.clone());
+                crate::repository_commit_hooks::start_repository_commit_hook_worker(
+                    pool,
+                    Some(channels),
+                    task_shutdown.child_token(),
+                );
+            }
+            #[cfg(not(feature = "ws"))]
             crate::repository_commit_hooks::start_repository_commit_hook_worker(
                 pool,
                 task_shutdown.child_token(),
@@ -4383,6 +4412,13 @@ impl AppBuilder {
         #[cfg(feature = "db")]
         if let Some(shards) = state.shards() {
             for shard in shards.iter() {
+                #[cfg(feature = "ws")]
+                crate::repository_commit_hooks::start_repository_commit_hook_worker(
+                    shard.primary_pool().clone(),
+                    Some(state.channels().clone()),
+                    task_shutdown.child_token(),
+                );
+                #[cfg(not(feature = "ws"))]
                 crate::repository_commit_hooks::start_repository_commit_hook_worker(
                     shard.primary_pool().clone(),
                     task_shutdown.child_token(),

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -3226,11 +3226,16 @@ impl AppBuilder {
         }
 
         #[cfg(feature = "db")]
+        {
+            #[cfg(feature = "ws")]
+            crate::repository_commit_hooks::set_global_channels(state.channels().clone());
+        }
+
+        #[cfg(feature = "db")]
         if let Some(pool) = state.pool().cloned() {
             #[cfg(feature = "ws")]
             {
                 let channels = state.channels().clone();
-                crate::repository_commit_hooks::set_global_channels(channels.clone());
                 crate::repository_commit_hooks::start_repository_commit_hook_worker(
                     pool,
                     Some(channels),
@@ -4390,11 +4395,16 @@ impl AppBuilder {
         }
 
         #[cfg(feature = "db")]
+        {
+            #[cfg(feature = "ws")]
+            crate::repository_commit_hooks::set_global_channels(state.channels().clone());
+        }
+
+        #[cfg(feature = "db")]
         if let Some(pool) = state.pool().cloned() {
             #[cfg(feature = "ws")]
             {
                 let channels = state.channels().clone();
-                crate::repository_commit_hooks::set_global_channels(channels.clone());
                 crate::repository_commit_hooks::start_repository_commit_hook_worker(
                     pool,
                     Some(channels),

--- a/autumn/src/assets.rs
+++ b/autumn/src/assets.rs
@@ -112,6 +112,14 @@ pub(crate) fn htmx_is_vendored() -> bool {
     load_vendor_manifest().is_some_and(|m| m.assets.contains_key("htmx"))
 }
 
+/// Returns `true` when the SSE extension has been pinned via `autumn assets add sse@…` or is present in the vendor manifest.
+///
+/// The router uses this to skip the built-in embedded sse handler so the
+/// vendored file is served by `ServeDir` instead.
+pub(crate) fn sse_is_vendored() -> bool {
+    load_vendor_manifest().is_some_and(|m| m.assets.contains_key("sse"))
+}
+
 #[cfg(feature = "embed-assets")]
 fn load_embedded_vendor_manifest() -> Option<VendorManifest> {
     EMBEDDED_STATIC

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -355,10 +355,9 @@ impl Broadcast {
             );
 
             if is_outer_html {
-                inject_hx_swap_oob(rendered, &value).map_or_else(
-                    || format!("<template hx-swap-oob=\"{escaped_value}\">{rendered}</template>"),
-                    |injected| injected,
-                )
+                inject_hx_swap_oob(rendered, &value).unwrap_or_else(|| {
+                    format!("<template hx-swap-oob=\"{escaped_value}\">{rendered}</template>")
+                })
             } else if matches!(strategy, OobSwap::Delete) {
                 format!("<div hx-swap-oob=\"{escaped_value}\"></div>")
             } else {

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -339,7 +339,7 @@ impl Broadcast {
         strategy: &crate::htmx::OobSwap,
         fragment: &maud::Markup,
     ) -> Result<usize, BroadcastError> {
-        use crate::htmx::{inject_hx_swap_oob, OobSwap};
+        use crate::htmx::{OobSwap, inject_hx_swap_oob};
         let rendered = &fragment.0;
         let envelope = if strategy == &OobSwap::Raw {
             rendered.clone()
@@ -347,7 +347,12 @@ impl Broadcast {
             let value = strategy.format_value(id);
             let escaped_value = crate::htmx::escape_attribute_string(&value);
 
-            let is_outer_html = matches!(strategy, OobSwap::True | OobSwap::OuterHTML | OobSwap::Target(crate::htmx::OobMethod::OuterHTML, _));
+            let is_outer_html = matches!(
+                strategy,
+                OobSwap::True
+                    | OobSwap::OuterHTML
+                    | OobSwap::Target(crate::htmx::OobMethod::OuterHTML, _)
+            );
 
             if is_outer_html {
                 inject_hx_swap_oob(rendered, &value).map_or_else(

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -339,12 +339,23 @@ impl Broadcast {
         strategy: crate::htmx::OobSwap,
         fragment: &maud::Markup,
     ) -> Result<usize, BroadcastError> {
-        use crate::htmx::HtmxFragments;
-        use maud::Render;
-        let envelope = HtmxFragments::oob_only()
-            .oob_with_strategy(id, strategy, fragment.clone())
-            .render()
-            .into_string();
+        use crate::htmx::{OobSwap, inject_hx_swap_oob};
+        let rendered = &fragment.0;
+        let envelope = if strategy == OobSwap::Raw {
+            rendered.clone()
+        } else {
+            let value = strategy.format_value(id);
+            if let Some(injected) = inject_hx_swap_oob(rendered, &value) {
+                injected
+            } else {
+                use crate::htmx::HtmxFragments;
+                use maud::Render;
+                HtmxFragments::oob_only()
+                    .oob_with_strategy(id, strategy, fragment.clone())
+                    .render()
+                    .into_string()
+            }
+        };
         self.publish(topic, envelope)
     }
 }
@@ -1551,5 +1562,30 @@ mod tests {
 
         tx.send("sse message").unwrap();
         let _stream = sse;
+    }
+
+    #[cfg(feature = "maud")]
+    #[tokio::test]
+    async fn test_publish_oob_injects_without_template_wrapper()
+    -> Result<(), broadcast::error::RecvError> {
+        let channels = Channels::new(16);
+        let mut rx = channels.subscribe("test_publish_oob");
+
+        let oob = maud::html! { li id="item-2" { "Value" } };
+        channels
+            .broadcast()
+            .publish_oob(
+                "test_publish_oob",
+                "list-id",
+                crate::htmx::OobSwap::BeforeEnd,
+                &oob,
+            )
+            .unwrap();
+
+        assert_eq!(
+            rx.recv().await?.as_str(),
+            "<li hx-swap-oob=\"beforeend:#list-id\" id=\"item-2\">Value</li>"
+        );
+        Ok(())
     }
 }

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -336,36 +336,28 @@ impl Broadcast {
         &self,
         topic: &str,
         id: &str,
-        strategy: crate::htmx::OobSwap,
+        strategy: &crate::htmx::OobSwap,
         fragment: &maud::Markup,
     ) -> Result<usize, BroadcastError> {
-        use crate::htmx::{OobSwap, inject_hx_swap_oob};
+        use crate::htmx::{inject_hx_swap_oob, OobSwap};
         let rendered = &fragment.0;
-        let envelope = if strategy == OobSwap::Raw {
+        let envelope = if strategy == &OobSwap::Raw {
             rendered.clone()
         } else {
             let value = strategy.format_value(id);
             let escaped_value = crate::htmx::escape_attribute_string(&value);
 
-            let is_outer_html = matches!(strategy, OobSwap::True | OobSwap::OuterHTML)
-                || match strategy {
-                    OobSwap::Target(crate::htmx::OobMethod::OuterHTML, _) => true,
-                    _ => false,
-                };
+            let is_outer_html = matches!(strategy, OobSwap::True | OobSwap::OuterHTML | OobSwap::Target(crate::htmx::OobMethod::OuterHTML, _));
 
             if is_outer_html {
-                if let Some(injected) = inject_hx_swap_oob(rendered, &value) {
-                    injected
-                } else {
-                    format!(
-                        "<template hx-swap-oob=\"{}\">{}</template>",
-                        escaped_value, rendered
-                    )
-                }
+                inject_hx_swap_oob(rendered, &value).map_or_else(
+                    || format!("<template hx-swap-oob=\"{escaped_value}\">{rendered}</template>"),
+                    |injected| injected,
+                )
             } else if matches!(strategy, OobSwap::Delete) {
-                format!("<div hx-swap-oob=\"{}\"></div>", escaped_value)
+                format!("<div hx-swap-oob=\"{escaped_value}\"></div>")
             } else {
-                format!("<div hx-swap-oob=\"{}\">{}</div>", escaped_value, rendered)
+                format!("<div hx-swap-oob=\"{escaped_value}\">{rendered}</div>")
             }
         };
         self.publish(topic, envelope)
@@ -1232,7 +1224,7 @@ mod tests {
             .publish_oob(
                 "feed",
                 "badge",
-                crate::htmx::OobSwap::BeforeEnd,
+                &crate::htmx::OobSwap::BeforeEnd,
                 &maud::html! {
                     span { "3" }
                 },
@@ -1589,7 +1581,7 @@ mod tests {
             .publish_oob(
                 "test_publish_oob",
                 "list-id",
-                crate::htmx::OobSwap::BeforeEnd,
+                &crate::htmx::OobSwap::BeforeEnd,
                 &oob,
             )
             .unwrap();
@@ -1613,7 +1605,7 @@ mod tests {
             .publish_oob(
                 "test_publish_oob_outerhtml",
                 "item-3",
-                crate::htmx::OobSwap::OuterHTML,
+                &crate::htmx::OobSwap::OuterHTML,
                 &oob,
             )
             .unwrap();
@@ -1637,7 +1629,7 @@ mod tests {
             .publish_oob(
                 "test_publish_oob_escape",
                 "\"bad-id\"",
-                crate::htmx::OobSwap::BeforeEnd,
+                &crate::htmx::OobSwap::BeforeEnd,
                 &oob,
             )
             .unwrap();

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -323,7 +323,7 @@ impl Broadcast {
     /// let channels = Channels::new(16);
     /// channels
     ///     .broadcast()
-    ///     .publish_oob("feed", "notice", OobSwap::OuterHTML, &html! { div id="notice" { "Saved" } })
+    ///     .publish_oob("feed", "notice", &OobSwap::OuterHTML, &html! { div id="notice" { "Saved" } })
     ///     .expect("html publish should succeed");
     /// ```
     ///

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -339,7 +339,7 @@ impl Broadcast {
         strategy: crate::htmx::OobSwap,
         fragment: &maud::Markup,
     ) -> Result<usize, BroadcastError> {
-        use crate::htmx::{inject_hx_swap_oob, OobSwap};
+        use crate::htmx::{OobSwap, inject_hx_swap_oob};
         let rendered = &fragment.0;
         let envelope = if strategy == OobSwap::Raw {
             rendered.clone()
@@ -1603,8 +1603,7 @@ mod tests {
 
     #[cfg(feature = "maud")]
     #[tokio::test]
-    async fn test_publish_oob_injects_for_outerhtml()
-    -> Result<(), broadcast::error::RecvError> {
+    async fn test_publish_oob_injects_for_outerhtml() -> Result<(), broadcast::error::RecvError> {
         let channels = Channels::new(16);
         let mut rx = channels.subscribe("test_publish_oob_outerhtml");
 
@@ -1628,8 +1627,7 @@ mod tests {
 
     #[cfg(feature = "maud")]
     #[tokio::test]
-    async fn test_publish_oob_escapes_attributes()
-    -> Result<(), broadcast::error::RecvError> {
+    async fn test_publish_oob_escapes_attributes() -> Result<(), broadcast::error::RecvError> {
         let channels = Channels::new(16);
         let mut rx = channels.subscribe("test_publish_oob_escape");
 

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -1239,7 +1239,7 @@ mod tests {
         let msg = rx.recv().await?;
         assert_eq!(
             msg.as_str(),
-            "<template hx-swap-oob=\"beforeend:#badge\"><span>3</span></template>"
+            "<div hx-swap-oob=\"beforeend:#badge\"><span>3</span></div>"
         );
         Ok(())
     }

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -339,21 +339,33 @@ impl Broadcast {
         strategy: crate::htmx::OobSwap,
         fragment: &maud::Markup,
     ) -> Result<usize, BroadcastError> {
-        use crate::htmx::{OobSwap, inject_hx_swap_oob};
+        use crate::htmx::{inject_hx_swap_oob, OobSwap};
         let rendered = &fragment.0;
         let envelope = if strategy == OobSwap::Raw {
             rendered.clone()
         } else {
             let value = strategy.format_value(id);
-            if let Some(injected) = inject_hx_swap_oob(rendered, &value) {
-                injected
+            let escaped_value = crate::htmx::escape_attribute_string(&value);
+
+            let is_outer_html = matches!(strategy, OobSwap::True | OobSwap::OuterHTML)
+                || match strategy {
+                    OobSwap::Target(crate::htmx::OobMethod::OuterHTML, _) => true,
+                    _ => false,
+                };
+
+            if is_outer_html {
+                if let Some(injected) = inject_hx_swap_oob(rendered, &value) {
+                    injected
+                } else {
+                    format!(
+                        "<template hx-swap-oob=\"{}\">{}</template>",
+                        escaped_value, rendered
+                    )
+                }
+            } else if matches!(strategy, OobSwap::Delete) {
+                format!("<div hx-swap-oob=\"{}\"></div>", escaped_value)
             } else {
-                use crate::htmx::HtmxFragments;
-                use maud::Render;
-                HtmxFragments::oob_only()
-                    .oob_with_strategy(id, strategy, fragment.clone())
-                    .render()
-                    .into_string()
+                format!("<div hx-swap-oob=\"{}\">{}</div>", escaped_value, rendered)
             }
         };
         self.publish(topic, envelope)
@@ -1584,7 +1596,57 @@ mod tests {
 
         assert_eq!(
             rx.recv().await?.as_str(),
-            "<li hx-swap-oob=\"beforeend:#list-id\" id=\"item-2\">Value</li>"
+            "<div hx-swap-oob=\"beforeend:#list-id\"><li id=\"item-2\">Value</li></div>"
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "maud")]
+    #[tokio::test]
+    async fn test_publish_oob_injects_for_outerhtml()
+    -> Result<(), broadcast::error::RecvError> {
+        let channels = Channels::new(16);
+        let mut rx = channels.subscribe("test_publish_oob_outerhtml");
+
+        let oob = maud::html! { li id="item-3" { "Value" } };
+        channels
+            .broadcast()
+            .publish_oob(
+                "test_publish_oob_outerhtml",
+                "item-3",
+                crate::htmx::OobSwap::OuterHTML,
+                &oob,
+            )
+            .unwrap();
+
+        assert_eq!(
+            rx.recv().await?.as_str(),
+            "<li hx-swap-oob=\"outerHTML\" id=\"item-3\">Value</li>"
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "maud")]
+    #[tokio::test]
+    async fn test_publish_oob_escapes_attributes()
+    -> Result<(), broadcast::error::RecvError> {
+        let channels = Channels::new(16);
+        let mut rx = channels.subscribe("test_publish_oob_escape");
+
+        let oob = maud::html! { li id="item-4" { "Value" } };
+        channels
+            .broadcast()
+            .publish_oob(
+                "test_publish_oob_escape",
+                "\"bad-id\"",
+                crate::htmx::OobSwap::BeforeEnd,
+                &oob,
+            )
+            .unwrap();
+
+        assert_eq!(
+            rx.recv().await?.as_str(),
+            "<div hx-swap-oob=\"beforeend:#&quot;bad-id&quot;\"><li id=\"item-4\">Value</li></div>"
         );
         Ok(())
     }

--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -389,6 +389,26 @@ impl HtmxFragments {
 }
 
 #[cfg(feature = "maud")]
+fn escape_attribute(w: &mut String, s: &str) {
+    for c in s.chars() {
+        match c {
+            '&' => w.push_str("&amp;"),
+            '"' => w.push_str("&quot;"),
+            '<' => w.push_str("&lt;"),
+            '>' => w.push_str("&gt;"),
+            _ => w.push(c),
+        }
+    }
+}
+
+#[cfg(feature = "maud")]
+pub fn escape_attribute_string(s: &str) -> String {
+    let mut w = String::with_capacity(s.len() + 10);
+    escape_attribute(&mut w, s);
+    w
+}
+
+#[cfg(feature = "maud")]
 pub fn inject_hx_swap_oob(html: &str, oob_value: &str) -> Option<String> {
     let mut idx = 0;
     while let Some(start_pos) = html[idx..].find('<') {
@@ -412,29 +432,17 @@ pub fn inject_hx_swap_oob(html: &str, oob_value: &str) -> Option<String> {
                 return None;
             }
             let insert_pos = abs_start + tag_name_end;
-            let mut result = String::with_capacity(html.len() + oob_value.len() + 30);
+            let escaped_val = escape_attribute_string(oob_value);
+            let mut result = String::with_capacity(html.len() + escaped_val.len() + 30);
             result.push_str(&html[..insert_pos]);
             result.push_str(" hx-swap-oob=\"");
-            result.push_str(oob_value);
+            result.push_str(&escaped_val);
             result.push('"');
             result.push_str(&html[insert_pos..]);
             return Some(result);
         }
     }
     None
-}
-
-#[cfg(feature = "maud")]
-fn escape_attribute(w: &mut String, s: &str) {
-    for c in s.chars() {
-        match c {
-            '&' => w.push_str("&amp;"),
-            '"' => w.push_str("&quot;"),
-            '<' => w.push_str("&lt;"),
-            '>' => w.push_str("&gt;"),
-            _ => w.push(c),
-        }
-    }
 }
 
 #[cfg(feature = "maud")]

--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -402,6 +402,7 @@ fn escape_attribute(w: &mut String, s: &str) {
 }
 
 #[cfg(feature = "maud")]
+#[must_use]
 pub fn escape_attribute_string(s: &str) -> String {
     let mut w = String::with_capacity(s.len() + 10);
     escape_attribute(&mut w, s);
@@ -409,6 +410,7 @@ pub fn escape_attribute_string(s: &str) -> String {
 }
 
 #[cfg(feature = "maud")]
+#[must_use]
 pub fn inject_hx_swap_oob(html: &str, oob_value: &str) -> Option<String> {
     let mut idx = 0;
     while let Some(start_pos) = html[idx..].find('<') {

--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -417,11 +417,8 @@ pub fn inject_hx_swap_oob(html: &str, oob_value: &str) -> Option<String> {
         let abs_start = idx + start_pos;
         let remaining = &html[abs_start..];
         if remaining.starts_with("<!--") {
-            if let Some(comment_end) = remaining.find("-->") {
-                idx = abs_start + comment_end + 3;
-            } else {
-                return None;
-            }
+            let comment_end = remaining.find("-->")?;
+            idx = abs_start + comment_end + 3;
         } else {
             let mut tag_name_end = 0;
             for (char_idx, c) in remaining.char_indices().skip(1) {

--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -389,6 +389,42 @@ impl HtmxFragments {
 }
 
 #[cfg(feature = "maud")]
+pub fn inject_hx_swap_oob(html: &str, oob_value: &str) -> Option<String> {
+    let mut idx = 0;
+    while let Some(start_pos) = html[idx..].find('<') {
+        let abs_start = idx + start_pos;
+        let remaining = &html[abs_start..];
+        if remaining.starts_with("<!--") {
+            if let Some(comment_end) = remaining.find("-->") {
+                idx = abs_start + comment_end + 3;
+            } else {
+                return None;
+            }
+        } else {
+            let mut tag_name_end = 0;
+            for (char_idx, c) in remaining.char_indices().skip(1) {
+                if c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '>' || c == '/' {
+                    tag_name_end = char_idx;
+                    break;
+                }
+            }
+            if tag_name_end == 0 {
+                return None;
+            }
+            let insert_pos = abs_start + tag_name_end;
+            let mut result = String::with_capacity(html.len() + oob_value.len() + 30);
+            result.push_str(&html[..insert_pos]);
+            result.push_str(" hx-swap-oob=\"");
+            result.push_str(oob_value);
+            result.push('"');
+            result.push_str(&html[insert_pos..]);
+            return Some(result);
+        }
+    }
+    None
+}
+
+#[cfg(feature = "maud")]
 fn escape_attribute(w: &mut String, s: &str) {
     for c in s.chars() {
         match c {
@@ -871,6 +907,34 @@ mod tests {
         assert_eq!(
             OobSwap::InnerHTML.format_value("#my-id"),
             "innerHTML:#my-id"
+        );
+    }
+
+    #[test]
+    fn test_inject_hx_swap_oob() {
+        assert_eq!(
+            inject_hx_swap_oob("<li id=\"1\"></li>", "beforeend:#container"),
+            Some("<li hx-swap-oob=\"beforeend:#container\" id=\"1\"></li>".to_string())
+        );
+        assert_eq!(
+            inject_hx_swap_oob("<!-- comment -->\n  <div class=\"foo\"></div>", "outerHTML"),
+            Some(
+                "<!-- comment -->\n  <div hx-swap-oob=\"outerHTML\" class=\"foo\"></div>"
+                    .to_string()
+            )
+        );
+        assert_eq!(inject_hx_swap_oob("Hello world", "true"), None);
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn test_inject_on_maud_markup() {
+        use maud::html;
+        let oob = html! { li id="item-1" { "Item" } };
+        let injected = inject_hx_swap_oob(&oob.0, "beforeend:#container");
+        assert_eq!(
+            injected,
+            Some("<li hx-swap-oob=\"beforeend:#container\" id=\"item-1\">Item</li>".to_string())
         );
     }
 }

--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -519,6 +519,45 @@ fn has_oob_attribute(html: &str) -> bool {
     false
 }
 
+/// Extracts the `id` attribute value from the root HTML element in the given HTML string.
+///
+/// Looks for an `id` attribute within the root start tag (before the first `>`).
+/// The attribute name must be preceded by a whitespace boundary.
+#[must_use]
+pub fn extract_html_id(html: &str) -> Option<String> {
+    let start_tag_end = html.find('>')?;
+    let start_tag = &html[..start_tag_end];
+    let mut id_idx = None;
+    let mut search_start = 0;
+    while let Some(offset) = start_tag[search_start..].find("id=") {
+        let absolute_idx = search_start + offset;
+        if absolute_idx > 0 {
+            let prev_char = start_tag.as_bytes()[absolute_idx - 1];
+            if prev_char == b' ' || prev_char == b'\t' || prev_char == b'\n' || prev_char == b'\r' {
+                id_idx = Some(absolute_idx);
+                break;
+            }
+        }
+        search_start = absolute_idx + 3;
+    }
+    let idx = id_idx?;
+    let after_id = &start_tag[idx + 3..];
+    let mut chars = after_id.chars();
+    let quote = chars.next()?;
+    if quote == '"' || quote == '\'' {
+        let mut val = String::new();
+        for c in chars {
+            if c == quote {
+                break;
+            }
+            val.push(c);
+        }
+        Some(val)
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -31,6 +31,12 @@ pub const HTMX_JS: &[u8] = include_bytes!("../vendor/htmx.min.js");
 /// Same-origin path where Autumn serves embedded htmx.
 pub const HTMX_JS_PATH: &str = "/static/js/htmx.min.js";
 
+/// htmx SSE extension JavaScript, embedded at compile time.
+pub const HTMX_SSE_JS: &[u8] = include_bytes!("../vendor/sse.js");
+
+/// Same-origin path where Autumn serves embedded htmx SSE extension.
+pub const HTMX_SSE_JS_PATH: &str = "/static/js/sse.js";
+
 /// Autumn widget runtime JavaScript, embedded at compile time.
 ///
 /// Provides CSP-compatible event-listener wiring for built-in widgets
@@ -522,6 +528,7 @@ mod tests {
     #[allow(clippy::const_is_empty)]
     fn htmx_js_is_not_empty() {
         assert!(!HTMX_JS.is_empty(), "htmx.min.js should not be empty");
+        assert!(!HTMX_SSE_JS.is_empty(), "sse.js should not be empty");
     }
 
     #[test]
@@ -530,6 +537,14 @@ mod tests {
         assert!(
             start.contains("htmx") || start.contains("function") || start.contains('('),
             "htmx.min.js doesn't look like JavaScript: {start}"
+        );
+        let sse_start = std::str::from_utf8(&HTMX_SSE_JS[..50]).expect("sse should be valid UTF-8");
+        assert!(
+            sse_start.contains("Server")
+                || sse_start.contains("function")
+                || sse_start.contains('/')
+                || sse_start.contains('*'),
+            "sse.js doesn't look like JavaScript: {sse_start}"
         );
     }
 
@@ -542,6 +557,7 @@ mod tests {
     fn htmx_asset_paths_are_same_origin_static_paths() {
         assert_eq!(HTMX_JS_PATH, "/static/js/htmx.min.js");
         assert_eq!(HTMX_CSRF_JS_PATH, "/static/js/autumn-htmx-csrf.js");
+        assert_eq!(HTMX_SSE_JS_PATH, "/static/js/sse.js");
     }
 
     #[test]

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -336,7 +336,10 @@ pub mod __private {
         finalize_repository_commit_hook_after_hook, kick_repository_commit_hook_dispatcher,
         mark_repository_commit_hook_after_hook_failed, register_repository_commit_hook_runner,
         start_repository_commit_hook_pending_finalizer_heartbeat,
+        start_repository_commit_hook_worker,
     };
+    #[cfg(all(feature = "db", feature = "ws"))]
+    pub use crate::repository_commit_hooks::{get_global_channels, set_global_channels};
     #[cfg(feature = "db")]
     pub use crate::version_history::VersionedRepositoryDescriptor;
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -338,7 +338,7 @@ pub mod __private {
         start_repository_commit_hook_pending_finalizer_heartbeat,
         start_repository_commit_hook_worker,
     };
-    #[cfg(all(feature = "db", feature = "ws"))]
+    #[cfg(feature = "db")]
     pub use crate::repository_commit_hooks::{get_global_channels, set_global_channels};
     #[cfg(feature = "db")]
     pub use crate::version_history::VersionedRepositoryDescriptor;
@@ -439,7 +439,10 @@ pub use validation::Validated;
 /// Useful for cache-busting or diagnostic logging. The corresponding
 /// minified JS is served automatically at `/static/js/htmx.min.js`.
 #[cfg(feature = "htmx")]
-pub use htmx::{AUTUMN_WIDGETS_JS_PATH, HTMX_CSRF_JS_PATH, HTMX_JS, HTMX_JS_PATH, HTMX_VERSION};
+pub use htmx::{
+    AUTUMN_WIDGETS_JS_PATH, HTMX_CSRF_JS_PATH, HTMX_JS, HTMX_JS_PATH, HTMX_SSE_JS,
+    HTMX_SSE_JS_PATH, HTMX_VERSION,
+};
 #[cfg(all(feature = "htmx", feature = "maud"))]
 pub use htmx::{HtmxFragments, OobSwap};
 #[cfg(feature = "mail")]

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -77,7 +77,7 @@ pub use crate::flash::{Flash, FlashLevel, FlashMessage};
 pub use crate::htmx::HxResponseExt;
 /// htmx request extractor.
 #[cfg(feature = "htmx")]
-pub use crate::htmx::{HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HxRequest};
+pub use crate::htmx::{HTMX_CSRF_JS_PATH, HTMX_JS_PATH, HTMX_SSE_JS_PATH, HxRequest};
 /// Out-of-band multi-region swaps response builder.
 #[cfg(all(feature = "htmx", feature = "maud"))]
 pub use crate::htmx::{HtmxFragments, OobSwap};

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -240,6 +240,95 @@ pub fn repository_upsert_advisory_lock_key(table_name: &str, record_id: i64) -> 
     i64::from_be_bytes(bytes)
 }
 
+/// Trait for formatting repository model fields into SSE broadcast topic segments.
+///
+/// This provides a uniform display format for both primitive types and optional/nullable values.
+pub trait DisplayTopicField {
+    /// Formats the field into a string suitable for a topic name.
+    fn to_topic_string(&self) -> String;
+}
+
+impl DisplayTopicField for String {
+    fn to_topic_string(&self) -> String {
+        self.clone()
+    }
+}
+
+impl DisplayTopicField for &str {
+    fn to_topic_string(&self) -> String {
+        (*self).to_string()
+    }
+}
+
+impl DisplayTopicField for bool {
+    fn to_topic_string(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl DisplayTopicField for char {
+    fn to_topic_string(&self) -> String {
+        self.to_string()
+    }
+}
+
+macro_rules! impl_display_topic_field_num {
+    ($($t:ty),*) => {
+        $(
+            impl DisplayTopicField for $t {
+                fn to_topic_string(&self) -> String {
+                    self.to_string()
+                }
+            }
+        )*
+    };
+}
+
+impl_display_topic_field_num!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, f32, f64);
+
+impl DisplayTopicField for ::uuid::Uuid {
+    fn to_topic_string(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl DisplayTopicField for ::chrono::NaiveDateTime {
+    fn to_topic_string(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl DisplayTopicField for ::chrono::NaiveDate {
+    fn to_topic_string(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl DisplayTopicField for ::chrono::NaiveTime {
+    fn to_topic_string(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl<T> DisplayTopicField for ::chrono::DateTime<T>
+where
+    T: ::chrono::TimeZone,
+    T::Offset: std::fmt::Display,
+{
+    fn to_topic_string(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl<T: DisplayTopicField> DisplayTopicField for Option<T> {
+    fn to_topic_string(&self) -> String {
+        match self {
+            Some(val) => val.to_topic_string(),
+            None => "none".to_string(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -322,10 +322,7 @@ where
 
 impl<T: DisplayTopicField> DisplayTopicField for Option<T> {
     fn to_topic_string(&self) -> String {
-        match self {
-            Some(val) => val.to_topic_string(),
-            None => "none".to_string(),
-        }
+        self.as_ref().map_or_else(|| "none".to_string(), DisplayTopicField::to_topic_string)
     }
 }
 

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -322,7 +322,8 @@ where
 
 impl<T: DisplayTopicField> DisplayTopicField for Option<T> {
     fn to_topic_string(&self) -> String {
-        self.as_ref().map_or_else(|| "none".to_string(), DisplayTopicField::to_topic_string)
+        self.as_ref()
+            .map_or_else(|| "none".to_string(), DisplayTopicField::to_topic_string)
     }
 }
 

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -208,6 +208,12 @@ pub trait CanSetTenantId {
     fn set_tenant_id(&mut self, tenant_id: String);
 }
 
+/// Trait implemented by models to expose their primary key value.
+pub trait ModelPrimaryKey {
+    type IdType: ::std::fmt::Display + ::core::clone::Clone + Send + Sync + 'static;
+    fn primary_key_value(&self) -> Self::IdType;
+}
+
 /// Metadata trait implemented for model structs to expose FTS configuration.
 pub trait AutumnSearchableModel {
     const IS_SEARCHABLE: bool;

--- a/autumn/src/repository_commit_hooks.rs
+++ b/autumn/src/repository_commit_hooks.rs
@@ -1394,6 +1394,42 @@ pub fn get_global_channels() -> Option<crate::channels::Channels> {
         .or_else(|| GLOBAL_CHANNELS.read().ok().and_then(|lock| lock.clone()))
 }
 
+#[cfg(not(feature = "ws"))]
+#[derive(Clone)]
+pub struct Channels;
+
+#[cfg(not(feature = "ws"))]
+pub struct DummyBroadcast;
+
+#[cfg(not(feature = "ws"))]
+impl Channels {
+    pub fn broadcast(&self) -> DummyBroadcast {
+        DummyBroadcast
+    }
+}
+
+#[cfg(not(feature = "ws"))]
+impl DummyBroadcast {
+    pub fn publish_oob<T, S>(
+        &self,
+        _topic: &str,
+        _id: &str,
+        _swap: S,
+        _fragment: &T,
+    ) -> Result<(), std::convert::Infallible> {
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "ws"))]
+pub fn set_global_channels(_channels: Channels) {}
+
+#[cfg(not(feature = "ws"))]
+#[must_use]
+pub fn get_global_channels() -> Option<Channels> {
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/autumn/src/repository_commit_hooks.rs
+++ b/autumn/src/repository_commit_hooks.rs
@@ -153,6 +153,8 @@ static REPOSITORY_COMMIT_HOOK_KICKERS: OnceLock<
 struct RepositoryCommitHookKickState {
     notify: Notify,
     pending: AtomicBool,
+    #[cfg(feature = "ws")]
+    channels: OnceLock<crate::channels::Channels>,
 }
 
 impl Default for RepositoryCommitHookKickState {
@@ -160,6 +162,8 @@ impl Default for RepositoryCommitHookKickState {
         Self {
             notify: Notify::new(),
             pending: AtomicBool::new(false),
+            #[cfg(feature = "ws")]
+            channels: OnceLock::new(),
         }
     }
 }
@@ -780,6 +784,11 @@ pub fn start_repository_commit_hook_worker(
         return;
     }
 
+    if let Some(ch) = channels.clone() {
+        let kick_state = repository_commit_hook_kick_state(&pool);
+        let _ = kick_state.channels.set(ch);
+    }
+
     let worker_id = repository_commit_hook_worker_id();
     tokio::spawn(async move {
         if let Some(ch) = channels {
@@ -886,7 +895,8 @@ fn spawn_repository_commit_hook_kick_worker(
             while state.take_pending_kick() {
                 #[cfg(feature = "ws")]
                 {
-                    if let Some(ch) = get_global_channels() {
+                    let ch_opt = state.channels.get().cloned().or_else(get_global_channels);
+                    if let Some(ch) = ch_opt {
                         let pool_clone = pool.clone();
                         let worker_id_clone = worker_id.clone();
                         CURRENT_CHANNELS

--- a/autumn/src/repository_commit_hooks.rs
+++ b/autumn/src/repository_commit_hooks.rs
@@ -783,7 +783,7 @@ pub fn start_repository_commit_hook_worker(
     let worker_id = repository_commit_hook_worker_id();
     tokio::spawn(async move {
         if let Some(ch) = channels {
-            let _ = CURRENT_CHANNELS
+            CURRENT_CHANNELS
                 .scope(ch, async move {
                     loop {
                         tokio::select! {
@@ -889,9 +889,14 @@ fn spawn_repository_commit_hook_kick_worker(
                     if let Some(ch) = get_global_channels() {
                         let pool_clone = pool.clone();
                         let worker_id_clone = worker_id.clone();
-                        let _ = CURRENT_CHANNELS
+                        CURRENT_CHANNELS
                             .scope(ch, async move {
-                                drain_ready_repository_commit_hooks(&pool_clone, &worker_id_clone, 32).await;
+                                drain_ready_repository_commit_hooks(
+                                    &pool_clone,
+                                    &worker_id_clone,
+                                    32,
+                                )
+                                .await;
                             })
                             .await;
                         continue;
@@ -1381,9 +1386,10 @@ pub fn set_global_channels(channels: crate::channels::Channels) {
 }
 
 #[cfg(feature = "ws")]
+#[must_use]
 pub fn get_global_channels() -> Option<crate::channels::Channels> {
     CURRENT_CHANNELS
-        .try_with(|c| c.clone())
+        .try_with(std::clone::Clone::clone)
         .ok()
         .or_else(|| GLOBAL_CHANNELS.read().ok().and_then(|lock| lock.clone()))
 }

--- a/autumn/src/repository_commit_hooks.rs
+++ b/autumn/src/repository_commit_hooks.rs
@@ -769,6 +769,48 @@ where
     Ok((context, record))
 }
 
+#[cfg(feature = "ws")]
+pub fn start_repository_commit_hook_worker(
+    pool: PgPool,
+    channels: Option<crate::channels::Channels>,
+    shutdown: CancellationToken,
+) {
+    register_inventory_repository_commit_hook_runners();
+    if !should_start_repository_commit_hook_worker(&registered_handler_keys()) {
+        return;
+    }
+
+    let worker_id = repository_commit_hook_worker_id();
+    tokio::spawn(async move {
+        if let Some(ch) = channels {
+            let _ = CURRENT_CHANNELS
+                .scope(ch, async move {
+                    loop {
+                        tokio::select! {
+                            () = shutdown.cancelled() => break,
+                            () = tokio::time::sleep(HOOK_WORKER_IDLE_SLEEP) => {
+                                recover_stale_repository_commit_hooks(&pool, &worker_id).await;
+                                drain_ready_repository_commit_hooks(&pool, &worker_id, 32).await;
+                            }
+                        }
+                    }
+                })
+                .await;
+        } else {
+            loop {
+                tokio::select! {
+                    () = shutdown.cancelled() => break,
+                    () = tokio::time::sleep(HOOK_WORKER_IDLE_SLEEP) => {
+                        recover_stale_repository_commit_hooks(&pool, &worker_id).await;
+                        drain_ready_repository_commit_hooks(&pool, &worker_id, 32).await;
+                    }
+                }
+            }
+        }
+    });
+}
+
+#[cfg(not(feature = "ws"))]
 pub fn start_repository_commit_hook_worker(pool: PgPool, shutdown: CancellationToken) {
     register_inventory_repository_commit_hook_runners();
     if !should_start_repository_commit_hook_worker(&registered_handler_keys()) {
@@ -838,7 +880,25 @@ fn spawn_repository_commit_hook_kick_worker(
     state: Arc<RepositoryCommitHookKickState>,
 ) {
     let worker_id = repository_commit_hook_worker_id();
+    #[cfg(feature = "ws")]
+    let channels = get_global_channels();
     tokio::spawn(async move {
+        #[cfg(feature = "ws")]
+        {
+            if let Some(ch) = channels {
+                let _ = CURRENT_CHANNELS
+                    .scope(ch, async move {
+                        loop {
+                            state.notify.notified().await;
+                            while state.take_pending_kick() {
+                                drain_ready_repository_commit_hooks(&pool, &worker_id, 32).await;
+                            }
+                        }
+                    })
+                    .await;
+                return;
+            }
+        }
         loop {
             state.notify.notified().await;
             while state.take_pending_kick() {
@@ -1307,6 +1367,30 @@ fn repository_commit_hook_worker_id() -> String {
 
 fn repository_commit_hook_pending_owner_id() -> String {
     format!("repository-hook-pending-{}", uuid::Uuid::new_v4())
+}
+
+#[cfg(feature = "ws")]
+tokio::task_local! {
+    pub static CURRENT_CHANNELS: crate::channels::Channels;
+}
+
+#[cfg(feature = "ws")]
+static GLOBAL_CHANNELS: std::sync::RwLock<Option<crate::channels::Channels>> =
+    std::sync::RwLock::new(None);
+
+#[cfg(feature = "ws")]
+pub fn set_global_channels(channels: crate::channels::Channels) {
+    if let Ok(mut lock) = GLOBAL_CHANNELS.write() {
+        *lock = Some(channels);
+    }
+}
+
+#[cfg(feature = "ws")]
+pub fn get_global_channels() -> Option<crate::channels::Channels> {
+    CURRENT_CHANNELS
+        .try_with(|c| c.clone())
+        .ok()
+        .or_else(|| GLOBAL_CHANNELS.read().ok().and_then(|lock| lock.clone()))
 }
 
 #[cfg(test)]

--- a/autumn/src/repository_commit_hooks.rs
+++ b/autumn/src/repository_commit_hooks.rs
@@ -880,28 +880,23 @@ fn spawn_repository_commit_hook_kick_worker(
     state: Arc<RepositoryCommitHookKickState>,
 ) {
     let worker_id = repository_commit_hook_worker_id();
-    #[cfg(feature = "ws")]
-    let channels = get_global_channels();
     tokio::spawn(async move {
-        #[cfg(feature = "ws")]
-        {
-            if let Some(ch) = channels {
-                let _ = CURRENT_CHANNELS
-                    .scope(ch, async move {
-                        loop {
-                            state.notify.notified().await;
-                            while state.take_pending_kick() {
-                                drain_ready_repository_commit_hooks(&pool, &worker_id, 32).await;
-                            }
-                        }
-                    })
-                    .await;
-                return;
-            }
-        }
         loop {
             state.notify.notified().await;
             while state.take_pending_kick() {
+                #[cfg(feature = "ws")]
+                {
+                    if let Some(ch) = get_global_channels() {
+                        let pool_clone = pool.clone();
+                        let worker_id_clone = worker_id.clone();
+                        let _ = CURRENT_CHANNELS
+                            .scope(ch, async move {
+                                drain_ready_repository_commit_hooks(&pool_clone, &worker_id_clone, 32).await;
+                            })
+                            .await;
+                        continue;
+                    }
+                }
                 drain_ready_repository_commit_hooks(&pool, &worker_id, 32).await;
             }
         }

--- a/autumn/src/repository_commit_hooks.rs
+++ b/autumn/src/repository_commit_hooks.rs
@@ -1413,13 +1413,15 @@ pub struct DummyBroadcast;
 
 #[cfg(not(feature = "ws"))]
 impl Channels {
-    pub fn broadcast(&self) -> DummyBroadcast {
+    #[allow(clippy::unused_self)]
+    pub const fn broadcast(&self) -> DummyBroadcast {
         DummyBroadcast
     }
 }
 
 #[cfg(not(feature = "ws"))]
 impl DummyBroadcast {
+    #[allow(clippy::unused_self, clippy::unnecessary_wraps)]
     pub fn publish_oob<T, S>(
         &self,
         _topic: &str,
@@ -1432,10 +1434,12 @@ impl DummyBroadcast {
 }
 
 #[cfg(not(feature = "ws"))]
+#[allow(clippy::missing_const_for_fn)]
 pub fn set_global_channels(_channels: Channels) {}
 
 #[cfg(not(feature = "ws"))]
 #[must_use]
+#[allow(clippy::missing_const_for_fn)]
 pub fn get_global_channels() -> Option<Channels> {
     None
 }

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -241,6 +241,16 @@ pub(crate) fn append_framework_routes(
             status: None,
             sunset_opt_out: None,
         });
+        infos.push(RouteInfo {
+            method: "GET".to_owned(),
+            path: crate::htmx::HTMX_SSE_JS_PATH.to_owned(),
+            handler: "htmx_sse".to_owned(),
+            source: RouteSource::Framework,
+            middleware: Vec::new(),
+            api_version: None,
+            status: None,
+            sunset_opt_out: None,
+        });
     }
 
     #[cfg(feature = "mail")]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1382,6 +1382,62 @@ const fn is_i18n_bundle_extension_layer(_type_id: std::any::TypeId) -> bool {
     false
 }
 
+#[cfg(feature = "htmx")]
+fn mount_htmx_routes(mut router: axum::Router<AppState>) -> axum::Router<AppState> {
+    if crate::assets::htmx_is_vendored() {
+        tracing::debug!(
+            path = crate::htmx::HTMX_JS_PATH,
+            "htmx vendored via `autumn assets`; built-in handler skipped, ServeDir serves it"
+        );
+    } else {
+        router = router.route(crate::htmx::HTMX_JS_PATH, axum::routing::get(htmx_handler));
+        tracing::debug!(
+            method = "GET",
+            path = crate::htmx::HTMX_JS_PATH,
+            name = format!("htmx {}", crate::htmx::HTMX_VERSION),
+            "Mounted route"
+        );
+    }
+    router = router.route(
+        crate::htmx::HTMX_CSRF_JS_PATH,
+        axum::routing::get(htmx_csrf_handler),
+    );
+    router = router.route(
+        crate::htmx::AUTUMN_WIDGETS_JS_PATH,
+        axum::routing::get(autumn_widgets_handler),
+    );
+    if crate::assets::sse_is_vendored() {
+        tracing::debug!(
+            path = crate::htmx::HTMX_SSE_JS_PATH,
+            "sse extension vendored via `autumn assets`; built-in handler skipped, ServeDir serves it"
+        );
+    } else {
+        router = router.route(
+            crate::htmx::HTMX_SSE_JS_PATH,
+            axum::routing::get(htmx_sse_handler),
+        );
+        tracing::debug!(
+            method = "GET",
+            path = crate::htmx::HTMX_SSE_JS_PATH,
+            name = "htmx sse extension",
+            "Mounted route"
+        );
+    }
+    tracing::debug!(
+        method = "GET",
+        path = crate::htmx::HTMX_CSRF_JS_PATH,
+        name = "htmx csrf helper",
+        "Mounted route"
+    );
+    tracing::debug!(
+        method = "GET",
+        path = crate::htmx::AUTUMN_WIDGETS_JS_PATH,
+        name = "autumn widget runtime",
+        "Mounted route"
+    );
+    router
+}
+
 #[cfg_attr(not(feature = "mail"), allow(unused_variables))]
 #[allow(clippy::cognitive_complexity)]
 fn mount_framework_routes(
@@ -1395,61 +1451,7 @@ fn mount_framework_routes(
     // Framework-provided routes
     #[cfg(feature = "htmx")]
     {
-        // When htmx is vendored via `autumn assets add htmx@…`, skip the
-        // built-in handler so ServeDir serves the correctly-pinned file.
-        // Axum explicit routes beat `nest_service`, so without this guard the
-        // embedded 2.0.4 bytes would shadow any updated vendored version.
-        if crate::assets::htmx_is_vendored() {
-            tracing::debug!(
-                path = crate::htmx::HTMX_JS_PATH,
-                "htmx vendored via `autumn assets`; built-in handler skipped, ServeDir serves it"
-            );
-        } else {
-            router = router.route(crate::htmx::HTMX_JS_PATH, axum::routing::get(htmx_handler));
-            tracing::debug!(
-                method = "GET",
-                path = crate::htmx::HTMX_JS_PATH,
-                name = format!("htmx {}", crate::htmx::HTMX_VERSION),
-                "Mounted route"
-            );
-        }
-        router = router.route(
-            crate::htmx::HTMX_CSRF_JS_PATH,
-            axum::routing::get(htmx_csrf_handler),
-        );
-        router = router.route(
-            crate::htmx::AUTUMN_WIDGETS_JS_PATH,
-            axum::routing::get(autumn_widgets_handler),
-        );
-        if crate::assets::sse_is_vendored() {
-            tracing::debug!(
-                path = crate::htmx::HTMX_SSE_JS_PATH,
-                "sse extension vendored via `autumn assets`; built-in handler skipped, ServeDir serves it"
-            );
-        } else {
-            router = router.route(
-                crate::htmx::HTMX_SSE_JS_PATH,
-                axum::routing::get(htmx_sse_handler),
-            );
-            tracing::debug!(
-                method = "GET",
-                path = crate::htmx::HTMX_SSE_JS_PATH,
-                name = "htmx sse extension",
-                "Mounted route"
-            );
-        }
-        tracing::debug!(
-            method = "GET",
-            path = crate::htmx::HTMX_CSRF_JS_PATH,
-            name = "htmx csrf helper",
-            "Mounted route"
-        );
-        tracing::debug!(
-            method = "GET",
-            path = crate::htmx::AUTUMN_WIDGETS_JS_PATH,
-            name = "autumn widget runtime",
-            "Mounted route"
-        );
+        router = mount_htmx_routes(router);
     }
 
     // Framework-provided flash-message stylesheet. Served as a same-origin

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1045,6 +1045,7 @@ fn collect_claimed_get_paths(
         }
         claimed.insert(crate::htmx::HTMX_CSRF_JS_PATH.to_owned());
         claimed.insert(crate::htmx::AUTUMN_WIDGETS_JS_PATH.to_owned());
+        claimed.insert(crate::htmx::HTMX_SSE_JS_PATH.to_owned());
     }
     // Dev live-reload endpoints are only mounted when the env vars
     // that enable them are set, but reserving the paths regardless
@@ -1420,6 +1421,10 @@ fn mount_framework_routes(
             crate::htmx::AUTUMN_WIDGETS_JS_PATH,
             axum::routing::get(autumn_widgets_handler),
         );
+        router = router.route(
+            crate::htmx::HTMX_SSE_JS_PATH,
+            axum::routing::get(htmx_sse_handler),
+        );
         tracing::debug!(
             method = "GET",
             path = crate::htmx::HTMX_CSRF_JS_PATH,
@@ -1430,6 +1435,12 @@ fn mount_framework_routes(
             method = "GET",
             path = crate::htmx::AUTUMN_WIDGETS_JS_PATH,
             name = "autumn widget runtime",
+            "Mounted route"
+        );
+        tracing::debug!(
+            method = "GET",
+            path = crate::htmx::HTMX_SSE_JS_PATH,
+            name = "htmx sse extension",
             "Mounted route"
         );
     }
@@ -3195,6 +3206,22 @@ pub async fn autumn_widgets_handler() -> axum::response::Response {
             ),
         ],
         crate::htmx::AUTUMN_WIDGETS_JS,
+    )
+        .into_response()
+}
+
+#[cfg(feature = "htmx")]
+pub async fn htmx_sse_handler() -> axum::response::Response {
+    use axum::response::IntoResponse;
+    (
+        [
+            (http::header::CONTENT_TYPE, "application/javascript"),
+            (
+                http::header::CACHE_CONTROL,
+                "public, max-age=31536000, immutable",
+            ),
+        ],
+        crate::htmx::HTMX_SSE_JS,
     )
         .into_response()
 }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1421,10 +1421,23 @@ fn mount_framework_routes(
             crate::htmx::AUTUMN_WIDGETS_JS_PATH,
             axum::routing::get(autumn_widgets_handler),
         );
-        router = router.route(
-            crate::htmx::HTMX_SSE_JS_PATH,
-            axum::routing::get(htmx_sse_handler),
-        );
+        if crate::assets::sse_is_vendored() {
+            tracing::debug!(
+                path = crate::htmx::HTMX_SSE_JS_PATH,
+                "sse extension vendored via `autumn assets`; built-in handler skipped, ServeDir serves it"
+            );
+        } else {
+            router = router.route(
+                crate::htmx::HTMX_SSE_JS_PATH,
+                axum::routing::get(htmx_sse_handler),
+            );
+            tracing::debug!(
+                method = "GET",
+                path = crate::htmx::HTMX_SSE_JS_PATH,
+                name = "htmx sse extension",
+                "Mounted route"
+            );
+        }
         tracing::debug!(
             method = "GET",
             path = crate::htmx::HTMX_CSRF_JS_PATH,
@@ -1435,12 +1448,6 @@ fn mount_framework_routes(
             method = "GET",
             path = crate::htmx::AUTUMN_WIDGETS_JS_PATH,
             name = "autumn widget runtime",
-            "Mounted route"
-        );
-        tracing::debug!(
-            method = "GET",
-            path = crate::htmx::HTMX_SSE_JS_PATH,
-            name = "htmx sse extension",
             "Mounted route"
         );
     }

--- a/autumn/src/tenancy.rs
+++ b/autumn/src/tenancy.rs
@@ -568,6 +568,24 @@ where
     }
 }
 
+/// Helper trait to display or extract a string representation of the tenant ID.
+pub trait DisplayTenantId {
+    /// Returns the string slice of the tenant ID.
+    fn tenant_id_str(&self) -> &str;
+}
+
+impl DisplayTenantId for String {
+    fn tenant_id_str(&self) -> &str {
+        self
+    }
+}
+
+impl DisplayTenantId for Option<String> {
+    fn tenant_id_str(&self) -> &str {
+        self.as_deref().unwrap_or("default")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/autumn/tests/auto_broadcast.rs
+++ b/autumn/tests/auto_broadcast.rs
@@ -130,6 +130,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "requires Docker (testcontainers)"]
+    #[allow(clippy::too_many_lines)]
     async fn test_auto_broadcast_lifecycle() {
         let _ = ::tracing_subscriber::fmt()
             .with_env_filter(::tracing_subscriber::EnvFilter::from_default_env())

--- a/autumn/tests/auto_broadcast.rs
+++ b/autumn/tests/auto_broadcast.rs
@@ -221,7 +221,7 @@ mod tests {
             .expect("timeout waiting for custom update broadcast")
             .expect("recv error");
         let html_content = msg.into_string();
-        assert!(html_content.contains("hx-swap-oob=\"outerHTML\""));
+        assert!(html_content.contains("hx-swap-oob=\"beforeend:#custom-posts-list\""));
         assert!(html_content.contains(&format!("id=\"custom-post-{}", custom_post.id)));
         assert!(html_content.contains("world"));
 
@@ -314,6 +314,7 @@ mod tests {
             .into_string();
 
         let combined = format!("{msg_go1} {msg_go2}");
+        assert!(combined.contains("hx-swap-oob=\"beforeend:#nullable_posts-list\""));
         assert!(combined.contains(&format!("nullable_post-{}", post_none.id)));
         assert!(combined.contains(&format!("nullable_post-{}", post_some.id)));
 

--- a/autumn/tests/auto_broadcast.rs
+++ b/autumn/tests/auto_broadcast.rs
@@ -157,7 +157,6 @@ mod tests {
 
         let update_changes = UpdateBroadcastPost {
             title: autumn_web::hooks::Patch::Set("world".to_owned()),
-            ..Default::default()
         };
         custom_repo
             .update(custom_post.id, &update_changes)

--- a/autumn/tests/auto_broadcast.rs
+++ b/autumn/tests/auto_broadcast.rs
@@ -1,0 +1,157 @@
+//! Integration tests for declarative auto-broadcasting.
+//!
+//! Run with:
+//!
+//!     cargo test --test auto_broadcast --features "ws,db"
+
+#[cfg(all(feature = "db", feature = "ws"))]
+mod tests {
+    use autumn_web::prelude::*;
+    use autumn_web::test::TestDb;
+    use diesel_async::RunQueryDsl;
+
+    // ── Schema ─────────────────────────────────────────────────
+
+    diesel::table! {
+        broadcast_posts (id) {
+            id -> Int8,
+            title -> Text,
+        }
+    }
+
+    #[autumn_web::model(table = "broadcast_posts")]
+    pub struct BroadcastPost {
+        #[id]
+        pub id: i64,
+        pub title: String,
+    }
+
+    // A model with a custom render function.
+    fn render_custom_post(post: &BroadcastPost) -> maud::Markup {
+        maud::html! {
+            div id=(format!("custom-post-{}", post.id)) {
+                h2 { (post.title) }
+            }
+        }
+    }
+
+    // 1. Basic auto-broadcasting (defaults to topic = "broadcast_posts", container = "broadcast_posts-list")
+    #[autumn_web::repository(BroadcastPost, table = "broadcast_posts", broadcasts = true)]
+    pub trait BasicPostRepository {}
+
+    // 2. Custom broadcasting (custom topic with field interpolation, custom container, custom render)
+    #[autumn_web::repository(
+        BroadcastPost,
+        table = "broadcast_posts",
+        broadcasts = true,
+        topic = "post_topic:{title}",
+        render = render_custom_post,
+        container = "custom-posts-list"
+    )]
+    pub trait CustomPostRepository {}
+
+    // ── Setup ──────────────────────────────────────────────────
+
+    async fn setup_db(db: &TestDb) {
+        let mut conn = db.pool().get().await.expect("db connection");
+        diesel::sql_query(
+            "CREATE TABLE IF NOT EXISTS broadcast_posts (
+                id BIGSERIAL PRIMARY KEY,
+                title TEXT NOT NULL
+            )",
+        )
+        .execute(&mut *conn)
+        .await
+        .expect("create broadcast_posts table");
+
+        diesel::sql_query(
+            "CREATE TABLE IF NOT EXISTS autumn_repository_commit_hooks (
+                id TEXT PRIMARY KEY,
+                handler_key TEXT NOT NULL,
+                hook_name TEXT NOT NULL,
+                context JSONB NOT NULL,
+                record JSONB NOT NULL,
+                status TEXT NOT NULL,
+                attempt INTEGER NOT NULL,
+                max_attempts INTEGER NOT NULL,
+                initial_backoff_ms BIGINT NOT NULL,
+                enqueued_at TIMESTAMP NOT NULL,
+                run_at TIMESTAMP NOT NULL,
+                claimed_by TEXT,
+                claimed_at TIMESTAMP,
+                started_at TIMESTAMP,
+                finished_at TIMESTAMP,
+                last_error TEXT
+            )",
+        )
+        .execute(&mut *conn)
+        .await
+        .expect("create autumn_repository_commit_hooks table");
+    }
+
+    // ── Tests ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn test_auto_broadcast_lifecycle() {
+        let db = TestDb::shared().await;
+        setup_db(db).await;
+
+        let state = AppState::detached();
+        let channels = state.channels().clone();
+        // Register channels globally in the worker
+        autumn_web::__private::set_global_channels(channels.clone());
+
+        // Subscribe to basic and custom topics
+        let mut basic_sub = channels.subscribe("broadcast_posts");
+        let mut custom_sub = channels.subscribe("post_topic:hello");
+
+        let repo = PgBasicPostRepository::with_pool_untracked(db.pool().clone());
+        let custom_repo = PgCustomPostRepository::with_pool_untracked(db.pool().clone());
+
+        // Start the background commit hook worker
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        autumn_web::__private::start_repository_commit_hook_worker(
+            db.pool().clone(),
+            Some(channels.clone()),
+            shutdown.child_token(),
+        );
+
+        // 1. Create on basic repository
+        let new_post = repo
+            .save(&NewBroadcastPost {
+                title: "hello".to_owned(),
+            })
+            .await
+            .expect("save post");
+
+        // Wait for the background worker to drain the hook and publish
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(3), basic_sub.recv())
+            .await
+            .expect("timeout waiting for basic create broadcast")
+            .expect("recv error");
+        let html_content = msg.into_string();
+        assert!(html_content.contains("hx-swap-oob=\"beforeend:#broadcast_posts-list\""));
+        assert!(html_content.contains(&format!("broadcast_post-{}", new_post.id)));
+
+        // 2. Create on custom repository
+        let custom_post = custom_repo
+            .save(&NewBroadcastPost {
+                title: "hello".to_owned(),
+            })
+            .await
+            .expect("save custom post");
+
+        // Wait for the background worker to drain and publish on custom topic (interpolated post_topic:hello)
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(3), custom_sub.recv())
+            .await
+            .expect("timeout waiting for custom create broadcast")
+            .expect("recv error");
+        let html_content = msg.into_string();
+        assert!(html_content.contains("hx-swap-oob=\"beforeend:#custom-posts-list\""));
+        assert!(html_content.contains(&format!("id=\"custom-post-{}", custom_post.id)));
+        assert!(html_content.contains("hello"));
+
+        shutdown.cancel();
+    }
+}

--- a/autumn/tests/auto_broadcast.rs
+++ b/autumn/tests/auto_broadcast.rs
@@ -2,9 +2,9 @@
 //!
 //! Run with:
 //!
-//!     cargo test --test auto_broadcast --features "ws,db"
+//!     cargo test --test auto_broadcast --features "ws,db,test-support"
 
-#[cfg(all(feature = "db", feature = "ws"))]
+#[cfg(all(feature = "db", feature = "ws", feature = "test-support"))]
 mod tests {
     use autumn_web::prelude::*;
     use autumn_web::test::TestDb;

--- a/autumn/tests/auto_broadcast.rs
+++ b/autumn/tests/auto_broadcast.rs
@@ -152,6 +152,43 @@ mod tests {
         assert!(html_content.contains(&format!("id=\"custom-post-{}", custom_post.id)));
         assert!(html_content.contains("hello"));
 
+        // 3. Update on custom repository
+        let mut custom_update_sub = channels.subscribe("post_topic:world");
+
+        let mut update_changes = UpdateBroadcastPost::default();
+        update_changes.title = autumn_web::hooks::Patch::Set("world".to_owned());
+        custom_repo
+            .update(custom_post.id, &update_changes)
+            .await
+            .expect("update custom post");
+
+        // Wait for the background worker to drain and publish update on custom topic
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(3), custom_update_sub.recv())
+            .await
+            .expect("timeout waiting for custom update broadcast")
+            .expect("recv error");
+        let html_content = msg.into_string();
+        assert!(html_content.contains("hx-swap-oob=\"outerHTML\""));
+        assert!(html_content.contains(&format!("id=\"custom-post-{}", custom_post.id)));
+        assert!(html_content.contains("world"));
+
+        // 4. Delete on custom repository
+        custom_repo
+            .delete_by_id(custom_post.id)
+            .await
+            .expect("delete custom post");
+
+        // Wait for the background worker to drain and publish delete on custom topic
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(3), custom_update_sub.recv())
+            .await
+            .expect("timeout waiting for custom delete broadcast")
+            .expect("recv error");
+        let html_content = msg.into_string();
+        assert!(html_content.contains(&format!(
+            "hx-swap-oob=\"delete:#custom-post-{}\"",
+            custom_post.id
+        )));
+
         shutdown.cancel();
     }
 }

--- a/autumn/tests/auto_broadcast.rs
+++ b/autumn/tests/auto_broadcast.rs
@@ -94,6 +94,9 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires Docker (testcontainers)"]
     async fn test_auto_broadcast_lifecycle() {
+        let _ = ::tracing_subscriber::fmt()
+            .with_env_filter(::tracing_subscriber::EnvFilter::from_default_env())
+            .try_init();
         let db = TestDb::shared().await;
         setup_db(db).await;
 
@@ -152,7 +155,8 @@ mod tests {
         assert!(html_content.contains(&format!("id=\"custom-post-{}", custom_post.id)));
         assert!(html_content.contains("hello"));
 
-        // 3. Update on custom repository
+        // 3. Update on custom repository (which changes the topic from post_topic:hello to post_topic:world)
+        let mut old_topic_sub = channels.subscribe("post_topic:hello");
         let mut custom_update_sub = channels.subscribe("post_topic:world");
 
         let update_changes = UpdateBroadcastPost {
@@ -162,6 +166,17 @@ mod tests {
             .update(custom_post.id, &update_changes)
             .await
             .expect("update custom post");
+
+        // Wait for the background worker to drain and publish delete on the old topic
+        let msg_old = tokio::time::timeout(std::time::Duration::from_secs(3), old_topic_sub.recv())
+            .await
+            .expect("timeout waiting for delete on old topic broadcast")
+            .expect("recv error");
+        let html_content_old = msg_old.into_string();
+        assert!(html_content_old.contains(&format!(
+            "hx-swap-oob=\"delete:#custom-post-{}\"",
+            custom_post.id
+        )));
 
         // Wait for the background worker to drain and publish update on custom topic
         let msg = tokio::time::timeout(std::time::Duration::from_secs(3), custom_update_sub.recv())

--- a/autumn/tests/auto_broadcast.rs
+++ b/autumn/tests/auto_broadcast.rs
@@ -29,7 +29,7 @@ mod tests {
     // A model with a custom render function.
     fn render_custom_post(post: &BroadcastPost) -> maud::Markup {
         maud::html! {
-            div id=(format!("custom-post-{}", post.id)) {
+            div data-id="123" id=(format!("custom-post-{}", post.id)) {
                 h2 { (post.title) }
             }
         }

--- a/autumn/tests/auto_broadcast.rs
+++ b/autumn/tests/auto_broadcast.rs
@@ -106,13 +106,13 @@ mod tests {
         let mut basic_sub = channels.subscribe("broadcast_posts");
         let mut custom_sub = channels.subscribe("post_topic:hello");
 
-        let repo = PgBasicPostRepository::with_pool_untracked(db.pool().clone());
-        let custom_repo = PgCustomPostRepository::with_pool_untracked(db.pool().clone());
+        let repo = PgBasicPostRepository::with_pool_untracked(db.pool());
+        let custom_repo = PgCustomPostRepository::with_pool_untracked(db.pool());
 
         // Start the background commit hook worker
         let shutdown = tokio_util::sync::CancellationToken::new();
         autumn_web::__private::start_repository_commit_hook_worker(
-            db.pool().clone(),
+            db.pool(),
             Some(channels.clone()),
             shutdown.child_token(),
         );
@@ -155,8 +155,10 @@ mod tests {
         // 3. Update on custom repository
         let mut custom_update_sub = channels.subscribe("post_topic:world");
 
-        let mut update_changes = UpdateBroadcastPost::default();
-        update_changes.title = autumn_web::hooks::Patch::Set("world".to_owned());
+        let update_changes = UpdateBroadcastPost {
+            title: autumn_web::hooks::Patch::Set("world".to_owned()),
+            ..Default::default()
+        };
         custom_repo
             .update(custom_post.id, &update_changes)
             .await

--- a/autumn/tests/auto_broadcast.rs
+++ b/autumn/tests/auto_broadcast.rs
@@ -315,7 +315,7 @@ mod tests {
             .into_string();
 
         let combined = format!("{msg_go1} {msg_go2}");
-        assert!(combined.contains("hx-swap-oob=\"beforeend:#nullable_posts-list\""));
+        assert!(combined.contains("hx-swap-oob=\"beforeend:#category-posts-list\""));
         assert!(combined.contains(&format!("nullable_post-{}", post_none.id)));
         assert!(combined.contains(&format!("nullable_post-{}", post_some.id)));
 

--- a/autumn/tests/auto_broadcast.rs
+++ b/autumn/tests/auto_broadcast.rs
@@ -50,6 +50,32 @@ mod tests {
     )]
     pub trait CustomPostRepository {}
 
+    // 3. Nullable model with a category (Option<String>)
+    diesel::table! {
+        nullable_posts (id) {
+            id -> Int8,
+            title -> Text,
+            category -> Nullable<Text>,
+        }
+    }
+
+    #[autumn_web::model(table = "nullable_posts")]
+    pub struct NullablePost {
+        #[id]
+        pub id: i64,
+        pub title: String,
+        pub category: Option<String>,
+    }
+
+    #[autumn_web::repository(
+        NullablePost,
+        table = "nullable_posts",
+        broadcasts = true,
+        topic = "category_posts:{category}",
+        container = "category-posts-list"
+    )]
+    pub trait NullablePostRepository {}
+
     // ── Setup ──────────────────────────────────────────────────
 
     async fn setup_db(db: &TestDb) {
@@ -63,6 +89,17 @@ mod tests {
         .execute(&mut *conn)
         .await
         .expect("create broadcast_posts table");
+
+        diesel::sql_query(
+            "CREATE TABLE IF NOT EXISTS nullable_posts (
+                id BIGSERIAL PRIMARY KEY,
+                title TEXT NOT NULL,
+                category TEXT
+            )",
+        )
+        .execute(&mut *conn)
+        .await
+        .expect("create nullable_posts table");
 
         diesel::sql_query(
             "CREATE TABLE IF NOT EXISTS autumn_repository_commit_hooks (
@@ -204,6 +241,81 @@ mod tests {
             "hx-swap-oob=\"delete:#custom-post-{}\"",
             custom_post.id
         )));
+
+        // 5. Test bulk update (update_many) and nullable topic placeholders
+        let nullable_repo = PgNullablePostRepository::with_pool_untracked(db.pool());
+
+        let post_none = nullable_repo
+            .save(&NewNullablePost {
+                title: "post_none".to_owned(),
+                category: None,
+            })
+            .await
+            .expect("save post_none");
+
+        let post_some = nullable_repo
+            .save(&NewNullablePost {
+                title: "post_some".to_owned(),
+                category: Some("rust".to_owned()),
+            })
+            .await
+            .expect("save post_some");
+
+        // We subscribe to the topics
+        let mut none_sub = channels.subscribe("category_posts:none");
+        let mut rust_sub = channels.subscribe("category_posts:rust");
+        let mut go_sub = channels.subscribe("category_posts:go");
+
+        // Drain any initial creation broadcasts
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(500), none_sub.recv()).await;
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(500), rust_sub.recv()).await;
+
+        // Perform a bulk update changing category from None -> Some("go") and Some("rust") -> Some("go")
+        let update_changes = UpdateNullablePost {
+            title: autumn_web::hooks::Patch::Unchanged,
+            category: autumn_web::hooks::Patch::Set(Some("go".to_owned())),
+        };
+        nullable_repo
+            .update_many(&[post_none.id, post_some.id], &update_changes)
+            .await
+            .expect("update_many posts");
+
+        // Wait for OOB deletes on the old topics:
+        // - category_posts:none should receive a delete for post_none.id
+        let msg_none = tokio::time::timeout(std::time::Duration::from_secs(3), none_sub.recv())
+            .await
+            .expect("timeout waiting for delete on none topic")
+            .expect("recv error");
+        assert!(msg_none.into_string().contains(&format!(
+            "hx-swap-oob=\"delete:#nullable_post-{}\"",
+            post_none.id
+        )));
+
+        // - category_posts:rust should receive a delete for post_some.id
+        let msg_rust = tokio::time::timeout(std::time::Duration::from_secs(3), rust_sub.recv())
+            .await
+            .expect("timeout waiting for delete on rust topic")
+            .expect("recv error");
+        assert!(msg_rust.into_string().contains(&format!(
+            "hx-swap-oob=\"delete:#nullable_post-{}\"",
+            post_some.id
+        )));
+
+        // - category_posts:go should receive updates for both
+        let msg_go1 = tokio::time::timeout(std::time::Duration::from_secs(3), go_sub.recv())
+            .await
+            .expect("timeout waiting for go topic update 1")
+            .expect("recv error")
+            .into_string();
+        let msg_go2 = tokio::time::timeout(std::time::Duration::from_secs(3), go_sub.recv())
+            .await
+            .expect("timeout waiting for go topic update 2")
+            .expect("recv error")
+            .into_string();
+
+        let combined = format!("{msg_go1} {msg_go2}");
+        assert!(combined.contains(&format!("nullable_post-{}", post_none.id)));
+        assert!(combined.contains(&format!("nullable_post-{}", post_some.id)));
 
         shutdown.cancel();
     }

--- a/autumn/vendor/sse.js
+++ b/autumn/vendor/sse.js
@@ -1,0 +1,290 @@
+/*
+Server Sent Events Extension
+============================
+This extension adds support for Server Sent Events to htmx.  See /www/extensions/sse.md for usage instructions.
+
+*/
+
+(function() {
+  /** @type {import("../htmx").HtmxInternalApi} */
+  var api
+
+  htmx.defineExtension('sse', {
+
+    /**
+     * Init saves the provided reference to the internal HTMX API.
+     *
+     * @param {import("../htmx").HtmxInternalApi} api
+     * @returns void
+     */
+    init: function(apiRef) {
+      // store a reference to the internal API.
+      api = apiRef
+
+      // set a function in the public API for creating new EventSource objects
+      if (htmx.createEventSource == undefined) {
+        htmx.createEventSource = createEventSource
+      }
+    },
+
+    getSelectors: function() {
+      return ['[sse-connect]', '[data-sse-connect]', '[sse-swap]', '[data-sse-swap]']
+    },
+
+    /**
+     * onEvent handles all events passed to this extension.
+     *
+     * @param {string} name
+     * @param {Event} evt
+     * @returns void
+     */
+    onEvent: function(name, evt) {
+      var parent = evt.target || evt.detail.elt
+      switch (name) {
+        case 'htmx:beforeCleanupElement':
+          var internalData = api.getInternalData(parent)
+          // Try to remove remove an EventSource when elements are removed
+          var source = internalData.sseEventSource
+          if (source) {
+            api.triggerEvent(parent, 'htmx:sseClose', {
+              source,
+              type: 'nodeReplaced',
+            })
+            internalData.sseEventSource.close()
+          }
+
+          return
+
+        // Try to create EventSources when elements are processed
+        case 'htmx:afterProcessNode':
+          ensureEventSourceOnElement(parent)
+      }
+    }
+  })
+
+  /// ////////////////////////////////////////////
+  // HELPER FUNCTIONS
+  /// ////////////////////////////////////////////
+
+  /**
+   * createEventSource is the default method for creating new EventSource objects.
+   * it is hoisted into htmx.config.createEventSource to be overridden by the user, if needed.
+   *
+   * @param {string} url
+   * @returns EventSource
+   */
+  function createEventSource(url) {
+    return new EventSource(url, { withCredentials: true })
+  }
+
+  /**
+   * registerSSE looks for attributes that can contain sse events, right
+   * now hx-trigger and sse-swap and adds listeners based on these attributes too
+   * the closest event source
+   *
+   * @param {HTMLElement} elt
+   */
+  function registerSSE(elt) {
+    // Add message handlers for every `sse-swap` attribute
+    if (api.getAttributeValue(elt, 'sse-swap')) {
+      // Find closest existing event source
+      var sourceElement = api.getClosestMatch(elt, hasEventSource)
+      if (sourceElement == null) {
+        // api.triggerErrorEvent(elt, "htmx:noSSESourceError")
+        return null // no eventsource in parentage, orphaned element
+      }
+
+      // Set internalData and source
+      var internalData = api.getInternalData(sourceElement)
+      var source = internalData.sseEventSource
+
+      var sseSwapAttr = api.getAttributeValue(elt, 'sse-swap')
+      var sseEventNames = sseSwapAttr.split(',')
+
+      for (var i = 0; i < sseEventNames.length; i++) {
+        const sseEventName = sseEventNames[i].trim()
+        const listener = function(event) {
+          // If the source is missing then close SSE
+          if (maybeCloseSSESource(sourceElement)) {
+            return
+          }
+
+          // If the body no longer contains the element, remove the listener
+          if (!api.bodyContains(elt)) {
+            source.removeEventListener(sseEventName, listener)
+            return
+          }
+
+          // swap the response into the DOM and trigger a notification
+          if (!api.triggerEvent(elt, 'htmx:sseBeforeMessage', event)) {
+            return
+          }
+          swap(elt, event.data)
+          api.triggerEvent(elt, 'htmx:sseMessage', event)
+        }
+
+        // Register the new listener
+        api.getInternalData(elt).sseEventListener = listener
+        source.addEventListener(sseEventName, listener)
+      }
+    }
+
+    // Add message handlers for every `hx-trigger="sse:*"` attribute
+    if (api.getAttributeValue(elt, 'hx-trigger')) {
+      // Find closest existing event source
+      var sourceElement = api.getClosestMatch(elt, hasEventSource)
+      if (sourceElement == null) {
+        // api.triggerErrorEvent(elt, "htmx:noSSESourceError")
+        return null // no eventsource in parentage, orphaned element
+      }
+
+      // Set internalData and source
+      var internalData = api.getInternalData(sourceElement)
+      var source = internalData.sseEventSource
+
+      var triggerSpecs = api.getTriggerSpecs(elt)
+      triggerSpecs.forEach(function(ts) {
+        if (ts.trigger.slice(0, 4) !== 'sse:') {
+          return
+        }
+
+        var listener = function (event) {
+          if (maybeCloseSSESource(sourceElement)) {
+            return
+          }
+          if (!api.bodyContains(elt)) {
+            source.removeEventListener(ts.trigger.slice(4), listener)
+          }
+          // Trigger events to be handled by the rest of htmx
+          htmx.trigger(elt, ts.trigger, event)
+          htmx.trigger(elt, 'htmx:sseMessage', event)
+        }
+
+        // Register the new listener
+        api.getInternalData(elt).sseEventListener = listener
+        source.addEventListener(ts.trigger.slice(4), listener)
+      })
+    }
+  }
+
+  /**
+   * ensureEventSourceOnElement creates a new EventSource connection on the provided element.
+   * If a usable EventSource already exists, then it is returned.  If not, then a new EventSource
+   * is created and stored in the element's internalData.
+   * @param {HTMLElement} elt
+   * @param {number} retryCount
+   * @returns {EventSource | null}
+   */
+  function ensureEventSourceOnElement(elt, retryCount) {
+    if (elt == null) {
+      return null
+    }
+
+    // handle extension source creation attribute
+    if (api.getAttributeValue(elt, 'sse-connect')) {
+      var sseURL = api.getAttributeValue(elt, 'sse-connect')
+      if (sseURL == null) {
+        return
+      }
+
+      ensureEventSource(elt, sseURL, retryCount)
+    }
+
+    registerSSE(elt)
+  }
+
+  function ensureEventSource(elt, url, retryCount) {
+    var source = htmx.createEventSource(url)
+
+    source.onerror = function(err) {
+      // Log an error event
+      api.triggerErrorEvent(elt, 'htmx:sseError', { error: err, source })
+
+      // If parent no longer exists in the document, then clean up this EventSource
+      if (maybeCloseSSESource(elt)) {
+        return
+      }
+
+      // Otherwise, try to reconnect the EventSource
+      if (source.readyState === EventSource.CLOSED) {
+        retryCount = retryCount || 0
+        retryCount = Math.max(Math.min(retryCount * 2, 128), 1)
+        var timeout = retryCount * 500
+        window.setTimeout(function() {
+          ensureEventSourceOnElement(elt, retryCount)
+        }, timeout)
+      }
+    }
+
+    source.onopen = function(evt) {
+      api.triggerEvent(elt, 'htmx:sseOpen', { source })
+
+      if (retryCount && retryCount > 0) {
+        const childrenToFix = elt.querySelectorAll("[sse-swap], [data-sse-swap], [hx-trigger], [data-hx-trigger]")
+        for (let i = 0; i < childrenToFix.length; i++) {
+          registerSSE(childrenToFix[i])
+        }
+        // We want to increase the reconnection delay for consecutive failed attempts only
+        retryCount = 0
+      }
+    }
+
+    api.getInternalData(elt).sseEventSource = source
+
+
+    var closeAttribute = api.getAttributeValue(elt, "sse-close");
+    if (closeAttribute) {
+      // close eventsource when this message is received
+      source.addEventListener(closeAttribute, function() {
+        api.triggerEvent(elt, 'htmx:sseClose', {
+          source,
+          type: 'message',
+        })
+        source.close()
+      });
+    }
+  }
+
+  /**
+   * maybeCloseSSESource confirms that the parent element still exists.
+   * If not, then any associated SSE source is closed and the function returns true.
+   *
+   * @param {HTMLElement} elt
+   * @returns boolean
+   */
+  function maybeCloseSSESource(elt) {
+    if (!api.bodyContains(elt)) {
+      var source = api.getInternalData(elt).sseEventSource
+      if (source != undefined) {
+        api.triggerEvent(elt, 'htmx:sseClose', {
+          source,
+          type: 'nodeMissing',
+        })
+        source.close()
+        // source = null
+        return true
+      }
+    }
+    return false
+  }
+
+
+  /**
+   * @param {HTMLElement} elt
+   * @param {string} content
+   */
+  function swap(elt, content) {
+    api.withExtensions(elt, function(extension) {
+      content = extension.transformResponse(content, null, elt)
+    })
+
+    var swapSpec = api.getSwapSpecification(elt)
+    var target = api.getTarget(elt)
+    api.swap(target, content, swapSpec)
+  }
+
+
+  function hasEventSource(node) {
+    return api.getInternalData(node).sseEventSource != null
+  }
+})()


### PR DESCRIPTION
## Summary

This PR adds declarative auto-broadcasting support to the `#[repository]` macro, enabling automatic publication of model mutations (create, update, delete) to WebSocket subscribers via SSE and HTMX. When enabled, repositories automatically broadcast HTML fragments to configured topics, allowing real-time UI updates without explicit broadcast code.

## Key Changes

- **Repository macro enhancements** (`autumn-macros/src/repository.rs`):
  - Added `generate_topic_format()` function to parse and interpolate topic templates with field placeholders (e.g., `"post_topic:{title}"`)
  - Extended `RepoConfig` with new broadcast-related fields: `broadcasts`, `broadcast_topic`, `broadcast_render`, `broadcast_container`, and `generated_internal_hooks`
  - Added parsing for new macro attributes: `broadcasts = true`, `topic = "..."`, `render = path::to::fn`, `container = "..."`
  - Auto-generates internal hooks trait when `broadcasts = true` but no explicit `hooks` type is provided
  - Generates broadcast code for create, update, and delete operations with intelligent topic/container handling and HTMX OOB swap strategies

- **Repository traits** (`autumn/src/repository.rs`):
  - Added `ModelPrimaryKey` trait to expose primary key values for broadcast HTML generation
  - Added `DisplayTopicField` trait with implementations for primitive types and `Option<T>` to format field values for topic interpolation
  - Added `DisplayTenantId` trait helper for tenant-scoped topic formatting

- **Broadcast infrastructure** (`autumn/src/channels.rs`):
  - Updated `publish_oob()` to accept `&OobSwap` reference and improved HTML injection logic
  - Simplified OOB envelope generation with direct HTML attribute injection instead of template-based approach

- **HTMX utilities** (`autumn/src/htmx.rs`):
  - Added `escape_attribute_string()` and `inject_hx_swap_oob()` functions for safe HTML attribute injection
  - Added `extract_html_id()` function to parse `id` attributes from rendered HTML
  - Embedded SSE extension JavaScript (`HTMX_SSE_JS`, `HTMX_SSE_JS_PATH`)

- **Hook worker integration** (`autumn/src/repository_commit_hooks.rs`):
  - Added `#[cfg(feature = "ws")]` variant of `start_repository_commit_hook_worker()` that accepts optional `Channels` parameter
  - Integrated channels context into hook worker loop for broadcast publishing

- **Router and assets** (`autumn/src/router.rs`, `autumn/src/assets.rs`):
  - Added `mount_htmx_routes()` to serve SSE extension JavaScript
  - Added `sse_is_vendored()` check for asset vendoring support

- **Scaffold generator** (`autumn-cli/src/generate/scaffold.rs`):
  - Added `live` option to `ScaffoldOptions` for enabling auto-broadcasting in generated code
  - Updated repository template generation to include `broadcasts = true` attribute when `--live` flag is used
  - Added automatic feature flag management (`ws`, `maud`, `htmx`) in `Cargo.toml` when live mode is enabled
  - Updated route templates with live-specific destroy/create/update logic

- **CLI** (`autumn-cli/src/main.rs`):
  - Added `--live` flag to `scaffold` command for enabling auto-broadcasting

- **Integration tests** (`autumn/tests/auto_broadcast.rs`):
  - Comprehensive test suite covering basic broadcasting, custom topics with field interpolation, nullable fields, and lifecycle operations

- **New project scaffolding** (`autumn-cli/src/new.rs`):
  - Added SSE extension asset vendoring during new project creation

## Notable Implementation Details

- Topic interpolation uses a simple `{field_name}` syntax with compile-time validation of field identifiers
- Update broadcasts intelligently detect topic changes and handle element ID remapping via HTMX OOB swaps
- Delete broadcasts use empty div elements with `hx-swap-oob="delete"` for removal
- Tenant-scoped repositories automatically prefix topics with

https://claude.ai/code/session_01CDenbSG5TAX1mHnxiJve1N