### PR TITLE
Add `autumn generate tauri` to scaffold native desktop apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **cli:** `autumn generate tauri` — scaffolds a complete `src-tauri/` sidecar
+  project so any existing autumn app ships as a native desktop installer with a
+  single additional command (`cargo tauri build`). Uses the Tauri v2 sidecar
+  model: the autumn server binary is supervised by the Tauri shell and the
+  webview loads from an ephemeral loopback port chosen at runtime. Fully
+  self-contained at runtime via managed local Postgres (#1119,
+  `managed-pg-bundled`) and single-binary asset embedding (#1004,
+  `embed-assets`). Generator is purely additive — never rewrites your app's
+  `src/main.rs` or root `Cargo.toml`. Idempotent, dry-run capable, prints
+  required external prerequisites after scaffolding (#1150).
 - **ui:** reusable Maud pagination-nav renderer — `autumn_web::ui::pagination::{pagination_nav, cursor_pagination_nav, PagerOptions}`,
   re-exported from the prelude. Renders an accessible (`<nav>` with
   `aria-current="page"` and non-focusable disabled prev/next), filter-preserving

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -108,6 +108,47 @@ fn build_embedded(
     eprintln!("\n\u{1F342} Build complete! Assets and locales embedded into the binary.");
 }
 
+/// Set up environment variables for the static-renderer command.
+///
+/// Factored out of [`run`] so the env-setup logic is unit-testable without
+/// invoking `cargo build` or the app binary.
+fn apply_renderer_env(
+    cmd: &mut Command,
+    debug: bool,
+    package: Option<&str>,
+    bin: Option<&str>,
+    resolved_pkg: Option<&str>,
+    manifest_dir: Option<&PathBuf>,
+) {
+    // Clear any inherited attach URL so a stale value can't redirect the static
+    // renderer to the wrong database; re-set below only when a live cluster is
+    // discovered.
+    cmd.env_remove(crate::serve::MANAGED_PG_ATTACH_URL_ENV);
+    // When --bin selects a workspace member without -p, use the resolved package
+    // name so the renderer shares that member's cluster, not the workspace root's.
+    let effective_pkg = package.or_else(|| bin.and(resolved_pkg));
+    if let Some(pg) = crate::serve::managed_pg_env(effective_pkg) {
+        cmd.env(crate::serve::MANAGED_PG_DATA_DIR_ENV, &pg.data_dir);
+        if let Some(url) = pg.attach_url {
+            cmd.env(crate::serve::MANAGED_PG_ATTACH_URL_ENV, url);
+        }
+    }
+    // Mirror cargo's profile selection so dev builds skip production-only
+    // validation and release builds apply prod config overrides.
+    // Users can override by setting AUTUMN_PROFILE explicitly.
+    if std::env::var("AUTUMN_PROFILE").is_err() {
+        cmd.env("AUTUMN_PROFILE", if debug { "dev" } else { "prod" });
+    }
+    // Pin CWD to the package directory so config loading and dist/ output are
+    // relative to the correct project root when -p <package> points to a subdir.
+    if let Some(dir) = manifest_dir {
+        let cwd = std::env::current_dir().expect("current dir");
+        if dir != &cwd {
+            cmd.current_dir(dir);
+        }
+    }
+}
+
 /// Run the static build pipeline.
 pub fn run(
     debug: bool,
@@ -152,43 +193,14 @@ pub fn run(
 
     let mut cmd = Command::new(&binary);
     cmd.env("AUTUMN_BUILD_STATIC", "1");
-    // Share the serve daemon's managed-Postgres cluster (and attach to it when
-    // live) so the static renderer doesn't try to start a second postmaster on
-    // the daemon's locked data dir. A no-op for apps that don't use managed PG.
-    // The attach URL is CLI→child plumbing, not an operator knob. Clear any
-    // inherited value up front (even when an explicit AUTUMN_MANAGED_PG_DATA_DIR
-    // override makes `managed_pg_env` return None) so a stale/foreign value can't
-    // redirect the static renderer to the wrong database; re-set it only when a
-    // live cluster is discovered.
-    cmd.env_remove(crate::serve::MANAGED_PG_ATTACH_URL_ENV);
-    // When --bin selects a member without -p, use the resolved package name for
-    // managed-PG namespacing so the static renderer shares the member's cluster
-    // rather than the workspace root's.
-    let effective_pkg = package.or_else(|| bin.and(resolved_pkg.as_deref()));
-    if let Some(pg) = crate::serve::managed_pg_env(effective_pkg) {
-        cmd.env(crate::serve::MANAGED_PG_DATA_DIR_ENV, &pg.data_dir);
-        if let Some(url) = pg.attach_url {
-            cmd.env(crate::serve::MANAGED_PG_ATTACH_URL_ENV, url);
-        }
-    }
-    // Mirror cargo's profile selection: dev builds use the dev Autumn profile
-    // (skips production-only validation), release builds use prod so that
-    // prod config overrides (robots.txt, SEO settings, etc.) are applied.
-    // Users can override either by setting AUTUMN_PROFILE explicitly.
-    if std::env::var("AUTUMN_PROFILE").is_err() {
-        cmd.env("AUTUMN_PROFILE", if debug { "dev" } else { "prod" });
-    }
-    // When -p <package> is given and the package lives in a subdirectory (e.g.
-    // `autumn build -p reddit-clone` from the workspace root), the binary would
-    // otherwise inherit the CLI's CWD and look for autumn.toml in the wrong
-    // place. Pin it to the package's directory so config loading and the dist/
-    // output path are always relative to the correct project root.
-    if let Some(dir) = &manifest_dir {
-        let cwd = std::env::current_dir().expect("current dir");
-        if dir != &cwd {
-            cmd.current_dir(dir);
-        }
-    }
+    apply_renderer_env(
+        &mut cmd,
+        debug,
+        package,
+        bin,
+        resolved_pkg.as_deref(),
+        manifest_dir.as_ref(),
+    );
     let status = cmd.status().unwrap_or_else(|e| {
         eprintln!("\u{2717} Failed to run {}: {e}", binary.display());
         std::process::exit(1);
@@ -967,6 +979,97 @@ mod tests {
         assert!(!is_fingerprinted_filename("autumn.zzzzzzzz.css"));
         // bare name with no dot
         assert!(!is_fingerprinted_filename("CNAME"));
+    }
+
+    #[test]
+    fn run_cargo_or_exit_succeeds_on_zero_exit() {
+        // `cargo --version` is always available and always exits 0.
+        let mut cmd = Command::new("cargo");
+        cmd.arg("--version");
+        run_cargo_or_exit(cmd);
+    }
+
+    #[test]
+    fn apply_renderer_env_removes_pg_attach_url_unconditionally() {
+        let mut cmd = Command::new("echo");
+        apply_renderer_env(&mut cmd, false, None, None, None, None);
+        let removed = cmd.get_envs().any(|(k, v)| {
+            k.to_str() == Some(crate::serve::MANAGED_PG_ATTACH_URL_ENV) && v.is_none()
+        });
+        assert!(
+            removed,
+            "MANAGED_PG_ATTACH_URL must be removed from env regardless of managed-PG state"
+        );
+    }
+
+    #[test]
+    fn apply_renderer_env_sets_autumn_profile_when_absent() {
+        if std::env::var("AUTUMN_PROFILE").is_ok() {
+            // Parent env already has it; helper intentionally won't override it.
+            return;
+        }
+        let find_profile = |cmd: &Command| -> Option<String> {
+            cmd.get_envs().find_map(|(k, v)| {
+                if k.to_str() == Some("AUTUMN_PROFILE") {
+                    v.and_then(|s| s.to_str().map(str::to_owned))
+                } else {
+                    None
+                }
+            })
+        };
+        let mut cmd_debug = Command::new("echo");
+        apply_renderer_env(&mut cmd_debug, true, None, None, None, None);
+        assert_eq!(
+            find_profile(&cmd_debug).as_deref(),
+            Some("dev"),
+            "debug=true must set AUTUMN_PROFILE=dev when not already in env"
+        );
+
+        let mut cmd_release = Command::new("echo");
+        apply_renderer_env(&mut cmd_release, false, None, None, None, None);
+        assert_eq!(
+            find_profile(&cmd_release).as_deref(),
+            Some("prod"),
+            "debug=false must set AUTUMN_PROFILE=prod when not already in env"
+        );
+    }
+
+    #[test]
+    fn apply_renderer_env_pins_current_dir_when_manifest_differs_from_cwd() {
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let manifest_dir = tmp.path().to_path_buf();
+        let cwd = std::env::current_dir().unwrap();
+        if manifest_dir == cwd {
+            return; // extremely unlikely, but guard anyway
+        }
+        let mut cmd = Command::new("echo");
+        apply_renderer_env(&mut cmd, false, None, None, None, Some(&manifest_dir));
+        assert_eq!(
+            cmd.get_current_dir(),
+            Some(manifest_dir.as_path()),
+            "current_dir must be pinned to manifest_dir when it differs from cwd"
+        );
+    }
+
+    #[test]
+    fn apply_renderer_env_effective_pkg_prefers_package_over_resolved() {
+        // When both --package and --bin are given, effective_pkg uses --package.
+        // (Verifies the or_else short-circuit without touching managed-PG state.)
+        let mut cmd = Command::new("echo");
+        // Just verify the function doesn't panic with both args supplied.
+        apply_renderer_env(
+            &mut cmd,
+            false,
+            Some("my-pkg"),
+            Some("my-bin"),
+            Some("resolved"),
+            None,
+        );
+        let removed = cmd.get_envs().any(|(k, v)| {
+            k.to_str() == Some(crate::serve::MANAGED_PG_ATTACH_URL_ENV) && v.is_none()
+        });
+        assert!(removed);
     }
 
     #[test]

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -87,7 +87,7 @@ fn build_embedded(
     // Resolve the selected package's directory so `-p <pkg>` fingerprints that
     // package's `static/` (which `embed_static!` reads via $CARGO_MANIFEST_DIR),
     // not whatever `static/` happens to sit next to the CLI's cwd.
-    let (_, manifest_dir) = find_binary(debug, package, bin);
+    let (_, manifest_dir, _) = find_binary(debug, package, bin);
     let static_dir = manifest_dir
         .unwrap_or_else(|| std::env::current_dir().expect("current dir"))
         .join("static");
@@ -135,7 +135,7 @@ pub fn run(
     // Resolve the selected package's directory before fingerprinting so that
     // when --bin selects a member of a workspace without -p, we fingerprint
     // that member's static/ tree rather than the workspace root's.
-    let (binary, manifest_dir) = find_binary(debug, package, bin);
+    let (binary, manifest_dir, resolved_pkg) = find_binary(debug, package, bin);
 
     // Release builds fingerprint *after* the compile (the runtime reads the
     // manifest from disk, so order doesn't matter, and the static renderer below
@@ -161,7 +161,11 @@ pub fn run(
     // redirect the static renderer to the wrong database; re-set it only when a
     // live cluster is discovered.
     cmd.env_remove(crate::serve::MANAGED_PG_ATTACH_URL_ENV);
-    if let Some(pg) = crate::serve::managed_pg_env(package) {
+    // When --bin selects a member without -p, use the resolved package name for
+    // managed-PG namespacing so the static renderer shares the member's cluster
+    // rather than the workspace root's.
+    let effective_pkg = package.or_else(|| bin.and(resolved_pkg.as_deref()));
+    if let Some(pg) = crate::serve::managed_pg_env(effective_pkg) {
         cmd.env(crate::serve::MANAGED_PG_DATA_DIR_ENV, &pg.data_dir);
         if let Some(url) = pg.attach_url {
             cmd.env(crate::serve::MANAGED_PG_ATTACH_URL_ENV, url);
@@ -391,7 +395,7 @@ fn find_binary(
     debug: bool,
     package: Option<&str>,
     bin: Option<&str>,
-) -> (PathBuf, Option<PathBuf>) {
+) -> (PathBuf, Option<PathBuf>, Option<String>) {
     let output = Command::new("cargo")
         .args(["metadata", "--format-version=1", "--no-deps"])
         .output()
@@ -430,7 +434,7 @@ fn resolve_binary_from_metadata(
     package: Option<&str>,
     bin: Option<&str>,
     cwd: &Path,
-) -> Result<(PathBuf, Option<PathBuf>), String> {
+) -> Result<(PathBuf, Option<PathBuf>, Option<String>), String> {
     let target_dir = metadata["target_directory"]
         .as_str()
         .ok_or("target_directory missing from cargo metadata")?;
@@ -478,7 +482,7 @@ fn resolve_binary_from_metadata(
         }
     }
 
-    let (bin_name, manifest_dir) = matching_packages
+    let (bin_name, manifest_dir, resolved_pkg_name) = matching_packages
         .iter()
         .find_map(|pkg| {
             // --bin wins when the caller already knows which target to run.
@@ -509,7 +513,8 @@ fn resolve_binary_from_metadata(
             let dir = pkg["manifest_path"]
                 .as_str()
                 .and_then(|p| Path::new(p).parent().map(PathBuf::from));
-            Some((name, dir))
+            let pkg_name = pkg["name"].as_str().map(ToOwned::to_owned);
+            Some((name, dir, pkg_name))
         })
         .ok_or_else(|| {
             bin.map_or_else(
@@ -539,7 +544,7 @@ fn resolve_binary_from_metadata(
         path.set_extension("exe");
     }
 
-    Ok((path, manifest_dir))
+    Ok((path, manifest_dir, resolved_pkg_name))
 }
 
 #[cfg(test)]
@@ -653,7 +658,7 @@ mod tests {
     #[test]
     fn resolve_binary_by_package_name() {
         let metadata = sample_metadata("/tmp/target", "hello", "/projects/hello");
-        let (bin, manifest_dir) = resolve_binary_from_metadata(
+        let (bin, manifest_dir, _) = resolve_binary_from_metadata(
             &metadata,
             true,
             Some("hello"),
@@ -668,7 +673,7 @@ mod tests {
     #[test]
     fn resolve_binary_by_cwd() {
         let metadata = sample_metadata("/tmp/target", "hello", "/projects/hello");
-        let (bin, manifest_dir) =
+        let (bin, manifest_dir, _) =
             resolve_binary_from_metadata(&metadata, true, None, None, Path::new("/projects/hello"))
                 .unwrap();
         assert_eq!(bin, expected_binary("/tmp/target/debug/hello"));
@@ -678,7 +683,7 @@ mod tests {
     #[test]
     fn resolve_binary_uses_release_profile() {
         let metadata = sample_metadata("/tmp/target", "hello", "/projects/hello");
-        let (bin, _) = resolve_binary_from_metadata(
+        let (bin, _, _) = resolve_binary_from_metadata(
             &metadata,
             false,
             Some("hello"),
@@ -737,7 +742,7 @@ mod tests {
                 ]
             }]
         });
-        let (bin, _) = resolve_binary_from_metadata(
+        let (bin, _, _) = resolve_binary_from_metadata(
             &metadata,
             true,
             Some("todo-app"),
@@ -763,7 +768,7 @@ mod tests {
                 ]
             }]
         });
-        let (bin, _) = resolve_binary_from_metadata(
+        let (bin, _, _) = resolve_binary_from_metadata(
             &metadata,
             true,
             Some("todo-app"),
@@ -794,7 +799,7 @@ mod tests {
             ]
         });
         // Both members are under the CWD (/workspace); --bin web belongs to app-b.
-        let (bin, manifest_dir) = resolve_binary_from_metadata(
+        let (bin, manifest_dir, _) = resolve_binary_from_metadata(
             &metadata,
             true,
             None,
@@ -883,7 +888,7 @@ mod tests {
             }]
         });
         // Simulates: `autumn build -p reddit-clone` from workspace root
-        let (bin, manifest_dir) = resolve_binary_from_metadata(
+        let (bin, manifest_dir, _) = resolve_binary_from_metadata(
             &metadata,
             false,
             Some("reddit-clone"),
@@ -898,6 +903,43 @@ mod tests {
         assert_eq!(
             manifest_dir,
             Some(PathBuf::from("/workspace/examples/reddit-clone"))
+        );
+    }
+
+    #[test]
+    fn resolve_binary_returns_pkg_name_for_bin_without_package() {
+        // When --bin selects a workspace member without -p, the resolved package name
+        // must be returned so managed_pg_env can namespace to the member rather than
+        // the workspace root's CWD-derived identity.
+        let metadata = serde_json::json!({
+            "target_directory": "/workspace/target",
+            "packages": [
+                {
+                    "name": "api",
+                    "manifest_path": "/workspace/api/Cargo.toml",
+                    "targets": [{ "name": "api-server", "kind": ["bin"], "src_path": "/workspace/api/src/main.rs" }]
+                },
+                {
+                    "name": "web",
+                    "manifest_path": "/workspace/web/Cargo.toml",
+                    "targets": [{ "name": "web-server", "kind": ["bin"], "src_path": "/workspace/web/src/main.rs" }]
+                }
+            ]
+        });
+        let (bin, manifest_dir, resolved_pkg) = resolve_binary_from_metadata(
+            &metadata,
+            false,
+            None,
+            Some("api-server"),
+            Path::new("/workspace"),
+        )
+        .unwrap();
+        assert_eq!(bin, expected_binary("/workspace/target/release/api-server"));
+        assert_eq!(manifest_dir, Some(PathBuf::from("/workspace/api")));
+        assert_eq!(
+            resolved_pkg,
+            Some("api".to_owned()),
+            "--bin without -p must return the resolved package name for managed-PG namespacing"
         );
     }
 

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -20,7 +20,12 @@ use sha2::{Digest, Sha256};
 /// Factored out so the flags are unit-testable. With `embed`, the
 /// `autumn-web/embed-assets` feature is enabled so the binary bakes in the
 /// `static/` tree (and its manifest) plus i18n locales.
-fn build_cargo_command(debug: bool, embed: bool, package: Option<&str>) -> Command {
+fn build_cargo_command(
+    debug: bool,
+    embed: bool,
+    package: Option<&str>,
+    bin: Option<&str>,
+) -> Command {
     let mut cargo = Command::new("cargo");
     cargo.arg("build");
     if !debug {
@@ -28,6 +33,9 @@ fn build_cargo_command(debug: bool, embed: bool, package: Option<&str>) -> Comma
     }
     if let Some(pkg) = package {
         cargo.args(["-p", pkg]);
+    }
+    if let Some(b) = bin {
+        cargo.args(["--bin", b]);
     }
     if embed {
         // Enable the app crate's `embed-assets` feature, which the scaffold
@@ -59,7 +67,7 @@ fn run_cargo_or_exit(mut cargo: Command) {
 ///    (not the CLI cwd), writing the manifest + hashed copies.
 /// 3. Recompile **with** the embed feature so `include_dir!` bakes the
 ///    fingerprinted tree into the binary.
-fn build_embedded(debug: bool, profile: &str, package: Option<&str>) {
+fn build_embedded(debug: bool, profile: &str, package: Option<&str>, bin: Option<&str>) {
     // Resolve the selected package's directory so `-p <pkg>` fingerprints that
     // package's `static/` (which `embed_static!` reads via $CARGO_MANIFEST_DIR),
     // not whatever `static/` happens to sit next to the CLI's cwd.
@@ -69,19 +77,19 @@ fn build_embedded(debug: bool, profile: &str, package: Option<&str>) {
         .join("static");
 
     eprintln!("Compiling ({profile} profile)...");
-    run_cargo_or_exit(build_cargo_command(debug, false, package));
+    run_cargo_or_exit(build_cargo_command(debug, false, package, bin));
 
     eprintln!("\nFingerprinting static assets for embedding...");
     fingerprint_assets_in(&static_dir);
 
     eprintln!("\nEmbedding assets and locales into the binary...");
-    run_cargo_or_exit(build_cargo_command(debug, true, package));
+    run_cargo_or_exit(build_cargo_command(debug, true, package, bin));
 
     eprintln!("\n\u{1F342} Build complete! Assets and locales embedded into the binary.");
 }
 
 /// Run the static build pipeline.
-pub fn run(debug: bool, embed: bool, package: Option<&str>) {
+pub fn run(debug: bool, embed: bool, package: Option<&str>, bin: Option<&str>) {
     eprintln!("\u{1F342} autumn build\n");
 
     let profile = if debug { "dev" } else { "release" };
@@ -91,12 +99,12 @@ pub fn run(debug: bool, embed: bool, package: Option<&str>) {
     // routes and the app's runtime state) and lets dynamic-server apps build a
     // single binary without a database or pre-render step.
     if embed {
-        build_embedded(debug, profile, package);
+        build_embedded(debug, profile, package, bin);
         return;
     }
 
     eprintln!("Compiling ({profile} profile)...");
-    run_cargo_or_exit(build_cargo_command(debug, embed, package));
+    run_cargo_or_exit(build_cargo_command(debug, embed, package, bin));
 
     // Release builds fingerprint *after* the compile (the runtime reads the
     // manifest from disk, so order doesn't matter, and the static renderer below
@@ -447,8 +455,13 @@ fn resolve_binary_from_metadata(
 mod tests {
     use super::*;
 
-    fn cargo_args(debug: bool, embed: bool, package: Option<&str>) -> Vec<String> {
-        build_cargo_command(debug, embed, package)
+    fn cargo_args(
+        debug: bool,
+        embed: bool,
+        package: Option<&str>,
+        bin: Option<&str>,
+    ) -> Vec<String> {
+        build_cargo_command(debug, embed, package, bin)
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
             .collect()
@@ -456,7 +469,7 @@ mod tests {
 
     #[test]
     fn embed_build_enables_feature_in_release() {
-        let args = cargo_args(false, true, None);
+        let args = cargo_args(false, true, None, None);
         assert!(args.contains(&"--release".to_string()));
         assert!(
             args.windows(2).any(|w| w == ["--features", "embed-assets"]),
@@ -466,10 +479,20 @@ mod tests {
 
     #[test]
     fn non_embed_build_omits_embed_feature() {
-        let args = cargo_args(false, false, Some("blog"));
+        let args = cargo_args(false, false, Some("blog"), None);
         assert!(
             !args.iter().any(|a| a.contains("embed-assets")),
             "non-embed build must not enable embed-assets: {args:?}"
+        );
+        assert!(args.windows(2).any(|w| w == ["-p", "blog"]));
+    }
+
+    #[test]
+    fn bin_arg_is_passed_to_cargo() {
+        let args = cargo_args(false, true, Some("blog"), Some("blog-server"));
+        assert!(
+            args.windows(2).any(|w| w == ["--bin", "blog-server"]),
+            "--bin must be forwarded to cargo: {args:?}"
         );
         assert!(args.windows(2).any(|w| w == ["-p", "blog"]));
     }

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -25,6 +25,7 @@ fn build_cargo_command(
     embed: bool,
     package: Option<&str>,
     bin: Option<&str>,
+    extra_features: Option<&str>,
 ) -> Command {
     let mut cargo = Command::new("cargo");
     cargo.arg("build");
@@ -37,13 +38,22 @@ fn build_cargo_command(
     if let Some(b) = bin {
         cargo.args(["--bin", b]);
     }
-    if embed {
-        // Enable the app crate's `embed-assets` feature, which the scaffold
-        // defines as `["autumn-web/embed-assets"]`. Using the app-crate feature
-        // (rather than `autumn-web/embed-assets` directly) lets app code gate the
-        // `.embedded_static()` / `.embedded_locales()` wiring on
-        // `#[cfg(feature = "embed-assets")]`.
-        cargo.args(["--features", "embed-assets"]);
+    // Build the feature string. `embed-assets` (the app-crate feature that pulls
+    // in `autumn-web/embed-assets`) is added when we are in the embed phase.
+    // `extra_features` (e.g. `autumn-web/managed-pg-bundled`) is forwarded from
+    // the CLI so that apps wiring ManagedPostgresPoolProvider can compile in both
+    // the fingerprint phase and the final embed phase without feature-gate errors.
+    match (embed, extra_features) {
+        (true, Some(extra)) => {
+            cargo.args(["--features", &format!("embed-assets,{extra}")]);
+        }
+        (true, None) => {
+            cargo.args(["--features", "embed-assets"]);
+        }
+        (false, Some(extra)) => {
+            cargo.args(["--features", extra]);
+        }
+        (false, None) => {}
     }
     cargo
 }
@@ -67,7 +77,13 @@ fn run_cargo_or_exit(mut cargo: Command) {
 ///    (not the CLI cwd), writing the manifest + hashed copies.
 /// 3. Recompile **with** the embed feature so `include_dir!` bakes the
 ///    fingerprinted tree into the binary.
-fn build_embedded(debug: bool, profile: &str, package: Option<&str>, bin: Option<&str>) {
+fn build_embedded(
+    debug: bool,
+    profile: &str,
+    package: Option<&str>,
+    bin: Option<&str>,
+    features: Option<&str>,
+) {
     // Resolve the selected package's directory so `-p <pkg>` fingerprints that
     // package's `static/` (which `embed_static!` reads via $CARGO_MANIFEST_DIR),
     // not whatever `static/` happens to sit next to the CLI's cwd.
@@ -77,19 +93,29 @@ fn build_embedded(debug: bool, profile: &str, package: Option<&str>, bin: Option
         .join("static");
 
     eprintln!("Compiling ({profile} profile)...");
-    run_cargo_or_exit(build_cargo_command(debug, false, package, bin));
+    // Phase 1: compile WITHOUT embed-assets so build scripts populate static/.
+    // Pass extra features (e.g. managed-pg-bundled) so apps wiring
+    // ManagedPostgresPoolProvider can compile even in this pre-embed phase.
+    run_cargo_or_exit(build_cargo_command(debug, false, package, bin, features));
 
     eprintln!("\nFingerprinting static assets for embedding...");
     fingerprint_assets_in(&static_dir);
 
     eprintln!("\nEmbedding assets and locales into the binary...");
-    run_cargo_or_exit(build_cargo_command(debug, true, package, bin));
+    // Phase 3: recompile WITH embed-assets so include_dir! bakes the tree in.
+    run_cargo_or_exit(build_cargo_command(debug, true, package, bin, features));
 
     eprintln!("\n\u{1F342} Build complete! Assets and locales embedded into the binary.");
 }
 
 /// Run the static build pipeline.
-pub fn run(debug: bool, embed: bool, package: Option<&str>, bin: Option<&str>) {
+pub fn run(
+    debug: bool,
+    embed: bool,
+    package: Option<&str>,
+    bin: Option<&str>,
+    features: Option<&str>,
+) {
     eprintln!("\u{1F342} autumn build\n");
 
     let profile = if debug { "dev" } else { "release" };
@@ -99,12 +125,12 @@ pub fn run(debug: bool, embed: bool, package: Option<&str>, bin: Option<&str>) {
     // routes and the app's runtime state) and lets dynamic-server apps build a
     // single binary without a database or pre-render step.
     if embed {
-        build_embedded(debug, profile, package, bin);
+        build_embedded(debug, profile, package, bin, features);
         return;
     }
 
     eprintln!("Compiling ({profile} profile)...");
-    run_cargo_or_exit(build_cargo_command(debug, embed, package, bin));
+    run_cargo_or_exit(build_cargo_command(debug, embed, package, bin, features));
 
     // Resolve the selected package's directory before fingerprinting so that
     // when --bin selects a member of a workspace without -p, we fingerprint
@@ -501,8 +527,9 @@ mod tests {
         embed: bool,
         package: Option<&str>,
         bin: Option<&str>,
+        extra_features: Option<&str>,
     ) -> Vec<String> {
-        build_cargo_command(debug, embed, package, bin)
+        build_cargo_command(debug, embed, package, bin, extra_features)
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
             .collect()
@@ -510,7 +537,7 @@ mod tests {
 
     #[test]
     fn embed_build_enables_feature_in_release() {
-        let args = cargo_args(false, true, None, None);
+        let args = cargo_args(false, true, None, None, None);
         assert!(args.contains(&"--release".to_string()));
         assert!(
             args.windows(2).any(|w| w == ["--features", "embed-assets"]),
@@ -520,7 +547,7 @@ mod tests {
 
     #[test]
     fn non_embed_build_omits_embed_feature() {
-        let args = cargo_args(false, false, Some("blog"), None);
+        let args = cargo_args(false, false, Some("blog"), None, None);
         assert!(
             !args.iter().any(|a| a.contains("embed-assets")),
             "non-embed build must not enable embed-assets: {args:?}"
@@ -529,8 +556,46 @@ mod tests {
     }
 
     #[test]
+    fn extra_features_forwarded_to_cargo() {
+        // Non-embed: only the extra feature is added.
+        let args = cargo_args(
+            false,
+            false,
+            None,
+            None,
+            Some("autumn-web/managed-pg-bundled"),
+        );
+        assert!(
+            args.windows(2)
+                .any(|w| w == ["--features", "autumn-web/managed-pg-bundled"]),
+            "extra_features must be forwarded when embed is false: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a.contains("embed-assets")),
+            "embed-assets must not appear in non-embed build: {args:?}"
+        );
+    }
+
+    #[test]
+    fn extra_features_combined_with_embed_assets() {
+        // Embed: extra feature is combined with embed-assets in one --features flag.
+        let args = cargo_args(
+            false,
+            true,
+            None,
+            None,
+            Some("autumn-web/managed-pg-bundled"),
+        );
+        assert!(
+            args.windows(2)
+                .any(|w| w == ["--features", "embed-assets,autumn-web/managed-pg-bundled"]),
+            "embed + extra_features must produce a combined --features value: {args:?}"
+        );
+    }
+
+    #[test]
     fn bin_arg_is_passed_to_cargo() {
-        let args = cargo_args(false, true, Some("blog"), Some("blog-server"));
+        let args = cargo_args(false, true, Some("blog"), Some("blog-server"), None);
         assert!(
             args.windows(2).any(|w| w == ["--bin", "blog-server"]),
             "--bin must be forwarded to cargo: {args:?}"

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -71,7 +71,7 @@ fn build_embedded(debug: bool, profile: &str, package: Option<&str>, bin: Option
     // Resolve the selected package's directory so `-p <pkg>` fingerprints that
     // package's `static/` (which `embed_static!` reads via $CARGO_MANIFEST_DIR),
     // not whatever `static/` happens to sit next to the CLI's cwd.
-    let (_, manifest_dir) = find_binary(debug, package);
+    let (_, manifest_dir) = find_binary(debug, package, bin);
     let static_dir = manifest_dir
         .unwrap_or_else(|| std::env::current_dir().expect("current dir"))
         .join("static");
@@ -114,7 +114,7 @@ pub fn run(debug: bool, embed: bool, package: Option<&str>, bin: Option<&str>) {
         fingerprint_static_assets();
     }
 
-    let (binary, manifest_dir) = find_binary(debug, package);
+    let (binary, manifest_dir) = find_binary(debug, package, bin);
     eprintln!("\nRunning static renderer...\n");
 
     let mut cmd = Command::new(&binary);
@@ -353,10 +353,18 @@ fn is_fingerprinted_filename(filename: &str) -> bool {
 /// Otherwise falls back to matching the package whose manifest is in
 /// the current directory.
 ///
+/// When `bin` is `Some`, it is used as the binary name directly instead of
+/// resolving via `default-run` or target scanning — mirrors the `--bin` flag
+/// passed to `cargo build`.
+///
 /// Returns `(binary_path, manifest_dir)` so the caller can set
 /// `AUTUMN_MANIFEST_DIR` when the binary is run from a different CWD
 /// (e.g. `autumn build -p reddit-clone` from the workspace root).
-fn find_binary(debug: bool, package: Option<&str>) -> (PathBuf, Option<PathBuf>) {
+fn find_binary(
+    debug: bool,
+    package: Option<&str>,
+    bin: Option<&str>,
+) -> (PathBuf, Option<PathBuf>) {
     let output = Command::new("cargo")
         .args(["metadata", "--format-version=1", "--no-deps"])
         .output()
@@ -371,7 +379,7 @@ fn find_binary(debug: bool, package: Option<&str>) -> (PathBuf, Option<PathBuf>)
         serde_json::from_slice(&output.stdout).expect("parse cargo metadata");
     let cwd = std::env::current_dir().expect("current dir");
 
-    resolve_binary_from_metadata(&metadata, debug, package, &cwd).unwrap_or_else(|error| {
+    resolve_binary_from_metadata(&metadata, debug, package, bin, &cwd).unwrap_or_else(|error| {
         eprintln!("\u{2717} {error}");
         std::process::exit(1);
     })
@@ -381,6 +389,7 @@ fn resolve_binary_from_metadata(
     metadata: &serde_json::Value,
     debug: bool,
     package: Option<&str>,
+    bin: Option<&str>,
     cwd: &Path,
 ) -> Result<(PathBuf, Option<PathBuf>), String> {
     let target_dir = metadata["target_directory"]
@@ -413,9 +422,12 @@ fn resolve_binary_from_metadata(
     let (bin_name, manifest_dir) = matching_packages
         .iter()
         .find_map(|pkg| {
-            // Prefer `default-run` so packages with multiple binaries always
-            // start the right one. Mirror the same logic as `dev.rs`.
-            let name = if let Some(name) = pkg["default_run"].as_str() {
+            // --bin wins when the caller already knows which target to run.
+            // Otherwise prefer `default-run` so packages with multiple binaries
+            // always start the right one. Mirror the same logic as `dev.rs`.
+            let name = if let Some(explicit) = bin {
+                explicit.to_owned()
+            } else if let Some(name) = pkg["default_run"].as_str() {
                 name.to_owned()
             } else {
                 pkg["targets"].as_array()?.iter().find_map(|t| {
@@ -523,9 +535,14 @@ mod tests {
     #[test]
     fn resolve_binary_by_package_name() {
         let metadata = sample_metadata("/tmp/target", "hello", "/projects/hello");
-        let (bin, manifest_dir) =
-            resolve_binary_from_metadata(&metadata, true, Some("hello"), Path::new("/projects"))
-                .unwrap();
+        let (bin, manifest_dir) = resolve_binary_from_metadata(
+            &metadata,
+            true,
+            Some("hello"),
+            None,
+            Path::new("/projects"),
+        )
+        .unwrap();
         assert_eq!(bin, expected_binary("/tmp/target/debug/hello"));
         assert_eq!(manifest_dir, Some(PathBuf::from("/projects/hello")));
     }
@@ -534,7 +551,7 @@ mod tests {
     fn resolve_binary_by_cwd() {
         let metadata = sample_metadata("/tmp/target", "hello", "/projects/hello");
         let (bin, manifest_dir) =
-            resolve_binary_from_metadata(&metadata, true, None, Path::new("/projects/hello"))
+            resolve_binary_from_metadata(&metadata, true, None, None, Path::new("/projects/hello"))
                 .unwrap();
         assert_eq!(bin, expected_binary("/tmp/target/debug/hello"));
         assert_eq!(manifest_dir, Some(PathBuf::from("/projects/hello")));
@@ -543,17 +560,27 @@ mod tests {
     #[test]
     fn resolve_binary_uses_release_profile() {
         let metadata = sample_metadata("/tmp/target", "hello", "/projects/hello");
-        let (bin, _) =
-            resolve_binary_from_metadata(&metadata, false, Some("hello"), Path::new("/projects"))
-                .unwrap();
+        let (bin, _) = resolve_binary_from_metadata(
+            &metadata,
+            false,
+            Some("hello"),
+            None,
+            Path::new("/projects"),
+        )
+        .unwrap();
         assert_eq!(bin, expected_binary("/tmp/target/release/hello"));
     }
 
     #[test]
     fn resolve_binary_reports_missing_package() {
         let metadata = sample_metadata("/tmp/target", "hello", "/projects/hello");
-        let result =
-            resolve_binary_from_metadata(&metadata, true, Some("missing"), Path::new("/projects"));
+        let result = resolve_binary_from_metadata(
+            &metadata,
+            true,
+            Some("missing"),
+            None,
+            Path::new("/projects"),
+        );
         assert!(result.unwrap_err().contains("package 'missing'"));
     }
 
@@ -568,8 +595,13 @@ mod tests {
             }]
         });
 
-        let result =
-            resolve_binary_from_metadata(&metadata, true, Some("hello"), Path::new("/projects"));
+        let result = resolve_binary_from_metadata(
+            &metadata,
+            true,
+            Some("hello"),
+            None,
+            Path::new("/projects"),
+        );
         assert!(result.unwrap_err().contains("package 'hello'"));
     }
 
@@ -587,10 +619,41 @@ mod tests {
                 ]
             }]
         });
-        let (bin, _) =
-            resolve_binary_from_metadata(&metadata, true, Some("todo-app"), Path::new("/projects"))
-                .unwrap();
+        let (bin, _) = resolve_binary_from_metadata(
+            &metadata,
+            true,
+            Some("todo-app"),
+            None,
+            Path::new("/projects"),
+        )
+        .unwrap();
         assert_eq!(bin, expected_binary("/tmp/target/debug/todo-app"));
+    }
+
+    #[test]
+    fn resolve_binary_explicit_bin_overrides_default_run() {
+        // --bin wins over default-run so the static renderer runs the requested target.
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [{
+                "name": "todo-app",
+                "manifest_path": "/projects/todo-app/Cargo.toml",
+                "default_run": "todo-app",
+                "targets": [
+                    { "name": "seed", "kind": ["bin"], "src_path": "/projects/todo-app/src/bin/seed.rs" },
+                    { "name": "todo-app", "kind": ["bin"], "src_path": "/projects/todo-app/src/main.rs" }
+                ]
+            }]
+        });
+        let (bin, _) = resolve_binary_from_metadata(
+            &metadata,
+            true,
+            Some("todo-app"),
+            Some("seed"),
+            Path::new("/projects"),
+        )
+        .unwrap();
+        assert_eq!(bin, expected_binary("/tmp/target/debug/seed"));
     }
 
     #[test]
@@ -608,6 +671,7 @@ mod tests {
             &metadata,
             false,
             Some("reddit-clone"),
+            None,
             Path::new("/workspace"),
         )
         .unwrap();

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -412,6 +412,18 @@ fn find_binary(
     })
 }
 
+/// Return `true` when `pkg`'s target list contains a binary named `bin_name`.
+fn pkg_owns_bin(pkg: &serde_json::Value, bin_name: &str) -> bool {
+    pkg["targets"].as_array().is_some_and(|ts| {
+        ts.iter().any(|t| {
+            t["name"].as_str() == Some(bin_name)
+                && t["kind"]
+                    .as_array()
+                    .is_some_and(|ks| ks.iter().any(|k| k == "bin"))
+        })
+    })
+}
+
 fn resolve_binary_from_metadata(
     metadata: &serde_json::Value,
     debug: bool,
@@ -446,6 +458,26 @@ fn resolve_binary_from_metadata(
         },
     );
 
+    // Guard: when --bin is given without -p, reject the request if more than one
+    // package in the workspace owns a binary with that name.  Cargo would build
+    // all matching targets and emit an output-filename-collision warning; we must
+    // error here so the caller gets a clear message rather than silently using
+    // the first match's manifest_dir with the last-written binary on disk.
+    if let (Some(explicit), None) = (bin, package) {
+        let owners: Vec<&str> = matching_packages
+            .iter()
+            .filter(|pkg| pkg_owns_bin(pkg, explicit))
+            .filter_map(|pkg| pkg["name"].as_str())
+            .collect();
+        if owners.len() > 1 {
+            return Err(format!(
+                "binary target '{explicit}' is defined in multiple packages: {}; \
+                 use -p <package> to select one",
+                owners.join(", ")
+            ));
+        }
+    }
+
     let (bin_name, manifest_dir) = matching_packages
         .iter()
         .find_map(|pkg| {
@@ -458,15 +490,7 @@ fn resolve_binary_from_metadata(
                 // members matching the CWD filter would always pick the first
                 // member regardless of which one owns the bin, giving the wrong
                 // manifest_dir for fingerprinting and static rendering.
-                let has_target = pkg["targets"].as_array().is_some_and(|ts| {
-                    ts.iter().any(|t| {
-                        t["name"].as_str() == Some(explicit)
-                            && t["kind"]
-                                .as_array()
-                                .is_some_and(|ks| ks.iter().any(|k| k == "bin"))
-                    })
-                });
-                if !has_target {
+                if !pkg_owns_bin(pkg, explicit) {
                     return None;
                 }
                 explicit.to_owned()
@@ -783,6 +807,45 @@ mod tests {
             manifest_dir,
             Some(PathBuf::from("/workspace/app-b")),
             "--bin web must resolve to app-b's manifest_dir, not app-a's"
+        );
+    }
+
+    #[test]
+    fn resolve_binary_bin_ambiguous_across_workspace_members_errors() {
+        // When two workspace members expose the same binary name and no -p is
+        // given, cargo would produce an output-filename collision; autumn must
+        // reject the request so the user is told to pass -p.
+        let metadata = serde_json::json!({
+            "target_directory": "/workspace/target",
+            "packages": [
+                {
+                    "name": "app-a",
+                    "manifest_path": "/workspace/app-a/Cargo.toml",
+                    "targets": [{ "name": "web", "kind": ["bin"], "src_path": "/workspace/app-a/src/main.rs" }]
+                },
+                {
+                    "name": "app-b",
+                    "manifest_path": "/workspace/app-b/Cargo.toml",
+                    "targets": [{ "name": "web", "kind": ["bin"], "src_path": "/workspace/app-b/src/main.rs" }]
+                }
+            ]
+        });
+        let result = resolve_binary_from_metadata(
+            &metadata,
+            false,
+            None,
+            Some("web"),
+            Path::new("/workspace"),
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("web") && err.contains("app-a") && err.contains("app-b"),
+            "error must name the binary and the conflicting packages so the user \
+             knows to add -p; got: {err}"
+        );
+        assert!(
+            err.contains("-p"),
+            "error must suggest -p <package> to disambiguate; got: {err}"
         );
     }
 

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -426,6 +426,22 @@ fn resolve_binary_from_metadata(
             // Otherwise prefer `default-run` so packages with multiple binaries
             // always start the right one. Mirror the same logic as `dev.rs`.
             let name = if let Some(explicit) = bin {
+                // Only accept this package when it actually owns the requested
+                // binary target — without this guard, a workspace with multiple
+                // members matching the CWD filter would always pick the first
+                // member regardless of which one owns the bin, giving the wrong
+                // manifest_dir for fingerprinting and static rendering.
+                let has_target = pkg["targets"].as_array().is_some_and(|ts| {
+                    ts.iter().any(|t| {
+                        t["name"].as_str() == Some(explicit)
+                            && t["kind"]
+                                .as_array()
+                                .is_some_and(|ks| ks.iter().any(|k| k == "bin"))
+                    })
+                });
+                if !has_target {
+                    return None;
+                }
                 explicit.to_owned()
             } else if let Some(name) = pkg["default_run"].as_str() {
                 name.to_owned()
@@ -445,9 +461,21 @@ fn resolve_binary_from_metadata(
             Some((name, dir))
         })
         .ok_or_else(|| {
-            package.map_or_else(
-                || "no binary target found in current package".to_owned(),
-                |pkg_name| format!("no binary target found in package '{pkg_name}'"),
+            bin.map_or_else(
+                || {
+                    package.map_or_else(
+                        || "no binary target found in current package".to_owned(),
+                        |pkg_name| format!("no binary target found in package '{pkg_name}'"),
+                    )
+                },
+                |explicit| {
+                    package.map_or_else(
+                        || format!("no binary target '{explicit}' found in current package"),
+                        |pkg_name| {
+                            format!("no binary target '{explicit}' found in package '{pkg_name}'")
+                        },
+                    )
+                },
             )
         })?;
 
@@ -654,6 +682,65 @@ mod tests {
         )
         .unwrap();
         assert_eq!(bin, expected_binary("/tmp/target/debug/seed"));
+    }
+
+    #[test]
+    fn resolve_binary_bin_picks_correct_workspace_member() {
+        // Without -p, autumn build --bin web from a workspace root must pick the
+        // member that actually owns bin "web", not just the first CWD-matching member.
+        let metadata = serde_json::json!({
+            "target_directory": "/workspace/target",
+            "packages": [
+                {
+                    "name": "app-a",
+                    "manifest_path": "/workspace/app-a/Cargo.toml",
+                    "targets": [{ "name": "server", "kind": ["bin"], "src_path": "/workspace/app-a/src/main.rs" }]
+                },
+                {
+                    "name": "app-b",
+                    "manifest_path": "/workspace/app-b/Cargo.toml",
+                    "targets": [{ "name": "web", "kind": ["bin"], "src_path": "/workspace/app-b/src/main.rs" }]
+                }
+            ]
+        });
+        // Both members are under the CWD (/workspace); --bin web belongs to app-b.
+        let (bin, manifest_dir) = resolve_binary_from_metadata(
+            &metadata,
+            true,
+            None,
+            Some("web"),
+            Path::new("/workspace"),
+        )
+        .unwrap();
+        assert_eq!(bin, expected_binary("/workspace/target/debug/web"));
+        assert_eq!(
+            manifest_dir,
+            Some(PathBuf::from("/workspace/app-b")),
+            "--bin web must resolve to app-b's manifest_dir, not app-a's"
+        );
+    }
+
+    #[test]
+    fn resolve_binary_bin_not_in_any_member_errors() {
+        let metadata = serde_json::json!({
+            "target_directory": "/tmp/target",
+            "packages": [{
+                "name": "app-a",
+                "manifest_path": "/workspace/app-a/Cargo.toml",
+                "targets": [{ "name": "server", "kind": ["bin"], "src_path": "/workspace/app-a/src/main.rs" }]
+            }]
+        });
+        let result = resolve_binary_from_metadata(
+            &metadata,
+            true,
+            None,
+            Some("missing-bin"),
+            Path::new("/workspace"),
+        );
+        assert!(
+            result.unwrap_err().contains("missing-bin"),
+            "error must name the missing binary target"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/build.rs
+++ b/autumn-cli/src/build.rs
@@ -106,15 +106,22 @@ pub fn run(debug: bool, embed: bool, package: Option<&str>, bin: Option<&str>) {
     eprintln!("Compiling ({profile} profile)...");
     run_cargo_or_exit(build_cargo_command(debug, embed, package, bin));
 
+    // Resolve the selected package's directory before fingerprinting so that
+    // when --bin selects a member of a workspace without -p, we fingerprint
+    // that member's static/ tree rather than the workspace root's.
+    let (binary, manifest_dir) = find_binary(debug, package, bin);
+
     // Release builds fingerprint *after* the compile (the runtime reads the
     // manifest from disk, so order doesn't matter, and the static renderer below
     // then resolves the new hashed URLs).
     if !debug {
         eprintln!("\nFingerprinting static assets...");
-        fingerprint_static_assets();
+        let static_dir = manifest_dir.as_deref().map_or_else(
+            || std::path::Path::new("static").to_owned(),
+            |d| d.join("static"),
+        );
+        fingerprint_assets_in(&static_dir);
     }
-
-    let (binary, manifest_dir) = find_binary(debug, package, bin);
     eprintln!("\nRunning static renderer...\n");
 
     let mut cmd = Command::new(&binary);
@@ -163,12 +170,6 @@ pub fn run(debug: bool, embed: bool, package: Option<&str>, bin: Option<&str>) {
     }
 
     eprintln!("\n\u{1F342} Build complete!");
-}
-
-/// Fingerprint every file under `static/`, write content-hashed copies, and
-/// emit `static/.autumn-manifest.json`.
-fn fingerprint_static_assets() {
-    fingerprint_assets_in(Path::new("static"));
 }
 
 /// Core fingerprinting implementation.

--- a/autumn-cli/src/generate/mod.rs
+++ b/autumn-cli/src/generate/mod.rs
@@ -28,6 +28,7 @@ pub mod scaffold;
 pub mod schema_edit;
 pub mod system_test;
 pub mod task;
+pub mod tauri;
 pub mod wizard;
 
 use std::path::{Path, PathBuf};

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -843,10 +843,12 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
     // 4. Poll for server readiness in a background thread so setup() returns immediately
     //    and the Tauri event loop starts.  Blocking here freezes the UI and can trigger
     //    OS ANR watchdogs on macOS and Windows.
-    //    We probe the root path and accept ANY valid HTTP response (any status code) as
-    //    the readiness signal.  This avoids depending on a specific route path, which
-    //    would conflict if the app has a custom GET /health or configures [health].path
-    //    differently (Axum panics on duplicate route registration).
+    //    We probe GET /health — the cheap readiness endpoint autumn always registers.
+    //    Even if [health].path is customised to a different path, the server still
+    //    accepts the TCP connection and returns a fast HTTP response (e.g. 404), which
+    //    starts with "HTTP/" and is enough to confirm the server is up and routing.
+    //    Using /health instead of / avoids timing out against a slow app root handler
+    //    (e.g. a DB-backed dashboard that queries before writing headers).
     let handle = app.handle().clone();
     std::thread::spawn(move || {{
         // Build SocketAddr directly to avoid repeated string formatting and parse() panics.
@@ -867,7 +869,7 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
                 let _ = stream.set_read_timeout(Some(poll_timeout));
                 use std::io::{{Read, Write}};
                 let req =
-                    "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
+                    "GET /health HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
                 if stream.write_all(req.as_bytes()).is_ok() {{
                     let mut buf = [0u8; 8];
                     // Any valid HTTP response (200, 301, 401, 404, …) means the server
@@ -2763,15 +2765,17 @@ mod tests {
     #[test]
     fn lib_rs_polls_for_http_response() {
         let lib = render_shell_lib_rs("my-app", "my-app");
-        // Probe accepts any valid HTTP response rather than a specific path/status,
-        // so it works regardless of the app's health route configuration.
+        // Probe /health — autumn always registers this endpoint and it responds cheaply.
+        // Any valid HTTP response (200, 404, …) starts with "HTTP/" and signals the
+        // server is up, avoiding a timeout against a slow app root handler.
         assert!(
             lib.contains("HTTP/"),
             "lib.rs readiness probe must accept any HTTP response prefix"
         );
         assert!(
-            lib.contains("GET /"),
-            "lib.rs must send a GET request to probe server readiness"
+            lib.contains("GET /health"),
+            "lib.rs must probe GET /health — a cheap readiness endpoint autumn always \
+             registers — instead of GET / which can time out for slow app root handlers"
         );
     }
 
@@ -2805,13 +2809,14 @@ mod tests {
     #[test]
     fn lib_rs_does_not_override_health_path() {
         let lib = render_shell_lib_rs("my-app", "my-app");
-        // Setting AUTUMN_HEALTH__PATH=/health can cause Axum to panic when the app
-        // already has a custom GET /health route (duplicate route registration).
-        // The probe instead accepts any HTTP response so no specific path is needed.
+        // The sidecar env must NOT set AUTUMN_HEALTH__PATH.  The probe already targets
+        // GET /health directly; overriding the path via env would only move where autumn
+        // registers the endpoint, not change what the probe hits.  Leave the app's
+        // [health].path config untouched so developer expectations are not violated.
         assert!(
             !lib.contains("AUTUMN_HEALTH__PATH"),
-            "lib.rs must NOT set AUTUMN_HEALTH__PATH — overriding it can conflict with \
-             app-defined routes and cause Axum to panic on duplicate registration"
+            "lib.rs must NOT set AUTUMN_HEALTH__PATH — the probe targets /health directly \
+             and overriding the env var only moves the framework endpoint unnecessarily"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -257,7 +257,15 @@ fn normalize_manifest_path(p: &str) -> Vec<&str> {
         match seg {
             "" | "." => {}
             ".." => {
-                segs.pop();
+                // Only pop when there is a real segment to cancel.  When the stack is
+                // empty (or the top is already ".."), the path escapes the package root;
+                // preserve the ".." so that "../src/main.rs" stays distinct from
+                // "src/main.rs" and is never mistaken for the package main binary.
+                if segs.last().map_or(false, |&s| s != "..") {
+                    segs.pop();
+                } else {
+                    segs.push("..");
+                }
             }
             s => segs.push(s),
         }
@@ -2264,6 +2272,27 @@ mod tests {
             normalize_manifest_path("a/b/../../src/main.rs"),
             vec!["src", "main.rs"],
             "a/b/../../src/main.rs must normalize to [src, main.rs]"
+        );
+        // A leading ".." escapes the package root.  The result must NOT equal
+        // ["src", "main.rs"] so that an external helper bin is never mistaken
+        // for the package's own main binary.
+        assert_ne!(
+            normalize_manifest_path("../src/main.rs"),
+            vec!["src", "main.rs"],
+            "../src/main.rs must preserve the leading '..' and must NOT normalize \
+             to [src, main.rs]; otherwise an out-of-package helper bin is \
+             incorrectly treated as the package main binary"
+        );
+        assert_eq!(
+            normalize_manifest_path("../src/main.rs"),
+            vec!["..", "src", "main.rs"],
+            "../src/main.rs must normalize to ['..', 'src', 'main.rs']"
+        );
+        // Multiple leading ".." are all preserved.
+        assert_eq!(
+            normalize_manifest_path("../../lib/main.rs"),
+            vec!["..", "..", "lib", "main.rs"],
+            "../../lib/main.rs must preserve both leading '..' segments"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -4069,10 +4069,8 @@ mod tests {
         fs::create_dir_all(tmp.path().join("src/bin")).unwrap();
         // A non-.rs file: triggers the `None` arm of the filter_map.
         fs::write(tmp.path().join("src/bin/README.md"), "# ignore me").unwrap();
-        let doc: toml::Value = toml::from_str(
-            "[package]\nname=\"my-app\"\nversion=\"0.1.0\"\n",
-        )
-        .unwrap();
+        let doc: toml::Value =
+            toml::from_str("[package]\nname=\"my-app\"\nversion=\"0.1.0\"\n").unwrap();
         let err = resolve_bin_name(tmp.path(), "my-app", None, true, &doc).unwrap_err();
         assert!(
             err.to_string().contains("no binary target"),

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -665,7 +665,7 @@ fn render_shell_lib_rs(package_name: &str, bin_name: &str) -> String {
 
 use std::net::TcpListener;
 use tauri::{{Manager, App}};
-use tauri_plugin_shell::{{ShellExt, process::CommandChild}};
+use tauri_plugin_shell::{{ShellExt, process::{{CommandChild, CommandEvent}}}};
 
 struct SidecarHandle(std::sync::Mutex<Option<CommandChild>>);
 
@@ -767,7 +767,7 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
 
     // 3. Spawn the autumn server sidecar (built with autumn-web/embed-assets + managed-pg-bundled).
     //    The sidecar() argument is the binary basename matching externalBin in tauri.conf.json.
-    let (_rx, child) = app
+    let (mut rx, child) = app
         .shell()
         .sidecar("{bin_name}")?
         // Working directory = resource dir so autumn.toml is found via CWD fallback.
@@ -900,6 +900,29 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         // A first-launch managed-Postgres cluster must initialise (pg_ctl init) and then
         // run migrations before serving HTTP; on slow disks this can take several minutes.
         for _ in 0..1500 {{
+            // Fail fast: if the sidecar has already terminated (bad bundled config,
+            // migration panic, missing runtime dependency, …) there is no point
+            // waiting the full 300 s for a TCP connection that will never arrive.
+            while let Ok(event) = rx.try_recv() {{
+                if let CommandEvent::Terminated(p) = event {{
+                    eprintln!(
+                        "[{package_name}] Sidecar exited before becoming ready \
+                         (code={{:?}}, signal={{:?}}) — aborting.",
+                        p.code, p.signal
+                    );
+                    if let Some(mut c) = handle
+                        .state::<SidecarHandle>()
+                        .0
+                        .lock()
+                        .unwrap()
+                        .take()
+                    {{
+                        let _ = c.kill();
+                    }}
+                    handle.exit(1);
+                    return;
+                }}
+            }}
             if let Ok(mut stream) =
                 std::net::TcpStream::connect_timeout(&addr, poll_timeout)
             {{
@@ -3630,6 +3653,23 @@ mod tests {
             lib.contains("\"AUTUMN_SESSION__SECURE\", \"false\""),
             "AUTUMN_SESSION__SECURE must be set to \"false\"; the sidecar is \
              loopback-only so Secure cookies add no security but break functionality"
+        );
+    }
+
+    #[test]
+    fn lib_rs_aborts_readiness_poll_on_sidecar_terminated_event() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        assert!(
+            lib.contains("CommandEvent::Terminated"),
+            "readiness poll must check for early sidecar termination via CommandEvent::Terminated"
+        );
+        assert!(
+            lib.contains("try_recv"),
+            "readiness poll must drain the event receiver with try_recv() each iteration"
+        );
+        assert!(
+            lib.contains("CommandEvent"),
+            "CommandEvent must be imported so Terminated variant is in scope"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -329,17 +329,16 @@ fn resolve_bin_name(
         // is correctly flagged as ambiguous rather than silently picking the
         // explicit entry.
         let auto_bin_count = if autobins {
-            std::fs::read_dir(project_root.join("src/bin"))
-                .map_or(0, |entries| {
-                    entries
-                        .filter_map(std::result::Result::ok)
-                        .filter(|e| {
-                            let p = e.path();
-                            p.extension().is_some_and(|x| x == "rs")
-                                || (p.is_dir() && p.join("main.rs").is_file())
-                        })
-                        .count()
-                })
+            std::fs::read_dir(project_root.join("src/bin")).map_or(0, |entries| {
+                entries
+                    .filter_map(std::result::Result::ok)
+                    .filter(|e| {
+                        let p = e.path();
+                        p.extension().is_some_and(|x| x == "rs")
+                            || (p.is_dir() && p.join("main.rs").is_file())
+                    })
+                    .count()
+            })
         } else {
             0
         };

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -334,34 +334,32 @@ fn resolve_bin_name(
     // `autobins = false` is set in [package], Cargo does not auto-discover
     // src/bin/ entries, so scanning it here would return names that Cargo
     // itself would reject in `cargo build --bin <name>`.
-    if autobins {
-        if let Ok(entries) = std::fs::read_dir(project_root.join("src/bin")) {
-            let stems: Vec<String> = entries
-                .filter_map(std::result::Result::ok)
-                .filter_map(|e| {
-                    let p = e.path();
-                    if p.extension().is_some_and(|x| x == "rs") {
-                        p.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
-                    } else if p.is_dir() && p.join("main.rs").is_file() {
-                        p.file_name().and_then(|s| s.to_str()).map(str::to_owned)
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            match stems.len() {
-                1 => return Ok(stems.into_iter().next().unwrap()),
-                0 => {}
-                _ => {
-                    let mut sorted = stems;
-                    sorted.sort();
-                    return Err(GenerateError::Config(format!(
-                        "ambiguous sidecar target: found multiple auto-discovered \
-                         src/bin/ binaries ({}) and no [package] default-run is set; \
-                         add `default-run = \"<bin>\"` to Cargo.toml to select one",
-                        sorted.join(", ")
-                    )));
+    if autobins && let Ok(entries) = std::fs::read_dir(project_root.join("src/bin")) {
+        let stems: Vec<String> = entries
+            .filter_map(std::result::Result::ok)
+            .filter_map(|e| {
+                let p = e.path();
+                if p.extension().is_some_and(|x| x == "rs") {
+                    p.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
+                } else if p.is_dir() && p.join("main.rs").is_file() {
+                    p.file_name().and_then(|s| s.to_str()).map(str::to_owned)
+                } else {
+                    None
                 }
+            })
+            .collect();
+        match stems.len() {
+            1 => return Ok(stems.into_iter().next().unwrap()),
+            0 => {}
+            _ => {
+                let mut sorted = stems;
+                sorted.sort();
+                return Err(GenerateError::Config(format!(
+                    "ambiguous sidecar target: found multiple auto-discovered \
+                     src/bin/ binaries ({}) and no [package] default-run is set; \
+                     add `default-run = \"<bin>\"` to Cargo.toml to select one",
+                    sorted.join(", ")
+                )));
             }
         }
     }
@@ -1002,65 +1000,8 @@ fn render_placeholder_icon_svg() -> String {
     .to_owned()
 }
 
-fn render_stage_sidecar_sh(
-    package_name: &str,
-    bin_name: &str,
-    has_embed_assets: bool,
-    dep_key: &str,
-) -> String {
-    // dep_key is the [dependencies] key for autumn-web; may differ from the
-    // package name when the app aliases it (e.g. `autumn_web = { package = ... }`).
-    let embed_feature = if has_embed_assets {
-        format!("embed-assets,{dep_key}/managed-pg-bundled")
-    } else {
-        format!("{dep_key}/embed-assets,{dep_key}/managed-pg-bundled")
-    };
-    // Only fingerprint when the app-level alias exists; `autumn build --embed` passes
-    // --features embed-assets (app-level), which fails for apps without that alias.
-    // We also pass managed-pg-bundled so apps wiring ManagedPostgresPoolProvider
-    // (without a cfg gate) can compile during the fingerprint phase 1.
-    let fingerprint = if has_embed_assets {
-        format!(
-            "autumn build --embed -p {package_name} --bin {bin_name} \
-             --features {dep_key}/managed-pg-bundled\n"
-        )
-    } else {
-        String::new()
-    };
-    format!(
-        r#"#!/usr/bin/env bash
-# Build the autumn server sidecar (embedded assets + managed Postgres) and
-# place it in src-tauri/binaries/ for Tauri to bundle.
-# Wired into tauri.conf.json > build.beforeBuildCommand.
-# Run manually: bash src-tauri/stage-sidecar.sh
-set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
-APP_DIR="$(dirname "$SCRIPT_DIR")"
-cd "$APP_DIR"
-# TAURI_ENV_TARGET_TRIPLE is set by Tauri for cross-compilation; fall back to host.
-TARGET_TRIPLE="${{TAURI_ENV_TARGET_TRIPLE:-$(rustc -Vv | awk '/^host/{{print $2}}')}}";
-# Resolve Cargo output dir (CARGO_TARGET_DIR or workspace target/).
-TARGET_DIR="${{CARGO_TARGET_DIR:-$(cargo metadata --no-deps --format-version 1 --quiet \
-    | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')}}"
-mkdir -p src-tauri/binaries
-{fingerprint}# universal-apple-darwin: build both Darwin slices and lipo them together.
-if [ "${{TARGET_TRIPLE}}" = "universal-apple-darwin" ]; then
-    for ARCH in x86_64-apple-darwin aarch64-apple-darwin; do
-        cargo build --release -p {package_name} --target "$ARCH" --bin {bin_name} \
-          --features {embed_feature}
-    done
-    lipo -create -output "src-tauri/binaries/{bin_name}-universal-apple-darwin" \
-      "${{TARGET_DIR}}/x86_64-apple-darwin/release/{bin_name}" \
-      "${{TARGET_DIR}}/aarch64-apple-darwin/release/{bin_name}"
-    echo "Staged (universal): src-tauri/binaries/{bin_name}-universal-apple-darwin"
-else
-    cargo build --release -p {package_name} --target "${{TARGET_TRIPLE}}" --bin {bin_name} \
-      --features {embed_feature}
-    cp "${{TARGET_DIR}}/${{TARGET_TRIPLE}}/release/{bin_name}" \
-       "src-tauri/binaries/{bin_name}-${{TARGET_TRIPLE}}"
-    echo "Staged: src-tauri/binaries/{bin_name}-${{TARGET_TRIPLE}}"
-fi
-# Stage profile config files into src-tauri/configs/ so tauri.conf.json resource
+const fn render_stage_configs_sh() -> &'static str {
+    r#"# Stage profile config files into src-tauri/configs/ so tauri.conf.json resource
 # entries are always satisfiable at bundle time.
 # For alias pairs (prod/production, dev/development): AutumnConfig stops at the
 # first existing file in its ordered lookup list.  Copy the available file to
@@ -1126,7 +1067,140 @@ if [ -d "config/credentials" ]; then
     cp -r config/credentials/. src-tauri/configs/credentials/
 fi
 "#
+}
+
+fn render_stage_sidecar_sh(
+    package_name: &str,
+    bin_name: &str,
+    has_embed_assets: bool,
+    dep_key: &str,
+) -> String {
+    // dep_key is the [dependencies] key for autumn-web; may differ from the
+    // package name when the app aliases it (e.g. `autumn_web = { package = ... }`).
+    let embed_feature = if has_embed_assets {
+        format!("embed-assets,{dep_key}/managed-pg-bundled")
+    } else {
+        format!("{dep_key}/embed-assets,{dep_key}/managed-pg-bundled")
+    };
+    // Only fingerprint when the app-level alias exists; `autumn build --embed` passes
+    // --features embed-assets (app-level), which fails for apps without that alias.
+    // We also pass managed-pg-bundled so apps wiring ManagedPostgresPoolProvider
+    // (without a cfg gate) can compile during the fingerprint phase 1.
+    let fingerprint = if has_embed_assets {
+        format!(
+            "autumn build --embed -p {package_name} --bin {bin_name} \
+             --features {dep_key}/managed-pg-bundled\n"
+        )
+    } else {
+        String::new()
+    };
+    let configs = render_stage_configs_sh();
+    format!(
+        r#"#!/usr/bin/env bash
+# Build the autumn server sidecar (embedded assets + managed Postgres) and
+# place it in src-tauri/binaries/ for Tauri to bundle.
+# Wired into tauri.conf.json > build.beforeBuildCommand.
+# Run manually: bash src-tauri/stage-sidecar.sh
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
+APP_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$APP_DIR"
+# TAURI_ENV_TARGET_TRIPLE is set by Tauri for cross-compilation; fall back to host.
+TARGET_TRIPLE="${{TAURI_ENV_TARGET_TRIPLE:-$(rustc -Vv | awk '/^host/{{print $2}}')}}";
+# Resolve Cargo output dir (CARGO_TARGET_DIR or workspace target/).
+TARGET_DIR="${{CARGO_TARGET_DIR:-$(cargo metadata --no-deps --format-version 1 --quiet \
+    | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')}}"
+mkdir -p src-tauri/binaries
+{fingerprint}# universal-apple-darwin: build both Darwin slices and lipo them together.
+if [ "${{TARGET_TRIPLE}}" = "universal-apple-darwin" ]; then
+    for ARCH in x86_64-apple-darwin aarch64-apple-darwin; do
+        cargo build --release -p {package_name} --target "$ARCH" --bin {bin_name} \
+          --features {embed_feature}
+    done
+    lipo -create -output "src-tauri/binaries/{bin_name}-universal-apple-darwin" \
+      "${{TARGET_DIR}}/x86_64-apple-darwin/release/{bin_name}" \
+      "${{TARGET_DIR}}/aarch64-apple-darwin/release/{bin_name}"
+    echo "Staged (universal): src-tauri/binaries/{bin_name}-universal-apple-darwin"
+else
+    cargo build --release -p {package_name} --target "${{TARGET_TRIPLE}}" --bin {bin_name} \
+      --features {embed_feature}
+    cp "${{TARGET_DIR}}/${{TARGET_TRIPLE}}/release/{bin_name}" \
+       "src-tauri/binaries/{bin_name}-${{TARGET_TRIPLE}}"
+    echo "Staged: src-tauri/binaries/{bin_name}-${{TARGET_TRIPLE}}"
+fi
+{configs}"#
     )
+}
+
+const fn render_stage_configs_ps1() -> &'static str {
+    r#"# Stage profile config files into src-tauri\configs\ so tauri.conf.json resource
+# entries are always satisfiable at bundle time.
+# For alias pairs (prod/production, dev/development): AutumnConfig stops at the
+# first existing file in its ordered lookup list.  Copy the available file to
+# BOTH names so the profile resolves correctly regardless of AUTUMN_ENV spelling,
+# avoiding an empty stub from shadowing real config in the other alias.
+New-Item -ItemType Directory -Force -Path src-tauri\configs | Out-Null
+# Ensure autumn.toml exists at the project root — tauri.conf.json always
+# lists it as a bundle resource.  Projects without a config file use
+# AutumnConfig defaults; an empty TOML is a valid no-op.
+if (-not (Test-Path autumn.toml)) {
+    New-Item -ItemType File -Force -Path autumn.toml | Out-Null
+}
+# prod/production alias pair
+if ((Test-Path autumn-prod.toml) -and (Test-Path autumn-production.toml)) {
+    Copy-Item autumn-prod.toml src-tauri\configs\autumn-prod.toml
+    Copy-Item autumn-production.toml src-tauri\configs\autumn-production.toml
+} elseif (Test-Path autumn-prod.toml) {
+    Copy-Item autumn-prod.toml src-tauri\configs\autumn-prod.toml
+    Copy-Item autumn-prod.toml src-tauri\configs\autumn-production.toml
+} elseif (Test-Path autumn-production.toml) {
+    Copy-Item autumn-production.toml src-tauri\configs\autumn-prod.toml
+    Copy-Item autumn-production.toml src-tauri\configs\autumn-production.toml
+} else {
+    New-Item -ItemType File -Force -Path src-tauri\configs\autumn-prod.toml | Out-Null
+    New-Item -ItemType File -Force -Path src-tauri\configs\autumn-production.toml | Out-Null
+}
+# dev/development alias pair (same logic)
+if ((Test-Path autumn-dev.toml) -and (Test-Path autumn-development.toml)) {
+    Copy-Item autumn-dev.toml src-tauri\configs\autumn-dev.toml
+    Copy-Item autumn-development.toml src-tauri\configs\autumn-development.toml
+} elseif (Test-Path autumn-dev.toml) {
+    Copy-Item autumn-dev.toml src-tauri\configs\autumn-dev.toml
+    Copy-Item autumn-dev.toml src-tauri\configs\autumn-development.toml
+} elseif (Test-Path autumn-development.toml) {
+    Copy-Item autumn-development.toml src-tauri\configs\autumn-dev.toml
+    Copy-Item autumn-development.toml src-tauri\configs\autumn-development.toml
+} else {
+    New-Item -ItemType File -Force -Path src-tauri\configs\autumn-dev.toml | Out-Null
+    New-Item -ItemType File -Force -Path src-tauri\configs\autumn-development.toml | Out-Null
+}
+# Standalone profiles (no aliases)
+foreach ($f in @("autumn-staging.toml", "autumn-test.toml")) {
+    if (Test-Path $f) {
+        Copy-Item $f "src-tauri\configs\$f"
+    } else {
+        New-Item -ItemType File -Force -Path "src-tauri\configs\$f" | Out-Null
+    }
+}
+# Stage encrypted credentials so apps using `config.credentials()` find them at
+# AUTUMN_MANIFEST_DIR\config\credentials\<profile>.toml.enc in the installed bundle.
+# The staging directory is always created so the tauri.conf.json resource entry
+# is satisfiable at bundle time (an empty dir is a no-op for apps with no credentials).
+# Note: decryption at runtime requires the AUTUMN_MASTER_KEY env var (or the
+# config/master.key file placed in the resource dir).  See the Tauri section
+# of the Autumn docs for recommended key distribution strategies.
+# Remove and recreate the staging directory so stale .toml.enc files from a
+# previous build (deleted or rotated credentials) are not carried into the
+# installer.  Autumn loads any .toml.enc it finds via AUTUMN_MANIFEST_DIR, so
+# a stale file from a prior build would silently keep a revoked secret active.
+if (Test-Path "src-tauri\configs\credentials") {
+    Remove-Item -Recurse -Force "src-tauri\configs\credentials"
+}
+New-Item -ItemType Directory -Force -Path "src-tauri\configs\credentials" | Out-Null
+if (Test-Path "config\credentials") {
+    Copy-Item -Recurse -Force "config\credentials\*" "src-tauri\configs\credentials\"
+}
+"#
 }
 
 fn render_stage_sidecar_ps1(
@@ -1152,6 +1226,7 @@ fn render_stage_sidecar_ps1(
     } else {
         String::new()
     };
+    let configs = render_stage_configs_ps1();
     format!(
         r#"# Build the autumn server sidecar with embedded assets and managed Postgres,
 # then place it in src-tauri\binaries\ for Tauri to bundle.
@@ -1181,74 +1256,7 @@ cargo build --release -p {package_name} --target "$TargetTriple" --bin {bin_name
 Copy-Item "$TargetDir\$TargetTriple\release\{bin_name}.exe" `
           "src-tauri\binaries\{bin_name}-$TargetTriple.exe"
 Write-Host "Staged: src-tauri/binaries/{bin_name}-$TargetTriple.exe"
-# Stage profile config files into src-tauri\configs\ so tauri.conf.json resource
-# entries are always satisfiable at bundle time.
-# For alias pairs (prod/production, dev/development): AutumnConfig stops at the
-# first existing file in its ordered lookup list.  Copy the available file to
-# BOTH names so the profile resolves correctly regardless of AUTUMN_ENV spelling,
-# avoiding an empty stub from shadowing real config in the other alias.
-New-Item -ItemType Directory -Force -Path src-tauri\configs | Out-Null
-# Ensure autumn.toml exists at the project root — tauri.conf.json always
-# lists it as a bundle resource.  Projects without a config file use
-# AutumnConfig defaults; an empty TOML is a valid no-op.
-if (-not (Test-Path autumn.toml)) {{
-    New-Item -ItemType File -Force -Path autumn.toml | Out-Null
-}}
-# prod/production alias pair
-if ((Test-Path autumn-prod.toml) -and (Test-Path autumn-production.toml)) {{
-    Copy-Item autumn-prod.toml src-tauri\configs\autumn-prod.toml
-    Copy-Item autumn-production.toml src-tauri\configs\autumn-production.toml
-}} elseif (Test-Path autumn-prod.toml) {{
-    Copy-Item autumn-prod.toml src-tauri\configs\autumn-prod.toml
-    Copy-Item autumn-prod.toml src-tauri\configs\autumn-production.toml
-}} elseif (Test-Path autumn-production.toml) {{
-    Copy-Item autumn-production.toml src-tauri\configs\autumn-prod.toml
-    Copy-Item autumn-production.toml src-tauri\configs\autumn-production.toml
-}} else {{
-    New-Item -ItemType File -Force -Path src-tauri\configs\autumn-prod.toml | Out-Null
-    New-Item -ItemType File -Force -Path src-tauri\configs\autumn-production.toml | Out-Null
-}}
-# dev/development alias pair (same logic)
-if ((Test-Path autumn-dev.toml) -and (Test-Path autumn-development.toml)) {{
-    Copy-Item autumn-dev.toml src-tauri\configs\autumn-dev.toml
-    Copy-Item autumn-development.toml src-tauri\configs\autumn-development.toml
-}} elseif (Test-Path autumn-dev.toml) {{
-    Copy-Item autumn-dev.toml src-tauri\configs\autumn-dev.toml
-    Copy-Item autumn-dev.toml src-tauri\configs\autumn-development.toml
-}} elseif (Test-Path autumn-development.toml) {{
-    Copy-Item autumn-development.toml src-tauri\configs\autumn-dev.toml
-    Copy-Item autumn-development.toml src-tauri\configs\autumn-development.toml
-}} else {{
-    New-Item -ItemType File -Force -Path src-tauri\configs\autumn-dev.toml | Out-Null
-    New-Item -ItemType File -Force -Path src-tauri\configs\autumn-development.toml | Out-Null
-}}
-# Standalone profiles (no aliases)
-foreach ($f in @("autumn-staging.toml", "autumn-test.toml")) {{
-    if (Test-Path $f) {{
-        Copy-Item $f "src-tauri\configs\$f"
-    }} else {{
-        New-Item -ItemType File -Force -Path "src-tauri\configs\$f" | Out-Null
-    }}
-}}
-# Stage encrypted credentials so apps using `config.credentials()` find them at
-# AUTUMN_MANIFEST_DIR\config\credentials\<profile>.toml.enc in the installed bundle.
-# The staging directory is always created so the tauri.conf.json resource entry
-# is satisfiable at bundle time (an empty dir is a no-op for apps with no credentials).
-# Note: decryption at runtime requires the AUTUMN_MASTER_KEY env var (or the
-# config/master.key file placed in the resource dir).  See the Tauri section
-# of the Autumn docs for recommended key distribution strategies.
-# Remove and recreate the staging directory so stale .toml.enc files from a
-# previous build (deleted or rotated credentials) are not carried into the
-# installer.  Autumn loads any .toml.enc it finds via AUTUMN_MANIFEST_DIR, so
-# a stale file from a prior build would silently keep a revoked secret active.
-if (Test-Path "src-tauri\configs\credentials") {{
-    Remove-Item -Recurse -Force "src-tauri\configs\credentials"
-}}
-New-Item -ItemType Directory -Force -Path "src-tauri\configs\credentials" | Out-Null
-if (Test-Path "config\credentials") {{
-    Copy-Item -Recurse -Force "config\credentials\*" "src-tauri\configs\credentials\"
-}}
-"#
+{configs}"#
     )
 }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -324,14 +324,34 @@ fn resolve_bin_name(
         if autobins && project_root.join("src/main.rs").is_file() {
             return Ok(name.to_owned());
         }
-        if bins.len() > 1 {
+        // Count auto-discovered src/bin/ entries alongside the explicit ones so
+        // that a layout like `[[bin]] path="src/server.rs"` + `src/bin/helper.rs`
+        // is correctly flagged as ambiguous rather than silently picking the
+        // explicit entry.
+        let auto_bin_count = if autobins {
+            std::fs::read_dir(project_root.join("src/bin"))
+                .map(|entries| {
+                    entries
+                        .filter_map(std::result::Result::ok)
+                        .filter(|e| {
+                            let p = e.path();
+                            p.extension().is_some_and(|x| x == "rs")
+                                || (p.is_dir() && p.join("main.rs").is_file())
+                        })
+                        .count()
+                })
+                .unwrap_or(0)
+        } else {
+            0
+        };
+        if bins.len() + auto_bin_count > 1 {
             let mut names: Vec<&str> = bins
                 .iter()
                 .filter_map(|b| b.get("name").and_then(|n| n.as_str()))
                 .collect();
             names.sort_unstable();
             return Err(GenerateError::Config(format!(
-                "ambiguous sidecar target: found multiple explicit [[bin]] entries ({}) \
+                "ambiguous sidecar target: found multiple binary targets ({}) \
                  and no [package] default-run is set; add `default-run = \"<bin>\"` to \
                  Cargo.toml to select one",
                 names.join(", ")

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -1203,7 +1203,12 @@ if (Test-Path "src-tauri\configs\credentials") {
 }
 New-Item -ItemType Directory -Force -Path "src-tauri\configs\credentials" | Out-Null
 if (Test-Path "config\credentials") {
-    Copy-Item -Recurse -Force "config\credentials\*" "src-tauri\configs\credentials\"
+    # Guard against an empty directory: Copy-Item with a wildcard and
+    # $ErrorActionPreference = "Stop" throws when there are no matches.
+    $credItems = Get-ChildItem "config\credentials" -ErrorAction SilentlyContinue
+    if ($credItems) {
+        Copy-Item -Recurse -Force "config\credentials\*" "src-tauri\configs\credentials\"
+    }
 }
 "#
 }
@@ -3252,6 +3257,32 @@ mod tests {
             ps1.contains("autumn_web/embed-assets")
                 && ps1.contains("autumn_web/managed-pg-bundled"),
             "stage-sidecar.ps1 must use the dependency key 'autumn_web' in feature selectors"
+        );
+    }
+
+    #[test]
+    fn staging_ps1_guards_empty_credentials_dir_before_copy() {
+        // When config\credentials exists but is empty, Copy-Item with a wildcard
+        // source ("config\credentials\*") matches nothing.  With
+        // $ErrorActionPreference = "Stop" that becomes a terminating error.
+        // The generated script must check for children before calling Copy-Item.
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true, "autumn-web");
+        // Must gate Copy-Item behind a Get-ChildItem / count check.
+        assert!(
+            ps1.contains("Get-ChildItem") || ps1.contains("Measure-Object"),
+            "stage-sidecar.ps1 must guard Copy-Item with Get-ChildItem so an empty \
+             config\\credentials directory does not abort the script under \
+             $ErrorActionPreference = 'Stop'"
+        );
+        // The guard must appear before the Copy-Item call for credentials.
+        let guard_pos = ps1
+            .find("Get-ChildItem")
+            .or_else(|| ps1.find("Measure-Object"))
+            .unwrap_or(usize::MAX);
+        let copy_pos = ps1.rfind("Copy-Item").unwrap_or(usize::MAX);
+        assert!(
+            guard_pos < copy_pos,
+            "Get-ChildItem guard must appear before the Copy-Item credentials call"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -330,7 +330,7 @@ fn resolve_bin_name(
         // explicit entry.
         let auto_bin_count = if autobins {
             std::fs::read_dir(project_root.join("src/bin"))
-                .map(|entries| {
+                .map_or(0, |entries| {
                     entries
                         .filter_map(std::result::Result::ok)
                         .filter(|e| {
@@ -340,7 +340,6 @@ fn resolve_bin_name(
                         })
                         .count()
                 })
-                .unwrap_or(0)
         } else {
             0
         };

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -261,7 +261,7 @@ fn normalize_manifest_path(p: &str) -> Vec<&str> {
                 // empty (or the top is already ".."), the path escapes the package root;
                 // preserve the ".." so that "../src/main.rs" stays distinct from
                 // "src/main.rs" and is never mistaken for the package main binary.
-                if segs.last().map_or(false, |&s| s != "..") {
+                if segs.last().is_some_and(|&s| s != "..") {
                     segs.pop();
                 } else {
                     segs.push("..");
@@ -306,13 +306,10 @@ fn resolve_bin_name(
                 // the same as the relative `src/main.rs`.
                 let path = Path::new(p);
                 if path.is_absolute() {
-                    match path.strip_prefix(project_root) {
-                        Ok(rel) => {
-                            let rel_str = rel.to_string_lossy();
-                            normalize_manifest_path(rel_str.as_ref()) == ["src", "main.rs"]
-                        }
-                        Err(_) => false,
-                    }
+                    path.strip_prefix(project_root).is_ok_and(|rel| {
+                        let rel_str = rel.to_string_lossy();
+                        normalize_manifest_path(rel_str.as_ref()) == ["src", "main.rs"]
+                    })
                 } else {
                     normalize_manifest_path(p) == ["src", "main.rs"]
                 }

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -363,7 +363,10 @@ fn resolve_bin_name(
             }
         }
     }
-    Ok(name.to_owned())
+    Err(GenerateError::Config(format!(
+        "no binary target found for package `{name}`: add `src/main.rs`, \
+         a `[[bin]]` entry, or `default-run = \"<bin>\"` to Cargo.toml"
+    )))
 }
 
 fn read_package_meta(
@@ -2290,9 +2293,9 @@ mod tests {
     #[test]
     fn plan_respects_autobins_false_ignores_src_bin_dir() {
         // autobins=false means Cargo does NOT auto-discover src/bin/ entries.
-        // The generator must not scan src/bin/ in this case — doing so would
-        // return a name that `cargo build --bin <name>` would reject because Cargo
-        // itself does not register those as targets.
+        // With no explicit [[bin]] the package has no bin target at all, so
+        // plan_tauri must error rather than silently use a package-name binary
+        // that `cargo build --bin` would reject.
         let tmp = TempDir::new().unwrap();
         fs::write(
             tmp.path().join("Cargo.toml"),
@@ -2303,27 +2306,36 @@ mod tests {
         fs::create_dir_all(tmp.path().join("src/bin")).unwrap();
         // src/bin/web.rs exists on disk but autobins=false → NOT a Cargo target.
         fs::write(tmp.path().join("src/bin/web.rs"), "fn main() {}\n").unwrap();
-        // With autobins=false and no explicit [[bin]], cargo metadata returns no
-        // bin targets for this package; plan_tauri must not discover "web" from
-        // src/bin/ and must not include `--bin web` in the staging scripts.
-        let plan = plan_tauri(tmp.path()).unwrap();
-        let sh: &str = plan
-            .actions
-            .iter()
-            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
-            .and_then(|a| {
-                if let crate::generate::emit::Action::Create { contents, .. } = a {
-                    Some(contents.as_str())
-                } else {
-                    None
-                }
-            })
-            .expect("stage-sidecar.sh action not found");
+        let err = plan_tauri(tmp.path()).unwrap_err().to_string();
         assert!(
-            !sh.contains("--bin web"),
-            "with autobins=false, src/bin/web.rs must NOT be discovered; \
-             Cargo does not register it as a target so `--bin web` would be rejected; \
-             got:\n{sh}"
+            err.contains("no binary target"),
+            "expected 'no binary target' error when autobins=false and no [[bin]]; got: {err}"
+        );
+        assert!(
+            !err.contains("web"),
+            "error must not mention 'web' — src/bin/web.rs is not a Cargo target with autobins=false; got: {err}"
+        );
+    }
+
+    #[test]
+    fn plan_errors_when_package_has_no_bin_target() {
+        // A lib-only package (autobins=false, no [[bin]], no src/main.rs) has no
+        // binary target to use as a sidecar.  plan_tauri must return a clear error
+        // instead of fabricating a package-named binary that `cargo build --bin`
+        // would reject.
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"my-lib\"\nversion=\"0.1.0\"\nedition=\"2024\"\nautobins=false\n\
+             \n[lib]\nname=\"my_lib\"\n\n[dependencies]\nautumn-web = \"0.5.0\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/lib.rs"), "").unwrap();
+        let err = plan_tauri(tmp.path()).unwrap_err().to_string();
+        assert!(
+            err.contains("no binary target"),
+            "expected a 'no binary target' error for a lib-only package; got: {err}"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -771,11 +771,14 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         // Encrypted credentials (config/credentials/<profile>.toml.enc) are bundled
         // into resource_dir/config/credentials/ by the staging script.  Autumn loads
         // them automatically when AUTUMN_MANIFEST_DIR is set.  If the app reads
-        // secrets via `config.credentials()`, set AUTUMN_MASTER_KEY to the hex
-        // master key at launch time (e.g. via Tauri's deep-link or an OS keychain
-        // integration) so the bundled .toml.enc files can be decrypted.  Leaving it
-        // unset is safe for apps that don't use the credentials store: autumn returns
-        // an empty CredentialsStore when no .toml.enc file is found.
+        // secrets via `config.credentials()`, provide the decryption key via either:
+        //   • AUTUMN_MASTER_KEY env var (hex string), or
+        //   • resource_dir/config/master.key file (hex string, one line).
+        // The key file path is `<AUTUMN_MANIFEST_DIR>/config/master.key`; it must
+        // be staged alongside the .toml.enc files (do NOT ship it in the installer —
+        // deliver it out-of-band, e.g. via OS keychain or a secure download on first
+        // launch).  Leaving both absent is safe when the app has no credentials store:
+        // autumn returns CredentialsStore::default() when no .toml.enc file is found.
         // Clear any inherited Unix-socket config so the sidecar always binds
         // TCP on the loopback address the probe polls.  Without this, an
         // inherited AUTUMN_SERVER__UNIX_SOCKET or AUTUMN_SERVE_FORCE_UNIX_SOCKET
@@ -809,6 +812,14 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         // the force-kill window.  Setting it to 0 lets on_shutdown hooks (including
         // ManagedPostgresPoolProvider::stop()) run immediately after SIGTERM.
         .env("AUTUMN_SERVER__PRESTOP_GRACE_SECS", "0")
+        // The webview loads the app over plain HTTP (http://127.0.0.1:<port>).
+        // Autumn's prod profile sets session.secure = true, which emits the
+        // `Secure` attribute on session/CSRF/flash cookies.  Browsers never send
+        // Secure cookies over non-HTTPS origins, so sessions, auth, and flash
+        // messages silently stop working on installed release bundles.
+        // Setting secure=false is safe here: the sidecar is loopback-only and
+        // no external network can reach it; cookie confidentiality is not at risk.
+        .env("AUTUMN_SESSION__SECURE", "false")
         // Clear one-off mode flags inherited from the calling environment.
         // If any of these are set, AppBuilder::run() enters a non-serving mode
         // (asset fingerprinting, route dump, task execution) and exits before
@@ -1103,7 +1114,7 @@ done
 # The staging directory is always created so the tauri.conf.json resource entry
 # is satisfiable at bundle time (an empty dir is a no-op for apps with no credentials).
 # Note: decryption at runtime requires the AUTUMN_MASTER_KEY env var (or the
-# .autumn-master-key key file placed in the resource dir).  See the Tauri section
+# config/master.key file placed in the resource dir).  See the Tauri section
 # of the Autumn docs for recommended key distribution strategies.
 # Remove and recreate the staging directory so stale .toml.enc files from a
 # previous build (deleted or rotated credentials) are not carried into the
@@ -1224,7 +1235,7 @@ foreach ($f in @("autumn-staging.toml", "autumn-test.toml")) {{
 # The staging directory is always created so the tauri.conf.json resource entry
 # is satisfiable at bundle time (an empty dir is a no-op for apps with no credentials).
 # Note: decryption at runtime requires the AUTUMN_MASTER_KEY env var (or the
-# .autumn-master-key key file placed in the resource dir).  See the Tauri section
+# config/master.key file placed in the resource dir).  See the Tauri section
 # of the Autumn docs for recommended key distribution strategies.
 # Remove and recreate the staging directory so stale .toml.enc files from a
 # previous build (deleted or rotated credentials) are not carried into the
@@ -3470,6 +3481,40 @@ mod tests {
             "lib.rs must mention AUTUMN_MASTER_KEY so developers wiring \
              config.credentials() know how to pass the decryption key to the sidecar \
              at desktop launch time"
+        );
+    }
+
+    #[test]
+    fn lib_rs_documents_config_master_key_file_path() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        // The key file is `<AUTUMN_MANIFEST_DIR>/config/master.key`, not
+        // `.autumn-master-key`.  Documenting the wrong path leads to NoKeyFound
+        // errors for developers who follow the comment.
+        assert!(
+            lib.contains("config/master.key"),
+            "lib.rs must document the correct key file path (config/master.key) so \
+             developers who follow the comment can place the key where autumn's \
+             credentials resolver actually looks; the resolver checks AUTUMN_MASTER_KEY \
+             env var first, then <base_dir>/config/master.key"
+        );
+    }
+
+    #[test]
+    fn lib_rs_disables_secure_cookies_for_loopback() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        // Prod profile's session.secure=true emits the Secure attribute.
+        // Browsers never send Secure cookies over plain HTTP, so sessions, auth,
+        // and flash messages silently fail on http://127.0.0.1:<port>.
+        assert!(
+            lib.contains("AUTUMN_SESSION__SECURE"),
+            "lib.rs must set AUTUMN_SESSION__SECURE=false; prod profile sets \
+             session.secure=true which prevents cookies being sent over the \
+             non-HTTPS loopback origin, silently breaking sessions/auth/flash"
+        );
+        assert!(
+            lib.contains("\"AUTUMN_SESSION__SECURE\", \"false\""),
+            "AUTUMN_SESSION__SECURE must be set to \"false\"; the sidecar is \
+             loopback-only so Secure cookies add no security but break functionality"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -504,7 +504,8 @@ fn render_tauri_conf(package_name: &str, version: &str, bin_name: &str) -> Strin
       "configs/autumn-dev.toml": "autumn-dev.toml",
       "configs/autumn-development.toml": "autumn-development.toml",
       "configs/autumn-staging.toml": "autumn-staging.toml",
-      "configs/autumn-test.toml": "autumn-test.toml"
+      "configs/autumn-test.toml": "autumn-test.toml",
+      "configs/credentials": "config/credentials"
     }}
   }},
   "app": {{
@@ -767,6 +768,14 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
             "AUTUMN_MANIFEST_DIR",
             resource_dir.to_string_lossy().as_ref(),
         )
+        // Encrypted credentials (config/credentials/<profile>.toml.enc) are bundled
+        // into resource_dir/config/credentials/ by the staging script.  Autumn loads
+        // them automatically when AUTUMN_MANIFEST_DIR is set.  If the app reads
+        // secrets via `config.credentials()`, set AUTUMN_MASTER_KEY to the hex
+        // master key at launch time (e.g. via Tauri's deep-link or an OS keychain
+        // integration) so the bundled .toml.enc files can be decrypted.  Leaving it
+        // unset is safe for apps that don't use the credentials store: autumn returns
+        // an empty CredentialsStore when no .toml.enc file is found.
         // Clear any inherited Unix-socket config so the sidecar always binds
         // TCP on the loopback address the probe polls.  Without this, an
         // inherited AUTUMN_SERVER__UNIX_SOCKET or AUTUMN_SERVE_FORCE_UNIX_SOCKET
@@ -1089,6 +1098,17 @@ for f in autumn-staging.toml autumn-test.toml; do
         : > "src-tauri/configs/$f"
     fi
 done
+# Stage encrypted credentials so apps using `config.credentials()` find them at
+# AUTUMN_MANIFEST_DIR/config/credentials/<profile>.toml.enc in the installed bundle.
+# The staging directory is always created so the tauri.conf.json resource entry
+# is satisfiable at bundle time (an empty dir is a no-op for apps with no credentials).
+# Note: decryption at runtime requires the AUTUMN_MASTER_KEY env var (or the
+# .autumn-master-key key file placed in the resource dir).  See the Tauri section
+# of the Autumn docs for recommended key distribution strategies.
+mkdir -p src-tauri/configs/credentials
+if [ -d "config/credentials" ]; then
+    cp -r config/credentials/. src-tauri/configs/credentials/
+fi
 "#
     )
 }
@@ -1193,6 +1213,17 @@ foreach ($f in @("autumn-staging.toml", "autumn-test.toml")) {{
     }} else {{
         New-Item -ItemType File -Force -Path "src-tauri\configs\$f" | Out-Null
     }}
+}}
+# Stage encrypted credentials so apps using `config.credentials()` find them at
+# AUTUMN_MANIFEST_DIR\config\credentials\<profile>.toml.enc in the installed bundle.
+# The staging directory is always created so the tauri.conf.json resource entry
+# is satisfiable at bundle time (an empty dir is a no-op for apps with no credentials).
+# Note: decryption at runtime requires the AUTUMN_MASTER_KEY env var (or the
+# .autumn-master-key key file placed in the resource dir).  See the Tauri section
+# of the Autumn docs for recommended key distribution strategies.
+New-Item -ItemType Directory -Force -Path "src-tauri\configs\credentials" | Out-Null
+if (Test-Path "config\credentials") {{
+    Copy-Item -Recurse -Force "config\credentials\*" "src-tauri\configs\credentials\"
 }}
 "#
     )
@@ -3335,6 +3366,60 @@ mod tests {
         assert!(
             has_development,
             "tauri.conf.json must include configs/autumn-development.toml (dev alias)"
+        );
+    }
+
+    #[test]
+    fn tauri_conf_bundles_credentials_directory_as_resource() {
+        let conf = render_tauri_conf("my-app", "0.1.0", "my-app");
+        let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
+        let resources = parsed["bundle"]["resources"]
+            .as_object()
+            .expect("bundle.resources must be a map");
+        // The staging script always creates src-tauri/configs/credentials/ (possibly
+        // empty), and the resource entry maps it to config/credentials/ in the bundle
+        // so AutumnConfig can find .toml.enc files at AUTUMN_MANIFEST_DIR/config/credentials/.
+        let has_credentials = resources.iter().any(|(k, v)| {
+            k.contains("credentials") || v.as_str().is_some_and(|s| s.contains("credentials"))
+        });
+        assert!(
+            has_credentials,
+            "tauri.conf.json must bundle configs/credentials as a resource so apps \
+             using config.credentials() find their .toml.enc files in the installed \
+             bundle at AUTUMN_MANIFEST_DIR/config/credentials/<profile>.toml.enc"
+        );
+    }
+
+    #[test]
+    fn staging_sh_stages_credentials_directory() {
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true, "autumn-web");
+        assert!(
+            sh.contains("credentials"),
+            "stage-sidecar.sh must create src-tauri/configs/credentials/ and copy \
+             config/credentials/ into it so the tauri.conf.json resource entry is \
+             satisfiable and .toml.enc files are bundled for installed apps"
+        );
+        assert!(
+            sh.contains("mkdir") && sh.contains("configs/credentials"),
+            "stage-sidecar.sh must always create src-tauri/configs/credentials/ \
+             (even when empty) so the tauri.conf.json resource entry never causes \
+             a GlobPathNotFound/missing-source error at bundle time"
+        );
+        assert!(
+            sh.contains("AUTUMN_MASTER_KEY"),
+            "stage-sidecar.sh must mention AUTUMN_MASTER_KEY so developers know how \
+             to provide the decryption key for bundled .toml.enc credential files"
+        );
+    }
+
+    #[test]
+    fn lib_rs_documents_autumn_master_key() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        assert!(
+            lib.contains("AUTUMN_MASTER_KEY"),
+            "lib.rs must mention AUTUMN_MASTER_KEY so developers wiring \
+             config.credentials() know how to pass the decryption key to the sidecar \
+             at desktop launch time"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -308,32 +308,38 @@ fn resolve_bin_name(
     if autobins && project_root.join("src/main.rs").is_file() {
         return Ok(name.to_owned());
     }
-    if let Ok(entries) = std::fs::read_dir(project_root.join("src/bin")) {
-        let stems: Vec<String> = entries
-            .filter_map(std::result::Result::ok)
-            .filter_map(|e| {
-                let p = e.path();
-                if p.extension().is_some_and(|x| x == "rs") {
-                    p.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
-                } else if p.is_dir() && p.join("main.rs").is_file() {
-                    p.file_name().and_then(|s| s.to_str()).map(str::to_owned)
-                } else {
-                    None
+    // Only scan src/bin/ when autobins is enabled (the default).  When
+    // `autobins = false` is set in [package], Cargo does not auto-discover
+    // src/bin/ entries, so scanning it here would return names that Cargo
+    // itself would reject in `cargo build --bin <name>`.
+    if autobins {
+        if let Ok(entries) = std::fs::read_dir(project_root.join("src/bin")) {
+            let stems: Vec<String> = entries
+                .filter_map(std::result::Result::ok)
+                .filter_map(|e| {
+                    let p = e.path();
+                    if p.extension().is_some_and(|x| x == "rs") {
+                        p.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
+                    } else if p.is_dir() && p.join("main.rs").is_file() {
+                        p.file_name().and_then(|s| s.to_str()).map(str::to_owned)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            match stems.len() {
+                1 => return Ok(stems.into_iter().next().unwrap()),
+                0 => {}
+                _ => {
+                    let mut sorted = stems;
+                    sorted.sort();
+                    return Err(GenerateError::Config(format!(
+                        "ambiguous sidecar target: found multiple auto-discovered \
+                         src/bin/ binaries ({}) and no [package] default-run is set; \
+                         add `default-run = \"<bin>\"` to Cargo.toml to select one",
+                        sorted.join(", ")
+                    )));
                 }
-            })
-            .collect();
-        match stems.len() {
-            1 => return Ok(stems.into_iter().next().unwrap()),
-            0 => {}
-            _ => {
-                let mut sorted = stems;
-                sorted.sort();
-                return Err(GenerateError::Config(format!(
-                    "ambiguous sidecar target: found multiple auto-discovered \
-                     src/bin/ binaries ({}) and no [package] default-run is set; \
-                     add `default-run = \"<bin>\"` to Cargo.toml to select one",
-                    sorted.join(", ")
-                )));
             }
         }
     }
@@ -806,8 +812,10 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         );
         let poll_timeout = std::time::Duration::from_millis(200);
         let mut ready = false;
-        // 150 × 200 ms = 30 s total — enough headroom for cold Postgres initialisation.
-        for _ in 0..150 {{
+        // 1500 × 200 ms = 300 s total — matches autumn serve's READY_TIMEOUT_MANAGED_PG.
+        // A first-launch managed-Postgres cluster must initialise (pg_ctl init) and then
+        // run migrations before serving HTTP; on slow disks this can take several minutes.
+        for _ in 0..1500 {{
             if let Ok(mut stream) =
                 std::net::TcpStream::connect_timeout(&addr, poll_timeout)
             {{
@@ -830,7 +838,7 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         }}
         if !ready {{
             eprintln!(
-                "[{package_name}] Server did not become ready within 30 s — exiting."
+                "[{package_name}] Server did not become ready within 300 s — exiting."
             );
             // No window has been created yet, so WindowEvent::Destroyed cannot
             // fire.  Kill the sidecar explicitly before exiting so no orphaned
@@ -2161,6 +2169,46 @@ mod tests {
     }
 
     #[test]
+    fn plan_respects_autobins_false_ignores_src_bin_dir() {
+        // autobins=false means Cargo does NOT auto-discover src/bin/ entries.
+        // The generator must not scan src/bin/ in this case — doing so would
+        // return a name that `cargo build --bin <name>` would reject because Cargo
+        // itself does not register those as targets.
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"my-app\"\nversion=\"0.1.0\"\nedition=\"2024\"\nautobins=false\n\
+             \n[dependencies]\nautumn-web = \"0.5.0\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src/bin")).unwrap();
+        // src/bin/web.rs exists on disk but autobins=false → NOT a Cargo target.
+        fs::write(tmp.path().join("src/bin/web.rs"), "fn main() {}\n").unwrap();
+        // With autobins=false and no explicit [[bin]], cargo metadata returns no
+        // bin targets for this package; plan_tauri must not discover "web" from
+        // src/bin/ and must not include `--bin web` in the staging scripts.
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let sh: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("stage-sidecar.sh action not found");
+        assert!(
+            !sh.contains("--bin web"),
+            "with autobins=false, src/bin/web.rs must NOT be discovered; \
+             Cargo does not register it as a target so `--bin web` would be rejected; \
+             got:\n{sh}"
+        );
+    }
+
+    #[test]
     fn plan_errors_on_multiple_explicit_bins_without_default_run() {
         // Multiple [[bin]] entries with no default-run and no src/main.rs must error
         // rather than silently pick the first entry (which may be an auxiliary binary).
@@ -2780,6 +2828,27 @@ mod tests {
             has_adequate_timeout,
             "lib.rs kill timeout must be >= 5 s (the default prestop grace) so \
              on_shutdown hooks complete before the force-kill; got:\n{lib}"
+        );
+    }
+
+    #[test]
+    fn lib_rs_waits_300s_for_managed_postgres_cold_start() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        // A first-launch managed-Postgres cluster must initialise (pg_ctl init) and
+        // run migrations before serving HTTP; on slow disks this can take several
+        // minutes.  autumn serve uses READY_TIMEOUT_MANAGED_PG = 300 s; the generated
+        // shell must match so the first-launch window is not rejected prematurely.
+        // We look for 1500 iterations × 200 ms = 300 s, or any explicit "300" in context.
+        assert!(
+            lib.contains("0..1500") || lib.contains("300 s") || lib.contains("300s"),
+            "lib.rs readiness poll must allow at least 300 s (1500 × 200 ms) for \
+             managed-Postgres cold-start; the current limit is too short and will kill \
+             the sidecar before the cluster finishes initialising on a slow disk; \
+             got a snippet:\n{}",
+            lib.lines()
+                .filter(|l| l.contains("150") || l.contains("1500") || l.contains("300"))
+                .collect::<Vec<_>>()
+                .join("\n")
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -3947,4 +3947,220 @@ mod tests {
             "productName for 'my_app' must not contain underscores, got: {name}"
         );
     }
+
+    // ── resolve_dep_key unit tests ────────────────────────────────────────────
+
+    #[test]
+    fn resolve_dep_key_no_dependencies_section_returns_package_name() {
+        // When Cargo.toml has no [dependencies] table, resolve_dep_key must fall
+        // through the early-return path and return the raw package name unchanged.
+        let doc: toml::Value =
+            toml::from_str("[package]\nname=\"foo\"\nversion=\"0.1.0\"\n").unwrap();
+        let result = resolve_dep_key(Path::new("/"), &doc, "autumn-web");
+        assert_eq!(
+            result, "autumn-web",
+            "resolve_dep_key must return the package name when no [dependencies] table exists"
+        );
+    }
+
+    #[test]
+    fn resolve_dep_key_direct_package_alias() {
+        // When a dep entry has `package = "autumn-web"` under a different key, the
+        // function must return the alias key, not the package name.
+        let doc: toml::Value = toml::from_str(
+            "[package]\nname=\"foo\"\nversion=\"0.1.0\"\n\
+             \n[dependencies]\nautumn_web = { version = \"0.5\", package = \"autumn-web\" }\n",
+        )
+        .unwrap();
+        let result = resolve_dep_key(Path::new("/"), &doc, "autumn-web");
+        assert_eq!(
+            result, "autumn_web",
+            "resolve_dep_key must return the alias key 'autumn_web' for package 'autumn-web'"
+        );
+    }
+
+    #[test]
+    fn resolve_dep_key_no_matching_dep_returns_package_name() {
+        // When none of the [dependencies] entries match the target package name,
+        // resolve_dep_key must return the package name itself as fallback.
+        let doc: toml::Value = toml::from_str(
+            "[package]\nname=\"foo\"\nversion=\"0.1.0\"\n\
+             \n[dependencies]\nserde = \"1.0\"\ntokio = { version = \"1.0\" }\n",
+        )
+        .unwrap();
+        let result = resolve_dep_key(Path::new("/"), &doc, "autumn-web");
+        assert_eq!(
+            result, "autumn-web",
+            "resolve_dep_key must return the package name when no entry matches it"
+        );
+    }
+
+    // ── resolve_workspace_dep_package unit tests ──────────────────────────────
+
+    #[test]
+    fn resolve_workspace_dep_package_stops_at_workspace_root_without_dep() {
+        // When the workspace root Cargo.toml exists but has no [workspace.dependencies]
+        // entry for the key, the function must stop (not walk further) and return None.
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"app\"]\n",
+        )
+        .unwrap();
+        let app = tmp.path().join("app");
+        fs::create_dir_all(&app).unwrap();
+        fs::write(
+            app.join("Cargo.toml"),
+            "[package]\nname=\"my-app\"\nversion=\"0.1.0\"\n\
+             \n[dependencies]\nautumn_web = { workspace = true }\n",
+        )
+        .unwrap();
+        // resolve_workspace_dep_package must find the workspace root Cargo.toml,
+        // see that [workspace] exists but has no matching dep, and return None.
+        let result = resolve_workspace_dep_package(&app, "autumn_web");
+        assert_eq!(
+            result, None,
+            "must return None when workspace root has no matching [workspace.dependencies] entry"
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_dep_package_returns_none_when_no_workspace_found() {
+        // When walking from the project root finds no Cargo.toml with [workspace],
+        // the function exhausts all ancestors and returns None.
+        let tmp = TempDir::new().unwrap();
+        // No Cargo.toml with [workspace] — the function will walk up past tmp root
+        // to filesystem root without finding one.
+        let result = resolve_workspace_dep_package(tmp.path(), "autumn_web");
+        assert_eq!(
+            result, None,
+            "must return None when no ancestor Cargo.toml contains [workspace]"
+        );
+    }
+
+    // ── resolve_bin_name unit tests ────────────────────────────────────────────
+
+    #[test]
+    fn resolve_bin_name_default_run_without_bin_section() {
+        // When [package] has default-run but no [[bin]] array, resolve_bin_name
+        // must return the default-run value (the path after the [[bin]] block is
+        // absent, so control reaches the second default_run check at line 328).
+        let tmp = TempDir::new().unwrap();
+        let doc: toml::Value = toml::from_str(
+            "[package]\nname=\"my-app\"\nversion=\"0.1.0\"\ndefault-run=\"webserver\"\n\
+             \n[dependencies]\nautumn-web = \"0.5.0\"\n",
+        )
+        .unwrap();
+        let result = resolve_bin_name(tmp.path(), "my-app", Some("webserver"), true, &doc);
+        assert_eq!(
+            result.unwrap(),
+            "webserver",
+            "resolve_bin_name must return default_run when there is no [[bin]] section"
+        );
+    }
+
+    #[test]
+    fn resolve_bin_name_empty_src_bin_dir_errors_with_no_binary_target() {
+        // When src/bin/ exists but contains no .rs files and no dir/main.rs,
+        // the 0 => {} match arm is hit (no binary found there either) and the
+        // function falls through to the final Err path.  Also exercises the
+        // `None` arm in the filter_map for non-.rs files.
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("src/bin")).unwrap();
+        // A non-.rs file: triggers the `None` arm of the filter_map.
+        fs::write(tmp.path().join("src/bin/README.md"), "# ignore me").unwrap();
+        let doc: toml::Value = toml::from_str(
+            "[package]\nname=\"my-app\"\nversion=\"0.1.0\"\n",
+        )
+        .unwrap();
+        let err = resolve_bin_name(tmp.path(), "my-app", None, true, &doc).unwrap_err();
+        assert!(
+            err.to_string().contains("no binary target"),
+            "must error about no binary target; got: {err}"
+        );
+    }
+
+    // ── version fallback unit test ─────────────────────────────────────────────
+
+    #[test]
+    fn plan_uses_fallback_version_when_no_version_field_in_cargo_toml() {
+        // When [package] has no version field at all, the `_ => "0.1.0"` arm in
+        // read_package_meta must fire and the plan must succeed with version "0.1.0".
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"no-version-app\"\nedition=\"2024\"\n\
+             \n[dependencies]\nautumn-web = \"0.5.0\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let conf_action = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("tauri.conf.json"))
+            .expect("tauri.conf.json action must be present");
+        let contents = match conf_action {
+            crate::generate::emit::Action::Create { contents, .. } => contents.as_str(),
+            _ => panic!("expected Create action for tauri.conf.json"),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(contents).unwrap();
+        assert_eq!(
+            parsed["version"].as_str(),
+            Some("0.1.0"),
+            "when no version field is present, tauri.conf.json must default to '0.1.0'"
+        );
+    }
+
+    // ── resolve_workspace_version unit tests ──────────────────────────────────
+
+    #[test]
+    fn resolve_workspace_version_walks_up_to_find_workspace_package_version() {
+        // When the project is a workspace member and the version lives in the
+        // parent Cargo.toml under [workspace.package], resolve_workspace_version
+        // must walk up (hitting the dir = d.parent() line) and return the version.
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"app\"]\n\
+             \n[workspace.package]\nversion = \"2.7.0\"\n",
+        )
+        .unwrap();
+        let app = tmp.path().join("app");
+        fs::create_dir_all(app.join("src")).unwrap();
+        fs::write(
+            app.join("Cargo.toml"),
+            "[package]\nname=\"my-app\"\nversion.workspace = true\nedition=\"2024\"\n\
+             \n[dependencies]\nautumn-web = \"0.5.0\"\n",
+        )
+        .unwrap();
+        fs::write(app.join("src/main.rs"), "fn main() {}\n").unwrap();
+        // resolve_workspace_version must walk from app/ up to root and find "2.7.0".
+        let version = resolve_workspace_version(&app);
+        assert_eq!(
+            version.as_deref(),
+            Some("2.7.0"),
+            "must walk up to parent workspace and return the workspace.package.version"
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_version_returns_none_when_no_ancestor_has_workspace_version() {
+        // When no ancestor Cargo.toml has [workspace.package] version, the function
+        // exhausts the directory tree and returns None (the final None after the loop).
+        let tmp = TempDir::new().unwrap();
+        // A bare Cargo.toml with no [workspace.package] section.
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"my-app\"\nversion.workspace = true\nedition=\"2024\"\n\
+             \n[dependencies]\nautumn-web = \"0.5.0\"\n",
+        )
+        .unwrap();
+        let version = resolve_workspace_version(tmp.path());
+        assert_eq!(
+            version, None,
+            "must return None when no ancestor has [workspace.package] version"
+        );
+    }
 }

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -1035,7 +1035,7 @@ mkdir -p src-tauri/binaries
 {fingerprint}# universal-apple-darwin: build both Darwin slices and lipo them together.
 if [ "${{TARGET_TRIPLE}}" = "universal-apple-darwin" ]; then
     for ARCH in x86_64-apple-darwin aarch64-apple-darwin; do
-        cargo build --release --target "$ARCH" --bin {bin_name} \
+        cargo build --release -p {package_name} --target "$ARCH" --bin {bin_name} \
           --features {embed_feature}
     done
     lipo -create -output "src-tauri/binaries/{bin_name}-universal-apple-darwin" \
@@ -1043,7 +1043,7 @@ if [ "${{TARGET_TRIPLE}}" = "universal-apple-darwin" ]; then
       "${{TARGET_DIR}}/aarch64-apple-darwin/release/{bin_name}"
     echo "Staged (universal): src-tauri/binaries/{bin_name}-universal-apple-darwin"
 else
-    cargo build --release --target "${{TARGET_TRIPLE}}" --bin {bin_name} \
+    cargo build --release -p {package_name} --target "${{TARGET_TRIPLE}}" --bin {bin_name} \
       --features {embed_feature}
     cp "${{TARGET_DIR}}/${{TARGET_TRIPLE}}/release/{bin_name}" \
        "src-tauri/binaries/{bin_name}-${{TARGET_TRIPLE}}"
@@ -1105,6 +1105,11 @@ done
 # Note: decryption at runtime requires the AUTUMN_MASTER_KEY env var (or the
 # .autumn-master-key key file placed in the resource dir).  See the Tauri section
 # of the Autumn docs for recommended key distribution strategies.
+# Remove and recreate the staging directory so stale .toml.enc files from a
+# previous build (deleted or rotated credentials) are not carried into the
+# installer.  Autumn loads any .toml.enc it finds via AUTUMN_MANIFEST_DIR, so
+# a stale file from a prior build would silently keep a revoked secret active.
+rm -rf src-tauri/configs/credentials
 mkdir -p src-tauri/configs/credentials
 if [ -d "config/credentials" ]; then
     cp -r config/credentials/. src-tauri/configs/credentials/
@@ -1160,7 +1165,7 @@ if (-not $TargetDir) {{
     $TargetDir = (cargo metadata --no-deps --format-version 1 --quiet | ConvertFrom-Json).target_directory
 }}
 {fingerprint}New-Item -ItemType Directory -Force -Path src-tauri\binaries | Out-Null
-cargo build --release --target "$TargetTriple" --bin {bin_name} `
+cargo build --release -p {package_name} --target "$TargetTriple" --bin {bin_name} `
   --features {embed_feature}
 Copy-Item "$TargetDir\$TargetTriple\release\{bin_name}.exe" `
           "src-tauri\binaries\{bin_name}-$TargetTriple.exe"
@@ -1221,6 +1226,13 @@ foreach ($f in @("autumn-staging.toml", "autumn-test.toml")) {{
 # Note: decryption at runtime requires the AUTUMN_MASTER_KEY env var (or the
 # .autumn-master-key key file placed in the resource dir).  See the Tauri section
 # of the Autumn docs for recommended key distribution strategies.
+# Remove and recreate the staging directory so stale .toml.enc files from a
+# previous build (deleted or rotated credentials) are not carried into the
+# installer.  Autumn loads any .toml.enc it finds via AUTUMN_MANIFEST_DIR, so
+# a stale file from a prior build would silently keep a revoked secret active.
+if (Test-Path "src-tauri\configs\credentials") {{
+    Remove-Item -Recurse -Force "src-tauri\configs\credentials"
+}}
 New-Item -ItemType Directory -Force -Path "src-tauri\configs\credentials" | Out-Null
 if (Test-Path "config\credentials") {{
     Copy-Item -Recurse -Force "config\credentials\*" "src-tauri\configs\credentials\"
@@ -3409,6 +3421,44 @@ mod tests {
             sh.contains("AUTUMN_MASTER_KEY"),
             "stage-sidecar.sh must mention AUTUMN_MASTER_KEY so developers know how \
              to provide the decryption key for bundled .toml.enc credential files"
+        );
+    }
+
+    #[test]
+    fn staging_sh_clears_credentials_before_copying() {
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true, "autumn-web");
+        // Stale .toml.enc files from a prior build (deleted or rotated credentials)
+        // must not survive into the next installer.  The staging directory must be
+        // removed and recreated, not merely appended to.
+        assert!(
+            sh.contains("rm -rf") && sh.contains("configs/credentials"),
+            "stage-sidecar.sh must remove src-tauri/configs/credentials/ before \
+             recreating it so revoked or renamed .toml.enc files from prior builds \
+             are not silently bundled into the next installer"
+        );
+        // rm -rf must come before the mkdir that follows it.
+        let rm_pos = sh.find("rm -rf").unwrap_or(usize::MAX);
+        let mkdir_pos = sh
+            .find("mkdir -p src-tauri/configs/credentials")
+            .unwrap_or(usize::MAX);
+        assert!(
+            rm_pos < mkdir_pos,
+            "stage-sidecar.sh must rm -rf credentials dir BEFORE mkdir; \
+             otherwise the directory is never actually cleared"
+        );
+    }
+
+    #[test]
+    fn staging_sh_passes_package_flag_to_cargo_build() {
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true, "autumn-web");
+        // In workspaces where `default-members` excludes the root package,
+        // `cargo build --bin <name>` fails unless `-p <package>` is also passed.
+        // The fingerprint phase already passes -p; the final cargo build must too.
+        assert!(
+            sh.contains("-p my-app"),
+            "stage-sidecar.sh must pass `-p my-app` to cargo build so the correct \
+             package is selected in workspaces where default-members excludes it; \
+             without -p, Cargo may report 'no bin target named ...' for valid workspaces"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -300,8 +300,22 @@ fn resolve_bin_name(
                 // or `./src/main.rs` all compare equal to `src/main.rs`.  We process
                 // components into a stack so that `..` properly pops its parent, just
                 // as Cargo does when resolving [[bin]] paths in the manifest.
-                let segs = normalize_manifest_path(p);
-                segs == ["src", "main.rs"]
+                //
+                // For absolute paths (Cargo permits them) strip the project root
+                // first so that `/abs/path/to/project/src/main.rs` is treated
+                // the same as the relative `src/main.rs`.
+                let path = Path::new(p);
+                if path.is_absolute() {
+                    match path.strip_prefix(project_root) {
+                        Ok(rel) => {
+                            let rel_str = rel.to_string_lossy();
+                            normalize_manifest_path(rel_str.as_ref()) == ["src", "main.rs"]
+                        }
+                        Err(_) => false,
+                    }
+                } else {
+                    normalize_manifest_path(p) == ["src", "main.rs"]
+                }
             })
         });
         if let Some(n) = main_bin
@@ -4140,6 +4154,55 @@ mod tests {
         assert!(
             err.to_string().contains("no binary target"),
             "must error about no binary target; got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_bin_name_absolute_path_to_src_main_matches_package_name() {
+        // Cargo permits absolute [[bin]] path values.  When the absolute path
+        // points to <project_root>/src/main.rs it must be treated the same as
+        // the relative "src/main.rs" so the package-name bin is chosen.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/main.rs"), "fn main() {}").unwrap();
+
+        let abs_path = root.join("src/main.rs");
+        let abs_str = abs_path.to_string_lossy();
+        // Escape backslashes for TOML (matters on Windows paths in tests).
+        let toml_path = abs_str.replace('\\', "\\\\");
+        let manifest = format!(
+            "[package]\nname=\"my-app\"\nversion=\"0.1.0\"\n\
+             [[bin]]\nname=\"my-app\"\npath=\"{toml_path}\"\n"
+        );
+        let doc: toml::Value = toml::from_str(&manifest).unwrap();
+        let result = resolve_bin_name(root, "my-app", None, true, &doc).unwrap();
+        assert_eq!(
+            result, "my-app",
+            "absolute path to src/main.rs must resolve to the package-name bin"
+        );
+    }
+
+    #[test]
+    fn resolve_bin_name_absolute_path_outside_project_root_is_not_main() {
+        // An absolute [[bin]] path that does not live under project_root cannot
+        // be the package's src/main.rs; strip_prefix fails → treated as non-main.
+        // Use autobins=false so the autobins guard doesn't fire and the single-bin
+        // fallback picks up the "external" name directly.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/main.rs"), "fn main() {}").unwrap();
+
+        // Point the single [[bin]] to an arbitrary absolute path outside root.
+        let manifest = "[package]\nname=\"my-app\"\nversion=\"0.1.0\"\nautobins=false\n\
+             [[bin]]\nname=\"external\"\npath=\"/some/other/location/main.rs\"\n";
+        let doc: toml::Value = toml::from_str(manifest).unwrap();
+        // The single non-main bin must be returned directly.
+        let result = resolve_bin_name(root, "my-app", None, false, &doc).unwrap();
+        assert_eq!(
+            result, "external",
+            "a single non-main absolute-path bin must be returned as-is"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -244,6 +244,27 @@ fn resolve_dep_key(project_root: &Path, doc: &toml::Value, package_name: &str) -
 
 /// Resolve the Cargo binary target name for the Tauri sidecar.
 ///
+/// Normalize a Cargo manifest path component-by-component, resolving both `.`
+/// (current-dir) and `..` (parent-dir) segments, and accepting both `/` and `\`
+/// as separators.  Returns the logical path segments as a `Vec<&str>`.
+///
+/// This mirrors the normalization Cargo applies when resolving `[[bin]] path =
+/// "…"` entries, so that e.g. `"src/../src/main.rs"` and `"./src/main.rs"` both
+/// produce `["src", "main.rs"]`.
+fn normalize_manifest_path(p: &str) -> Vec<&str> {
+    let mut segs: Vec<&str> = Vec::new();
+    for seg in p.split(['/', '\\']) {
+        match seg {
+            "" | "." => {}
+            ".." => {
+                segs.pop();
+            }
+            s => segs.push(s),
+        }
+    }
+    segs
+}
+
 /// Priority when `[[bin]]` entries are present:
 ///
 ///   1. `[package] default-run` — the developer's explicit selection.
@@ -267,10 +288,11 @@ fn resolve_bin_name(
         }
         let main_bin = bins.iter().find(|b| {
             b.get("path").and_then(|p| p.as_str()).is_some_and(|p| {
-                let segs: Vec<&str> = p
-                    .split(['/', '\\'])
-                    .filter(|&s| !s.is_empty() && s != ".")
-                    .collect();
+                // Fully normalize the path so that variants like `src/../src/main.rs`
+                // or `./src/main.rs` all compare equal to `src/main.rs`.  We process
+                // components into a stack so that `..` properly pops its parent, just
+                // as Cargo does when resolving [[bin]] paths in the manifest.
+                let segs = normalize_manifest_path(p);
                 segs == ["src", "main.rs"]
             })
         });
@@ -778,13 +800,6 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         // the force-kill window.  Setting it to 0 lets on_shutdown hooks (including
         // ManagedPostgresPoolProvider::stop()) run immediately after SIGTERM.
         .env("AUTUMN_SERVER__PRESTOP_GRACE_SECS", "0")
-        // Auto-apply pending migrations on every launch so that a freshly
-        // provisioned managed-Postgres cluster (first launch, or after data-dir
-        // wipe) has a fully migrated schema before the first request arrives.
-        // Autumn's default requires `database.auto_migrate_in_production = true`
-        // in autumn.toml; for the desktop bundle we inject it via env so the app's
-        // production autumn.toml stays server-deployment-friendly (default off).
-        .env("AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION", "true")
         // Clear one-off mode flags inherited from the calling environment.
         // If any of these are set, AppBuilder::run() enters a non-serving mode
         // (asset fingerprinting, route dump, task execution) and exits before
@@ -793,6 +808,14 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         .env("AUTUMN_DUMP_ROUTES", "")
         .env("AUTUMN_LIST_TASKS", "")
         .env("AUTUMN_RUN_TASK", "")
+        // ── Opt-in: auto-migrate managed-Postgres on first launch ──────────────
+        // If this app wires ManagedPostgresPoolProvider (desktop-bundled Postgres),
+        // uncomment the next line so a fresh local cluster is migrated before the
+        // first request arrives.  Leave it commented out when the sidecar connects
+        // to a remote / shared database — enabling it there would run pending
+        // migrations against that shared DB on every desktop client launch.
+        // .env("AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION", "true")
+        // ───────────────────────────────────────────────────────────────────────
         .spawn()?;
     *app.state::<SidecarHandle>().0.lock().unwrap() = Some(child);
 
@@ -2139,6 +2162,40 @@ mod tests {
     }
 
     #[test]
+    fn normalize_manifest_path_resolves_dotdot_and_dot() {
+        // Cargo normalizes manifest paths before matching, so `src/../src/main.rs`
+        // is equivalent to `src/main.rs`.  Our helper must do the same so we
+        // don't miss the main_bin match and fall through to the wrong fallback.
+        assert_eq!(
+            normalize_manifest_path("src/../src/main.rs"),
+            vec!["src", "main.rs"],
+            "src/../src/main.rs must normalize to [src, main.rs]"
+        );
+        assert_eq!(
+            normalize_manifest_path("./src/main.rs"),
+            vec!["src", "main.rs"],
+            "./src/main.rs must normalize to [src, main.rs]"
+        );
+        assert_eq!(
+            normalize_manifest_path("src/main.rs"),
+            vec!["src", "main.rs"],
+            "plain src/main.rs must pass through unchanged"
+        );
+        // Windows-style separator.
+        assert_eq!(
+            normalize_manifest_path(r"src\main.rs"),
+            vec!["src", "main.rs"],
+            r"src\main.rs must normalize to [src, main.rs]"
+        );
+        // Multiple consecutive .. resolve correctly.
+        assert_eq!(
+            normalize_manifest_path("a/b/../../src/main.rs"),
+            vec!["src", "main.rs"],
+            "a/b/../../src/main.rs must normalize to [src, main.rs]"
+        );
+    }
+
+    #[test]
     fn plan_respects_autobins_false_ignores_main_rs() {
         // autobins=false disables src/main.rs auto-discovery.  The explicit [[bin]]
         // target must be used even though src/main.rs exists.
@@ -3011,22 +3068,32 @@ mod tests {
     }
 
     #[test]
-    fn lib_rs_auto_migrates_on_desktop_launch() {
+    fn lib_rs_documents_managed_pg_auto_migrate_opt_in() {
         let lib = render_shell_lib_rs("my-app", "my-app");
-        // A fresh managed-Postgres cluster starts with no schema; without
-        // auto-migration the first route that touches a table returns 500.
-        // The prod autumn.toml default is off (server-friendly), so we inject
-        // the override via env for the desktop bundle only.
+        // AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION is safe only for desktop
+        // apps that use ManagedPostgresPoolProvider (bundled Postgres).  Emitting
+        // it unconditionally would run pending migrations against any remote /
+        // shared database on every desktop client launch.  The generated shell must
+        // include the env var as a commented-out opt-in with an explanation.
         assert!(
             lib.contains("AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION"),
-            "lib.rs must set AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION=true so a \
-             fresh managed-Postgres cluster is migrated on first launch; otherwise \
-             routes that touch migrated tables fail with 500 on first desktop launch"
+            "lib.rs must mention AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION (as a \
+             commented-out opt-in) so developers wiring ManagedPostgresPoolProvider \
+             know to uncomment it; without it, a fresh cluster is never migrated and \
+             routes fail with 500 on first desktop launch"
         );
+        // Must NOT be emitted as a live .env() call — that would run migrations
+        // against any remote/shared database on every desktop client launch.
+        let live = lib.lines().any(|line| {
+            !line.trim_start().starts_with("//")
+                && line.contains("AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION")
+        });
         assert!(
-            lib.contains("\"AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION\", \"true\""),
-            "AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION must be set to \"true\"; \
-             an empty string or \"false\" would leave the fresh cluster unmigrated"
+            !live,
+            "AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION must be commented out in \
+             lib.rs, not emitted as a live .env() call; enabling it unconditionally \
+             would run pending migrations against any remote/shared database on every \
+             desktop client launch, overriding the user's prod-config default-off"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -329,6 +329,9 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
             "AUTUMN_MANAGED_PG_DATA_DIR",
             app_data_dir.to_string_lossy().as_ref(),
         )
+        // Force the health endpoint to /health so the readiness probe below
+        // always works, regardless of what [health].path is configured in the app.
+        .env("AUTUMN_HEALTH__PATH", "/health")
         .spawn()?;
     *app.state::<SidecarHandle>().0.lock().unwrap() = Some(child);
 
@@ -369,6 +372,18 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
             eprintln!(
                 "[{package_name}] Server did not become ready within 30 s — exiting."
             );
+            // No window has been created yet, so WindowEvent::Destroyed cannot
+            // fire.  Kill the sidecar explicitly before exiting so no orphaned
+            // server process is left behind.
+            if let Some(mut child) = handle
+                .state::<SidecarHandle>()
+                .0
+                .lock()
+                .unwrap()
+                .take()
+            {{
+                let _ = child.kill();
+            }}
             handle.exit(1);
             return;
         }}
@@ -384,6 +399,17 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         .build()
         {{
             eprintln!("[{package_name}] Failed to open window: {{e}}");
+            // The window was never created so Destroyed cannot clean up; kill
+            // the sidecar here too.
+            if let Some(mut child) = handle
+                .state::<SidecarHandle>()
+                .0
+                .lock()
+                .unwrap()
+                .take()
+            {{
+                let _ = child.kill();
+            }}
             handle.exit(1);
         }}
     }});
@@ -497,8 +523,9 @@ Required prerequisites for `cargo tauri build`:\n\
        cd src-tauri && cargo tauri build\n\
 \n\
   The sidecar is built with autumn-web/embed-assets (#1004) and\n\
-  autumn-web/managed-pg-bundled (#1119) so the packaged desktop app needs\n\
-  no separately-installed database or loose asset files.\n\
+  autumn-web/managed-pg-bundled (#1119).  For a DB-backed app the bundled\n\
+  Postgres only activates if ManagedPostgresPoolProvider is wired in your\n\
+  app's pool configuration (see docs/guide/managed-pg.md).\n\
 \n\
   Replace the placeholder icons before shipping:\n\
        cargo tauri icon static/icons/icon.svg   (from the app root)\n"
@@ -892,6 +919,30 @@ mod tests {
         assert!(
             lib.contains(".join(\"db\")"),
             "lib.rs must isolate Postgres files in <app-data-dir>/db, not the root"
+        );
+    }
+
+    #[test]
+    fn lib_rs_forces_health_path_env() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains("AUTUMN_HEALTH__PATH"),
+            "lib.rs must set AUTUMN_HEALTH__PATH=/health so the readiness probe works \
+             regardless of the app's configured health path"
+        );
+    }
+
+    #[test]
+    fn lib_rs_kills_sidecar_on_timeout() {
+        let lib = render_shell_lib_rs("my-app");
+        // The timeout branch must kill the sidecar before handle.exit(1);
+        // check that .kill() appears more than once (once for Destroyed, once for timeout).
+        let kill_count = lib.matches(".kill()").count();
+        assert!(
+            kill_count >= 2,
+            "lib.rs must kill the sidecar in both the timeout path and the window-build \
+             failure path, not only in WindowEvent::Destroyed; found {} .kill() call(s)",
+            kill_count
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -197,7 +197,8 @@ fn render_tauri_conf(package_name: &str) -> String {
       "binaries/{package_name}"
     ],
     "resources": {{
-      "../autumn.toml": "autumn.toml"
+      "../autumn.toml": "autumn.toml",
+      "../autumn-*.toml": "."
     }}
   }},
   "app": {{
@@ -1010,6 +1011,14 @@ mod tests {
             has_autumn_toml,
             "tauri.conf.json must bundle autumn.toml as a resource so the installed \
              sidecar can find the app's production configuration"
+        );
+        // Profile override files (autumn-prod.toml, autumn-production.toml, etc.) must
+        // also be bundled so the sidecar picks them up at runtime under the active profile.
+        let has_profile_glob = resources.iter().any(|(k, _)| k.contains("autumn-*.toml"));
+        assert!(
+            has_profile_glob,
+            "tauri.conf.json must include a glob for autumn-*.toml resources so profile \
+             config overrides are bundled alongside the base autumn.toml"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -671,6 +671,17 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
     // Postgres cluster (#1119) in db/.  Create proactively; the sidecar won't if absent.
     let app_data_dir = data_root.join("db");
     std::fs::create_dir_all(&app_data_dir)?;
+    // Local blob storage in blobs/.  Create before the sidecar spawns so we can
+    // restrict the directory to owner-only — LocalBlobStore::new/put use
+    // create_dir_all/write which inherit the process umask (typically 0755/0644),
+    // leaving private uploads readable by other local accounts on multi-user systems.
+    let blobs_dir = data_root.join("blobs");
+    std::fs::create_dir_all(&blobs_dir)?;
+    #[cfg(unix)]
+    {{
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&blobs_dir, std::fs::Permissions::from_mode(0o700))?;
+    }}
     // Per-install signing secret: autumn requires one in prod mode.  Generate 32
     // random bytes on first launch and persist them so tokens survive restarts.
     let signing_secret = load_or_generate_signing_secret(&data_root)?;
@@ -2785,6 +2796,27 @@ mod tests {
             lib.contains("data_root") && lib.contains("join(\"blobs\")"),
             "AUTUMN_STORAGE__LOCAL__ROOT must point to a writable subdirectory of \
              app_data_dir (e.g. data_root.join(\"blobs\")), not the read-only resource_dir"
+        );
+    }
+
+    #[test]
+    fn lib_rs_restricts_blob_storage_dir_permissions() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        // The blobs/ directory must be created explicitly before the sidecar spawns
+        // so we can apply 0700 on Unix — LocalBlobStore uses create_dir_all which
+        // inherits the process umask (typically 0755), leaving files 0644 and readable
+        // by other local accounts.
+        assert!(
+            lib.contains("blobs_dir") && lib.contains("create_dir_all"),
+            "lib.rs must create the blobs/ directory explicitly (not rely on \
+             LocalBlobStore::new) so permissions can be restricted before any \
+             data is written"
+        );
+        assert!(
+            lib.contains("set_permissions") && lib.contains("0o700"),
+            "lib.rs must restrict the blobs/ directory to 0700 on Unix; otherwise \
+             LocalBlobStore creates it with the process umask (typically 0755) and \
+             other local accounts can read private uploads from disk"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -96,6 +96,22 @@ pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
     plan.create_bytes(icons_dir.join("icon.ico"), PLACEHOLDER_ICO);
     plan.create_bytes(icons_dir.join("icon.icns"), PLACEHOLDER_ICNS);
 
+    // Platform-specific Tauri config overlays — Tauri CLI merges them at build/dev time.
+    // beforeBuildCommand and beforeDevCommand live here so tauri.conf.json is
+    // host-OS-agnostic and cargo tauri dev also stages the sidecar.
+    plan.create(
+        tauri.join("tauri.linux.conf.json"),
+        render_tauri_linux_conf(),
+    );
+    plan.create(
+        tauri.join("tauri.macos.conf.json"),
+        render_tauri_macos_conf(),
+    );
+    plan.create(
+        tauri.join("tauri.windows.conf.json"),
+        render_tauri_windows_conf(),
+    );
+
     // Staging scripts
     plan.create(
         tauri.join("stage-sidecar.sh"),
@@ -197,70 +213,71 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String, boo
         .get("default-run")
         .and_then(|v| v.as_str())
         .map(str::to_owned);
-    let bin_name = doc
-        .get("bin")
-        .and_then(|b| b.as_array())
-        .map_or_else(
-            // Step 5: no [[bin]] table — honour default-run, then src/bin/ discovery,
-            // then fall back to the package name (which Cargo uses for src/main.rs).
-            || {
-                if let Some(dr) = &default_run {
-                    return dr.clone();
-                }
-                // Inspect src/bin/ for auto-discovered binaries.  Cargo names each
-                // binary after the file stem (not the package), so `src/bin/web.rs`
-                // produces a `web` binary, not `<package>`.
-                if let Ok(entries) = std::fs::read_dir(project_root.join("src/bin")) {
-                    let stems: Vec<String> = entries
-                        .filter_map(std::result::Result::ok)
-                        .filter_map(|e| {
-                            let p = e.path();
-                            if p.extension().is_some_and(|x| x == "rs") {
-                                p.file_stem()
-                                    .and_then(|s| s.to_str())
-                                    .map(str::to_owned)
-                            } else {
-                                None
-                            }
-                        })
-                        .collect();
-                    if stems.len() == 1 {
-                        return stems.into_iter().next().unwrap();
-                    }
-                }
-                name.clone()
-            },
-            |bins| {
-                // Step 1: explicit [[bin]] entry whose path is src/main.rs.
-                bins.iter()
-                    .find(|b| {
-                        b.get("path")
-                            .and_then(|p| p.as_str())
-                            .is_some_and(|p| p == "src/main.rs" || p == "src\\main.rs")
-                    })
-                    .and_then(|b| b.get("name"))
-                    .and_then(|n| n.as_str())
-                    .map(str::to_owned)
-                    .or_else(|| {
-                        if project_root.join("src/main.rs").is_file() {
-                            // Step 2: src/main.rs exists but is not declared in [[bin]];
-                            // Cargo auto-discovers it as the package-named binary.
-                            // The [[bin]] entries are for other auxiliary programs.
-                            Some(name.clone())
+    let bin_name = doc.get("bin").and_then(|b| b.as_array()).map_or_else(
+        // Step 5: no [[bin]] table — honour default-run, then check src/main.rs,
+        // then src/bin/ discovery, then fall back to the package name.
+        || {
+            if let Some(dr) = &default_run {
+                return dr.clone();
+            }
+            // Step 5a: src/main.rs exists → Cargo auto-discovers it as the
+            // package-named binary, even when src/bin/ also has files.
+            // Prefer the package name over any src/bin/ stem.
+            if project_root.join("src/main.rs").is_file() {
+                return name.clone();
+            }
+            // Inspect src/bin/ for auto-discovered binaries.  Cargo names each
+            // binary after the file stem (not the package), so `src/bin/web.rs`
+            // produces a `web` binary, not `<package>`.
+            if let Ok(entries) = std::fs::read_dir(project_root.join("src/bin")) {
+                let stems: Vec<String> = entries
+                    .filter_map(std::result::Result::ok)
+                    .filter_map(|e| {
+                        let p = e.path();
+                        if p.extension().is_some_and(|x| x == "rs") {
+                            p.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
                         } else {
-                            // Step 3: honour [package] default-run when set.
-                            default_run.clone().or_else(|| {
-                                // Step 4: single or first explicit [[bin]] as last resort.
-                                bins.first()
-                                    .and_then(|b| b.get("name"))
-                                    .and_then(|n| n.as_str())
-                                    .map(str::to_owned)
-                            })
+                            None
                         }
                     })
-                    .unwrap_or_else(|| name.clone())
-            },
-        );
+                    .collect();
+                if stems.len() == 1 {
+                    return stems.into_iter().next().unwrap();
+                }
+            }
+            name.clone()
+        },
+        |bins| {
+            // Step 1: explicit [[bin]] entry whose path is src/main.rs.
+            bins.iter()
+                .find(|b| {
+                    b.get("path")
+                        .and_then(|p| p.as_str())
+                        .is_some_and(|p| p == "src/main.rs" || p == "src\\main.rs")
+                })
+                .and_then(|b| b.get("name"))
+                .and_then(|n| n.as_str())
+                .map(str::to_owned)
+                .or_else(|| {
+                    if project_root.join("src/main.rs").is_file() {
+                        // Step 2: src/main.rs exists but is not declared in [[bin]];
+                        // Cargo auto-discovers it as the package-named binary.
+                        // The [[bin]] entries are for other auxiliary programs.
+                        Some(name.clone())
+                    } else {
+                        // Step 3: honour [package] default-run when set.
+                        default_run.clone().or_else(|| {
+                            // Step 4: single or first explicit [[bin]] as last resort.
+                            bins.first()
+                                .and_then(|b| b.get("name"))
+                                .and_then(|n| n.as_str())
+                                .map(str::to_owned)
+                        })
+                    }
+                })
+                .unwrap_or_else(|| name.clone())
+        },
+    );
 
     // Check whether the app defines an `embed-assets` Cargo feature.
     // `autumn new` generates this; it typically expands to
@@ -315,16 +332,12 @@ fn render_tauri_conf(package_name: &str, version: &str, bin_name: &str) -> Strin
         })
         .collect::<Vec<_>>()
         .join(" ");
-    // beforeBuildCommand must use the native shell for the host OS.
-    // cfg!(windows) is evaluated when the generator binary compiles, which runs on
-    // the same host where `cargo tauri build` will later be invoked.
-    // Use `bash` explicitly — the staging script uses BASH_SOURCE and `pipefail`,
-    // which are not supported by POSIX `sh` (e.g. dash on Debian/Ubuntu).
-    let before_build_cmd = if cfg!(windows) {
-        "powershell -ExecutionPolicy Bypass -File stage-sidecar.ps1"
-    } else {
-        "bash stage-sidecar.sh"
-    };
+    // beforeBuildCommand and beforeDevCommand are declared in the platform-specific
+    // overlay files (tauri.linux.conf.json, tauri.macos.conf.json,
+    // tauri.windows.conf.json) that Tauri CLI merges at build/dev time.
+    // Keeping them out of tauri.conf.json makes the generated scaffold
+    // host-OS-agnostic: it stays correct regardless of which OS generated it.
+    //
     // Profile config entries always point to src-tauri/configs/, which the staging
     // script (beforeBuildCommand) populates at build time — copying real files or
     // creating empty stubs for profiles that don't yet exist.  An empty TOML file
@@ -338,9 +351,6 @@ fn render_tauri_conf(package_name: &str, version: &str, bin_name: &str) -> Strin
   "productName": "{title}",
   "version": "{version}",
   "identifier": "{identifier}",
-  "build": {{
-    "beforeBuildCommand": "{before_build_cmd}"
-  }},
   "bundle": {{
     "active": true,
     "targets": "all",
@@ -373,6 +383,42 @@ fn render_tauri_conf(package_name: &str, version: &str, bin_name: &str) -> Strin
 }}
 "#
     )
+}
+
+/// Platform-specific Tauri config overlays — Tauri CLI merges these at build/dev time.
+/// Keeping `beforeBuildCommand` / `beforeDevCommand` here (not in `tauri.conf.json`)
+/// means the generated scaffold is host-OS-agnostic.
+fn render_tauri_linux_conf() -> String {
+    r#"{
+  "build": {
+    "beforeBuildCommand": "bash stage-sidecar.sh",
+    "beforeDevCommand": "bash stage-sidecar.sh"
+  }
+}
+"#
+    .to_owned()
+}
+
+fn render_tauri_macos_conf() -> String {
+    r#"{
+  "build": {
+    "beforeBuildCommand": "bash stage-sidecar.sh",
+    "beforeDevCommand": "bash stage-sidecar.sh"
+  }
+}
+"#
+    .to_owned()
+}
+
+fn render_tauri_windows_conf() -> String {
+    r#"{
+  "build": {
+    "beforeBuildCommand": "powershell -ExecutionPolicy Bypass -File stage-sidecar.ps1",
+    "beforeDevCommand": "powershell -ExecutionPolicy Bypass -File stage-sidecar.ps1"
+  }
+}
+"#
+    .to_owned()
 }
 
 fn render_shell_cargo_toml(package_name: &str) -> String {
@@ -887,11 +933,13 @@ Required prerequisites for `cargo tauri build`:\n\
        macOS:   xcode-select --install\n\
        Windows: Install WebView2 + Visual Studio C++ build tools\n\
 \n\
-  3. Stage the autumn server sidecar (also wired into beforeBuildCommand):\n\
+  3. Stage the autumn server sidecar (also wired into beforeBuildCommand /\n\
+     beforeDevCommand in the platform-specific overlay files):\n\
        bash src-tauri/stage-sidecar.sh\n\
 \n\
-  4. Build the desktop app:\n\
+  4. Build or develop the desktop app:\n\
        cd src-tauri && cargo tauri build\n\
+       cd src-tauri && cargo tauri dev\n\
 \n\
   The sidecar is built with autumn-web/embed-assets (#1004) and\n\
   autumn-web/managed-pg-bundled (#1119).  For a DB-backed app the bundled\n\
@@ -1076,6 +1124,29 @@ mod tests {
         .unwrap();
         fs::create_dir_all(tmp.path().join("src")).unwrap();
         fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        tmp
+    }
+
+    /// Project with BOTH `src/main.rs` AND `src/bin/<bin_name>.rs` but NO `[[bin]]`
+    /// table — Cargo auto-discovers src/main.rs as the package-named binary; the
+    /// generator must prefer that over the src/bin/ stem.
+    fn project_with_main_and_src_bin(pkg_name: &str, bin_stem: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+                 \n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src/bin")).unwrap();
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        fs::write(
+            tmp.path().join(format!("src/bin/{bin_stem}.rs")),
+            "fn main() {}\n",
+        )
+        .unwrap();
         tmp
     }
 
@@ -1506,6 +1577,36 @@ mod tests {
     }
 
     #[test]
+    fn plan_prefers_main_rs_over_src_bin_when_both_exist() {
+        // A package with BOTH src/main.rs AND src/bin/worker.rs and NO [[bin]] table —
+        // Cargo treats src/main.rs as the primary binary (package-named), and src/bin/
+        // as an additional binary.  The generator must pick the package name, not "worker".
+        let tmp = project_with_main_and_src_bin("my-app", "worker");
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let sh: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("stage-sidecar.sh action not found");
+        assert!(
+            sh.contains("my-app"),
+            "when src/main.rs and src/bin/worker.rs both exist without [[bin]], \
+             the package name 'my-app' must be used (not the src/bin/ stem 'worker')"
+        );
+        assert!(
+            !sh.contains("--bin worker"),
+            "staging script must not use the src/bin/ stem 'worker' when src/main.rs is present"
+        );
+    }
+
+    #[test]
     fn plan_detects_src_bin_auto_discovered_binary() {
         // A package with src/bin/web.rs and no src/main.rs or [[bin]] table —
         // Cargo auto-discovers it as binary "web" (file stem, not package name).
@@ -1655,15 +1756,83 @@ mod tests {
     }
 
     #[test]
-    fn tauri_conf_has_before_build_command() {
+    fn tauri_conf_has_no_before_build_command() {
+        // beforeBuildCommand lives in the platform-specific overlay files, not the
+        // main tauri.conf.json, so the generated scaffold is host-OS-agnostic.
         let conf = render_tauri_conf("my-app", "0.1.0", "my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
-        let cmd = parsed["build"]["beforeBuildCommand"]
-            .as_str()
-            .expect("build.beforeBuildCommand must be a string");
         assert!(
-            cmd.contains("stage-sidecar"),
-            "beforeBuildCommand must reference the staging script"
+            parsed["build"]["beforeBuildCommand"].is_null(),
+            "beforeBuildCommand must be absent from tauri.conf.json; \
+             it belongs in the platform-specific overlay files"
+        );
+    }
+
+    #[test]
+    fn platform_conf_files_are_in_plan() {
+        let tmp = project("my-app");
+        assert!(has_action(&tmp, "src-tauri/tauri.linux.conf.json"));
+        assert!(has_action(&tmp, "src-tauri/tauri.macos.conf.json"));
+        assert!(has_action(&tmp, "src-tauri/tauri.windows.conf.json"));
+    }
+
+    #[test]
+    fn platform_conf_linux_has_before_build_and_dev_commands() {
+        let conf = render_tauri_linux_conf();
+        let parsed: serde_json::Value = serde_json::from_str(&conf).expect("valid JSON");
+        let build_cmd = parsed["build"]["beforeBuildCommand"].as_str().unwrap_or("");
+        let dev_cmd = parsed["build"]["beforeDevCommand"].as_str().unwrap_or("");
+        assert!(
+            build_cmd.contains("stage-sidecar"),
+            "linux conf must have beforeBuildCommand referencing the staging script"
+        );
+        assert!(
+            dev_cmd.contains("stage-sidecar"),
+            "linux conf must have beforeDevCommand so `cargo tauri dev` stages the sidecar"
+        );
+        assert!(
+            build_cmd.contains("bash"),
+            "linux beforeBuildCommand must use bash"
+        );
+    }
+
+    #[test]
+    fn platform_conf_macos_has_before_build_and_dev_commands() {
+        let conf = render_tauri_macos_conf();
+        let parsed: serde_json::Value = serde_json::from_str(&conf).expect("valid JSON");
+        let build_cmd = parsed["build"]["beforeBuildCommand"].as_str().unwrap_or("");
+        let dev_cmd = parsed["build"]["beforeDevCommand"].as_str().unwrap_or("");
+        assert!(
+            build_cmd.contains("stage-sidecar"),
+            "macos conf must have beforeBuildCommand referencing the staging script"
+        );
+        assert!(
+            dev_cmd.contains("stage-sidecar"),
+            "macos conf must have beforeDevCommand so `cargo tauri dev` stages the sidecar"
+        );
+        assert!(
+            build_cmd.contains("bash"),
+            "macos beforeBuildCommand must use bash"
+        );
+    }
+
+    #[test]
+    fn platform_conf_windows_has_before_build_and_dev_commands() {
+        let conf = render_tauri_windows_conf();
+        let parsed: serde_json::Value = serde_json::from_str(&conf).expect("valid JSON");
+        let build_cmd = parsed["build"]["beforeBuildCommand"].as_str().unwrap_or("");
+        let dev_cmd = parsed["build"]["beforeDevCommand"].as_str().unwrap_or("");
+        assert!(
+            build_cmd.contains("stage-sidecar"),
+            "windows conf must have beforeBuildCommand referencing the staging script"
+        );
+        assert!(
+            dev_cmd.contains("stage-sidecar"),
+            "windows conf must have beforeDevCommand so `cargo tauri dev` stages the sidecar"
+        );
+        assert!(
+            build_cmd.contains("powershell") || build_cmd.contains("ps1"),
+            "windows beforeBuildCommand must use PowerShell"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -54,7 +54,7 @@ use super::{Flags, GenerateError, ensure_project_root};
 pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
     ensure_project_root(project_root)?;
 
-    let (package_name, package_version, bin_name, has_embed_assets) =
+    let (package_name, package_version, bin_name, has_embed_assets, dep_key) =
         read_package_meta(project_root)?;
     let mut plan = Plan::new(project_root);
     let tauri = project_root.join("src-tauri");
@@ -115,11 +115,11 @@ pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
     // Staging scripts
     plan.create(
         tauri.join("stage-sidecar.sh"),
-        render_stage_sidecar_sh(&package_name, &bin_name, has_embed_assets),
+        render_stage_sidecar_sh(&package_name, &bin_name, has_embed_assets, &dep_key),
     );
     plan.create(
         tauri.join("stage-sidecar.ps1"),
-        render_stage_sidecar_ps1(&package_name, &bin_name, has_embed_assets),
+        render_stage_sidecar_ps1(&package_name, &bin_name, has_embed_assets, &dep_key),
     );
     plan.create(tauri.join(".gitignore"), render_gitignore());
 
@@ -169,6 +169,34 @@ pub fn run(flags: Flags) {
 /// `--features autumn-web/embed-assets` (dep path only), so that the app's
 /// `#[cfg(feature = "embed-assets")]` guard on `.embedded_static()` is
 /// satisfied — mirroring what `autumn build --embed` does.
+/// Find the `[dependencies]` key used to depend on `package_name`.
+///
+/// Cargo feature syntax requires the *dependency key*, not the package name.
+/// An aliased dep like `autumn_web = {{ package = "autumn-web" }}` must be
+/// referenced as `autumn_web/feature`, not `autumn-web/feature`.
+/// Returns `package_name` itself when no alias is found.
+fn resolve_dep_key(doc: &toml::Value, package_name: &str) -> String {
+    let Some(deps) = doc.get("dependencies").and_then(toml::Value::as_table) else {
+        return package_name.to_owned();
+    };
+    for (key, val) in deps {
+        // Direct dependency: key matches package name.
+        if key == package_name {
+            return key.clone();
+        }
+        // Aliased dependency: table entry has `package = <package_name>`.
+        if val
+            .as_table()
+            .and_then(|t| t.get("package"))
+            .and_then(toml::Value::as_str)
+            == Some(package_name)
+        {
+            return key.clone();
+        }
+    }
+    package_name.to_owned()
+}
+
 /// Resolve the Cargo binary target name for the Tauri sidecar.
 ///
 /// Priority when `[[bin]]` entries are present:
@@ -267,7 +295,9 @@ fn resolve_bin_name(
     Ok(name.to_owned())
 }
 
-fn read_package_meta(project_root: &Path) -> Result<(String, String, String, bool), GenerateError> {
+fn read_package_meta(
+    project_root: &Path,
+) -> Result<(String, String, String, bool, String), GenerateError> {
     let cargo_path = project_root.join("Cargo.toml");
     let content = std::fs::read_to_string(&cargo_path).map_err(GenerateError::Io)?;
     let doc: toml::Value = toml::from_str(&content)
@@ -312,7 +342,12 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String, boo
         .and_then(toml::Value::as_table)
         .is_some_and(|features| features.contains_key("embed-assets"));
 
-    Ok((name, version, bin_name, has_embed_assets_feature))
+    // Resolve the dependency key for autumn-web.  Apps may alias it (e.g.
+    // `autumn_web = { package = "autumn-web" }`); Cargo feature selectors
+    // must use the key (`autumn_web/feature`), not the package name.
+    let dep_key = resolve_dep_key(&doc, "autumn-web");
+
+    Ok((name, version, bin_name, has_embed_assets_feature, dep_key))
 }
 
 /// Walk from `project_root` upward looking for a `Cargo.toml` that declares
@@ -781,7 +816,22 @@ fn load_or_generate_signing_secret(
     // Propagate RNG failure — an all-zero secret would be trivially guessable.
     getrandom::getrandom(&mut bytes)?;
     let hex: String = bytes.iter().map(|b| format!("{{b:02x}}")).collect();
-    let _ = std::fs::write(&path, &hex);
+    // Write with restricted permissions: signing secrets must not be world-readable.
+    // On Unix create the file with mode 0600; on other platforms use the default ACLs.
+    #[cfg(unix)]
+    {{
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let _ = std::fs::OpenOptions::new()
+            .write(true).create(true).truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .and_then(|mut f| f.write_all(hex.as_bytes()));
+    }}
+    #[cfg(not(unix))]
+    {{
+        let _ = std::fs::write(&path, &hex);
+    }}
     Ok(hex)
 }}
 "#
@@ -801,12 +851,18 @@ fn render_placeholder_icon_svg() -> String {
     .to_owned()
 }
 
-fn render_stage_sidecar_sh(package_name: &str, bin_name: &str, has_embed_assets: bool) -> String {
-    // Use the app-level alias when present; fall back to the crate feature path.
+fn render_stage_sidecar_sh(
+    package_name: &str,
+    bin_name: &str,
+    has_embed_assets: bool,
+    dep_key: &str,
+) -> String {
+    // dep_key is the [dependencies] key for autumn-web; may differ from the
+    // package name when the app aliases it (e.g. `autumn_web = { package = ... }`).
     let embed_feature = if has_embed_assets {
-        "embed-assets,autumn-web/managed-pg-bundled"
+        format!("embed-assets,{dep_key}/managed-pg-bundled")
     } else {
-        "autumn-web/embed-assets,autumn-web/managed-pg-bundled"
+        format!("{dep_key}/embed-assets,{dep_key}/managed-pg-bundled")
     };
     // Only fingerprint when the app-level alias exists; `autumn build --embed` passes
     // --features embed-assets (app-level), which fails for apps without that alias.
@@ -901,11 +957,16 @@ done
     )
 }
 
-fn render_stage_sidecar_ps1(package_name: &str, bin_name: &str, has_embed_assets: bool) -> String {
+fn render_stage_sidecar_ps1(
+    package_name: &str,
+    bin_name: &str,
+    has_embed_assets: bool,
+    dep_key: &str,
+) -> String {
     let embed_feature = if has_embed_assets {
-        "embed-assets,autumn-web/managed-pg-bundled"
+        format!("embed-assets,{dep_key}/managed-pg-bundled")
     } else {
-        "autumn-web/embed-assets,autumn-web/managed-pg-bundled"
+        format!("{dep_key}/embed-assets,{dep_key}/managed-pg-bundled")
     };
     let fingerprint = if has_embed_assets {
         format!(
@@ -1494,7 +1555,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_sh_uses_cargo_metadata_for_target_dir() {
-        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true, "autumn-web");
         // cargo metadata resolves the real output dir for workspace members and
         // respects CARGO_TARGET_DIR overrides.
         assert!(
@@ -1515,7 +1576,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_sh_handles_universal_apple_darwin() {
-        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true, "autumn-web");
         // universal-apple-darwin is a Tauri meta-target; cargo build --target
         // universal-apple-darwin fails because rustc doesn't know it.
         assert!(
@@ -1534,7 +1595,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_ps1_uses_cargo_metadata_for_target_dir() {
-        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true);
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true, "autumn-web");
         assert!(
             ps1.contains("cargo metadata"),
             "stage-sidecar.ps1 must use `cargo metadata` to locate the Cargo target directory"
@@ -1551,7 +1612,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_sh_stages_profile_configs() {
-        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true, "autumn-web");
         // Profile configs are staged at build time (beforeBuildCommand) so that the
         // static resource entries in tauri.conf.json are always satisfiable — even when
         // autumn-prod.toml is created after `autumn generate tauri` was run.
@@ -1568,7 +1629,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_ps1_stages_profile_configs() {
-        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true);
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true, "autumn-web");
         assert!(
             ps1.contains("src-tauri\\configs") || ps1.contains("src-tauri/configs"),
             "stage-sidecar.ps1 must create src-tauri\\configs\\ and populate it with \
@@ -1585,7 +1646,7 @@ mod tests {
     // real config because AutumnConfig stops at the first existing file in the lookup list.
     #[test]
     fn stage_sidecar_sh_copies_alias_to_both_names() {
-        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true, "autumn-web");
         // Must handle the case where only autumn-production.toml exists by copying it
         // to autumn-prod.toml as well — look for the elif + both cp lines.
         assert!(
@@ -1607,7 +1668,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_ps1_copies_alias_to_both_names() {
-        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true);
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true, "autumn-web");
         assert!(
             ps1.contains("autumn-production.toml") && ps1.contains("autumn-prod.toml"),
             "stage-sidecar.ps1 must handle prod/production alias pair explicitly"
@@ -1689,7 +1750,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_sh_uses_bin_name_for_binary() {
-        let sh = render_stage_sidecar_sh("my-app", "my-server", true);
+        let sh = render_stage_sidecar_sh("my-app", "my-server", true, "autumn-web");
         assert!(
             sh.contains("my-server"),
             "stage-sidecar.sh must reference the binary target name in copy commands"
@@ -1703,7 +1764,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_ps1_uses_bin_name_for_binary() {
-        let ps1 = render_stage_sidecar_ps1("my-app", "my-server", true);
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-server", true, "autumn-web");
         assert!(
             ps1.contains("my-server"),
             "stage-sidecar.ps1 must reference the binary target name in copy commands"
@@ -2071,7 +2132,7 @@ mod tests {
         // When the app defines an `embed-assets` Cargo feature, the staging
         // script must pass it (not just the dep path) so that
         // `#[cfg(feature = "embed-assets")]` guards in app code are active.
-        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true, "autumn-web");
         assert!(
             sh.contains("--features embed-assets,autumn-web/managed-pg-bundled"),
             "when app has embed-assets feature the script must use the app-crate feature flag"
@@ -2080,7 +2141,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_sh_falls_back_to_dep_path_when_no_app_feature() {
-        let sh = render_stage_sidecar_sh("my-app", "my-app", false);
+        let sh = render_stage_sidecar_sh("my-app", "my-app", false, "autumn-web");
         assert!(
             sh.contains("--features autumn-web/embed-assets,autumn-web/managed-pg-bundled"),
             "without app-level embed-assets, script must use the dep feature path"
@@ -2113,7 +2174,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_sh_creates_autumn_toml_when_absent() {
-        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true, "autumn-web");
         assert!(
             sh.contains(": > autumn.toml") || sh.contains("> autumn.toml"),
             "staging script must create an empty autumn.toml when none exists \
@@ -2123,7 +2184,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_ps1_creates_autumn_toml_when_absent() {
-        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true);
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true, "autumn-web");
         assert!(
             ps1.contains("autumn.toml"),
             "PowerShell staging script must handle a missing autumn.toml"
@@ -2662,7 +2723,7 @@ mod tests {
 
     #[test]
     fn staging_sh_fingerprints_before_embed() {
-        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true, "autumn-web");
         let fingerprint_pos = sh.find("autumn build --embed").unwrap_or(usize::MAX);
         let cargo_pos = sh.find("cargo build --release").unwrap_or(usize::MAX);
         assert!(
@@ -2675,7 +2736,7 @@ mod tests {
 
     #[test]
     fn staging_sh_fingerprints_includes_package_name() {
-        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true, "autumn-web");
         assert!(
             sh.contains("autumn build --embed -p my-app"),
             "stage-sidecar.sh must pass -p <package> to autumn build --embed so workspace \
@@ -2685,13 +2746,106 @@ mod tests {
 
     #[test]
     fn staging_ps1_fingerprints_before_embed() {
-        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true);
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true, "autumn-web");
         let fingerprint_pos = ps1.find("autumn build --embed").unwrap_or(usize::MAX);
         let cargo_pos = ps1.find("cargo build --release").unwrap_or(usize::MAX);
         assert!(
             fingerprint_pos < cargo_pos,
             "stage-sidecar.ps1 must run `autumn build --embed` before the embed cargo build \
              to fingerprint static/ (mirror the 3-phase autumn build --embed process)"
+        );
+    }
+
+    #[test]
+    fn staging_sh_uses_dep_key_not_package_name_for_features() {
+        // When the app aliases autumn-web as `autumn_web = { package = "autumn-web" }`,
+        // the feature selector must use the dep key "autumn_web", not "autumn-web".
+        let sh = render_stage_sidecar_sh("my-app", "my-app", false, "autumn_web");
+        assert!(
+            sh.contains("autumn_web/embed-assets"),
+            "stage-sidecar.sh must use the dependency key 'autumn_web' in feature selectors, \
+             not the package name 'autumn-web'; got: {sh}"
+        );
+        assert!(
+            sh.contains("autumn_web/managed-pg-bundled"),
+            "stage-sidecar.sh must use the dependency key 'autumn_web' for managed-pg feature; \
+             got: {sh}"
+        );
+    }
+
+    #[test]
+    fn staging_sh_with_embed_assets_uses_dep_key_for_managed_pg() {
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true, "autumn_web");
+        // The app-level embed-assets feature stays as-is; only dep features use the key.
+        assert!(
+            sh.contains("embed-assets,autumn_web/managed-pg-bundled"),
+            "with has_embed_assets=true and dep_key='autumn_web', the feature string must be \
+             'embed-assets,autumn_web/managed-pg-bundled'"
+        );
+    }
+
+    #[test]
+    fn staging_ps1_uses_dep_key_not_package_name_for_features() {
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", false, "autumn_web");
+        assert!(
+            ps1.contains("autumn_web/embed-assets") && ps1.contains("autumn_web/managed-pg-bundled"),
+            "stage-sidecar.ps1 must use the dependency key 'autumn_web' in feature selectors"
+        );
+    }
+
+    #[test]
+    fn plan_uses_dep_key_alias_in_staging_scripts() {
+        // An app that aliases autumn-web as autumn_web must generate staging scripts
+        // with the correct feature key; cargo fails with "Package 'foo' does not have
+        // feature 'autumn-web/managed-pg-bundled'" when the package name is used.
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"my-app\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+             \n[dependencies]\nautumn_web = { package = \"autumn-web\", version = \"0.5\" }\n",
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let sh: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("stage-sidecar.sh action not found");
+        assert!(
+            sh.contains("autumn_web/managed-pg-bundled"),
+            "stage-sidecar.sh must use the dep key 'autumn_web' (not package name 'autumn-web') \
+             when the app aliases the dependency; got: {sh}"
+        );
+        assert!(
+            !sh.contains("autumn-web/managed-pg-bundled"),
+            "stage-sidecar.sh must not contain 'autumn-web/managed-pg-bundled' when the dep is \
+             aliased as 'autumn_web'; Cargo would reject it with 'Package does not have feature'"
+        );
+    }
+
+    #[test]
+    fn lib_rs_writes_signing_secret_with_restricted_permissions() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        // The generated code must use platform-specific file creation so the secret
+        // is not world-readable on Unix (default umask 022 → 0644).
+        assert!(
+            lib.contains("0o600") || lib.contains("OpenOptionsExt"),
+            "load_or_generate_signing_secret must write the secret file with mode 0600 on Unix; \
+             std::fs::write uses the default umask and leaves the file world-readable"
+        );
+        assert!(
+            lib.contains("#[cfg(unix)]"),
+            "signing secret write must be gated on #[cfg(unix)] to use mode 0600 there \
+             while falling back to platform defaults elsewhere"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -312,28 +312,29 @@ pub fn run() {{
                         .unwrap()
                         .take()
                     {{
-                        // Send a graceful shutdown signal so autumn's on_shutdown
-                        // hooks run (including ManagedPostgresPoolProvider::stop()).
-                        // Fall back to force-kill after 3 s on all platforms.
+                        // On Unix: send SIGTERM so autumn's tokio signal handler
+                        // runs on_shutdown hooks (including ManagedPostgresPoolProvider
+                        // ::stop()), then force-kill after 3 s.
+                        // On Windows: autumn only handles tokio::signal::ctrl_c()
+                        // (CTRL_C_EVENT).  taskkill sends WM_CLOSE/CTRL_CLOSE_EVENT
+                        // which autumn does not handle; graceful shutdown via external
+                        // signal is not achievable without process-group manipulation,
+                        // so force-kill immediately.
+                        #[cfg(unix)]
                         let graceful_pid = child.pid();
                         std::thread::spawn(move || {{
-                            // Unix: SIGTERM triggers autumn's tokio signal handler.
                             #[cfg(unix)]
                             {{
                                 let _ = std::process::Command::new("kill")
                                     .args(["-TERM", &graceful_pid.to_string()])
                                     .status();
+                                std::thread::sleep(std::time::Duration::from_secs(3));
+                                let _ = child.kill();
                             }}
-                            // Windows: taskkill without /f sends CTRL_CLOSE_EVENT /
-                            // WM_CLOSE for a graceful-termination attempt.
                             #[cfg(windows)]
                             {{
-                                let _ = std::process::Command::new("taskkill")
-                                    .args(["/pid", &graceful_pid.to_string()])
-                                    .status();
+                                let _ = child.kill();
                             }}
-                            std::thread::sleep(std::time::Duration::from_secs(3));
-                            let _ = child.kill();
                         }});
                     }}
                 }}
@@ -402,6 +403,14 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         // times out and exits.
         .env("AUTUMN_SERVER__UNIX_SOCKET", "")
         .env("AUTUMN_SERVE_FORCE_UNIX_SOCKET", "")
+        // Clear inherited profile-selection vars so the sidecar's compile-time
+        // AUTUMN_IS_DEBUG (baked in by #[autumn_web::main]: "0" for release
+        // builds, "1" for debug) determines the active profile.  Without this,
+        // a shell that exports AUTUMN_ENV=dev causes the installed desktop app
+        // to load dev config regardless of build mode, potentially connecting to
+        // the wrong database or skipping production security settings.
+        .env("AUTUMN_ENV", "")
+        .env("AUTUMN_PROFILE", "")
         .spawn()?;
     *app.state::<SidecarHandle>().0.lock().unwrap() = Some(child);
 
@@ -1289,20 +1298,41 @@ mod tests {
     #[test]
     fn lib_rs_sends_graceful_shutdown_signal_before_kill() {
         let lib = render_shell_lib_rs("my-app");
-        // Graceful shutdown lets autumn's on_shutdown hooks run (including pg.stop()).
-        // Force-kill is the fallback after a timeout.  Both Unix (SIGTERM) and Windows
-        // (taskkill without /f) paths must be present for cross-platform correctness.
+        // Unix: SIGTERM triggers autumn's tokio signal handler so on_shutdown hooks run.
+        // Windows: autumn only handles ctrl_c() (CTRL_C_EVENT); taskkill sends
+        // WM_CLOSE/CTRL_CLOSE_EVENT which autumn does not handle, so we force-kill
+        // immediately without a delay rather than waiting 3 s for a signal that
+        // never arrives.
         assert!(
             lib.contains("SIGTERM") || lib.contains("-TERM"),
             "lib.rs on_window_event must send SIGTERM on Unix before force-killing"
         );
         assert!(
-            lib.contains("taskkill"),
-            "lib.rs on_window_event must use taskkill on Windows for graceful shutdown"
+            !lib.contains("Command::new(\"taskkill\")"),
+            "lib.rs must not invoke taskkill — it sends WM_CLOSE/CTRL_CLOSE_EVENT which \
+             autumn does not handle; use child.kill() directly on Windows"
         );
         assert!(
             lib.contains("pid()"),
-            "lib.rs must call child.pid() to get the sidecar PID for signal/taskkill"
+            "lib.rs must call child.pid() to get the sidecar PID for the Unix kill signal"
+        );
+    }
+
+    #[test]
+    fn lib_rs_clears_inherited_profile_env_vars() {
+        let lib = render_shell_lib_rs("my-app");
+        // If AUTUMN_ENV or AUTUMN_PROFILE is set in the shell that launches the desktop
+        // app, the sidecar would inherit it and load the wrong profile (e.g. dev config
+        // on an installed release app).  Clearing them lets the sidecar's compile-time
+        // AUTUMN_IS_DEBUG auto-detection determine the active profile.
+        assert!(
+            lib.contains("\"AUTUMN_ENV\", \"\""),
+            "lib.rs must clear AUTUMN_ENV so inherited shell profile vars don't \
+             override the sidecar's compile-time profile auto-detection"
+        );
+        assert!(
+            lib.contains("\"AUTUMN_PROFILE\", \"\""),
+            "lib.rs must clear AUTUMN_PROFILE (legacy alias) for the same reason"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -217,12 +217,16 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String, boo
     let bin_name: String = (|| -> Result<String, GenerateError> {
         if let Some(bins) = doc.get("bin").and_then(|b| b.as_array()) {
             // Step 1: explicit [[bin]] entry whose path resolves to src/main.rs.
-            // Normalize the manifest path (strip leading "./" or ".\") before
-            // comparing so "path = './src/main.rs'" matches as well.
+            // Canonicalize by splitting on both separators and filtering empty and
+            // CurDir (".") segments so "src/./main.rs", "./src/main.rs", and
+            // "src/main.rs" all match identically.
             let main_bin = bins.iter().find(|b| {
                 b.get("path").and_then(|p| p.as_str()).is_some_and(|p| {
-                    let norm = p.trim_start_matches("./").trim_start_matches(".\\");
-                    norm == "src/main.rs" || norm == "src\\main.rs"
+                    let segs: Vec<&str> = p
+                        .split(['/', '\\'])
+                        .filter(|&s| !s.is_empty() && s != ".")
+                        .collect();
+                    segs == ["src", "main.rs"]
                 })
             });
             if let Some(n) = main_bin
@@ -464,6 +468,7 @@ tauri-build = {{ version = "2", features = [] }}
 [dependencies]
 tauri = {{ version = "2", features = [] }}
 tauri-plugin-shell = "2"
+getrandom = "0.2"
 
 [profile.release]
 panic = "abort"
@@ -583,6 +588,9 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
     // Postgres cluster (#1119) in db/.  Create proactively; the sidecar won't if absent.
     let app_data_dir = data_root.join("db");
     std::fs::create_dir_all(&app_data_dir)?;
+    // Per-install signing secret: autumn requires one in prod mode.  Generate 32
+    // random bytes on first launch and persist them so tokens survive restarts.
+    let signing_secret = load_or_generate_signing_secret(&data_root);
 
     // autumn.toml is bundled as a Tauri resource (see tauri.conf.json bundle.resources).
     // The sidecar's working directory is set to resource_dir so AutumnConfig finds it.
@@ -642,6 +650,9 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         // unconditionally — the server is loopback-only so no external traffic
         // can reach it regardless of this setting.
         .env("AUTUMN_SECURITY__TRUSTED_HOSTS__HOSTS", "127.0.0.1,localhost")
+        // Per-install signing secret so autumn's prod-mode JWT signing always
+        // has a valid secret and doesn't abort before binding the HTTP port.
+        .env("AUTUMN_SECURITY__SIGNING_SECRET", &signing_secret)
         // Profile selection: in a debug Tauri build (`cargo tauri dev`) the
         // stage-sidecar script always produces a --release sidecar (AUTUMN_IS_DEBUG=0
         // baked in → prod profile), but the developer expects dev config (dev DB,
@@ -749,6 +760,26 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
 
     Ok(())
 }}
+
+/// Generate a 32-byte random signing secret on first launch, persist it to
+/// `{{data_root}}/signing_secret.txt`, and return it as a hex string.
+/// Autumn requires a signing secret in prod mode to sign JWTs / session tokens.
+/// Without this, the release sidecar calls `fail_fast_on_invalid_signing_secret`
+/// and exits before binding the HTTP port, leaving the TCP probe to time out.
+fn load_or_generate_signing_secret(data_root: &std::path::Path) -> String {{
+    let path = data_root.join("signing_secret.txt");
+    if let Ok(s) = std::fs::read_to_string(&path) {{
+        let s = s.trim().to_owned();
+        if s.len() >= 32 {{
+            return s;
+        }}
+    }}
+    let mut bytes = [0u8; 32];
+    getrandom::getrandom(&mut bytes).unwrap_or(());
+    let hex: String = bytes.iter().map(|b| format!("{{b:02x}}")).collect();
+    let _ = std::fs::write(&path, &hex);
+    hex
+}}
 "#
     )
 }
@@ -767,43 +798,36 @@ fn render_placeholder_icon_svg() -> String {
 }
 
 fn render_stage_sidecar_sh(package_name: &str, bin_name: &str, has_embed_assets: bool) -> String {
-    // When the app defines an `embed-assets` Cargo feature (as `autumn new` generates),
-    // enable it so that `#[cfg(feature = "embed-assets")]` guards in app code are
-    // satisfied and `.embedded_static()` is actually wired in.  Fall back to the
-    // dependency path when the app doesn't define its own feature alias.
+    // Use the app-level alias when present; fall back to the crate feature path.
     let embed_feature = if has_embed_assets {
         "embed-assets,autumn-web/managed-pg-bundled"
     } else {
         "autumn-web/embed-assets,autumn-web/managed-pg-bundled"
     };
+    // Only fingerprint when the app-level alias exists; `autumn build --embed` passes
+    // --features embed-assets (app-level), which fails for apps without that alias.
+    let fingerprint = if has_embed_assets {
+        format!("autumn build --embed -p {package_name}\n")
+    } else {
+        String::new()
+    };
     format!(
         r#"#!/usr/bin/env bash
-# Build the autumn server sidecar with embedded assets and managed Postgres,
-# then place it in src-tauri/binaries/ for Tauri to bundle.
-#
+# Build the autumn server sidecar (embedded assets + managed Postgres) and
+# place it in src-tauri/binaries/ for Tauri to bundle.
 # Wired into tauri.conf.json > build.beforeBuildCommand.
 # Run manually: bash src-tauri/stage-sidecar.sh
-#
-# Requires autumn features:
-#   embed-assets / autumn-web/embed-assets  (#1004 — single-binary asset embed)
-#   autumn-web/managed-pg-bundled           (#1119 — bundled Postgres, no external install)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
 APP_DIR="$(dirname "$SCRIPT_DIR")"
 cd "$APP_DIR"
-# TAURI_ENV_TARGET_TRIPLE is set by `cargo tauri build` for cross-compilation;
-# fall back to the host triple when running the script manually.
+# TAURI_ENV_TARGET_TRIPLE is set by Tauri for cross-compilation; fall back to host.
 TARGET_TRIPLE="${{TAURI_ENV_TARGET_TRIPLE:-$(rustc -Vv | awk '/^host/{{print $2}}')}}";
-# Resolve the real Cargo output directory.  Workspace members share the workspace
-# root's target/ and CARGO_TARGET_DIR / .cargo/config.toml can redirect it.
+# Resolve Cargo output dir (CARGO_TARGET_DIR or workspace target/).
 TARGET_DIR="${{CARGO_TARGET_DIR:-$(cargo metadata --no-deps --format-version 1 --quiet \
     | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')}}"
 mkdir -p src-tauri/binaries
-# Fingerprint static/ before the embed compile (mirrors autumn build --embed phases 1-2):
-# compile → write .autumn-manifest.json → the target-specific cargo build below embeds it.
-autumn build --embed -p {package_name}
-# universal-apple-darwin is a Tauri meta-target, not a rustc triple.  Build both
-# Darwin slices separately and combine with lipo(1) into a fat binary.
+{fingerprint}# universal-apple-darwin: build both Darwin slices and lipo them together.
 if [ "${{TARGET_TRIPLE}}" = "universal-apple-darwin" ]; then
     for ARCH in x86_64-apple-darwin aarch64-apple-darwin; do
         cargo build --release --target "$ARCH" --bin {bin_name} \
@@ -879,6 +903,15 @@ fn render_stage_sidecar_ps1(package_name: &str, bin_name: &str, has_embed_assets
     } else {
         "autumn-web/embed-assets,autumn-web/managed-pg-bundled"
     };
+    let fingerprint = if has_embed_assets {
+        format!(
+            "# Fingerprint static/ before the embed compile (mirrors autumn build --embed phases 1-2):\n\
+             # compile → write .autumn-manifest.json → the cargo build below embeds it.\n\
+             autumn build --embed -p {package_name}\n"
+        )
+    } else {
+        String::new()
+    };
     format!(
         r#"# Build the autumn server sidecar with embedded assets and managed Postgres,
 # then place it in src-tauri\binaries\ for Tauri to bundle.
@@ -902,12 +935,7 @@ $TargetDir = $Env:CARGO_TARGET_DIR
 if (-not $TargetDir) {{
     $TargetDir = (cargo metadata --no-deps --format-version 1 --quiet | ConvertFrom-Json).target_directory
 }}
-# Fingerprint static/ so include_dir! bakes current hashed asset URLs into the sidecar.
-# autumn build --embed runs: compile → fingerprint static/ → embed compile (host arch).
-# The target-specific cargo build below then bakes the fingerprinted tree.
-# autumn must be installed: cargo install autumn-cli (already needed for `autumn generate`).
-autumn build --embed -p {package_name}
-New-Item -ItemType Directory -Force -Path src-tauri\binaries | Out-Null
+{fingerprint}New-Item -ItemType Directory -Force -Path src-tauri\binaries | Out-Null
 cargo build --release --target "$TargetTriple" --bin {bin_name} `
   --features {embed_feature}
 Copy-Item "$TargetDir\$TargetTriple\release\{bin_name}.exe" `
@@ -1107,6 +1135,23 @@ mod tests {
             format!(
                 "[package]\nname=\"{pkg_name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
                  \n[[bin]]\nname=\"{bin_name}\"\npath=\"./src/main.rs\"\n\
+                 \n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        tmp
+    }
+
+    /// Project whose `[[bin]] path` contains a middle `.` component (`src/./main.rs`).
+    fn project_with_middle_dot_bin(pkg_name: &str, bin_name: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+                 \n[[bin]]\nname=\"{bin_name}\"\npath=\"src/./main.rs\"\n\
                  \n[dependencies]\nautumn-web = \"0.5.0\"\n"
             ),
         )
@@ -1637,6 +1682,34 @@ mod tests {
         assert!(
             !sh.contains("--bin my-app"),
             "generator must not fall back to package name for a ./src/main.rs [[bin]] path"
+        );
+    }
+
+    #[test]
+    fn plan_normalizes_middle_dot_bin_path() {
+        // [[bin]] path = "src/./main.rs" (CurDir component in the middle) must
+        // canonicalize to src/main.rs, identifying it as the main binary entry point.
+        let tmp = project_with_middle_dot_bin("my-app", "my-server");
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let sh: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("stage-sidecar.sh action not found");
+        assert!(
+            sh.contains("my-server"),
+            "[[bin]] with path='src/./main.rs' must resolve to the custom bin name (not package name)"
+        );
+        assert!(
+            !sh.contains("--bin my-app"),
+            "generator must canonicalize 'src/./main.rs' and not fall back to the package name"
         );
     }
 
@@ -2366,6 +2439,45 @@ mod tests {
             lib.contains("data_root") && lib.contains("join(\"blobs\")"),
             "AUTUMN_STORAGE__LOCAL__ROOT must point to a writable subdirectory of \
              app_data_dir (e.g. data_root.join(\"blobs\")), not the read-only resource_dir"
+        );
+    }
+
+    #[test]
+    fn lib_rs_generates_per_install_signing_secret() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        assert!(
+            lib.contains("load_or_generate_signing_secret"),
+            "lib.rs must define load_or_generate_signing_secret() so a per-install signing \
+             secret is generated on first launch; without it, autumn's prod mode calls \
+             fail_fast_on_invalid_signing_secret and aborts before binding the HTTP port"
+        );
+        assert!(
+            lib.contains("getrandom::getrandom"),
+            "load_or_generate_signing_secret must use getrandom to produce cryptographic \
+             randomness; a weak source would allow signing secret prediction"
+        );
+        assert!(
+            lib.contains("signing_secret.txt"),
+            "load_or_generate_signing_secret must persist the secret to a file so it \
+             survives app restarts; re-generating on every launch would invalidate all \
+             existing sessions"
+        );
+    }
+
+    #[test]
+    fn lib_rs_sets_signing_secret_env_var() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        assert!(
+            lib.contains("AUTUMN_SECURITY__SIGNING_SECRET"),
+            "lib.rs must pass AUTUMN_SECURITY__SIGNING_SECRET to the sidecar; without it \
+             autumn's prod mode calls fail_fast_on_invalid_signing_secret and exits before \
+             binding the HTTP port, causing the TCP health probe to time out"
+        );
+        // The env var must be set using the local signing_secret variable.
+        assert!(
+            lib.contains("signing_secret"),
+            "AUTUMN_SECURITY__SIGNING_SECRET must be sourced from the signing_secret local \
+             variable returned by load_or_generate_signing_secret"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -190,7 +190,9 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String, boo
     //   3. `[package] default-run` — the developer's declared preference when there
     //      are multiple explicit [[bin]] entries and no src/main.rs.
     //   4. `bins.first()` — last resort when only one [[bin]] is declared.
-    //   5. The package name (Cargo default when no [[bin]] is declared).
+    //   5. No [[bin]] table at all: honour `default-run` first; then if exactly one
+    //      `src/bin/*.rs` file exists, Cargo auto-discovers it (named after the stem,
+    //      not the package), so use that stem; otherwise fall back to the package name.
     let default_run = pkg
         .get("default-run")
         .and_then(|v| v.as_str())
@@ -199,8 +201,35 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String, boo
         .get("bin")
         .and_then(|b| b.as_array())
         .map_or_else(
-            // Step 5: no [[bin]] at all — package name is the binary name.
-            || name.clone(),
+            // Step 5: no [[bin]] table — honour default-run, then src/bin/ discovery,
+            // then fall back to the package name (which Cargo uses for src/main.rs).
+            || {
+                if let Some(dr) = &default_run {
+                    return dr.clone();
+                }
+                // Inspect src/bin/ for auto-discovered binaries.  Cargo names each
+                // binary after the file stem (not the package), so `src/bin/web.rs`
+                // produces a `web` binary, not `<package>`.
+                if let Ok(entries) = std::fs::read_dir(project_root.join("src/bin")) {
+                    let stems: Vec<String> = entries
+                        .filter_map(std::result::Result::ok)
+                        .filter_map(|e| {
+                            let p = e.path();
+                            if p.extension().is_some_and(|x| x == "rs") {
+                                p.file_stem()
+                                    .and_then(|s| s.to_str())
+                                    .map(str::to_owned)
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    if stems.len() == 1 {
+                        return stems.into_iter().next().unwrap();
+                    }
+                }
+                name.clone()
+            },
             |bins| {
                 // Step 1: explicit [[bin]] entry whose path is src/main.rs.
                 bins.iter()
@@ -534,6 +563,14 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         // the wrong database or skipping production security settings.
         .env("AUTUMN_ENV", "")
         .env("AUTUMN_PROFILE", "")
+        // Clear one-off mode flags inherited from the calling environment.
+        // If any of these are set, AppBuilder::run() enters a non-serving mode
+        // (asset fingerprinting, route dump, task execution) and exits before
+        // binding the HTTP port — leaving the TCP health probe to time out.
+        .env("AUTUMN_BUILD_STATIC", "")
+        .env("AUTUMN_DUMP_ROUTES", "")
+        .env("AUTUMN_LIST_TASKS", "")
+        .env("AUTUMN_RUN_TASK", "")
         .spawn()?;
     *app.state::<SidecarHandle>().0.lock().unwrap() = Some(child);
 
@@ -1042,6 +1079,27 @@ mod tests {
         tmp
     }
 
+    /// Project with a single `src/bin/<bin_name>.rs` and no `src/main.rs` or
+    /// `[[bin]]` — Cargo auto-discovers the binary named after the file stem.
+    fn project_with_src_bin(pkg_name: &str, bin_stem: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+                 \n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src/bin")).unwrap();
+        fs::write(
+            tmp.path().join(format!("src/bin/{bin_stem}.rs")),
+            "fn main() {}\n",
+        )
+        .unwrap();
+        tmp
+    }
+
     // ── plan_tauri: error cases ───────────────────────────────────────────────
 
     #[test]
@@ -1448,6 +1506,34 @@ mod tests {
     }
 
     #[test]
+    fn plan_detects_src_bin_auto_discovered_binary() {
+        // A package with src/bin/web.rs and no src/main.rs or [[bin]] table —
+        // Cargo auto-discovers it as binary "web" (file stem, not package name).
+        let tmp = project_with_src_bin("my-app", "web");
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let sh: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("stage-sidecar.sh action not found");
+        assert!(
+            sh.contains("--bin web"),
+            "staging script must use the src/bin/ file stem 'web', not the package name 'my-app'"
+        );
+        assert!(
+            !sh.contains("--bin my-app"),
+            "staging script must not use the package name when a src/bin/ binary is auto-discovered"
+        );
+    }
+
+    #[test]
     fn stage_sidecar_sh_uses_app_embed_feature_when_defined() {
         // When the app defines an `embed-assets` Cargo feature, the staging
         // script must pass it (not just the dep path) so that
@@ -1804,6 +1890,23 @@ mod tests {
             lib.contains("\"AUTUMN_PROFILE\", \"\""),
             "lib.rs must clear AUTUMN_PROFILE (legacy alias) for the same reason"
         );
+    }
+
+    #[test]
+    fn lib_rs_clears_one_off_mode_env_vars() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        for var in &[
+            "AUTUMN_BUILD_STATIC",
+            "AUTUMN_DUMP_ROUTES",
+            "AUTUMN_LIST_TASKS",
+            "AUTUMN_RUN_TASK",
+        ] {
+            assert!(
+                lib.contains(&format!("\"{var}\", \"\"")),
+                "lib.rs must clear {var} so an inherited one-off mode flag \
+                 doesn't prevent the sidecar from binding its HTTP port"
+            );
+        }
     }
 
     #[test]

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -166,10 +166,12 @@ fn render_tauri_conf(package_name: &str) -> String {
     // beforeBuildCommand must use the native shell for the host OS.
     // cfg!(windows) is evaluated when the generator binary compiles, which runs on
     // the same host where `cargo tauri build` will later be invoked.
+    // Use `bash` explicitly — the staging script uses BASH_SOURCE and `pipefail`,
+    // which are not supported by POSIX `sh` (e.g. dash on Debian/Ubuntu).
     let before_build_cmd = if cfg!(windows) {
         "powershell -ExecutionPolicy Bypass -File stage-sidecar.ps1"
     } else {
-        "sh stage-sidecar.sh"
+        "bash stage-sidecar.sh"
     };
     format!(
         r#"{{
@@ -424,8 +426,12 @@ cd "$APP_DIR"
 # TAURI_ENV_TARGET_TRIPLE is set by `cargo tauri build` for cross-compilation;
 # fall back to the host triple when running the script manually.
 TARGET_TRIPLE="${{TAURI_ENV_TARGET_TRIPLE:-$(rustc -Vv | awk '/^host/{{print $2}}')}}";
+# Use the app-level `embed-assets` feature (not `autumn-web/embed-assets` directly)
+# so that #[cfg(feature = "embed-assets")] in the scaffolded main.rs activates
+# the .embedded_static() wiring.  autumn-web/managed-pg-bundled has no app-level
+# analog so it must be addressed via the dependency path.
 cargo build --release --target "${{TARGET_TRIPLE}}" \
-  --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
+  --features embed-assets,autumn-web/managed-pg-bundled
 mkdir -p src-tauri/binaries
 cp "target/${{TARGET_TRIPLE}}/release/{package_name}" \
    "src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
@@ -452,8 +458,11 @@ $TargetTriple = $Env:TAURI_ENV_TARGET_TRIPLE
 if (-not $TargetTriple) {{
     $TargetTriple = (rustc -Vv | Select-String "^host").Line.Split()[1]
 }}
+# Use the app-level embed-assets feature (not autumn-web/embed-assets directly)
+# so that #[cfg(feature = "embed-assets")] in the scaffolded main.rs activates
+# the .embedded_static() wiring.
 cargo build --release --target "$TargetTriple" `
-  --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
+  --features embed-assets,autumn-web/managed-pg-bundled
 New-Item -ItemType Directory -Force -Path src-tauri\binaries | Out-Null
 Copy-Item "target\$TargetTriple\release\{package_name}.exe" `
           "src-tauri\binaries\{package_name}-$TargetTriple.exe"
@@ -486,7 +495,7 @@ Required prerequisites for `cargo tauri build`:\n\
   4. Build the desktop app:\n\
        cd src-tauri && cargo tauri build\n\
 \n\
-  The sidecar is built with autumn-web/embed-assets (#1004) and\n\
+  The sidecar is built with the app-level embed-assets feature (#1004) and\n\
   autumn-web/managed-pg-bundled (#1119) so the packaged desktop app needs\n\
   no separately-installed database or loose asset files.\n\
 \n\

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -54,14 +54,14 @@ use super::{Flags, GenerateError, ensure_project_root};
 pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
     ensure_project_root(project_root)?;
 
-    let (package_name, package_version) = read_package_meta(project_root)?;
+    let (package_name, package_version, bin_name) = read_package_meta(project_root)?;
     let mut plan = Plan::new(project_root);
     let tauri = project_root.join("src-tauri");
 
     // Core Tauri project files
     plan.create(
         tauri.join("tauri.conf.json"),
-        render_tauri_conf(&package_name, &package_version),
+        render_tauri_conf(&package_name, &package_version, &bin_name),
     );
     plan.create(
         tauri.join("Cargo.toml"),
@@ -74,7 +74,7 @@ pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
     );
     plan.create(
         tauri.join("src").join("lib.rs"),
-        render_shell_lib_rs(&package_name),
+        render_shell_lib_rs(&package_name, &bin_name),
     );
 
     // Icons — reuse the PWA icon when the user already ran `autumn generate pwa`
@@ -98,11 +98,11 @@ pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
     // Staging scripts
     plan.create(
         tauri.join("stage-sidecar.sh"),
-        render_stage_sidecar_sh(&package_name),
+        render_stage_sidecar_sh(&package_name, &bin_name),
     );
     plan.create(
         tauri.join("stage-sidecar.ps1"),
-        render_stage_sidecar_ps1(&package_name),
+        render_stage_sidecar_ps1(&package_name, &bin_name),
     );
     plan.create(tauri.join(".gitignore"), render_gitignore());
 
@@ -133,7 +133,19 @@ pub fn run(flags: Flags) {
 
 // ── Package metadata helper ───────────────────────────────────────────────────
 
-fn read_package_meta(project_root: &Path) -> Result<(String, String), GenerateError> {
+/// Returns `(package_name, version, bin_name)`.
+///
+/// `bin_name` is the Cargo binary target name used for the sidecar — it
+/// matches the filename `cargo build` writes under `target/.../release/`.
+/// When no `[[bin]]` section is declared, Cargo defaults to `src/main.rs`
+/// with the same name as the package, so `bin_name == package_name` in that
+/// common case.  When `[[bin]] name = "…"` is set, Cargo writes that name
+/// instead, so staging scripts and Tauri's `.sidecar()` call must use it.
+///
+/// `version` resolves workspace inheritance: if `[package] version.workspace
+/// = true` the function walks up the directory tree to find
+/// `[workspace.package] version` in an ancestor `Cargo.toml`.
+fn read_package_meta(project_root: &Path) -> Result<(String, String, String), GenerateError> {
     let cargo_path = project_root.join("Cargo.toml");
     let content = std::fs::read_to_string(&cargo_path).map_err(GenerateError::Io)?;
     let doc: toml::Value = toml::from_str(&content)
@@ -146,17 +158,71 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String), GenerateEr
         .and_then(|n| n.as_str())
         .map(str::to_owned)
         .ok_or_else(|| GenerateError::Config("Cargo.toml missing [package].name".to_owned()))?;
-    let version = pkg
-        .get("version")
-        .and_then(|v| v.as_str())
-        .unwrap_or("0.1.0")
+
+    // Resolve version, handling workspace inheritance (`version.workspace = true`).
+    let version = match pkg.get("version") {
+        Some(toml::Value::String(s)) => s.clone(),
+        Some(toml::Value::Table(t))
+            if t.get("workspace").and_then(|v| v.as_bool()) == Some(true) =>
+        {
+            resolve_workspace_version(project_root).unwrap_or_else(|| "0.1.0".to_owned())
+        }
+        _ => "0.1.0".to_owned(),
+    };
+
+    // Derive the binary target name from [[bin]] sections.  When a custom name
+    // is set, `cargo build` writes that name (not the package name) under
+    // `target/.../release/`.  Prefer the bin whose path is `src/main.rs`
+    // (the primary entry point), then fall back to the first declared bin, then
+    // the package name (the Cargo default when no [[bin]] is declared).
+    let bin_name = doc
+        .get("bin")
+        .and_then(|b| b.as_array())
+        .and_then(|bins| {
+            bins.iter()
+                .find(|b| {
+                    b.get("path")
+                        .and_then(|p| p.as_str())
+                        .is_some_and(|p| p == "src/main.rs" || p == "src\\main.rs")
+                })
+                .or_else(|| bins.first())
+                .and_then(|b| b.get("name"))
+                .and_then(|n| n.as_str())
+        })
+        .unwrap_or(&name)
         .to_owned();
-    Ok((name, version))
+
+    Ok((name, version, bin_name))
+}
+
+/// Walk from `project_root` upward looking for a `Cargo.toml` that declares
+/// `[workspace.package] version = "…"`.  Returns `None` if not found.
+fn resolve_workspace_version(project_root: &Path) -> Option<String> {
+    let mut dir: Option<&Path> = Some(project_root);
+    while let Some(d) = dir {
+        let cargo = d.join("Cargo.toml");
+        if cargo.is_file() {
+            if let Ok(content) = std::fs::read_to_string(&cargo) {
+                if let Ok(doc) = toml::from_str::<toml::Value>(&content) {
+                    if let Some(v) = doc
+                        .get("workspace")
+                        .and_then(|w| w.get("package"))
+                        .and_then(|p| p.get("version"))
+                        .and_then(|v| v.as_str())
+                    {
+                        return Some(v.to_owned());
+                    }
+                }
+            }
+        }
+        dir = d.parent();
+    }
+    None
 }
 
 // ── Content renderers ─────────────────────────────────────────────────────────
 
-fn render_tauri_conf(package_name: &str, version: &str) -> String {
+fn render_tauri_conf(package_name: &str, version: &str, bin_name: &str) -> String {
     // Bundle identifier: reverse-DNS with underscores replaced by hyphens.
     // Apple's spec allows only alphanumerics, hyphens, and periods — underscores are invalid.
     let identifier = format!("com.example.{}", package_name.replace('_', "-"));
@@ -210,7 +276,7 @@ fn render_tauri_conf(package_name: &str, version: &str) -> String {
       "icons/icon.icns"
     ],
     "externalBin": [
-      "binaries/{package_name}"
+      "binaries/{bin_name}"
     ],
     "resources": {{
       "../autumn.toml": "autumn.toml",
@@ -277,7 +343,7 @@ fn render_shell_main_rs(package_name: &str) -> String {
 }
 
 #[allow(clippy::too_many_lines)]
-fn render_shell_lib_rs(package_name: &str) -> String {
+fn render_shell_lib_rs(package_name: &str, bin_name: &str) -> String {
     format!(
         r#"//! Tauri desktop shell for {package_name}.
 //!
@@ -384,7 +450,7 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
     //    The sidecar() argument is the binary basename matching externalBin in tauri.conf.json.
     let (_rx, child) = app
         .shell()
-        .sidecar("{package_name}")?
+        .sidecar("{bin_name}")?
         // Working directory = resource dir so autumn.toml is found via CWD fallback.
         .current_dir(&resource_dir)
         .env("AUTUMN_SERVER__HOST", "127.0.0.1")
@@ -526,7 +592,7 @@ fn render_placeholder_icon_svg() -> String {
     .to_owned()
 }
 
-fn render_stage_sidecar_sh(package_name: &str) -> String {
+fn render_stage_sidecar_sh(_package_name: &str, bin_name: &str) -> String {
     format!(
         r#"#!/usr/bin/env bash
 # Build the autumn server sidecar with embedded assets and managed Postgres,
@@ -554,23 +620,23 @@ mkdir -p src-tauri/binaries
 # Darwin slices separately and combine with lipo(1) into a fat binary.
 if [ "${{TARGET_TRIPLE}}" = "universal-apple-darwin" ]; then
     for ARCH in x86_64-apple-darwin aarch64-apple-darwin; do
-        cargo build --release --target "$ARCH" \
+        cargo build --release --target "$ARCH" --bin {bin_name} \
           --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
     done
-    lipo -create -output "src-tauri/binaries/{package_name}-universal-apple-darwin" \
-      "${{TARGET_DIR}}/x86_64-apple-darwin/release/{package_name}" \
-      "${{TARGET_DIR}}/aarch64-apple-darwin/release/{package_name}"
-    echo "Staged (universal): src-tauri/binaries/{package_name}-universal-apple-darwin"
+    lipo -create -output "src-tauri/binaries/{bin_name}-universal-apple-darwin" \
+      "${{TARGET_DIR}}/x86_64-apple-darwin/release/{bin_name}" \
+      "${{TARGET_DIR}}/aarch64-apple-darwin/release/{bin_name}"
+    echo "Staged (universal): src-tauri/binaries/{bin_name}-universal-apple-darwin"
 else
     # Build with both autumn-web features so the sidecar binary embeds static assets
     # and bundles Postgres.  Both are specified via the dependency path so this script
     # works with any autumn project regardless of whether the app's Cargo.toml defines
     # a top-level `embed-assets` feature alias.
-    cargo build --release --target "${{TARGET_TRIPLE}}" \
+    cargo build --release --target "${{TARGET_TRIPLE}}" --bin {bin_name} \
       --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
-    cp "${{TARGET_DIR}}/${{TARGET_TRIPLE}}/release/{package_name}" \
-       "src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
-    echo "Staged: src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
+    cp "${{TARGET_DIR}}/${{TARGET_TRIPLE}}/release/{bin_name}" \
+       "src-tauri/binaries/{bin_name}-${{TARGET_TRIPLE}}"
+    echo "Staged: src-tauri/binaries/{bin_name}-${{TARGET_TRIPLE}}"
 fi
 # Stage profile config files into src-tauri/configs/ so tauri.conf.json resource
 # entries are always satisfiable at bundle time.
@@ -619,7 +685,7 @@ done
     )
 }
 
-fn render_stage_sidecar_ps1(package_name: &str) -> String {
+fn render_stage_sidecar_ps1(_package_name: &str, bin_name: &str) -> String {
     format!(
         r#"# Build the autumn server sidecar with embedded assets and managed Postgres,
 # then place it in src-tauri\binaries\ for Tauri to bundle.
@@ -647,12 +713,12 @@ if (-not $TargetDir) {{
 # and bundles Postgres.  Both are specified via the dependency path so this script
 # works with any autumn project regardless of whether the app's Cargo.toml defines
 # a top-level `embed-assets` feature alias.
-cargo build --release --target "$TargetTriple" `
+cargo build --release --target "$TargetTriple" --bin {bin_name} `
   --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
 New-Item -ItemType Directory -Force -Path src-tauri\binaries | Out-Null
-Copy-Item "$TargetDir\$TargetTriple\release\{package_name}.exe" `
-          "src-tauri\binaries\{package_name}-$TargetTriple.exe"
-Write-Host "Staged: src-tauri/binaries/{package_name}-$TargetTriple.exe"
+Copy-Item "$TargetDir\$TargetTriple\release\{bin_name}.exe" `
+          "src-tauri\binaries\{bin_name}-$TargetTriple.exe"
+Write-Host "Staged: src-tauri/binaries/{bin_name}-$TargetTriple.exe"
 # Stage profile config files into src-tauri\configs\ so tauri.conf.json resource
 # entries are always satisfiable at bundle time.
 # For alias pairs (prod/production, dev/development): AutumnConfig stops at the
@@ -812,6 +878,38 @@ mod tests {
         tmp
     }
 
+    fn project_with_custom_bin(pkg_name: &str, bin_name: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+                 \n[[bin]]\nname=\"{bin_name}\"\npath=\"src/main.rs\"\n\
+                 \n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        tmp
+    }
+
+    fn project_with_workspace_version(pkg_name: &str, ws_version: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion.workspace = true\nedition=\"2024\"\n\
+                 \n[workspace]\n\n[workspace.package]\nversion=\"{ws_version}\"\n\
+                 \n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        tmp
+    }
+
     // ── plan_tauri: error cases ───────────────────────────────────────────────
 
     #[test]
@@ -888,7 +986,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_sh_uses_cargo_metadata_for_target_dir() {
-        let sh = render_stage_sidecar_sh("my-app");
+        let sh = render_stage_sidecar_sh("my-app", "my-app");
         // cargo metadata resolves the real output dir for workspace members and
         // respects CARGO_TARGET_DIR overrides.
         assert!(
@@ -909,7 +1007,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_sh_handles_universal_apple_darwin() {
-        let sh = render_stage_sidecar_sh("my-app");
+        let sh = render_stage_sidecar_sh("my-app", "my-app");
         // universal-apple-darwin is a Tauri meta-target; cargo build --target
         // universal-apple-darwin fails because rustc doesn't know it.
         assert!(
@@ -928,7 +1026,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_ps1_uses_cargo_metadata_for_target_dir() {
-        let ps1 = render_stage_sidecar_ps1("my-app");
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app");
         assert!(
             ps1.contains("cargo metadata"),
             "stage-sidecar.ps1 must use `cargo metadata` to locate the Cargo target directory"
@@ -945,7 +1043,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_sh_stages_profile_configs() {
-        let sh = render_stage_sidecar_sh("my-app");
+        let sh = render_stage_sidecar_sh("my-app", "my-app");
         // Profile configs are staged at build time (beforeBuildCommand) so that the
         // static resource entries in tauri.conf.json are always satisfiable — even when
         // autumn-prod.toml is created after `autumn generate tauri` was run.
@@ -962,7 +1060,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_ps1_stages_profile_configs() {
-        let ps1 = render_stage_sidecar_ps1("my-app");
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app");
         assert!(
             ps1.contains("src-tauri\\configs") || ps1.contains("src-tauri/configs"),
             "stage-sidecar.ps1 must create src-tauri\\configs\\ and populate it with \
@@ -979,7 +1077,7 @@ mod tests {
     // real config because AutumnConfig stops at the first existing file in the lookup list.
     #[test]
     fn stage_sidecar_sh_copies_alias_to_both_names() {
-        let sh = render_stage_sidecar_sh("my-app");
+        let sh = render_stage_sidecar_sh("my-app", "my-app");
         // Must handle the case where only autumn-production.toml exists by copying it
         // to autumn-prod.toml as well — look for the elif + both cp lines.
         assert!(
@@ -1001,7 +1099,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_ps1_copies_alias_to_both_names() {
-        let ps1 = render_stage_sidecar_ps1("my-app");
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app");
         assert!(
             ps1.contains("autumn-production.toml") && ps1.contains("autumn-prod.toml"),
             "stage-sidecar.ps1 must handle prod/production alias pair explicitly"
@@ -1048,7 +1146,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_is_valid_json() {
-        let conf = render_tauri_conf("my-app", "0.1.0");
+        let conf = render_tauri_conf("my-app", "0.1.0", "my-app");
         let parsed: serde_json::Value =
             serde_json::from_str(&conf).expect("tauri.conf.json must be valid JSON");
         assert!(parsed.is_object());
@@ -1056,7 +1154,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_uses_package_version() {
-        let conf = render_tauri_conf("my-app", "1.4.2");
+        let conf = render_tauri_conf("my-app", "1.4.2", "my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         assert_eq!(
             parsed["version"].as_str(),
@@ -1067,8 +1165,102 @@ mod tests {
     }
 
     #[test]
+    fn tauri_conf_externalbin_uses_bin_name() {
+        let conf = render_tauri_conf("my-app", "0.1.0", "my-server");
+        let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
+        let ext_bin = parsed["bundle"]["externalBin"][0].as_str().unwrap_or("");
+        assert!(
+            ext_bin.contains("my-server"),
+            "externalBin must use the [[bin]] target name, not the package name; got: {ext_bin}"
+        );
+        assert!(
+            !ext_bin.contains("my-app"),
+            "externalBin must not use the package name when [[bin]] name differs; got: {ext_bin}"
+        );
+    }
+
+    #[test]
+    fn stage_sidecar_sh_uses_bin_name_for_binary() {
+        let sh = render_stage_sidecar_sh("my-app", "my-server");
+        assert!(
+            sh.contains("my-server"),
+            "stage-sidecar.sh must reference the binary target name in copy commands"
+        );
+        assert!(
+            !sh.contains("/release/my-app") && !sh.contains("my-app-$"),
+            "stage-sidecar.sh must not use the package name for the compiled binary path \
+             when the [[bin]] name differs"
+        );
+    }
+
+    #[test]
+    fn stage_sidecar_ps1_uses_bin_name_for_binary() {
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-server");
+        assert!(
+            ps1.contains("my-server"),
+            "stage-sidecar.ps1 must reference the binary target name in copy commands"
+        );
+        assert!(
+            !ps1.contains("release\\my-app") && !ps1.contains("my-app-$"),
+            "stage-sidecar.ps1 must not use the package name for the compiled binary path \
+             when the [[bin]] name differs"
+        );
+    }
+
+    #[test]
+    fn plan_reads_custom_bin_name_from_cargo_toml() {
+        let tmp = project_with_custom_bin("my-app", "my-server");
+        let plan = plan_tauri(tmp.path()).unwrap();
+        // The staging script must use the [[bin]] name, not the package name.
+        let sh: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("stage-sidecar.sh action not found");
+        assert!(
+            sh.contains("my-server"),
+            "stage-sidecar.sh must use [[bin]] name 'my-server' for the compiled binary"
+        );
+        assert!(
+            !sh.contains("/release/my-app"),
+            "stage-sidecar.sh must not hardcode the package name 'my-app' as the binary path"
+        );
+    }
+
+    #[test]
+    fn plan_resolves_workspace_inherited_version() {
+        let tmp = project_with_workspace_version("my-app", "3.1.4");
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let conf: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("tauri.conf.json"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("tauri.conf.json action not found");
+        let parsed: serde_json::Value = serde_json::from_str(conf).unwrap();
+        assert_eq!(
+            parsed["version"].as_str(),
+            Some("3.1.4"),
+            "tauri.conf.json must use the resolved workspace version, not fall back to 0.1.0"
+        );
+    }
+
+    #[test]
     fn tauri_conf_has_identifier() {
-        let conf = render_tauri_conf("my-app", "0.1.0");
+        let conf = render_tauri_conf("my-app", "0.1.0", "my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         assert!(
             parsed["identifier"].is_string(),
@@ -1082,7 +1274,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_product_name() {
-        let conf = render_tauri_conf("my-app", "0.1.0");
+        let conf = render_tauri_conf("my-app", "0.1.0", "my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         assert!(
             parsed["productName"].is_string(),
@@ -1092,7 +1284,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_external_bin() {
-        let conf = render_tauri_conf("my-app", "0.1.0");
+        let conf = render_tauri_conf("my-app", "0.1.0", "my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let bins = parsed["bundle"]["externalBin"]
             .as_array()
@@ -1107,7 +1299,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_icon_array() {
-        let conf = render_tauri_conf("my-app", "0.1.0");
+        let conf = render_tauri_conf("my-app", "0.1.0", "my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let icons = parsed["bundle"]["icon"]
             .as_array()
@@ -1121,7 +1313,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_before_build_command() {
-        let conf = render_tauri_conf("my-app", "0.1.0");
+        let conf = render_tauri_conf("my-app", "0.1.0", "my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let cmd = parsed["build"]["beforeBuildCommand"]
             .as_str()
@@ -1183,7 +1375,7 @@ mod tests {
 
     #[test]
     fn lib_rs_binds_loopback_ephemeral_port() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         assert!(
             lib.contains("127.0.0.1:0"),
             "lib.rs must bind loopback:0 to find a free ephemeral port"
@@ -1192,7 +1384,7 @@ mod tests {
 
     #[test]
     fn lib_rs_sets_autumn_server_port_env() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         assert!(
             lib.contains("AUTUMN_SERVER__PORT"),
             "lib.rs must pass AUTUMN_SERVER__PORT to the sidecar"
@@ -1201,7 +1393,7 @@ mod tests {
 
     #[test]
     fn lib_rs_sets_autumn_server_host_env() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         assert!(
             lib.contains("AUTUMN_SERVER__HOST"),
             "lib.rs must pass AUTUMN_SERVER__HOST to the sidecar"
@@ -1210,7 +1402,7 @@ mod tests {
 
     #[test]
     fn lib_rs_sets_managed_pg_data_dir() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         assert!(
             lib.contains("AUTUMN_MANAGED_PG_DATA_DIR"),
             "lib.rs must pass AUTUMN_MANAGED_PG_DATA_DIR for managed Postgres (#1119)"
@@ -1219,7 +1411,7 @@ mod tests {
 
     #[test]
     fn lib_rs_spawns_sidecar() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         assert!(
             lib.contains(".sidecar("),
             "lib.rs must spawn the sidecar via tauri-plugin-shell"
@@ -1232,7 +1424,7 @@ mod tests {
 
     #[test]
     fn lib_rs_polls_for_http_response() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         // Probe accepts any valid HTTP response rather than a specific path/status,
         // so it works regardless of the app's health route configuration.
         assert!(
@@ -1247,7 +1439,7 @@ mod tests {
 
     #[test]
     fn lib_rs_kills_sidecar_on_window_destroyed() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         assert!(
             lib.contains("Destroyed"),
             "lib.rs must handle WindowEvent::Destroyed"
@@ -1265,7 +1457,7 @@ mod tests {
 
     #[test]
     fn lib_rs_pg_data_dir_uses_db_subdirectory() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         assert!(
             lib.contains(".join(\"db\")"),
             "lib.rs must isolate Postgres files in <app-data-dir>/db, not the root"
@@ -1274,7 +1466,7 @@ mod tests {
 
     #[test]
     fn lib_rs_does_not_override_health_path() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         // Setting AUTUMN_HEALTH__PATH=/health can cause Axum to panic when the app
         // already has a custom GET /health route (duplicate route registration).
         // The probe instead accepts any HTTP response so no specific path is needed.
@@ -1287,7 +1479,7 @@ mod tests {
 
     #[test]
     fn lib_rs_clears_unix_socket_env() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         assert!(
             lib.contains("AUTUMN_SERVER__UNIX_SOCKET"),
             "lib.rs must clear AUTUMN_SERVER__UNIX_SOCKET so an inherited env var \
@@ -1304,7 +1496,7 @@ mod tests {
 
     #[test]
     fn lib_rs_clears_managed_pg_attach_url() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         // If AUTUMN_MANAGED_PG_ATTACH_URL is inherited (e.g. from a terminal where
         // `autumn serve` is running), ManagedPostgresPoolProvider connects to that
         // existing cluster instead of starting the bundled one.  Clearing it ensures
@@ -1318,7 +1510,7 @@ mod tests {
 
     #[test]
     fn lib_rs_sends_graceful_shutdown_signal_before_kill() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         // Unix: SIGTERM triggers autumn's tokio signal handler so on_shutdown hooks run.
         // Windows: autumn only handles ctrl_c() (CTRL_C_EVENT); taskkill sends
         // WM_CLOSE/CTRL_CLOSE_EVENT which autumn does not handle, so we force-kill
@@ -1341,7 +1533,7 @@ mod tests {
 
     #[test]
     fn lib_rs_clears_inherited_profile_env_vars() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         // If AUTUMN_ENV or AUTUMN_PROFILE is set in the shell that launches the desktop
         // app, the sidecar would inherit it and load the wrong profile (e.g. dev config
         // on an installed release app).  Clearing them lets the sidecar's compile-time
@@ -1359,7 +1551,7 @@ mod tests {
 
     #[test]
     fn lib_rs_sets_autumn_manifest_dir() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         assert!(
             lib.contains("AUTUMN_MANIFEST_DIR"),
             "lib.rs must set AUTUMN_MANIFEST_DIR to the Tauri resource dir so the \
@@ -1369,7 +1561,7 @@ mod tests {
 
     #[test]
     fn lib_rs_sets_sidecar_cwd_to_resource_dir() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         assert!(
             lib.contains(".current_dir("),
             "lib.rs must set the sidecar's working directory to resource_dir; \
@@ -1382,7 +1574,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_bundles_autumn_toml_as_resource() {
-        let conf = render_tauri_conf("my-app", "0.1.0");
+        let conf = render_tauri_conf("my-app", "0.1.0", "my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         // Tauri v2 resources must be a map { source_path: dest_path }, not an array.
         let resources = parsed["bundle"]["resources"]
@@ -1440,7 +1632,7 @@ mod tests {
 
     #[test]
     fn lib_rs_kills_sidecar_on_timeout() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         // The timeout branch must kill the sidecar before handle.exit(1);
         // check that .kill() appears more than once (once for Destroyed, once for timeout).
         let kill_count = lib.matches(".kill()").count();
@@ -1453,7 +1645,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_identifier_replaces_underscores() {
-        let conf = render_tauri_conf("my_app", "0.1.0");
+        let conf = render_tauri_conf("my_app", "0.1.0", "my_app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let id = parsed["identifier"].as_str().unwrap();
         assert!(
@@ -1468,7 +1660,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_security_is_under_app() {
-        let conf = render_tauri_conf("my-app", "0.1.0");
+        let conf = render_tauri_conf("my-app", "0.1.0", "my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         assert!(
             parsed["app"]["security"].is_object(),
@@ -1804,7 +1996,7 @@ mod tests {
 
     #[test]
     fn lib_rs_uses_background_thread_for_health_poll() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         assert!(
             lib.contains("thread::spawn"),
             "lib.rs must move the health poll into a background thread so setup() \
@@ -1814,7 +2006,7 @@ mod tests {
 
     #[test]
     fn lib_rs_exits_app_on_sidecar_timeout() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         assert!(
             lib.contains(".exit("),
             "lib.rs must call handle.exit() when the sidecar fails to become ready, \
@@ -1824,7 +2016,7 @@ mod tests {
 
     #[test]
     fn lib_rs_uses_connect_timeout_for_health_poll() {
-        let lib = render_shell_lib_rs("my-app");
+        let lib = render_shell_lib_rs("my-app", "my-app");
         assert!(
             lib.contains("connect_timeout"),
             "lib.rs must use TcpStream::connect_timeout so each poll attempt is bounded"
@@ -1835,7 +2027,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_product_name_handles_underscore_separator() {
-        let conf = render_tauri_conf("my_app", "0.1.0");
+        let conf = render_tauri_conf("my_app", "0.1.0", "my_app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let name = parsed["productName"].as_str().unwrap();
         assert!(

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -388,11 +388,16 @@ fn render_tauri_conf(package_name: &str, version: &str, bin_name: &str) -> Strin
 /// Platform-specific Tauri config overlays — Tauri CLI merges these at build/dev time.
 /// Keeping `beforeBuildCommand` / `beforeDevCommand` here (not in `tauri.conf.json`)
 /// means the generated scaffold is host-OS-agnostic.
+///
+/// `beforeDevCommand` uses the object form with `"wait": true` because Tauri v2 treats
+/// a plain string as `{ "wait": false }` for dev commands (designed for long-running dev
+/// servers). The staging script must complete before Tauri tries to spawn the sidecar,
+/// so we must opt in to blocking behaviour explicitly.
 fn render_tauri_linux_conf() -> String {
     r#"{
   "build": {
     "beforeBuildCommand": "bash stage-sidecar.sh",
-    "beforeDevCommand": "bash stage-sidecar.sh"
+    "beforeDevCommand": { "script": "bash stage-sidecar.sh", "wait": true }
   }
 }
 "#
@@ -403,7 +408,7 @@ fn render_tauri_macos_conf() -> String {
     r#"{
   "build": {
     "beforeBuildCommand": "bash stage-sidecar.sh",
-    "beforeDevCommand": "bash stage-sidecar.sh"
+    "beforeDevCommand": { "script": "bash stage-sidecar.sh", "wait": true }
   }
 }
 "#
@@ -414,7 +419,7 @@ fn render_tauri_windows_conf() -> String {
     r#"{
   "build": {
     "beforeBuildCommand": "powershell -ExecutionPolicy Bypass -File stage-sidecar.ps1",
-    "beforeDevCommand": "powershell -ExecutionPolicy Bypass -File stage-sidecar.ps1"
+    "beforeDevCommand": { "script": "powershell -ExecutionPolicy Bypass -File stage-sidecar.ps1", "wait": true }
   }
 }
 "#
@@ -1781,14 +1786,24 @@ mod tests {
         let conf = render_tauri_linux_conf();
         let parsed: serde_json::Value = serde_json::from_str(&conf).expect("valid JSON");
         let build_cmd = parsed["build"]["beforeBuildCommand"].as_str().unwrap_or("");
-        let dev_cmd = parsed["build"]["beforeDevCommand"].as_str().unwrap_or("");
+        // beforeDevCommand is the object form { script, wait: true } — not a plain string.
+        let dev_script = parsed["build"]["beforeDevCommand"]["script"]
+            .as_str()
+            .unwrap_or("");
+        let dev_wait = parsed["build"]["beforeDevCommand"]["wait"]
+            .as_bool()
+            .unwrap_or(false);
         assert!(
             build_cmd.contains("stage-sidecar"),
             "linux conf must have beforeBuildCommand referencing the staging script"
         );
         assert!(
-            dev_cmd.contains("stage-sidecar"),
-            "linux conf must have beforeDevCommand so `cargo tauri dev` stages the sidecar"
+            dev_script.contains("stage-sidecar"),
+            "linux conf must have beforeDevCommand.script referencing the staging script"
+        );
+        assert!(
+            dev_wait,
+            "linux beforeDevCommand must set wait:true so staging completes before sidecar spawn"
         );
         assert!(
             build_cmd.contains("bash"),
@@ -1801,14 +1816,23 @@ mod tests {
         let conf = render_tauri_macos_conf();
         let parsed: serde_json::Value = serde_json::from_str(&conf).expect("valid JSON");
         let build_cmd = parsed["build"]["beforeBuildCommand"].as_str().unwrap_or("");
-        let dev_cmd = parsed["build"]["beforeDevCommand"].as_str().unwrap_or("");
+        let dev_script = parsed["build"]["beforeDevCommand"]["script"]
+            .as_str()
+            .unwrap_or("");
+        let dev_wait = parsed["build"]["beforeDevCommand"]["wait"]
+            .as_bool()
+            .unwrap_or(false);
         assert!(
             build_cmd.contains("stage-sidecar"),
             "macos conf must have beforeBuildCommand referencing the staging script"
         );
         assert!(
-            dev_cmd.contains("stage-sidecar"),
-            "macos conf must have beforeDevCommand so `cargo tauri dev` stages the sidecar"
+            dev_script.contains("stage-sidecar"),
+            "macos conf must have beforeDevCommand.script referencing the staging script"
+        );
+        assert!(
+            dev_wait,
+            "macos beforeDevCommand must set wait:true so staging completes before sidecar spawn"
         );
         assert!(
             build_cmd.contains("bash"),
@@ -1821,14 +1845,23 @@ mod tests {
         let conf = render_tauri_windows_conf();
         let parsed: serde_json::Value = serde_json::from_str(&conf).expect("valid JSON");
         let build_cmd = parsed["build"]["beforeBuildCommand"].as_str().unwrap_or("");
-        let dev_cmd = parsed["build"]["beforeDevCommand"].as_str().unwrap_or("");
+        let dev_script = parsed["build"]["beforeDevCommand"]["script"]
+            .as_str()
+            .unwrap_or("");
+        let dev_wait = parsed["build"]["beforeDevCommand"]["wait"]
+            .as_bool()
+            .unwrap_or(false);
         assert!(
             build_cmd.contains("stage-sidecar"),
             "windows conf must have beforeBuildCommand referencing the staging script"
         );
         assert!(
-            dev_cmd.contains("stage-sidecar"),
-            "windows conf must have beforeDevCommand so `cargo tauri dev` stages the sidecar"
+            dev_script.contains("stage-sidecar"),
+            "windows conf must have beforeDevCommand.script referencing the staging script"
+        );
+        assert!(
+            dev_wait,
+            "windows beforeDevCommand must set wait:true so staging completes before sidecar spawn"
         );
         assert!(
             build_cmd.contains("powershell") || build_cmd.contains("ps1"),

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -179,8 +179,14 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String), Ge
     //   2. If `src/main.rs` exists on disk but isn't in [[bin]], Cargo auto-discovers
     //      it under the package name; any explicit [[bin]] entries are auxiliary bins
     //      and must NOT override the primary target.
-    //   3. The first (and only) [[bin]] when there is no `src/main.rs` at all.
-    //   4. The package name (Cargo default when no [[bin]] is declared).
+    //   3. `[package] default-run` — the developer's declared preference when there
+    //      are multiple explicit [[bin]] entries and no src/main.rs.
+    //   4. `bins.first()` — last resort when only one [[bin]] is declared.
+    //   5. The package name (Cargo default when no [[bin]] is declared).
+    let default_run = pkg
+        .get("default-run")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
     let bin_name = {
         let explicit_bins = doc.get("bin").and_then(|b| b.as_array());
         if let Some(bins) = explicit_bins {
@@ -201,16 +207,19 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String), Ge
                         // The [[bin]] entries are for other auxiliary programs.
                         Some(name.clone())
                     } else {
-                        // Step 3: no src/main.rs — the first declared bin IS the app.
-                        bins.first()
-                            .and_then(|b| b.get("name"))
-                            .and_then(|n| n.as_str())
-                            .map(str::to_owned)
+                        // Step 3: honour [package] default-run when set.
+                        default_run.clone().or_else(|| {
+                            // Step 4: single or first explicit [[bin]] as last resort.
+                            bins.first()
+                                .and_then(|b| b.get("name"))
+                                .and_then(|n| n.as_str())
+                                .map(str::to_owned)
+                        })
                     }
                 })
                 .unwrap_or_else(|| name.clone())
         } else {
-            // Step 4: no [[bin]] at all — package name is the binary name.
+            // Step 5: no [[bin]] at all — package name is the binary name.
             name.clone()
         }
     };
@@ -951,6 +960,31 @@ mod tests {
         tmp
     }
 
+    /// Project with `[package] default-run` and multiple explicit `[[bin]]`
+    /// targets but no `src/main.rs`.  The generator must pick the `default-run`
+    /// binary, not the first manifest entry.
+    fn project_with_default_run(pkg_name: &str, default_run: &str, bins: &[&str]) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        let bin_sections: String = bins
+            .iter()
+            .map(|b| format!("\n[[bin]]\nname=\"{b}\"\npath=\"src/{b}.rs\"\n"))
+            .collect();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+                 default-run=\"{default_run}\"\n\
+                 {bin_sections}\n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        for b in bins {
+            fs::write(tmp.path().join(format!("src/{b}.rs")), "fn main() {}\n").unwrap();
+        }
+        tmp
+    }
+
     fn project_with_workspace_version(pkg_name: &str, ws_version: &str) -> TempDir {
         let tmp = TempDir::new().unwrap();
         fs::write(
@@ -1341,6 +1375,34 @@ mod tests {
         assert!(
             !sh.contains("/release/worker") && !sh.contains("--bin worker"),
             "stage-sidecar.sh must not use the auxiliary [[bin]] name 'worker' as the primary target"
+        );
+    }
+
+    #[test]
+    fn plan_honours_default_run_over_first_bin() {
+        // A package with multiple explicit [[bin]] entries and `default-run = "web"`
+        // must stage the "web" binary, not the first-listed one (e.g. "seed").
+        let tmp = project_with_default_run("my-app", "web", &["seed", "web", "worker"]);
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let sh: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("stage-sidecar.sh action not found");
+        assert!(
+            sh.contains("--bin web"),
+            "stage-sidecar.sh must use the default-run binary 'web', not the first [[bin]] entry"
+        );
+        assert!(
+            !sh.contains("--bin seed"),
+            "stage-sidecar.sh must not use 'seed' (first [[bin]] entry) when default-run is set"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -58,10 +58,20 @@ pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
     let mut plan = Plan::new(project_root);
     let tauri = project_root.join("src-tauri");
 
+    // Detect profile override config files that exist now so they can be bundled
+    // as concrete Tauri resources.  A glob entry would cause `cargo tauri build` to
+    // fail with GlobPathNotFound when no files match (common for fresh projects).
+    let profile_configs: Vec<String> = ["autumn-prod.toml", "autumn-production.toml",
+        "autumn-staging.toml", "autumn-development.toml", "autumn-test.toml"]
+        .iter()
+        .filter(|f| project_root.join(f).is_file())
+        .map(|f| (*f).to_owned())
+        .collect();
+
     // Core Tauri project files
     plan.create(
         tauri.join("tauri.conf.json"),
-        render_tauri_conf(&package_name),
+        render_tauri_conf(&package_name, &profile_configs),
     );
     plan.create(
         tauri.join("Cargo.toml"),
@@ -147,7 +157,7 @@ fn read_package_name(project_root: &Path) -> Result<String, GenerateError> {
 
 // ── Content renderers ─────────────────────────────────────────────────────────
 
-fn render_tauri_conf(package_name: &str) -> String {
+fn render_tauri_conf(package_name: &str, profile_configs: &[String]) -> String {
     // Bundle identifier: reverse-DNS with underscores replaced by hyphens.
     // Apple's spec allows only alphanumerics, hyphens, and periods — underscores are invalid.
     let identifier = format!("com.example.{}", package_name.replace('_', "-"));
@@ -173,6 +183,14 @@ fn render_tauri_conf(package_name: &str) -> String {
     } else {
         "bash stage-sidecar.sh"
     };
+    // Concrete resource entries for profile config files that exist at plan time.
+    // We emit only files that are present so Tauri doesn't fail with GlobPathNotFound
+    // when no profile overrides exist (the common case for fresh projects).
+    let profile_resources: String = profile_configs.iter().fold(String::new(), |mut acc, f| {
+        use std::fmt::Write as _;
+        let _ = write!(acc, ",\n      \"../{f}\": \"{f}\"");
+        acc
+    });
     format!(
         r#"{{
   "$schema": "https://schema.tauri.app/config/2",
@@ -197,8 +215,7 @@ fn render_tauri_conf(package_name: &str) -> String {
       "binaries/{package_name}"
     ],
     "resources": {{
-      "../autumn.toml": "autumn.toml",
-      "../autumn-*.toml": "."
+      "../autumn.toml": "autumn.toml"{profile_resources}
     }}
   }},
   "app": {{
@@ -352,9 +369,6 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
             "AUTUMN_MANIFEST_DIR",
             resource_dir.to_string_lossy().as_ref(),
         )
-        // Force the health endpoint to /health so the readiness probe below
-        // always works, regardless of what [health].path is configured in the app.
-        .env("AUTUMN_HEALTH__PATH", "/health")
         // Clear any inherited Unix-socket config so the sidecar always binds
         // TCP on the loopback address the probe polls.  Without this, an
         // inherited AUTUMN_SERVER__UNIX_SOCKET would make the sidecar healthy
@@ -363,9 +377,13 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         .spawn()?;
     *app.state::<SidecarHandle>().0.lock().unwrap() = Some(child);
 
-    // 4. Poll /health in a background thread so setup() returns immediately and the
-    //    Tauri event loop starts.  Blocking here freezes the UI and can trigger OS
-    //    ANR watchdogs on macOS and Windows.
+    // 4. Poll for server readiness in a background thread so setup() returns immediately
+    //    and the Tauri event loop starts.  Blocking here freezes the UI and can trigger
+    //    OS ANR watchdogs on macOS and Windows.
+    //    We probe the root path and accept ANY valid HTTP response (any status code) as
+    //    the readiness signal.  This avoids depending on a specific route path, which
+    //    would conflict if the app has a custom GET /health or configures [health].path
+    //    differently (Axum panics on duplicate route registration).
     let handle = app.handle().clone();
     std::thread::spawn(move || {{
         // Build SocketAddr directly to avoid repeated string formatting and parse() panics.
@@ -383,12 +401,13 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
                 // Bound the read so a silent connection doesn't stall the loop.
                 let _ = stream.set_read_timeout(Some(poll_timeout));
                 use std::io::{{Read, Write}};
-                let req = format!(
-                    "GET /health HTTP/1.1\r\nHost: 127.0.0.1:{{port}}\r\nConnection: close\r\n\r\n"
-                );
+                let req =
+                    "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
                 if stream.write_all(req.as_bytes()).is_ok() {{
-                    let mut buf = [0u8; 16];
-                    if stream.read(&mut buf).is_ok() && buf.starts_with(b"HTTP/1.1 200") {{
+                    let mut buf = [0u8; 8];
+                    // Any valid HTTP response (200, 301, 401, 404, …) means the server
+                    // is up and routing — accept the `HTTP/` prefix regardless of status.
+                    if stream.read(&mut buf).is_ok() && buf.starts_with(b"HTTP/") {{
                         ready = true;
                         break;
                     }}
@@ -744,7 +763,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_is_valid_json() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", &[]);
         let parsed: serde_json::Value =
             serde_json::from_str(&conf).expect("tauri.conf.json must be valid JSON");
         assert!(parsed.is_object());
@@ -752,7 +771,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_identifier() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", &[]);
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         assert!(
             parsed["identifier"].is_string(),
@@ -766,7 +785,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_product_name() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", &[]);
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         assert!(
             parsed["productName"].is_string(),
@@ -776,7 +795,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_external_bin() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", &[]);
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let bins = parsed["bundle"]["externalBin"]
             .as_array()
@@ -791,7 +810,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_icon_array() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", &[]);
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let icons = parsed["bundle"]["icon"]
             .as_array()
@@ -805,7 +824,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_before_build_command() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", &[]);
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let cmd = parsed["build"]["beforeBuildCommand"]
             .as_str()
@@ -915,11 +934,17 @@ mod tests {
     }
 
     #[test]
-    fn lib_rs_polls_health_endpoint() {
+    fn lib_rs_polls_for_http_response() {
         let lib = render_shell_lib_rs("my-app");
+        // Probe accepts any valid HTTP response rather than a specific path/status,
+        // so it works regardless of the app's health route configuration.
         assert!(
-            lib.contains("/health"),
-            "lib.rs must poll GET /health to wait for server ready"
+            lib.contains("HTTP/"),
+            "lib.rs readiness probe must accept any HTTP response prefix"
+        );
+        assert!(
+            lib.contains("GET /"),
+            "lib.rs must send a GET request to probe server readiness"
         );
     }
 
@@ -951,12 +976,15 @@ mod tests {
     }
 
     #[test]
-    fn lib_rs_forces_health_path_env() {
+    fn lib_rs_does_not_override_health_path() {
         let lib = render_shell_lib_rs("my-app");
+        // Setting AUTUMN_HEALTH__PATH=/health can cause Axum to panic when the app
+        // already has a custom GET /health route (duplicate route registration).
+        // The probe instead accepts any HTTP response so no specific path is needed.
         assert!(
-            lib.contains("AUTUMN_HEALTH__PATH"),
-            "lib.rs must set AUTUMN_HEALTH__PATH=/health so the readiness probe works \
-             regardless of the app's configured health path"
+            !lib.contains("AUTUMN_HEALTH__PATH"),
+            "lib.rs must NOT set AUTUMN_HEALTH__PATH — overriding it can conflict with \
+             app-defined routes and cause Axum to panic on duplicate registration"
         );
     }
 
@@ -995,7 +1023,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_bundles_autumn_toml_as_resource() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", &[]);
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         // Tauri v2 resources must be a map { source_path: dest_path }, not an array.
         let resources = parsed["bundle"]["resources"]
@@ -1012,13 +1040,14 @@ mod tests {
             "tauri.conf.json must bundle autumn.toml as a resource so the installed \
              sidecar can find the app's production configuration"
         );
-        // Profile override files (autumn-prod.toml, autumn-production.toml, etc.) must
-        // also be bundled so the sidecar picks them up at runtime under the active profile.
-        let has_profile_glob = resources.iter().any(|(k, _)| k.contains("autumn-*.toml"));
+        // With no profile configs passed, resources should contain only the base entry.
+        // A glob entry must NOT be emitted because it causes GlobPathNotFound failures
+        // in cargo tauri build when no profile files exist.
+        let has_glob = resources.iter().any(|(k, _)| k.contains('*'));
         assert!(
-            has_profile_glob,
-            "tauri.conf.json must include a glob for autumn-*.toml resources so profile \
-             config overrides are bundled alongside the base autumn.toml"
+            !has_glob,
+            "tauri.conf.json must not emit resource glob entries — Tauri fails with \
+             GlobPathNotFound when the glob matches no files (common for fresh projects)"
         );
     }
 
@@ -1037,7 +1066,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_identifier_replaces_underscores() {
-        let conf = render_tauri_conf("my_app");
+        let conf = render_tauri_conf("my_app", &[]);
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let id = parsed["identifier"].as_str().unwrap();
         assert!(
@@ -1052,7 +1081,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_security_is_under_app() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", &[]);
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         assert!(
             parsed["app"]["security"].is_object(),
@@ -1415,7 +1444,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_product_name_handles_underscore_separator() {
-        let conf = render_tauri_conf("my_app");
+        let conf = render_tauri_conf("my_app", &[]);
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let name = parsed["productName"].as_str().unwrap();
         assert!(

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -148,8 +148,9 @@ fn read_package_name(project_root: &Path) -> Result<String, GenerateError> {
 // ── Content renderers ─────────────────────────────────────────────────────────
 
 fn render_tauri_conf(package_name: &str) -> String {
-    // Bundle identifier: reverse-DNS style, hyphens kept (valid per Apple/Android specs)
-    let identifier = format!("com.example.{package_name}");
+    // Bundle identifier: reverse-DNS with underscores replaced by hyphens.
+    // Apple's spec allows only alphanumerics, hyphens, and periods — underscores are invalid.
+    let identifier = format!("com.example.{}", package_name.replace('_', "-"));
     // Display title: capitalise first letter of each word; split on both '-' and '_'
     // so kebab-case (`my-app` → `My App`) and snake_case (`my_app` → `My App`) both work.
     let title: String = package_name
@@ -194,8 +195,10 @@ fn render_tauri_conf(package_name: &str) -> String {
       "binaries/{package_name}"
     ]
   }},
-  "security": {{
-    "csp": null
+  "app": {{
+    "security": {{
+      "csp": null
+    }}
   }}
 }}
 "#
@@ -246,9 +249,8 @@ fn render_shell_main_rs(package_name: &str) -> String {
     )
 }
 
+#[allow(clippy::too_many_lines)]
 fn render_shell_lib_rs(package_name: &str) -> String {
-    // The sidecar binary name (must match the Cargo package `name` in the app workspace).
-    let sidecar_bin = format!("binaries/{package_name}");
     format!(
         r#"//! Tauri desktop shell for {package_name}.
 //!
@@ -257,12 +259,12 @@ fn render_shell_lib_rs(package_name: &str) -> String {
 //!      Note: there is a brief window between dropping the listener and the sidecar
 //!      binding the port; in practice this race is extremely rare on loopback.
 //!   2. Spawn the autumn server sidecar with `AUTUMN_SERVER__PORT` set to that port.
-//!      `AUTUMN_MANAGED_PG_DATA_DIR` is set to the OS app-data dir so the managed
+//!      `AUTUMN_MANAGED_PG_DATA_DIR` is set to `<app-data-dir>/db` so the managed
 //!      Postgres cluster (autumn feature #1119) persists across restarts.
-//!   3. Poll GET /health in a background thread until the server is ready (up to 15 s),
+//!   3. Poll GET /health in a background thread until the server is ready (up to 30 s),
 //!      then open the webview window pointing at http://127.0.0.1:<port>.
 //!      On timeout, the app exits with a non-zero code rather than showing a blank window.
-//!   4. On window close, kill the sidecar — no orphaned server process.
+//!   4. On main window close, kill the sidecar — no orphaned server process.
 
 use std::net::TcpListener;
 use tauri::{{Manager, App}};
@@ -278,15 +280,19 @@ pub fn run() {{
         .setup(|app| setup(app))
         .on_window_event(|window, event| {{
             if let tauri::WindowEvent::Destroyed = event {{
-                let handle = window.app_handle();
-                if let Some(mut child) = handle
-                    .state::<SidecarHandle>()
-                    .0
-                    .lock()
-                    .unwrap()
-                    .take()
-                {{
-                    let _ = child.kill();
+                // Only kill the sidecar when the main window closes, not on any
+                // secondary window (dialogs, settings panels, etc.).
+                if window.label() == "main" {{
+                    let handle = window.app_handle();
+                    if let Some(mut child) = handle
+                        .state::<SidecarHandle>()
+                        .0
+                        .lock()
+                        .unwrap()
+                        .take()
+                    {{
+                        let _ = child.kill();
+                    }}
                 }}
             }}
         }})
@@ -305,12 +311,16 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
     }};
 
     // 2. Persistent data dir for the managed Postgres cluster (#1119).
-    let app_data_dir = app.path().app_data_dir()?;
+    //    Use a `db/` subdirectory so Postgres cluster files don't clutter
+    //    the app-data root.  Create it proactively; the sidecar won't if absent.
+    let app_data_dir = app.path().app_data_dir()?.join("db");
+    std::fs::create_dir_all(&app_data_dir)?;
 
     // 3. Spawn the autumn server sidecar (built with embed-assets + managed-pg-bundled).
+    //    The sidecar() argument is the binary basename matching externalBin in tauri.conf.json.
     let (_rx, child) = app
         .shell()
-        .sidecar("{sidecar_bin}")?
+        .sidecar("{package_name}")?
         .env("AUTUMN_SERVER__HOST", "127.0.0.1")
         .env("AUTUMN_SERVER__PORT", port.to_string())
         .env(
@@ -325,17 +335,24 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
     //    ANR watchdogs on macOS and Windows.
     let handle = app.handle().clone();
     std::thread::spawn(move || {{
-        let addr = format!("127.0.0.1:{{port}}");
+        // Build SocketAddr directly to avoid repeated string formatting and parse() panics.
+        let addr = std::net::SocketAddr::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
+            port,
+        );
         let poll_timeout = std::time::Duration::from_millis(200);
         let mut ready = false;
-        for _ in 0..75 {{
-            if let Ok(mut stream) = std::net::TcpStream::connect_timeout(
-                &addr.parse().unwrap(),
-                poll_timeout,
-            ) {{
+        // 150 × 200 ms = 30 s total — enough headroom for cold Postgres initialisation.
+        for _ in 0..150 {{
+            if let Ok(mut stream) =
+                std::net::TcpStream::connect_timeout(&addr, poll_timeout)
+            {{
+                // Bound the read so a silent connection doesn't stall the loop.
+                let _ = stream.set_read_timeout(Some(poll_timeout));
                 use std::io::{{Read, Write}};
-                let req =
-                    format!("GET /health HTTP/1.1\r\nHost: {{addr}}\r\nConnection: close\r\n\r\n");
+                let req = format!(
+                    "GET /health HTTP/1.1\r\nHost: 127.0.0.1:{{port}}\r\nConnection: close\r\n\r\n"
+                );
                 if stream.write_all(req.as_bytes()).is_ok() {{
                     let mut buf = [0u8; 16];
                     if stream.read(&mut buf).is_ok() && buf.starts_with(b"HTTP/1.1 200") {{
@@ -348,7 +365,7 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         }}
         if !ready {{
             eprintln!(
-                "[{package_name}] Server did not become ready within 15 s — exiting."
+                "[{package_name}] Server did not become ready within 30 s — exiting."
             );
             handle.exit(1);
             return;
@@ -404,11 +421,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
 APP_DIR="$(dirname "$SCRIPT_DIR")"
 cd "$APP_DIR"
-TARGET_TRIPLE="$(rustc -Vv | awk '/^host/{{print $2}}')"
-cargo build --release \
+# TAURI_ENV_TARGET_TRIPLE is set by `cargo tauri build` for cross-compilation;
+# fall back to the host triple when running the script manually.
+TARGET_TRIPLE="${{TAURI_ENV_TARGET_TRIPLE:-$(rustc -Vv | awk '/^host/{{print $2}}')}}";
+cargo build --release --target "${{TARGET_TRIPLE}}" \
   --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
 mkdir -p src-tauri/binaries
-cp "target/release/{package_name}" \
+cp "target/${{TARGET_TRIPLE}}/release/{package_name}" \
    "src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
 echo "Staged: src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
 "#
@@ -427,11 +446,16 @@ $ErrorActionPreference = "Stop"
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $AppDir = Split-Path -Parent $ScriptDir
 Set-Location $AppDir
-$TargetTriple = (rustc -Vv | Select-String "^host").Line.Split()[1]
-cargo build --release `
+# TAURI_ENV_TARGET_TRIPLE is set by `cargo tauri build` for cross-compilation;
+# fall back to the host triple when running the script manually.
+$TargetTriple = $Env:TAURI_ENV_TARGET_TRIPLE
+if (-not $TargetTriple) {{
+    $TargetTriple = (rustc -Vv | Select-String "^host").Line.Split()[1]
+}}
+cargo build --release --target "$TargetTriple" `
   --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
 New-Item -ItemType Directory -Force -Path src-tauri\binaries | Out-Null
-Copy-Item "target\release\{package_name}.exe" `
+Copy-Item "target\$TargetTriple\release\{package_name}.exe" `
           "src-tauri\binaries\{package_name}-$TargetTriple.exe"
 Write-Host "Staged: src-tauri/binaries/{package_name}-$TargetTriple.exe"
 "#
@@ -844,6 +868,49 @@ mod tests {
         assert!(
             lib.contains(".kill()"),
             "lib.rs must kill the sidecar child on window close"
+        );
+        assert!(
+            lib.contains("window.label()") && lib.contains("\"main\""),
+            "lib.rs must guard kill behind window.label() == \"main\" so secondary windows \
+             don't prematurely terminate the sidecar"
+        );
+    }
+
+    #[test]
+    fn lib_rs_pg_data_dir_uses_db_subdirectory() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains(".join(\"db\")"),
+            "lib.rs must isolate Postgres files in <app-data-dir>/db, not the root"
+        );
+    }
+
+    #[test]
+    fn tauri_conf_identifier_replaces_underscores() {
+        let conf = render_tauri_conf("my_app");
+        let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
+        let id = parsed["identifier"].as_str().unwrap();
+        assert!(
+            !id.contains('_'),
+            "bundle identifier must not contain underscores (invalid per Apple spec), got: {id}"
+        );
+        assert!(
+            id.contains("my-app"),
+            "bundle identifier must use hyphens instead of underscores, got: {id}"
+        );
+    }
+
+    #[test]
+    fn tauri_conf_security_is_under_app() {
+        let conf = render_tauri_conf("my-app");
+        let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
+        assert!(
+            parsed["app"]["security"].is_object(),
+            "security config must be nested under 'app' (Tauri v2 schema requirement)"
+        );
+        assert!(
+            parsed["security"].is_null(),
+            "security must NOT appear at the top level (invalid in Tauri v2 schema)"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -610,13 +610,22 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         // times out and exits.
         .env("AUTUMN_SERVER__UNIX_SOCKET", "")
         .env("AUTUMN_SERVE_FORCE_UNIX_SOCKET", "")
-        // Clear inherited profile-selection vars so the sidecar's compile-time
-        // AUTUMN_IS_DEBUG (baked in by #[autumn_web::main]: "0" for release
-        // builds, "1" for debug) determines the active profile.  Without this,
-        // a shell that exports AUTUMN_ENV=dev causes the installed desktop app
-        // to load dev config regardless of build mode, potentially connecting to
-        // the wrong database or skipping production security settings.
-        .env("AUTUMN_ENV", "")
+        // The sidecar binds only on loopback (AUTUMN_SERVER__HOST=127.0.0.1), but
+        // if the app's production autumn.toml sets trusted_hosts.hosts to the
+        // public domain, Autumn's trusted-host middleware would reject the webview's
+        // Host: 127.0.0.1 requests with a 400.  Override to allow loopback hosts
+        // unconditionally — the server is loopback-only so no external traffic
+        // can reach it regardless of this setting.
+        .env("AUTUMN_SECURITY__TRUSTED_HOSTS__HOSTS", "127.0.0.1,localhost")
+        // Profile selection: in a debug Tauri build (`cargo tauri dev`) the
+        // stage-sidecar script always produces a --release sidecar (AUTUMN_IS_DEBUG=0
+        // baked in → prod profile), but the developer expects dev config (dev DB,
+        // relaxed security, etc.).  Set AUTUMN_ENV=dev so the release sidecar still
+        // loads dev settings.  In a release Tauri build (`cargo tauri build`) clear
+        // it instead so the sidecar's baked-in AUTUMN_IS_DEBUG=0 selects prod.
+        .env("AUTUMN_ENV", if cfg!(debug_assertions) {{ "dev" }} else {{ "" }})
+        // Clear AUTUMN_PROFILE regardless — it is the legacy spelling of AUTUMN_ENV
+        // and should never be inherited from the calling shell environment.
         .env("AUTUMN_PROFILE", "")
         // Clear one-off mode flags inherited from the calling environment.
         // If any of these are set, AppBuilder::run() enters a non-serving mode
@@ -2132,18 +2141,50 @@ mod tests {
     #[test]
     fn lib_rs_clears_inherited_profile_env_vars() {
         let lib = render_shell_lib_rs("my-app", "my-app");
-        // If AUTUMN_ENV or AUTUMN_PROFILE is set in the shell that launches the desktop
-        // app, the sidecar would inherit it and load the wrong profile (e.g. dev config
-        // on an installed release app).  Clearing them lets the sidecar's compile-time
-        // AUTUMN_IS_DEBUG auto-detection determine the active profile.
+        // AUTUMN_ENV is set conditionally: "dev" in debug Tauri builds (cargo tauri dev)
+        // and "" in release Tauri builds (cargo tauri build), using cfg!(debug_assertions).
         assert!(
-            lib.contains("\"AUTUMN_ENV\", \"\""),
-            "lib.rs must clear AUTUMN_ENV so inherited shell profile vars don't \
-             override the sidecar's compile-time profile auto-detection"
+            lib.contains("AUTUMN_ENV") && lib.contains("cfg!(debug_assertions)"),
+            "lib.rs must set AUTUMN_ENV conditionally on cfg!(debug_assertions) \
+             so cargo tauri dev uses dev config and cargo tauri build uses prod config"
         );
         assert!(
             lib.contains("\"AUTUMN_PROFILE\", \"\""),
-            "lib.rs must clear AUTUMN_PROFILE (legacy alias) for the same reason"
+            "lib.rs must clear AUTUMN_PROFILE (legacy alias) so it is never inherited"
+        );
+    }
+
+    #[test]
+    fn lib_rs_sets_dev_profile_in_debug_tauri_builds() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        // cargo tauri dev compiles the shell in debug mode; the sidecar is always a
+        // --release binary (AUTUMN_IS_DEBUG=0 baked in → prod profile). Setting
+        // AUTUMN_ENV=dev in cfg!(debug_assertions) makes the sidecar load dev config.
+        assert!(
+            lib.contains("\"dev\"") && lib.contains("cfg!(debug_assertions)"),
+            "lib.rs must set AUTUMN_ENV=\"dev\" when cfg!(debug_assertions) so \
+             cargo tauri dev loads dev config even though the sidecar is --release"
+        );
+    }
+
+    #[test]
+    fn lib_rs_overrides_trusted_hosts_to_loopback() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        // Production autumn.toml may set trusted_hosts.hosts = ["example.com"].
+        // The webview connects to http://127.0.0.1:{port} (Host: 127.0.0.1) which
+        // would be rejected by the trusted-host middleware with a 400.  The shell
+        // always overrides the setting to allow loopback — the server only binds
+        // loopback so no external traffic reaches it regardless.
+        assert!(
+            lib.contains("AUTUMN_SECURITY__TRUSTED_HOSTS__HOSTS"),
+            "lib.rs must set AUTUMN_SECURITY__TRUSTED_HOSTS__HOSTS to override \
+             any production trusted-host config that would reject the webview's \
+             loopback Host header"
+        );
+        assert!(
+            lib.contains("127.0.0.1") && lib.contains("localhost"),
+            "AUTUMN_SECURITY__TRUSTED_HOSTS__HOSTS must include both 127.0.0.1 \
+             and localhost so either form of the loopback address is accepted"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -981,7 +981,10 @@ mod tests {
             .expect("bundle.resources must be a map (Tauri v2 schema requirement)");
         let has_autumn_toml = resources
             .iter()
-            .any(|(k, v)| k.contains("autumn.toml") || v.as_str().map(|s| s.contains("autumn.toml")).unwrap_or(false));
+            .any(|(k, v)| {
+                k.contains("autumn.toml")
+                    || v.as_str().is_some_and(|s| s.contains("autumn.toml"))
+            });
         assert!(
             has_autumn_toml,
             "tauri.conf.json must bundle autumn.toml as a resource so the installed \
@@ -998,8 +1001,7 @@ mod tests {
         assert!(
             kill_count >= 2,
             "lib.rs must kill the sidecar in both the timeout path and the window-build \
-             failure path, not only in WindowEvent::Destroyed; found {} .kill() call(s)",
-            kill_count
+             failure path, not only in WindowEvent::Destroyed; found {kill_count} .kill() call(s)"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -772,6 +772,13 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         // the force-kill window.  Setting it to 0 lets on_shutdown hooks (including
         // ManagedPostgresPoolProvider::stop()) run immediately after SIGTERM.
         .env("AUTUMN_SERVER__PRESTOP_GRACE_SECS", "0")
+        // Auto-apply pending migrations on every launch so that a freshly
+        // provisioned managed-Postgres cluster (first launch, or after data-dir
+        // wipe) has a fully migrated schema before the first request arrives.
+        // Autumn's default requires `database.auto_migrate_in_production = true`
+        // in autumn.toml; for the desktop bundle we inject it via env so the app's
+        // production autumn.toml stays server-deployment-friendly (default off).
+        .env("AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION", "true")
         // Clear one-off mode flags inherited from the calling environment.
         // If any of these are set, AppBuilder::run() enters a non-serving mode
         // (asset fingerprinting, route dump, task execution) and exits before
@@ -884,6 +891,22 @@ fn load_or_generate_signing_secret(
     if let Ok(s) = std::fs::read_to_string(&path) {{
         let s = s.trim().to_owned();
         if s.len() >= 32 {{
+            // Harden permissions on an existing file in case it was created by
+            // an older generated shell (0644) or manually without a mode flag.
+            // Failure is non-fatal: log and continue with the existing secret.
+            #[cfg(unix)]
+            {{
+                use std::os::unix::fs::PermissionsExt;
+                if let Err(e) = std::fs::set_permissions(
+                    &path,
+                    std::fs::Permissions::from_mode(0o600),
+                ) {{
+                    eprintln!(
+                        "[{package_name}] warning: could not restrict signing_secret.txt \
+                         permissions: {{e}}"
+                    );
+                }}
+            }}
             return Ok(s);
         }}
     }}
@@ -2893,6 +2916,48 @@ mod tests {
             lib.contains("signing_secret"),
             "AUTUMN_SECURITY__SIGNING_SECRET must be sourced from the signing_secret local \
              variable returned by load_or_generate_signing_secret"
+        );
+    }
+
+    #[test]
+    fn lib_rs_hardens_existing_signing_secret_permissions() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        // If the file already exists (early-return path), we must still chmod it
+        // to 0600 on Unix — an existing file created by an older generated shell
+        // (0644) or manually stays world-readable otherwise.
+        assert!(
+            lib.contains("from_mode(0o600)"),
+            "load_or_generate_signing_secret must call set_permissions(0o600) on \
+             an existing signing_secret.txt before returning it; a file created by \
+             an older shell at 0644 would expose the JWT key to other local accounts"
+        );
+        // The chmod must appear BEFORE the early return, not only in the create path.
+        let chmod_pos = lib.find("from_mode(0o600)").unwrap_or(usize::MAX);
+        let early_return_pos = lib.find("return Ok(s)").unwrap_or(usize::MAX);
+        assert!(
+            chmod_pos < early_return_pos,
+            "set_permissions(0o600) must appear before `return Ok(s)` so the existing \
+             file is hardened on every read, not just on creation"
+        );
+    }
+
+    #[test]
+    fn lib_rs_auto_migrates_on_desktop_launch() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        // A fresh managed-Postgres cluster starts with no schema; without
+        // auto-migration the first route that touches a table returns 500.
+        // The prod autumn.toml default is off (server-friendly), so we inject
+        // the override via env for the desktop bundle only.
+        assert!(
+            lib.contains("AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION"),
+            "lib.rs must set AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION=true so a \
+             fresh managed-Postgres cluster is migrated on first launch; otherwise \
+             routes that touch migrated tables fail with 500 on first desktop launch"
+        );
+        assert!(
+            lib.contains("\"AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION\", \"true\""),
+            "AUTUMN_DATABASE__AUTO_MIGRATE_IN_PRODUCTION must be set to \"true\"; \
+             an empty string or \"false\" would leave the fresh cluster unmigrated"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -169,13 +169,49 @@ pub fn run(flags: Flags) {
 /// `--features autumn-web/embed-assets` (dep path only), so that the app's
 /// `#[cfg(feature = "embed-assets")]` guard on `.embedded_static()` is
 /// satisfied — mirroring what `autumn build --embed` does.
+/// Walk ancestor `Cargo.toml` files to find the `package` field of a
+/// workspace-inherited dependency entry.
+///
+/// When a member has `autumn_web = { workspace = true }`, the `package` alias
+/// is recorded in `[workspace.dependencies]` of an ancestor, not the member.
+/// Returns `None` when the dep key is not found or has no `package` field.
+fn resolve_workspace_dep_package(project_root: &Path, dep_key: &str) -> Option<String> {
+    let mut dir: Option<&Path> = Some(project_root);
+    while let Some(d) = dir {
+        let cargo = d.join("Cargo.toml");
+        if cargo.is_file()
+            && let Ok(content) = std::fs::read_to_string(&cargo)
+            && let Ok(ws_doc) = toml::from_str::<toml::Value>(&content)
+        {
+            if let Some(pkg_name) = ws_doc
+                .get("workspace")
+                .and_then(|w| w.get("dependencies"))
+                .and_then(|deps| deps.get(dep_key))
+                .and_then(toml::Value::as_table)
+                .and_then(|t| t.get("package"))
+                .and_then(toml::Value::as_str)
+            {
+                return Some(pkg_name.to_owned());
+            }
+            // Stop at the workspace root even when the dep is not there.
+            if ws_doc.get("workspace").is_some() {
+                return None;
+            }
+        }
+        dir = d.parent();
+    }
+    None
+}
+
 /// Find the `[dependencies]` key used to depend on `package_name`.
 ///
 /// Cargo feature syntax requires the *dependency key*, not the package name.
-/// An aliased dep like `autumn_web = {{ package = "autumn-web" }}` must be
-/// referenced as `autumn_web/feature`, not `autumn-web/feature`.
+/// An aliased dep like `autumn_web = { package = "autumn-web" }` must be
+/// referenced as `autumn_web/feature`, not `autumn-web/feature`.  Handles
+/// workspace-inherited deps (`autumn_web = { workspace = true }`) by walking
+/// up to the workspace `Cargo.toml` to read the effective `package` there.
 /// Returns `package_name` itself when no alias is found.
-fn resolve_dep_key(doc: &toml::Value, package_name: &str) -> String {
+fn resolve_dep_key(project_root: &Path, doc: &toml::Value, package_name: &str) -> String {
     let Some(deps) = doc.get("dependencies").and_then(toml::Value::as_table) else {
         return package_name.to_owned();
     };
@@ -184,13 +220,22 @@ fn resolve_dep_key(doc: &toml::Value, package_name: &str) -> String {
         if key == package_name {
             return key.clone();
         }
-        // Aliased dependency: table entry has `package = <package_name>`.
-        if val
+        // Determine the effective package name for this entry.
+        let effective_pkg = if val
             .as_table()
-            .and_then(|t| t.get("package"))
-            .and_then(toml::Value::as_str)
-            == Some(package_name)
+            .and_then(|t| t.get("workspace"))
+            .and_then(toml::Value::as_bool)
+            == Some(true)
         {
+            // Workspace-inherited: package alias lives in [workspace.dependencies].
+            resolve_workspace_dep_package(project_root, key)
+        } else {
+            val.as_table()
+                .and_then(|t| t.get("package"))
+                .and_then(toml::Value::as_str)
+                .map(str::to_owned)
+        };
+        if effective_pkg.as_deref() == Some(package_name) {
             return key.clone();
         }
     }
@@ -343,9 +388,10 @@ fn read_package_meta(
         .is_some_and(|features| features.contains_key("embed-assets"));
 
     // Resolve the dependency key for autumn-web.  Apps may alias it (e.g.
-    // `autumn_web = { package = "autumn-web" }`); Cargo feature selectors
-    // must use the key (`autumn_web/feature`), not the package name.
-    let dep_key = resolve_dep_key(&doc, "autumn-web");
+    // `autumn_web = { package = "autumn-web" }` or via workspace inheritance);
+    // Cargo feature selectors must use the key (`autumn_web/feature`), not the
+    // package name.
+    let dep_key = resolve_dep_key(project_root, &doc, "autumn-web");
 
     Ok((name, version, bin_name, has_embed_assets_feature, dep_key))
 }
@@ -867,7 +913,7 @@ fn render_stage_sidecar_sh(
     // Only fingerprint when the app-level alias exists; `autumn build --embed` passes
     // --features embed-assets (app-level), which fails for apps without that alias.
     let fingerprint = if has_embed_assets {
-        format!("autumn build --embed -p {package_name}\n")
+        format!("autumn build --embed -p {package_name} --bin {bin_name}\n")
     } else {
         String::new()
     };
@@ -972,7 +1018,7 @@ fn render_stage_sidecar_ps1(
         format!(
             "# Fingerprint static/ before the embed compile (mirrors autumn build --embed phases 1-2):\n\
              # compile → write .autumn-manifest.json → the cargo build below embeds it.\n\
-             autumn build --embed -p {package_name}\n"
+             autumn build --embed -p {package_name} --bin {bin_name}\n"
         )
     } else {
         String::new()
@@ -1966,8 +2012,7 @@ mod tests {
         // [package] default-run = "web", the generator must use "web" (not the
         // package-named auto-discovered binary from src/main.rs).
         // Matches `autumn dev`/`autumn build` behaviour which prefers default_run.
-        let tmp =
-            project_with_default_run_and_main_rs("my-app", "web", &["web", "seed"]);
+        let tmp = project_with_default_run_and_main_rs("my-app", "web", &["web", "seed"]);
         let plan = plan_tauri(tmp.path()).unwrap();
         let sh: &str = plan
             .actions
@@ -2735,12 +2780,13 @@ mod tests {
     }
 
     #[test]
-    fn staging_sh_fingerprints_includes_package_name() {
-        let sh = render_stage_sidecar_sh("my-app", "my-app", true, "autumn-web");
+    fn staging_sh_fingerprints_includes_package_and_bin_name() {
+        let sh = render_stage_sidecar_sh("my-app", "my-server", true, "autumn-web");
         assert!(
-            sh.contains("autumn build --embed -p my-app"),
-            "stage-sidecar.sh must pass -p <package> to autumn build --embed so workspace \
-             members fingerprint the correct package's static/ directory"
+            sh.contains("autumn build --embed -p my-app --bin my-server"),
+            "stage-sidecar.sh must pass both -p <package> and --bin <bin> to autumn build \
+             --embed so workspace members fingerprint the correct package and only the \
+             sidecar binary is compiled (not all [[bin]] targets); got:\n{sh}"
         );
     }
 
@@ -2788,7 +2834,8 @@ mod tests {
     fn staging_ps1_uses_dep_key_not_package_name_for_features() {
         let ps1 = render_stage_sidecar_ps1("my-app", "my-app", false, "autumn_web");
         assert!(
-            ps1.contains("autumn_web/embed-assets") && ps1.contains("autumn_web/managed-pg-bundled"),
+            ps1.contains("autumn_web/embed-assets")
+                && ps1.contains("autumn_web/managed-pg-bundled"),
             "stage-sidecar.ps1 must use the dependency key 'autumn_web' in feature selectors"
         );
     }
@@ -2829,6 +2876,54 @@ mod tests {
             !sh.contains("autumn-web/managed-pg-bundled"),
             "stage-sidecar.sh must not contain 'autumn-web/managed-pg-bundled' when the dep is \
              aliased as 'autumn_web'; Cargo would reject it with 'Package does not have feature'"
+        );
+    }
+
+    #[test]
+    fn plan_uses_dep_key_for_workspace_inherited_alias() {
+        // When a workspace member has `autumn_web = { workspace = true }` and the
+        // workspace Cargo.toml defines `autumn_web = { package = "autumn-web" }`,
+        // resolve_dep_key must return "autumn_web" (the alias key), not "autumn-web".
+        let tmp = TempDir::new().unwrap();
+        // Write workspace root Cargo.toml with [workspace.dependencies] alias.
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"app\"]\n\
+             \n[workspace.dependencies]\nautumn_web = { package = \"autumn-web\", version = \"0.5\" }\n",
+        )
+        .unwrap();
+        let app_dir = tmp.path().join("app");
+        fs::create_dir_all(&app_dir).unwrap();
+        fs::write(
+            app_dir.join("Cargo.toml"),
+            "[package]\nname=\"my-app\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+             \n[dependencies]\nautumn_web = { workspace = true }\n",
+        )
+        .unwrap();
+        fs::create_dir_all(app_dir.join("src")).unwrap();
+        fs::write(app_dir.join("src/main.rs"), "fn main() {}\n").unwrap();
+        let plan = plan_tauri(&app_dir).unwrap();
+        let sh: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("stage-sidecar.sh action not found");
+        assert!(
+            sh.contains("autumn_web/managed-pg-bundled"),
+            "resolve_dep_key must resolve the workspace-inherited alias 'autumn_web' \
+             (not 'autumn-web') when the member dep has workspace = true; got:\n{sh}"
+        );
+        assert!(
+            !sh.contains("autumn-web/managed-pg-bundled"),
+            "stage-sidecar.sh must not use the package name 'autumn-web' when it is \
+             aliased as 'autumn_web' via workspace inheritance; got:\n{sh}"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -622,7 +622,10 @@ pub fn run() {{
                     {{
                         // On Unix: send SIGTERM so autumn's tokio signal handler
                         // runs on_shutdown hooks (including ManagedPostgresPoolProvider
-                        // ::stop()), then force-kill after 3 s.
+                        // ::stop()), then force-kill after 5 s.
+                        // AUTUMN_SERVER__PRESTOP_GRACE_SECS is set to 0 above so the
+                        // listener drain is skipped; the full 5 s budget is available
+                        // for on_shutdown hooks (e.g. pg_ctl stop -m fast).
                         // On Windows: autumn only handles tokio::signal::ctrl_c()
                         // (CTRL_C_EVENT).  taskkill sends WM_CLOSE/CTRL_CLOSE_EVENT
                         // which autumn does not handle; graceful shutdown via external
@@ -636,7 +639,7 @@ pub fn run() {{
                                 let _ = std::process::Command::new("kill")
                                     .args(["-TERM", &graceful_pid.to_string()])
                                     .status();
-                                std::thread::sleep(std::time::Duration::from_secs(3));
+                                std::thread::sleep(std::time::Duration::from_secs(5));
                                 let _ = child.kill();
                             }}
                             #[cfg(windows)]
@@ -747,6 +750,12 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         // Clear AUTUMN_PROFILE regardless — it is the legacy spelling of AUTUMN_ENV
         // and should never be inherited from the calling shell environment.
         .env("AUTUMN_PROFILE", "")
+        // Skip the prestop listener-drain on desktop: no load balancer drains
+        // connections to the loopback-only sidecar, so the 5-second default grace
+        // (server.prestop_grace_secs) only delays managed-Postgres cleanup past
+        // the force-kill window.  Setting it to 0 lets on_shutdown hooks (including
+        // ManagedPostgresPoolProvider::stop()) run immediately after SIGTERM.
+        .env("AUTUMN_SERVER__PRESTOP_GRACE_SECS", "0")
         // Clear one-off mode flags inherited from the calling environment.
         // If any of these are set, AppBuilder::run() enters a non-serving mode
         // (asset fingerprinting, route dump, task execution) and exits before
@@ -2230,6 +2239,25 @@ mod tests {
     }
 
     #[test]
+    fn new_project_template_defines_embed_assets_feature() {
+        // `autumn new` must scaffold the `embed-assets` Cargo feature so that:
+        //   1. `autumn generate tauri` detects it (has_embed_assets=true) and uses
+        //      the app-crate feature path instead of the dep-only path.
+        //   2. The `#[cfg(feature = "embed-assets")]` guards in main.rs.tmpl are
+        //      activated by `--features embed-assets`, so `.embedded_static()` is
+        //      wired and desktop apps ship their CSS/JS in the sidecar binary.
+        let tmpl = include_str!("../templates/Cargo.toml.tmpl");
+        assert!(
+            tmpl.contains("embed-assets"),
+            "Cargo.toml.tmpl must define an `embed-assets` feature mapping to \
+             `autumn-web/embed-assets`; without it `autumn generate tauri` falls back \
+             to the dep-only feature path and `.embedded_static()` is never called \
+             (main.rs.tmpl guards it on #[cfg(feature = \"embed-assets\")]); \
+             got:\n{tmpl}"
+        );
+    }
+
+    #[test]
     fn stage_sidecar_sh_creates_autumn_toml_when_absent() {
         let sh = render_stage_sidecar_sh("my-app", "my-app", true, "autumn-web");
         assert!(
@@ -2686,6 +2714,32 @@ mod tests {
                  doesn't prevent the sidecar from binding its HTTP port"
             );
         }
+    }
+
+    #[test]
+    fn lib_rs_sets_prestop_grace_to_zero() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        assert!(
+            lib.contains("AUTUMN_SERVER__PRESTOP_GRACE_SECS") && lib.contains("\"0\""),
+            "lib.rs must set AUTUMN_SERVER__PRESTOP_GRACE_SECS=0 so the sidecar skips \
+             the listener-drain delay; without this, the default 5-second prestop grace \
+             causes on_shutdown hooks (managed Postgres cleanup) to run after the \
+             force-kill fires; got:\n{lib}"
+        );
+    }
+
+    #[test]
+    fn lib_rs_kill_timeout_exceeds_default_prestop_grace() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        // The default prestop_grace_secs is 5; the force-kill must wait at least
+        // that long so shutdown hooks finish even if the env override is absent.
+        // Look for from_secs(N) where N >= 5.
+        let has_adequate_timeout = (5u64..=60).any(|n| lib.contains(&format!("from_secs({n})")));
+        assert!(
+            has_adequate_timeout,
+            "lib.rs kill timeout must be >= 5 s (the default prestop grace) so \
+             on_shutdown hooks complete before the force-kill; got:\n{lib}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -198,17 +198,15 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String, boo
     // is set, `cargo build` writes that name (not the package name) under
     // `target/.../release/`.
     //
-    // Priority:
-    //   1. A [[bin]] entry whose path is explicitly `src/main.rs` (renamed main).
-    //   2. If `src/main.rs` exists on disk but isn't in [[bin]], Cargo auto-discovers
-    //      it under the package name; any explicit [[bin]] entries are auxiliary bins
-    //      and must NOT override the primary target.
-    //   3. `[package] default-run` — the developer's declared preference when there
-    //      are multiple explicit [[bin]] entries and no src/main.rs.
+    // Priority when [[bin]] entries are present:
+    //   1. `[package] default-run` — the developer's explicit selection; takes
+    //      precedence over any auto-discovered src/main.rs target.
+    //   2. A [[bin]] entry whose path is explicitly `src/main.rs` (renamed main).
+    //   3. If `src/main.rs` exists on disk but isn't in [[bin]], Cargo auto-discovers
+    //      it under the package name; any explicit [[bin]] entries are auxiliary bins.
     //   4. `bins.first()` — last resort when only one [[bin]] is declared.
-    //   5. No [[bin]] table at all: honour `default-run` first; then if exactly one
-    //      `src/bin/*.rs` file exists, Cargo auto-discovers it (named after the stem,
-    //      not the package), so use that stem; otherwise fall back to the package name.
+    // When there are no [[bin]] entries:
+    //   5. `default-run` first, then `src/main.rs`, then `src/bin/` discovery.
     let default_run = pkg
         .get("default-run")
         .and_then(|v| v.as_str())
@@ -216,7 +214,14 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String, boo
     // Resolve bin name in a Result-returning block so ambiguous cases can error.
     let bin_name: String = (|| -> Result<String, GenerateError> {
         if let Some(bins) = doc.get("bin").and_then(|b| b.as_array()) {
-            // Step 1: explicit [[bin]] entry whose path resolves to src/main.rs.
+            // Step 1: honour [package] default-run — the developer's explicit selection.
+            // Must come before src/main.rs auto-discovery so a project that has
+            // src/main.rs *plus* explicit [[bin]] targets and sets default-run = "web"
+            // stages the declared default, not the package-named auto-discovered bin.
+            if let Some(dr) = &default_run {
+                return Ok(dr.clone());
+            }
+            // Step 2: explicit [[bin]] entry whose path resolves to src/main.rs.
             // Canonicalize by splitting on both separators and filtering empty and
             // CurDir (".") segments so "src/./main.rs", "./src/main.rs", and
             // "src/main.rs" all match identically.
@@ -235,17 +240,12 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String, boo
             {
                 return Ok(n.to_owned());
             }
+            // Step 3: src/main.rs exists but is not declared in [[bin]];
+            // Cargo auto-discovers it as the package-named binary.
             if project_root.join("src/main.rs").is_file() {
-                // Step 2: src/main.rs exists but is not declared in [[bin]];
-                // Cargo auto-discovers it as the package-named binary.
-                // The [[bin]] entries are for other auxiliary programs.
                 return Ok(name.clone());
             }
-            // Step 3: honour [package] default-run when set.
-            if let Some(dr) = &default_run {
-                return Ok(dr.clone());
-            }
-            // Step 4: single or first explicit [[bin]] as last resort.
+            // Step 4: first explicit [[bin]] as last resort.
             return Ok(bins
                 .first()
                 .and_then(|b| b.get("name"))
@@ -590,7 +590,7 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
     std::fs::create_dir_all(&app_data_dir)?;
     // Per-install signing secret: autumn requires one in prod mode.  Generate 32
     // random bytes on first launch and persist them so tokens survive restarts.
-    let signing_secret = load_or_generate_signing_secret(&data_root);
+    let signing_secret = load_or_generate_signing_secret(&data_root)?;
 
     // autumn.toml is bundled as a Tauri resource (see tauri.conf.json bundle.resources).
     // The sidecar's working directory is set to resource_dir so AutumnConfig finds it.
@@ -766,19 +766,24 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
 /// Autumn requires a signing secret in prod mode to sign JWTs / session tokens.
 /// Without this, the release sidecar calls `fail_fast_on_invalid_signing_secret`
 /// and exits before binding the HTTP port, leaving the TCP probe to time out.
-fn load_or_generate_signing_secret(data_root: &std::path::Path) -> String {{
+/// Returns `Err` (and aborts startup) on RNG failure so no predictable all-zero
+/// secret is silently accepted.
+fn load_or_generate_signing_secret(
+    data_root: &std::path::Path,
+) -> Result<String, Box<dyn std::error::Error>> {{
     let path = data_root.join("signing_secret.txt");
     if let Ok(s) = std::fs::read_to_string(&path) {{
         let s = s.trim().to_owned();
         if s.len() >= 32 {{
-            return s;
+            return Ok(s);
         }}
     }}
     let mut bytes = [0u8; 32];
-    getrandom::getrandom(&mut bytes).unwrap_or(());
+    // Propagate RNG failure — an all-zero secret would be trivially guessable.
+    getrandom::getrandom(&mut bytes)?;
     let hex: String = bytes.iter().map(|b| format!("{{b:02x}}")).collect();
     let _ = std::fs::write(&path, &hex);
-    hex
+    Ok(hex)
 }}
 "#
     )
@@ -1205,6 +1210,39 @@ mod tests {
         fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
         // The explicit auxiliary bin.
         fs::write(tmp.path().join("src/worker.rs"), "fn main() {}\n").unwrap();
+        tmp
+    }
+
+    /// Project with `[package] default-run`, explicit `[[bin]]` entries for other
+    /// binaries, AND `src/main.rs` present.  The generator must honour `default-run`
+    /// even when `src/main.rs` exists (which would otherwise be auto-discovered under
+    /// the package name).
+    fn project_with_default_run_and_main_rs(
+        pkg_name: &str,
+        default_run: &str,
+        extra_bins: &[&str],
+    ) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        let bin_sections = extra_bins.iter().fold(String::new(), |mut acc, b| {
+            write!(acc, "\n[[bin]]\nname=\"{b}\"\npath=\"src/{b}.rs\"\n").unwrap();
+            acc
+        });
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+                 default-run=\"{default_run}\"\
+                 {bin_sections}\n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        // src/main.rs is present — without the default-run check it would be
+        // auto-discovered and the package name would be used instead.
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        for b in extra_bins {
+            fs::write(tmp.path().join(format!("src/{b}.rs")), "fn main() {}\n").unwrap();
+        }
         tmp
     }
 
@@ -1810,6 +1848,39 @@ mod tests {
         assert!(
             !sh.contains("--bin seed"),
             "stage-sidecar.sh must not use 'seed' (first [[bin]] entry) when default-run is set"
+        );
+    }
+
+    #[test]
+    fn plan_honours_default_run_over_main_rs_when_explicit_bins_exist() {
+        // When src/main.rs is present alongside explicit [[bin]] entries and
+        // [package] default-run = "web", the generator must use "web" (not the
+        // package-named auto-discovered binary from src/main.rs).
+        // Matches `autumn dev`/`autumn build` behaviour which prefers default_run.
+        let tmp =
+            project_with_default_run_and_main_rs("my-app", "web", &["web", "seed"]);
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let sh: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("stage-sidecar.sh action not found");
+        assert!(
+            sh.contains("--bin web"),
+            "stage-sidecar.sh must use the default-run binary 'web' even when src/main.rs \
+             also exists; the package-named auto-bin must not override default-run"
+        );
+        assert!(
+            !sh.contains("--bin my-app"),
+            "stage-sidecar.sh must not use the package name 'my-app' when default-run = 'web' \
+             is set, even though src/main.rs would be auto-discovered as 'my-app'"
         );
     }
 
@@ -2461,6 +2532,18 @@ mod tests {
             "load_or_generate_signing_secret must persist the secret to a file so it \
              survives app restarts; re-generating on every launch would invalidate all \
              existing sessions"
+        );
+        // Must NOT silently continue with zero bytes on RNG failure.
+        assert!(
+            !lib.contains("unwrap_or(())"),
+            "getrandom failure must propagate as an error, not be silently swallowed with \
+             unwrap_or(()); an all-zero signing secret is trivially guessable"
+        );
+        // The function must return a Result so the caller can propagate the error.
+        assert!(
+            lib.contains("Result<String,") || lib.contains("Result<String, "),
+            "load_or_generate_signing_secret must return Result<String, ...> so getrandom \
+             failure aborts setup() rather than continuing with a predictable zero secret"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -292,7 +292,8 @@ fn render_shell_lib_rs(package_name: &str) -> String {
 //!   3. Poll GET /health in a background thread until the server is ready (up to 30 s),
 //!      then open the webview window pointing at http://127.0.0.1:<port>.
 //!      On timeout, the app exits with a non-zero code rather than showing a blank window.
-//!   4. On main window close, kill the sidecar — no orphaned server process.
+//!   4. On main window close, send SIGTERM for graceful shutdown (so on_shutdown hooks
+//!      run, including ManagedPostgresPoolProvider::stop()), then force-kill after 3 s.
 
 use std::net::TcpListener;
 use tauri::{{Manager, App}};
@@ -308,18 +309,32 @@ pub fn run() {{
         .setup(|app| setup(app))
         .on_window_event(|window, event| {{
             if let tauri::WindowEvent::Destroyed = event {{
-                // Only kill the sidecar when the main window closes, not on any
-                // secondary window (dialogs, settings panels, etc.).
+                // Only shut down the sidecar when the main window closes, not on
+                // secondary windows (dialogs, settings panels, etc.).
                 if window.label() == "main" {{
                     let handle = window.app_handle();
-                    if let Some(mut child) = handle
+                    if let Some(child) = handle
                         .state::<SidecarHandle>()
                         .0
                         .lock()
                         .unwrap()
                         .take()
                     {{
-                        let _ = child.kill();
+                        // Send SIGTERM first so autumn's on_shutdown hooks run
+                        // (including ManagedPostgresPoolProvider::stop() if wired).
+                        // Fall back to SIGKILL / TerminateProcess after 3 s.
+                        #[cfg(unix)]
+                        let graceful_pid = child.pid() as i32;
+                        std::thread::spawn(move || {{
+                            #[cfg(unix)]
+                            {{
+                                let _ = std::process::Command::new("kill")
+                                    .args(["-TERM", &graceful_pid.to_string()])
+                                    .status();
+                                std::thread::sleep(std::time::Duration::from_secs(3));
+                            }}
+                            let _ = child.kill();
+                        }});
                     }}
                 }}
             }}
@@ -368,6 +383,12 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
             "AUTUMN_MANAGED_PG_DATA_DIR",
             app_data_dir.to_string_lossy().as_ref(),
         )
+        // Clear any inherited attach URL so the sidecar owns its bundled Postgres
+        // cluster rather than connecting to a stale or foreign database.
+        // ManagedPostgresPoolProvider checks AUTUMN_MANAGED_PG_ATTACH_URL before
+        // AUTUMN_MANAGED_PG_DATA_DIR and returns it without starting a local cluster;
+        // an empty value is ignored by the provider.
+        .env("AUTUMN_MANAGED_PG_ATTACH_URL", "")
         // Belt-and-suspenders for apps not using #[autumn_web::main] where
         // AUTUMN_MANIFEST_DIR env var IS consulted before the CWD fallback.
         .env(
@@ -376,9 +397,11 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         )
         // Clear any inherited Unix-socket config so the sidecar always binds
         // TCP on the loopback address the probe polls.  Without this, an
-        // inherited AUTUMN_SERVER__UNIX_SOCKET would make the sidecar healthy
-        // on a socket path while the TCP health probe times out and exits.
+        // inherited AUTUMN_SERVER__UNIX_SOCKET or AUTUMN_SERVE_FORCE_UNIX_SOCKET
+        // would make the sidecar bind a socket path while the TCP health probe
+        // times out and exits.
         .env("AUTUMN_SERVER__UNIX_SOCKET", "")
+        .env("AUTUMN_SERVE_FORCE_UNIX_SOCKET", "")
         .spawn()?;
     *app.state::<SidecarHandle>().0.lock().unwrap() = Some(child);
 
@@ -1080,6 +1103,43 @@ mod tests {
             lib.contains("AUTUMN_SERVER__UNIX_SOCKET"),
             "lib.rs must clear AUTUMN_SERVER__UNIX_SOCKET so an inherited env var \
              cannot redirect the sidecar to a Unix socket the TCP probe cannot reach"
+        );
+        // AUTUMN_SERVE_FORCE_UNIX_SOCKET is a separate out-of-band override in
+        // app.rs that bypasses the config-system socket setting; must also be cleared.
+        assert!(
+            lib.contains("AUTUMN_SERVE_FORCE_UNIX_SOCKET"),
+            "lib.rs must also clear AUTUMN_SERVE_FORCE_UNIX_SOCKET — it overrides \
+             AUTUMN_SERVER__UNIX_SOCKET and would still redirect to a Unix socket"
+        );
+    }
+
+    #[test]
+    fn lib_rs_clears_managed_pg_attach_url() {
+        let lib = render_shell_lib_rs("my-app");
+        // If AUTUMN_MANAGED_PG_ATTACH_URL is inherited (e.g. from a terminal where
+        // `autumn serve` is running), ManagedPostgresPoolProvider connects to that
+        // existing cluster instead of starting the bundled one.  Clearing it ensures
+        // the desktop app always owns its local database.
+        assert!(
+            lib.contains("AUTUMN_MANAGED_PG_ATTACH_URL"),
+            "lib.rs must clear AUTUMN_MANAGED_PG_ATTACH_URL so an inherited attach \
+             URL cannot redirect the sidecar to a foreign or stale database cluster"
+        );
+    }
+
+    #[test]
+    fn lib_rs_sends_sigterm_before_kill() {
+        let lib = render_shell_lib_rs("my-app");
+        // Graceful SIGTERM lets autumn's on_shutdown hooks run (including pg.stop()).
+        // Force-kill is the fallback after a timeout.
+        assert!(
+            lib.contains("SIGTERM") || lib.contains("-TERM"),
+            "lib.rs on_window_event must send SIGTERM before force-killing the sidecar \
+             so ManagedPostgresPoolProvider::stop() runs during graceful shutdown"
+        );
+        assert!(
+            lib.contains("pid()"),
+            "lib.rs must call child.pid() to get the sidecar PID for SIGTERM"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -54,7 +54,8 @@ use super::{Flags, GenerateError, ensure_project_root};
 pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
     ensure_project_root(project_root)?;
 
-    let (package_name, package_version, bin_name) = read_package_meta(project_root)?;
+    let (package_name, package_version, bin_name, has_embed_assets) =
+        read_package_meta(project_root)?;
     let mut plan = Plan::new(project_root);
     let tauri = project_root.join("src-tauri");
 
@@ -98,11 +99,11 @@ pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
     // Staging scripts
     plan.create(
         tauri.join("stage-sidecar.sh"),
-        render_stage_sidecar_sh(&package_name, &bin_name),
+        render_stage_sidecar_sh(&package_name, &bin_name, has_embed_assets),
     );
     plan.create(
         tauri.join("stage-sidecar.ps1"),
-        render_stage_sidecar_ps1(&package_name, &bin_name),
+        render_stage_sidecar_ps1(&package_name, &bin_name, has_embed_assets),
     );
     plan.create(tauri.join(".gitignore"), render_gitignore());
 
@@ -145,7 +146,14 @@ pub fn run(flags: Flags) {
 /// `version` resolves workspace inheritance: if `[package] version.workspace
 /// = true` the function walks up the directory tree to find
 /// `[workspace.package] version` in an ancestor `Cargo.toml`.
-fn read_package_meta(project_root: &Path) -> Result<(String, String, String), GenerateError> {
+///
+/// `has_embed_assets_feature` is `true` when the app's `Cargo.toml` declares
+/// an `embed-assets` entry under `[features]`.  When true, staging scripts
+/// pass `--features embed-assets` (the app-crate feature) rather than
+/// `--features autumn-web/embed-assets` (dep path only), so that the app's
+/// `#[cfg(feature = "embed-assets")]` guard on `.embedded_static()` is
+/// satisfied — mirroring what `autumn build --embed` does.
+fn read_package_meta(project_root: &Path) -> Result<(String, String, String, bool), GenerateError> {
     let cargo_path = project_root.join("Cargo.toml");
     let content = std::fs::read_to_string(&cargo_path).map_err(GenerateError::Io)?;
     let doc: toml::Value = toml::from_str(&content)
@@ -163,7 +171,7 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String), Ge
     let version = match pkg.get("version") {
         Some(toml::Value::String(s)) => s.clone(),
         Some(toml::Value::Table(t))
-            if t.get("workspace").and_then(|v| v.as_bool()) == Some(true) =>
+            if t.get("workspace").and_then(toml::Value::as_bool) == Some(true) =>
         {
             resolve_workspace_version(project_root).unwrap_or_else(|| "0.1.0".to_owned())
         }
@@ -187,44 +195,55 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String), Ge
         .get("default-run")
         .and_then(|v| v.as_str())
         .map(str::to_owned);
-    let bin_name = {
-        let explicit_bins = doc.get("bin").and_then(|b| b.as_array());
-        if let Some(bins) = explicit_bins {
-            // Step 1: explicit [[bin]] entry whose path is src/main.rs.
-            bins.iter()
-                .find(|b| {
-                    b.get("path")
-                        .and_then(|p| p.as_str())
-                        .is_some_and(|p| p == "src/main.rs" || p == "src\\main.rs")
-                })
-                .and_then(|b| b.get("name"))
-                .and_then(|n| n.as_str())
-                .map(str::to_owned)
-                .or_else(|| {
-                    if project_root.join("src/main.rs").is_file() {
-                        // Step 2: src/main.rs exists but is not declared in [[bin]];
-                        // Cargo auto-discovers it as the package-named binary.
-                        // The [[bin]] entries are for other auxiliary programs.
-                        Some(name.clone())
-                    } else {
-                        // Step 3: honour [package] default-run when set.
-                        default_run.clone().or_else(|| {
-                            // Step 4: single or first explicit [[bin]] as last resort.
-                            bins.first()
-                                .and_then(|b| b.get("name"))
-                                .and_then(|n| n.as_str())
-                                .map(str::to_owned)
-                        })
-                    }
-                })
-                .unwrap_or_else(|| name.clone())
-        } else {
+    let bin_name = doc
+        .get("bin")
+        .and_then(|b| b.as_array())
+        .map_or_else(
             // Step 5: no [[bin]] at all — package name is the binary name.
-            name.clone()
-        }
-    };
+            || name.clone(),
+            |bins| {
+                // Step 1: explicit [[bin]] entry whose path is src/main.rs.
+                bins.iter()
+                    .find(|b| {
+                        b.get("path")
+                            .and_then(|p| p.as_str())
+                            .is_some_and(|p| p == "src/main.rs" || p == "src\\main.rs")
+                    })
+                    .and_then(|b| b.get("name"))
+                    .and_then(|n| n.as_str())
+                    .map(str::to_owned)
+                    .or_else(|| {
+                        if project_root.join("src/main.rs").is_file() {
+                            // Step 2: src/main.rs exists but is not declared in [[bin]];
+                            // Cargo auto-discovers it as the package-named binary.
+                            // The [[bin]] entries are for other auxiliary programs.
+                            Some(name.clone())
+                        } else {
+                            // Step 3: honour [package] default-run when set.
+                            default_run.clone().or_else(|| {
+                                // Step 4: single or first explicit [[bin]] as last resort.
+                                bins.first()
+                                    .and_then(|b| b.get("name"))
+                                    .and_then(|n| n.as_str())
+                                    .map(str::to_owned)
+                            })
+                        }
+                    })
+                    .unwrap_or_else(|| name.clone())
+            },
+        );
 
-    Ok((name, version, bin_name))
+    // Check whether the app defines an `embed-assets` Cargo feature.
+    // `autumn new` generates this; it typically expands to
+    // `["autumn-web/embed-assets"]`.  App code gates `.embedded_static()` on
+    // `#[cfg(feature = "embed-assets")]`, so the staging script must enable the
+    // *app-crate* feature — not just the dep path — to satisfy that guard.
+    let has_embed_assets_feature = doc
+        .get("features")
+        .and_then(toml::Value::as_table)
+        .is_some_and(|features| features.contains_key("embed-assets"));
+
+    Ok((name, version, bin_name, has_embed_assets_feature))
 }
 
 /// Walk from `project_root` upward looking for a `Cargo.toml` that declares
@@ -233,19 +252,16 @@ fn resolve_workspace_version(project_root: &Path) -> Option<String> {
     let mut dir: Option<&Path> = Some(project_root);
     while let Some(d) = dir {
         let cargo = d.join("Cargo.toml");
-        if cargo.is_file() {
-            if let Ok(content) = std::fs::read_to_string(&cargo) {
-                if let Ok(doc) = toml::from_str::<toml::Value>(&content) {
-                    if let Some(v) = doc
-                        .get("workspace")
-                        .and_then(|w| w.get("package"))
-                        .and_then(|p| p.get("version"))
-                        .and_then(|v| v.as_str())
-                    {
-                        return Some(v.to_owned());
-                    }
-                }
-            }
+        if cargo.is_file()
+            && let Ok(content) = std::fs::read_to_string(&cargo)
+            && let Ok(doc) = toml::from_str::<toml::Value>(&content)
+            && let Some(v) = doc
+                .get("workspace")
+                .and_then(|w| w.get("package"))
+                .and_then(|p| p.get("version"))
+                .and_then(|v| v.as_str())
+        {
+            return Some(v.to_owned());
         }
         dir = d.parent();
     }
@@ -624,7 +640,16 @@ fn render_placeholder_icon_svg() -> String {
     .to_owned()
 }
 
-fn render_stage_sidecar_sh(_package_name: &str, bin_name: &str) -> String {
+fn render_stage_sidecar_sh(_package_name: &str, bin_name: &str, has_embed_assets: bool) -> String {
+    // When the app defines an `embed-assets` Cargo feature (as `autumn new` generates),
+    // enable it so that `#[cfg(feature = "embed-assets")]` guards in app code are
+    // satisfied and `.embedded_static()` is actually wired in.  Fall back to the
+    // dependency path when the app doesn't define its own feature alias.
+    let embed_feature = if has_embed_assets {
+        "embed-assets,autumn-web/managed-pg-bundled"
+    } else {
+        "autumn-web/embed-assets,autumn-web/managed-pg-bundled"
+    };
     format!(
         r#"#!/usr/bin/env bash
 # Build the autumn server sidecar with embedded assets and managed Postgres,
@@ -634,8 +659,8 @@ fn render_stage_sidecar_sh(_package_name: &str, bin_name: &str) -> String {
 # Run manually: bash src-tauri/stage-sidecar.sh
 #
 # Requires autumn features:
-#   autumn-web/embed-assets        (#1004 — single-binary asset embed)
-#   autumn-web/managed-pg-bundled  (#1119 — bundled Postgres, no external install)
+#   embed-assets / autumn-web/embed-assets  (#1004 — single-binary asset embed)
+#   autumn-web/managed-pg-bundled           (#1119 — bundled Postgres, no external install)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
 APP_DIR="$(dirname "$SCRIPT_DIR")"
@@ -653,19 +678,15 @@ mkdir -p src-tauri/binaries
 if [ "${{TARGET_TRIPLE}}" = "universal-apple-darwin" ]; then
     for ARCH in x86_64-apple-darwin aarch64-apple-darwin; do
         cargo build --release --target "$ARCH" --bin {bin_name} \
-          --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
+          --features {embed_feature}
     done
     lipo -create -output "src-tauri/binaries/{bin_name}-universal-apple-darwin" \
       "${{TARGET_DIR}}/x86_64-apple-darwin/release/{bin_name}" \
       "${{TARGET_DIR}}/aarch64-apple-darwin/release/{bin_name}"
     echo "Staged (universal): src-tauri/binaries/{bin_name}-universal-apple-darwin"
 else
-    # Build with both autumn-web features so the sidecar binary embeds static assets
-    # and bundles Postgres.  Both are specified via the dependency path so this script
-    # works with any autumn project regardless of whether the app's Cargo.toml defines
-    # a top-level `embed-assets` feature alias.
     cargo build --release --target "${{TARGET_TRIPLE}}" --bin {bin_name} \
-      --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
+      --features {embed_feature}
     cp "${{TARGET_DIR}}/${{TARGET_TRIPLE}}/release/{bin_name}" \
        "src-tauri/binaries/{bin_name}-${{TARGET_TRIPLE}}"
     echo "Staged: src-tauri/binaries/{bin_name}-${{TARGET_TRIPLE}}"
@@ -723,7 +744,12 @@ done
     )
 }
 
-fn render_stage_sidecar_ps1(_package_name: &str, bin_name: &str) -> String {
+fn render_stage_sidecar_ps1(_package_name: &str, bin_name: &str, has_embed_assets: bool) -> String {
+    let embed_feature = if has_embed_assets {
+        "embed-assets,autumn-web/managed-pg-bundled"
+    } else {
+        "autumn-web/embed-assets,autumn-web/managed-pg-bundled"
+    };
     format!(
         r#"# Build the autumn server sidecar with embedded assets and managed Postgres,
 # then place it in src-tauri\binaries\ for Tauri to bundle.
@@ -747,12 +773,8 @@ $TargetDir = $Env:CARGO_TARGET_DIR
 if (-not $TargetDir) {{
     $TargetDir = (cargo metadata --no-deps --format-version 1 --quiet | ConvertFrom-Json).target_directory
 }}
-# Build with both autumn-web features so the sidecar binary embeds static assets
-# and bundles Postgres.  Both are specified via the dependency path so this script
-# works with any autumn project regardless of whether the app's Cargo.toml defines
-# a top-level `embed-assets` feature alias.
 cargo build --release --target "$TargetTriple" --bin {bin_name} `
-  --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
+  --features {embed_feature}
 New-Item -ItemType Directory -Force -Path src-tauri\binaries | Out-Null
 Copy-Item "$TargetDir\$TargetTriple\release\{bin_name}.exe" `
           "src-tauri\binaries\{bin_name}-$TargetTriple.exe"
@@ -898,6 +920,7 @@ const PLACEHOLDER_ICNS: &[u8] = &[
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write as FmtWrite;
     use std::fs;
 
     use tempfile::TempDir;
@@ -965,10 +988,10 @@ mod tests {
     /// binary, not the first manifest entry.
     fn project_with_default_run(pkg_name: &str, default_run: &str, bins: &[&str]) -> TempDir {
         let tmp = TempDir::new().unwrap();
-        let bin_sections: String = bins
-            .iter()
-            .map(|b| format!("\n[[bin]]\nname=\"{b}\"\npath=\"src/{b}.rs\"\n"))
-            .collect();
+        let bin_sections = bins.iter().fold(String::new(), |mut acc, b| {
+            write!(acc, "\n[[bin]]\nname=\"{b}\"\npath=\"src/{b}.rs\"\n").unwrap();
+            acc
+        });
         fs::write(
             tmp.path().join("Cargo.toml"),
             format!(
@@ -992,6 +1015,24 @@ mod tests {
             format!(
                 "[package]\nname=\"{pkg_name}\"\nversion.workspace = true\nedition=\"2024\"\n\
                  \n[workspace]\n\n[workspace.package]\nversion=\"{ws_version}\"\n\
+                 \n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        tmp
+    }
+
+    /// Project that defines an `embed-assets` Cargo feature (as `autumn new`
+    /// generates it), mapping to `["autumn-web/embed-assets"]`.
+    fn project_with_embed_assets(pkg_name: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+                 \n[features]\nembed-assets = [\"autumn-web/embed-assets\"]\n\
                  \n[dependencies]\nautumn-web = \"0.5.0\"\n"
             ),
         )
@@ -1077,7 +1118,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_sh_uses_cargo_metadata_for_target_dir() {
-        let sh = render_stage_sidecar_sh("my-app", "my-app");
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
         // cargo metadata resolves the real output dir for workspace members and
         // respects CARGO_TARGET_DIR overrides.
         assert!(
@@ -1098,7 +1139,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_sh_handles_universal_apple_darwin() {
-        let sh = render_stage_sidecar_sh("my-app", "my-app");
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
         // universal-apple-darwin is a Tauri meta-target; cargo build --target
         // universal-apple-darwin fails because rustc doesn't know it.
         assert!(
@@ -1117,7 +1158,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_ps1_uses_cargo_metadata_for_target_dir() {
-        let ps1 = render_stage_sidecar_ps1("my-app", "my-app");
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true);
         assert!(
             ps1.contains("cargo metadata"),
             "stage-sidecar.ps1 must use `cargo metadata` to locate the Cargo target directory"
@@ -1134,7 +1175,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_sh_stages_profile_configs() {
-        let sh = render_stage_sidecar_sh("my-app", "my-app");
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
         // Profile configs are staged at build time (beforeBuildCommand) so that the
         // static resource entries in tauri.conf.json are always satisfiable — even when
         // autumn-prod.toml is created after `autumn generate tauri` was run.
@@ -1151,7 +1192,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_ps1_stages_profile_configs() {
-        let ps1 = render_stage_sidecar_ps1("my-app", "my-app");
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true);
         assert!(
             ps1.contains("src-tauri\\configs") || ps1.contains("src-tauri/configs"),
             "stage-sidecar.ps1 must create src-tauri\\configs\\ and populate it with \
@@ -1168,7 +1209,7 @@ mod tests {
     // real config because AutumnConfig stops at the first existing file in the lookup list.
     #[test]
     fn stage_sidecar_sh_copies_alias_to_both_names() {
-        let sh = render_stage_sidecar_sh("my-app", "my-app");
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
         // Must handle the case where only autumn-production.toml exists by copying it
         // to autumn-prod.toml as well — look for the elif + both cp lines.
         assert!(
@@ -1190,7 +1231,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_ps1_copies_alias_to_both_names() {
-        let ps1 = render_stage_sidecar_ps1("my-app", "my-app");
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true);
         assert!(
             ps1.contains("autumn-production.toml") && ps1.contains("autumn-prod.toml"),
             "stage-sidecar.ps1 must handle prod/production alias pair explicitly"
@@ -1272,7 +1313,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_sh_uses_bin_name_for_binary() {
-        let sh = render_stage_sidecar_sh("my-app", "my-server");
+        let sh = render_stage_sidecar_sh("my-app", "my-server", true);
         assert!(
             sh.contains("my-server"),
             "stage-sidecar.sh must reference the binary target name in copy commands"
@@ -1286,7 +1327,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_ps1_uses_bin_name_for_binary() {
-        let ps1 = render_stage_sidecar_ps1("my-app", "my-server");
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-server", true);
         assert!(
             ps1.contains("my-server"),
             "stage-sidecar.ps1 must reference the binary target name in copy commands"
@@ -1407,8 +1448,53 @@ mod tests {
     }
 
     #[test]
+    fn stage_sidecar_sh_uses_app_embed_feature_when_defined() {
+        // When the app defines an `embed-assets` Cargo feature, the staging
+        // script must pass it (not just the dep path) so that
+        // `#[cfg(feature = "embed-assets")]` guards in app code are active.
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
+        assert!(
+            sh.contains("--features embed-assets,autumn-web/managed-pg-bundled"),
+            "when app has embed-assets feature the script must use the app-crate feature flag"
+        );
+    }
+
+    #[test]
+    fn stage_sidecar_sh_falls_back_to_dep_path_when_no_app_feature() {
+        let sh = render_stage_sidecar_sh("my-app", "my-app", false);
+        assert!(
+            sh.contains("--features autumn-web/embed-assets,autumn-web/managed-pg-bundled"),
+            "without app-level embed-assets, script must use the dep feature path"
+        );
+    }
+
+    #[test]
+    fn plan_uses_app_embed_feature_for_generated_scaffold() {
+        // The `project()` fixture matches a scaffold generated by `autumn new`,
+        // which always defines an `embed-assets` feature.
+        let tmp = project_with_embed_assets("my-app");
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let sh: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("stage-sidecar.sh action not found");
+        assert!(
+            sh.contains("--features embed-assets,"),
+            "generated scaffold with embed-assets feature must use app-crate feature in staging script"
+        );
+    }
+
+    #[test]
     fn stage_sidecar_sh_creates_autumn_toml_when_absent() {
-        let sh = render_stage_sidecar_sh("my-app", "my-app");
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
         assert!(
             sh.contains(": > autumn.toml") || sh.contains("> autumn.toml"),
             "staging script must create an empty autumn.toml when none exists \
@@ -1418,7 +1504,7 @@ mod tests {
 
     #[test]
     fn stage_sidecar_ps1_creates_autumn_toml_when_absent() {
-        let ps1 = render_stage_sidecar_ps1("my-app", "my-app");
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true);
         assert!(
             ps1.contains("autumn.toml"),
             "PowerShell staging script must handle a missing autumn.toml"

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -321,11 +321,15 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
     let app_data_dir = app.path().app_data_dir()?.join("db");
     std::fs::create_dir_all(&app_data_dir)?;
 
-    // autumn.toml is bundled as a resource (see tauri.conf.json bundle.resources).
-    // Point the sidecar at the resource directory so AutumnConfig::load_with_env()
-    // finds autumn.toml on the installed machine — without this, the sidecar looks
-    // in its CWD and falls back to compiled-in defaults, silently missing production
-    // settings such as auth, SEO, auto-migrate, and security configuration.
+    // autumn.toml is bundled as a Tauri resource (see tauri.conf.json bundle.resources).
+    // The sidecar's working directory is set to resource_dir so AutumnConfig finds it.
+    //
+    // Why CWD and not AUTUMN_MANIFEST_DIR env var:
+    //   OsEnv::var("AUTUMN_MANIFEST_DIR") returns the compile-time CARGO_MANIFEST_DIR
+    //   set by #[autumn_web::main], overriding the process environment.  That path
+    //   doesn't exist on the installed machine, so find_config_file_named() falls back
+    //   to PathBuf::from("autumn.toml") — i.e. the current working directory.
+    //   Setting CWD to resource_dir makes that CWD fallback find the bundled config.
     let resource_dir = app.path().resource_dir()?;
 
     // 3. Spawn the autumn server sidecar (built with autumn-web/embed-assets + managed-pg-bundled).
@@ -333,12 +337,16 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
     let (_rx, child) = app
         .shell()
         .sidecar("{package_name}")?
+        // Working directory = resource dir so autumn.toml is found via CWD fallback.
+        .current_dir(&resource_dir)
         .env("AUTUMN_SERVER__HOST", "127.0.0.1")
         .env("AUTUMN_SERVER__PORT", port.to_string())
         .env(
             "AUTUMN_MANAGED_PG_DATA_DIR",
             app_data_dir.to_string_lossy().as_ref(),
         )
+        // Belt-and-suspenders for apps not using #[autumn_web::main] where
+        // AUTUMN_MANIFEST_DIR env var IS consulted before the CWD fallback.
         .env(
             "AUTUMN_MANIFEST_DIR",
             resource_dir.to_string_lossy().as_ref(),
@@ -968,6 +976,19 @@ mod tests {
             lib.contains("AUTUMN_MANIFEST_DIR"),
             "lib.rs must set AUTUMN_MANIFEST_DIR to the Tauri resource dir so the \
              sidecar finds the bundled autumn.toml on the installed machine"
+        );
+    }
+
+    #[test]
+    fn lib_rs_sets_sidecar_cwd_to_resource_dir() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains(".current_dir("),
+            "lib.rs must set the sidecar's working directory to resource_dir; \
+             OsEnv::var(AUTUMN_MANIFEST_DIR) returns the compile-time CARGO_MANIFEST_DIR \
+             (which is absent on installed machines), so AutumnConfig falls back to \
+             PathBuf::from(\"autumn.toml\") — setting CWD to resource_dir makes that \
+             fallback find the bundled autumn.toml"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -1,0 +1,1123 @@
+//! `autumn generate tauri` — scaffold a Tauri desktop wrapper around an autumn app.
+//!
+//! Creates a `src-tauri/` sub-project using the **sidecar model**: the autumn
+//! server binary is supervised by the Tauri shell, and the webview loads the app
+//! from a loopback port chosen at runtime (no hardcoded port, no orphaned process).
+//! The entire existing autumn app — routes, Maud/htmx, sessions — runs unmodified;
+//! the generator does **not** rewrite handlers or move to a static export.
+//!
+//! # Runtime dependencies on autumn features
+//!
+//! The staging scripts build the sidecar with two autumn features that make the
+//! packaged desktop app fully self-contained:
+//!
+//! - **#1119 managed local Postgres** (`autumn-web/managed-pg-bundled`) — embeds the
+//!   Postgres binaries so the desktop app needs no separately-installed database.
+//!   The sidecar is pointed at a per-app data directory via `AUTUMN_MANAGED_PG_DATA_DIR`.
+//! - **#1004 single-binary asset embed** (`autumn-web/embed-assets`) — embeds the
+//!   `static/` tree into the release binary so the packaged app has no loose files.
+//!
+//! # Generated files
+//!
+//! ```text
+//! src-tauri/
+//!   tauri.conf.json          — Tauri v2 config (productName, bundle, sidecar ref)
+//!   Cargo.toml               — standalone shell crate with its own [workspace]
+//!   build.rs                 — calls tauri_build::build()
+//!   src/main.rs              — #![windows_subsystem] + calls lib::run()
+//!   src/lib.rs               — sidecar lifecycle: bind loopback:0, spawn sidecar,
+//!                               poll /health, open webview window, kill on exit
+//!   icons/icon.svg           — SVG source (reuse PWA icon if present; replace to customise)
+//!   icons/32x32.png          }
+//!   icons/128x128.png        } placeholder icons so `cargo tauri build` succeeds
+//!   icons/128x128@2x.png     } out-of-the-box; regenerate with `cargo tauri icon`
+//!   icons/icon.png           }
+//!   icons/icon.ico           — Windows
+//!   icons/icon.icns          — macOS
+//!   stage-sidecar.sh         — Unix: build sidecar → copy to binaries/
+//!   stage-sidecar.ps1        — Windows: same in PowerShell
+//!   .gitignore               — /target /binaries /gen
+//! ```
+
+use std::path::Path;
+
+use super::emit::Plan;
+use super::{Flags, GenerateError, ensure_project_root};
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Compute the file actions for `autumn generate tauri`.
+///
+/// # Errors
+/// Returns [`GenerateError::NotInProject`] when not at a project root, or
+/// [`GenerateError::Config`] if `Cargo.toml` is missing `[package].name`.
+pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
+    ensure_project_root(project_root)?;
+
+    let package_name = read_package_name(project_root)?;
+    let mut plan = Plan::new(project_root);
+    let tauri = project_root.join("src-tauri");
+
+    // Core Tauri project files
+    plan.create(
+        tauri.join("tauri.conf.json"),
+        render_tauri_conf(&package_name),
+    );
+    plan.create(
+        tauri.join("Cargo.toml"),
+        render_shell_cargo_toml(&package_name),
+    );
+    plan.create(tauri.join("build.rs"), render_build_rs());
+    plan.create(
+        tauri.join("src").join("main.rs"),
+        render_shell_main_rs(&package_name),
+    );
+    plan.create(
+        tauri.join("src").join("lib.rs"),
+        render_shell_lib_rs(&package_name),
+    );
+
+    // Icons — reuse the PWA icon when the user already ran `autumn generate pwa`
+    let icons_dir = tauri.join("icons");
+    let pwa_icon_src = project_root.join("static").join("icons").join("icon.svg");
+    if pwa_icon_src.is_file() {
+        let contents = std::fs::read_to_string(&pwa_icon_src).map_err(GenerateError::Io)?;
+        plan.create_if_absent(icons_dir.join("icon.svg"), contents);
+    } else {
+        plan.create_if_absent(icons_dir.join("icon.svg"), render_placeholder_icon_svg());
+    }
+    // Placeholder raster icons so `cargo tauri build` works immediately.
+    // Replace with proper icons by running: cargo tauri icon static/icons/icon.svg
+    plan.create_bytes(icons_dir.join("32x32.png"), PLACEHOLDER_PNG);
+    plan.create_bytes(icons_dir.join("128x128.png"), PLACEHOLDER_PNG);
+    plan.create_bytes(icons_dir.join("128x128@2x.png"), PLACEHOLDER_PNG);
+    plan.create_bytes(icons_dir.join("icon.png"), PLACEHOLDER_PNG);
+    plan.create_bytes(icons_dir.join("icon.ico"), PLACEHOLDER_ICO);
+    plan.create_bytes(icons_dir.join("icon.icns"), PLACEHOLDER_ICNS);
+
+    // Staging scripts
+    plan.create(
+        tauri.join("stage-sidecar.sh"),
+        render_stage_sidecar_sh(&package_name),
+    );
+    plan.create(
+        tauri.join("stage-sidecar.ps1"),
+        render_stage_sidecar_ps1(&package_name),
+    );
+    plan.create(tauri.join(".gitignore"), render_gitignore());
+
+    Ok(plan)
+}
+
+/// CLI entry point — executes the plan and prints required prerequisites.
+pub fn run(flags: Flags) {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: cannot determine current directory: {e}");
+            std::process::exit(1);
+        }
+    };
+    match plan_tauri(&cwd).and_then(|p| p.execute(flags)) {
+        Ok(()) => {
+            if !flags.dry_run {
+                println!("\n{}", render_prerequisites());
+            }
+        }
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+// ── Package name helper ───────────────────────────────────────────────────────
+
+fn read_package_name(project_root: &Path) -> Result<String, GenerateError> {
+    let cargo_path = project_root.join("Cargo.toml");
+    let content = std::fs::read_to_string(&cargo_path).map_err(GenerateError::Io)?;
+    let doc: toml::Value = toml::from_str(&content)
+        .map_err(|e| GenerateError::Config(format!("failed to parse Cargo.toml: {e}")))?;
+    doc.get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .map(str::to_owned)
+        .ok_or_else(|| GenerateError::Config("Cargo.toml missing [package].name".to_owned()))
+}
+
+// ── Content renderers ─────────────────────────────────────────────────────────
+
+fn render_tauri_conf(package_name: &str) -> String {
+    // Bundle identifier: reverse-DNS style, hyphens kept (valid per Apple/Android specs)
+    let identifier = format!("com.example.{package_name}");
+    // Display title: capitalise first letter of each word
+    let title: String = package_name
+        .split('-')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!(
+        r#"{{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "{title}",
+  "version": "0.1.0",
+  "identifier": "{identifier}",
+  "build": {{
+    "beforeBuildCommand": "sh stage-sidecar.sh"
+  }},
+  "bundle": {{
+    "active": true,
+    "targets": "all",
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.png",
+      "icons/icon.ico",
+      "icons/icon.icns"
+    ],
+    "externalBin": [
+      "binaries/{package_name}"
+    ]
+  }},
+  "security": {{
+    "csp": null
+  }}
+}}
+"#
+    )
+}
+
+fn render_shell_cargo_toml(package_name: &str) -> String {
+    let desktop_name = format!("{package_name}-desktop");
+    format!(
+        r#"[package]
+name = "{desktop_name}"
+version = "0.0.1"
+edition = "2021"
+
+# Standalone workspace so this crate is independent from the autumn app workspace —
+# no change to the root Cargo.toml is needed.
+[workspace]
+
+[build-dependencies]
+tauri-build = {{ version = "2", features = [] }}
+
+[dependencies]
+tauri = {{ version = "2", features = [] }}
+tauri-plugin-shell = "2"
+
+[profile.release]
+panic = "abort"
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+"#
+    )
+}
+
+fn render_build_rs() -> String {
+    "fn main() {\n    tauri_build::build()\n}\n".to_owned()
+}
+
+fn render_shell_main_rs(package_name: &str) -> String {
+    let lib_name = package_name.replace('-', "_") + "_desktop";
+    format!(
+        "#![cfg_attr(not(debug_assertions), windows_subsystem = \"windows\")]\n\
+         \n\
+         fn main() {{\n\
+         \x20   {lib_name}::run();\n\
+         }}\n"
+    )
+}
+
+fn render_shell_lib_rs(package_name: &str) -> String {
+    // The sidecar binary name (must match the Cargo package `name` in the app workspace).
+    let sidecar_bin = format!("binaries/{package_name}");
+    format!(
+        r#"//! Tauri desktop shell for {package_name}.
+//!
+//! Lifecycle:
+//!   1. Bind loopback:0 to find a free ephemeral port (no hardcoded port collision).
+//!   2. Spawn the autumn server sidecar with `AUTUMN_SERVER__PORT` set to that port.
+//!      `AUTUMN_MANAGED_PG_DATA_DIR` is set to the OS app-data dir so the managed
+//!      Postgres cluster (autumn feature #1119) persists across restarts.
+//!   3. Poll GET /health until the server is ready (up to 15 s), then open the
+//!      webview window pointing at http://127.0.0.1:<port>.
+//!   4. Kill the sidecar when the last window closes — no orphaned server process.
+
+use std::net::TcpListener;
+use tauri::{{Manager, App}};
+use tauri_plugin_shell::{{ShellExt, process::CommandChild}};
+
+struct SidecarHandle(std::sync::Mutex<Option<CommandChild>>);
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {{
+    tauri::Builder::default()
+        .plugin(tauri_plugin_shell::init())
+        .manage(SidecarHandle(std::sync::Mutex::new(None)))
+        .setup(|app| setup(app))
+        .on_window_event(|window, event| {{
+            if let tauri::WindowEvent::Destroyed = event {{
+                let handle = window.app_handle();
+                if let Some(mut child) = handle
+                    .state::<SidecarHandle>()
+                    .0
+                    .lock()
+                    .unwrap()
+                    .take()
+                {{
+                    let _ = child.kill();
+                }}
+            }}
+        }})
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}}
+
+fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
+    // 1. Find a free loopback port: bind :0, read the assigned port, then drop
+    //    the listener so the autumn server can bind that same address.
+    let port = {{
+        let l = TcpListener::bind("127.0.0.1:0")?;
+        l.local_addr()?.port()
+    }};
+
+    // 2. Persistent data dir for the managed Postgres cluster (#1119).
+    let app_data_dir = app.path().app_data_dir()?;
+
+    // 3. Spawn the autumn server sidecar (built with embed-assets + managed-pg-bundled).
+    let (_rx, child) = app
+        .shell()
+        .sidecar("{sidecar_bin}")?
+        .env("AUTUMN_SERVER__HOST", "127.0.0.1")
+        .env("AUTUMN_SERVER__PORT", port.to_string())
+        .env("AUTUMN_MANAGED_PG_DATA_DIR", app_data_dir.to_string_lossy().as_ref())
+        .spawn()?;
+    *app.state::<SidecarHandle>().0.lock().unwrap() = Some(child);
+
+    // 4. Poll GET /health until the server responds 200 (≤ 15 s).
+    let addr = format!("127.0.0.1:{{port}}");
+    'wait: for _ in 0..75 {{
+        if let Ok(mut stream) = std::net::TcpStream::connect(&addr) {{
+            use std::io::{{Read, Write}};
+            let req = format!(
+                "GET /health HTTP/1.1\r\nHost: {{addr}}\r\nConnection: close\r\n\r\n"
+            );
+            if stream.write_all(req.as_bytes()).is_ok() {{
+                let mut buf = [0u8; 16];
+                if stream.read(&mut buf).is_ok() && buf.starts_with(b"HTTP/1.1 200") {{
+                    break 'wait;
+                }}
+            }}
+        }}
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }}
+
+    // 5. Open the webview window pointing at the local server.
+    tauri::WebviewWindowBuilder::new(
+        app,
+        "main",
+        tauri::WebviewUrl::External(format!("http://127.0.0.1:{{port}}").parse()?),
+    )
+    .title("{package_name}")
+    .inner_size(1200.0, 800.0)
+    .build()?;
+
+    Ok(())
+}}
+"#
+    )
+}
+
+fn render_placeholder_icon_svg() -> String {
+    concat!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 512 512\">\n",
+        "  <!-- Placeholder app icon. Replace with your own, then run:\n",
+        "       cargo tauri icon static/icons/icon.svg -->\n",
+        "  <rect width=\"512\" height=\"512\" rx=\"64\" fill=\"#4F7942\"/>\n",
+        "  <text x=\"256\" y=\"370\" font-size=\"280\" text-anchor=\"middle\"",
+        " font-family=\"system-ui\">&#x1F342;</text>\n",
+        "</svg>\n",
+    )
+    .to_owned()
+}
+
+fn render_stage_sidecar_sh(package_name: &str) -> String {
+    format!(
+        r#"#!/usr/bin/env bash
+# Build the autumn server sidecar with embedded assets and managed Postgres,
+# then place it in src-tauri/binaries/ for Tauri to bundle.
+#
+# Wired into tauri.conf.json > build.beforeBuildCommand.
+# Run manually: bash src-tauri/stage-sidecar.sh
+#
+# Requires autumn features:
+#   autumn-web/embed-assets        (#1004 — single-binary asset embed)
+#   autumn-web/managed-pg-bundled  (#1119 — bundled Postgres, no external install)
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
+APP_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$APP_DIR"
+TARGET_TRIPLE="$(rustc -Vv | awk '/^host/{{print $2}}')"
+cargo build --release \
+  --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
+mkdir -p src-tauri/binaries
+cp "target/release/{package_name}" \
+   "src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
+echo "Staged: src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
+"#
+    )
+}
+
+fn render_stage_sidecar_ps1(package_name: &str) -> String {
+    format!(
+        r#"# Build the autumn server sidecar with embedded assets and managed Postgres,
+# then place it in src-tauri\binaries\ for Tauri to bundle.
+#
+# Run manually: powershell -File src-tauri\stage-sidecar.ps1
+# Or set tauri.conf.json > build.beforeBuildCommand to:
+#   "powershell -ExecutionPolicy Bypass -File stage-sidecar.ps1"
+$ErrorActionPreference = "Stop"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$AppDir = Split-Path -Parent $ScriptDir
+Set-Location $AppDir
+$TargetTriple = (rustc -Vv | Select-String "^host").Line.Split()[1]
+cargo build --release `
+  --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
+New-Item -ItemType Directory -Force -Path src-tauri\binaries | Out-Null
+Copy-Item "target\release\{package_name}.exe" `
+          "src-tauri\binaries\{package_name}-$TargetTriple.exe"
+Write-Host "Staged: src-tauri/binaries/{package_name}-$TargetTriple.exe"
+"#
+    )
+}
+
+fn render_gitignore() -> String {
+    "/target\n/binaries\n/gen\n".to_owned()
+}
+
+/// Human-readable prerequisites message printed after a successful scaffold.
+pub fn render_prerequisites() -> String {
+    "\
+Required prerequisites for `cargo tauri build`:\n\
+\n\
+  1. Tauri CLI:\n\
+       cargo install tauri-cli --version '^2'\n\
+\n\
+  2. Platform toolchain:\n\
+       Linux:   sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget \\\n\
+                  file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev\n\
+       macOS:   xcode-select --install\n\
+       Windows: Install WebView2 + Visual Studio C++ build tools\n\
+\n\
+  3. Stage the autumn server sidecar (also wired into beforeBuildCommand):\n\
+       bash src-tauri/stage-sidecar.sh\n\
+\n\
+  4. Build the desktop app:\n\
+       cd src-tauri && cargo tauri build\n\
+\n\
+  The sidecar is built with autumn-web/embed-assets (#1004) and\n\
+  autumn-web/managed-pg-bundled (#1119) so the packaged desktop app needs\n\
+  no separately-installed database or loose asset files.\n\
+\n\
+  Replace the placeholder icons before shipping:\n\
+       cargo tauri icon static/icons/icon.svg   (from the app root)\n"
+        .to_owned()
+}
+
+// ── Placeholder icon bytes ────────────────────────────────────────────────────
+// Minimal valid 1×1 RGBA PNG (autumn green #4F7942, opaque).
+// Replace with proper icons using: cargo tauri icon static/icons/icon.svg
+const PLACEHOLDER_PNG: &[u8] = &[
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG signature
+    0x00, 0x00, 0x00, 0x0d, // IHDR length = 13
+    0x49, 0x48, 0x44, 0x52, // "IHDR"
+    0x00, 0x00, 0x00, 0x01, // width = 1
+    0x00, 0x00, 0x00, 0x01, // height = 1
+    0x08, 0x06, 0x00, 0x00, 0x00, // depth=8, colortype=6(RGBA), compress=filter=interlace=0
+    0x1f, 0x15, 0xc4, 0x89, // IHDR CRC
+    0x00, 0x00, 0x00, 0x0d, // IDAT length = 13
+    0x49, 0x44, 0x41, 0x54, // "IDAT"
+    0x78, 0x9c, 0x63, 0xf0, 0xaf, 0x74, 0xfa, 0x0f, 0x00, 0x04, 0x2f, 0x02, 0x0a, // deflate
+    0x5e, 0x60, 0x4a, 0x2d, // IDAT CRC
+    0x00, 0x00, 0x00, 0x00, // IEND length = 0
+    0x49, 0x45, 0x4e, 0x44, // "IEND"
+    0xae, 0x42, 0x60, 0x82, // IEND CRC
+];
+
+// Minimal ICO wrapping the placeholder PNG.
+const PLACEHOLDER_ICO: &[u8] = &[
+    0x00, 0x00, 0x01, 0x00, // ICO header: reserved=0, type=1(ICO)
+    0x01, 0x00, // image count = 1
+    0x00, 0x00, 0x00, 0x00, // width=0(→256), height=0(→256), palette=0, reserved=0
+    0x01, 0x00, 0x20, 0x00, // planes=1, bit_count=32
+    0x46, 0x00, 0x00, 0x00, // image data size = 70 bytes
+    0x16, 0x00, 0x00, 0x00, // image data offset = 22 (6+16)
+    // PNG data (same as PLACEHOLDER_PNG, 70 bytes)
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+    0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0xf0, 0xaf, 0x74, 0xfa,
+    0x0f, 0x00, 0x04, 0x2f, 0x02, 0x0a, 0x5e, 0x60, 0x4a, 0x2d, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
+    0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+];
+
+// Minimal ICNS container wrapping the placeholder PNG as icp6 (PNG icon).
+const PLACEHOLDER_ICNS: &[u8] = &[
+    0x69, 0x63, 0x6e, 0x73, // "icns" magic
+    0x00, 0x00, 0x00, 0x56, // total file size = 86
+    0x69, 0x63, 0x70, 0x36, // icon type "icp6" (PNG icon)
+    0x00, 0x00, 0x00, 0x4e, // entry size = 78 (8 header + 70 PNG)
+    // PNG data (same as PLACEHOLDER_PNG, 70 bytes)
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+    0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0xf0, 0xaf, 0x74, 0xfa,
+    0x0f, 0x00, 0x04, 0x2f, 0x02, 0x0a, 0x5e, 0x60, 0x4a, 0x2d, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
+    0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+];
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::generate::Flags;
+
+    // ── Fixtures ──────────────────────────────────────────────────────────────
+
+    fn project(name: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+                 \n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        tmp
+    }
+
+    // ── plan_tauri: error cases ───────────────────────────────────────────────
+
+    #[test]
+    fn plan_tauri_requires_project_root() {
+        let tmp = TempDir::new().unwrap();
+        let err = plan_tauri(tmp.path()).unwrap_err();
+        assert!(matches!(err, GenerateError::NotInProject));
+    }
+
+    #[test]
+    fn plan_tauri_errors_when_package_name_missing() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[workspace]\nmembers=[]\n").unwrap();
+        let err = plan_tauri(tmp.path()).unwrap_err();
+        assert!(
+            matches!(err, GenerateError::Config(_)),
+            "expected Config error, got: {err:?}"
+        );
+    }
+
+    // ── plan_tauri: file list ─────────────────────────────────────────────────
+
+    fn has_action(tmp: &TempDir, suffix: &str) -> bool {
+        let plan = plan_tauri(tmp.path()).unwrap();
+        plan.actions.iter().any(|a| {
+            a.path()
+                .to_string_lossy()
+                .replace('\\', "/")
+                .ends_with(suffix)
+        })
+    }
+
+    #[test]
+    fn plan_creates_tauri_conf_json() {
+        let tmp = project("my-app");
+        assert!(has_action(&tmp, "src-tauri/tauri.conf.json"));
+    }
+
+    #[test]
+    fn plan_creates_shell_cargo_toml() {
+        let tmp = project("my-app");
+        assert!(has_action(&tmp, "src-tauri/Cargo.toml"));
+    }
+
+    #[test]
+    fn plan_creates_build_rs() {
+        let tmp = project("my-app");
+        assert!(has_action(&tmp, "src-tauri/build.rs"));
+    }
+
+    #[test]
+    fn plan_creates_src_main_rs() {
+        let tmp = project("my-app");
+        assert!(has_action(&tmp, "src-tauri/src/main.rs"));
+    }
+
+    #[test]
+    fn plan_creates_src_lib_rs() {
+        let tmp = project("my-app");
+        assert!(has_action(&tmp, "src-tauri/src/lib.rs"));
+    }
+
+    #[test]
+    fn plan_creates_stage_sidecar_sh() {
+        let tmp = project("my-app");
+        assert!(has_action(&tmp, "src-tauri/stage-sidecar.sh"));
+    }
+
+    #[test]
+    fn plan_creates_stage_sidecar_ps1() {
+        let tmp = project("my-app");
+        assert!(has_action(&tmp, "src-tauri/stage-sidecar.ps1"));
+    }
+
+    #[test]
+    fn plan_creates_gitignore() {
+        let tmp = project("my-app");
+        assert!(has_action(&tmp, "src-tauri/.gitignore"));
+    }
+
+    #[test]
+    fn plan_creates_icon_svg() {
+        let tmp = project("my-app");
+        assert!(has_action(&tmp, "src-tauri/icons/icon.svg"));
+    }
+
+    #[test]
+    fn plan_creates_png_icons() {
+        let tmp = project("my-app");
+        assert!(has_action(&tmp, "src-tauri/icons/32x32.png"));
+        assert!(has_action(&tmp, "src-tauri/icons/128x128.png"));
+        assert!(has_action(&tmp, "src-tauri/icons/128x128@2x.png"));
+        assert!(has_action(&tmp, "src-tauri/icons/icon.png"));
+    }
+
+    #[test]
+    fn plan_creates_ico_and_icns() {
+        let tmp = project("my-app");
+        assert!(has_action(&tmp, "src-tauri/icons/icon.ico"));
+        assert!(has_action(&tmp, "src-tauri/icons/icon.icns"));
+    }
+
+    // ── render_tauri_conf ─────────────────────────────────────────────────────
+
+    #[test]
+    fn tauri_conf_is_valid_json() {
+        let conf = render_tauri_conf("my-app");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&conf).expect("tauri.conf.json must be valid JSON");
+        assert!(parsed.is_object());
+    }
+
+    #[test]
+    fn tauri_conf_has_identifier() {
+        let conf = render_tauri_conf("my-app");
+        let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
+        assert!(
+            parsed["identifier"].is_string(),
+            "tauri.conf.json must have an identifier"
+        );
+        assert!(
+            parsed["identifier"].as_str().unwrap().contains("my-app"),
+            "identifier must include the package name"
+        );
+    }
+
+    #[test]
+    fn tauri_conf_has_product_name() {
+        let conf = render_tauri_conf("my-app");
+        let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
+        assert!(
+            parsed["productName"].is_string(),
+            "tauri.conf.json must have productName"
+        );
+    }
+
+    #[test]
+    fn tauri_conf_has_external_bin() {
+        let conf = render_tauri_conf("my-app");
+        let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
+        let bins = parsed["bundle"]["externalBin"]
+            .as_array()
+            .expect("bundle.externalBin must be an array");
+        assert!(!bins.is_empty(), "must list at least one external binary");
+        assert!(
+            bins.iter()
+                .any(|b| b.as_str().unwrap_or("").contains("my-app")),
+            "externalBin must reference the app name"
+        );
+    }
+
+    #[test]
+    fn tauri_conf_has_icon_array() {
+        let conf = render_tauri_conf("my-app");
+        let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
+        let icons = parsed["bundle"]["icon"]
+            .as_array()
+            .expect("bundle.icon must be an array");
+        assert!(
+            icons.len() >= 4,
+            "must list at least 4 icon files, got {}",
+            icons.len()
+        );
+    }
+
+    #[test]
+    fn tauri_conf_has_before_build_command() {
+        let conf = render_tauri_conf("my-app");
+        let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
+        let cmd = parsed["build"]["beforeBuildCommand"]
+            .as_str()
+            .expect("build.beforeBuildCommand must be a string");
+        assert!(
+            cmd.contains("stage-sidecar"),
+            "beforeBuildCommand must reference the staging script"
+        );
+    }
+
+    // ── render_shell_cargo_toml ───────────────────────────────────────────────
+
+    #[test]
+    fn shell_cargo_toml_has_own_workspace_table() {
+        let cargo = render_shell_cargo_toml("my-app");
+        assert!(
+            cargo.contains("[workspace]"),
+            "shell Cargo.toml must have its own [workspace] table to be independent"
+        );
+    }
+
+    #[test]
+    fn shell_cargo_toml_has_tauri_dep() {
+        let cargo = render_shell_cargo_toml("my-app");
+        assert!(
+            cargo.contains("tauri"),
+            "shell Cargo.toml must depend on tauri"
+        );
+    }
+
+    #[test]
+    fn shell_cargo_toml_has_tauri_plugin_shell_dep() {
+        let cargo = render_shell_cargo_toml("my-app");
+        assert!(
+            cargo.contains("tauri-plugin-shell"),
+            "shell Cargo.toml must depend on tauri-plugin-shell"
+        );
+    }
+
+    #[test]
+    fn shell_cargo_toml_has_tauri_build_dep() {
+        let cargo = render_shell_cargo_toml("my-app");
+        assert!(
+            cargo.contains("tauri-build"),
+            "shell Cargo.toml must depend on tauri-build in build-dependencies"
+        );
+    }
+
+    #[test]
+    fn shell_cargo_toml_package_name_includes_app_name() {
+        let cargo = render_shell_cargo_toml("my-app");
+        assert!(
+            cargo.contains("my-app"),
+            "shell crate name must reference the app name"
+        );
+    }
+
+    // ── render_shell_lib_rs (sidecar lifecycle) ───────────────────────────────
+
+    #[test]
+    fn lib_rs_binds_loopback_ephemeral_port() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains("127.0.0.1:0"),
+            "lib.rs must bind loopback:0 to find a free ephemeral port"
+        );
+    }
+
+    #[test]
+    fn lib_rs_sets_autumn_server_port_env() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains("AUTUMN_SERVER__PORT"),
+            "lib.rs must pass AUTUMN_SERVER__PORT to the sidecar"
+        );
+    }
+
+    #[test]
+    fn lib_rs_sets_autumn_server_host_env() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains("AUTUMN_SERVER__HOST"),
+            "lib.rs must pass AUTUMN_SERVER__HOST to the sidecar"
+        );
+    }
+
+    #[test]
+    fn lib_rs_sets_managed_pg_data_dir() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains("AUTUMN_MANAGED_PG_DATA_DIR"),
+            "lib.rs must pass AUTUMN_MANAGED_PG_DATA_DIR for managed Postgres (#1119)"
+        );
+    }
+
+    #[test]
+    fn lib_rs_spawns_sidecar() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains(".sidecar("),
+            "lib.rs must spawn the sidecar via tauri-plugin-shell"
+        );
+        assert!(
+            lib.contains("my-app"),
+            "lib.rs must reference the app name as the sidecar binary"
+        );
+    }
+
+    #[test]
+    fn lib_rs_polls_health_endpoint() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains("/health"),
+            "lib.rs must poll GET /health to wait for server ready"
+        );
+    }
+
+    #[test]
+    fn lib_rs_kills_sidecar_on_window_destroyed() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains("Destroyed"),
+            "lib.rs must handle WindowEvent::Destroyed"
+        );
+        assert!(
+            lib.contains(".kill()"),
+            "lib.rs must kill the sidecar child on window close"
+        );
+    }
+
+    // ── render_shell_main_rs ─────────────────────────────────────────────────
+
+    #[test]
+    fn shell_main_rs_has_windows_subsystem_attr() {
+        let main = render_shell_main_rs("my-app");
+        assert!(
+            main.contains("windows_subsystem"),
+            "main.rs must set windows_subsystem to suppress console on Windows"
+        );
+    }
+
+    #[test]
+    fn shell_main_rs_calls_run() {
+        let main = render_shell_main_rs("my-app");
+        assert!(
+            main.contains("::run()"),
+            "main.rs must call the lib's run() function"
+        );
+    }
+
+    // ── render_prerequisites ─────────────────────────────────────────────────
+
+    #[test]
+    fn prerequisites_mentions_tauri_cli() {
+        let prereq = render_prerequisites();
+        assert!(
+            prereq.contains("tauri-cli") || prereq.contains("cargo tauri"),
+            "prerequisites must mention the Tauri CLI"
+        );
+    }
+
+    #[test]
+    fn prerequisites_mentions_linux_toolchain() {
+        let prereq = render_prerequisites();
+        assert!(
+            prereq.contains("webkit2gtk") || prereq.contains("libwebkit"),
+            "prerequisites must mention the Linux WebKit dependency"
+        );
+    }
+
+    #[test]
+    fn prerequisites_mentions_macos_toolchain() {
+        let prereq = render_prerequisites();
+        assert!(
+            prereq.contains("xcode") || prereq.contains("Xcode"),
+            "prerequisites must mention Xcode for macOS"
+        );
+    }
+
+    #[test]
+    fn prerequisites_mentions_embed_assets_feature() {
+        let prereq = render_prerequisites();
+        assert!(
+            prereq.contains("embed-assets"),
+            "prerequisites must document the embed-assets dependency (#1004)"
+        );
+    }
+
+    #[test]
+    fn prerequisites_mentions_managed_pg_feature() {
+        let prereq = render_prerequisites();
+        assert!(
+            prereq.contains("managed-pg"),
+            "prerequisites must document the managed-pg dependency (#1119)"
+        );
+    }
+
+    // ── placeholder icons ─────────────────────────────────────────────────────
+
+    #[test]
+    fn placeholder_png_starts_with_png_signature() {
+        assert_eq!(
+            &PLACEHOLDER_PNG[..8],
+            &[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+            "placeholder PNG must start with the PNG file signature"
+        );
+    }
+
+    #[test]
+    fn placeholder_ico_starts_with_ico_header() {
+        assert_eq!(
+            &PLACEHOLDER_ICO[..4],
+            &[0x00, 0x00, 0x01, 0x00],
+            "placeholder ICO must start with the ICO reserved+type header"
+        );
+    }
+
+    #[test]
+    fn placeholder_icns_starts_with_icns_magic() {
+        assert_eq!(
+            &PLACEHOLDER_ICNS[..4],
+            b"icns",
+            "placeholder ICNS must start with the 'icns' magic bytes"
+        );
+    }
+
+    // ── additive (does not touch app's src/main.rs or root Cargo.toml) ───────
+
+    #[test]
+    fn plan_does_not_modify_app_main_rs() {
+        let tmp = project("my-app");
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let app_main = tmp.path().join("src/main.rs");
+        assert!(
+            !plan.actions.iter().any(|a| a.path() == app_main.as_path()),
+            "plan must not touch the app's src/main.rs"
+        );
+    }
+
+    #[test]
+    fn plan_does_not_modify_root_cargo_toml() {
+        let tmp = project("my-app");
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let root_cargo = tmp.path().join("Cargo.toml");
+        assert!(
+            !plan
+                .actions
+                .iter()
+                .any(|a| a.path() == root_cargo.as_path()),
+            "plan must not touch the root Cargo.toml"
+        );
+    }
+
+    // ── icon reuse when PWA generator already ran ─────────────────────────────
+
+    #[test]
+    fn plan_reuses_pwa_icon_when_present() {
+        let tmp = project("my-app");
+        // Simulate that `autumn generate pwa` already created the icon
+        fs::create_dir_all(tmp.path().join("static/icons")).unwrap();
+        fs::write(
+            tmp.path().join("static/icons/icon.svg"),
+            "<svg><!-- pwa icon --></svg>\n",
+        )
+        .unwrap();
+
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let svg_action = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("icons/icon.svg"))
+            .expect("icon.svg must be in the plan");
+
+        if let super::super::emit::Action::CreateIfAbsent { contents, .. } = svg_action {
+            assert!(
+                contents.contains("pwa icon"),
+                "must reuse the PWA icon content"
+            );
+        } else {
+            panic!("icon.svg must use CreateIfAbsent action");
+        }
+    }
+
+    // ── plan execution (full write to tempdir) ────────────────────────────────
+
+    #[test]
+    fn execute_creates_tauri_conf_json() {
+        let tmp = project("my-app");
+        plan_tauri(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        let path = tmp.path().join("src-tauri/tauri.conf.json");
+        assert!(path.exists(), "src-tauri/tauri.conf.json must be created");
+        let content = fs::read_to_string(&path).unwrap();
+        let _: serde_json::Value =
+            serde_json::from_str(&content).expect("tauri.conf.json must be valid JSON");
+    }
+
+    #[test]
+    fn execute_creates_shell_cargo_toml() {
+        let tmp = project("my-app");
+        plan_tauri(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(tmp.path().join("src-tauri/Cargo.toml").exists());
+    }
+
+    #[test]
+    fn execute_creates_lib_rs() {
+        let tmp = project("my-app");
+        plan_tauri(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        let lib = fs::read_to_string(tmp.path().join("src-tauri/src/lib.rs")).unwrap();
+        assert!(
+            lib.contains("127.0.0.1:0"),
+            "lib.rs must bind ephemeral port"
+        );
+        assert!(lib.contains(".kill()"), "lib.rs must kill sidecar on close");
+    }
+
+    #[test]
+    fn execute_creates_png_icon_files() {
+        let tmp = project("my-app");
+        plan_tauri(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        for name in &["32x32.png", "128x128.png", "128x128@2x.png", "icon.png"] {
+            let path = tmp.path().join("src-tauri/icons").join(name);
+            assert!(path.exists(), "{name} must be created");
+            let bytes = fs::read(&path).unwrap();
+            assert_eq!(
+                &bytes[..8],
+                &[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+                "{name} must be a valid PNG"
+            );
+        }
+    }
+
+    #[test]
+    fn execute_creates_gitignore() {
+        let tmp = project("my-app");
+        plan_tauri(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        let gi = fs::read_to_string(tmp.path().join("src-tauri/.gitignore")).unwrap();
+        assert!(gi.contains("/target"), ".gitignore must exclude /target");
+        assert!(
+            gi.contains("/binaries"),
+            ".gitignore must exclude /binaries"
+        );
+    }
+
+    #[test]
+    fn execute_does_not_touch_app_main_rs() {
+        let tmp = project("my-app");
+        let original_main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        plan_tauri(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        let after_main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert_eq!(
+            original_main, after_main,
+            "src/main.rs must be unchanged after generate tauri"
+        );
+    }
+
+    #[test]
+    fn execute_does_not_touch_root_cargo_toml() {
+        let tmp = project("my-app");
+        let original_cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        plan_tauri(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        let after_cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert_eq!(
+            original_cargo, after_cargo,
+            "root Cargo.toml must be unchanged after generate tauri"
+        );
+    }
+
+    #[test]
+    fn execute_is_idempotent_with_force() {
+        let tmp = project("my-app");
+        plan_tauri(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        // Second run with --force must not corrupt files
+        plan_tauri(tmp.path())
+            .unwrap()
+            .execute(Flags {
+                force: true,
+                dry_run: false,
+            })
+            .unwrap();
+        let conf = fs::read_to_string(tmp.path().join("src-tauri/tauri.conf.json")).unwrap();
+        let _: serde_json::Value = serde_json::from_str(&conf)
+            .expect("tauri.conf.json must still be valid JSON after re-run");
+    }
+
+    #[test]
+    fn dry_run_writes_nothing() {
+        let tmp = project("my-app");
+        plan_tauri(tmp.path())
+            .unwrap()
+            .execute(Flags {
+                dry_run: true,
+                force: false,
+            })
+            .unwrap();
+        assert!(
+            !tmp.path().join("src-tauri").exists(),
+            "dry-run must not create any files"
+        );
+    }
+
+    #[test]
+    fn collision_without_force_errors() {
+        let tmp = project("my-app");
+        plan_tauri(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        let err = plan_tauri(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap_err();
+        assert!(
+            matches!(err, GenerateError::Collisions(_)),
+            "re-running without --force must return a Collisions error"
+        );
+    }
+}

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -227,15 +227,19 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String, boo
                 return name.clone();
             }
             // Inspect src/bin/ for auto-discovered binaries.  Cargo names each
-            // binary after the file stem (not the package), so `src/bin/web.rs`
-            // produces a `web` binary, not `<package>`.
+            // binary after the file stem (for `src/bin/web.rs`) or the directory
+            // name (for `src/bin/web/main.rs`), not the package name.
             if let Ok(entries) = std::fs::read_dir(project_root.join("src/bin")) {
                 let stems: Vec<String> = entries
                     .filter_map(std::result::Result::ok)
                     .filter_map(|e| {
                         let p = e.path();
                         if p.extension().is_some_and(|x| x == "rs") {
+                            // Flat file: src/bin/web.rs → "web"
                             p.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
+                        } else if p.is_dir() && p.join("main.rs").is_file() {
+                            // Directory-style: src/bin/web/main.rs → "web"
+                            p.file_name().and_then(|s| s.to_str()).map(str::to_owned)
                         } else {
                             None
                         }
@@ -1176,6 +1180,27 @@ mod tests {
         tmp
     }
 
+    /// Project with a directory-style `src/bin/<bin_stem>/main.rs` and no
+    /// `src/main.rs` or `[[bin]]` — Cargo auto-discovers the binary as `<bin_stem>`.
+    fn project_with_src_bin_dir(pkg_name: &str, bin_stem: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+                 \n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join(format!("src/bin/{bin_stem}"))).unwrap();
+        fs::write(
+            tmp.path().join(format!("src/bin/{bin_stem}/main.rs")),
+            "fn main() {}\n",
+        )
+        .unwrap();
+        tmp
+    }
+
     // ── plan_tauri: error cases ───────────────────────────────────────────────
 
     #[test]
@@ -1636,6 +1661,34 @@ mod tests {
         assert!(
             !sh.contains("--bin my-app"),
             "staging script must not use the package name when a src/bin/ binary is auto-discovered"
+        );
+    }
+
+    #[test]
+    fn plan_detects_src_bin_dir_style_binary() {
+        // A package with src/bin/web/main.rs and no src/main.rs or [[bin]] table —
+        // Cargo auto-discovers it as binary "web" (directory name, not package name).
+        let tmp = project_with_src_bin_dir("my-app", "web");
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let sh: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("stage-sidecar.sh action not found");
+        assert!(
+            sh.contains("--bin web"),
+            "staging script must detect src/bin/web/main.rs directory-style bin as 'web'"
+        );
+        assert!(
+            !sh.contains("--bin my-app"),
+            "staging script must not fall back to the package name for a directory-style bin"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -213,75 +213,91 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String, boo
         .get("default-run")
         .and_then(|v| v.as_str())
         .map(str::to_owned);
-    let bin_name = doc.get("bin").and_then(|b| b.as_array()).map_or_else(
-        // Step 5: no [[bin]] table — honour default-run, then check src/main.rs,
-        // then src/bin/ discovery, then fall back to the package name.
-        || {
-            if let Some(dr) = &default_run {
-                return dr.clone();
-            }
-            // Step 5a: src/main.rs exists → Cargo auto-discovers it as the
-            // package-named binary, even when src/bin/ also has files.
-            // Prefer the package name over any src/bin/ stem.
-            if project_root.join("src/main.rs").is_file() {
-                return name.clone();
-            }
-            // Inspect src/bin/ for auto-discovered binaries.  Cargo names each
-            // binary after the file stem (for `src/bin/web.rs`) or the directory
-            // name (for `src/bin/web/main.rs`), not the package name.
-            if let Ok(entries) = std::fs::read_dir(project_root.join("src/bin")) {
-                let stems: Vec<String> = entries
-                    .filter_map(std::result::Result::ok)
-                    .filter_map(|e| {
-                        let p = e.path();
-                        if p.extension().is_some_and(|x| x == "rs") {
-                            // Flat file: src/bin/web.rs → "web"
-                            p.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
-                        } else if p.is_dir() && p.join("main.rs").is_file() {
-                            // Directory-style: src/bin/web/main.rs → "web"
-                            p.file_name().and_then(|s| s.to_str()).map(str::to_owned)
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                if stems.len() == 1 {
-                    return stems.into_iter().next().unwrap();
-                }
-            }
-            name.clone()
-        },
-        |bins| {
-            // Step 1: explicit [[bin]] entry whose path is src/main.rs.
-            bins.iter()
-                .find(|b| {
-                    b.get("path")
-                        .and_then(|p| p.as_str())
-                        .is_some_and(|p| p == "src/main.rs" || p == "src\\main.rs")
+    // Resolve bin name in a Result-returning block so ambiguous cases can error.
+    let bin_name: String = (|| -> Result<String, GenerateError> {
+        if let Some(bins) = doc.get("bin").and_then(|b| b.as_array()) {
+            // Step 1: explicit [[bin]] entry whose path resolves to src/main.rs.
+            // Normalize the manifest path (strip leading "./" or ".\") before
+            // comparing so "path = './src/main.rs'" matches as well.
+            let main_bin = bins.iter().find(|b| {
+                b.get("path").and_then(|p| p.as_str()).is_some_and(|p| {
+                    let norm = p.trim_start_matches("./").trim_start_matches(".\\");
+                    norm == "src/main.rs" || norm == "src\\main.rs"
                 })
+            });
+            if let Some(n) = main_bin
                 .and_then(|b| b.get("name"))
                 .and_then(|n| n.as_str())
-                .map(str::to_owned)
-                .or_else(|| {
-                    if project_root.join("src/main.rs").is_file() {
-                        // Step 2: src/main.rs exists but is not declared in [[bin]];
-                        // Cargo auto-discovers it as the package-named binary.
-                        // The [[bin]] entries are for other auxiliary programs.
-                        Some(name.clone())
+            {
+                return Ok(n.to_owned());
+            }
+            if project_root.join("src/main.rs").is_file() {
+                // Step 2: src/main.rs exists but is not declared in [[bin]];
+                // Cargo auto-discovers it as the package-named binary.
+                // The [[bin]] entries are for other auxiliary programs.
+                return Ok(name.clone());
+            }
+            // Step 3: honour [package] default-run when set.
+            if let Some(dr) = &default_run {
+                return Ok(dr.clone());
+            }
+            // Step 4: single or first explicit [[bin]] as last resort.
+            return Ok(bins
+                .first()
+                .and_then(|b| b.get("name"))
+                .and_then(|n| n.as_str())
+                .map_or_else(|| name.clone(), str::to_owned));
+        }
+        // Step 5: no [[bin]] table — honour default-run, then check src/main.rs,
+        // then src/bin/ discovery; error on ambiguous multi-bin packages.
+        if let Some(dr) = &default_run {
+            return Ok(dr.clone());
+        }
+        // Step 5a: src/main.rs exists → Cargo auto-discovers it as the
+        // package-named binary, even when src/bin/ also has files.
+        if project_root.join("src/main.rs").is_file() {
+            return Ok(name.clone());
+        }
+        // Inspect src/bin/ for auto-discovered binaries.  Cargo names each
+        // binary after the file stem (for `src/bin/web.rs`) or the directory
+        // name (for `src/bin/web/main.rs`), not the package name.
+        if let Ok(entries) = std::fs::read_dir(project_root.join("src/bin")) {
+            let stems: Vec<String> = entries
+                .filter_map(std::result::Result::ok)
+                .filter_map(|e| {
+                    let p = e.path();
+                    if p.extension().is_some_and(|x| x == "rs") {
+                        // Flat file: src/bin/web.rs → "web"
+                        p.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
+                    } else if p.is_dir() && p.join("main.rs").is_file() {
+                        // Directory-style: src/bin/web/main.rs → "web"
+                        p.file_name().and_then(|s| s.to_str()).map(str::to_owned)
                     } else {
-                        // Step 3: honour [package] default-run when set.
-                        default_run.clone().or_else(|| {
-                            // Step 4: single or first explicit [[bin]] as last resort.
-                            bins.first()
-                                .and_then(|b| b.get("name"))
-                                .and_then(|n| n.as_str())
-                                .map(str::to_owned)
-                        })
+                        None
                     }
                 })
-                .unwrap_or_else(|| name.clone())
-        },
-    );
+                .collect();
+            match stems.len() {
+                1 => return Ok(stems.into_iter().next().unwrap()),
+                0 => {}
+                _ => {
+                    // Multiple src/bin/ targets with no default-run: Cargo cannot
+                    // build `--bin <package>` because that name doesn't exist.
+                    // Fail fast so the developer sees a clear error rather than
+                    // staging scripts that reference a nonexistent binary.
+                    let mut sorted = stems;
+                    sorted.sort();
+                    return Err(GenerateError::Config(format!(
+                        "ambiguous sidecar target: found multiple auto-discovered \
+                         src/bin/ binaries ({}) and no [package] default-run is set; \
+                         add `default-run = \"<bin>\"` to Cargo.toml to select one",
+                        sorted.join(", ")
+                    )));
+                }
+            }
+        }
+        Ok(name.clone())
+    })()?;
 
     // Check whether the app defines an `embed-assets` Cargo feature.
     // `autumn new` generates this; it typically expands to
@@ -1064,6 +1080,50 @@ mod tests {
         tmp
     }
 
+    /// Like `project_with_custom_bin` but the [[bin]] path uses a `./` prefix
+    /// (e.g. `path = "./src/main.rs"`), which is valid Cargo TOML but must be
+    /// normalized before comparing to detect the src/main.rs target.
+    fn project_with_dotslash_bin(pkg_name: &str, bin_name: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+                 \n[[bin]]\nname=\"{bin_name}\"\npath=\"./src/main.rs\"\n\
+                 \n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        tmp
+    }
+
+    /// Project with multiple `src/bin/` files and no `src/main.rs` or [[bin]] table
+    /// and no `default-run`.  Cargo cannot build `--bin <package>` because that name
+    /// doesn't exist; the generator must return an error rather than silently using
+    /// the package name.
+    fn project_with_multi_src_bin(pkg_name: &str, bin_stems: &[&str]) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+                 \n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src/bin")).unwrap();
+        for stem in bin_stems {
+            fs::write(
+                tmp.path().join(format!("src/bin/{stem}.rs")),
+                "fn main() {}\n",
+            )
+            .unwrap();
+        }
+        tmp
+    }
+
     /// Project with src/main.rs (the primary autumn binary, auto-discovered by
     /// Cargo under the package name) plus an auxiliary [[bin]] for a background
     /// worker.  The generator must pick the package-named binary, not the worker.
@@ -1532,6 +1592,54 @@ mod tests {
             !sh.contains("/release/my-app"),
             "stage-sidecar.sh must not hardcode the package name 'my-app' as the binary path"
         );
+    }
+
+    #[test]
+    fn plan_normalizes_dotslash_bin_path() {
+        // [[bin]] path = "./src/main.rs" (with ./ prefix) must be treated the same
+        // as "src/main.rs" — both point to the same file, and the [[bin]] name must
+        // override the package name just like the non-prefixed form.
+        let tmp = project_with_dotslash_bin("my-app", "my-server");
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let sh: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("stage-sidecar.sh action not found");
+        assert!(
+            sh.contains("my-server"),
+            "[[bin]] with path='./src/main.rs' must still resolve to the custom bin name"
+        );
+        assert!(
+            !sh.contains("--bin my-app"),
+            "generator must not fall back to package name for a ./src/main.rs [[bin]] path"
+        );
+    }
+
+    #[test]
+    fn plan_errors_on_ambiguous_multi_src_bin() {
+        // A package with multiple src/bin/ files and no default-run has no single
+        // sidecar target; the generator must return an error rather than silently
+        // using the package name (which cargo build --bin <package> would reject).
+        let tmp = project_with_multi_src_bin("my-app", &["web", "worker"]);
+        let err = plan_tauri(tmp.path()).unwrap_err();
+        assert!(
+            matches!(err, GenerateError::Config(_)),
+            "expected Config error for ambiguous multi-bin package, got: {err:?}"
+        );
+        if let GenerateError::Config(msg) = err {
+            assert!(
+                msg.contains("ambiguous") || msg.contains("default-run"),
+                "error message must mention ambiguity and how to resolve it, got: {msg}"
+            );
+        }
     }
 
     #[test]

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -54,14 +54,14 @@ use super::{Flags, GenerateError, ensure_project_root};
 pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
     ensure_project_root(project_root)?;
 
-    let package_name = read_package_name(project_root)?;
+    let (package_name, package_version) = read_package_meta(project_root)?;
     let mut plan = Plan::new(project_root);
     let tauri = project_root.join("src-tauri");
 
     // Core Tauri project files
     plan.create(
         tauri.join("tauri.conf.json"),
-        render_tauri_conf(&package_name),
+        render_tauri_conf(&package_name, &package_version),
     );
     plan.create(
         tauri.join("Cargo.toml"),
@@ -131,23 +131,32 @@ pub fn run(flags: Flags) {
     }
 }
 
-// ── Package name helper ───────────────────────────────────────────────────────
+// ── Package metadata helper ───────────────────────────────────────────────────
 
-fn read_package_name(project_root: &Path) -> Result<String, GenerateError> {
+fn read_package_meta(project_root: &Path) -> Result<(String, String), GenerateError> {
     let cargo_path = project_root.join("Cargo.toml");
     let content = std::fs::read_to_string(&cargo_path).map_err(GenerateError::Io)?;
     let doc: toml::Value = toml::from_str(&content)
         .map_err(|e| GenerateError::Config(format!("failed to parse Cargo.toml: {e}")))?;
-    doc.get("package")
-        .and_then(|p| p.get("name"))
+    let pkg = doc
+        .get("package")
+        .ok_or_else(|| GenerateError::Config("Cargo.toml missing [package].name".to_owned()))?;
+    let name = pkg
+        .get("name")
         .and_then(|n| n.as_str())
         .map(str::to_owned)
-        .ok_or_else(|| GenerateError::Config("Cargo.toml missing [package].name".to_owned()))
+        .ok_or_else(|| GenerateError::Config("Cargo.toml missing [package].name".to_owned()))?;
+    let version = pkg
+        .get("version")
+        .and_then(|v| v.as_str())
+        .unwrap_or("0.1.0")
+        .to_owned();
+    Ok((name, version))
 }
 
 // ── Content renderers ─────────────────────────────────────────────────────────
 
-fn render_tauri_conf(package_name: &str) -> String {
+fn render_tauri_conf(package_name: &str, version: &str) -> String {
     // Bundle identifier: reverse-DNS with underscores replaced by hyphens.
     // Apple's spec allows only alphanumerics, hyphens, and periods — underscores are invalid.
     let identifier = format!("com.example.{}", package_name.replace('_', "-"));
@@ -184,7 +193,7 @@ fn render_tauri_conf(package_name: &str) -> String {
         r#"{{
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "{title}",
-  "version": "0.1.0",
+  "version": "{version}",
   "identifier": "{identifier}",
   "build": {{
     "beforeBuildCommand": "{before_build_cmd}"
@@ -1039,15 +1048,27 @@ mod tests {
 
     #[test]
     fn tauri_conf_is_valid_json() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", "0.1.0");
         let parsed: serde_json::Value =
             serde_json::from_str(&conf).expect("tauri.conf.json must be valid JSON");
         assert!(parsed.is_object());
     }
 
     #[test]
+    fn tauri_conf_uses_package_version() {
+        let conf = render_tauri_conf("my-app", "1.4.2");
+        let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
+        assert_eq!(
+            parsed["version"].as_str(),
+            Some("1.4.2"),
+            "tauri.conf.json version must match [package].version from Cargo.toml, \
+             not a hardcoded 0.1.0"
+        );
+    }
+
+    #[test]
     fn tauri_conf_has_identifier() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", "0.1.0");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         assert!(
             parsed["identifier"].is_string(),
@@ -1061,7 +1082,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_product_name() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", "0.1.0");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         assert!(
             parsed["productName"].is_string(),
@@ -1071,7 +1092,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_external_bin() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", "0.1.0");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let bins = parsed["bundle"]["externalBin"]
             .as_array()
@@ -1086,7 +1107,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_icon_array() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", "0.1.0");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let icons = parsed["bundle"]["icon"]
             .as_array()
@@ -1100,7 +1121,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_before_build_command() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", "0.1.0");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let cmd = parsed["build"]["beforeBuildCommand"]
             .as_str()
@@ -1361,7 +1382,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_bundles_autumn_toml_as_resource() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", "0.1.0");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         // Tauri v2 resources must be a map { source_path: dest_path }, not an array.
         let resources = parsed["bundle"]["resources"]
@@ -1432,7 +1453,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_identifier_replaces_underscores() {
-        let conf = render_tauri_conf("my_app");
+        let conf = render_tauri_conf("my_app", "0.1.0");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let id = parsed["identifier"].as_str().unwrap();
         assert!(
@@ -1447,7 +1468,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_security_is_under_app() {
-        let conf = render_tauri_conf("my-app");
+        let conf = render_tauri_conf("my-app", "0.1.0");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         assert!(
             parsed["app"]["security"].is_object(),
@@ -1814,7 +1835,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_product_name_handles_underscore_separator() {
-        let conf = render_tauri_conf("my_app");
+        let conf = render_tauri_conf("my_app", "0.1.0");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let name = parsed["productName"].as_str().unwrap();
         assert!(

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -318,7 +318,7 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
     let app_data_dir = app.path().app_data_dir()?.join("db");
     std::fs::create_dir_all(&app_data_dir)?;
 
-    // 3. Spawn the autumn server sidecar (built with embed-assets + managed-pg-bundled).
+    // 3. Spawn the autumn server sidecar (built with autumn-web/embed-assets + managed-pg-bundled).
     //    The sidecar() argument is the binary basename matching externalBin in tauri.conf.json.
     let (_rx, child) = app
         .shell()
@@ -426,12 +426,12 @@ cd "$APP_DIR"
 # TAURI_ENV_TARGET_TRIPLE is set by `cargo tauri build` for cross-compilation;
 # fall back to the host triple when running the script manually.
 TARGET_TRIPLE="${{TAURI_ENV_TARGET_TRIPLE:-$(rustc -Vv | awk '/^host/{{print $2}}')}}";
-# Use the app-level `embed-assets` feature (not `autumn-web/embed-assets` directly)
-# so that #[cfg(feature = "embed-assets")] in the scaffolded main.rs activates
-# the .embedded_static() wiring.  autumn-web/managed-pg-bundled has no app-level
-# analog so it must be addressed via the dependency path.
+# Build with both autumn-web features so the sidecar binary embeds static assets
+# and bundles Postgres.  Both are specified via the dependency path so this script
+# works with any autumn project regardless of whether the app's Cargo.toml defines
+# a top-level `embed-assets` feature alias.
 cargo build --release --target "${{TARGET_TRIPLE}}" \
-  --features embed-assets,autumn-web/managed-pg-bundled
+  --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
 mkdir -p src-tauri/binaries
 cp "target/${{TARGET_TRIPLE}}/release/{package_name}" \
    "src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
@@ -458,11 +458,12 @@ $TargetTriple = $Env:TAURI_ENV_TARGET_TRIPLE
 if (-not $TargetTriple) {{
     $TargetTriple = (rustc -Vv | Select-String "^host").Line.Split()[1]
 }}
-# Use the app-level embed-assets feature (not autumn-web/embed-assets directly)
-# so that #[cfg(feature = "embed-assets")] in the scaffolded main.rs activates
-# the .embedded_static() wiring.
+# Build with both autumn-web features so the sidecar binary embeds static assets
+# and bundles Postgres.  Both are specified via the dependency path so this script
+# works with any autumn project regardless of whether the app's Cargo.toml defines
+# a top-level `embed-assets` feature alias.
 cargo build --release --target "$TargetTriple" `
-  --features embed-assets,autumn-web/managed-pg-bundled
+  --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
 New-Item -ItemType Directory -Force -Path src-tauri\binaries | Out-Null
 Copy-Item "target\$TargetTriple\release\{package_name}.exe" `
           "src-tauri\binaries\{package_name}-$TargetTriple.exe"
@@ -495,7 +496,7 @@ Required prerequisites for `cargo tauri build`:\n\
   4. Build the desktop app:\n\
        cd src-tauri && cargo tauri build\n\
 \n\
-  The sidecar is built with the app-level embed-assets feature (#1004) and\n\
+  The sidecar is built with autumn-web/embed-assets (#1004) and\n\
   autumn-web/managed-pg-bundled (#1119) so the packaged desktop app needs\n\
   no separately-installed database or loose asset files.\n\
 \n\
@@ -1063,7 +1064,12 @@ mod tests {
         let svg_action = plan
             .actions
             .iter()
-            .find(|a| a.path().to_string_lossy().ends_with("icons/icon.svg"))
+            .find(|a| {
+                a.path()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+                    .ends_with("icons/icon.svg")
+            })
             .expect("icon.svg must be in the plan");
 
         if let super::super::emit::Action::CreateIfAbsent { contents, .. } = svg_action {

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -207,8 +207,9 @@ fn render_tauri_conf(package_name: &str) -> String {
       "../autumn.toml": "autumn.toml",
       "configs/autumn-prod.toml": "autumn-prod.toml",
       "configs/autumn-production.toml": "autumn-production.toml",
-      "configs/autumn-staging.toml": "autumn-staging.toml",
+      "configs/autumn-dev.toml": "autumn-dev.toml",
       "configs/autumn-development.toml": "autumn-development.toml",
+      "configs/autumn-staging.toml": "autumn-staging.toml",
       "configs/autumn-test.toml": "autumn-test.toml"
     }}
   }},
@@ -553,12 +554,43 @@ else
        "src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
     echo "Staged: src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
 fi
-# Stage profile config files so tauri.conf.json's static resource entries are
-# always satisfiable at bundle time, regardless of when the files were created
-# relative to when `autumn generate tauri` was run.  An empty TOML file is
-# valid and results in no overrides; AutumnConfig treats it as a no-op.
+# Stage profile config files into src-tauri/configs/ so tauri.conf.json resource
+# entries are always satisfiable at bundle time.
+# For alias pairs (prod/production, dev/development): AutumnConfig stops at the
+# first existing file in its ordered lookup list.  Copy the available file to
+# BOTH names so the profile resolves correctly regardless of AUTUMN_ENV spelling,
+# avoiding an empty stub from shadowing real config in the other alias.
 mkdir -p src-tauri/configs
-for f in autumn-prod.toml autumn-production.toml autumn-staging.toml autumn-development.toml autumn-test.toml; do
+# prod/production alias pair
+if [ -f "autumn-prod.toml" ] && [ -f "autumn-production.toml" ]; then
+    cp autumn-prod.toml src-tauri/configs/autumn-prod.toml
+    cp autumn-production.toml src-tauri/configs/autumn-production.toml
+elif [ -f "autumn-prod.toml" ]; then
+    cp autumn-prod.toml src-tauri/configs/autumn-prod.toml
+    cp autumn-prod.toml src-tauri/configs/autumn-production.toml
+elif [ -f "autumn-production.toml" ]; then
+    cp autumn-production.toml src-tauri/configs/autumn-prod.toml
+    cp autumn-production.toml src-tauri/configs/autumn-production.toml
+else
+    : > src-tauri/configs/autumn-prod.toml
+    : > src-tauri/configs/autumn-production.toml
+fi
+# dev/development alias pair (same logic)
+if [ -f "autumn-dev.toml" ] && [ -f "autumn-development.toml" ]; then
+    cp autumn-dev.toml src-tauri/configs/autumn-dev.toml
+    cp autumn-development.toml src-tauri/configs/autumn-development.toml
+elif [ -f "autumn-dev.toml" ]; then
+    cp autumn-dev.toml src-tauri/configs/autumn-dev.toml
+    cp autumn-dev.toml src-tauri/configs/autumn-development.toml
+elif [ -f "autumn-development.toml" ]; then
+    cp autumn-development.toml src-tauri/configs/autumn-dev.toml
+    cp autumn-development.toml src-tauri/configs/autumn-development.toml
+else
+    : > src-tauri/configs/autumn-dev.toml
+    : > src-tauri/configs/autumn-development.toml
+fi
+# Standalone profiles (no aliases)
+for f in autumn-staging.toml autumn-test.toml; do
     if [ -f "$f" ]; then
         cp "$f" "src-tauri/configs/$f"
     else
@@ -603,12 +635,43 @@ New-Item -ItemType Directory -Force -Path src-tauri\binaries | Out-Null
 Copy-Item "$TargetDir\$TargetTriple\release\{package_name}.exe" `
           "src-tauri\binaries\{package_name}-$TargetTriple.exe"
 Write-Host "Staged: src-tauri/binaries/{package_name}-$TargetTriple.exe"
-# Stage profile config files so tauri.conf.json's static resource entries are
-# always satisfiable at bundle time, regardless of when the files were created
-# relative to when `autumn generate tauri` was run.  An empty TOML file is
-# valid and results in no overrides; AutumnConfig treats it as a no-op.
+# Stage profile config files into src-tauri\configs\ so tauri.conf.json resource
+# entries are always satisfiable at bundle time.
+# For alias pairs (prod/production, dev/development): AutumnConfig stops at the
+# first existing file in its ordered lookup list.  Copy the available file to
+# BOTH names so the profile resolves correctly regardless of AUTUMN_ENV spelling,
+# avoiding an empty stub from shadowing real config in the other alias.
 New-Item -ItemType Directory -Force -Path src-tauri\configs | Out-Null
-foreach ($f in @("autumn-prod.toml", "autumn-production.toml", "autumn-staging.toml", "autumn-development.toml", "autumn-test.toml")) {{
+# prod/production alias pair
+if ((Test-Path autumn-prod.toml) -and (Test-Path autumn-production.toml)) {{
+    Copy-Item autumn-prod.toml src-tauri\configs\autumn-prod.toml
+    Copy-Item autumn-production.toml src-tauri\configs\autumn-production.toml
+}} elseif (Test-Path autumn-prod.toml) {{
+    Copy-Item autumn-prod.toml src-tauri\configs\autumn-prod.toml
+    Copy-Item autumn-prod.toml src-tauri\configs\autumn-production.toml
+}} elseif (Test-Path autumn-production.toml) {{
+    Copy-Item autumn-production.toml src-tauri\configs\autumn-prod.toml
+    Copy-Item autumn-production.toml src-tauri\configs\autumn-production.toml
+}} else {{
+    New-Item -ItemType File -Force -Path src-tauri\configs\autumn-prod.toml | Out-Null
+    New-Item -ItemType File -Force -Path src-tauri\configs\autumn-production.toml | Out-Null
+}}
+# dev/development alias pair (same logic)
+if ((Test-Path autumn-dev.toml) -and (Test-Path autumn-development.toml)) {{
+    Copy-Item autumn-dev.toml src-tauri\configs\autumn-dev.toml
+    Copy-Item autumn-development.toml src-tauri\configs\autumn-development.toml
+}} elseif (Test-Path autumn-dev.toml) {{
+    Copy-Item autumn-dev.toml src-tauri\configs\autumn-dev.toml
+    Copy-Item autumn-dev.toml src-tauri\configs\autumn-development.toml
+}} elseif (Test-Path autumn-development.toml) {{
+    Copy-Item autumn-development.toml src-tauri\configs\autumn-dev.toml
+    Copy-Item autumn-development.toml src-tauri\configs\autumn-development.toml
+}} else {{
+    New-Item -ItemType File -Force -Path src-tauri\configs\autumn-dev.toml | Out-Null
+    New-Item -ItemType File -Force -Path src-tauri\configs\autumn-development.toml | Out-Null
+}}
+# Standalone profiles (no aliases)
+foreach ($f in @("autumn-staging.toml", "autumn-test.toml")) {{
     if (Test-Path $f) {{
         Copy-Item $f "src-tauri\configs\$f"
     }} else {{
@@ -890,6 +953,48 @@ mod tests {
         assert!(
             ps1.contains("autumn-prod.toml"),
             "stage-sidecar.ps1 must stage autumn-prod.toml into configs\\"
+        );
+    }
+
+    // When only one of a prod/production (or dev/development) alias pair exists, the
+    // staging script must copy it to BOTH names so an empty stub can never shadow
+    // real config because AutumnConfig stops at the first existing file in the lookup list.
+    #[test]
+    fn stage_sidecar_sh_copies_alias_to_both_names() {
+        let sh = render_stage_sidecar_sh("my-app");
+        // Must handle the case where only autumn-production.toml exists by copying it
+        // to autumn-prod.toml as well — look for the elif + both cp lines.
+        assert!(
+            sh.contains("autumn-production.toml") && sh.contains("autumn-prod.toml"),
+            "stage-sidecar.sh must handle prod/production alias pair explicitly"
+        );
+        // The alias-pair logic copies to BOTH names from a single source, so each
+        // destination path must appear at least twice (once in the both-exist branch
+        // and once in the single-file branch).
+        assert!(
+            sh.matches("autumn-prod.toml").count() >= 2,
+            "stage-sidecar.sh must copy to autumn-prod.toml in multiple alias branches"
+        );
+        assert!(
+            sh.contains("autumn-dev.toml") && sh.contains("autumn-development.toml"),
+            "stage-sidecar.sh must handle dev/development alias pair explicitly"
+        );
+    }
+
+    #[test]
+    fn stage_sidecar_ps1_copies_alias_to_both_names() {
+        let ps1 = render_stage_sidecar_ps1("my-app");
+        assert!(
+            ps1.contains("autumn-production.toml") && ps1.contains("autumn-prod.toml"),
+            "stage-sidecar.ps1 must handle prod/production alias pair explicitly"
+        );
+        assert!(
+            ps1.matches("autumn-prod.toml").count() >= 2,
+            "stage-sidecar.ps1 must copy to autumn-prod.toml in multiple alias branches"
+        );
+        assert!(
+            ps1.contains("autumn-dev.toml") && ps1.contains("autumn-development.toml"),
+            "stage-sidecar.ps1 must handle dev/development alias pair explicitly"
         );
     }
 
@@ -1247,16 +1352,38 @@ mod tests {
             "tauri.conf.json must not emit resource glob entries — Tauri fails with \
              GlobPathNotFound when the glob matches no files (common for fresh projects)"
         );
-        // Profile configs must always be included from configs/ so they are bundled
-        // regardless of when the files were created relative to `autumn generate tauri`.
-        // The staging script creates the files (or empty stubs) at build time.
+        // Both alias names for prod and dev must be included so the staging script's
+        // alias-pair copy logic always has a resource destination for each name,
+        // and the sidecar finds the config regardless of AUTUMN_ENV spelling.
         let has_prod = resources
             .keys()
-            .any(|k| k.contains("configs/") && k.contains("prod"));
+            .any(|k| k.contains("configs/") && k.contains("autumn-prod.toml"));
         assert!(
             has_prod,
-            "tauri.conf.json must include profile config entries from configs/ so \
-             autumn-prod.toml is bundled even when added after `autumn generate tauri`"
+            "tauri.conf.json must include configs/autumn-prod.toml so autumn-prod.toml \
+             is bundled even when added after `autumn generate tauri`"
+        );
+        let has_production = resources
+            .keys()
+            .any(|k| k.contains("configs/") && k.contains("autumn-production.toml"));
+        assert!(
+            has_production,
+            "tauri.conf.json must include configs/autumn-production.toml (prod alias)"
+        );
+        let has_dev = resources
+            .keys()
+            .any(|k| k.contains("configs/") && k.contains("autumn-dev.toml"));
+        assert!(
+            has_dev,
+            "tauri.conf.json must include configs/autumn-dev.toml so the dev alias \
+             is bundled alongside autumn-development.toml"
+        );
+        let has_development = resources
+            .keys()
+            .any(|k| k.contains("configs/") && k.contains("autumn-development.toml"));
+        assert!(
+            has_development,
+            "tauri.conf.json must include configs/autumn-development.toml (dev alias)"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -195,6 +195,9 @@ fn render_tauri_conf(package_name: &str) -> String {
     ],
     "externalBin": [
       "binaries/{package_name}"
+    ],
+    "resources": [
+      {{ "from": "../autumn.toml", "to": "autumn.toml" }}
     ]
   }},
   "app": {{
@@ -318,6 +321,13 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
     let app_data_dir = app.path().app_data_dir()?.join("db");
     std::fs::create_dir_all(&app_data_dir)?;
 
+    // autumn.toml is bundled as a resource (see tauri.conf.json bundle.resources).
+    // Point the sidecar at the resource directory so AutumnConfig::load_with_env()
+    // finds autumn.toml on the installed machine — without this, the sidecar looks
+    // in its CWD and falls back to compiled-in defaults, silently missing production
+    // settings such as auth, SEO, auto-migrate, and security configuration.
+    let resource_dir = app.path().resource_dir()?;
+
     // 3. Spawn the autumn server sidecar (built with autumn-web/embed-assets + managed-pg-bundled).
     //    The sidecar() argument is the binary basename matching externalBin in tauri.conf.json.
     let (_rx, child) = app
@@ -328,6 +338,10 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         .env(
             "AUTUMN_MANAGED_PG_DATA_DIR",
             app_data_dir.to_string_lossy().as_ref(),
+        )
+        .env(
+            "AUTUMN_MANIFEST_DIR",
+            resource_dir.to_string_lossy().as_ref(),
         )
         // Force the health endpoint to /health so the readiness probe below
         // always works, regardless of what [health].path is configured in the app.
@@ -944,6 +958,41 @@ mod tests {
             lib.contains("AUTUMN_SERVER__UNIX_SOCKET"),
             "lib.rs must clear AUTUMN_SERVER__UNIX_SOCKET so an inherited env var \
              cannot redirect the sidecar to a Unix socket the TCP probe cannot reach"
+        );
+    }
+
+    #[test]
+    fn lib_rs_sets_autumn_manifest_dir() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains("AUTUMN_MANIFEST_DIR"),
+            "lib.rs must set AUTUMN_MANIFEST_DIR to the Tauri resource dir so the \
+             sidecar finds the bundled autumn.toml on the installed machine"
+        );
+    }
+
+    #[test]
+    fn tauri_conf_bundles_autumn_toml_as_resource() {
+        let conf = render_tauri_conf("my-app");
+        let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
+        let resources = parsed["bundle"]["resources"]
+            .as_array()
+            .expect("bundle.resources must be an array");
+        let has_autumn_toml = resources.iter().any(|r| {
+            // resource entries can be strings or {"from": "...", "to": "..."}
+            r.as_str()
+                .map(|s| s.contains("autumn.toml"))
+                .unwrap_or_else(|| {
+                    r["from"]
+                        .as_str()
+                        .map(|s| s.contains("autumn.toml"))
+                        .unwrap_or(false)
+                })
+        });
+        assert!(
+            has_autumn_toml,
+            "tauri.conf.json must bundle autumn.toml as a resource so the installed \
+             sidecar can find the app's production configuration"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -169,6 +169,104 @@ pub fn run(flags: Flags) {
 /// `--features autumn-web/embed-assets` (dep path only), so that the app's
 /// `#[cfg(feature = "embed-assets")]` guard on `.embedded_static()` is
 /// satisfied — mirroring what `autumn build --embed` does.
+/// Resolve the Cargo binary target name for the Tauri sidecar.
+///
+/// Priority when `[[bin]]` entries are present:
+///
+///   1. `[package] default-run` — the developer's explicit selection.
+///   2. An explicit `[[bin]]` whose path resolves to `src/main.rs`.
+///   3. `src/main.rs` on disk (only when `autobins != false`).
+///   4. Single `[[bin]]` → use it; multiple without `default-run` → error.
+///
+/// When there are no `[[bin]]` entries:
+///
+///   5. `default-run` → `src/main.rs` (autobins guard) → `src/bin/` discovery.
+fn resolve_bin_name(
+    project_root: &Path,
+    name: &str,
+    default_run: Option<&str>,
+    autobins: bool,
+    doc: &toml::Value,
+) -> Result<String, GenerateError> {
+    if let Some(bins) = doc.get("bin").and_then(toml::Value::as_array) {
+        if let Some(dr) = default_run {
+            return Ok(dr.to_owned());
+        }
+        let main_bin = bins.iter().find(|b| {
+            b.get("path").and_then(|p| p.as_str()).is_some_and(|p| {
+                let segs: Vec<&str> = p
+                    .split(['/', '\\'])
+                    .filter(|&s| !s.is_empty() && s != ".")
+                    .collect();
+                segs == ["src", "main.rs"]
+            })
+        });
+        if let Some(n) = main_bin
+            .and_then(|b| b.get("name"))
+            .and_then(|n| n.as_str())
+        {
+            return Ok(n.to_owned());
+        }
+        if autobins && project_root.join("src/main.rs").is_file() {
+            return Ok(name.to_owned());
+        }
+        if bins.len() > 1 {
+            let mut names: Vec<&str> = bins
+                .iter()
+                .filter_map(|b| b.get("name").and_then(|n| n.as_str()))
+                .collect();
+            names.sort_unstable();
+            return Err(GenerateError::Config(format!(
+                "ambiguous sidecar target: found multiple explicit [[bin]] entries ({}) \
+                 and no [package] default-run is set; add `default-run = \"<bin>\"` to \
+                 Cargo.toml to select one",
+                names.join(", ")
+            )));
+        }
+        return Ok(bins
+            .first()
+            .and_then(|b| b.get("name"))
+            .and_then(|n| n.as_str())
+            .map_or_else(|| name.to_owned(), str::to_owned));
+    }
+    if let Some(dr) = default_run {
+        return Ok(dr.to_owned());
+    }
+    if autobins && project_root.join("src/main.rs").is_file() {
+        return Ok(name.to_owned());
+    }
+    if let Ok(entries) = std::fs::read_dir(project_root.join("src/bin")) {
+        let stems: Vec<String> = entries
+            .filter_map(std::result::Result::ok)
+            .filter_map(|e| {
+                let p = e.path();
+                if p.extension().is_some_and(|x| x == "rs") {
+                    p.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
+                } else if p.is_dir() && p.join("main.rs").is_file() {
+                    p.file_name().and_then(|s| s.to_str()).map(str::to_owned)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        match stems.len() {
+            1 => return Ok(stems.into_iter().next().unwrap()),
+            0 => {}
+            _ => {
+                let mut sorted = stems;
+                sorted.sort();
+                return Err(GenerateError::Config(format!(
+                    "ambiguous sidecar target: found multiple auto-discovered \
+                     src/bin/ binaries ({}) and no [package] default-run is set; \
+                     add `default-run = \"<bin>\"` to Cargo.toml to select one",
+                    sorted.join(", ")
+                )));
+            }
+        }
+    }
+    Ok(name.to_owned())
+}
+
 fn read_package_meta(project_root: &Path) -> Result<(String, String, String, bool), GenerateError> {
     let cargo_path = project_root.join("Cargo.toml");
     let content = std::fs::read_to_string(&cargo_path).map_err(GenerateError::Io)?;
@@ -194,114 +292,15 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String, boo
         _ => "0.1.0".to_owned(),
     };
 
-    // Derive the binary target name from [[bin]] sections.  When a custom name
-    // is set, `cargo build` writes that name (not the package name) under
-    // `target/.../release/`.
-    //
-    // Priority when [[bin]] entries are present:
-    //   1. `[package] default-run` — the developer's explicit selection; takes
-    //      precedence over any auto-discovered src/main.rs target.
-    //   2. A [[bin]] entry whose path is explicitly `src/main.rs` (renamed main).
-    //   3. If `src/main.rs` exists on disk but isn't in [[bin]], Cargo auto-discovers
-    //      it under the package name; any explicit [[bin]] entries are auxiliary bins.
-    //   4. `bins.first()` — last resort when only one [[bin]] is declared.
-    // When there are no [[bin]] entries:
-    //   5. `default-run` first, then `src/main.rs`, then `src/bin/` discovery.
     let default_run = pkg
         .get("default-run")
         .and_then(|v| v.as_str())
         .map(str::to_owned);
-    // Resolve bin name in a Result-returning block so ambiguous cases can error.
-    let bin_name: String = (|| -> Result<String, GenerateError> {
-        if let Some(bins) = doc.get("bin").and_then(|b| b.as_array()) {
-            // Step 1: honour [package] default-run — the developer's explicit selection.
-            // Must come before src/main.rs auto-discovery so a project that has
-            // src/main.rs *plus* explicit [[bin]] targets and sets default-run = "web"
-            // stages the declared default, not the package-named auto-discovered bin.
-            if let Some(dr) = &default_run {
-                return Ok(dr.clone());
-            }
-            // Step 2: explicit [[bin]] entry whose path resolves to src/main.rs.
-            // Canonicalize by splitting on both separators and filtering empty and
-            // CurDir (".") segments so "src/./main.rs", "./src/main.rs", and
-            // "src/main.rs" all match identically.
-            let main_bin = bins.iter().find(|b| {
-                b.get("path").and_then(|p| p.as_str()).is_some_and(|p| {
-                    let segs: Vec<&str> = p
-                        .split(['/', '\\'])
-                        .filter(|&s| !s.is_empty() && s != ".")
-                        .collect();
-                    segs == ["src", "main.rs"]
-                })
-            });
-            if let Some(n) = main_bin
-                .and_then(|b| b.get("name"))
-                .and_then(|n| n.as_str())
-            {
-                return Ok(n.to_owned());
-            }
-            // Step 3: src/main.rs exists but is not declared in [[bin]];
-            // Cargo auto-discovers it as the package-named binary.
-            if project_root.join("src/main.rs").is_file() {
-                return Ok(name.clone());
-            }
-            // Step 4: first explicit [[bin]] as last resort.
-            return Ok(bins
-                .first()
-                .and_then(|b| b.get("name"))
-                .and_then(|n| n.as_str())
-                .map_or_else(|| name.clone(), str::to_owned));
-        }
-        // Step 5: no [[bin]] table — honour default-run, then check src/main.rs,
-        // then src/bin/ discovery; error on ambiguous multi-bin packages.
-        if let Some(dr) = &default_run {
-            return Ok(dr.clone());
-        }
-        // Step 5a: src/main.rs exists → Cargo auto-discovers it as the
-        // package-named binary, even when src/bin/ also has files.
-        if project_root.join("src/main.rs").is_file() {
-            return Ok(name.clone());
-        }
-        // Inspect src/bin/ for auto-discovered binaries.  Cargo names each
-        // binary after the file stem (for `src/bin/web.rs`) or the directory
-        // name (for `src/bin/web/main.rs`), not the package name.
-        if let Ok(entries) = std::fs::read_dir(project_root.join("src/bin")) {
-            let stems: Vec<String> = entries
-                .filter_map(std::result::Result::ok)
-                .filter_map(|e| {
-                    let p = e.path();
-                    if p.extension().is_some_and(|x| x == "rs") {
-                        // Flat file: src/bin/web.rs → "web"
-                        p.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
-                    } else if p.is_dir() && p.join("main.rs").is_file() {
-                        // Directory-style: src/bin/web/main.rs → "web"
-                        p.file_name().and_then(|s| s.to_str()).map(str::to_owned)
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            match stems.len() {
-                1 => return Ok(stems.into_iter().next().unwrap()),
-                0 => {}
-                _ => {
-                    // Multiple src/bin/ targets with no default-run: Cargo cannot
-                    // build `--bin <package>` because that name doesn't exist.
-                    // Fail fast so the developer sees a clear error rather than
-                    // staging scripts that reference a nonexistent binary.
-                    let mut sorted = stems;
-                    sorted.sort();
-                    return Err(GenerateError::Config(format!(
-                        "ambiguous sidecar target: found multiple auto-discovered \
-                         src/bin/ binaries ({}) and no [package] default-run is set; \
-                         add `default-run = \"<bin>\"` to Cargo.toml to select one",
-                        sorted.join(", ")
-                    )));
-                }
-            }
-        }
-        Ok(name.clone())
-    })()?;
+    let autobins = pkg
+        .get("autobins")
+        .and_then(toml::Value::as_bool)
+        .unwrap_or(true);
+    let bin_name = resolve_bin_name(project_root, &name, default_run.as_deref(), autobins, &doc)?;
 
     // Check whether the app defines an `embed-assets` Cargo feature.
     // `autumn new` generates this; it typically expands to
@@ -1271,6 +1270,55 @@ mod tests {
         tmp
     }
 
+    /// Project with `autobins = false` and one explicit `[[bin]]`, plus `src/main.rs`.
+    /// With autobins disabled, Cargo does NOT auto-discover `src/main.rs`; the
+    /// generator must use the explicit bin name, not the package name.
+    fn project_with_autobins_false(pkg_name: &str, bin_name: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+                 autobins=false\n\
+                 \n[[bin]]\nname=\"{bin_name}\"\npath=\"src/{bin_name}.rs\"\n\
+                 \n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        // src/main.rs exists but is NOT a Cargo target because autobins=false.
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        fs::write(
+            tmp.path().join(format!("src/{bin_name}.rs")),
+            "fn main() {}\n",
+        )
+        .unwrap();
+        tmp
+    }
+
+    /// Project with multiple explicit `[[bin]]` entries, no `default-run`, and no
+    /// `src/main.rs`.  The generator must error rather than silently pick the first bin.
+    fn project_with_multiple_bins_no_default(pkg_name: &str, bins: &[&str]) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        let bin_sections = bins.iter().fold(String::new(), |mut acc, b| {
+            write!(acc, "\n[[bin]]\nname=\"{b}\"\npath=\"src/{b}.rs\"\n").unwrap();
+            acc
+        });
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\
+                 {bin_sections}\n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        for b in bins {
+            fs::write(tmp.path().join(format!("src/{b}.rs")), "fn main() {}\n").unwrap();
+        }
+        tmp
+    }
+
     fn project_with_workspace_version(pkg_name: &str, ws_version: &str) -> TempDir {
         let tmp = TempDir::new().unwrap();
         fs::write(
@@ -1911,6 +1959,54 @@ mod tests {
         assert!(
             !sh.contains("--bin worker"),
             "staging script must not use the src/bin/ stem 'worker' when src/main.rs is present"
+        );
+    }
+
+    #[test]
+    fn plan_respects_autobins_false_ignores_main_rs() {
+        // autobins=false disables src/main.rs auto-discovery.  The explicit [[bin]]
+        // target must be used even though src/main.rs exists.
+        let tmp = project_with_autobins_false("my-app", "web");
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let sh: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("stage-sidecar.sh action not found");
+        assert!(
+            sh.contains("--bin web"),
+            "with autobins=false the explicit [[bin]] name 'web' must be used; \
+             src/main.rs is not a Cargo target when autobins is disabled"
+        );
+        assert!(
+            !sh.contains("--bin my-app"),
+            "with autobins=false the package name 'my-app' must NOT be used; \
+             there is no auto-discovered binary for src/main.rs"
+        );
+    }
+
+    #[test]
+    fn plan_errors_on_multiple_explicit_bins_without_default_run() {
+        // Multiple [[bin]] entries with no default-run and no src/main.rs must error
+        // rather than silently pick the first entry (which may be an auxiliary binary).
+        let tmp = project_with_multiple_bins_no_default("my-app", &["worker", "web"]);
+        let err = plan_tauri(tmp.path()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ambiguous") || msg.contains("default-run"),
+            "expected an ambiguous-sidecar error when multiple explicit [[bin]] entries \
+             exist and no default-run is set; got: {msg}"
+        );
+        assert!(
+            msg.contains("web") && msg.contains("worker"),
+            "error message must list the ambiguous bin names; got: {msg}"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -172,25 +172,48 @@ fn read_package_meta(project_root: &Path) -> Result<(String, String, String), Ge
 
     // Derive the binary target name from [[bin]] sections.  When a custom name
     // is set, `cargo build` writes that name (not the package name) under
-    // `target/.../release/`.  Prefer the bin whose path is `src/main.rs`
-    // (the primary entry point), then fall back to the first declared bin, then
-    // the package name (the Cargo default when no [[bin]] is declared).
-    let bin_name = doc
-        .get("bin")
-        .and_then(|b| b.as_array())
-        .and_then(|bins| {
+    // `target/.../release/`.
+    //
+    // Priority:
+    //   1. A [[bin]] entry whose path is explicitly `src/main.rs` (renamed main).
+    //   2. If `src/main.rs` exists on disk but isn't in [[bin]], Cargo auto-discovers
+    //      it under the package name; any explicit [[bin]] entries are auxiliary bins
+    //      and must NOT override the primary target.
+    //   3. The first (and only) [[bin]] when there is no `src/main.rs` at all.
+    //   4. The package name (Cargo default when no [[bin]] is declared).
+    let bin_name = {
+        let explicit_bins = doc.get("bin").and_then(|b| b.as_array());
+        if let Some(bins) = explicit_bins {
+            // Step 1: explicit [[bin]] entry whose path is src/main.rs.
             bins.iter()
                 .find(|b| {
                     b.get("path")
                         .and_then(|p| p.as_str())
                         .is_some_and(|p| p == "src/main.rs" || p == "src\\main.rs")
                 })
-                .or_else(|| bins.first())
                 .and_then(|b| b.get("name"))
                 .and_then(|n| n.as_str())
-        })
-        .unwrap_or(&name)
-        .to_owned();
+                .map(str::to_owned)
+                .or_else(|| {
+                    if project_root.join("src/main.rs").is_file() {
+                        // Step 2: src/main.rs exists but is not declared in [[bin]];
+                        // Cargo auto-discovers it as the package-named binary.
+                        // The [[bin]] entries are for other auxiliary programs.
+                        Some(name.clone())
+                    } else {
+                        // Step 3: no src/main.rs — the first declared bin IS the app.
+                        bins.first()
+                            .and_then(|b| b.get("name"))
+                            .and_then(|n| n.as_str())
+                            .map(str::to_owned)
+                    }
+                })
+                .unwrap_or_else(|| name.clone())
+        } else {
+            // Step 4: no [[bin]] at all — package name is the binary name.
+            name.clone()
+        }
+    };
 
     Ok((name, version, bin_name))
 }
@@ -645,6 +668,12 @@ fi
 # BOTH names so the profile resolves correctly regardless of AUTUMN_ENV spelling,
 # avoiding an empty stub from shadowing real config in the other alias.
 mkdir -p src-tauri/configs
+# Ensure autumn.toml exists at the project root — tauri.conf.json always
+# lists it as a bundle resource.  Projects without a config file use
+# AutumnConfig defaults; an empty TOML is a valid no-op.
+if [ ! -f "autumn.toml" ]; then
+    : > autumn.toml
+fi
 # prod/production alias pair
 if [ -f "autumn-prod.toml" ] && [ -f "autumn-production.toml" ]; then
     cp autumn-prod.toml src-tauri/configs/autumn-prod.toml
@@ -726,6 +755,12 @@ Write-Host "Staged: src-tauri/binaries/{bin_name}-$TargetTriple.exe"
 # BOTH names so the profile resolves correctly regardless of AUTUMN_ENV spelling,
 # avoiding an empty stub from shadowing real config in the other alias.
 New-Item -ItemType Directory -Force -Path src-tauri\configs | Out-Null
+# Ensure autumn.toml exists at the project root — tauri.conf.json always
+# lists it as a bundle resource.  Projects without a config file use
+# AutumnConfig defaults; an empty TOML is a valid no-op.
+if (-not (Test-Path autumn.toml)) {{
+    New-Item -ItemType File -Force -Path autumn.toml | Out-Null
+}}
 # prod/production alias pair
 if ((Test-Path autumn-prod.toml) -and (Test-Path autumn-production.toml)) {{
     Copy-Item autumn-prod.toml src-tauri\configs\autumn-prod.toml
@@ -891,6 +926,28 @@ mod tests {
         .unwrap();
         fs::create_dir_all(tmp.path().join("src")).unwrap();
         fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        tmp
+    }
+
+    /// Project with src/main.rs (the primary autumn binary, auto-discovered by
+    /// Cargo under the package name) plus an auxiliary [[bin]] for a background
+    /// worker.  The generator must pick the package-named binary, not the worker.
+    fn project_with_aux_bin(pkg_name: &str, worker_name: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion=\"0.1.0\"\nedition=\"2024\"\n\
+                 \n[[bin]]\nname=\"{worker_name}\"\npath=\"src/worker.rs\"\n\
+                 \n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        // Auto-discovered primary binary (NOT listed in [[bin]]).
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        // The explicit auxiliary bin.
+        fs::write(tmp.path().join("src/worker.rs"), "fn main() {}\n").unwrap();
         tmp
     }
 
@@ -1255,6 +1312,58 @@ mod tests {
             parsed["version"].as_str(),
             Some("3.1.4"),
             "tauri.conf.json must use the resolved workspace version, not fall back to 0.1.0"
+        );
+    }
+
+    #[test]
+    fn plan_aux_bin_does_not_override_main_binary() {
+        // A project with src/main.rs (auto-discovered as the primary binary, package
+        // name) plus an auxiliary [[bin]] for a worker should stage the package-named
+        // binary, NOT the worker.
+        let tmp = project_with_aux_bin("my-app", "worker");
+        let plan = plan_tauri(tmp.path()).unwrap();
+        let sh: &str = plan
+            .actions
+            .iter()
+            .find(|a| a.path().to_string_lossy().ends_with("stage-sidecar.sh"))
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("stage-sidecar.sh action not found");
+        assert!(
+            sh.contains("my-app"),
+            "stage-sidecar.sh must use the package (primary) binary name when src/main.rs is auto-discovered"
+        );
+        assert!(
+            !sh.contains("/release/worker") && !sh.contains("--bin worker"),
+            "stage-sidecar.sh must not use the auxiliary [[bin]] name 'worker' as the primary target"
+        );
+    }
+
+    #[test]
+    fn stage_sidecar_sh_creates_autumn_toml_when_absent() {
+        let sh = render_stage_sidecar_sh("my-app", "my-app");
+        assert!(
+            sh.contains(": > autumn.toml") || sh.contains("> autumn.toml"),
+            "staging script must create an empty autumn.toml when none exists \
+             (tauri.conf.json always lists it as a bundle resource)"
+        );
+    }
+
+    #[test]
+    fn stage_sidecar_ps1_creates_autumn_toml_when_absent() {
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app");
+        assert!(
+            ps1.contains("autumn.toml"),
+            "PowerShell staging script must handle a missing autumn.toml"
+        );
+        assert!(
+            ps1.contains("New-Item") || ps1.contains("Set-Content"),
+            "PowerShell staging script must create autumn.toml when absent"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -58,25 +58,10 @@ pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
     let mut plan = Plan::new(project_root);
     let tauri = project_root.join("src-tauri");
 
-    // Detect profile override config files that exist now so they can be bundled
-    // as concrete Tauri resources.  A glob entry would cause `cargo tauri build` to
-    // fail with GlobPathNotFound when no files match (common for fresh projects).
-    let profile_configs: Vec<String> = [
-        "autumn-prod.toml",
-        "autumn-production.toml",
-        "autumn-staging.toml",
-        "autumn-development.toml",
-        "autumn-test.toml",
-    ]
-    .iter()
-    .filter(|f| project_root.join(f).is_file())
-    .map(|f| (*f).to_owned())
-    .collect();
-
     // Core Tauri project files
     plan.create(
         tauri.join("tauri.conf.json"),
-        render_tauri_conf(&package_name, &profile_configs),
+        render_tauri_conf(&package_name),
     );
     plan.create(
         tauri.join("Cargo.toml"),
@@ -162,7 +147,7 @@ fn read_package_name(project_root: &Path) -> Result<String, GenerateError> {
 
 // ── Content renderers ─────────────────────────────────────────────────────────
 
-fn render_tauri_conf(package_name: &str, profile_configs: &[String]) -> String {
+fn render_tauri_conf(package_name: &str) -> String {
     // Bundle identifier: reverse-DNS with underscores replaced by hyphens.
     // Apple's spec allows only alphanumerics, hyphens, and periods — underscores are invalid.
     let identifier = format!("com.example.{}", package_name.replace('_', "-"));
@@ -188,14 +173,13 @@ fn render_tauri_conf(package_name: &str, profile_configs: &[String]) -> String {
     } else {
         "bash stage-sidecar.sh"
     };
-    // Concrete resource entries for profile config files that exist at plan time.
-    // We emit only files that are present so Tauri doesn't fail with GlobPathNotFound
-    // when no profile overrides exist (the common case for fresh projects).
-    let profile_resources: String = profile_configs.iter().fold(String::new(), |mut acc, f| {
-        use std::fmt::Write as _;
-        let _ = write!(acc, ",\n      \"../{f}\": \"{f}\"");
-        acc
-    });
+    // Profile config entries always point to src-tauri/configs/, which the staging
+    // script (beforeBuildCommand) populates at build time — copying real files or
+    // creating empty stubs for profiles that don't yet exist.  An empty TOML file
+    // is valid and results in no overrides (AutumnConfig treats it as a no-op).
+    // This keeps the resource list in sync regardless of when profile files are created,
+    // avoiding the silent loss of production settings when autumn-prod.toml is added
+    // after `autumn generate tauri` was run.
     format!(
         r#"{{
   "$schema": "https://schema.tauri.app/config/2",
@@ -220,7 +204,12 @@ fn render_tauri_conf(package_name: &str, profile_configs: &[String]) -> String {
       "binaries/{package_name}"
     ],
     "resources": {{
-      "../autumn.toml": "autumn.toml"{profile_resources}
+      "../autumn.toml": "autumn.toml",
+      "configs/autumn-prod.toml": "autumn-prod.toml",
+      "configs/autumn-production.toml": "autumn-production.toml",
+      "configs/autumn-staging.toml": "autumn-staging.toml",
+      "configs/autumn-development.toml": "autumn-development.toml",
+      "configs/autumn-test.toml": "autumn-test.toml"
     }}
   }},
   "app": {{
@@ -289,6 +278,8 @@ fn render_shell_lib_rs(package_name: &str) -> String {
 //!   2. Spawn the autumn server sidecar with `AUTUMN_SERVER__PORT` set to that port.
 //!      `AUTUMN_MANAGED_PG_DATA_DIR` is set to `<app-data-dir>/db` so the managed
 //!      Postgres cluster (autumn feature #1119) persists across restarts.
+//!      `AUTUMN_MANAGED_PG_ATTACH_URL` is cleared so an inherited attach URL cannot
+//!      redirect the sidecar to a foreign cluster instead of the bundled one.
 //!   3. Poll GET /health in a background thread until the server is ready (up to 30 s),
 //!      then open the webview window pointing at http://127.0.0.1:<port>.
 //!      On timeout, the app exits with a non-zero code rather than showing a blank window.
@@ -320,19 +311,27 @@ pub fn run() {{
                         .unwrap()
                         .take()
                     {{
-                        // Send SIGTERM first so autumn's on_shutdown hooks run
-                        // (including ManagedPostgresPoolProvider::stop() if wired).
-                        // Fall back to SIGKILL / TerminateProcess after 3 s.
-                        #[cfg(unix)]
-                        let graceful_pid = child.pid() as i32;
+                        // Send a graceful shutdown signal so autumn's on_shutdown
+                        // hooks run (including ManagedPostgresPoolProvider::stop()).
+                        // Fall back to force-kill after 3 s on all platforms.
+                        let graceful_pid = child.pid();
                         std::thread::spawn(move || {{
+                            // Unix: SIGTERM triggers autumn's tokio signal handler.
                             #[cfg(unix)]
                             {{
                                 let _ = std::process::Command::new("kill")
                                     .args(["-TERM", &graceful_pid.to_string()])
                                     .status();
-                                std::thread::sleep(std::time::Duration::from_secs(3));
                             }}
+                            // Windows: taskkill without /f sends CTRL_CLOSE_EVENT /
+                            // WM_CLOSE for a graceful-termination attempt.
+                            #[cfg(windows)]
+                            {{
+                                let _ = std::process::Command::new("taskkill")
+                                    .args(["/pid", &graceful_pid.to_string()])
+                                    .status();
+                            }}
+                            std::thread::sleep(std::time::Duration::from_secs(3));
                             let _ = child.kill();
                         }});
                     }}
@@ -554,6 +553,18 @@ else
        "src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
     echo "Staged: src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
 fi
+# Stage profile config files so tauri.conf.json's static resource entries are
+# always satisfiable at bundle time, regardless of when the files were created
+# relative to when `autumn generate tauri` was run.  An empty TOML file is
+# valid and results in no overrides; AutumnConfig treats it as a no-op.
+mkdir -p src-tauri/configs
+for f in autumn-prod.toml autumn-production.toml autumn-staging.toml autumn-development.toml autumn-test.toml; do
+    if [ -f "$f" ]; then
+        cp "$f" "src-tauri/configs/$f"
+    else
+        : > "src-tauri/configs/$f"
+    fi
+done
 "#
     )
 }
@@ -592,12 +603,24 @@ New-Item -ItemType Directory -Force -Path src-tauri\binaries | Out-Null
 Copy-Item "$TargetDir\$TargetTriple\release\{package_name}.exe" `
           "src-tauri\binaries\{package_name}-$TargetTriple.exe"
 Write-Host "Staged: src-tauri/binaries/{package_name}-$TargetTriple.exe"
+# Stage profile config files so tauri.conf.json's static resource entries are
+# always satisfiable at bundle time, regardless of when the files were created
+# relative to when `autumn generate tauri` was run.  An empty TOML file is
+# valid and results in no overrides; AutumnConfig treats it as a no-op.
+New-Item -ItemType Directory -Force -Path src-tauri\configs | Out-Null
+foreach ($f in @("autumn-prod.toml", "autumn-production.toml", "autumn-staging.toml", "autumn-development.toml", "autumn-test.toml")) {{
+    if (Test-Path $f) {{
+        Copy-Item $f "src-tauri\configs\$f"
+    }} else {{
+        New-Item -ItemType File -Force -Path "src-tauri\configs\$f" | Out-Null
+    }}
+}}
 "#
     )
 }
 
 fn render_gitignore() -> String {
-    "/target\n/binaries\n/gen\n".to_owned()
+    "/target\n/binaries\n/configs\n/gen\n".to_owned()
 }
 
 /// Human-readable prerequisites message printed after a successful scaffold.
@@ -840,6 +863,37 @@ mod tests {
     }
 
     #[test]
+    fn stage_sidecar_sh_stages_profile_configs() {
+        let sh = render_stage_sidecar_sh("my-app");
+        // Profile configs are staged at build time (beforeBuildCommand) so that the
+        // static resource entries in tauri.conf.json are always satisfiable — even when
+        // autumn-prod.toml is created after `autumn generate tauri` was run.
+        assert!(
+            sh.contains("src-tauri/configs"),
+            "stage-sidecar.sh must create src-tauri/configs/ and populate it with \
+             profile config files (or empty stubs) so tauri.conf.json resource entries resolve"
+        );
+        assert!(
+            sh.contains("autumn-prod.toml"),
+            "stage-sidecar.sh must stage autumn-prod.toml into configs/"
+        );
+    }
+
+    #[test]
+    fn stage_sidecar_ps1_stages_profile_configs() {
+        let ps1 = render_stage_sidecar_ps1("my-app");
+        assert!(
+            ps1.contains("src-tauri\\configs") || ps1.contains("src-tauri/configs"),
+            "stage-sidecar.ps1 must create src-tauri\\configs\\ and populate it with \
+             profile config files (or empty stubs)"
+        );
+        assert!(
+            ps1.contains("autumn-prod.toml"),
+            "stage-sidecar.ps1 must stage autumn-prod.toml into configs\\"
+        );
+    }
+
+    #[test]
     fn plan_creates_gitignore() {
         let tmp = project("my-app");
         assert!(has_action(&tmp, "src-tauri/.gitignore"));
@@ -871,7 +925,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_is_valid_json() {
-        let conf = render_tauri_conf("my-app", &[]);
+        let conf = render_tauri_conf("my-app");
         let parsed: serde_json::Value =
             serde_json::from_str(&conf).expect("tauri.conf.json must be valid JSON");
         assert!(parsed.is_object());
@@ -879,7 +933,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_identifier() {
-        let conf = render_tauri_conf("my-app", &[]);
+        let conf = render_tauri_conf("my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         assert!(
             parsed["identifier"].is_string(),
@@ -893,7 +947,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_product_name() {
-        let conf = render_tauri_conf("my-app", &[]);
+        let conf = render_tauri_conf("my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         assert!(
             parsed["productName"].is_string(),
@@ -903,7 +957,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_external_bin() {
-        let conf = render_tauri_conf("my-app", &[]);
+        let conf = render_tauri_conf("my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let bins = parsed["bundle"]["externalBin"]
             .as_array()
@@ -918,7 +972,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_icon_array() {
-        let conf = render_tauri_conf("my-app", &[]);
+        let conf = render_tauri_conf("my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let icons = parsed["bundle"]["icon"]
             .as_array()
@@ -932,7 +986,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_has_before_build_command() {
-        let conf = render_tauri_conf("my-app", &[]);
+        let conf = render_tauri_conf("my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let cmd = parsed["build"]["beforeBuildCommand"]
             .as_str()
@@ -1128,18 +1182,22 @@ mod tests {
     }
 
     #[test]
-    fn lib_rs_sends_sigterm_before_kill() {
+    fn lib_rs_sends_graceful_shutdown_signal_before_kill() {
         let lib = render_shell_lib_rs("my-app");
-        // Graceful SIGTERM lets autumn's on_shutdown hooks run (including pg.stop()).
-        // Force-kill is the fallback after a timeout.
+        // Graceful shutdown lets autumn's on_shutdown hooks run (including pg.stop()).
+        // Force-kill is the fallback after a timeout.  Both Unix (SIGTERM) and Windows
+        // (taskkill without /f) paths must be present for cross-platform correctness.
         assert!(
             lib.contains("SIGTERM") || lib.contains("-TERM"),
-            "lib.rs on_window_event must send SIGTERM before force-killing the sidecar \
-             so ManagedPostgresPoolProvider::stop() runs during graceful shutdown"
+            "lib.rs on_window_event must send SIGTERM on Unix before force-killing"
+        );
+        assert!(
+            lib.contains("taskkill"),
+            "lib.rs on_window_event must use taskkill on Windows for graceful shutdown"
         );
         assert!(
             lib.contains("pid()"),
-            "lib.rs must call child.pid() to get the sidecar PID for SIGTERM"
+            "lib.rs must call child.pid() to get the sidecar PID for signal/taskkill"
         );
     }
 
@@ -1168,7 +1226,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_bundles_autumn_toml_as_resource() {
-        let conf = render_tauri_conf("my-app", &[]);
+        let conf = render_tauri_conf("my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         // Tauri v2 resources must be a map { source_path: dest_path }, not an array.
         let resources = parsed["bundle"]["resources"]
@@ -1182,14 +1240,23 @@ mod tests {
             "tauri.conf.json must bundle autumn.toml as a resource so the installed \
              sidecar can find the app's production configuration"
         );
-        // With no profile configs passed, resources should contain only the base entry.
-        // A glob entry must NOT be emitted because it causes GlobPathNotFound failures
-        // in cargo tauri build when no profile files exist.
+        // No glob entries — globs cause GlobPathNotFound when no files match.
         let has_glob = resources.iter().any(|(k, _)| k.contains('*'));
         assert!(
             !has_glob,
             "tauri.conf.json must not emit resource glob entries — Tauri fails with \
              GlobPathNotFound when the glob matches no files (common for fresh projects)"
+        );
+        // Profile configs must always be included from configs/ so they are bundled
+        // regardless of when the files were created relative to `autumn generate tauri`.
+        // The staging script creates the files (or empty stubs) at build time.
+        let has_prod = resources
+            .keys()
+            .any(|k| k.contains("configs/") && k.contains("prod"));
+        assert!(
+            has_prod,
+            "tauri.conf.json must include profile config entries from configs/ so \
+             autumn-prod.toml is bundled even when added after `autumn generate tauri`"
         );
     }
 
@@ -1208,7 +1275,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_identifier_replaces_underscores() {
-        let conf = render_tauri_conf("my_app", &[]);
+        let conf = render_tauri_conf("my_app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let id = parsed["identifier"].as_str().unwrap();
         assert!(
@@ -1223,7 +1290,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_security_is_under_app() {
-        let conf = render_tauri_conf("my-app", &[]);
+        let conf = render_tauri_conf("my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         assert!(
             parsed["app"]["security"].is_object(),
@@ -1466,6 +1533,10 @@ mod tests {
             gi.contains("/binaries"),
             ".gitignore must exclude /binaries"
         );
+        assert!(
+            gi.contains("/configs"),
+            ".gitignore must exclude /configs (staging area for profile config files)"
+        );
     }
 
     #[test]
@@ -1586,7 +1657,7 @@ mod tests {
 
     #[test]
     fn tauri_conf_product_name_handles_underscore_separator() {
-        let conf = render_tauri_conf("my_app", &[]);
+        let conf = render_tauri_conf("my_app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
         let name = parsed["productName"].as_str().unwrap();
         assert!(

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -916,8 +916,13 @@ fn render_stage_sidecar_sh(
     };
     // Only fingerprint when the app-level alias exists; `autumn build --embed` passes
     // --features embed-assets (app-level), which fails for apps without that alias.
+    // We also pass managed-pg-bundled so apps wiring ManagedPostgresPoolProvider
+    // (without a cfg gate) can compile during the fingerprint phase 1.
     let fingerprint = if has_embed_assets {
-        format!("autumn build --embed -p {package_name} --bin {bin_name}\n")
+        format!(
+            "autumn build --embed -p {package_name} --bin {bin_name} \
+             --features {dep_key}/managed-pg-bundled\n"
+        )
     } else {
         String::new()
     };
@@ -1022,7 +1027,10 @@ fn render_stage_sidecar_ps1(
         format!(
             "# Fingerprint static/ before the embed compile (mirrors autumn build --embed phases 1-2):\n\
              # compile → write .autumn-manifest.json → the cargo build below embeds it.\n\
-             autumn build --embed -p {package_name} --bin {bin_name}\n"
+             # --features passes managed-pg-bundled so apps wiring ManagedPostgresPoolProvider\n\
+             # without a cfg gate can compile during the fingerprint phase.\n\
+             autumn build --embed -p {package_name} --bin {bin_name} \
+             --features {dep_key}/managed-pg-bundled\n"
         )
     } else {
         String::new()
@@ -2791,6 +2799,11 @@ mod tests {
             "stage-sidecar.sh must pass both -p <package> and --bin <bin> to autumn build \
              --embed so workspace members fingerprint the correct package and only the \
              sidecar binary is compiled (not all [[bin]] targets); got:\n{sh}"
+        );
+        assert!(
+            sh.contains("--features autumn-web/managed-pg-bundled"),
+            "fingerprint line must pass --features <dep_key>/managed-pg-bundled so apps \
+             wiring ManagedPostgresPoolProvider compile in the pre-embed phase; got:\n{sh}"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -710,8 +710,12 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         // AUTUMN_MANAGED_PG_DATA_DIR and returns it without starting a local cluster;
         // an empty value is ignored by the provider.
         .env("AUTUMN_MANAGED_PG_ATTACH_URL", "")
-        // Belt-and-suspenders for apps not using #[autumn_web::main] where
-        // AUTUMN_MANIFEST_DIR env var IS consulted before the CWD fallback.
+        // Override the compile-time manifest dir so config loading reads from
+        // the bundled resource dir on all machines, including the developer's
+        // machine where the source tree still exists.  autumn's OsEnv::var
+        // checks the process env before the #[autumn_web::main] baked-in path
+        // when AUTUMN_MANIFEST_DIR is set, so this overrides both the CWD
+        // fallback and the macro-injected compile-time value.
         .env(
             "AUTUMN_MANIFEST_DIR",
             resource_dir.to_string_lossy().as_ref(),

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -61,12 +61,17 @@ pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
     // Detect profile override config files that exist now so they can be bundled
     // as concrete Tauri resources.  A glob entry would cause `cargo tauri build` to
     // fail with GlobPathNotFound when no files match (common for fresh projects).
-    let profile_configs: Vec<String> = ["autumn-prod.toml", "autumn-production.toml",
-        "autumn-staging.toml", "autumn-development.toml", "autumn-test.toml"]
-        .iter()
-        .filter(|f| project_root.join(f).is_file())
-        .map(|f| (*f).to_owned())
-        .collect();
+    let profile_configs: Vec<String> = [
+        "autumn-prod.toml",
+        "autumn-production.toml",
+        "autumn-staging.toml",
+        "autumn-development.toml",
+        "autumn-test.toml",
+    ]
+    .iter()
+    .filter(|f| project_root.join(f).is_file())
+    .map(|f| (*f).to_owned())
+    .collect();
 
     // Core Tauri project files
     plan.create(
@@ -499,16 +504,33 @@ cd "$APP_DIR"
 # TAURI_ENV_TARGET_TRIPLE is set by `cargo tauri build` for cross-compilation;
 # fall back to the host triple when running the script manually.
 TARGET_TRIPLE="${{TAURI_ENV_TARGET_TRIPLE:-$(rustc -Vv | awk '/^host/{{print $2}}')}}";
-# Build with both autumn-web features so the sidecar binary embeds static assets
-# and bundles Postgres.  Both are specified via the dependency path so this script
-# works with any autumn project regardless of whether the app's Cargo.toml defines
-# a top-level `embed-assets` feature alias.
-cargo build --release --target "${{TARGET_TRIPLE}}" \
-  --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
+# Resolve the real Cargo output directory.  Workspace members share the workspace
+# root's target/ and CARGO_TARGET_DIR / .cargo/config.toml can redirect it.
+TARGET_DIR="${{CARGO_TARGET_DIR:-$(cargo metadata --no-deps --format-version 1 --quiet \
+    | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')}}"
 mkdir -p src-tauri/binaries
-cp "target/${{TARGET_TRIPLE}}/release/{package_name}" \
-   "src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
-echo "Staged: src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
+# universal-apple-darwin is a Tauri meta-target, not a rustc triple.  Build both
+# Darwin slices separately and combine with lipo(1) into a fat binary.
+if [ "${{TARGET_TRIPLE}}" = "universal-apple-darwin" ]; then
+    for ARCH in x86_64-apple-darwin aarch64-apple-darwin; do
+        cargo build --release --target "$ARCH" \
+          --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
+    done
+    lipo -create -output "src-tauri/binaries/{package_name}-universal-apple-darwin" \
+      "${{TARGET_DIR}}/x86_64-apple-darwin/release/{package_name}" \
+      "${{TARGET_DIR}}/aarch64-apple-darwin/release/{package_name}"
+    echo "Staged (universal): src-tauri/binaries/{package_name}-universal-apple-darwin"
+else
+    # Build with both autumn-web features so the sidecar binary embeds static assets
+    # and bundles Postgres.  Both are specified via the dependency path so this script
+    # works with any autumn project regardless of whether the app's Cargo.toml defines
+    # a top-level `embed-assets` feature alias.
+    cargo build --release --target "${{TARGET_TRIPLE}}" \
+      --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
+    cp "${{TARGET_DIR}}/${{TARGET_TRIPLE}}/release/{package_name}" \
+       "src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
+    echo "Staged: src-tauri/binaries/{package_name}-${{TARGET_TRIPLE}}"
+fi
 "#
     )
 }
@@ -531,6 +553,12 @@ $TargetTriple = $Env:TAURI_ENV_TARGET_TRIPLE
 if (-not $TargetTriple) {{
     $TargetTriple = (rustc -Vv | Select-String "^host").Line.Split()[1]
 }}
+# Resolve the real Cargo output directory.  Workspace members share the workspace
+# root's target\ and CARGO_TARGET_DIR / .cargo/config.toml can redirect it.
+$TargetDir = $Env:CARGO_TARGET_DIR
+if (-not $TargetDir) {{
+    $TargetDir = (cargo metadata --no-deps --format-version 1 --quiet | ConvertFrom-Json).target_directory
+}}
 # Build with both autumn-web features so the sidecar binary embeds static assets
 # and bundles Postgres.  Both are specified via the dependency path so this script
 # works with any autumn project regardless of whether the app's Cargo.toml defines
@@ -538,7 +566,7 @@ if (-not $TargetTriple) {{
 cargo build --release --target "$TargetTriple" `
   --features autumn-web/embed-assets,autumn-web/managed-pg-bundled
 New-Item -ItemType Directory -Force -Path src-tauri\binaries | Out-Null
-Copy-Item "target\$TargetTriple\release\{package_name}.exe" `
+Copy-Item "$TargetDir\$TargetTriple\release\{package_name}.exe" `
           "src-tauri\binaries\{package_name}-$TargetTriple.exe"
 Write-Host "Staged: src-tauri/binaries/{package_name}-$TargetTriple.exe"
 "#
@@ -729,6 +757,63 @@ mod tests {
     fn plan_creates_stage_sidecar_ps1() {
         let tmp = project("my-app");
         assert!(has_action(&tmp, "src-tauri/stage-sidecar.ps1"));
+    }
+
+    #[test]
+    fn stage_sidecar_sh_uses_cargo_metadata_for_target_dir() {
+        let sh = render_stage_sidecar_sh("my-app");
+        // cargo metadata resolves the real output dir for workspace members and
+        // respects CARGO_TARGET_DIR overrides.
+        assert!(
+            sh.contains("cargo metadata"),
+            "stage-sidecar.sh must use `cargo metadata` to locate the Cargo target directory"
+        );
+        assert!(
+            sh.contains("TARGET_DIR"),
+            "stage-sidecar.sh must use a TARGET_DIR variable derived from cargo metadata"
+        );
+        // The hardcoded relative path is no longer used — workspace builds would
+        // look in the wrong place if we still had `target/$TARGET_TRIPLE/...`.
+        assert!(
+            !sh.contains(r#""target/$"#) && !sh.contains("\"target/${"),
+            "stage-sidecar.sh must not use a hardcoded `target/` prefix for the copy"
+        );
+    }
+
+    #[test]
+    fn stage_sidecar_sh_handles_universal_apple_darwin() {
+        let sh = render_stage_sidecar_sh("my-app");
+        // universal-apple-darwin is a Tauri meta-target; cargo build --target
+        // universal-apple-darwin fails because rustc doesn't know it.
+        assert!(
+            sh.contains("universal-apple-darwin"),
+            "stage-sidecar.sh must detect universal-apple-darwin and handle it separately"
+        );
+        assert!(
+            sh.contains("lipo"),
+            "stage-sidecar.sh must combine Darwin slices with lipo for universal builds"
+        );
+        assert!(
+            sh.contains("x86_64-apple-darwin") && sh.contains("aarch64-apple-darwin"),
+            "stage-sidecar.sh must build both x86_64 and aarch64 Darwin slices"
+        );
+    }
+
+    #[test]
+    fn stage_sidecar_ps1_uses_cargo_metadata_for_target_dir() {
+        let ps1 = render_stage_sidecar_ps1("my-app");
+        assert!(
+            ps1.contains("cargo metadata"),
+            "stage-sidecar.ps1 must use `cargo metadata` to locate the Cargo target directory"
+        );
+        assert!(
+            ps1.contains("TargetDir"),
+            "stage-sidecar.ps1 must use a $TargetDir variable derived from cargo metadata"
+        );
+        assert!(
+            ps1.contains("ConvertFrom-Json"),
+            "stage-sidecar.ps1 must use ConvertFrom-Json to properly decode the JSON path"
+        );
     }
 
     #[test]
@@ -1029,12 +1114,9 @@ mod tests {
         let resources = parsed["bundle"]["resources"]
             .as_object()
             .expect("bundle.resources must be a map (Tauri v2 schema requirement)");
-        let has_autumn_toml = resources
-            .iter()
-            .any(|(k, v)| {
-                k.contains("autumn.toml")
-                    || v.as_str().is_some_and(|s| s.contains("autumn.toml"))
-            });
+        let has_autumn_toml = resources.iter().any(|(k, v)| {
+            k.contains("autumn.toml") || v.as_str().is_some_and(|s| s.contains("autumn.toml"))
+        });
         assert!(
             has_autumn_toml,
             "tauri.conf.json must bundle autumn.toml as a resource so the installed \

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -150,18 +150,26 @@ fn read_package_name(project_root: &Path) -> Result<String, GenerateError> {
 fn render_tauri_conf(package_name: &str) -> String {
     // Bundle identifier: reverse-DNS style, hyphens kept (valid per Apple/Android specs)
     let identifier = format!("com.example.{package_name}");
-    // Display title: capitalise first letter of each word
+    // Display title: capitalise first letter of each word; split on both '-' and '_'
+    // so kebab-case (`my-app` → `My App`) and snake_case (`my_app` → `My App`) both work.
     let title: String = package_name
-        .split('-')
+        .split(['-', '_'])
         .map(|word| {
             let mut chars = word.chars();
-            match chars.next() {
-                None => String::new(),
-                Some(c) => c.to_uppercase().to_string() + chars.as_str(),
-            }
+            chars.next().map_or_else(String::new, |c| {
+                c.to_uppercase().to_string() + chars.as_str()
+            })
         })
         .collect::<Vec<_>>()
         .join(" ");
+    // beforeBuildCommand must use the native shell for the host OS.
+    // cfg!(windows) is evaluated when the generator binary compiles, which runs on
+    // the same host where `cargo tauri build` will later be invoked.
+    let before_build_cmd = if cfg!(windows) {
+        "powershell -ExecutionPolicy Bypass -File stage-sidecar.ps1"
+    } else {
+        "sh stage-sidecar.sh"
+    };
     format!(
         r#"{{
   "$schema": "https://schema.tauri.app/config/2",
@@ -169,7 +177,7 @@ fn render_tauri_conf(package_name: &str) -> String {
   "version": "0.1.0",
   "identifier": "{identifier}",
   "build": {{
-    "beforeBuildCommand": "sh stage-sidecar.sh"
+    "beforeBuildCommand": "{before_build_cmd}"
   }},
   "bundle": {{
     "active": true,
@@ -246,12 +254,15 @@ fn render_shell_lib_rs(package_name: &str) -> String {
 //!
 //! Lifecycle:
 //!   1. Bind loopback:0 to find a free ephemeral port (no hardcoded port collision).
+//!      Note: there is a brief window between dropping the listener and the sidecar
+//!      binding the port; in practice this race is extremely rare on loopback.
 //!   2. Spawn the autumn server sidecar with `AUTUMN_SERVER__PORT` set to that port.
 //!      `AUTUMN_MANAGED_PG_DATA_DIR` is set to the OS app-data dir so the managed
 //!      Postgres cluster (autumn feature #1119) persists across restarts.
-//!   3. Poll GET /health until the server is ready (up to 15 s), then open the
-//!      webview window pointing at http://127.0.0.1:<port>.
-//!   4. Kill the sidecar when the last window closes — no orphaned server process.
+//!   3. Poll GET /health in a background thread until the server is ready (up to 15 s),
+//!      then open the webview window pointing at http://127.0.0.1:<port>.
+//!      On timeout, the app exits with a non-zero code rather than showing a blank window.
+//!   4. On window close, kill the sidecar — no orphaned server process.
 
 use std::net::TcpListener;
 use tauri::{{Manager, App}};
@@ -286,6 +297,8 @@ pub fn run() {{
 fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
     // 1. Find a free loopback port: bind :0, read the assigned port, then drop
     //    the listener so the autumn server can bind that same address.
+    //    Note: there is a brief window between dropping the listener and the sidecar
+    //    binding; in practice this race is extremely rare on loopback.
     let port = {{
         let l = TcpListener::bind("127.0.0.1:0")?;
         l.local_addr()?.port()
@@ -300,37 +313,61 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         .sidecar("{sidecar_bin}")?
         .env("AUTUMN_SERVER__HOST", "127.0.0.1")
         .env("AUTUMN_SERVER__PORT", port.to_string())
-        .env("AUTUMN_MANAGED_PG_DATA_DIR", app_data_dir.to_string_lossy().as_ref())
+        .env(
+            "AUTUMN_MANAGED_PG_DATA_DIR",
+            app_data_dir.to_string_lossy().as_ref(),
+        )
         .spawn()?;
     *app.state::<SidecarHandle>().0.lock().unwrap() = Some(child);
 
-    // 4. Poll GET /health until the server responds 200 (≤ 15 s).
-    let addr = format!("127.0.0.1:{{port}}");
-    'wait: for _ in 0..75 {{
-        if let Ok(mut stream) = std::net::TcpStream::connect(&addr) {{
-            use std::io::{{Read, Write}};
-            let req = format!(
-                "GET /health HTTP/1.1\r\nHost: {{addr}}\r\nConnection: close\r\n\r\n"
-            );
-            if stream.write_all(req.as_bytes()).is_ok() {{
-                let mut buf = [0u8; 16];
-                if stream.read(&mut buf).is_ok() && buf.starts_with(b"HTTP/1.1 200") {{
-                    break 'wait;
+    // 4. Poll /health in a background thread so setup() returns immediately and the
+    //    Tauri event loop starts.  Blocking here freezes the UI and can trigger OS
+    //    ANR watchdogs on macOS and Windows.
+    let handle = app.handle().clone();
+    std::thread::spawn(move || {{
+        let addr = format!("127.0.0.1:{{port}}");
+        let poll_timeout = std::time::Duration::from_millis(200);
+        let mut ready = false;
+        for _ in 0..75 {{
+            if let Ok(mut stream) = std::net::TcpStream::connect_timeout(
+                &addr.parse().unwrap(),
+                poll_timeout,
+            ) {{
+                use std::io::{{Read, Write}};
+                let req =
+                    format!("GET /health HTTP/1.1\r\nHost: {{addr}}\r\nConnection: close\r\n\r\n");
+                if stream.write_all(req.as_bytes()).is_ok() {{
+                    let mut buf = [0u8; 16];
+                    if stream.read(&mut buf).is_ok() && buf.starts_with(b"HTTP/1.1 200") {{
+                        ready = true;
+                        break;
+                    }}
                 }}
             }}
+            std::thread::sleep(poll_timeout);
         }}
-        std::thread::sleep(std::time::Duration::from_millis(200));
-    }}
-
-    // 5. Open the webview window pointing at the local server.
-    tauri::WebviewWindowBuilder::new(
-        app,
-        "main",
-        tauri::WebviewUrl::External(format!("http://127.0.0.1:{{port}}").parse()?),
-    )
-    .title("{package_name}")
-    .inner_size(1200.0, 800.0)
-    .build()?;
+        if !ready {{
+            eprintln!(
+                "[{package_name}] Server did not become ready within 15 s — exiting."
+            );
+            handle.exit(1);
+            return;
+        }}
+        if let Err(e) = tauri::WebviewWindowBuilder::new(
+            &handle,
+            "main",
+            tauri::WebviewUrl::External(
+                format!("http://127.0.0.1:{{port}}").parse().unwrap(),
+            ),
+        )
+        .title("{package_name}")
+        .inner_size(1200.0, 800.0)
+        .build()
+        {{
+            eprintln!("[{package_name}] Failed to open window: {{e}}");
+            handle.exit(1);
+        }}
+    }});
 
     Ok(())
 }}
@@ -1118,6 +1155,54 @@ mod tests {
         assert!(
             matches!(err, GenerateError::Collisions(_)),
             "re-running without --force must return a Collisions error"
+        );
+    }
+
+    // ── lib.rs background thread + timeout behaviour ──────────────────────────
+
+    #[test]
+    fn lib_rs_uses_background_thread_for_health_poll() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains("thread::spawn"),
+            "lib.rs must move the health poll into a background thread so setup() \
+             returns immediately and the Tauri event loop starts"
+        );
+    }
+
+    #[test]
+    fn lib_rs_exits_app_on_sidecar_timeout() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains(".exit("),
+            "lib.rs must call handle.exit() when the sidecar fails to become ready, \
+             not silently open a blank window"
+        );
+    }
+
+    #[test]
+    fn lib_rs_uses_connect_timeout_for_health_poll() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains("connect_timeout"),
+            "lib.rs must use TcpStream::connect_timeout so each poll attempt is bounded"
+        );
+    }
+
+    // ── productName title-case handles snake_case package names ──────────────
+
+    #[test]
+    fn tauri_conf_product_name_handles_underscore_separator() {
+        let conf = render_tauri_conf("my_app");
+        let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
+        let name = parsed["productName"].as_str().unwrap();
+        assert!(
+            name.contains(' '),
+            "productName for 'my_app' must contain spaces (title-case), got: {name}"
+        );
+        assert!(
+            !name.contains('_'),
+            "productName for 'my_app' must not contain underscores, got: {name}"
         );
     }
 }

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -332,6 +332,11 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         // Force the health endpoint to /health so the readiness probe below
         // always works, regardless of what [health].path is configured in the app.
         .env("AUTUMN_HEALTH__PATH", "/health")
+        // Clear any inherited Unix-socket config so the sidecar always binds
+        // TCP on the loopback address the probe polls.  Without this, an
+        // inherited AUTUMN_SERVER__UNIX_SOCKET would make the sidecar healthy
+        // on a socket path while the TCP health probe times out and exits.
+        .env("AUTUMN_SERVER__UNIX_SOCKET", "")
         .spawn()?;
     *app.state::<SidecarHandle>().0.lock().unwrap() = Some(child);
 
@@ -929,6 +934,16 @@ mod tests {
             lib.contains("AUTUMN_HEALTH__PATH"),
             "lib.rs must set AUTUMN_HEALTH__PATH=/health so the readiness probe works \
              regardless of the app's configured health path"
+        );
+    }
+
+    #[test]
+    fn lib_rs_clears_unix_socket_env() {
+        let lib = render_shell_lib_rs("my-app");
+        assert!(
+            lib.contains("AUTUMN_SERVER__UNIX_SOCKET"),
+            "lib.rs must clear AUTUMN_SERVER__UNIX_SOCKET so an inherited env var \
+             cannot redirect the sidecar to a Unix socket the TCP probe cannot reach"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -577,10 +577,11 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         l.local_addr()?.port()
     }};
 
-    // 2. Persistent data dir for the managed Postgres cluster (#1119).
-    //    Use a `db/` subdirectory so Postgres cluster files don't clutter
-    //    the app-data root.  Create it proactively; the sidecar won't if absent.
-    let app_data_dir = app.path().app_data_dir()?.join("db");
+    // 2. Persistent per-app data directories.
+    //    Use subdirectories so distinct concerns don't share the same root.
+    let data_root = app.path().app_data_dir()?;
+    // Postgres cluster (#1119) in db/.  Create proactively; the sidecar won't if absent.
+    let app_data_dir = data_root.join("db");
     std::fs::create_dir_all(&app_data_dir)?;
 
     // autumn.toml is bundled as a Tauri resource (see tauri.conf.json bundle.resources).
@@ -606,6 +607,14 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
         .env(
             "AUTUMN_MANAGED_PG_DATA_DIR",
             app_data_dir.to_string_lossy().as_ref(),
+        )
+        // Redirect local blob storage to a writable per-app location.
+        // Default storage.local.root is "target/blobs" — relative to CWD (resource_dir),
+        // which is read-only in installed bundles; the app would abort before opening the window.
+        // Route blobs to {{app-data-dir}}/blobs where the process always has write access.
+        .env(
+            "AUTUMN_STORAGE__LOCAL__ROOT",
+            data_root.join("blobs").to_string_lossy().as_ref(),
         )
         // Clear any inherited attach URL so the sidecar owns its bundled Postgres
         // cluster rather than connecting to a stale or foreign database.
@@ -757,7 +766,7 @@ fn render_placeholder_icon_svg() -> String {
     .to_owned()
 }
 
-fn render_stage_sidecar_sh(_package_name: &str, bin_name: &str, has_embed_assets: bool) -> String {
+fn render_stage_sidecar_sh(package_name: &str, bin_name: &str, has_embed_assets: bool) -> String {
     // When the app defines an `embed-assets` Cargo feature (as `autumn new` generates),
     // enable it so that `#[cfg(feature = "embed-assets")]` guards in app code are
     // satisfied and `.embedded_static()` is actually wired in.  Fall back to the
@@ -790,6 +799,9 @@ TARGET_TRIPLE="${{TAURI_ENV_TARGET_TRIPLE:-$(rustc -Vv | awk '/^host/{{print $2}
 TARGET_DIR="${{CARGO_TARGET_DIR:-$(cargo metadata --no-deps --format-version 1 --quiet \
     | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')}}"
 mkdir -p src-tauri/binaries
+# Fingerprint static/ before the embed compile (mirrors autumn build --embed phases 1-2):
+# compile → write .autumn-manifest.json → the target-specific cargo build below embeds it.
+autumn build --embed -p {package_name}
 # universal-apple-darwin is a Tauri meta-target, not a rustc triple.  Build both
 # Darwin slices separately and combine with lipo(1) into a fat binary.
 if [ "${{TARGET_TRIPLE}}" = "universal-apple-darwin" ]; then
@@ -861,7 +873,7 @@ done
     )
 }
 
-fn render_stage_sidecar_ps1(_package_name: &str, bin_name: &str, has_embed_assets: bool) -> String {
+fn render_stage_sidecar_ps1(package_name: &str, bin_name: &str, has_embed_assets: bool) -> String {
     let embed_feature = if has_embed_assets {
         "embed-assets,autumn-web/managed-pg-bundled"
     } else {
@@ -890,9 +902,14 @@ $TargetDir = $Env:CARGO_TARGET_DIR
 if (-not $TargetDir) {{
     $TargetDir = (cargo metadata --no-deps --format-version 1 --quiet | ConvertFrom-Json).target_directory
 }}
+# Fingerprint static/ so include_dir! bakes current hashed asset URLs into the sidecar.
+# autumn build --embed runs: compile → fingerprint static/ → embed compile (host arch).
+# The target-specific cargo build below then bakes the fingerprinted tree.
+# autumn must be installed: cargo install autumn-cli (already needed for `autumn generate`).
+autumn build --embed -p {package_name}
+New-Item -ItemType Directory -Force -Path src-tauri\binaries | Out-Null
 cargo build --release --target "$TargetTriple" --bin {bin_name} `
   --features {embed_feature}
-New-Item -ItemType Directory -Force -Path src-tauri\binaries | Out-Null
 Copy-Item "$TargetDir\$TargetTriple\release\{bin_name}.exe" `
           "src-tauri\binaries\{bin_name}-$TargetTriple.exe"
 Write-Host "Staged: src-tauri/binaries/{bin_name}-$TargetTriple.exe"
@@ -2333,6 +2350,57 @@ mod tests {
              (which is absent on installed machines), so AutumnConfig falls back to \
              PathBuf::from(\"autumn.toml\") — setting CWD to resource_dir makes that \
              fallback find the bundled autumn.toml"
+        );
+    }
+
+    #[test]
+    fn lib_rs_redirects_blob_storage_to_app_data_dir() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        assert!(
+            lib.contains("AUTUMN_STORAGE__LOCAL__ROOT"),
+            "lib.rs must set AUTUMN_STORAGE__LOCAL__ROOT; default storage.local.root is \
+             'target/blobs' (relative to CWD = resource_dir, which is read-only in \
+             installed bundles), so apps using local blob storage would abort at startup"
+        );
+        assert!(
+            lib.contains("data_root") && lib.contains("join(\"blobs\")"),
+            "AUTUMN_STORAGE__LOCAL__ROOT must point to a writable subdirectory of \
+             app_data_dir (e.g. data_root.join(\"blobs\")), not the read-only resource_dir"
+        );
+    }
+
+    #[test]
+    fn staging_sh_fingerprints_before_embed() {
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
+        let fingerprint_pos = sh.find("autumn build --embed").unwrap_or(usize::MAX);
+        let cargo_pos = sh.find("cargo build --release").unwrap_or(usize::MAX);
+        assert!(
+            fingerprint_pos < cargo_pos,
+            "stage-sidecar.sh must run `autumn build --embed` before the embed cargo build \
+             to fingerprint static/ (mirror the 3-phase autumn build --embed process); \
+             stale .autumn-manifest.json would bake wrong asset hashes into the sidecar"
+        );
+    }
+
+    #[test]
+    fn staging_sh_fingerprints_includes_package_name() {
+        let sh = render_stage_sidecar_sh("my-app", "my-app", true);
+        assert!(
+            sh.contains("autumn build --embed -p my-app"),
+            "stage-sidecar.sh must pass -p <package> to autumn build --embed so workspace \
+             members fingerprint the correct package's static/ directory"
+        );
+    }
+
+    #[test]
+    fn staging_ps1_fingerprints_before_embed() {
+        let ps1 = render_stage_sidecar_ps1("my-app", "my-app", true);
+        let fingerprint_pos = ps1.find("autumn build --embed").unwrap_or(usize::MAX);
+        let cargo_pos = ps1.find("cargo build --release").unwrap_or(usize::MAX);
+        assert!(
+            fingerprint_pos < cargo_pos,
+            "stage-sidecar.ps1 must run `autumn build --embed` before the embed cargo build \
+             to fingerprint static/ (mirror the 3-phase autumn build --embed process)"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -707,6 +707,11 @@ fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {{
             "AUTUMN_STORAGE__LOCAL__ROOT",
             data_root.join("blobs").to_string_lossy().as_ref(),
         )
+        // Autumn's StorageConfig::backend_plan rejects local-backend configs in prod
+        // mode unless this flag is set, aborting startup before the window opens.
+        // A loopback-only desktop sidecar is single-user and the storage root is
+        // already in app-data, so local storage is safe and intentional here.
+        .env("AUTUMN_STORAGE__ALLOW_LOCAL_IN_PRODUCTION", "true")
         // Clear any inherited attach URL so the sidecar owns its bundled Postgres
         // cluster rather than connecting to a stale or foreign database.
         // ManagedPostgresPoolProvider checks AUTUMN_MANAGED_PG_ATTACH_URL before
@@ -877,19 +882,21 @@ fn load_or_generate_signing_secret(
     let hex: String = bytes.iter().map(|b| format!("{{b:02x}}")).collect();
     // Write with restricted permissions: signing secrets must not be world-readable.
     // On Unix create the file with mode 0600; on other platforms use the default ACLs.
+    // Propagate write failures: a disk-full or permission error must abort startup
+    // rather than silently returning an ephemeral secret that rotates every launch.
     #[cfg(unix)]
     {{
         use std::io::Write;
         use std::os::unix::fs::OpenOptionsExt;
-        let _ = std::fs::OpenOptions::new()
+        std::fs::OpenOptions::new()
             .write(true).create(true).truncate(true)
             .mode(0o600)
             .open(&path)
-            .and_then(|mut f| f.write_all(hex.as_bytes()));
+            .and_then(|mut f| f.write_all(hex.as_bytes()))?;
     }}
     #[cfg(not(unix))]
     {{
-        let _ = std::fs::write(&path, &hex);
+        std::fs::write(&path, &hex)?;
     }}
     Ok(hex)
 }}
@@ -2782,6 +2789,22 @@ mod tests {
     }
 
     #[test]
+    fn lib_rs_allows_local_storage_in_production() {
+        let lib = render_shell_lib_rs("my-app", "my-app");
+        assert!(
+            lib.contains("AUTUMN_STORAGE__ALLOW_LOCAL_IN_PRODUCTION"),
+            "lib.rs must set AUTUMN_STORAGE__ALLOW_LOCAL_IN_PRODUCTION=true; \
+             StorageConfig::backend_plan rejects local-backend configs in prod mode \
+             without this flag, aborting sidecar startup before the window opens"
+        );
+        assert!(
+            lib.contains("\"AUTUMN_STORAGE__ALLOW_LOCAL_IN_PRODUCTION\", \"true\""),
+            "AUTUMN_STORAGE__ALLOW_LOCAL_IN_PRODUCTION must be set to \"true\"; \
+             the loopback-only sidecar with app-data blob root is single-user and safe"
+        );
+    }
+
+    #[test]
     fn lib_rs_generates_per_install_signing_secret() {
         let lib = render_shell_lib_rs("my-app", "my-app");
         assert!(
@@ -2812,6 +2835,15 @@ mod tests {
             lib.contains("Result<String,") || lib.contains("Result<String, "),
             "load_or_generate_signing_secret must return Result<String, ...> so getrandom \
              failure aborts setup() rather than continuing with a predictable zero secret"
+        );
+        // Write failures must also propagate — a disk-full or permission error must abort
+        // startup rather than silently returning an ephemeral secret that rotates every launch.
+        assert!(
+            !lib.contains("let _ = std::fs::write")
+                && !lib.contains("let _ = std::fs::OpenOptions"),
+            "signing-secret write errors must propagate with `?`, not be silently discarded \
+             with `let _ = ...`; a failed write leaves a truncated file and the app runs \
+             with an ephemeral secret that rotates on every restart"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -196,9 +196,9 @@ fn render_tauri_conf(package_name: &str) -> String {
     "externalBin": [
       "binaries/{package_name}"
     ],
-    "resources": [
-      {{ "from": "../autumn.toml", "to": "autumn.toml" }}
-    ]
+    "resources": {{
+      "../autumn.toml": "autumn.toml"
+    }}
   }},
   "app": {{
     "security": {{
@@ -975,20 +975,13 @@ mod tests {
     fn tauri_conf_bundles_autumn_toml_as_resource() {
         let conf = render_tauri_conf("my-app");
         let parsed: serde_json::Value = serde_json::from_str(&conf).unwrap();
+        // Tauri v2 resources must be a map { source_path: dest_path }, not an array.
         let resources = parsed["bundle"]["resources"]
-            .as_array()
-            .expect("bundle.resources must be an array");
-        let has_autumn_toml = resources.iter().any(|r| {
-            // resource entries can be strings or {"from": "...", "to": "..."}
-            r.as_str()
-                .map(|s| s.contains("autumn.toml"))
-                .unwrap_or_else(|| {
-                    r["from"]
-                        .as_str()
-                        .map(|s| s.contains("autumn.toml"))
-                        .unwrap_or(false)
-                })
-        });
+            .as_object()
+            .expect("bundle.resources must be a map (Tauri v2 schema requirement)");
+        let has_autumn_toml = resources
+            .iter()
+            .any(|(k, v)| k.contains("autumn.toml") || v.as_str().map(|s| s.contains("autumn.toml")).unwrap_or(false));
         assert!(
             has_autumn_toml,
             "tauri.conf.json must bundle autumn.toml as a resource so the installed \

--- a/autumn-cli/src/generate/wizard.rs
+++ b/autumn-cli/src/generate/wizard.rs
@@ -2,7 +2,9 @@
 //!
 //! # Usage
 //!
+//! ```text
 //!   autumn generate wizard <name> <step1> <step2> ...
+//! ```
 //!
 //! # Example
 //!

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -877,7 +877,7 @@ enum MigrateCommands {
     ///   # Revert the last 3 applied user migrations:
     ///   autumn migrate down --steps 3
     ///
-    ///   # Revert until <version> is the latest applied:
+    ///   # Revert until VERSION is the latest applied:
     ///   autumn migrate down --to 20260101000000
     ///
     ///   # Required when the active profile is prod/production:
@@ -1577,12 +1577,12 @@ enum GenerateCommands {
     ///
     /// Example:
     ///
-    ///   autumn generate system-test <Name>
-    ///   autumn generate system-test <Name> --dry-run
+    ///   autumn generate system-test NAME
+    ///   autumn generate system-test NAME --dry-run
     ///
     /// After generation, run with:
     ///
-    ///   cargo test --features system-tests --test <name> -- --include-ignored
+    ///   cargo test --features system-tests --test NAME -- --include-ignored
     #[command(name = "system-test", verbatim_doc_comment)]
     SystemTest {
         /// Test name (`PascalCase` or `snake_case`, e.g. `TodoFlow`).

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -108,7 +108,7 @@ enum Commands {
         /// Package to build (for workspaces)
         #[arg(short, long)]
         package: Option<String>,
-        /// Binary target to build (for packages with multiple [[bin]] targets)
+        /// Binary target to build (for packages with multiple \[\[bin\]\] targets)
         #[arg(long)]
         bin: Option<String>,
         /// Embed static assets + i18n locales into the binary for a true

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1610,6 +1610,38 @@ enum GenerateCommands {
         #[arg(long)]
         force: bool,
     },
+    /// Scaffold a Tauri desktop wrapper that ships the autumn app as a native installer.
+    ///
+    /// Uses the **sidecar model**: the autumn server binary runs as a supervised child
+    /// of the Tauri shell, and the webview loads the app from a free loopback port.
+    /// The existing autumn app (routes, Maud/htmx, sessions) runs unmodified.
+    ///
+    /// The sidecar is built with `autumn-web/embed-assets` (#1004) and
+    /// `autumn-web/managed-pg-bundled` (#1119) so the packaged desktop app needs
+    /// no separately-installed database or loose asset files.
+    ///
+    /// Creates:
+    ///   - `src-tauri/`                 — standalone Tauri shell crate
+    ///   - `src-tauri/tauri.conf.json`  — Tauri v2 config (productName, bundle, sidecar)
+    ///   - `src-tauri/src/lib.rs`       — sidecar lifecycle glue (ephemeral port, /health
+    ///                                     polling, kill-on-close)
+    ///   - `src-tauri/icons/`           — placeholder icons for immediate buildability
+    ///   - `src-tauri/stage-sidecar.sh` — build + stage the sidecar (Unix)
+    ///   - `src-tauri/stage-sidecar.ps1`— build + stage the sidecar (Windows)
+    ///
+    /// Example:
+    ///
+    ///   autumn generate tauri
+    ///   autumn generate tauri --dry-run
+    #[command(verbatim_doc_comment)]
+    Tauri {
+        /// Print the file plan and exit without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Overwrite existing files instead of erroring on collision.
+        #[arg(long)]
+        force: bool,
+    },
     /// Scaffold a multi-step form wizard with session-backed state and per-step validation.
     ///
     /// Emits step structs, GET + POST handlers, progress rendering, commit and
@@ -2490,6 +2522,9 @@ fn run_generate_command(cmd: GenerateCommands) {
         } => generate::system_test::run(&name, generate::Flags { dry_run, force }),
         GenerateCommands::Pwa { dry_run, force } => {
             generate::pwa::run(generate::Flags { dry_run, force });
+        }
+        GenerateCommands::Tauri { dry_run, force } => {
+            generate::tauri::run(generate::Flags { dry_run, force });
         }
         GenerateCommands::Auth {
             name,
@@ -5321,6 +5356,40 @@ mod tests {
         let cli = Cli::try_parse_from(["autumn", "generate", "pwa", "--force"]).unwrap();
         let Commands::Generate(GenerateCommands::Pwa { dry_run, force }) = cli.command else {
             panic!("expected Pwa variant");
+        };
+        assert!(!dry_run);
+        assert!(force);
+    }
+
+    // ── autumn generate tauri ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_generate_tauri() {
+        let cli = Cli::try_parse_from(["autumn", "generate", "tauri"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Generate(GenerateCommands::Tauri {
+                dry_run: false,
+                force: false
+            })
+        ));
+    }
+
+    #[test]
+    fn parse_generate_tauri_dry_run() {
+        let cli = Cli::try_parse_from(["autumn", "generate", "tauri", "--dry-run"]).unwrap();
+        let Commands::Generate(GenerateCommands::Tauri { dry_run, force }) = cli.command else {
+            panic!("expected Tauri variant");
+        };
+        assert!(dry_run);
+        assert!(!force);
+    }
+
+    #[test]
+    fn parse_generate_tauri_force() {
+        let cli = Cli::try_parse_from(["autumn", "generate", "tauri", "--force"]).unwrap();
+        let Commands::Generate(GenerateCommands::Tauri { dry_run, force }) = cli.command else {
+            panic!("expected Tauri variant");
         };
         assert!(!dry_run);
         assert!(force);

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1623,8 +1623,8 @@ enum GenerateCommands {
     /// Creates:
     ///   - `src-tauri/`                 — standalone Tauri shell crate
     ///   - `src-tauri/tauri.conf.json`  — Tauri v2 config (productName, bundle, sidecar)
-    ///   - `src-tauri/src/lib.rs`       — sidecar lifecycle glue (ephemeral port, /health
-    ///                                     polling, kill-on-close)
+    ///   - `src-tauri/src/lib.rs`       — sidecar lifecycle glue (ephemeral port,
+    ///     /health polling, kill-on-close)
     ///   - `src-tauri/icons/`           — placeholder icons for immediate buildability
     ///   - `src-tauri/stage-sidecar.sh` — build + stage the sidecar (Unix)
     ///   - `src-tauri/stage-sidecar.ps1`— build + stage the sidecar (Windows)

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -108,6 +108,9 @@ enum Commands {
         /// Package to build (for workspaces)
         #[arg(short, long)]
         package: Option<String>,
+        /// Binary target to build (for packages with multiple [[bin]] targets)
+        #[arg(long)]
+        bin: Option<String>,
         /// Embed static assets + i18n locales into the binary for a true
         /// single-binary deploy (enables the `autumn-web/embed-assets` feature
         /// and fingerprints before compiling so the manifest is baked in).
@@ -1758,8 +1761,9 @@ fn run_command(command: Commands) {
         Commands::Build {
             debug,
             package,
+            bin,
             embed,
-        } => build::run(debug, embed, package.as_deref()),
+        } => build::run(debug, embed, package.as_deref(), bin.as_deref()),
         Commands::Dev {
             package,
             show_config,
@@ -2933,6 +2937,7 @@ mod tests {
             Commands::Build {
                 debug: false,
                 package: None,
+                bin: None,
                 embed: false
             }
         ));
@@ -2946,6 +2951,7 @@ mod tests {
             Commands::Build {
                 debug: true,
                 package: None,
+                bin: None,
                 embed: false
             }
         ));
@@ -2958,11 +2964,25 @@ mod tests {
             Commands::Build {
                 debug,
                 package,
+                bin,
                 embed,
             } => {
                 assert!(!debug);
                 assert!(!embed);
+                assert!(bin.is_none());
                 assert_eq!(package.as_deref(), Some("blog"));
+            }
+            _ => panic!("expected Build command"),
+        }
+    }
+
+    #[test]
+    fn parse_build_with_bin() {
+        let cli = Cli::try_parse_from(["autumn", "build", "--embed", "--bin", "server"]).unwrap();
+        match cli.command {
+            Commands::Build { embed, bin, .. } => {
+                assert!(embed);
+                assert_eq!(bin.as_deref(), Some("server"));
             }
             _ => panic!("expected Build command"),
         }

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -116,6 +116,11 @@ enum Commands {
         /// and fingerprints before compiling so the manifest is baked in).
         #[arg(long)]
         embed: bool,
+        /// Extra Cargo features to enable (comma-separated). Forwarded to both
+        /// the fingerprint phase and the embed compile so features like
+        /// `autumn-web/managed-pg-bundled` are active throughout all build steps.
+        #[arg(long, value_name = "FEATURES")]
+        features: Option<String>,
     },
     /// Start the dev server with hot reload (watch mode)
     Dev {
@@ -1763,7 +1768,14 @@ fn run_command(command: Commands) {
             package,
             bin,
             embed,
-        } => build::run(debug, embed, package.as_deref(), bin.as_deref()),
+            features,
+        } => build::run(
+            debug,
+            embed,
+            package.as_deref(),
+            bin.as_deref(),
+            features.as_deref(),
+        ),
         Commands::Dev {
             package,
             show_config,
@@ -2938,7 +2950,8 @@ mod tests {
                 debug: false,
                 package: None,
                 bin: None,
-                embed: false
+                embed: false,
+                features: None,
             }
         ));
     }
@@ -2952,7 +2965,8 @@ mod tests {
                 debug: true,
                 package: None,
                 bin: None,
-                embed: false
+                embed: false,
+                features: None,
             }
         ));
     }
@@ -2966,6 +2980,7 @@ mod tests {
                 package,
                 bin,
                 embed,
+                ..
             } => {
                 assert!(!debug);
                 assert!(!embed);
@@ -3007,6 +3022,31 @@ mod tests {
             Commands::Build { debug, package, .. } => {
                 assert!(debug);
                 assert_eq!(package.as_deref(), Some("blog"));
+            }
+            _ => panic!("expected Build command"),
+        }
+    }
+
+    #[test]
+    fn parse_build_with_features() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "build",
+            "--embed",
+            "--features",
+            "autumn-web/managed-pg-bundled",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Build {
+                embed, features, ..
+            } => {
+                assert!(embed);
+                assert_eq!(
+                    features.as_deref(),
+                    Some("autumn-web/managed-pg-bundled"),
+                    "--features must be captured"
+                );
             }
             _ => panic!("expected Build command"),
         }

--- a/autumn-cli/src/templates/Cargo.toml.tmpl
+++ b/autumn-cli/src/templates/Cargo.toml.tmpl
@@ -14,6 +14,9 @@ diesel_migrations = "2"
 # Flash messages are on by default — the scaffold wires Flash into every handler.
 default = ["flash"]
 flash = ["autumn-web/flash"]
+# Enable single-binary asset embedding (autumn build --embed / autumn generate tauri).
+# Active only when explicitly requested; dev builds serve static/ from disk.
+embed-assets = ["autumn-web/embed-assets"]
 
 [dev-dependencies]
 # tokio runtime macros are needed for #[tokio::test] in integration tests.

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -4082,3 +4082,246 @@ fn generate_scaffold_auto_discovery_ignores_per_resource_recipe() {
         "CLI fields must be used, not the recipe's fields; got:\n{model}"
     );
 }
+
+// ── autumn generate tauri ─────────────────────────────────────────────────────
+
+#[test]
+fn generate_tauri_scaffolds_expected_files() {
+    let (_tmp, project) = fresh_project("tauri-scaffold-app");
+    run_autumn(&project, &["generate", "tauri"]);
+
+    // Core Tauri project files must exist
+    assert!(
+        project.join("src-tauri/tauri.conf.json").is_file(),
+        "src-tauri/tauri.conf.json must be created"
+    );
+    assert!(
+        project.join("src-tauri/Cargo.toml").is_file(),
+        "src-tauri/Cargo.toml must be created"
+    );
+    assert!(
+        project.join("src-tauri/build.rs").is_file(),
+        "src-tauri/build.rs must be created"
+    );
+    assert!(
+        project.join("src-tauri/src/main.rs").is_file(),
+        "src-tauri/src/main.rs must be created"
+    );
+    assert!(
+        project.join("src-tauri/src/lib.rs").is_file(),
+        "src-tauri/src/lib.rs must be created"
+    );
+
+    // Staging scripts
+    assert!(
+        project.join("src-tauri/stage-sidecar.sh").is_file(),
+        "stage-sidecar.sh must be created"
+    );
+    assert!(
+        project.join("src-tauri/stage-sidecar.ps1").is_file(),
+        "stage-sidecar.ps1 must be created"
+    );
+
+    // Icons
+    assert!(
+        project.join("src-tauri/icons/icon.svg").is_file(),
+        "icons/icon.svg must be created"
+    );
+    for name in &["32x32.png", "128x128.png", "128x128@2x.png", "icon.png"] {
+        assert!(
+            project.join("src-tauri/icons").join(name).is_file(),
+            "icons/{name} must be created"
+        );
+    }
+    assert!(
+        project.join("src-tauri/icons/icon.ico").is_file(),
+        "icons/icon.ico must be created"
+    );
+    assert!(
+        project.join("src-tauri/icons/icon.icns").is_file(),
+        "icons/icon.icns must be created"
+    );
+
+    // .gitignore
+    assert!(
+        project.join("src-tauri/.gitignore").is_file(),
+        "src-tauri/.gitignore must be created"
+    );
+}
+
+#[test]
+fn generate_tauri_conf_is_valid_json_with_required_fields() {
+    let (_tmp, project) = fresh_project("tauri-conf-app");
+    run_autumn(&project, &["generate", "tauri"]);
+
+    let conf = fs::read_to_string(project.join("src-tauri/tauri.conf.json")).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&conf).expect("tauri.conf.json must be valid JSON");
+
+    assert!(parsed["identifier"].is_string(), "must have identifier");
+    assert!(parsed["productName"].is_string(), "must have productName");
+    assert!(
+        parsed["bundle"]["externalBin"].is_array(),
+        "must have bundle.externalBin"
+    );
+    assert!(
+        !parsed["bundle"]["externalBin"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "externalBin must not be empty"
+    );
+    assert!(parsed["bundle"]["icon"].is_array(), "must have bundle.icon");
+    assert!(
+        parsed["build"]["beforeBuildCommand"].is_string(),
+        "must have build.beforeBuildCommand"
+    );
+    // The externalBin must reference the app name
+    let bins = parsed["bundle"]["externalBin"].as_array().unwrap();
+    assert!(
+        bins.iter()
+            .any(|b| b.as_str().unwrap_or("").contains("tauri-conf-app")),
+        "externalBin must reference the app package name"
+    );
+}
+
+#[test]
+fn generate_tauri_shell_cargo_toml_has_own_workspace() {
+    let (_tmp, project) = fresh_project("tauri-ws-app");
+    run_autumn(&project, &["generate", "tauri"]);
+
+    let cargo = fs::read_to_string(project.join("src-tauri/Cargo.toml")).unwrap();
+    assert!(
+        cargo.contains("[workspace]"),
+        "src-tauri/Cargo.toml must have its own [workspace] so it is independent"
+    );
+    assert!(cargo.contains("tauri"), "must depend on tauri");
+    assert!(
+        cargo.contains("tauri-plugin-shell"),
+        "must depend on tauri-plugin-shell"
+    );
+}
+
+#[test]
+fn generate_tauri_lib_rs_has_sidecar_lifecycle() {
+    let (_tmp, project) = fresh_project("tauri-lifecycle-app");
+    run_autumn(&project, &["generate", "tauri"]);
+
+    let lib = fs::read_to_string(project.join("src-tauri/src/lib.rs")).unwrap();
+    assert!(
+        lib.contains("127.0.0.1:0"),
+        "must bind ephemeral loopback port"
+    );
+    assert!(
+        lib.contains("AUTUMN_SERVER__PORT"),
+        "must pass port env to sidecar"
+    );
+    assert!(
+        lib.contains("AUTUMN_MANAGED_PG_DATA_DIR"),
+        "must pass DB dir env (#1119)"
+    );
+    assert!(lib.contains(".sidecar("), "must spawn sidecar");
+    assert!(lib.contains("/health"), "must poll /health for readiness");
+    assert!(lib.contains(".kill()"), "must kill sidecar on window close");
+    assert!(
+        lib.contains("Destroyed"),
+        "must handle WindowEvent::Destroyed"
+    );
+}
+
+#[test]
+fn generate_tauri_prints_prerequisites() {
+    let (_tmp, project) = fresh_project("tauri-prereq-app");
+    let (stdout, _stderr) = run_autumn(&project, &["generate", "tauri"]);
+    assert!(
+        stdout.contains("tauri-cli") || stdout.contains("cargo tauri"),
+        "must print Tauri CLI prerequisite; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("embed-assets"),
+        "must mention embed-assets (#1004); got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("managed-pg"),
+        "must mention managed-pg (#1119); got:\n{stdout}"
+    );
+}
+
+#[test]
+fn generate_tauri_is_additive_no_app_files_modified() {
+    let (_tmp, project) = fresh_project("tauri-additive-app");
+    let original_main = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    let original_cargo = fs::read_to_string(project.join("Cargo.toml")).unwrap();
+
+    run_autumn(&project, &["generate", "tauri"]);
+
+    assert_eq!(
+        original_main,
+        fs::read_to_string(project.join("src/main.rs")).unwrap(),
+        "src/main.rs must be unchanged after generate tauri"
+    );
+    assert_eq!(
+        original_cargo,
+        fs::read_to_string(project.join("Cargo.toml")).unwrap(),
+        "root Cargo.toml must be unchanged after generate tauri"
+    );
+}
+
+#[test]
+fn generate_tauri_dry_run_writes_nothing() {
+    let (_tmp, project) = fresh_project("tauri-dry-run-app");
+    let (stdout, _stderr) = run_autumn(&project, &["generate", "tauri", "--dry-run"]);
+    assert!(
+        !project.join("src-tauri").exists(),
+        "dry-run must not create src-tauri/; got stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("tauri.conf.json") || stdout.contains("Would create"),
+        "dry-run must print the file plan; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn generate_tauri_collision_without_force_exits_nonzero() {
+    let (_tmp, project) = fresh_project("tauri-collision-app");
+    run_autumn(&project, &["generate", "tauri"]);
+
+    let (_, stderr, code) = run_autumn_failing(&project, &["generate", "tauri"]);
+    assert_eq!(code, Some(1), "re-running without --force must exit 1");
+    assert!(
+        stderr.contains("would overwrite") || stderr.contains("already exists"),
+        "must explain collision; got stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn generate_tauri_force_is_idempotent() {
+    let (_tmp, project) = fresh_project("tauri-force-app");
+    run_autumn(&project, &["generate", "tauri"]);
+    run_autumn(&project, &["generate", "tauri", "--force"]);
+
+    // After --force, the JSON must still be valid
+    let conf = fs::read_to_string(project.join("src-tauri/tauri.conf.json")).unwrap();
+    let _: serde_json::Value =
+        serde_json::from_str(&conf).expect("tauri.conf.json must still be valid after --force");
+}
+
+#[test]
+fn generate_tauri_reuses_pwa_icon() {
+    let (_tmp, project) = fresh_project("tauri-pwa-icon-app");
+    // Simulate PWA generator having run
+    run_autumn(&project, &["generate", "pwa"]);
+
+    run_autumn(&project, &["generate", "tauri"]);
+
+    // The tauri icon.svg must exist and must contain PWA icon content
+    assert!(
+        project.join("src-tauri/icons/icon.svg").is_file(),
+        "icons/icon.svg must be created"
+    );
+    // Both the PWA and tauri icon.svg exist
+    assert!(
+        project.join("static/icons/icon.svg").is_file(),
+        "PWA icon must still exist"
+    );
+}

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -4312,14 +4312,20 @@ fn generate_tauri_reuses_pwa_icon() {
     // Simulate PWA generator having run
     run_autumn(&project, &["generate", "pwa"]);
 
+    // Read the PWA icon before running the Tauri generator
+    let pwa_icon =
+        fs::read_to_string(project.join("static/icons/icon.svg")).expect("PWA icon must exist");
+
     run_autumn(&project, &["generate", "tauri"]);
 
-    // The tauri icon.svg must exist and must contain PWA icon content
-    assert!(
-        project.join("src-tauri/icons/icon.svg").is_file(),
-        "icons/icon.svg must be created"
+    // The Tauri icon.svg must contain the same content as the PWA icon
+    let tauri_icon = fs::read_to_string(project.join("src-tauri/icons/icon.svg"))
+        .expect("src-tauri/icons/icon.svg must be created");
+    assert_eq!(
+        pwa_icon, tauri_icon,
+        "src-tauri/icons/icon.svg must contain the same content as the PWA icon"
     );
-    // Both the PWA and tauri icon.svg exist
+    // Original PWA icon must be untouched
     assert!(
         project.join("static/icons/icon.svg").is_file(),
         "PWA icon must still exist"

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -4112,6 +4112,20 @@ fn generate_tauri_scaffolds_expected_files() {
         "src-tauri/src/lib.rs must be created"
     );
 
+    // Platform-specific Tauri config overlays (beforeBuildCommand/beforeDevCommand)
+    assert!(
+        project.join("src-tauri/tauri.linux.conf.json").is_file(),
+        "tauri.linux.conf.json must be created"
+    );
+    assert!(
+        project.join("src-tauri/tauri.macos.conf.json").is_file(),
+        "tauri.macos.conf.json must be created"
+    );
+    assert!(
+        project.join("src-tauri/tauri.windows.conf.json").is_file(),
+        "tauri.windows.conf.json must be created"
+    );
+
     // Staging scripts
     assert!(
         project.join("src-tauri/stage-sidecar.sh").is_file(),
@@ -4172,9 +4186,10 @@ fn generate_tauri_conf_is_valid_json_with_required_fields() {
         "externalBin must not be empty"
     );
     assert!(parsed["bundle"]["icon"].is_array(), "must have bundle.icon");
+    // beforeBuildCommand lives in platform-specific overlay files, not the main conf.
     assert!(
-        parsed["build"]["beforeBuildCommand"].is_string(),
-        "must have build.beforeBuildCommand"
+        parsed["build"]["beforeBuildCommand"].is_null(),
+        "beforeBuildCommand must be absent from tauri.conf.json (lives in platform overlays)"
     );
     // The externalBin must reference the app name
     let bins = parsed["bundle"]["externalBin"].as_array().unwrap();

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -182,6 +182,12 @@ pub struct OsEnv;
 impl Env for OsEnv {
     fn var(&self, key: &str) -> Result<String, std::env::VarError> {
         if key == "AUTUMN_MANIFEST_DIR" {
+            // Process env takes priority over the compile-time baked-in path so
+            // installed apps (e.g. Tauri sidecars) can redirect config loading to
+            // their bundled resource dir by setting AUTUMN_MANIFEST_DIR at launch.
+            if let Ok(override_val) = std::env::var(key) {
+                return Ok(override_val);
+            }
             if let Some(dir) = MACRO_MANIFEST_DIR.get() {
                 return Ok(dir.clone());
             }

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -12,6 +12,7 @@ single command. Four subcommands cover the cases you actually hit:
 | `autumn generate scaffold`           | Everything `model` does plus `#[repository]`, HTML routes, smoke test, `routes![]` registration |
 | `autumn generate wizard`             | A session-backed multi-step form wizard with per-step validation and a confirm/commit/cancel flow |
 | `autumn generate admin`              | An `AdminModel` adapter for an existing model, wired to `autumn-admin-plugin`   |
+| `autumn generate tauri`              | A complete `src-tauri/` sidecar project so the app ships as a native desktop installer (see [Tauri guide](tauri.md)) |
 
 The generators only emit code that uses macros and conventions Autumn already
 ships (`#[model]`, `#[repository]`, `#[get]/#[post]`, the `i64`-PK convention,

--- a/docs/guide/tauri.md
+++ b/docs/guide/tauri.md
@@ -93,11 +93,13 @@ is reused as the Tauri icon source automatically.
    needs it. No hardcoded ports, no firewall rules.
 
 2. **Spawn sidecar**: the Tauri `setup` hook uses `tauri-plugin-shell` to launch
-   the autumn binary with `AUTUMN_SERVER__HOST=127.0.0.1`,
+   the autumn binary with its working directory set to the Tauri resource directory
+   (where `autumn.toml` is bundled), plus `AUTUMN_SERVER__HOST=127.0.0.1`,
    `AUTUMN_SERVER__PORT={port}`, `AUTUMN_MANAGED_PG_DATA_DIR={app-data-dir}/db`,
-   and `AUTUMN_MANIFEST_DIR={resource-dir}` so the sidecar finds the bundled
-   `autumn.toml` on the installed machine (see below). `AUTUMN_HEALTH__PATH` is
-   forced to `/health` so the readiness probe always works regardless of any
+   and `AUTUMN_MANIFEST_DIR={resource-dir}`. Setting the working directory is the
+   key mechanism: `AutumnConfig` falls back to a CWD-relative `autumn.toml` lookup
+   when the compile-time path is absent on the installed machine. `AUTUMN_HEALTH__PATH`
+   is forced to `/health` so the readiness probe always works regardless of any
    `[health].path` configuration in the app.
 
 3. **Wait for ready**: the setup hook polls `GET /health` (the existing autumn

--- a/docs/guide/tauri.md
+++ b/docs/guide/tauri.md
@@ -98,13 +98,12 @@ is reused as the Tauri icon source automatically.
    `AUTUMN_SERVER__PORT={port}`, `AUTUMN_MANAGED_PG_DATA_DIR={app-data-dir}/db`,
    and `AUTUMN_MANIFEST_DIR={resource-dir}`. Setting the working directory is the
    key mechanism: `AutumnConfig` falls back to a CWD-relative `autumn.toml` lookup
-   when the compile-time path is absent on the installed machine. `AUTUMN_HEALTH__PATH`
-   is forced to `/health` so the readiness probe always works regardless of any
-   `[health].path` configuration in the app.
+   when the compile-time path is absent on the installed machine.
 
-3. **Wait for ready**: the setup hook polls `GET /health` (the existing autumn
-   health endpoint) over raw TCP until it gets an `HTTP/1.1 200` response or
-   times out after 30 seconds.
+3. **Wait for ready**: the setup hook sends `GET /` over raw TCP and accepts any
+   valid HTTP response (any status code) as the readiness signal, then waits up
+   to 30 seconds. Using `GET /` rather than a specific health path avoids a
+   duplicate-route panic if your app already defines a `GET /health` handler.
 
 4. **Open window**: once the server is ready, the webview navigates to
    `http://127.0.0.1:{port}`.
@@ -169,21 +168,38 @@ cargo tauri icon icons/icon.svg
 
 ## Dev workflow
 
-During development you can run the autumn server normally (`autumn dev` or
-`cargo run`) and open the Tauri shell against it:
+`cargo tauri dev` is self-contained — no separate `autumn dev` process is needed
+or should be running alongside it:
 
 ```bash
-# Terminal 1 — run the autumn server
-autumn dev
-
-# Terminal 2 — run the Tauri shell in dev mode
 cd src-tauri
 cargo tauri dev
 ```
 
-`tauri dev` hot-reloads the webview when the server's HTML changes; the
-`beforeDevCommand` in `tauri.conf.json` is intentionally left empty so
-`cargo tauri dev` does not try to start a second server instance.
+What happens:
+
+1. `beforeDevCommand` (in `tauri.linux.conf.json` / `tauri.macos.conf.json` /
+   `tauri.windows.conf.json`) runs the staging script with `"wait": true`,
+   building the autumn binary and copying it to `binaries/`.
+2. Tauri compiles the shell crate and launches it.
+3. The generated `lib.rs` spawns the staged sidecar as a child process on an
+   ephemeral loopback port, waits for it to respond to HTTP, then opens the
+   webview.
+
+**Do not** run `autumn dev` in a separate terminal alongside `cargo tauri dev`:
+the shell always spawns its own sidecar instance, so you would have two server
+processes on different ports and the webview would connect to the sidecar, not
+the external `autumn dev` server.
+
+For rapid iteration rebuild with `cargo tauri dev` again after changing server
+code. Template changes that don't affect the binary (e.g. pure CSS tweaks)
+don't require re-staging; re-run to pick them up once the binary is rebuilt.
+
+> **Note:** Tauri's webview live-reload is not applicable here because the server
+> is a supervised sidecar, not a URL the webview watches externally. Full
+> hot-reload in the sidecar model would require a separate mechanism (e.g.
+> `cargo-watch` rebuilding the sidecar binary and signalling the shell to
+> restart it) which is out of scope for the generator.
 
 ## Relationship to PWA support
 

--- a/docs/guide/tauri.md
+++ b/docs/guide/tauri.md
@@ -114,16 +114,20 @@ is reused as the Tauri icon source automatically.
 
 ## App configuration (`autumn.toml`)
 
-`autumn.toml` is automatically included in the installer as a Tauri bundle resource
-(via `bundle.resources` in `tauri.conf.json`). The generated shell sets
-`AUTUMN_MANIFEST_DIR` to the resource directory when spawning the sidecar, so
-`AutumnConfig::load_with_env` finds it on the installed machine.
+`autumn.toml` and any profile override files (`autumn-prod.toml`,
+`autumn-production.toml`, etc.) are automatically included in the installer as Tauri
+bundle resources (via `bundle.resources` in `tauri.conf.json`). The generated shell
+sets the sidecar's working directory to the resource directory, so
+`AutumnConfig::load_with_env` finds them on the installed machine via its CWD
+fallback.
 
 This means your production `autumn.toml` — auth keys, SEO settings, security
 headers, `auto_migrate_in_production`, and anything else you configure there — is
-packaged with the installer and takes effect at runtime. Secrets that should not be
-committed to source control (e.g. `database.primary_url`, third-party API keys)
-should be supplied via environment variables as normal.
+packaged with the installer and takes effect at runtime. Profile files must exist in
+the project root at the time you run `cargo tauri build` to be included; Tauri skips
+glob entries that match no files. Secrets that should not be committed to source
+control (e.g. `database.primary_url`, third-party API keys) should be supplied via
+environment variables as normal.
 
 ## Building a native installer
 

--- a/docs/guide/tauri.md
+++ b/docs/guide/tauri.md
@@ -112,7 +112,7 @@ From inside `src-tauri/`:
 
 ```bash
 # Stage the sidecar binary (called automatically by tauri build, but can run standalone):
-sh stage-sidecar.sh          # Unix
+bash stage-sidecar.sh        # Unix (script uses bash-specific features)
 .\stage-sidecar.ps1          # Windows PowerShell
 
 # Build the installer for the host OS:

--- a/docs/guide/tauri.md
+++ b/docs/guide/tauri.md
@@ -1,0 +1,169 @@
+# Desktop Apps with Tauri (`autumn generate tauri`)
+
+`autumn generate tauri` scaffolds a complete `src-tauri/` sub-project that
+wraps any existing autumn app in a native desktop shell. The generated project
+uses Tauri v2's **sidecar model**: the autumn server binary runs as a supervised
+child process and the webview loads the app from a loopback port chosen at
+runtime. Your existing routes, Maud/htmx templates, and sessions run entirely
+unmodified — the generator is purely additive and never rewrites your app code.
+
+## Prerequisites
+
+### External toolchain
+
+Install the Tauri CLI:
+
+```bash
+cargo install tauri-cli --version "^2"
+```
+
+The Tauri CLI also requires platform-specific toolchain components:
+
+| Platform | Required components |
+|----------|-------------------|
+| **Linux** | `webkit2gtk-4.1`, `build-essential`, `curl`, `wget`, `file`, `libssl-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev` |
+| **macOS** | Xcode Command Line Tools (`xcode-select --install`) |
+| **Windows** | [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) and [WebView2](https://developer.microsoft.com/microsoft-edge/webview2/) (pre-installed on Windows 11) |
+
+See the [Tauri prerequisites guide](https://v2.tauri.app/start/prerequisites/) for the full up-to-date list.
+
+### autumn feature dependencies
+
+The scaffolded desktop app relies on two autumn features that must be enabled
+when building the sidecar binary:
+
+- **`autumn-web/managed-pg-bundled`** (issue #1119 — managed local Postgres):
+  embeds the Postgres binaries into the sidecar so the packaged desktop app
+  needs no separately-installed database. The sidecar is pointed at a
+  persistent per-app data directory via the `AUTUMN_MANAGED_PG_DATA_DIR`
+  environment variable, which the generated Tauri shell sets automatically to
+  `{app-data-dir}/db`.
+
+- **`autumn-web/embed-assets`** (issue #1004 — single-binary asset embed):
+  embeds the `static/` tree (CSS, JS, images, the fingerprint manifest) into
+  the release binary so the packaged app has no loose files alongside it.
+
+Both features are already enabled by the generated `stage-sidecar.sh` /
+`stage-sidecar.ps1` scripts; you only need to wire `ManagedPostgresPoolProvider`
+in your app's pool configuration if you haven't already (see the
+[managed Postgres guide](managed-pg.md)).
+
+## Scaffolding
+
+Run the generator from your project root:
+
+```bash
+autumn generate tauri
+```
+
+The generator is idempotent. Re-running without `--force` errors on existing
+files; re-running with `--force` regenerates them deterministically. It never
+touches your app's `src/main.rs` or root `Cargo.toml`.
+
+```
+src-tauri/
+  tauri.conf.json          — Tauri v2 config (productName, identifier, bundle, sidecar ref)
+  Cargo.toml               — standalone shell crate with its own [workspace]
+  build.rs                 — calls tauri_build::build()
+  src/
+    main.rs                — #![windows_subsystem = "windows"] + calls lib::run()
+    lib.rs                 — sidecar lifecycle glue (see below)
+  icons/
+    icon.svg               — SVG source; replace with your own, then run `cargo tauri icon`
+    32x32.png              }
+    128x128.png            } placeholder icons; regenerate from icon.svg with `cargo tauri icon`
+    128x128@2x.png         }
+    icon.png               }
+    icon.ico               — Windows icon
+    icon.icns              — macOS icon
+  stage-sidecar.sh         — Unix: build autumn sidecar → copy to binaries/
+  stage-sidecar.ps1        — Windows: same in PowerShell
+  .gitignore               — /target  /binaries  /gen
+```
+
+If you previously ran `autumn generate pwa`, the existing `static/icons/icon.svg`
+is reused as the Tauri icon source automatically.
+
+## Sidecar lifecycle
+
+`src-tauri/src/lib.rs` implements the full desktop process lifecycle:
+
+1. **Ephemeral port**: `TcpListener::bind("127.0.0.1:0")` picks an OS-assigned
+   port; the port number is saved and the listener is dropped before the sidecar
+   needs it. No hardcoded ports, no firewall rules.
+
+2. **Spawn sidecar**: the Tauri `setup` hook uses `tauri-plugin-shell` to launch
+   the autumn binary with `AUTUMN_SERVER__HOST=127.0.0.1`,
+   `AUTUMN_SERVER__PORT={port}`, and `AUTUMN_MANAGED_PG_DATA_DIR={app-data-dir}/db`.
+
+3. **Wait for ready**: the setup hook polls `GET /health` (the existing autumn
+   health endpoint) over raw TCP until it gets an `HTTP/1.1 200` response or
+   times out after 30 seconds.
+
+4. **Open window**: once the server is ready, the webview navigates to
+   `http://127.0.0.1:{port}`.
+
+5. **Clean shutdown**: on `WindowEvent::Destroyed`, the stored `CommandChild`
+   handle is killed. No orphaned server process survives after the window closes.
+
+## Building a native installer
+
+From inside `src-tauri/`:
+
+```bash
+# Stage the sidecar binary (called automatically by tauri build, but can run standalone):
+sh stage-sidecar.sh          # Unix
+.\stage-sidecar.ps1          # Windows PowerShell
+
+# Build the installer for the host OS:
+cargo tauri build
+```
+
+Installer outputs by platform:
+
+| Platform | Output |
+|----------|--------|
+| Linux | `.deb`, `.rpm`, `.AppImage` under `src-tauri/target/release/bundle/` |
+| macOS | `.dmg`, `.app` under `src-tauri/target/release/bundle/` |
+| Windows | `.msi`, NSIS `.exe` under `src-tauri\target\release\bundle\` |
+
+Cross-compilation is not supported by Tauri out of the box; build on each
+target platform or use a CI matrix (GitHub Actions with `ubuntu-latest`,
+`macos-latest`, `windows-latest`).
+
+## Customising icons
+
+Replace the placeholder icons with your own:
+
+```bash
+# Provide a 1024×1024 PNG or square SVG:
+cp my-logo.svg src-tauri/icons/icon.svg
+cd src-tauri
+cargo tauri icon icons/icon.svg
+```
+
+`cargo tauri icon` regenerates all required sizes and formats automatically.
+
+## Dev workflow
+
+During development you can run the autumn server normally (`autumn dev` or
+`cargo run`) and open the Tauri shell against it:
+
+```bash
+# Terminal 1 — run the autumn server
+autumn dev
+
+# Terminal 2 — run the Tauri shell in dev mode
+cd src-tauri
+cargo tauri dev
+```
+
+`tauri dev` hot-reloads the webview when the server's HTML changes; the
+`beforeDevCommand` in `tauri.conf.json` is intentionally left empty so
+`cargo tauri dev` does not try to start a second server instance.
+
+## Relationship to PWA support
+
+`autumn generate tauri` and `autumn generate pwa` are independent. Running both
+gives you a Progressive Web App installable from the browser **and** a native
+desktop installer from the same server-rendered codebase — no code duplication.

--- a/docs/guide/tauri.md
+++ b/docs/guide/tauri.md
@@ -94,7 +94,11 @@ is reused as the Tauri icon source automatically.
 
 2. **Spawn sidecar**: the Tauri `setup` hook uses `tauri-plugin-shell` to launch
    the autumn binary with `AUTUMN_SERVER__HOST=127.0.0.1`,
-   `AUTUMN_SERVER__PORT={port}`, and `AUTUMN_MANAGED_PG_DATA_DIR={app-data-dir}/db`.
+   `AUTUMN_SERVER__PORT={port}`, `AUTUMN_MANAGED_PG_DATA_DIR={app-data-dir}/db`,
+   and `AUTUMN_MANIFEST_DIR={resource-dir}` so the sidecar finds the bundled
+   `autumn.toml` on the installed machine (see below). `AUTUMN_HEALTH__PATH` is
+   forced to `/health` so the readiness probe always works regardless of any
+   `[health].path` configuration in the app.
 
 3. **Wait for ready**: the setup hook polls `GET /health` (the existing autumn
    health endpoint) over raw TCP until it gets an `HTTP/1.1 200` response or
@@ -105,6 +109,19 @@ is reused as the Tauri icon source automatically.
 
 5. **Clean shutdown**: on `WindowEvent::Destroyed`, the stored `CommandChild`
    handle is killed. No orphaned server process survives after the window closes.
+
+## App configuration (`autumn.toml`)
+
+`autumn.toml` is automatically included in the installer as a Tauri bundle resource
+(via `bundle.resources` in `tauri.conf.json`). The generated shell sets
+`AUTUMN_MANIFEST_DIR` to the resource directory when spawning the sidecar, so
+`AutumnConfig::load_with_env` finds it on the installed machine.
+
+This means your production `autumn.toml` — auth keys, SEO settings, security
+headers, `auto_migrate_in_production`, and anything else you configure there — is
+packaged with the installer and takes effect at runtime. Secrets that should not be
+committed to source control (e.g. `database.primary_url`, third-party API keys)
+should be supplied via environment variables as normal.
 
 ## Building a native installer
 

--- a/scripts/check-release-image-boot.sh
+++ b/scripts/check-release-image-boot.sh
@@ -160,6 +160,19 @@ stage_vendor_before_chef_cook() {
     "${PROJECT_DIR}/Dockerfile"
 }
 
+# Inject the locally-built autumn binary into the Docker build context so the
+# generated Dockerfile's `RUN autumn build --embed` uses the in-tree CLI rather
+# than the last published crates.io release (which may lack new sub-commands like
+# `--embed`). The generated Dockerfile is unchanged from what users receive.
+inject_local_autumn_binary() {
+  log "Injecting locally-built autumn binary into Docker build context"
+  cp "${AUTUMN}" "${PROJECT_DIR}/autumn-ci-bin"
+  chmod +x "${PROJECT_DIR}/autumn-ci-bin"
+  sed -i \
+    's|^RUN cargo install --locked autumn-cli.*$|COPY ./autumn-ci-bin /usr/local/bin/autumn|' \
+    "${PROJECT_DIR}/Dockerfile"
+}
+
 vendor_in_tree_autumn_web
 
 # ── health probe helper ─────────────────────────────────────────────────────
@@ -226,6 +239,7 @@ run_default_target() {
   log "release init (bare/default target)"
   ( cd "${PROJECT_DIR}" && "${AUTUMN}" release init --force )
   stage_vendor_before_chef_cook
+  inject_local_autumn_binary
 
   log "docker build the generated image"
   if ! ( cd "${PROJECT_DIR}" && docker build -t "${IMAGE_TAG}" . 2>&1 | tee "${WORKDIR}/build.log" ); then
@@ -275,6 +289,7 @@ run_compose_target() {
   log "release init --target docker-compose"
   ( cd "${PROJECT_DIR}" && "${AUTUMN}" release init --force --target docker-compose )
   stage_vendor_before_chef_cook
+  inject_local_autumn_binary
 
   # The generated compose app runs in the prod profile, which requires a
   # non-empty trusted-host allowlist to bind. Inject it (and a signing secret)

--- a/scripts/check-release-image-boot.sh
+++ b/scripts/check-release-image-boot.sh
@@ -119,6 +119,11 @@ vendor_in_tree_autumn_web() {
   # Drop any stray build artifacts so the context stays small and deterministic.
   rm -rf "${vendor_dir}/autumn/target" "${vendor_dir}/autumn-macros/target" \
          "${vendor_dir}/autumn-cli/target"
+  # Copy the monorepo Cargo.lock into vendor/ so `cargo install --locked` inside
+  # Docker uses the same pinned dependency versions as the main workspace (e.g.
+  # time=0.3.47, which is compatible with cookie-0.18.1; free resolution picks
+  # time=0.3.52 which broke the time::parse() API).
+  cp "${REPO_ROOT}/Cargo.lock" "${vendor_dir}/Cargo.lock"
 
   # A workspace root so the vendored crates' `*.workspace = true` keys,
   # `[workspace.dependencies]`, and `[workspace.lints]` resolve exactly as in the
@@ -161,13 +166,8 @@ TOML
 # post-processing is CI-only and matches the CI-only vendoring above; the
 # generated artifact a user gets is unchanged.
 stage_vendor_before_chef_cook() {
-  # Also stage the root Cargo.lock into vendor/ so that
-  # `cargo install --locked --path ./vendor/autumn-cli` resolves to the same
-  # pinned dependency versions used by the main workspace.  Without it, cargo
-  # resolves freely and may pick an incompatible combination (e.g. cookie-0.18.1
-  # with time-0.3.52, which broke the time::parse() API).
   sed -i \
-    's|^COPY --from=planner /app/recipe.json recipe.json$|COPY --from=planner /app/vendor vendor\nCOPY --from=planner /app/Cargo.lock vendor/Cargo.lock\nCOPY --from=planner /app/recipe.json recipe.json|' \
+    's|^COPY --from=planner /app/recipe.json recipe.json$|COPY --from=planner /app/vendor vendor\nCOPY --from=planner /app/recipe.json recipe.json|' \
     "${PROJECT_DIR}/Dockerfile"
 }
 

--- a/scripts/check-release-image-boot.sh
+++ b/scripts/check-release-image-boot.sh
@@ -115,14 +115,20 @@ vendor_in_tree_autumn_web() {
   # workspace root, so these crate dirs are source-only and cheap to copy.
   cp -R "${REPO_ROOT}/autumn" "${vendor_dir}/autumn"
   cp -R "${REPO_ROOT}/autumn-macros" "${vendor_dir}/autumn-macros"
+  cp -R "${REPO_ROOT}/autumn-cli" "${vendor_dir}/autumn-cli"
   # Drop any stray build artifacts so the context stays small and deterministic.
-  rm -rf "${vendor_dir}/autumn/target" "${vendor_dir}/autumn-macros/target"
+  rm -rf "${vendor_dir}/autumn/target" "${vendor_dir}/autumn-macros/target" \
+         "${vendor_dir}/autumn-cli/target"
 
   # A workspace root so the vendored crates' `*.workspace = true` keys,
   # `[workspace.dependencies]`, and `[workspace.lints]` resolve exactly as in the
-  # real tree. Derived from the real root manifest (members trimmed to the two
+  # real tree. Derived from the real root manifest (members trimmed to the three
   # vendored crates) so it stays in sync automatically.
-  sed 's|^members = \[.*\]|members = ["autumn", "autumn-macros"]|' \
+  # autumn-cli is included so that `cargo install --path ./vendor/autumn-cli` (used
+  # by inject_local_autumn_binary) resolves workspace dependencies correctly and
+  # compiles inside Docker against the builder's glibc — avoiding the glibc version
+  # mismatch that arises when copying a runner-built binary into the container.
+  sed 's|^members = \[.*\]|members = ["autumn", "autumn-macros", "autumn-cli"]|' \
     "${REPO_ROOT}/Cargo.toml" > "${vendor_dir}/Cargo.toml"
 
   # The scaffold's own Cargo.toml declares an (empty) `[workspace]`, which makes
@@ -160,16 +166,17 @@ stage_vendor_before_chef_cook() {
     "${PROJECT_DIR}/Dockerfile"
 }
 
-# Inject the locally-built autumn binary into the Docker build context so the
-# generated Dockerfile's `RUN autumn build --embed` uses the in-tree CLI rather
-# than the last published crates.io release (which may lack new sub-commands like
-# `--embed`). The generated Dockerfile is unchanged from what users receive.
+# Patch the generated Dockerfile to install autumn-cli from the vendored in-tree
+# source rather than from crates.io. This avoids the glibc version mismatch that
+# arises when a runner-built binary is copied into the Docker builder container
+# (the runner may link against a newer glibc than the Debian Bookworm base image),
+# and ensures sub-commands like `autumn build --embed` that post-date the last
+# published release are available inside the build.  The generated Dockerfile is
+# unchanged from what users receive.
 inject_local_autumn_binary() {
-  log "Injecting locally-built autumn binary into Docker build context"
-  cp "${AUTUMN}" "${PROJECT_DIR}/autumn-ci-bin"
-  chmod +x "${PROJECT_DIR}/autumn-ci-bin"
+  log "Patching Dockerfile to install autumn-cli from in-tree vendor source"
   sed -i \
-    's|^RUN cargo install --locked autumn-cli.*$|COPY ./autumn-ci-bin /usr/local/bin/autumn|' \
+    's|^RUN cargo install --locked autumn-cli.*$|RUN cargo install --locked --path ./vendor/autumn-cli|' \
     "${PROJECT_DIR}/Dockerfile"
 }
 

--- a/scripts/check-release-image-boot.sh
+++ b/scripts/check-release-image-boot.sh
@@ -161,8 +161,13 @@ TOML
 # post-processing is CI-only and matches the CI-only vendoring above; the
 # generated artifact a user gets is unchanged.
 stage_vendor_before_chef_cook() {
+  # Also stage the root Cargo.lock into vendor/ so that
+  # `cargo install --locked --path ./vendor/autumn-cli` resolves to the same
+  # pinned dependency versions used by the main workspace.  Without it, cargo
+  # resolves freely and may pick an incompatible combination (e.g. cookie-0.18.1
+  # with time-0.3.52, which broke the time::parse() API).
   sed -i \
-    's|^COPY --from=planner /app/recipe.json recipe.json$|COPY --from=planner /app/vendor vendor\nCOPY --from=planner /app/recipe.json recipe.json|' \
+    's|^COPY --from=planner /app/recipe.json recipe.json$|COPY --from=planner /app/vendor vendor\nCOPY --from=planner /app/Cargo.lock vendor/Cargo.lock\nCOPY --from=planner /app/recipe.json recipe.json|' \
     "${PROJECT_DIR}/Dockerfile"
 }
 


### PR DESCRIPTION
## Summary

Adds a new `autumn generate tauri` command that scaffolds a complete Tauri v2 desktop wrapper around any existing autumn web app. The generated `src-tauri/` sub-project uses the sidecar model: the autumn server runs as a supervised child process and the webview loads the app from a dynamically-chosen loopback port. The existing autumn app code (routes, templates, sessions) runs entirely unmodified.

## Key Changes

- **New module `autumn-cli/src/generate/tauri.rs`** (1208 lines):
  - `plan_tauri()` — computes file actions for the scaffold
  - `run()` — CLI entry point that executes the plan and prints prerequisites
  - Renderers for all generated files:
    - `tauri.conf.json` — Tauri v2 config with sidecar reference and bundle settings
    - `src-tauri/Cargo.toml` — standalone shell crate with its own `[workspace]`
    - `src-tauri/src/lib.rs` — sidecar lifecycle glue:
      - Binds ephemeral loopback port (`:0`)
      - Spawns autumn binary with `AUTUMN_SERVER__PORT` and `AUTUMN_MANAGED_PG_DATA_DIR` env vars
      - Polls `/health` endpoint until server is ready (30s timeout)
      - Opens webview window pointing at `http://127.0.0.1:{port}`
      - Kills sidecar on window close
    - `src-tauri/src/main.rs` — entry point with `#![windows_subsystem = "windows"]`
    - `stage-sidecar.sh` / `stage-sidecar.ps1` — build scripts that compile the sidecar with `embed-assets` and `managed-pg-bundled` features
    - Placeholder icons (SVG, PNG, ICO, ICNS) for immediate buildability
    - `.gitignore` for Tauri build artifacts
  - Comprehensive unit tests (60+ test cases) covering:
    - Error handling (missing project root, missing package name)
    - File list generation
    - JSON/TOML validity
    - Sidecar lifecycle requirements
    - Icon format validation
    - Additive nature (no app files modified)

- **CLI integration** (`autumn-cli/src/main.rs`):
  - Added `Tauri` variant to `GenerateCommands` enum
  - Wired `--dry-run` and `--force` flags
  - Integrated into `run_generate_command()` dispatcher

- **Documentation** (`docs/guide/tauri.md`):
  - Complete guide covering prerequisites (Tauri CLI, platform toolchain, autumn features)
  - Scaffolding walkthrough and file structure
  - Sidecar lifecycle explanation
  - Building and packaging instructions
  - Icon customization workflow

- **Integration tests** (`autumn-cli/tests/generate.rs`):
  - 10 end-to-end tests validating file creation, JSON validity, lifecycle requirements, prerequisites output, additivity, dry-run behavior, and collision handling

- **Documentation index updates**:
  - Added `tauri` to `docs/guide/generators.md` table
  - Updated `CHANGELOG.md` with feature announcement

## Notable Implementation Details

- **Sidecar binary discovery**: Uses `binaries/{package_name}` path in `tauri.conf.json` so Tauri can locate the autumn binary after staging
- **Ephemeral port selection**: Binds `:0` to let the OS assign a free port, then drops the listener before the sidecar needs it (brief race window is acceptable on loopback)
- **Health polling**: Raw TCP + HTTP/1.1 request parsing (no external HTTP client) to avoid adding dependencies to the shell crate
- **Icon reuse**: Automatically copies `static/icons/icon.svg` from PWA scaffold if present, otherwise generates a placeholder
- **Placeholder icons**: Minimal valid PNG/ICO/ICNS files (1×1 pixels) so `cargo tauri build` succeeds immediately; users regenerate with `cargo tauri

https://claude.ai/code/session_01TDrCFo66NqUBcEYNhBQ1nt