### PR TITLE
Add read-your-own-writes support to bookmarks examples

### DIFF
--- a/autumn/src/system_test.rs
+++ b/autumn/src/system_test.rs
@@ -225,6 +225,19 @@ pub enum SystemTestError {
     Browser(#[from] chromiumoxide::error::CdpError),
 }
 
+/// True for CDP errors that just mean "the page navigated away mid-poll" —
+/// e.g. a plain (non-htmx) form submit's full-page redirect racing an
+/// in-flight `evaluate()` call, which briefly leaves no valid JS execution
+/// context to evaluate against. Transient by construction, not a real
+/// failure: assertion polling loops treat these as "not ready yet" and keep
+/// polling rather than aborting on the first unlucky tick.
+fn is_transient_navigation_error(err: &chromiumoxide::error::CdpError) -> bool {
+    matches!(
+        err,
+        chromiumoxide::error::CdpError::Chrome(inner) if inner.message.contains("context")
+    )
+}
+
 // ── Artifact directory ─────────────────────────────────────────────────────
 
 /// Return the canonical artifact directory for a given test name.
@@ -820,15 +833,19 @@ impl Page {
         let deadline = tokio::time::Instant::now() + timeout;
 
         loop {
-            let result = self
+            let evaluated = self
                 .inner
                 .evaluate(format!(
                     "document.body && document.body.innerText.includes({})",
                     js_string_literal(text)
                 ))
-                .await?;
+                .await;
 
-            let found: bool = result.into_value().unwrap_or(false);
+            let found = match evaluated {
+                Ok(result) => result.into_value().unwrap_or(false),
+                Err(e) if is_transient_navigation_error(&e) => false,
+                Err(e) => return Err(e.into()),
+            };
             if found {
                 return Ok(self);
             }
@@ -854,15 +871,19 @@ impl Page {
         let deadline = tokio::time::Instant::now() + timeout;
 
         loop {
-            let result = self
+            let evaluated = self
                 .inner
                 .evaluate(format!(
                     "window.location.href.includes({})",
                     js_string_literal(pattern)
                 ))
-                .await?;
+                .await;
 
-            let found: bool = result.into_value().unwrap_or(false);
+            let found = match evaluated {
+                Ok(result) => result.into_value().unwrap_or(false),
+                Err(e) if is_transient_navigation_error(&e) => false,
+                Err(e) => return Err(e.into()),
+            };
             if found {
                 return Ok(self);
             }
@@ -910,8 +931,11 @@ impl Page {
                 attr = js_string_literal(attr),
                 val = js_string_literal(value),
             );
-            let result = self.inner.evaluate(js).await?;
-            let found: bool = result.into_value().unwrap_or(false);
+            let found = match self.inner.evaluate(js).await {
+                Ok(result) => result.into_value().unwrap_or(false),
+                Err(e) if is_transient_navigation_error(&e) => false,
+                Err(e) => return Err(e.into()),
+            };
             if found {
                 return Ok(self);
             }
@@ -1041,9 +1065,11 @@ impl Page {
                 id = js_string_literal(stream_id)
             );
 
-            let result = self.inner.evaluate(js).await?;
-
-            let text: Option<String> = result.into_value().ok();
+            let text: Option<String> = match self.inner.evaluate(js).await {
+                Ok(result) => result.into_value().ok(),
+                Err(e) if is_transient_navigation_error(&e) => None,
+                Err(e) => return Err(e.into()),
+            };
             if let Some(ref t) = text
                 && predicate(t)
             {
@@ -1096,11 +1122,19 @@ impl Page {
     async fn wait_for_hx_settle(&self) -> Result<(), SystemTestError> {
         let deadline = tokio::time::Instant::now() + self.hx_settle_timeout;
         loop {
-            let result = self
+            let evaluated = self
                 .inner
                 .evaluate("document.querySelectorAll('.htmx-request,.htmx-settling,.htmx-swapping').length === 0")
-                .await?;
-            let settled: bool = result.into_value().unwrap_or(true);
+                .await;
+            // A destroyed execution context (the page navigated away, e.g. a
+            // plain form submit's full-page redirect) means there is no more
+            // htmx activity on that page to wait for — that counts as settled,
+            // not "keep polling a page that no longer exists".
+            let settled = match evaluated {
+                Ok(result) => result.into_value().unwrap_or(true),
+                Err(e) if is_transient_navigation_error(&e) => true,
+                Err(e) => return Err(e.into()),
+            };
             if settled {
                 return Ok(());
             }

--- a/autumn/tests/system_test_api.rs
+++ b/autumn/tests/system_test_api.rs
@@ -204,6 +204,56 @@ async fn expect_hx_settle_waits_for_htmx() {
     page.expect_text("Swapped!").await.expect("assert swap");
 }
 
+/// A plain (non-htmx) form submit triggers a full-page navigation, which
+/// briefly destroys the JS execution context an in-flight `evaluate()` call
+/// (inside `click()`'s implicit settle wait, or a subsequent `expect_*`
+/// poll) may still be targeting. That must not surface as a hard CDP error —
+/// see `is_transient_navigation_error` in `system_test.rs`.
+#[tokio::test]
+#[ignore = "requires Chromium"]
+async fn click_triggering_full_page_navigation_does_not_break_polling() {
+    use autumn_web::prelude::*;
+
+    #[get("/")]
+    async fn form_page() -> Markup {
+        maud::html! {
+            html {
+                body {
+                    form action="/submit" method="post" {
+                        button type="submit" { "Go" }
+                    }
+                }
+            }
+        }
+    }
+
+    #[post("/submit")]
+    async fn submit() -> Redirect {
+        Redirect::to("/done")
+    }
+
+    #[get("/done")]
+    async fn done() -> &'static str {
+        "Navigated successfully"
+    }
+
+    let runner = SystemTest::new()
+        .routes(routes![form_page, submit, done])
+        .build()
+        .await
+        .expect("start");
+
+    let page = runner.page().await.expect("page");
+    page.visit("/").await.expect("visit");
+    page.click("button[type=submit]")
+        .await
+        .expect("submit form — triggers a full-page redirect");
+    page.expect_text("Navigated successfully").await.expect(
+        "text on the post-redirect page must be visible without the poll \
+         aborting on a transient destroyed-execution-context error",
+    );
+}
+
 // ── attach(): browser-only mode against an already-running server ─────────
 //
 // Issue #1192: the fan-out example harness spawns each example's real

--- a/docs/guide/signing-secrets.md
+++ b/docs/guide/signing-secrets.md
@@ -34,6 +34,7 @@ key** at startup. You do not need to set anything.
 | Process restart | All existing sessions are invalidated immediately |
 | Signed URLs from a previous process | Return `403 Forbidden` — the signature cannot be verified |
 | Multiple dev replicas | Sessions started on one replica are not readable by another |
+| `database.read_your_writes = "session"` | The ephemeral key is deliberately **not** threaded into the RYW middleware (see `router.rs`), so the `autumn.ryw` cookie is never issued — cross-request pinning silently does nothing until a secret is configured. A warning is logged at startup. `request` mode is unaffected (it needs no cookie). |
 
 This is intentional: ephemeral keys keep local development zero-config and
 ensure you never accidentally use a development secret in production. The

--- a/examples/bookmarks-distributed/README.md
+++ b/examples/bookmarks-distributed/README.md
@@ -15,6 +15,7 @@ runtime seams pulled into the open instead of hidden behind happy-path defaults.
 | **Profiles** | `autumn.toml` + `autumn-dev.toml` + `autumn-docker.toml` | Local dev and Docker deployment use canonical `[database]` primary/replica wiring without touching framework internals |
 | **`#[model]`** | `models.rs` | Generates `Bookmark`, `NewBookmark`, `UpdateBookmark` from one struct |
 | **Explicit repository** | `repositories.rs` | Routes reads to replica, writes to primary, and defines `/api/bookmarks` handlers by hand |
+| **Read-your-own-writes** | `autumn.toml` `[database]` + `repositories.rs` | `read_your_writes = "session"` pins a client's reads to the primary for `pin_after_write_secs` after any write; since this repository predates the `#[repository(...)]` macro it opts in explicitly via the public `read_your_writes::is_pinned`/`mark_write` calls |
 | **Partitioned scheduled task** | `tasks.rs` | `#[scheduled(every = "1h")]` link checker partitions work into fixed shards and uses Postgres advisory locks for ownership |
 | **Explicit migrator** | `src/bin/migrate.rs` | Runs embedded migrations once against the primary before web replicas start |
 | **Compose deployment** | `docker-compose.yml` + `docker/` | Primary + streaming replica + one-shot migrator + 2 web replicas + nginx |
@@ -181,6 +182,15 @@ page), regardless of which replica handles it.
   split wanted an explicit repository seam almost immediately.
 - Scheduled tasks are process-local by default, so distributed safety required
   explicit shard ownership and advisory-lock coordination in application code.
+- Splitting reads to the replica for real also means a client can create a
+  bookmark and then, on the very next page load, not see it — the classic
+  read-your-own-writes gap whenever replication lag (or, as here, a second
+  independent database standing in for one) sits between the write and the
+  next read. `read_your_writes = "session"` closes this for the common
+  create-then-redirect flow, but because this repository predates the
+  `#[repository(...)]` macro it doesn't get that wiring automatically —
+  `BookmarkRepository::conn()` opts in by hand via the same public
+  `is_pinned`/`mark_write` calls the macro emits.
   Use `#[scheduled]` for light in-process work like this demo; move durable or
   coordinated multi-step work to Harvest.
 - Non-dev deployment needed an explicit migration runner because

--- a/examples/bookmarks-distributed/README.md
+++ b/examples/bookmarks-distributed/README.md
@@ -190,7 +190,13 @@ page), regardless of which replica handles it.
   create-then-redirect flow, but because this repository predates the
   `#[repository(...)]` macro it doesn't get that wiring automatically —
   `BookmarkRepository::conn()` opts in by hand via the same public
-  `is_pinned`/`mark_write` calls the macro emits.
+  `is_pinned`/`mark_write` calls the macro emits. Session-mode pinning
+  itself needs a configured signing secret to issue its `autumn.ryw` cookie
+  (see `docs/guide/signing-secrets.md`) — dev's zero-config ephemeral key is
+  deliberately not used for it, so a plain `cargo run` with no
+  `AUTUMN_SECURITY__SIGNING_SECRET` set will quietly keep missing the
+  just-created bookmark. `docker compose` already requires that variable
+  (see below); for a plain `cargo run`, set it yourself to see pinning work.
   Use `#[scheduled]` for light in-process work like this demo; move durable or
   coordinated multi-step work to Harvest.
 - Non-dev deployment needed an explicit migration runner because

--- a/examples/bookmarks-distributed/autumn.toml
+++ b/examples/bookmarks-distributed/autumn.toml
@@ -25,5 +25,13 @@ auto_migrate_in_production = false
 # spans two separate requests. See BookmarkRepository::conn() in
 # src/repositories.rs — this repository predates the #[repository(...)]
 # macro, so it opts into RYWW explicitly rather than getting it for free.
+#
+# The autumn.ryw cookie needs a configured signing secret to actually be
+# issued (see docs/guide/signing-secrets.md) — without one, dev's zero-config
+# ephemeral per-process key is deliberately NOT used for it, so this setting
+# quietly does nothing across the create -> redirect -> list flow. `docker
+# compose` already requires AUTUMN_SECURITY__SIGNING_SECRET (see
+# docker-compose.yml); for a plain `cargo run`, set the same env var to see
+# session pinning actually take effect.
 read_your_writes = "session"
 pin_after_write_secs = 10

--- a/examples/bookmarks-distributed/autumn.toml
+++ b/examples/bookmarks-distributed/autumn.toml
@@ -17,3 +17,13 @@ primary_pool_size = 4
 replica_pool_size = 2
 replica_fallback = "fail_readiness"
 auto_migrate_in_production = false
+# The whole point of this example is routing reads to the replica pool — but
+# a client that just wrote a bookmark should still see it on the very next
+# page load rather than racing replication lag. "session" pins a client's
+# reads to the primary (via a signed cookie) for pin_after_write_secs after
+# any write, covering the common create-then-redirect-to-list flow that
+# spans two separate requests. See BookmarkRepository::conn() in
+# src/repositories.rs — this repository predates the #[repository(...)]
+# macro, so it opts into RYWW explicitly rather than getting it for free.
+read_your_writes = "session"
+pin_after_write_secs = 10

--- a/examples/bookmarks-distributed/src/repositories.rs
+++ b/examples/bookmarks-distributed/src/repositories.rs
@@ -34,6 +34,10 @@ pub enum BookmarkOperation {
     Update,
     DeleteById,
     MarkDead,
+    /// Acquiring the link checker's per-shard advisory lock — needs a
+    /// primary connection like a write does, but isn't itself a write, so
+    /// it's kept out of `conn()`'s `mark_write()` set.
+    AcquireShardLease,
 }
 
 pub(crate) const LINK_CHECKER_SHARD_COUNT: u32 = 16;
@@ -75,7 +79,8 @@ impl BookmarkRepository {
             BookmarkOperation::Save
             | BookmarkOperation::Update
             | BookmarkOperation::DeleteById
-            | BookmarkOperation::MarkDead => PoolRole::Primary,
+            | BookmarkOperation::MarkDead
+            | BookmarkOperation::AcquireShardLease => PoolRole::Primary,
         }
     }
 
@@ -126,6 +131,22 @@ impl BookmarkRepository {
         }
     }
 
+    /// Whether `operation` is a genuine write that should call `mark_write()`.
+    ///
+    /// `AcquireShardLease` also targets the primary (see [`Self::role_for`])
+    /// but taking an advisory lock isn't a write, so it's deliberately
+    /// excluded — split out from [`Self::conn`] so that's testable without a
+    /// live pool.
+    const fn is_write(operation: BookmarkOperation) -> bool {
+        matches!(
+            operation,
+            BookmarkOperation::Save
+                | BookmarkOperation::Update
+                | BookmarkOperation::DeleteById
+                | BookmarkOperation::MarkDead
+        )
+    }
+
     /// Acquire a connection for `operation` from the pool [`Self::effective_role`]
     /// selects. Only genuine writes call `mark_write()` — mirroring the
     /// macro's "mark only after a successful primary acquire" behavior —
@@ -137,13 +158,7 @@ impl BookmarkRepository {
         let state = Self::distributed_state()?;
         let pool = Self::pool(&state, role);
         let conn = pool.get().await.map_err(AutumnError::from)?;
-        if matches!(
-            operation,
-            BookmarkOperation::Save
-                | BookmarkOperation::Update
-                | BookmarkOperation::DeleteById
-                | BookmarkOperation::MarkDead
-        ) {
+        if Self::is_write(operation) {
             autumn_web::read_your_writes::mark_write();
         }
         Ok(conn)
@@ -177,7 +192,7 @@ impl BookmarkRepository {
     }
 
     async fn try_acquire_shard_lease(shard: u32) -> AutumnResult<Option<ShardLease>> {
-        let mut conn = Self::conn(BookmarkOperation::MarkDead).await?;
+        let mut conn = Self::conn(BookmarkOperation::AcquireShardLease).await?;
         let (namespace, shard_key) = Self::link_checker_lock_key(shard);
         let result = diesel::sql_query("SELECT pg_try_advisory_lock($1, $2) AS acquired")
             .bind::<Integer, _>(namespace)
@@ -425,6 +440,31 @@ mod tests {
             BookmarkRepository::role_for(BookmarkOperation::MarkDead),
             PoolRole::Primary
         );
+        assert_eq!(
+            BookmarkRepository::role_for(BookmarkOperation::AcquireShardLease),
+            PoolRole::Primary
+        );
+    }
+
+    #[test]
+    fn acquire_shard_lease_targets_primary_but_is_not_a_write() {
+        assert!(
+            !BookmarkRepository::is_write(BookmarkOperation::AcquireShardLease),
+            "taking an advisory lock must not call mark_write(), even though it \
+             needs a primary connection like a write does"
+        );
+    }
+
+    #[test]
+    fn writes_are_all_marked() {
+        for op in [
+            BookmarkOperation::Save,
+            BookmarkOperation::Update,
+            BookmarkOperation::DeleteById,
+            BookmarkOperation::MarkDead,
+        ] {
+            assert!(BookmarkRepository::is_write(op), "{op:?} must mark a write");
+        }
     }
 
     // ── RYWW wiring (BookmarkRepository::effective_role) ────────────────────

--- a/examples/bookmarks-distributed/src/repositories.rs
+++ b/examples/bookmarks-distributed/src/repositories.rs
@@ -105,12 +105,48 @@ impl BookmarkRepository {
         }
     }
 
+    /// Resolve the pool `operation` should actually use, honoring
+    /// `database.read_your_writes`.
+    ///
+    /// This repository predates the `#[repository(...)]` macro (it hand-rolls
+    /// pool selection for finer-grained shard-lease control), so it doesn't
+    /// get RYWW's generated-code wiring for free — it opts in explicitly via
+    /// the same public `is_pinned` call the macro emits. A replica-eligible
+    /// read is redirected to primary while the current request (or session,
+    /// depending on `read_your_writes` mode) is pinned; `role_for`'s answer
+    /// is otherwise final. Split out from [`Self::conn`] so this decision is
+    /// testable without a live pool.
+    fn effective_role(operation: BookmarkOperation) -> PoolRole {
+        let role = Self::role_for(operation);
+        if role == PoolRole::Replica && autumn_web::read_your_writes::is_pinned() {
+            autumn_web::read_your_writes::note_pin_redirect();
+            PoolRole::Primary
+        } else {
+            role
+        }
+    }
+
+    /// Acquire a connection for `operation` from the pool [`Self::effective_role`]
+    /// selects. Only genuine writes call `mark_write()` — mirroring the
+    /// macro's "mark only after a successful primary acquire" behavior —
+    /// not every pin-redirected read.
     async fn conn(
-        role: PoolRole,
+        operation: BookmarkOperation,
     ) -> AutumnResult<diesel_async::pooled_connection::deadpool::Object<AsyncPgConnection>> {
+        let role = Self::effective_role(operation);
         let state = Self::distributed_state()?;
         let pool = Self::pool(&state, role);
-        pool.get().await.map_err(AutumnError::from)
+        let conn = pool.get().await.map_err(AutumnError::from)?;
+        if matches!(
+            operation,
+            BookmarkOperation::Save
+                | BookmarkOperation::Update
+                | BookmarkOperation::DeleteById
+                | BookmarkOperation::MarkDead
+        ) {
+            autumn_web::read_your_writes::mark_write();
+        }
+        Ok(conn)
     }
 
     fn missing_bookmark_error(operation: &'static str, id: i64) -> AutumnError {
@@ -141,7 +177,7 @@ impl BookmarkRepository {
     }
 
     async fn try_acquire_shard_lease(shard: u32) -> AutumnResult<Option<ShardLease>> {
-        let mut conn = Self::conn(Self::role_for(BookmarkOperation::MarkDead)).await?;
+        let mut conn = Self::conn(BookmarkOperation::MarkDead).await?;
         let (namespace, shard_key) = Self::link_checker_lock_key(shard);
         let result = diesel::sql_query("SELECT pg_try_advisory_lock($1, $2) AS acquired")
             .bind::<Integer, _>(namespace)
@@ -184,7 +220,7 @@ impl BookmarkRepository {
     }
 
     pub async fn find_all(&self) -> AutumnResult<Vec<Bookmark>> {
-        let mut conn = Self::conn(Self::role_for(BookmarkOperation::FindAll)).await?;
+        let mut conn = Self::conn(BookmarkOperation::FindAll).await?;
         bookmarks::table
             .load::<Bookmark>(&mut conn)
             .await
@@ -192,7 +228,7 @@ impl BookmarkRepository {
     }
 
     pub async fn find_alive_in_shard(&self, shard: u32) -> AutumnResult<Vec<(i64, String)>> {
-        let mut conn = Self::conn(Self::role_for(BookmarkOperation::FindAliveInShard)).await?;
+        let mut conn = Self::conn(BookmarkOperation::FindAliveInShard).await?;
         diesel::sql_query(
             "SELECT id, url FROM bookmarks WHERE alive = true AND (id % $1) = $2 ORDER BY id",
         )
@@ -205,7 +241,7 @@ impl BookmarkRepository {
     }
 
     pub async fn find_by_tag(&self, tag: String) -> AutumnResult<Vec<Bookmark>> {
-        let mut conn = Self::conn(Self::role_for(BookmarkOperation::FindByTag)).await?;
+        let mut conn = Self::conn(BookmarkOperation::FindByTag).await?;
         bookmarks::table
             .filter(bookmarks::tag.eq(tag))
             .load::<Bookmark>(&mut conn)
@@ -214,7 +250,7 @@ impl BookmarkRepository {
     }
 
     pub async fn find_by_id(&self, id: i64) -> AutumnResult<Option<Bookmark>> {
-        let mut conn = Self::conn(Self::role_for(BookmarkOperation::FindById)).await?;
+        let mut conn = Self::conn(BookmarkOperation::FindById).await?;
         bookmarks::table
             .find(id)
             .first::<Bookmark>(&mut conn)
@@ -224,7 +260,7 @@ impl BookmarkRepository {
     }
 
     pub async fn save(&self, new: &NewBookmark) -> AutumnResult<Bookmark> {
-        let mut conn = Self::conn(Self::role_for(BookmarkOperation::Save)).await?;
+        let mut conn = Self::conn(BookmarkOperation::Save).await?;
         diesel::insert_into(bookmarks::table)
             .values(new)
             .get_result::<Bookmark>(&mut conn)
@@ -233,7 +269,7 @@ impl BookmarkRepository {
     }
 
     pub async fn update(&self, id: i64, changes: &UpdateBookmark) -> AutumnResult<Bookmark> {
-        let mut conn = Self::conn(Self::role_for(BookmarkOperation::Update)).await?;
+        let mut conn = Self::conn(BookmarkOperation::Update).await?;
         let changeset = changes.__to_changeset();
         let result = diesel::update(bookmarks::table.find(id))
             .set(&changeset)
@@ -243,7 +279,7 @@ impl BookmarkRepository {
     }
 
     pub async fn delete_by_id(&self, id: i64) -> AutumnResult<()> {
-        let mut conn = Self::conn(Self::role_for(BookmarkOperation::DeleteById)).await?;
+        let mut conn = Self::conn(BookmarkOperation::DeleteById).await?;
         let affected = diesel::delete(bookmarks::table.find(id))
             .execute(&mut conn)
             .await
@@ -255,7 +291,7 @@ impl BookmarkRepository {
     }
 
     pub async fn mark_dead(&self, id: i64) -> AutumnResult<bool> {
-        let mut conn = Self::conn(Self::role_for(BookmarkOperation::MarkDead)).await?;
+        let mut conn = Self::conn(BookmarkOperation::MarkDead).await?;
         let affected = diesel::update(bookmarks::table.find(id))
             .set(bookmarks::alive.eq(false))
             .execute(&mut conn)
@@ -273,7 +309,7 @@ impl BookmarkRepository {
     }
 
     pub async fn count_all(&self) -> AutumnResult<i64> {
-        let mut conn = Self::conn(Self::role_for(BookmarkOperation::FindAll)).await?;
+        let mut conn = Self::conn(BookmarkOperation::FindAll).await?;
         bookmarks::table
             .count()
             .get_result::<i64>(&mut conn)
@@ -349,6 +385,8 @@ mod tests {
     use crate::config::DistributedConfig;
     use crate::db::create_dual_pools;
     use crate::state::DistributedState;
+    use autumn_web::config::ReadYourWrites;
+    use autumn_web::read_your_writes::{RequestPin, mark_write, scope};
     use autumn_web::test::TestDb;
     use diesel::result::Error as DieselError;
     use std::sync::Arc;
@@ -387,6 +425,88 @@ mod tests {
             BookmarkRepository::role_for(BookmarkOperation::MarkDead),
             PoolRole::Primary
         );
+    }
+
+    // ── RYWW wiring (BookmarkRepository::effective_role) ────────────────────
+    //
+    // This repository predates the `#[repository(...)]` macro, so it doesn't
+    // get RYWW's pin-checking for free — it opts in explicitly in `conn()`.
+    // These tests exercise that opt-in against the same public `is_pinned`
+    // task-local the framework's own generated code and RYW middleware use
+    // (see `autumn/src/read_your_writes.rs`), without needing a live pool —
+    // the full write-then-read path is covered by
+    // `tests/system/smoke.rs::bookmarks_distributed_read_your_own_write_after_create`.
+
+    #[tokio::test]
+    async fn effective_role_replica_reads_stay_on_replica_with_no_pin() {
+        assert_eq!(
+            BookmarkRepository::effective_role(BookmarkOperation::FindAll),
+            PoolRole::Replica,
+            "outside any RYWW scope, reads must keep going to the replica"
+        );
+    }
+
+    #[tokio::test]
+    async fn effective_role_replica_reads_stay_on_replica_before_a_write() {
+        let pin = RequestPin::new(ReadYourWrites::Request);
+        scope(pin, async {
+            assert_eq!(
+                BookmarkRepository::effective_role(BookmarkOperation::FindAll),
+                PoolRole::Replica,
+                "a pin scope alone (no write yet) must not redirect reads"
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn effective_role_redirects_replica_reads_to_primary_after_a_write() {
+        let pin = RequestPin::new(ReadYourWrites::Request);
+        scope(pin, async {
+            mark_write();
+            assert_eq!(
+                BookmarkRepository::effective_role(BookmarkOperation::FindAll),
+                PoolRole::Primary,
+                "a replica-eligible read after a write must redirect to primary"
+            );
+            assert_eq!(
+                BookmarkRepository::effective_role(BookmarkOperation::FindByTag),
+                PoolRole::Primary
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn effective_role_ignores_the_pin_when_read_your_writes_is_off() {
+        let pin = RequestPin::new(ReadYourWrites::Off);
+        scope(pin, async {
+            mark_write();
+            assert_eq!(
+                BookmarkRepository::effective_role(BookmarkOperation::FindAll),
+                PoolRole::Replica,
+                "off mode must never redirect, even after a write"
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn effective_role_writes_always_target_primary_regardless_of_pin_state() {
+        assert_eq!(
+            BookmarkRepository::effective_role(BookmarkOperation::Save),
+            PoolRole::Primary,
+            "writes are already Primary via role_for, pin or not"
+        );
+        let pin = RequestPin::new(ReadYourWrites::Request);
+        scope(pin, async {
+            mark_write();
+            assert_eq!(
+                BookmarkRepository::effective_role(BookmarkOperation::Save),
+                PoolRole::Primary
+            );
+        })
+        .await;
     }
 
     #[test]

--- a/examples/bookmarks-distributed/src/repositories.rs
+++ b/examples/bookmarks-distributed/src/repositories.rs
@@ -345,6 +345,13 @@ pub async fn cached_bookmark_count() -> AutumnResult<i64> {
 
 #[get("/api/bookmarks/count")]
 pub async fn bookmark_api_count() -> AutumnResult<Json<i64>> {
+    // `cached_bookmark_count()`'s TTL cache is global (unkeyed by session),
+    // so it would silently defeat RYWW: a client pinned to primary after a
+    // write must see a live count, not whatever was cached — possibly from
+    // the replica, possibly from before the write — up to 30s ago.
+    if autumn_web::read_your_writes::is_pinned() {
+        return Ok(Json(BookmarkRepository.count_all().await?));
+    }
     Ok(Json(cached_bookmark_count().await?))
 }
 

--- a/examples/bookmarks-distributed/tests/system/smoke.rs
+++ b/examples/bookmarks-distributed/tests/system/smoke.rs
@@ -232,5 +232,21 @@ secret = "{TEST_SIGNING_SECRET}"
         .await
         .expect("no console errors across the create -> redirect -> list flow");
 
+    // `/api/bookmarks/count` sits behind a 30s process-wide cache
+    // (`cached_bookmark_count()`), unkeyed by session — bypassed while RYWW-
+    // pinned so this still reflects the just-created bookmark rather than a
+    // stale (here: zero) cached count. See BookmarkRepository::bookmark_api_count.
+    page.evaluate(
+        "fetch('/api/bookmarks/count')\
+         .then(r => r.text())\
+         .then(t => { document.body.textContent = 'count:' + t; })",
+    )
+    .await
+    .expect("evaluate count fetch");
+    page.expect_text("count:1").await.expect(
+        "the cached /api/bookmarks/count endpoint must also see the just-created bookmark \
+         while RYWW-pinned, not the 30s-stale cached count",
+    );
+
     let _ = std::fs::remove_dir_all(&scratch_dir);
 }

--- a/examples/bookmarks-distributed/tests/system/smoke.rs
+++ b/examples/bookmarks-distributed/tests/system/smoke.rs
@@ -65,6 +65,10 @@ fn setup_scratch_dir(
     replica_url: &str,
     extra_toml: &str,
 ) {
+    // A prior run that panicked before its own cleanup (or a reused PID)
+    // could leave this scratch dir behind; without clearing it first, the
+    // `static` symlink below would fail with `AlreadyExists`.
+    let _ = std::fs::remove_dir_all(dir);
     std::fs::create_dir_all(dir).expect("create scratch config dir");
     std::fs::write(
         dir.join("autumn.toml"),

--- a/examples/bookmarks-distributed/tests/system/smoke.rs
+++ b/examples/bookmarks-distributed/tests/system/smoke.rs
@@ -41,6 +41,59 @@ use diesel_migrations::{EmbeddedMigrations, embed_migrations};
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 
+/// A dev-only placeholder signing secret — 64 hex chars (32 bytes), the
+/// framework's `security.signing_secret` minimum. Never used outside this
+/// process; each test run gets an ephemeral testcontainer database anyway.
+const TEST_SIGNING_SECRET: &str = "e2e0123456789abcdef0123456789abcdef0123456789abcdef0123456789a";
+
+/// Build a scratch directory unique to `(this process, test_name)` — plain
+/// `std::process::id()` alone would collide if `cargo test` runs more than
+/// one `#[tokio::test]` from this binary concurrently (the default).
+fn scratch_dir(test_name: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "bookmarks-distributed-smoke-{}-{test_name}",
+        std::process::id()
+    ))
+}
+
+/// Write a scratch `autumn.toml` (`database` config plus whatever
+/// `extra_toml` sections the caller needs) and symlink `static/` into it —
+/// see module docs for why both are necessary under `AUTUMN_MANIFEST_DIR`.
+fn setup_scratch_dir(
+    dir: &std::path::Path,
+    primary_url: &str,
+    replica_url: &str,
+    extra_toml: &str,
+) {
+    std::fs::create_dir_all(dir).expect("create scratch config dir");
+    std::fs::write(
+        dir.join("autumn.toml"),
+        format!(
+            r#"
+[health]
+path = "/health"
+
+[database]
+primary_url = "{primary_url}"
+replica_url = "{replica_url}"
+primary_pool_size = 2
+replica_pool_size = 2
+replica_fallback = "fail_readiness"
+
+{extra_toml}
+"#
+        ),
+    )
+    .expect("write scratch autumn.toml");
+
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("static"),
+        dir.join("static"),
+    )
+    .expect("symlink scratch static dir to the real project's static dir");
+}
+
 #[tokio::test]
 #[ignore = "requires Chromium + Docker — set AUTUMN_CHROMIUM or install chromium-browser"]
 async fn bookmarks_distributed_boots_with_dual_pools() {
@@ -54,41 +107,8 @@ async fn bookmarks_distributed_boots_with_dual_pools() {
     autumn_web::migrate::run_pending(replica_url, MIGRATIONS)
         .expect("migrate replica-stand-in testcontainer");
 
-    // Redirect both `DistributedConfig::load()` and the framework's own
-    // `AutumnConfig` to a scratch autumn.toml carrying the testcontainer
-    // URLs — see module docs.
-    let scratch_dir = std::env::temp_dir().join(format!(
-        "bookmarks-distributed-smoke-{}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&scratch_dir).expect("create scratch config dir");
-    std::fs::write(
-        scratch_dir.join("autumn.toml"),
-        format!(
-            r#"
-[health]
-path = "/health"
-
-[database]
-primary_url = "{primary_url}"
-replica_url = "{replica_url}"
-primary_pool_size = 2
-replica_pool_size = 2
-replica_fallback = "fail_readiness"
-"#
-        ),
-    )
-    .expect("write scratch autumn.toml");
-
-    // See module docs: redirecting AUTUMN_MANIFEST_DIR to the scratch dir
-    // also redirects `/static` file serving there, so without this the page
-    // would 404 on its real CSS/JS instead of exercising them.
-    #[cfg(unix)]
-    std::os::unix::fs::symlink(
-        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("static"),
-        scratch_dir.join("static"),
-    )
-    .expect("symlink scratch static dir to the real project's static dir");
+    let scratch_dir = scratch_dir("boots_with_dual_pools");
+    setup_scratch_dir(&scratch_dir, primary_url, replica_url, "");
 
     let app = example_e2e::spawn_example(
         env!("CARGO_BIN_EXE_bookmarks-distributed"),
@@ -115,6 +135,98 @@ replica_fallback = "fail_readiness"
     page.expect_no_console_errors()
         .await
         .expect("no console errors on /");
+
+    let _ = std::fs::remove_dir_all(&scratch_dir);
+}
+
+/// Regression guard for the RYWW wiring in `BookmarkRepository::conn()`
+/// (see `src/repositories.rs`): a client that just created a bookmark must
+/// see it on the very next page load, even though `list()` normally reads
+/// from the replica pool.
+///
+/// This example's "replica" is a second, wholly independent testcontainer
+/// database (no real streaming replication — see module docs), so without
+/// RYWW correctly redirecting the post-write read to primary, the create ->
+/// redirect -> list flow below would deterministically show "No bookmarks
+/// yet." rather than the bookmark just created — there is no lag/flakiness
+/// to race against, it either redirects or it doesn't.
+#[tokio::test]
+#[ignore = "requires Chromium + Docker — set AUTUMN_CHROMIUM or install chromium-browser"]
+async fn bookmarks_distributed_read_your_own_write_after_create() {
+    let db = example_e2e::provision_postgres(2).await;
+    let primary_url = &db.urls()[0];
+    let replica_url = &db.urls()[1];
+
+    autumn_web::migrate::run_pending(primary_url, MIGRATIONS)
+        .expect("migrate primary testcontainer");
+    autumn_web::migrate::run_pending(replica_url, MIGRATIONS)
+        .expect("migrate replica-stand-in testcontainer");
+
+    let scratch_dir = scratch_dir("read_your_own_write_after_create");
+    setup_scratch_dir(
+        &scratch_dir,
+        primary_url,
+        replica_url,
+        &format!(
+            r#"
+read_your_writes = "session"
+pin_after_write_secs = 10
+
+[security.signing_secret]
+secret = "{TEST_SIGNING_SECRET}"
+"#
+        ),
+    );
+
+    let app = example_e2e::spawn_example(
+        env!("CARGO_BIN_EXE_bookmarks-distributed"),
+        env!("CARGO_MANIFEST_DIR"),
+        &[(
+            "AUTUMN_MANIFEST_DIR",
+            scratch_dir.to_str().expect("scratch dir path is UTF-8"),
+        )],
+        example_e2e::DEFAULT_READY_TIMEOUT,
+    )
+    .await
+    .expect("spawn bookmarks-distributed example — is it built?");
+
+    let runner = app
+        .attach_browser()
+        .await
+        .expect("attach browser — is Chromium installed?");
+    let page = runner.page().await.expect("open page");
+
+    // A fresh page load hits the replica-routed list before any write has
+    // happened in this browser session, so there is nothing to see yet.
+    page.visit("/").await.expect("visit /");
+    page.expect_text("No bookmarks yet.")
+        .await
+        .expect("list starts empty on the replica-stand-in database");
+
+    // Real form submission — a plain (non-htmx) POST that 303-redirects to
+    // the list, the same create -> redirect -> list flow a real user drives.
+    page.visit("/new").await.expect("visit /new");
+    page.fill("#url", "https://example.com/ryww")
+        .await
+        .expect("fill url");
+    page.fill("#title", "RYWW smoke bookmark")
+        .await
+        .expect("fill title");
+    page.fill("#tag", "ryww").await.expect("fill tag");
+    page.click("button[type=submit]")
+        .await
+        .expect("submit create form");
+
+    // `list()` is the only route that renders bookmark cards, so this text
+    // appearing is itself proof the 303 redirect landed back on `/`.
+    page.expect_text("RYWW smoke bookmark").await.expect(
+        "created bookmark visible on the very next list read — RYWW must have redirected \
+             this replica-routed read to primary, since the replica-stand-in database never \
+             receives this write",
+    );
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors across the create -> redirect -> list flow");
 
     let _ = std::fs::remove_dir_all(&scratch_dir);
 }

--- a/examples/bookmarks-sharded/tests/system/smoke.rs
+++ b/examples/bookmarks-sharded/tests/system/smoke.rs
@@ -5,7 +5,9 @@
 //! headless-Chromium browser against the cross-shard `/api/stats`
 //! fan-out endpoint, and asserts both shards answer with no uncaught
 //! console errors — the direct regression guard for the framework's
-//! `[[database.shards]]` shard-routing feature.
+//! `[[database.shards]]` shard-routing feature. A second test proves
+//! read-your-own-writes shard consistency: a tenant's create and their very
+//! next list read must always land on the same shard.
 //!
 //! `bookmarks-sharded` uses the framework's own `AutumnConfig`, so unlike
 //! `bookmarks-distributed`'s bespoke loader, standard
@@ -25,9 +27,14 @@
 
 #![cfg(feature = "system-tests")]
 
-#[tokio::test]
-#[ignore = "requires Chromium + Docker — set AUTUMN_CHROMIUM or install chromium-browser"]
-async fn bookmarks_sharded_boots_and_fans_out_across_shards() {
+/// Spawn `bookmarks-sharded` against a fresh 3-container topology (control +
+/// shard0 + shard1), using the same fixed slot split every test in this file
+/// relies on.
+///
+/// Returns the [`PgTopology`](example_e2e::PgTopology) alongside the spawned
+/// process: dropping it tears the containers down, so callers must keep it
+/// bound for as long as `ExampleProcess` is in use.
+async fn spawn() -> (example_e2e::ExampleProcess, example_e2e::PgTopology) {
     let db = example_e2e::provision_postgres(3).await;
     let control_url = &db.urls()[0];
     let shard0_url = &db.urls()[1];
@@ -55,6 +62,14 @@ async fn bookmarks_sharded_boots_and_fans_out_across_shards() {
     )
     .await
     .expect("spawn bookmarks-sharded example — is it built?");
+
+    (app, db)
+}
+
+#[tokio::test]
+#[ignore = "requires Chromium + Docker — set AUTUMN_CHROMIUM or install chromium-browser"]
+async fn bookmarks_sharded_boots_and_fans_out_across_shards() {
+    let (app, _db) = spawn().await;
 
     let runner = app
         .attach_browser()
@@ -91,4 +106,56 @@ async fn bookmarks_sharded_boots_and_fans_out_across_shards() {
     page.expect_no_console_errors()
         .await
         .expect("no console errors on /api/stats");
+}
+
+/// Regression guard for `[[database.shards]]` routing consistency: a tenant
+/// who just created a bookmark must see it on the very next list read.
+///
+/// `ShardedDb` hashes the tenant id onto a shard the same way for every
+/// request — no cache, no staleness — so the create and the list below
+/// should always land on the same shard by construction (see
+/// `autumn/src/sharding.rs`'s `HashShardRouter`). This is a deterministic
+/// pass/fail, not a timing race: shard0 and shard1 here are two wholly
+/// independent testcontainer databases, so if routing were ever
+/// inconsistent for the same tenant, the created bookmark would never
+/// appear — it would be sitting in the other shard's database instead.
+#[tokio::test]
+#[ignore = "requires Chromium + Docker — set AUTUMN_CHROMIUM or install chromium-browser"]
+async fn bookmarks_sharded_read_your_own_write_after_create() {
+    let (app, _db) = spawn().await;
+
+    let runner = app
+        .attach_browser()
+        .await
+        .expect("attach browser — is Chromium installed?");
+    let page = runner.page().await.expect("open page");
+
+    // See the fan-out test above for why /health is visited first: every
+    // route requires X-Tenant-Id, and a plain navigation can't set headers.
+    page.visit("/health").await.expect("visit /health");
+    page.evaluate(
+        "fetch('/api/bookmarks', { \
+           method: 'POST', \
+           headers: { 'X-Tenant-Id': 'acme', 'Content-Type': 'application/json' }, \
+           body: JSON.stringify({ \
+             url: 'https://example.com/ryow', \
+             title: 'RYOW shard bookmark', \
+             tag: 'ryow' \
+           }) \
+         }) \
+         .then(r => r.text()) \
+         .then(() => fetch('/api/bookmarks', { headers: { 'X-Tenant-Id': 'acme' } })) \
+         .then(r => r.text()) \
+         .then(t => { document.body.textContent = t; })",
+    )
+    .await
+    .expect("evaluate create-then-list fetch chain");
+
+    page.expect_text("RYOW shard bookmark").await.expect(
+        "bookmark created for tenant \"acme\" must appear on the very next list read for \
+         the same tenant — the create and the list must have routed to the same shard",
+    );
+    page.expect_no_console_errors()
+        .await
+        .expect("no console errors across the create -> list flow");
 }


### PR DESCRIPTION
## Summary
Implements read-your-own-writes (RYWW) functionality across the bookmarks examples to ensure clients see their writes on subsequent reads, even when using replica pools. This prevents the common issue where a user creates a bookmark and doesn't see it on the next page load due to replication lag.

## Key Changes

**bookmarks-distributed example:**
- Added `read_your_writes = "session"` and `pin_after_write_secs = 10` configuration to `autumn.toml` to pin clients to the primary pool after writes
- Refactored `BookmarkRepository::conn()` to accept `BookmarkOperation` instead of `PoolRole`, enabling automatic RYWW pin checking via new `effective_role()` method
- Implemented `effective_role()` to redirect replica-eligible reads to primary when the current request/session is pinned after a write
- Added `mark_write()` calls in `conn()` for genuine write operations (Save, Update, DeleteById, MarkDead)
- Extracted test setup into reusable `scratch_dir()` and `setup_scratch_dir()` helper functions to support multiple test cases
- Added comprehensive unit tests for `effective_role()` covering pin state transitions and write detection
- Added new system test `bookmarks_distributed_read_your_own_write_after_create()` that verifies the create→redirect→list flow works correctly with independent primary/replica databases

**bookmarks-sharded example:**
- Extracted common spawn logic into reusable `spawn()` helper function
- Added new system test `bookmarks_sharded_read_your_own_write_after_create()` that verifies shard routing consistency for create→list flows
- Updated module documentation to mention RYWW shard consistency guarantees

## Implementation Details

The `BookmarkRepository` predates the `#[repository(...)]` macro and doesn't get RYWW's generated-code wiring automatically. It opts in explicitly by:
1. Calling `autumn_web::read_your_writes::is_pinned()` in `effective_role()` to check if the current request is pinned
2. Calling `autumn_web::read_your_writes::mark_write()` after successful primary pool acquires for write operations
3. Redirecting replica reads to primary when pinned, with `note_pin_redirect()` tracking the redirect

The system tests use independent testcontainer databases (no real replication) to make RYWW behavior deterministic: without correct pin-based redirection, the create→redirect→list flow would always show "No bookmarks yet" rather than the newly created bookmark.

https://claude.ai/code/session_01WqhFDjdF5951y9uUVjGwLH