### PR TITLE
🗺️ Atlas: [architectural change] Extract ProvideAuthorizationState to break dependency cycle

### DIFF
--- a/autumn/src/authorization.rs
+++ b/autumn/src/authorization.rs
@@ -60,6 +60,21 @@ use http::StatusCode;
 
 use crate::session::Session;
 
+/// Provides the specific application state needed by the authorization subsystem.
+///
+/// This trait severs the dependency from the `authorization` module back to the
+/// `state` module, breaking a circular dependency (`state` -> `authorization` -> `session` -> `state`).
+pub trait ProvideAuthorizationState: Send + Sync {
+    fn policy_registry(&self) -> &PolicyRegistry;
+    fn auth_session_key(&self) -> &str;
+    fn forbidden_response(&self) -> &ForbiddenResponse;
+
+    #[cfg(feature = "db")]
+    fn pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>;
+}
+
 /// Boxed future returned by [`Policy`] and [`Scope`] methods so the
 /// traits remain object-safe (`dyn Policy<R>` works regardless of
 /// rust edition).
@@ -127,10 +142,10 @@ impl PolicyContext {
         }
     }
 
-    /// Build a fully-populated [`PolicyContext`] from `AppState` +
+    /// Build a fully-populated [`PolicyContext`] from state +
     /// `Session`. Used by the `#[authorize]` macro and
     /// `#[repository(policy = ...)]`-generated handlers.
-    pub async fn from_request(state: &crate::AppState, session: &Session) -> Self {
+    pub async fn from_request(state: &impl ProvideAuthorizationState, session: &Session) -> Self {
         let mut ctx = Self::from_session(session, state.auth_session_key()).await;
         ctx.policy_registry = state.policy_registry().clone();
         #[cfg(feature = "db")]
@@ -396,9 +411,9 @@ impl<T: Send + Sync + 'static> Scoped for T {}
 /// Process-wide registry of resource → policy and resource →
 /// scope bindings.
 ///
-/// Stored on [`AppState`](crate::AppState) so handlers and
+/// Stored on application state so handlers and
 /// `#[repository]`-generated endpoints can resolve a policy by
-/// resource type via [`AppState::policy::<R>`](crate::AppState::policy).
+/// resource type.
 #[derive(Clone, Default)]
 pub struct PolicyRegistry {
     inner: Arc<RwLock<RegistryInner>>,
@@ -621,7 +636,7 @@ impl<'de> serde::Deserialize<'de> for ForbiddenResponse {
 /// }
 /// ```
 pub async fn authorize<R>(
-    state: &crate::AppState,
+    state: &impl ProvideAuthorizationState,
     session: &Session,
     action: &str,
     resource: &R,
@@ -651,7 +666,7 @@ where
 /// the public API** — call [`authorize`] from user code.
 #[doc(hidden)]
 pub async fn __check_policy<R>(
-    state: &crate::AppState,
+    state: &impl ProvideAuthorizationState,
     session: &Session,
     action: &str,
     resource: &R,
@@ -673,7 +688,7 @@ where
 /// alias for older macro output.
 #[doc(hidden)]
 pub async fn __check_policy_create<R>(
-    state: &crate::AppState,
+    state: &impl ProvideAuthorizationState,
     session: &Session,
 ) -> crate::AutumnResult<()>
 where
@@ -692,7 +707,7 @@ where
 /// only `autumn-web` is upgraded.
 #[doc(hidden)]
 pub async fn __check_policy_create_payload<R>(
-    state: &crate::AppState,
+    state: &impl ProvideAuthorizationState,
     session: &Session,
     payload: &serde_json::Value,
 ) -> crate::AutumnResult<()>
@@ -713,7 +728,7 @@ where
 /// Returns the configured deny response when the policy denies.
 /// Returns `500` when no policy is registered for `R`.
 pub async fn authorize_create<R>(
-    state: &crate::AppState,
+    state: &impl ProvideAuthorizationState,
     session: &Session,
 ) -> crate::AutumnResult<()>
 where
@@ -749,7 +764,7 @@ where
 /// Returns the configured deny response when the policy denies.
 /// Returns `500` when no policy is registered for `R`.
 pub async fn authorize_create_payload<R>(
-    state: &crate::AppState,
+    state: &impl ProvideAuthorizationState,
     session: &Session,
     payload: &serde_json::Value,
 ) -> crate::AutumnResult<()>
@@ -1050,13 +1065,54 @@ mod tests {
         assert!(dbg.contains("scopes"));
     }
 
-    fn detached_state_with(
-        _registry: PolicyRegistry,
-        forbidden: ForbiddenResponse,
-    ) -> crate::AppState {
-        crate::AppState::detached()
-            .with_forbidden_response(forbidden)
-            .with_auth_session_key("user_id")
+    #[derive(Clone)]
+    struct MockState {
+        policy_registry: PolicyRegistry,
+        forbidden_response: ForbiddenResponse,
+        auth_session_key: String,
+    }
+
+    impl ProvideAuthorizationState for MockState {
+        fn policy_registry(&self) -> &PolicyRegistry {
+            &self.policy_registry
+        }
+
+        fn auth_session_key(&self) -> &str {
+            &self.auth_session_key
+        }
+
+        fn forbidden_response(&self) -> &ForbiddenResponse {
+            &self.forbidden_response
+        }
+
+        #[cfg(feature = "db")]
+        fn pool(
+            &self,
+        ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+        {
+            None
+        }
+    }
+
+    impl MockState {
+        fn with_forbidden_response(mut self, forbidden: ForbiddenResponse) -> Self {
+            self.forbidden_response = forbidden;
+            self
+        }
+    }
+
+    fn detached_state() -> MockState {
+        MockState {
+            policy_registry: PolicyRegistry::default(),
+            forbidden_response: ForbiddenResponse::default(),
+            auth_session_key: "user_id".to_owned(),
+        }
+    }
+
+    fn detached_state_with(registry: PolicyRegistry, forbidden: ForbiddenResponse) -> MockState {
+        let mut state = detached_state().with_forbidden_response(forbidden);
+        state.policy_registry = registry;
+        state
     }
 
     fn session_with(user_id: Option<&str>, role: Option<&str>) -> Session {
@@ -1086,11 +1142,7 @@ mod tests {
         let registry = PolicyRegistry::default();
         registry.register_policy::<Note, _>(AdminOrOwnerPolicy);
         let state = detached_state_with(registry.clone(), ForbiddenResponse::Forbidden403);
-        // Inject the registry into the live state's registry.
-        let live = state.policy_registry();
-        // Move registrations from `registry` into the state's registry.
-        // (`detached()` starts with an empty registry; we copy in.)
-        live.register_policy::<Note, _>(AdminOrOwnerPolicy);
+        // `state` already has the registry we passed in via `detached_state_with`.
 
         let session = session_with(Some("99"), None); // not the owner, no role
         let n = Note { author_id: 42 };
@@ -1102,7 +1154,7 @@ mod tests {
 
     #[tokio::test]
     async fn authorize_returns_ok_when_policy_allows() {
-        let state = crate::AppState::detached();
+        let state = detached_state();
         state
             .policy_registry()
             .register_policy::<Note, _>(AdminOrOwnerPolicy);
@@ -1115,7 +1167,7 @@ mod tests {
 
     #[tokio::test]
     async fn authorize_create_returns_500_when_no_policy_registered() {
-        let state = crate::AppState::detached();
+        let state = detached_state();
         let session = session_with(Some("42"), None);
         let err = authorize_create::<Note>(&state, &session)
             .await
@@ -1132,8 +1184,7 @@ mod tests {
             }
         }
 
-        let state =
-            crate::AppState::detached().with_forbidden_response(ForbiddenResponse::Forbidden403);
+        let state = detached_state().with_forbidden_response(ForbiddenResponse::Forbidden403);
         state
             .policy_registry()
             .register_policy::<Note, _>(AuthOnlyCreatePolicy);
@@ -1164,8 +1215,7 @@ mod tests {
             }
         }
 
-        let state =
-            crate::AppState::detached().with_forbidden_response(ForbiddenResponse::Forbidden403);
+        let state = detached_state().with_forbidden_response(ForbiddenResponse::Forbidden403);
         state
             .policy_registry()
             .register_policy::<Note, _>(OwnerPayloadPolicy);
@@ -1192,8 +1242,7 @@ mod tests {
             }
         }
 
-        let state =
-            crate::AppState::detached().with_forbidden_response(ForbiddenResponse::Forbidden403);
+        let state = detached_state().with_forbidden_response(ForbiddenResponse::Forbidden403);
         state
             .policy_registry()
             .register_policy::<Note, _>(AuthOnlyCreatePolicy);
@@ -1226,8 +1275,7 @@ mod tests {
             }
         }
 
-        let state =
-            crate::AppState::detached().with_forbidden_response(ForbiddenResponse::Forbidden403);
+        let state = detached_state().with_forbidden_response(ForbiddenResponse::Forbidden403);
         state
             .policy_registry()
             .register_policy::<Note, _>(OwnerPayloadPolicy);
@@ -1241,7 +1289,7 @@ mod tests {
 
     #[tokio::test]
     async fn check_policy_alias_round_trips() {
-        let state = crate::AppState::detached();
+        let state = detached_state();
         state
             .policy_registry()
             .register_policy::<Note, _>(AdminOrOwnerPolicy);
@@ -1256,7 +1304,7 @@ mod tests {
 
     #[tokio::test]
     async fn from_request_clones_pool_and_registry_from_state() {
-        let state = crate::AppState::detached();
+        let state = detached_state();
         state
             .policy_registry()
             .register_policy::<Note, _>(AdminOrOwnerPolicy);
@@ -1270,7 +1318,7 @@ mod tests {
 
     #[tokio::test]
     async fn scoped_blanket_trait_constructible_without_registered_scope() {
-        let state = crate::AppState::detached();
+        let state = detached_state();
         let session = session_with(Some("1"), None);
         let ctx = PolicyContext::from_request(&state, &session).await;
         // No scope registered for `Note`.

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -156,6 +156,28 @@ pub struct AppState {
     pub(crate) clock: Arc<dyn ClockSource>,
 }
 
+impl crate::authorization::ProvideAuthorizationState for AppState {
+    fn policy_registry(&self) -> &crate::authorization::PolicyRegistry {
+        &self.policy_registry
+    }
+
+    fn auth_session_key(&self) -> &str {
+        &self.auth_session_key
+    }
+
+    fn forbidden_response(&self) -> &crate::authorization::ForbiddenResponse {
+        &self.forbidden_response
+    }
+
+    #[cfg(feature = "db")]
+    fn pool(
+        &self,
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    {
+        self.pool.as_ref()
+    }
+}
+
 impl AppState {
     /// Install or replace a typed runtime extension.
     ///


### PR DESCRIPTION
🕸️ Tangle: The `state` module depended on `authorization` for PolicyRegistry, while `authorization` functions depended on `crate::AppState` to retrieve the database pool and configuration. This formed a dependency cycle (`state` -> `authorization` -> `session` -> `state`).

📐 Blueprint: Extracted a new trait `ProvideAuthorizationState` inside the `authorization` module. The `authorize*` helper functions and `PolicyContext::from_request` now operate against any `impl ProvideAuthorizationState` rather than requiring the concrete `AppState`. The `state` module implements this trait on `AppState`. 

🧱 Stability: Strict separation of concerns is restored. The `authorization` module no longer has any structural knowledge of `AppState` or the `state` module. Tests for `authorization.rs` have also been refactored to rely purely on an isolated `MockState` struct rather than a detached `AppState`.

🔬 Verification: The cycle was detected via script and verified resolved. `cargo test -p autumn-web --lib`, `cargo check`, and `cargo clippy -p autumn-web --lib -- -D warnings` executed successfully.

---
*PR created automatically by Jules for task [8063940322222488376](https://jules.google.com/task/8063940322222488376) started by @madmax983*