### PR TITLE
Extract card and stat_card widgets; refactor admin templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `telemetry-otlp`) — so downstream apps building with a trimmed feature set
   can't silently break between releases (#982).
 
+## [0.6.0] - 2026-06-30
+
+### Added
+
+- **ui:** reusable `card` and `stat_card` Maud widget helpers in
+  `autumn_web::widgets`, re-exported from the prelude. `card()` renders a
+  titled content panel with an optional header-action slot, footer, and
+  configurable heading level (`HeadingLevel::H1`–`H6`, default `H2`);
+  `stat_card()` renders a metric tile with label, value, and optional link.
+  Both are CSP-safe and HTML-escape caller-supplied text via Maud.
+  `CardConfig` uses a builder pattern with `const fn` and private fields
+  so the `title()` / `title_html()` escape path cannot be bypassed.
+  The admin plugin's 12 hand-rolled card blocks and dashboard stat tiles are
+  migrated to the new helpers, removing the duplication (#1122).
+
 ## [0.5.0] - 2026-06-16
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ autumn-web = { path = "autumn" }
 [workspace.package]
 edition = "2024"
 rust-version = "1.88.0"
-version = "0.5.0"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/madmax983/autumn"
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ for that same "ship the app, not the plumbing" shape in Rust.
 
 ```bash
 # Install the published CLI
-cargo install autumn-cli --version 0.5.0
+cargo install autumn-cli --version 0.6.0
 
 # Local development only, from an Autumn checkout:
 # cargo install --path autumn-cli

--- a/autumn-admin-plugin/Cargo.toml
+++ b/autumn-admin-plugin/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["web", "admin", "axum", "htmx", "fullstack"]
 categories = ["web-programming", "web-programming::http-server"]
 
 [dependencies]
-autumn-web = { version = "0.5.0", path = "../autumn", features = ["maud", "htmx", "db", "flash", "multipart"] }
+autumn-web = { version = "0.6.0", path = "../autumn", features = ["maud", "htmx", "db", "flash", "multipart"] }
 axum = { workspace = true, features = ["multipart"] }
 csv = { workspace = true }
 diesel = { workspace = true }

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -134,21 +134,22 @@ const ADMIN_CSS: &str = "
         background: var(--surface);
         border-radius: var(--radius);
         box-shadow: var(--shadow);
-        padding: 1.5rem;
         margin-bottom: 1.5rem;
     }
     .card-header {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        margin-bottom: 1rem;
-        padding-bottom: 0.75rem;
+        padding: 1rem 1.5rem 0.75rem;
         border-bottom: 1px solid var(--border);
     }
     .card-title {
         font-size: 1.125rem;
         font-weight: 600;
         margin: 0;
+    }
+    .card-body {
+        padding: 1.5rem;
     }
 
     /* Buttons */
@@ -632,10 +633,13 @@ fn job_list_card(
             (page.total) " total"
         }
     };
-    let body = html! {
-        div style="font-size: 0.8125rem; color: var(--text-muted); margin-bottom: 0.75rem;" {
+    let title_markup = html! {
+        (title)
+        span style="display: block; font-size: 0.8125rem; color: var(--text-muted); margin-top: 0.25rem; font-weight: 400;" {
             (description)
         }
+    };
+    let body = html! {
         div class="table-wrap" {
             table {
                 thead {
@@ -667,7 +671,7 @@ fn job_list_card(
         }
         (jobs_pagination(page, page_param, prefix))
     };
-    card(&body, &CardConfig::new().title(title).header_action(header_action))
+    card(&body, &CardConfig::new().title_html(title_markup).header_action(header_action))
 }
 
 fn job_row(

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -11,6 +11,7 @@ use autumn_web::job::{
 use autumn_web::pagination::Page;
 use autumn_web::runtime_config::{ConfigChangeRecord, ConfigEntry};
 use autumn_web::ui::pagination::{PagerOptions, pagination_nav};
+use autumn_web::widgets::{CardConfig, card, stat_card};
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 use serde_json::Value;
 
@@ -147,6 +148,7 @@ const ADMIN_CSS: &str = "
     .card-title {
         font-size: 1.125rem;
         font-weight: 600;
+        margin: 0;
     }
 
     /* Buttons */
@@ -625,51 +627,47 @@ fn job_list_card(
     csrf_form_field: &str,
     prefix: &str,
 ) -> Markup {
-    html! {
-        div class="card" {
-            div class="card-header" {
-                div {
-                    span class="card-title" { (title) }
-                    div style="font-size: 0.8125rem; color: var(--text-muted); margin-top: 0.25rem;" {
-                        (description)
+    let header_action = html! {
+        span style="font-size: 0.875rem; color: var(--text-muted);" {
+            (page.total) " total"
+        }
+    };
+    let body = html! {
+        div style="font-size: 0.8125rem; color: var(--text-muted); margin-bottom: 0.75rem;" {
+            (description)
+        }
+        div class="table-wrap" {
+            table {
+                thead {
+                    tr {
+                        th { "Job" }
+                        th { "Enqueued At" }
+                        th { "Started At" }
+                        th { "Finished At" }
+                        th { "Attempts" }
+                        th { "Principal" }
+                        th { "Correlation" }
+                        th { "Last Error" }
+                        th { "Actions" }
                     }
                 }
-                span style="font-size: 0.875rem; color: var(--text-muted);" {
-                    (page.total) " total"
-                }
-            }
-            div class="table-wrap" {
-                table {
-                    thead {
+                tbody {
+                    @if page.records.is_empty() {
                         tr {
-                            th { "Job" }
-                            th { "Enqueued At" }
-                            th { "Started At" }
-                            th { "Finished At" }
-                            th { "Attempts" }
-                            th { "Principal" }
-                            th { "Correlation" }
-                            th { "Last Error" }
-                            th { "Actions" }
-                        }
-                    }
-                    tbody {
-                        @if page.records.is_empty() {
-                            tr {
-                                td colspan="9" style="text-align: center; padding: 1.5rem; color: var(--text-muted);" {
-                                    "No jobs."
-                                }
+                            td colspan="9" style="text-align: center; padding: 1.5rem; color: var(--text-muted);" {
+                                "No jobs."
                             }
                         }
-                        @for record in &page.records {
-                            (job_row(record, csrf_token, csrf_form_field, prefix))
-                        }
+                    }
+                    @for record in &page.records {
+                        (job_row(record, csrf_token, csrf_form_field, prefix))
                     }
                 }
             }
-            (jobs_pagination(page, page_param, prefix))
         }
-    }
+        (jobs_pagination(page, page_param, prefix))
+    };
+    card(&body, &CardConfig::new().title(title).header_action(header_action))
 }
 
 fn job_row(
@@ -774,42 +772,38 @@ fn jobs_pagination(page: &JobAdminPage, page_param: &str, prefix: &str) -> Marku
 }
 
 fn job_schedules_card(schedules: &[JobScheduleSummary]) -> Markup {
-    html! {
-        div class="card" {
-            div class="card-header" {
-                span class="card-title" { "Recurring Schedules" }
-            }
-            div class="table-wrap" {
-                table {
-                    thead {
+    let body = html! {
+        div class="table-wrap" {
+            table {
+                thead {
+                    tr {
+                        th { "Name" }
+                        th { "Schedule" }
+                        th { "Next Run At" }
+                        th { "Last Run Status" }
+                    }
+                }
+                tbody {
+                    @if schedules.is_empty() {
                         tr {
-                            th { "Name" }
-                            th { "Schedule" }
-                            th { "Next Run At" }
-                            th { "Last Run Status" }
+                            td colspan="4" style="text-align: center; padding: 1.5rem; color: var(--text-muted);" {
+                                "No scheduled tasks registered."
+                            }
                         }
                     }
-                    tbody {
-                        @if schedules.is_empty() {
-                            tr {
-                                td colspan="4" style="text-align: center; padding: 1.5rem; color: var(--text-muted);" {
-                                    "No scheduled tasks registered."
-                                }
-                            }
-                        }
-                        @for schedule in schedules {
-                            tr {
-                                td { (schedule.name) }
-                                td { (schedule.schedule) }
-                                td { (optional_text(schedule.next_run_at.as_deref())) }
-                                td { (optional_text(schedule.last_run_status.as_deref())) }
-                            }
+                    @for schedule in schedules {
+                        tr {
+                            td { (schedule.name) }
+                            td { (schedule.schedule) }
+                            td { (optional_text(schedule.next_run_at.as_deref())) }
+                            td { (optional_text(schedule.last_run_status.as_deref())) }
                         }
                     }
                 }
             }
         }
-    }
+    };
+    card(&body, &CardConfig::new().title("Recurring Schedules"))
 }
 
 fn optional_text(value: Option<&str>) -> Markup {
@@ -840,26 +834,22 @@ pub fn dashboard_page(
 
         div class="stats-grid" {
             @for (slug, name, count) in model_counts {
-                div class="stat-card" {
-                    div class="stat-label" { (name) }
-                    div class="stat-value" { (count) }
-                    div class="stat-link" {
-                        a href={ (prefix) "/" (slug) } { "View all →" }
-                    }
-                }
+                (stat_card(name, &count.to_string(), Some((&format!("{prefix}/{slug}"), "View all →"))))
             }
         }
 
         // Actuator summary (loaded via HTMX)
-        div class="card" {
-            div class="card-header" {
-                span class="card-title" { "System Health" }
+        ({
+            let action = html! {
                 a href={ (actuator_prefix) "/ui" } class="btn btn-sm" { "Full Dashboard →" }
-            }
-            div hx-get={ (actuator_prefix) "/ui/metrics" } hx-trigger="load, every 5s" {
-                "Loading metrics…"
-            }
-        }
+            };
+            let body = html! {
+                div hx-get={ (actuator_prefix) "/ui/metrics" } hx-trigger="load, every 5s" {
+                    "Loading metrics…"
+                }
+            };
+            card(&body, &CardConfig::new().title("System Health").header_action(action))
+        })
     };
     admin_layout(
         registry,
@@ -946,14 +936,14 @@ pub fn model_list_page(
             span { (model_name_plural) }
         }
 
-        div class="card" {
-            div class="card-header" {
-                span class="card-title" {
-                    (model_name_plural)
-                    span style="font-weight: 400; color: var(--text-muted); margin-left: 0.5rem;" {
-                        "(" (result.total) ")"
-                    }
+        ({
+            let title = html! {
+                (model_name_plural)
+                span style="font-weight: 400; color: var(--text-muted); margin-left: 0.5rem;" {
+                    "(" (result.total) ")"
                 }
+            };
+            let header_action = html! {
                 div style="display: flex; gap: 0.5rem; align-items: center;" {
                     @if supports_csv_export {
                         a href=(export_csv_url) class="btn btn-sm"
@@ -971,101 +961,102 @@ pub fn model_list_page(
                         "+ Add " (model_slug.trim_end_matches('s'))
                     }
                 }
-            }
-
-            // Search. Hidden inputs preserve any active filters so both
-            // full-form GET submits AND live-search HTMX requests carry
-            // the filter set forward (htmx only includes the triggering
-            // element by default — `hx-include="closest form"` pulls in
-            // every input in the form, including the filter hiddens).
-            form class="search-bar" method="get" {
-                input type="search" name="q" placeholder="Search…"
-                    value=(search_query)
-                    hx-get={ (prefix) "/" (model_slug) }
-                    hx-trigger="input changed delay:300ms"
-                    hx-include="closest form"
-                    hx-target="closest .card"
-                    hx-select=".card > *"
-                    hx-push-url="true" {}
-                @for (k, v) in filters {
-                    input type="hidden" name={ "filter." (k) } value=(v);
-                }
-            }
-
-            // Bulk-action form wraps the table so the row checkboxes
-            // submit alongside the action selector.
-            form method="post" action={ (prefix) "/" (model_slug) "/actions" } {
-                (csrf_hidden_input(csrf_token, csrf_form_field))
-
-            // Table
-            div class="table-wrap" {
-                table {
-                    thead {
-                        tr {
-                            th class="checkbox-cell" {
-                                // Wired up by admin.js via event delegation on #select-all.
-                                input type="checkbox" id="select-all";
-                            }
-                            @for field in &list_fields {
-                                @let is_sorted = sort_by == Some(field.name);
-                                @let next_dir = if is_sorted { sort_dir.flipped() } else { SortDirection::Asc };
-                                th {
-                                    @if field.sortable {
-                                        a href={ (prefix) "/" (model_slug) "?sort=" (field.name) "&dir=" (next_dir.as_str())
-                                            @if !search_enc.is_empty() { "&q=" (search_enc) }
-                                            (filters_enc)
-                                        }
-                                        style="color: inherit; text-decoration: none;" {
-                                            (field.label)
-                                            @if is_sorted {
-                                                span class="sort-icon" {
-                                                    @if matches!(sort_dir, SortDirection::Asc) { "▲" } @else { "▼" }
-                                                }
-                                            }
-                                        }
-                                    } @else {
-                                        (field.label)
-                                    }
-                                }
-                            }
-                            th { "Actions" }
-                        }
+            };
+            let body = html! {
+                // Search. Hidden inputs preserve any active filters so both
+                // full-form GET submits AND live-search HTMX requests carry
+                // the filter set forward (htmx only includes the triggering
+                // element by default — `hx-include="closest form"` pulls in
+                // every input in the form, including the filter hiddens).
+                form class="search-bar" method="get" {
+                    input type="search" name="q" placeholder="Search…"
+                        value=(search_query)
+                        hx-get={ (prefix) "/" (model_slug) }
+                        hx-trigger="input changed delay:300ms"
+                        hx-include="closest form"
+                        hx-target="closest .card"
+                        hx-select=".card > *"
+                        hx-push-url="true" {}
+                    @for (k, v) in filters {
+                        input type="hidden" name={ "filter." (k) } value=(v);
                     }
-                    tbody {
-                        @if result.records.is_empty() {
+                }
+
+                // Bulk-action form wraps the table so the row checkboxes
+                // submit alongside the action selector.
+                form method="post" action={ (prefix) "/" (model_slug) "/actions" } {
+                    (csrf_hidden_input(csrf_token, csrf_form_field))
+
+                // Table
+                div class="table-wrap" {
+                    table {
+                        thead {
                             tr {
-                                td colspan=(list_fields.len() + 2)
-                                    style="text-align: center; padding: 2rem; color: var(--text-muted);" {
-                                    "No records found."
-                                }
-                            }
-                        }
-                        @for record in &result.records {
-                            @let row_id = record_id(record);
-                            tr {
-                                td class="checkbox-cell" {
-                                    // Only emit a bulk-action checkbox for rows with a
-                                    // routable id — otherwise the form would post id="" or
-                                    // the wrong record.
-                                    @if let Some(id) = row_id {
-                                        input type="checkbox" class="row-check"
-                                            name="ids" value=(id);
-                                    }
+                                th class="checkbox-cell" {
+                                    // Wired up by admin.js via event delegation on #select-all.
+                                    input type="checkbox" id="select-all";
                                 }
                                 @for field in &list_fields {
-                                    td { (render_cell_value(record, field)) }
+                                    @let is_sorted = sort_by == Some(field.name);
+                                    @let next_dir = if is_sorted { sort_dir.flipped() } else { SortDirection::Asc };
+                                    th {
+                                        @if field.sortable {
+                                            a href={ (prefix) "/" (model_slug) "?sort=" (field.name) "&dir=" (next_dir.as_str())
+                                                @if !search_enc.is_empty() { "&q=" (search_enc) }
+                                                (filters_enc)
+                                            }
+                                            style="color: inherit; text-decoration: none;" {
+                                                (field.label)
+                                                @if is_sorted {
+                                                    span class="sort-icon" {
+                                                        @if matches!(sort_dir, SortDirection::Asc) { "▲" } @else { "▼" }
+                                                    }
+                                                }
+                                            }
+                                        } @else {
+                                            (field.label)
+                                        }
+                                    }
                                 }
-                                td {
-                                    @if let Some(id) = row_id {
-                                        a href={ (prefix) "/" (model_slug) "/" (id) }
-                                            class="btn btn-sm" { "View" }
-                                        " "
-                                        a href={ (prefix) "/" (model_slug) "/" (id) "/edit" }
-                                            class="btn btn-sm" { "Edit" }
-                                    } @else {
-                                        // Surface the issue rather than rendering links to /0.
-                                        span style="color: var(--text-muted); font-size: 0.75rem;" {
-                                            "no id"
+                                th { "Actions" }
+                            }
+                        }
+                        tbody {
+                            @if result.records.is_empty() {
+                                tr {
+                                    td colspan=(list_fields.len() + 2)
+                                        style="text-align: center; padding: 2rem; color: var(--text-muted);" {
+                                        "No records found."
+                                    }
+                                }
+                            }
+                            @for record in &result.records {
+                                @let row_id = record_id(record);
+                                tr {
+                                    td class="checkbox-cell" {
+                                        // Only emit a bulk-action checkbox for rows with a
+                                        // routable id — otherwise the form would post id="" or
+                                        // the wrong record.
+                                        @if let Some(id) = row_id {
+                                            input type="checkbox" class="row-check"
+                                                name="ids" value=(id);
+                                        }
+                                    }
+                                    @for field in &list_fields {
+                                        td { (render_cell_value(record, field)) }
+                                    }
+                                    td {
+                                        @if let Some(id) = row_id {
+                                            a href={ (prefix) "/" (model_slug) "/" (id) }
+                                                class="btn btn-sm" { "View" }
+                                            " "
+                                            a href={ (prefix) "/" (model_slug) "/" (id) "/edit" }
+                                                class="btn btn-sm" { "Edit" }
+                                        } @else {
+                                            // Surface the issue rather than rendering links to /0.
+                                            span style="color: var(--text-muted); font-size: 0.75rem;" {
+                                                "no id"
+                                            }
                                         }
                                     }
                                 }
@@ -1073,35 +1064,36 @@ pub fn model_list_page(
                         }
                     }
                 }
-            }
 
-                // Bulk-action bar — only rendered when the model declares
-                // at least one action. Sits below the table inside the
-                // wrapping form.
-                @if !actions.is_empty() {
-                    div class="action-bar" {
-                        label for="bulk-action" { "With selected:" }
-                        select name="action" id="bulk-action" class="form-input"
-                            style="width: auto; display: inline-block;" {
-                            @for a in actions {
-                                option value=(a.name) data-confirm=[a.confirm.then_some("1")] {
-                                    (a.label)
+                    // Bulk-action bar — only rendered when the model declares
+                    // at least one action. Sits below the table inside the
+                    // wrapping form.
+                    @if !actions.is_empty() {
+                        div class="action-bar" {
+                            label for="bulk-action" { "With selected:" }
+                            select name="action" id="bulk-action" class="form-input"
+                                style="width: auto; display: inline-block;" {
+                                @for a in actions {
+                                    option value=(a.name) data-confirm=[a.confirm.then_some("1")] {
+                                        (a.label)
+                                    }
                                 }
                             }
-                        }
-                        button type="submit" class="btn" data-bulk-submit="1" {
-                            "Apply"
+                            button type="submit" class="btn" data-bulk-submit="1" {
+                                "Apply"
+                            }
                         }
                     }
+
+                } // /form
+
+                // Pagination
+                @if result.total_pages() > 1 {
+                    (render_pagination(result, model_slug, &search_enc, sort_by, sort_dir, &filters_enc, prefix))
                 }
-
-            } // /form
-
-            // Pagination
-            @if result.total_pages() > 1 {
-                (render_pagination(result, model_slug, &search_enc, sort_by, sort_dir, &filters_enc, prefix))
-            }
-        }
+            };
+            card(&body, &CardConfig::new().title_html(title).header_action(header_action))
+        })
     };
     admin_layout(
         registry,
@@ -1142,12 +1134,9 @@ pub fn model_import_form_page(
             span { "Import CSV" }
         }
 
-        div class="card" {
-            div class="card-header" {
-                span class="card-title" { "Import " (model_name_plural) " from CSV" }
-            }
-
-            div style="padding: 1.5rem;" {
+        ({
+            let title = html! { "Import " (model_name_plural) " from CSV" };
+            let body = html! {
                 p style="color: var(--text-muted); margin-bottom: 1rem;" {
                     "Upload a CSV file with a header row. Column names must match the model's field names."
                 }
@@ -1200,8 +1189,9 @@ pub fn model_import_form_page(
                         }
                     }
                 }
-            }
-        }
+            };
+            card(&body, &CardConfig::new().title_html(title))
+        })
     };
 
     admin_layout(
@@ -1248,12 +1238,9 @@ pub fn model_import_result_page(
             span { "Import Result" }
         }
 
-        div class="card" {
-            div class="card-header" {
-                span class="card-title" { "Import Report — " (mode_label) }
-            }
-
-            div style="padding: 1.5rem;" {
+        ({
+            let title = html! { "Import Report — " (mode_label) };
+            let body = html! {
                 div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; margin-bottom: 1.5rem;" {
                     div style="text-align: center; padding: 1rem; background: var(--success-light); border-radius: 0.375rem;" {
                         div style="font-size: 1.5rem; font-weight: 700; color: var(--success);" { (report.inserted) }
@@ -1316,8 +1303,9 @@ pub fn model_import_result_page(
                     a href={ (prefix) "/" (model_slug) } class="btn btn-primary" { "Back to list" }
                     a href={ (prefix) "/" (model_slug) "/import" } class="btn" { "Import another file" }
                 }
-            }
-        }
+            };
+            card(&body, &CardConfig::new().title_html(title))
+        })
     };
 
     admin_layout(
@@ -1367,9 +1355,8 @@ pub fn model_detail_page(
             span { (record_display) }
         }
 
-        div class="card" {
-            div class="card-header" {
-                span class="card-title" { (record_display) }
+        ({
+            let header_action = html! {
                 div {
                     @if has_history {
                         a href={ (prefix) "/" (model_slug) "/" (id) "/history" }
@@ -1386,17 +1373,19 @@ pub fn model_detail_page(
                         "Delete"
                     }
                 }
-            }
-
-            div class="detail-grid" {
-                @for field in fields {
-                    div class="detail-label" { (field.label) }
-                    div class="detail-value" {
-                        (render_detail_value(record, field))
+            };
+            let body = html! {
+                div class="detail-grid" {
+                    @for field in fields {
+                        div class="detail-label" { (field.label) }
+                        div class="detail-value" {
+                            (render_detail_value(record, field))
+                        }
                     }
                 }
-            }
-        }
+            };
+            card(&body, &CardConfig::new().title(record_display).header_action(header_action))
+        })
     };
     admin_layout(
         registry,
@@ -1452,49 +1441,48 @@ pub fn model_form_page(
             span { (title) }
         }
 
-        div class="card" {
-            div class="card-header" {
-                span class="card-title" { (title) }
-            }
+        ({
+            let body = html! {
+                form method="post"
+                    action={
+                        @if let Some(id) = id {
+                            (prefix) "/" (model_slug) "/" (id)
+                        } @else {
+                            (prefix) "/" (model_slug)
+                        }
+                    } {
+                    (csrf_hidden_input(csrf_token, csrf_form_field))
 
-            form method="post"
-                action={
-                    @if let Some(id) = id {
-                        (prefix) "/" (model_slug) "/" (id)
-                    } @else {
-                        (prefix) "/" (model_slug)
-                    }
-                } {
-                (csrf_hidden_input(csrf_token, csrf_form_field))
-
-                @for field in &editable_fields {
-                    div class="form-group" {
-                        label class="form-label" for=(field.name) {
-                            (field.label)
-                            @if field.required && !(is_edit && field.create_only) {
-                                span class="required" { "*" }
+                    @for field in &editable_fields {
+                        div class="form-group" {
+                            label class="form-label" for=(field.name) {
+                                (field.label)
+                                @if field.required && !(is_edit && field.create_only) {
+                                    span class="required" { "*" }
+                                }
+                            }
+                            @if is_edit && field.create_only {
+                                // Immutable-after-create: show current value as read-only text
+                                // so the admin can see it but cannot change it.
+                                (render_readonly_display(field, record))
+                            } @else {
+                                (render_form_widget(field, record))
                             }
                         }
-                        @if is_edit && field.create_only {
-                            // Immutable-after-create: show current value as read-only text
-                            // so the admin can see it but cannot change it.
-                            (render_readonly_display(field, record))
-                        } @else {
-                            (render_form_widget(field, record))
+                    }
+
+                    div style="display: flex; gap: 0.75rem; margin-top: 1.5rem;" {
+                        button type="submit" class="btn btn-primary" {
+                            @if is_edit { "Save Changes" } @else { "Create" }
+                        }
+                        a href={ (prefix) "/" (model_slug) } class="btn" {
+                            "Cancel"
                         }
                     }
                 }
-
-                div style="display: flex; gap: 0.75rem; margin-top: 1.5rem;" {
-                    button type="submit" class="btn btn-primary" {
-                        @if is_edit { "Save Changes" } @else { "Create" }
-                    }
-                    a href={ (prefix) "/" (model_slug) } class="btn" {
-                        "Cancel"
-                    }
-                }
-            }
-        }
+            };
+            card(&body, &CardConfig::new().title(&title))
+        })
     };
     admin_layout(
         registry,
@@ -1539,7 +1527,7 @@ pub fn config_page(
         }
 
         @if entries.is_empty() {
-            div class="card" {
+            (card(&html! {
                 p style="color: var(--text-muted); padding: 1rem;" {
                     "No config keys have been registered. Declare keys with "
                     code { "ConfigRegistry::define" }
@@ -1547,9 +1535,9 @@ pub fn config_page(
                     code { "AdminPlugin::with_runtime_config" }
                     "."
                 }
-            }
+            }, &CardConfig::new()))
         } @else {
-            div class="card" {
+            (card(&html! {
                 table class="table" {
                     thead {
                         tr {
@@ -1617,7 +1605,7 @@ pub fn config_page(
                         }
                     }
                 }
-            }
+            }, &CardConfig::new()))
         }
     };
     admin_layout(
@@ -1660,7 +1648,7 @@ pub fn config_history_page(
             "History: " (key)
         }
 
-        div class="card" {
+        (card(&html! {
             @if history.is_empty() {
                 p style="color: var(--text-muted); padding: 1rem;" {
                     "No changes recorded for this key yet."
@@ -1711,7 +1699,7 @@ pub fn config_history_page(
                     }
                 }
             }
-        }
+        }, &CardConfig::new()))
 
         a href={ (prefix) "/config" } class="btn" style="margin-top: 1rem;" {
             "← Back to Runtime Config"
@@ -2162,69 +2150,67 @@ pub fn model_history_page(
             span { "History" }
         }
 
-        div class="card" {
-            div class="card-header" {
-                span class="card-title" { "Version History" }
-                small { " " (history.total) " entries" }
-            }
-
-            @if history.entries.is_empty() {
-                p class="text-muted" style="padding:1rem" { "No history entries yet." }
-            } @else {
-                table class="admin-table" {
-                    thead {
-                        tr {
-                            th { "#" }
-                            th { "Operation" }
-                            th { "Actor" }
-                            th { "Request ID" }
-                            th { "Changes" }
-                            th { "Recorded At" }
-                        }
-                    }
-                    tbody {
-                        @for entry in &history.entries {
+        ({
+            let header_action = html! { small { " " (history.total) " entries" } };
+            let body = html! {
+                @if history.entries.is_empty() {
+                    p class="text-muted" style="padding:1rem" { "No history entries yet." }
+                } @else {
+                    table class="admin-table" {
+                        thead {
                             tr {
-                                td { (entry.id) }
-                                td {
-                                    span class={ "badge badge-" (entry.op) } { (entry.op) }
-                                }
-                                td { code { (entry.actor) } }
-                                td {
-                                    @if let Some(ref req_id) = entry.request_id {
-                                        code class="text-muted" { (req_id) }
-                                    } @else {
-                                        span class="text-muted" { "—" }
+                                th { "#" }
+                                th { "Operation" }
+                                th { "Actor" }
+                                th { "Request ID" }
+                                th { "Changes" }
+                                th { "Recorded At" }
+                            }
+                        }
+                        tbody {
+                            @for entry in &history.entries {
+                                tr {
+                                    td { (entry.id) }
+                                    td {
+                                        span class={ "badge badge-" (entry.op) } { (entry.op) }
                                     }
-                                }
-                                td {
-                                    @if entry.changes.is_empty() {
-                                        span class="text-muted" { "no changes" }
-                                    } @else {
-                                        details {
-                                            summary { (entry.changes.len()) " column(s)" }
-                                            ul class="change-list" {
-                                                @for change in &entry.changes {
-                                                    li {
-                                                        @if let Some(col) = change.get("column").and_then(Value::as_str) {
-                                                            code { (col) }
-                                                        }
-                                                        @if change.get("sensitive").and_then(Value::as_bool).unwrap_or(false) {
-                                                            span class="badge-sensitive" { " [sensitive]" }
-                                                        } @else {
-                                                            " "
-                                                            span class="text-muted" { "before: " }
-                                                            @if let Some(before) = change.get("before") {
-                                                                code { (before) }
-                                                            } @else {
-                                                                em { "null" }
+                                    td { code { (entry.actor) } }
+                                    td {
+                                        @if let Some(ref req_id) = entry.request_id {
+                                            code class="text-muted" { (req_id) }
+                                        } @else {
+                                            span class="text-muted" { "—" }
+                                        }
+                                    }
+                                    td {
+                                        @if entry.changes.is_empty() {
+                                            span class="text-muted" { "no changes" }
+                                        } @else {
+                                            details {
+                                                summary { (entry.changes.len()) " column(s)" }
+                                                ul class="change-list" {
+                                                    @for change in &entry.changes {
+                                                        li {
+                                                            @if let Some(col) = change.get("column").and_then(Value::as_str) {
+                                                                code { (col) }
                                                             }
-                                                            " → "
-                                                            span class="text-muted" { "after: " }
-                                                            @if let Some(after) = change.get("after") {
-                                                                code { (after) }
+                                                            @if change.get("sensitive").and_then(Value::as_bool).unwrap_or(false) {
+                                                                span class="badge-sensitive" { " [sensitive]" }
                                                             } @else {
-                                                                em { "null" }
+                                                                " "
+                                                                span class="text-muted" { "before: " }
+                                                                @if let Some(before) = change.get("before") {
+                                                                    code { (before) }
+                                                                } @else {
+                                                                    em { "null" }
+                                                                }
+                                                                " → "
+                                                                span class="text-muted" { "after: " }
+                                                                @if let Some(after) = change.get("after") {
+                                                                    code { (after) }
+                                                                } @else {
+                                                                    em { "null" }
+                                                                }
                                                             }
                                                         }
                                                     }
@@ -2232,32 +2218,33 @@ pub fn model_history_page(
                                             }
                                         }
                                     }
-                                }
-                                td {
-                                    time datetime=(entry.recorded_at.to_rfc3339()) {
-                                        (entry.recorded_at.format("%Y-%m-%d %H:%M:%S UTC"))
+                                    td {
+                                        time datetime=(entry.recorded_at.to_rfc3339()) {
+                                            (entry.recorded_at.format("%Y-%m-%d %H:%M:%S UTC"))
+                                        }
                                     }
                                 }
                             }
                         }
                     }
-                }
 
-                @if history.total_pages() > 1 {
-                    div class="pagination" {
-                        @if history.page > 1 {
-                            a href=(history_page_href(history.page - 1))
-                                class="btn btn-secondary btn-sm" { "← Prev" }
-                        }
-                        span { " Page " (history.page) " of " (history.total_pages()) " " }
-                        @if history.has_next_page() {
-                            a href=(history_page_href(history.page + 1))
-                                class="btn btn-secondary btn-sm" { "Next →" }
+                    @if history.total_pages() > 1 {
+                        div class="pagination" {
+                            @if history.page > 1 {
+                                a href=(history_page_href(history.page - 1))
+                                    class="btn btn-secondary btn-sm" { "← Prev" }
+                            }
+                            span { " Page " (history.page) " of " (history.total_pages()) " " }
+                            @if history.has_next_page() {
+                                a href=(history_page_href(history.page + 1))
+                                    class="btn btn-secondary btn-sm" { "Next →" }
+                            }
                         }
                     }
                 }
-            }
-        }
+            };
+            card(&body, &CardConfig::new().title("Version History").header_action(header_action))
+        })
     };
     admin_layout(
         registry,

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -671,7 +671,12 @@ fn job_list_card(
         }
         (jobs_pagination(page, page_param, prefix))
     };
-    card(&body, &CardConfig::new().title_html(title_markup).header_action(header_action))
+    card(
+        &body,
+        &CardConfig::new()
+            .title_html(title_markup)
+            .header_action(header_action),
+    )
 }
 
 fn job_row(

--- a/autumn-cache-redis/Cargo.toml
+++ b/autumn-cache-redis/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["web", "redis", "cache", "axum", "fullstack"]
 categories = ["web-programming", "web-programming::http-server"]
 
 [dependencies]
-autumn-web = { version = "0.5.0", path = "../autumn", features = ["redis"] }
+autumn-web = { version = "0.6.0", path = "../autumn", features = ["redis"] }
 redis = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/autumn-cli/Cargo.toml
+++ b/autumn-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "autumn"
 path = "src/main.rs"
 
 [dependencies]
-autumn-web = { version = "0.5.0", path = "../autumn", default-features = false, features = [
+autumn-web = { version = "0.6.0", path = "../autumn", default-features = false, features = [
     "db", "htmx", "maud", "mail", "storage", "i18n", "telemetry-otlp", "redis", "cache-moka", "http-client", "reporting"
 ] }
 base64 = "0.22"

--- a/autumn-storage-s3/Cargo.toml
+++ b/autumn-storage-s3/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["web", "s3", "storage", "axum", "fullstack"]
 categories = ["web-programming", "web-programming::http-server"]
 
 [dependencies]
-autumn-web = { version = "0.5.0", path = "../autumn", features = ["storage"] }
+autumn-web = { version = "0.6.0", path = "../autumn", features = ["storage"] }
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-credential-types = { version = "1", features = ["hardcoded-credentials"] }
 aws-runtime = ">=1, <1.7"

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -114,7 +114,7 @@ managed-pg = ["db", "dep:postgresql_embedded"]
 managed-pg-bundled = ["managed-pg", "postgresql_embedded/bundled"]
 
 [dependencies]
-autumn-macros = { version = "0.5.0", path = "../autumn-macros" }
+autumn-macros = { version = "0.6.0", path = "../autumn-macros" }
 axum.workspace = true
 bytes = "1"
 http-body = "1"

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -176,10 +176,9 @@ pub use crate::form::{Changeset, ChangesetForm, IntoChangeset};
 #[cfg(feature = "maud")]
 pub use crate::widgets::{
     ActiveSearchConfig, AutocompleteConfig, CardConfig, Column, Crumb, DataTableConfig,
-    HeadingLevel, SearchMethod, SortDir,
-    active_search, active_search_empty_state, active_search_input, active_search_results,
-    autocomplete_empty_state, autocomplete_input, autocomplete_option, breadcrumb, card,
-    data_table, property_list, stat_card,
+    HeadingLevel, SearchMethod, SortDir, active_search, active_search_empty_state,
+    active_search_input, active_search_results, autocomplete_empty_state, autocomplete_input,
+    autocomplete_option, breadcrumb, card, data_table, property_list, stat_card,
 };
 
 // ── Hooks ───────────────────────────────────────────────────────

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -168,15 +168,18 @@ pub use validator::Validate;
 /// See [`crate::form`] for the full surface including Maud rendering helpers.
 pub use crate::form::{Changeset, ChangesetForm, IntoChangeset};
 
-// ── Search & autocomplete widgets ─────────────────────────────────
-/// Active search, autocomplete, data table, and breadcrumb configuration types and rendering helpers.
+// ── Display & search widgets ───────────────────────────────────────
+/// Card, stat tile, active search, autocomplete, data table, property list,
+/// and breadcrumb configuration types and rendering helpers.
 ///
 /// See [`crate::widgets`] for the full API.
 #[cfg(feature = "maud")]
 pub use crate::widgets::{
-    ActiveSearchConfig, AutocompleteConfig, Column, Crumb, DataTableConfig, SearchMethod, SortDir,
+    ActiveSearchConfig, AutocompleteConfig, CardConfig, Column, Crumb, DataTableConfig,
+    HeadingLevel, SearchMethod, SortDir,
     active_search, active_search_empty_state, active_search_input, active_search_results,
-    autocomplete_empty_state, autocomplete_input, autocomplete_option, breadcrumb, data_table,
+    autocomplete_empty_state, autocomplete_input, autocomplete_option, breadcrumb, card,
+    data_table, property_list, stat_card,
 };
 
 // ── Hooks ───────────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1154,16 +1154,16 @@ pub struct CardConfig<'a> {
     /// Optional title text rendered in a `<hN class="card-title">` element.
     /// Set via [`CardConfig::title`] (HTML-escaped) or [`CardConfig::title_html`]
     /// (pre-built [`maud::Markup`] for rich content).
-    pub title: Option<maud::Markup>,
+    title: Option<maud::Markup>,
     /// Heading level for the title element (default [`HeadingLevel::H2`]).
-    pub level: HeadingLevel,
+    level: HeadingLevel,
     /// Optional right-side header slot — e.g. action buttons.
     /// Rendered inside `card-header` alongside the title.
-    pub header_action: Option<maud::Markup>,
+    header_action: Option<maud::Markup>,
     /// Optional footer content rendered in `<div class="card-footer">`.
-    pub footer: Option<maud::Markup>,
+    footer: Option<maud::Markup>,
     /// Extra CSS class(es) appended to the root `card` element.
-    pub class: Option<&'a str>,
+    class: Option<&'a str>,
 }
 
 #[cfg(feature = "maud")]
@@ -2357,23 +2357,25 @@ mod tests {
 
     #[test]
     fn card_config_defaults() {
-        let c = CardConfig::new();
-        assert!(c.title.is_none());
-        assert_eq!(c.level, HeadingLevel::H2);
-        assert!(c.header_action.is_none());
-        assert!(c.footer.is_none());
-        assert!(c.class.is_none());
+        // no title/action → no card-header rendered
+        let html = card(&maud::html! {}, &CardConfig::new()).into_string();
+        assert!(!html.contains("card-header"), "{html}");
+        assert!(!html.contains("card-footer"), "{html}");
+        // default heading level is H2: setting a title renders <h2
+        let html2 = card(&maud::html! {}, &CardConfig::new().title("X")).into_string();
+        assert!(html2.contains("<h2"), "{html2}");
     }
 
     #[test]
     fn card_config_builders_chain() {
-        let c = CardConfig::new()
-            .title("T")
-            .level(HeadingLevel::H3)
-            .class("wide");
-        assert!(c.title.is_some());
-        assert_eq!(c.level, HeadingLevel::H3);
-        assert_eq!(c.class, Some("wide"));
+        let html = card(
+            &maud::html! {},
+            &CardConfig::new().title("T").level(HeadingLevel::H3).class("wide"),
+        )
+        .into_string();
+        assert!(html.contains(r#"class="card wide""#), "{html}");
+        assert!(html.contains("<h3"), "{html}");
+        assert!(html.contains("T"), "{html}");
     }
 
     // ── card structure ─────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1,10 +1,20 @@
-//! Active search and autocomplete form primitives with htmx integration.
+//! Server-rendered widget helpers: display primitives and interactive search.
 //!
-//! These helpers generate server-rendered HTML with embedded htmx attributes
-//! so Autumn applications can add live search and autocomplete with zero
-//! custom JavaScript.
+//! All widgets return [`maud::Markup`] and are composable — pass the output of
+//! one as the body of another. Every widget is CSP-safe (no inline JS) and
+//! HTML-escapes caller-supplied text via Maud.
 //!
-//! # Choosing the right primitive
+//! # Display widgets
+//!
+//! | Widget | Use |
+//! |--------|-----|
+//! | [`card`] | Titled content panel with optional header action and footer |
+//! | [`stat_card`] | Metric tile: label / value / optional link |
+//! | [`property_list`] | `<dl>` of label/value rows for a record detail view |
+//! | [`data_table`] | Column-driven, sortable `<table>` |
+//! | [`breadcrumb`] | Accessible `<nav>` breadcrumb trail |
+//!
+//! # Interactive / search widgets
 //!
 //! | Situation | Use |
 //! |-----------|-----|
@@ -1097,6 +1107,266 @@ pub fn breadcrumb(crumbs: &[Crumb<'_>]) -> maud::Markup {
     }
 }
 
+// ── card ──────────────────────────────────────────────────────────────────
+
+/// Heading level for the title element inside a [`card`].
+///
+/// Used by [`CardConfig::level`] to pick the `<h1>`–`<h6>` element that wraps
+/// the card title. Defaults to `<h2>`.
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HeadingLevel {
+    /// `<h1>`
+    H1,
+    /// `<h2>` (default)
+    #[default]
+    H2,
+    /// `<h3>`
+    H3,
+    /// `<h4>`
+    H4,
+    /// `<h5>`
+    H5,
+    /// `<h6>`
+    H6,
+}
+
+/// Configuration for a [`card`] widget.
+///
+/// Build with [`CardConfig::new`] and chain builder methods for optional slots.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::widgets::{CardConfig, HeadingLevel, card};
+/// use maud::html;
+///
+/// let action = html! { a class="btn" href="/posts/new" { "+ New" } };
+/// let config = CardConfig::new()
+///     .title("Posts")
+///     .level(HeadingLevel::H2)
+///     .header_action(action);
+/// let markup = card(&html! { p { "body" } }, &config);
+/// ```
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone, Default)]
+pub struct CardConfig<'a> {
+    /// Optional title text rendered in a `<hN class="card-title">` element.
+    /// Set via [`CardConfig::title`] (HTML-escaped) or [`CardConfig::title_html`]
+    /// (pre-built [`maud::Markup`] for rich content).
+    pub title: Option<maud::Markup>,
+    /// Heading level for the title element (default [`HeadingLevel::H2`]).
+    pub level: HeadingLevel,
+    /// Optional right-side header slot — e.g. action buttons.
+    /// Rendered inside `card-header` alongside the title.
+    pub header_action: Option<maud::Markup>,
+    /// Optional footer content rendered in `<div class="card-footer">`.
+    pub footer: Option<maud::Markup>,
+    /// Extra CSS class(es) appended to the root `card` element.
+    pub class: Option<&'a str>,
+}
+
+#[cfg(feature = "maud")]
+impl<'a> CardConfig<'a> {
+    /// Create a new card configuration with all slots empty and heading level `H2`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            title: None,
+            level: HeadingLevel::H2,
+            header_action: None,
+            footer: None,
+            class: None,
+        }
+    }
+
+    /// Set the card title from a plain `&str`. The text is HTML-escaped by Maud.
+    ///
+    /// Use [`CardConfig::title_html`] when you need rich markup inside the heading.
+    #[must_use]
+    pub fn title(mut self, title: &str) -> Self {
+        self.title = Some(maud::html! { (title) });
+        self
+    }
+
+    /// Set the card title from pre-built [`maud::Markup`] for rich heading content
+    /// (e.g. a title with an inline badge or count).
+    ///
+    /// Callers are responsible for escaping any user-supplied content inside `title`.
+    #[must_use]
+    pub fn title_html(mut self, title: maud::Markup) -> Self {
+        self.title = Some(title);
+        self
+    }
+
+    /// Set the heading level for the title element (default [`HeadingLevel::H2`]).
+    #[must_use]
+    pub const fn level(mut self, level: HeadingLevel) -> Self {
+        self.level = level;
+        self
+    }
+
+    /// Set the right-side header action slot (e.g. buttons/links).
+    #[must_use]
+    pub fn header_action(mut self, action: maud::Markup) -> Self {
+        self.header_action = Some(action);
+        self
+    }
+
+    /// Set the footer content rendered in `<div class="card-footer">`.
+    #[must_use]
+    pub fn footer(mut self, footer: maud::Markup) -> Self {
+        self.footer = Some(footer);
+        self
+    }
+
+    /// Add extra CSS class(es) to the root `card` element.
+    #[must_use]
+    pub const fn class(mut self, class: &'a str) -> Self {
+        self.class = Some(class);
+        self
+    }
+}
+
+/// Build the `class` string for the root card element, merging the base `"card"`
+/// with any caller-supplied extra classes.
+#[cfg(feature = "maud")]
+fn merge_class(extra: Option<&str>) -> String {
+    match extra {
+        Some(e) if !e.is_empty() => format!("card {e}"),
+        _ => "card".to_string(),
+    }
+}
+
+/// Render a composable card container.
+///
+/// Emits a `<div class="card">` with an optional header (title + action slot),
+/// a `<div class="card-body">` wrapping `body`, and an optional
+/// `<div class="card-footer">`.
+///
+/// The header is rendered only when a title or `header_action` is set.
+/// The title is wrapped in a heading element (`<h2>` by default, configurable
+/// via [`CardConfig::level`]) so screen readers can navigate card titles.
+///
+/// All class names (`card`, `card-header`, `card-title`, `card-body`,
+/// `card-footer`) are stable so existing CSS and the admin plugin can adopt
+/// the widget with no restyling.
+///
+/// # CSS hooks
+///
+/// | Selector | Element |
+/// |---|---|
+/// | `.card` | Root wrapper |
+/// | `.card-header` | Header row (title + action) |
+/// | `.card-title` | Title heading element |
+/// | `.card-body` | Body wrapper |
+/// | `.card-footer` | Footer wrapper |
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::widgets::{
+///     card, CardConfig, property_list, data_table, Column, DataTableConfig,
+/// };
+/// use maud::html;
+///
+/// struct Post { id: i64, title: String }
+/// let posts = vec![Post { id: 1, title: "Hello".into() }];
+///
+/// let summary = property_list(&[
+///     ("Total", html! { (posts.len()) }),
+/// ]);
+///
+/// let cols: Vec<Column<Post>> = vec![
+///     Column::new("ID",    |p: &Post| html! { (p.id) }),
+///     Column::new("Title", |p: &Post| html! { (p.title.as_str()) }),
+/// ];
+/// let table = data_table(&posts, &cols, &DataTableConfig::new("No posts."));
+///
+/// let new_btn = html! { a class="btn" href="/posts/new" { "New post" } };
+/// let config = CardConfig::new().title("Posts").header_action(new_btn);
+///
+/// let out = card(&html! { (summary) (table) }, &config).into_string();
+/// assert!(out.contains(r#"class="card-header""#));
+/// assert!(out.contains(r#"<h2 class="card-title">Posts</h2>"#));
+/// assert!(out.contains(r#"class="card-body""#));
+/// assert!(out.contains(r#"class="autumn-property-list""#));
+/// assert!(out.contains("<table"));
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn card(body: &maud::Markup, config: &CardConfig<'_>) -> maud::Markup {
+    let root_class = merge_class(config.class);
+    let has_header = config.title.is_some() || config.header_action.is_some();
+    maud::html! {
+        div class=(root_class) {
+            @if has_header {
+                div class="card-header" {
+                    @if let Some(title) = &config.title {
+                        @match config.level {
+                            HeadingLevel::H1 => h1 class="card-title" { (title) },
+                            HeadingLevel::H2 => h2 class="card-title" { (title) },
+                            HeadingLevel::H3 => h3 class="card-title" { (title) },
+                            HeadingLevel::H4 => h4 class="card-title" { (title) },
+                            HeadingLevel::H5 => h5 class="card-title" { (title) },
+                            HeadingLevel::H6 => h6 class="card-title" { (title) },
+                        }
+                    }
+                    @if let Some(action) = &config.header_action {
+                        (action)
+                    }
+                }
+            }
+            div class="card-body" { (body) }
+            @if let Some(footer) = &config.footer {
+                div class="card-footer" { (footer) }
+            }
+        }
+    }
+}
+
+/// Render a metric stat-card tile: label, value, and an optional "view all" link.
+///
+/// Emits a `<div class="stat-card">` matching the pattern used by the admin
+/// dashboard for model-count tiles. Both `label` and `value` are HTML-escaped.
+///
+/// `link` is `(href, link_text)`; omit with `None` to render without the link row.
+///
+/// # CSS hooks
+///
+/// | Selector | Element |
+/// |---|---|
+/// | `.stat-card` | Root tile |
+/// | `.stat-label` | Metric label |
+/// | `.stat-value` | Metric number/value |
+/// | `.stat-link` | Link row (only present when `link` is `Some`) |
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::widgets::stat_card;
+///
+/// let html = stat_card("Users", "1 024", Some(("/users", "View all →"))).into_string();
+/// assert!(html.contains(r#"class="stat-card""#));
+/// assert!(html.contains("1 024"));
+/// assert!(html.contains(r#"href="/users""#));
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn stat_card(label: &str, value: &str, link: Option<(&str, &str)>) -> maud::Markup {
+    maud::html! {
+        div class="stat-card" {
+            div class="stat-label" { (label) }
+            div class="stat-value" { (value) }
+            @if let Some((href, text)) = link {
+                div class="stat-link" {
+                    a href=(href) { (text) }
+                }
+            }
+        }
+    }
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 #[cfg(all(test, feature = "maud"))]
@@ -2081,5 +2351,175 @@ mod tests {
         assert!(html.contains("q=foo"), "{html}");
         // no duplicate old sort
         assert!(!html.contains("sort=old"), "{html}");
+    }
+
+    // ── CardConfig builder ─────────────────────────────────────────────
+
+    #[test]
+    fn card_config_defaults() {
+        let c = CardConfig::new();
+        assert!(c.title.is_none());
+        assert_eq!(c.level, HeadingLevel::H2);
+        assert!(c.header_action.is_none());
+        assert!(c.footer.is_none());
+        assert!(c.class.is_none());
+    }
+
+    #[test]
+    fn card_config_builders_chain() {
+        let c = CardConfig::new()
+            .title("T")
+            .level(HeadingLevel::H3)
+            .class("wide");
+        assert!(c.title.is_some());
+        assert_eq!(c.level, HeadingLevel::H3);
+        assert_eq!(c.class, Some("wide"));
+    }
+
+    // ── card structure ─────────────────────────────────────────────────
+
+    #[test]
+    fn card_has_root_and_body_classes() {
+        let body = maud::html! { p { "hello" } };
+        let html = card(&body, &CardConfig::new()).into_string();
+        assert!(html.contains(r#"class="card""#), "{html}");
+        assert!(html.contains(r#"class="card-body""#), "{html}");
+        assert!(html.contains("hello"), "{html}");
+        assert!(!html.contains("card-header"), "{html}");
+        assert!(!html.contains("card-footer"), "{html}");
+    }
+
+    #[test]
+    fn card_renders_title_as_h2_by_default() {
+        let body = maud::html! {};
+        let html = card(&body, &CardConfig::new().title("Posts")).into_string();
+        assert!(
+            html.contains(r#"<h2 class="card-title">Posts</h2>"#),
+            "{html}"
+        );
+        assert!(html.contains(r#"class="card-header""#), "{html}");
+    }
+
+    #[test]
+    fn card_title_respects_heading_level() {
+        let body = maud::html! {};
+        let html = card(
+            &body,
+            &CardConfig::new().title("X").level(HeadingLevel::H3),
+        )
+        .into_string();
+        assert!(html.contains(r#"<h3 class="card-title">"#), "{html}");
+        assert!(!html.contains("<h2"), "{html}");
+    }
+
+    #[test]
+    fn card_omits_header_when_empty() {
+        let body = maud::html! {};
+        let html = card(&body, &CardConfig::new()).into_string();
+        assert!(!html.contains("card-header"), "{html}");
+    }
+
+    #[test]
+    fn card_renders_header_action() {
+        let action = maud::html! { a class="btn" href="/new" { "New" } };
+        let body = maud::html! {};
+        let html = card(&body, &CardConfig::new().header_action(action)).into_string();
+        assert!(html.contains(r#"class="card-header""#), "{html}");
+        assert!(html.contains(r#"class="btn""#), "{html}");
+        assert!(html.contains(r#"href="/new""#), "{html}");
+    }
+
+    #[test]
+    fn card_header_action_only_no_title() {
+        let action = maud::html! { button { "Click" } };
+        let body = maud::html! {};
+        let html = card(&body, &CardConfig::new().header_action(action)).into_string();
+        assert!(html.contains("card-header"), "{html}");
+        assert!(!html.contains("card-title"), "{html}");
+        assert!(!html.contains("<h2"), "{html}");
+    }
+
+    #[test]
+    fn card_renders_footer() {
+        let footer = maud::html! { span { "Save" } };
+        let body = maud::html! {};
+        let html = card(&body, &CardConfig::new().footer(footer)).into_string();
+        assert!(html.contains(r#"class="card-footer""#), "{html}");
+        assert!(html.contains("Save"), "{html}");
+    }
+
+    #[test]
+    fn card_omits_footer_when_none() {
+        let body = maud::html! {};
+        let html = card(&body, &CardConfig::new()).into_string();
+        assert!(!html.contains("card-footer"), "{html}");
+    }
+
+    #[test]
+    fn card_extra_class_escape_hatch() {
+        let body = maud::html! {};
+        let html = card(&body, &CardConfig::new().class("dashboard")).into_string();
+        assert!(html.contains(r#"class="card dashboard""#), "{html}");
+    }
+
+    #[test]
+    fn card_escapes_title() {
+        let body = maud::html! {};
+        let html = card(
+            &body,
+            &CardConfig::new().title("<script>alert(1)</script>"),
+        )
+        .into_string();
+        assert!(html.contains("&lt;script&gt;"), "{html}");
+        assert!(!html.contains("<script>alert"), "{html}");
+    }
+
+    #[test]
+    fn card_title_html_passes_markup() {
+        let rich = maud::html! {
+            span { "Posts" }
+            span class="muted" { " (42)" }
+        };
+        let body = maud::html! {};
+        let html = card(&body, &CardConfig::new().title_html(rich)).into_string();
+        assert!(html.contains(r#"class="muted""#), "{html}");
+        assert!(html.contains("(42)"), "{html}");
+    }
+
+    #[test]
+    fn card_body_composes_property_list() {
+        let rows = vec![("Name", maud::html! { "Alice" })];
+        let body = property_list(&rows);
+        let html = card(&body, &CardConfig::new().title("Detail")).into_string();
+        assert!(html.contains(r#"class="card-body""#), "{html}");
+        assert!(html.contains(r#"class="autumn-property-list""#), "{html}");
+    }
+
+    // ── stat_card ──────────────────────────────────────────────────────
+
+    #[test]
+    fn stat_card_renders_label_value() {
+        let html = stat_card("Users", "42", None).into_string();
+        assert!(html.contains(r#"class="stat-card""#), "{html}");
+        assert!(html.contains(r#"class="stat-label""#), "{html}");
+        assert!(html.contains(r#"class="stat-value""#), "{html}");
+        assert!(html.contains("Users"), "{html}");
+        assert!(html.contains("42"), "{html}");
+        assert!(!html.contains("stat-link"), "{html}");
+    }
+
+    #[test]
+    fn stat_card_renders_optional_link() {
+        let html = stat_card("Users", "42", Some(("/users", "View all →"))).into_string();
+        assert!(html.contains(r#"class="stat-link""#), "{html}");
+        assert!(html.contains(r#"href="/users""#), "{html}");
+        assert!(html.contains("View all"), "{html}");
+    }
+
+    #[test]
+    fn stat_card_escapes_value() {
+        let html = stat_card("L", "<b>x</b>", None).into_string();
+        assert!(html.contains("&lt;b&gt;"), "{html}");
+        assert!(!html.contains("<b>x</b>"), "{html}");
     }
 }

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -8,11 +8,11 @@
 //!
 //! | Widget | Use |
 //! |--------|-----|
-//! | [`card`] | Titled content panel with optional header action and footer |
-//! | [`stat_card`] | Metric tile: label / value / optional link |
-//! | [`property_list`] | `<dl>` of label/value rows for a record detail view |
-//! | [`data_table`] | Column-driven, sortable `<table>` |
-//! | [`breadcrumb`] | Accessible `<nav>` breadcrumb trail |
+//! | `card` | Titled content panel with optional header action and footer |
+//! | `stat_card` | Metric tile: label / value / optional link |
+//! | `property_list` | `<dl>` of label/value rows for a record detail view |
+//! | `data_table` | Column-driven, sortable `<table>` |
+//! | `breadcrumb` | Accessible `<nav>` breadcrumb trail |
 //!
 //! # Interactive / search widgets
 //!

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -2370,7 +2370,10 @@ mod tests {
     fn card_config_builders_chain() {
         let html = card(
             &maud::html! {},
-            &CardConfig::new().title("T").level(HeadingLevel::H3).class("wide"),
+            &CardConfig::new()
+                .title("T")
+                .level(HeadingLevel::H3)
+                .class("wide"),
         )
         .into_string();
         assert!(html.contains(r#"class="card wide""#), "{html}");
@@ -2405,11 +2408,7 @@ mod tests {
     #[test]
     fn card_title_respects_heading_level() {
         let body = maud::html! {};
-        let html = card(
-            &body,
-            &CardConfig::new().title("X").level(HeadingLevel::H3),
-        )
-        .into_string();
+        let html = card(&body, &CardConfig::new().title("X").level(HeadingLevel::H3)).into_string();
         assert!(html.contains(r#"<h3 class="card-title">"#), "{html}");
         assert!(!html.contains("<h2"), "{html}");
     }
@@ -2467,11 +2466,7 @@ mod tests {
     #[test]
     fn card_escapes_title() {
         let body = maud::html! {};
-        let html = card(
-            &body,
-            &CardConfig::new().title("<script>alert(1)</script>"),
-        )
-        .into_string();
+        let html = card(&body, &CardConfig::new().title("<script>alert(1)</script>")).into_string();
         assert!(html.contains("&lt;script&gt;"), "{html}");
         assert!(!html.contains("<script>alert"), "{html}");
     }

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -2378,7 +2378,7 @@ mod tests {
         .into_string();
         assert!(html.contains(r#"class="card wide""#), "{html}");
         assert!(html.contains("<h3"), "{html}");
-        assert!(html.contains("T"), "{html}");
+        assert!(html.contains('T'), "{html}");
     }
 
     // ── card structure ─────────────────────────────────────────────────

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -27,7 +27,7 @@ internet connection.
 - **Rust 1.88.0+** with `cargo`
 - **Docker** (or Docker Desktop) — `docker --version`
 - **PostgreSQL** accessible at a connection string you control (local or remote)
-- The `autumn` CLI - `cargo install autumn-cli --version 0.5.0`
+- The `autumn` CLI - `cargo install autumn-cli --version 0.6.0`
 
 ---
 
@@ -121,7 +121,7 @@ Visit [http://localhost:3000/health](http://localhost:3000/health) — a healthy
 response looks like:
 
 ```json
-{ "status": "ok", "version": "0.5.0" }
+{ "status": "ok", "version": "0.6.0" }
 ```
 
 > **Migration failure stops the rollout.** If the primary URL is wrong or the

--- a/docs/guide/docs-smoke.md
+++ b/docs/guide/docs-smoke.md
@@ -8,7 +8,7 @@ Run it in a clean temporary directory, not inside the Autumn checkout:
 
 ```bash
 rustc --version
-cargo install autumn-cli --version 0.5.0
+cargo install autumn-cli --version 0.6.0
 
 mkdir autumn-docs-smoke
 cd autumn-docs-smoke
@@ -33,7 +33,7 @@ Passing output:
 - `/health` returns:
 
   ```json
-  { "status": "ok", "version": "0.5.0" }
+  { "status": "ok", "version": "0.6.0" }
   ```
 
 Do not add `[patch.crates-io]`, path dependencies, or `cargo install --path`
@@ -52,5 +52,5 @@ were not yet available on crates.io.
 ```
 
 That rehearsal does not certify the release. The published docs-smoke must be
-rerun with `cargo install autumn-cli --version 0.5.0` and no workspace patches
+rerun with `cargo install autumn-cli --version 0.6.0` and no workspace patches
 before announcing the release.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -39,7 +39,7 @@ Autumn ships a small CLI for project scaffolding and tooling setup. Install the
 published CLI from crates.io:
 
 ```bash
-cargo install autumn-cli --version 0.5.0
+cargo install autumn-cli --version 0.6.0
 ```
 
 For local development only, from an Autumn source checkout, install the CLI you
@@ -239,7 +239,7 @@ Probe endpoints are also available at `/live`, `/ready`, and `/startup`.
 The `/health` response looks like:
 
 ```json
-{ "status": "ok", "version": "0.5.0" }
+{ "status": "ok", "version": "0.6.0" }
 ```
 
 Press **Ctrl+C** to stop the server (graceful shutdown with a configurable
@@ -471,7 +471,7 @@ Add the required dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-autumn-web = "0.5"
+autumn-web = "0.6"
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "2", features = ["postgres", "chrono"] }
 diesel-async = { version = "0.8", features = ["postgres"] }

--- a/docs/guide/tutorial/01-project-setup.md
+++ b/docs/guide/tutorial/01-project-setup.md
@@ -11,7 +11,7 @@ Before you start, make sure you have:
 
 - **Rust 1.88.0+** (edition 2024) — install from <https://rustup.rs> if you haven't already
 - **The Autumn CLI** — install the published CLI with
-  `cargo install autumn-cli --version 0.5.0`
+  `cargo install autumn-cli --version 0.6.0`
 - A terminal and a text editor
 
 Docker is not needed until Chapter 3 (Database Setup). For now, you only need
@@ -85,7 +85,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-autumn-web = "0.5"
+autumn-web = "0.6"
 ```
 
 This is a standard Rust project manifest. The only dependency is `autumn-web`

--- a/docs/guide/websockets.md
+++ b/docs/guide/websockets.md
@@ -32,7 +32,7 @@ async fn main() {
 Enable the feature in your `Cargo.toml`:
 
 ```toml
-autumn-web = { version = "0.5", features = ["ws"] }
+autumn-web = { version = "0.6", features = ["ws"] }
 ```
 
 ## The two-function pattern


### PR DESCRIPTION
## Summary

This PR extracts reusable card and stat_card display widgets from the admin plugin into the core `autumn_web::widgets` module, then refactors the admin templates to use them. This improves code reuse, reduces duplication, and establishes stable CSS class names for card-based layouts across the framework.

## Key Changes

- **New widgets in `autumn/src/widgets.rs`:**
  - `CardConfig` builder for configurable card containers (title, heading level, header action, footer, extra classes)
  - `card()` function to render a titled panel with optional header action and footer
  - `stat_card()` function to render metric tiles (label/value/optional link)
  - `HeadingLevel` enum to control title heading level (H1–H6, default H2)
  - Comprehensive tests for all new widget functionality

- **Admin template refactoring (`autumn-admin-plugin/src/templates.rs`):**
  - Replaced inline card HTML with `card()` calls in 8+ locations (job lists, schedules, dashboard, model list, import forms, detail/edit pages)
  - Replaced inline stat-card divs with `stat_card()` calls on the dashboard
  - Adjusted CSS for `.card` and `.card-header` to work with the new widget structure (moved padding from `.card` to `.card-body`, updated header padding)
  - Extracted title, body, and header_action markup into variables for clarity

- **CSS updates:**
  - Removed `padding: 1.5rem` from `.card` base rule
  - Added `padding: 1.5rem` to new `.card-body` class
  - Updated `.card-header` padding to `1rem 1.5rem 0.75rem`
  - Added `margin: 0` to `.card-title` to normalize heading margins

- **Documentation:**
  - Updated `autumn/src/widgets.rs` module doc to describe display widgets (card, stat_card, property_list, data_table, breadcrumb)
  - Added comprehensive rustdoc for `CardConfig`, `card()`, and `stat_card()` with examples
  - Updated `autumn/src/prelude.rs` to reflect new widget exports

- **Version bump:** 0.5.0 → 0.6.0 across all workspace crates

## Implementation Details

- All widgets return `maud::Markup` and are composable (output of one can be passed as body of another)
- CSS class names (`.card`, `.card-header`, `.card-title`, `.card-body`, `.card-footer`, `.stat-card`, etc.) are stable and documented as public API
- `CardConfig` uses a builder pattern with `const fn` for zero-cost abstractions
- Title can be set as plain text (HTML-escaped) via `title()` or as pre-built `Markup` via `title_html()` for rich content
- Header action slot is optional and rendered alongside the title in the header
- All widgets are CSP-safe (no inline JavaScript) and HTML-escape caller-supplied text via Maud
- Extensive test coverage for card structure, title escaping, heading levels, and stat_card rendering

https://claude.ai/code/session_01MsyyPZS9KDQHf6BBGYRzkk