### PR TITLE
Add property_list widget for rendering record field details

### DIFF
--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1532,19 +1532,18 @@ fn render_columns_vec(pascal_name: &str, plural: &str, fields: &[Field]) -> Stri
 /// Produces one `("Label", maud::html! { value_expr })` tuple per row:
 /// `id`, every DSL-declared field (humanized label), then `created_at`.
 fn render_show_property_rows(fields: &[Field]) -> String {
-    let mut out = String::new();
-    out.push_str(r#"        ("Id", maud::html! { (row.id) }),"#);
-    out.push('\n');
+    let mut out = String::with_capacity(fields.len() * 100 + 150);
+    out.push_str("        (\"Id\", maud::html! { (row.id) }),\n");
     for f in fields {
         let label = humanize(&f.name);
         let cell_expr = cell_value_expr(f);
-        out.push_str(&format!(
-            r#"        ("{label}", maud::html! {{ ({cell_expr}) }}),"#
-        ));
-        out.push('\n');
+        out.push_str("        (\"");
+        out.push_str(&label);
+        out.push_str("\", maud::html! { (");
+        out.push_str(&cell_expr);
+        out.push_str(") }),\n");
     }
-    out.push_str(r#"        ("Created at", maud::html! { (row.created_at.to_string()) }),"#);
-    out.push('\n');
+    out.push_str("        (\"Created at\", maud::html! { (row.created_at.to_string()) }),\n");
     out
 }
 

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -166,6 +166,7 @@ pub fn plan_scaffold_with_options(
                 &snake_name,
                 &plural,
                 &form_fields,
+                &fields,
                 options_with_key.model.sharded,
                 options_with_key.model.soft_delete,
                 options_with_key.model.id_type,
@@ -613,6 +614,7 @@ fn render_routes_file(
     snake_name: &str,
     plural: &str,
     fields: &[Field],
+    all_fields: &[Field],
     sharded: bool,
     soft_delete: bool,
     id_type: IdType,
@@ -823,7 +825,7 @@ fn render_routes_file(
     };
 
     let list_render = if live { &live_ul_render } else { &table_render };
-    let show_rows = render_show_property_rows(fields);
+    let show_rows = render_show_property_rows(all_fields);
 
     let index_handler = if sharded {
         if live {
@@ -2825,6 +2827,34 @@ async fn main() {
         assert!(
             routes.contains("\"User name\""),
             "humanize must produce 'User name': {routes}"
+        );
+    }
+
+    #[test]
+    fn show_includes_defaulted_fields_in_property_list() {
+        // Regression test: fields with `#[default]` are excluded from the
+        // form (form_fields), but must still appear in the show property list.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "views:i64".into()],
+            "20260427000000",
+            &ScaffoldOptions {
+                model: ModelOptions {
+                    defaults: vec!["views=0".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(
+            routes.contains("\"Views\""),
+            "show must include defaulted field 'views': {routes}"
         );
     }
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -823,6 +823,7 @@ fn render_routes_file(
     };
 
     let list_render = if live { &live_ul_render } else { &table_render };
+    let show_rows = render_show_property_rows(fields);
 
     let index_handler = if sharded {
         if live {
@@ -1149,8 +1150,11 @@ pub async fn show(id: Path<{id_rust}>, mut db: {db_ty}, flash: Flash) -> AutumnR
         .first(&mut *db)
         .await
         .map_err(AutumnError::not_found)?;
+    let props: Vec<(&str, maud::Markup)> = vec![
+{show_rows}    ];
     Ok(layout(&format!("{pascal_name} #{{}}", row.id), flash.render().await, html! {{
         h1 {{ "{pascal_name} #" (row.id) }}
+        (autumn_web::widgets::property_list(&props))
         a href="/{plural}" {{ "Back to list" }}
         " "
         a href=(format!("/{plural}/{{}}/edit", row.id)) {{ "Edit" }}
@@ -1521,6 +1525,39 @@ fn render_columns_vec(pascal_name: &str, plural: &str, fields: &[Field]) -> Stri
     );
     let _ = writeln!(out, "    ];");
     out
+}
+
+/// Emit the `vec![…]` body for the `props` binding in the `show` handler.
+///
+/// Produces one `("Label", maud::html! { value_expr })` tuple per row:
+/// `id`, every DSL-declared field (humanized label), then `created_at`.
+fn render_show_property_rows(fields: &[Field]) -> String {
+    let mut out = String::new();
+    out.push_str(r#"        ("Id", maud::html! { (row.id) }),"#);
+    out.push('\n');
+    for f in fields {
+        let label = humanize(&f.name);
+        let cell_expr = cell_value_expr(f);
+        out.push_str(&format!(
+            r#"        ("{label}", maud::html! {{ ({cell_expr}) }}),"#
+        ));
+        out.push('\n');
+    }
+    out.push_str(r#"        ("Created at", maud::html! { (row.created_at.to_string()) }),"#);
+    out.push('\n');
+    out
+}
+
+/// Humanize a `snake_case` field name: capitalize only the first word.
+///
+/// `created_at` → `"Created at"`, `user_name` → `"User name"`.
+/// Matches the humanization convention used in Phoenix / Rails form labels.
+fn humanize(s: &str) -> String {
+    let replaced = s.replace('_', " ");
+    let mut chars = replaced.chars();
+    chars
+        .next()
+        .map_or_else(String::new, |c| c.to_uppercase().to_string() + chars.as_str())
 }
 
 /// Convert `snake_case` field name to `Title Case` header label.
@@ -2718,5 +2755,56 @@ async fn main() {
         assert!(cargo.contains("\"ws\""));
         assert!(cargo.contains("\"maud\""));
         assert!(cargo.contains("\"htmx\""));
+    }
+
+    // ── property_list scaffold conformance (issue #1120) ──────────────────
+
+    #[test]
+    fn show_uses_property_list_widget_with_declared_fields() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &[
+                "title:String".into(),
+                "body:Text".into(),
+                "published:bool".into(),
+            ],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        // show handler references property_list widget
+        assert!(
+            routes.contains("autumn_web::widgets::property_list"),
+            "show must use property_list widget: {routes}"
+        );
+        // Each declared field appears with humanized label
+        assert!(routes.contains("\"Title\""), "show must list 'title' field: {routes}");
+        assert!(routes.contains("\"Body\""), "show must list 'body' field: {routes}");
+        assert!(routes.contains("\"Published\""), "show must list 'published' field: {routes}");
+        // id and created_at always present
+        assert!(routes.contains("\"Id\""), "show must include id: {routes}");
+        assert!(routes.contains("\"Created at\""), "show must include created_at: {routes}");
+    }
+
+    #[test]
+    fn show_property_list_label_humanization() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["published_at:NaiveDateTime".into(), "user_name:String".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        // humanized: first word capitalized, rest lowercase (snake_case → "Word rest")
+        assert!(routes.contains("\"Published at\""), "humanize must produce 'Published at': {routes}");
+        assert!(routes.contains("\"User name\""), "humanize must produce 'User name': {routes}");
     }
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1554,9 +1554,9 @@ fn render_show_property_rows(fields: &[Field]) -> String {
 fn humanize(s: &str) -> String {
     let replaced = s.replace('_', " ");
     let mut chars = replaced.chars();
-    chars
-        .next()
-        .map_or_else(String::new, |c| c.to_uppercase().to_string() + chars.as_str())
+    chars.next().map_or_else(String::new, |c| {
+        c.to_uppercase().to_string() + chars.as_str()
+    })
 }
 
 /// Convert `snake_case` field name to `Title Case` header label.
@@ -2781,12 +2781,24 @@ async fn main() {
             "show must use property_list widget: {routes}"
         );
         // Each declared field appears with humanized label
-        assert!(routes.contains("\"Title\""), "show must list 'title' field: {routes}");
-        assert!(routes.contains("\"Body\""), "show must list 'body' field: {routes}");
-        assert!(routes.contains("\"Published\""), "show must list 'published' field: {routes}");
+        assert!(
+            routes.contains("\"Title\""),
+            "show must list 'title' field: {routes}"
+        );
+        assert!(
+            routes.contains("\"Body\""),
+            "show must list 'body' field: {routes}"
+        );
+        assert!(
+            routes.contains("\"Published\""),
+            "show must list 'published' field: {routes}"
+        );
         // id and created_at always present
         assert!(routes.contains("\"Id\""), "show must include id: {routes}");
-        assert!(routes.contains("\"Created at\""), "show must include created_at: {routes}");
+        assert!(
+            routes.contains("\"Created at\""),
+            "show must include created_at: {routes}"
+        );
     }
 
     #[test]
@@ -2795,7 +2807,10 @@ async fn main() {
         let plan = plan_scaffold(
             tmp.path(),
             "Post",
-            &["published_at:NaiveDateTime".into(), "user_name:String".into()],
+            &[
+                "published_at:NaiveDateTime".into(),
+                "user_name:String".into(),
+            ],
             "20260427000000",
         )
         .unwrap();
@@ -2803,7 +2818,13 @@ async fn main() {
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
         // humanized: first word capitalized, rest lowercase (snake_case → "Word rest")
-        assert!(routes.contains("\"Published at\""), "humanize must produce 'Published at': {routes}");
-        assert!(routes.contains("\"User name\""), "humanize must produce 'User name': {routes}");
+        assert!(
+            routes.contains("\"Published at\""),
+            "humanize must produce 'Published at': {routes}"
+        );
+        assert!(
+            routes.contains("\"User name\""),
+            "humanize must produce 'User name': {routes}"
+        );
     }
 }

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -316,7 +316,8 @@ pub mod ui;
 /// Active search and autocomplete form primitives with htmx integration.
 ///
 /// See [`widgets`] for the full API including [`widgets::active_search`],
-/// [`widgets::autocomplete_input`], and their configuration types.
+/// [`widgets::autocomplete_input`], [`widgets::data_table`],
+/// [`widgets::property_list`], and their configuration types.
 pub mod widgets;
 /// First-class multi-step form wizards with session-backed state and per-step validation.
 ///

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -592,6 +592,58 @@ pub fn autocomplete_empty_state(message: &str) -> maud::Markup {
     }
 }
 
+// ── property_list ─────────────────────────────────────────────────────────
+
+/// Render a property list (definition list) for a record's fields.
+///
+/// Emits a `<dl class="autumn-property-list">` with one `<dt>`/`<dd>` pair per
+/// entry. Labels (`&str`) are HTML-escaped; values are pre-escaped [`Markup`](maud::Markup)
+/// so callers can pass plain text, a formatted date, or a nested link/badge
+/// without escaping foot-guns.
+///
+/// An empty `rows` slice renders an empty `<dl>`, never panics.
+///
+/// # CSS hooks
+///
+/// | Selector | Element |
+/// |---|---|
+/// | `.autumn-property-list` | The `<dl>` wrapper |
+/// | `.autumn-property-list dt` | Label term |
+/// | `.autumn-property-list dd` | Value description |
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::widgets::property_list;
+/// use maud::html;
+///
+/// struct Post { id: i64, title: String, published: bool }
+/// let post = Post { id: 1, title: "Hello".into(), published: true };
+///
+/// let rows = vec![
+///     ("Id", html! { (post.id) }),
+///     ("Title", html! { (&post.title) }),
+///     ("Published", html! { (post.published.to_string()) }),
+/// ];
+/// let markup = property_list(&rows);
+/// let html = markup.into_string();
+/// assert!(html.contains(r#"class="autumn-property-list""#));
+/// assert!(html.contains("<dt>Id</dt>"));
+/// assert!(html.contains("<dd>1</dd>"));
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn property_list(rows: &[(&str, maud::Markup)]) -> maud::Markup {
+    maud::html! {
+        dl class="autumn-property-list" {
+            @for (label, value) in rows {
+                dt { (label) }
+                dd { (value) }
+            }
+        }
+    }
+}
+
 // ── data_table ────────────────────────────────────────────────────────────
 
 /// Sort direction for a [`data_table`] sortable column header.
@@ -1555,6 +1607,61 @@ mod tests {
             html.contains(r#"role="status""#) || html.contains("aria-live"),
             "{html}"
         );
+    }
+
+    // ── property_list ──────────────────────────────────────────────────
+
+    #[test]
+    fn property_list_empty_slice_renders_empty_dl_never_panics() {
+        let html = property_list(&[]).into_string();
+        assert!(html.contains("<dl"), "{html}");
+        assert!(!html.contains("<dt"), "{html}");
+    }
+
+    #[test]
+    fn property_list_has_autumn_property_list_class() {
+        let html = property_list(&[]).into_string();
+        assert!(html.contains(r#"class="autumn-property-list""#), "{html}");
+    }
+
+    #[test]
+    fn property_list_renders_dt_and_dd_per_row() {
+        let rows = vec![
+            ("Title", maud::html! { "My Post" }),
+            ("Published", maud::html! { "true" }),
+        ];
+        let html = property_list(&rows).into_string();
+        assert!(html.contains("<dt>Title</dt>"), "{html}");
+        assert!(html.contains("<dt>Published</dt>"), "{html}");
+        assert!(html.contains("<dd>My Post</dd>"), "{html}");
+        assert!(html.contains("<dd>true</dd>"), "{html}");
+    }
+
+    #[test]
+    fn property_list_escapes_label() {
+        let rows = vec![("<script>alert(1)</script>", maud::html! { "safe" })];
+        let html = property_list(&rows).into_string();
+        assert!(!html.contains("<script>"), "{html}");
+        assert!(html.contains("&lt;script&gt;"), "{html}");
+    }
+
+    #[test]
+    fn property_list_renders_markup_value_unescaped() {
+        let rows = vec![("Link", maud::html! { a href="/foo" { "click" } })];
+        let html = property_list(&rows).into_string();
+        assert!(html.contains(r#"<a href="/foo">click</a>"#), "{html}");
+    }
+
+    #[test]
+    fn property_list_multiple_rows_all_rendered() {
+        let rows = vec![
+            ("A", maud::html! { "1" }),
+            ("B", maud::html! { "2" }),
+            ("C", maud::html! { "3" }),
+        ];
+        let html = property_list(&rows).into_string();
+        assert_eq!(html.matches("<dt>").count(), 3, "{html}");
+        assert_eq!(html.matches("<dd>").count(), 3, "{html}");
     }
 
     // ── data_table ─────────────────────────────────────────────────────

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -56,42 +56,6 @@ fn layout(title: &str, content: Markup) -> Markup {
     }
 }
 
-fn bookmark_card(bookmark: &Bookmark) -> Markup {
-    html! {
-        li id=(format!("bookmark-{}", bookmark.id))
-           class="p-4 bg-white rounded shadow flex justify-between items-center gap-4" {
-            div {
-                a href=(bookmark.url) target="_blank"
-                   class="text-indigo-600 font-medium hover:underline" {
-                    (bookmark.title)
-                }
-                a href=(format!("/bookmarks/tag/{}", bookmark.tag))
-                   class="ml-2 text-xs bg-gray-200 rounded px-2 py-0.5" {
-                    (bookmark.tag)
-                }
-                @if !bookmark.alive {
-                    span class="ml-2 text-xs bg-red-100 text-red-600 rounded px-2 py-0.5" {
-                        "dead link"
-                    }
-                }
-            }
-            div class="flex items-center gap-3 text-sm" {
-                a href=(format!("/bookmarks/{}/edit", bookmark.id))
-                   class="text-gray-500 hover:text-gray-700" {
-                    "Edit"
-                }
-                button
-                    hx-delete=(format!("/api/bookmarks/{}", bookmark.id))
-                    hx-target=(format!("#bookmark-{}", bookmark.id))
-                    hx-swap="outerHTML"
-                    hx-confirm="Delete this bookmark?"
-                    class="text-red-500 hover:text-red-700" {
-                    "Delete"
-                }
-            }
-        }
-    }
-}
 
 /// Column definitions shared by the index, by-tag, and search-result views.
 ///

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -11,13 +11,15 @@
 //! - **`active_search`** — wires the search input to `/bookmarks/search` via
 //!   htmx; search results swap in a fresh `data_table`.
 //! - **`autocomplete_input`** — tag picker on the new/edit forms.
+//! - **`property_list`** — renders the detail view (`/bookmarks/{id}`) as a
+//!   semantic `<dl>` of labelled field values, replacing hand-rolled markup.
 //!
-//! All three compose in the index view without special wiring, demonstrating
-//! the composition AC from issue #1116.
+//! All four compose without special wiring, demonstrating the widget lane
+//! (data_table, active_search, autocomplete_input, property_list).
 
 use autumn_web::extract::{Form, Path};
 use autumn_web::prelude::*;
-use autumn_web::widgets::{Column, DataTableConfig, data_table};
+use autumn_web::widgets::{Column, DataTableConfig, data_table, property_list};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
@@ -188,13 +190,21 @@ pub async fn show(id: Path<i64>, mut db: Db) -> AutumnResult<Markup> {
         .await
         .map_err(AutumnError::not_found)?;
 
+    let props: Vec<(&str, maud::Markup)> = vec![
+        ("Id", html! { (row.id) }),
+        ("Url", html! { a href=(&row.url) { (&row.url) } }),
+        ("Title", html! { (&row.title) }),
+        ("Tag", html! { a href=(format!("/bookmarks/tag/{}", row.tag)) { (&row.tag) } }),
+        ("Alive", html! { (row.alive.to_string()) }),
+        ("Created at", html! { (row.created_at.to_string()) }),
+    ];
     Ok(layout(
         &format!("Bookmark #{}", row.id),
         html! {
             div class="mb-6" {
                 a href="/bookmarks" class="text-sm text-indigo-600 hover:underline" { "Back to list" }
             }
-            (bookmark_card(&row))
+            (property_list(&props))
         },
     ))
 }

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -194,7 +194,10 @@ pub async fn show(id: Path<i64>, mut db: Db) -> AutumnResult<Markup> {
         ("Id", html! { (row.id) }),
         ("Url", html! { a href=(&row.url) { (&row.url) } }),
         ("Title", html! { (&row.title) }),
-        ("Tag", html! { a href=(format!("/bookmarks/tag/{}", row.tag)) { (&row.tag) } }),
+        (
+            "Tag",
+            html! { a href=(format!("/bookmarks/tag/{}", row.tag)) { (&row.tag) } },
+        ),
         ("Alive", html! { (row.alive.to_string()) }),
         ("Created at", html! { (row.created_at.to_string()) }),
     ];

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -208,6 +208,20 @@ pub async fn show(id: Path<i64>, mut db: Db) -> AutumnResult<Markup> {
                 a href="/bookmarks" class="text-sm text-indigo-600 hover:underline" { "Back to list" }
             }
             (property_list(&props))
+            div class="flex gap-3 mt-6" {
+                a href=(format!("/bookmarks/{}/edit", row.id))
+                   class="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700 text-sm" {
+                    "Edit"
+                }
+                button
+                    hx-delete=(format!("/api/bookmarks/{}", row.id))
+                    hx-target="body"
+                    hx-push-url="/bookmarks"
+                    hx-confirm="Delete this bookmark?"
+                    class="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 text-sm" {
+                    "Delete"
+                }
+            }
         },
     ))
 }

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -56,7 +56,6 @@ fn layout(title: &str, content: Markup) -> Markup {
     }
 }
 
-
 /// Column definitions shared by the index, by-tag, and search-result views.
 ///
 /// Closures capture nothing from the outer scope, so the lifetime is `'static`.

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -215,9 +215,8 @@ pub async fn show(id: Path<i64>, mut db: Db) -> AutumnResult<Markup> {
                 }
                 button
                     hx-delete=(format!("/api/bookmarks/{}", row.id))
-                    hx-target="body"
-                    hx-push-url="/bookmarks"
                     hx-confirm="Delete this bookmark?"
+                    hx-on--after-request="if(event.detail.successful) window.location='/bookmarks'"
                     class="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 text-sm" {
                     "Delete"
                 }


### PR DESCRIPTION
## Summary

Introduces a new `property_list` widget that renders record fields as a semantic HTML definition list (`<dl>`), replacing hand-rolled markup in detail views. This completes the widget lane alongside `data_table`, `active_search`, and `autocomplete_input`.

## Key Changes

- **New `property_list` widget** (`autumn/src/widgets.rs`):
  - Renders a `<dl class="autumn-property-list">` with `<dt>`/`<dd>` pairs for each field
  - Accepts `&[(&str, maud::Markup)]` rows: labels are HTML-escaped, values are pre-escaped markup
  - Handles empty slices gracefully without panicking
  - Includes comprehensive documentation with CSS hooks and usage examples
  - Fully tested with 6 test cases covering empty state, escaping, markup rendering, and multiple rows

- **Scaffold generator integration** (`autumn-cli/src/generate/scaffold.rs`):
  - Updated `show` handler template to use `property_list` widget
  - Added `render_show_property_rows()` function to generate property list rows from DSL fields
  - Added `humanize()` helper to convert `snake_case` field names to human-readable labels (e.g., `created_at` → `"Created at"`)
  - Includes `id`, all declared fields, and `created_at` in the property list
  - Added 2 integration tests verifying scaffold conformance and label humanization

- **Example update** (`examples/bookmarks/src/routes/bookmarks.rs`):
  - Replaced hand-rolled `bookmark_card()` markup with `property_list` widget in the `show` handler
  - Demonstrates real-world usage with links and formatted values
  - Updated module documentation to reflect the new widget

- **Documentation** (`autumn/src/lib.rs`):
  - Updated module-level docs to mention `property_list` alongside other widgets

## Implementation Details

- The `humanize()` function follows Rails/Phoenix conventions: capitalize only the first word, replace underscores with spaces
- Values are pre-escaped `maud::Markup` to allow callers to pass plain text, formatted dates, or nested HTML (links, badges) without escaping foot-guns
- The widget is gated behind the `maud` feature flag, consistent with other markup-generating widgets

https://claude.ai/code/session_01D7ZHf3gZetgbeyQjADnTk7