### PR TITLE
Add view-layer formatting helpers for templates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ testcontainers-modules = { version = "0.15", features = ["postgres", "redis", "m
 time = { version = ">=0.3, <0.3.48" }
 
 csv = "1.3"
+rust_decimal = "1"
 pulldown-cmark = { version = "0.13", default-features = false, features = ["html"] }
 chromiumoxide = { version = "0.9", default-features = false }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ See [EXAMPLES.md](EXAMPLES.md) for the full catalog with personas, journeys, pre
 - [Operating Background Jobs](docs/guide/operating-background-jobs.md) - admin dashboard and recovery actions for `#[job]`
 - [Exposing Your API as MCP Tools](docs/guide/mcp.md) — project typed endpoints into a Model Context Protocol server with `#[api_doc(mcp)]` + `mount_mcp`
 - [Mail Guide](docs/guide/mail.md)
+- [View Formatting Helpers](docs/guide/format-helpers.md) — `number_to_currency`, `pluralize`, `truncate`, `time_ago_in_words`, and friends for Maud templates
 - [Cloud-Native Guide](docs/guide/cloud-native.md)
 - [Logging & PII](docs/guide/logging-pii.md)
 - [Todo Tutorial](docs/guide/tutorial/index.md)

--- a/autumn-cli/src/generate/naming.rs
+++ b/autumn-cli/src/generate/naming.rs
@@ -37,14 +37,12 @@ pub fn snake_to_pascal(s: &str) -> String {
 /// Naive English pluraliser, intentionally limited to the cases that come up
 /// in identifier-shaped words (table names, route paths, file names).
 ///
-/// Rules, in order:
-/// 1. Already pluralisable irregulars handled explicitly.
-/// 2. Words ending in `s|x|z|ch|sh` → +`es`.
-/// 3. Words ending in consonant + `y` → strip `y`, add `ies`.
-/// 4. Otherwise → +`s`.
-///
-/// All input is treated as a single ASCII identifier (`snake_case` chunks
-/// are pluralised on the *last* chunk only — `blog_post` → `blog_posts`).
+/// Word-level rules (irregulars, sibilant endings, consonant+`y`) live in
+/// [`autumn_web::format::pluralize_word`], shared with the view-layer
+/// `pluralize` template helper so generated identifiers and rendered page
+/// text agree. This wraps it with `snake_case` segment-splitting: all input
+/// is treated as a single ASCII identifier, pluralised on the *last* chunk
+/// only — `blog_post` → `blog_posts`.
 #[must_use]
 pub fn pluralize(s: &str) -> String {
     if s.is_empty() {
@@ -53,42 +51,7 @@ pub fn pluralize(s: &str) -> String {
     let (prefix, last) = s
         .rfind('_')
         .map_or(("", s), |idx| (&s[..=idx], &s[idx + 1..]));
-    format!("{prefix}{}", pluralize_word(last))
-}
-
-fn pluralize_word(s: &str) -> String {
-    if s.is_empty() {
-        return String::new();
-    }
-    // Irregulars covering the most common identifiers we see in practice.
-    match s {
-        "person" => return "people".into(),
-        "child" => return "children".into(),
-        "man" => return "men".into(),
-        "woman" => return "women".into(),
-        "mouse" => return "mice".into(),
-        "goose" => return "geese".into(),
-        _ => {}
-    }
-    let lower = s.to_ascii_lowercase();
-    if lower.ends_with("ss")
-        || lower.ends_with('x')
-        || lower.ends_with('z')
-        || lower.ends_with("ch")
-        || lower.ends_with("sh")
-    {
-        return format!("{s}es");
-    }
-    if lower.ends_with('y') {
-        // consonant + y → ies
-        let prev = s.chars().rev().nth(1);
-        if prev.is_some_and(|c| !"aeiou".contains(c)) {
-            let mut out: String = s.chars().take(s.chars().count() - 1).collect();
-            out.push_str("ies");
-            return out;
-        }
-    }
-    format!("{s}s")
+    format!("{prefix}{}", autumn_web::format::pluralize_word(last))
 }
 
 /// Convert a resource name from any reasonable casing into `snake_case`.

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -161,6 +161,7 @@ validator.workspace = true
 uuid = { version = "1", features = ["v4"] }
 chrono = { workspace = true }
 chrono-tz.workspace = true
+rust_decimal.workspace = true
 croner = "3.0.1"
 testcontainers = { workspace = true, optional = true }
 testcontainers-modules = { workspace = true, optional = true }

--- a/autumn/src/format.rs
+++ b/autumn/src/format.rs
@@ -39,7 +39,7 @@ use rust_decimal::Decimal;
 /// Configuration for [`CurrencyOptions::format`] — symbol, precision, and
 /// thousands/decimal separators.
 #[cfg(feature = "maud")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub struct CurrencyOptions<'a> {
     symbol: &'a str,
     precision: u32,
@@ -121,23 +121,20 @@ fn format_currency(value: Decimal, options: &CurrencyOptions<'_>) -> String {
         rust_decimal::RoundingStrategy::MidpointAwayFromZero,
     );
     let negative = rounded.is_sign_negative() && !rounded.is_zero();
-    let abs = rounded.abs();
-    let digits = format!("{:.prec$}", abs, prec = options.precision as usize);
+    let digits = format!(
+        "{:.prec$}",
+        rounded.abs(),
+        prec = options.precision as usize
+    );
     let (int_part, frac_part) = split_decimal_string(&digits);
-    let grouped_int = group_thousands(int_part, options.thousands_separator);
-
-    let mut out =
-        String::with_capacity(options.symbol.len() + grouped_int.len() + frac_part.len() + 2);
-    if negative {
-        out.push('-');
-    }
-    out.push_str(options.symbol);
-    out.push_str(&grouped_int);
-    if options.precision > 0 {
-        out.push(options.decimal_separator);
-        out.push_str(frac_part);
-    }
-    out
+    assemble_signed_grouped(
+        negative,
+        int_part,
+        frac_part,
+        options.thousands_separator,
+        options.decimal_separator,
+        options.symbol,
+    )
 }
 
 // ── Delimited numbers ────────────────────────────────────────────────────────
@@ -151,20 +148,9 @@ fn format_currency(value: Decimal, options: &CurrencyOptions<'_>) -> String {
 pub fn number_with_delimiter<T: Into<Decimal>>(value: T) -> maud::Markup {
     let value: Decimal = value.into();
     let negative = value.is_sign_negative() && !value.is_zero();
-    let abs = value.abs();
-    let digits = abs.to_string();
+    let digits = value.abs().to_string();
     let (int_part, frac_part) = split_decimal_string(&digits);
-    let grouped_int = group_thousands(int_part, ',');
-
-    let mut out = String::with_capacity(grouped_int.len() + frac_part.len() + 2);
-    if negative {
-        out.push('-');
-    }
-    out.push_str(&grouped_int);
-    if !frac_part.is_empty() {
-        out.push('.');
-        out.push_str(frac_part);
-    }
+    let out = assemble_signed_grouped(negative, int_part, frac_part, ',', '.', "");
     maud::html! { (out) }
 }
 
@@ -172,6 +158,32 @@ pub fn number_with_delimiter<T: Into<Decimal>>(value: T) -> maud::Markup {
 /// and fractional parts (without the separating dot).
 fn split_decimal_string(s: &str) -> (&str, &str) {
     s.split_once('.').unwrap_or((s, ""))
+}
+
+/// Assemble a signed, thousands-grouped decimal string:
+/// `[-][symbol]grouped-int[decimal_sep+frac]`. Shared by [`format_currency`]
+/// and [`number_with_delimiter`], which differ only in `symbol` and
+/// separators.
+fn assemble_signed_grouped(
+    negative: bool,
+    int_part: &str,
+    frac_part: &str,
+    thousands_separator: char,
+    decimal_separator: char,
+    symbol: &str,
+) -> String {
+    let grouped_int = group_thousands(int_part, thousands_separator);
+    let mut out = String::with_capacity(symbol.len() + grouped_int.len() + frac_part.len() + 2);
+    if negative {
+        out.push('-');
+    }
+    out.push_str(symbol);
+    out.push_str(&grouped_int);
+    if !frac_part.is_empty() {
+        out.push(decimal_separator);
+        out.push_str(frac_part);
+    }
+    out
 }
 
 /// Group the ASCII digits of `int_digits` into threes, joined by `separator`.
@@ -215,10 +227,15 @@ pub fn pluralize_with(count: i64, singular: &str, plural: &str) -> maud::Markup 
     maud::html! { (count) " " (word) }
 }
 
-/// Naive English pluraliser for display words. Mirrors the identifier
-/// pluraliser in `autumn-cli`'s naming helpers, minus the `snake_case`
-/// segment-splitting (display words are whole words, not identifiers).
-fn pluralize_word(word: &str) -> String {
+/// Naive English pluraliser for a single word: irregulars, sibilant endings
+/// (`+es`), consonant+`y` (`y` → `ies`), otherwise `+s`.
+///
+/// Shared with `autumn-cli`'s identifier pluraliser
+/// ([`autumn_web::format::pluralize_word`] wrapped with `snake_case`
+/// segment-splitting there), so both the CLI-generated names and the
+/// rendered page text agree on the same rules.
+#[must_use]
+pub fn pluralize_word(word: &str) -> String {
     if word.is_empty() {
         return String::new();
     }
@@ -270,7 +287,13 @@ pub fn truncate_with(text: &str, len: usize, omission: &str) -> maud::Markup {
         return maud::html! { (text) };
     }
     let omission_len = omission.chars().count();
-    let keep = len.saturating_sub(omission_len);
+    if omission_len >= len {
+        // Even the omission marker doesn't fit `len` on its own; clip it so
+        // the total output still honors the caller's length cap.
+        let clipped: String = omission.chars().take(len).collect();
+        return maud::html! { (clipped) };
+    }
+    let keep = len - omission_len;
     let truncated: String = text.chars().take(keep).collect();
     maud::html! { (truncated) (omission) }
 }
@@ -310,7 +333,9 @@ pub fn time_ago_in_words(dt: DateTime<Utc>, now: DateTime<Utc>) -> maud::Markup 
     maud::html! { (text) }
 }
 
-fn relative_time_words(dt: DateTime<Utc>, now: DateTime<Utc>) -> String {
+/// Render the relative-time phrase shared with [`crate::time_zone::time_ago`]
+/// (which additionally wraps it in a localized `<time>` element).
+pub(crate) fn relative_time_words(dt: DateTime<Utc>, now: DateTime<Utc>) -> String {
     let secs = now.signed_duration_since(dt).num_seconds();
     if secs < 0 {
         format!("in {}", duration_words(secs.unsigned_abs()))
@@ -531,6 +556,15 @@ mod tests {
         assert_eq!(
             truncate_with("The quick brown fox", 16, " [more]").into_string(),
             "The quick [more]"
+        );
+    }
+
+    #[test]
+    fn truncate_with_omission_longer_than_len_is_clipped() {
+        // The omission marker itself must not push the total past `len`.
+        assert_eq!(
+            truncate_with("The quick brown fox", 2, " [read more]").into_string(),
+            " ["
         );
     }
 

--- a/autumn/src/format.rs
+++ b/autumn/src/format.rs
@@ -188,10 +188,10 @@ fn assemble_signed_grouped(
 
 /// Group the ASCII digits of `int_digits` into threes, joined by `separator`.
 fn group_thousands(int_digits: &str, separator: char) -> String {
-    let len = int_digits.len();
-    let mut out = String::with_capacity(len + len / 3);
+    let char_count = int_digits.chars().count();
+    let mut out = String::with_capacity(char_count + char_count / 3);
     for (i, ch) in int_digits.chars().enumerate() {
-        if i > 0 && (len - i).is_multiple_of(3) {
+        if i > 0 && (char_count - i).is_multiple_of(3) {
             out.push(separator);
         }
         out.push(ch);
@@ -209,12 +209,11 @@ fn group_thousands(int_digits: &str, separator: char) -> String {
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn pluralize(count: i64, singular: &str) -> maud::Markup {
-    let word = if count == 1 {
-        singular.to_owned()
+    if count == 1 {
+        maud::html! { (count) " " (singular) }
     } else {
-        pluralize_word(singular)
-    };
-    maud::html! { (count) " " (word) }
+        maud::html! { (count) " " (pluralize_word(singular)) }
+    }
 }
 
 /// Render `"{count} {word}"`, choosing between `singular` and an explicit
@@ -258,11 +257,12 @@ pub fn pluralize_word(word: &str) -> String {
         return format!("{word}es");
     }
     if lower.ends_with('y') {
-        let prev = word.chars().rev().nth(1);
-        if prev.is_some_and(|c| !"aeiouAEIOU".contains(c)) {
-            let mut out: String = word.chars().take(word.chars().count() - 1).collect();
-            out.push_str("ies");
-            return out;
+        // 'y' is 1-byte ASCII, so slicing off the last byte stays on a char boundary.
+        let prefix = &word[..word.len() - 1];
+        if let Some(prev) = prefix.chars().next_back()
+            && !"aeiouAEIOU".contains(prev)
+        {
+            return format!("{prefix}ies");
         }
     }
     format!("{word}s")
@@ -290,12 +290,18 @@ pub fn truncate_with(text: &str, len: usize, omission: &str) -> maud::Markup {
     if omission_len >= len {
         // Even the omission marker doesn't fit `len` on its own; clip it so
         // the total output still honors the caller's length cap.
-        let clipped: String = omission.chars().take(len).collect();
-        return maud::html! { (clipped) };
+        let byte_idx = omission
+            .char_indices()
+            .nth(len)
+            .map_or(omission.len(), |(idx, _)| idx);
+        return maud::html! { (&omission[..byte_idx]) };
     }
     let keep = len - omission_len;
-    let truncated: String = text.chars().take(keep).collect();
-    maud::html! { (truncated) (omission) }
+    let byte_idx = text
+        .char_indices()
+        .nth(keep)
+        .map_or(text.len(), |(idx, _)| idx);
+    maud::html! { (&text[..byte_idx]) (omission) }
 }
 
 /// Shorten `text` to at most `n` whitespace-delimited words.
@@ -313,8 +319,13 @@ pub fn truncate_words_with(text: &str, n: usize, omission: &str) -> maud::Markup
     if words.len() <= n {
         return maud::html! { (text) };
     }
-    let truncated = words[..n].join(" ");
-    maud::html! { (truncated) (omission) }
+    maud::html! {
+        @for (i, word) in words[..n].iter().enumerate() {
+            @if i > 0 { " " }
+            (word)
+        }
+        (omission)
+    }
 }
 
 // ── Dates & times ────────────────────────────────────────────────────────────

--- a/autumn/src/format.rs
+++ b/autumn/src/format.rs
@@ -1,0 +1,479 @@
+//! View-layer value formatting helpers for Maud templates.
+//!
+//! Autumn's widget lane (`crate::widgets`) renders *containers* — tables,
+//! cards, property lists — but stops short of formatting the scalar values
+//! that go inside them. This module fills that gap with small, pure,
+//! allocation-light helpers that return [`maud::Markup`] so their output is
+//! HTML-escaped by construction and safe to interpolate directly into
+//! `html! { ... }` blocks.
+//!
+//! # Quick example
+//!
+//! ```rust,ignore
+//! use autumn_web::format::{number_to_currency, pluralize, time_ago_in_words};
+//! use autumn_web::time::FixedClock;
+//! use chrono::{TimeZone, Utc};
+//! use maud::html;
+//! use rust_decimal::Decimal;
+//!
+//! let price: Decimal = "1234.5".parse().unwrap();
+//! let posted_at = Utc.with_ymd_and_hms(2026, 1, 1, 11, 58, 0).unwrap();
+//! let clock = FixedClock::at(Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap());
+//!
+//! let markup = html! {
+//!     (number_to_currency(price))
+//!     " — "
+//!     (pluralize(3, "comment"))
+//!     " — "
+//!     (time_ago_in_words(posted_at, &clock))
+//! };
+//!
+//! assert_eq!(markup.into_string(), "$1,234.50 — 3 comments — 2 minutes ago");
+//! ```
+
+use crate::time::ClockSource;
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+
+// ── Currency ───────────────────────────────────────────────────────────────
+
+/// Configuration for [`CurrencyOptions::format`] — symbol, precision, and
+/// thousands/decimal separators.
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CurrencyOptions<'a> {
+    symbol: &'a str,
+    precision: u32,
+    thousands_separator: char,
+    decimal_separator: char,
+}
+
+#[cfg(feature = "maud")]
+impl<'a> CurrencyOptions<'a> {
+    /// Create a new currency configuration with sane defaults: `$` symbol,
+    /// 2 decimal places, `,` thousands separator, `.` decimal separator.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            symbol: "$",
+            precision: 2,
+            thousands_separator: ',',
+            decimal_separator: '.',
+        }
+    }
+
+    /// Set the currency symbol prefix (default `"$"`).
+    #[must_use]
+    pub const fn symbol(mut self, symbol: &'a str) -> Self {
+        self.symbol = symbol;
+        self
+    }
+
+    /// Set the number of decimal places to round and display (default `2`).
+    #[must_use]
+    pub const fn precision(mut self, precision: u32) -> Self {
+        self.precision = precision;
+        self
+    }
+
+    /// Set the character grouping integer digits in threes (default `,`).
+    #[must_use]
+    pub const fn thousands_separator(mut self, separator: char) -> Self {
+        self.thousands_separator = separator;
+        self
+    }
+
+    /// Set the character separating the integer and fractional parts (default `.`).
+    #[must_use]
+    pub const fn decimal_separator(mut self, separator: char) -> Self {
+        self.decimal_separator = separator;
+        self
+    }
+
+    /// Format `value` per this configuration, returning HTML-escaped [`maud::Markup`].
+    #[must_use]
+    pub fn format(&self, _value: Decimal) -> maud::Markup {
+        // TODO(red): not implemented yet.
+        maud::html! { "" }
+    }
+}
+
+#[cfg(feature = "maud")]
+impl Default for CurrencyOptions<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Format `value` as currency using [`CurrencyOptions`] defaults (`$1,234.50`).
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn number_to_currency(value: Decimal) -> maud::Markup {
+    CurrencyOptions::new().format(value)
+}
+
+// ── Delimited numbers ────────────────────────────────────────────────────────
+
+/// Render an integer or decimal with grouped thousands (`1,234,567`).
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn number_with_delimiter<T: Into<Decimal>>(_value: T) -> maud::Markup {
+    // TODO(red): not implemented yet.
+    maud::html! { "" }
+}
+
+// ── Pluralize ────────────────────────────────────────────────────────────────
+
+/// Render `"{count} {word}"`, pluralizing `singular` with a simple
+/// irregular-aware English rule when `count != 1`.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn pluralize(_count: i64, _singular: &str) -> maud::Markup {
+    // TODO(red): not implemented yet.
+    maud::html! { "" }
+}
+
+/// Render `"{count} {word}"`, choosing between `singular` and an explicit `plural`.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn pluralize_with(_count: i64, _singular: &str, _plural: &str) -> maud::Markup {
+    // TODO(red): not implemented yet.
+    maud::html! { "" }
+}
+
+// ── Truncation ────────────────────────────────────────────────────────────────
+
+/// Shorten `text` to at most `len` characters (including the ellipsis),
+/// never splitting a UTF-8 character mid-byte.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn truncate(text: &str, len: usize) -> maud::Markup {
+    truncate_with(text, len, "…")
+}
+
+/// Like [`truncate`], with a caller-supplied omission marker instead of `"…"`.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn truncate_with(_text: &str, _len: usize, _omission: &str) -> maud::Markup {
+    // TODO(red): not implemented yet.
+    maud::html! { "" }
+}
+
+/// Shorten `text` to at most `n` whitespace-delimited words.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn truncate_words(text: &str, n: usize) -> maud::Markup {
+    truncate_words_with(text, n, "…")
+}
+
+/// Like [`truncate_words`], with a caller-supplied omission marker instead of `"…"`.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn truncate_words_with(_text: &str, _n: usize, _omission: &str) -> maud::Markup {
+    // TODO(red): not implemented yet.
+    maud::html! { "" }
+}
+
+// ── Dates & times ────────────────────────────────────────────────────────────
+
+/// Render a human-readable relative time (`"3 minutes ago"`, `"in 2 days"`)
+/// between `dt` and the current instant of `clock`.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn time_ago_in_words(_dt: DateTime<Utc>, _clock: &dyn ClockSource) -> maud::Markup {
+    // TODO(red): not implemented yet.
+    maud::html! { "" }
+}
+
+/// Render `dt` (UTC) using a `chrono` strftime-style absolute format string.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn format_datetime(_dt: DateTime<Utc>, _fmt: &str) -> maud::Markup {
+    // TODO(red): not implemented yet.
+    maud::html! { "" }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "maud"))]
+mod tests {
+    use super::*;
+    use crate::time::FixedClock;
+    use chrono::TimeZone;
+
+    fn dec(s: &str) -> Decimal {
+        s.parse().unwrap()
+    }
+
+    // ── number_to_currency / CurrencyOptions ────────────────────────────
+
+    #[test]
+    fn currency_formats_with_default_options() {
+        assert_eq!(
+            number_to_currency(dec("1234.5")).into_string(),
+            "$1,234.50"
+        );
+    }
+
+    #[test]
+    fn currency_formats_zero() {
+        assert_eq!(number_to_currency(dec("0")).into_string(), "$0.00");
+    }
+
+    #[test]
+    fn currency_formats_negative() {
+        assert_eq!(
+            number_to_currency(dec("-42.5")).into_string(),
+            "-$42.50"
+        );
+    }
+
+    #[test]
+    fn currency_groups_large_values() {
+        assert_eq!(
+            number_to_currency(dec("1234567.89")).into_string(),
+            "$1,234,567.89"
+        );
+    }
+
+    #[test]
+    fn currency_rounds_to_precision() {
+        assert_eq!(number_to_currency(dec("1.005")).into_string(), "$1.01");
+    }
+
+    #[test]
+    fn currency_custom_options() {
+        let opts = CurrencyOptions::new()
+            .symbol("€")
+            .precision(2)
+            .thousands_separator('.')
+            .decimal_separator(',');
+        assert_eq!(opts.format(dec("1234.5")).into_string(), "€1.234,50");
+    }
+
+    #[test]
+    fn currency_zero_precision_omits_decimal_separator() {
+        let opts = CurrencyOptions::new().precision(0);
+        assert_eq!(opts.format(dec("42.6")).into_string(), "$43");
+    }
+
+    #[test]
+    fn currency_does_not_render_negative_zero() {
+        assert_eq!(number_to_currency(dec("-0.001")).into_string(), "$0.00");
+    }
+
+    // ── number_with_delimiter ────────────────────────────────────────────
+
+    #[test]
+    fn delimiter_groups_large_integer() {
+        assert_eq!(
+            number_with_delimiter(1_234_567_i64).into_string(),
+            "1,234,567"
+        );
+    }
+
+    #[test]
+    fn delimiter_no_grouping_needed() {
+        assert_eq!(number_with_delimiter(42_i64).into_string(), "42");
+    }
+
+    #[test]
+    fn delimiter_handles_negative() {
+        assert_eq!(number_with_delimiter(-1_234_i64).into_string(), "-1,234");
+    }
+
+    #[test]
+    fn delimiter_handles_decimal() {
+        assert_eq!(
+            number_with_delimiter(dec("1234567.89")).into_string(),
+            "1,234,567.89"
+        );
+    }
+
+    #[test]
+    fn delimiter_handles_zero() {
+        assert_eq!(number_with_delimiter(0_i64).into_string(), "0");
+    }
+
+    // ── pluralize / pluralize_with ───────────────────────────────────────
+
+    #[test]
+    fn pluralize_singular_boundary() {
+        assert_eq!(pluralize(1, "comment").into_string(), "1 comment");
+    }
+
+    #[test]
+    fn pluralize_many_boundary() {
+        assert_eq!(pluralize(2, "comment").into_string(), "2 comments");
+    }
+
+    #[test]
+    fn pluralize_zero_is_plural() {
+        assert_eq!(pluralize(0, "comment").into_string(), "0 comments");
+    }
+
+    #[test]
+    fn pluralize_sibilant_ending() {
+        assert_eq!(pluralize(2, "box").into_string(), "2 boxes");
+    }
+
+    #[test]
+    fn pluralize_consonant_y() {
+        assert_eq!(pluralize(2, "category").into_string(), "2 categories");
+    }
+
+    #[test]
+    fn pluralize_vowel_y_keeps_y() {
+        assert_eq!(pluralize(2, "day").into_string(), "2 days");
+    }
+
+    #[test]
+    fn pluralize_built_in_irregular() {
+        assert_eq!(pluralize(2, "person").into_string(), "2 people");
+    }
+
+    #[test]
+    fn pluralize_with_custom_irregular() {
+        assert_eq!(
+            pluralize_with(2, "octopus", "octopi").into_string(),
+            "2 octopi"
+        );
+        assert_eq!(
+            pluralize_with(1, "octopus", "octopi").into_string(),
+            "1 octopus"
+        );
+    }
+
+    // ── truncate / truncate_with ──────────────────────────────────────────
+
+    #[test]
+    fn truncate_shortens_long_text() {
+        assert_eq!(
+            truncate("The quick brown fox", 10).into_string(),
+            "The quick…"
+        );
+    }
+
+    #[test]
+    fn truncate_leaves_short_text_untouched() {
+        assert_eq!(truncate("short", 10).into_string(), "short");
+    }
+
+    #[test]
+    fn truncate_exact_length_untouched() {
+        assert_eq!(truncate("exactly10!", 10).into_string(), "exactly10!");
+    }
+
+    #[test]
+    fn truncate_never_splits_multibyte_grapheme() {
+        // Each "🎉" is a 4-byte UTF-8 scalar; a byte-oriented truncation would panic.
+        let text = "🎉🎉🎉🎉🎉";
+        let result = truncate(text, 3).into_string();
+        assert!(result.is_char_boundary(0));
+        assert!(result.chars().all(|c| c == '🎉' || c == '…'));
+    }
+
+    #[test]
+    fn truncate_with_custom_omission() {
+        assert_eq!(
+            truncate_with("The quick brown fox", 12, " [more]").into_string(),
+            "The quick [more]"
+        );
+    }
+
+    // ── truncate_words / truncate_words_with ─────────────────────────────
+
+    #[test]
+    fn truncate_words_shortens_long_text() {
+        assert_eq!(
+            truncate_words("The quick brown fox jumps", 3).into_string(),
+            "The quick brown…"
+        );
+    }
+
+    #[test]
+    fn truncate_words_leaves_short_text_untouched() {
+        assert_eq!(truncate_words("short text", 5).into_string(), "short text");
+    }
+
+    #[test]
+    fn truncate_words_custom_omission() {
+        assert_eq!(
+            truncate_words_with("The quick brown fox", 2, " [read more]").into_string(),
+            "The quick [read more]"
+        );
+    }
+
+    // ── time_ago_in_words ──────────────────────────────────────────────────
+
+    #[test]
+    fn time_ago_seconds() {
+        let now = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 30).unwrap();
+        let dt = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
+        let clock = FixedClock::at(now);
+        assert_eq!(
+            time_ago_in_words(dt, &clock).into_string(),
+            "30 seconds ago"
+        );
+    }
+
+    #[test]
+    fn time_ago_one_minute_is_singular() {
+        let now = Utc.with_ymd_and_hms(2026, 1, 1, 12, 1, 0).unwrap();
+        let dt = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
+        let clock = FixedClock::at(now);
+        assert_eq!(time_ago_in_words(dt, &clock).into_string(), "1 minute ago");
+    }
+
+    #[test]
+    fn time_ago_minutes() {
+        let now = Utc.with_ymd_and_hms(2026, 1, 1, 12, 3, 0).unwrap();
+        let dt = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
+        let clock = FixedClock::at(now);
+        assert_eq!(
+            time_ago_in_words(dt, &clock).into_string(),
+            "3 minutes ago"
+        );
+    }
+
+    #[test]
+    fn time_ago_hours() {
+        let now = Utc.with_ymd_and_hms(2026, 1, 1, 14, 0, 0).unwrap();
+        let dt = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
+        let clock = FixedClock::at(now);
+        assert_eq!(time_ago_in_words(dt, &clock).into_string(), "2 hours ago");
+    }
+
+    #[test]
+    fn time_ago_days() {
+        let now = Utc.with_ymd_and_hms(2026, 1, 3, 12, 0, 0).unwrap();
+        let dt = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
+        let clock = FixedClock::at(now);
+        assert_eq!(time_ago_in_words(dt, &clock).into_string(), "2 days ago");
+    }
+
+    #[test]
+    fn time_ago_future() {
+        let now = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
+        let dt = Utc.with_ymd_and_hms(2026, 1, 3, 12, 0, 0).unwrap();
+        let clock = FixedClock::at(now);
+        assert_eq!(time_ago_in_words(dt, &clock).into_string(), "in 2 days");
+    }
+
+    // ── format_datetime ─────────────────────────────────────────────────────
+
+    #[test]
+    fn format_datetime_custom_format() {
+        let dt = Utc.with_ymd_and_hms(2026, 6, 7, 14, 32, 1).unwrap();
+        assert_eq!(
+            format_datetime(dt, "%Y-%m-%d %H:%M:%S").into_string(),
+            "2026-06-07 14:32:01"
+        );
+    }
+
+    #[test]
+    fn format_datetime_date_only() {
+        let dt = Utc.with_ymd_and_hms(2026, 6, 7, 14, 32, 1).unwrap();
+        assert_eq!(format_datetime(dt, "%Y-%m-%d").into_string(), "2026-06-07");
+    }
+}

--- a/autumn/src/format.rs
+++ b/autumn/src/format.rs
@@ -11,27 +11,26 @@
 //!
 //! ```rust
 //! use autumn_web::format::{number_to_currency, pluralize, time_ago_in_words};
-//! use autumn_web::time::FixedClock;
+//! use autumn_web::time::{ClockSource, FixedClock};
 //! use chrono::{TimeZone, Utc};
 //! use maud::html;
 //! use rust_decimal::Decimal;
 //!
 //! let price: Decimal = "1234.5".parse().unwrap();
 //! let posted_at = Utc.with_ymd_and_hms(2026, 1, 1, 11, 58, 0).unwrap();
-//! let clock = FixedClock::at(Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap());
+//! let now = FixedClock::at(Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap()).now();
 //!
 //! let markup = html! {
 //!     (number_to_currency(price))
 //!     " — "
 //!     (pluralize(3, "comment"))
 //!     " — "
-//!     (time_ago_in_words(posted_at, &clock))
+//!     (time_ago_in_words(posted_at, now))
 //! };
 //!
 //! assert_eq!(markup.into_string(), "$1,234.50 — 3 comments — 2 minutes ago");
 //! ```
 
-use crate::time::ClockSource;
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 
@@ -298,14 +297,16 @@ pub fn truncate_words_with(text: &str, n: usize, omission: &str) -> maud::Markup
 // ── Dates & times ────────────────────────────────────────────────────────────
 
 /// Render a human-readable relative time (`"3 minutes ago"`, `"in 2 days"`)
-/// between `dt` and the current instant of `clock`.
+/// between `dt` and `now`.
 ///
-/// Pass a [`crate::time::FixedClock`] or [`crate::time::TickingClock`] in
-/// tests for deterministic output.
+/// Pass `now` from the [`crate::time::Clock`] extractor (`clock.now()`) in
+/// handlers, or from a [`crate::time::ClockSource`] like
+/// [`crate::time::FixedClock`] (`clock.now()`) in tests for deterministic
+/// output.
 #[cfg(feature = "maud")]
 #[must_use]
-pub fn time_ago_in_words(dt: DateTime<Utc>, clock: &dyn ClockSource) -> maud::Markup {
-    let text = relative_time_words(dt, clock.now());
+pub fn time_ago_in_words(dt: DateTime<Utc>, now: DateTime<Utc>) -> maud::Markup {
+    let text = relative_time_words(dt, now);
     maud::html! { (text) }
 }
 
@@ -354,7 +355,7 @@ pub fn format_datetime(dt: DateTime<Utc>, fmt: &str) -> maud::Markup {
 #[cfg(all(test, feature = "maud"))]
 mod tests {
     use super::*;
-    use crate::time::FixedClock;
+    use crate::time::{ClockSource, FixedClock};
     use chrono::TimeZone;
 
     fn dec(s: &str) -> Decimal {
@@ -564,7 +565,7 @@ mod tests {
         let dt = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
         let clock = FixedClock::at(now);
         assert_eq!(
-            time_ago_in_words(dt, &clock).into_string(),
+            time_ago_in_words(dt, clock.now()).into_string(),
             "30 seconds ago"
         );
     }
@@ -574,7 +575,10 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 1, 1, 12, 1, 0).unwrap();
         let dt = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
         let clock = FixedClock::at(now);
-        assert_eq!(time_ago_in_words(dt, &clock).into_string(), "1 minute ago");
+        assert_eq!(
+            time_ago_in_words(dt, clock.now()).into_string(),
+            "1 minute ago"
+        );
     }
 
     #[test]
@@ -582,7 +586,10 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 1, 1, 12, 3, 0).unwrap();
         let dt = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
         let clock = FixedClock::at(now);
-        assert_eq!(time_ago_in_words(dt, &clock).into_string(), "3 minutes ago");
+        assert_eq!(
+            time_ago_in_words(dt, clock.now()).into_string(),
+            "3 minutes ago"
+        );
     }
 
     #[test]
@@ -590,7 +597,10 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 1, 1, 14, 0, 0).unwrap();
         let dt = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
         let clock = FixedClock::at(now);
-        assert_eq!(time_ago_in_words(dt, &clock).into_string(), "2 hours ago");
+        assert_eq!(
+            time_ago_in_words(dt, clock.now()).into_string(),
+            "2 hours ago"
+        );
     }
 
     #[test]
@@ -598,7 +608,10 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 1, 3, 12, 0, 0).unwrap();
         let dt = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
         let clock = FixedClock::at(now);
-        assert_eq!(time_ago_in_words(dt, &clock).into_string(), "2 days ago");
+        assert_eq!(
+            time_ago_in_words(dt, clock.now()).into_string(),
+            "2 days ago"
+        );
     }
 
     #[test]
@@ -606,7 +619,10 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
         let dt = Utc.with_ymd_and_hms(2026, 1, 3, 12, 0, 0).unwrap();
         let clock = FixedClock::at(now);
-        assert_eq!(time_ago_in_words(dt, &clock).into_string(), "in 2 days");
+        assert_eq!(
+            time_ago_in_words(dt, clock.now()).into_string(),
+            "in 2 days"
+        );
     }
 
     // ── format_datetime ─────────────────────────────────────────────────────

--- a/autumn/src/format.rs
+++ b/autumn/src/format.rs
@@ -9,7 +9,7 @@
 //!
 //! # Quick example
 //!
-//! ```rust,ignore
+//! ```rust
 //! use autumn_web::format::{number_to_currency, pluralize, time_ago_in_words};
 //! use autumn_web::time::FixedClock;
 //! use chrono::{TimeZone, Utc};
@@ -92,9 +92,9 @@ impl<'a> CurrencyOptions<'a> {
 
     /// Format `value` per this configuration, returning HTML-escaped [`maud::Markup`].
     #[must_use]
-    pub fn format(&self, _value: Decimal) -> maud::Markup {
-        // TODO(red): not implemented yet.
-        maud::html! { "" }
+    pub fn format(&self, value: Decimal) -> maud::Markup {
+        let text = format_currency(value, self);
+        maud::html! { (text) }
     }
 }
 
@@ -112,33 +112,144 @@ pub fn number_to_currency(value: Decimal) -> maud::Markup {
     CurrencyOptions::new().format(value)
 }
 
+#[cfg(feature = "maud")]
+fn format_currency(value: Decimal, options: &CurrencyOptions<'_>) -> String {
+    // `round_dp` rounds but does not pad trailing zeros onto a shorter scale
+    // (e.g. 1234.5 stays scale=1), so the digit string is built by rounding
+    // first, then formatting with an explicit precision to force zero-padding.
+    let rounded = value.round_dp_with_strategy(
+        options.precision,
+        rust_decimal::RoundingStrategy::MidpointAwayFromZero,
+    );
+    let negative = rounded.is_sign_negative() && !rounded.is_zero();
+    let abs = rounded.abs();
+    let digits = format!("{:.prec$}", abs, prec = options.precision as usize);
+    let (int_part, frac_part) = split_decimal_string(&digits);
+    let grouped_int = group_thousands(int_part, options.thousands_separator);
+
+    let mut out =
+        String::with_capacity(options.symbol.len() + grouped_int.len() + frac_part.len() + 2);
+    if negative {
+        out.push('-');
+    }
+    out.push_str(options.symbol);
+    out.push_str(&grouped_int);
+    if options.precision > 0 {
+        out.push(options.decimal_separator);
+        out.push_str(frac_part);
+    }
+    out
+}
+
 // ── Delimited numbers ────────────────────────────────────────────────────────
 
 /// Render an integer or decimal with grouped thousands (`1,234,567`).
+///
+/// Accepts any type that converts into [`rust_decimal::Decimal`] (the common
+/// Rust integer types, plus `Decimal` itself).
 #[cfg(feature = "maud")]
 #[must_use]
-pub fn number_with_delimiter<T: Into<Decimal>>(_value: T) -> maud::Markup {
-    // TODO(red): not implemented yet.
-    maud::html! { "" }
+pub fn number_with_delimiter<T: Into<Decimal>>(value: T) -> maud::Markup {
+    let value: Decimal = value.into();
+    let negative = value.is_sign_negative() && !value.is_zero();
+    let abs = value.abs();
+    let digits = abs.to_string();
+    let (int_part, frac_part) = split_decimal_string(&digits);
+    let grouped_int = group_thousands(int_part, ',');
+
+    let mut out = String::with_capacity(grouped_int.len() + frac_part.len() + 2);
+    if negative {
+        out.push('-');
+    }
+    out.push_str(&grouped_int);
+    if !frac_part.is_empty() {
+        out.push('.');
+        out.push_str(frac_part);
+    }
+    maud::html! { (out) }
+}
+
+/// Split a plain decimal string (`"1234.50"` or `"1234"`) into its integer
+/// and fractional parts (without the separating dot).
+fn split_decimal_string(s: &str) -> (&str, &str) {
+    s.split_once('.').unwrap_or((s, ""))
+}
+
+/// Group the ASCII digits of `int_digits` into threes, joined by `separator`.
+fn group_thousands(int_digits: &str, separator: char) -> String {
+    let len = int_digits.len();
+    let mut out = String::with_capacity(len + len / 3);
+    for (i, ch) in int_digits.chars().enumerate() {
+        if i > 0 && (len - i).is_multiple_of(3) {
+            out.push(separator);
+        }
+        out.push(ch);
+    }
+    out
 }
 
 // ── Pluralize ────────────────────────────────────────────────────────────────
 
 /// Render `"{count} {word}"`, pluralizing `singular` with a simple
 /// irregular-aware English rule when `count != 1`.
+///
+/// Use [`pluralize_with`] to supply an explicit plural for irregulars this
+/// rule misses.
 #[cfg(feature = "maud")]
 #[must_use]
-pub fn pluralize(_count: i64, _singular: &str) -> maud::Markup {
-    // TODO(red): not implemented yet.
-    maud::html! { "" }
+pub fn pluralize(count: i64, singular: &str) -> maud::Markup {
+    let word = if count == 1 {
+        singular.to_owned()
+    } else {
+        pluralize_word(singular)
+    };
+    maud::html! { (count) " " (word) }
 }
 
-/// Render `"{count} {word}"`, choosing between `singular` and an explicit `plural`.
+/// Render `"{count} {word}"`, choosing between `singular` and an explicit
+/// `plural` — the escape hatch for irregulars [`pluralize`]'s built-in rule
+/// misses.
 #[cfg(feature = "maud")]
 #[must_use]
-pub fn pluralize_with(_count: i64, _singular: &str, _plural: &str) -> maud::Markup {
-    // TODO(red): not implemented yet.
-    maud::html! { "" }
+pub fn pluralize_with(count: i64, singular: &str, plural: &str) -> maud::Markup {
+    let word = if count == 1 { singular } else { plural };
+    maud::html! { (count) " " (word) }
+}
+
+/// Naive English pluraliser for display words. Mirrors the identifier
+/// pluraliser in `autumn-cli`'s naming helpers, minus the `snake_case`
+/// segment-splitting (display words are whole words, not identifiers).
+fn pluralize_word(word: &str) -> String {
+    if word.is_empty() {
+        return String::new();
+    }
+    match word {
+        "person" => return "people".to_owned(),
+        "child" => return "children".to_owned(),
+        "man" => return "men".to_owned(),
+        "woman" => return "women".to_owned(),
+        "mouse" => return "mice".to_owned(),
+        "goose" => return "geese".to_owned(),
+        _ => {}
+    }
+    let lower = word.to_ascii_lowercase();
+    if lower.ends_with("ss")
+        || lower.ends_with('x')
+        || lower.ends_with('z')
+        || lower.ends_with("ch")
+        || lower.ends_with("sh")
+    {
+        return format!("{word}es");
+    }
+    if lower.ends_with('y') {
+        let prev = word.chars().rev().nth(1);
+        if prev.is_some_and(|c| !"aeiouAEIOU".contains(c)) {
+            let mut out: String = word.chars().take(word.chars().count() - 1).collect();
+            out.push_str("ies");
+            return out;
+        }
+    }
+    format!("{word}s")
 }
 
 // ── Truncation ────────────────────────────────────────────────────────────────
@@ -154,9 +265,15 @@ pub fn truncate(text: &str, len: usize) -> maud::Markup {
 /// Like [`truncate`], with a caller-supplied omission marker instead of `"…"`.
 #[cfg(feature = "maud")]
 #[must_use]
-pub fn truncate_with(_text: &str, _len: usize, _omission: &str) -> maud::Markup {
-    // TODO(red): not implemented yet.
-    maud::html! { "" }
+pub fn truncate_with(text: &str, len: usize, omission: &str) -> maud::Markup {
+    let char_count = text.chars().count();
+    if char_count <= len {
+        return maud::html! { (text) };
+    }
+    let omission_len = omission.chars().count();
+    let keep = len.saturating_sub(omission_len);
+    let truncated: String = text.chars().take(keep).collect();
+    maud::html! { (truncated) (omission) }
 }
 
 /// Shorten `text` to at most `n` whitespace-delimited words.
@@ -169,28 +286,67 @@ pub fn truncate_words(text: &str, n: usize) -> maud::Markup {
 /// Like [`truncate_words`], with a caller-supplied omission marker instead of `"…"`.
 #[cfg(feature = "maud")]
 #[must_use]
-pub fn truncate_words_with(_text: &str, _n: usize, _omission: &str) -> maud::Markup {
-    // TODO(red): not implemented yet.
-    maud::html! { "" }
+pub fn truncate_words_with(text: &str, n: usize, omission: &str) -> maud::Markup {
+    let words: Vec<&str> = text.split_whitespace().collect();
+    if words.len() <= n {
+        return maud::html! { (text) };
+    }
+    let truncated = words[..n].join(" ");
+    maud::html! { (truncated) (omission) }
 }
 
 // ── Dates & times ────────────────────────────────────────────────────────────
 
 /// Render a human-readable relative time (`"3 minutes ago"`, `"in 2 days"`)
 /// between `dt` and the current instant of `clock`.
+///
+/// Pass a [`crate::time::FixedClock`] or [`crate::time::TickingClock`] in
+/// tests for deterministic output.
 #[cfg(feature = "maud")]
 #[must_use]
-pub fn time_ago_in_words(_dt: DateTime<Utc>, _clock: &dyn ClockSource) -> maud::Markup {
-    // TODO(red): not implemented yet.
-    maud::html! { "" }
+pub fn time_ago_in_words(dt: DateTime<Utc>, clock: &dyn ClockSource) -> maud::Markup {
+    let text = relative_time_words(dt, clock.now());
+    maud::html! { (text) }
+}
+
+fn relative_time_words(dt: DateTime<Utc>, now: DateTime<Utc>) -> String {
+    let secs = now.signed_duration_since(dt).num_seconds();
+    if secs < 0 {
+        format!("in {}", duration_words(secs.unsigned_abs()))
+    } else {
+        format!("{} ago", duration_words(secs.unsigned_abs()))
+    }
+}
+
+/// Render a whole-unit duration as `"{n} {second,minute,hour,day}(s)"`.
+fn duration_words(secs: u64) -> String {
+    let (n, singular, plural) = if secs < 60 {
+        (secs, "second", "seconds")
+    } else if secs < 3600 {
+        (secs / 60, "minute", "minutes")
+    } else if secs < 86_400 {
+        (secs / 3600, "hour", "hours")
+    } else {
+        (secs / 86_400, "day", "days")
+    };
+    let word = if n == 1 { singular } else { plural };
+    format!("{n} {word}")
 }
 
 /// Render `dt` (UTC) using a `chrono` strftime-style absolute format string.
+///
+/// ```rust
+/// use autumn_web::format::format_datetime;
+/// use chrono::{TimeZone, Utc};
+///
+/// let dt = Utc.with_ymd_and_hms(2026, 6, 7, 14, 32, 1).unwrap();
+/// assert_eq!(format_datetime(dt, "%Y-%m-%d").into_string(), "2026-06-07");
+/// ```
 #[cfg(feature = "maud")]
 #[must_use]
-pub fn format_datetime(_dt: DateTime<Utc>, _fmt: &str) -> maud::Markup {
-    // TODO(red): not implemented yet.
-    maud::html! { "" }
+pub fn format_datetime(dt: DateTime<Utc>, fmt: &str) -> maud::Markup {
+    let text = dt.format(fmt).to_string();
+    maud::html! { (text) }
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -209,10 +365,7 @@ mod tests {
 
     #[test]
     fn currency_formats_with_default_options() {
-        assert_eq!(
-            number_to_currency(dec("1234.5")).into_string(),
-            "$1,234.50"
-        );
+        assert_eq!(number_to_currency(dec("1234.5")).into_string(), "$1,234.50");
     }
 
     #[test]
@@ -222,10 +375,7 @@ mod tests {
 
     #[test]
     fn currency_formats_negative() {
-        assert_eq!(
-            number_to_currency(dec("-42.5")).into_string(),
-            "-$42.50"
-        );
+        assert_eq!(number_to_currency(dec("-42.5")).into_string(), "-$42.50");
     }
 
     #[test]
@@ -375,8 +525,10 @@ mod tests {
 
     #[test]
     fn truncate_with_custom_omission() {
+        // len (16) caps the *total* output, including the omission marker:
+        // "The quick" (9 chars) + " [more]" (7 chars) = 16.
         assert_eq!(
-            truncate_with("The quick brown fox", 12, " [more]").into_string(),
+            truncate_with("The quick brown fox", 16, " [more]").into_string(),
             "The quick [more]"
         );
     }
@@ -430,10 +582,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 1, 1, 12, 3, 0).unwrap();
         let dt = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
         let clock = FixedClock::at(now);
-        assert_eq!(
-            time_ago_in_words(dt, &clock).into_string(),
-            "3 minutes ago"
-        );
+        assert_eq!(time_ago_in_words(dt, &clock).into_string(), "3 minutes ago");
     }
 
     #[test]

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -94,7 +94,7 @@ pub mod extract;
 /// View-layer value formatting helpers (currency, delimited numbers,
 /// pluralize, truncate, relative/absolute dates) for Maud templates.
 ///
-/// See [`format`] for the full API.
+/// See [`mod@format`] for the full API.
 pub mod format;
 pub mod health;
 #[cfg(feature = "db")]

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -1163,6 +1163,7 @@ pub mod reexports {
     pub use inventory;
     #[cfg(feature = "mail")]
     pub use lettre;
+    pub use rust_decimal;
     #[cfg(feature = "db")]
     pub use scoped_futures;
     pub use serde;

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -91,6 +91,11 @@ pub mod error;
 #[cfg(feature = "maud")]
 pub mod error_pages;
 pub mod extract;
+/// View-layer value formatting helpers (currency, delimited numbers,
+/// pluralize, truncate, relative/absolute dates) for Maud templates.
+///
+/// See [`format`] for the full API.
+pub mod format;
 pub mod health;
 #[cfg(feature = "db")]
 pub mod hooks;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -285,6 +285,39 @@ pub use crate::i18n::Locale;
 #[cfg(feature = "i18n")]
 pub use crate::i18n::t;
 
+// ── Formatting ───────────────────────────────────────────────────
+/// Currency, delimited-number, precision/separator configuration for
+/// [`number_to_currency`]. See [`crate::format`] for the full API.
+#[cfg(feature = "maud")]
+pub use crate::format::CurrencyOptions;
+/// Format a `chrono` UTC timestamp with a strftime-style absolute format string.
+#[cfg(feature = "maud")]
+pub use crate::format::format_datetime;
+/// Format a [`rust_decimal::Decimal`] as currency (`$1,234.50`) using sane defaults.
+#[cfg(feature = "maud")]
+pub use crate::format::number_to_currency;
+/// Render an integer or decimal with grouped thousands (`1,234,567`).
+#[cfg(feature = "maud")]
+pub use crate::format::number_with_delimiter;
+/// Render `"{count} {word}"`, pluralizing with a simple irregular-aware rule.
+#[cfg(feature = "maud")]
+pub use crate::format::pluralize;
+/// Render `"{count} {word}"`, choosing between an explicit singular and plural.
+#[cfg(feature = "maud")]
+pub use crate::format::pluralize_with;
+/// Render `"3 minutes ago"` / `"in 2 days"` relative to a [`crate::time::ClockSource`].
+#[cfg(feature = "maud")]
+pub use crate::format::time_ago_in_words;
+/// Shorten text to at most `len` characters without splitting a UTF-8 character mid-byte.
+#[cfg(feature = "maud")]
+pub use crate::format::{truncate, truncate_with};
+/// Shorten text to at most `n` whitespace-delimited words.
+#[cfg(feature = "maud")]
+pub use crate::format::{truncate_words, truncate_words_with};
+/// Exact-precision decimal type accepted by [`number_to_currency`] and
+/// [`number_with_delimiter`].
+pub use rust_decimal::Decimal;
+
 // ── Time zones ────────────────────────────────────────────────────
 /// Request-scoped time zone extractor (resolves from user extension,
 /// session, cookie, and query parameter — see [`crate::time_zone`]).
@@ -392,5 +425,13 @@ mod tests {
     fn maud_types_work_through_prelude() {
         let markup: Markup = html! { "hello" };
         assert!(markup.into_string().contains("hello"));
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn format_helpers_work_through_prelude() {
+        let price: Decimal = "9.5".parse().unwrap();
+        assert_eq!(number_to_currency(price).into_string(), "$9.50");
+        assert_eq!(pluralize(1, "comment").into_string(), "1 comment");
     }
 }

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -306,7 +306,7 @@ pub use crate::format::pluralize;
 #[cfg(feature = "maud")]
 pub use crate::format::pluralize_with;
 /// Render `"3 minutes ago"` / `"in 2 days"` relative to `now` (pass `clock.now()`
-/// from the [`Clock`](crate::time::Clock) extractor, or a [`crate::time::ClockSource`]
+/// from the [`Clock`] extractor, or a [`crate::time::ClockSource`]
 /// like [`crate::time::FixedClock`] in tests).
 #[cfg(feature = "maud")]
 pub use crate::format::time_ago_in_words;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -305,7 +305,9 @@ pub use crate::format::pluralize;
 /// Render `"{count} {word}"`, choosing between an explicit singular and plural.
 #[cfg(feature = "maud")]
 pub use crate::format::pluralize_with;
-/// Render `"3 minutes ago"` / `"in 2 days"` relative to a [`crate::time::ClockSource`].
+/// Render `"3 minutes ago"` / `"in 2 days"` relative to `now` (pass `clock.now()`
+/// from the [`Clock`](crate::time::Clock) extractor, or a [`crate::time::ClockSource`]
+/// like [`crate::time::FixedClock`] in tests).
 #[cfg(feature = "maud")]
 pub use crate::format::time_ago_in_words;
 /// Shorten text to at most `len` characters without splitting a UTF-8 character mid-byte.

--- a/autumn/src/time_zone.rs
+++ b/autumn/src/time_zone.rs
@@ -430,38 +430,12 @@ pub fn local_date(dt: DateTime<Utc>, tz: Tz) -> maud::Markup {
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn time_ago(dt: DateTime<Utc>, now: DateTime<Utc>, tz: Tz) -> maud::Markup {
-    let diff = now.signed_duration_since(dt);
-    let relative = format_relative(diff);
+    let relative = crate::format::relative_time_words(dt, now);
     let rfc = dt.to_rfc3339();
     let local = tz.from_utc_datetime(&dt.naive_utc());
     let display = local.format("%Y-%m-%d %H:%M %Z").to_string();
     maud::html! {
         time datetime=(rfc) title=(display) { (relative) }
-    }
-}
-
-fn format_relative(diff: chrono::Duration) -> String {
-    let secs = diff.num_seconds();
-    if secs < 0 {
-        let future = secs.unsigned_abs();
-        return if future < 60 {
-            format!("in {future} seconds")
-        } else if future < 3600 {
-            format!("in {} minutes", future / 60)
-        } else if future < 86400 {
-            format!("in {} hours", future / 3600)
-        } else {
-            format!("in {} days", future / 86400)
-        };
-    }
-    if secs < 60 {
-        format!("{secs} seconds ago")
-    } else if secs < 3600 {
-        format!("{} minutes ago", secs / 60)
-    } else if secs < 86400 {
-        format!("{} hours ago", secs / 3600)
-    } else {
-        format!("{} days ago", secs / 86400)
     }
 }
 

--- a/docs/guide/format-helpers.md
+++ b/docs/guide/format-helpers.md
@@ -1,0 +1,119 @@
+# View Formatting Helpers
+
+Autumn's widget lane (`card`, `data_table`, `property_list`, `hero`,
+`breadcrumb`) renders *containers*. `autumn_web::format` renders the
+**scalar values** that go inside them — money, counts, and timestamps —
+so apps stop hand-rolling `format!("${:.2}", price)` and ad-hoc relative-time
+math in every template.
+
+All helpers are pure functions that return HTML-escaped [`maud::Markup`],
+so they're safe to interpolate directly into `html! { ... }` blocks. They
+ship in the `autumn_web::prelude` (behind the default `maud` feature), so
+no extra imports are needed beyond the usual `use autumn_web::prelude::*;`.
+
+## Helpers at a glance
+
+| Helper | Example output |
+|--------|-----------------|
+| `number_to_currency(price)` | `$1,234.50` |
+| `CurrencyOptions::new().symbol("€")...format(price)` | `€1.234,50` |
+| `number_with_delimiter(count)` | `1,234,567` |
+| `pluralize(count, "comment")` | `1 comment` / `2 comments` |
+| `pluralize_with(count, "octopus", "octopi")` | `1 octopus` / `2 octopi` |
+| `truncate(text, 30)` | `The quick brown fox jumps ov…` |
+| `truncate_words(text, 5)` | `The quick brown fox jumps…` |
+| `time_ago_in_words(dt, &clock)` | `3 minutes ago` / `in 2 days` |
+| `format_datetime(dt, "%Y-%m-%d")` | `2026-06-07` |
+
+`number_to_currency` takes a [`rust_decimal::Decimal`](https://docs.rs/rust_decimal)
+— the same exact-precision type used by decimal model fields — so money never
+rounds through a float on its way to the page.
+
+## Copy-paste example: money, count, and timestamp in a `data_table`
+
+```rust
+use autumn_web::prelude::*;
+use autumn_web::widgets::{Column, DataTableConfig, data_table};
+
+struct Order {
+    id: i64,
+    total: Decimal,
+    item_count: i64,
+    placed_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[get("/orders")]
+async fn index(clock: Clock, orders: Vec<Order>) -> Markup {
+    let cols: Vec<Column<Order>> = vec![
+        Column::new("Total", |row: &Order| html! { (number_to_currency(row.total)) }),
+        Column::new("Items", |row: &Order| html! { (pluralize(row.item_count, "item")) }),
+        Column::new("Placed", |row: &Order| {
+            html! { (time_ago_in_words(row.placed_at, &clock)) }
+        }),
+    ];
+
+    html! {
+        (data_table(&orders, &cols, &DataTableConfig::new("No orders yet.")))
+    }
+}
+```
+
+This renders each row's `total` as `$1,234.50`, `item_count` as `3 items`
+(or `1 item`), and `placed_at` as `2 hours ago` — three helper calls, zero
+hand-written `format!`s.
+
+## Customizing currency output
+
+`number_to_currency` uses [`CurrencyOptions`] defaults (`$`, 2 decimal
+places, `,`/`.` separators). Build a [`CurrencyOptions`] directly for a
+different symbol, precision, or separators:
+
+```rust
+use autumn_web::prelude::*;
+
+let opts = CurrencyOptions::new()
+    .symbol("€")
+    .precision(2)
+    .thousands_separator('.')
+    .decimal_separator(',');
+
+let price: Decimal = "1234.5".parse().unwrap();
+assert_eq!(opts.format(price).into_string(), "€1.234,50");
+```
+
+## Pluralize and truncate escape hatches
+
+`pluralize` covers common English rules (sibilant endings, consonant+`y`,
+and a handful of irregulars like `person`/`people`). For irregulars it
+misses, use `pluralize_with` with an explicit plural:
+
+```rust
+pluralize_with(count, "octopus", "octopi")
+```
+
+`truncate`/`truncate_words` default to an `"…"` ellipsis and never split a
+UTF-8 character mid-byte; use `truncate_with`/`truncate_words_with` for a
+custom marker (e.g. `" [read more]"`).
+
+## Deterministic relative time in tests
+
+`time_ago_in_words` takes any [`autumn_web::time::ClockSource`], so tests
+get exact, non-flaky output with [`autumn_web::time::FixedClock`]:
+
+```rust
+use autumn_web::prelude::*;
+use autumn_web::time::FixedClock;
+use chrono::{TimeZone, Utc};
+
+let posted_at = Utc.with_ymd_and_hms(2026, 1, 1, 11, 58, 0).unwrap();
+let clock = FixedClock::at(Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap());
+assert_eq!(time_ago_in_words(posted_at, &clock).into_string(), "2 minutes ago");
+```
+
+## Out of scope
+
+Single-locale only (configurable separators/symbol, not full CLDR/ICU
+locale catalogs) — see the [i18n guide](i18n.md) for message translation.
+No number-to-words, ordinalize, or file-size humanizers yet; no
+auto-formatting wired into scaffolded views (scaffolds still emit the raw
+value — call these helpers explicitly in the generated template).

--- a/docs/guide/format-helpers.md
+++ b/docs/guide/format-helpers.md
@@ -48,7 +48,7 @@ async fn index(clock: Clock, orders: Vec<Order>) -> Markup {
         Column::new("Total", |row: &Order| html! { (number_to_currency(row.total)) }),
         Column::new("Items", |row: &Order| html! { (pluralize(row.item_count, "item")) }),
         Column::new("Placed", |row: &Order| {
-            html! { (time_ago_in_words(row.placed_at, &clock)) }
+            html! { (time_ago_in_words(row.placed_at, clock.now())) }
         }),
     ];
 
@@ -97,17 +97,18 @@ custom marker (e.g. `" [read more]"`).
 
 ## Deterministic relative time in tests
 
-`time_ago_in_words` takes any [`autumn_web::time::ClockSource`], so tests
-get exact, non-flaky output with [`autumn_web::time::FixedClock`]:
+`time_ago_in_words` takes `now` as a plain `DateTime<Utc>` — pass
+`clock.now()` from the `Clock` extractor in handlers, or from any
+`ClockSource` (like `FixedClock`) in tests for exact, non-flaky output:
 
 ```rust
 use autumn_web::prelude::*;
-use autumn_web::time::FixedClock;
+use autumn_web::time::{ClockSource, FixedClock};
 use chrono::{TimeZone, Utc};
 
 let posted_at = Utc.with_ymd_and_hms(2026, 1, 1, 11, 58, 0).unwrap();
-let clock = FixedClock::at(Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap());
-assert_eq!(time_ago_in_words(posted_at, &clock).into_string(), "2 minutes ago");
+let now = FixedClock::at(Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap()).now();
+assert_eq!(time_ago_in_words(posted_at, now).into_string(), "2 minutes ago");
 ```
 
 ## Out of scope

--- a/docs/guide/format-helpers.md
+++ b/docs/guide/format-helpers.md
@@ -22,7 +22,7 @@ no extra imports are needed beyond the usual `use autumn_web::prelude::*;`.
 | `pluralize_with(count, "octopus", "octopi")` | `1 octopus` / `2 octopi` |
 | `truncate(text, 30)` | `The quick brown fox jumps ov…` |
 | `truncate_words(text, 5)` | `The quick brown fox jumps…` |
-| `time_ago_in_words(dt, &clock)` | `3 minutes ago` / `in 2 days` |
+| `time_ago_in_words(dt, clock.now())` | `3 minutes ago` / `in 2 days` |
 | `format_datetime(dt, "%Y-%m-%d")` | `2026-06-07` |
 
 `number_to_currency` takes a [`rust_decimal::Decimal`](https://docs.rs/rust_decimal)


### PR DESCRIPTION
## Summary

Introduces a new `format` module with pure, allocation-light helpers for rendering scalar values in Maud templates. These helpers return HTML-escaped `Markup` so output is safe by construction, eliminating hand-rolled `format!` calls in views.

## Key Changes

- **New `autumn/src/format.rs` module** with formatting helpers:
  - `number_to_currency()` / `CurrencyOptions` — format `Decimal` as currency with configurable symbol, precision, and separators
  - `number_with_delimiter()` — render integers/decimals with grouped thousands
  - `pluralize()` / `pluralize_with()` — render count + word with English pluralization rules
  - `truncate()` / `truncate_words()` — shorten text safely without splitting UTF-8 characters
  - `time_ago_in_words()` / `format_datetime()` — render relative and absolute timestamps

- **Shared pluralization logic** between CLI and view layer:
  - Extracted `pluralize_word()` from `autumn-cli/src/generate/naming.rs` into `autumn_web::format`
  - CLI now calls the shared implementation to ensure generated identifiers and rendered text agree on pluralization rules

- **Refactored relative time formatting**:
  - Extracted `relative_time_words()` helper in `format` module
  - `time_zone::time_ago()` now delegates to this shared implementation, eliminating duplication

- **Updated prelude** (`autumn/src/prelude.rs`):
  - Exported all formatting helpers and `Decimal` type behind the `maud` feature flag
  - No additional imports needed beyond the standard prelude

- **Added documentation**:
  - Comprehensive module-level docs with quick example
  - New guide page `docs/guide/format-helpers.md` with usage patterns and copy-paste examples
  - All functions include doc comments with examples

- **Added `rust_decimal` dependency** to workspace and autumn crate

## Implementation Details

- All helpers are pure functions returning `maud::Markup` for safe HTML interpolation
- Currency formatting uses `Decimal::round_dp_with_strategy()` for exact precision without float rounding
- Pluralization covers common English rules (sibilants, consonant+y, irregulars) with escape hatches for edge cases
- Truncation is UTF-8-aware and never splits characters mid-byte
- Relative time uses whole-unit durations (seconds → minutes → hours → days) for readable output
- Comprehensive test coverage for all helpers with edge cases (negative values, zero, multibyte characters, etc.)

https://claude.ai/code/session_01L5dSDFiDeqwxCDiod8DbwB