### PR TITLE
Add read-your-own-writes (RYWW) routing to prevent stale reads

### DIFF
--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -10263,6 +10263,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             pub fn __autumn_effective_read_route(&self) -> ::autumn_web::repository::ReadRoute {
                 match &self.__autumn_read_route {
                     ::autumn_web::repository::ReadRoute::ReadPool(_)
+                    | ::autumn_web::repository::ReadRoute::Unavailable
                         if ::autumn_web::read_your_writes::is_pinned() =>
                     {
                         ::autumn_web::read_your_writes::note_pin_redirect();
@@ -10307,10 +10308,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     ::autumn_web::reexports::diesel_async::AsyncPgConnection,
                 >,
             > {
-                // Notify the RYWW task-local that a primary connection is being
-                // acquired for a mutating method. No-op when read_your_writes = "off".
-                ::autumn_web::read_your_writes::mark_write();
-                self.__autumn_acquire_from(&self.pool).await
+                let result = self.__autumn_acquire_from(&self.pool).await;
+                // Mark write only after a successful primary checkout, mirroring
+                // the guard in `Db::from_request_parts`. A failed acquire (pool
+                // exhausted, timeout) must not pin subsequent reads to primary.
+                if result.is_ok() {
+                    ::autumn_web::read_your_writes::mark_write();
+                }
+                result
             }
 
             /// Acquire a connection for a generated read-only method,
@@ -10325,12 +10330,26 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     ::autumn_web::reexports::diesel_async::AsyncPgConnection,
                 >,
             > {
-                match self.__autumn_effective_read_route() {
+                // Match by reference to avoid cloning `ReadRoute` on the common
+                // (non-pinned) path. The pin check is inlined here so that
+                // `__autumn_effective_read_route` (the test accessor) retains its
+                // own clone-based return without adding overhead to the hot path.
+                if ::autumn_web::read_your_writes::is_pinned() {
+                    if matches!(
+                        &self.__autumn_read_route,
+                        ::autumn_web::repository::ReadRoute::ReadPool(_)
+                            | ::autumn_web::repository::ReadRoute::Unavailable
+                    ) {
+                        ::autumn_web::read_your_writes::note_pin_redirect();
+                        return self.__autumn_acquire_from(&self.pool).await;
+                    }
+                }
+                match &self.__autumn_read_route {
                     ::autumn_web::repository::ReadRoute::Primary => {
                         self.__autumn_acquire_from(&self.pool).await
                     }
                     ::autumn_web::repository::ReadRoute::ReadPool(pool) => {
-                        self.__autumn_acquire_from(&pool).await
+                        self.__autumn_acquire_from(pool).await
                     }
                     ::autumn_web::repository::ReadRoute::Unavailable => {
                         ::core::result::Result::Err(

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -10263,7 +10263,6 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             pub fn __autumn_effective_read_route(&self) -> ::autumn_web::repository::ReadRoute {
                 match &self.__autumn_read_route {
                     ::autumn_web::repository::ReadRoute::ReadPool(_)
-                    | ::autumn_web::repository::ReadRoute::Unavailable
                         if ::autumn_web::read_your_writes::is_pinned() =>
                     {
                         ::autumn_web::read_your_writes::note_pin_redirect();
@@ -10338,7 +10337,6 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     if matches!(
                         &self.__autumn_read_route,
                         ::autumn_web::repository::ReadRoute::ReadPool(_)
-                            | ::autumn_web::repository::ReadRoute::Unavailable
                     ) {
                         ::autumn_web::read_your_writes::note_pin_redirect();
                         return self.__autumn_acquire_from(&self.pool).await;

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -10249,6 +10249,29 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 &self.__autumn_read_route
             }
 
+            /// The effective read route for the current request, applying any
+            /// read-your-own-writes pin from the task-local context.
+            ///
+            /// When the snapshot is `ReadPool(_)` and the RYWW task-local is
+            /// pinned (a primary write occurred earlier in this request or the
+            /// incoming session cookie is fresh), returns `Primary` and records
+            /// a pin-redirect metric/trace event. All other cases return the
+            /// snapshot unchanged.
+            ///
+            /// Exposed for tests; not a public API.
+            #[doc(hidden)]
+            pub fn __autumn_effective_read_route(&self) -> ::autumn_web::repository::ReadRoute {
+                match &self.__autumn_read_route {
+                    ::autumn_web::repository::ReadRoute::ReadPool(_)
+                        if ::autumn_web::read_your_writes::is_pinned() =>
+                    {
+                        ::autumn_web::read_your_writes::note_pin_redirect();
+                        ::autumn_web::repository::ReadRoute::Primary
+                    }
+                    other => ::core::clone::Clone::clone(other),
+                }
+            }
+
             /// The primary/write pool. Exposed for tests; not a public API.
             #[doc(hidden)]
             pub fn __autumn_write_pool(
@@ -10284,12 +10307,16 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     ::autumn_web::reexports::diesel_async::AsyncPgConnection,
                 >,
             > {
+                // Notify the RYWW task-local that a primary connection is being
+                // acquired for a mutating method. No-op when read_your_writes = "off".
+                ::autumn_web::read_your_writes::mark_write();
                 self.__autumn_acquire_from(&self.pool).await
             }
 
             /// Acquire a connection for a generated read-only method,
-            /// following the repository's read route: the replica pool when
-            /// one is configured and healthy, otherwise the primary (#971).
+            /// following the repository's effective read route: the replica pool
+            /// when one is configured and healthy (and no RYWW pin is active),
+            /// otherwise the primary (#971, #1201).
             #[doc(hidden)]
             pub async fn __autumn_acquire_read_conn(
                 &self,
@@ -10298,12 +10325,12 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     ::autumn_web::reexports::diesel_async::AsyncPgConnection,
                 >,
             > {
-                match &self.__autumn_read_route {
+                match self.__autumn_effective_read_route() {
                     ::autumn_web::repository::ReadRoute::Primary => {
                         self.__autumn_acquire_from(&self.pool).await
                     }
                     ::autumn_web::repository::ReadRoute::ReadPool(pool) => {
-                        self.__autumn_acquire_from(pool).await
+                        self.__autumn_acquire_from(&pool).await
                     }
                     ::autumn_web::repository::ReadRoute::Unavailable => {
                         ::core::result::Result::Err(

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -2269,6 +2269,18 @@ fn write_builtin_http_metrics(
         snapshot.http.request_timeouts_total
     );
 
+    // autumn_read_your_writes_pins_total
+    out.push_str(
+        "# HELP autumn_read_your_writes_pins_total \
+         Replica reads redirected to the primary by the read-your-own-writes pin\n",
+    );
+    out.push_str("# TYPE autumn_read_your_writes_pins_total counter\n");
+    let _ = writeln!(
+        out,
+        "autumn_read_your_writes_pins_total{{version=\"{version}\"}} {}",
+        snapshot.read_your_writes_pins_total
+    );
+
     // by_route
     if !snapshot.http.by_route.is_empty() {
         out.push_str("# HELP autumn_http_route_requests_total HTTP requests by route and method\n");
@@ -2312,6 +2324,7 @@ pub(crate) async fn prometheus_endpoint<S: ProvideActuatorState + Send + Sync + 
             "autumn_http_request_duration_seconds",
             "autumn_shutdown_aborted_requests_total",
             "autumn_request_timeouts_total",
+            "autumn_read_your_writes_pins_total",
             "autumn_http_route_requests_total",
             "autumn_metrics_source_errors_total",
         ]

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -4291,6 +4291,10 @@ mod tests {
         assert!(text.contains("# HELP autumn_request_timeouts_total"));
         assert!(text.contains("# TYPE autumn_request_timeouts_total counter"));
         assert!(text.contains("autumn_request_timeouts_total{version=\"stable\"} 0"));
+
+        assert!(text.contains("# HELP autumn_read_your_writes_pins_total"));
+        assert!(text.contains("# TYPE autumn_read_your_writes_pins_total counter"));
+        assert!(text.contains("autumn_read_your_writes_pins_total{version=\"stable\"} 0"));
     }
 
     #[tokio::test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -3636,6 +3636,51 @@ impl std::str::FromStr for ReplicaFallback {
     }
 }
 
+/// Strategy for routing reads that follow a write within the same request or
+/// client session.
+///
+/// Replication is asynchronous: a read immediately after a write can land on a
+/// lagging replica and return stale data (the read-your-own-writes anomaly).
+/// This setting lets Autumn pin such reads to the primary.
+///
+/// Configured via `database.read_your_writes` in `autumn.toml` or
+/// `AUTUMN_DATABASE__READ_YOUR_WRITES` in the environment.
+///
+/// Default: `off` (preserves today's behavior — no post-write pinning).
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ReadYourWrites {
+    /// No post-write read pinning. Replica reads are always served from the
+    /// replica. This is the default and preserves existing behavior exactly.
+    #[default]
+    Off,
+    /// Once the current request checks out a **primary** connection (via `Db`
+    /// or a generated mutating repository method), all subsequent
+    /// replica-eligible reads within the same request are redirected to the
+    /// primary. Analogous to Laravel's "sticky" behavior.
+    Request,
+    /// Like `request`, and additionally pins a client's reads to the primary
+    /// for [`pin_after_write_secs`](DatabaseConfig::pin_after_write_secs)
+    /// seconds after a write, via a signed `autumn.ryw` cookie. Reads within
+    /// that window are served from the primary even if the request itself
+    /// performed no write. Analogous to Rails' automatic role switching.
+    Session,
+}
+
+impl std::str::FromStr for ReadYourWrites {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "off" => Ok(Self::Off),
+            "request" => Ok(Self::Request),
+            "session" => Ok(Self::Session),
+            _ => Err(()),
+        }
+    }
+}
+
 /// A logical slot assignment entry in a shard's `slots` list.
 ///
 /// Accepts a single slot index (`5`) or an inclusive range written as a
@@ -3864,6 +3909,26 @@ pub struct DatabaseConfig {
     /// reads. Default: fail readiness.
     #[serde(default)]
     pub replica_fallback: ReplicaFallback,
+
+    /// Post-write read pinning strategy. Default: `off` (no pinning).
+    ///
+    /// Set to `request` to pin reads to the primary for the remainder of the
+    /// request after the first write. Set to `session` to additionally pin
+    /// reads across requests via a signed cookie.
+    ///
+    /// Override via `AUTUMN_DATABASE__READ_YOUR_WRITES`.
+    #[serde(default)]
+    pub read_your_writes: ReadYourWrites,
+
+    /// Duration (seconds) for cross-request session pins.
+    ///
+    /// Only used when `read_your_writes = "session"`. A signed `autumn.ryw`
+    /// cookie pins the client's reads to the primary for this many seconds
+    /// after a write. Default: `5`.
+    ///
+    /// Override via `AUTUMN_DATABASE__PIN_AFTER_WRITE_SECS`.
+    #[serde(default = "default_pin_after_write_secs")]
+    pub pin_after_write_secs: u64,
 
     /// Seconds to wait while acquiring a pooled connection, including
     /// creating a new connection when the pool grows.
@@ -4796,6 +4861,10 @@ const fn default_connect_timeout() -> u64 {
     5
 }
 
+const fn default_pin_after_write_secs() -> u64 {
+    5
+}
+
 fn default_log_level() -> String {
     "info".to_owned()
 }
@@ -4869,6 +4938,8 @@ impl Default for DatabaseConfig {
             primary_pool_size: None,
             replica_pool_size: None,
             replica_fallback: ReplicaFallback::default(),
+            read_your_writes: ReadYourWrites::default(),
+            pin_after_write_secs: default_pin_after_write_secs(),
             connect_timeout_secs: default_connect_timeout(),
             startup_wait_secs: 0,
             auto_migrate_in_production: false,

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -6894,6 +6894,30 @@ path = "/healthz"
     }
 
     #[test]
+    fn env_override_read_your_writes() {
+        let env = MockEnv::new().with("AUTUMN_DATABASE__READ_YOUR_WRITES", "request");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.database.read_your_writes, ReadYourWrites::Request);
+    }
+
+    #[test]
+    fn env_override_read_your_writes_session() {
+        let env = MockEnv::new().with("AUTUMN_DATABASE__READ_YOUR_WRITES", "session");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.database.read_your_writes, ReadYourWrites::Session);
+    }
+
+    #[test]
+    fn env_override_pin_after_write_secs() {
+        let env = MockEnv::new().with("AUTUMN_DATABASE__PIN_AFTER_WRITE_SECS", "10");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.database.pin_after_write_secs, 10);
+    }
+
+    #[test]
     fn env_override_invalid_pool_size_ignored() {
         let env = MockEnv::new().with("AUTUMN_DATABASE__POOL_SIZE", "not_a_number");
         let mut config = AutumnConfig::default();

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2682,6 +2682,16 @@ impl AutumnConfig {
         );
         parse_env(
             env,
+            "AUTUMN_DATABASE__READ_YOUR_WRITES",
+            &mut self.database.read_your_writes,
+        );
+        parse_env(
+            env,
+            "AUTUMN_DATABASE__PIN_AFTER_WRITE_SECS",
+            &mut self.database.pin_after_write_secs,
+        );
+        parse_env(
+            env,
             "AUTUMN_DATABASE__CONNECT_TIMEOUT_SECS",
             &mut self.database.connect_timeout_secs,
         );

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -1109,7 +1109,7 @@ where
             .ok_or_else(|| AutumnError::service_unavailable_msg("Database not configured"))?;
         let ctx = RequestDbContext::from_parts(parts, state);
 
-        Self::checkout(DbCheckoutParams {
+        let result = Self::checkout(DbCheckoutParams {
             pool,
             pool_name: "primary",
             shard: None,
@@ -1119,7 +1119,13 @@ where
             slow_query_threshold: ctx.slow_query_threshold,
             interceptors: ctx.interceptors,
         })
-        .await
+        .await;
+        // Notify the RYWW task-local that a primary connection was checked out.
+        // No-op when read_your_writes = "off" (task-local absent).
+        if result.is_ok() {
+            crate::read_your_writes::mark_write();
+        }
+        result
     }
 }
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -200,6 +200,15 @@ pub(crate) mod repository_commit_hooks;
 #[cfg(feature = "db")]
 pub use repository::RepositoryError;
 
+/// Read-your-own-writes routing support.
+///
+/// When `database.read_your_writes` is `request` or `session`, generated
+/// repository read methods consult the per-request task-local at acquire time
+/// and redirect replica-eligible reads to the primary when a write has
+/// occurred in the same request (or within the session cookie window).
+#[cfg(feature = "db")]
+pub mod read_your_writes;
+
 /// Automatic record version history for `#[repository]` writes.
 ///
 /// See [`version_history`] module documentation for the full API.

--- a/autumn/src/middleware/metrics.rs
+++ b/autumn/src/middleware/metrics.rs
@@ -56,6 +56,9 @@ struct MetricsInner {
     /// Requests that exceeded the configured per-request timeout.
     /// Exposed as `autumn_request_timeouts_total`.
     request_timeouts_total: AtomicU64,
+    /// Replica reads redirected to the primary by the RYWW pin.
+    /// Exposed as `autumn_read_your_writes_pins_total`.
+    read_your_writes_pins_total: AtomicU64,
 }
 
 #[derive(Debug, Default)]
@@ -106,6 +109,7 @@ impl MetricsCollector {
                 idempotency_conflicts: AtomicU64::new(0),
                 shutdown_aborted_requests: AtomicU64::new(0),
                 request_timeouts_total: AtomicU64::new(0),
+                read_your_writes_pins_total: AtomicU64::new(0),
             }),
         }
     }
@@ -124,6 +128,13 @@ impl MetricsCollector {
     pub fn record_request_timeout(&self) {
         self.inner
             .request_timeouts_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the read-your-own-writes pin redirect counter.
+    pub fn record_read_your_writes_pin(&self) {
+        self.inner
+            .read_your_writes_pins_total
             .fetch_add(1, Ordering::Relaxed);
     }
 
@@ -344,6 +355,10 @@ impl MetricsCollector {
                 conflicts: self.inner.idempotency_conflicts.load(Ordering::Relaxed),
             },
             db_queries,
+            read_your_writes_pins_total: self
+                .inner
+                .read_your_writes_pins_total
+                .load(Ordering::Relaxed),
         }
     }
 }
@@ -373,6 +388,9 @@ pub struct MetricsSnapshot {
     /// Database queries tracked.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub db_queries: HashMap<String, DbQueryMetric>,
+    /// Read-your-own-writes: number of replica reads redirected to the primary
+    /// due to an active RYWW pin. Zero when `read_your_writes = "off"`.
+    pub read_your_writes_pins_total: u64,
 }
 
 /// Idempotency-key middleware counters.

--- a/autumn/src/read_your_writes.rs
+++ b/autumn/src/read_your_writes.rs
@@ -159,7 +159,13 @@ fn parse_session_cookie(
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    now.saturating_sub(ts) < window_secs
+    // Reject timestamps more than 5 s in the future so clock skew on a signing
+    // server can't produce a cookie that is accepted indefinitely on other nodes.
+    if ts > now {
+        ts - now < 5
+    } else {
+        now - ts < window_secs
+    }
 }
 
 /// Build the value for a `Set-Cookie: autumn.ryw=…` response header.
@@ -419,6 +425,24 @@ mod tests {
         assert!(
             !pin.incoming_pin(),
             "cookie with invalid HMAC must NOT set incoming_pin"
+        );
+    }
+
+    #[test]
+    fn future_cookie_beyond_skew_tolerance_does_not_set_incoming_pin() {
+        let keys = test_keys();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        // 60 s in the future — well beyond the 5 s skew tolerance.
+        let ts = (now + 60).to_string();
+        let sig = keys.sign(ts.as_bytes());
+        let cookie = format!("{ts}.{sig}");
+        let pin = RequestPin::with_session_cookie(&cookie, &keys, 5);
+        assert!(
+            !pin.incoming_pin(),
+            "far-future cookie must NOT set incoming_pin"
         );
     }
 

--- a/autumn/src/read_your_writes.rs
+++ b/autumn/src/read_your_writes.rs
@@ -11,8 +11,8 @@
 //! code is reachable from hot paths** — `is_pinned()` fast-returns `false`
 //! without touching the task-local, and no middleware layer is installed.
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::config::ReadYourWrites;
 
@@ -311,9 +311,7 @@ pub async fn middleware(
 /// Delegates to `session::get_cookie` so that duplicate-name rejection
 /// (cookie-tossing mitigation) and exact-name matching are handled uniformly
 /// with the session layer.
-fn extract_ryw_cookie_value(
-    req: &axum::http::Request<axum::body::Body>,
-) -> Option<String> {
+fn extract_ryw_cookie_value(req: &axum::http::Request<axum::body::Body>) -> Option<String> {
     crate::session::get_cookie(req.headers(), RYW_COOKIE_NAME)
 }
 
@@ -372,10 +370,7 @@ mod tests {
 
     // Cookie parsing tests (use pub(crate) ResolvedSigningKeys directly)
     fn test_keys() -> crate::security::config::ResolvedSigningKeys {
-        crate::security::config::ResolvedSigningKeys::new(
-            b"test-key-for-ryw-unit".to_vec(),
-            vec![],
-        )
+        crate::security::config::ResolvedSigningKeys::new(b"test-key-for-ryw-unit".to_vec(), vec![])
     }
 
     fn fresh_cookie(keys: &crate::security::config::ResolvedSigningKeys) -> String {
@@ -393,7 +388,10 @@ mod tests {
         let keys = test_keys();
         let cookie = fresh_cookie(&keys);
         let pin = RequestPin::with_session_cookie(&cookie, &keys, 5);
-        assert!(pin.incoming_pin(), "fresh signed cookie must set incoming_pin");
+        assert!(
+            pin.incoming_pin(),
+            "fresh signed cookie must set incoming_pin"
+        );
     }
 
     #[test]
@@ -457,7 +455,10 @@ mod tests {
         // Manually simulate mark_write on the pin.
         pin.inner.wrote.store(true, Ordering::Relaxed);
         let val = session_cookie_value(&pin, &keys);
-        assert!(val.is_some(), "session mode + wrote must produce a cookie value");
+        assert!(
+            val.is_some(),
+            "session mode + wrote must produce a cookie value"
+        );
         let val = val.unwrap();
         // Must be parseable as a fresh cookie.
         let fresh_pin = RequestPin::with_session_cookie(&val, &keys, 5);

--- a/autumn/src/read_your_writes.rs
+++ b/autumn/src/read_your_writes.rs
@@ -491,4 +491,210 @@ mod tests {
             "produced cookie must be parseable as a fresh incoming_pin"
         );
     }
+
+    #[tokio::test]
+    async fn note_pin_redirect_increments_metric_via_new_with_metrics() {
+        let metrics = crate::middleware::MetricsCollector::new();
+        let pin = RequestPin::new_with_metrics(ReadYourWrites::Request, metrics.clone());
+        scope(pin, async {
+            mark_write();
+            note_pin_redirect();
+        })
+        .await;
+        assert_eq!(
+            metrics.snapshot().read_your_writes_pins_total,
+            1,
+            "note_pin_redirect must increment the metric counter"
+        );
+    }
+
+    #[tokio::test]
+    async fn note_pin_redirect_trace_fires_only_once_per_request() {
+        let metrics = crate::middleware::MetricsCollector::new();
+        let pin = RequestPin::new_with_metrics(ReadYourWrites::Request, metrics.clone());
+        scope(pin, async {
+            mark_write();
+            note_pin_redirect();
+            note_pin_redirect();
+            note_pin_redirect();
+        })
+        .await;
+        // Metric increments on every call; trace deduplicated (can't assert trace
+        // but we verify the counter reflects all three calls).
+        assert_eq!(metrics.snapshot().read_your_writes_pins_total, 3);
+    }
+
+    #[test]
+    fn with_session_cookie_and_metrics_fresh_sets_incoming_pin() {
+        let keys = test_keys();
+        let cookie = fresh_cookie(&keys);
+        let metrics = crate::middleware::MetricsCollector::new();
+        let pin = RequestPin::with_session_cookie_and_metrics(&cookie, &keys, 5, metrics);
+        assert!(
+            pin.incoming_pin(),
+            "with_session_cookie_and_metrics: fresh cookie must set incoming_pin"
+        );
+    }
+
+    #[test]
+    fn with_session_cookie_and_metrics_expired_does_not_set_incoming_pin() {
+        let keys = test_keys();
+        let ts = 1_000u64.to_string();
+        let sig = keys.sign(ts.as_bytes());
+        let cookie = format!("{ts}.{sig}");
+        let metrics = crate::middleware::MetricsCollector::new();
+        let pin = RequestPin::with_session_cookie_and_metrics(&cookie, &keys, 5, metrics);
+        assert!(
+            !pin.incoming_pin(),
+            "with_session_cookie_and_metrics: expired cookie must NOT set incoming_pin"
+        );
+    }
+
+    // ── middleware() integration tests ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn middleware_request_mode_no_set_cookie() {
+        use axum::{Router, body::Body, http::Request, routing::get};
+        use tower::ServiceExt;
+
+        let metrics = crate::middleware::MetricsCollector::new();
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn(move |req, next| {
+                middleware(req, next, ReadYourWrites::Request, 5, None, metrics.clone())
+            }));
+
+        let req = Request::builder()
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert!(
+            !resp.headers().contains_key("set-cookie"),
+            "request mode must not set a cookie"
+        );
+    }
+
+    #[tokio::test]
+    async fn middleware_session_mode_write_sets_cookie() {
+        use axum::{Router, body::Body, http::Request, routing::get};
+        use tower::ServiceExt;
+
+        let keys = std::sync::Arc::new(test_keys());
+        let metrics = crate::middleware::MetricsCollector::new();
+        let keys_clone = keys.clone();
+        let app = Router::new()
+            .route(
+                "/",
+                get(|| async {
+                    mark_write();
+                    "ok"
+                }),
+            )
+            .layer(axum::middleware::from_fn(move |req, next| {
+                middleware(
+                    req,
+                    next,
+                    ReadYourWrites::Session,
+                    5,
+                    Some(keys_clone.clone()),
+                    metrics.clone(),
+                )
+            }));
+
+        let req = Request::builder()
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let set_cookie = resp.headers().get("set-cookie");
+        assert!(
+            set_cookie.is_some(),
+            "session mode + write must set the autumn.ryw cookie"
+        );
+        let cv = set_cookie.unwrap().to_str().unwrap();
+        assert!(
+            cv.starts_with("autumn.ryw="),
+            "Set-Cookie must be the autumn.ryw cookie, got: {cv}"
+        );
+    }
+
+    #[tokio::test]
+    async fn middleware_session_mode_no_write_no_set_cookie() {
+        use axum::{Router, body::Body, http::Request, routing::get};
+        use tower::ServiceExt;
+
+        let keys = std::sync::Arc::new(test_keys());
+        let metrics = crate::middleware::MetricsCollector::new();
+        let keys_clone = keys.clone();
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn(move |req, next| {
+                middleware(
+                    req,
+                    next,
+                    ReadYourWrites::Session,
+                    5,
+                    Some(keys_clone.clone()),
+                    metrics.clone(),
+                )
+            }));
+
+        let req = Request::builder()
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert!(
+            !resp.headers().contains_key("set-cookie"),
+            "session mode without write must NOT set a cookie"
+        );
+    }
+
+    #[tokio::test]
+    async fn middleware_session_mode_incoming_cookie_pins_read() {
+        use axum::{Router, body::Body, http::Request, routing::get};
+        use tower::ServiceExt;
+
+        let keys = std::sync::Arc::new(test_keys());
+        let cookie = fresh_cookie(&keys);
+        let metrics = crate::middleware::MetricsCollector::new();
+        let keys_clone = keys.clone();
+
+        // Track whether the handler saw a pin via a shared flag.
+        let saw_pin = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let saw_pin_clone = saw_pin.clone();
+        let app = Router::new()
+            .route(
+                "/",
+                get(move || {
+                    let flag = saw_pin_clone.clone();
+                    async move {
+                        flag.store(is_pinned(), Ordering::Relaxed);
+                        "ok"
+                    }
+                }),
+            )
+            .layer(axum::middleware::from_fn(move |req, next| {
+                middleware(
+                    req,
+                    next,
+                    ReadYourWrites::Session,
+                    5,
+                    Some(keys_clone.clone()),
+                    metrics.clone(),
+                )
+            }));
+
+        let req = Request::builder()
+            .uri("/")
+            .header("cookie", format!("autumn.ryw={cookie}"))
+            .body(Body::empty())
+            .unwrap();
+        app.oneshot(req).await.unwrap();
+        assert!(
+            saw_pin.load(Ordering::Relaxed),
+            "a valid incoming autumn.ryw cookie must activate the pin inside the handler"
+        );
+    }
 }

--- a/autumn/src/read_your_writes.rs
+++ b/autumn/src/read_your_writes.rs
@@ -1,0 +1,465 @@
+//! Read-your-own-writes (RYWW) routing support.
+//!
+//! When `database.read_your_writes` is `request` or `session`, Autumn installs
+//! a per-request task-local that generated repository read methods consult at
+//! acquire time. Once the current request has checked out a **primary** connection
+//! (via the `Db` extractor or a generated mutating method), subsequent
+//! replica-eligible reads are redirected to the primary pool — preventing the
+//! classic stale-read anomaly that arises when replication lag is non-zero.
+//!
+//! When `read_your_writes` is `off` (the default), **none of this module's
+//! code is reachable from hot paths** — `is_pinned()` fast-returns `false`
+//! without touching the task-local, and no middleware layer is installed.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use crate::config::ReadYourWrites;
+
+struct Inner {
+    mode: ReadYourWrites,
+    incoming_pin: bool,
+    wrote: AtomicBool,
+    metrics: Option<crate::middleware::MetricsCollector>,
+}
+
+/// Per-request pin state, cheaply cloneable via `Arc`.
+#[derive(Clone)]
+pub struct RequestPin {
+    inner: Arc<Inner>,
+}
+
+impl RequestPin {
+    /// Build a basic pin for `request` mode (or `session` without a cookie).
+    #[must_use]
+    pub fn new(mode: ReadYourWrites) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                mode,
+                incoming_pin: false,
+                wrote: AtomicBool::new(false),
+                metrics: None,
+            }),
+        }
+    }
+
+    /// Build a pin that also records metrics when a redirect occurs.
+    #[must_use]
+    pub fn new_with_metrics(
+        mode: ReadYourWrites,
+        metrics: crate::middleware::MetricsCollector,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                mode,
+                incoming_pin: false,
+                wrote: AtomicBool::new(false),
+                metrics: Some(metrics),
+            }),
+        }
+    }
+
+    /// Build a session-mode pin, parsing a signed cookie value.
+    ///
+    /// Cookie format: `{unix_timestamp_secs}.{hmac_hex}`.
+    /// `incoming_pin` is set when the signature is valid and the timestamp
+    /// is within `window_secs` of now.
+    #[must_use]
+    pub fn with_session_cookie(
+        cookie: &str,
+        keys: &crate::security::config::ResolvedSigningKeys,
+        window_secs: u64,
+    ) -> Self {
+        let incoming_pin = parse_session_cookie(cookie, keys, window_secs);
+        Self {
+            inner: Arc::new(Inner {
+                mode: ReadYourWrites::Session,
+                incoming_pin,
+                wrote: AtomicBool::new(false),
+                metrics: None,
+            }),
+        }
+    }
+
+    /// Build a pin with an explicit `incoming_pin` flag, bypassing cookie
+    /// parsing. Intended for integration tests that need to verify session-mode
+    /// routing behavior without constructing a real signed cookie.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_incoming_pin(mode: ReadYourWrites, incoming_pin: bool) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                mode,
+                incoming_pin,
+                wrote: AtomicBool::new(false),
+                metrics: None,
+            }),
+        }
+    }
+
+    /// Build a session-mode pin with metrics, parsing a signed cookie.
+    #[must_use]
+    pub fn with_session_cookie_and_metrics(
+        cookie: &str,
+        keys: &crate::security::config::ResolvedSigningKeys,
+        window_secs: u64,
+        metrics: crate::middleware::MetricsCollector,
+    ) -> Self {
+        let incoming_pin = parse_session_cookie(cookie, keys, window_secs);
+        Self {
+            inner: Arc::new(Inner {
+                mode: ReadYourWrites::Session,
+                incoming_pin,
+                wrote: AtomicBool::new(false),
+                metrics: Some(metrics),
+            }),
+        }
+    }
+
+    /// Returns `true` when the cross-request session cookie was valid and fresh.
+    #[must_use]
+    pub fn incoming_pin(&self) -> bool {
+        self.inner.incoming_pin
+    }
+
+    /// Returns `true` when a write has been marked in this request scope.
+    #[must_use]
+    pub fn wrote(&self) -> bool {
+        self.inner.wrote.load(Ordering::Relaxed)
+    }
+}
+
+/// Parse and validate the `autumn.ryw` signed cookie.
+///
+/// Returns `true` only when the HMAC signature is valid and the timestamp
+/// is within `window_secs` of the current wall time.
+fn parse_session_cookie(
+    cookie: &str,
+    keys: &crate::security::config::ResolvedSigningKeys,
+    window_secs: u64,
+) -> bool {
+    let Some((ts_str, sig)) = cookie.rsplit_once('.') else {
+        return false;
+    };
+    let Ok(ts) = ts_str.parse::<u64>() else {
+        return false;
+    };
+    if !keys.verify(ts_str.as_bytes(), sig) {
+        return false;
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    now.saturating_sub(ts) < window_secs
+}
+
+/// Build the value for a `Set-Cookie: autumn.ryw=…` response header.
+///
+/// Returns `None` when the pin mode is not `Session` or no write occurred
+/// in this scope — callers should only set the cookie when this returns `Some`.
+///
+/// The cookie value is `{unix_secs}.{hmac_hex}`, matching the format parsed
+/// by [`RequestPin::with_session_cookie`].
+#[must_use]
+pub fn session_cookie_value(
+    pin: &RequestPin,
+    keys: &crate::security::config::ResolvedSigningKeys,
+) -> Option<String> {
+    if !matches!(pin.inner.mode, ReadYourWrites::Session) {
+        return None;
+    }
+    if !pin.inner.wrote.load(Ordering::Relaxed) {
+        return None;
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let ts_str = now.to_string();
+    let sig = keys.sign(ts_str.as_bytes());
+    Some(format!("{ts_str}.{sig}"))
+}
+
+tokio::task_local! {
+    static PIN: RequestPin;
+}
+
+/// Install the task-local pin for a request and run `fut` within its scope.
+///
+/// Called by the RYW middleware for every request when mode is not `off`.
+pub async fn scope<F: std::future::Future>(pin: RequestPin, fut: F) -> F::Output {
+    PIN.scope(pin, fut).await
+}
+
+/// Mark that the current request has performed a primary write.
+///
+/// No-op when called outside a [`scope`] (i.e. when `read_your_writes = "off"`
+/// and no middleware installed the task-local). Safe to call unconditionally
+/// from `Db::from_request_parts` and generated mutating methods.
+pub fn mark_write() {
+    PIN.try_with(|pin| {
+        pin.inner.wrote.store(true, Ordering::Relaxed);
+    })
+    .ok();
+}
+
+/// Returns `true` when the task-local pin is active and reads should be
+/// redirected to the primary.
+///
+/// Fast path: if the task-local is absent (no scope installed, i.e. `off`
+/// mode), returns `false` in O(1) with no heap allocation.
+#[inline]
+#[must_use]
+pub fn is_pinned() -> bool {
+    PIN.try_with(|pin| {
+        matches!(
+            pin.inner.mode,
+            ReadYourWrites::Request | ReadYourWrites::Session
+        ) && (pin.inner.wrote.load(Ordering::Relaxed) || pin.inner.incoming_pin)
+    })
+    .unwrap_or(false)
+}
+
+/// Record a pin-redirected read: increment the metric and emit a trace event.
+///
+/// Called by generated repository read methods when a replica-eligible read is
+/// redirected to the primary. The `try_with` is defensive — the task-local is
+/// expected to be set when this is called.
+pub fn note_pin_redirect() {
+    PIN.try_with(|pin| {
+        if let Some(ref metrics) = pin.inner.metrics {
+            metrics.record_read_your_writes_pin();
+        }
+        tracing::debug!(
+            target: "autumn::db",
+            ryw_pinned = true,
+            "read redirected to primary (read-your-own-writes pin active)"
+        );
+    })
+    .ok();
+}
+
+/// Name of the signed cross-request session cookie.
+pub const RYW_COOKIE_NAME: &str = "autumn.ryw";
+
+/// Axum middleware function that installs the RYWW task-local for every
+/// request and, in `session` mode, handles the signed cookie lifecycle.
+///
+/// Installed by `apply_middleware` in `router.rs` when
+/// `database.read_your_writes != "off"`.
+pub async fn middleware(
+    req: axum::http::Request<axum::body::Body>,
+    next: axum::middleware::Next,
+    mode: crate::config::ReadYourWrites,
+    window_secs: u64,
+    keys: Option<std::sync::Arc<crate::security::config::ResolvedSigningKeys>>,
+    metrics: crate::middleware::MetricsCollector,
+) -> axum::http::Response<axum::body::Body> {
+    let pin = match mode {
+        crate::config::ReadYourWrites::Session => {
+            let cookie_val = extract_ryw_cookie_value(&req);
+            match (cookie_val, &keys) {
+                (Some(cv), Some(k)) => {
+                    RequestPin::with_session_cookie_and_metrics(&cv, k, window_secs, metrics)
+                }
+                _ => RequestPin::new_with_metrics(mode, metrics),
+            }
+        }
+        crate::config::ReadYourWrites::Request => RequestPin::new_with_metrics(mode, metrics),
+        crate::config::ReadYourWrites::Off => unreachable!("RYW middleware installed in off mode"),
+    };
+
+    let pin_for_response = pin.clone();
+
+    let mut response = scope(pin, next.run(req)).await;
+
+    // Session mode: stamp a Set-Cookie if a write occurred so subsequent
+    // requests within the freshness window also route to primary.
+    if mode == crate::config::ReadYourWrites::Session
+        && let Some(k) = &keys
+        && let Some(cv) = session_cookie_value(&pin_for_response, k)
+    {
+        let cookie_str = format!(
+            "{RYW_COOKIE_NAME}={cv}; Max-Age={window_secs}; HttpOnly; \
+             Secure; SameSite=Lax; Path=/"
+        );
+        if let Ok(hv) = axum::http::HeaderValue::from_str(&cookie_str) {
+            response
+                .headers_mut()
+                .append(axum::http::header::SET_COOKIE, hv);
+        }
+    }
+
+    response
+}
+
+/// Extract the `autumn.ryw` cookie value from raw `Cookie` headers.
+fn extract_ryw_cookie_value(
+    req: &axum::http::Request<axum::body::Body>,
+) -> Option<String> {
+    for hv in req.headers().get_all(axum::http::header::COOKIE) {
+        let Ok(s) = hv.to_str() else { continue };
+        for part in s.split(';') {
+            let part = part.trim();
+            if let Some(val) = part.strip_prefix(RYW_COOKIE_NAME) {
+                let val = val.trim_start_matches([' ', '=']);
+                if !val.is_empty() {
+                    return Some(val.to_owned());
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mark_write_no_op_outside_scope() {
+        mark_write(); // must not panic
+        assert!(!is_pinned());
+    }
+
+    #[tokio::test]
+    async fn is_pinned_false_outside_scope() {
+        assert!(!is_pinned());
+    }
+
+    #[tokio::test]
+    async fn is_pinned_request_mode_before_write() {
+        let pin = RequestPin::new(ReadYourWrites::Request);
+        scope(pin, async {
+            assert!(!is_pinned(), "no write yet");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn is_pinned_request_mode_after_write() {
+        let pin = RequestPin::new(ReadYourWrites::Request);
+        scope(pin, async {
+            mark_write();
+            assert!(is_pinned(), "write marked");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn is_pinned_off_mode_never_pins() {
+        let pin = RequestPin::new(ReadYourWrites::Off);
+        scope(pin, async {
+            mark_write();
+            assert!(!is_pinned(), "off mode must never pin");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn incoming_pin_pins_without_write() {
+        let pin = RequestPin::with_incoming_pin(ReadYourWrites::Session, true);
+        scope(pin, async {
+            assert!(is_pinned(), "incoming_pin should activate the pin");
+        })
+        .await;
+    }
+
+    // Cookie parsing tests (use pub(crate) ResolvedSigningKeys directly)
+    fn test_keys() -> crate::security::config::ResolvedSigningKeys {
+        crate::security::config::ResolvedSigningKeys::new(
+            b"test-key-for-ryw-unit".to_vec(),
+            vec![],
+        )
+    }
+
+    fn fresh_cookie(keys: &crate::security::config::ResolvedSigningKeys) -> String {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let ts = now.to_string();
+        let sig = keys.sign(ts.as_bytes());
+        format!("{ts}.{sig}")
+    }
+
+    #[test]
+    fn fresh_cookie_sets_incoming_pin() {
+        let keys = test_keys();
+        let cookie = fresh_cookie(&keys);
+        let pin = RequestPin::with_session_cookie(&cookie, &keys, 5);
+        assert!(pin.incoming_pin(), "fresh signed cookie must set incoming_pin");
+    }
+
+    #[test]
+    fn expired_cookie_does_not_set_incoming_pin() {
+        let keys = test_keys();
+        let ts = 1_000u64.to_string(); // Jan 1970 — clearly expired
+        let sig = keys.sign(ts.as_bytes());
+        let cookie = format!("{ts}.{sig}");
+        let pin = RequestPin::with_session_cookie(&cookie, &keys, 5);
+        assert!(
+            !pin.incoming_pin(),
+            "expired cookie must NOT set incoming_pin"
+        );
+    }
+
+    #[test]
+    fn tampered_cookie_does_not_set_incoming_pin() {
+        let keys = test_keys();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let cookie = format!("{now}.deadbeef");
+        let pin = RequestPin::with_session_cookie(&cookie, &keys, 5);
+        assert!(
+            !pin.incoming_pin(),
+            "cookie with invalid HMAC must NOT set incoming_pin"
+        );
+    }
+
+    #[test]
+    fn malformed_cookie_does_not_set_incoming_pin() {
+        let keys = test_keys();
+        for bad in &["", "notimestamp", "abc.def.ghi"] {
+            let pin = RequestPin::with_session_cookie(bad, &keys, 5);
+            assert!(
+                !pin.incoming_pin(),
+                "malformed cookie {bad:?} must NOT set incoming_pin"
+            );
+        }
+    }
+
+    #[test]
+    fn session_cookie_value_returns_none_for_request_mode() {
+        let keys = test_keys();
+        let pin = RequestPin::new(ReadYourWrites::Request);
+        assert!(session_cookie_value(&pin, &keys).is_none());
+    }
+
+    #[test]
+    fn session_cookie_value_returns_none_when_no_write() {
+        let keys = test_keys();
+        let pin = RequestPin::new(ReadYourWrites::Session);
+        assert!(session_cookie_value(&pin, &keys).is_none());
+    }
+
+    #[test]
+    fn session_cookie_value_returns_value_after_write() {
+        let keys = test_keys();
+        let pin = RequestPin::new(ReadYourWrites::Session);
+        // Manually simulate mark_write on the pin.
+        pin.inner.wrote.store(true, Ordering::Relaxed);
+        let val = session_cookie_value(&pin, &keys);
+        assert!(val.is_some(), "session mode + wrote must produce a cookie value");
+        let val = val.unwrap();
+        // Must be parseable as a fresh cookie.
+        let fresh_pin = RequestPin::with_session_cookie(&val, &keys, 5);
+        assert!(
+            fresh_pin.incoming_pin(),
+            "produced cookie must be parseable as a fresh incoming_pin"
+        );
+    }
+}

--- a/autumn/src/read_your_writes.rs
+++ b/autumn/src/read_your_writes.rs
@@ -558,16 +558,14 @@ mod tests {
         use tower::ServiceExt;
 
         let metrics = crate::middleware::MetricsCollector::new();
-        let app = Router::new()
-            .route("/", get(|| async { "ok" }))
-            .layer(axum::middleware::from_fn(move |req, next| {
-                middleware(req, next, ReadYourWrites::Request, 5, None, metrics.clone())
-            }));
+        let app =
+            Router::new()
+                .route("/", get(|| async { "ok" }))
+                .layer(axum::middleware::from_fn(move |req, next| {
+                    middleware(req, next, ReadYourWrites::Request, 5, None, metrics.clone())
+                }));
 
-        let req = Request::builder()
-            .uri("/")
-            .body(Body::empty())
-            .unwrap();
+        let req = Request::builder().uri("/").body(Body::empty()).unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert!(
             !resp.headers().contains_key("set-cookie"),
@@ -602,10 +600,7 @@ mod tests {
                 )
             }));
 
-        let req = Request::builder()
-            .uri("/")
-            .body(Body::empty())
-            .unwrap();
+        let req = Request::builder().uri("/").body(Body::empty()).unwrap();
         let resp = app.oneshot(req).await.unwrap();
         let set_cookie = resp.headers().get("set-cookie");
         assert!(
@@ -627,23 +622,21 @@ mod tests {
         let keys = std::sync::Arc::new(test_keys());
         let metrics = crate::middleware::MetricsCollector::new();
         let keys_clone = keys.clone();
-        let app = Router::new()
-            .route("/", get(|| async { "ok" }))
-            .layer(axum::middleware::from_fn(move |req, next| {
-                middleware(
-                    req,
-                    next,
-                    ReadYourWrites::Session,
-                    5,
-                    Some(keys_clone.clone()),
-                    metrics.clone(),
-                )
-            }));
+        let app =
+            Router::new()
+                .route("/", get(|| async { "ok" }))
+                .layer(axum::middleware::from_fn(move |req, next| {
+                    middleware(
+                        req,
+                        next,
+                        ReadYourWrites::Session,
+                        5,
+                        Some(keys_clone.clone()),
+                        metrics.clone(),
+                    )
+                }));
 
-        let req = Request::builder()
-            .uri("/")
-            .body(Body::empty())
-            .unwrap();
+        let req = Request::builder().uri("/").body(Body::empty()).unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert!(
             !resp.headers().contains_key("set-cookie"),

--- a/autumn/src/read_your_writes.rs
+++ b/autumn/src/read_your_writes.rs
@@ -20,6 +20,9 @@ struct Inner {
     mode: ReadYourWrites,
     incoming_pin: bool,
     wrote: AtomicBool,
+    /// Set on the first pin-redirect trace so subsequent redirects within the
+    /// same request don't produce unbounded log volume.
+    pin_traced: AtomicBool,
     metrics: Option<crate::middleware::MetricsCollector>,
 }
 
@@ -38,6 +41,7 @@ impl RequestPin {
                 mode,
                 incoming_pin: false,
                 wrote: AtomicBool::new(false),
+                pin_traced: AtomicBool::new(false),
                 metrics: None,
             }),
         }
@@ -54,6 +58,7 @@ impl RequestPin {
                 mode,
                 incoming_pin: false,
                 wrote: AtomicBool::new(false),
+                pin_traced: AtomicBool::new(false),
                 metrics: Some(metrics),
             }),
         }
@@ -76,6 +81,7 @@ impl RequestPin {
                 mode: ReadYourWrites::Session,
                 incoming_pin,
                 wrote: AtomicBool::new(false),
+                pin_traced: AtomicBool::new(false),
                 metrics: None,
             }),
         }
@@ -92,6 +98,7 @@ impl RequestPin {
                 mode,
                 incoming_pin,
                 wrote: AtomicBool::new(false),
+                pin_traced: AtomicBool::new(false),
                 metrics: None,
             }),
         }
@@ -111,6 +118,7 @@ impl RequestPin {
                 mode: ReadYourWrites::Session,
                 incoming_pin,
                 wrote: AtomicBool::new(false),
+                pin_traced: AtomicBool::new(false),
                 metrics: Some(metrics),
             }),
         }
@@ -231,11 +239,15 @@ pub fn note_pin_redirect() {
         if let Some(ref metrics) = pin.inner.metrics {
             metrics.record_read_your_writes_pin();
         }
-        tracing::debug!(
-            target: "autumn::db",
-            ryw_pinned = true,
-            "read redirected to primary (read-your-own-writes pin active)"
-        );
+        // Emit the trace at most once per request to avoid log spam on
+        // read-heavy handlers where every read is redirected.
+        if !pin.inner.pin_traced.swap(true, Ordering::Relaxed) {
+            tracing::debug!(
+                target: "autumn::db",
+                ryw_pinned = true,
+                "read redirected to primary (read-your-own-writes pin active)"
+            );
+        }
     })
     .ok();
 }
@@ -295,22 +307,14 @@ pub async fn middleware(
 }
 
 /// Extract the `autumn.ryw` cookie value from raw `Cookie` headers.
+///
+/// Delegates to `session::get_cookie` so that duplicate-name rejection
+/// (cookie-tossing mitigation) and exact-name matching are handled uniformly
+/// with the session layer.
 fn extract_ryw_cookie_value(
     req: &axum::http::Request<axum::body::Body>,
 ) -> Option<String> {
-    for hv in req.headers().get_all(axum::http::header::COOKIE) {
-        let Ok(s) = hv.to_str() else { continue };
-        for part in s.split(';') {
-            let part = part.trim();
-            if let Some(val) = part.strip_prefix(RYW_COOKIE_NAME) {
-                let val = val.trim_start_matches([' ', '=']);
-                if !val.is_empty() {
-                    return Some(val.to_owned());
-                }
-            }
-        }
-    }
-    None
+    crate::session::get_cookie(req.headers(), RYW_COOKIE_NAME)
 }
 
 #[cfg(test)]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -2491,6 +2491,13 @@ fn apply_middleware(
         let ryw_mode = config.database.read_your_writes;
         let window_secs = config.database.pin_after_write_secs;
         let keys = signing_keys_for_ryw;
+        if ryw_mode == crate::config::ReadYourWrites::Session && keys.is_none() {
+            tracing::warn!(
+                "read_your_writes = \"session\" requires a configured \
+                 security.signing_secret to sign the autumn.ryw cookie; \
+                 cross-request pinning is disabled until a secret is set"
+            );
+        }
         let metrics = state.metrics().clone();
         router.layer(axum::middleware::from_fn(move |req, next| {
             crate::read_your_writes::middleware(

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -2464,6 +2464,11 @@ fn apply_middleware(
     // session, logs, and trace context.
     let router = router.layer(RequestIdLayer);
 
+    // Pre-clone signing keys for the RYWW middleware (session mode needs to
+    // sign/verify the `autumn.ryw` cookie; `signing_keys_opt` is consumed below).
+    #[cfg(feature = "db")]
+    let signing_keys_for_ryw = signing_keys_opt.clone();
+
     let router = crate::session::apply_session_layer(
         router,
         &config.session,
@@ -2472,6 +2477,32 @@ fn apply_middleware(
         signing_keys_opt,
     )?;
     tracing::debug!(backend = ?config.session.backend, "Session management enabled");
+
+    // Read-your-own-writes middleware: installed only when the mode is not
+    // `off`. When active, it scopes a per-request task-local `RequestPin`
+    // that generated repository read methods consult at acquire time.
+    // Inner to Session so the task-local wraps the handler; the `autumn.ryw`
+    // cookie is parsed from raw `Cookie` headers and does not require the
+    // Session extractor to have run first.
+    #[cfg(feature = "db")]
+    let router = if config.database.read_your_writes == crate::config::ReadYourWrites::Off {
+        router
+    } else {
+        let ryw_mode = config.database.read_your_writes;
+        let window_secs = config.database.pin_after_write_secs;
+        let keys = signing_keys_for_ryw;
+        let metrics = state.metrics().clone();
+        router.layer(axum::middleware::from_fn(move |req, next| {
+            crate::read_your_writes::middleware(
+                req,
+                next,
+                ryw_mode,
+                window_secs,
+                keys.clone(),
+                metrics.clone(),
+            )
+        }))
+    };
 
     // Error page filter: renders HTML error pages for browser requests.
     // Always registered (uses default renderer if no custom one is provided).

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -576,7 +576,7 @@ fn is_production_profile(profile: Option<&str>) -> bool {
 // ── Cookie helpers ──────────────────────────────────────────────
 
 /// Extract a named cookie value from the Cookie header.
-fn get_cookie(headers: &http::HeaderMap, name: &str) -> Option<String> {
+pub(crate) fn get_cookie(headers: &http::HeaderMap, name: &str) -> Option<String> {
     let mut found_token = None;
 
     for cookie_header in headers.get_all(COOKIE) {

--- a/autumn/src/sharding.rs
+++ b/autumn/src/sharding.rs
@@ -2025,6 +2025,7 @@ impl axum::extract::FromRequestParts<crate::AppState> for ShardedDb {
         );
         let shard_set = shards.set.clone();
         let db = shards.checkout_primary(shard).await?;
+        crate::read_your_writes::mark_write();
         Ok(Self {
             db,
             shard_name,

--- a/autumn/tests/fixtures/schema_keys.snapshot
+++ b/autumn/tests/fixtures/schema_keys.snapshot
@@ -26,9 +26,11 @@ database.url
 dev
 health
 http
+i18n
 idempotency
 jobs
 log
+mail
 openapi
 reporting
 resilience
@@ -45,6 +47,7 @@ server.timeouts
 server.timeouts.request_timeout_ms
 server.unix_socket
 session
+storage
 telemetry
 tenancy
 time_zone

--- a/autumn/tests/fixtures/schema_keys.snapshot
+++ b/autumn/tests/fixtures/schema_keys.snapshot
@@ -10,9 +10,11 @@ database.auto_migrate_in_production
 database.connect_timeout_secs
 database.directory_shard_router
 database.max_connections_warn_threshold
+database.pin_after_write_secs
 database.pool_size
 database.primary_pool_size
 database.primary_url
+database.read_your_writes
 database.replica_fallback
 database.replica_pool_size
 database.replica_url
@@ -24,11 +26,9 @@ database.url
 dev
 health
 http
-i18n
 idempotency
 jobs
 log
-mail
 openapi
 reporting
 resilience
@@ -45,7 +45,6 @@ server.timeouts
 server.timeouts.request_timeout_ms
 server.unix_socket
 session
-storage
 telemetry
 tenancy
 time_zone

--- a/autumn/tests/read_your_writes_routing.rs
+++ b/autumn/tests/read_your_writes_routing.rs
@@ -1,0 +1,291 @@
+//! Issue #1201: generated `#[repository]` read methods route to the primary
+//! when a read-your-own-writes (RYWW) pin is active — either because the
+//! current request acquired a primary write connection, or because a fresh
+//! signed `autumn.ryw` session cookie arrived from a previous write request.
+//!
+//! All tests run without a live database: pools are created lazily (no TCP
+//! connection until a checkout), sized 5/2 so `pool.status().max_size`
+//! distinguishes primary from replica, mirroring `repository_replica_routing.rs`.
+//!
+//! Cookie-parsing unit tests live in `autumn/src/read_your_writes.rs` where
+//! `ResolvedSigningKeys` (pub(crate)) is accessible.
+
+#![cfg(feature = "db")]
+
+use autumn_web::AppState;
+use autumn_web::config::{DatabaseConfig, ReadYourWrites};
+use autumn_web::db;
+use autumn_web::middleware::MetricsCollector;
+use autumn_web::read_your_writes::{self, RequestPin};
+use autumn_web::reexports::axum::extract::FromRequestParts;
+use autumn_web::reexports::diesel_async::AsyncPgConnection;
+use autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool;
+use autumn_web::reexports::http::Request;
+use autumn_web::repository::ReadRoute;
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        ryw_notes (id) {
+            id -> Int8,
+            content -> Text,
+        }
+    }
+}
+
+use schema::ryw_notes;
+
+#[autumn_web::model(table = "ryw_notes")]
+pub struct RywNote {
+    #[id]
+    pub id: i64,
+    pub content: String,
+}
+
+#[autumn_web::repository(RywNote, table = "ryw_notes")]
+pub trait RywNoteRepository {
+    fn find_by_content(content: String) -> Vec<RywNote>;
+}
+
+const PRIMARY_POOL_SIZE: usize = 5;
+const REPLICA_POOL_SIZE: usize = 2;
+
+fn make_pool(database: &str, pool_size: usize) -> Pool<AsyncPgConnection> {
+    let config = DatabaseConfig {
+        url: Some(format!("postgres://localhost/{database}")),
+        pool_size,
+        ..Default::default()
+    };
+    db::create_pool(&config)
+        .expect("pool config is valid")
+        .expect("url is set")
+}
+
+fn two_pool_state() -> AppState {
+    AppState::for_test()
+        .with_pool(make_pool("primary", PRIMARY_POOL_SIZE))
+        .with_replica_pool(make_pool("replica", REPLICA_POOL_SIZE))
+}
+
+async fn extract<R>(state: &AppState) -> R
+where
+    R: FromRequestParts<AppState, Rejection = autumn_web::AutumnError>,
+{
+    let (mut parts, ()) = Request::builder().body(()).unwrap().into_parts();
+    R::from_request_parts(&mut parts, state)
+        .await
+        .expect("repository extraction succeeds")
+}
+
+fn read_pool_size(route: &ReadRoute) -> Option<usize> {
+    match route {
+        ReadRoute::ReadPool(pool) => Some(pool.status().max_size),
+        ReadRoute::Primary | ReadRoute::Unavailable => None,
+    }
+}
+
+// ── AC 1: request mode — reads stay on replica before any write ─────────────
+
+#[tokio::test]
+async fn request_mode_reads_replica_before_write() {
+    let state = two_pool_state();
+    let repo: PgRywNoteRepository = extract(&state).await;
+    let pin = RequestPin::new(ReadYourWrites::Request);
+
+    read_your_writes::scope(pin, async {
+        assert_eq!(
+            read_pool_size(&repo.__autumn_effective_read_route()),
+            Some(REPLICA_POOL_SIZE),
+            "before any write, reads must still route to the replica"
+        );
+    })
+    .await;
+}
+
+// ── AC 2: request mode — reads pin to primary after mark_write() ────────────
+
+#[tokio::test]
+async fn request_mode_pins_reads_after_mark_write() {
+    let state = two_pool_state();
+    let repo: PgRywNoteRepository = extract(&state).await;
+    let pin = RequestPin::new(ReadYourWrites::Request);
+
+    read_your_writes::scope(pin, async {
+        read_your_writes::mark_write();
+
+        assert!(
+            matches!(repo.__autumn_effective_read_route(), ReadRoute::Primary),
+            "after mark_write(), reads must be pinned to the primary"
+        );
+    })
+    .await;
+}
+
+// ── AC 3: concurrent isolation — second scope without write is not pinned ────
+
+#[tokio::test]
+async fn concurrent_scopes_are_isolated() {
+    let state1 = two_pool_state();
+    let state2 = two_pool_state();
+
+    let (wrote_result, clean_result) = tokio::join!(
+        tokio::spawn(async move {
+            let repo: PgRywNoteRepository = extract(&state1).await;
+            let pin = RequestPin::new(ReadYourWrites::Request);
+            read_your_writes::scope(pin, async move {
+                read_your_writes::mark_write();
+                matches!(repo.__autumn_effective_read_route(), ReadRoute::Primary)
+            })
+            .await
+        }),
+        tokio::spawn(async move {
+            let repo: PgRywNoteRepository = extract(&state2).await;
+            let pin = RequestPin::new(ReadYourWrites::Request);
+            read_your_writes::scope(pin, async move {
+                read_pool_size(&repo.__autumn_effective_read_route())
+            })
+            .await
+        })
+    );
+
+    assert!(
+        wrote_result.unwrap(),
+        "task that wrote must have reads pinned to primary"
+    );
+    assert_eq!(
+        clean_result.unwrap(),
+        Some(REPLICA_POOL_SIZE),
+        "task that did not write must keep reading from the replica"
+    );
+}
+
+// ── AC 4: off mode (no scope) — existing behavior preserved ─────────────────
+
+#[tokio::test]
+async fn off_mode_no_scope_preserves_replica_routing() {
+    let state = two_pool_state();
+    let repo: PgRywNoteRepository = extract(&state).await;
+
+    assert!(
+        !read_your_writes::is_pinned(),
+        "is_pinned() must be false outside any scope"
+    );
+    assert_eq!(
+        read_pool_size(&repo.__autumn_effective_read_route()),
+        read_pool_size(repo.__autumn_read_route()),
+        "__autumn_effective_read_route() must match snapshot outside any scope"
+    );
+}
+
+// ── AC 5: config parsing round-trips ────────────────────────────────────────
+
+#[test]
+fn read_your_writes_from_str_round_trips() {
+    use std::str::FromStr;
+
+    assert!(matches!(
+        ReadYourWrites::from_str("off").unwrap(),
+        ReadYourWrites::Off
+    ));
+    assert!(matches!(
+        ReadYourWrites::from_str("request").unwrap(),
+        ReadYourWrites::Request
+    ));
+    assert!(matches!(
+        ReadYourWrites::from_str("session").unwrap(),
+        ReadYourWrites::Session
+    ));
+    assert!(ReadYourWrites::from_str("invalid").is_err());
+}
+
+#[test]
+fn database_config_defaults() {
+    let config = DatabaseConfig::default();
+    assert!(
+        matches!(config.read_your_writes, ReadYourWrites::Off),
+        "default mode must be off"
+    );
+    assert_eq!(config.pin_after_write_secs, 5, "default window must be 5 s");
+}
+
+// ── AC 6: session-mode incoming_pin (cookie-based) pins reads to primary ────
+//
+// Cookie parsing is unit-tested in `read_your_writes.rs`. Here we verify the
+// routing effect using `RequestPin::with_incoming_pin`.
+
+#[tokio::test]
+async fn session_mode_incoming_pin_routes_reads_to_primary() {
+    let state = two_pool_state();
+    let repo: PgRywNoteRepository = extract(&state).await;
+
+    let pin = RequestPin::with_incoming_pin(ReadYourWrites::Session, true);
+    read_your_writes::scope(pin, async {
+        assert!(
+            matches!(repo.__autumn_effective_read_route(), ReadRoute::Primary),
+            "incoming_pin=true must route reads to primary without an explicit write"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn session_mode_expired_pin_routes_reads_to_replica() {
+    let state = two_pool_state();
+    let repo: PgRywNoteRepository = extract(&state).await;
+
+    // incoming_pin=false simulates an expired or absent cookie.
+    let pin = RequestPin::with_incoming_pin(ReadYourWrites::Session, false);
+    read_your_writes::scope(pin, async {
+        assert_eq!(
+            read_pool_size(&repo.__autumn_effective_read_route()),
+            Some(REPLICA_POOL_SIZE),
+            "incoming_pin=false without a write must still use the replica"
+        );
+    })
+    .await;
+}
+
+// ── AC 7: metrics incremented on each pin-redirected read ───────────────────
+
+#[tokio::test]
+async fn metrics_incremented_on_each_pin_redirect() {
+    let state = two_pool_state();
+    let repo: PgRywNoteRepository = extract(&state).await;
+    let metrics = MetricsCollector::new();
+
+    let pin = RequestPin::new_with_metrics(ReadYourWrites::Request, metrics.clone());
+    read_your_writes::scope(pin, async {
+        read_your_writes::mark_write();
+
+        // Two pin-redirected reads.
+        let _ = repo.__autumn_effective_read_route();
+        let _ = repo.__autumn_effective_read_route();
+    })
+    .await;
+
+    let snapshot = metrics.snapshot();
+    assert_eq!(
+        snapshot.read_your_writes_pins_total, 2,
+        "each redirected read must increment the counter"
+    );
+}
+
+// ── Regression: existing snapshot accessor must be unaffected ───────────────
+
+#[tokio::test]
+async fn snapshot_accessor_unaffected_by_ryw_pin() {
+    let state = two_pool_state();
+    let repo: PgRywNoteRepository = extract(&state).await;
+    let pin = RequestPin::new(ReadYourWrites::Request);
+
+    read_your_writes::scope(pin, async {
+        read_your_writes::mark_write();
+
+        // Even when the effective route is Primary, the snapshot is unchanged.
+        assert_eq!(
+            read_pool_size(repo.__autumn_read_route()),
+            Some(REPLICA_POOL_SIZE),
+            "__autumn_read_route() must always return the immutable snapshot"
+        );
+    })
+    .await;
+}

--- a/docs/guide/cloud-native.md
+++ b/docs/guide/cloud-native.md
@@ -448,6 +448,56 @@ The distributed bookmarks example uses this shape explicitly with a primary,
 streaming replica, one migration job, two web replicas, and a readiness gate
 that fails while the replica has not replayed the latest Diesel migration.
 
+## Replication lag and read-your-own-writes
+
+> **Warning — the classic anomaly.** Replication is asynchronous. A read
+> immediately after a write can land on a lagging replica and return stale data
+> — the user submits a form, is redirected, reloads the page, and the change
+> appears gone. DDIA §5 calls this the *read-your-own-writes* anomaly.
+
+Autumn's default behavior routes all replica-eligible reads to the replica
+regardless of whether the same request performed a write. Add
+`read_your_writes` in `[database]` to pin post-write reads to the primary:
+
+```toml
+[database]
+primary_url   = "postgres://user:pass@primary:5432/app"
+replica_url   = "postgres://user:pass@replica:5432/app"
+
+# Option A — intra-request pin only (Laravel "sticky")
+read_your_writes = "request"
+
+# Option B — cross-request pin via signed cookie (Rails automatic role switching)
+read_your_writes = "session"
+pin_after_write_secs = 5          # how long the cookie pins reads; default 5 s
+```
+
+### Modes
+
+| Mode | What happens | Tradeoff |
+|------|-------------|----------|
+| `off` (default) | No pinning. Replica reads always use the replica. | Zero overhead; stale reads possible after writes. |
+| `request` | Once the current request checks out a **primary** connection (via `Db` or a generated mutating method), all subsequent replica-eligible reads in that request route to the primary. | Eliminates intra-request anomalies at negligible overhead. A read-only handler that still injects `Db` will pin its reads unnecessarily — document this in your team's conventions. |
+| `session` | Like `request`, plus a signed `autumn.ryw` cookie pins the same client's reads to the primary for `pin_after_write_secs` seconds after a write. | Eliminates post-redirect anomalies. Adds a small cookie round-trip and increases primary read load during the pin window. |
+
+### Composing with `replica_fallback`
+
+`read_your_writes` and `replica_fallback` are independent: you can have
+`read_your_writes = "request"` and `replica_fallback = "primary"` simultaneously.
+When the replica is unready and fallback is `primary`, all reads already go to
+the primary regardless of the pin. When fallback is `fail_readiness`, a
+`ReadRoute::Unavailable` repo returns an error on reads even while pinned — the
+pin does not bypass the health gate.
+
+### Observability
+
+Every pin-redirected read (a replica-eligible read sent to the primary because
+the pin is active) increments `autumn_read_your_writes_pins_total` in
+`/actuator/metrics` and emits a `DEBUG` event to the `autumn::db` tracing
+target. A spike in this counter after a deployment indicates more reads than
+expected are being pinned — tune `pin_after_write_secs` or audit which handlers
+are injecting `Db` unnecessarily.
+
 ## Shared Cache
 
 In-process Moka caches are the zero-config default and are perfect for


### PR DESCRIPTION
## Summary

Implements read-your-own-writes (RYWW) routing to prevent the classic stale-read anomaly when replication lag is non-zero. After a write in the current request or within a fresh session window, subsequent replica-eligible reads are automatically redirected to the primary.

## Key Changes

- **New `read_your_writes` module** (`autumn/src/read_your_writes.rs`): Core RYWW implementation with three modes:
  - `off` (default): No pinning; preserves existing behavior
  - `request`: Pins reads to primary for the remainder of the request after a write
  - `session`: Extends `request` with cross-request pinning via a signed `autumn.ryw` cookie

- **Configuration additions** (`autumn/src/config.rs`):
  - New `ReadYourWrites` enum with `FromStr` support for TOML parsing
  - `DatabaseConfig::read_your_writes` field (default: `off`)
  - `DatabaseConfig::pin_after_write_secs` field (default: 5 seconds)

- **Repository macro enhancements** (`autumn-macros/src/repository.rs`):
  - New `__autumn_effective_read_route()` method that applies RYWW pin logic
  - Generated mutating methods now call `mark_write()` after successful primary checkout
  - Pin-redirected reads increment metrics and emit trace events

- **Middleware integration** (`autumn/src/router.rs`):
  - New RYWW middleware layer installed when mode is not `off`
  - Handles signed cookie lifecycle in session mode
  - Positioned inner to session layer to wrap the handler

- **Metrics support** (`autumn/src/middleware/metrics.rs`):
  - New `read_your_writes_pins_total` counter tracking pin-redirected reads

- **Database extractor** (`autumn/src/db.rs`):
  - `Db::from_request_parts` now calls `mark_write()` after successful primary checkout

- **Documentation** (`docs/guide/cloud-native.md`):
  - Comprehensive guide explaining the anomaly, modes, tradeoffs, and composition with `replica_fallback`

- **Tests**:
  - Unit tests in `read_your_writes.rs` covering cookie parsing, validation, and scope isolation
  - Integration tests in `read_your_writes_routing.rs` verifying routing behavior across modes

## Implementation Details

- **Task-local design**: Per-request `RequestPin` stored in a tokio task-local, enabling zero-overhead fast-path when mode is `off` (no heap allocation, no task-local access)
- **Atomic flags**: Uses `AtomicBool` for lock-free `wrote` and `pin_traced` state
- **Cookie format**: `{unix_timestamp_secs}.{hmac_hex}` with freshness window validation
- **Metrics**: Pin redirects are counted and traced (once per request to avoid log spam)
- **Isolation**: Concurrent requests have independent task-local scopes; no cross-request state pollution

https://claude.ai/code/session_01G46aPpYgdxa92eBmZsXnkn