### PR TITLE
Add `references` field type for foreign key scaffolding (issue #1026)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   generated `#[model]` field is `post_id: i64` (`Int8` in `schema.rs`), and
   `down.sql` reverses cleanly (`DROP TABLE`, or an implicit column-owned
   index/constraint drop for the `ALTER TABLE ADD COLUMN` migration shape). An
-  unknown referenced model (no `src/models/<base>.rs`) still scaffolds, with a
-  warning that the table is assumed to already exist. `references` is listed
-  in `SUPPORTED_TYPES` / `--help`, and the generated scaffold smoke test
-  creates a minimal stand-in for the referenced table so it stays runnable
+  unknown referenced model (no `src/models/<base>.rs` or matching
+  `src/models.rs` entry) still scaffolds, with a warning that the table is
+  assumed to already exist; a referenced model that *is* found but declares a
+  UUID primary key fails fast with a clear error instead of emitting a
+  `BIGINT`-vs-`UUID` foreign key that would break at `autumn migrate` time.
+  `generate migration Add…To…` gets the same warning/error behavior as
+  `generate model`/`scaffold` for consistency. `references` is listed in
+  `SUPPORTED_TYPES` / `--help`, and the generated scaffold smoke test creates
+  a minimal stand-in for the referenced table (skipping self-referential FKs,
+  which target the table already being created) so it stays runnable
   standalone.
 - **auth:** scoped service tokens whose scopes flow into policy checks (#1158).
   Mint named, optionally-expiring API tokens carrying a set of flat scopes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **cli:** `references` field type for `autumn generate model`/`scaffold`
+  (#1026). `post:references` (or `references:`, either casing) scaffolds a
+  foreign key: the field name resolves to `post_id`, the referenced table is
+  derived via the existing `naming::pluralize` (`Post` -> `posts`), and the
+  migration emits `post_id BIGINT NOT NULL REFERENCES posts(id)` plus an
+  automatic index (`idx_<table>_post_id`) — no `--index` flag needed. Append
+  `?` for a nullable FK (`post:references?` -> `post_id: Option<i64>`). The
+  generated `#[model]` field is `post_id: i64` (`Int8` in `schema.rs`), and
+  `down.sql` reverses cleanly (`DROP TABLE`, or an implicit column-owned
+  index/constraint drop for the `ALTER TABLE ADD COLUMN` migration shape). An
+  unknown referenced model (no `src/models/<base>.rs`) still scaffolds, with a
+  warning that the table is assumed to already exist. `references` is listed
+  in `SUPPORTED_TYPES` / `--help`, and the generated scaffold smoke test
+  creates a minimal stand-in for the referenced table so it stays runnable
+  standalone.
 - **auth:** scoped service tokens whose scopes flow into policy checks (#1158).
   Mint named, optionally-expiring API tokens carrying a set of flat scopes
   (e.g. `posts:read`) via `IssueTokenSpec` + `issue_scoped_api_token`; tokens

--- a/autumn-cli/src/generate/admin.rs
+++ b/autumn-cli/src/generate/admin.rs
@@ -335,7 +335,8 @@ const fn admin_field_kind(field: &Field) -> &'static str {
     match field.kind {
         FieldKind::String | FieldKind::Uuid => "AdminFieldKind::Text",
         FieldKind::Text => "AdminFieldKind::TextArea",
-        FieldKind::I32 | FieldKind::I64 => "AdminFieldKind::Integer",
+        // A foreign-key id renders the same as any other integer column.
+        FieldKind::I32 | FieldKind::I64 | FieldKind::References => "AdminFieldKind::Integer",
         FieldKind::Bool => "AdminFieldKind::Boolean",
         FieldKind::F32 | FieldKind::F64 => "AdminFieldKind::Float",
         FieldKind::NaiveDateTime | FieldKind::DateTime => "AdminFieldKind::DateTime",

--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -5,6 +5,7 @@
 //! Rust type (for the `#[model]` struct) and its SQL type (for the migration).
 
 use super::GenerateError;
+use super::naming;
 
 /// A single field parsed from the command line.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -51,6 +52,20 @@ impl Field {
     pub const fn sql_nullability(&self) -> &'static str {
         if self.nullable { "NULL" } else { "NOT NULL" }
     }
+
+    /// For a [`FieldKind::References`] field, the referenced table name —
+    /// the `_id` suffix is stripped from the column name and the remainder
+    /// is pluralised via [`naming::pluralize`] (`post_id` -> `posts`).
+    ///
+    /// Returns `None` for every other field kind.
+    #[must_use]
+    pub fn reference_table(&self) -> Option<String> {
+        if !self.kind.is_reference() {
+            return None;
+        }
+        let base = self.name.strip_suffix("_id").unwrap_or(&self.name);
+        Some(naming::pluralize(base))
+    }
 }
 
 /// The supported field types. Mirrors the documented public surface in the
@@ -90,6 +105,12 @@ pub enum FieldKind {
     /// be explicit, or leave as `Attachment` (equivalent: nullable is the default
     /// and safe choice for file fields).
     Attachment,
+    /// `references` — a foreign-key column (`i64`/`BIGINT`), matching the
+    /// default `i64` primary-key convention. The DSL rewrites the declared
+    /// field name to end in `_id` (`post:references` -> `post_id`) and the
+    /// referenced table is derived from the base name via [`naming::pluralize`]
+    /// (`post` -> `posts`). See [`Field::reference_table`].
+    References,
 }
 
 impl FieldKind {
@@ -102,7 +123,8 @@ impl FieldKind {
         match self {
             Self::String | Self::Text => "String",
             Self::I32 => "i32",
-            Self::I64 => "i64",
+            // `References` is always `i64`, matching the default `i64` PK convention.
+            Self::I64 | Self::References => "i64",
             Self::Bool => "bool",
             Self::F32 => "f32",
             Self::F64 => "f64",
@@ -120,7 +142,7 @@ impl FieldKind {
         match self {
             Self::String | Self::Text => "Text",
             Self::I32 => "Int4",
-            Self::I64 => "Int8",
+            Self::I64 | Self::References => "Int8",
             Self::Bool => "Bool",
             Self::F32 => "Float4",
             Self::F64 => "Float8",
@@ -138,7 +160,7 @@ impl FieldKind {
         match self {
             Self::String | Self::Text => "TEXT",
             Self::I32 => "INTEGER",
-            Self::I64 => "BIGINT",
+            Self::I64 | Self::References => "BIGINT",
             Self::Bool => "BOOLEAN",
             Self::F32 => "REAL",
             Self::F64 => "DOUBLE PRECISION",
@@ -157,6 +179,12 @@ impl FieldKind {
     #[must_use]
     pub const fn is_attachment(self) -> bool {
         matches!(self, Self::Attachment)
+    }
+
+    /// Returns `true` for a foreign-key `references` field.
+    #[must_use]
+    pub const fn is_reference(self) -> bool {
+        matches!(self, Self::References)
     }
 }
 
@@ -237,7 +265,7 @@ impl IdType {
 
 /// Comma-separated list of supported types, for error messages and `--help`.
 pub const SUPPORTED_TYPES: &str = "String, Text, i32, i64, bool, f32, f64, \
-    Uuid, NaiveDateTime, DateTime, Vec<u8>, Bytea, Attachment, Option<…>";
+    Uuid, NaiveDateTime, DateTime, Vec<u8>, Bytea, Attachment, references, Option<…>";
 
 /// Comma-separated list of supported Postgres column types (`udt_name`), for
 /// the `db pull` introspection error message.
@@ -320,8 +348,17 @@ pub fn parse_field(token: &str) -> Result<Field, GenerateError> {
         reason: format!("unsupported type '{ty}'. Supported: {SUPPORTED_TYPES}"),
     })?;
 
+    // `references` fields always end in `_id` — `post:references` resolves to
+    // the column `post_id`. Tolerate an already-suffixed name (`post_id:references`)
+    // rather than doubling the suffix.
+    let name = if kind == FieldKind::References && !name.ends_with("_id") {
+        format!("{name}_id")
+    } else {
+        name.to_owned()
+    };
+
     Ok(Field {
-        name: name.to_owned(),
+        name,
         kind,
         nullable,
     })
@@ -353,6 +390,13 @@ pub fn parse_fields(tokens: &[String]) -> Result<Vec<Field>, GenerateError> {
 }
 
 fn parse_type(ty: &str) -> Option<(FieldKind, bool)> {
+    // A trailing `?` is a terser nullable marker than `Option<…>` — chiefly
+    // used for `references` fields (`post:references?`), but accepted for any
+    // atomic type.
+    if let Some(inner) = ty.strip_suffix('?') {
+        let kind = atomic_type(inner.trim())?;
+        return Some((kind, true));
+    }
     if let Some(inner) = strip_wrapper(ty, "Option") {
         let kind = atomic_type(inner.trim())?;
         Some((kind, true))
@@ -384,6 +428,9 @@ fn atomic_type(ty: &str) -> Option<FieldKind> {
         // Accept both casing variants so `cover_image:Attachment` and
         // `cover_image:attachment` both work.
         "Attachment" | "attachment" => Some(FieldKind::Attachment),
+        // References / references: foreign-key column, resolved to `_id` and
+        // `BIGINT REFERENCES <table>(id)` by the callers that emit SQL.
+        "References" | "references" => Some(FieldKind::References),
         _ => {
             // Allow `Vec<u8>` as a synonym for `Bytea`.
             strip_wrapper(ty, "Vec").and_then(|inner| {
@@ -814,6 +861,91 @@ mod tests {
                 "'{token}' should parse to BigSerial"
             );
         }
+    }
+
+    // ── references field kind (issue #1026) ────────────────────────────────
+
+    #[test]
+    fn parse_references_resolves_column_name_to_id() {
+        let f = parse_field("post:references").unwrap();
+        assert_eq!(f.name, "post_id");
+        assert_eq!(f.kind, FieldKind::References);
+        assert!(!f.nullable);
+    }
+
+    #[test]
+    fn parse_references_pascal_case_also_accepted() {
+        let f = parse_field("post:References").unwrap();
+        assert_eq!(f.name, "post_id");
+        assert_eq!(f.kind, FieldKind::References);
+    }
+
+    #[test]
+    fn parse_references_does_not_double_suffix_already_named_column() {
+        let f = parse_field("post_id:references").unwrap();
+        assert_eq!(f.name, "post_id");
+    }
+
+    #[test]
+    fn parse_references_multi_word_base_name() {
+        let f = parse_field("blog_post:references").unwrap();
+        assert_eq!(f.name, "blog_post_id");
+        assert_eq!(f.reference_table().as_deref(), Some("blog_posts"));
+    }
+
+    #[test]
+    fn references_rust_type_is_i64() {
+        let f = parse_field("post:references").unwrap();
+        assert_eq!(f.rust_type(), "i64");
+    }
+
+    #[test]
+    fn references_sql_type_is_bigint() {
+        let f = parse_field("post:references").unwrap();
+        assert_eq!(f.sql_type(), "BIGINT");
+        assert_eq!(f.sql_nullability(), "NOT NULL");
+    }
+
+    #[test]
+    fn references_schema_type_is_int8() {
+        let f = parse_field("post:references").unwrap();
+        assert_eq!(f.schema_type(), "Int8");
+    }
+
+    #[test]
+    fn references_target_table_derived_via_pluralize() {
+        let f = parse_field("post:references").unwrap();
+        assert_eq!(f.reference_table().as_deref(), Some("posts"));
+    }
+
+    #[test]
+    fn references_nullable_form_with_question_mark() {
+        let f = parse_field("post:references?").unwrap();
+        assert_eq!(f.name, "post_id");
+        assert!(f.nullable);
+        assert_eq!(f.rust_type(), "Option<i64>");
+        assert_eq!(f.schema_type(), "Nullable<Int8>");
+        assert_eq!(f.sql_nullability(), "NULL");
+    }
+
+    #[test]
+    fn references_is_reference_predicate() {
+        assert!(FieldKind::References.is_reference());
+        assert!(!FieldKind::I64.is_reference());
+    }
+
+    #[test]
+    fn non_reference_field_has_no_reference_table() {
+        let f = parse_field("title:String").unwrap();
+        assert_eq!(f.reference_table(), None);
+    }
+
+    #[test]
+    fn references_appears_in_supported_types_constant() {
+        assert!(
+            SUPPORTED_TYPES.contains("references"),
+            "SUPPORTED_TYPES must list references"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -390,12 +390,12 @@ pub fn parse_fields(tokens: &[String]) -> Result<Vec<Field>, GenerateError> {
 }
 
 fn parse_type(ty: &str) -> Option<(FieldKind, bool)> {
-    // A trailing `?` is a terser nullable marker than `Option<…>` — chiefly
-    // used for `references` fields (`post:references?`), but accepted for any
-    // atomic type.
-    if let Some(inner) = ty.strip_suffix('?') {
-        let kind = atomic_type(inner.trim())?;
-        return Some((kind, true));
+    // A trailing `?` is a terser nullable marker than `Option<…>`, but is only
+    // recognized for `references` (`post:references?`) — every other type
+    // must use `Option<…>` for nullability, so this doesn't silently expand
+    // the DSL's accepted grammar (e.g. `count:i64?` stays an error).
+    if matches!(ty.strip_suffix('?'), Some("references" | "References")) {
+        return Some((FieldKind::References, true));
     }
     if let Some(inner) = strip_wrapper(ty, "Option") {
         let kind = atomic_type(inner.trim())?;
@@ -926,6 +926,26 @@ mod tests {
         assert_eq!(f.rust_type(), "Option<i64>");
         assert_eq!(f.schema_type(), "Nullable<Int8>");
         assert_eq!(f.sql_nullability(), "NULL");
+    }
+
+    #[test]
+    fn question_mark_suffix_is_not_a_general_nullability_marker() {
+        // `?` is only recognized for `references` — every other type must use
+        // `Option<…>`. Otherwise this silently expands the DSL's grammar
+        // (undocumented and untested) for every field kind.
+        for token in [
+            "count:i64?",
+            "flag:bool?",
+            "title:String?",
+            "data:Vec<u8>?",
+            "id:Uuid?",
+        ] {
+            let err = parse_field(token).unwrap_err();
+            assert!(
+                err.to_string().contains("unsupported type"),
+                "expected '{token}' to be rejected like before: {err}"
+            );
+        }
     }
 
     #[test]

--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -394,7 +394,10 @@ fn parse_type(ty: &str) -> Option<(FieldKind, bool)> {
     // recognized for `references` (`post:references?`) — every other type
     // must use `Option<…>` for nullability, so this doesn't silently expand
     // the DSL's accepted grammar (e.g. `count:i64?` stays an error).
-    if matches!(ty.strip_suffix('?'), Some("references" | "References")) {
+    if matches!(
+        ty.strip_suffix('?').map(str::trim),
+        Some("references" | "References")
+    ) {
         return Some((FieldKind::References, true));
     }
     if let Some(inner) = strip_wrapper(ty, "Option") {
@@ -926,6 +929,18 @@ mod tests {
         assert_eq!(f.rust_type(), "Option<i64>");
         assert_eq!(f.schema_type(), "Nullable<Int8>");
         assert_eq!(f.sql_nullability(), "NULL");
+    }
+
+    #[test]
+    fn references_nullable_form_tolerates_internal_whitespace() {
+        // `parse_field` trims the raw type text before `parse_type` sees it,
+        // but a CLI token could still carry whitespace before the `?` (e.g.
+        // `"post: references ?"` after the name/type split trims only the
+        // outer edges); this must still resolve to a nullable reference
+        // rather than "unsupported type".
+        let f = parse_field("post: references ?").unwrap();
+        assert_eq!(f.kind, FieldKind::References);
+        assert!(f.nullable);
     }
 
     #[test]

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -133,11 +133,8 @@ impl Plan {
     /// an existing file and `--force` was not passed; or [`GenerateError::Io`]
     /// for filesystem failures during emission.
     pub fn execute(&self, flags: Flags) -> Result<(), GenerateError> {
-        for warning in &self.warnings {
-            eprintln!("Warning: {warning}");
-        }
-
         if flags.dry_run {
+            self.print_warnings();
             self.print_dry_run();
             return Ok(());
         }
@@ -148,6 +145,8 @@ impl Plan {
                 return Err(GenerateError::Collisions(collisions));
             }
         }
+
+        self.print_warnings();
 
         // Make sure parent directories of every file action exist.
         let mut dirs: BTreeSet<PathBuf> = BTreeSet::new();
@@ -201,6 +200,17 @@ impl Plan {
             }
         }
         Ok(())
+    }
+
+    /// Print every advisory warning to stderr. Called only on a path that
+    /// will actually run (dry-run or a real, non-colliding execution) — never
+    /// before a `--force`/collision check that might abort the plan, so a
+    /// failed, no-op run never emits misleading warnings about a plan that
+    /// was never applied.
+    fn print_warnings(&self) {
+        for warning in &self.warnings {
+            eprintln!("Warning: {warning}");
+        }
     }
 
     fn print_dry_run(&self) {
@@ -257,6 +267,21 @@ mod tests {
         assert_eq!(plan.warnings.len(), 1);
         // A warning never fails the plan — it's advisory only.
         plan.execute(Flags::default()).unwrap();
+    }
+
+    #[test]
+    fn warnings_do_not_block_a_collision_error() {
+        // A colliding Create must still fail with Collisions even when the
+        // plan also carries a warning (the warning is printed to stderr,
+        // which this test can't capture in-process, but it must never be
+        // allowed to suppress or alter the underlying error).
+        let (tmp, mut plan) = fixture();
+        let target = tmp.path().join("out.txt");
+        fs::write(&target, "existing").unwrap();
+        plan.warn("some advisory message");
+        plan.create(target, "new");
+        let err = plan.execute(Flags::default()).unwrap_err();
+        assert!(matches!(err, GenerateError::Collisions(_)));
     }
 
     #[test]

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -50,6 +50,10 @@ pub struct Plan {
     pub project_root: PathBuf,
     /// The actions this plan will perform when executed.
     pub actions: Vec<Action>,
+    /// Advisory messages surfaced to the user on [`Plan::execute`] (both
+    /// `--dry-run` and a real run), without failing the generator — e.g. a
+    /// `references` field whose target model doesn't exist yet.
+    pub warnings: Vec<String>,
 }
 
 impl Plan {
@@ -59,7 +63,14 @@ impl Plan {
         Self {
             project_root: project_root.into(),
             actions: Vec::new(),
+            warnings: Vec::new(),
         }
+    }
+
+    /// Record an advisory message, printed by [`Plan::execute`] but never
+    /// fatal to the plan.
+    pub fn warn(&mut self, message: impl Into<String>) {
+        self.warnings.push(message.into());
     }
 
     /// Push a [`Action::Create`] action.
@@ -122,6 +133,10 @@ impl Plan {
     /// an existing file and `--force` was not passed; or [`GenerateError::Io`]
     /// for filesystem failures during emission.
     pub fn execute(&self, flags: Flags) -> Result<(), GenerateError> {
+        for warning in &self.warnings {
+            eprintln!("Warning: {warning}");
+        }
+
         if flags.dry_run {
             self.print_dry_run();
             return Ok(());
@@ -227,6 +242,21 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let plan = Plan::new(tmp.path());
         (tmp, plan)
+    }
+
+    #[test]
+    fn new_plan_has_no_warnings() {
+        let (_tmp, plan) = fixture();
+        assert!(plan.warnings.is_empty());
+    }
+
+    #[test]
+    fn warn_records_message_and_execute_does_not_fail() {
+        let (_tmp, mut plan) = fixture();
+        plan.warn("referenced table 'posts' is assumed to exist");
+        assert_eq!(plan.warnings.len(), 1);
+        // A warning never fails the plan — it's advisory only.
+        plan.execute(Flags::default()).unwrap();
     }
 
     #[test]

--- a/autumn-cli/src/generate/migration.rs
+++ b/autumn-cli/src/generate/migration.rs
@@ -64,7 +64,11 @@ pub fn plan_migration(
             // UUID-PK error as `generate model`/`generate scaffold` (issue
             // #1026) — otherwise the same DSL token gives inconsistent
             // feedback depending only on which subcommand declared it.
-            super::model::check_reference_targets(&mut plan, project_root, &fields)?;
+            // `own_id_type` is `None`: this shape only `ALTER TABLE`s an
+            // *existing* table, so its actual primary-key type isn't tracked
+            // anywhere the generator can see — a self-reference here is left
+            // unvalidated rather than guessed at.
+            super::model::check_reference_targets(&mut plan, project_root, &fields, table, None)?;
             (
                 add_columns_up_sql(table, &fields),
                 add_columns_down_sql(table, &fields),
@@ -391,5 +395,23 @@ pub struct Post {
         )
         .unwrap_err();
         assert!(err.to_string().contains("UUID"));
+    }
+
+    #[test]
+    fn add_columns_self_reference_to_table_being_altered_has_no_warning() {
+        // `AddCategoryToCategories category:references` targets the very
+        // table it's altering — a filesystem lookup for a "Category" model
+        // is irrelevant here (the table obviously already exists, that's
+        // the point of ALTER TABLE), so no "model not found" warning should
+        // fire for the self-reference.
+        let tmp = project();
+        let plan = plan_migration(
+            tmp.path(),
+            "AddCategoryToCategories",
+            &["category:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert!(plan.warnings.is_empty(), "warnings: {:?}", plan.warnings);
     }
 }

--- a/autumn-cli/src/generate/migration.rs
+++ b/autumn-cli/src/generate/migration.rs
@@ -74,10 +74,18 @@ pub fn plan_migration(
                 add_columns_down_sql(table, &fields),
             )
         }
-        MigrationShape::RemoveColumns { ref table } if !fields.is_empty() => (
-            remove_columns_up_sql(table, &fields),
-            remove_columns_down_sql(table, &fields),
-        ),
+        MigrationShape::RemoveColumns { ref table } if !fields.is_empty() => {
+            // `remove_columns_down_sql`'s rollback restores the FK
+            // constraint/index for a `references` field (issue #1026), so it
+            // needs the same UUID-PK guard as `AddColumns` — otherwise a
+            // target with a UUID primary key still produces a `down.sql`
+            // that fails to apply on rollback.
+            super::model::check_reference_targets(&mut plan, project_root, &fields, table, None)?;
+            (
+                remove_columns_up_sql(table, &fields),
+                remove_columns_down_sql(table, &fields),
+            )
+        }
         MigrationShape::EncryptColumns {
             ref table,
             ref columns,
@@ -295,6 +303,44 @@ mod tests {
             down.contains("CREATE INDEX idx_comments_post_id ON comments (post_id);"),
             "down.sql: {down}"
         );
+    }
+
+    #[test]
+    fn remove_columns_with_references_field_errors_on_uuid_target() {
+        // The restored FK constraint in remove_columns_down_sql needs the
+        // same UUID-PK guard as AddColumns — otherwise a target with a UUID
+        // primary key still produces a down.sql that fails on rollback.
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(
+            models_dir.join("post.rs"),
+            "#[autumn_web::model]\npub struct Post {\n    #[id]\n    pub id: uuid::Uuid,\n}\n",
+        )
+        .unwrap();
+
+        let err = plan_migration(
+            tmp.path(),
+            "RemovePostFromComments",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("UUID"));
+    }
+
+    #[test]
+    fn remove_columns_with_references_field_warns_when_target_model_missing() {
+        let tmp = project();
+        let plan = plan_migration(
+            tmp.path(),
+            "RemovePostFromComments",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert_eq!(plan.warnings.len(), 1, "warnings: {:?}", plan.warnings);
+        assert!(plan.warnings[0].contains("posts"));
     }
 
     #[test]

--- a/autumn-cli/src/generate/migration.rs
+++ b/autumn-cli/src/generate/migration.rs
@@ -55,12 +55,21 @@ pub fn plan_migration(
     let dir_name = format!("{timestamp}_{}", snake_or_pascal_to_snake(name));
     let migration_dir = project_root.join("migrations").join(&dir_name);
 
+    let mut plan = Plan::new(project_root);
+
     let shape = detect_migration_shape(&pascalish(name));
     let (up, down) = match shape {
-        MigrationShape::AddColumns { ref table } if !fields.is_empty() => (
-            add_columns_up_sql(table, &fields),
-            add_columns_down_sql(table, &fields),
-        ),
+        MigrationShape::AddColumns { ref table } if !fields.is_empty() => {
+            // A `references` field here gets the same target-model warning /
+            // UUID-PK error as `generate model`/`generate scaffold` (issue
+            // #1026) — otherwise the same DSL token gives inconsistent
+            // feedback depending only on which subcommand declared it.
+            super::model::check_reference_targets(&mut plan, project_root, &fields)?;
+            (
+                add_columns_up_sql(table, &fields),
+                add_columns_down_sql(table, &fields),
+            )
+        }
         MigrationShape::RemoveColumns { ref table } if !fields.is_empty() => (
             remove_columns_up_sql(table, &fields),
             remove_columns_down_sql(table, &fields),
@@ -140,7 +149,6 @@ pub fn plan_migration(
         _ => (String::new(), String::new()),
     };
 
-    let mut plan = Plan::new(project_root);
     plan.create(migration_dir.join("up.sql"), up);
     plan.create(migration_dir.join("down.sql"), down);
     Ok(plan)
@@ -326,5 +334,62 @@ pub struct Post {
         );
         assert!(down.contains("DROP INDEX IF EXISTS idx_posts_search_vector;"));
         assert!(down.contains("ALTER TABLE posts DROP COLUMN IF EXISTS search_vector;"));
+    }
+
+    // ── references field: parity with `generate model` (issue #1026) ───────
+
+    #[test]
+    fn add_columns_with_references_field_emits_fk_and_index() {
+        let tmp = project();
+        let plan = plan_migration(
+            tmp.path(),
+            "AddPostToComments",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let up = fs::read_to_string(
+            tmp.path()
+                .join("migrations/20260427000000_add_post_to_comments/up.sql"),
+        )
+        .unwrap();
+        assert!(up.contains("post_id BIGINT NOT NULL REFERENCES posts(id)"));
+        assert!(up.contains("CREATE INDEX idx_comments_post_id ON comments (post_id);"));
+    }
+
+    #[test]
+    fn add_columns_with_references_field_warns_when_target_model_missing() {
+        let tmp = project();
+        let plan = plan_migration(
+            tmp.path(),
+            "AddPostToComments",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert_eq!(plan.warnings.len(), 1, "warnings: {:?}", plan.warnings);
+        assert!(plan.warnings[0].contains("posts"));
+    }
+
+    #[test]
+    fn add_columns_with_references_field_errors_on_uuid_target() {
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(
+            models_dir.join("post.rs"),
+            "#[autumn_web::model]\npub struct Post {\n    #[id]\n    pub id: uuid::Uuid,\n}\n",
+        )
+        .unwrap();
+
+        let err = plan_migration(
+            tmp.path(),
+            "AddPostToComments",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("UUID"));
     }
 }

--- a/autumn-cli/src/generate/migration.rs
+++ b/autumn-cli/src/generate/migration.rs
@@ -414,4 +414,31 @@ pub struct Post {
         .unwrap();
         assert!(plan.warnings.is_empty(), "warnings: {:?}", plan.warnings);
     }
+
+    #[test]
+    fn add_columns_self_reference_errors_when_existing_model_has_uuid_pk() {
+        // Unlike `generate model`, `generate migration Add…To…` alters an
+        // EXISTING table — if that table's own model file is on disk and
+        // declares a UUID primary key, the self-reference must still be
+        // caught (it's not "unknown PK type, can't check", it's "known PK
+        // type, from the file the caller didn't think to look at").
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(
+            models_dir.join("category.rs"),
+            "#[autumn_web::model]\npub struct Category {\n    #[id]\n    pub id: uuid::Uuid,\n}\n",
+        )
+        .unwrap();
+
+        let err = plan_migration(
+            tmp.path(),
+            "AddCategoryToCategories",
+            &["category:references".into()],
+            "20260427000000",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("UUID"));
+        assert!(err.to_string().contains("self-referential"));
+    }
 }

--- a/autumn-cli/src/generate/migration.rs
+++ b/autumn-cli/src/generate/migration.rs
@@ -268,6 +268,36 @@ mod tests {
     }
 
     #[test]
+    fn remove_columns_migration_with_references_field_restores_fk_on_rollback() {
+        // `RemovePostFromComments post:references` — down.sql must restore
+        // the FK constraint and index, not just a bare column (issue #1026).
+        let tmp = project();
+        let plan = plan_migration(
+            tmp.path(),
+            "RemovePostFromComments",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let down = fs::read_to_string(
+            tmp.path()
+                .join("migrations/20260427000000_remove_post_from_comments/down.sql"),
+        )
+        .unwrap();
+        assert!(
+            down.contains(
+                "ALTER TABLE comments ADD COLUMN post_id BIGINT NOT NULL REFERENCES posts(id);"
+            ),
+            "down.sql: {down}"
+        );
+        assert!(
+            down.contains("CREATE INDEX idx_comments_post_id ON comments (post_id);"),
+            "down.sql: {down}"
+        );
+    }
+
+    #[test]
     fn add_pattern_with_no_fields_is_empty() {
         let tmp = project();
         let plan = plan_migration(tmp.path(), "AddTitleToPosts", &[], "20260427000000").unwrap();

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -303,8 +303,11 @@ fn struct_has_uuid_pk(struct_body: &str) -> bool {
     lines.iter().enumerate().any(|(i, line)| {
         *line == "#[id]"
             && lines[i + 1..]
+                // Skip blank lines, any other attributes (`#[...]`), and doc
+                // comments (`///`/`//!`) that may sit between `#[id]` and the
+                // actual field declaration (e.g. `#[serde(rename = "id")]`).
                 .iter()
-                .find(|l| !l.is_empty())
+                .find(|l| !l.is_empty() && !l.starts_with('#') && !l.starts_with("//"))
                 .is_some_and(|field_line| field_type_is_uuid(field_line))
     })
 }
@@ -2254,6 +2257,51 @@ autumn-web = \"0.3\"\n";
         fs::write(
             models_dir.join("post.rs"),
             "use uuid::Uuid;\n\n#[autumn_web::model]\npub struct Post {\n    #[id]\n    pub id: Uuid,\n}\n",
+        )
+        .unwrap();
+
+        let err = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("UUID"));
+    }
+
+    #[test]
+    fn references_field_detects_uuid_pk_through_intervening_attribute() {
+        // An attribute (or doc comment) between `#[id]` and the field
+        // declaration — e.g. `#[serde(rename = "id")]` — must not be
+        // mistaken for the field line itself.
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(
+            models_dir.join("post.rs"),
+            "#[autumn_web::model]\npub struct Post {\n    #[id]\n    #[serde(rename = \"id\")]\n    pub id: uuid::Uuid,\n}\n",
+        )
+        .unwrap();
+
+        let err = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("UUID"));
+    }
+
+    #[test]
+    fn references_field_detects_uuid_pk_through_intervening_doc_comment() {
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(
+            models_dir.join("post.rs"),
+            "#[autumn_web::model]\npub struct Post {\n    #[id]\n    /// The primary key.\n    pub id: uuid::Uuid,\n}\n",
         )
         .unwrap();
 

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -114,7 +114,7 @@ pub fn plan_model_with_options(
     let schema_fields = augment_fields_for_soft_delete(&fields, options.soft_delete)?;
 
     let mut plan = Plan::new(project_root);
-    warn_about_unknown_references(&mut plan, project_root, &fields);
+    check_reference_targets(&mut plan, project_root, &fields)?;
 
     // (a) `src/models/<snake>.rs` + `src/models/mod.rs`
     let models_dir = project_root.join("src").join("models");
@@ -186,16 +186,70 @@ pub fn plan_model_with_options(
     Ok(plan)
 }
 
-/// Warn on every `references` field whose target model file doesn't exist in
-/// this project yet (AC8, issue #1026). The generator still scaffolds the FK
-/// column, constraint, and index — the referenced table is simply assumed to
-/// already exist (e.g. it's created by an out-of-band migration, or the
-/// referenced model will be generated in a later command).
-pub(super) fn warn_about_unknown_references(
+/// Where a referenced model's source was found, per [`find_model_file`].
+enum ModelFileMatch {
+    /// The conventional per-resource `src/models/<base>.rs` — its entire
+    /// content belongs to exactly this one model, so it's safe to inspect
+    /// for that model's own `#[id]` type.
+    PerResource(std::path::PathBuf),
+    /// The single-file `src/models.rs` layout, which may define several
+    /// models in one file — content-based checks scoped to *this* model
+    /// (like the UUID-PK check below) can't safely be run against it.
+    SingleFile,
+}
+
+/// Locate the source file (if any) that defines resource `base`'s model,
+/// checking both layouts the codebase already treats as valid (see
+/// `migration.rs`'s `AddSearch` migration shape, which checks the same two
+/// locations): the per-resource `src/models/<base>.rs`, and the single-file
+/// `src/models.rs` — the latter only counts as a match if its content
+/// actually references the resource's table (`use crate::schema::<table>;`,
+/// which every generated model file emits), so an unrelated `src/models.rs`
+/// doesn't produce a false "model exists" result.
+fn find_model_file(project_root: &Path, table: &str, base: &str) -> Option<ModelFileMatch> {
+    let per_resource = project_root
+        .join("src")
+        .join("models")
+        .join(format!("{base}.rs"));
+    if per_resource.exists() {
+        return Some(ModelFileMatch::PerResource(per_resource));
+    }
+    let single_file = project_root.join("src").join("models.rs");
+    if single_file.exists() {
+        let content = read_or_empty(&single_file);
+        if content.contains(&format!("schema::{table}")) {
+            return Some(ModelFileMatch::SingleFile);
+        }
+    }
+    None
+}
+
+/// Validate every `references` field against its target model (issue #1026):
+///
+/// - If the target model can't be found anywhere (AC8), record a warning on
+///   `plan` — the generator still scaffolds the FK column, constraint, and
+///   index, simply assuming the referenced table already exists (e.g. it's
+///   created by an out-of-band migration, or generated in a later command).
+/// - If the target model *can* be found and its own `#[id]` field is a UUID,
+///   fail loudly: `references` only supports the i64/BIGSERIAL PK convention
+///   (see issue #1026's scope), and emitting a `BIGINT` FK column against a
+///   `UUID PRIMARY KEY` would produce a migration that fails at
+///   `autumn migrate` time with an opaque Postgres type-mismatch error —
+///   better to fail fast here with an actionable message.
+///
+/// Shared by `generate model`, `generate scaffold` (via
+/// [`plan_model_with_options`]), and `generate migration Add…To…` (via
+/// `migration::plan_migration`) so a `references` field gets the same
+/// feedback regardless of which subcommand declares it.
+///
+/// # Errors
+/// Returns [`GenerateError::Config`] when a referenced model's own `#[id]`
+/// field is a UUID.
+pub(super) fn check_reference_targets(
     plan: &mut Plan,
     project_root: &Path,
     fields: &[Field],
-) {
+) -> Result<(), GenerateError> {
     for f in fields {
         if !f.kind.is_reference() {
             continue;
@@ -204,18 +258,33 @@ pub(super) fn warn_about_unknown_references(
             continue;
         };
         let base = f.name.strip_suffix("_id").unwrap_or(&f.name);
-        let model_path = project_root
-            .join("src")
-            .join("models")
-            .join(format!("{base}.rs"));
-        if !model_path.exists() {
-            plan.warn(format!(
-                "'{}' references model '{base}', but src/models/{base}.rs was not found — \
-                 assuming table '{table}' already exists.",
-                f.name
-            ));
+        match find_model_file(project_root, &table, base) {
+            None => {
+                plan.warn(format!(
+                    "'{}' references model '{base}', but src/models/{base}.rs (or src/models.rs) \
+                     was not found — assuming table '{table}' already exists.",
+                    f.name
+                ));
+            }
+            Some(ModelFileMatch::PerResource(path)) => {
+                if read_or_empty(&path).contains("pub id: uuid::Uuid,") {
+                    return Err(GenerateError::Config(format!(
+                        "'{}' references model '{base}' ({}), which declares a UUID primary \
+                         key. `references` fields only support i64/BIGSERIAL-keyed targets \
+                         (issue #1026) — hand-write the migration for a UUID foreign key instead.",
+                        f.name,
+                        path.display()
+                    )));
+                }
+            }
+            Some(ModelFileMatch::SingleFile) => {
+                // Can't safely isolate this one model's `#[id]` type from a
+                // shared `src/models.rs` file that may define several models,
+                // so the UUID-PK check is skipped for that layout.
+            }
         }
     }
+    Ok(())
 }
 
 /// Append the virtual `deleted_at` column that `--soft-delete` models add to
@@ -1768,5 +1837,106 @@ autumn-web = \"0.3\"\n";
         )
         .unwrap();
         assert!(plan.warnings.is_empty());
+    }
+
+    #[test]
+    fn references_field_errors_when_target_model_has_uuid_pk() {
+        // `references` only supports the i64/BIGSERIAL PK convention; a FK
+        // column typed BIGINT against a UUID PRIMARY KEY would fail at
+        // `autumn migrate` time with an opaque Postgres error, so this must
+        // fail loudly at generate time instead.
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(
+            models_dir.join("post.rs"),
+            "#[autumn_web::model]\npub struct Post {\n    #[id]\n    pub id: uuid::Uuid,\n}\n",
+        )
+        .unwrap();
+
+        let err = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("post"), "error should name the field: {msg}");
+        assert!(
+            msg.contains("UUID"),
+            "error should explain the UUID PK mismatch: {msg}"
+        );
+    }
+
+    #[test]
+    fn references_field_no_error_when_target_model_has_bigserial_pk() {
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(
+            models_dir.join("post.rs"),
+            "#[autumn_web::model]\npub struct Post {\n    #[id]\n    pub id: i64,\n}\n",
+        )
+        .unwrap();
+
+        let plan = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert!(plan.warnings.is_empty());
+    }
+
+    #[test]
+    fn references_field_no_warning_when_target_declared_in_single_file_models_rs() {
+        // The single-file `src/models.rs` layout is an equally valid place
+        // for a model to live (see `migration.rs`'s `AddSearch` shape, which
+        // checks both locations) — it must not produce a false-positive
+        // "model not found" warning.
+        let tmp = project();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(
+            tmp.path().join("src/models.rs"),
+            "use crate::schema::posts;\n\n#[autumn_web::model]\npub struct Post {\n    #[id]\n    pub id: i64,\n}\n",
+        )
+        .unwrap();
+
+        let plan = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert!(
+            plan.warnings.is_empty(),
+            "no warning expected once Post is declared in src/models.rs: {:?}",
+            plan.warnings
+        );
+    }
+
+    #[test]
+    fn references_field_still_warns_when_single_file_models_rs_lacks_the_model() {
+        // An unrelated `src/models.rs` (e.g. only declaring `User`) must not
+        // be mistaken for a `Post` declaration.
+        let tmp = project();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(
+            tmp.path().join("src/models.rs"),
+            "use crate::schema::users;\n\n#[autumn_web::model]\npub struct User {\n    #[id]\n    pub id: i64,\n}\n",
+        )
+        .unwrap();
+
+        let plan = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert_eq!(plan.warnings.len(), 1, "warnings: {:?}", plan.warnings);
     }
 }

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -117,7 +117,13 @@ pub fn plan_model_with_options(
     let schema_fields = augment_fields_for_soft_delete(&fields, options.soft_delete)?;
 
     let mut plan = Plan::new(project_root);
-    check_reference_targets(&mut plan, project_root, &fields)?;
+    check_reference_targets(
+        &mut plan,
+        project_root,
+        &fields,
+        &table,
+        Some(options.id_type),
+    )?;
 
     // (a) `src/models/<snake>.rs` + `src/models/mod.rs`
     let models_dir = project_root.join("src").join("models");
@@ -291,7 +297,7 @@ fn extract_struct_body(content: &str, struct_name: &str) -> Option<String> {
 
 /// Whether a `#[model]` struct body's primary key (the field tagged `#[id]`,
 /// regardless of its name — the macro identifies the PK by attribute, not by
-/// the name `id`) is a `uuid::Uuid`.
+/// the name `id`) is a UUID.
 fn struct_has_uuid_pk(struct_body: &str) -> bool {
     let lines: Vec<&str> = struct_body.lines().map(str::trim).collect();
     lines.iter().enumerate().any(|(i, line)| {
@@ -299,16 +305,39 @@ fn struct_has_uuid_pk(struct_body: &str) -> bool {
             && lines[i + 1..]
                 .iter()
                 .find(|l| !l.is_empty())
-                .is_some_and(|field_line| field_line.contains("uuid::Uuid"))
+                .is_some_and(|field_line| field_type_is_uuid(field_line))
     })
+}
+
+/// Whether a `pub <name>: <Type>,` field declaration's type is a UUID —
+/// either the fully-qualified `uuid::Uuid` (what the generator itself always
+/// emits) or the bare `Uuid` (idiomatic with a `use uuid::Uuid;` import at
+/// the top of the file, a common hand-edit of a generated model).
+fn field_type_is_uuid(field_line: &str) -> bool {
+    let Some((_, after_colon)) = field_line.split_once(':') else {
+        return false;
+    };
+    let ty = after_colon.trim().trim_end_matches(',').trim();
+    ty == "uuid::Uuid" || ty == "Uuid"
 }
 
 /// Validate every `references` field against its target model (issue #1026):
 ///
-/// - If the target model can't be found anywhere (AC8), record a warning on
-///   `plan` — the generator still scaffolds the FK column, constraint, and
-///   index, simply assuming the referenced table already exists (e.g. it's
-///   created by an out-of-band migration, or generated in a later command).
+/// - A *self*-reference (the target table is `own_table` — the resource this
+///   very command is generating) is checked against `own_id_type` directly
+///   instead of a filesystem lookup: the target model's file doesn't exist
+///   yet (this command is creating it), so a file-existence check could
+///   never see it, and a naive "not found, assume it exists" warning would
+///   both misfire (the table obviously exists — it's the one being created)
+///   and, worse, skip the UUID check entirely. `own_id_type` is `None` for
+///   callers that don't track a PK type for the table being altered (`generate
+///   migration Add…To…`, which only ever `ALTER TABLE`s an existing table) —
+///   in that case the self-reference is simply left unvalidated.
+/// - Otherwise, if the target model can't be found anywhere (AC8), record a
+///   warning on `plan` — the generator still scaffolds the FK column,
+///   constraint, and index, simply assuming the referenced table already
+///   exists (e.g. it's created by an out-of-band migration, or generated in
+///   a later command).
 /// - If the target model *can* be found and its own `#[id]` field is a UUID,
 ///   fail loudly: `references` only supports the i64/BIGSERIAL PK convention
 ///   (see issue #1026's scope), and emitting a `BIGINT` FK column against a
@@ -322,12 +351,14 @@ fn struct_has_uuid_pk(struct_body: &str) -> bool {
 /// feedback regardless of which subcommand declares it.
 ///
 /// # Errors
-/// Returns [`GenerateError::Config`] when a referenced model's own `#[id]`
-/// field is a UUID.
+/// Returns [`GenerateError::Config`] when a referenced (or self-referenced)
+/// model's `#[id]` field is a UUID.
 pub(super) fn check_reference_targets(
     plan: &mut Plan,
     project_root: &Path,
     fields: &[Field],
+    own_table: &str,
+    own_id_type: Option<IdType>,
 ) -> Result<(), GenerateError> {
     for f in fields {
         if !f.kind.is_reference() {
@@ -337,6 +368,19 @@ pub(super) fn check_reference_targets(
             continue;
         };
         let base = f.name.strip_suffix("_id").unwrap_or(&f.name);
+
+        if table == own_table {
+            if own_id_type == Some(IdType::Uuid) {
+                return Err(GenerateError::Config(format!(
+                    "'{}' is a self-referential foreign key, but this model uses a UUID \
+                     primary key (`--id uuid`). `references` fields only support \
+                     i64/BIGSERIAL-keyed targets (issue #1026).",
+                    f.name
+                )));
+            }
+            continue;
+        }
+
         if !model_file_exists(project_root, &table, base) {
             plan.warn(format!(
                 "'{}' references model '{base}', but src/models/{base}.rs (or a matching \
@@ -2197,5 +2241,92 @@ autumn-web = \"0.3\"\n";
             "an unrelated field named 'id' must not trigger a false UUID-PK error: {:?}",
             plan.warnings
         );
+    }
+
+    #[test]
+    fn references_field_detects_unqualified_uuid_type() {
+        // A hand-edited model using `use uuid::Uuid;` + `pub id: Uuid,`
+        // (idiomatic, not what the generator itself emits, but a common
+        // hand-edit) must still be detected as a UUID primary key.
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(
+            models_dir.join("post.rs"),
+            "use uuid::Uuid;\n\n#[autumn_web::model]\npub struct Post {\n    #[id]\n    pub id: Uuid,\n}\n",
+        )
+        .unwrap();
+
+        let err = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("UUID"));
+    }
+
+    // ── self-referential `references` (issue #1026 follow-up) ──────────────
+
+    #[test]
+    fn self_referential_references_errors_when_own_id_is_uuid() {
+        // `Category category:references --id uuid`: the target model
+        // ("Category" itself) doesn't exist on disk yet — this command is
+        // creating it — so a filesystem lookup can never see it. The
+        // self-reference must be checked against the model's own
+        // `--id uuid` directly instead of silently skipping the UUID check.
+        let tmp = project();
+        let err = plan_model_with_options(
+            tmp.path(),
+            "Category",
+            &["name:String".into(), "category:references".into()],
+            "20260427000000",
+            &ModelOptions {
+                id_type: IdType::Uuid,
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("UUID"));
+        assert!(err.to_string().contains("self-referential"));
+    }
+
+    #[test]
+    fn self_referential_references_fine_with_default_bigserial_id() {
+        let tmp = project();
+        let plan = plan_model(
+            tmp.path(),
+            "Category",
+            &["name:String".into(), "category:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert!(
+            plan.warnings.is_empty(),
+            "a self-reference to the table being created now must not warn \
+             'model not found': {:?}",
+            plan.warnings
+        );
+    }
+
+    #[test]
+    fn self_referential_references_emits_correct_fk_sql() {
+        let tmp = project();
+        let plan = plan_model(
+            tmp.path(),
+            "Category",
+            &["name:String".into(), "category:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let up = fs::read_to_string(
+            tmp.path()
+                .join("migrations/20260427000000_create_categories/up.sql"),
+        )
+        .unwrap();
+        assert!(up.contains("category_id BIGINT NOT NULL REFERENCES categories(id)"));
     }
 }

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -209,17 +209,34 @@ fn model_file_exists(project_root: &Path, table: &str, base: &str) -> bool {
     single_file.exists() && declares_schema_table(&read_or_empty(&single_file), table)
 }
 
-/// True if `content` contains `schema::<table>` immediately followed by a
-/// non-identifier character (or nothing) — i.e. an exact match on `table`,
-/// not merely a prefix of a longer table name sharing the same start.
+/// True if `content` declares `use crate::schema::<table>` for exactly
+/// `table` — either as a bare `schema::<table>;` import or as one entry of a
+/// grouped import (`schema::{<table>, other};`, possibly wrapped across
+/// multiple lines), which is a multi-model `src/models.rs` layout this repo
+/// itself uses (see `examples/reddit-clone/src/models.rs`:
+/// `use crate::schema::{comments, posts, subreddits, users, votes};`).
+/// Word-boundary-aware so `posts` isn't confused with a longer table name
+/// like `posts_tags`.
 fn declares_schema_table(content: &str, table: &str) -> bool {
-    let needle = format!("schema::{table}");
-    content.match_indices(&needle).any(|(idx, _)| {
-        content[idx + needle.len()..]
-            .chars()
-            .next()
-            .is_none_or(|c| !c.is_alphanumeric() && c != '_')
-    })
+    for (idx, _) in content.match_indices("schema::") {
+        let after = &content[idx + "schema::".len()..];
+        if let Some(rest) = after.strip_prefix('{') {
+            let Some(end) = rest.find('}') else {
+                continue;
+            };
+            if rest[..end].split(',').any(|name| name.trim() == table) {
+                return true;
+            }
+        } else if after.starts_with(table)
+            && after[table.len()..]
+                .chars()
+                .next()
+                .is_none_or(|c| !c.is_alphanumeric() && c != '_')
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// Locate the source text of resource `base`'s `#[model]` struct body (the
@@ -1969,6 +1986,112 @@ autumn-web = \"0.3\"\n";
         assert!(
             plan.warnings.is_empty(),
             "no warning expected once Post is declared in src/models.rs: {:?}",
+            plan.warnings
+        );
+    }
+
+    #[test]
+    fn references_field_no_warning_for_grouped_schema_import_in_single_file_models_rs() {
+        // Multi-model `src/models.rs` files commonly group their schema
+        // imports (e.g. `examples/reddit-clone/src/models.rs`:
+        // `use crate::schema::{comments, posts, subreddits, users, votes};`)
+        // rather than one `use` per table — this must still count as "Post
+        // declared here", not a false "model not found" warning.
+        let tmp = project();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(
+            tmp.path().join("src/models.rs"),
+            "use crate::schema::{comments, posts, subreddits, users, votes};\n\n\
+             #[autumn_web::model]\npub struct Post {\n    #[id]\n    pub id: i64,\n}\n",
+        )
+        .unwrap();
+
+        let plan = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert!(
+            plan.warnings.is_empty(),
+            "grouped schema import must be recognized: {:?}",
+            plan.warnings
+        );
+    }
+
+    #[test]
+    fn references_field_detects_uuid_pk_with_grouped_schema_import() {
+        // Same grouped-import layout, but the target model has a UUID PK —
+        // the hard error must still fire, not be silently skipped.
+        let tmp = project();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(
+            tmp.path().join("src/models.rs"),
+            "use crate::schema::{comments, posts};\n\n\
+             #[autumn_web::model]\npub struct Post {\n    #[id]\n    pub id: uuid::Uuid,\n}\n",
+        )
+        .unwrap();
+
+        let err = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("UUID"));
+    }
+
+    #[test]
+    fn references_field_grouped_schema_import_not_confused_by_table_name_prefix() {
+        // Only `posts_tags` is grouped-imported — `posts` must not match.
+        let tmp = project();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(
+            tmp.path().join("src/models.rs"),
+            "use crate::schema::{posts_tags, users};\n\n\
+             #[autumn_web::model]\npub struct PostsTag {\n    #[id]\n    pub id: i64,\n}\n",
+        )
+        .unwrap();
+
+        let plan = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert_eq!(
+            plan.warnings.len(),
+            1,
+            "'posts_tags' in a grouped import must not satisfy a reference to 'posts': {:?}",
+            plan.warnings
+        );
+    }
+
+    #[test]
+    fn references_field_no_warning_for_multiline_grouped_schema_import() {
+        // rustfmt commonly wraps long grouped imports across lines.
+        let tmp = project();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(
+            tmp.path().join("src/models.rs"),
+            "use crate::schema::{\n    comments,\n    posts,\n    users,\n};\n\n\
+             #[autumn_web::model]\npub struct Post {\n    #[id]\n    pub id: i64,\n}\n",
+        )
+        .unwrap();
+
+        let plan = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert!(
+            plan.warnings.is_empty(),
+            "multi-line grouped schema import must be recognized: {:?}",
             plan.warnings
         );
     }

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -252,80 +252,74 @@ fn declares_schema_table(content: &str, table: &str) -> bool {
 /// Scoping to the specific struct's body (rather than the whole file) means
 /// callers can inspect the resource's own `#[id]` field even when other
 /// models are declared in the same `src/models.rs`. Returns `None` when the
-/// struct can't be located textually (e.g. a hand-written model using an
-/// unconventional struct name) — callers should treat that as "can't verify,
-/// don't guess" rather than "model missing", since [`model_file_exists`]
-/// already established the model is present.
-fn find_model_struct_body(project_root: &Path, base: &str) -> Option<String> {
+/// struct can't be located/parsed (e.g. a hand-written model using an
+/// unconventional struct name, or the file fails to parse as valid Rust) —
+/// callers should treat that as "can't verify, don't guess" rather than
+/// "model missing", since [`model_file_exists`] already established the
+/// model is present.
+///
+/// Parses the file with `syn` rather than scanning text: earlier text-based
+/// heuristics here kept missing real UUID primary keys behind cosmetic
+/// variation the compiler doesn't care about — grouped attributes, doc
+/// comments, and both `//` and `/* */` comments all defeated a
+/// string-matching approach one at a time (issue #1026 follow-ups). A real
+/// parse isn't fooled by any of that, since it operates on the token tree,
+/// not the source text.
+fn model_struct_has_uuid_pk(project_root: &Path, base: &str) -> bool {
     let pascal_name = pascal(base);
     let per_resource = project_root
         .join("src")
         .join("models")
         .join(format!("{base}.rs"));
-    if per_resource.exists() {
-        return extract_struct_body(&read_or_empty(&per_resource), &pascal_name);
-    }
-    let single_file = project_root.join("src").join("models.rs");
-    if single_file.exists() {
-        return extract_struct_body(&read_or_empty(&single_file), &pascal_name);
-    }
-    None
-}
-
-/// Extract the text between `struct <name> {` and its matching closing `}`,
-/// tracking brace depth so a struct containing nested braces (there are none
-/// in practice — model fields are plain types — but this stays correct if
-/// that ever changes) isn't truncated at the first inner `}`.
-fn extract_struct_body(content: &str, struct_name: &str) -> Option<String> {
-    let needle = format!("struct {struct_name} {{");
-    let start = content.find(&needle)? + needle.len();
-    let mut depth: usize = 1;
-    for (i, b) in content.as_bytes()[start..].iter().enumerate() {
-        match b {
-            b'{' => depth += 1,
-            b'}' => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some(content[start..start + i].to_string());
-                }
-            }
-            _ => {}
+    let content = if per_resource.exists() {
+        read_or_empty(&per_resource)
+    } else {
+        let single_file = project_root.join("src").join("models.rs");
+        if !single_file.exists() {
+            return false;
         }
-    }
-    None
-}
+        read_or_empty(&single_file)
+    };
 
-/// Whether a `#[model]` struct body's primary key (the field tagged `#[id]`,
-/// regardless of its name — the macro identifies the PK by attribute, not by
-/// the name `id`) is a UUID.
-fn struct_has_uuid_pk(struct_body: &str) -> bool {
-    let lines: Vec<&str> = struct_body.lines().map(str::trim).collect();
-    lines.iter().enumerate().any(|(i, line)| {
-        *line == "#[id]"
-            && lines[i + 1..]
-                // Skip blank lines, any other attributes (`#[...]`), and doc
-                // comments (`///`/`//!`) that may sit between `#[id]` and the
-                // actual field declaration (e.g. `#[serde(rename = "id")]`).
-                .iter()
-                .find(|l| !l.is_empty() && !l.starts_with('#') && !l.starts_with("//"))
-                .is_some_and(|field_line| field_type_is_uuid(field_line))
-    })
-}
-
-/// Whether a `pub <name>: <Type>,` field declaration's type is a UUID —
-/// either the fully-qualified `uuid::Uuid` (what the generator itself always
-/// emits) or the bare `Uuid` (idiomatic with a `use uuid::Uuid;` import at
-/// the top of the file, a common hand-edit of a generated model). Tolerates
-/// a trailing `// comment` on the same line (e.g. `pub id: uuid::Uuid, //
-/// primary key`), which would otherwise get swept into the extracted type
-/// text since it comes after the trailing comma.
-fn field_type_is_uuid(field_line: &str) -> bool {
-    let code = field_line.split("//").next().unwrap_or(field_line);
-    let Some((_, after_colon)) = code.split_once(':') else {
+    let Ok(file) = syn::parse_file(&content) else {
         return false;
     };
-    let ty = after_colon.trim().trim_end_matches(',').trim();
-    ty == "uuid::Uuid" || ty == "Uuid"
+
+    let Some(item_struct) = file.items.iter().find_map(|item| match item {
+        syn::Item::Struct(s) if s.ident == pascal_name => Some(s),
+        _ => None,
+    }) else {
+        return false;
+    };
+
+    let syn::Fields::Named(fields) = &item_struct.fields else {
+        return false;
+    };
+    fields
+        .named
+        .iter()
+        .find(|field| field.attrs.iter().any(|a| a.path().is_ident("id")))
+        .is_some_and(|field| type_is_uuid(&field.ty))
+}
+
+/// Whether a `syn::Type` is a UUID — either the fully-qualified `uuid::Uuid`
+/// (what the generator itself always emits) or the bare `Uuid` (idiomatic
+/// with a `use uuid::Uuid;` import at the top of the file, a common
+/// hand-edit of a generated model).
+fn type_is_uuid(ty: &syn::Type) -> bool {
+    let syn::Type::Path(type_path) = ty else {
+        return false;
+    };
+    if type_path.qself.is_some() {
+        return false;
+    }
+    match type_path.path.segments.len() {
+        1 => type_path.path.segments[0].ident == "Uuid",
+        2 => {
+            type_path.path.segments[0].ident == "uuid" && type_path.path.segments[1].ident == "Uuid"
+        }
+        _ => false,
+    }
 }
 
 /// Validate every `references` field against its target model (issue #1026):
@@ -396,9 +390,7 @@ pub(super) fn check_reference_targets(
                 // "model not found" for a self-reference, since the table
                 // obviously already exists (that's the point of ALTER TABLE).
                 None => {
-                    if find_model_struct_body(project_root, base)
-                        .is_some_and(|body| struct_has_uuid_pk(&body))
-                    {
+                    if model_struct_has_uuid_pk(project_root, base) {
                         return Err(GenerateError::Config(format!(
                             "'{}' is a self-referential foreign key, but the existing model \
                              declares a UUID primary key. `references` fields only support \
@@ -420,8 +412,7 @@ pub(super) fn check_reference_targets(
             ));
             continue;
         }
-        if find_model_struct_body(project_root, base).is_some_and(|body| struct_has_uuid_pk(&body))
-        {
+        if model_struct_has_uuid_pk(project_root, base) {
             return Err(GenerateError::Config(format!(
                 "'{}' references model '{base}', which declares a UUID primary key. \
                  `references` fields only support i64/BIGSERIAL-keyed targets \
@@ -2364,6 +2355,73 @@ autumn-web = \"0.3\"\n";
         )
         .unwrap_err();
         assert!(err.to_string().contains("UUID"));
+    }
+
+    #[test]
+    fn references_field_detects_uuid_pk_with_trailing_block_comment() {
+        // `pub id: uuid::Uuid, /* primary key */` — a block comment, not a
+        // line comment. The syn-based parser isn't fooled by either.
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(
+            models_dir.join("post.rs"),
+            "#[autumn_web::model]\npub struct Post {\n    #[id]\n    pub id: uuid::Uuid, /* primary key */\n}\n",
+        )
+        .unwrap();
+
+        let err = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("UUID"));
+    }
+
+    #[test]
+    fn references_field_detects_uuid_pk_regardless_of_attribute_order() {
+        // `#[id]` doesn't have to be the first attribute on the field — a
+        // real parse (unlike a "look at the line after #[id]" scan) handles
+        // any attribute order the same way rustc does.
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(
+            models_dir.join("post.rs"),
+            "#[autumn_web::model]\npub struct Post {\n    #[serde(rename = \"id\")]\n    #[id]\n    pub id: uuid::Uuid,\n}\n",
+        )
+        .unwrap();
+
+        let err = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("UUID"));
+    }
+
+    #[test]
+    fn references_field_handles_unparseable_model_file_gracefully() {
+        // A model file that isn't valid Rust (or uses a struct name that
+        // doesn't match) must not panic — "can't verify" falls back to no
+        // error, same as if the model couldn't be found at all.
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(models_dir.join("post.rs"), "this is not valid rust {{{").unwrap();
+
+        let plan = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert!(plan.warnings.is_empty());
     }
 
     // ── self-referential `references` (issue #1026 follow-up) ──────────────

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -66,8 +66,11 @@ impl ModelMetadata {
 
 /// Compute every action a `generate model` invocation would perform.
 ///
-/// Pure planning step — no I/O happens here. Tests use this directly so they
-/// can inspect the emitted file list and contents without touching the disk.
+/// Planning-only step — no file is *written* here (that's [`Plan::execute`]).
+/// It does read a few existing files (`mod.rs`/`schema.rs` to merge into, and
+/// any `references` target's model file to validate it — see
+/// [`check_reference_targets`]), so tests can inspect the emitted file list
+/// and contents without any writes reaching disk.
 ///
 /// # Errors
 /// Surfaces project-layout, DSL, and naming errors before any file is written.
@@ -186,42 +189,101 @@ pub fn plan_model_with_options(
     Ok(plan)
 }
 
-/// Where a referenced model's source was found, per [`find_model_file`].
-enum ModelFileMatch {
-    /// The conventional per-resource `src/models/<base>.rs` — its entire
-    /// content belongs to exactly this one model, so it's safe to inspect
-    /// for that model's own `#[id]` type.
-    PerResource(std::path::PathBuf),
-    /// The single-file `src/models.rs` layout, which may define several
-    /// models in one file — content-based checks scoped to *this* model
-    /// (like the UUID-PK check below) can't safely be run against it.
-    SingleFile,
-}
-
-/// Locate the source file (if any) that defines resource `base`'s model,
+/// Whether resource `base`'s model can be found anywhere in the project,
 /// checking both layouts the codebase already treats as valid (see
 /// `migration.rs`'s `AddSearch` migration shape, which checks the same two
-/// locations): the per-resource `src/models/<base>.rs`, and the single-file
-/// `src/models.rs` — the latter only counts as a match if its content
-/// actually references the resource's table (`use crate::schema::<table>;`,
-/// which every generated model file emits), so an unrelated `src/models.rs`
-/// doesn't produce a false "model exists" result.
-fn find_model_file(project_root: &Path, table: &str, base: &str) -> Option<ModelFileMatch> {
+/// locations): the per-resource `src/models/<base>.rs` (mere existence
+/// counts — it's this resource's own file, however it's written), and the
+/// single-file `src/models.rs` (only counts if its content actually declares
+/// the resource's table, via a word-boundary-aware check so `posts` isn't
+/// confused with a longer table name like `posts_tags`).
+fn model_file_exists(project_root: &Path, table: &str, base: &str) -> bool {
     let per_resource = project_root
         .join("src")
         .join("models")
         .join(format!("{base}.rs"));
     if per_resource.exists() {
-        return Some(ModelFileMatch::PerResource(per_resource));
+        return true;
+    }
+    let single_file = project_root.join("src").join("models.rs");
+    single_file.exists() && declares_schema_table(&read_or_empty(&single_file), table)
+}
+
+/// True if `content` contains `schema::<table>` immediately followed by a
+/// non-identifier character (or nothing) — i.e. an exact match on `table`,
+/// not merely a prefix of a longer table name sharing the same start.
+fn declares_schema_table(content: &str, table: &str) -> bool {
+    let needle = format!("schema::{table}");
+    content.match_indices(&needle).any(|(idx, _)| {
+        content[idx + needle.len()..]
+            .chars()
+            .next()
+            .is_none_or(|c| !c.is_alphanumeric() && c != '_')
+    })
+}
+
+/// Locate the source text of resource `base`'s `#[model]` struct body (the
+/// text between its opening and matching closing brace), checking both
+/// model-file layouts (see [`model_file_exists`]).
+///
+/// Scoping to the specific struct's body (rather than the whole file) means
+/// callers can inspect the resource's own `#[id]` field even when other
+/// models are declared in the same `src/models.rs`. Returns `None` when the
+/// struct can't be located textually (e.g. a hand-written model using an
+/// unconventional struct name) — callers should treat that as "can't verify,
+/// don't guess" rather than "model missing", since [`model_file_exists`]
+/// already established the model is present.
+fn find_model_struct_body(project_root: &Path, base: &str) -> Option<String> {
+    let pascal_name = pascal(base);
+    let per_resource = project_root
+        .join("src")
+        .join("models")
+        .join(format!("{base}.rs"));
+    if per_resource.exists() {
+        return extract_struct_body(&read_or_empty(&per_resource), &pascal_name);
     }
     let single_file = project_root.join("src").join("models.rs");
     if single_file.exists() {
-        let content = read_or_empty(&single_file);
-        if content.contains(&format!("schema::{table}")) {
-            return Some(ModelFileMatch::SingleFile);
+        return extract_struct_body(&read_or_empty(&single_file), &pascal_name);
+    }
+    None
+}
+
+/// Extract the text between `struct <name> {` and its matching closing `}`,
+/// tracking brace depth so a struct containing nested braces (there are none
+/// in practice — model fields are plain types — but this stays correct if
+/// that ever changes) isn't truncated at the first inner `}`.
+fn extract_struct_body(content: &str, struct_name: &str) -> Option<String> {
+    let needle = format!("struct {struct_name} {{");
+    let start = content.find(&needle)? + needle.len();
+    let mut depth: usize = 1;
+    for (i, b) in content.as_bytes()[start..].iter().enumerate() {
+        match b {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(content[start..start + i].to_string());
+                }
+            }
+            _ => {}
         }
     }
     None
+}
+
+/// Whether a `#[model]` struct body's primary key (the field tagged `#[id]`,
+/// regardless of its name — the macro identifies the PK by attribute, not by
+/// the name `id`) is a `uuid::Uuid`.
+fn struct_has_uuid_pk(struct_body: &str) -> bool {
+    let lines: Vec<&str> = struct_body.lines().map(str::trim).collect();
+    lines.iter().enumerate().any(|(i, line)| {
+        *line == "#[id]"
+            && lines[i + 1..]
+                .iter()
+                .find(|l| !l.is_empty())
+                .is_some_and(|field_line| field_line.contains("uuid::Uuid"))
+    })
 }
 
 /// Validate every `references` field against its target model (issue #1026):
@@ -258,30 +320,23 @@ pub(super) fn check_reference_targets(
             continue;
         };
         let base = f.name.strip_suffix("_id").unwrap_or(&f.name);
-        match find_model_file(project_root, &table, base) {
-            None => {
-                plan.warn(format!(
-                    "'{}' references model '{base}', but src/models/{base}.rs (or src/models.rs) \
-                     was not found — assuming table '{table}' already exists.",
-                    f.name
-                ));
-            }
-            Some(ModelFileMatch::PerResource(path)) => {
-                if read_or_empty(&path).contains("pub id: uuid::Uuid,") {
-                    return Err(GenerateError::Config(format!(
-                        "'{}' references model '{base}' ({}), which declares a UUID primary \
-                         key. `references` fields only support i64/BIGSERIAL-keyed targets \
-                         (issue #1026) — hand-write the migration for a UUID foreign key instead.",
-                        f.name,
-                        path.display()
-                    )));
-                }
-            }
-            Some(ModelFileMatch::SingleFile) => {
-                // Can't safely isolate this one model's `#[id]` type from a
-                // shared `src/models.rs` file that may define several models,
-                // so the UUID-PK check is skipped for that layout.
-            }
+        if !model_file_exists(project_root, &table, base) {
+            plan.warn(format!(
+                "'{}' references model '{base}', but src/models/{base}.rs (or a matching \
+                 src/models.rs declaration) was not found — assuming table '{table}' \
+                 already exists.",
+                f.name
+            ));
+            continue;
+        }
+        if find_model_struct_body(project_root, base).is_some_and(|body| struct_has_uuid_pk(&body))
+        {
+            return Err(GenerateError::Config(format!(
+                "'{}' references model '{base}', which declares a UUID primary key. \
+                 `references` fields only support i64/BIGSERIAL-keyed targets \
+                 (issue #1026) — hand-write the migration for a UUID foreign key instead.",
+                f.name
+            )));
         }
     }
     Ok(())
@@ -1938,5 +1993,86 @@ autumn-web = \"0.3\"\n";
         )
         .unwrap();
         assert_eq!(plan.warnings.len(), 1, "warnings: {:?}", plan.warnings);
+    }
+
+    #[test]
+    fn references_field_not_confused_by_table_name_prefix_in_single_file_models_rs() {
+        // Only `posts_tags`/`PostsTag` is declared — `posts` must not be
+        // treated as found just because it's a string-prefix of
+        // `posts_tags` (regression: word-boundary-unaware substring match).
+        let tmp = project();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(
+            tmp.path().join("src/models.rs"),
+            "use crate::schema::posts_tags;\n\n#[autumn_web::model]\npub struct PostsTag {\n    #[id]\n    pub id: i64,\n}\n",
+        )
+        .unwrap();
+
+        let plan = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert_eq!(
+            plan.warnings.len(),
+            1,
+            "'posts_tags' must not satisfy a reference to 'posts': {:?}",
+            plan.warnings
+        );
+    }
+
+    #[test]
+    fn references_field_detects_uuid_pk_even_when_id_field_is_renamed() {
+        // The `#[model]` macro identifies the primary key by the `#[id]`
+        // attribute, not by the field name `id` — a hand-edited model file
+        // (the generator's own doc comment says these are "ordinary user
+        // code" once generated) can legally rename it.
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(
+            models_dir.join("post.rs"),
+            "#[autumn_web::model]\npub struct Post {\n    #[id]\n    pub uid: uuid::Uuid,\n}\n",
+        )
+        .unwrap();
+
+        let err = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("UUID"));
+    }
+
+    #[test]
+    fn references_field_not_confused_by_an_unrelated_field_literally_named_id() {
+        // The real primary key is `pk: i64`; an unrelated field happens to be
+        // named `id` and typed `uuid::Uuid`. Only the `#[id]`-tagged field
+        // should be inspected.
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(
+            models_dir.join("post.rs"),
+            "#[autumn_web::model]\npub struct Post {\n    #[id]\n    pub pk: i64,\n    pub id: uuid::Uuid,\n}\n",
+        )
+        .unwrap();
+
+        let plan = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert!(
+            plan.warnings.is_empty(),
+            "an unrelated field named 'id' must not trigger a false UUID-PK error: {:?}",
+            plan.warnings
+        );
     }
 }

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -315,9 +315,13 @@ fn struct_has_uuid_pk(struct_body: &str) -> bool {
 /// Whether a `pub <name>: <Type>,` field declaration's type is a UUID —
 /// either the fully-qualified `uuid::Uuid` (what the generator itself always
 /// emits) or the bare `Uuid` (idiomatic with a `use uuid::Uuid;` import at
-/// the top of the file, a common hand-edit of a generated model).
+/// the top of the file, a common hand-edit of a generated model). Tolerates
+/// a trailing `// comment` on the same line (e.g. `pub id: uuid::Uuid, //
+/// primary key`), which would otherwise get swept into the extracted type
+/// text since it comes after the trailing comma.
 fn field_type_is_uuid(field_line: &str) -> bool {
-    let Some((_, after_colon)) = field_line.split_once(':') else {
+    let code = field_line.split("//").next().unwrap_or(field_line);
+    let Some((_, after_colon)) = code.split_once(':') else {
         return false;
     };
     let ty = after_colon.trim().trim_end_matches(',').trim();
@@ -373,15 +377,38 @@ pub(super) fn check_reference_targets(
         let base = f.name.strip_suffix("_id").unwrap_or(&f.name);
 
         if table == own_table {
-            if own_id_type == Some(IdType::Uuid) {
-                return Err(GenerateError::Config(format!(
-                    "'{}' is a self-referential foreign key, but this model uses a UUID \
-                     primary key (`--id uuid`). `references` fields only support \
-                     i64/BIGSERIAL-keyed targets (issue #1026).",
-                    f.name
-                )));
+            match own_id_type {
+                Some(IdType::Uuid) => {
+                    return Err(GenerateError::Config(format!(
+                        "'{}' is a self-referential foreign key, but this model uses a UUID \
+                         primary key (`--id uuid`). `references` fields only support \
+                         i64/BIGSERIAL-keyed targets (issue #1026).",
+                        f.name
+                    )));
+                }
+                // Known non-UUID PK: the table is being created right now
+                // with that type, so the self-reference is fine.
+                Some(_) => continue,
+                // Unknown (`generate migration Add…To…`, altering a table
+                // whose PK type isn't tracked here): unlike `generate model`,
+                // this table may already exist on disk, so still check its
+                // model file for a UUID PK if one is found — but don't warn
+                // "model not found" for a self-reference, since the table
+                // obviously already exists (that's the point of ALTER TABLE).
+                None => {
+                    if find_model_struct_body(project_root, base)
+                        .is_some_and(|body| struct_has_uuid_pk(&body))
+                    {
+                        return Err(GenerateError::Config(format!(
+                            "'{}' is a self-referential foreign key, but the existing model \
+                             declares a UUID primary key. `references` fields only support \
+                             i64/BIGSERIAL-keyed targets (issue #1026).",
+                            f.name
+                        )));
+                    }
+                    continue;
+                }
             }
-            continue;
         }
 
         if !model_file_exists(project_root, &table, base) {
@@ -2302,6 +2329,30 @@ autumn-web = \"0.3\"\n";
         fs::write(
             models_dir.join("post.rs"),
             "#[autumn_web::model]\npub struct Post {\n    #[id]\n    /// The primary key.\n    pub id: uuid::Uuid,\n}\n",
+        )
+        .unwrap();
+
+        let err = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("UUID"));
+    }
+
+    #[test]
+    fn references_field_detects_uuid_pk_with_trailing_inline_comment() {
+        // `pub id: uuid::Uuid, // primary key` — the trailing comment must
+        // not get swept into the extracted type text (which would make it
+        // compare unequal to "uuid::Uuid" and miss the UUID PK).
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(
+            models_dir.join("post.rs"),
+            "#[autumn_web::model]\npub struct Post {\n    #[id]\n    pub id: uuid::Uuid, // primary key\n}\n",
         )
         .unwrap();
 

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -114,6 +114,7 @@ pub fn plan_model_with_options(
     let schema_fields = augment_fields_for_soft_delete(&fields, options.soft_delete)?;
 
     let mut plan = Plan::new(project_root);
+    warn_about_unknown_references(&mut plan, project_root, &fields);
 
     // (a) `src/models/<snake>.rs` + `src/models/mod.rs`
     let models_dir = project_root.join("src").join("models");
@@ -183,6 +184,38 @@ pub fn plan_model_with_options(
     plan_cargo_deps(&mut plan, project_root, &deps);
 
     Ok(plan)
+}
+
+/// Warn on every `references` field whose target model file doesn't exist in
+/// this project yet (AC8, issue #1026). The generator still scaffolds the FK
+/// column, constraint, and index — the referenced table is simply assumed to
+/// already exist (e.g. it's created by an out-of-band migration, or the
+/// referenced model will be generated in a later command).
+pub(super) fn warn_about_unknown_references(
+    plan: &mut Plan,
+    project_root: &Path,
+    fields: &[Field],
+) {
+    for f in fields {
+        if !f.kind.is_reference() {
+            continue;
+        }
+        let Some(table) = f.reference_table() else {
+            continue;
+        };
+        let base = f.name.strip_suffix("_id").unwrap_or(&f.name);
+        let model_path = project_root
+            .join("src")
+            .join("models")
+            .join(format!("{base}.rs"));
+        if !model_path.exists() {
+            plan.warn(format!(
+                "'{}' references model '{base}', but src/models/{base}.rs was not found — \
+                 assuming table '{table}' already exists.",
+                f.name
+            ));
+        }
+    }
 }
 
 /// Append the virtual `deleted_at` column that `--soft-delete` models add to
@@ -669,7 +702,8 @@ fn sql_default_literal(field: &Field, value: &str) -> Result<String, String> {
         | FieldKind::NaiveDateTime
         | FieldKind::DateTime
         | FieldKind::Bytea
-        | FieldKind::Attachment => Err(format!(
+        | FieldKind::Attachment
+        | FieldKind::References => Err(format!(
             "defaults for {} fields are not supported by `autumn generate` yet",
             field.rust_type()
         )),
@@ -1605,5 +1639,134 @@ autumn-web = \"0.3\"\n";
             up.contains("author_id UUID NOT NULL"),
             "FK Uuid migration: {up}"
         );
+    }
+
+    // ── references field type (issue #1026) ────────────────────────────────
+
+    #[test]
+    fn references_field_emits_i64_struct_field_fk_constraint_and_index() {
+        let tmp = project();
+        let plan = plan_model(
+            tmp.path(),
+            "Comment",
+            &["body:Text".into(), "post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let model = fs::read_to_string(tmp.path().join("src/models/comment.rs")).unwrap();
+        assert!(
+            model.contains("pub post_id: i64,"),
+            "references field must render as i64: {model}"
+        );
+
+        let up = fs::read_to_string(
+            tmp.path()
+                .join("migrations/20260427000000_create_comments/up.sql"),
+        )
+        .unwrap();
+        assert!(
+            up.contains("post_id BIGINT NOT NULL REFERENCES posts(id)"),
+            "up.sql must emit the FK column + constraint: {up}"
+        );
+        assert!(
+            up.contains("CREATE INDEX idx_comments_post_id ON comments (post_id);"),
+            "up.sql must emit an automatic FK index: {up}"
+        );
+
+        let down = fs::read_to_string(
+            tmp.path()
+                .join("migrations/20260427000000_create_comments/down.sql"),
+        )
+        .unwrap();
+        assert!(
+            down.contains("DROP TABLE comments"),
+            "down.sql drops the whole table, cleanly reversing the FK/index/column: {down}"
+        );
+
+        let schema = fs::read_to_string(tmp.path().join("src/schema.rs")).unwrap();
+        assert!(
+            schema.contains("post_id -> Int8,"),
+            "schema.rs must use Int8 for the FK column: {schema}"
+        );
+    }
+
+    #[test]
+    fn nullable_references_field_emits_option_i64() {
+        let tmp = project();
+        let plan = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references?".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let model = fs::read_to_string(tmp.path().join("src/models/comment.rs")).unwrap();
+        assert!(
+            model.contains("pub post_id: Option<i64>,"),
+            "nullable references field must render as Option<i64>: {model}"
+        );
+
+        let up = fs::read_to_string(
+            tmp.path()
+                .join("migrations/20260427000000_create_comments/up.sql"),
+        )
+        .unwrap();
+        assert!(
+            up.contains("post_id BIGINT NULL REFERENCES posts(id)"),
+            "{up}"
+        );
+    }
+
+    #[test]
+    fn references_field_warns_when_target_model_is_missing() {
+        let tmp = project();
+        let plan = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert_eq!(plan.warnings.len(), 1, "warnings: {:?}", plan.warnings);
+        assert!(plan.warnings[0].contains("post"));
+        assert!(plan.warnings[0].contains("posts"));
+    }
+
+    #[test]
+    fn references_field_no_warning_when_target_model_exists() {
+        let tmp = project();
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(models_dir.join("post.rs"), "// existing Post model\n").unwrap();
+
+        let plan = plan_model(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert!(
+            plan.warnings.is_empty(),
+            "no warning expected once src/models/post.rs exists: {:?}",
+            plan.warnings
+        );
+    }
+
+    #[test]
+    fn no_references_field_means_no_warnings() {
+        let tmp = project();
+        let plan = plan_model(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert!(plan.warnings.is_empty());
     }
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1841,11 +1841,19 @@ fn render_api_smoke_test(plural: &str, id_schema_type: &str, setup_calls: &str) 
 /// A minimal stand-in table (just the `id` column the FK constraint checks
 /// against) is enough to satisfy Postgres without duplicating the target's
 /// full schema.
-fn render_reference_stub_tables_sql(fields: &[Field]) -> String {
+///
+/// Skips `own_table` — a self-referential `references` field (e.g. a
+/// `Category` model with a `category:references` field) targets the model's
+/// own table, which is about to be created for real by the very next
+/// statement. Postgres allows a self-referential FK within the same
+/// `CREATE TABLE`, so no stub is needed there; emitting one anyway would
+/// collide with the real (non-`IF NOT EXISTS`) `CREATE TABLE` that follows.
+fn render_reference_stub_tables_sql(fields: &[Field], own_table: &str) -> String {
     let mut out = String::new();
     let mut seen = BTreeSet::new();
     for f in fields {
         if let Some(target) = f.reference_table()
+            && target != own_table
             && seen.insert(target.clone())
         {
             let _ = writeln!(
@@ -1875,7 +1883,7 @@ fn render_smoke_test(
     indexes: &BTreeSet<String>,
     defaults: &BTreeMap<String, String>,
 ) -> String {
-    let stub_tables_sql = render_reference_stub_tables_sql(fields);
+    let stub_tables_sql = render_reference_stub_tables_sql(fields, plural);
     let create_table_sql =
         create_table_sql_with_metadata_and_id(plural, fields, indexes, defaults, id_type);
     let mut setup_calls = render_execute_sql_calls(&stub_tables_sql);
@@ -3334,22 +3342,66 @@ async fn main() {
 
     #[test]
     fn render_reference_stub_tables_sql_dedupes_identical_targets() {
-        // Two references whose base names happen to pluralise to the same
-        // table must only emit one `CREATE TABLE IF NOT EXISTS` for it.
-        let fields = super::super::dsl::parse_fields(&[
-            "person:references".into(),
-            "people:references".into(),
-        ])
-        .unwrap();
-        let sql = render_reference_stub_tables_sql(&fields);
+        // Two references that resolve to the same target table must only
+        // emit one `CREATE TABLE IF NOT EXISTS` for it. Constructed directly
+        // (bypassing `parse_fields`, which enforces unique column names) so
+        // the collision is deterministic rather than relying on two English
+        // words coincidentally pluralising to the same string.
+        let fields = vec![
+            Field {
+                name: "author_id".to_string(),
+                kind: FieldKind::References,
+                nullable: false,
+            },
+            Field {
+                name: "author_id".to_string(),
+                kind: FieldKind::References,
+                nullable: true,
+            },
+        ];
+        assert_eq!(
+            fields[0].reference_table(),
+            fields[1].reference_table(),
+            "test setup: both fields must target the same table"
+        );
+        let sql = render_reference_stub_tables_sql(&fields, "unrelated_table");
         assert_eq!(
             sql.matches("CREATE TABLE IF NOT EXISTS").count(),
-            fields
-                .iter()
-                .filter_map(Field::reference_table)
-                .collect::<BTreeSet<_>>()
-                .len(),
-            "stub tables must be de-duplicated by target name: {sql}"
+            1,
+            "identical targets must be de-duplicated: {sql}"
         );
+    }
+
+    #[test]
+    fn render_reference_stub_tables_sql_skips_own_table() {
+        // A self-referential `references` field (e.g. `Category` with
+        // `category:references`) targets the model's own table, which the
+        // real (non-`IF NOT EXISTS`) `CREATE TABLE` creates right after —
+        // stubbing it first would collide with that statement.
+        let fields = super::super::dsl::parse_fields(&["category:references".into()]).unwrap();
+        assert_eq!(fields[0].reference_table().as_deref(), Some("categories"));
+        let sql = render_reference_stub_tables_sql(&fields, "categories");
+        assert!(sql.is_empty(), "must not stub the model's own table: {sql}");
+    }
+
+    #[test]
+    fn scaffold_self_referential_reference_compiles_one_create_table() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Category",
+            &["name:String".into(), "category:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let test = fs::read_to_string(tmp.path().join("tests/category.rs")).unwrap();
+        assert_eq!(
+            test.matches("CREATE TABLE").count(),
+            1,
+            "a self-referential FK must not stub its own table before creating it for real: {test}"
+        );
+        assert!(test.contains("category_id BIGINT NOT NULL REFERENCES categories(id)"));
     }
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1829,13 +1829,43 @@ fn render_api_smoke_test(plural: &str, id_schema_type: &str, setup_calls: &str) 
     )
 }
 
+/// Emit `CREATE TABLE IF NOT EXISTS <target> (id BIGSERIAL PRIMARY KEY);` for
+/// every distinct table a `references` field points at.
+///
+/// `TestDb::shared()` starts one Postgres testcontainer per `tests/*.rs`
+/// binary (a process-global `OnceLock`), so a scaffold's own smoke test can't
+/// assume some *other* scaffolded resource's smoke test already created the
+/// referenced table — `CREATE TABLE comments (... REFERENCES posts(id) ...)`
+/// would otherwise fail with "relation posts does not exist" whenever
+/// `Comment` is scaffolded without also scaffolding `Post` in the same run.
+/// A minimal stand-in table (just the `id` column the FK constraint checks
+/// against) is enough to satisfy Postgres without duplicating the target's
+/// full schema.
+fn render_reference_stub_tables_sql(fields: &[Field]) -> String {
+    let mut out = String::new();
+    let mut seen = BTreeSet::new();
+    for f in fields {
+        if let Some(target) = f.reference_table()
+            && seen.insert(target.clone())
+        {
+            let _ = writeln!(
+                out,
+                "CREATE TABLE IF NOT EXISTS {target} (id BIGSERIAL PRIMARY KEY);"
+            );
+        }
+    }
+    out
+}
+
 /// Render the `tests/<snake>.rs` smoke test.
 ///
 /// Delegates to [`render_index_smoke_test`] or [`render_api_smoke_test`]
 /// depending on `api`, after computing the exact `CREATE TABLE`/`CREATE
 /// INDEX` SQL the generated migration also emits (see
 /// [`create_table_sql_with_metadata_and_id`]), so the throwaway table the
-/// test creates in `TestDb` matches the real schema.
+/// test creates in `TestDb` matches the real schema. Any `references` field
+/// also gets a stub target table created first — see
+/// [`render_reference_stub_tables_sql`].
 fn render_smoke_test(
     pascal_name: &str,
     plural: &str,
@@ -1845,9 +1875,11 @@ fn render_smoke_test(
     indexes: &BTreeSet<String>,
     defaults: &BTreeMap<String, String>,
 ) -> String {
+    let stub_tables_sql = render_reference_stub_tables_sql(fields);
     let create_table_sql =
         create_table_sql_with_metadata_and_id(plural, fields, indexes, defaults, id_type);
-    let setup_calls = render_execute_sql_calls(&create_table_sql);
+    let mut setup_calls = render_execute_sql_calls(&stub_tables_sql);
+    setup_calls.push_str(&render_execute_sql_calls(&create_table_sql));
     let id_schema_type = id_type.schema_type();
 
     if api {
@@ -3205,6 +3237,119 @@ async fn main() {
             test.matches("CREATE TABLE").count(),
             1,
             "CREATE TABLE must appear in a single execute_sql call, not split across two: {test}"
+        );
+    }
+
+    // ── references field: scaffold + smoke-test wiring (issue #1026) ───────
+
+    #[test]
+    fn scaffold_references_field_emits_fk_column_constraint_and_index() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Comment",
+            &["body:Text".into(), "post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let up = fs::read_to_string(
+            tmp.path()
+                .join("migrations/20260427000000_create_comments/up.sql"),
+        )
+        .unwrap();
+        assert!(
+            up.contains("post_id BIGINT NOT NULL REFERENCES posts(id)"),
+            "up.sql: {up}"
+        );
+        assert!(
+            up.contains("CREATE INDEX idx_comments_post_id ON comments (post_id);"),
+            "up.sql: {up}"
+        );
+    }
+
+    #[test]
+    fn scaffold_references_field_warns_when_target_model_missing() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Comment",
+            &["post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert_eq!(plan.warnings.len(), 1, "warnings: {:?}", plan.warnings);
+        assert!(plan.warnings[0].contains("posts"));
+    }
+
+    #[test]
+    fn scaffold_smoke_test_creates_a_stub_referenced_table_before_the_real_one() {
+        // The generated smoke test runs in its own throwaway `TestDb` (one
+        // Postgres testcontainer per `tests/*.rs` binary, per-process — see
+        // `TestDb::shared()`), so it can't rely on some *other* scaffolded
+        // resource's smoke test having already created the referenced table.
+        // A `CREATE TABLE comments (... REFERENCES posts(id) ...)` would fail
+        // with "relation posts does not exist" unless the comments smoke test
+        // creates a minimal stand-in `posts` table itself first.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Comment",
+            &["body:Text".into(), "post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let test = fs::read_to_string(tmp.path().join("tests/comment.rs")).unwrap();
+        let stub_pos = test
+            .find("CREATE TABLE IF NOT EXISTS posts")
+            .unwrap_or_else(|| panic!("expected a stub `posts` table in the smoke test: {test}"));
+        let real_pos = test.find("CREATE TABLE comments").unwrap_or_else(|| {
+            panic!("expected the real `comments` table in the smoke test: {test}")
+        });
+        assert!(
+            stub_pos < real_pos,
+            "the stub referenced table must be created before the table under test: {test}"
+        );
+    }
+
+    #[test]
+    fn scaffold_smoke_test_emits_one_stub_per_distinct_reference_target() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Follow",
+            &["follower:references".into(), "followee:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let test = fs::read_to_string(tmp.path().join("tests/follow.rs")).unwrap();
+        assert!(test.contains("CREATE TABLE IF NOT EXISTS followers"));
+        assert!(test.contains("CREATE TABLE IF NOT EXISTS followees"));
+    }
+
+    #[test]
+    fn render_reference_stub_tables_sql_dedupes_identical_targets() {
+        // Two references whose base names happen to pluralise to the same
+        // table must only emit one `CREATE TABLE IF NOT EXISTS` for it.
+        let fields = super::super::dsl::parse_fields(&[
+            "person:references".into(),
+            "people:references".into(),
+        ])
+        .unwrap();
+        let sql = render_reference_stub_tables_sql(&fields);
+        assert_eq!(
+            sql.matches("CREATE TABLE IF NOT EXISTS").count(),
+            fields
+                .iter()
+                .filter_map(Field::reference_table)
+                .collect::<BTreeSet<_>>()
+                .len(),
+            "stub tables must be de-duplicated by target name: {sql}"
         );
     }
 }

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -487,18 +487,33 @@ pub fn remove_columns_up_sql(table: &str, fields: &[Field]) -> String {
     out
 }
 
-/// `down.sql` companion to [`remove_columns_up_sql`].
+/// `down.sql` companion to [`remove_columns_up_sql`]. Restores a `references`
+/// field's `REFERENCES <table>(id)` constraint and automatic index (see
+/// [`create_table_sql_with_metadata_and_id`]/[`add_columns_up_sql`]) — a
+/// bare re-added column would silently drop the foreign-key relationship and
+/// its lookup index on rollback (issue #1026).
 #[must_use]
 pub fn remove_columns_down_sql(table: &str, fields: &[Field]) -> String {
     let mut out = String::new();
     for f in fields.iter().rev() {
-        let _ = writeln!(
+        let _ = write!(
             out,
-            "ALTER TABLE {table} ADD COLUMN {} {} {};",
+            "ALTER TABLE {table} ADD COLUMN {} {} {}",
             f.name,
             f.sql_type(),
             f.sql_nullability()
         );
+        if let Some(target) = f.reference_table() {
+            let _ = write!(out, " REFERENCES {target}(id)");
+        }
+        out.push_str(";\n");
+        if f.kind.is_reference() {
+            let _ = writeln!(
+                out,
+                "CREATE INDEX idx_{table}_{} ON {table} ({});",
+                f.name, f.name
+            );
+        }
     }
     out
 }
@@ -3272,6 +3287,26 @@ mod tests {
             "DROP COLUMN must carry a safety comment; got:\n{sql}"
         );
         assert!(sql.contains("ALTER TABLE posts DROP COLUMN body;"));
+    }
+
+    #[test]
+    fn remove_columns_down_sql_restores_fk_constraint_and_index_for_references_field() {
+        // Rolling back `RemovePostFromComments post:references` must restore
+        // the FK constraint and its index, not just a bare BIGINT column —
+        // otherwise the relationship and its lookup index silently vanish
+        // on rollback (issue #1026).
+        let f = fields(&["post:references"]);
+        let sql = remove_columns_down_sql("comments", &f);
+        assert!(
+            sql.contains(
+                "ALTER TABLE comments ADD COLUMN post_id BIGINT NOT NULL REFERENCES posts(id);"
+            ),
+            "got:\n{sql}"
+        );
+        assert!(
+            sql.contains("CREATE INDEX idx_comments_post_id ON comments (post_id);"),
+            "got:\n{sql}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -119,12 +119,25 @@ pub fn create_table_sql_with_metadata_and_id(
             f.sql_type(),
             f.sql_nullability()
         );
+        if let Some(target) = f.reference_table() {
+            let _ = write!(sql, " REFERENCES {target}(id)");
+        }
         if let Some(default) = defaults.get(&f.name) {
             let _ = write!(sql, " DEFAULT {default}");
         }
     }
     sql.push_str(",\n    created_at TIMESTAMP NOT NULL DEFAULT NOW()\n);\n");
-    for field_name in indexes {
+    // Every `references` field gets an index automatically (Rails' `add_reference`
+    // behaviour), in addition to any explicit `--index` fields. Merging into the
+    // same sorted set keeps `CREATE INDEX` output deterministic and de-duplicates
+    // a reference field that was *also* passed via `--index`.
+    let mut index_fields = indexes.clone();
+    for f in fields {
+        if f.kind.is_reference() {
+            index_fields.insert(f.name.clone());
+        }
+    }
+    for field_name in &index_fields {
         let _ = writeln!(
             sql,
             "CREATE INDEX idx_{table}_{field_name} ON {table} ({field_name});"
@@ -264,13 +277,26 @@ pub fn add_columns_up_sql(table: &str, fields: &[Field]) -> String {
                  -- add a DEFAULT or backfill existing rows before enforcing NOT NULL"
             );
         }
-        let _ = writeln!(
+        let _ = write!(
             out,
-            "ALTER TABLE {table} ADD COLUMN {} {} {};",
+            "ALTER TABLE {table} ADD COLUMN {} {} {}",
             f.name,
             f.sql_type(),
             f.sql_nullability()
         );
+        if let Some(target) = f.reference_table() {
+            let _ = write!(out, " REFERENCES {target}(id)");
+        }
+        out.push_str(";\n");
+        if f.kind.is_reference() {
+            // Postgres auto-drops this index (and the FK constraint above) when
+            // the column is dropped, so `add_columns_down_sql` needs no change.
+            let _ = writeln!(
+                out,
+                "CREATE INDEX idx_{table}_{} ON {table} ({});",
+                f.name, f.name
+            );
+        }
     }
     out
 }
@@ -3055,6 +3081,88 @@ mod tests {
     #[test]
     fn drop_table_sql_simple() {
         assert_eq!(drop_table_sql("posts"), "DROP TABLE posts;\n");
+    }
+
+    // ── references field: FK column + constraint + index (issue #1026) ─────
+
+    #[test]
+    fn create_table_sql_emits_fk_column_with_constraint() {
+        let sql = create_table_sql_with_metadata_and_id(
+            "comments",
+            &fields(&["body:Text", "post:references"]),
+            &BTreeSet::new(),
+            &BTreeMap::new(),
+            IdType::BigSerial,
+        );
+        assert!(
+            sql.contains("post_id BIGINT NOT NULL REFERENCES posts(id)"),
+            "expected FK column with constraint; got:\n{sql}"
+        );
+    }
+
+    #[test]
+    fn create_table_sql_emits_fk_index_automatically() {
+        let sql = create_table_sql_with_metadata_and_id(
+            "comments",
+            &fields(&["post:references"]),
+            &BTreeSet::new(),
+            &BTreeMap::new(),
+            IdType::BigSerial,
+        );
+        assert!(
+            sql.contains("CREATE INDEX idx_comments_post_id ON comments (post_id);"),
+            "expected an automatic FK index; got:\n{sql}"
+        );
+    }
+
+    #[test]
+    fn create_table_sql_nullable_reference_has_no_not_null_but_keeps_constraint_and_index() {
+        let sql = create_table_sql_with_metadata_and_id(
+            "comments",
+            &fields(&["post:references?"]),
+            &BTreeSet::new(),
+            &BTreeMap::new(),
+            IdType::BigSerial,
+        );
+        assert!(
+            sql.contains("post_id BIGINT NULL REFERENCES posts(id)"),
+            "nullable FK column must omit NOT NULL but keep the constraint; got:\n{sql}"
+        );
+        assert!(sql.contains("CREATE INDEX idx_comments_post_id ON comments (post_id);"));
+    }
+
+    #[test]
+    fn create_table_sql_fk_index_not_duplicated_when_also_passed_via_index_flag() {
+        let mut explicit_indexes = BTreeSet::new();
+        explicit_indexes.insert("post_id".to_owned());
+        let sql = create_table_sql_with_metadata_and_id(
+            "comments",
+            &fields(&["post:references"]),
+            &explicit_indexes,
+            &BTreeMap::new(),
+            IdType::BigSerial,
+        );
+        assert_eq!(
+            sql.matches("CREATE INDEX idx_comments_post_id").count(),
+            1,
+            "the FK index and an explicit --index on the same field must not \
+             produce two CREATE INDEX statements:\n{sql}"
+        );
+    }
+
+    #[test]
+    fn add_columns_up_sql_emits_fk_constraint_and_index() {
+        let sql = add_columns_up_sql("comments", &fields(&["post:references"]));
+        assert!(
+            sql.contains(
+                "ALTER TABLE comments ADD COLUMN post_id BIGINT NOT NULL REFERENCES posts(id);"
+            ),
+            "got:\n{sql}"
+        );
+        assert!(
+            sql.contains("CREATE INDEX idx_comments_post_id ON comments (post_id);"),
+            "got:\n{sql}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1361,9 +1361,18 @@ enum ReleaseCommands {
 enum GenerateCommands {
     /// Generate a `#[model]` struct, Diesel migration, and schema entry.
     ///
-    /// Example:
+    /// Field types: String, Text, i32, i64, bool, f32, f64, Uuid, `NaiveDateTime`,
+    /// `DateTime`, Vec<u8>/Bytea, Attachment, references, Option<...>.
+    ///
+    /// `field:references` scaffolds a foreign key: a `field_id BIGINT` column
+    /// with a `REFERENCES <table>(id)` constraint and an index, where `<table>`
+    /// is the pluralised form of `field`. Append `?` for a nullable FK
+    /// (`post:references?` -> `post_id: Option<i64>`).
+    ///
+    /// Examples:
     ///
     ///   autumn generate model Post title:String body:Text published:bool
+    ///   autumn generate model Comment body:Text post:references
     #[command(verbatim_doc_comment)]
     Model {
         /// Resource name (`PascalCase` or `snake_case`, e.g. `Post`).
@@ -1708,6 +1717,13 @@ enum GenerateCommands {
     },
     /// Generate model, migration, repository, HTML routes, smoke test, and
     /// register the new routes in `src/main.rs`.
+    ///
+    /// Field types: String, Text, i32, i64, bool, f32, f64, Uuid, `NaiveDateTime`,
+    /// `DateTime`, Vec<u8>/Bytea, Attachment, references, Option<...>.
+    ///
+    /// `field:references` scaffolds a foreign key (`field_id BIGINT
+    /// REFERENCES <table>(id)` plus an index), e.g.
+    /// `autumn generate scaffold Comment body:Text post:references`.
     Scaffold {
         /// Resource name (`PascalCase` or `snake_case`, e.g. `Post`).
         name: String,

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -317,6 +317,28 @@ fn generate_model_references_warns_when_target_model_missing() {
 }
 
 #[test]
+fn generate_model_references_warning_not_printed_on_a_failed_collision_run() {
+    // A run that fails before writing anything (a file collision without
+    // --force) must not print advisory warnings for a plan that was never
+    // applied — warnings are informational about what *did* happen.
+    let (_tmp, project) = fresh_project("references-warn-collision-app");
+    run_autumn(
+        &project,
+        &["generate", "model", "Comment", "post:references"],
+    );
+    let (_, stderr, code) = run_autumn_failing(
+        &project,
+        &["generate", "model", "Comment", "post:references"],
+    );
+    assert_eq!(code, Some(1));
+    assert!(stderr.contains("would overwrite"));
+    assert!(
+        !stderr.contains("Warning"),
+        "no warning should print on a failed, no-op run: {stderr}"
+    );
+}
+
+#[test]
 fn generate_model_references_no_warning_when_target_model_exists() {
     let (_tmp, project) = fresh_project("references-nowarn-app");
     run_autumn(&project, &["generate", "model", "Post", "title:String"]);
@@ -383,6 +405,25 @@ fn generate_model_dry_run_lists_migration_file_for_references_field() {
     assert!(stdout.contains("Dry run"));
     assert!(stdout.contains("migrations/"));
     assert!(stdout.contains("create_comments/up.sql"));
+    assert!(!project.join("src/models/comment.rs").exists());
+}
+
+#[test]
+fn generate_model_references_errors_when_target_has_uuid_pk() {
+    let (_tmp, project) = fresh_project("references-uuid-mismatch-app");
+    run_autumn(
+        &project,
+        &["generate", "model", "Post", "--id", "uuid", "title:String"],
+    );
+    let (_, stderr, code) = run_autumn_failing(
+        &project,
+        &["generate", "model", "Comment", "post:references"],
+    );
+    assert_eq!(code, Some(1));
+    assert!(
+        stderr.contains("UUID"),
+        "expected a clear UUID-mismatch error; got stderr: {stderr}"
+    );
     assert!(!project.join("src/models/comment.rs").exists());
 }
 

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -266,6 +266,126 @@ fn generate_model_invalid_field_lists_supported_set() {
     assert!(stderr.contains("String"));
 }
 
+// ── `references` field type (issue #1026) ───────────────────────────────────
+
+#[test]
+fn generate_model_references_field_emits_fk_column_constraint_and_index() {
+    let (_tmp, project) = fresh_project("references-app");
+    run_autumn(
+        &project,
+        &[
+            "generate",
+            "model",
+            "Comment",
+            "body:Text",
+            "post:references",
+        ],
+    );
+
+    let model = fs::read_to_string(project.join("src/models/comment.rs")).unwrap();
+    assert!(model.contains("pub post_id: i64,"));
+
+    let schema = fs::read_to_string(project.join("src/schema.rs")).unwrap();
+    assert!(schema.contains("post_id -> Int8,"));
+
+    let migrations = fs::read_dir(project.join("migrations"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .ends_with("_create_comments")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(migrations.len(), 1);
+    let up = fs::read_to_string(migrations[0].path().join("up.sql")).unwrap();
+    assert!(up.contains("post_id BIGINT NOT NULL REFERENCES posts(id)"));
+    assert!(up.contains("CREATE INDEX idx_comments_post_id ON comments (post_id);"));
+}
+
+#[test]
+fn generate_model_references_warns_when_target_model_missing() {
+    let (_tmp, project) = fresh_project("references-warn-app");
+    let (_stdout, stderr) = run_autumn(
+        &project,
+        &["generate", "model", "Comment", "post:references"],
+    );
+    assert!(
+        stderr.contains("Warning") && stderr.contains("posts"),
+        "expected a warning about the missing 'post' model; got stderr: {stderr}"
+    );
+}
+
+#[test]
+fn generate_model_references_no_warning_when_target_model_exists() {
+    let (_tmp, project) = fresh_project("references-nowarn-app");
+    run_autumn(&project, &["generate", "model", "Post", "title:String"]);
+    let (_stdout, stderr) = run_autumn(
+        &project,
+        &["generate", "model", "Comment", "post:references"],
+    );
+    assert!(
+        !stderr.contains("Warning"),
+        "no warning expected once the Post model exists; got stderr: {stderr}"
+    );
+}
+
+#[test]
+fn generate_model_references_nullable_form() {
+    let (_tmp, project) = fresh_project("references-nullable-app");
+    run_autumn(
+        &project,
+        &["generate", "model", "Comment", "post:references?"],
+    );
+    let model = fs::read_to_string(project.join("src/models/comment.rs")).unwrap();
+    assert!(model.contains("pub post_id: Option<i64>,"));
+}
+
+#[test]
+fn generate_model_help_documents_references_field() {
+    let tmp = tempfile::tempdir().unwrap();
+    let autumn_bin = env!("CARGO_BIN_EXE_autumn");
+    let output = Command::new(autumn_bin)
+        .args(["generate", "model", "--help"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("references"));
+}
+
+#[test]
+fn generate_scaffold_help_documents_references_field() {
+    let tmp = tempfile::tempdir().unwrap();
+    let autumn_bin = env!("CARGO_BIN_EXE_autumn");
+    let output = Command::new(autumn_bin)
+        .args(["generate", "scaffold", "--help"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("references"));
+}
+
+#[test]
+fn generate_model_dry_run_lists_migration_file_for_references_field() {
+    let (_tmp, project) = fresh_project("references-dryrun-app");
+    let (stdout, _stderr) = run_autumn(
+        &project,
+        &[
+            "generate",
+            "model",
+            "Comment",
+            "post:references",
+            "--dry-run",
+        ],
+    );
+    assert!(stdout.contains("Dry run"));
+    assert!(stdout.contains("migrations/"));
+    assert!(stdout.contains("create_comments/up.sql"));
+    assert!(!project.join("src/models/comment.rs").exists());
+}
+
 #[test]
 fn generate_migration_add_columns_emits_alter() {
     let (_tmp, project) = fresh_project("migrate-app");

--- a/autumn-cli/tests/generate_references_postgres.rs
+++ b/autumn-cli/tests/generate_references_postgres.rs
@@ -1,0 +1,156 @@
+//! Postgres-backed generator test for the `references` field type (issue #1026).
+//!
+//! Exercises the issue's Success Metric end to end: scaffold a two-table
+//! related schema (`Post` + `Comment`, where `Comment` has `post:references`),
+//! apply the generated migrations with `autumn migrate`, confirm the foreign
+//! key constraint and its index exist in Postgres's catalogs, confirm
+//! referential integrity is actually enforced, then roll the migrations back
+//! and confirm both tables are gone.
+//!
+//! Requires Docker (via testcontainers) and is marked `#[ignore]` so it only
+//! runs when explicitly requested:
+//!
+//!   cargo test -p autumn-cli --test `generate_references_postgres` -- --ignored --nocapture
+
+use std::path::Path;
+use std::process::Command;
+
+use diesel::{Connection as _, PgConnection, QueryableByName, RunQueryDsl as _, sql_query};
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+fn run_autumn(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String, Option<i32>) {
+    let output = Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .envs(envs.iter().copied())
+        .output()
+        .expect("failed to run autumn");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code(),
+    )
+}
+
+fn run_autumn_ok(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String) {
+    let (stdout, stderr, code) = run_autumn(dir, args, envs);
+    assert_eq!(
+        code,
+        Some(0),
+        "autumn {args:?} failed (exit={code:?})\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    (stdout, stderr)
+}
+
+#[derive(QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    count: i64,
+}
+
+fn count(conn: &mut PgConnection, sql: &str) -> i64 {
+    sql_query(sql)
+        .get_result::<CountRow>(conn)
+        .unwrap_or_else(|e| panic!("query failed: {sql}\n{e}"))
+        .count
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn references_field_creates_fk_and_index_enforces_integrity_and_reverts_cleanly() {
+    use testcontainers::runners::AsyncRunner as _;
+    use testcontainers_modules::postgres::Postgres;
+
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres testcontainer — is Docker running?");
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let db_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", db_url.as_str())];
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path();
+    std::fs::write(
+        project.join("Cargo.toml"),
+        "[package]\nname = \"refs_app\"\n",
+    )
+    .unwrap();
+
+    // Two related tables: Post (the referenced side) and Comment (the FK side).
+    // Migration directories are timestamped to whole-second resolution and
+    // applied in filename order, so `Post`'s migration must sort before
+    // `Comment`'s — sleep past the second boundary to make that deterministic
+    // rather than relying on two process spawns landing in different seconds.
+    run_autumn_ok(project, &["generate", "model", "Post", "title:String"], &[]);
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    run_autumn_ok(
+        project,
+        &[
+            "generate",
+            "model",
+            "Comment",
+            "body:Text",
+            "post:references",
+        ],
+        &[],
+    );
+
+    // Apply both migrations against real Postgres — no manual SQL edits.
+    run_autumn_ok(project, &["migrate"], &envs);
+
+    let mut conn = PgConnection::establish(&db_url).expect("connect to postgres");
+
+    // The FK constraint exists on `comments`.
+    let fk_count = count(
+        &mut conn,
+        "SELECT COUNT(*)::bigint AS count FROM information_schema.table_constraints \
+         WHERE table_name = 'comments' AND constraint_type = 'FOREIGN KEY'",
+    );
+    assert_eq!(
+        fk_count, 1,
+        "expected exactly one FK constraint on comments"
+    );
+
+    // The FK index exists on `comments`.
+    let index_count = count(
+        &mut conn,
+        "SELECT COUNT(*)::bigint AS count FROM pg_indexes \
+         WHERE tablename = 'comments' AND indexname = 'idx_comments_post_id'",
+    );
+    assert_eq!(index_count, 1, "expected idx_comments_post_id to exist");
+
+    // Referential integrity is enforced: a comment referencing a non-existent
+    // post is rejected...
+    let bad_insert = sql_query("INSERT INTO comments (body, post_id) VALUES ('orphan', 999999)")
+        .execute(&mut conn);
+    assert!(
+        bad_insert.is_err(),
+        "FK constraint should reject a comment referencing a non-existent post"
+    );
+
+    // ...but a comment referencing a real post succeeds.
+    sql_query("INSERT INTO posts (title) VALUES ('hello')")
+        .execute(&mut conn)
+        .expect("insert post");
+    sql_query("INSERT INTO comments (body, post_id) VALUES ('hi', 1)")
+        .execute(&mut conn)
+        .expect("insert comment referencing a real post");
+
+    // Reverting both migrations (down.sql) applies and errors cleanly.
+    run_autumn_ok(project, &["migrate", "down", "--steps", "2"], &envs);
+
+    let remaining_tables = count(
+        &mut conn,
+        "SELECT COUNT(*)::bigint AS count FROM information_schema.tables \
+         WHERE table_name IN ('posts', 'comments')",
+    );
+    assert_eq!(
+        remaining_tables, 0,
+        "both tables (and their FK/index/columns) must be gone after migrate down"
+    );
+}

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -56,6 +56,7 @@ set.
 | `at:NaiveDateTime`| `chrono::NaiveDateTime`         | `Timestamp`        | `TIMESTAMP`         |
 | `at:DateTime`     | `chrono::DateTime<chrono::Utc>` | `Timestamptz`      | `TIMESTAMPTZ`       |
 | `data:Bytea` *(or `Vec<u8>`)* | `Vec<u8>`           | `Bytea`            | `BYTEA`             |
+| `post:references` | `i64`                           | `Int8`             | `BIGINT`            |
 
 Wrap any of the above in `Option<…>` to make the column nullable
 (`Option<String>`, `Option<i64>`, `Option<NaiveDateTime>`, …). The generator
@@ -67,6 +68,28 @@ Every generated table also includes:
   in Autumn).
 - `created_at TIMESTAMP NOT NULL DEFAULT NOW()` annotated `#[default]` on
   the model so it stays out of `NewX`.
+
+### Foreign keys with `references`
+
+`post:references` scaffolds a foreign-key column: the declared name is
+rewritten to end in `_id` (`post` -> `post_id`), the referenced table is
+derived by pluralising the base name (`post` -> `posts`, matching
+`naming::pluralize`), and the column is emitted as
+`post_id BIGINT NOT NULL REFERENCES posts(id)` with an automatic index
+(`CREATE INDEX idx_comments_post_id ON comments (post_id);`) — no `--index`
+flag required. Append `?` for a nullable foreign key
+(`post:references?` -> `post_id: Option<i64>`, column `NULL`):
+
+```bash
+autumn generate scaffold Comment body:Text post:references
+```
+
+If the referenced model doesn't exist yet (no `src/models/post.rs`), the
+generator still scaffolds the column, constraint, and index — it just prints
+a warning that the referenced table is assumed to already exist. Composite
+foreign keys, cascade policy (`ON DELETE`/`ON UPDATE`), and runtime
+association traversal (`belongs_to`/`has_many`) are not in scope for this
+token — see issue #835 for the latter.
 
 ## `autumn generate model`
 

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -84,10 +84,18 @@ flag required. Append `?` for a nullable foreign key
 autumn generate scaffold Comment body:Text post:references
 ```
 
-If the referenced model doesn't exist yet (no `src/models/post.rs`), the
-generator still scaffolds the column, constraint, and index — it just prints
-a warning that the referenced table is assumed to already exist. Composite
-foreign keys, cascade policy (`ON DELETE`/`ON UPDATE`), and runtime
+If the referenced model doesn't exist yet (no `src/models/post.rs`, or a
+matching declaration in a single-file `src/models.rs`), the generator still
+scaffolds the column, constraint, and index — it just prints a warning that
+the referenced table is assumed to already exist.
+
+`references` only supports the i64/BIGSERIAL primary-key convention. If the
+referenced model *is* found but was generated with `--id uuid`, the generator
+fails fast with an error instead of emitting a migration that would break at
+`autumn migrate` time with a `BIGINT`-vs-`UUID` type mismatch — hand-write
+the migration for a UUID foreign key instead.
+
+Composite foreign keys, cascade policy (`ON DELETE`/`ON UPDATE`), and runtime
 association traversal (`belongs_to`/`has_many`) are not in scope for this
 token — see issue #835 for the latter.
 


### PR DESCRIPTION
## Summary

Implements the `references` field type for `autumn generate model`, `scaffold`, and `generate migration Add…To…` commands. This allows developers to declare foreign key relationships using a simple DSL syntax (`post:references`) that automatically scaffolds the FK column, constraint, and index.

## Key Changes

- **DSL Enhancement**: Added `FieldKind::References` variant that:
  - Automatically rewrites field names to end in `_id` (`post:references` → `post_id`)
  - Derives the referenced table name via pluralization (`post` → `posts`)
  - Supports nullable form with `?` suffix (`post:references?` → `Option<i64>`)

- **SQL Generation**: 
  - Emits `BIGINT NOT NULL REFERENCES <table>(id)` columns in migrations
  - Automatically creates indexes on FK columns (`idx_<table>_<field_id>`)
  - Generates proper Diesel schema entries (`Int8` type)
  - Handles both `CREATE TABLE` and `ALTER TABLE ADD COLUMN` scenarios

- **Validation & Safety**:
  - Added `check_reference_targets()` function that validates FK targets:
    - Warns (non-fatal) when a referenced model file doesn't exist yet
    - Errors (fatal) when a referenced model uses UUID primary keys, since `references` only supports the i64/BIGSERIAL convention
  - Shared validation across all three generator subcommands for consistency

- **Smoke Test Support**:
  - Scaffold generator now creates stub tables for referenced models in smoke tests
  - Prevents "relation does not exist" errors when testing in isolation
  - Handles self-referential FKs correctly (no duplicate stub)

- **Documentation & Help**:
  - Updated CLI help text and generator documentation
  - Added comprehensive test coverage including Postgres integration tests
  - Updated CHANGELOG with feature description

## Implementation Details

- The `references` field type always maps to `i64` (matching the default `i64` PK convention)
- FK validation happens during planning phase, before any files are written
- Warnings are printed only on successful plan execution (not on dry-run failures or collisions)
- The implementation reuses existing naming utilities (`pluralize`) for consistency
- Struct body extraction uses brace-depth tracking to handle nested structures correctly

https://claude.ai/code/session_01L9YiTKoRSWs3v3CdNjVbRj