### PR TITLE
Add built-in mail recording and assertion helpers to TestClient

### DIFF
--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -185,6 +185,134 @@ use diesel_async::RunQueryDsl;
 #[cfg(feature = "db")]
 use diesel_async::pooled_connection::deadpool::Pool;
 
+// ── Mail recording helpers ─────────────────────────────────────
+
+/// Snapshot of an email captured by the built-in test mail recorder.
+///
+/// Available on [`TestClient`] via [`TestClient::sent_mail()`] when the `mail`
+/// feature is enabled.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::test::TestApp;
+///
+/// let client = TestApp::new().config(cfg).routes(routes![handler]).build();
+/// client.post("/signup").json(&body).send().await.assert_ok();
+///
+/// // ≤ 3 lines to assert an email was sent:
+/// client.assert_email_count(1);
+/// client.assert_email_sent(|m| m.to.iter().any(|a| a == "alice@example.com"));
+/// client.assert_email_sent(|m| m.subject == "Welcome!");
+/// ```
+#[cfg(feature = "mail")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SentMail {
+    /// `From` header value (after mailer defaults are applied).
+    pub from: Option<String>,
+    /// `Reply-To` header value.
+    pub reply_to: Option<String>,
+    /// `To` recipients.
+    pub to: Vec<String>,
+    /// `Subject` header.
+    pub subject: String,
+    /// HTML body, if provided.
+    pub html: Option<String>,
+    /// Plain-text body, if provided.
+    pub text: Option<String>,
+}
+
+#[cfg(feature = "mail")]
+impl From<&crate::mail::Mail> for SentMail {
+    fn from(m: &crate::mail::Mail) -> Self {
+        SentMail {
+            from: m.from.clone(),
+            reply_to: m.reply_to.clone(),
+            to: m.to.clone(),
+            subject: m.subject.clone(),
+            html: m.html.clone(),
+            text: m.text.clone(),
+        }
+    }
+}
+
+/// Built-in per-`TestClient` recording mail interceptor.
+///
+/// Auto-installed by [`TestApp::build`] — no `.with_mail_interceptor()` needed.
+/// Composes with any user-supplied interceptor (the user's interceptor still runs).
+#[cfg(feature = "mail")]
+#[derive(Clone, Default)]
+struct MailRecorder {
+    mails: std::sync::Arc<std::sync::Mutex<Vec<SentMail>>>,
+}
+
+#[cfg(feature = "mail")]
+impl MailRecorder {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn get_sent(&self) -> Vec<SentMail> {
+        self.mails.lock().unwrap().clone()
+    }
+}
+
+#[cfg(feature = "mail")]
+impl crate::interceptor::MailInterceptor for MailRecorder {
+    fn intercept<'a>(
+        &'a self,
+        mail: &'a crate::mail::Mail,
+        next: std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<(), crate::mail::MailError>>
+                    + Send
+                    + 'a,
+            >,
+        >,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<(), crate::mail::MailError>>
+                + Send
+                + 'a,
+        >,
+    > {
+        self.mails.lock().unwrap().push(SentMail::from(mail));
+        next
+    }
+}
+
+/// Chains two [`MailInterceptor`](crate::interceptor::MailInterceptor)s so that
+/// `first` runs before `second`, both before the underlying transport.
+#[cfg(feature = "mail")]
+struct ChainedMailInterceptor {
+    first: std::sync::Arc<dyn crate::interceptor::MailInterceptor>,
+    second: std::sync::Arc<dyn crate::interceptor::MailInterceptor>,
+}
+
+#[cfg(feature = "mail")]
+impl crate::interceptor::MailInterceptor for ChainedMailInterceptor {
+    fn intercept<'a>(
+        &'a self,
+        mail: &'a crate::mail::Mail,
+        next: std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<(), crate::mail::MailError>>
+                    + Send
+                    + 'a,
+            >,
+        >,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<(), crate::mail::MailError>>
+                + Send
+                + 'a,
+        >,
+    > {
+        let second_next = self.second.intercept(mail, next);
+        self.first.intercept(mail, second_next)
+    }
+}
+
 // ── TestApp ────────────────────────────────────────────────────
 
 /// Builder for constructing a fully-configured Autumn application in tests.
@@ -240,6 +368,8 @@ pub struct TestApp {
     forbidden_response_override: Option<crate::authorization::ForbiddenResponse>,
     #[cfg(feature = "mail")]
     mail_interceptor: Option<std::sync::Arc<dyn crate::interceptor::MailInterceptor>>,
+    #[cfg(feature = "mail")]
+    mail_recorder: MailRecorder,
     job_interceptor: Option<std::sync::Arc<dyn crate::interceptor::JobInterceptor>>,
     #[cfg(feature = "db")]
     db_interceptor: Option<std::sync::Arc<dyn crate::interceptor::DbConnectionInterceptor>>,
@@ -314,6 +444,8 @@ impl TestApp {
             forbidden_response_override: None,
             #[cfg(feature = "mail")]
             mail_interceptor: None,
+            #[cfg(feature = "mail")]
+            mail_recorder: MailRecorder::new(),
             job_interceptor: None,
             #[cfg(feature = "db")]
             db_interceptor: None,
@@ -594,6 +726,8 @@ impl TestApp {
             state,
             _job_runtime: None,
             clock_as_any: None,
+            #[cfg(feature = "mail")]
+            mail_recorder: MailRecorder::new(),
         }
     }
 
@@ -1172,8 +1306,18 @@ impl TestApp {
         state.insert_extension(self.config.clone());
 
         #[cfg(feature = "mail")]
-        if let Some(interceptor) = self.mail_interceptor {
-            state.insert_extension(interceptor);
+        {
+            let recorder = std::sync::Arc::new(self.mail_recorder.clone());
+            let effective: std::sync::Arc<dyn crate::interceptor::MailInterceptor> =
+                if let Some(user) = self.mail_interceptor {
+                    std::sync::Arc::new(ChainedMailInterceptor {
+                        first: recorder.clone(),
+                        second: user,
+                    })
+                } else {
+                    recorder.clone()
+                };
+            state.insert_extension(effective);
         }
         if let Some(interceptor) = self.job_interceptor {
             state.insert_extension(interceptor);
@@ -1372,6 +1516,8 @@ impl TestApp {
             state,
             _job_runtime: job_runtime,
             clock_as_any: self.clock_as_any,
+            #[cfg(feature = "mail")]
+            mail_recorder: self.mail_recorder,
         }
     }
 }
@@ -1420,6 +1566,8 @@ pub struct TestClient {
     _job_runtime: Option<TestJobRuntime>,
     /// Retained so `advance_clock` can downcast to [`crate::time::TickingClock`].
     clock_as_any: Option<std::sync::Arc<dyn std::any::Any + Send + Sync>>,
+    #[cfg(feature = "mail")]
+    mail_recorder: MailRecorder,
 }
 
 struct TestJobRuntime {
@@ -1516,6 +1664,82 @@ impl TestClient {
     /// and verify the HTTP probe endpoints reflect state changes.
     pub const fn probes(&self) -> &crate::probe::ProbeState {
         &self.probes
+    }
+
+    /// Returns all emails sent during this test, in the order they were sent.
+    ///
+    /// The built-in recorder is installed automatically — no
+    /// `.with_mail_interceptor(…)` call is required.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// client.post("/signup").json(&body).send().await.assert_ok();
+    /// let mail = &client.sent_mail()[0];
+    /// assert_eq!(mail.subject, "Welcome!");
+    /// ```
+    #[cfg(feature = "mail")]
+    #[must_use]
+    pub fn sent_mail(&self) -> Vec<SentMail> {
+        self.mail_recorder.get_sent()
+    }
+
+    /// Asserts that exactly `n` emails were sent, panicking with a list of
+    /// what was actually sent on failure.
+    ///
+    /// Returns `&self` for chaining.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the count does not match.
+    #[cfg(feature = "mail")]
+    pub fn assert_email_count(&self, n: usize) -> &Self {
+        let sent = self.sent_mail();
+        assert_eq!(
+            sent.len(),
+            n,
+            "expected {n} email(s) to have been sent, got {};\nactually sent: {sent:#?}",
+            sent.len(),
+        );
+        self
+    }
+
+    /// Asserts that no emails were sent.
+    ///
+    /// Returns `&self` for chaining.
+    ///
+    /// # Panics
+    ///
+    /// Panics when any emails were sent.
+    #[cfg(feature = "mail")]
+    pub fn assert_no_email_sent(&self) -> &Self {
+        self.assert_email_count(0)
+    }
+
+    /// Asserts that at least one sent email satisfies `predicate`, panicking
+    /// with a list of what was actually sent on failure.
+    ///
+    /// Returns `&self` for chaining.
+    ///
+    /// # Panics
+    ///
+    /// Panics when no sent email matches.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// client
+    ///     .assert_email_sent(|m| m.to.iter().any(|a| a == "alice@example.com"))
+    ///     .assert_email_sent(|m| m.subject == "Welcome!");
+    /// ```
+    #[cfg(feature = "mail")]
+    pub fn assert_email_sent(&self, predicate: impl Fn(&SentMail) -> bool) -> &Self {
+        let sent = self.sent_mail();
+        assert!(
+            sent.iter().any(|m| predicate(m)),
+            "no sent email matched the predicate;\nactually sent: {sent:#?}",
+        );
+        self
     }
 
     /// Start building a GET request.

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -263,18 +263,10 @@ impl crate::interceptor::MailInterceptor for MailRecorder {
         &'a self,
         mail: &'a crate::mail::Mail,
         next: std::pin::Pin<
-            Box<
-                dyn std::future::Future<Output = Result<(), crate::mail::MailError>>
-                    + Send
-                    + 'a,
-            >,
+            Box<dyn std::future::Future<Output = Result<(), crate::mail::MailError>> + Send + 'a>,
         >,
     ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<(), crate::mail::MailError>>
-                + Send
-                + 'a,
-        >,
+        Box<dyn std::future::Future<Output = Result<(), crate::mail::MailError>> + Send + 'a>,
     > {
         let snapshot = SentMail::from(mail);
         let mails = std::sync::Arc::clone(&self.mails);
@@ -302,18 +294,10 @@ impl crate::interceptor::MailInterceptor for ChainedMailInterceptor {
         &'a self,
         mail: &'a crate::mail::Mail,
         next: std::pin::Pin<
-            Box<
-                dyn std::future::Future<Output = Result<(), crate::mail::MailError>>
-                    + Send
-                    + 'a,
-            >,
+            Box<dyn std::future::Future<Output = Result<(), crate::mail::MailError>> + Send + 'a>,
         >,
     ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<(), crate::mail::MailError>>
-                + Send
-                + 'a,
-        >,
+        Box<dyn std::future::Future<Output = Result<(), crate::mail::MailError>> + Send + 'a>,
     > {
         let second_next = self.second.intercept(mail, next);
         self.first.intercept(mail, second_next)

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -725,7 +725,7 @@ impl TestApp {
             _job_runtime: None,
             clock_as_any: None,
             #[cfg(feature = "mail")]
-            mail_recorder: MailRecorder::new(),
+            mail_recorder: None,
         }
     }
 
@@ -1304,8 +1304,9 @@ impl TestApp {
         state.insert_extension(self.config.clone());
 
         #[cfg(feature = "mail")]
-        {
-            let recorder = std::sync::Arc::new(self.mail_recorder.clone());
+        let mail_recorder_for_client = {
+            let recorder_for_client = self.mail_recorder.clone();
+            let recorder = std::sync::Arc::new(self.mail_recorder);
             let effective: std::sync::Arc<dyn crate::interceptor::MailInterceptor> =
                 if let Some(user) = self.mail_interceptor {
                     std::sync::Arc::new(ChainedMailInterceptor {
@@ -1316,7 +1317,8 @@ impl TestApp {
                     recorder
                 };
             state.insert_extension(effective);
-        }
+            recorder_for_client
+        };
         if let Some(interceptor) = self.job_interceptor {
             state.insert_extension(interceptor);
         }
@@ -1515,7 +1517,7 @@ impl TestApp {
             _job_runtime: job_runtime,
             clock_as_any: self.clock_as_any,
             #[cfg(feature = "mail")]
-            mail_recorder: self.mail_recorder,
+            mail_recorder: Some(mail_recorder_for_client),
         }
     }
 }
@@ -1564,8 +1566,10 @@ pub struct TestClient {
     _job_runtime: Option<TestJobRuntime>,
     /// Retained so `advance_clock` can downcast to [`crate::time::TickingClock`].
     clock_as_any: Option<std::sync::Arc<dyn std::any::Any + Send + Sync>>,
+    /// `None` when built via [`TestApp::from_router`], which bypasses recorder
+    /// wiring. `Some` for all clients produced by [`TestApp::build`].
     #[cfg(feature = "mail")]
-    mail_recorder: MailRecorder,
+    mail_recorder: Option<MailRecorder>,
 }
 
 struct TestJobRuntime {
@@ -1679,7 +1683,10 @@ impl TestClient {
     #[cfg(feature = "mail")]
     #[must_use]
     pub fn sent_mail(&self) -> Vec<SentMail> {
-        self.mail_recorder.get_sent()
+        self.mail_recorder
+            .as_ref()
+            .expect("sent_mail() is not available on a TestClient built via from_router(); use TestApp::new().merge(router).build() instead")
+            .get_sent()
     }
 
     /// Asserts that exactly `n` emails were sent, panicking with a list of

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -718,6 +718,13 @@ impl TestApp {
     /// against a standard axum Router.  The probe state returned by
     /// [`TestClient::probes`] will be in the default ready state; it is not
     /// connected to any handler in the supplied router.
+    ///
+    /// **Note:** [`TestClient::sent_mail`] will always return an empty list for
+    /// clients built this way.  The built-in mail recorder is wired in during
+    /// [`TestApp::build`]; because `from_router` receives an already-constructed
+    /// `AppState` (with the mailer already installed), the recorder cannot be
+    /// injected into its interceptor chain.  Use [`TestApp::new().merge(router).build()`](TestApp::merge)
+    /// to get recording support.
     #[must_use]
     pub fn from_router(router: axum::Router, state: AppState) -> TestClient {
         TestClient {

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -225,7 +225,7 @@ pub struct SentMail {
 #[cfg(feature = "mail")]
 impl From<&crate::mail::Mail> for SentMail {
     fn from(m: &crate::mail::Mail) -> Self {
-        SentMail {
+        Self {
             from: m.from.clone(),
             reply_to: m.reply_to.clone(),
             to: m.to.clone(),
@@ -1309,11 +1309,11 @@ impl TestApp {
             let effective: std::sync::Arc<dyn crate::interceptor::MailInterceptor> =
                 if let Some(user) = self.mail_interceptor {
                     std::sync::Arc::new(ChainedMailInterceptor {
-                        first: recorder.clone(),
+                        first: recorder,
                         second: user,
                     })
                 } else {
-                    recorder.clone()
+                    recorder
                 };
             state.insert_extension(effective);
         }
@@ -1734,7 +1734,7 @@ impl TestClient {
     pub fn assert_email_sent(&self, predicate: impl Fn(&SentMail) -> bool) -> &Self {
         let sent = self.sent_mail();
         assert!(
-            sent.iter().any(|m| predicate(m)),
+            sent.iter().any(predicate),
             "no sent email matched the predicate;\nactually sent: {sent:#?}",
         );
         self

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -276,8 +276,15 @@ impl crate::interceptor::MailInterceptor for MailRecorder {
                 + 'a,
         >,
     > {
-        self.mails.lock().unwrap().push(SentMail::from(mail));
-        next
+        let snapshot = SentMail::from(mail);
+        let mails = std::sync::Arc::clone(&self.mails);
+        Box::pin(async move {
+            let result = next.await;
+            if result.is_ok() {
+                mails.lock().unwrap().push(snapshot);
+            }
+            result
+        })
     }
 }
 

--- a/autumn/tests/boundary_hooks_integration.rs
+++ b/autumn/tests/boundary_hooks_integration.rs
@@ -167,38 +167,10 @@ fn app_builder_registers_interceptors() {
 #[cfg(feature = "mail")]
 #[tokio::test]
 async fn mail_interceptor_intercepts_sends() {
+    // Converted from hand-rolled RecordingMailInterceptor to the built-in helpers.
     use autumn_web::get;
     use autumn_web::mail::{Mail, Mailer, Transport};
     use autumn_web::test::TestApp;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    static CALLS: AtomicUsize = AtomicUsize::new(0);
-
-    struct RecordingMailInterceptor;
-    impl MailInterceptor for RecordingMailInterceptor {
-        fn intercept<'a>(
-            &'a self,
-            _mail: &'a Mail,
-            next: std::pin::Pin<
-                Box<
-                    dyn std::future::Future<Output = Result<(), autumn_web::mail::MailError>>
-                        + Send
-                        + 'a,
-                >,
-            >,
-        ) -> std::pin::Pin<
-            Box<
-                dyn std::future::Future<Output = Result<(), autumn_web::mail::MailError>>
-                    + Send
-                    + 'a,
-            >,
-        > {
-            Box::pin(async move {
-                CALLS.fetch_add(1, Ordering::SeqCst);
-                next.await
-            })
-        }
-    }
 
     #[get("/send-test-mail")]
     async fn send_test_mail(mailer: Mailer) -> &'static str {
@@ -218,14 +190,13 @@ async fn mail_interceptor_intercepts_sends() {
 
     let client = TestApp::new()
         .config(config)
-        .with_mail_interceptor(RecordingMailInterceptor)
         .routes(autumn_web::routes![send_test_mail])
         .build();
 
-    let response = client.get("/send-test-mail").send().await;
-    response.assert_ok();
+    client.get("/send-test-mail").send().await.assert_ok();
 
-    assert_eq!(CALLS.load(Ordering::SeqCst), 1);
+    // ~40-line hand-rolled interceptor replaced by one assertion:
+    client.assert_email_count(1);
 }
 
 #[tokio::test]

--- a/autumn/tests/mail_recorder_integration.rs
+++ b/autumn/tests/mail_recorder_integration.rs
@@ -133,17 +133,15 @@ async fn user_interceptor_composes_with_recorder() {
             _mail: &'a Mail,
             next: std::pin::Pin<
                 Box<
-                    dyn std::future::Future<
-                            Output = Result<(), autumn_web::mail::MailError>,
-                        > + Send
+                    dyn std::future::Future<Output = Result<(), autumn_web::mail::MailError>>
+                        + Send
                         + 'a,
                 >,
             >,
         ) -> std::pin::Pin<
             Box<
-                dyn std::future::Future<
-                        Output = Result<(), autumn_web::mail::MailError>,
-                    > + Send
+                dyn std::future::Future<Output = Result<(), autumn_web::mail::MailError>>
+                    + Send
                     + 'a,
             >,
         > {

--- a/autumn/tests/mail_recorder_integration.rs
+++ b/autumn/tests/mail_recorder_integration.rs
@@ -1,0 +1,255 @@
+#![cfg(feature = "mail")]
+
+//! Integration tests for the built-in recording mail interceptor and
+//! assertion helpers on `TestClient`.
+
+use autumn_web::config::AutumnConfig;
+use autumn_web::get;
+use autumn_web::mail::{Mail, Mailer, Transport};
+use autumn_web::prelude::*;
+use autumn_web::test::TestApp;
+
+fn mail_config() -> AutumnConfig {
+    let mut cfg = AutumnConfig::default();
+    cfg.mail.transport = Transport::Log;
+    cfg.mail.from = Some("noreply@example.com".to_string());
+    cfg
+}
+
+// ── AC1 / AC2: default recorder, sent_mail() accessor ─────────────────────
+
+#[tokio::test]
+async fn default_recorder_captures_single_send() {
+    #[get("/send")]
+    async fn send_one(mailer: Mailer) -> &'static str {
+        let mail = Mail::builder()
+            .to("alice@example.com")
+            .subject("Hello Alice")
+            .text("hi")
+            .build()
+            .unwrap();
+        mailer.send(mail).await.unwrap();
+        "ok"
+    }
+
+    let client = TestApp::new()
+        .config(mail_config())
+        .routes(routes![send_one])
+        .build();
+
+    // no .with_mail_interceptor() call — recorder is auto-installed
+    client.get("/send").send().await.assert_ok();
+
+    let sent = client.sent_mail();
+    assert_eq!(sent.len(), 1);
+    assert_eq!(sent[0].to, vec!["alice@example.com"]);
+    assert_eq!(sent[0].subject, "Hello Alice");
+}
+
+// ── AC3: assert_email_count / assert_no_email_sent / assert_email_sent ────
+
+#[tokio::test]
+async fn assert_email_count_passes_when_correct() {
+    #[get("/send2")]
+    async fn send_two(mailer: Mailer) -> &'static str {
+        for addr in ["a@example.com", "b@example.com"] {
+            let mail = Mail::builder()
+                .to(addr)
+                .subject("Batch")
+                .text("body")
+                .build()
+                .unwrap();
+            mailer.send(mail).await.unwrap();
+        }
+        "ok"
+    }
+
+    let client = TestApp::new()
+        .config(mail_config())
+        .routes(routes![send_two])
+        .build();
+
+    client.get("/send2").send().await.assert_ok();
+
+    client.assert_email_count(2);
+}
+
+#[tokio::test]
+async fn assert_no_email_sent_passes_when_none() {
+    #[get("/noop")]
+    async fn noop() -> &'static str {
+        "quiet"
+    }
+
+    let client = TestApp::new()
+        .config(mail_config())
+        .routes(routes![noop])
+        .build();
+
+    client.get("/noop").send().await.assert_ok();
+
+    client.assert_no_email_sent();
+}
+
+#[tokio::test]
+async fn assert_email_sent_passes_with_matching_predicate() {
+    #[get("/send3")]
+    async fn send_welcome(mailer: Mailer) -> &'static str {
+        let mail = Mail::builder()
+            .to("bob@example.com")
+            .subject("Welcome!")
+            .html("<p>welcome</p>")
+            .build()
+            .unwrap();
+        mailer.send(mail).await.unwrap();
+        "ok"
+    }
+
+    let client = TestApp::new()
+        .config(mail_config())
+        .routes(routes![send_welcome])
+        .build();
+
+    client.get("/send3").send().await.assert_ok();
+
+    client
+        .assert_email_sent(|m| m.to.iter().any(|t| t == "bob@example.com"))
+        .assert_email_sent(|m| m.subject == "Welcome!");
+}
+
+// ── AC4: user-supplied interceptor still runs (composing) ─────────────────
+
+#[tokio::test]
+async fn user_interceptor_composes_with_recorder() {
+    use autumn_web::interceptor::MailInterceptor;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static CUSTOM_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    struct CountingInterceptor;
+    impl MailInterceptor for CountingInterceptor {
+        fn intercept<'a>(
+            &'a self,
+            _mail: &'a Mail,
+            next: std::pin::Pin<
+                Box<
+                    dyn std::future::Future<
+                            Output = Result<(), autumn_web::mail::MailError>,
+                        > + Send
+                        + 'a,
+                >,
+            >,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = Result<(), autumn_web::mail::MailError>,
+                    > + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async move {
+                CUSTOM_CALLS.fetch_add(1, Ordering::SeqCst);
+                next.await
+            })
+        }
+    }
+
+    #[get("/send4")]
+    async fn send_once(mailer: Mailer) -> &'static str {
+        let mail = Mail::builder()
+            .to("c@example.com")
+            .subject("Compose Test")
+            .text("body")
+            .build()
+            .unwrap();
+        mailer.send(mail).await.unwrap();
+        "ok"
+    }
+
+    CUSTOM_CALLS.store(0, Ordering::SeqCst);
+
+    let client = TestApp::new()
+        .config(mail_config())
+        .with_mail_interceptor(CountingInterceptor)
+        .routes(routes![send_once])
+        .build();
+
+    client.get("/send4").send().await.assert_ok();
+
+    // built-in recorder captured it
+    client.assert_email_count(1);
+    // user interceptor also ran
+    assert_eq!(CUSTOM_CALLS.load(Ordering::SeqCst), 1);
+}
+
+// ── AC6: regression — two mails in order ──────────────────────────────────
+
+#[tokio::test]
+async fn two_mails_captured_in_send_order() {
+    #[get("/send-two-ordered")]
+    async fn send_two_ordered(mailer: Mailer) -> &'static str {
+        let first = Mail::builder()
+            .to("first@example.com")
+            .subject("First")
+            .text("1")
+            .build()
+            .unwrap();
+        mailer.send(first).await.unwrap();
+
+        let second = Mail::builder()
+            .to("second@example.com")
+            .subject("Second")
+            .text("2")
+            .build()
+            .unwrap();
+        mailer.send(second).await.unwrap();
+
+        "ok"
+    }
+
+    let client = TestApp::new()
+        .config(mail_config())
+        .routes(routes![send_two_ordered])
+        .build();
+
+    client.get("/send-two-ordered").send().await.assert_ok();
+
+    client.assert_email_count(2);
+
+    let sent = client.sent_mail();
+    assert_eq!(sent[0].to, vec!["first@example.com"], "first mail order");
+    assert_eq!(sent[1].to, vec!["second@example.com"], "second mail order");
+}
+
+// ── AC5: Transport::Disabled never opens SMTP ─────────────────────────────
+
+#[tokio::test]
+async fn disabled_transport_captures_nothing_and_no_smtp() {
+    #[get("/send5")]
+    async fn send_disabled(mailer: Mailer) -> &'static str {
+        let mail = Mail::builder()
+            .to("d@example.com")
+            .subject("Disabled")
+            .text("body")
+            .build()
+            .unwrap();
+        // Disabled transport returns Ok(()) without sending
+        let _ = mailer.send(mail).await;
+        "ok"
+    }
+
+    let mut cfg = AutumnConfig::default();
+    cfg.mail.transport = Transport::Disabled;
+    cfg.mail.from = Some("noreply@example.com".to_string());
+
+    let client = TestApp::new()
+        .config(cfg)
+        .routes(routes![send_disabled])
+        .build();
+
+    client.get("/send5").send().await.assert_ok();
+
+    // With Disabled transport the interceptor still runs and captures;
+    // the transport itself is a no-op (no SMTP).
+    client.assert_email_count(1);
+}


### PR DESCRIPTION
## Summary

This PR adds a built-in mail recording interceptor to `TestClient` that automatically captures all emails sent during tests, along with convenient assertion helpers. This eliminates the need for users to write custom recording interceptors for basic email testing scenarios.

## Key Changes

- **New `SentMail` struct**: A snapshot of captured email data (from, reply_to, to, subject, html, text) that implements `From<&Mail>` for easy conversion.

- **Built-in `MailRecorder` interceptor**: Auto-installed on every `TestClient` via `TestApp::build()`. Uses `Arc<Mutex<Vec<SentMail>>>` to thread-safely accumulate sent emails in order.

- **Composable interceptor chain**: Introduced `ChainedMailInterceptor` to allow user-supplied mail interceptors to compose with the built-in recorder. The recorder always runs first, then the user's interceptor, ensuring both capture and custom logic work together.

- **New `TestClient` assertion methods**:
  - `sent_mail()` — returns all captured emails in send order
  - `assert_email_count(n)` — asserts exactly n emails were sent
  - `assert_no_email_sent()` — asserts no emails were sent
  - `assert_email_sent(predicate)` — asserts at least one email matches the predicate; all methods support chaining

- **Comprehensive integration tests** (`mail_recorder_integration.rs`): 
  - AC1/AC2: Default recorder and `sent_mail()` accessor
  - AC3: Count and existence assertions
  - AC4: User interceptor composition
  - AC5: `Transport::Disabled` behavior
  - AC6: Email ordering regression test

- **Simplified existing test**: Converted `boundary_hooks_integration.rs::mail_interceptor_intercepts_sends()` from a ~40-line hand-rolled interceptor to a single `assert_email_count(1)` call, demonstrating the improvement.

## Implementation Details

- The recorder is stored on both `TestApp` and `TestClient` and is cloned/passed through the build pipeline.
- When building the app state, if a user interceptor exists, it's wrapped in a `ChainedMailInterceptor` with the recorder as the first link; otherwise, the recorder alone is used.
- All mail recording functionality is gated behind the `mail` feature flag.
- The implementation maintains backward compatibility — existing user interceptors continue to work unchanged.

https://claude.ai/code/session_016zTCzsemY6W6jNHCqxpnEf