### PR TITLE
👺 Havoc: [Idempotency TTL Overflow Panic]

### DIFF
--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -467,7 +467,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
         let entry = IdempotencyEntry {
             record,
             body_hash,
-            expires_at: Instant::now() + ttl,
+            expires_at: Instant::now().checked_add(ttl).unwrap_or_else(Instant::now),
         };
         let mut entries = self.entries.write().unwrap();
         entries.insert(key.to_owned(), entry);
@@ -504,7 +504,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
             key.to_owned(),
             MemoryInFlightLock {
                 owner: owner.to_owned(),
-                expires_at: now + ttl,
+                expires_at: now.checked_add(ttl).unwrap_or(now),
             },
         );
         true

--- a/autumn/tests/chaos_idempotency.rs
+++ b/autumn/tests/chaos_idempotency.rs
@@ -1,0 +1,19 @@
+use autumn_web::idempotency::{IdempotencyRecord, IdempotencyStore, MemoryIdempotencyStore};
+use std::time::Duration;
+
+#[test]
+fn havoc_idempotency_ttl_overflow() {
+    let store = MemoryIdempotencyStore::new(Duration::from_secs(60));
+    let record = IdempotencyRecord {
+        status: 200,
+        headers: vec![],
+        body: vec![],
+        metadata: Default::default(),
+    };
+
+    // This will panic if direct addition Instant::now() + ttl is used
+    store.set("havoc_key", record, vec![], Duration::MAX);
+
+    // This will also panic if direct addition is used for locks
+    store.try_lock("havoc_lock", Duration::MAX);
+}


### PR DESCRIPTION
🧨 **The Trigger:** 
A client or subsystem submits an idempotency request where the lock TTL evaluates to `Duration::MAX` or a value large enough to overflow `Instant`.

📉 **The Stack Trace:**
```text
thread 'havoc_idempotency_ttl_overflow' panicked at /rustc/.../library/std/src/time.rs:429:33:
overflow when adding duration to instant
```

🧪 **Reproduction:**
Run the newly added chaos test: `cargo test -p autumn-web --test chaos_idempotency`

😈 **Comment:** 
You assumed a `Duration` would always be small enough to add to the current time. You were wrong. An overflow takes down the process. The fix safely fails closed by collapsing the expiry back to `now` instead of panicking.

---
*PR created automatically by Jules for task [10522470326649719760](https://jules.google.com/task/10522470326649719760) started by @madmax983*