### PR TITLE
👺 Havoc: [Fix panic on massive TTL values]

### DIFF
--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -467,7 +467,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
         let entry = IdempotencyEntry {
             record,
             body_hash,
-            expires_at: Instant::now() + ttl,
+            expires_at: Instant::now().checked_add(ttl).unwrap_or_else(Instant::now),
         };
         let mut entries = self.entries.write().unwrap();
         entries.insert(key.to_owned(), entry);
@@ -504,7 +504,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
             key.to_owned(),
             MemoryInFlightLock {
                 owner: owner.to_owned(),
-                expires_at: now + ttl,
+                expires_at: now.checked_add(ttl).unwrap_or_else(Instant::now),
             },
         );
         true

--- a/autumn/tests/chaos_idempotency_proptest.rs
+++ b/autumn/tests/chaos_idempotency_proptest.rs
@@ -14,7 +14,7 @@ proptest! {
         };
 
         let ttl = Duration::new(ttl_secs, ttl_nanos % 1_000_000_000);
-        store.set("test_key", record.clone(), vec![], ttl);
+        store.set("test_key", record, vec![], ttl);
         store.try_lock("test_key_2", ttl);
     }
 }

--- a/autumn/tests/chaos_idempotency_proptest.rs
+++ b/autumn/tests/chaos_idempotency_proptest.rs
@@ -1,0 +1,20 @@
+use autumn_web::idempotency::*;
+use proptest::prelude::*;
+use std::time::Duration;
+
+proptest! {
+    #[test]
+    fn test_memory_store_panic_on_huge_ttl(ttl_secs in any::<u64>(), ttl_nanos in any::<u32>()) {
+        let store = MemoryIdempotencyStore::new(Duration::from_secs(3600));
+        let record = IdempotencyRecord {
+            status: 200,
+            headers: vec![],
+            body: vec![],
+            metadata: vec![],
+        };
+
+        let ttl = Duration::new(ttl_secs, ttl_nanos % 1_000_000_000);
+        store.set("test_key", record.clone(), vec![], ttl);
+        store.try_lock("test_key_2", ttl);
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** "Untrusted or massive TTL values passed to IdempotencyStore."
📉 **The Stack Trace:** "overflow when adding duration to instant"
🧪 **Reproduction:** "Run `cargo test --test chaos_idempotency_proptest -p autumn-web`."
😈 **Comment:** "You assumed time wouldn't overflow. You were wrong."

---
*PR created automatically by Jules for task [8433218146022474458](https://jules.google.com/task/8433218146022474458) started by @madmax983*