### PR TITLE
Add breadcrumb navigation widget

### DIFF
--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -169,14 +169,14 @@ pub use validator::Validate;
 pub use crate::form::{Changeset, ChangesetForm, IntoChangeset};
 
 // ── Search & autocomplete widgets ─────────────────────────────────
-/// Active search, autocomplete, and data table configuration types and rendering helpers.
+/// Active search, autocomplete, data table, and breadcrumb configuration types and rendering helpers.
 ///
 /// See [`crate::widgets`] for the full API.
 #[cfg(feature = "maud")]
 pub use crate::widgets::{
-    ActiveSearchConfig, AutocompleteConfig, Column, DataTableConfig, SearchMethod, SortDir,
+    ActiveSearchConfig, AutocompleteConfig, Column, Crumb, DataTableConfig, SearchMethod, SortDir,
     active_search, active_search_empty_state, active_search_input, active_search_results,
-    autocomplete_empty_state, autocomplete_input, autocomplete_option, data_table,
+    autocomplete_empty_state, autocomplete_input, autocomplete_option, breadcrumb, data_table,
 };
 
 // ── Hooks ───────────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1823,12 +1823,12 @@ mod tests {
     fn breadcrumb_non_last_crumb_without_href_renders_span_not_bare_text() {
         // A Crumb with href:None in a non-last position must still be wrapped
         // in a <span> so it has an accessible element, not invisible bare text.
-        let crumbs = [
-            Crumb::current("Unlinked Middle"),
-            Crumb::current("Current"),
-        ];
+        let crumbs = [Crumb::current("Unlinked Middle"), Crumb::current("Current")];
         let html = breadcrumb(&crumbs).into_string();
-        assert!(html.contains("<span class=\"autumn-breadcrumb__text\">Unlinked Middle</span>"), "{html}");
+        assert!(
+            html.contains("<span class=\"autumn-breadcrumb__text\">Unlinked Middle</span>"),
+            "{html}"
+        );
         // Only the last item carries aria-current
         assert_eq!(html.matches(r#"aria-current="page""#).count(), 1, "{html}");
     }

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1009,6 +1009,94 @@ pub fn data_table<T>(
     }
 }
 
+// ── breadcrumb ────────────────────────────────────────────────────────────
+
+/// A single crumb in a [`breadcrumb`] navigation trail.
+///
+/// Build with [`Crumb::link`] for a linked crumb or [`Crumb::current`] for the
+/// current (non-linked) page. The last item in the slice passed to [`breadcrumb`]
+/// is always treated as the current page regardless of whether `href` is set.
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone)]
+pub struct Crumb<'a> {
+    /// Visible label for this crumb. HTML-escaped by Maud.
+    pub label: &'a str,
+    /// Optional URL for this crumb. `None` on the last crumb (current page).
+    pub href: Option<&'a str>,
+}
+
+#[cfg(feature = "maud")]
+impl<'a> Crumb<'a> {
+    /// Create a linked crumb.
+    #[must_use]
+    pub const fn link(label: &'a str, href: &'a str) -> Self {
+        Self {
+            label,
+            href: Some(href),
+        }
+    }
+
+    /// Create the current-page crumb (no link).
+    #[must_use]
+    pub const fn current(label: &'a str) -> Self {
+        Self { label, href: None }
+    }
+}
+
+/// Render an accessible breadcrumb navigation trail.
+///
+/// Emits a `<nav aria-label="Breadcrumb">` containing an `<ol>`. Every crumb
+/// except the last renders as an `<a>` link (using `href` when provided); the
+/// last crumb renders as the current page marked with `aria-current="page"`.
+/// Separators are wrapped in `<span aria-hidden="true">` so screen readers
+/// announce only the crumb labels.
+///
+/// An empty slice renders empty [`maud::Markup`] (no output, no panic).
+/// A single crumb renders without a leading separator.
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::widgets::{Crumb, breadcrumb};
+///
+/// let crumbs = [
+///     Crumb::link("Home", "/"),
+///     Crumb::link("Posts", "/posts"),
+///     Crumb::current("My Post"),
+/// ];
+/// let html = breadcrumb(&crumbs).into_string();
+/// assert!(html.contains(r#"aria-current="page""#));
+/// assert!(html.contains(r#"href="/posts""#));
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn breadcrumb(crumbs: &[Crumb<'_>]) -> maud::Markup {
+    if crumbs.is_empty() {
+        return maud::html! {};
+    }
+    let last = crumbs.len() - 1;
+    maud::html! {
+        nav aria-label="Breadcrumb" {
+            ol {
+                @for (i, crumb) in crumbs.iter().enumerate() {
+                    li {
+                        @if i > 0 {
+                            span aria-hidden="true" { "›" }
+                        }
+                        @if i == last {
+                            span aria-current="page" { (crumb.label) }
+                        } @else if let Some(href) = crumb.href {
+                            a href=(href) { (crumb.label) }
+                        } @else {
+                            (crumb.label)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 #[cfg(all(test, feature = "maud"))]
@@ -1607,6 +1695,127 @@ mod tests {
             html.contains(r#"role="status""#) || html.contains("aria-live"),
             "{html}"
         );
+    }
+
+    // ── breadcrumb ─────────────────────────────────────────────────────
+
+    #[test]
+    fn breadcrumb_empty_slice_renders_nothing_no_panic() {
+        let html = breadcrumb(&[]).into_string();
+        assert!(html.is_empty(), "expected empty output, got: {html}");
+    }
+
+    #[test]
+    fn breadcrumb_wrapped_in_nav_with_aria_label() {
+        let crumbs = [Crumb::link("Home", "/"), Crumb::current("Posts")];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(html.contains("<nav"), "{html}");
+        assert!(html.contains("aria-label"), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_contains_ordered_list() {
+        let crumbs = [Crumb::link("Home", "/"), Crumb::current("Posts")];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(html.contains("<ol"), "{html}");
+        assert!(html.contains("</ol>"), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_last_crumb_has_aria_current_page() {
+        let crumbs = [
+            Crumb::link("Home", "/"),
+            Crumb::link("Posts", "/posts"),
+            Crumb::current("My Post"),
+        ];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(html.contains(r#"aria-current="page""#), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_preceding_crumbs_render_as_links() {
+        let crumbs = [
+            Crumb::link("Home", "/"),
+            Crumb::link("Posts", "/posts"),
+            Crumb::current("My Post"),
+        ];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(html.contains(r#"href="/""#), "{html}");
+        assert!(html.contains(r#"href="/posts""#), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_last_crumb_is_not_a_link() {
+        let crumbs = [Crumb::link("Home", "/"), Crumb::current("Current Page")];
+        let html = breadcrumb(&crumbs).into_string();
+        // "Current Page" must not be wrapped in an <a>; it carries aria-current="page" instead.
+        assert!(html.contains("Current Page"), "{html}");
+        // The current page span must not itself be a link.
+        assert!(!html.contains("<a href=\"\">Current Page"), "{html}");
+        assert!(html.contains("aria-current=\"page\">Current Page"), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_single_crumb_no_leading_separator() {
+        let crumbs = [Crumb::current("Only Page")];
+        let html = breadcrumb(&crumbs).into_string();
+        // No separator before the first (and only) item
+        assert!(!html.contains("aria-hidden"), "{html}");
+        assert!(html.contains("Only Page"), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_single_crumb_has_aria_current_page() {
+        let crumbs = [Crumb::current("Only Page")];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(html.contains(r#"aria-current="page""#), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_separators_are_aria_hidden() {
+        let crumbs = [
+            Crumb::link("Home", "/"),
+            Crumb::link("Posts", "/posts"),
+            Crumb::current("Current"),
+        ];
+        let html = breadcrumb(&crumbs).into_string();
+        // Every separator must carry aria-hidden="true"
+        assert!(html.contains(r#"aria-hidden="true""#), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_label_containing_html_is_escaped() {
+        let crumbs = [
+            Crumb::link("<script>alert(1)</script>", "/"),
+            Crumb::current("Safe"),
+        ];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(!html.contains("<script>"), "{html}");
+        assert!(html.contains("&lt;script&gt;"), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_href_containing_html_is_escaped() {
+        let crumbs = [
+            Crumb::link("Home", r#"/" onerror="bad"#),
+            Crumb::current("Page"),
+        ];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(!html.contains("onerror=\"bad"), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_crumb_link_constructor() {
+        let c = Crumb::link("Posts", "/posts");
+        assert_eq!(c.label, "Posts");
+        assert_eq!(c.href, Some("/posts"));
+    }
+
+    #[test]
+    fn breadcrumb_crumb_current_constructor() {
+        let c = Crumb::current("My Page");
+        assert_eq!(c.label, "My Page");
+        assert!(c.href.is_none());
     }
 
     // ── property_list ──────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1088,7 +1088,7 @@ pub fn breadcrumb(crumbs: &[Crumb<'_>]) -> maud::Markup {
                         } @else if let Some(href) = crumb.href {
                             a href=(href) { (crumb.label) }
                         } @else {
-                            (crumb.label)
+                            span { (crumb.label) }
                         }
                     }
                 }
@@ -1816,6 +1816,20 @@ mod tests {
         let c = Crumb::current("My Page");
         assert_eq!(c.label, "My Page");
         assert!(c.href.is_none());
+    }
+
+    #[test]
+    fn breadcrumb_non_last_crumb_without_href_renders_span_not_bare_text() {
+        // A Crumb with href:None in a non-last position must still be wrapped
+        // in a <span> so it has an accessible element, not invisible bare text.
+        let crumbs = [
+            Crumb::current("Unlinked Middle"),
+            Crumb::current("Current"),
+        ];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(html.contains("<span>Unlinked Middle</span>"), "{html}");
+        // Only the last item carries aria-current
+        assert_eq!(html.matches(r#"aria-current="page""#).count(), 1, "{html}");
     }
 
     // ── property_list ──────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1076,19 +1076,19 @@ pub fn breadcrumb(crumbs: &[Crumb<'_>]) -> maud::Markup {
     }
     let last = crumbs.len() - 1;
     maud::html! {
-        nav aria-label="Breadcrumb" {
-            ol {
+        nav aria-label="Breadcrumb" class="autumn-breadcrumb" {
+            ol class="autumn-breadcrumb__list" {
                 @for (i, crumb) in crumbs.iter().enumerate() {
-                    li {
+                    li class="autumn-breadcrumb__item" {
                         @if i > 0 {
-                            span aria-hidden="true" { "›" }
+                            span aria-hidden="true" class="autumn-breadcrumb__separator" { "›" }
                         }
                         @if i == last {
-                            span aria-current="page" { (crumb.label) }
+                            span aria-current="page" class="autumn-breadcrumb__current" { (crumb.label) }
                         } @else if let Some(href) = crumb.href {
-                            a href=(href) { (crumb.label) }
+                            a href=(href) class="autumn-breadcrumb__link" { (crumb.label) }
                         } @else {
-                            span { (crumb.label) }
+                            span class="autumn-breadcrumb__text" { (crumb.label) }
                         }
                     }
                 }
@@ -1752,7 +1752,8 @@ mod tests {
         assert!(html.contains("Current Page"), "{html}");
         // The current page span must not itself be a link.
         assert!(!html.contains("<a href=\"\">Current Page"), "{html}");
-        assert!(html.contains("aria-current=\"page\">Current Page"), "{html}");
+        assert!(html.contains("aria-current=\"page\""), "{html}");
+        assert!(html.contains("autumn-breadcrumb__current"), "{html}");
     }
 
     #[test]
@@ -1827,7 +1828,7 @@ mod tests {
             Crumb::current("Current"),
         ];
         let html = breadcrumb(&crumbs).into_string();
-        assert!(html.contains("<span>Unlinked Middle</span>"), "{html}");
+        assert!(html.contains("<span class=\"autumn-breadcrumb__text\">Unlinked Middle</span>"), "{html}");
         // Only the last item carries aria-current
         assert_eq!(html.matches(r#"aria-current="page""#).count(), 1, "{html}");
     }


### PR DESCRIPTION
## Summary
This PR adds a new accessible breadcrumb navigation widget to the `autumn_web` library, enabling developers to render semantic breadcrumb trails with proper ARIA attributes for screen readers.

## Key Changes
- **New `Crumb` struct**: Represents a single breadcrumb item with a label and optional href
  - `Crumb::link(label, href)` for linked crumbs
  - `Crumb::current(label)` for the current (non-linked) page
- **New `breadcrumb()` function**: Renders an accessible breadcrumb navigation trail
  - Wraps output in `<nav aria-label="Breadcrumb">` with an ordered list
  - All crumbs except the last render as `<a>` links
  - Last crumb renders as a `<span>` with `aria-current="page"`
  - Separators (›) are wrapped in `<span aria-hidden="true">` to hide from screen readers
  - Handles edge cases: empty slices render nothing, single crumbs render without leading separator
  - HTML-escapes labels and hrefs via Maud
- **Updated prelude exports**: Added `Crumb` and `breadcrumb` to the public API in `prelude.rs`
- **Comprehensive test suite**: 14 tests covering functionality, accessibility, security, and edge cases

## Implementation Details
- Feature-gated behind `#[cfg(feature = "maud")]` to match existing widget patterns
- Uses Maud's HTML templating for safe, ergonomic markup generation
- Follows accessibility best practices: semantic HTML, ARIA attributes, and hidden decorative elements
- All crumb labels and hrefs are automatically escaped by Maud to prevent XSS

https://claude.ai/code/session_01KmbVr97KQFwsUft52roG95