### PR TITLE
Add typed form input widgets for bool, number, date, datetime

### DIFF
--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1650,8 +1650,11 @@ fn render_create_form_inputs(
                     required = required,
                     hx_attrs = hx_attrs
                 ),
+                // `step="any"` lets the browser's picker show/accept
+                // seconds — see edit_datetime_local_value_expr for why a
+                // value with seconds must not be step-mismatch-rejected.
                 (FieldKind::NaiveDateTime | FieldKind::DateTime, _) => format!(
-                    "input type=\"datetime-local\" name=\"{name}\"{required}{hx_attrs}",
+                    "input type=\"datetime-local\" name=\"{name}\" step=\"any\"{required}{hx_attrs}",
                     name = f.name,
                     required = required,
                     hx_attrs = hx_attrs
@@ -1748,7 +1751,7 @@ fn render_edit_form_inputs(
                     hx_attrs = hx_attrs
                 ),
                 (FieldKind::NaiveDateTime | FieldKind::DateTime, _) => format!(
-                    "input type=\"datetime-local\" name=\"{name}\" value=({value}){required}{hx_attrs}",
+                    "input type=\"datetime-local\" name=\"{name}\" step=\"any\" value=({value}){required}{hx_attrs}",
                     name = f.name,
                     value = edit_datetime_local_value_expr(f),
                     required = required,
@@ -1840,16 +1843,26 @@ fn edit_bool_select_selected_exprs(field: &Field) -> (String, String, String) {
 /// Value expression for an edit-form `datetime-local` input. Unlike
 /// [`edit_value_expr`]'s `.to_string()` (which relies on `Display`, e.g.
 /// `"2024-01-15 10:30:00 UTC"` for `DateTime<Utc>` — a shape browsers
-/// reject), this formats explicitly as `YYYY-MM-DDTHH:MM`, the only value
-/// `<input type="datetime-local">` accepts.
+/// reject), this formats explicitly as `YYYY-MM-DDTHH:MM[:SS[.fff]]`, the
+/// value shape `<input type="datetime-local">` accepts.
+///
+/// Seconds/fractional-seconds are included when present (`%.f` omits them
+/// entirely when zero) rather than truncated to `YYYY-MM-DDTHH:MM`: a
+/// minute-only value round-trips back through [`normalize_datetime_local`]
+/// as `:00` seconds, and the generated `update` handler writes every column
+/// unconditionally — a stored `12:34:56.789` would otherwise be silently
+/// overwritten as `12:34:00` by re-submitting the form without touching
+/// this field. Pair with `step="any"` on the input (see
+/// `render_edit_form_inputs`) so a value with seconds doesn't fail the
+/// browser's step constraint validation.
 fn edit_datetime_local_value_expr(field: &Field) -> String {
     let name = &field.name;
     if field.nullable {
         format!(
-            "row.{name}.as_ref().map(|value| value.format(\"%Y-%m-%dT%H:%M\").to_string()).unwrap_or_default()"
+            "row.{name}.as_ref().map(|value| value.format(\"%Y-%m-%dT%H:%M:%S%.f\").to_string()).unwrap_or_default()"
         )
     } else {
-        format!("row.{name}.format(\"%Y-%m-%dT%H:%M\").to_string()")
+        format!("row.{name}.format(\"%Y-%m-%dT%H:%M:%S%.f\").to_string()")
     }
 }
 
@@ -3246,6 +3259,25 @@ async fn main() {
         // (`%.f`) — without it, a datetime-local value submitted with
         // milliseconds (e.g. from a finer-grained `step`) fails to parse.
         assert!(routes.contains("\"%Y-%m-%dT%H:%M:%S%.f\")"), "{routes}");
+        // Regression test: the edit form's value must preserve seconds/
+        // fractional precision, not truncate to minutes. A minute-only
+        // value round-trips as `:00` seconds via normalize_datetime_local,
+        // and the generated update handler writes every column
+        // unconditionally — a no-op re-submit of a row with non-zero
+        // seconds would otherwise silently corrupt the stored timestamp
+        // (e.g. `12:34:56` -> `12:34:00`).
+        assert!(
+            routes
+                .contains("value=(row.published_at.format(\"%Y-%m-%dT%H:%M:%S%.f\").to_string())"),
+            "{routes}"
+        );
+        // `step="any"` so a value carrying seconds/fractional seconds
+        // doesn't fail the browser's step-mismatch constraint validation
+        // (default step is minute-granularity) and block submission.
+        assert!(
+            routes.contains("input type=\"datetime-local\" name=\"published_at\" step=\"any\""),
+            "{routes}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -607,8 +607,11 @@ fn render_repository_queries(pascal_name: &str, queries: &[QuerySpec]) -> String
 }
 
 /// Normalizes an HTML `datetime-local` value (`YYYY-MM-DDTHH:MM`, seconds
-/// omitted by the browser) into the `YYYY-MM-DDTHH:MM:SS` shape chrono's
-/// strict datetime parser requires.
+/// omitted by the browser at minute granularity) into the
+/// `YYYY-MM-DDTHH:MM:SS` shape chrono's parser expects at minimum. Callers
+/// parse with the `%.f` format specifier, so fractional seconds (submitted
+/// when a finer-grained `step` is used) are accepted whether or not this
+/// function's padding runs.
 const NORMALIZE_DATETIME_LOCAL_FN: &str = r#"
 fn normalize_datetime_local(raw: &str) -> String {
     if raw.len() == 16 {
@@ -625,7 +628,7 @@ where
     D: serde::Deserializer<'de>,
 {
     let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
-    chrono::NaiveDateTime::parse_from_str(&normalize_datetime_local(&raw), "%Y-%m-%dT%H:%M:%S")
+    chrono::NaiveDateTime::parse_from_str(&normalize_datetime_local(&raw), "%Y-%m-%dT%H:%M:%S%.f")
         .map_err(serde::de::Error::custom)
 }
 "#;
@@ -640,7 +643,7 @@ where
     let raw = <Option<String> as serde::Deserialize>::deserialize(deserializer)?;
     match raw {
         Some(s) if !s.is_empty() => {
-            chrono::NaiveDateTime::parse_from_str(&normalize_datetime_local(&s), "%Y-%m-%dT%H:%M:%S")
+            chrono::NaiveDateTime::parse_from_str(&normalize_datetime_local(&s), "%Y-%m-%dT%H:%M:%S%.f")
                 .map(Some)
                 .map_err(serde::de::Error::custom)
         }
@@ -657,7 +660,7 @@ where
     D: serde::Deserializer<'de>,
 {
     let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
-    chrono::NaiveDateTime::parse_from_str(&normalize_datetime_local(&raw), "%Y-%m-%dT%H:%M:%S")
+    chrono::NaiveDateTime::parse_from_str(&normalize_datetime_local(&raw), "%Y-%m-%dT%H:%M:%S%.f")
         .map(|ndt| ndt.and_utc())
         .map_err(serde::de::Error::custom)
 }
@@ -673,7 +676,7 @@ where
     let raw = <Option<String> as serde::Deserialize>::deserialize(deserializer)?;
     match raw {
         Some(s) if !s.is_empty() => {
-            chrono::NaiveDateTime::parse_from_str(&normalize_datetime_local(&s), "%Y-%m-%dT%H:%M:%S")
+            chrono::NaiveDateTime::parse_from_str(&normalize_datetime_local(&s), "%Y-%m-%dT%H:%M:%S%.f")
                 .map(|ndt| Some(ndt.and_utc()))
                 .map_err(serde::de::Error::custom)
         }
@@ -1561,6 +1564,24 @@ fn has_attachment_fields(fields: &[Field]) -> bool {
     fields.iter().any(|f| f.kind.is_attachment())
 }
 
+// `render_create_form_inputs` and `render_edit_form_inputs` below hand-roll
+// bare HTML (no `Changeset`/`ChangesetForm`, no `autumn-field` wrapper divs
+// or ARIA wiring) rather than calling `autumn_web::form::{checkbox_input,
+// number_input, date_input, datetime_input, select_input}` — consistent
+// with how every other field kind (including plain `String`) has always
+// been emitted here, not a pattern introduced for these widgets. That means
+// the two are independently maintained and can drift; at minimum, keep
+// these invariants in sync with the `autumn_web::form` helpers of the same
+// name when either changes:
+//   - `Bool` (non-nullable): a bare `<input type="checkbox">`, **no** hidden
+//     `value="false"` sibling sharing the `name` — see `checkbox_input`'s
+//     doc comment for why (duplicate-key 400 on every checked submission).
+//   - `Bool` (nullable): a 3-option `<select>` (unset/true/false), never a
+//     checkbox — a checkbox can't represent a `None` distinct from `false`.
+//   - `I32`/`I64`/`F32`/`F64`: `type="number"` with `step="1"` for integers,
+//     `step="any"` for floats.
+//   - `NaiveDateTime`/`DateTime`: `type="datetime-local"`, decoded via a
+//     `%.f`-tolerant parser (see `DESERIALIZE_*_DATETIME_LOCAL_FN` below).
 fn render_create_form_inputs(
     fields: &[Field],
     live_validation: bool,
@@ -1597,21 +1618,39 @@ fn render_create_form_inputs(
             } else {
                 String::new()
             };
-            let input_tag = match f.kind {
-                FieldKind::Bool => format!(
-                    "input type=\"hidden\" name=\"{name}\" value=\"false\"; \
-                     input type=\"checkbox\" name=\"{name}\" value=\"true\"{hx_attrs}",
+            let input_tag = match (f.kind, f.nullable) {
+                // No hidden `false` fallback: a checked box would then submit
+                // the key twice (`field=false` from the hidden input,
+                // `field=true` from the checkbox), and serde_urlencoded
+                // rejects duplicate keys instead of taking the last value —
+                // every checked submission would 400. `#[serde(default)]` on
+                // the DecodedForm field (see render_decoded_form) recovers
+                // `false` from the key's *absence* when unchecked instead.
+                (FieldKind::Bool, false) => format!(
+                    "input type=\"checkbox\" name=\"{name}\" value=\"true\"{hx_attrs}",
                     name = f.name,
                     hx_attrs = hx_attrs
                 ),
-                FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 => format!(
+                // A checkbox can't losslessly represent a nullable bool (no
+                // way to distinguish "leave false" from "set to null" when
+                // unchecked) — a 3-option select keeps NULL reachable.
+                (FieldKind::Bool, true) => format!(
+                    "select name=\"{name}\"{hx_attrs} {{ \
+                         option value=\"\" {{ \"— Unset —\" }} \
+                         option value=\"true\" {{ \"Yes\" }} \
+                         option value=\"false\" {{ \"No\" }} \
+                     }}",
+                    name = f.name,
+                    hx_attrs = hx_attrs
+                ),
+                (FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64, _) => format!(
                     "input type=\"number\" name=\"{name}\" step=\"{step}\"{required}{hx_attrs}",
                     name = f.name,
                     step = number_step(f.kind),
                     required = required,
                     hx_attrs = hx_attrs
                 ),
-                FieldKind::NaiveDateTime | FieldKind::DateTime => format!(
+                (FieldKind::NaiveDateTime | FieldKind::DateTime, _) => format!(
                     "input type=\"datetime-local\" name=\"{name}\"{required}{hx_attrs}",
                     name = f.name,
                     required = required,
@@ -1679,15 +1718,28 @@ fn render_edit_form_inputs(
             } else {
                 String::new()
             };
-            let input_tag = match f.kind {
-                FieldKind::Bool => format!(
-                    "input type=\"hidden\" name=\"{name}\" value=\"false\"; \
-                     input type=\"checkbox\" name=\"{name}\" value=\"true\" checked[{checked}]{hx_attrs}",
+            let input_tag = match (f.kind, f.nullable) {
+                // See render_create_form_inputs for why there is no hidden
+                // `false` fallback sibling here.
+                (FieldKind::Bool, false) => format!(
+                    "input type=\"checkbox\" name=\"{name}\" value=\"true\" checked[{checked}]{hx_attrs}",
                     name = f.name,
                     checked = edit_checked_expr(f),
                     hx_attrs = hx_attrs
                 ),
-                FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 => format!(
+                (FieldKind::Bool, true) => {
+                    let (unset, is_true, is_false) = edit_bool_select_selected_exprs(f);
+                    format!(
+                        "select name=\"{name}\"{hx_attrs} {{ \
+                             option value=\"\" selected[{unset}] {{ \"— Unset —\" }} \
+                             option value=\"true\" selected[{is_true}] {{ \"Yes\" }} \
+                             option value=\"false\" selected[{is_false}] {{ \"No\" }} \
+                         }}",
+                        name = f.name,
+                        hx_attrs = hx_attrs
+                    )
+                }
+                (FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64, _) => format!(
                     "input type=\"number\" name=\"{name}\" step=\"{step}\" value=({value}){required}{hx_attrs}",
                     name = f.name,
                     step = number_step(f.kind),
@@ -1695,7 +1747,7 @@ fn render_edit_form_inputs(
                     required = required,
                     hx_attrs = hx_attrs
                 ),
-                FieldKind::NaiveDateTime | FieldKind::DateTime => format!(
+                (FieldKind::NaiveDateTime | FieldKind::DateTime, _) => format!(
                     "input type=\"datetime-local\" name=\"{name}\" value=({value}){required}{hx_attrs}",
                     name = f.name,
                     value = edit_datetime_local_value_expr(f),
@@ -1737,6 +1789,20 @@ fn edit_value_expr(field: &Field) -> String {
                 "row.{name}.as_ref().map(|value| String::from_utf8_lossy(value).to_string()).unwrap_or_default()"
             )
         }
+        // f32/f64 Display renders NaN/Infinity as "NaN"/"inf"/"-inf", none of
+        // which satisfy HTML5's <input type="number"> value grammar — the
+        // browser would silently blank the field. Render an explicit empty
+        // value for non-finite floats instead of an invalid one.
+        (true, FieldKind::F32 | FieldKind::F64) => {
+            format!(
+                "row.{name}.as_ref().filter(|value| value.is_finite()).map(ToString::to_string).unwrap_or_default()"
+            )
+        }
+        (false, FieldKind::F32 | FieldKind::F64) => {
+            format!(
+                "if row.{name}.is_finite() {{ row.{name}.to_string() }} else {{ String::new() }}"
+            )
+        }
         (true, _) => {
             format!("row.{name}.as_ref().map(ToString::to_string).unwrap_or_default()")
         }
@@ -1748,15 +1814,27 @@ fn edit_value_expr(field: &Field) -> String {
 }
 
 /// Boolean expression for the `checked[...]` attribute of an edit-form
-/// checkbox — `row.{name}` directly for `bool`, `.unwrap_or(false)` for
-/// `Option<bool>`.
+/// checkbox. Only called for non-nullable `bool` fields — nullable
+/// `Option<bool>` fields render as a 3-option select instead (see
+/// [`edit_bool_select_selected_exprs`]), so there is no `Option<bool>` case
+/// to unwrap here.
 fn edit_checked_expr(field: &Field) -> String {
+    format!("row.{}", field.name)
+}
+
+/// The three `selected[...]` boolean expressions (unset / true / false) for
+/// an edit-form `<select>` rendering a nullable `Option<bool>` field.
+///
+/// A checkbox cannot losslessly represent a nullable bool (no way to
+/// distinguish "leave false" from "set to null" when unchecked), so nullable
+/// `Bool` fields render as this 3-option select instead of a checkbox.
+fn edit_bool_select_selected_exprs(field: &Field) -> (String, String, String) {
     let name = &field.name;
-    if field.nullable {
-        format!("row.{name}.unwrap_or(false)")
-    } else {
-        format!("row.{name}")
-    }
+    (
+        format!("row.{name}.is_none()"),
+        format!("row.{name} == Some(true)"),
+        format!("row.{name} == Some(false)"),
+    )
 }
 
 /// Value expression for an edit-form `datetime-local` input. Unlike
@@ -2944,11 +3022,20 @@ async fn main() {
             !routes.contains("input type=\"text\" name=\"active\""),
             "bool field must not render input type=\"text\": {routes}"
         );
-        // Unchecked checkboxes are absent from submitted form data — a
-        // hidden "false" sibling guarantees the field always round-trips.
+        // No hidden "false" fallback sharing the checkbox's name: a checked
+        // box would then submit the key twice (active=false&active=true),
+        // and serde_urlencoded rejects duplicate keys — every checked
+        // submission would 400 (issue #1131 follow-up fix). Exactly one
+        // `name="active"` input must exist per form.
         assert!(
-            routes.contains("input type=\"hidden\" name=\"active\" value=\"false\""),
+            !routes.contains("input type=\"hidden\" name=\"active\" value=\"false\""),
             "{routes}"
+        );
+        assert_eq!(
+            routes.matches("name=\"active\"").count(),
+            2,
+            "expected exactly one `name=\"active\"` input in each of the \
+             create and edit forms (no duplicate-key hidden fallback): {routes}"
         );
         // Edit form must reflect the current value via `checked[...]`.
         assert!(routes.contains("checked[row.active]"), "{routes}");
@@ -2956,6 +3043,46 @@ async fn main() {
         // (missing key) doesn't 400.
         assert!(
             routes.contains("#[serde(default)]\n    pub active: bool,"),
+            "{routes}"
+        );
+    }
+
+    #[test]
+    fn execute_writes_select_for_nullable_bool_field() {
+        // A checkbox can't losslessly represent Option<bool> (no way to
+        // distinguish "leave false" from "set to null" when unchecked), so
+        // nullable bool fields must render a 3-option select instead.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "archived:Option<bool>".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+
+        assert!(
+            !routes.contains("input type=\"checkbox\" name=\"archived\""),
+            "nullable bool must not render a checkbox: {routes}"
+        );
+        assert!(routes.contains("select name=\"archived\""), "{routes}");
+        assert!(routes.contains("option value=\"\""), "{routes}");
+        assert!(routes.contains("option value=\"true\""), "{routes}");
+        assert!(routes.contains("option value=\"false\""), "{routes}");
+        // Edit form must reflect the current tri-state value.
+        assert!(
+            routes.contains("selected[row.archived.is_none()]"),
+            "{routes}"
+        );
+        assert!(
+            routes.contains("selected[row.archived == Some(true)]"),
+            "{routes}"
+        );
+        assert!(
+            routes.contains("selected[row.archived == Some(false)]"),
             "{routes}"
         );
     }
@@ -3012,6 +3139,42 @@ async fn main() {
         );
         assert!(
             routes.contains("input type=\"number\" name=\"weight\" step=\"any\""),
+            "{routes}"
+        );
+    }
+
+    #[test]
+    fn execute_writes_finite_guard_for_float_edit_form_value() {
+        // f32/f64 Display renders NaN/Infinity as "NaN"/"inf"/"-inf", none
+        // of which satisfy HTML5's <input type="number"> value grammar —
+        // the browser would silently blank the field. The generated value
+        // expression must guard with is_finite() instead of a bare
+        // .to_string() for float fields.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &[
+                "title:String".into(),
+                "price:f64".into(),
+                "weight:Option<f32>".into(),
+            ],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(
+            routes.contains(
+                "value=(if row.price.is_finite() { row.price.to_string() } else { String::new() })"
+            ),
+            "{routes}"
+        );
+        assert!(
+            routes.contains(
+                "value=(row.weight.as_ref().filter(|value| value.is_finite()).map(ToString::to_string).unwrap_or_default())"
+            ),
             "{routes}"
         );
     }
@@ -3079,6 +3242,10 @@ async fn main() {
             !routes.contains("fn deserialize_utc_datetime_local"),
             "{routes}"
         );
+        // The parse format must accept optional fractional seconds
+        // (`%.f`) — without it, a datetime-local value submitted with
+        // milliseconds (e.g. from a finer-grained `step`) fails to parse.
+        assert!(routes.contains("\"%Y-%m-%dT%H:%M:%S%.f\")"), "{routes}");
     }
 
     #[test]

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -606,10 +606,156 @@ fn render_repository_queries(pascal_name: &str, queries: &[QuerySpec]) -> String
     out
 }
 
-fn render_decoded_form(_pascal_name: &str, fields: &[Field]) -> (String, String) {
+/// Normalizes an HTML `datetime-local` value (`YYYY-MM-DDTHH:MM`, seconds
+/// omitted by the browser) into the `YYYY-MM-DDTHH:MM:SS` shape chrono's
+/// strict datetime parser requires.
+const NORMALIZE_DATETIME_LOCAL_FN: &str = r#"
+fn normalize_datetime_local(raw: &str) -> String {
+    if raw.len() == 16 {
+        format!("{raw}:00")
+    } else {
+        raw.to_string()
+    }
+}
+"#;
+
+const DESERIALIZE_NAIVE_DATETIME_LOCAL_FN: &str = r#"
+fn deserialize_naive_datetime_local<'de, D>(deserializer: D) -> Result<chrono::NaiveDateTime, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+    chrono::NaiveDateTime::parse_from_str(&normalize_datetime_local(&raw), "%Y-%m-%dT%H:%M:%S")
+        .map_err(serde::de::Error::custom)
+}
+"#;
+
+const DESERIALIZE_OPTION_NAIVE_DATETIME_LOCAL_FN: &str = r#"
+fn deserialize_option_naive_datetime_local<'de, D>(
+    deserializer: D,
+) -> Result<Option<chrono::NaiveDateTime>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = <Option<String> as serde::Deserialize>::deserialize(deserializer)?;
+    match raw {
+        Some(s) if !s.is_empty() => {
+            chrono::NaiveDateTime::parse_from_str(&normalize_datetime_local(&s), "%Y-%m-%dT%H:%M:%S")
+                .map(Some)
+                .map_err(serde::de::Error::custom)
+        }
+        _ => Ok(None),
+    }
+}
+"#;
+
+const DESERIALIZE_UTC_DATETIME_LOCAL_FN: &str = r#"
+fn deserialize_utc_datetime_local<'de, D>(
+    deserializer: D,
+) -> Result<chrono::DateTime<chrono::Utc>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+    chrono::NaiveDateTime::parse_from_str(&normalize_datetime_local(&raw), "%Y-%m-%dT%H:%M:%S")
+        .map(|ndt| ndt.and_utc())
+        .map_err(serde::de::Error::custom)
+}
+"#;
+
+const DESERIALIZE_OPTION_UTC_DATETIME_LOCAL_FN: &str = r#"
+fn deserialize_option_utc_datetime_local<'de, D>(
+    deserializer: D,
+) -> Result<Option<chrono::DateTime<chrono::Utc>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = <Option<String> as serde::Deserialize>::deserialize(deserializer)?;
+    match raw {
+        Some(s) if !s.is_empty() => {
+            chrono::NaiveDateTime::parse_from_str(&normalize_datetime_local(&s), "%Y-%m-%dT%H:%M:%S")
+                .map(|ndt| Some(ndt.and_utc()))
+                .map_err(serde::de::Error::custom)
+        }
+        _ => Ok(None),
+    }
+}
+"#;
+
+/// Tracks which `datetime-local` deserialize helpers a `DecodedForm` actually
+/// references, so [`datetime_helper_fns`] emits only what's used — an unused
+/// helper would be dead code in the generated project.
+#[derive(Default)]
+#[allow(clippy::struct_excessive_bools)] // orthogonal flags on a plain tally, not a state machine
+struct DatetimeHelpersNeeded {
+    naive_scalar: bool,
+    naive_option: bool,
+    utc_scalar: bool,
+    utc_option: bool,
+}
+
+/// The `#[serde(...)]` attribute + struct-field line for a `NaiveDateTime`/
+/// `DateTime` field, recording which shared deserialize helper it needs.
+fn datetime_struct_field_line(f: &Field, needed: &mut DatetimeHelpersNeeded) -> String {
+    let attr = match (f.kind, f.nullable) {
+        (FieldKind::NaiveDateTime, false) => {
+            needed.naive_scalar = true;
+            "#[serde(deserialize_with = \"deserialize_naive_datetime_local\")]"
+        }
+        (FieldKind::NaiveDateTime, true) => {
+            needed.naive_option = true;
+            "#[serde(default, deserialize_with = \"deserialize_option_naive_datetime_local\")]"
+        }
+        (FieldKind::DateTime, false) => {
+            needed.utc_scalar = true;
+            "#[serde(deserialize_with = \"deserialize_utc_datetime_local\")]"
+        }
+        (FieldKind::DateTime, true) => {
+            needed.utc_option = true;
+            "#[serde(default, deserialize_with = \"deserialize_option_utc_datetime_local\")]"
+        }
+        _ => unreachable!("called only for NaiveDateTime | DateTime fields"),
+    };
+    format!(
+        "    {attr}\n    pub {name}: {rust_type},\n",
+        name = f.name,
+        rust_type = f.rust_type()
+    )
+}
+
+/// Assemble just the shared helper functions a `DecodedForm` needs, per
+/// [`DatetimeHelpersNeeded`].
+fn datetime_helper_fns(needed: &DatetimeHelpersNeeded) -> String {
+    let mut helper_fns = String::new();
+    if needed.naive_scalar || needed.naive_option || needed.utc_scalar || needed.utc_option {
+        helper_fns.push_str(NORMALIZE_DATETIME_LOCAL_FN);
+    }
+    if needed.naive_scalar {
+        helper_fns.push_str(DESERIALIZE_NAIVE_DATETIME_LOCAL_FN);
+    }
+    if needed.naive_option {
+        helper_fns.push_str(DESERIALIZE_OPTION_NAIVE_DATETIME_LOCAL_FN);
+    }
+    if needed.utc_scalar {
+        helper_fns.push_str(DESERIALIZE_UTC_DATETIME_LOCAL_FN);
+    }
+    if needed.utc_option {
+        helper_fns.push_str(DESERIALIZE_OPTION_UTC_DATETIME_LOCAL_FN);
+    }
+    helper_fns
+}
+
+/// Emit the `DecodedForm` struct, its field-by-field mapping into
+/// `New{Pascal}`, and any shared helper functions its `#[serde(...)]`
+/// attributes reference (currently just the `datetime-local` deserializers).
+///
+/// Returns `(decoded_struct, mapping_fields, helper_fns)`. `helper_fns` is
+/// empty unless a `NaiveDateTime`/`DateTime` field is present.
+fn render_decoded_form(_pascal_name: &str, fields: &[Field]) -> (String, String, String) {
     use std::fmt::Write;
     let mut struct_fields = String::new();
     let mut mapping_fields = String::new();
+    let mut needed = DatetimeHelpersNeeded::default();
 
     for f in fields {
         if f.kind.is_attachment() {
@@ -636,6 +782,28 @@ fn render_decoded_form(_pascal_name: &str, fields: &[Field]) -> (String, String)
                  }},",
                 name = f.name
             );
+        } else if f.kind == FieldKind::Bool {
+            // Unchecked checkboxes are absent from submitted form data;
+            // `#[serde(default)]` maps that absence to `false` instead of a
+            // "missing field" 400.
+            let _ = writeln!(
+                struct_fields,
+                "    #[serde(default)]\n    pub {name}: {rust_type},",
+                name = f.name,
+                rust_type = f.rust_type()
+            );
+            let _ = writeln!(
+                mapping_fields,
+                "        {name}: decoded.{name},",
+                name = f.name
+            );
+        } else if matches!(f.kind, FieldKind::NaiveDateTime | FieldKind::DateTime) {
+            struct_fields.push_str(&datetime_struct_field_line(f, &mut needed));
+            let _ = writeln!(
+                mapping_fields,
+                "        {name}: decoded.{name},",
+                name = f.name
+            );
         } else {
             let _ = writeln!(
                 struct_fields,
@@ -658,7 +826,7 @@ fn render_decoded_form(_pascal_name: &str, fields: &[Field]) -> (String, String)
          }}"
     );
 
-    (decoded_struct, mapping_fields)
+    (decoded_struct, mapping_fields, datetime_helper_fns(&needed))
 }
 
 #[allow(
@@ -688,7 +856,8 @@ fn render_routes_file(
     let update_columns = render_update_columns(plural, fields);
     let nullable_field_match = render_nullable_field_match(fields);
     let has_attachments = has_attachment_fields(fields);
-    let (decoded_form_struct, decoded_form_mapping) = render_decoded_form(pascal_name, fields);
+    let (decoded_form_struct, decoded_form_mapping, datetime_helper_fns) =
+        render_decoded_form(pascal_name, fields);
     // The destroy handler must honour the resource's delete semantics: when the
     // scaffold was generated with `--soft-delete`, mark `deleted_at` (matching
     // the soft-delete repository) instead of issuing a physical `DELETE`.
@@ -1325,7 +1494,7 @@ pub async fn destroy(
 }}
 
 {decoded_form_struct}
-
+{datetime_helper_fns}
 {decode_form_sig} {{
     let pairs: Vec<_> = url::form_urlencoded::parse(body.as_ref())
         .filter(|(key, value)| !(value.is_empty() && is_nullable_form_field(key)))
@@ -1428,17 +1597,52 @@ fn render_create_form_inputs(
             } else {
                 String::new()
             };
+            let input_tag = match f.kind {
+                FieldKind::Bool => format!(
+                    "input type=\"hidden\" name=\"{name}\" value=\"false\"; \
+                     input type=\"checkbox\" name=\"{name}\" value=\"true\"{hx_attrs}",
+                    name = f.name,
+                    hx_attrs = hx_attrs
+                ),
+                FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 => format!(
+                    "input type=\"number\" name=\"{name}\" step=\"{step}\"{required}{hx_attrs}",
+                    name = f.name,
+                    step = number_step(f.kind),
+                    required = required,
+                    hx_attrs = hx_attrs
+                ),
+                FieldKind::NaiveDateTime | FieldKind::DateTime => format!(
+                    "input type=\"datetime-local\" name=\"{name}\"{required}{hx_attrs}",
+                    name = f.name,
+                    required = required,
+                    hx_attrs = hx_attrs
+                ),
+                _ => format!(
+                    "input type=\"text\" name=\"{name}\"{required}{hx_attrs}",
+                    name = f.name,
+                    required = required,
+                    hx_attrs = hx_attrs
+                ),
+            };
             let _ = writeln!(
                 out,
-                "            label {{ \"{name}\" }} input type=\"text\" name=\"{name}\"{required}{hx_attrs};{error_span}",
+                "            label {{ \"{name}\" }} {input_tag};{error_span}",
                 name = f.name,
-                required = required,
-                hx_attrs = hx_attrs,
+                input_tag = input_tag,
                 error_span = error_span
             );
         }
     }
     out
+}
+
+/// The HTML `step` attribute value for a `number_input`-shaped `FieldKind`.
+/// Integers step by whole numbers; floating-point fields allow any value.
+const fn number_step(kind: FieldKind) -> &'static str {
+    match kind {
+        FieldKind::F32 | FieldKind::F64 => "any",
+        _ => "1",
+    }
 }
 
 fn render_edit_form_inputs(
@@ -1460,7 +1664,6 @@ fn render_edit_form_inputs(
                 name = f.name
             );
         } else {
-            let value = edit_value_expr(f);
             let required = required_attr(f);
             let hx_attrs = if live_validation && validated.contains(&f.name.as_str()) {
                 format!(
@@ -1476,13 +1679,42 @@ fn render_edit_form_inputs(
             } else {
                 String::new()
             };
+            let input_tag = match f.kind {
+                FieldKind::Bool => format!(
+                    "input type=\"hidden\" name=\"{name}\" value=\"false\"; \
+                     input type=\"checkbox\" name=\"{name}\" value=\"true\" checked[{checked}]{hx_attrs}",
+                    name = f.name,
+                    checked = edit_checked_expr(f),
+                    hx_attrs = hx_attrs
+                ),
+                FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 => format!(
+                    "input type=\"number\" name=\"{name}\" step=\"{step}\" value=({value}){required}{hx_attrs}",
+                    name = f.name,
+                    step = number_step(f.kind),
+                    value = edit_value_expr(f),
+                    required = required,
+                    hx_attrs = hx_attrs
+                ),
+                FieldKind::NaiveDateTime | FieldKind::DateTime => format!(
+                    "input type=\"datetime-local\" name=\"{name}\" value=({value}){required}{hx_attrs}",
+                    name = f.name,
+                    value = edit_datetime_local_value_expr(f),
+                    required = required,
+                    hx_attrs = hx_attrs
+                ),
+                _ => format!(
+                    "input type=\"text\" name=\"{name}\" value=({value}){required}{hx_attrs}",
+                    name = f.name,
+                    value = edit_value_expr(f),
+                    required = required,
+                    hx_attrs = hx_attrs
+                ),
+            };
             let _ = writeln!(
                 out,
-                "            label {{ \"{name}\" }} input type=\"text\" name=\"{name}\" value=({value}){required}{hx_attrs};{error_span}",
+                "            label {{ \"{name}\" }} {input_tag};{error_span}",
                 name = f.name,
-                value = value,
-                required = required,
-                hx_attrs = hx_attrs,
+                input_tag = input_tag,
                 error_span = error_span
             );
         }
@@ -1512,6 +1744,34 @@ fn edit_value_expr(field: &Field) -> String {
             format!("String::from_utf8_lossy(&row.{name}).to_string()")
         }
         (false, _) => format!("row.{name}.to_string()"),
+    }
+}
+
+/// Boolean expression for the `checked[...]` attribute of an edit-form
+/// checkbox — `row.{name}` directly for `bool`, `.unwrap_or(false)` for
+/// `Option<bool>`.
+fn edit_checked_expr(field: &Field) -> String {
+    let name = &field.name;
+    if field.nullable {
+        format!("row.{name}.unwrap_or(false)")
+    } else {
+        format!("row.{name}")
+    }
+}
+
+/// Value expression for an edit-form `datetime-local` input. Unlike
+/// [`edit_value_expr`]'s `.to_string()` (which relies on `Display`, e.g.
+/// `"2024-01-15 10:30:00 UTC"` for `DateTime<Utc>` — a shape browsers
+/// reject), this formats explicitly as `YYYY-MM-DDTHH:MM`, the only value
+/// `<input type="datetime-local">` accepts.
+fn edit_datetime_local_value_expr(field: &Field) -> String {
+    let name = &field.name;
+    if field.nullable {
+        format!(
+            "row.{name}.as_ref().map(|value| value.format(\"%Y-%m-%dT%H:%M\").to_string()).unwrap_or_default()"
+        )
+    } else {
+        format!("row.{name}.format(\"%Y-%m-%dT%H:%M\").to_string()")
     }
 }
 
@@ -2090,16 +2350,16 @@ async fn main() {
         );
         assert!(
             routes.contains(
-                r#"label { "views" } input type="text" name="views" value=(row.views.as_ref().map(ToString::to_string).unwrap_or_default());"#
+                r#"label { "views" } input type="number" name="views" step="1" value=(row.views.as_ref().map(ToString::to_string).unwrap_or_default());"#
             ),
-            "edit form must prefill nullable numeric fields from the loaded row: {routes}"
+            "edit form must prefill nullable numeric fields from the loaded row as a number input (issue #1131): {routes}"
         );
         assert!(
             routes.contains(r#"label { "subtitle" } input type="text" name="subtitle";"#),
             "new form must not mark nullable fields required: {routes}"
         );
         assert!(
-            routes.contains(r#"label { "views" } input type="text" name="views";"#),
+            routes.contains(r#"label { "views" } input type="number" name="views" step="1";"#),
             "new form must not mark nullable numeric fields required: {routes}"
         );
     }
@@ -2656,6 +2916,277 @@ async fn main() {
         // Assert decode_form contains DecodedForm struct
         assert!(routes.contains("struct DecodedForm"));
         assert!(routes.contains("pub avatar: Option<String>"));
+    }
+
+    // ── Typed form-input widgets (issue #1131) ──────────────────────
+
+    #[test]
+    fn execute_writes_checkbox_for_bool_field() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "active:bool".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+
+        // Both create and edit forms must render a real checkbox for `active`,
+        // never a text box.
+        assert!(
+            routes.contains("input type=\"checkbox\" name=\"active\""),
+            "{routes}"
+        );
+        assert!(
+            !routes.contains("input type=\"text\" name=\"active\""),
+            "bool field must not render input type=\"text\": {routes}"
+        );
+        // Unchecked checkboxes are absent from submitted form data — a
+        // hidden "false" sibling guarantees the field always round-trips.
+        assert!(
+            routes.contains("input type=\"hidden\" name=\"active\" value=\"false\""),
+            "{routes}"
+        );
+        // Edit form must reflect the current value via `checked[...]`.
+        assert!(routes.contains("checked[row.active]"), "{routes}");
+        // DecodedForm must default the field so an unchecked submission
+        // (missing key) doesn't 400.
+        assert!(
+            routes.contains("#[serde(default)]\n    pub active: bool,"),
+            "{routes}"
+        );
+    }
+
+    #[test]
+    fn execute_writes_number_input_for_integer_fields() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "views:i64".into(), "rank:i32".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+
+        assert!(
+            routes.contains("input type=\"number\" name=\"views\" step=\"1\""),
+            "{routes}"
+        );
+        assert!(
+            routes.contains("input type=\"number\" name=\"rank\" step=\"1\""),
+            "{routes}"
+        );
+        assert!(
+            !routes.contains("input type=\"text\" name=\"views\""),
+            "{routes}"
+        );
+    }
+
+    #[test]
+    fn execute_writes_number_input_with_any_step_for_float_fields() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &[
+                "title:String".into(),
+                "price:f64".into(),
+                "weight:f32".into(),
+            ],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+
+        assert!(
+            routes.contains("input type=\"number\" name=\"price\" step=\"any\""),
+            "{routes}"
+        );
+        assert!(
+            routes.contains("input type=\"number\" name=\"weight\" step=\"any\""),
+            "{routes}"
+        );
+    }
+
+    #[test]
+    fn execute_writes_number_input_value_on_edit_form() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "views:i64".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(
+            routes.contains(
+                "input type=\"number\" name=\"views\" step=\"1\" value=(row.views.to_string())"
+            ),
+            "{routes}"
+        );
+    }
+
+    #[test]
+    fn execute_writes_datetime_local_input_for_naive_datetime_field() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "published_at:NaiveDateTime".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+
+        assert!(
+            routes.contains("input type=\"datetime-local\" name=\"published_at\""),
+            "{routes}"
+        );
+        assert!(
+            !routes.contains("input type=\"text\" name=\"published_at\""),
+            "{routes}"
+        );
+        // DecodedForm must use the local-shape-aware deserializer so a
+        // browser-submitted `YYYY-MM-DDTHH:MM` value parses without a
+        // hand-edit.
+        assert!(
+            routes.contains(
+                "#[serde(deserialize_with = \"deserialize_naive_datetime_local\")]\n    pub published_at: chrono::NaiveDateTime,"
+            ),
+            "{routes}"
+        );
+        assert!(
+            routes.contains("fn deserialize_naive_datetime_local"),
+            "{routes}"
+        );
+        assert!(routes.contains("fn normalize_datetime_local"), "{routes}");
+        // No DateTime<Utc> field present — the tz-aware helper must not be
+        // emitted as dead code.
+        assert!(
+            !routes.contains("fn deserialize_utc_datetime_local"),
+            "{routes}"
+        );
+    }
+
+    #[test]
+    fn execute_writes_datetime_local_input_for_tz_datetime_field() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "scheduled_at:DateTime".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+
+        assert!(
+            routes.contains("input type=\"datetime-local\" name=\"scheduled_at\""),
+            "{routes}"
+        );
+        assert!(
+            routes.contains(
+                "#[serde(deserialize_with = \"deserialize_utc_datetime_local\")]\n    pub scheduled_at: chrono::DateTime<chrono::Utc>,"
+            ),
+            "{routes}"
+        );
+        assert!(
+            routes.contains("fn deserialize_utc_datetime_local"),
+            "{routes}"
+        );
+        assert!(
+            !routes.contains("fn deserialize_naive_datetime_local"),
+            "{routes}"
+        );
+    }
+
+    #[test]
+    fn execute_writes_datetime_local_input_for_nullable_datetime_field() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &[
+                "title:String".into(),
+                "published_at:Option<NaiveDateTime>".into(),
+            ],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(
+            routes.contains(
+                "#[serde(default, deserialize_with = \"deserialize_option_naive_datetime_local\")]\n    pub published_at: Option<chrono::NaiveDateTime>,"
+            ),
+            "{routes}"
+        );
+        assert!(
+            routes.contains("fn deserialize_option_naive_datetime_local"),
+            "{routes}"
+        );
+        // Scalar variant must not be emitted when only the nullable form is used.
+        assert!(
+            !routes.contains("fn deserialize_naive_datetime_local<'de, D>(deserializer: D) -> Result<chrono::NaiveDateTime, D::Error>"),
+            "{routes}"
+        );
+    }
+
+    #[test]
+    fn execute_writes_text_input_only_for_genuine_string_fields() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &[
+                "title:String".into(),
+                "body:Text".into(),
+                "active:bool".into(),
+                "views:i64".into(),
+                "published_at:NaiveDateTime".into(),
+            ],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(
+            routes.contains("input type=\"text\" name=\"title\""),
+            "{routes}"
+        );
+        assert!(
+            routes.contains("input type=\"text\" name=\"body\""),
+            "{routes}"
+        );
+        assert!(
+            !routes.contains("input type=\"text\" name=\"active\""),
+            "{routes}"
+        );
+        assert!(
+            !routes.contains("input type=\"text\" name=\"views\""),
+            "{routes}"
+        );
+        assert!(
+            !routes.contains("input type=\"text\" name=\"published_at\""),
+            "{routes}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1848,8 +1848,9 @@ fn edit_bool_select_selected_exprs(field: &Field) -> (String, String, String) {
 ///
 /// Seconds/fractional-seconds are included when present (`%.f` omits them
 /// entirely when zero) rather than truncated to `YYYY-MM-DDTHH:MM`: a
-/// minute-only value round-trips back through [`normalize_datetime_local`]
-/// as `:00` seconds, and the generated `update` handler writes every column
+/// minute-only value round-trips back through the generated project's
+/// `normalize_datetime_local` (see `NORMALIZE_DATETIME_LOCAL_FN` below) as
+/// `:00` seconds, and the generated `update` handler writes every column
 /// unconditionally — a stored `12:34:56.789` would otherwise be silently
 /// overwritten as `12:34:00` by re-submitting the form without touching
 /// this field. Pair with `step="any"` on the input (see

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -614,7 +614,7 @@ fn render_repository_queries(pascal_name: &str, queries: &[QuerySpec]) -> String
 /// function's padding runs.
 const NORMALIZE_DATETIME_LOCAL_FN: &str = r#"
 fn normalize_datetime_local(raw: &str) -> String {
-    if raw.len() == 16 {
+    if raw.chars().count() == 16 {
         format!("{raw}:00")
     } else {
         raw.to_string()

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -786,7 +786,11 @@ fn generated_scaffold_cargo_checks() {
             "published:bool",
             "subtitle:Option<String>",
             "views:Option<i64>",
+            "rank:i32",
+            "rating:f64",
+            "weight:Option<f32>",
             "published_at:Option<NaiveDateTime>",
+            "scheduled_at:DateTime",
             "token:Option<Uuid>",
         ],
     );

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -784,6 +784,7 @@ fn generated_scaffold_cargo_checks() {
             "title:String",
             "body:Text",
             "published:bool",
+            "archived:Option<bool>",
             "subtitle:Option<String>",
             "views:Option<i64>",
             "rank:i32",

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1073,13 +1073,18 @@ fn normalize_date_value(raw: &str) -> String {
     if raw.is_empty() {
         return String::new();
     }
-    if let Ok(date) = chrono::NaiveDate::parse_from_str(raw, "%Y-%m-%d") {
+    // `NaiveDateTime`'s `Display` (as opposed to its serde serialization,
+    // which uses `T`) separates date and time with a space, e.g. from a raw
+    // `.to_string()` or some database drivers. Normalize defensively so
+    // those still parse instead of falling through to the raw string.
+    let normalized = raw.replace(' ', "T");
+    if let Ok(date) = chrono::NaiveDate::parse_from_str(&normalized, "%Y-%m-%d") {
         return date.to_string();
     }
-    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(raw) {
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&normalized) {
         return dt.format("%Y-%m-%d").to_string();
     }
-    if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H:%M:%S%.f") {
+    if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(&normalized, "%Y-%m-%dT%H:%M:%S%.f") {
         return ndt.format("%Y-%m-%d").to_string();
     }
     raw.to_owned()
@@ -1098,13 +1103,15 @@ fn normalize_datetime_local_value(raw: &str) -> String {
     if raw.is_empty() {
         return String::new();
     }
-    if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H:%M") {
+    // See `normalize_date_value`'s comment on space-separated input.
+    let normalized = raw.replace(' ', "T");
+    if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(&normalized, "%Y-%m-%dT%H:%M") {
         return ndt.format("%Y-%m-%dT%H:%M").to_string();
     }
-    if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H:%M:%S%.f") {
+    if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(&normalized, "%Y-%m-%dT%H:%M:%S%.f") {
         return ndt.format("%Y-%m-%dT%H:%M").to_string();
     }
-    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(raw) {
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&normalized) {
         return dt.naive_local().format("%Y-%m-%dT%H:%M").to_string();
     }
     raw.to_owned()
@@ -1112,7 +1119,7 @@ fn normalize_datetime_local_value(raw: &str) -> String {
 
 /// Render a labeled `<input type="date">` tied to a changeset field.
 ///
-/// The current value is normalized via [`normalize_date_value`] to the
+/// The current value is normalized via `normalize_date_value` to the
 /// `YYYY-MM-DD` shape HTML5 date pickers require, regardless of whether the
 /// underlying field serializes as a bare date or a full timestamp. Wraps in
 /// `<div id="{field}-field">` for stable htmx targeting. ARIA annotations
@@ -1155,7 +1162,7 @@ pub fn date_input<T: Serialize>(
 /// Render a labeled `<input type="datetime-local">` tied to a changeset
 /// field (`NaiveDateTime` or `DateTime`).
 ///
-/// The current value is normalized via [`normalize_datetime_local_value`] to
+/// The current value is normalized via `normalize_datetime_local_value` to
 /// the `YYYY-MM-DDTHH:MM` shape HTML5 datetime pickers require. Wraps in
 /// `<div id="{field}-field">` for stable htmx targeting. ARIA annotations
 /// behave identically to [`text_input`].
@@ -2398,6 +2405,24 @@ mod tests {
 
     #[cfg(feature = "maud")]
     #[test]
+    fn date_input_normalizes_space_separated_datetime_to_date_only() {
+        // `NaiveDateTime`'s `Display` (as opposed to its serde
+        // serialization) uses a space separator, e.g. from a raw
+        // `.to_string()` or some database drivers — accept it defensively
+        // rather than falling through to the raw (browser-rejected) string.
+        #[derive(serde::Serialize)]
+        struct F {
+            born_on: String,
+        }
+        let cs = Changeset::new(F {
+            born_on: "2024-03-15 10:30:00".into(),
+        });
+        let html = date_input(&cs, "born_on", "Born on").into_string();
+        assert!(html.contains(r#"value="2024-03-15""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
     fn date_input_emits_aria_invalid_and_errors() {
         #[derive(serde::Serialize)]
         struct F {
@@ -2447,6 +2472,24 @@ mod tests {
         // must be reduced to the bare local-shaped `YYYY-MM-DDTHH:MM`.
         assert!(html.contains(r#"value="2024-03-15T10:30""#), "{html}");
         assert!(!html.contains(r#"value="2024-03-15T10:30:00Z""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn datetime_input_normalizes_space_separated_datetime() {
+        // `NaiveDateTime`'s `Display` uses a space separator, e.g. from a
+        // raw `.to_string()` or some database drivers — accept it
+        // defensively rather than falling through to the raw string, which
+        // `<input type="datetime-local">` (strictly requiring `T`) rejects.
+        #[derive(serde::Serialize)]
+        struct F {
+            starts_at: String,
+        }
+        let cs = Changeset::new(F {
+            starts_at: "2024-03-15 10:30:00".into(),
+        });
+        let html = datetime_input(&cs, "starts_at", "Starts at").into_string();
+        assert!(html.contains(r#"value="2024-03-15T10:30""#), "{html}");
     }
 
     #[cfg(feature = "maud")]

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1127,6 +1127,84 @@ fn normalize_datetime_local_value(raw: &str) -> String {
     raw.to_owned()
 }
 
+/// Pad an HTML `datetime-local` submission (`YYYY-MM-DDTHH:MM`, seconds
+/// omitted by the browser at minute granularity) to `YYYY-MM-DDTHH:MM:00` so
+/// chrono's parser — which requires the seconds component — accepts it.
+#[cfg(feature = "maud")]
+fn pad_datetime_local_seconds(raw: &str) -> String {
+    if raw.chars().count() == 16 {
+        format!("{raw}:00")
+    } else {
+        raw.to_owned()
+    }
+}
+
+/// Deserialize an HTML `datetime-local` submission into `chrono::DateTime<Utc>`,
+/// treating the submitted wall-clock value as UTC.
+///
+/// `<input type="datetime-local">` has no timezone concept, so [`datetime_input`]
+/// necessarily strips any offset when rendering a `DateTime<Utc>` field's
+/// current value — the browser then posts back an offsetless string (e.g.
+/// `2024-03-15T10:30:56`). Chrono's *default* `Deserialize` for
+/// `DateTime<Utc>` requires an RFC 3339 offset and rejects that string with
+/// "premature end of input" on every submission. Attach this function to any
+/// `DateTime<Utc>` field rendered with `datetime_input`:
+///
+/// ```rust,ignore
+/// #[derive(serde::Deserialize)]
+/// struct EventForm {
+///     #[serde(deserialize_with = "autumn_web::form::deserialize_datetime_local_utc")]
+///     starts_at: chrono::DateTime<chrono::Utc>,
+/// }
+/// ```
+///
+/// `chrono::NaiveDateTime` fields need no such attribute — chrono's default
+/// `Deserialize` for `NaiveDateTime` doesn't require an offset.
+///
+/// # Errors
+///
+/// Returns a deserializer error when the submitted value isn't a valid
+/// `YYYY-MM-DDTHH:MM[:SS[.f]]` local datetime string.
+#[cfg(feature = "maud")]
+pub fn deserialize_datetime_local_utc<'de, D>(
+    deserializer: D,
+) -> Result<chrono::DateTime<chrono::Utc>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+    chrono::NaiveDateTime::parse_from_str(&pad_datetime_local_seconds(&raw), "%Y-%m-%dT%H:%M:%S%.f")
+        .map(|ndt| ndt.and_utc())
+        .map_err(serde::de::Error::custom)
+}
+
+/// `Option<chrono::DateTime<Utc>>` counterpart to
+/// [`deserialize_datetime_local_utc`], for a nullable field — an absent or
+/// empty submitted value decodes as `None`.
+///
+/// # Errors
+///
+/// Returns a deserializer error when a non-empty submitted value isn't a
+/// valid `YYYY-MM-DDTHH:MM[:SS[.f]]` local datetime string.
+#[cfg(feature = "maud")]
+pub fn deserialize_datetime_local_utc_option<'de, D>(
+    deserializer: D,
+) -> Result<Option<chrono::DateTime<chrono::Utc>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = <Option<String> as serde::Deserialize>::deserialize(deserializer)?;
+    match raw {
+        Some(s) if !s.is_empty() => chrono::NaiveDateTime::parse_from_str(
+            &pad_datetime_local_seconds(&s),
+            "%Y-%m-%dT%H:%M:%S%.f",
+        )
+        .map(|ndt| Some(ndt.and_utc()))
+        .map_err(serde::de::Error::custom),
+        _ => Ok(None),
+    }
+}
+
 /// Render a labeled `<input type="date">` tied to a changeset field.
 ///
 /// The current value is normalized via `normalize_date_value` to the
@@ -1181,6 +1259,16 @@ pub fn date_input<T: Serialize>(
 /// constraint validation (the default step is minute-granularity). Wraps in
 /// `<div id="{field}-field">` for stable htmx targeting. ARIA annotations
 /// behave identically to [`text_input`].
+///
+/// # `DateTime<Utc>` fields need [`deserialize_datetime_local_utc`]
+///
+/// `<input type="datetime-local">` has no timezone concept, so the value
+/// this renders for a `DateTime<Utc>` field never carries an offset —
+/// chrono's default `Deserialize` for `DateTime<Utc>` requires one and
+/// rejects the submission. Attach [`deserialize_datetime_local_utc`] (or
+/// [`deserialize_datetime_local_utc_option`] for `Option<DateTime<Utc>>`)
+/// via `#[serde(deserialize_with = "...")]` on that field. `NaiveDateTime`
+/// fields need no such attribute.
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn datetime_input<T: Serialize>(
@@ -2570,6 +2658,102 @@ mod tests {
         let decoded: Decoded =
             serde_urlencoded::from_str(&body).expect("pre-filled value must decode");
         assert_eq!(decoded.starts_at, stored);
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn datetime_input_value_round_trips_for_utc_datetime_with_deserialize_helper() {
+        // Regression test: a DateTime<Utc> field's datetime_input value has
+        // no offset (datetime-local has no timezone concept), which chrono's
+        // *default* Deserialize for DateTime<Utc> rejects. Confirm the
+        // pre-filled value decodes successfully when the field is annotated
+        // with deserialize_datetime_local_utc, as documented on
+        // datetime_input.
+        #[derive(serde::Serialize)]
+        struct F {
+            starts_at: chrono::DateTime<chrono::Utc>,
+        }
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            #[serde(deserialize_with = "deserialize_datetime_local_utc")]
+            starts_at: chrono::DateTime<chrono::Utc>,
+        }
+        let stored = chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
+            chrono::NaiveDate::from_ymd_opt(2024, 3, 15)
+                .unwrap()
+                .and_hms_opt(10, 30, 56)
+                .unwrap(),
+            chrono::Utc,
+        );
+        let cs = Changeset::new(F { starts_at: stored });
+        let html = datetime_input(&cs, "starts_at", "Starts at").into_string();
+        // The rendered value must not carry an offset/Z (would break the
+        // datetime-local input); confirm that first.
+        let value = html
+            .split("value=\"")
+            .nth(1)
+            .and_then(|s| s.split('"').next())
+            .expect("value attribute present");
+        assert!(!value.contains('Z') && !value.contains('+'), "{value}");
+
+        let body = format!("starts_at={value}");
+        let decoded: Decoded =
+            serde_urlencoded::from_str(&body).expect("pre-filled value must decode");
+        assert_eq!(decoded.starts_at, stored);
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn deserialize_datetime_local_utc_pads_missing_seconds() {
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            #[serde(deserialize_with = "deserialize_datetime_local_utc")]
+            starts_at: chrono::DateTime<chrono::Utc>,
+        }
+        let decoded: Decoded = serde_urlencoded::from_str("starts_at=2024-03-15T10:30").unwrap();
+        assert_eq!(
+            decoded.starts_at,
+            chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
+                chrono::NaiveDate::from_ymd_opt(2024, 3, 15)
+                    .unwrap()
+                    .and_hms_opt(10, 30, 0)
+                    .unwrap(),
+                chrono::Utc,
+            )
+        );
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn deserialize_datetime_local_utc_option_absent_key_is_none() {
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            #[serde(default, deserialize_with = "deserialize_datetime_local_utc_option")]
+            starts_at: Option<chrono::DateTime<chrono::Utc>>,
+        }
+        let decoded: Decoded = serde_urlencoded::from_str("").unwrap();
+        assert_eq!(decoded.starts_at, None);
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn deserialize_datetime_local_utc_option_present_key_is_some() {
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            #[serde(default, deserialize_with = "deserialize_datetime_local_utc_option")]
+            starts_at: Option<chrono::DateTime<chrono::Utc>>,
+        }
+        let decoded: Decoded = serde_urlencoded::from_str("starts_at=2024-03-15T10:30:56").unwrap();
+        assert_eq!(
+            decoded.starts_at,
+            Some(chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
+                chrono::NaiveDate::from_ymd_opt(2024, 3, 15)
+                    .unwrap()
+                    .and_hms_opt(10, 30, 56)
+                    .unwrap(),
+                chrono::Utc,
+            ))
+        );
     }
 
     #[cfg(feature = "maud")]

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -950,12 +950,32 @@ pub fn required_text_input<T: Serialize>(
 
 /// Render a labeled `<input type="checkbox">` tied to a `bool` changeset field.
 ///
-/// HTML checkboxes are omitted from submitted form data when unchecked, so
-/// this always emits a hidden `false` sibling `<input>` ahead of the
-/// checkbox (same `name`) — the checkbox's `"true"` overrides it when
-/// checked, and the hidden fallback wins when unchecked. This gives `bool`
-/// fields (not just `Option<bool>`) a value on every submission with no
-/// extra `#[serde(default)]` ceremony required by hand-written forms.
+/// # Required: `#[serde(default)]` on the target field
+///
+/// HTML checkboxes are omitted from submitted form data entirely when
+/// unchecked — there is no way to distinguish "unchecked" from "field not
+/// present" on the wire. **Do not** pair this with a hidden `<input
+/// type="hidden" value="false">` sibling sharing the same `name`: a checked
+/// box then submits the key *twice* (`field=false` from the hidden input,
+/// `field=true` from the checkbox), and `serde_urlencoded` (used by both
+/// axum's `Form` extractor and [`ChangesetForm`]) rejects duplicate keys
+/// with a "duplicate field" deserialize error instead of taking the last
+/// value — every checked submission would 400.
+///
+/// Instead, mark the target `bool` field `#[serde(default)]` so a missing
+/// key decodes as `false`:
+///
+/// ```rust,ignore
+/// #[derive(serde::Deserialize)]
+/// struct PostForm {
+///     #[serde(default)]
+///     published: bool,
+/// }
+/// ```
+///
+/// For a nullable `Option<bool>` field where `None` is a meaningful third
+/// state (distinct from `Some(false)`), a checkbox cannot represent it
+/// losslessly — use [`select_input`] with three options instead.
 ///
 /// The `checked` attribute reflects the changeset's current value via
 /// [`Changeset::field_value`], which serializes `bool` as `"true"`/`"false"`.
@@ -977,7 +997,6 @@ pub fn checkbox_input<T: Serialize>(
     maud::html! {
         div id=(wrapper_id) class="autumn-field" {
             label for=(field) class="autumn-field__label" { (label) }
-            input type="hidden" name=(field) value="false";
             input
                 type="checkbox"
                 id=(field)
@@ -2190,18 +2209,68 @@ mod tests {
 
     #[cfg(feature = "maud")]
     #[test]
-    fn checkbox_input_emits_hidden_false_fallback() {
-        // Unchecked checkboxes are absent from submitted form data; a hidden
-        // "false" sibling with the same name guarantees the field is always
-        // present so `bool` (not just `Option<bool>`) round-trips.
+    fn checkbox_input_never_emits_a_hidden_fallback() {
+        // A hidden "false" sibling sharing the checkbox's `name` would make a
+        // *checked* submission send the key twice (`field=false&field=true`).
+        // serde_urlencoded rejects duplicate keys outright rather than taking
+        // the last value, so every checked submission would 400. Unchecked
+        // state must be recovered via `#[serde(default)]` on the target
+        // field instead (see the function's doc comment) — never via a
+        // hidden fallback input.
         #[derive(serde::Serialize)]
         struct F {
             active: bool,
         }
         let cs = Changeset::new(F { active: false });
         let html = checkbox_input(&cs, "active", "Active").into_string();
-        assert!(html.contains(r#"type="hidden""#), "{html}");
-        assert!(html.contains(r#"value="false""#), "{html}");
+        assert!(!html.contains(r#"type="hidden""#), "{html}");
+        assert_eq!(
+            html.matches(r#"name="active""#).count(),
+            1,
+            "checkbox_input must emit exactly one input named `active` \
+             (a second `name=\"active\"` sibling would duplicate the key \
+             on submission): {html}"
+        );
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn checkbox_input_round_trips_through_real_url_decode_when_checked() {
+        // Regression test for the duplicate-key 400: decode the *exact*
+        // query string a browser sends for a CHECKED box rendered by
+        // checkbox_input (i.e. only the fields checkbox_input itself
+        // renders — no hidden sibling), through the same serde_urlencoded
+        // machinery axum's `Form` extractor and ChangesetForm use.
+        #[derive(serde::Serialize)]
+        struct F {
+            active: bool,
+        }
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            #[serde(default)]
+            active: bool,
+        }
+        let cs = Changeset::new(F { active: true });
+        let html = checkbox_input(&cs, "active", "Active").into_string();
+        assert!(html.contains("checked"), "{html}");
+
+        // A checked box submits `active=true` and nothing else.
+        let decoded: Decoded = serde_urlencoded::from_str("active=true").unwrap();
+        assert!(decoded.active);
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn checkbox_input_round_trips_through_real_url_decode_when_unchecked() {
+        // An unchecked box submits no `active` key at all; `#[serde(default)]`
+        // must recover `false` rather than erroring "missing field".
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            #[serde(default)]
+            active: bool,
+        }
+        let decoded: Decoded = serde_urlencoded::from_str("").unwrap();
+        assert!(!decoded.active);
     }
 
     #[cfg(feature = "maud")]

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1090,9 +1090,19 @@ fn normalize_date_value(raw: &str) -> String {
     raw.to_owned()
 }
 
-/// Normalize a stored datetime string into `YYYY-MM-DDTHH:MM`, the only
-/// shape the HTML `<input type="datetime-local">` control accepts. Browsers
-/// silently reject RFC 3339 timestamps carrying a `Z`/offset suffix.
+/// Normalize a stored datetime string into a shape the HTML `<input
+/// type="datetime-local">` control accepts (`YYYY-MM-DDTHH:MM[:SS[.fff]]`).
+/// Browsers silently reject RFC 3339 timestamps carrying a `Z`/offset
+/// suffix.
+///
+/// **Seconds/fractional-seconds preserved when present.** `chrono`'s default
+/// `serde::Deserialize` for `NaiveDateTime`/`DateTime<Utc>` requires the
+/// seconds component — truncating to `YYYY-MM-DDTHH:MM` here would make
+/// [`ChangesetForm`] fail to decode the *pre-filled* value on any
+/// submission where the user doesn't manually retype it (chrono's parser
+/// returns "premature end of input"). `%.f` omits the fractional part
+/// cleanly when it's zero, so whole-second values still render without a
+/// trailing dot.
 ///
 /// **Wall-clock preserved.** For RFC 3339 input with an explicit offset, the
 /// offset is dropped but the local clock components are kept as-is (no
@@ -1105,14 +1115,14 @@ fn normalize_datetime_local_value(raw: &str) -> String {
     }
     // See `normalize_date_value`'s comment on space-separated input.
     let normalized = raw.replace(' ', "T");
-    if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(&normalized, "%Y-%m-%dT%H:%M") {
-        return ndt.format("%Y-%m-%dT%H:%M").to_string();
-    }
     if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(&normalized, "%Y-%m-%dT%H:%M:%S%.f") {
-        return ndt.format("%Y-%m-%dT%H:%M").to_string();
+        return ndt.format("%Y-%m-%dT%H:%M:%S%.f").to_string();
+    }
+    if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(&normalized, "%Y-%m-%dT%H:%M") {
+        return ndt.format("%Y-%m-%dT%H:%M:%S%.f").to_string();
     }
     if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&normalized) {
-        return dt.naive_local().format("%Y-%m-%dT%H:%M").to_string();
+        return dt.naive_local().format("%Y-%m-%dT%H:%M:%S%.f").to_string();
     }
     raw.to_owned()
 }
@@ -1163,7 +1173,12 @@ pub fn date_input<T: Serialize>(
 /// field (`NaiveDateTime` or `DateTime`).
 ///
 /// The current value is normalized via `normalize_datetime_local_value` to
-/// the `YYYY-MM-DDTHH:MM` shape HTML5 datetime pickers require. Wraps in
+/// the shape HTML5 datetime pickers require, preserving seconds/fractional
+/// seconds when present — `chrono`'s default `Deserialize` requires the
+/// seconds component, so truncating to minutes would break decoding the
+/// pre-filled value on any untouched submission. Renders `step="any"` so a
+/// value carrying seconds doesn't fail the browser's step-mismatch
+/// constraint validation (the default step is minute-granularity). Wraps in
 /// `<div id="{field}-field">` for stable htmx targeting. ARIA annotations
 /// behave identically to [`text_input`].
 #[cfg(feature = "maud")]
@@ -1187,6 +1202,7 @@ pub fn datetime_input<T: Serialize>(
                 id=(field)
                 name=(field)
                 value=(value)
+                step="any"
                 class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
                 aria-invalid=(if has_errors { "true" } else { "false" })
                 aria-describedby=(if has_errors { error_id.as_str() } else { "" });
@@ -2454,7 +2470,13 @@ mod tests {
         });
         let html = datetime_input(&cs, "starts_at", "Starts at").into_string();
         assert!(html.contains(r#"type="datetime-local""#), "{html}");
-        assert!(html.contains(r#"value="2024-03-15T10:30""#), "{html}");
+        // Seconds must be preserved, not truncated to minutes: chrono's
+        // default Deserialize requires the seconds component, so a
+        // minute-only value would fail to decode on an untouched submission.
+        assert!(html.contains(r#"value="2024-03-15T10:30:00""#), "{html}");
+        // `step="any"` so that value doesn't fail step-mismatch validation
+        // (default step is minute-granularity) and block submission.
+        assert!(html.contains(r#"step="any""#), "{html}");
     }
 
     #[cfg(feature = "maud")]
@@ -2469,8 +2491,8 @@ mod tests {
         });
         let html = datetime_input(&cs, "starts_at", "Starts at").into_string();
         // Browsers reject a trailing `Z`/offset in a `datetime-local` value;
-        // must be reduced to the bare local-shaped `YYYY-MM-DDTHH:MM`.
-        assert!(html.contains(r#"value="2024-03-15T10:30""#), "{html}");
+        // must be reduced to the bare local-shaped `YYYY-MM-DDTHH:MM:SS`.
+        assert!(html.contains(r#"value="2024-03-15T10:30:00""#), "{html}");
         assert!(!html.contains(r#"value="2024-03-15T10:30:00Z""#), "{html}");
     }
 
@@ -2489,7 +2511,7 @@ mod tests {
             starts_at: "2024-03-15 10:30:00".into(),
         });
         let html = datetime_input(&cs, "starts_at", "Starts at").into_string();
-        assert!(html.contains(r#"value="2024-03-15T10:30""#), "{html}");
+        assert!(html.contains(r#"value="2024-03-15T10:30:00""#), "{html}");
     }
 
     #[cfg(feature = "maud")]
@@ -2511,6 +2533,43 @@ mod tests {
         assert!(html.contains(r#"aria-invalid="true""#), "{html}");
         assert!(html.contains(r#"role="alert""#), "{html}");
         assert!(html.contains("required"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn datetime_input_value_round_trips_through_chronos_default_deserialize() {
+        // Regression test: chrono's default `serde::Deserialize` for
+        // `NaiveDateTime` requires the seconds component ("premature end of
+        // input" otherwise). A hand-written form using `datetime_input` with
+        // a plain `chrono::NaiveDateTime` changeset field must be able to
+        // submit the *pre-filled, untouched* value and have it decode
+        // successfully — not just render without visible truncation.
+        #[derive(serde::Serialize)]
+        struct F {
+            starts_at: chrono::NaiveDateTime,
+        }
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            starts_at: chrono::NaiveDateTime,
+        }
+        let stored = chrono::NaiveDate::from_ymd_opt(2024, 3, 15)
+            .unwrap()
+            .and_hms_opt(10, 30, 56)
+            .unwrap();
+        let cs = Changeset::new(F { starts_at: stored });
+        let html = datetime_input(&cs, "starts_at", "Starts at").into_string();
+
+        // Extract the rendered value attribute and submit it exactly as a
+        // browser would on a no-op edit (field untouched).
+        let value = html
+            .split("value=\"")
+            .nth(1)
+            .and_then(|s| s.split('"').next())
+            .expect("value attribute present");
+        let body = format!("starts_at={value}");
+        let decoded: Decoded =
+            serde_urlencoded::from_str(&body).expect("pre-filled value must decode");
+        assert_eq!(decoded.starts_at, stored);
     }
 
     #[cfg(feature = "maud")]

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -948,6 +948,284 @@ pub fn required_text_input<T: Serialize>(
     }
 }
 
+/// Render a labeled `<input type="checkbox">` tied to a `bool` changeset field.
+///
+/// HTML checkboxes are omitted from submitted form data when unchecked, so
+/// this always emits a hidden `false` sibling `<input>` ahead of the
+/// checkbox (same `name`) — the checkbox's `"true"` overrides it when
+/// checked, and the hidden fallback wins when unchecked. This gives `bool`
+/// fields (not just `Option<bool>`) a value on every submission with no
+/// extra `#[serde(default)]` ceremony required by hand-written forms.
+///
+/// The `checked` attribute reflects the changeset's current value via
+/// [`Changeset::field_value`], which serializes `bool` as `"true"`/`"false"`.
+/// Wraps in `<div id="{field}-field">` for stable htmx targeting. ARIA
+/// annotations behave identically to [`text_input`].
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn checkbox_input<T: Serialize>(
+    changeset: &Changeset<T>,
+    field: &str,
+    label: &str,
+) -> maud::Markup {
+    let errors = changeset.errors_for(field);
+    let has_errors = !errors.is_empty();
+    let checked = changeset.field_value(field).as_deref() == Some("true");
+    let error_id = format!("{field}-error");
+    let wrapper_id = format!("{field}-field");
+
+    maud::html! {
+        div id=(wrapper_id) class="autumn-field" {
+            label for=(field) class="autumn-field__label" { (label) }
+            input type="hidden" name=(field) value="false";
+            input
+                type="checkbox"
+                id=(field)
+                name=(field)
+                value="true"
+                checked[checked]
+                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
+                aria-invalid=(if has_errors { "true" } else { "false" })
+                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+            @if has_errors {
+                div id=(error_id) role="alert" class="autumn-field__errors" {
+                    @for error in errors {
+                        p class="autumn-field__error" { (error) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Render a labeled `<input type="number">` tied to a numeric changeset field
+/// (`i32`, `i64`, `f32`, `f64`).
+///
+/// `step` sets the HTML `step` attribute — pass `Some("1")` for integer
+/// fields, `Some("0.01")` or `Some("any")` for floating-point fields, or
+/// `None` to leave the browser default (`step="1"`, whole numbers only).
+/// Wraps in `<div id="{field}-field">` for stable htmx targeting. ARIA
+/// annotations behave identically to [`text_input`].
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn number_input<T: Serialize>(
+    changeset: &Changeset<T>,
+    field: &str,
+    label: &str,
+    step: Option<&str>,
+) -> maud::Markup {
+    let errors = changeset.errors_for(field);
+    let has_errors = !errors.is_empty();
+    let value = changeset.field_value(field).unwrap_or_default();
+    let error_id = format!("{field}-error");
+    let wrapper_id = format!("{field}-field");
+
+    maud::html! {
+        div id=(wrapper_id) class="autumn-field" {
+            label for=(field) class="autumn-field__label" { (label) }
+            input
+                type="number"
+                id=(field)
+                name=(field)
+                value=(value)
+                step=[step]
+                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
+                aria-invalid=(if has_errors { "true" } else { "false" })
+                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+            @if has_errors {
+                div id=(error_id) role="alert" class="autumn-field__errors" {
+                    @for error in errors {
+                        p class="autumn-field__error" { (error) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Normalize a stored date/datetime string into `YYYY-MM-DD`, the shape the
+/// HTML `<input type="date">` control requires.
+///
+/// Accepts a bare date, a full RFC 3339 timestamp (with offset/`Z`), or a
+/// naive datetime, and keeps just the date component. Falls back to the
+/// input unchanged when none of those shapes match (e.g. an empty string).
+#[cfg(feature = "maud")]
+fn normalize_date_value(raw: &str) -> String {
+    if raw.is_empty() {
+        return String::new();
+    }
+    if let Ok(date) = chrono::NaiveDate::parse_from_str(raw, "%Y-%m-%d") {
+        return date.to_string();
+    }
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(raw) {
+        return dt.format("%Y-%m-%d").to_string();
+    }
+    if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H:%M:%S%.f") {
+        return ndt.format("%Y-%m-%d").to_string();
+    }
+    raw.to_owned()
+}
+
+/// Normalize a stored datetime string into `YYYY-MM-DDTHH:MM`, the only
+/// shape the HTML `<input type="datetime-local">` control accepts. Browsers
+/// silently reject RFC 3339 timestamps carrying a `Z`/offset suffix.
+///
+/// **Wall-clock preserved.** For RFC 3339 input with an explicit offset, the
+/// offset is dropped but the local clock components are kept as-is (no
+/// conversion to UTC) — the datetime-local input has no timezone concept, so
+/// shifting the clock would mutate the value on a no-op save.
+#[cfg(feature = "maud")]
+fn normalize_datetime_local_value(raw: &str) -> String {
+    if raw.is_empty() {
+        return String::new();
+    }
+    if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H:%M") {
+        return ndt.format("%Y-%m-%dT%H:%M").to_string();
+    }
+    if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H:%M:%S%.f") {
+        return ndt.format("%Y-%m-%dT%H:%M").to_string();
+    }
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(raw) {
+        return dt.naive_local().format("%Y-%m-%dT%H:%M").to_string();
+    }
+    raw.to_owned()
+}
+
+/// Render a labeled `<input type="date">` tied to a changeset field.
+///
+/// The current value is normalized via [`normalize_date_value`] to the
+/// `YYYY-MM-DD` shape HTML5 date pickers require, regardless of whether the
+/// underlying field serializes as a bare date or a full timestamp. Wraps in
+/// `<div id="{field}-field">` for stable htmx targeting. ARIA annotations
+/// behave identically to [`text_input`].
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn date_input<T: Serialize>(
+    changeset: &Changeset<T>,
+    field: &str,
+    label: &str,
+) -> maud::Markup {
+    let errors = changeset.errors_for(field);
+    let has_errors = !errors.is_empty();
+    let value = normalize_date_value(&changeset.field_value(field).unwrap_or_default());
+    let error_id = format!("{field}-error");
+    let wrapper_id = format!("{field}-field");
+
+    maud::html! {
+        div id=(wrapper_id) class="autumn-field" {
+            label for=(field) class="autumn-field__label" { (label) }
+            input
+                type="date"
+                id=(field)
+                name=(field)
+                value=(value)
+                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
+                aria-invalid=(if has_errors { "true" } else { "false" })
+                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+            @if has_errors {
+                div id=(error_id) role="alert" class="autumn-field__errors" {
+                    @for error in errors {
+                        p class="autumn-field__error" { (error) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Render a labeled `<input type="datetime-local">` tied to a changeset
+/// field (`NaiveDateTime` or `DateTime`).
+///
+/// The current value is normalized via [`normalize_datetime_local_value`] to
+/// the `YYYY-MM-DDTHH:MM` shape HTML5 datetime pickers require. Wraps in
+/// `<div id="{field}-field">` for stable htmx targeting. ARIA annotations
+/// behave identically to [`text_input`].
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn datetime_input<T: Serialize>(
+    changeset: &Changeset<T>,
+    field: &str,
+    label: &str,
+) -> maud::Markup {
+    let errors = changeset.errors_for(field);
+    let has_errors = !errors.is_empty();
+    let value = normalize_datetime_local_value(&changeset.field_value(field).unwrap_or_default());
+    let error_id = format!("{field}-error");
+    let wrapper_id = format!("{field}-field");
+
+    maud::html! {
+        div id=(wrapper_id) class="autumn-field" {
+            label for=(field) class="autumn-field__label" { (label) }
+            input
+                type="datetime-local"
+                id=(field)
+                name=(field)
+                value=(value)
+                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
+                aria-invalid=(if has_errors { "true" } else { "false" })
+                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+            @if has_errors {
+                div id=(error_id) role="alert" class="autumn-field__errors" {
+                    @for error in errors {
+                        p class="autumn-field__error" { (error) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Render a labeled `<select>` tied to a closed-set changeset field, with
+/// `options` given as `(value, label)` pairs.
+///
+/// The option whose `value` matches the changeset's current field value
+/// (via [`Changeset::field_value`]) is marked `selected`. This is the
+/// control the enum ([#1030]) and references ([#1026]) field types render
+/// once those field kinds ship — this slice ships the widget, not the DSL
+/// tokens that will target it.
+/// Wraps in `<div id="{field}-field">` for stable htmx targeting. ARIA
+/// annotations behave identically to [`text_input`].
+///
+/// [#1030]: https://github.com/madmax983/autumn/issues/1030
+/// [#1026]: https://github.com/madmax983/autumn/issues/1026
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn select_input<T: Serialize>(
+    changeset: &Changeset<T>,
+    field: &str,
+    label: &str,
+    options: &[(&str, &str)],
+) -> maud::Markup {
+    let errors = changeset.errors_for(field);
+    let has_errors = !errors.is_empty();
+    let current = changeset.field_value(field).unwrap_or_default();
+    let error_id = format!("{field}-error");
+    let wrapper_id = format!("{field}-field");
+
+    maud::html! {
+        div id=(wrapper_id) class="autumn-field" {
+            label for=(field) class="autumn-field__label" { (label) }
+            select
+                id=(field)
+                name=(field)
+                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
+                aria-invalid=(if has_errors { "true" } else { "false" })
+                aria-describedby=(if has_errors { error_id.as_str() } else { "" }) {
+                @for (option_value, option_label) in options {
+                    option value=(option_value) selected[*option_value == current] { (option_label) }
+                }
+            }
+            @if has_errors {
+                div id=(error_id) role="alert" class="autumn-field__errors" {
+                    @for error in errors {
+                        p class="autumn-field__error" { (error) }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Render an ARIA live region for htmx swap announcements.
 ///
 /// Emits `<div id="…" role="status" aria-live="polite" aria-atomic="true">`.
@@ -1867,6 +2145,347 @@ mod tests {
         let html = text_input_htmx(&cs, "email", "Email", "/v").into_string();
         assert!(html.contains("email-error"), "{html}");
         assert!(html.contains(r#"aria-describedby="email-error""#), "{html}");
+    }
+
+    // ── Typed inputs: checkbox_input / number_input / date_input /
+    //    datetime_input / select_input (issue #1131) ────────────────
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn checkbox_input_renders_type_checkbox() {
+        #[derive(serde::Serialize)]
+        struct F {
+            active: bool,
+        }
+        let cs = Changeset::new(F { active: false });
+        let html = checkbox_input(&cs, "active", "Active").into_string();
+        assert!(html.contains(r#"type="checkbox""#), "{html}");
+        assert!(html.contains(r#"name="active""#), "{html}");
+        assert!(html.contains("Active"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn checkbox_input_unchecked_when_value_false() {
+        #[derive(serde::Serialize)]
+        struct F {
+            active: bool,
+        }
+        let cs = Changeset::new(F { active: false });
+        let html = checkbox_input(&cs, "active", "Active").into_string();
+        assert!(!html.contains("checked"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn checkbox_input_checked_when_value_true() {
+        #[derive(serde::Serialize)]
+        struct F {
+            active: bool,
+        }
+        let cs = Changeset::new(F { active: true });
+        let html = checkbox_input(&cs, "active", "Active").into_string();
+        assert!(html.contains("checked"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn checkbox_input_emits_hidden_false_fallback() {
+        // Unchecked checkboxes are absent from submitted form data; a hidden
+        // "false" sibling with the same name guarantees the field is always
+        // present so `bool` (not just `Option<bool>`) round-trips.
+        #[derive(serde::Serialize)]
+        struct F {
+            active: bool,
+        }
+        let cs = Changeset::new(F { active: false });
+        let html = checkbox_input(&cs, "active", "Active").into_string();
+        assert!(html.contains(r#"type="hidden""#), "{html}");
+        assert!(html.contains(r#"value="false""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn checkbox_input_wrapper_div_has_stable_id() {
+        #[derive(serde::Serialize)]
+        struct F {
+            active: bool,
+        }
+        let cs = Changeset::new(F { active: false });
+        let html = checkbox_input(&cs, "active", "Active").into_string();
+        assert!(html.contains(r#"id="active-field""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn checkbox_input_emits_aria_invalid_and_errors() {
+        #[derive(serde::Serialize)]
+        struct F {
+            active: bool,
+        }
+        let mut errors = HashMap::new();
+        errors.insert("active".to_string(), vec!["must be true".to_string()]);
+        let cs = Changeset::from_errors(F { active: false }, errors);
+        let html = checkbox_input(&cs, "active", "Active").into_string();
+        assert!(html.contains(r#"aria-invalid="true""#), "{html}");
+        assert!(html.contains(r#"role="alert""#), "{html}");
+        assert!(html.contains("must be true"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn number_input_renders_type_number() {
+        #[derive(serde::Serialize)]
+        struct F {
+            age: i32,
+        }
+        let cs = Changeset::new(F { age: 30 });
+        let html = number_input(&cs, "age", "Age", Some("1")).into_string();
+        assert!(html.contains(r#"type="number""#), "{html}");
+        assert!(html.contains(r#"name="age""#), "{html}");
+        assert!(html.contains(r#"value="30""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn number_input_renders_step_when_provided() {
+        #[derive(serde::Serialize)]
+        struct F {
+            price: f64,
+        }
+        let cs = Changeset::new(F { price: 9.99 });
+        let html = number_input(&cs, "price", "Price", Some("0.01")).into_string();
+        assert!(html.contains(r#"step="0.01""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn number_input_omits_step_when_none() {
+        #[derive(serde::Serialize)]
+        struct F {
+            age: i32,
+        }
+        let cs = Changeset::new(F { age: 30 });
+        let html = number_input(&cs, "age", "Age", None).into_string();
+        assert!(!html.contains("step="), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn number_input_emits_aria_invalid_and_errors() {
+        #[derive(serde::Serialize)]
+        struct F {
+            age: i32,
+        }
+        let mut errors = HashMap::new();
+        errors.insert("age".to_string(), vec!["must be positive".to_string()]);
+        let cs = Changeset::from_errors(F { age: -1 }, errors);
+        let html = number_input(&cs, "age", "Age", None).into_string();
+        assert!(html.contains(r#"aria-invalid="true""#), "{html}");
+        assert!(html.contains(r#"role="alert""#), "{html}");
+        assert!(html.contains("must be positive"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn number_input_wrapper_div_has_stable_id() {
+        #[derive(serde::Serialize)]
+        struct F {
+            age: i32,
+        }
+        let cs = Changeset::new(F { age: 30 });
+        let html = number_input(&cs, "age", "Age", None).into_string();
+        assert!(html.contains(r#"id="age-field""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn date_input_renders_type_date() {
+        #[derive(serde::Serialize)]
+        struct F {
+            born_on: String,
+        }
+        let cs = Changeset::new(F {
+            born_on: "2024-03-15".into(),
+        });
+        let html = date_input(&cs, "born_on", "Born on").into_string();
+        assert!(html.contains(r#"type="date""#), "{html}");
+        assert!(html.contains(r#"value="2024-03-15""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn date_input_normalizes_full_timestamp_to_date_only() {
+        #[derive(serde::Serialize)]
+        struct F {
+            born_on: String,
+        }
+        let cs = Changeset::new(F {
+            born_on: "2024-03-15T10:30:00Z".into(),
+        });
+        let html = date_input(&cs, "born_on", "Born on").into_string();
+        assert!(html.contains(r#"value="2024-03-15""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn date_input_emits_aria_invalid_and_errors() {
+        #[derive(serde::Serialize)]
+        struct F {
+            born_on: String,
+        }
+        let mut errors = HashMap::new();
+        errors.insert("born_on".to_string(), vec!["required".to_string()]);
+        let cs = Changeset::from_errors(
+            F {
+                born_on: String::new(),
+            },
+            errors,
+        );
+        let html = date_input(&cs, "born_on", "Born on").into_string();
+        assert!(html.contains(r#"aria-invalid="true""#), "{html}");
+        assert!(html.contains(r#"role="alert""#), "{html}");
+        assert!(html.contains("required"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn datetime_input_renders_type_datetime_local() {
+        #[derive(serde::Serialize)]
+        struct F {
+            starts_at: String,
+        }
+        let cs = Changeset::new(F {
+            starts_at: "2024-03-15T10:30:00".into(),
+        });
+        let html = datetime_input(&cs, "starts_at", "Starts at").into_string();
+        assert!(html.contains(r#"type="datetime-local""#), "{html}");
+        assert!(html.contains(r#"value="2024-03-15T10:30""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn datetime_input_normalizes_rfc3339_with_offset_to_local_shape() {
+        #[derive(serde::Serialize)]
+        struct F {
+            starts_at: String,
+        }
+        let cs = Changeset::new(F {
+            starts_at: "2024-03-15T10:30:00Z".into(),
+        });
+        let html = datetime_input(&cs, "starts_at", "Starts at").into_string();
+        // Browsers reject a trailing `Z`/offset in a `datetime-local` value;
+        // must be reduced to the bare local-shaped `YYYY-MM-DDTHH:MM`.
+        assert!(html.contains(r#"value="2024-03-15T10:30""#), "{html}");
+        assert!(!html.contains(r#"value="2024-03-15T10:30:00Z""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn datetime_input_emits_aria_invalid_and_errors() {
+        #[derive(serde::Serialize)]
+        struct F {
+            starts_at: String,
+        }
+        let mut errors = HashMap::new();
+        errors.insert("starts_at".to_string(), vec!["required".to_string()]);
+        let cs = Changeset::from_errors(
+            F {
+                starts_at: String::new(),
+            },
+            errors,
+        );
+        let html = datetime_input(&cs, "starts_at", "Starts at").into_string();
+        assert!(html.contains(r#"aria-invalid="true""#), "{html}");
+        assert!(html.contains(r#"role="alert""#), "{html}");
+        assert!(html.contains("required"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn datetime_input_wrapper_div_has_stable_id() {
+        #[derive(serde::Serialize)]
+        struct F {
+            starts_at: String,
+        }
+        let cs = Changeset::new(F {
+            starts_at: "2024-03-15T10:30:00".into(),
+        });
+        let html = datetime_input(&cs, "starts_at", "Starts at").into_string();
+        assert!(html.contains(r#"id="starts_at-field""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn select_input_renders_select_element_with_options() {
+        #[derive(serde::Serialize)]
+        struct F {
+            status: String,
+        }
+        let cs = Changeset::new(F {
+            status: "draft".into(),
+        });
+        let options = [("draft", "Draft"), ("published", "Published")];
+        let html = select_input(&cs, "status", "Status", &options).into_string();
+        assert!(html.contains("<select"), "{html}");
+        assert!(html.contains(r#"name="status""#), "{html}");
+        assert!(html.contains(r#"value="draft""#), "{html}");
+        assert!(html.contains("Draft"), "{html}");
+        assert!(html.contains(r#"value="published""#), "{html}");
+        assert!(html.contains("Published"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn select_input_marks_current_value_selected() {
+        #[derive(serde::Serialize)]
+        struct F {
+            status: String,
+        }
+        let cs = Changeset::new(F {
+            status: "published".into(),
+        });
+        let options = [("draft", "Draft"), ("published", "Published")];
+        let html = select_input(&cs, "status", "Status", &options).into_string();
+        assert!(html.contains(r#"value="published" selected"#), "{html}");
+        assert!(!html.contains(r#"value="draft" selected"#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn select_input_emits_aria_invalid_and_errors() {
+        #[derive(serde::Serialize)]
+        struct F {
+            status: String,
+        }
+        let mut errors = HashMap::new();
+        errors.insert("status".to_string(), vec!["required".to_string()]);
+        let cs = Changeset::from_errors(
+            F {
+                status: String::new(),
+            },
+            errors,
+        );
+        let options = [("draft", "Draft"), ("published", "Published")];
+        let html = select_input(&cs, "status", "Status", &options).into_string();
+        assert!(html.contains(r#"aria-invalid="true""#), "{html}");
+        assert!(html.contains(r#"role="alert""#), "{html}");
+        assert!(html.contains("required"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn select_input_wrapper_div_has_stable_id() {
+        #[derive(serde::Serialize)]
+        struct F {
+            status: String,
+        }
+        let cs = Changeset::new(F {
+            status: "draft".into(),
+        });
+        let options = [("draft", "Draft"), ("published", "Published")];
+        let html = select_input(&cs, "status", "Status", &options).into_string();
+        assert!(html.contains(r#"id="status-field""#), "{html}");
     }
 
     // ── ChangesetForm extractor (axum integration) ─────────────────

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1158,8 +1158,9 @@ fn pad_datetime_local_seconds(raw: &str) -> String {
 /// }
 /// ```
 ///
-/// `chrono::NaiveDateTime` fields need no such attribute — chrono's default
-/// `Deserialize` for `NaiveDateTime` doesn't require an offset.
+/// `chrono::NaiveDateTime` fields don't need an offset, but still benefit
+/// from [`deserialize_naive_datetime_local`] as a defensive measure — see
+/// its doc comment.
 ///
 /// # Errors
 ///
@@ -1200,6 +1201,68 @@ where
             "%Y-%m-%dT%H:%M:%S%.f",
         )
         .map(|ndt| Some(ndt.and_utc()))
+        .map_err(serde::de::Error::custom),
+        _ => Ok(None),
+    }
+}
+
+/// Deserialize an HTML `datetime-local` submission into `chrono::NaiveDateTime`.
+///
+/// The *pre-filled* value [`datetime_input`] renders always includes seconds
+/// (see `normalize_datetime_local_value`), so chrono's default `Deserialize`
+/// — which requires the seconds component — decodes an untouched submission
+/// fine on its own. But a value the user actively edits through the
+/// browser's native picker isn't guaranteed to include seconds (`step="any"`
+/// only requests that the control *allow* seconds; it doesn't guarantee
+/// every browser's UI captures them), which would otherwise 400 with
+/// "premature end of input". Attach this function to defend against that:
+///
+/// ```rust,ignore
+/// #[derive(serde::Deserialize)]
+/// struct EventForm {
+///     #[serde(deserialize_with = "autumn_web::form::deserialize_naive_datetime_local")]
+///     starts_at: chrono::NaiveDateTime,
+/// }
+/// ```
+///
+/// # Errors
+///
+/// Returns a deserializer error when the submitted value isn't a valid
+/// `YYYY-MM-DDTHH:MM[:SS[.f]]` local datetime string.
+#[cfg(feature = "maud")]
+pub fn deserialize_naive_datetime_local<'de, D>(
+    deserializer: D,
+) -> Result<chrono::NaiveDateTime, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+    chrono::NaiveDateTime::parse_from_str(&pad_datetime_local_seconds(&raw), "%Y-%m-%dT%H:%M:%S%.f")
+        .map_err(serde::de::Error::custom)
+}
+
+/// `Option<chrono::NaiveDateTime>` counterpart to
+/// [`deserialize_naive_datetime_local`], for a nullable field — an absent or
+/// empty submitted value decodes as `None`.
+///
+/// # Errors
+///
+/// Returns a deserializer error when a non-empty submitted value isn't a
+/// valid `YYYY-MM-DDTHH:MM[:SS[.f]]` local datetime string.
+#[cfg(feature = "maud")]
+pub fn deserialize_naive_datetime_local_option<'de, D>(
+    deserializer: D,
+) -> Result<Option<chrono::NaiveDateTime>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = <Option<String> as serde::Deserialize>::deserialize(deserializer)?;
+    match raw {
+        Some(s) if !s.is_empty() => chrono::NaiveDateTime::parse_from_str(
+            &pad_datetime_local_seconds(&s),
+            "%Y-%m-%dT%H:%M:%S%.f",
+        )
+        .map(Some)
         .map_err(serde::de::Error::custom),
         _ => Ok(None),
     }
@@ -1260,15 +1323,22 @@ pub fn date_input<T: Serialize>(
 /// `<div id="{field}-field">` for stable htmx targeting. ARIA annotations
 /// behave identically to [`text_input`].
 ///
-/// # `DateTime<Utc>` fields need [`deserialize_datetime_local_utc`]
+/// # Attach a `deserialize_with` matching the field's chrono type
 ///
 /// `<input type="datetime-local">` has no timezone concept, so the value
 /// this renders for a `DateTime<Utc>` field never carries an offset —
 /// chrono's default `Deserialize` for `DateTime<Utc>` requires one and
 /// rejects the submission. Attach [`deserialize_datetime_local_utc`] (or
 /// [`deserialize_datetime_local_utc_option`] for `Option<DateTime<Utc>>`)
-/// via `#[serde(deserialize_with = "...")]` on that field. `NaiveDateTime`
-/// fields need no such attribute.
+/// via `#[serde(deserialize_with = "...")]` on that field.
+///
+/// `NaiveDateTime` fields don't hit that offset problem, but a value the
+/// user actively edits through the browser's native picker isn't guaranteed
+/// to include seconds (unlike the always-seconds-inclusive pre-filled
+/// value), which chrono's default `Deserialize` also rejects. Attach
+/// [`deserialize_naive_datetime_local`] (or
+/// [`deserialize_naive_datetime_local_option`] for `Option<NaiveDateTime>`)
+/// as a defensive measure.
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn datetime_input<T: Serialize>(
@@ -2753,6 +2823,77 @@ mod tests {
                     .unwrap(),
                 chrono::Utc,
             ))
+        );
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn deserialize_naive_datetime_local_pads_missing_seconds() {
+        // Regression test: a value the user actively edits through the
+        // native picker isn't guaranteed to include seconds, unlike the
+        // always-seconds-inclusive pre-filled value — this must not 400.
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            #[serde(deserialize_with = "deserialize_naive_datetime_local")]
+            starts_at: chrono::NaiveDateTime,
+        }
+        let decoded: Decoded = serde_urlencoded::from_str("starts_at=2024-03-15T10:30").unwrap();
+        assert_eq!(
+            decoded.starts_at,
+            chrono::NaiveDate::from_ymd_opt(2024, 3, 15)
+                .unwrap()
+                .and_hms_opt(10, 30, 0)
+                .unwrap()
+        );
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn deserialize_naive_datetime_local_preserves_seconds_when_present() {
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            #[serde(deserialize_with = "deserialize_naive_datetime_local")]
+            starts_at: chrono::NaiveDateTime,
+        }
+        let decoded: Decoded = serde_urlencoded::from_str("starts_at=2024-03-15T10:30:56").unwrap();
+        assert_eq!(
+            decoded.starts_at,
+            chrono::NaiveDate::from_ymd_opt(2024, 3, 15)
+                .unwrap()
+                .and_hms_opt(10, 30, 56)
+                .unwrap()
+        );
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn deserialize_naive_datetime_local_option_absent_key_is_none() {
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            #[serde(default, deserialize_with = "deserialize_naive_datetime_local_option")]
+            starts_at: Option<chrono::NaiveDateTime>,
+        }
+        let decoded: Decoded = serde_urlencoded::from_str("").unwrap();
+        assert_eq!(decoded.starts_at, None);
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn deserialize_naive_datetime_local_option_present_key_is_some() {
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            #[serde(default, deserialize_with = "deserialize_naive_datetime_local_option")]
+            starts_at: Option<chrono::NaiveDateTime>,
+        }
+        let decoded: Decoded = serde_urlencoded::from_str("starts_at=2024-03-15T10:30").unwrap();
+        assert_eq!(
+            decoded.starts_at,
+            Some(
+                chrono::NaiveDate::from_ymd_opt(2024, 3, 15)
+                    .unwrap()
+                    .and_hms_opt(10, 30, 0)
+                    .unwrap()
+            )
         );
     }
 

--- a/docs/guide/accessibility.md
+++ b/docs/guide/accessibility.md
@@ -146,7 +146,21 @@ struct EventForm {
 }
 ```
 
-`chrono::NaiveDateTime` fields need no such attribute.
+`chrono::NaiveDateTime` fields don't hit that offset problem, but a value
+the user actively edits through the browser's native picker isn't
+guaranteed to include seconds (unlike the always-seconds-inclusive
+pre-filled value), which chrono's default `Deserialize` also rejects.
+Attach `deserialize_naive_datetime_local` (or
+`deserialize_naive_datetime_local_option` for `Option<NaiveDateTime>`) as a
+defensive measure:
+
+```rust
+#[derive(serde::Deserialize)]
+struct EventForm {
+    #[serde(deserialize_with = "autumn_web::form::deserialize_naive_datetime_local")]
+    starts_at: chrono::NaiveDateTime,
+}
+```
 
 ### `select_input`
 

--- a/docs/guide/accessibility.md
+++ b/docs/guide/accessibility.md
@@ -120,9 +120,10 @@ html! {
 ### `date_input` / `datetime_input`
 
 Render `<input type="date">` and `<input type="datetime-local">`
-respectively. The current value is normalized to the exact shape each
-control requires (`YYYY-MM-DD` / `YYYY-MM-DDTHH:MM`), regardless of whether
-the underlying field serializes as a bare date or a full RFC 3339 timestamp.
+respectively. The current value is normalized to the shape each control
+requires (`YYYY-MM-DD` / `YYYY-MM-DDTHH:MM[:SS[.f]]`, preserving
+seconds/fractional seconds when present), regardless of whether the
+underlying field serializes as a bare date or a full RFC 3339 timestamp.
 
 ```rust
 html! {
@@ -130,6 +131,22 @@ html! {
     (datetime_input(&changeset, "starts_at", "Starts at"))
 }
 ```
+
+`<input type="datetime-local">` has no timezone concept, so a
+`chrono::DateTime<Utc>` field's rendered value never carries an offset —
+chrono's default `Deserialize` for `DateTime<Utc>` requires one and rejects
+the submission. Attach `deserialize_datetime_local_utc` (or
+`deserialize_datetime_local_utc_option` for `Option<DateTime<Utc>>`):
+
+```rust
+#[derive(serde::Deserialize)]
+struct EventForm {
+    #[serde(deserialize_with = "autumn_web::form::deserialize_datetime_local_utc")]
+    starts_at: chrono::DateTime<chrono::Utc>,
+}
+```
+
+`chrono::NaiveDateTime` fields need no such attribute.
 
 ### `select_input`
 

--- a/docs/guide/accessibility.md
+++ b/docs/guide/accessibility.md
@@ -91,10 +91,11 @@ html! {
 
 ### `checkbox_input`
 
-Renders a labelled `<input type="checkbox">` for a `bool` field. A hidden
-`<input type="hidden" value="false">` with the same `name` precedes it, so
-the field always round-trips even when the checkbox is left unchecked
-(unchecked checkboxes are omitted from submitted form data by the browser).
+Renders a labelled `<input type="checkbox">` for a `bool` field. Unchecked
+checkboxes are omitted from submitted form data by the browser, so the
+target field must be marked with `#[serde(default)]` to decode as `false`
+when absent (rather than pairing it with a hidden input sibling, which
+would cause duplicate-key errors on checked submissions).
 
 ```rust
 html! {

--- a/docs/guide/accessibility.md
+++ b/docs/guide/accessibility.md
@@ -27,8 +27,9 @@ Import the helpers you need:
 
 ```rust
 use autumn_web::form::{
-    text_input, password_input, textarea_input,
-    required_text_input, aria_live_region, skip_link,
+    text_input, password_input, textarea_input, required_text_input,
+    checkbox_input, number_input, date_input, datetime_input, select_input,
+    aria_live_region, skip_link,
 };
 ```
 
@@ -85,6 +86,60 @@ Renders a labelled `<textarea>` with the same error-linking pattern.
 ```rust
 html! {
     (textarea_input(&changeset, "body", "Post body"))
+}
+```
+
+### `checkbox_input`
+
+Renders a labelled `<input type="checkbox">` for a `bool` field. A hidden
+`<input type="hidden" value="false">` with the same `name` precedes it, so
+the field always round-trips even when the checkbox is left unchecked
+(unchecked checkboxes are omitted from submitted form data by the browser).
+
+```rust
+html! {
+    (checkbox_input(&changeset, "published", "Published"))
+}
+```
+
+### `number_input`
+
+Renders a labelled `<input type="number">` for `i32`/`i64`/`f32`/`f64`
+fields. Pass `step` to control the HTML `step` attribute — `Some("1")` for
+integers, `Some("0.01")` or `Some("any")` for floats, `None` for the browser
+default.
+
+```rust
+html! {
+    (number_input(&changeset, "quantity", "Quantity", Some("1")))
+    (number_input(&changeset, "price", "Price", Some("0.01")))
+}
+```
+
+### `date_input` / `datetime_input`
+
+Render `<input type="date">` and `<input type="datetime-local">`
+respectively. The current value is normalized to the exact shape each
+control requires (`YYYY-MM-DD` / `YYYY-MM-DDTHH:MM`), regardless of whether
+the underlying field serializes as a bare date or a full RFC 3339 timestamp.
+
+```rust
+html! {
+    (date_input(&changeset, "birthday", "Birthday"))
+    (datetime_input(&changeset, "starts_at", "Starts at"))
+}
+```
+
+### `select_input`
+
+Renders a labelled `<select>` from `(value, label)` option pairs, marking the
+option matching the changeset's current value as `selected`. This is the
+control closed-set fields (enums, references) target.
+
+```rust
+let statuses = [("draft", "Draft"), ("published", "Published")];
+html! {
+    (select_input(&changeset, "status", "Status", &statuses))
 }
 ```
 


### PR DESCRIPTION
## Summary

Implements typed HTML form input widgets for `bool`, numeric (`i32`/`i64`/`f32`/`f64`), `NaiveDateTime`, and `DateTime` fields, replacing generic text inputs with semantically correct controls. This improves both UX (native date/number pickers) and accessibility (proper input types and ARIA annotations).

## Key Changes

**autumn_web form helpers** (`autumn/src/form.rs`):
- Added `checkbox_input()` for `bool` fields with proper `#[serde(default)]` handling (no hidden fallback to avoid duplicate-key 400 errors)
- Added `number_input()` for numeric fields with configurable `step` attribute
- Added `date_input()` and `datetime_input()` for date/datetime fields with value normalization
- Added `select_input()` for closed-set fields (foundation for future enum/reference support)
- Added helper functions `normalize_date_value()` and `normalize_datetime_local_value()` to convert various timestamp formats to HTML5 input shapes
- Comprehensive test coverage for all new widgets including round-trip form submission tests

**Scaffold generation** (`autumn-cli/src/generate/scaffold.rs`):
- Modified `render_decoded_form()` to return a third tuple element containing generated helper functions
- Added `DatetimeHelpersNeeded` struct to track which datetime deserializers are actually used
- Added `datetime_struct_field_line()` to emit `#[serde(deserialize_with = "...")]` attributes for datetime fields
- Added `datetime_helper_fns()` to emit only the datetime deserializers referenced by the form
- Added five const helper function strings for datetime deserialization:
  - `NORMALIZE_DATETIME_LOCAL_FN`: pads browser's minute-granularity `YYYY-MM-DDTHH:MM` to `YYYY-MM-DDTHH:MM:SS`
  - `DESERIALIZE_NAIVE_DATETIME_LOCAL_FN` / `DESERIALIZE_OPTION_NAIVE_DATETIME_LOCAL_FN`
  - `DESERIALIZE_UTC_DATETIME_LOCAL_FN` / `DESERIALIZE_OPTION_UTC_DATETIME_LOCAL_FN`
- Updated `render_create_form_inputs()` to emit correct input types:
  - `<input type="checkbox">` for non-nullable `bool` (with `#[serde(default)]` on struct field)
  - `<select>` with three options for nullable `Option<bool>` (checkbox can't represent `None`)
  - `<input type="number" step="1">` for integers, `step="any"` for floats
  - `<input type="datetime-local">` for datetime fields
- Updated `render_edit_form_inputs()` with same input types plus:
  - `checked[...]` attribute for checkbox state reflection
  - `selected[...]` attributes for nullable bool select options
  - `edit_checked_expr()` and `edit_bool_select_selected_exprs()` helpers for edit form state
  - `edit_datetime_local_value_expr()` to format datetime values as `YYYY-MM-DDTHH:MM`
- Added `number_step()` const function to determine step values by field kind
- Enhanced `edit_value_expr()` to handle non-finite floats (NaN/Infinity) by rendering empty string instead of invalid HTML5 values
- Added extensive documentation comment explaining the hand-rolled HTML approach and invariants to maintain with `autumn_web::form` helpers

**Documentation** (`docs/guide/accessibility.md`):
- Updated import examples to include new form helpers
- Added sections documenting `checkbox_input`, `number_input`, `date_input`, `datetime_input`, and `select_input` with usage examples

**Tests** (`autumn-cli/tests/generate.rs`):
- Added comprehensive test suite covering:
  - Checkbox rendering for non-nullable `bool` fields
  - Select rendering for nullable `Option<bool>` fields
  - Number input rendering with correct `step` attributes
  - Datetime input rendering with proper deserialization helpers

https://claude.ai/code/session_01TYahdfZ24WvmLcxcEZAMAK