### PR TITLE
Add nav_link widget for accessible navigation with active state

### DIFF
--- a/autumn-admin-plugin/src/registry.rs
+++ b/autumn-admin-plugin/src/registry.rs
@@ -8,11 +8,22 @@ use std::collections::btree_map::{BTreeMap, Entry};
 
 use crate::traits::AdminModel;
 
+/// Sentinel `active_slug` value that marks the built-in Jobs page active in
+/// the sidebar nav (see `templates::admin_layout`). Reserved below so a
+/// model can never register this exact slug and hijack the Jobs nav item's
+/// active state.
+pub const JOBS_NAV_SLUG: &str = "__admin_jobs";
+
+/// Sentinel `active_slug` value that marks the built-in Runtime Config page
+/// active in the sidebar nav (see `templates::admin_layout`). Reserved below
+/// for the same reason as [`JOBS_NAV_SLUG`].
+pub const RUNTIME_CONFIG_NAV_SLUG: &str = "__admin_config";
+
 // "config" is NOT reserved here: the /config route is only mounted when
 // with_runtime_config is enabled.  The collision check for that case is
 // deferred to AdminPlugin::build() so deployments without runtime-config
 // can freely use a model with slug "config".
-const RESERVED_MODEL_SLUGS: &[&str] = &["jobs"];
+const RESERVED_MODEL_SLUGS: &[&str] = &["jobs", JOBS_NAV_SLUG, RUNTIME_CONFIG_NAV_SLUG];
 
 /// Holds all registered admin models, keyed by their URL slug.
 ///
@@ -204,6 +215,30 @@ mod tests {
         registry.register(DummyModel {
             slug: "jobs",
             name: "Jobs",
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "reserved model slug '__admin_jobs'")]
+    fn reserved_jobs_nav_sentinel_slug_panics() {
+        // admin_layout's sidebar nav derives the active-link path from this
+        // exact sentinel string (JOBS_NAV_SLUG); a model slug matching it
+        // would make the Jobs nav item claim active state instead of the
+        // model's own link.
+        let mut registry = AdminRegistry::new();
+        registry.register(DummyModel {
+            slug: JOBS_NAV_SLUG,
+            name: "Fake Jobs",
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "reserved model slug '__admin_config'")]
+    fn reserved_runtime_config_nav_sentinel_slug_panics() {
+        let mut registry = AdminRegistry::new();
+        registry.register(DummyModel {
+            slug: RUNTIME_CONFIG_NAV_SLUG,
+            name: "Fake Config",
         });
     }
 

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -11,7 +11,7 @@ use autumn_web::job::{
 use autumn_web::pagination::Page;
 use autumn_web::runtime_config::{ConfigChangeRecord, ConfigEntry};
 use autumn_web::ui::pagination::{PagerOptions, pagination_nav};
-use autumn_web::widgets::{CardConfig, card, stat_card};
+use autumn_web::widgets::{CardConfig, card, nav_link, stat_card};
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 use serde_json::Value;
 
@@ -414,6 +414,15 @@ pub fn admin_layout(
     show_config: bool,
     content: &Markup,
 ) -> Markup {
+    // Synthesize the current path from active_slug so nav_link's own
+    // path-comparison logic (rather than a second hand-rolled comparison)
+    // decides which sidebar item is active.
+    let current_path = match active_slug {
+        None => prefix.to_owned(),
+        Some(JOBS_NAV_SLUG) => format!("{prefix}/jobs"),
+        Some(RUNTIME_CONFIG_NAV_SLUG) => format!("{prefix}/config"),
+        Some(slug) => format!("{prefix}/{slug}"),
+    };
     html! {
         (DOCTYPE)
         html lang="en" {
@@ -446,35 +455,30 @@ pub fn admin_layout(
                         nav class="admin-sidebar" aria-label="Admin navigation" {
                             div class="admin-logo" { "🍂 Autumn Admin" }
                             ul class="admin-nav" {
-                                li {
-                                    a href=(prefix) class=[active_slug.is_none().then_some("active")] {
-                                        "Dashboard"
-                                    }
-                                }
+                                li { (nav_link(&current_path, prefix, "Dashboard")) }
                                 @if registry.model_count() > 0 {
                                     li { div class="admin-nav-section" { "Models" } }
                                     @for (slug, model) in registry.iter() {
                                         li {
-                                            a href={ (prefix) "/" (slug) }
-                                              class=[(active_slug == Some(slug)).then_some("active")] {
-                                                (model.display_name_plural())
-                                            }
+                                            (nav_link(
+                                                &current_path,
+                                                &format!("{prefix}/{slug}"),
+                                                model.display_name_plural(),
+                                            ))
                                         }
                                     }
                                 }
                                 li { div class="admin-nav-section" { "System" } }
                                 li {
-                                    a href={ (prefix) "/jobs" }
-                                      class=[(active_slug == Some(JOBS_NAV_SLUG)).then_some("active")] {
-                                        "Jobs"
-                                    }
+                                    (nav_link(&current_path, &format!("{prefix}/jobs"), "Jobs"))
                                 }
                                 @if show_config {
                                     li {
-                                        a href={ (prefix) "/config" }
-                                          class=[(active_slug == Some(RUNTIME_CONFIG_NAV_SLUG)).then_some("active")] {
-                                            "Runtime Config"
-                                        }
+                                        (nav_link(
+                                            &current_path,
+                                            &format!("{prefix}/config"),
+                                            "Runtime Config",
+                                        ))
                                     }
                                 }
                                 li { a href={ (actuator_prefix) "/ui" } { "Actuator" } }

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -3905,4 +3905,65 @@ mod tests {
         let s = format_timestamp(1_700_000_000);
         assert!(s.contains("2023"), "expected 2023 in formatted output: {s}");
     }
+
+    // ── admin_layout nav (#1134) ─────────────────────────────────────────
+
+    fn render_layout(active_slug: Option<&str>) -> String {
+        let registry = AdminRegistry::new();
+        admin_layout(
+            &registry,
+            active_slug,
+            "Title",
+            "/admin",
+            "/actuator",
+            "tok",
+            "X-CSRF-Token",
+            &[],
+            true,
+            &html! {},
+        )
+        .into_string()
+    }
+
+    #[test]
+    fn admin_layout_dashboard_active_has_aria_current() {
+        let html = render_layout(None);
+        assert_eq!(html.matches(r#"aria-current="page""#).count(), 1, "{html}");
+        assert!(
+            html.contains(r#"href="/admin" class="active" aria-current="page""#),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn admin_layout_jobs_active_has_aria_current() {
+        let html = render_layout(Some(JOBS_NAV_SLUG));
+        assert_eq!(html.matches(r#"aria-current="page""#).count(), 1, "{html}");
+        assert!(
+            html.contains(r#"href="/admin/jobs" class="active" aria-current="page""#),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn admin_layout_runtime_config_active_has_aria_current() {
+        let html = render_layout(Some(RUNTIME_CONFIG_NAV_SLUG));
+        assert_eq!(html.matches(r#"aria-current="page""#).count(), 1, "{html}");
+        assert!(
+            html.contains(r#"href="/admin/config" class="active" aria-current="page""#),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn admin_layout_no_active_slug_has_no_dashboard_aria_current() {
+        // active_slug = Some(...) for an unrelated slug: Dashboard must not
+        // claim the active state, and nothing else should either since the
+        // registry is empty (no model nav items).
+        let html = render_layout(Some(JOBS_NAV_SLUG));
+        assert!(
+            !html.contains(r#"href="/admin" class="active""#),
+            "dashboard must not be active: {html}"
+        );
+    }
 }

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -15,7 +15,7 @@ use autumn_web::widgets::{CardConfig, card, nav_link, stat_card};
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 use serde_json::Value;
 
-use crate::registry::AdminRegistry;
+use crate::registry::{AdminRegistry, JOBS_NAV_SLUG, RUNTIME_CONFIG_NAV_SLUG};
 use crate::routes::ADMIN_JS_PATH;
 use crate::traits::{
     AdminAction, AdminField, AdminFieldKind, AdminHistoryPage, AdminImportReport, CsvImportMode,
@@ -25,8 +25,6 @@ use crate::traits::{
 const HTMX_JS_PATH: &str = "/static/js/htmx.min.js";
 const HTMX_CSRF_JS_PATH: &str = "/static/js/autumn-htmx-csrf.js";
 const TOKENS_CSS: &str = include_str!("tokens.css");
-const JOBS_NAV_SLUG: &str = "__admin_jobs";
-const RUNTIME_CONFIG_NAV_SLUG: &str = "__admin_config";
 const FLASH_CSS: &str = "\
 .flash {
     padding: 0.75rem 1rem;
@@ -414,13 +412,17 @@ pub fn admin_layout(
     show_config: bool,
     content: &Markup,
 ) -> Markup {
-    // Synthesize the current path from active_slug so nav_link's own
-    // path-comparison logic (rather than a second hand-rolled comparison)
-    // decides which sidebar item is active.
+    // Each nav item's href is computed once here and reused both to
+    // synthesize current_path (so nav_link's own path-comparison logic
+    // decides which sidebar item is active) and as the anchor's href below —
+    // so the "/jobs" and "/config" route suffixes each appear as a literal
+    // exactly once.
+    let jobs_href = format!("{prefix}/jobs");
+    let config_href = format!("{prefix}/config");
     let current_path = match active_slug {
         None => prefix.to_owned(),
-        Some(JOBS_NAV_SLUG) => format!("{prefix}/jobs"),
-        Some(RUNTIME_CONFIG_NAV_SLUG) => format!("{prefix}/config"),
+        Some(JOBS_NAV_SLUG) => jobs_href.clone(),
+        Some(RUNTIME_CONFIG_NAV_SLUG) => config_href.clone(),
         Some(slug) => format!("{prefix}/{slug}"),
     };
     html! {
@@ -470,13 +472,13 @@ pub fn admin_layout(
                                 }
                                 li { div class="admin-nav-section" { "System" } }
                                 li {
-                                    (nav_link(&current_path, &format!("{prefix}/jobs"), "Jobs"))
+                                    (nav_link(&current_path, &jobs_href, "Jobs"))
                                 }
                                 @if show_config {
                                     li {
                                         (nav_link(
                                             &current_path,
-                                            &format!("{prefix}/config"),
+                                            &config_href,
                                             "Runtime Config",
                                         ))
                                     }

--- a/autumn/src/extract.rs
+++ b/autumn/src/extract.rs
@@ -775,9 +775,18 @@ where
 
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
-        _state: &S,
+        state: &S,
     ) -> Result<Self, Self::Rejection> {
-        Ok(Self(parts.uri.path().to_owned()))
+        // Use OriginalUri rather than parts.uri directly: axum's Router::nest
+        // strips the mount prefix from parts.uri inside the nested service,
+        // but nav_link needs the full browser-visible path to compare against
+        // normal absolute hrefs. OriginalUri falls back to parts.uri itself
+        // when the request wasn't dispatched through a nested router.
+        let axum::extract::OriginalUri(uri) =
+            axum::extract::OriginalUri::from_request_parts(parts, state)
+                .await
+                .unwrap();
+        Ok(Self(uri.path().to_owned()))
     }
 }
 
@@ -1110,6 +1119,29 @@ mod trusted_proxy_extractor_tests {
         let app = Router::new().route("/admin/posts", get(handler));
         let req = axum::http::Request::builder()
             .uri("/admin/posts?page=2")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), 64).await.unwrap();
+        assert_eq!(&body[..], b"/admin/posts");
+    }
+
+    #[tokio::test]
+    async fn current_path_preserves_prefix_under_nested_router() {
+        // axum's Router::nest strips the mount prefix from `parts.uri` inside
+        // the nested service, so a request to "/admin/posts" is seen as
+        // "/posts" there. nav_link's documented use compares CurrentPath
+        // against normal absolute hrefs like "/admin/posts", so CurrentPath
+        // must return the browser-visible path (via OriginalUri), not the
+        // nest-relative one.
+        async fn handler(CurrentPath(path): CurrentPath) -> String {
+            path
+        }
+
+        let inner = Router::new().route("/posts", get(handler));
+        let app = Router::new().nest("/admin", inner);
+        let req = axum::http::Request::builder()
+            .uri("/admin/posts")
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();

--- a/autumn/src/extract.rs
+++ b/autumn/src/extract.rs
@@ -742,9 +742,9 @@ mod tests {
 /// query string.
 ///
 /// Infallible — always succeeds, even on requests with no matched route.
-/// Intended for path-aware view helpers such as
-/// [`nav_link`](crate::widgets::nav_link), which need to know the current
-/// path to decide whether a navigation link is active.
+/// Intended for path-aware view helpers such as `nav_link`
+/// (`autumn_web::widgets::nav_link`, behind the `maud` feature), which need
+/// to know the current path to decide whether a navigation link is active.
 ///
 /// # Example
 ///

--- a/autumn/src/extract.rs
+++ b/autumn/src/extract.rs
@@ -736,6 +736,51 @@ mod tests {
     }
 }
 
+// ── Current request path ─────────────────────────────────────────────────────
+
+/// The current request's URI path (e.g. `"/admin/posts/3/edit"`), without the
+/// query string.
+///
+/// Infallible — always succeeds, even on requests with no matched route.
+/// Intended for path-aware view helpers such as
+/// [`nav_link`](crate::widgets::nav_link), which need to know the current
+/// path to decide whether a navigation link is active.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use autumn_web::prelude::*;
+///
+/// #[get("/posts")]
+/// async fn index(CurrentPath(path): CurrentPath) -> Markup {
+///     nav_link(&path, "/posts", "Posts")
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CurrentPath(pub String);
+
+impl CurrentPath {
+    /// The current request path as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<S> FromRequestParts<S> for CurrentPath
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(Self(parts.uri.path().to_owned()))
+    }
+}
+
 // ── Trusted-proxy client-identity extractors ─────────────────────────────────
 
 use crate::security::trusted_proxies::ResolvedClientIdentity;
@@ -1038,5 +1083,37 @@ mod trusted_proxy_extractor_tests {
         let resp = app.oneshot(req).await.unwrap();
         let body = axum::body::to_bytes(resp.into_body(), 64).await.unwrap();
         assert_eq!(&body[..], b"none");
+    }
+
+    #[tokio::test]
+    async fn current_path_extracts_uri_path() {
+        async fn handler(CurrentPath(path): CurrentPath) -> String {
+            path
+        }
+
+        let app = Router::new().route("/admin/posts", get(handler));
+        let req = axum::http::Request::builder()
+            .uri("/admin/posts")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), 64).await.unwrap();
+        assert_eq!(&body[..], b"/admin/posts");
+    }
+
+    #[tokio::test]
+    async fn current_path_strips_query_string() {
+        async fn handler(CurrentPath(path): CurrentPath) -> String {
+            path
+        }
+
+        let app = Router::new().route("/admin/posts", get(handler));
+        let req = axum::http::Request::builder()
+            .uri("/admin/posts?page=2")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), 64).await.unwrap();
+        assert_eq!(&body[..], b"/admin/posts");
     }
 }

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -57,12 +57,12 @@ pub use crate::canary::CanaryRoute;
 /// Database connection extractor.
 #[cfg(feature = "db")]
 pub use crate::db::Db;
-/// Current request path extractor, for path-aware view helpers like `nav_link`.
-pub use crate::extract::CurrentPath;
 /// Typed domain event bus publisher extractor. The `Event` trait it works with
 /// lives at [`crate::events::Event`] (kept out of the prelude to avoid clashing
 /// with [`crate::sse::Event`]).
 pub use crate::events::Events;
+/// Current request path extractor, for path-aware view helpers like `nav_link`.
+pub use crate::extract::CurrentPath;
 /// Form data extractor.
 pub use crate::extract::Form;
 /// JSON request/response type.

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -57,6 +57,8 @@ pub use crate::canary::CanaryRoute;
 /// Database connection extractor.
 #[cfg(feature = "db")]
 pub use crate::db::Db;
+/// Current request path extractor, for path-aware view helpers like `nav_link`.
+pub use crate::extract::CurrentPath;
 /// Typed domain event bus publisher extractor. The `Event` trait it works with
 /// lives at [`crate::events::Event`] (kept out of the prelude to avoid clashing
 /// with [`crate::sse::Event`]).
@@ -176,10 +178,10 @@ pub use crate::form::{Changeset, ChangesetForm, IntoChangeset};
 #[cfg(feature = "maud")]
 pub use crate::widgets::{
     ActiveSearchConfig, AutocompleteConfig, CardConfig, Column, Crumb, Cta, CtaStyle,
-    DataTableConfig, HeadingLevel, HeroConfig, SearchMethod, SortDir, active_search,
+    DataTableConfig, HeadingLevel, HeroConfig, NavLinkMatch, SearchMethod, SortDir, active_search,
     active_search_empty_state, active_search_input, active_search_results,
     autocomplete_empty_state, autocomplete_input, autocomplete_option, breadcrumb, card,
-    data_table, hero, property_list, stat_card,
+    data_table, hero, nav_link, nav_link_matched, property_list, stat_card,
 };
 
 // ── Hooks ───────────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -14,6 +14,7 @@
 //! | `data_table` | Column-driven, sortable `<table>` |
 //! | `breadcrumb` | Accessible `<nav>` breadcrumb trail |
 //! | `hero` | Landing-page banner: headline, optional subtitle, and CTAs |
+//! | `nav_link` | Navigation anchor, auto-marked active + `aria-current` |
 //!
 //! # Interactive / search widgets
 //!
@@ -1105,6 +1106,47 @@ pub fn breadcrumb(crumbs: &[Crumb<'_>]) -> maud::Markup {
                 }
             }
         }
+    }
+}
+
+// ── nav_link ────────────────────────────────────────────────────────────────
+
+/// Match mode for [`nav_link_matched`] — how the current request path is
+/// compared against a link's `href` to decide the active state.
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NavLinkMatch {
+    /// Active only when the current path equals `href` exactly (default).
+    #[default]
+    Exact,
+    /// Active when the current path equals `href`, or starts with `href`
+    /// followed by a `/` segment boundary — so `/admin/posts/3/edit`
+    /// activates an `/admin/posts` link, but `/admin/postsX` does not.
+    Prefix,
+}
+
+/// Render a navigation anchor, marked active when `href` equals `current_path`.
+///
+/// Uses [`NavLinkMatch::Exact`]; see [`nav_link_matched`] for prefix matching.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn nav_link(current_path: &str, href: &str, label: &str) -> maud::Markup {
+    nav_link_matched(current_path, href, label, NavLinkMatch::Exact)
+}
+
+/// Render a navigation anchor with an explicit [`NavLinkMatch`] mode.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn nav_link_matched(
+    current_path: &str,
+    href: &str,
+    label: &str,
+    mode: NavLinkMatch,
+) -> maud::Markup {
+    // Red-phase stub: renders the anchor without any active-state handling.
+    let _ = (current_path, mode);
+    maud::html! {
+        a href=(href) { (label) }
     }
 }
 
@@ -2328,6 +2370,75 @@ mod tests {
         );
         // Only the last item carries aria-current
         assert_eq!(html.matches(r#"aria-current="page""#).count(), 1, "{html}");
+    }
+
+    // ── nav_link ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn nav_link_exact_match_is_active() {
+        let html = nav_link("/admin/posts", "/admin/posts", "Posts").into_string();
+        assert!(html.contains(r#"class="active""#), "{html}");
+        assert!(html.contains(r#"aria-current="page""#), "{html}");
+    }
+
+    #[test]
+    fn nav_link_no_match_is_inactive() {
+        let html = nav_link("/admin/jobs", "/admin/posts", "Posts").into_string();
+        assert!(!html.contains("active"), "{html}");
+        assert!(!html.contains("aria-current"), "{html}");
+    }
+
+    #[test]
+    fn nav_link_exact_mode_rejects_sub_paths() {
+        let html = nav_link("/admin/posts/3", "/admin/posts", "Posts").into_string();
+        assert!(!html.contains("active"), "{html}");
+        assert!(!html.contains("aria-current"), "{html}");
+    }
+
+    #[test]
+    fn nav_link_prefix_match_is_active() {
+        let html = nav_link_matched(
+            "/admin/posts/3/edit",
+            "/admin/posts",
+            "Posts",
+            NavLinkMatch::Prefix,
+        )
+        .into_string();
+        assert!(html.contains(r#"class="active""#), "{html}");
+        assert!(html.contains(r#"aria-current="page""#), "{html}");
+    }
+
+    #[test]
+    fn nav_link_prefix_mode_rejects_false_positive() {
+        // "/admin/postsX" must NOT match "/admin/posts" as a prefix.
+        let html = nav_link_matched(
+            "/admin/postsX",
+            "/admin/posts",
+            "Posts",
+            NavLinkMatch::Prefix,
+        )
+        .into_string();
+        assert!(!html.contains("active"), "{html}");
+        assert!(!html.contains("aria-current"), "{html}");
+    }
+
+    #[test]
+    fn nav_link_prefix_mode_exact_path_is_active() {
+        let html = nav_link_matched(
+            "/admin/posts",
+            "/admin/posts",
+            "Posts",
+            NavLinkMatch::Prefix,
+        )
+        .into_string();
+        assert!(html.contains(r#"class="active""#), "{html}");
+    }
+
+    #[test]
+    fn nav_link_renders_label_and_href() {
+        let html = nav_link("/somewhere/else", "/admin/posts", "Posts").into_string();
+        assert!(html.contains(r#"href="/admin/posts""#), "{html}");
+        assert!(html.contains(">Posts<"), "{html}");
     }
 
     // ── property_list ──────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1121,7 +1121,11 @@ pub enum NavLinkMatch {
     Exact,
     /// Active when the current path equals `href`, or starts with `href`
     /// followed by a `/` segment boundary — so `/admin/posts/3/edit`
-    /// activates an `/admin/posts` link, but `/admin/postsX` does not.
+    /// activates an `/admin/posts` link, but `/admin/postsX` does not. A
+    /// trailing slash on `href` is normalized away first, so `/admin/posts/`
+    /// behaves identically to `/admin/posts`. An empty `href` — or `href`
+    /// that normalizes to one — never matches, since that would otherwise
+    /// activate on every absolute path.
     Prefix,
 }
 
@@ -1190,10 +1194,19 @@ fn nav_link_is_active(current_path: &str, href: &str, mode: NavLinkMatch) -> boo
     match mode {
         NavLinkMatch::Exact => current_path == href,
         NavLinkMatch::Prefix => {
-            current_path == href
-                || current_path
-                    .strip_prefix(href)
-                    .is_some_and(|rest| rest.starts_with('/'))
+            if current_path == href {
+                return true;
+            }
+            // Normalize a trailing slash so "/posts/" behaves the same as
+            // "/posts", but preserve a bare "/" rather than trimming it to an
+            // empty prefix — same convention as tenancy::is_public_path, since
+            // an empty prefix would otherwise match every absolute path.
+            let href = if href.len() > 1 {
+                href.trim_end_matches('/')
+            } else {
+                href
+            };
+            !href.is_empty() && crate::router::path_matches_route_prefix(current_path, href)
         }
     }
 }
@@ -2479,6 +2492,40 @@ mod tests {
             NavLinkMatch::Prefix,
         )
         .into_string();
+        assert!(html.contains(r#"class="active""#), "{html}");
+    }
+
+    #[test]
+    fn nav_link_prefix_mode_trailing_slash_href_still_matches() {
+        // href with a trailing slash must behave the same as without one.
+        let html = nav_link_matched(
+            "/admin/posts/3/edit",
+            "/admin/posts/",
+            "Posts",
+            NavLinkMatch::Prefix,
+        )
+        .into_string();
+        assert!(html.contains(r#"class="active""#), "{html}");
+    }
+
+    #[test]
+    fn nav_link_prefix_mode_empty_href_never_matches() {
+        // An empty href must never act as a wildcard that matches every path.
+        let html = nav_link_matched("/admin/posts/3/edit", "", "Posts", NavLinkMatch::Prefix)
+            .into_string();
+        assert!(!html.contains("active"), "{html}");
+        assert!(!html.contains("aria-current"), "{html}");
+    }
+
+    #[test]
+    fn nav_link_prefix_mode_root_href_does_not_match_every_path() {
+        // href="/" must not wildcard-match every path either; only an exact "/"
+        // current_path is active.
+        let html =
+            nav_link_matched("/admin/posts", "/", "Home", NavLinkMatch::Prefix).into_string();
+        assert!(!html.contains("active"), "{html}");
+
+        let html = nav_link_matched("/", "/", "Home", NavLinkMatch::Prefix).into_string();
         assert!(html.contains(r#"class="active""#), "{html}");
     }
 

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1135,6 +1135,24 @@ pub fn nav_link(current_path: &str, href: &str, label: &str) -> maud::Markup {
 }
 
 /// Render a navigation anchor with an explicit [`NavLinkMatch`] mode.
+///
+/// When active, the anchor carries `class="active"` and
+/// `aria-current="page"`; when inactive, neither attribute is emitted.
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::widgets::{NavLinkMatch, nav_link, nav_link_matched};
+///
+/// let html = nav_link("/posts", "/posts", "Posts").into_string();
+/// assert!(html.contains(r#"class="active""#));
+/// assert!(html.contains(r#"aria-current="page""#));
+///
+/// // `/posts/3/edit` activates the `/posts` link only in Prefix mode.
+/// let html = nav_link_matched("/posts/3/edit", "/posts", "Posts", NavLinkMatch::Prefix)
+///     .into_string();
+/// assert!(html.contains(r#"class="active""#));
+/// ```
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn nav_link_matched(
@@ -1143,10 +1161,25 @@ pub fn nav_link_matched(
     label: &str,
     mode: NavLinkMatch,
 ) -> maud::Markup {
-    // Red-phase stub: renders the anchor without any active-state handling.
-    let _ = (current_path, mode);
+    let active = nav_link_is_active(current_path, href, mode);
     maud::html! {
-        a href=(href) { (label) }
+        a href=(href) class=[active.then_some("active")] aria-current=[active.then_some("page")] {
+            (label)
+        }
+    }
+}
+
+/// Decide whether `href` is the active link for `current_path` under `mode`.
+#[cfg(feature = "maud")]
+fn nav_link_is_active(current_path: &str, href: &str, mode: NavLinkMatch) -> bool {
+    match mode {
+        NavLinkMatch::Exact => current_path == href,
+        NavLinkMatch::Prefix => {
+            current_path == href
+                || current_path
+                    .strip_prefix(href)
+                    .is_some_and(|rest| rest.starts_with('/'))
+        }
     }
 }
 

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1128,6 +1128,21 @@ pub enum NavLinkMatch {
 /// Render a navigation anchor, marked active when `href` equals `current_path`.
 ///
 /// Uses [`NavLinkMatch::Exact`]; see [`nav_link_matched`] for prefix matching.
+/// Pair with the [`CurrentPath`](crate::extract::CurrentPath) extractor to
+/// get `current_path` from the incoming request.
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::widgets::nav_link;
+///
+/// let html = nav_link("/posts", "/posts/new", "New Post").into_string();
+/// assert!(!html.contains("active"), "different path stays inactive: {html}");
+///
+/// let html = nav_link("/posts", "/posts", "Posts").into_string();
+/// assert!(html.contains(r#"class="active""#));
+/// assert!(html.contains(r#"aria-current="page""#));
+/// ```
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn nav_link(current_path: &str, href: &str, label: &str) -> maud::Markup {


### PR DESCRIPTION
## Summary

Introduces a new `nav_link` widget for rendering navigation anchors that automatically mark themselves as active based on the current request path. This provides a reusable, accessible way to build navigation menus with proper ARIA attributes.

## Key Changes

- **New `nav_link` widget** (`autumn/src/widgets.rs`):
  - `nav_link()` function for exact path matching (default behavior)
  - `nav_link_matched()` function supporting configurable match modes via `NavLinkMatch` enum
  - `NavLinkMatch::Exact` - active only when paths match exactly
  - `NavLinkMatch::Prefix` - active when current path equals href or starts with href followed by `/` segment boundary
  - Automatically applies `class="active"` and `aria-current="page"` when active
  - Comprehensive test coverage including edge cases (trailing slashes, false positives, empty/root hrefs)

- **New `CurrentPath` extractor** (`autumn/src/extract.rs`):
  - Infallible extractor that provides the current request URI path (without query string)
  - Enables view helpers to determine which navigation link should be active
  - Includes tests verifying path extraction and query string stripping

- **Updated admin plugin** (`autumn-admin-plugin/src/templates.rs`):
  - Refactored `admin_layout` sidebar navigation to use `nav_link` widget
  - Eliminates manual active state management in favor of path-based comparison
  - Moves `JOBS_NAV_SLUG` and `RUNTIME_CONFIG_NAV_SLUG` constants to registry for reuse

- **Reserved sentinel slugs** (`autumn-admin-plugin/src/registry.rs`):
  - Added `JOBS_NAV_SLUG` (`"__admin_jobs"`) and `RUNTIME_CONFIG_NAV_SLUG` (`"__admin_config"`) as reserved model slugs
  - Prevents user models from hijacking built-in nav item active states
  - Includes validation tests ensuring these slugs cannot be registered

- **Updated prelude** (`autumn/src/prelude.rs`):
  - Exports `CurrentPath` extractor and `NavLinkMatch` enum for convenient access

## Implementation Details

- Prefix matching normalizes trailing slashes on `href` for consistent behavior (`/posts/` behaves identically to `/posts`)
- Empty or root-only hrefs never match in Prefix mode to prevent wildcard-like behavior
- Uses existing `crate::router::path_matches_route_prefix()` utility for segment-boundary-aware prefix matching
- All attributes are conditionally rendered using Maud's `class=[...]` and `aria-current=[...]` syntax to avoid emitting them when inactive

https://claude.ai/code/session_01TZc9ee4toV9xXv3CusqT1K