### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -1638,11 +1638,14 @@ fn build_request(
         // Use the same full segment encoder the typed path helpers use, so an
         // MCP call accepts the same values a direct HTTP caller could pass.
         let encoded = if is_catch_all {
-            value
-                .split('/')
-                .map(crate::paths::encode_path_segment)
-                .collect::<Vec<_>>()
-                .join("/")
+            let mut result = String::with_capacity(value.len() + 10);
+            for (i, segment) in value.split('/').enumerate() {
+                if i > 0 {
+                    result.push('/');
+                }
+                result.push_str(&crate::paths::encode_path_segment(segment));
+            }
+            result
         } else {
             crate::paths::encode_path_segment(&value)
         };

--- a/autumn/src/paths.rs
+++ b/autumn/src/paths.rs
@@ -58,18 +58,20 @@ pub fn encode_path_segment(value: impl std::fmt::Display) -> String {
 #[must_use]
 pub fn encode_catch_all_param(value: impl std::fmt::Display) -> String {
     let s = value.to_string();
-    s.split('/')
-        .map(|segment| {
-            if segment == "." {
-                "%2E".to_string()
-            } else if segment == ".." {
-                "%2E%2E".to_string()
-            } else {
-                percent_encode(segment)
-            }
-        })
-        .collect::<Vec<String>>()
-        .join("/")
+    let mut result = String::with_capacity(s.len() + 10);
+    for (i, segment) in s.split('/').enumerate() {
+        if i > 0 {
+            result.push('/');
+        }
+        if segment == "." {
+            result.push_str("%2E");
+        } else if segment == ".." {
+            result.push_str("%2E%2E");
+        } else {
+            result.push_str(&percent_encode(segment));
+        }
+    }
+    result
 }
 
 /// Percent-encode a query component per RFC 3986.

--- a/autumn/src/test_html.rs
+++ b/autumn/src/test_html.rs
@@ -81,7 +81,16 @@ fn collect_text(nodes: &[Node], out: &mut String) {
 /// text/`assert_text` comparisons survive indentation and line-wrapping
 /// changes in templates.
 pub fn normalize_ws(s: &str) -> String {
-    s.split_whitespace().collect::<Vec<_>>().join(" ")
+    let mut result = String::with_capacity(s.len());
+    let mut words = s.split_whitespace();
+    if let Some(first) = words.next() {
+        result.push_str(first);
+        for word in words {
+            result.push(' ');
+            result.push_str(word);
+        }
+    }
+    result
 }
 
 // ── Parser ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
💡 What: Removed intermediate `.collect::<Vec<_>>().join()` chains and replaced them with pre-allocated Strings and iterative `.push()` or `.push_str()` operations.
🎯 Why: String concatenation using `.join()` over iterators requires an intermediate vector allocation, generating unnecessary heap allocations on hot paths.
📊 Impact: Removes heap allocations during URL catch-all encoding, HTML whitespace normalization, and MCP request building.
🔬 Measurement: Run `cargo test -p autumn-web --lib` and observe correct test execution along with reduced heap allocations during path processing.

---
*PR created automatically by Jules for task [4050158735938893287](https://jules.google.com/task/4050158735938893287) started by @madmax983*