### PR TITLE
⚡ Bolt: [performance improvement] optimize normalize_path_for_collision to avoid Vec allocation

### DIFF
--- a/autumn/src/plugin_conformance.rs
+++ b/autumn/src/plugin_conformance.rs
@@ -350,17 +350,21 @@ pub fn check_route_prefix(
 /// Both named params (`{id}`) and catch-all params (`{*rest}`) normalize to
 /// `{}`. matchit (Axum's router) treats a named param and a catch-all at the
 /// same path position as a conflict, so they must map to the same key.
+///
+/// ⚡ Bolt: Optimization - Pre-allocates capacity and removes intermediate `Vec` allocation.
 fn normalize_path_for_collision(path: &str) -> String {
-    path.split('/')
-        .map(|seg| {
-            if seg.starts_with('{') && seg.ends_with('}') {
-                "{}"
-            } else {
-                seg
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
+    let mut out = String::with_capacity(path.len());
+    for (i, seg) in path.split('/').enumerate() {
+        if i > 0 {
+            out.push('/');
+        }
+        if seg.starts_with('{') && seg.ends_with('}') {
+            out.push_str("{}");
+        } else {
+            out.push_str(seg);
+        }
+    }
+    out
 }
 
 /// Detect route collisions: any two routes sharing the same (method, path) pair.


### PR DESCRIPTION
💡 What: Replaced the `.split().map().collect::<Vec<_>>().join("/")` iterator chain in `normalize_path_for_collision` with a pre-allocated `String` and a manual formatting loop.

🎯 Why: The original implementation caused a temporary `Vec` heap allocation for every route evaluated during collision checking on application boot, which was an unnecessary allocation in a highly repetitive validation step.

📊 Impact: Reduces memory allocations by 1 `Vec` per route segment normalization check. Since route structures can grow significantly, this reduces heap thrashing and minimizes memory footprints during boot without impacting readability or safety.

🔬 Measurement: Run `cargo test -p autumn-web --lib plugin_conformance` to verify tests pass smoothly. The optimization is in-place string manipulation and avoids `Vec` generation entirely.

---
*PR created automatically by Jules for task [12522263013798674573](https://jules.google.com/task/12522263013798674573) started by @madmax983*