### PR TITLE
Add breadcrumb navigation widget

### DIFF
--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -169,14 +169,14 @@ pub use validator::Validate;
 pub use crate::form::{Changeset, ChangesetForm, IntoChangeset};
 
 // ── Search & autocomplete widgets ─────────────────────────────────
-/// Active search, autocomplete, and data table configuration types and rendering helpers.
+/// Active search, autocomplete, data table, and breadcrumb configuration types and rendering helpers.
 ///
 /// See [`crate::widgets`] for the full API.
 #[cfg(feature = "maud")]
 pub use crate::widgets::{
-    ActiveSearchConfig, AutocompleteConfig, Column, DataTableConfig, SearchMethod, SortDir,
+    ActiveSearchConfig, AutocompleteConfig, Column, Crumb, DataTableConfig, SearchMethod, SortDir,
     active_search, active_search_empty_state, active_search_input, active_search_results,
-    autocomplete_empty_state, autocomplete_input, autocomplete_option, data_table,
+    autocomplete_empty_state, autocomplete_input, autocomplete_option, breadcrumb, data_table,
 };
 
 // ── Hooks ───────────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1017,7 +1017,7 @@ pub fn data_table<T>(
 /// current (non-linked) page. The last item in the slice passed to [`breadcrumb`]
 /// is always treated as the current page regardless of whether `href` is set.
 #[cfg(feature = "maud")]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Crumb<'a> {
     /// Visible label for this crumb. HTML-escaped by Maud.
     pub label: &'a str,

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1823,12 +1823,12 @@ mod tests {
     fn breadcrumb_non_last_crumb_without_href_renders_span_not_bare_text() {
         // A Crumb with href:None in a non-last position must still be wrapped
         // in a <span> so it has an accessible element, not invisible bare text.
-        let crumbs = [
-            Crumb::current("Unlinked Middle"),
-            Crumb::current("Current"),
-        ];
+        let crumbs = [Crumb::current("Unlinked Middle"), Crumb::current("Current")];
         let html = breadcrumb(&crumbs).into_string();
-        assert!(html.contains("<span class=\"autumn-breadcrumb__text\">Unlinked Middle</span>"), "{html}");
+        assert!(
+            html.contains("<span class=\"autumn-breadcrumb__text\">Unlinked Middle</span>"),
+            "{html}"
+        );
         // Only the last item carries aria-current
         assert_eq!(html.matches(r#"aria-current="page""#).count(), 1, "{html}");
     }

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1009,6 +1009,94 @@ pub fn data_table<T>(
     }
 }
 
+// ── breadcrumb ────────────────────────────────────────────────────────────
+
+/// A single crumb in a [`breadcrumb`] navigation trail.
+///
+/// Build with [`Crumb::link`] for a linked crumb or [`Crumb::current`] for the
+/// current (non-linked) page. The last item in the slice passed to [`breadcrumb`]
+/// is always treated as the current page regardless of whether `href` is set.
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone)]
+pub struct Crumb<'a> {
+    /// Visible label for this crumb. HTML-escaped by Maud.
+    pub label: &'a str,
+    /// Optional URL for this crumb. `None` on the last crumb (current page).
+    pub href: Option<&'a str>,
+}
+
+#[cfg(feature = "maud")]
+impl<'a> Crumb<'a> {
+    /// Create a linked crumb.
+    #[must_use]
+    pub const fn link(label: &'a str, href: &'a str) -> Self {
+        Self {
+            label,
+            href: Some(href),
+        }
+    }
+
+    /// Create the current-page crumb (no link).
+    #[must_use]
+    pub const fn current(label: &'a str) -> Self {
+        Self { label, href: None }
+    }
+}
+
+/// Render an accessible breadcrumb navigation trail.
+///
+/// Emits a `<nav aria-label="Breadcrumb">` containing an `<ol>`. Every crumb
+/// except the last renders as an `<a>` link (using `href` when provided); the
+/// last crumb renders as the current page marked with `aria-current="page"`.
+/// Separators are wrapped in `<span aria-hidden="true">` so screen readers
+/// announce only the crumb labels.
+///
+/// An empty slice renders empty [`maud::Markup`] (no output, no panic).
+/// A single crumb renders without a leading separator.
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::widgets::{Crumb, breadcrumb};
+///
+/// let crumbs = [
+///     Crumb::link("Home", "/"),
+///     Crumb::link("Posts", "/posts"),
+///     Crumb::current("My Post"),
+/// ];
+/// let html = breadcrumb(&crumbs).into_string();
+/// assert!(html.contains(r#"aria-current="page""#));
+/// assert!(html.contains(r#"href="/posts""#));
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn breadcrumb(crumbs: &[Crumb<'_>]) -> maud::Markup {
+    if crumbs.is_empty() {
+        return maud::html! {};
+    }
+    let last = crumbs.len() - 1;
+    maud::html! {
+        nav aria-label="Breadcrumb" {
+            ol {
+                @for (i, crumb) in crumbs.iter().enumerate() {
+                    li {
+                        @if i > 0 {
+                            span aria-hidden="true" { "›" }
+                        }
+                        @if i == last {
+                            span aria-current="page" { (crumb.label) }
+                        } @else if let Some(href) = crumb.href {
+                            a href=(href) { (crumb.label) }
+                        } @else {
+                            (crumb.label)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 #[cfg(all(test, feature = "maud"))]
@@ -1607,6 +1695,127 @@ mod tests {
             html.contains(r#"role="status""#) || html.contains("aria-live"),
             "{html}"
         );
+    }
+
+    // ── breadcrumb ─────────────────────────────────────────────────────
+
+    #[test]
+    fn breadcrumb_empty_slice_renders_nothing_no_panic() {
+        let html = breadcrumb(&[]).into_string();
+        assert!(html.is_empty(), "expected empty output, got: {html}");
+    }
+
+    #[test]
+    fn breadcrumb_wrapped_in_nav_with_aria_label() {
+        let crumbs = [Crumb::link("Home", "/"), Crumb::current("Posts")];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(html.contains("<nav"), "{html}");
+        assert!(html.contains("aria-label"), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_contains_ordered_list() {
+        let crumbs = [Crumb::link("Home", "/"), Crumb::current("Posts")];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(html.contains("<ol"), "{html}");
+        assert!(html.contains("</ol>"), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_last_crumb_has_aria_current_page() {
+        let crumbs = [
+            Crumb::link("Home", "/"),
+            Crumb::link("Posts", "/posts"),
+            Crumb::current("My Post"),
+        ];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(html.contains(r#"aria-current="page""#), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_preceding_crumbs_render_as_links() {
+        let crumbs = [
+            Crumb::link("Home", "/"),
+            Crumb::link("Posts", "/posts"),
+            Crumb::current("My Post"),
+        ];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(html.contains(r#"href="/""#), "{html}");
+        assert!(html.contains(r#"href="/posts""#), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_last_crumb_is_not_a_link() {
+        let crumbs = [Crumb::link("Home", "/"), Crumb::current("Current Page")];
+        let html = breadcrumb(&crumbs).into_string();
+        // "Current Page" must not be wrapped in an <a>; it carries aria-current="page" instead.
+        assert!(html.contains("Current Page"), "{html}");
+        // The current page span must not itself be a link.
+        assert!(!html.contains("<a href=\"\">Current Page"), "{html}");
+        assert!(html.contains("aria-current=\"page\">Current Page"), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_single_crumb_no_leading_separator() {
+        let crumbs = [Crumb::current("Only Page")];
+        let html = breadcrumb(&crumbs).into_string();
+        // No separator before the first (and only) item
+        assert!(!html.contains("aria-hidden"), "{html}");
+        assert!(html.contains("Only Page"), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_single_crumb_has_aria_current_page() {
+        let crumbs = [Crumb::current("Only Page")];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(html.contains(r#"aria-current="page""#), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_separators_are_aria_hidden() {
+        let crumbs = [
+            Crumb::link("Home", "/"),
+            Crumb::link("Posts", "/posts"),
+            Crumb::current("Current"),
+        ];
+        let html = breadcrumb(&crumbs).into_string();
+        // Every separator must carry aria-hidden="true"
+        assert!(html.contains(r#"aria-hidden="true""#), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_label_containing_html_is_escaped() {
+        let crumbs = [
+            Crumb::link("<script>alert(1)</script>", "/"),
+            Crumb::current("Safe"),
+        ];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(!html.contains("<script>"), "{html}");
+        assert!(html.contains("&lt;script&gt;"), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_href_containing_html_is_escaped() {
+        let crumbs = [
+            Crumb::link("Home", r#"/" onerror="bad"#),
+            Crumb::current("Page"),
+        ];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(!html.contains("onerror=\"bad"), "{html}");
+    }
+
+    #[test]
+    fn breadcrumb_crumb_link_constructor() {
+        let c = Crumb::link("Posts", "/posts");
+        assert_eq!(c.label, "Posts");
+        assert_eq!(c.href, Some("/posts"));
+    }
+
+    #[test]
+    fn breadcrumb_crumb_current_constructor() {
+        let c = Crumb::current("My Page");
+        assert_eq!(c.label, "My Page");
+        assert!(c.href.is_none());
     }
 
     // ── property_list ──────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1088,7 +1088,7 @@ pub fn breadcrumb(crumbs: &[Crumb<'_>]) -> maud::Markup {
                         } @else if let Some(href) = crumb.href {
                             a href=(href) { (crumb.label) }
                         } @else {
-                            (crumb.label)
+                            span { (crumb.label) }
                         }
                     }
                 }
@@ -1816,6 +1816,20 @@ mod tests {
         let c = Crumb::current("My Page");
         assert_eq!(c.label, "My Page");
         assert!(c.href.is_none());
+    }
+
+    #[test]
+    fn breadcrumb_non_last_crumb_without_href_renders_span_not_bare_text() {
+        // A Crumb with href:None in a non-last position must still be wrapped
+        // in a <span> so it has an accessible element, not invisible bare text.
+        let crumbs = [
+            Crumb::current("Unlinked Middle"),
+            Crumb::current("Current"),
+        ];
+        let html = breadcrumb(&crumbs).into_string();
+        assert!(html.contains("<span>Unlinked Middle</span>"), "{html}");
+        // Only the last item carries aria-current
+        assert_eq!(html.matches(r#"aria-current="page""#).count(), 1, "{html}");
     }
 
     // ── property_list ──────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1076,19 +1076,19 @@ pub fn breadcrumb(crumbs: &[Crumb<'_>]) -> maud::Markup {
     }
     let last = crumbs.len() - 1;
     maud::html! {
-        nav aria-label="Breadcrumb" {
-            ol {
+        nav aria-label="Breadcrumb" class="autumn-breadcrumb" {
+            ol class="autumn-breadcrumb__list" {
                 @for (i, crumb) in crumbs.iter().enumerate() {
-                    li {
+                    li class="autumn-breadcrumb__item" {
                         @if i > 0 {
-                            span aria-hidden="true" { "›" }
+                            span aria-hidden="true" class="autumn-breadcrumb__separator" { "›" }
                         }
                         @if i == last {
-                            span aria-current="page" { (crumb.label) }
+                            span aria-current="page" class="autumn-breadcrumb__current" { (crumb.label) }
                         } @else if let Some(href) = crumb.href {
-                            a href=(href) { (crumb.label) }
+                            a href=(href) class="autumn-breadcrumb__link" { (crumb.label) }
                         } @else {
-                            span { (crumb.label) }
+                            span class="autumn-breadcrumb__text" { (crumb.label) }
                         }
                     }
                 }
@@ -1752,7 +1752,8 @@ mod tests {
         assert!(html.contains("Current Page"), "{html}");
         // The current page span must not itself be a link.
         assert!(!html.contains("<a href=\"\">Current Page"), "{html}");
-        assert!(html.contains("aria-current=\"page\">Current Page"), "{html}");
+        assert!(html.contains("aria-current=\"page\""), "{html}");
+        assert!(html.contains("autumn-breadcrumb__current"), "{html}");
     }
 
     #[test]
@@ -1827,7 +1828,7 @@ mod tests {
             Crumb::current("Current"),
         ];
         let html = breadcrumb(&crumbs).into_string();
-        assert!(html.contains("<span>Unlinked Middle</span>"), "{html}");
+        assert!(html.contains("<span class=\"autumn-breadcrumb__text\">Unlinked Middle</span>"), "{html}");
         // Only the last item carries aria-current
         assert_eq!(html.matches(r#"aria-current="page""#).count(), 1, "{html}");
     }

--- a/examples/blog/src/routes/posts.rs
+++ b/examples/blog/src/routes/posts.rs
@@ -8,6 +8,7 @@ use autumn_web::cache::cache_fragment_global;
 use autumn_web::extract::{Form, Path};
 use autumn_web::i18n::Locale;
 use autumn_web::seo::SeoMeta;
+use autumn_web::widgets::{Crumb, breadcrumb};
 use autumn_web::{AutumnError, AutumnResult, Db, Markup, Redirect, delete, get, html, post, t};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
@@ -296,13 +297,11 @@ pub async fn show(locale: Locale, slug: Path<String>, mut db: Db) -> AutumnResul
         &locale,
         seo,
         html! {
+            (breadcrumb(&[
+                Crumb::link("Blog", &paths::index()),
+                Crumb::current(&p.title),
+            ]))
             article {
-                // Back link
-                a href=(paths::index())
-                   class="inline-flex items-center gap-1 text-sm text-stone-600 \
-                          hover:text-amber-700 transition-colors mb-8" {
-                    "\u{2190} Back to blog"
-                }
 
                 // Post header
                 header class="mb-8" {
@@ -427,11 +426,10 @@ pub async fn new_form(locale: Locale) -> Markup {
         &locale,
         "New Post \u{2022} Autumn Blog",
         html! {
-            a href=(paths::admin_list())
-               class="inline-flex items-center gap-1 text-sm text-stone-600 \
-                      hover:text-amber-700 transition-colors mb-6" {
-                "\u{2190} Back to admin"
-            }
+            (breadcrumb(&[
+                Crumb::link("Admin", &paths::admin_list()),
+                Crumb::current("New Post"),
+            ]))
             h1 class="text-2xl font-semibold tracking-tight text-stone-900 mb-6" {
                 "New Post"
             }
@@ -462,11 +460,10 @@ pub async fn edit_form(locale: Locale, id: Path<i64>, mut db: Db) -> AutumnResul
         &locale,
         &format!("Edit: {} \u{2022} Autumn Blog", p.title),
         html! {
-            a href=(paths::admin_list())
-               class="inline-flex items-center gap-1 text-sm text-stone-600 \
-                      hover:text-amber-700 transition-colors mb-6" {
-                "\u{2190} Back to admin"
-            }
+            (breadcrumb(&[
+                Crumb::link("Admin", &paths::admin_list()),
+                Crumb::current(&format!("Edit: {}", p.title)),
+            ]))
             h1 class="text-2xl font-semibold tracking-tight text-stone-900 mb-6" {
                 "Edit Post"
             }

--- a/examples/blog/static/css/input.css
+++ b/examples/blog/static/css/input.css
@@ -262,3 +262,48 @@
     background-color: #ede9fe;
     color: #4f46e5;
 }
+
+/* ── Breadcrumb navigation (autumn-breadcrumb) ────────────────────────────── */
+
+.autumn-breadcrumb {
+    margin-bottom: 1rem;
+}
+
+.autumn-breadcrumb__list {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    gap: 0.25rem;
+    font-size: 0.875rem;
+}
+
+.autumn-breadcrumb__item {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.autumn-breadcrumb__link {
+    color: #4f46e5;
+    text-decoration: none;
+}
+
+.autumn-breadcrumb__link:hover {
+    text-decoration: underline;
+}
+
+.autumn-breadcrumb__separator {
+    color: #9ca3af;
+    user-select: none;
+}
+
+.autumn-breadcrumb__current {
+    color: #6b7280;
+}
+
+.autumn-breadcrumb__text {
+    color: #374151;
+}

--- a/examples/wiki/src/routes/pages.rs
+++ b/examples/wiki/src/routes/pages.rs
@@ -137,6 +137,10 @@ pub async fn show(
     Ok(layout(
         &page.title,
         html! {
+            (breadcrumb(&[
+                Crumb::link("Wiki", &paths::list()),
+                Crumb::current(&page.title),
+            ]))
             article {
                 div class="flex justify-between items-center mb-4" {
                     h1 class="text-3xl font-bold" { (page.title) }
@@ -191,6 +195,10 @@ pub async fn new_form() -> Markup {
     layout(
         "New Page",
         html! {
+            (breadcrumb(&[
+                Crumb::link("Wiki", &paths::list()),
+                Crumb::current("New Page"),
+            ]))
             h1 class="text-2xl font-bold mb-6" { "New Page" }
             form action=(paths::create()) method="post"
                  class="space-y-4 bg-white rounded shadow p-6" {
@@ -254,6 +262,11 @@ pub async fn edit_form(Path(slug): Path<String>, repo: PgPageRepository) -> Autu
     Ok(layout(
         &format!("Edit: {}", page.title),
         html! {
+            (breadcrumb(&[
+                Crumb::link("Wiki", &paths::list()),
+                Crumb::link(&page.title, &paths::show(page.slug.clone())),
+                Crumb::current("Edit"),
+            ]))
             h1 class="text-2xl font-bold mb-6" { "Edit: " (page.title) }
             form action=(paths::update(page.slug.clone())) method="post"
                  class="space-y-4 bg-white rounded shadow p-6" {
@@ -375,6 +388,11 @@ pub async fn history(
     Ok(layout(
         &format!("History: {}", page.title),
         html! {
+            (breadcrumb(&[
+                Crumb::link("Wiki", &paths::list()),
+                Crumb::link(&page.title, &paths::show(page.slug.clone())),
+                Crumb::current("History"),
+            ]))
             div class="flex justify-between items-center mb-6" {
                 h1 class="text-2xl font-bold" { "History: " (page.title) }
                 a href=(paths::show(page.slug.clone()))

--- a/examples/wiki/static/css/input.css
+++ b/examples/wiki/static/css/input.css
@@ -262,3 +262,48 @@
     background-color: #ede9fe;
     color: #4f46e5;
 }
+
+/* ── Breadcrumb navigation (autumn-breadcrumb) ────────────────────────────── */
+
+.autumn-breadcrumb {
+    margin-bottom: 1rem;
+}
+
+.autumn-breadcrumb__list {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    gap: 0.25rem;
+    font-size: 0.875rem;
+}
+
+.autumn-breadcrumb__item {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.autumn-breadcrumb__link {
+    color: #059669;
+    text-decoration: none;
+}
+
+.autumn-breadcrumb__link:hover {
+    text-decoration: underline;
+}
+
+.autumn-breadcrumb__separator {
+    color: #9ca3af;
+    user-select: none;
+}
+
+.autumn-breadcrumb__current {
+    color: #6b7280;
+}
+
+.autumn-breadcrumb__text {
+    color: #374151;
+}


### PR DESCRIPTION
## Summary
Adds a new accessible breadcrumb navigation widget to the Autumn web framework, enabling developers to easily render semantic breadcrumb trails with proper ARIA attributes and HTML escaping.

## Key Changes
- **New `Crumb` struct**: Represents a single breadcrumb item with a label and optional href
  - `Crumb::link(label, href)` for linked crumbs
  - `Crumb::current(label)` for the current page (non-linked)
- **New `breadcrumb()` function**: Renders an accessible breadcrumb navigation trail
  - Wraps output in `<nav aria-label="Breadcrumb">` with an ordered list
  - Last crumb marked with `aria-current="page"` and rendered as a span
  - Preceding crumbs rendered as links (when href is provided)
  - Separators wrapped in `aria-hidden="true"` spans for screen reader accessibility
  - Handles empty slices gracefully (returns empty markup)
  - All labels and hrefs are HTML-escaped by Maud
- **Comprehensive test coverage**: 14 tests covering empty slices, accessibility attributes, link rendering, HTML escaping, and edge cases
- **Updated prelude**: Exported `Crumb` and `breadcrumb` in the public API
- **Example usage**: Integrated breadcrumb widget into blog and wiki example applications, replacing manual back-link implementations

## Implementation Details
- Gated behind the `maud` feature flag (consistent with other widget exports)
- Uses semantic HTML (`<nav>`, `<ol>`, `<li>`) with appropriate ARIA attributes
- Provides CSS class hooks (`autumn-breadcrumb`, `autumn-breadcrumb__list`, etc.) for styling
- Renders non-last crumbs without href as `<span>` elements (not bare text) for accessibility
- Single crumb renders without a leading separator

https://claude.ai/code/session_01KmbVr97KQFwsUft52roG95