### PR TITLE
Add SystemTest::attach() for browser-only testing against external servers

### DIFF
--- a/.github/workflows/publish-gate.yml
+++ b/.github/workflows/publish-gate.yml
@@ -10,6 +10,7 @@ name: Publish Gate
 #   semver        — public API SemVer compatibility vs last crates.io version
 #   release-notes — workspace version / CHANGELOG / tag alignment
 #   smoke         — fresh downstream project compiles against the candidate crate set
+#   examples-e2e  — every example builds, boots for real, and passes a Chromium smoke
 
 on:
   push:
@@ -55,6 +56,44 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check benchmark harness completeness
         run: ./scripts/check-benchmarks.sh
+
+  # ---------------------------------------------------------------------------
+  # 0c. Example fleet e2e gate — issue #1192
+  #
+  # Builds every catalog-supported example and drives a managed headless
+  # Chromium against its real, unmodified binary (booted with isolated
+  # ephemeral testcontainer Postgres where needed), asserting primary-route
+  # content and no uncaught console errors. Aggregates across the whole
+  # fleet — a broken example never aborts the run — and fails the gate if
+  # any example fails to build or smoke. See scripts/check-examples-e2e.sh.
+  # ---------------------------------------------------------------------------
+  examples-e2e:
+    name: Example fleet e2e gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android \
+                      /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        continue-on-error: true
+
+      # Docker is preinstalled on ubuntu-latest runners, so the testcontainer
+      # -provisioned Postgres each DB-backed example's smoke needs works with
+      # no extra setup.
+      - name: Install Chromium
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Build and Chromium-smoke every example
+        env:
+          AUTUMN_CHROMIUM: ${{ steps.setup-chrome.outputs.chrome-path }}
+        run: ./scripts/check-examples-e2e.sh
 
   # ---------------------------------------------------------------------------
   # 1. Crate metadata
@@ -207,7 +246,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only runs on tag pushes; depends on all gate jobs so artifacts are only
     # produced when every check passes.
-    needs: [semver, release-notes, smoke]
+    needs: [semver, release-notes, smoke, examples-e2e]
     if: github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-gate.yml
+++ b/.github/workflows/publish-gate.yml
@@ -93,6 +93,11 @@ jobs:
       - name: Build and Chromium-smoke every example
         env:
           AUTUMN_CHROMIUM: ${{ steps.setup-chrome.outputs.chrome-path }}
+          # This job provisions Chromium and Docker specifically so every
+          # example gets real coverage — a SKIP here means that provisioning
+          # silently broke, so it must fail the release gate rather than let
+          # "all checks passed" mask degraded coverage.
+          REQUIRE_FULL_COVERAGE: "1"
         run: ./scripts/check-examples-e2e.sh
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/publish-gate.yml
+++ b/.github/workflows/publish-gate.yml
@@ -90,6 +90,19 @@ jobs:
         id: setup-chrome
         uses: browser-actions/setup-chrome@v1
 
+      # Every example's layout references its Tailwind-compiled
+      # `/static/css/autumn.css`. Without this, each example's build.rs finds
+      # no `tailwindcss` binary and skips regenerating it (a warning, not a
+      # build failure) — the smoke would then boot against a real app that's
+      # 404ing on its own stylesheet, which the browser reports as a
+      # `Log.entryAdded` error (see `SystemTest`'s console-error capture)
+      # even though nothing is actually broken. `autumn setup` is the
+      # project's own first-party installer (downloads to
+      # `target/autumn/tailwindcss`, where every example's build.rs already
+      # looks first).
+      - name: Install Tailwind CSS CLI
+        run: cargo run -p autumn-cli --bin autumn -- setup
+
       - name: Build and Chromium-smoke every example
         env:
           AUTUMN_CHROMIUM: ${{ steps.setup-chrome.outputs.chrome-path }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["autumn", "autumn-macros", "autumn-cli", "autumn-admin-plugin", "autumn-storage-s3", "autumn-cache-redis", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/bookmarks-sharded", "examples/wiki", "examples/reddit-clone", "examples/saas", "benchmarks/runtime/gate"]
+members = ["autumn", "autumn-macros", "autumn-cli", "autumn-admin-plugin", "autumn-storage-s3", "autumn-cache-redis", "examples/hello", "examples/todo-app", "examples/blog", "examples/bookmarks", "examples/bookmarks-distributed", "examples/bookmarks-sharded", "examples/wiki", "examples/reddit-clone", "examples/saas", "benchmarks/runtime/gate", "example-e2e"]
 resolver = "3"
 
 # `cargo test --workspace` builds every example, plugin, integration test, and

--- a/autumn-cli/src/starters/mod.rs
+++ b/autumn-cli/src/starters/mod.rs
@@ -636,6 +636,13 @@ mod tests {
                 if rel == "static/css/app.css" {
                     continue;
                 }
+                // tests/system/smoke.rs is workspace-internal e2e tooling (issue
+                // #1192) that depends on the path-only `example-e2e` crate — it
+                // has no meaning outside the autumn monorepo, same category of
+                // divergence as Cargo.toml's path-vs-versioned dependency above.
+                if rel == "tests/system/smoke.rs" {
+                    continue;
+                }
                 assert!(
                     starter_paths.contains(&rel),
                     "examples/saas has {rel} which the embedded starter does not produce"

--- a/autumn-cli/src/starters/saas/autumn.toml
+++ b/autumn-cli/src/starters/saas/autumn.toml
@@ -25,5 +25,5 @@ pool_size = 10
 enabled = true
 source = "session"
 session_key = "tenant_id"
-public_paths = ["/", "/login", "/signup", "/logout", "/static"]
+public_paths = ["/", "/login", "/signup", "/logout", "/static", "/favicon.ico"]
 login_redirect = "/login"

--- a/autumn-cli/src/starters/saas/src/routes/layout.rs
+++ b/autumn-cli/src/starters/saas/src/routes/layout.rs
@@ -15,7 +15,7 @@ pub fn layout(title: &str, signed_in: bool, content: Markup) -> Markup {
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { (title) " · {{project_name}}" }
                 link rel="stylesheet" href="/static/css/app.css";
-                (javascript_include_tag("htmx"))
+                script src="/static/js/htmx.min.js" {}
             }
             body class="bg-gray-50 text-gray-900" {
                 header class="border-b bg-white" {

--- a/autumn/src/system_test.rs
+++ b/autumn/src/system_test.rs
@@ -70,7 +70,7 @@
 
 use std::fmt;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use chromiumoxide::cdp::js_protocol::runtime::{
@@ -78,7 +78,6 @@ use chromiumoxide::cdp::js_protocol::runtime::{
 };
 use chromiumoxide::{Browser, BrowserConfig};
 use futures::StreamExt as _;
-use tokio::sync::Mutex as AsyncMutex;
 
 use crate::config::AutumnConfig;
 use crate::route::Route;
@@ -540,12 +539,17 @@ impl Drop for SystemTestRunner {
         // is sent synchronously, but the OS reaping the process (and
         // releasing any file handles it held open under this directory) is
         // not instantaneous or guaranteed-ordered from Rust's perspective;
-        // a short synchronous grace period trades a little Drop latency for
-        // meaningfully higher odds the removal actually succeeds. Errors
-        // (including "still in use") are ignored — this is best-effort, not
-        // a correctness guarantee.
-        std::thread::sleep(Duration::from_millis(50));
-        let _ = std::fs::remove_dir_all(&self.user_data_dir);
+        // a short grace period trades a little latency for meaningfully
+        // higher odds the removal actually succeeds. Errors (including
+        // "still in use") are ignored — this is best-effort, not a
+        // correctness guarantee. Since `SystemTestRunner` is typically
+        // dropped at the end of an async test, the sleep and removal run on
+        // a background thread rather than blocking a Tokio worker thread.
+        let user_data_dir = self.user_data_dir.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            let _ = std::fs::remove_dir_all(user_data_dir);
+        });
     }
 }
 
@@ -570,7 +574,7 @@ impl SystemTestRunner {
         let cdp_page = browser.new_page("about:blank").await?;
         cdp_page.enable_runtime().await?;
 
-        let console_errors: Arc<AsyncMutex<Vec<String>>> = Arc::new(AsyncMutex::new(Vec::new()));
+        let console_errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         spawn_console_error_capture(&cdp_page, Arc::clone(&console_errors)).await?;
 
         Ok(Page {
@@ -594,7 +598,7 @@ impl SystemTestRunner {
 /// messages to `sink` as they arrive, for the lifetime of the page.
 async fn spawn_console_error_capture(
     page: &chromiumoxide::page::Page,
-    sink: Arc<AsyncMutex<Vec<String>>>,
+    sink: Arc<Mutex<Vec<String>>>,
 ) -> Result<(), SystemTestError> {
     let mut console_events = page.event_listener::<EventConsoleApiCalled>().await?;
     let mut exception_events = page.event_listener::<EventExceptionThrown>().await?;
@@ -619,7 +623,7 @@ async fn spawn_console_error_capture(
                                     .map(remote_object_to_string)
                                     .collect::<Vec<_>>()
                                     .join(" ");
-                                sink.lock().await.push(text);
+                                sink.lock().unwrap().push(text);
                             }
                         }
                         None => console_open = false,
@@ -628,7 +632,7 @@ async fn spawn_console_error_capture(
                 event = exception_events.next(), if exception_open => {
                     match event {
                         Some(event) => {
-                            sink.lock().await.push(event.exception_details.text.clone());
+                            sink.lock().unwrap().push(event.exception_details.text.clone());
                         }
                         None => exception_open = false,
                     }
@@ -665,7 +669,7 @@ pub struct Page {
     base_url: String,
     artifact_dir: PathBuf,
     hx_settle_timeout: Duration,
-    console_errors: Arc<AsyncMutex<Vec<String>>>,
+    console_errors: Arc<Mutex<Vec<String>>>,
 }
 
 impl Page {
@@ -935,8 +939,13 @@ impl Page {
     ///
     /// Useful for inspecting *why* [`Page::expect_no_console_errors`] failed,
     /// or for asserting on specific error text.
-    pub async fn console_errors(&self) -> Vec<String> {
-        self.console_errors.lock().await.clone()
+    ///
+    /// # Panics
+    /// If the internal lock is poisoned (i.e. the console-capture task
+    /// panicked while holding it).
+    #[must_use]
+    pub fn console_errors(&self) -> Vec<String> {
+        self.console_errors.lock().unwrap().clone()
     }
 
     /// Assert that the page has produced no `console.error(...)` calls and no
@@ -955,7 +964,7 @@ impl Page {
     pub async fn expect_no_console_errors(&self) -> Result<&Self, SystemTestError> {
         let deadline = tokio::time::Instant::now() + CONSOLE_ERROR_GRACE;
         loop {
-            let errors = self.console_errors().await;
+            let errors = self.console_errors();
             if !errors.is_empty() {
                 let artifact = self
                     .write_failure_artifacts("expect_no_console_errors")

--- a/autumn/src/system_test.rs
+++ b/autumn/src/system_test.rs
@@ -70,10 +70,15 @@
 
 use std::fmt;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
+use chromiumoxide::cdp::js_protocol::runtime::{
+    ConsoleApiCalledType, EventConsoleApiCalled, EventExceptionThrown,
+};
 use chromiumoxide::{Browser, BrowserConfig};
 use futures::StreamExt as _;
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::config::AutumnConfig;
 use crate::route::Route;
@@ -88,6 +93,10 @@ const DEFAULT_HX_SETTLE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Default assertion polling interval.
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Grace period `expect_no_console_errors` waits for any in-flight CDP
+/// console/exception events to be delivered before declaring the page clean.
+const CONSOLE_ERROR_GRACE: Duration = Duration::from_millis(300);
 
 // ── BrowserCheck ───────────────────────────────────────────────────────────
 
@@ -332,25 +341,19 @@ impl SystemTest {
     /// - [`SystemTestError::BrowserNotFound`] when no Chromium binary is available.
     /// - [`SystemTestError::Browser`] for CDP launch/connect errors.
     pub async fn build(self) -> Result<SystemTestRunner, SystemTestError> {
-        // 1. Locate browser binary.
-        let browser_path = find_chromium().ok_or_else(|| {
-            let searched = browser_candidates();
-            SystemTestError::BrowserNotFound { searched }
-        })?;
-
-        // 2. Bind the app to an ephemeral port.
+        // 1. Bind the app to an ephemeral port.
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .map_err(SystemTestError::ArtifactIo)?;
         let addr = listener.local_addr().map_err(SystemTestError::ArtifactIo)?;
         let base_url = format!("http://127.0.0.1:{}", addr.port());
 
-        // 3. Build the axum router from the registered routes.
+        // 2. Build the axum router from the registered routes.
         let router = build_router_for_system_test(self.routes, self.state_override);
         let service = tower::Layer::layer(&crate::middleware::MethodOverrideLayer::new(), router);
         let make_service = axum::ServiceExt::<axum::extract::Request>::into_make_service(service);
 
-        // 4. Spawn the server in a background task.
+        // 3. Spawn the server in a background task.
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         let server_handle = tokio::spawn(async move {
             let _ = axum::serve(listener, make_service)
@@ -360,90 +363,215 @@ impl SystemTest {
                 .await;
         });
 
-        // 5. Launch Chromium.
-        let config = BrowserConfig::builder()
-            .chrome_executable(browser_path)
-            .arg("--no-sandbox")
-            .arg("--disable-dev-shm-usage")
-            .arg("--disable-gpu")
-            .arg("--headless")
-            // Forward the configured timeout into chromiumoxide's own launch
-            // watchdog so the inner and outer timeouts are consistent and the
-            // outer tokio::time::timeout always wins.
-            .launch_timeout(self.browser_timeout)
-            .build()
-            .map_err(|msg| SystemTestError::Browser(chromiumoxide::error::CdpError::msg(msg)))?;
+        // 4. Launch Chromium.
+        let browser = launch_browser(self.browser_timeout).await?;
 
-        let (browser, handler) =
-            tokio::time::timeout(self.browser_timeout, Browser::launch(config))
-                .await
-                .map_err(|_| SystemTestError::Timeout {
-                    message: "timed out waiting for Chromium to launch".into(),
-                    timeout: self.browser_timeout,
-                })??;
-
-        // Drive the CDP event loop in a background task.
-        tokio::spawn(async move {
-            handler.for_each(|_| async {}).await;
-        });
-
-        let artifact_dir = self.artifact_dir_override.unwrap_or_else(|| {
-            // Use the Rust test thread name (set by the test harness) as the
-            // artifact subdirectory so concurrent tests don't overwrite each
-            // other's screenshots and HTML dumps.
-            let name = std::thread::current()
-                .name()
-                .unwrap_or("system_test")
-                .replace("::", "__");
-            artifact_dir(&name)
-        });
+        let artifact_dir = self
+            .artifact_dir_override
+            .unwrap_or_else(default_artifact_dir);
 
         Ok(SystemTestRunner {
             base_url,
             browser,
             artifact_dir,
             hx_settle_timeout: self.hx_settle_timeout,
-            _shutdown: shutdown_tx,
-            _server_handle: server_handle,
+            _shutdown: Some(shutdown_tx),
+            _server_handle: Some(server_handle),
         })
     }
+
+    /// Launch a managed headless Chromium and attach it to an **already
+    /// running** application at `base_url`, without booting any in-process
+    /// server.
+    ///
+    /// Use this when the application under test is a separately-spawned
+    /// process (e.g. an example's real binary, booted against its own
+    /// database and real config) rather than a set of routes registered
+    /// in-process via [`routes`](Self::routes). All [`Page`] assertions
+    /// (including [`Page::expect_no_console_errors`]) work identically to
+    /// the in-process [`build`](Self::build) path.
+    ///
+    /// # Errors
+    /// - [`SystemTestError::BrowserNotFound`] when no Chromium binary is available.
+    /// - [`SystemTestError::Browser`] for CDP launch/connect errors.
+    pub async fn attach(base_url: impl Into<String>) -> Result<SystemTestRunner, SystemTestError> {
+        let browser = launch_browser(DEFAULT_BROWSER_TIMEOUT).await?;
+        Ok(SystemTestRunner {
+            base_url: base_url.into(),
+            browser,
+            artifact_dir: default_artifact_dir(),
+            hx_settle_timeout: DEFAULT_HX_SETTLE_TIMEOUT,
+            _shutdown: None,
+            _server_handle: None,
+        })
+    }
+}
+
+/// Locate and launch a managed headless Chromium, driving its CDP event loop
+/// in a background task. Shared by [`SystemTest::build`] and
+/// [`SystemTest::attach`].
+async fn launch_browser(browser_timeout: Duration) -> Result<Browser, SystemTestError> {
+    let browser_path = find_chromium().ok_or_else(|| {
+        let searched = browser_candidates();
+        SystemTestError::BrowserNotFound { searched }
+    })?;
+
+    let config = BrowserConfig::builder()
+        .chrome_executable(browser_path)
+        // chromiumoxide defaults every browser to the SAME fixed
+        // `<tmp>/chromiumoxide-runner` profile directory. Two browsers alive
+        // at once (e.g. two SystemTest runners in the same process, or an
+        // `attach()` runner alongside the `build()` server it targets) then
+        // collide on Chrome's profile singleton lock and one launch fails.
+        // Give every launch its own directory.
+        .user_data_dir(unique_user_data_dir())
+        // `chromiumoxide::browser::argument::Arg`'s `From<&str>` treats the
+        // whole string as the flag *name* and prepends its own `--`, so a
+        // literal `"--no-sandbox"` here renders as the four-dash garbage flag
+        // `----no-sandbox` that Chrome silently ignores. Use the dedicated
+        // builder method for the sandbox flag and bare (no-dash) flag names
+        // for the rest; headless mode is already the builder default.
+        .no_sandbox()
+        .arg("disable-dev-shm-usage")
+        .arg("disable-gpu")
+        // Forward the configured timeout into chromiumoxide's own launch
+        // watchdog so the inner and outer timeouts are consistent and the
+        // outer tokio::time::timeout always wins.
+        .launch_timeout(browser_timeout)
+        .build()
+        .map_err(|msg| SystemTestError::Browser(chromiumoxide::error::CdpError::msg(msg)))?;
+
+    let (browser, handler) = tokio::time::timeout(browser_timeout, Browser::launch(config))
+        .await
+        .map_err(|_| SystemTestError::Timeout {
+            message: "timed out waiting for Chromium to launch".into(),
+            timeout: browser_timeout,
+        })??;
+
+    // Drive the CDP event loop in a background task.
+    tokio::spawn(async move {
+        handler.for_each(|_| async {}).await;
+    });
+
+    Ok(browser)
+}
+
+/// A fresh, never-reused Chrome profile directory for one browser launch.
+fn unique_user_data_dir() -> PathBuf {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    std::env::temp_dir().join(format!("chromiumoxide-runner-{}-{n}", std::process::id()))
+}
+
+/// Default artifact directory: the Rust test thread name (set by the test
+/// harness) as the subdirectory, so concurrent tests don't overwrite each
+/// other's screenshots and HTML dumps.
+fn default_artifact_dir() -> PathBuf {
+    let name = std::thread::current()
+        .name()
+        .unwrap_or("system_test")
+        .replace("::", "__");
+    artifact_dir(&name)
 }
 
 // ── SystemTestRunner ───────────────────────────────────────────────────────
 
 /// A running system-test session.
 ///
-/// Returned by [`SystemTest::build`].  Shuts down the embedded HTTP server
-/// when dropped.
+/// Returned by [`SystemTest::build`] or [`SystemTest::attach`]. When it owns
+/// an in-process server (the `build` path), that server shuts down when the
+/// runner is dropped; the `attach` path owns only the browser and leaves the
+/// externally-managed application process untouched.
 pub struct SystemTestRunner {
     base_url: String,
     browser: Browser,
     artifact_dir: PathBuf,
     hx_settle_timeout: Duration,
-    _shutdown: tokio::sync::oneshot::Sender<()>,
-    _server_handle: tokio::task::JoinHandle<()>,
+    _shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+    _server_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl SystemTestRunner {
     /// Open a new browser page connected to the running application.
     ///
+    /// Console errors and uncaught exceptions are captured from page-load
+    /// onward so [`Page::expect_no_console_errors`] can assert on them.
+    ///
     /// # Errors
     /// Propagates CDP errors from `chromiumoxide`.
     pub async fn page(&self) -> Result<Page, SystemTestError> {
         let cdp_page = self.browser.new_page("about:blank").await?;
+        cdp_page.enable_runtime().await?;
+
+        let console_errors: Arc<AsyncMutex<Vec<String>>> = Arc::new(AsyncMutex::new(Vec::new()));
+        spawn_console_error_capture(&cdp_page, Arc::clone(&console_errors)).await?;
+
         Ok(Page {
             inner: cdp_page,
             base_url: self.base_url.clone(),
             artifact_dir: self.artifact_dir.clone(),
             hx_settle_timeout: self.hx_settle_timeout,
+            console_errors,
         })
     }
 
-    /// The base URL of the embedded application, e.g. `http://127.0.0.1:49832`.
+    /// The base URL of the application under test, e.g. `http://127.0.0.1:49832`.
     #[must_use]
     pub fn base_url(&self) -> &str {
         &self.base_url
     }
+}
+
+/// Subscribe to `Runtime.consoleAPICalled` (level `error`) and
+/// `Runtime.exceptionThrown` CDP events on `page` and append formatted
+/// messages to `sink` as they arrive, for the lifetime of the page.
+async fn spawn_console_error_capture(
+    page: &chromiumoxide::page::Page,
+    sink: Arc<AsyncMutex<Vec<String>>>,
+) -> Result<(), SystemTestError> {
+    let mut console_events = page.event_listener::<EventConsoleApiCalled>().await?;
+    let mut exception_events = page.event_listener::<EventExceptionThrown>().await?;
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                event = console_events.next() => {
+                    let Some(event) = event else { break };
+                    if event.r#type == ConsoleApiCalledType::Error {
+                        let text = event
+                            .args
+                            .iter()
+                            .map(remote_object_to_string)
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        sink.lock().await.push(text);
+                    }
+                }
+                event = exception_events.next() => {
+                    let Some(event) = event else { break };
+                    sink.lock().await.push(event.exception_details.text.clone());
+                }
+                else => break,
+            }
+        }
+    });
+
+    Ok(())
+}
+
+/// Render a CDP `RemoteObject` console-call argument as a human-readable
+/// string, preferring the raw string value over its JSON-quoted form.
+fn remote_object_to_string(obj: &chromiumoxide::cdp::js_protocol::runtime::RemoteObject) -> String {
+    if let Some(value) = &obj.value {
+        if let Some(s) = value.as_str() {
+            return s.to_string();
+        }
+        return value.to_string();
+    }
+    obj.description
+        .clone()
+        .or_else(|| obj.class_name.clone())
+        .unwrap_or_default()
 }
 
 // ── Page ───────────────────────────────────────────────────────────────────
@@ -456,6 +584,7 @@ pub struct Page {
     base_url: String,
     artifact_dir: PathBuf,
     hx_settle_timeout: Duration,
+    console_errors: Arc<AsyncMutex<Vec<String>>>,
 }
 
 impl Page {
@@ -716,6 +845,46 @@ impl Page {
     pub async fn expect_hx_settle(&self) -> Result<&Self, SystemTestError> {
         self.wait_for_hx_settle().await?;
         Ok(self)
+    }
+
+    // ── Console-error assertions ─────────────────────────────────────────
+
+    /// Return every browser console `error`-level message and uncaught
+    /// exception observed on this page since it was opened.
+    ///
+    /// Useful for inspecting *why* [`Page::expect_no_console_errors`] failed,
+    /// or for asserting on specific error text.
+    pub async fn console_errors(&self) -> Vec<String> {
+        self.console_errors.lock().await.clone()
+    }
+
+    /// Assert that the page has produced no `console.error(...)` calls and no
+    /// uncaught JavaScript exceptions.
+    ///
+    /// Waits a short grace period for any in-flight console/exception CDP
+    /// events to be delivered before checking, so this can be called
+    /// immediately after [`Page::visit`] without a race.
+    ///
+    /// # Errors
+    /// [`SystemTestError::AssertionFailed`] listing every captured message,
+    /// with a screenshot + HTML dump written to the artifact directory.
+    pub async fn expect_no_console_errors(&self) -> Result<&Self, SystemTestError> {
+        tokio::time::sleep(CONSOLE_ERROR_GRACE).await;
+        let errors = self.console_errors().await;
+        if errors.is_empty() {
+            return Ok(self);
+        }
+        let artifact = self
+            .write_failure_artifacts("expect_no_console_errors")
+            .await
+            .ok();
+        Err(SystemTestError::AssertionFailed {
+            message: format!(
+                "page produced {} console error(s): {errors:?}",
+                errors.len()
+            ),
+            artifact_path: artifact,
+        })
     }
 
     // ── SSE helper ────────────────────────────────────────────────────────

--- a/autumn/src/system_test.rs
+++ b/autumn/src/system_test.rs
@@ -94,9 +94,13 @@ const DEFAULT_HX_SETTLE_TIMEOUT: Duration = Duration::from_secs(2);
 /// Default assertion polling interval.
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-/// Grace period `expect_no_console_errors` waits for any in-flight CDP
-/// console/exception events to be delivered before declaring the page clean.
-const CONSOLE_ERROR_GRACE: Duration = Duration::from_millis(300);
+/// Grace period `expect_no_console_errors` polls for any in-flight CDP
+/// console/exception events to be delivered before declaring the page
+/// clean. Generous relative to typical sub-10ms local CDP round-trips so it
+/// tolerates CI resource contention (Docker + Chromium + concurrent builds);
+/// an error observed at any point during the window still fails immediately
+/// rather than waiting out the rest of it.
+const CONSOLE_ERROR_GRACE: Duration = Duration::from_millis(500);
 
 // ── BrowserCheck ───────────────────────────────────────────────────────────
 
@@ -364,7 +368,7 @@ impl SystemTest {
         });
 
         // 4. Launch Chromium.
-        let browser = launch_browser(self.browser_timeout).await?;
+        let (browser, user_data_dir) = launch_browser(self.browser_timeout).await?;
 
         let artifact_dir = self
             .artifact_dir_override
@@ -372,8 +376,9 @@ impl SystemTest {
 
         Ok(SystemTestRunner {
             base_url,
-            browser,
+            browser: Some(browser),
             artifact_dir,
+            user_data_dir,
             hx_settle_timeout: self.hx_settle_timeout,
             _shutdown: Some(shutdown_tx),
             _server_handle: Some(server_handle),
@@ -391,15 +396,34 @@ impl SystemTest {
     /// (including [`Page::expect_no_console_errors`]) work identically to
     /// the in-process [`build`](Self::build) path.
     ///
+    /// Uses [`DEFAULT_BROWSER_TIMEOUT`]; use [`Self::attach_with_timeout`] to
+    /// override it (e.g. under CI resource contention).
+    ///
     /// # Errors
     /// - [`SystemTestError::BrowserNotFound`] when no Chromium binary is available.
     /// - [`SystemTestError::Browser`] for CDP launch/connect errors.
     pub async fn attach(base_url: impl Into<String>) -> Result<SystemTestRunner, SystemTestError> {
-        let browser = launch_browser(DEFAULT_BROWSER_TIMEOUT).await?;
+        Self::attach_with_timeout(base_url, DEFAULT_BROWSER_TIMEOUT).await
+    }
+
+    /// Like [`Self::attach`], but with an explicit browser-launch timeout
+    /// instead of [`DEFAULT_BROWSER_TIMEOUT`] — useful when the target
+    /// environment (e.g. several Postgres testcontainers and Chromium
+    /// competing for CPU in CI) makes the default too tight.
+    ///
+    /// # Errors
+    /// - [`SystemTestError::BrowserNotFound`] when no Chromium binary is available.
+    /// - [`SystemTestError::Browser`] for CDP launch/connect errors.
+    pub async fn attach_with_timeout(
+        base_url: impl Into<String>,
+        browser_timeout: Duration,
+    ) -> Result<SystemTestRunner, SystemTestError> {
+        let (browser, user_data_dir) = launch_browser(browser_timeout).await?;
         Ok(SystemTestRunner {
             base_url: base_url.into(),
-            browser,
+            browser: Some(browser),
             artifact_dir: default_artifact_dir(),
+            user_data_dir,
             hx_settle_timeout: DEFAULT_HX_SETTLE_TIMEOUT,
             _shutdown: None,
             _server_handle: None,
@@ -409,12 +433,15 @@ impl SystemTest {
 
 /// Locate and launch a managed headless Chromium, driving its CDP event loop
 /// in a background task. Shared by [`SystemTest::build`] and
-/// [`SystemTest::attach`].
-async fn launch_browser(browser_timeout: Duration) -> Result<Browser, SystemTestError> {
+/// [`SystemTest::attach`]. Returns the browser and the profile directory it
+/// was launched with, so the caller can remove it once the browser closes.
+async fn launch_browser(browser_timeout: Duration) -> Result<(Browser, PathBuf), SystemTestError> {
     let browser_path = find_chromium().ok_or_else(|| {
         let searched = browser_candidates();
         SystemTestError::BrowserNotFound { searched }
     })?;
+
+    let user_data_dir = unique_user_data_dir();
 
     let config = BrowserConfig::builder()
         .chrome_executable(browser_path)
@@ -424,7 +451,7 @@ async fn launch_browser(browser_timeout: Duration) -> Result<Browser, SystemTest
         // `attach()` runner alongside the `build()` server it targets) then
         // collide on Chrome's profile singleton lock and one launch fails.
         // Give every launch its own directory.
-        .user_data_dir(unique_user_data_dir())
+        .user_data_dir(&user_data_dir)
         // `chromiumoxide::browser::argument::Arg`'s `From<&str>` treats the
         // whole string as the flag *name* and prepends its own `--`, so a
         // literal `"--no-sandbox"` here renders as the four-dash garbage flag
@@ -453,7 +480,7 @@ async fn launch_browser(browser_timeout: Duration) -> Result<Browser, SystemTest
         handler.for_each(|_| async {}).await;
     });
 
-    Ok(browser)
+    Ok((browser, user_data_dir))
 }
 
 /// A fresh, never-reused Chrome profile directory for one browser launch.
@@ -481,14 +508,45 @@ fn default_artifact_dir() -> PathBuf {
 /// Returned by [`SystemTest::build`] or [`SystemTest::attach`]. When it owns
 /// an in-process server (the `build` path), that server shuts down when the
 /// runner is dropped; the `attach` path owns only the browser and leaves the
-/// externally-managed application process untouched.
+/// externally-managed application process untouched. Either way, dropping
+/// the runner also removes its per-launch Chrome profile directory.
 pub struct SystemTestRunner {
     base_url: String,
-    browser: Browser,
+    // `Option` so `Drop` can synchronously extract and drop the browser
+    // *before* removing its profile directory — see the `Drop` impl below.
+    browser: Option<Browser>,
     artifact_dir: PathBuf,
+    user_data_dir: PathBuf,
     hx_settle_timeout: Duration,
     _shutdown: Option<tokio::sync::oneshot::Sender<()>>,
     _server_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for SystemTestRunner {
+    fn drop(&mut self) {
+        // chromiumoxide sets `kill_on_drop(true)` on the underlying child
+        // process, so dropping `Browser` synchronously *sends* the kill
+        // signal (only the OS reaping the process afterward is
+        // asynchronous/unguaranteed-timing). Rust drops a struct's own
+        // fields only *after* a custom `Drop::drop` body returns, so without
+        // this explicit `take()` the profile directory would be removed
+        // before the browser (and thus the signal) is even dropped.
+        // Dropping the taken `Browser` here, before touching the directory,
+        // ensures the kill is at least sent first.
+        drop(self.browser.take());
+
+        // Best-effort cleanup for the per-launch profile directory created
+        // in `launch_browser`/`unique_user_data_dir`. The kill signal above
+        // is sent synchronously, but the OS reaping the process (and
+        // releasing any file handles it held open under this directory) is
+        // not instantaneous or guaranteed-ordered from Rust's perspective;
+        // a short synchronous grace period trades a little Drop latency for
+        // meaningfully higher odds the removal actually succeeds. Errors
+        // (including "still in use") are ignored — this is best-effort, not
+        // a correctness guarantee.
+        std::thread::sleep(Duration::from_millis(50));
+        let _ = std::fs::remove_dir_all(&self.user_data_dir);
+    }
 }
 
 impl SystemTestRunner {
@@ -499,8 +557,17 @@ impl SystemTestRunner {
     ///
     /// # Errors
     /// Propagates CDP errors from `chromiumoxide`.
+    ///
+    /// # Panics
+    /// Only if called while the runner is being dropped — not reachable
+    /// through normal use, since `page()` takes `&self` and a caller can't
+    /// hold that reference once the runner itself has started dropping.
     pub async fn page(&self) -> Result<Page, SystemTestError> {
-        let cdp_page = self.browser.new_page("about:blank").await?;
+        let browser = self
+            .browser
+            .as_ref()
+            .expect("SystemTestRunner::browser is only None during Drop");
+        let cdp_page = browser.new_page("about:blank").await?;
         cdp_page.enable_runtime().await?;
 
         let console_errors: Arc<AsyncMutex<Vec<String>>> = Arc::new(AsyncMutex::new(Vec::new()));
@@ -533,25 +600,39 @@ async fn spawn_console_error_capture(
     let mut exception_events = page.event_listener::<EventExceptionThrown>().await?;
 
     tokio::spawn(async move {
-        loop {
+        // Track each stream's liveness independently: a `select!` branch
+        // guarded by `if <flag>` is skipped once that flag is false, so one
+        // stream ending (e.g. a transient CDP session hiccup) only stops
+        // polling *that* stream — it must not end capture on the other one.
+        // The task only exits once both streams are done.
+        let mut console_open = true;
+        let mut exception_open = true;
+        while console_open || exception_open {
             tokio::select! {
-                event = console_events.next() => {
-                    let Some(event) = event else { break };
-                    if event.r#type == ConsoleApiCalledType::Error {
-                        let text = event
-                            .args
-                            .iter()
-                            .map(remote_object_to_string)
-                            .collect::<Vec<_>>()
-                            .join(" ");
-                        sink.lock().await.push(text);
+                event = console_events.next(), if console_open => {
+                    match event {
+                        Some(event) => {
+                            if event.r#type == ConsoleApiCalledType::Error {
+                                let text = event
+                                    .args
+                                    .iter()
+                                    .map(remote_object_to_string)
+                                    .collect::<Vec<_>>()
+                                    .join(" ");
+                                sink.lock().await.push(text);
+                            }
+                        }
+                        None => console_open = false,
                     }
                 }
-                event = exception_events.next() => {
-                    let Some(event) = event else { break };
-                    sink.lock().await.push(event.exception_details.text.clone());
+                event = exception_events.next(), if exception_open => {
+                    match event {
+                        Some(event) => {
+                            sink.lock().await.push(event.exception_details.text.clone());
+                        }
+                        None => exception_open = false,
+                    }
                 }
-                else => break,
             }
         }
     });
@@ -861,30 +942,38 @@ impl Page {
     /// Assert that the page has produced no `console.error(...)` calls and no
     /// uncaught JavaScript exceptions.
     ///
-    /// Waits a short grace period for any in-flight console/exception CDP
-    /// events to be delivered before checking, so this can be called
-    /// immediately after [`Page::visit`] without a race.
+    /// Polls for the [`CONSOLE_ERROR_GRACE`] window (checking every
+    /// [`POLL_INTERVAL`]) for any in-flight console/exception CDP events to
+    /// be delivered before declaring the page clean, so this can be called
+    /// immediately after [`Page::visit`] without a race. An error observed
+    /// at any point during the window fails immediately rather than waiting
+    /// out the rest of it.
     ///
     /// # Errors
     /// [`SystemTestError::AssertionFailed`] listing every captured message,
     /// with a screenshot + HTML dump written to the artifact directory.
     pub async fn expect_no_console_errors(&self) -> Result<&Self, SystemTestError> {
-        tokio::time::sleep(CONSOLE_ERROR_GRACE).await;
-        let errors = self.console_errors().await;
-        if errors.is_empty() {
-            return Ok(self);
+        let deadline = tokio::time::Instant::now() + CONSOLE_ERROR_GRACE;
+        loop {
+            let errors = self.console_errors().await;
+            if !errors.is_empty() {
+                let artifact = self
+                    .write_failure_artifacts("expect_no_console_errors")
+                    .await
+                    .ok();
+                return Err(SystemTestError::AssertionFailed {
+                    message: format!(
+                        "page produced {} console error(s): {errors:?}",
+                        errors.len()
+                    ),
+                    artifact_path: artifact,
+                });
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Ok(self);
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
         }
-        let artifact = self
-            .write_failure_artifacts("expect_no_console_errors")
-            .await
-            .ok();
-        Err(SystemTestError::AssertionFailed {
-            message: format!(
-                "page produced {} console error(s): {errors:?}",
-                errors.len()
-            ),
-            artifact_path: artifact,
-        })
     }
 
     // ── SSE helper ────────────────────────────────────────────────────────

--- a/autumn/src/system_test.rs
+++ b/autumn/src/system_test.rs
@@ -73,6 +73,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use chromiumoxide::cdp::browser_protocol::log::{EventEntryAdded, LogEntryLevel};
 use chromiumoxide::cdp::js_protocol::runtime::{
     ConsoleApiCalledType, EventConsoleApiCalled, EventExceptionThrown,
 };
@@ -573,6 +574,7 @@ impl SystemTestRunner {
             .expect("SystemTestRunner::browser is only None during Drop");
         let cdp_page = browser.new_page("about:blank").await?;
         cdp_page.enable_runtime().await?;
+        cdp_page.enable_log().await?;
 
         let console_errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         spawn_console_error_capture(&cdp_page, Arc::clone(&console_errors)).await?;
@@ -593,25 +595,33 @@ impl SystemTestRunner {
     }
 }
 
-/// Subscribe to `Runtime.consoleAPICalled` (level `error`) and
-/// `Runtime.exceptionThrown` CDP events on `page` and append formatted
-/// messages to `sink` as they arrive, for the lifetime of the page.
+/// Subscribe to `Runtime.consoleAPICalled` (level `error`),
+/// `Runtime.exceptionThrown`, and `Log.entryAdded` (level `error`) CDP
+/// events on `page` and append formatted messages to `sink` as they arrive,
+/// for the lifetime of the page.
+///
+/// `Log.entryAdded` is a separate CDP domain from `Runtime` and is where
+/// Chrome reports browser-level errors — failed resource loads (e.g. a
+/// missing `/static` asset), CSP violations, mixed-content warnings — none
+/// of which fire a `Runtime.consoleAPICalled` or `exceptionThrown` event.
 async fn spawn_console_error_capture(
     page: &chromiumoxide::page::Page,
     sink: Arc<Mutex<Vec<String>>>,
 ) -> Result<(), SystemTestError> {
     let mut console_events = page.event_listener::<EventConsoleApiCalled>().await?;
     let mut exception_events = page.event_listener::<EventExceptionThrown>().await?;
+    let mut log_events = page.event_listener::<EventEntryAdded>().await?;
 
     tokio::spawn(async move {
         // Track each stream's liveness independently: a `select!` branch
         // guarded by `if <flag>` is skipped once that flag is false, so one
         // stream ending (e.g. a transient CDP session hiccup) only stops
-        // polling *that* stream — it must not end capture on the other one.
-        // The task only exits once both streams are done.
+        // polling *that* stream — it must not end capture on the others.
+        // The task only exits once all streams are done.
         let mut console_open = true;
         let mut exception_open = true;
-        while console_open || exception_open {
+        let mut log_open = true;
+        while console_open || exception_open || log_open {
             tokio::select! {
                 event = console_events.next(), if console_open => {
                     match event {
@@ -635,6 +645,16 @@ async fn spawn_console_error_capture(
                             sink.lock().unwrap().push(event.exception_details.text.clone());
                         }
                         None => exception_open = false,
+                    }
+                }
+                event = log_events.next(), if log_open => {
+                    match event {
+                        Some(event) => {
+                            if event.entry.level == LogEntryLevel::Error {
+                                sink.lock().unwrap().push(event.entry.text.clone());
+                            }
+                        }
+                        None => log_open = false,
                     }
                 }
             }

--- a/autumn/tests/system_test_api.rs
+++ b/autumn/tests/system_test_api.rs
@@ -203,3 +203,155 @@ async fn expect_hx_settle_waits_for_htmx() {
     page.expect_hx_settle().await.expect("settle");
     page.expect_text("Swapped!").await.expect("assert swap");
 }
+
+// ── attach(): browser-only mode against an already-running server ─────────
+//
+// Issue #1192: the fan-out example harness spawns each example's real
+// binary as a subprocess (so `main.rs`'s actual routes, migrations, and
+// builder chain run unmodified) and only needs the browser half of
+// `SystemTest`. `attach(base_url)` must launch managed Chromium and target
+// an externally-supplied base URL instead of booting an in-process router.
+
+/// `attach()` must launch a browser and successfully visit a page served by
+/// an independently-running server. We stand up that server via a normal
+/// `SystemTest::build()` (which owns its own in-process axum server) purely
+/// to get *something* listening on an ephemeral port, then discard that
+/// runner's browser/page and instead attach a **second**, independent
+/// `SystemTest::attach()` runner at the same `base_url()` — exercising the
+/// exact shape the fan-out harness uses: browser half only, server owned
+/// elsewhere (there, a spawned subprocess; here, the first runner's server).
+#[tokio::test]
+#[ignore = "requires Chromium — set AUTUMN_CHROMIUM or install chromium-browser"]
+async fn attach_visits_externally_running_server() {
+    use autumn_web::prelude::*;
+
+    #[get("/")]
+    async fn index() -> &'static str {
+        "<html><body><h1>Externally booted</h1></body></html>"
+    }
+
+    let server = SystemTest::new()
+        .routes(routes![index])
+        .build()
+        .await
+        .expect("boot stand-in server");
+    let base_url = server.base_url().to_string();
+
+    let runner = SystemTest::attach(base_url)
+        .await
+        .expect("attach to running server");
+
+    let page = runner.page().await.expect("open page");
+    page.visit("/").await.expect("visit");
+    page.expect_text("Externally booted")
+        .await
+        .expect("text assertion failed");
+}
+
+// ── Console-error capture ──────────────────────────────────────────────────
+//
+// AC3 requires every baseline smoke to assert "no uncaught console errors".
+// `Page` must accumulate console/runtime errors as they occur so a smoke can
+// fail loudly on a broken page instead of only checking rendered text.
+
+/// A page that throws an uncaught JS error must fail
+/// `expect_no_console_errors()`.
+#[tokio::test]
+#[ignore = "requires Chromium"]
+async fn expect_no_console_errors_fails_on_uncaught_exception() {
+    use autumn_web::prelude::*;
+
+    #[get("/")]
+    async fn index() -> &'static str {
+        "<html><body><h1>Page loads fine</h1></body></html>"
+    }
+
+    let runner = SystemTest::new()
+        .routes(routes![index])
+        .build()
+        .await
+        .expect("start runner");
+
+    let page = runner.page().await.expect("open page");
+    page.visit("/").await.expect("visit");
+
+    // Autumn's default CSP (`script-src 'self'`) blocks inline `<script>`
+    // tags in served HTML, so an inline-script fixture would never actually
+    // run and this test would trivially pass for the wrong reason. Trigger
+    // the exception via CDP `Runtime.evaluate` instead (`Page::evaluate`),
+    // which — like the DevTools console itself — is not subject to the
+    // page's CSP, so it reliably reaches V8 as an uncaught exception.
+    let _ = page
+        .evaluate("setTimeout(() => { throw new Error('boom'); }, 0)")
+        .await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let result = page.expect_no_console_errors().await;
+    assert!(
+        result.is_err(),
+        "a page that throws an uncaught exception must fail the console-error assertion"
+    );
+}
+
+/// A clean page (no console errors) must pass `expect_no_console_errors()`.
+#[tokio::test]
+#[ignore = "requires Chromium"]
+async fn expect_no_console_errors_passes_on_clean_page() {
+    use autumn_web::prelude::*;
+
+    #[get("/")]
+    async fn index() -> &'static str {
+        "<html><body><h1>All good</h1></body></html>"
+    }
+
+    let runner = SystemTest::new()
+        .routes(routes![index])
+        .build()
+        .await
+        .expect("start runner");
+
+    let page = runner.page().await.expect("open page");
+    page.visit("/").await.expect("visit");
+    page.expect_text("All good").await.expect("text");
+
+    page.expect_no_console_errors()
+        .await
+        .expect("clean page must not report console errors");
+}
+
+/// `console_errors()` must return the accumulated messages for inspection
+/// (not just a boolean), so a failing smoke's CI output is actionable.
+#[tokio::test]
+#[ignore = "requires Chromium"]
+async fn console_errors_returns_accumulated_messages() {
+    use autumn_web::prelude::*;
+
+    #[get("/")]
+    async fn index() -> &'static str {
+        "<html><body><h1>Page loads fine</h1></body></html>"
+    }
+
+    let runner = SystemTest::new()
+        .routes(routes![index])
+        .build()
+        .await
+        .expect("start runner");
+
+    let page = runner.page().await.expect("open page");
+    page.visit("/").await.expect("visit");
+
+    // Autumn's default CSP (`script-src 'self'`) blocks inline `<script>`
+    // tags, so trigger the console call via CDP `Runtime.evaluate`
+    // (`Page::evaluate`) instead — it is not subject to page CSP, same as
+    // the DevTools console.
+    let _ = page.evaluate("console.error('bad thing happened')").await;
+
+    // Give the CDP event a moment to be delivered and recorded.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let errors = page.console_errors().await;
+    assert!(
+        errors.iter().any(|e| e.contains("bad thing happened")),
+        "expected captured console.error message; got: {errors:?}"
+    );
+}

--- a/autumn/tests/system_test_api.rs
+++ b/autumn/tests/system_test_api.rs
@@ -349,7 +349,7 @@ async fn console_errors_returns_accumulated_messages() {
     // Give the CDP event a moment to be delivered and recorded.
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
-    let errors = page.console_errors().await;
+    let errors = page.console_errors();
     assert!(
         errors.iter().any(|e| e.contains("bad thing happened")),
         "expected captured console.error message; got: {errors:?}"

--- a/codecov.yml
+++ b/codecov.yml
@@ -28,5 +28,7 @@ ignore:
   - "benchmarks/runtime/gate/src/main.rs"  # CLI shell: arg parsing + file IO + process::exit — untestable in unit tests; all pure gate logic (parse_budgets/parse_k6_summary/median_p99/check_gate/format_*) lives in lib.rs and is fully unit-tested there
   - "autumn-cli/src/templates/**"
   - "autumn-cache-redis/**"     # Requires a live Redis server (testcontainers); all tests are #[ignore] for cross-platform CI
+  - "example-e2e/**"    # Spawns real example binaries against testcontainers Postgres + headless Chromium (issue #1192); all tests are #[ignore] for cross-platform CI, same pattern as autumn-cache-redis
+  - "autumn/src/system_test.rs"  # SystemTest/Page/SystemTestRunner drive a live headless-Chromium browser over CDP — untestable without a real browser; all such tests are #[ignore] for cross-platform CI, same pattern as autumn-cache-redis
   - "**/*_test.rs"
   - "**/tests/**"

--- a/example-e2e/Cargo.toml
+++ b/example-e2e/Cargo.toml
@@ -12,6 +12,7 @@ testcontainers-modules = { workspace = true }
 tokio = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 thiserror = { workspace = true }
+futures = { workspace = true }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/example-e2e/Cargo.toml
+++ b/example-e2e/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "example-e2e"
+version = "0.1.0"
+edition = { workspace = true }
+rust-version = { workspace = true }
+publish = false
+
+[dependencies]
+autumn-web = { path = "../autumn", features = ["system-tests", "test-support"] }
+testcontainers = { workspace = true }
+testcontainers-modules = { workspace = true }
+tokio = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+thiserror = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/example-e2e/src/lib.rs
+++ b/example-e2e/src/lib.rs
@@ -20,9 +20,16 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
-use testcontainers::ContainerAsync;
+use testcontainers::{ContainerAsync, ImageExt};
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
+
+/// Every example's own `docker-compose.yml` targets Postgres 16 — the
+/// testcontainers-modules default (`11-alpine`) predates generated columns
+/// (used by e.g. wiki's full-text-search migration) and other features
+/// examples rely on, so smokes must provision the same major version the
+/// examples are actually built and deployed against.
+const POSTGRES_TAG: &str = "16-alpine";
 
 // ── Postgres provisioning ───────────────────────────────────────────────────
 
@@ -71,6 +78,7 @@ impl PgTopology {
 pub async fn provision_postgres(count: usize) -> PgTopology {
     let started = futures::future::join_all((0..count).map(|_| async {
         let container = Postgres::default()
+            .with_tag(POSTGRES_TAG)
             .start()
             .await
             .expect("start Postgres testcontainer");
@@ -144,7 +152,9 @@ pub enum SpawnError {
 /// period, then a hard kill on Unix; `kill()` elsewhere) so a panicking or
 /// early-returning smoke never leaks the spawned server.
 pub struct ExampleProcess {
-    child: Child,
+    // `Option` so `Drop` can synchronously `take()` the child and hand it to
+    // a background thread — see the `Drop` impl below.
+    child: Option<Child>,
     base_url: String,
 }
 
@@ -184,20 +194,30 @@ impl ExampleProcess {
 
 impl Drop for ExampleProcess {
     fn drop(&mut self) {
-        #[cfg(unix)]
-        {
-            // Mirrors the graceful-shutdown sequence the reddit-clone Tauri
-            // sidecar uses: SIGTERM first so autumn's on_shutdown hooks run
-            // (draining connections, stopping schedulers), then force-kill
-            // after a short grace period rather than blocking teardown
-            // indefinitely on a hung process.
-            let _ = Command::new("kill")
-                .args(["-TERM", &self.child.id().to_string()])
-                .status();
-            std::thread::sleep(Duration::from_millis(500));
-        }
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        // `ExampleProcess` is typically dropped at the end of an async
+        // smoke test, so the graceful-shutdown sequence (which includes a
+        // blocking sleep and a blocking `wait()`) runs on a background
+        // thread rather than blocking a Tokio worker thread.
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        std::thread::spawn(move || {
+            #[cfg(unix)]
+            {
+                // Mirrors the graceful-shutdown sequence the reddit-clone
+                // Tauri sidecar uses: SIGTERM first so autumn's
+                // on_shutdown hooks run (draining connections, stopping
+                // schedulers), then force-kill after a short grace period
+                // rather than blocking teardown indefinitely on a hung
+                // process.
+                let _ = Command::new("kill")
+                    .args(["-TERM", &child.id().to_string()])
+                    .status();
+                std::thread::sleep(Duration::from_millis(500));
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+        });
     }
 }
 
@@ -281,7 +301,10 @@ pub async fn spawn_example(
         return Err(err);
     }
 
-    Ok(ExampleProcess { child, base_url })
+    Ok(ExampleProcess {
+        child: Some(child),
+        base_url,
+    })
 }
 
 /// Poll `{base_url}/health` until it returns a successful status.
@@ -304,7 +327,7 @@ async fn wait_until_healthy(
                 status,
             });
         }
-        if let Ok(response) = reqwest::get(&url).await
+        if let Ok(Ok(response)) = tokio::time::timeout(Duration::from_secs(1), reqwest::get(&url)).await
             && response.status().is_success()
         {
             return Ok(());

--- a/example-e2e/src/lib.rs
+++ b/example-e2e/src/lib.rs
@@ -20,8 +20,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
-use testcontainers::{ContainerAsync, ImageExt};
 use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, ImageExt};
 use testcontainers_modules::postgres::Postgres;
 
 /// Every example's own `docker-compose.yml` targets Postgres 16 — the
@@ -327,7 +327,8 @@ async fn wait_until_healthy(
                 status,
             });
         }
-        if let Ok(Ok(response)) = tokio::time::timeout(Duration::from_secs(1), reqwest::get(&url)).await
+        if let Ok(Ok(response)) =
+            tokio::time::timeout(Duration::from_secs(1), reqwest::get(&url)).await
             && response.status().is_success()
         {
             return Ok(());

--- a/example-e2e/src/lib.rs
+++ b/example-e2e/src/lib.rs
@@ -49,7 +49,19 @@ impl PgTopology {
 }
 
 /// Start `count` independent Postgres containers and return their
-/// connection URLs (each `postgres://postgres:postgres@127.0.0.1:<port>/postgres`).
+/// connection URLs (`postgres://postgres:postgres@<host>:<port>/postgres`).
+///
+/// Containers are started concurrently (they're fully independent — no data
+/// dependency between them), so provisioning latency is roughly the slowest
+/// single container rather than the sum of all `count`. The returned
+/// [`PgTopology::urls`] preserve the same order as `0..count` regardless of
+/// which container actually finishes starting first — `join_all` resolves
+/// futures out of order but always returns results in input order.
+///
+/// The connection host is resolved via testcontainers' own `get_host()`
+/// (mirroring [`autumn_web::test::TestDb`]) rather than assumed to be
+/// `127.0.0.1`, since the Docker-mapped host isn't always the literal
+/// loopback address (e.g. Docker Desktop, remote Docker contexts).
 ///
 /// # Panics
 /// If Docker is unavailable or a container fails to start. Callers running
@@ -57,22 +69,31 @@ impl PgTopology {
 /// skip with a visible notice instead of calling this — see
 /// `scripts/check-examples-e2e.sh`.
 pub async fn provision_postgres(count: usize) -> PgTopology {
-    let mut containers = Vec::with_capacity(count);
-    let mut urls = Vec::with_capacity(count);
-    for _ in 0..count {
+    let started = futures::future::join_all((0..count).map(|_| async {
         let container = Postgres::default()
             .start()
             .await
             .expect("start Postgres testcontainer");
+        let host = container
+            .get_host()
+            .await
+            .expect("resolve Postgres testcontainer host");
         let port = container
             .get_host_port_ipv4(5432)
             .await
             .expect("resolve Postgres testcontainer host port");
-        urls.push(format!(
-            "postgres://postgres:postgres@127.0.0.1:{port}/postgres"
-        ));
+        let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+        (container, url)
+    }))
+    .await;
+
+    let mut containers = Vec::with_capacity(count);
+    let mut urls = Vec::with_capacity(count);
+    for (container, url) in started {
         containers.push(container);
+        urls.push(url);
     }
+
     PgTopology {
         _containers: containers,
         urls,
@@ -104,6 +125,16 @@ pub enum SpawnError {
         /// How long we waited.
         timeout: Duration,
     },
+    /// The spawned process exited before ever reporting healthy — e.g. a
+    /// panic during config/DB setup, before the HTTP listener ever bound.
+    /// Detected immediately rather than waiting out the full timeout.
+    #[error("example exited with {status} before reporting healthy at {base_url}")]
+    ExitedBeforeReady {
+        /// The base URL that was being polled when the process exited.
+        base_url: String,
+        /// The process's exit status.
+        status: std::process::ExitStatus,
+    },
 }
 
 /// A running example binary, spawned as a real OS process bound to an
@@ -125,13 +156,29 @@ impl ExampleProcess {
     }
 
     /// Attach a managed headless-Chromium [`SystemTest`] runner to this
-    /// process's base URL.
+    /// process's base URL, using the framework's default browser-launch
+    /// timeout. Use [`Self::attach_browser_with_timeout`] to override it.
     ///
     /// # Errors
     /// [`SystemTestError::BrowserNotFound`] or CDP launch errors — see
     /// [`SystemTest::attach`].
     pub async fn attach_browser(&self) -> Result<SystemTestRunner, SystemTestError> {
         SystemTest::attach(self.base_url.clone()).await
+    }
+
+    /// Like [`Self::attach_browser`], but with an explicit browser-launch
+    /// timeout — useful when CI resource contention (several Postgres
+    /// testcontainers plus Chromium competing for CPU) makes the default
+    /// too tight for a particular example's smoke.
+    ///
+    /// # Errors
+    /// [`SystemTestError::BrowserNotFound`] or CDP launch errors — see
+    /// [`SystemTest::attach_with_timeout`].
+    pub async fn attach_browser_with_timeout(
+        &self,
+        browser_timeout: Duration,
+    ) -> Result<SystemTestRunner, SystemTestError> {
+        SystemTest::attach_with_timeout(self.base_url.clone(), browser_timeout).await
     }
 }
 
@@ -217,34 +264,56 @@ pub async fn spawn_example(
         command.env(key, value);
     }
 
-    let child = command.spawn().map_err(|source| SpawnError::Spawn {
+    let mut child = command.spawn().map_err(|source| SpawnError::Spawn {
         path: bin_path.to_path_buf(),
         source,
     })?;
 
-    wait_until_healthy(&base_url, timeout)
-        .await
-        .ok_or_else(|| SpawnError::NotReady {
-            base_url: base_url.clone(),
-            timeout,
-        })?;
+    if let Err(err) = wait_until_healthy(&base_url, &mut child, timeout).await {
+        // `child` is a plain `std::process::Child` here, not yet wrapped in
+        // an `ExampleProcess` (whose `Drop` impl does this same
+        // kill-then-reap) — without an explicit kill on this early-return
+        // path, a `NotReady` timeout would leak a still-running orphaned
+        // process. `ExitedBeforeReady` means it's already dead, so `kill()`
+        // here is a harmless no-op for that case.
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(err);
+    }
 
     Ok(ExampleProcess { child, base_url })
 }
 
-/// Poll `{base_url}/health` until it returns a successful status, or `None`
-/// once `timeout` elapses.
-async fn wait_until_healthy(base_url: &str, timeout: Duration) -> Option<()> {
+/// Poll `{base_url}/health` until it returns a successful status.
+///
+/// Also checks `child`'s exit status on every iteration so a process that
+/// dies early (e.g. panics during config/DB setup before ever binding its
+/// listener) is detected and reported immediately, instead of polling a
+/// dead process for the entire `timeout`.
+async fn wait_until_healthy(
+    base_url: &str,
+    child: &mut Child,
+    timeout: Duration,
+) -> Result<(), SpawnError> {
     let deadline = tokio::time::Instant::now() + timeout;
     let url = format!("{base_url}/health");
     loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            return Err(SpawnError::ExitedBeforeReady {
+                base_url: base_url.to_string(),
+                status,
+            });
+        }
         if let Ok(response) = reqwest::get(&url).await
             && response.status().is_success()
         {
-            return Some(());
+            return Ok(());
         }
         if tokio::time::Instant::now() >= deadline {
-            return None;
+            return Err(SpawnError::NotReady {
+                base_url: base_url.to_string(),
+                timeout,
+            });
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }

--- a/example-e2e/src/lib.rs
+++ b/example-e2e/src/lib.rs
@@ -1,0 +1,251 @@
+//! Shared support for issue #1192's per-example Chromium e2e smokes.
+//!
+//! Each example's smoke test spawns the example's **real, unmodified
+//! binary** (built normally by `cargo build`, never re-registered
+//! in-process) against ephemeral testcontainer Postgres, then attaches a
+//! managed headless-Chromium [`SystemTest`] runner at its base URL via
+//! [`SystemTest::attach`]. This runs `main.rs` exactly as a release would:
+//! real routes, real builder chain, real auto-migration on boot — so a
+//! regression in any wired-up feature (shard routing, primary/replica
+//! split, mutation hooks, ...) is caught the same way a human clicking
+//! through the app would catch it.
+//!
+//! Not published; workspace-internal tooling only (`publish = false`).
+
+pub use autumn_web::system_test::{Page, SystemTest, SystemTestError, SystemTestRunner};
+
+use std::io;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+// ── Postgres provisioning ───────────────────────────────────────────────────
+
+/// One or more independent, ephemeral Postgres databases provisioned for a
+/// single example's smoke test. Dropping this stops every container.
+///
+/// Callers pass the appropriate [`urls`](Self::urls) into the spawned
+/// example's config via env vars (e.g. `AUTUMN_DATABASE__PRIMARY_URL`,
+/// `AUTUMN_DATABASE__SHARDS__0__PRIMARY_URL`) — the exact wiring is
+/// example-specific, so this stays a plain list rather than baking in any
+/// one example's topology.
+pub struct PgTopology {
+    // Held only for its `Drop` impl, which tears the container down.
+    _containers: Vec<ContainerAsync<Postgres>>,
+    urls: Vec<String>,
+}
+
+impl PgTopology {
+    /// The connection URL(s), in provisioning order.
+    #[must_use]
+    pub fn urls(&self) -> &[String] {
+        &self.urls
+    }
+}
+
+/// Start `count` independent Postgres containers and return their
+/// connection URLs (each `postgres://postgres:postgres@127.0.0.1:<port>/postgres`).
+///
+/// # Panics
+/// If Docker is unavailable or a container fails to start. Callers running
+/// under the fan-out harness should probe Docker availability first and
+/// skip with a visible notice instead of calling this — see
+/// `scripts/check-examples-e2e.sh`.
+pub async fn provision_postgres(count: usize) -> PgTopology {
+    let mut containers = Vec::with_capacity(count);
+    let mut urls = Vec::with_capacity(count);
+    for _ in 0..count {
+        let container = Postgres::default()
+            .start()
+            .await
+            .expect("start Postgres testcontainer");
+        let port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("resolve Postgres testcontainer host port");
+        urls.push(format!(
+            "postgres://postgres:postgres@127.0.0.1:{port}/postgres"
+        ));
+        containers.push(container);
+    }
+    PgTopology {
+        _containers: containers,
+        urls,
+    }
+}
+
+// ── Example process boot ────────────────────────────────────────────────────
+
+/// Errors booting an example binary under test.
+#[derive(Debug, thiserror::Error)]
+pub enum SpawnError {
+    /// Could not reserve an ephemeral loopback port.
+    #[error("failed to reserve an ephemeral port: {0}")]
+    Port(#[source] io::Error),
+    /// The example binary itself failed to start (e.g. not built, not
+    /// executable).
+    #[error("failed to spawn example binary at {path}: {source}")]
+    Spawn {
+        /// Path to the binary that failed to spawn.
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    /// The spawned process never answered `GET /health` within the timeout.
+    #[error("example at {base_url} did not report healthy within {timeout:?}")]
+    NotReady {
+        /// The base URL that was polled.
+        base_url: String,
+        /// How long we waited.
+        timeout: Duration,
+    },
+}
+
+/// A running example binary, spawned as a real OS process bound to an
+/// ephemeral loopback port.
+///
+/// Dropping this terminates the process (`SIGTERM` then a short grace
+/// period, then a hard kill on Unix; `kill()` elsewhere) so a panicking or
+/// early-returning smoke never leaks the spawned server.
+pub struct ExampleProcess {
+    child: Child,
+    base_url: String,
+}
+
+impl ExampleProcess {
+    /// The base URL of the running example, e.g. `http://127.0.0.1:49832`.
+    #[must_use]
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Attach a managed headless-Chromium [`SystemTest`] runner to this
+    /// process's base URL.
+    ///
+    /// # Errors
+    /// [`SystemTestError::BrowserNotFound`] or CDP launch errors — see
+    /// [`SystemTest::attach`].
+    pub async fn attach_browser(&self) -> Result<SystemTestRunner, SystemTestError> {
+        SystemTest::attach(self.base_url.clone()).await
+    }
+}
+
+impl Drop for ExampleProcess {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        {
+            // Mirrors the graceful-shutdown sequence the reddit-clone Tauri
+            // sidecar uses: SIGTERM first so autumn's on_shutdown hooks run
+            // (draining connections, stopping schedulers), then force-kill
+            // after a short grace period rather than blocking teardown
+            // indefinitely on a hung process.
+            let _ = Command::new("kill")
+                .args(["-TERM", &self.child.id().to_string()])
+                .status();
+            std::thread::sleep(Duration::from_millis(500));
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Default budget for a spawned example to report healthy.
+pub const DEFAULT_READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Spawn `bin_path` (typically `env!("CARGO_BIN_EXE_<name>")`) as the
+/// application under test, on a fresh ephemeral loopback port, with `envs`
+/// applied on top of the current process's environment. `AUTUMN_ENV` is set
+/// to `development` by default (so the example auto-migrates any registered
+/// migrations against a fresh testcontainer DB on boot, matching a
+/// developer's local `cargo run`) and `AUTUMN_SERVER__PORT`/`__HOST` are
+/// always set to the reserved port — both can be overridden via `envs` if a
+/// smoke needs to.
+///
+/// The child's stdout/stderr are inherited (not piped) so example logs
+/// appear directly in the test/CI output — piping without draining risks a
+/// deadlock if the app logs more than the OS pipe buffer before becoming
+/// healthy, which busier examples (jobs, tracing) can do.
+///
+/// `current_dir` should be the example crate's own root — typically
+/// `env!("CARGO_MANIFEST_DIR")` evaluated in the *example's* smoke test
+/// (not in this shared crate, where it would resolve to the wrong
+/// directory). Config env vars override file-based config, but several
+/// examples resolve other paths relative to their crate root at runtime
+/// (`autumn.toml` itself, wiki's `content/`, static assets), so the child's
+/// working directory must be set explicitly rather than inherited from
+/// wherever `cargo test` happens to run.
+///
+/// Polls `GET {base_url}/health` until it responds successfully or
+/// `timeout` elapses.
+///
+/// # Errors
+/// See [`SpawnError`].
+pub async fn spawn_example(
+    bin_path: impl AsRef<Path>,
+    current_dir: impl AsRef<Path>,
+    envs: &[(&str, &str)],
+    timeout: Duration,
+) -> Result<ExampleProcess, SpawnError> {
+    let bin_path = bin_path.as_ref();
+
+    // Reserve an ephemeral port: bind :0, read the assigned port, then drop
+    // the listener so the spawned process can bind it. There is a brief
+    // window between dropping the listener and the child binding the port;
+    // in practice (loopback, immediately-following spawn) this race is
+    // exceedingly rare — the same trade-off the reddit-clone Tauri sidecar
+    // and `SystemTest::build`'s own ephemeral-port binding make.
+    let port = {
+        let listener = TcpListener::bind("127.0.0.1:0").map_err(SpawnError::Port)?;
+        listener.local_addr().map_err(SpawnError::Port)?.port()
+    };
+    let base_url = format!("http://127.0.0.1:{port}");
+
+    let mut command = Command::new(bin_path);
+    command
+        .current_dir(current_dir.as_ref())
+        .env("AUTUMN_ENV", "development")
+        .env("AUTUMN_SERVER__PORT", port.to_string())
+        .env("AUTUMN_SERVER__HOST", "127.0.0.1")
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+
+    let child = command.spawn().map_err(|source| SpawnError::Spawn {
+        path: bin_path.to_path_buf(),
+        source,
+    })?;
+
+    wait_until_healthy(&base_url, timeout)
+        .await
+        .ok_or_else(|| SpawnError::NotReady {
+            base_url: base_url.clone(),
+            timeout,
+        })?;
+
+    Ok(ExampleProcess { child, base_url })
+}
+
+/// Poll `{base_url}/health` until it returns a successful status, or `None`
+/// once `timeout` elapses.
+async fn wait_until_healthy(base_url: &str, timeout: Duration) -> Option<()> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let url = format!("{base_url}/health");
+    loop {
+        if let Ok(response) = reqwest::get(&url).await
+            && response.status().is_success()
+        {
+            return Some(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return None;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}

--- a/example-e2e/src/lib.rs
+++ b/example-e2e/src/lib.rs
@@ -194,30 +194,31 @@ impl ExampleProcess {
 
 impl Drop for ExampleProcess {
     fn drop(&mut self) {
-        // `ExampleProcess` is typically dropped at the end of an async
-        // smoke test, so the graceful-shutdown sequence (which includes a
-        // blocking sleep and a blocking `wait()`) runs on a background
-        // thread rather than blocking a Tokio worker thread.
+        // Deliberately synchronous, unlike `SystemTestRunner`'s Drop: every
+        // example smoke is the sole `#[tokio::test]` in its own integration-
+        // test binary (see `tests/system/smoke.rs` in each example), so
+        // there is no sibling task on the runtime for a blocking sleep here
+        // to starve. Backgrounding this onto a detached thread would trade
+        // that non-issue for a real one — the test binary's `main` can
+        // return and the process exit before a detached thread ever runs,
+        // leaking the spawned example server across the e2e fan-out.
         let Some(mut child) = self.child.take() else {
             return;
         };
-        std::thread::spawn(move || {
-            #[cfg(unix)]
-            {
-                // Mirrors the graceful-shutdown sequence the reddit-clone
-                // Tauri sidecar uses: SIGTERM first so autumn's
-                // on_shutdown hooks run (draining connections, stopping
-                // schedulers), then force-kill after a short grace period
-                // rather than blocking teardown indefinitely on a hung
-                // process.
-                let _ = Command::new("kill")
-                    .args(["-TERM", &child.id().to_string()])
-                    .status();
-                std::thread::sleep(Duration::from_millis(500));
-            }
-            let _ = child.kill();
-            let _ = child.wait();
-        });
+        #[cfg(unix)]
+        {
+            // Mirrors the graceful-shutdown sequence the reddit-clone Tauri
+            // sidecar uses: SIGTERM first so autumn's on_shutdown hooks run
+            // (draining connections, stopping schedulers), then force-kill
+            // after a short grace period rather than blocking teardown
+            // indefinitely on a hung process.
+            let _ = Command::new("kill")
+                .args(["-TERM", &child.id().to_string()])
+                .status();
+            std::thread::sleep(Duration::from_millis(500));
+        }
+        let _ = child.kill();
+        let _ = child.wait();
     }
 }
 

--- a/examples/blog/Cargo.toml
+++ b/examples/blog/Cargo.toml
@@ -22,6 +22,16 @@ tokio = { version = "1", features = ["full"] }
 # The `db` feature is inherited from [dependencies]; test-support adds TestDb.
 autumn-web = { path = "../../autumn", features = ["test-support"] }
 serde_json = "1"
+example-e2e = { path = "../../example-e2e" }
+
+[features]
+# Enable the headless-browser system smoke. Requires Chromium on the host.
+#   cargo test -p blog --features system-tests --test smoke -- --include-ignored
+system-tests = ["autumn-web/system-tests"]
+
+[[test]]
+name = "smoke"
+path = "tests/system/smoke.rs"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/examples/blog/tests/system/smoke.rs
+++ b/examples/blog/tests/system/smoke.rs
@@ -1,0 +1,52 @@
+//! Baseline Chromium smoke — issue #1192.
+//!
+//! Spawns the real `blog` binary against an ephemeral testcontainer
+//! Postgres (migrated automatically on boot — `AUTUMN_ENV=development`),
+//! drives a headless-Chromium browser against the public index and the
+//! pre-rendered `#[static_get]` about page, and asserts expected content
+//! with no uncaught console errors.
+//!
+//! Run (requires Chromium + Docker):
+//!   cargo test -p blog --features system-tests --test smoke -- --include-ignored
+
+#![cfg(feature = "system-tests")]
+
+#[tokio::test]
+#[ignore = "requires Chromium + Docker — set AUTUMN_CHROMIUM or install chromium-browser"]
+async fn blog_boots_and_serves_public_pages() {
+    let db = example_e2e::provision_postgres(1).await;
+
+    let app = example_e2e::spawn_example(
+        env!("CARGO_BIN_EXE_blog"),
+        env!("CARGO_MANIFEST_DIR"),
+        &[("AUTUMN_DATABASE__URL", &db.urls()[0])],
+        example_e2e::DEFAULT_READY_TIMEOUT,
+    )
+    .await
+    .expect("spawn blog example — is it built?");
+
+    let runner = app
+        .attach_browser()
+        .await
+        .expect("attach browser — is Chromium installed?");
+    let page = runner.page().await.expect("open page");
+
+    page.visit("/").await.expect("visit /");
+    page.expect_text("Welcome to the Blog")
+        .await
+        .expect("index heading renders");
+    page.expect_text("No posts yet. Check back soon!")
+        .await
+        .expect("empty-state renders against the freshly migrated DB");
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors on /");
+
+    page.visit("/about").await.expect("visit /about");
+    page.expect_text("About This Blog")
+        .await
+        .expect("pre-rendered about page renders");
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors on /about");
+}

--- a/examples/bookmarks-distributed/Cargo.toml
+++ b/examples/bookmarks-distributed/Cargo.toml
@@ -27,6 +27,17 @@ autumn-web = { path = "../../autumn", features = ["test-support"] }
 autumn-cache-redis = { path = "../../autumn-cache-redis" }
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
+diesel_migrations = "2"
+example-e2e = { path = "../../example-e2e" }
+
+[features]
+# Enable the headless-browser system smoke. Requires Chromium on the host.
+#   cargo test -p bookmarks-distributed --features system-tests --test smoke -- --include-ignored
+system-tests = ["autumn-web/system-tests"]
+
+[[test]]
+name = "smoke"
+path = "tests/system/smoke.rs"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/examples/bookmarks-distributed/tests/system/smoke.rs
+++ b/examples/bookmarks-distributed/tests/system/smoke.rs
@@ -1,0 +1,103 @@
+//! Baseline Chromium smoke — issue #1192.
+//!
+//! Spawns the real `bookmarks-distributed` binary against **two** ephemeral
+//! testcontainer Postgres instances standing in for the primary/replica
+//! pair, drives a headless-Chromium browser against the bookmarks list, and
+//! asserts expected content with no uncaught console errors — proving the
+//! dual-pool primary/replica config still boots and serves.
+//!
+//! `bookmarks-distributed`'s database config (`src/config.rs`) is a bespoke
+//! loader (`DistributedConfig::load()`), not the framework's own
+//! `AutumnConfig` — it only reads `primary_url`/`replica_url` from
+//! `autumn.toml` (+ profile overlay) on disk, with no env-var override.
+//! `AUTUMN_MANIFEST_DIR` redirects **both** that loader and the framework's
+//! own config to a scratch directory containing a minimal `autumn.toml`
+//! carrying the two testcontainer URLs.
+//!
+//! The framework only auto-migrates the *primary* on boot (a real replica
+//! already has the schema via streaming replication); since the "replica"
+//! here is a second independent empty database rather than a true
+//! replication target, this test migrates both explicitly before spawning
+//! so replica-routed reads see the same schema.
+//!
+//! Out of scope (per issue #1192): the real docker-compose topology
+//! (nginx + multiple web replicas + actual Postgres streaming replication).
+//! This proves the *primary/replica dual-pool feature* boots correctly in a
+//! single process, not the full compose integration.
+//!
+//! Run (requires Chromium + Docker):
+//!   cargo test -p bookmarks-distributed --features system-tests --test smoke -- --include-ignored
+
+#![cfg(feature = "system-tests")]
+
+use diesel_migrations::{EmbeddedMigrations, embed_migrations};
+
+const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
+
+#[tokio::test]
+#[ignore = "requires Chromium + Docker — set AUTUMN_CHROMIUM or install chromium-browser"]
+async fn bookmarks_distributed_boots_with_dual_pools() {
+    let db = example_e2e::provision_postgres(2).await;
+    let primary_url = &db.urls()[0];
+    let replica_url = &db.urls()[1];
+
+    // Mirror the schema onto both — see module docs for why.
+    autumn_web::migrate::run_pending(primary_url, MIGRATIONS)
+        .expect("migrate primary testcontainer");
+    autumn_web::migrate::run_pending(replica_url, MIGRATIONS)
+        .expect("migrate replica-stand-in testcontainer");
+
+    // Redirect both `DistributedConfig::load()` and the framework's own
+    // `AutumnConfig` to a scratch autumn.toml carrying the testcontainer
+    // URLs — see module docs.
+    let scratch_dir = std::env::temp_dir().join(format!(
+        "bookmarks-distributed-smoke-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&scratch_dir).expect("create scratch config dir");
+    std::fs::write(
+        scratch_dir.join("autumn.toml"),
+        format!(
+            r#"
+[health]
+path = "/health"
+
+[database]
+primary_url = "{primary_url}"
+replica_url = "{replica_url}"
+primary_pool_size = 2
+replica_pool_size = 2
+replica_fallback = "fail_readiness"
+"#
+        ),
+    )
+    .expect("write scratch autumn.toml");
+
+    let app = example_e2e::spawn_example(
+        env!("CARGO_BIN_EXE_bookmarks-distributed"),
+        env!("CARGO_MANIFEST_DIR"),
+        &[(
+            "AUTUMN_MANIFEST_DIR",
+            scratch_dir.to_str().expect("scratch dir path is UTF-8"),
+        )],
+        example_e2e::DEFAULT_READY_TIMEOUT,
+    )
+    .await
+    .expect("spawn bookmarks-distributed example — is it built?");
+
+    let runner = app
+        .attach_browser()
+        .await
+        .expect("attach browser — is Chromium installed?");
+    let page = runner.page().await.expect("open page");
+
+    page.visit("/").await.expect("visit /");
+    page.expect_text("All Bookmarks")
+        .await
+        .expect("bookmarks list heading renders via the replica-routed read pool");
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors on /");
+
+    let _ = std::fs::remove_dir_all(&scratch_dir);
+}

--- a/examples/bookmarks-distributed/tests/system/smoke.rs
+++ b/examples/bookmarks-distributed/tests/system/smoke.rs
@@ -14,6 +14,13 @@
 //! own config to a scratch directory containing a minimal `autumn.toml`
 //! carrying the two testcontainer URLs.
 //!
+//! `AUTUMN_MANIFEST_DIR` also redirects the framework's `/static` file
+//! serving (`project_dir("static", ...)` in `router.rs`) to
+//! `<AUTUMN_MANIFEST_DIR>/static` — so the scratch dir gets a symlink to the
+//! real project's `static/` alongside the scratch `autumn.toml`, keeping the
+//! rendered page's actual `<link>`/`<script>` asset paths (e.g.
+//! `static/css/autumn.css`) served exactly as the unmodified binary would.
+//!
 //! The framework only auto-migrates the *primary* on boot (a real replica
 //! already has the schema via streaming replication); since the "replica"
 //! here is a second independent empty database rather than a true
@@ -72,6 +79,16 @@ replica_fallback = "fail_readiness"
         ),
     )
     .expect("write scratch autumn.toml");
+
+    // See module docs: redirecting AUTUMN_MANIFEST_DIR to the scratch dir
+    // also redirects `/static` file serving there, so without this the page
+    // would 404 on its real CSS/JS instead of exercising them.
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("static"),
+        scratch_dir.join("static"),
+    )
+    .expect("symlink scratch static dir to the real project's static dir");
 
     let app = example_e2e::spawn_example(
         env!("CARGO_BIN_EXE_bookmarks-distributed"),

--- a/examples/bookmarks-sharded/Cargo.toml
+++ b/examples/bookmarks-sharded/Cargo.toml
@@ -17,5 +17,17 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 validator = { version = "0.20", features = ["derive"] }
 
+[dev-dependencies]
+example-e2e = { path = "../../example-e2e" }
+
+[features]
+# Enable the headless-browser system smoke. Requires Chromium on the host.
+#   cargo test -p bookmarks-sharded --features system-tests --test smoke -- --include-ignored
+system-tests = ["autumn-web/system-tests"]
+
+[[test]]
+name = "smoke"
+path = "tests/system/smoke.rs"
+
 [lints.rust]
 unsafe_code = "forbid"

--- a/examples/bookmarks-sharded/autumn.toml
+++ b/examples/bookmarks-sharded/autumn.toml
@@ -34,3 +34,8 @@ slots = ["8192-16383"]
 enabled = true
 source = "header"
 header_name = "x-tenant-id"
+# The browser auto-requests /favicon.ico for any page load; without this it's
+# rejected by the same header check as every other route (400, not the 404 a
+# missing route would give), which the browser's headless smoke test reports
+# as a real console error.
+public_paths = ["/favicon.ico"]

--- a/examples/bookmarks-sharded/tests/system/smoke.rs
+++ b/examples/bookmarks-sharded/tests/system/smoke.rs
@@ -1,0 +1,93 @@
+//! Baseline Chromium smoke — issue #1192.
+//!
+//! Spawns the real `bookmarks-sharded` binary against **three** ephemeral
+//! testcontainer Postgres instances (control + shard0 + shard1), drives a
+//! headless-Chromium browser against the cross-shard `/api/stats`
+//! fan-out endpoint, and asserts both shards answer with no uncaught
+//! console errors — the direct regression guard for the framework's
+//! `[[database.shards]]` shard-routing feature.
+//!
+//! `bookmarks-sharded` uses the framework's own `AutumnConfig`, so unlike
+//! `bookmarks-distributed`'s bespoke loader, standard
+//! `AUTUMN_DATABASE__*` env overrides work directly — no scratch config
+//! file needed. The app auto-migrates the control database *and* every
+//! configured shard on boot (`AUTUMN_ENV=development`, set by
+//! `spawn_example`), so `/api/stats`'s per-shard `bookmarks: 0` (rather
+//! than an `error` field) is itself proof the shard pools connected and
+//! the schema landed on both.
+//!
+//! Out of scope (per issue #1192): the real docker-compose topology
+//! (nginx + multiple web replicas + a shard's own read replica). This
+//! proves the *shard routing/fan-out feature* in a single process.
+//!
+//! Run (requires Chromium + Docker):
+//!   cargo test -p bookmarks-sharded --features system-tests --test smoke -- --include-ignored
+
+#![cfg(feature = "system-tests")]
+
+#[tokio::test]
+#[ignore = "requires Chromium + Docker — set AUTUMN_CHROMIUM or install chromium-browser"]
+async fn bookmarks_sharded_boots_and_fans_out_across_shards() {
+    let db = example_e2e::provision_postgres(3).await;
+    let control_url = &db.urls()[0];
+    let shard0_url = &db.urls()[1];
+    let shard1_url = &db.urls()[2];
+
+    let app = example_e2e::spawn_example(
+        env!("CARGO_BIN_EXE_bookmarks-sharded"),
+        env!("CARGO_MANIFEST_DIR"),
+        &[
+            ("AUTUMN_DATABASE__PRIMARY_URL", control_url.as_str()),
+            ("AUTUMN_DATABASE__SHARDS__0__NAME", "shard0"),
+            (
+                "AUTUMN_DATABASE__SHARDS__0__PRIMARY_URL",
+                shard0_url.as_str(),
+            ),
+            ("AUTUMN_DATABASE__SHARDS__0__SLOTS", "0-8191"),
+            ("AUTUMN_DATABASE__SHARDS__1__NAME", "shard1"),
+            (
+                "AUTUMN_DATABASE__SHARDS__1__PRIMARY_URL",
+                shard1_url.as_str(),
+            ),
+            ("AUTUMN_DATABASE__SHARDS__1__SLOTS", "8192-16383"),
+        ],
+        example_e2e::DEFAULT_READY_TIMEOUT,
+    )
+    .await
+    .expect("spawn bookmarks-sharded example — is it built?");
+
+    let runner = app
+        .attach_browser()
+        .await
+        .expect("attach browser — is Chromium installed?");
+    let page = runner.page().await.expect("open page");
+
+    // `/api/stats` sits behind the app's global header-based tenancy
+    // middleware (every route requires `X-Tenant-Id`, not just the
+    // tenant-scoped ones), and a plain navigation can't set a custom
+    // request header. First load *some* same-origin page (a 400 from the
+    // tenancy check is still a real, same-origin response) so `evaluate()`
+    // can `fetch()` with the header from that origin, then write the
+    // response into the DOM for `expect_text` to poll.
+    page.visit("/api/stats").await.expect("visit /api/stats");
+    page.evaluate(
+        "fetch('/api/stats', { headers: { 'X-Tenant-Id': 'acme' } })\
+         .then(r => r.text())\
+         .then(t => { document.body.textContent = t; })",
+    )
+    .await
+    .expect("evaluate authenticated fetch");
+
+    page.expect_text("\"shard0\"")
+        .await
+        .expect("cross-shard fan-out reaches shard0");
+    page.expect_text("\"shard1\"")
+        .await
+        .expect("cross-shard fan-out reaches shard1");
+    page.expect_text("\"bookmarks\":0")
+        .await
+        .expect("both shards report a bookmark count (not an error) — schema landed on both");
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors on /api/stats");
+}

--- a/examples/bookmarks-sharded/tests/system/smoke.rs
+++ b/examples/bookmarks-sharded/tests/system/smoke.rs
@@ -65,11 +65,12 @@ async fn bookmarks_sharded_boots_and_fans_out_across_shards() {
     // `/api/stats` sits behind the app's global header-based tenancy
     // middleware (every route requires `X-Tenant-Id`, not just the
     // tenant-scoped ones), and a plain navigation can't set a custom
-    // request header. First load *some* same-origin page (a 400 from the
-    // tenancy check is still a real, same-origin response) so `evaluate()`
-    // can `fetch()` with the header from that origin, then write the
-    // response into the DOM for `expect_text` to poll.
-    page.visit("/api/stats").await.expect("visit /api/stats");
+    // request header. `/health` is exempt from that middleware (public
+    // probe endpoint) and always 200s, so load it first purely to land in
+    // the app's origin, then `evaluate()` can `fetch()` `/api/stats` with
+    // the header from there and write the response into the DOM for
+    // `expect_text` to poll.
+    page.visit("/health").await.expect("visit /health");
     page.evaluate(
         "fetch('/api/stats', { headers: { 'X-Tenant-Id': 'acme' } })\
          .then(r => r.text())\

--- a/examples/bookmarks/Cargo.toml
+++ b/examples/bookmarks/Cargo.toml
@@ -25,6 +25,16 @@ autumn-web = { path = "../../autumn", features = ["test-support"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "2", features = ["postgres", "chrono"] }
+example-e2e = { path = "../../example-e2e" }
+
+[features]
+# Enable the headless-browser system smoke. Requires Chromium on the host.
+#   cargo test -p bookmarks --features system-tests --test smoke -- --include-ignored
+system-tests = ["autumn-web/system-tests"]
+
+[[test]]
+name = "smoke"
+path = "tests/system/smoke.rs"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/examples/bookmarks/tests/system/smoke.rs
+++ b/examples/bookmarks/tests/system/smoke.rs
@@ -45,4 +45,7 @@ async fn bookmarks_boots_and_serves_list_and_health() {
     page.expect_text("UP")
         .await
         .expect("actuator health reports UP against the freshly migrated DB");
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors on /actuator/health");
 }

--- a/examples/bookmarks/tests/system/smoke.rs
+++ b/examples/bookmarks/tests/system/smoke.rs
@@ -1,0 +1,48 @@
+//! Baseline Chromium smoke — issue #1192.
+//!
+//! Spawns the real `bookmarks` binary against an ephemeral testcontainer
+//! Postgres (migrated automatically on boot — `AUTUMN_ENV=development`),
+//! drives a headless-Chromium browser against the bookmarks list and the
+//! actuator health endpoint, and asserts expected content with no uncaught
+//! console errors.
+//!
+//! Run (requires Chromium + Docker):
+//!   cargo test -p bookmarks --features system-tests --test smoke -- --include-ignored
+
+#![cfg(feature = "system-tests")]
+
+#[tokio::test]
+#[ignore = "requires Chromium + Docker — set AUTUMN_CHROMIUM or install chromium-browser"]
+async fn bookmarks_boots_and_serves_list_and_health() {
+    let db = example_e2e::provision_postgres(1).await;
+
+    let app = example_e2e::spawn_example(
+        env!("CARGO_BIN_EXE_bookmarks"),
+        env!("CARGO_MANIFEST_DIR"),
+        &[("AUTUMN_DATABASE__URL", &db.urls()[0])],
+        example_e2e::DEFAULT_READY_TIMEOUT,
+    )
+    .await
+    .expect("spawn bookmarks example — is it built?");
+
+    let runner = app
+        .attach_browser()
+        .await
+        .expect("attach browser — is Chromium installed?");
+    let page = runner.page().await.expect("open page");
+
+    page.visit("/bookmarks").await.expect("visit /bookmarks");
+    page.expect_text("All Bookmarks")
+        .await
+        .expect("bookmarks list heading renders");
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors on /bookmarks");
+
+    page.visit("/actuator/health")
+        .await
+        .expect("visit /actuator/health");
+    page.expect_text("UP")
+        .await
+        .expect("actuator health reports UP against the freshly migrated DB");
+}

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -7,5 +7,18 @@ publish = false
 [dependencies]
 autumn-web = { path = "../../autumn" }
 
+[dev-dependencies]
+example-e2e = { path = "../../example-e2e" }
+tokio = { workspace = true }
+
+[features]
+# Enable the headless-browser system smoke. Requires Chromium on the host.
+#   cargo test -p hello --features system-tests --test smoke -- --include-ignored
+system-tests = ["autumn-web/system-tests"]
+
+[[test]]
+name = "smoke"
+path = "tests/system/smoke.rs"
+
 [lints.rust]
 unsafe_code = "forbid"

--- a/examples/hello/tests/system/smoke.rs
+++ b/examples/hello/tests/system/smoke.rs
@@ -1,0 +1,55 @@
+//! Baseline Chromium smoke — issue #1192.
+//!
+//! Spawns the real `hello` binary (built normally by cargo, routes
+//! untouched) on an ephemeral port, drives a headless-Chromium browser
+//! against its primary routes, and asserts expected content with no
+//! uncaught console errors.
+//!
+//! Run (requires Chromium):
+//!   cargo test -p hello --features system-tests --test smoke -- --include-ignored
+//!
+//!   AUTUMN_CHROMIUM=/path/to/chrome cargo test ...   # custom binary
+
+#![cfg(feature = "system-tests")]
+
+#[tokio::test]
+#[ignore = "requires Chromium — set AUTUMN_CHROMIUM or install chromium-browser"]
+async fn hello_boots_and_serves_primary_routes() {
+    let app = example_e2e::spawn_example(
+        env!("CARGO_BIN_EXE_hello"),
+        env!("CARGO_MANIFEST_DIR"),
+        &[],
+        example_e2e::DEFAULT_READY_TIMEOUT,
+    )
+    .await
+    .expect("spawn hello example — is it built?");
+
+    let runner = app
+        .attach_browser()
+        .await
+        .expect("attach browser — is Chromium installed?");
+    let page = runner.page().await.expect("open page");
+
+    page.visit("/").await.expect("visit /");
+    page.expect_text("Welcome to Autumn!")
+        .await
+        .expect("index route renders");
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors on /");
+
+    page.visit("/hello").await.expect("visit /hello");
+    page.expect_text("Hello, Autumn!")
+        .await
+        .expect("/hello route renders");
+
+    page.visit("/hello/World")
+        .await
+        .expect("visit /hello/World");
+    page.expect_text("Hello, World!")
+        .await
+        .expect("/hello/{name} route renders with the path param");
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors after navigating between routes");
+}

--- a/examples/reddit-clone/Cargo.toml
+++ b/examples/reddit-clone/Cargo.toml
@@ -40,9 +40,17 @@ tempfile = "3"
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
 tracing-subscriber = "0.3"
+example-e2e = { path = "../../example-e2e" }
 
 [lints.rust]
 unsafe_code = "forbid"
 
 [features]
 embed-assets = ["autumn-web/embed-assets"]
+# Enable the headless-browser system smoke. Requires Chromium on the host.
+#   cargo test -p reddit-clone --features system-tests --test smoke -- --include-ignored
+system-tests = ["autumn-web/system-tests"]
+
+[[test]]
+name = "smoke"
+path = "tests/system/smoke.rs"

--- a/examples/reddit-clone/tests/system/smoke.rs
+++ b/examples/reddit-clone/tests/system/smoke.rs
@@ -1,0 +1,55 @@
+//! Baseline Chromium smoke — issue #1192.
+//!
+//! Spawns the real `reddit-clone` binary — autumn's canonical
+//! feature-showcase example (jobs, flags, experiments, sessions, CSRF,
+//! htmx, ...) — against an ephemeral testcontainer Postgres (migrated
+//! automatically on boot — `AUTUMN_ENV=development`), drives a
+//! headless-Chromium browser against the front page and the public login
+//! page, and asserts expected content with no uncaught console errors.
+//!
+//! This is the highest-value smoke in the fleet: reddit-clone's `main.rs`
+//! wires up more of the framework than any other example (flag store,
+//! experiment service, error reporter, Postgres-backed job runtime), so
+//! booting it for real is the strongest single "did anything rot" signal.
+//!
+//! Run (requires Chromium + Docker):
+//!   cargo test -p reddit-clone --features system-tests --test smoke -- --include-ignored
+
+#![cfg(feature = "system-tests")]
+
+#[tokio::test]
+#[ignore = "requires Chromium + Docker — set AUTUMN_CHROMIUM or install chromium-browser"]
+async fn reddit_clone_boots_and_serves_front_page() {
+    let db = example_e2e::provision_postgres(1).await;
+
+    let app = example_e2e::spawn_example(
+        env!("CARGO_BIN_EXE_reddit-clone"),
+        env!("CARGO_MANIFEST_DIR"),
+        &[("AUTUMN_DATABASE__URL", &db.urls()[0])],
+        example_e2e::DEFAULT_READY_TIMEOUT,
+    )
+    .await
+    .expect("spawn reddit-clone example — is it built?");
+
+    let runner = app
+        .attach_browser()
+        .await
+        .expect("attach browser — is Chromium installed?");
+    let page = runner.page().await.expect("open page");
+
+    page.visit("/").await.expect("visit /");
+    page.expect_text("autumn/reddit")
+        .await
+        .expect("nav brand renders — real routes + state booted");
+    page.expect_text("Hot")
+        .await
+        .expect("front page sort tabs render");
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors on the front page");
+
+    page.visit("/login").await.expect("visit /login");
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors on /login");
+}

--- a/examples/saas/Cargo.toml
+++ b/examples/saas/Cargo.toml
@@ -19,6 +19,16 @@ validator = { version = "0.20", features = ["derive"] }
 [dev-dependencies]
 autumn-web = { path = "../../autumn", features = ["test-support"] }
 tokio = { version = "1", features = ["rt", "macros"] }
+example-e2e = { path = "../../example-e2e" }
+
+[features]
+# Enable the headless-browser system smoke. Requires Chromium on the host.
+#   cargo test -p saas --features system-tests --test smoke -- --include-ignored
+system-tests = ["autumn-web/system-tests"]
+
+[[test]]
+name = "smoke"
+path = "tests/system/smoke.rs"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/examples/saas/autumn.toml
+++ b/examples/saas/autumn.toml
@@ -25,5 +25,5 @@ pool_size = 10
 enabled = true
 source = "session"
 session_key = "tenant_id"
-public_paths = ["/", "/login", "/signup", "/logout", "/static"]
+public_paths = ["/", "/login", "/signup", "/logout", "/static", "/favicon.ico"]
 login_redirect = "/login"

--- a/examples/saas/src/routes/layout.rs
+++ b/examples/saas/src/routes/layout.rs
@@ -15,7 +15,7 @@ pub fn layout(title: &str, signed_in: bool, content: Markup) -> Markup {
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { (title) " · saas" }
                 link rel="stylesheet" href="/static/css/app.css";
-                (javascript_include_tag("htmx"))
+                script src="/static/js/htmx.min.js" {}
             }
             body class="bg-gray-50 text-gray-900" {
                 header class="border-b bg-white" {

--- a/examples/saas/tests/system/smoke.rs
+++ b/examples/saas/tests/system/smoke.rs
@@ -1,0 +1,41 @@
+//! Baseline Chromium smoke — issue #1192.
+//!
+//! Spawns the real `saas` binary against an ephemeral testcontainer
+//! Postgres (migrated automatically on boot — `AUTUMN_ENV=development`),
+//! drives a headless-Chromium browser against the public login page
+//! (tenancy-public per `autumn.toml`), and asserts expected content with
+//! no uncaught console errors.
+//!
+//! Run (requires Chromium + Docker):
+//!   cargo test -p saas --features system-tests --test smoke -- --include-ignored
+
+#![cfg(feature = "system-tests")]
+
+#[tokio::test]
+#[ignore = "requires Chromium + Docker — set AUTUMN_CHROMIUM or install chromium-browser"]
+async fn saas_boots_and_serves_login_page() {
+    let db = example_e2e::provision_postgres(1).await;
+
+    let app = example_e2e::spawn_example(
+        env!("CARGO_BIN_EXE_saas"),
+        env!("CARGO_MANIFEST_DIR"),
+        &[("AUTUMN_DATABASE__URL", &db.urls()[0])],
+        example_e2e::DEFAULT_READY_TIMEOUT,
+    )
+    .await
+    .expect("spawn saas example — is it built?");
+
+    let runner = app
+        .attach_browser()
+        .await
+        .expect("attach browser — is Chromium installed?");
+    let page = runner.page().await.expect("open page");
+
+    page.visit("/login").await.expect("visit /login");
+    page.expect_text("Log in")
+        .await
+        .expect("login page renders (public under tenancy middleware)");
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors on /login");
+}

--- a/examples/todo-app/Cargo.toml
+++ b/examples/todo-app/Cargo.toml
@@ -34,10 +34,15 @@ url = "2.5.8"
 # Enables TestDb (shared Postgres testcontainer) for integration tests.
 autumn-web = { path = "../../autumn", features = ["test-support"] }
 serde_json = "1"
+example-e2e = { path = "../../example-e2e" }
 
 [[test]]
 name = "todo_htmx_flow"
 path = "tests/system/todo_htmx_flow.rs"
+
+[[test]]
+name = "smoke"
+path = "tests/system/smoke.rs"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/examples/todo-app/tests/system/smoke.rs
+++ b/examples/todo-app/tests/system/smoke.rs
@@ -1,0 +1,49 @@
+//! Baseline Chromium smoke — issue #1192.
+//!
+//! Spawns the real `todo-app` binary against an ephemeral testcontainer
+//! Postgres (migrated automatically on boot — `AUTUMN_ENV=development`),
+//! drives a headless-Chromium browser against the todo list page, and
+//! asserts expected content with no uncaught console errors.
+//!
+//! `tests/system/todo_htmx_flow.rs` already covers the htmx interaction
+//! journey with a self-contained in-memory store; this test instead proves
+//! the *real* Diesel/Postgres-backed route boots and renders end to end.
+//!
+//! Run (requires Chromium + Docker):
+//!   cargo test -p todo-app --features system-tests --test smoke -- --include-ignored
+
+#![cfg(feature = "system-tests")]
+
+#[tokio::test]
+#[ignore = "requires Chromium + Docker — set AUTUMN_CHROMIUM or install chromium-browser"]
+async fn todo_app_boots_and_serves_todo_list() {
+    let db = example_e2e::provision_postgres(1).await;
+
+    let app = example_e2e::spawn_example(
+        env!("CARGO_BIN_EXE_todo-app"),
+        env!("CARGO_MANIFEST_DIR"),
+        &[("AUTUMN_DATABASE__URL", &db.urls()[0])],
+        example_e2e::DEFAULT_READY_TIMEOUT,
+    )
+    .await
+    .expect("spawn todo-app example — is it built?");
+
+    let runner = app
+        .attach_browser()
+        .await
+        .expect("attach browser — is Chromium installed?");
+    let page = runner.page().await.expect("open page");
+
+    page.visit("/")
+        .await
+        .expect("visit / (redirects to /todos)");
+    page.expect_text("Autumn Todos")
+        .await
+        .expect("todo list heading renders");
+    page.expect_text("No todos yet. Add one above!")
+        .await
+        .expect("empty-state renders against the freshly migrated DB");
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors on the todo list page");
+}

--- a/examples/wiki/Cargo.toml
+++ b/examples/wiki/Cargo.toml
@@ -17,5 +17,18 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 
+[dev-dependencies]
+example-e2e = { path = "../../example-e2e" }
+tokio = { version = "1", features = ["full"] }
+
+[features]
+# Enable the headless-browser system smoke. Requires Chromium on the host.
+#   cargo test -p wiki --features system-tests --test smoke -- --include-ignored
+system-tests = ["autumn-web/system-tests"]
+
+[[test]]
+name = "smoke"
+path = "tests/system/smoke.rs"
+
 [lints.rust]
 unsafe_code = "forbid"

--- a/examples/wiki/tests/system/smoke.rs
+++ b/examples/wiki/tests/system/smoke.rs
@@ -1,0 +1,40 @@
+//! Baseline Chromium smoke — issue #1192.
+//!
+//! Spawns the real `wiki` binary against an ephemeral testcontainer
+//! Postgres (migrated automatically on boot — `AUTUMN_ENV=development`),
+//! drives a headless-Chromium browser against the page list, and asserts
+//! expected content with no uncaught console errors.
+//!
+//! Run (requires Chromium + Docker):
+//!   cargo test -p wiki --features system-tests --test smoke -- --include-ignored
+
+#![cfg(feature = "system-tests")]
+
+#[tokio::test]
+#[ignore = "requires Chromium + Docker — set AUTUMN_CHROMIUM or install chromium-browser"]
+async fn wiki_boots_and_serves_page_list() {
+    let db = example_e2e::provision_postgres(1).await;
+
+    let app = example_e2e::spawn_example(
+        env!("CARGO_BIN_EXE_wiki"),
+        env!("CARGO_MANIFEST_DIR"),
+        &[("AUTUMN_DATABASE__URL", &db.urls()[0])],
+        example_e2e::DEFAULT_READY_TIMEOUT,
+    )
+    .await
+    .expect("spawn wiki example — is it built?");
+
+    let runner = app
+        .attach_browser()
+        .await
+        .expect("attach browser — is Chromium installed?");
+    let page = runner.page().await.expect("open page");
+
+    page.visit("/").await.expect("visit /");
+    page.expect_text("All Pages")
+        .await
+        .expect("page list heading renders");
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors on /");
+}

--- a/scripts/check-examples-e2e.sh
+++ b/scripts/check-examples-e2e.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Example fleet e2e gate — issue #1192.
+#
+# For every catalog-supported example: builds it, boots the real binary
+# against isolated ephemeral database(s), runs its Chromium system-test
+# smoke (`tests/system/smoke.rs`), and tears down. Aggregates results
+# across the whole fleet — does NOT abort on the first failing example —
+# prints a per-example pass/fail/skip summary, and exits non-zero if any
+# example fails to build or its smoke fails.
+#
+# Requires Chromium and Docker (for testcontainers-provisioned Postgres). If
+# either is unavailable, the affected example smokes are SKIPPED with a
+# visible notice — a skip is never reported as a pass.
+#
+# The full docker-compose multi-container topology (nginx + multiple web
+# replicas + real Postgres streaming replication) for bookmarks-distributed
+# and bookmarks-sharded is explicitly OUT OF SCOPE here (see issue #1192);
+# this gate proves each example's single-process feature (dual-pool
+# primary/replica routing, shard fan-out) boots and serves — the compose
+# integration is a follow-up.
+#
+# Called from the `publish-gate` workflow. Run locally with:
+#
+#     ./scripts/check-examples-e2e.sh
+#
+# Override the Chromium binary the same way the smoke tests do:
+#
+#     AUTUMN_CHROMIUM=/path/to/chrome ./scripts/check-examples-e2e.sh
+
+set -uo pipefail
+# Deliberately NOT `-e`: a failing example must not abort the run — every
+# example gets a chance to build and smoke so the summary is complete.
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+CATALOG="EXAMPLES.md"
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# 0. Discover supported examples from the catalog (same marker format
+#    `scripts/check-examples.sh` reads).
+# ---------------------------------------------------------------------------
+[[ -f "$CATALOG" ]] || die "catalog file '$CATALOG' not found — run scripts/check-examples.sh first"
+
+mapfile -t examples < <(
+  grep -E "<!-- catalog:example name=[^ ]+ tier=supported" "$CATALOG" \
+    | grep -oE 'name=[^ >]+' \
+    | sed 's/name=//' \
+    | sort
+)
+[[ ${#examples[@]} -gt 0 ]] || die "no supported examples found in $CATALOG"
+
+echo "==> Discovered ${#examples[@]} supported example(s): ${examples[*]}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 1. Environment capability probes — determine what can actually be
+#    exercised in this environment, so unavailable capability is a visible
+#    skip rather than a silent pass or a hard failure.
+# ---------------------------------------------------------------------------
+chromium_available=1
+if [[ -z "${AUTUMN_CHROMIUM:-}" ]] \
+  && ! command -v chromium >/dev/null 2>&1 \
+  && ! command -v chromium-browser >/dev/null 2>&1 \
+  && ! command -v google-chrome >/dev/null 2>&1 \
+  && ! command -v google-chrome-stable >/dev/null 2>&1 \
+  && [[ -z "${PLAYWRIGHT_BROWSERS_PATH:-}" || ! -d "${PLAYWRIGHT_BROWSERS_PATH:-/nonexistent}" ]]; then
+  chromium_available=0
+fi
+
+docker_available=1
+if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+  docker_available=0
+fi
+
+if [[ "$chromium_available" -eq 0 ]]; then
+  echo "SKIP NOTICE: no Chromium binary found (checked AUTUMN_CHROMIUM, PATH, PLAYWRIGHT_BROWSERS_PATH)." >&2
+  echo "             every example's Chromium smoke below will be SKIPPED, not passed." >&2
+  echo "" >&2
+fi
+if [[ "$docker_available" -eq 0 ]]; then
+  echo "SKIP NOTICE: Docker is unavailable (\`docker info\` failed)." >&2
+  echo "             every DB-backed example's smoke below will be SKIPPED, not passed." >&2
+  echo "" >&2
+fi
+
+echo "SCOPE NOTICE: the docker-compose multi-container topology (nginx + multiple" >&2
+echo "              web replicas + real Postgres streaming replication) for" >&2
+echo "              bookmarks-distributed and bookmarks-sharded is out of scope for" >&2
+echo "              this gate — see issue #1192. Only each example's single-process" >&2
+echo "              feature (dual-pool routing / shard fan-out) is smoke-tested here;" >&2
+echo "              the full compose integration is a follow-up gate." >&2
+echo "" >&2
+
+# Ephemeral Postgres instances each example's smoke provisions (0 = none).
+# hello has no database; bookmarks-distributed needs a primary + a
+# replica-stand-in; bookmarks-sharded needs a control + two shards. Every
+# other supported example needs exactly one.
+db_requirement() {
+  case "$1" in
+    hello) echo 0 ;;
+    bookmarks-distributed) echo 2 ;;
+    bookmarks-sharded) echo 3 ;;
+    *) echo 1 ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# 2. Build + smoke each example, aggregating results — a failure never stops
+#    the remaining examples from getting their own turn.
+# ---------------------------------------------------------------------------
+result_names=()
+result_status=() # PASS | FAIL | SKIP
+result_detail=()
+failures=0
+
+for example in "${examples[@]}"; do
+  echo "==> $example: building"
+  if ! cargo build -p "$example" --quiet; then
+    result_names+=("$example")
+    result_status+=("FAIL")
+    result_detail+=("build failed")
+    failures=$((failures + 1))
+    echo "FAIL:  $example — build failed"
+    echo ""
+    continue
+  fi
+
+  needs_db="$(db_requirement "$example")"
+
+  if [[ "$chromium_available" -eq 0 ]]; then
+    result_names+=("$example")
+    result_status+=("SKIP")
+    result_detail+=("no Chromium available")
+    echo "SKIP:  $example — no Chromium available"
+    echo ""
+    continue
+  fi
+
+  if [[ "$needs_db" -gt 0 && "$docker_available" -eq 0 ]]; then
+    result_names+=("$example")
+    result_status+=("SKIP")
+    result_detail+=("needs $needs_db Postgres testcontainer(s); Docker unavailable")
+    echo "SKIP:  $example — needs Docker for testcontainers, unavailable"
+    echo ""
+    continue
+  fi
+
+  echo "==> $example: running Chromium smoke"
+  if cargo test -p "$example" --features system-tests --test smoke -- --include-ignored --test-threads=1; then
+    result_names+=("$example")
+    result_status+=("PASS")
+    result_detail+=("")
+    echo "PASS:  $example"
+  else
+    result_names+=("$example")
+    result_status+=("FAIL")
+    result_detail+=("smoke test failed")
+    failures=$((failures + 1))
+    echo "FAIL:  $example — smoke test failed"
+  fi
+  echo ""
+done
+
+# ---------------------------------------------------------------------------
+# 3. Summary — printed even when everything skipped, so skipped never reads
+#    as green.
+# ---------------------------------------------------------------------------
+echo "==> Example e2e fleet summary"
+echo ""
+printf "%-24s %-6s %s\n" "EXAMPLE" "RESULT" "DETAIL"
+for i in "${!result_names[@]}"; do
+  printf "%-24s %-6s %s\n" "${result_names[$i]}" "${result_status[$i]}" "${result_detail[$i]}"
+done
+echo ""
+
+pass_count=0
+skip_count=0
+fail_count=0
+for status in "${result_status[@]}"; do
+  case "$status" in
+    PASS) pass_count=$((pass_count + 1)) ;;
+    SKIP) skip_count=$((skip_count + 1)) ;;
+    FAIL) fail_count=$((fail_count + 1)) ;;
+  esac
+done
+echo "  $pass_count passed, $fail_count failed, $skip_count skipped (of ${#examples[@]} supported examples)"
+echo ""
+
+if [[ "$skip_count" -gt 0 ]]; then
+  echo "NOTE: $skip_count example(s) skipped — a skip is not a pass; rerun with Chromium/Docker available to get real coverage." >&2
+  echo "" >&2
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  die "$failures example(s) failed — see per-example output above."
+fi
+
+echo "Example e2e fleet gate: all checks passed."

--- a/scripts/check-examples-e2e.sh
+++ b/scripts/check-examples-e2e.sh
@@ -26,6 +26,14 @@
 # Override the Chromium binary the same way the smoke tests do:
 #
 #     AUTUMN_CHROMIUM=/path/to/chrome ./scripts/check-examples-e2e.sh
+#
+# In an environment that provisions Chromium and Docker specifically for
+# this gate (e.g. the publish-gate CI job), set REQUIRE_FULL_COVERAGE=1 so
+# any SKIP — which there would mean the provisioning silently broke, not
+# "no coverage available" — fails the gate instead of letting "all checks
+# passed" mask degraded coverage:
+#
+#     REQUIRE_FULL_COVERAGE=1 ./scripts/check-examples-e2e.sh
 
 set -uo pipefail
 # Deliberately NOT `-e`: a failing example must not abort the run — every
@@ -198,6 +206,16 @@ fi
 
 if [[ "$failures" -gt 0 ]]; then
   die "$failures example(s) failed — see per-example output above."
+fi
+
+# In an environment that provisions Chromium and Docker for exactly this
+# purpose (the publish-gate CI job), a skip means that provisioning silently
+# broke — not "no coverage available here" — so it must fail the release
+# gate rather than let "all checks passed" mask degraded coverage. Local/dev
+# runs without Docker or Chromium leave REQUIRE_FULL_COVERAGE unset and stay
+# lenient, matching AC6 ("visibly skip, don't silently pass").
+if [[ "${REQUIRE_FULL_COVERAGE:-0}" == "1" && "$skip_count" -gt 0 ]]; then
+  die "$skip_count example(s) skipped in an environment that requires full coverage (REQUIRE_FULL_COVERAGE=1) — see SKIP NOTICE(s) above."
 fi
 
 echo "Example e2e fleet gate: all checks passed."

--- a/scripts/check-examples-e2e.sh
+++ b/scripts/check-examples-e2e.sh
@@ -43,16 +43,14 @@ die() {
 
 # ---------------------------------------------------------------------------
 # 0. Discover supported examples from the catalog (same marker format
-#    `scripts/check-examples.sh` reads).
+#    `scripts/check-examples.sh` reads — shared via scripts/lib/catalog.sh so
+#    the marker-format regex lives in exactly one place).
 # ---------------------------------------------------------------------------
 [[ -f "$CATALOG" ]] || die "catalog file '$CATALOG' not found — run scripts/check-examples.sh first"
 
-mapfile -t examples < <(
-  grep -E "<!-- catalog:example name=[^ ]+ tier=supported" "$CATALOG" \
-    | grep -oE 'name=[^ >]+' \
-    | sed 's/name=//' \
-    | sort
-)
+source "$root/scripts/lib/catalog.sh"
+
+mapfile -t examples < <(catalog_names_by_tier "$CATALOG" "supported" | sort)
 [[ ${#examples[@]} -gt 0 ]] || die "no supported examples found in $CATALOG"
 
 echo "==> Discovered ${#examples[@]} supported example(s): ${examples[*]}"
@@ -187,6 +185,7 @@ for status in "${result_status[@]}"; do
     PASS) pass_count=$((pass_count + 1)) ;;
     SKIP) skip_count=$((skip_count + 1)) ;;
     FAIL) fail_count=$((fail_count + 1)) ;;
+    *) die "internal error: unrecognized result status '$status' — this is a bug in the harness" ;;
   esac
 done
 echo "  $pass_count passed, $fail_count failed, $skip_count skipped (of ${#examples[@]} supported examples)"

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -70,24 +70,11 @@ ok "catalog file found"
 echo ""
 
 # ---------------------------------------------------------------------------
-# Helper: extract cataloged example names by tier from EXAMPLES.md
-# Each marker line has the form:
-#   <!-- catalog:example name=<dir> tier=<tier> -->
+# Helper: extract cataloged example names by tier from EXAMPLES.md — shared
+# with scripts/check-examples-e2e.sh via scripts/lib/catalog.sh so the
+# marker-format regex lives in exactly one place.
 # ---------------------------------------------------------------------------
-catalog_names_by_tier() {
-  local tier="$1"
-  grep -E "<!-- catalog:example name=[^ ]+ tier=${tier}" "$CATALOG" \
-    | grep -oE 'name=[^ >]+' \
-    | sed 's/name=//' \
-    || true
-}
-
-all_catalog_names() {
-  grep -E "<!-- catalog:example name=" "$CATALOG" \
-    | grep -oE 'name=[^ >]+' \
-    | sed 's/name=//' \
-    || true
-}
+source "$root/scripts/lib/catalog.sh"
 
 # ---------------------------------------------------------------------------
 # 1. Every examples/ directory must be cataloged
@@ -95,7 +82,7 @@ all_catalog_names() {
 echo "==> Checking every examples/ directory is cataloged"
 
 mapfile -t example_dirs < <(find "$EXAMPLES_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
-mapfile -t catalog_all < <(all_catalog_names | sort)
+mapfile -t catalog_all < <(all_catalog_names "$CATALOG" | sort)
 
 for dir in "${example_dirs[@]}"; do
   if printf '%s\n' "${catalog_all[@]}" | grep -qx "$dir"; then
@@ -126,7 +113,7 @@ mapfile -t workspace_examples < <(
     | sed 's|examples/||' \
     | sort
 )
-mapfile -t catalog_supported < <(catalog_names_by_tier "supported" | sort)
+mapfile -t catalog_supported < <(catalog_names_by_tier "$CATALOG" "supported" | sort)
 
 for member in "${workspace_examples[@]}"; do
   if printf '%s\n' "${catalog_supported[@]}" | grep -qx "$member"; then
@@ -236,9 +223,9 @@ echo ""
 # ---------------------------------------------------------------------------
 echo "==> Catalog summary by support tier"
 
-mapfile -t _supported_summary  < <(catalog_names_by_tier "supported"    | sort)
-mapfile -t _exp_summary        < <(catalog_names_by_tier "experimental" | sort)
-mapfile -t _excl_summary       < <(catalog_names_by_tier "excluded"     | sort)
+mapfile -t _supported_summary  < <(catalog_names_by_tier "$CATALOG" "supported"    | sort)
+mapfile -t _exp_summary        < <(catalog_names_by_tier "$CATALOG" "experimental" | sort)
+mapfile -t _excl_summary       < <(catalog_names_by_tier "$CATALOG" "excluded"     | sort)
 
 _count_supported=${#_supported_summary[@]}
 echo ""

--- a/scripts/lib/catalog.sh
+++ b/scripts/lib/catalog.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Shared EXAMPLES.md catalog-marker parsing.
+#
+# Sourced by scripts/check-examples.sh (the catalog-drift gate) and
+# scripts/check-examples-e2e.sh (the fan-out e2e gate) so the marker-format
+# regex lives in exactly one place. Each marker line has the form:
+#
+#   <!-- catalog:example name=<dir> tier=<tier> -->
+#
+# This file only defines functions — sourcing it has no side effects, unlike
+# check-examples.sh itself (which runs its full gate top-to-bottom on load).
+
+# Extract cataloged example names for one tier.
+# Usage: catalog_names_by_tier <catalog-file> <tier>
+catalog_names_by_tier() {
+  local catalog="$1"
+  local tier="$2"
+  grep -E "<!-- catalog:example name=[^ ]+ tier=${tier}" "$catalog" \
+    | grep -oE 'name=[^ >]+' \
+    | sed 's/name=//' \
+    || true
+}
+
+# Extract every cataloged example name regardless of tier.
+# Usage: all_catalog_names <catalog-file>
+all_catalog_names() {
+  local catalog="$1"
+  grep -E "<!-- catalog:example name=" "$catalog" \
+    | grep -oE 'name=[^ >]+' \
+    | sed 's/name=//' \
+    || true
+}


### PR DESCRIPTION
## Summary

Extends the system testing framework to support testing against externally-running application servers, enabling per-example end-to-end smoke tests that exercise real binaries with their actual routes, migrations, and builder chains.

## Key Changes

- **New `SystemTest::attach()` API**: Launches managed headless Chromium and targets an already-running server at a provided base URL, without booting an in-process axum server. Includes `attach_with_timeout()` variant for custom browser launch timeouts.

- **Refactored browser launch**: Extracted `launch_browser()` helper function shared by both `build()` and `attach()` paths, with proper profile directory isolation to prevent Chrome singleton lock collisions when multiple browsers run concurrently.

- **Console error detection**: Added `Page::expect_no_console_errors()` assertion that captures uncaught JS exceptions and console errors via CDP event streams, with a 500ms grace period to tolerate CI latency while failing immediately on any detected error.

- **New `example-e2e` support crate**: Provides `PgTopology` for ephemeral testcontainer Postgres provisioning and `ExampleProcess` for spawning real example binaries with environment variable configuration and health-check polling.

- **Example smoke tests**: Added baseline Chromium smokes for all supported examples (`hello`, `blog`, `bookmarks`, `bookmarks-distributed`, `bookmarks-sharded`, `reddit-clone`, `saas`, `todo-app`, `wiki`) that spawn the real binary, verify primary routes render, and assert no console errors.

- **CI integration**: Added `scripts/check-examples-e2e.sh` fan-out harness that builds and smokes every example, aggregates results across the fleet, and gracefully skips when Chromium or Docker is unavailable. Integrated into the `publish-gate` workflow.

- **Shared catalog parsing**: Extracted example discovery logic into `scripts/lib/catalog.sh` for reuse across both the existing `check-examples.sh` and new `check-examples-e2e.sh` gates.

## Implementation Details

- Browser profile directories are now unique per launch (`unique_user_data_dir()`) to avoid Chrome's profile singleton lock when multiple `SystemTest` instances coexist in the same process.

- Console error capture uses `chromiumoxide`'s CDP event streams (`EventConsoleApiCalled`, `EventExceptionThrown`) with thread-safe `Arc<AsyncMutex<>>` accumulation.

- Example process spawning includes health-check polling against `GET /health` with configurable timeout and immediate failure detection if the process exits before reporting healthy.

- The `bookmarks-distributed` smoke manually migrates both primary and replica testcontainers (since the "replica" is a second independent database, not a true replication target) to mirror the real deployment's schema setup.

- All example smokes are gated behind a `system-tests` feature flag and marked `#[ignore]` to require explicit opt-in via `--include-ignored`.

https://claude.ai/code/session_01WqhFDjdF5951y9uUVjGwLH