### PR TITLE
Add column-driven data_table widget and update scaffold index (#1116)

### DIFF
--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -813,17 +813,17 @@ fn render_routes_file(
     };
 
     // For non-live paths, generate the data_table columns and call.
-    let columns_let = if !live {
-        render_columns_vec(pascal_name, plural, fields)
-    } else {
+    let columns_let = if live {
         String::new()
+    } else {
+        render_columns_vec(pascal_name, plural, fields)
     };
-    let table_render = if !live {
+    let table_render = if live {
+        String::new()
+    } else {
         format!(
             r#"(autumn_web::widgets::data_table(&page_data.content, &columns, &autumn_web::widgets::DataTableConfig::new("No {plural} yet.").base_path("/{plural}")))"#
         )
-    } else {
-        String::new()
     };
 
     let list_render = if live { &live_ul_render } else { &table_render };
@@ -1455,7 +1455,7 @@ fn edit_value_expr(field: &Field) -> String {
     }
 }
 
-/// Produce the cell-body expression for a data_table column closure.
+/// Produce the cell-body expression for a `data_table` column closure.
 ///
 /// Every arm must evaluate to a type that implements `maud::Render` (`&str`,
 /// `String`, `Cow<str>`, integers). `bool`, `Option<T>`, chrono types, `Uuid`,
@@ -1487,9 +1487,7 @@ fn cell_value_expr(field: &Field) -> String {
         (false, FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64) => {
             format!("row.{name}")
         }
-        // Bool: no Render impl in maud 0.27; convert via Display like Uuid/chrono.
-        (false, FieldKind::Bool) => format!("row.{name}.to_string()"),
-        // Uuid, chrono types: no Render impl; convert to String.
+        // Bool, Uuid, chrono types: no Render impl in maud 0.27; convert via Display.
         (false, _) => format!("row.{name}.to_string()"),
     }
 }
@@ -1534,10 +1532,7 @@ fn title_case(s: &str) -> String {
     s.split('_')
         .map(|word| {
             let mut chars = word.chars();
-            match chars.next() {
-                None => String::new(),
-                Some(c) => c.to_uppercase().to_string() + chars.as_str(),
-            }
+            chars.next().map_or_else(String::new, |c| c.to_uppercase().to_string() + chars.as_str())
         })
         .collect::<Vec<_>>()
         .join(" ")

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1532,7 +1532,9 @@ fn title_case(s: &str) -> String {
     s.split('_')
         .map(|word| {
             let mut chars = word.chars();
-            chars.next().map_or_else(String::new, |c| c.to_uppercase().to_string() + chars.as_str())
+            chars.next().map_or_else(String::new, |c| {
+                c.to_uppercase().to_string() + chars.as_str()
+            })
         })
         .collect::<Vec<_>>()
         .join(" ")

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -772,15 +772,27 @@ fn render_routes_file(
 
     // The `index` handler: when sharded, use from_shard explicitly so the
     // generated code shows the canonical sharding pattern.
+    //
+    // Live (SSE) variant: keep the <ul>/<li> structure intact. LiveFragment
+    // renders `li id=…` and insert_swap() targets `#{plural}-list` via
+    // OobSwap::Target(BeforeEnd, …). Swapping to <table> would cause the SSE
+    // broadcast to append <li> into a <table> at runtime (invalid HTML). The
+    // table migration for the live path is a follow-up once LiveFragment
+    // supports <tr> fragments.
+    //
+    // Non-live variants: use data_table so the index shows real fields out of
+    // the box — no hand-authored <table>/<th>/<td> tags needed.
     let li_render = if live {
         format!(
             r#"li id=(format!("{snake_name}-{{}}", row.id)) {{ a href=(format!("/{plural}/{{}}", row.id)) {{ "{pascal_name} #{{}}" (row.id) }} }}"#
         )
     } else {
-        format!(r#"li {{ a href=(format!("/{plural}/{{}}", row.id)) {{ (row.id) }} }}"#)
+        String::new() // unused in the non-live path
     };
 
-    let ul_list_render = if live {
+    // For the live path we keep the original <ul> list so the SSE OOB-swap
+    // contract remains valid.
+    let live_ul_render = if live {
         format!(
             r#"@if page_req.page() == 1 {{
             ul id="{plural}-list" hx-ext="sse" sse-connect="/{plural}/events" sse-swap="message" hx-swap="none" {{
@@ -797,18 +809,29 @@ fn render_routes_file(
         }}"#
         )
     } else {
-        format!(
-            r#"ul id="{plural}-list" {{
-            @for row in &page_data.content {{
-                {li_render}
-            }}
-        }}"#
-        )
+        String::new()
     };
 
-    let index_handler = if sharded {
+    // For non-live paths, generate the data_table columns and call.
+    let columns_let = if !live {
+        render_columns_vec(pascal_name, plural, fields)
+    } else {
+        String::new()
+    };
+    let table_render = if !live {
         format!(
-            r#"/// `GET /{plural}` — paginated list of {snake_name}s.
+            r#"(autumn_web::widgets::data_table(&page_data.content, &columns, &autumn_web::widgets::DataTableConfig::new("No {plural} yet.").base_path("/{plural}")))"#
+        )
+    } else {
+        String::new()
+    };
+
+    let list_render = if live { &live_ul_render } else { &table_render };
+
+    let index_handler = if sharded {
+        if live {
+            format!(
+                r#"/// `GET /{plural}` — paginated list of {snake_name}s.
 ///
 /// Accepts `?page=N&size=M` query parameters via the [`PageRequest`] extractor.
 /// Out-of-range or missing values are clamped silently — list endpoints never
@@ -824,7 +847,53 @@ pub async fn index(
     Ok(layout("{pascal_name} index", flash.render().await, html! {{
         h1 {{ "{pascal_name}s" }}
         a href="/{plural}/new" {{ "New {pascal_name}" }}
-        {ul_list_render}
+        {list_render}
+        (pagination_nav(&page_data, &PagerOptions::new("/{plural}")))
+    }}))
+}}"#
+            )
+        } else {
+            format!(
+                r#"/// `GET /{plural}` — paginated list of {snake_name}s.
+///
+/// Accepts `?page=N&size=M` query parameters via the [`PageRequest`] extractor.
+/// Out-of-range or missing values are clamped silently — list endpoints never
+/// return HTTP 400 for bad paging parameters.
+#[get("/{plural}")]
+pub async fn index(
+    page_req: PageRequest,
+    db: ShardedDb,
+    flash: Flash,
+) -> AutumnResult<Markup> {{
+    let repo = Pg{pascal_name}Repository::from_shard(&db);
+    let page_data: Page<{pascal_name}> = repo.page(&page_req).await?;
+{columns_let}    Ok(layout("{pascal_name} index", flash.render().await, html! {{
+        h1 {{ "{pascal_name}s" }}
+        a href="/{plural}/new" {{ "New {pascal_name}" }}
+        {list_render}
+        (pagination_nav(&page_data, &PagerOptions::new("/{plural}")))
+    }}))
+}}"#
+            )
+        }
+    } else if live {
+        format!(
+            r#"/// `GET /{plural}` — paginated list of {snake_name}s.
+///
+/// Accepts `?page=N&size=M` query parameters via the [`PageRequest`] extractor.
+/// Out-of-range or missing values are clamped silently — list endpoints never
+/// return HTTP 400 for bad paging parameters.
+#[get("/{plural}")]
+pub async fn index(
+    page_req: PageRequest,
+    repo: Pg{pascal_name}Repository,
+    flash: Flash,
+) -> AutumnResult<Markup> {{
+    let page_data: Page<{pascal_name}> = repo.page(&page_req).await?;
+    Ok(layout("{pascal_name} index", flash.render().await, html! {{
+        h1 {{ "{pascal_name}s" }}
+        a href="/{plural}/new" {{ "New {pascal_name}" }}
+        {list_render}
         (pagination_nav(&page_data, &PagerOptions::new("/{plural}")))
     }}))
 }}"#
@@ -843,10 +912,10 @@ pub async fn index(
     flash: Flash,
 ) -> AutumnResult<Markup> {{
     let page_data: Page<{pascal_name}> = repo.page(&page_req).await?;
-    Ok(layout("{pascal_name} index", flash.render().await, html! {{
+{columns_let}    Ok(layout("{pascal_name} index", flash.render().await, html! {{
         h1 {{ "{pascal_name}s" }}
         a href="/{plural}/new" {{ "New {pascal_name}" }}
-        {ul_list_render}
+        {list_render}
         (pagination_nav(&page_data, &PagerOptions::new("/{plural}")))
     }}))
 }}"#
@@ -1384,6 +1453,88 @@ fn edit_value_expr(field: &Field) -> String {
         }
         (false, _) => format!("row.{name}.to_string()"),
     }
+}
+
+/// Produce the cell-body expression for a data_table column closure.
+///
+/// Every arm must evaluate to a type that implements `maud::Render` (`&str`,
+/// `String`, `Cow<str>`, integers, `bool`). `Option<T>`, chrono types, `Uuid`,
+/// `Vec<u8>`, and `Blob` do NOT implement `Render`, so we always coerce via
+/// `to_string()` / `unwrap_or_default()`.
+fn cell_value_expr(field: &Field) -> String {
+    let name = &field.name;
+    match (field.nullable, field.kind) {
+        // Attachment: always Option<Blob>; show presence only, no Blob internals.
+        (_, FieldKind::Attachment) => {
+            format!("if row.{name}.is_some() {{ \"attachment\" }} else {{ \"—\" }}")
+        }
+        (true, FieldKind::Bytea) => {
+            format!(
+                "row.{name}.as_ref().map(|v| String::from_utf8_lossy(v).to_string()).unwrap_or_default()"
+            )
+        }
+        // Nullable: Option<T> — no Render impl; unwrap to String.
+        (true, _) => format!("row.{name}.as_ref().map(ToString::to_string).unwrap_or_default()"),
+        // Non-nullable Bytea: Cow<str> does implement Render.
+        (false, FieldKind::Bytea) => format!("String::from_utf8_lossy(&row.{name})"),
+        // String/Text: implement Render directly.
+        (false, FieldKind::String | FieldKind::Text) => format!("row.{name}.as_str()"),
+        // Numerics and bool: implement Render directly.
+        (false, FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 | FieldKind::Bool) => {
+            format!("row.{name}")
+        }
+        // Uuid, chrono types: no Render impl; convert to String.
+        (false, _) => format!("row.{name}.to_string()"),
+    }
+}
+
+/// Emit the `let columns: Vec<Column<Pascal>> = vec![…];` block for the index handler.
+///
+/// Includes an "Id" column, one column per scaffold field (title-cased header),
+/// and a trailing "Show" actions column. All columns are non-sortable — server-side
+/// ordering per-column is out of scope; dead sort links would be worse than none.
+fn render_columns_vec(pascal_name: &str, plural: &str, fields: &[Field]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "    let columns: Vec<autumn_web::widgets::Column<{pascal_name}>> = vec!["
+    );
+    // ID column
+    let _ = writeln!(
+        out,
+        "        autumn_web::widgets::Column::new(\"Id\", |row: &{pascal_name}| maud::html! {{ (row.id) }}),"
+    );
+    // One column per field
+    for f in fields {
+        let header = title_case(&f.name);
+        let cell_expr = cell_value_expr(f);
+        let _ = writeln!(
+            out,
+            "        autumn_web::widgets::Column::new(\"{header}\", |row: &{pascal_name}| maud::html! {{ ({cell_expr}) }}),"
+        );
+    }
+    // Show link column
+    let _ = writeln!(
+        out,
+        "        autumn_web::widgets::Column::new(\"\", |row: &{pascal_name}| maud::html! {{ a href=(format!(\"/{plural}/{{}}\", row.id)) {{ \"Show\" }} }}),"
+    );
+    let _ = writeln!(out, "    ];");
+    out
+}
+
+/// Convert `snake_case` field name to `Title Case` header label.
+fn title_case(s: &str) -> String {
+    s.split('_')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn render_nullable_field_match(fields: &[Field]) -> String {
@@ -2418,6 +2569,107 @@ async fn main() {
         assert!(test_file.contains("/api/posts"));
         assert!(test_file.contains("DELETE"));
         assert!(!test_file.contains("contains(\"Posts\")"));
+    }
+
+    // ── data_table scaffold integration ────────────────────────────────
+
+    #[test]
+    fn index_uses_data_table_not_ul() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "body:Text".into(), "published:bool".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(routes.contains("data_table("), "{routes}");
+        assert!(routes.contains("DataTableConfig::new("), "{routes}");
+        assert!(routes.contains("Column::new(\"Title\""), "{routes}");
+        assert!(!routes.contains("ul id=\"posts-list\""), "still uses ul: {routes}");
+    }
+
+    #[test]
+    fn index_data_table_cell_handles_nullable_field() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:Option<String>".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(routes.contains("unwrap_or_default"), "{routes}");
+    }
+
+    #[test]
+    fn index_data_table_has_show_link_column() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(routes.contains("/posts/{}"), "{routes}");
+        assert!(routes.contains("row.id"), "{routes}");
+    }
+
+    #[test]
+    fn sharded_index_uses_data_table() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["tenant_id:i64".into(), "title:String".into()],
+            "20260427000000",
+            &ScaffoldOptions {
+                model: ModelOptions {
+                    sharded: true,
+                    shard_key: Some("tenant_id".into()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(routes.contains("data_table("), "{routes}");
+        assert!(routes.contains("from_shard"), "{routes}");
+    }
+
+    #[test]
+    fn live_index_keeps_sse_list_container() {
+        let tmp = project_with_main(default_main());
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"x\"\n\n[dependencies]\nautumn-web = \"0.5.0\"\n",
+        )
+        .unwrap();
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260427000000",
+            &ScaffoldOptions {
+                live: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        // Live variant must keep the ul/li SSE contract intact
+        assert!(routes.contains("ul id=\"posts-list\""), "{routes}");
+        assert!(routes.contains("sse-connect=\"/posts/events\""), "{routes}");
     }
 
     #[test]

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1481,8 +1481,8 @@ fn cell_value_expr(field: &Field) -> String {
         (true, _) => format!("row.{name}.as_ref().map(ToString::to_string).unwrap_or_default()"),
         // Non-nullable Bytea: Cow<str> does implement Render.
         (false, FieldKind::Bytea) => format!("String::from_utf8_lossy(&row.{name})"),
-        // String/Text: implement Render directly.
-        (false, FieldKind::String | FieldKind::Text) => format!("row.{name}.as_str()"),
+        // String/Text: &String implements Render via deref coercion.
+        (false, FieldKind::String | FieldKind::Text) => format!("&row.{name}"),
         // Numerics (i32, i64, f32, f64): implement Render directly.
         (false, FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64) => {
             format!("row.{name}")

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1458,9 +1458,9 @@ fn edit_value_expr(field: &Field) -> String {
 /// Produce the cell-body expression for a data_table column closure.
 ///
 /// Every arm must evaluate to a type that implements `maud::Render` (`&str`,
-/// `String`, `Cow<str>`, integers, `bool`). `Option<T>`, chrono types, `Uuid`,
-/// `Vec<u8>`, and `Blob` do NOT implement `Render`, so we always coerce via
-/// `to_string()` / `unwrap_or_default()`.
+/// `String`, `Cow<str>`, integers). `bool`, `Option<T>`, chrono types, `Uuid`,
+/// `Vec<u8>`, and `Blob` do NOT implement `Render` in maud 0.27, so we always
+/// coerce via `to_string()` / `unwrap_or_default()`.
 fn cell_value_expr(field: &Field) -> String {
     let name = &field.name;
     match (field.nullable, field.kind) {
@@ -1473,16 +1473,22 @@ fn cell_value_expr(field: &Field) -> String {
                 "row.{name}.as_ref().map(|v| String::from_utf8_lossy(v).to_string()).unwrap_or_default()"
             )
         }
+        // Nullable String/Text: use as_deref to avoid heap allocation.
+        (true, FieldKind::String | FieldKind::Text) => {
+            format!("row.{name}.as_deref().unwrap_or_default()")
+        }
         // Nullable: Option<T> — no Render impl; unwrap to String.
         (true, _) => format!("row.{name}.as_ref().map(ToString::to_string).unwrap_or_default()"),
         // Non-nullable Bytea: Cow<str> does implement Render.
         (false, FieldKind::Bytea) => format!("String::from_utf8_lossy(&row.{name})"),
         // String/Text: implement Render directly.
         (false, FieldKind::String | FieldKind::Text) => format!("row.{name}.as_str()"),
-        // Numerics and bool: implement Render directly.
-        (false, FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 | FieldKind::Bool) => {
+        // Numerics (i32, i64, f32, f64): implement Render directly.
+        (false, FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64) => {
             format!("row.{name}")
         }
+        // Bool: no Render impl in maud 0.27; convert via Display like Uuid/chrono.
+        (false, FieldKind::Bool) => format!("row.{name}.to_string()"),
         // Uuid, chrono types: no Render impl; convert to String.
         (false, _) => format!("row.{name}.to_string()"),
     }
@@ -1495,7 +1501,7 @@ fn cell_value_expr(field: &Field) -> String {
 /// ordering per-column is out of scope; dead sort links would be worse than none.
 fn render_columns_vec(pascal_name: &str, plural: &str, fields: &[Field]) -> String {
     use std::fmt::Write as _;
-    let mut out = String::new();
+    let mut out = String::with_capacity(fields.len() * 150 + 300);
     let _ = writeln!(
         out,
         "    let columns: Vec<autumn_web::widgets::Column<{pascal_name}>> = vec!["
@@ -2579,7 +2585,11 @@ async fn main() {
         let plan = plan_scaffold(
             tmp.path(),
             "Post",
-            &["title:String".into(), "body:Text".into(), "published:bool".into()],
+            &[
+                "title:String".into(),
+                "body:Text".into(),
+                "published:bool".into(),
+            ],
             "20260427000000",
         )
         .unwrap();
@@ -2588,7 +2598,10 @@ async fn main() {
         assert!(routes.contains("data_table("), "{routes}");
         assert!(routes.contains("DataTableConfig::new("), "{routes}");
         assert!(routes.contains("Column::new(\"Title\""), "{routes}");
-        assert!(!routes.contains("ul id=\"posts-list\""), "still uses ul: {routes}");
+        assert!(
+            !routes.contains("ul id=\"posts-list\""),
+            "still uses ul: {routes}"
+        );
     }
 
     #[test]

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -169,14 +169,14 @@ pub use validator::Validate;
 pub use crate::form::{Changeset, ChangesetForm, IntoChangeset};
 
 // ── Search & autocomplete widgets ─────────────────────────────────
-/// Active search and autocomplete configuration types and rendering helpers.
+/// Active search, autocomplete, and data table configuration types and rendering helpers.
 ///
 /// See [`crate::widgets`] for the full API.
 #[cfg(feature = "maud")]
 pub use crate::widgets::{
-    ActiveSearchConfig, AutocompleteConfig, SearchMethod, active_search, active_search_empty_state,
-    active_search_input, active_search_results, autocomplete_empty_state, autocomplete_input,
-    autocomplete_option,
+    ActiveSearchConfig, AutocompleteConfig, Column, DataTableConfig, SearchMethod, SortDir,
+    active_search, active_search_empty_state, active_search_input, active_search_results,
+    autocomplete_empty_state, autocomplete_input, autocomplete_option, data_table,
 };
 
 // ── Hooks ───────────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -683,7 +683,7 @@ impl<'a, T> Column<'a, T> {
     ///
     /// The server owns the actual ordering; the widget only renders the link.
     #[must_use]
-    pub fn sortable(mut self, sort_key: &'a str) -> Self {
+    pub const fn sortable(mut self, sort_key: &'a str) -> Self {
         self.sort_key = Some(sort_key);
         self
     }
@@ -796,7 +796,7 @@ impl<'a> DataTableConfig<'a> {
 /// Intentional duplication of the same helper in `ui::pagination` — that one is
 /// private to its module. Both are small enough that sharing outweighs coupling.
 #[cfg(feature = "maud")]
-fn dt_filter_query<'a>(query: &'a str, drop_keys: &[&str]) -> String {
+fn dt_filter_query(query: &str, drop_keys: &[&str]) -> String {
     let query = query.strip_prefix('?').unwrap_or(query);
     query
         .split('&')

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -592,6 +592,366 @@ pub fn autocomplete_empty_state(message: &str) -> maud::Markup {
     }
 }
 
+// ── data_table ────────────────────────────────────────────────────────────
+
+/// Sort direction for a [`data_table`] sortable column header.
+///
+/// `Asc` is the default. Use [`SortDir::toggled`] to flip the direction
+/// when building sort links for the active column.
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SortDir {
+    /// Ascending order (default).
+    #[default]
+    Asc,
+    /// Descending order.
+    Desc,
+}
+
+#[cfg(feature = "maud")]
+impl SortDir {
+    /// Query-parameter value: `"asc"` or `"desc"`.
+    #[must_use]
+    pub const fn param_value(self) -> &'static str {
+        match self {
+            Self::Asc => "asc",
+            Self::Desc => "desc",
+        }
+    }
+
+    /// `aria-sort` attribute value: `"ascending"` or `"descending"`.
+    #[must_use]
+    pub const fn aria_value(self) -> &'static str {
+        match self {
+            Self::Asc => "ascending",
+            Self::Desc => "descending",
+        }
+    }
+
+    /// Returns the opposite direction.
+    #[must_use]
+    pub const fn toggled(self) -> Self {
+        match self {
+            Self::Asc => Self::Desc,
+            Self::Desc => Self::Asc,
+        }
+    }
+}
+
+/// A single column definition for [`data_table`].
+///
+/// Each column carries a header label, an optional sort key (opt-in via
+/// [`Column::sortable`]), and a cell closure that maps a row reference to
+/// `Markup`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::widgets::{Column, data_table, DataTableConfig};
+///
+/// struct Post { id: i64, title: String }
+///
+/// let cols: Vec<Column<Post>> = vec![
+///     Column::new("ID", |row| html! { (row.id) }),
+///     Column::new("Title", |row| html! { (row.title.as_str()) })
+///         .sortable("title"),
+/// ];
+/// ```
+#[cfg(feature = "maud")]
+pub struct Column<'a, T> {
+    /// Column header label shown in `<th>`.
+    pub header: &'a str,
+    /// If `Some`, this column is sortable and the value is the `sort=` query param.
+    pub sort_key: Option<&'a str>,
+    /// Cell renderer: maps a row reference to rendered `Markup`.
+    pub cell: Box<dyn Fn(&T) -> maud::Markup + 'a>,
+}
+
+#[cfg(feature = "maud")]
+impl<'a, T> Column<'a, T> {
+    /// Create a new non-sortable column with a header label and cell closure.
+    #[must_use]
+    pub fn new(header: &'a str, cell: impl Fn(&T) -> maud::Markup + 'a) -> Self {
+        Self {
+            header,
+            sort_key: None,
+            cell: Box::new(cell),
+        }
+    }
+
+    /// Make this column sortable, linking the header with `sort={sort_key}` query params.
+    ///
+    /// The server owns the actual ordering; the widget only renders the link.
+    #[must_use]
+    pub fn sortable(mut self, sort_key: &'a str) -> Self {
+        self.sort_key = Some(sort_key);
+        self
+    }
+}
+
+/// Configuration for a [`data_table`] widget.
+///
+/// Build with [`DataTableConfig::new`] and chain builder methods for optional overrides.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::widgets::DataTableConfig;
+///
+/// let config = DataTableConfig::new("No posts found.")
+///     .base_path("/posts")
+///     .query("q=foo")
+///     .active_sort("title")
+///     .caption("Posts");
+/// ```
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone)]
+pub struct DataTableConfig<'a> {
+    /// Optional `<caption>` for the table (table name/description, not the empty state).
+    pub caption: Option<&'a str>,
+    /// Message shown when `rows` is empty (required).
+    pub empty_message: &'a str,
+    /// Base path for sort links, e.g. `"/posts"`.
+    pub base_path: &'a str,
+    /// Raw query string of the current request (preserved on sort links).
+    pub query: &'a str,
+    /// Query parameter name for the sort column (default `"sort"`).
+    pub sort_param: &'a str,
+    /// Query parameter name for the sort direction (default `"dir"`).
+    pub dir_param: &'a str,
+    /// Query parameter name for the page (stripped on sort, default `"page"`).
+    pub page_param: &'a str,
+    /// The currently active sort column key, if any.
+    pub active_sort: Option<&'a str>,
+    /// Direction of the active sort (default [`SortDir::Asc`]).
+    pub active_dir: SortDir,
+    /// Optional CSS class to add to the `<table>` element.
+    pub class: Option<&'a str>,
+}
+
+#[cfg(feature = "maud")]
+impl<'a> DataTableConfig<'a> {
+    /// Create a new config with the given empty-state message and sensible defaults.
+    #[must_use]
+    pub const fn new(empty_message: &'a str) -> Self {
+        Self {
+            caption: None,
+            empty_message,
+            base_path: "",
+            query: "",
+            sort_param: "sort",
+            dir_param: "dir",
+            page_param: "page",
+            active_sort: None,
+            active_dir: SortDir::Asc,
+            class: None,
+        }
+    }
+
+    /// Set the table `<caption>` (table name; use for accessibility, not for empty state).
+    #[must_use]
+    pub const fn caption(mut self, caption: &'a str) -> Self {
+        self.caption = Some(caption);
+        self
+    }
+
+    /// Set the base path for sort links (default `""`).
+    #[must_use]
+    pub const fn base_path(mut self, base_path: &'a str) -> Self {
+        self.base_path = base_path;
+        self
+    }
+
+    /// Preserve the current request query string on sort links.
+    #[must_use]
+    pub const fn query(mut self, query: &'a str) -> Self {
+        self.query = query;
+        self
+    }
+
+    /// Set the active sort column key.
+    #[must_use]
+    pub const fn active_sort(mut self, key: &'a str) -> Self {
+        self.active_sort = Some(key);
+        self
+    }
+
+    /// Set the active sort direction.
+    #[must_use]
+    pub const fn active_dir(mut self, dir: SortDir) -> Self {
+        self.active_dir = dir;
+        self
+    }
+
+    /// Add a CSS class to the `<table>` element.
+    #[must_use]
+    pub const fn class(mut self, class: &'a str) -> Self {
+        self.class = Some(class);
+        self
+    }
+}
+
+/// Strip named params from a raw query string, returning the preserved remainder.
+///
+/// Intentional duplication of the same helper in `ui::pagination` — that one is
+/// private to its module. Both are small enough that sharing outweighs coupling.
+#[cfg(feature = "maud")]
+fn dt_filter_query<'a>(query: &'a str, drop_keys: &[&str]) -> String {
+    let query = query.strip_prefix('?').unwrap_or(query);
+    query
+        .split('&')
+        .filter(|pair| {
+            if pair.is_empty() {
+                return false;
+            }
+            let key = pair.split('=').next().unwrap_or(pair);
+            !drop_keys.contains(&key)
+        })
+        .collect::<Vec<&str>>()
+        .join("&")
+}
+
+/// Render a column-driven data table from a slice of records.
+///
+/// Emits a semantic, accessible `<table>` with a `<thead>` row of `<th scope="col">`
+/// headers and a `<tbody>` of `<tr>`/`<td>` cells. Empty rows render a single
+/// placeholder row spanning all columns. Sortable columns (opt-in via
+/// [`Column::sortable`]) carry `aria-sort` on the `<th>` and a link that toggles
+/// direction while preserving the current query string (sort resets pagination).
+///
+/// # Composes with `active_search` and `pagination_nav`
+///
+/// ```rust
+/// # use autumn_web::pagination::{Page, PageRequest};
+/// # use autumn_web::ui::pagination::{pagination_nav, PagerOptions};
+/// # use autumn_web::widgets::{Column, DataTableConfig, data_table};
+/// # struct Post { id: i64, title: String }
+/// # let req = PageRequest::new(1, 10);
+/// # let rows: Vec<Post> = vec![];
+/// # let page: Page<Post> = Page::new(rows, 0, &req);
+/// let cols: Vec<Column<Post>> = vec![
+///     Column::new("ID", |row: &Post| maud::html! { (row.id) }),
+///     Column::new("Title", |row: &Post| maud::html! { (row.title.as_str()) }),
+/// ];
+/// let html = maud::html! {
+///     (data_table(&page.content, &cols, &DataTableConfig::new("No posts yet.").base_path("/posts")))
+///     (pagination_nav(&page, &PagerOptions::new("/posts")))
+/// };
+/// assert!(html.into_string().contains("<table"));
+/// ```
+///
+/// # Example with sortable columns
+///
+/// ```rust,ignore
+/// use autumn_web::prelude::*;
+/// use autumn_web::widgets::{Column, DataTableConfig, SortDir, data_table};
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct SortQuery { sort: Option<String>, dir: Option<String> }
+///
+/// #[get("/posts")]
+/// async fn index(
+///     Query(q): Query<SortQuery>,
+///     page_req: PageRequest,
+///     repo: PgPostRepository,
+/// ) -> AutumnResult<Markup> {
+///     let active_dir = if q.dir.as_deref() == Some("desc") { SortDir::Desc } else { SortDir::Asc };
+///     let page_data = repo.page(&page_req).await?;
+///     let cols: Vec<Column<Post>> = vec![
+///         Column::new("Title", |row| html! { (row.title.as_str()) }).sortable("title"),
+///         Column::new("", |row| html! { a href=(format!("/posts/{}", row.id)) { "Show" } }),
+///     ];
+///     let config = DataTableConfig::new("No posts yet.")
+///         .base_path("/posts")
+///         .active_sort(q.sort.as_deref().unwrap_or(""))
+///         .active_dir(active_dir);
+///     Ok(layout("Posts", html! {
+///         (data_table(&page_data.content, &cols, &config))
+///         (pagination_nav(&page_data, &PagerOptions::new("/posts")))
+///     }))
+/// }
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn data_table<T>(
+    rows: &[T],
+    columns: &[Column<'_, T>],
+    config: &DataTableConfig<'_>,
+) -> maud::Markup {
+    let col_count = columns.len();
+
+    maud::html! {
+        table class=[config.class] {
+            @if let Some(caption) = config.caption {
+                caption { (caption) }
+            }
+            thead {
+                tr {
+                    @for col in columns {
+                        @if let Some(sort_key) = col.sort_key {
+                            // Determine sort direction for this column's link.
+                            @let is_active = config.active_sort == Some(sort_key);
+                            @let link_dir = if is_active {
+                                config.active_dir.toggled()
+                            } else {
+                                SortDir::Asc
+                            };
+                            @let aria_sort = if is_active {
+                                config.active_dir.aria_value()
+                            } else {
+                                "none"
+                            };
+                            @let filtered = dt_filter_query(
+                                config.query,
+                                &[config.sort_param, config.dir_param, config.page_param],
+                            );
+                            @let href = if filtered.is_empty() {
+                                format!(
+                                    "{}?{}={}&{}={}",
+                                    config.base_path,
+                                    config.sort_param, sort_key,
+                                    config.dir_param, link_dir.param_value(),
+                                )
+                            } else {
+                                format!(
+                                    "{}?{}&{}={}&{}={}",
+                                    config.base_path,
+                                    filtered,
+                                    config.sort_param, sort_key,
+                                    config.dir_param, link_dir.param_value(),
+                                )
+                            };
+                            th scope="col" aria-sort=(aria_sort) {
+                                a href=(href) { (col.header) }
+                            }
+                        } @else {
+                            th scope="col" { (col.header) }
+                        }
+                    }
+                }
+            }
+            tbody {
+                @if rows.is_empty() {
+                    tr {
+                        td colspan=(col_count) {
+                            span role="status" { (config.empty_message) }
+                        }
+                    }
+                } @else {
+                    @for row in rows {
+                        tr {
+                            @for col in columns {
+                                td { ((col.cell)(row)) }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 #[cfg(all(test, feature = "maud"))]
@@ -1190,5 +1550,195 @@ mod tests {
             html.contains(r#"role="status""#) || html.contains("aria-live"),
             "{html}"
         );
+    }
+
+    // ── data_table ─────────────────────────────────────────────────────
+
+    #[test]
+    fn sortdir_param_value() {
+        assert_eq!(SortDir::Asc.param_value(), "asc");
+        assert_eq!(SortDir::Desc.param_value(), "desc");
+    }
+
+    #[test]
+    fn sortdir_aria_value() {
+        assert_eq!(SortDir::Asc.aria_value(), "ascending");
+        assert_eq!(SortDir::Desc.aria_value(), "descending");
+    }
+
+    #[test]
+    fn sortdir_toggled() {
+        assert_eq!(SortDir::Asc.toggled(), SortDir::Desc);
+        assert_eq!(SortDir::Desc.toggled(), SortDir::Asc);
+    }
+
+    #[test]
+    fn data_table_config_defaults() {
+        let cfg = DataTableConfig::new("No items");
+        assert_eq!(cfg.empty_message, "No items");
+        assert_eq!(cfg.sort_param, "sort");
+        assert_eq!(cfg.dir_param, "dir");
+        assert_eq!(cfg.page_param, "page");
+        assert!(cfg.active_sort.is_none());
+        assert_eq!(cfg.active_dir, SortDir::Asc);
+        assert!(cfg.caption.is_none());
+        assert!(cfg.class.is_none());
+        assert_eq!(cfg.base_path, "");
+        assert_eq!(cfg.query, "");
+    }
+
+    #[test]
+    fn data_table_config_builders() {
+        let cfg = DataTableConfig::new("No items")
+            .base_path("/posts")
+            .query("q=foo")
+            .caption("Posts table")
+            .active_sort("title")
+            .active_dir(SortDir::Desc)
+            .class("my-table");
+        assert_eq!(cfg.base_path, "/posts");
+        assert_eq!(cfg.query, "q=foo");
+        assert_eq!(cfg.caption, Some("Posts table"));
+        assert_eq!(cfg.active_sort, Some("title"));
+        assert_eq!(cfg.active_dir, SortDir::Desc);
+        assert_eq!(cfg.class, Some("my-table"));
+    }
+
+    #[test]
+    fn data_table_has_thead_th_scope_col() {
+        let cols: Vec<Column<i32>> = vec![
+            Column::new("Name", |_| maud::html! { "n" }),
+            Column::new("Age", |_| maud::html! { "a" }),
+        ];
+        let html = data_table(&[1i32], &cols, &DataTableConfig::new("empty")).into_string();
+        assert!(html.contains("<thead"), "{html}");
+        assert!(html.contains(r#"scope="col""#), "{html}");
+        assert!(html.contains("Name"), "{html}");
+        assert!(html.contains("Age"), "{html}");
+    }
+
+    #[test]
+    fn data_table_renders_tbody_rows_and_cells() {
+        let cols: Vec<Column<&str>> = vec![
+            Column::new("Word", |row| maud::html! { (*row) }),
+        ];
+        let html = data_table(&["hello", "world"], &cols, &DataTableConfig::new("empty")).into_string();
+        assert!(html.contains("<tbody"), "{html}");
+        assert!(html.contains("hello"), "{html}");
+        assert!(html.contains("world"), "{html}");
+        // Two data rows
+        assert_eq!(html.matches("<tr").count(), 3, "1 header row + 2 data rows: {html}");
+    }
+
+    #[test]
+    fn data_table_caption_when_set() {
+        let cols: Vec<Column<i32>> = vec![Column::new("X", |_| maud::html! { "x" })];
+        let html = data_table(&[1i32], &cols, &DataTableConfig::new("e").caption("My Table")).into_string();
+        assert!(html.contains("<caption"), "{html}");
+        assert!(html.contains("My Table"), "{html}");
+    }
+
+    #[test]
+    fn data_table_no_caption_by_default() {
+        let cols: Vec<Column<i32>> = vec![Column::new("X", |_| maud::html! { "x" })];
+        let html = data_table(&[1i32], &cols, &DataTableConfig::new("e")).into_string();
+        assert!(!html.contains("<caption"), "{html}");
+    }
+
+    #[test]
+    fn data_table_applies_class_when_set() {
+        let cols: Vec<Column<i32>> = vec![Column::new("X", |_| maud::html! { "x" })];
+        let html = data_table(&[1i32], &cols, &DataTableConfig::new("e").class("styled")).into_string();
+        assert!(html.contains(r#"class="styled""#), "{html}");
+    }
+
+    #[test]
+    fn data_table_empty_renders_single_colspan_row() {
+        let cols: Vec<Column<i32>> = vec![
+            Column::new("A", |_| maud::html! { "a" }),
+            Column::new("B", |_| maud::html! { "b" }),
+            Column::new("C", |_| maud::html! { "c" }),
+        ];
+        let html = data_table(&[], &cols, &DataTableConfig::new("Nothing here")).into_string();
+        assert!(html.contains("Nothing here"), "{html}");
+        assert!(html.contains(r#"colspan="3""#), "{html}");
+        // Only the header tr, no data rows
+        assert_eq!(html.matches("<tr").count(), 2, "header + empty row: {html}");
+    }
+
+    #[test]
+    fn data_table_empty_message_announced() {
+        let cols: Vec<Column<i32>> = vec![Column::new("X", |_| maud::html! { "x" })];
+        let html = data_table(&[], &cols, &DataTableConfig::new("No results")).into_string();
+        assert!(html.contains(r#"role="status""#), "{html}");
+    }
+
+    #[test]
+    fn data_table_nonsortable_header_is_plain() {
+        let cols: Vec<Column<i32>> = vec![Column::new("Title", |_| maud::html! { "t" })];
+        let html = data_table(&[1i32], &cols, &DataTableConfig::new("e")).into_string();
+        // No sort link in header
+        let thead_end = html.find("</thead>").unwrap_or(html.len());
+        let thead = &html[..thead_end];
+        assert!(!thead.contains("<a "), "{html}");
+        assert!(!thead.contains("aria-sort"), "{html}");
+    }
+
+    #[test]
+    fn data_table_sortable_inactive_has_link_and_aria_sort_none() {
+        let cols: Vec<Column<i32>> = vec![
+            Column::new("Title", |_| maud::html! { "t" }).sortable("title"),
+        ];
+        let cfg = DataTableConfig::new("e").base_path("/posts");
+        let html = data_table(&[1i32], &cols, &cfg).into_string();
+        assert!(html.contains(r#"aria-sort="none""#), "{html}");
+        assert!(html.contains("sort=title"), "{html}");
+        assert!(html.contains("dir=asc"), "{html}");
+    }
+
+    #[test]
+    fn data_table_sortable_active_reflects_dir_and_toggles() {
+        let cols: Vec<Column<i32>> = vec![
+            Column::new("Title", |_| maud::html! { "t" }).sortable("title"),
+        ];
+        let cfg = DataTableConfig::new("e")
+            .base_path("/posts")
+            .active_sort("title")
+            .active_dir(SortDir::Asc);
+        let html = data_table(&[1i32], &cols, &cfg).into_string();
+        assert!(html.contains(r#"aria-sort="ascending""#), "{html}");
+        // toggled dir link
+        assert!(html.contains("dir=desc"), "{html}");
+    }
+
+    #[test]
+    fn data_table_sortable_link_preserves_other_query_params() {
+        let cols: Vec<Column<i32>> = vec![
+            Column::new("Name", |_| maud::html! { "n" }).sortable("name"),
+        ];
+        let cfg = DataTableConfig::new("e")
+            .base_path("/posts")
+            .query("q=hello");
+        let html = data_table(&[1i32], &cols, &cfg).into_string();
+        assert!(html.contains("q=hello"), "{html}");
+    }
+
+    #[test]
+    fn data_table_sortable_link_drops_existing_sort_dir_page() {
+        let cols: Vec<Column<i32>> = vec![
+            Column::new("Name", |_| maud::html! { "n" }).sortable("name"),
+        ];
+        let cfg = DataTableConfig::new("e")
+            .base_path("/posts")
+            .query("q=foo&sort=old&dir=asc&page=3");
+        let html = data_table(&[1i32], &cols, &cfg).into_string();
+        // old sort params stripped, new sort=name present
+        assert!(html.contains("sort=name"), "{html}");
+        // page stripped (reset to page 1)
+        assert!(!html.contains("page=3"), "{html}");
+        // q preserved
+        assert!(html.contains("q=foo"), "{html}");
+        // no duplicate old sort
+        assert!(!html.contains("sort=old"), "{html}");
     }
 }

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -880,6 +880,11 @@ pub fn data_table<T>(
     config: &DataTableConfig<'_>,
 ) -> maud::Markup {
     let col_count = columns.len();
+    // Hoist loop-invariant: query/drop-keys are the same for every sortable column.
+    let filtered = dt_filter_query(
+        config.query,
+        &[config.sort_param, config.dir_param, config.page_param],
+    );
 
     maud::html! {
         table class=[config.class] {
@@ -902,24 +907,24 @@ pub fn data_table<T>(
                             } else {
                                 "none"
                             };
-                            @let filtered = dt_filter_query(
-                                config.query,
-                                &[config.sort_param, config.dir_param, config.page_param],
-                            );
                             @let href = if filtered.is_empty() {
                                 format!(
                                     "{}?{}={}&{}={}",
                                     config.base_path,
-                                    config.sort_param, sort_key,
-                                    config.dir_param, link_dir.param_value(),
+                                    config.sort_param,
+                                    sort_key,
+                                    config.dir_param,
+                                    link_dir.param_value(),
                                 )
                             } else {
                                 format!(
                                     "{}?{}&{}={}&{}={}",
                                     config.base_path,
                                     filtered,
-                                    config.sort_param, sort_key,
-                                    config.dir_param, link_dir.param_value(),
+                                    config.sort_param,
+                                    sort_key,
+                                    config.dir_param,
+                                    link_dir.param_value(),
                                 )
                             };
                             th scope="col" aria-sort=(aria_sort) {
@@ -1619,21 +1624,29 @@ mod tests {
 
     #[test]
     fn data_table_renders_tbody_rows_and_cells() {
-        let cols: Vec<Column<&str>> = vec![
-            Column::new("Word", |row| maud::html! { (*row) }),
-        ];
-        let html = data_table(&["hello", "world"], &cols, &DataTableConfig::new("empty")).into_string();
+        let cols: Vec<Column<&str>> = vec![Column::new("Word", |row| maud::html! { (*row) })];
+        let html =
+            data_table(&["hello", "world"], &cols, &DataTableConfig::new("empty")).into_string();
         assert!(html.contains("<tbody"), "{html}");
         assert!(html.contains("hello"), "{html}");
         assert!(html.contains("world"), "{html}");
         // Two data rows
-        assert_eq!(html.matches("<tr").count(), 3, "1 header row + 2 data rows: {html}");
+        assert_eq!(
+            html.matches("<tr").count(),
+            3,
+            "1 header row + 2 data rows: {html}"
+        );
     }
 
     #[test]
     fn data_table_caption_when_set() {
         let cols: Vec<Column<i32>> = vec![Column::new("X", |_| maud::html! { "x" })];
-        let html = data_table(&[1i32], &cols, &DataTableConfig::new("e").caption("My Table")).into_string();
+        let html = data_table(
+            &[1i32],
+            &cols,
+            &DataTableConfig::new("e").caption("My Table"),
+        )
+        .into_string();
         assert!(html.contains("<caption"), "{html}");
         assert!(html.contains("My Table"), "{html}");
     }
@@ -1648,7 +1661,8 @@ mod tests {
     #[test]
     fn data_table_applies_class_when_set() {
         let cols: Vec<Column<i32>> = vec![Column::new("X", |_| maud::html! { "x" })];
-        let html = data_table(&[1i32], &cols, &DataTableConfig::new("e").class("styled")).into_string();
+        let html =
+            data_table(&[1i32], &cols, &DataTableConfig::new("e").class("styled")).into_string();
         assert!(html.contains(r#"class="styled""#), "{html}");
     }
 
@@ -1686,9 +1700,8 @@ mod tests {
 
     #[test]
     fn data_table_sortable_inactive_has_link_and_aria_sort_none() {
-        let cols: Vec<Column<i32>> = vec![
-            Column::new("Title", |_| maud::html! { "t" }).sortable("title"),
-        ];
+        let cols: Vec<Column<i32>> =
+            vec![Column::new("Title", |_| maud::html! { "t" }).sortable("title")];
         let cfg = DataTableConfig::new("e").base_path("/posts");
         let html = data_table(&[1i32], &cols, &cfg).into_string();
         assert!(html.contains(r#"aria-sort="none""#), "{html}");
@@ -1698,9 +1711,8 @@ mod tests {
 
     #[test]
     fn data_table_sortable_active_reflects_dir_and_toggles() {
-        let cols: Vec<Column<i32>> = vec![
-            Column::new("Title", |_| maud::html! { "t" }).sortable("title"),
-        ];
+        let cols: Vec<Column<i32>> =
+            vec![Column::new("Title", |_| maud::html! { "t" }).sortable("title")];
         let cfg = DataTableConfig::new("e")
             .base_path("/posts")
             .active_sort("title")
@@ -1713,9 +1725,8 @@ mod tests {
 
     #[test]
     fn data_table_sortable_link_preserves_other_query_params() {
-        let cols: Vec<Column<i32>> = vec![
-            Column::new("Name", |_| maud::html! { "n" }).sortable("name"),
-        ];
+        let cols: Vec<Column<i32>> =
+            vec![Column::new("Name", |_| maud::html! { "n" }).sortable("name")];
         let cfg = DataTableConfig::new("e")
             .base_path("/posts")
             .query("q=hello");
@@ -1725,9 +1736,8 @@ mod tests {
 
     #[test]
     fn data_table_sortable_link_drops_existing_sort_dir_page() {
-        let cols: Vec<Column<i32>> = vec![
-            Column::new("Name", |_| maud::html! { "n" }).sortable("name"),
-        ];
+        let cols: Vec<Column<i32>> =
+            vec![Column::new("Name", |_| maud::html! { "n" }).sortable("name")];
         let cfg = DataTableConfig::new("e")
             .base_path("/posts")
             .query("q=foo&sort=old&dir=asc&page=3");

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -664,14 +664,14 @@ pub struct Column<'a, T> {
     /// If `Some`, this column is sortable and the value is the `sort=` query param.
     pub sort_key: Option<&'a str>,
     /// Cell renderer: maps a row reference to rendered `Markup`.
-    pub cell: Box<dyn Fn(&T) -> maud::Markup + 'a>,
+    pub cell: Box<dyn Fn(&T) -> maud::Markup + Send + 'a>,
 }
 
 #[cfg(feature = "maud")]
 impl<'a, T> Column<'a, T> {
     /// Create a new non-sortable column with a header label and cell closure.
     #[must_use]
-    pub fn new(header: &'a str, cell: impl Fn(&T) -> maud::Markup + 'a) -> Self {
+    pub fn new(header: &'a str, cell: impl Fn(&T) -> maud::Markup + Send + 'a) -> Self {
         Self {
             header,
             sort_key: None,

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -145,8 +145,7 @@ pub async fn index(repo: PgBookmarkRepository) -> AutumnResult<Markup> {
     .debounce(400)
     .min_length(2);
     let columns = bookmark_columns();
-    let table_config =
-        DataTableConfig::new("No bookmarks yet.").base_path("/bookmarks");
+    let table_config = DataTableConfig::new("No bookmarks yet.").base_path("/bookmarks");
 
     Ok(layout(
         "All",
@@ -204,8 +203,7 @@ pub async fn show(id: Path<i64>, mut db: Db) -> AutumnResult<Markup> {
 pub async fn by_tag(Path(tag): Path<String>, repo: PgBookmarkRepository) -> AutumnResult<Markup> {
     let tagged = repo.find_by_tag(tag.clone()).await?;
     let columns = bookmark_columns();
-    let table_config =
-        DataTableConfig::new("No bookmarks with this tag.").base_path("/bookmarks");
+    let table_config = DataTableConfig::new("No bookmarks with this tag.").base_path("/bookmarks");
 
     Ok(layout(
         &format!("#{tag}"),

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -3,21 +3,21 @@
 //! The generated scaffold provides the resource shape. The shipped example adds
 //! Tailwind styling, htmx affordances, tag filtering, and local-demo writes.
 //!
-//! # Active Search & Autocomplete (issue #768)
+//! # Widgets in use
 //!
-//! Two widget-driven routes are included to demonstrate the primitives:
+//! - **`data_table`** — renders the bookmark list as a semantic `<table>` with
+//!   typed columns (Title link, Tag link, Status badge, Edit action). Used in
+//!   the index, by-tag, and search-result views.
+//! - **`active_search`** — wires the search input to `/bookmarks/search` via
+//!   htmx; search results swap in a fresh `data_table`.
+//! - **`autocomplete_input`** — tag picker on the new/edit forms.
 //!
-//! - `GET /bookmarks/search?q=…` — returns a rendered partial of matching
-//!   bookmarks. The index page wires this up via [`autumn_web::widgets::active_search`].
-//! - `GET /bookmarks/tags/autocomplete?q=…` — returns matching tag option
-//!   partials. The new/edit forms wire this up via
-//!   [`autumn_web::widgets::autocomplete_input`].
-//!
-//! Both handlers are ordinary Autumn route handlers that return `Markup`.
-//! They own the Diesel query; the widgets own the htmx wiring.
+//! All three compose in the index view without special wiring, demonstrating
+//! the composition AC from issue #1116.
 
 use autumn_web::extract::{Form, Path};
 use autumn_web::prelude::*;
+use autumn_web::widgets::{Column, DataTableConfig, data_table};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
@@ -91,6 +91,49 @@ fn bookmark_card(bookmark: &Bookmark) -> Markup {
     }
 }
 
+/// Column definitions shared by the index, by-tag, and search-result views.
+///
+/// Closures capture nothing from the outer scope, so the lifetime is `'static`.
+fn bookmark_columns() -> Vec<Column<'static, Bookmark>> {
+    vec![
+        Column::new("Title", |row: &Bookmark| {
+            html! {
+                a href=(row.url) target="_blank"
+                   class="text-indigo-600 font-medium hover:underline" {
+                    (row.title)
+                }
+            }
+        }),
+        Column::new("Tag", |row: &Bookmark| {
+            html! {
+                a href=(format!("/bookmarks/tag/{}", row.tag))
+                   class="text-xs bg-gray-200 rounded px-2 py-0.5" {
+                    (row.tag)
+                }
+            }
+        }),
+        Column::new("Status", |row: &Bookmark| {
+            html! {
+                @if row.alive {
+                    span class="text-xs bg-green-100 text-green-700 rounded px-2 py-0.5" {
+                        "active"
+                    }
+                } @else {
+                    span class="text-xs bg-red-100 text-red-600 rounded px-2 py-0.5" {
+                        "dead link"
+                    }
+                }
+            }
+        }),
+        Column::new("", |row: &Bookmark| {
+            html! {
+                a href=(format!("/bookmarks/{}/edit", row.id))
+                   class="text-sm text-gray-500 hover:text-gray-700" { "Edit" }
+            }
+        }),
+    ]
+}
+
 #[get("/bookmarks")]
 pub async fn index(repo: PgBookmarkRepository) -> AutumnResult<Markup> {
     let rows = repo.find_all().await?;
@@ -101,6 +144,9 @@ pub async fn index(repo: PgBookmarkRepository) -> AutumnResult<Markup> {
     .placeholder("Search by title, URL, or tag…")
     .debounce(400)
     .min_length(2);
+    let columns = bookmark_columns();
+    let table_config =
+        DataTableConfig::new("No bookmarks yet.").base_path("/bookmarks");
 
     Ok(layout(
         "All",
@@ -126,16 +172,9 @@ pub async fn index(repo: PgBookmarkRepository) -> AutumnResult<Markup> {
                     &search_config,
                 ))
             }
-            // ── Results (initial list; replaced by search partial) ────────
+            // ── Results (initial table; swapped in by search partial) ─────
             div id="bookmark-search-results" role="status" aria-live="polite" aria-atomic="true" {
-                ul class="space-y-3" {
-                    @for row in &rows {
-                        (bookmark_card(row))
-                    }
-                    @if rows.is_empty() {
-                        li class="text-gray-400 text-center py-8" { "No bookmarks yet." }
-                    }
-                }
+                (data_table(&rows, &columns, &table_config))
             }
         },
     ))
@@ -164,6 +203,10 @@ pub async fn show(id: Path<i64>, mut db: Db) -> AutumnResult<Markup> {
 #[get("/bookmarks/tag/{tag}")]
 pub async fn by_tag(Path(tag): Path<String>, repo: PgBookmarkRepository) -> AutumnResult<Markup> {
     let tagged = repo.find_by_tag(tag.clone()).await?;
+    let columns = bookmark_columns();
+    let table_config =
+        DataTableConfig::new("No bookmarks with this tag.").base_path("/bookmarks");
+
     Ok(layout(
         &format!("#{tag}"),
         html! {
@@ -171,14 +214,7 @@ pub async fn by_tag(Path(tag): Path<String>, repo: PgBookmarkRepository) -> Autu
                 a href="/bookmarks" class="text-sm text-indigo-600 hover:underline" { "Back to all" }
                 h1 class="text-2xl font-bold mt-2" { "Tag: " (tag) }
             }
-            ul class="space-y-3" {
-                @for row in &tagged {
-                    (bookmark_card(row))
-                }
-                @if tagged.is_empty() {
-                    li class="text-gray-400 text-center py-8" { "No bookmarks with this tag." }
-                }
-            }
+            (data_table(&tagged, &columns, &table_config))
         },
     ))
 }
@@ -314,7 +350,7 @@ fn escape_like(s: &str) -> String {
         .replace('_', "\\_")
 }
 
-/// Active search handler — returns a `<ul>` partial of matching bookmarks.
+/// Active search handler — returns a `data_table` partial of matching bookmarks.
 ///
 /// Wired up by [`autumn_web::widgets::active_search_input`] on the index page.
 /// Works equally well without JavaScript (direct GET form submission).
@@ -339,17 +375,17 @@ pub async fn search(Query(params): Query<SearchQuery>, mut db: Db) -> AutumnResu
         .load(&mut *db)
         .await?;
 
-    Ok(html! {
-        @if results.is_empty() {
-            (autumn_web::widgets::active_search_empty_state("No bookmarks match your search."))
-        } @else {
-            ul class="space-y-3" {
-                @for row in &results {
-                    (bookmark_card(row))
-                }
-            }
-        }
-    })
+    if results.is_empty() {
+        return Ok(autumn_web::widgets::active_search_empty_state(
+            "No bookmarks match your search.",
+        ));
+    }
+    let columns = bookmark_columns();
+    Ok(data_table(
+        &results,
+        &columns,
+        &DataTableConfig::new("").base_path("/bookmarks"),
+    ))
 }
 
 // ── Tag autocomplete handler ──────────────────────────────────────────────────


### PR DESCRIPTION
- New public API in autumn/src/widgets.rs: SortDir, Column<T>,
  DataTableConfig, and data_table() — all gated behind the maud feature.
  Column closures use boxed Fn(&T)->Markup so callers build Vec<Column>
  ergonomically. DataTableConfig follows the const-builder pattern of
  PagerOptions (base_path, query, caption, active_sort, active_dir, class).
  Sortable column headers carry aria-sort and a sort/dir link that strips
  the current page param (resets to page 1 on re-sort); existing query
  state is preserved via a private dt_filter_query helper (intentional
  parallel to pagination's private filter_query). Empty rows render a
  single colspan <td> wrapping a role="status" span matching the
  active_search_empty_state a11y bar.

- Compiled module doctest in data_table() composes active_search +
  data_table + pagination_nav without special wiring, machine-verifying
  the composition AC. Full rust,ignore handler example shows sortable
  column wiring.

- Prelude updated: Column, DataTableConfig, SortDir, data_table added to
  the #[cfg(feature="maud")] pub use block alongside existing widgets.

- autumn-cli/src/generate/scaffold.rs: non-live scaffold index now emits
  let columns via render_columns_vec() (Id column + one per field with
  title-cased header + Show link) and calls data_table(), replacing the
  bare <ul> of row.id links. The live (SSE) variant retains <ul>/<li>
  because LiveFragment::render_fragment emits <li> and insert_swap()
  targets the list with BeforeEnd — migrating the live path to <table>
  is a follow-up. New helpers: cell_value_expr() (Attachment-safe,
  always maud::Render-safe), render_columns_vec(), title_case().

TDD: 16 widget unit tests + 5 scaffold integration tests added
(RED before each implementation, GREEN after).