### PR TITLE
Add tracked job handles with progress reporting and status polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **jobs:** tracked job handles with progress reporting and a built-in
+  pollable status route (#1373). `job::enqueue_tracked`/`enqueue_tracked_for`
+  (and the generated `{Job}::enqueue_tracked`/`enqueue_tracked_for`
+  companions) return a `TrackedJobHandle` carrying a public, unguessable
+  token distinct from the internal job id. `#[job]` accepts an optional third
+  `JobContext` argument (`async fn(AppState, Args, JobContext)`) so a handler
+  can call `ctx.set_progress(pct, message)`, `ctx.set_result(json)`, and
+  `ctx.set_user_error(message)`; only the final failed attempt (or a panic)
+  settles the tracked record, so progress survives retries. A new
+  `GET /_autumn/jobs/{token}` route (on by default; opt out via
+  `jobs.tracking.route_enabled = false`) returns the status as JSON for API
+  clients or a self-polling htmx fragment (`hx-trigger="every 2s"`) for
+  browsers, dropping the poll trigger once the job reaches a terminal state.
+  Tokens can be bound to a session/user via `TrackedJobOwner`/
+  `TrackedJobOwner::from_session`; a mismatched or unknown token gets an
+  identical 404 (no enumeration/ownership oracle). Records expire after a
+  configurable TTL (`jobs.tracking.ttl_secs`, default 24h) and are persisted
+  by whichever job backend is already configured — in-memory (`local`),
+  Redis (`redis`), or the new `autumn_job_tracking` table (`postgres`, via a
+  bundled framework migration) — so tracked jobs need no separate setup.
+  Purely additive: existing `#[job]` handlers and `enqueue` calls are
+  unaffected; minor version bump.
+
 - **auth:** scoped service tokens whose scopes flow into policy checks (#1158).
   Mint named, optionally-expiring API tokens carrying a set of flat scopes
   (e.g. `posts:read`) via `IssueTokenSpec` + `issue_scoped_api_token`; tokens

--- a/autumn-macros/src/job.rs
+++ b/autumn-macros/src/job.rs
@@ -259,13 +259,15 @@ pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             .to_compile_error();
     }
 
-    if input_fn.sig.inputs.len() != 2 {
+    if input_fn.sig.inputs.len() != 2 && input_fn.sig.inputs.len() != 3 {
         return syn::Error::new_spanned(
             &input_fn.sig.ident,
-            "#[job] function must have signature async fn(AppState, Args)",
+            "#[job] function must have signature async fn(AppState, Args) or \
+             async fn(AppState, Args, JobContext)",
         )
         .to_compile_error();
     }
+    let takes_context = input_fn.sig.inputs.len() == 3;
 
     let mut inputs = input_fn.sig.inputs.iter();
     let _state_arg = inputs.next();
@@ -279,6 +281,13 @@ pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             .to_compile_error();
         }
     };
+    if takes_context && !matches!(inputs.next(), Some(FnArg::Typed(_))) {
+        return syn::Error::new_spanned(
+            &input_fn.sig.ident,
+            "#[job] third argument must be a typed JobContext",
+        )
+        .to_compile_error();
+    }
 
     let fn_name = &input_fn.sig.ident;
     let companion_name = format_ident!("__autumn_job_info_{fn_name}");
@@ -289,6 +298,12 @@ pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let queue = attrs.queue.clone().unwrap_or_else(|| "default".to_string());
     let uniqueness = uniqueness_tokens(&attrs);
     let concurrency = concurrency_tokens(&attrs);
+
+    let handler_call = if takes_context {
+        quote! { #fn_name(state, args, ::autumn_web::job::JobContext::current()).await }
+    } else {
+        quote! { #fn_name(state, args).await }
+    };
 
     quote! {
         #input_fn
@@ -321,6 +336,27 @@ pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(format!("job args serialization failed: {e}"))))?;
                 ::autumn_web::job::enqueue_at(#job_name, payload, when).await
             }
+
+            /// Enqueue this job and return a handle carrying a public,
+            /// unguessable token that grants anonymous (capability-only)
+            /// access to its tracked status via the built-in status route.
+            pub async fn enqueue_tracked(args: #args_type) -> ::autumn_web::AutumnResult<::autumn_web::job::TrackedJobHandle> {
+                let payload = ::autumn_web::reexports::serde_json::to_value(&args)
+                    .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(format!("job args serialization failed: {e}"))))?;
+                ::autumn_web::job::enqueue_tracked(#job_name, payload).await
+            }
+
+            /// Like [`Self::enqueue_tracked`], binding the tracked status to
+            /// `owner` so only a request matching that session/user may poll
+            /// it.
+            pub async fn enqueue_tracked_for(
+                args: #args_type,
+                owner: ::autumn_web::job::TrackedJobOwner,
+            ) -> ::autumn_web::AutumnResult<::autumn_web::job::TrackedJobHandle> {
+                let payload = ::autumn_web::reexports::serde_json::to_value(&args)
+                    .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(format!("job args serialization failed: {e}"))))?;
+                ::autumn_web::job::enqueue_tracked_for(#job_name, payload, owner).await
+            }
         }
 
         #[doc(hidden)]
@@ -336,7 +372,7 @@ pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     Box::pin(async move {
                         let args: #args_type = ::autumn_web::reexports::serde_json::from_value(payload)
                             .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(format!("job args deserialization failed: {e}"))))?;
-                        #fn_name(state, args).await
+                        #handler_call
                     })
                 },
             }
@@ -569,6 +605,116 @@ mod tests {
         assert!(
             expanded.contains("concurrency : :: std :: option :: Option :: None"),
             "{expanded}"
+        );
+    }
+
+    #[test]
+    fn job_macro_generates_enqueue_tracked_companions() {
+        let expanded = job_macro(
+            quote! { name = "export_orders" },
+            quote! {
+                async fn export_orders(state: AppState, args: ExportArgs) -> AutumnResult<()> {
+                    Ok(())
+                }
+            },
+        )
+        .to_string();
+        assert!(
+            expanded.contains("async fn enqueue_tracked"),
+            "missing enqueue_tracked: {expanded}"
+        );
+        assert!(
+            expanded.contains("async fn enqueue_tracked_for"),
+            "missing enqueue_tracked_for: {expanded}"
+        );
+        assert!(
+            expanded.contains(":: autumn_web :: job :: enqueue_tracked (\"export_orders\" , payload)"),
+            "enqueue_tracked companion should delegate to the module-level free function: {expanded}"
+        );
+        assert!(
+            expanded.contains(":: autumn_web :: job :: enqueue_tracked_for"),
+            "enqueue_tracked_for companion should delegate to the module-level free function: {expanded}"
+        );
+        assert!(
+            expanded.contains("TrackedJobHandle"),
+            "companions should return TrackedJobHandle: {expanded}"
+        );
+        assert!(
+            expanded.contains("TrackedJobOwner"),
+            "enqueue_tracked_for should accept a TrackedJobOwner: {expanded}"
+        );
+    }
+
+    #[test]
+    fn job_macro_accepts_three_arg_signature_and_passes_context_current() {
+        let expanded = job_macro(
+            quote! {},
+            quote! {
+                async fn export_orders(state: AppState, args: ExportArgs, ctx: JobContext) -> AutumnResult<()> {
+                    Ok(())
+                }
+            },
+        )
+        .to_string();
+        assert!(
+            expanded.contains(":: autumn_web :: job :: JobContext :: current ()"),
+            "three-arg handler should be invoked with JobContext::current(): {expanded}"
+        );
+        assert!(
+            expanded.contains("export_orders (state , args , :: autumn_web :: job :: JobContext :: current ())"),
+            "generated handler closure should call the user fn with the context: {expanded}"
+        );
+    }
+
+    #[test]
+    fn job_macro_two_arg_expansion_does_not_reference_job_context() {
+        let expanded = job_macro(
+            quote! {},
+            quote! {
+                async fn plain(state: AppState, args: PlainArgs) -> AutumnResult<()> {
+                    Ok(())
+                }
+            },
+        )
+        .to_string();
+        assert!(
+            !expanded.contains("JobContext"),
+            "two-arg expansion must stay unchanged: {expanded}"
+        );
+        assert!(expanded.contains("plain (state , args) . await"), "{expanded}");
+    }
+
+    #[test]
+    fn job_macro_rejects_one_arg_signature() {
+        let expanded = job_macro(
+            quote! {},
+            quote! {
+                async fn plain(state: AppState) -> AutumnResult<()> {
+                    Ok(())
+                }
+            },
+        )
+        .to_string();
+        assert!(
+            expanded.contains("must have signature"),
+            "expected a compile error about the signature: {expanded}"
+        );
+    }
+
+    #[test]
+    fn job_macro_rejects_four_arg_signature() {
+        let expanded = job_macro(
+            quote! {},
+            quote! {
+                async fn plain(state: AppState, args: PlainArgs, ctx: JobContext, extra: u8) -> AutumnResult<()> {
+                    Ok(())
+                }
+            },
+        )
+        .to_string();
+        assert!(
+            expanded.contains("must have signature"),
+            "expected a compile error about the signature: {expanded}"
         );
     }
 }

--- a/autumn-macros/src/job.rs
+++ b/autumn-macros/src/job.rs
@@ -243,6 +243,7 @@ fn concurrency_tokens(attrs: &JobAttrs) -> TokenStream {
     )
 }
 
+#[allow(clippy::too_many_lines)]
 pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attrs = match parse_job_args(attr) {
         Ok(a) => a,

--- a/autumn-macros/src/job.rs
+++ b/autumn-macros/src/job.rs
@@ -629,7 +629,8 @@ mod tests {
             "missing enqueue_tracked_for: {expanded}"
         );
         assert!(
-            expanded.contains(":: autumn_web :: job :: enqueue_tracked (\"export_orders\" , payload)"),
+            expanded
+                .contains(":: autumn_web :: job :: enqueue_tracked (\"export_orders\" , payload)"),
             "enqueue_tracked companion should delegate to the module-level free function: {expanded}"
         );
         assert!(
@@ -662,7 +663,9 @@ mod tests {
             "three-arg handler should be invoked with JobContext::current(): {expanded}"
         );
         assert!(
-            expanded.contains("export_orders (state , args , :: autumn_web :: job :: JobContext :: current ())"),
+            expanded.contains(
+                "export_orders (state , args , :: autumn_web :: job :: JobContext :: current ())"
+            ),
             "generated handler closure should call the user fn with the context: {expanded}"
         );
     }
@@ -682,7 +685,10 @@ mod tests {
             !expanded.contains("JobContext"),
             "two-arg expansion must stay unchanged: {expanded}"
         );
-        assert!(expanded.contains("plain (state , args) . await"), "{expanded}");
+        assert!(
+            expanded.contains("plain (state , args) . await"),
+            "{expanded}"
+        );
     }
 
     #[test]

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -394,6 +394,23 @@ pub fn scheduled(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// // queues = ["critical", "default", "low"]
 /// SendPasswordResetJob::enqueue(ResetArgs { user_id: 1 }).await?;
 /// ```
+///
+/// Accept an optional third `JobContext` argument to report progress and
+/// record a terminal result/error for jobs enqueued with `enqueue_tracked`
+/// (the companion struct gains `enqueue_tracked` / `enqueue_tracked_for`
+/// alongside `enqueue`):
+///
+/// ```ignore
+/// #[job(name = "export_orders")]
+/// async fn export_orders(state: AppState, args: ExportArgs, ctx: JobContext) -> AutumnResult<()> {
+///     ctx.set_progress(50, Some("Rows 1200/5000")).await?;
+///     ctx.set_result(serde_json::json!({ "download_url": "/blob/abc.csv" }));
+///     Ok(())
+/// }
+///
+/// let handle = ExportOrdersJob::enqueue_tracked(ExportArgs { account_id: 1 }).await?;
+/// println!("poll at {}", handle.status_path());
+/// ```
 #[proc_macro_attribute]
 pub fn job(attr: TokenStream, item: TokenStream) -> TokenStream {
     job::job_macro(attr.into(), item.into()).into()

--- a/autumn/migrations/20260702000000_create_job_tracking/down.sql
+++ b/autumn/migrations/20260702000000_create_job_tracking/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS autumn_job_tracking;

--- a/autumn/migrations/20260702000000_create_job_tracking/up.sql
+++ b/autumn/migrations/20260702000000_create_job_tracking/up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS autumn_job_tracking (
+    key        TEXT        PRIMARY KEY,
+    record     JSONB       NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+-- Lazy-expiry reads and cleanup both filter/scan by expiry.
+CREATE INDEX IF NOT EXISTS idx_autumn_job_tracking_expires_at
+    ON autumn_job_tracking (expires_at);

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -7114,11 +7114,11 @@ path = "/healthz"
     #[test]
     fn jobs_toml_deserializes_tracking_fields() {
         let config: AutumnConfig = toml::from_str(
-            r#"
+            r"
             [jobs.tracking]
             ttl_secs = 7200
             route_enabled = false
-            "#,
+            ",
         )
         .unwrap();
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -104,6 +104,8 @@
 //! | `AUTUMN_JOBS__REDIS__KEY_PREFIX` | `jobs.redis.key_prefix` | `String` |
 //! | `AUTUMN_JOBS__REDIS__VISIBILITY_TIMEOUT_MS` | `jobs.redis.visibility_timeout_ms` | `u64` |
 //! | `AUTUMN_JOBS__POSTGRES__VISIBILITY_TIMEOUT_MS` | `jobs.postgres.visibility_timeout_ms` | `u64` |
+//! | `AUTUMN_JOBS__TRACKING__TTL_SECS` | `jobs.tracking.ttl_secs` | `u64` |
+//! | `AUTUMN_JOBS__TRACKING__ROUTE_ENABLED` | `jobs.tracking.route_enabled` | `bool` |
 //! | `AUTUMN_SCHEDULER__BACKEND` | `scheduler.backend` | `in_process` / `postgres` |
 //! | `AUTUMN_SCHEDULER__LEASE_TTL_SECS` | `scheduler.lease_ttl_secs` | `u64` |
 //! | `AUTUMN_SCHEDULER__REPLICA_ID` | `scheduler.replica_id` | `String` |
@@ -1710,6 +1712,10 @@ pub struct JobConfig {
     /// Postgres backend options.
     #[serde(default)]
     pub postgres: JobPostgresConfig,
+    /// Tracked-job progress/result store options (`enqueue_tracked`, the
+    /// built-in `GET /_autumn/jobs/{token}` status route).
+    #[serde(default)]
+    pub tracking: JobTrackingConfig,
 }
 
 impl Default for JobConfig {
@@ -1722,6 +1728,7 @@ impl Default for JobConfig {
             queues: JobQueuesConfig::default(),
             redis: JobRedisConfig::default(),
             postgres: JobPostgresConfig::default(),
+            tracking: JobTrackingConfig::default(),
         }
     }
 }
@@ -1910,6 +1917,36 @@ impl Default for JobPostgresConfig {
             visibility_timeout_ms: default_jobs_pg_visibility_timeout_ms(),
         }
     }
+}
+
+/// Tracked-job progress/result store configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct JobTrackingConfig {
+    /// How long a tracked job's progress/result record is retained after its
+    /// last write, in seconds. Default: 24 hours.
+    #[serde(default = "default_jobs_tracking_ttl_secs")]
+    pub ttl_secs: u64,
+    /// Whether the built-in `GET /_autumn/jobs/{token}` status route is
+    /// mounted. Default: `true`.
+    #[serde(default = "default_jobs_tracking_route_enabled")]
+    pub route_enabled: bool,
+}
+
+impl Default for JobTrackingConfig {
+    fn default() -> Self {
+        Self {
+            ttl_secs: default_jobs_tracking_ttl_secs(),
+            route_enabled: default_jobs_tracking_route_enabled(),
+        }
+    }
+}
+
+const fn default_jobs_tracking_ttl_secs() -> u64 {
+    86_400
+}
+
+const fn default_jobs_tracking_route_enabled() -> bool {
+    true
 }
 
 const fn default_jobs_pg_visibility_timeout_ms() -> u64 {
@@ -2474,6 +2511,8 @@ impl AutumnConfig {
     /// - `AUTUMN_JOBS__REDIS__URL` → `jobs.redis.url` (`String`)
     /// - `AUTUMN_JOBS__REDIS__KEY_PREFIX` → `jobs.redis.key_prefix` (`String`)
     /// - `AUTUMN_JOBS__REDIS__VISIBILITY_TIMEOUT_MS` → `jobs.redis.visibility_timeout_ms` (`u64`)
+    /// - `AUTUMN_JOBS__TRACKING__TTL_SECS` → `jobs.tracking.ttl_secs` (`u64`)
+    /// - `AUTUMN_JOBS__TRACKING__ROUTE_ENABLED` → `jobs.tracking.route_enabled` (`bool`)
     ///
     /// # Signed webhooks
     /// - `AUTUMN_SECURITY__WEBHOOKS__REPLAY__BACKEND` -> `security.webhooks.replay.backend` (`memory` / `redis`)
@@ -2991,6 +3030,16 @@ impl AutumnConfig {
             env,
             "AUTUMN_JOBS__POSTGRES__VISIBILITY_TIMEOUT_MS",
             &mut self.jobs.postgres.visibility_timeout_ms,
+        );
+        parse_env(
+            env,
+            "AUTUMN_JOBS__TRACKING__TTL_SECS",
+            &mut self.jobs.tracking.ttl_secs,
+        );
+        parse_env_bool(
+            env,
+            "AUTUMN_JOBS__TRACKING__ROUTE_ENABLED",
+            &mut self.jobs.tracking.route_enabled,
         );
     }
 
@@ -7041,6 +7090,40 @@ path = "/healthz"
         );
         assert_eq!(config.jobs.redis.key_prefix, "myapp:jobs");
         assert_eq!(config.jobs.redis.visibility_timeout_ms, 45_000);
+    }
+
+    #[test]
+    fn job_tracking_config_defaults_ttl_86400_and_route_enabled() {
+        let config = AutumnConfig::default();
+        assert_eq!(config.jobs.tracking.ttl_secs, 86_400);
+        assert!(config.jobs.tracking.route_enabled);
+    }
+
+    #[test]
+    fn env_override_jobs_tracking_fields() {
+        let env = MockEnv::new()
+            .with("AUTUMN_JOBS__TRACKING__TTL_SECS", "3600")
+            .with("AUTUMN_JOBS__TRACKING__ROUTE_ENABLED", "false");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+
+        assert_eq!(config.jobs.tracking.ttl_secs, 3_600);
+        assert!(!config.jobs.tracking.route_enabled);
+    }
+
+    #[test]
+    fn jobs_toml_deserializes_tracking_fields() {
+        let config: AutumnConfig = toml::from_str(
+            r#"
+            [jobs.tracking]
+            ttl_secs = 7200
+            route_enabled = false
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.jobs.tracking.ttl_secs, 7_200);
+        assert!(!config.jobs.tracking.route_enabled);
     }
 
     #[test]

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -5101,6 +5101,16 @@ async fn recover_stale_redis_jobs(
                         .job_registry
                         .record_failure(&dead.name, error.clone(), true);
                     job_admin.record_failure(&dead.id, error);
+                    // The worker that held this claim is gone and the job is
+                    // now terminally dead-lettered — settle the tracked
+                    // record too, or it stays pending/running until TTL
+                    // expiry even though the job will never run again.
+                    crate::job_tracking::settle_tracked_payload_as_failed(
+                        state,
+                        &dead.payload,
+                        crate::job_tracking::GENERIC_FAILURE_MESSAGE,
+                    )
+                    .await;
                 }
             }
         }
@@ -9877,6 +9887,84 @@ mod tests {
                 .unwrap(),
             EnqueueOutcome::Queued,
             "a dead worker must not deadlock the unique key"
+        );
+    }
+
+    #[cfg(feature = "redis")]
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn redis_stale_recovery_dead_letter_settles_the_tracked_record() {
+        let (_container, client) = redis_test_client().await;
+        // 10ms visibility timeout: an unsettled claim is immediately stale.
+        let worker_config = redis_test_worker_config("crash-tracked", "dead-worker", 10);
+        let mut connection = new_redis_connection_manager(&client, "test redis worker").unwrap();
+        let state = AppState::for_test().with_profile("dev");
+        state.job_registry().register("crashy_tracked");
+        let job_admin = JobAdminMemoryBackend::new_for_test(32);
+
+        let store: Arc<dyn crate::job_tracking::JobTrackingStore> =
+            Arc::new(crate::job_tracking::InMemoryJobTrackingStore::new(60));
+        crate::job_tracking::install_tracking_store(&state, store.clone());
+        let key = "crash-tracking-key";
+        store
+            .create(key, crate::job_tracking::TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
+        let payload = crate::job_tracking::wrap_tracked_payload(key, &serde_json::json!({}));
+
+        let connection_producer =
+            new_redis_connection_manager(&client, "test redis producer").unwrap();
+        let producer = RedisClient {
+            connection: connection_producer,
+            key_prefix: worker_config.key_prefix.clone(),
+            delayed_key: worker_config.delayed_key.clone(),
+            record_prefix: worker_config.record_prefix.clone(),
+            unique_prefix: worker_config.unique_prefix.clone(),
+        };
+        let constraints = ResolvedJobConstraints {
+            unique_key: None,
+            unique_window: None,
+            concurrency_limit: None,
+            concurrency_scope: None,
+        };
+        // max_attempts = 1 so stale recovery dead-letters instead of requeueing.
+        assert_eq!(
+            producer
+                .enqueue(
+                    "x1".to_string(),
+                    "crashy_tracked",
+                    "default",
+                    payload,
+                    1,
+                    1,
+                    None,
+                    &constraints,
+                )
+                .await
+                .unwrap(),
+            EnqueueOutcome::Queued
+        );
+
+        // Simulate a crashed worker: claim, never settle.
+        let _claimed = claim_next_redis_job(
+            &mut connection,
+            &worker_config,
+            std::slice::from_ref(&worker_config.queue_key),
+        )
+        .await
+        .unwrap()
+        .expect("claim");
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        recover_stale_redis_jobs(&mut connection, &worker_config, &state, &job_admin)
+            .await
+            .unwrap();
+
+        let record = store.get(key).await.unwrap().expect("record");
+        assert_eq!(
+            record.status,
+            crate::job_tracking::TrackedJobStatus::Failed,
+            "a stale-recovered, terminally dead-lettered tracked job must settle its status \
+             record instead of leaving it pending/running until TTL expiry"
         );
     }
 

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -1068,8 +1068,16 @@ impl JobAdminBackend for JobAdminMemoryBackend {
                 AutumnError::service_unavailable_msg("job runtime is not initialized")
             })?;
             let (name, payload) = self.retry_payload(&id)?;
+            let payload_for_reset = payload.clone();
             match client.enqueue_with_outcome(&name, payload).await {
-                Ok(EnqueueOutcome::Queued) => Ok(()),
+                Ok(EnqueueOutcome::Queued) => {
+                    // The record is currently `Failed` (terminal) from the
+                    // original run; reset it to `Pending` so the retried
+                    // attempt's mark_running/set_progress calls (which
+                    // otherwise no-op against a terminal record) surface.
+                    crate::job_tracking::reset_tracked_payload_for_retry(&payload_for_reset).await;
+                    Ok(())
+                }
                 Ok(EnqueueOutcome::Deduplicated) => {
                     // No retry was actually queued: an equivalent unique job
                     // already holds the key. Restore the failed record and
@@ -3889,6 +3897,18 @@ impl RedisJobAdminBackend {
         let mut connection = self.connection.clone();
         let new_id = uuid::Uuid::new_v4().to_string();
         let dead_record_key = format!("{}{id}", self.dead_record_prefix);
+        // Fetch the record's payload first (for a tracked-status reset on
+        // success below) — the script below moves this same dead record.
+        let raw_record: Option<String> = redis::cmd("GET")
+            .arg(&dead_record_key)
+            .query_async(&mut connection)
+            .await
+            .ok()
+            .flatten();
+        let tracked_payload = raw_record
+            .as_deref()
+            .and_then(|s| serde_json::from_str::<RedisJobRecord>(s).ok())
+            .map(|r| r.payload);
         // The unique lock was released when the job dead-lettered, so a
         // retried unique job must take it again under its new id — and the
         // retry must be refused when an equivalent job is already holding it,
@@ -3955,6 +3975,11 @@ return 1
             .query_async(&mut connection)
             .await
             .map_err(|error| redis_admin_error("retry failed job", &error))?;
+        if result == 1
+            && let Some(payload) = tracked_payload
+        {
+            crate::job_tracking::reset_tracked_payload_for_retry(&payload).await;
+        }
         redis_admin_operation_result(result, id, "retry failed job")
     }
 
@@ -6842,6 +6867,7 @@ impl PgJobAdminBackend {
     }
 
     async fn pg_retry_failed(&self, id: &str) -> AutumnResult<()> {
+        use diesel::OptionalExtension as _;
         use diesel_async::RunQueryDsl as _;
 
         let mut conn = self.pool.get().await.map_err(|e| {
@@ -6852,11 +6878,13 @@ impl PgJobAdminBackend {
              SET status = 'enqueued', attempt = 1, run_at = NOW(), enqueued_at = NOW(), \
                  started_at = NULL, finished_at = NULL, \
                  claimed_by = NULL, claimed_at = NULL, last_error = NULL \
-             WHERE id = $1 AND status = 'failed'",
+             WHERE id = $1 AND status = 'failed' \
+             RETURNING payload::TEXT AS payload",
         )
         .bind::<diesel::sql_types::Text, _>(id)
-        .execute(&mut *conn)
+        .get_result::<PgPayloadRow>(&mut *conn)
         .await
+        .optional()
         .map_err(|e| {
             // The retried row keeps its unique_key, so re-enqueueing while an
             // equivalent job is already in flight trips the partial unique
@@ -6871,11 +6899,17 @@ impl PgJobAdminBackend {
                 AutumnError::internal_server_error_msg(format!("pg admin retry failed: {e}"))
             }
         })?;
-        if updated == 0 {
+        let Some(row) = updated else {
             return Err(AutumnError::not_found_msg(format!(
                 "job '{id}' not found or not in failed state"
             )));
-        }
+        };
+        // The record is currently `Failed` (terminal) from the original run;
+        // reset it to `Pending` so the retried attempt's
+        // mark_running/set_progress calls (which otherwise no-op against a
+        // terminal record) surface.
+        let payload = serde_json::from_str::<Value>(&row.payload).unwrap_or(Value::Null);
+        crate::job_tracking::reset_tracked_payload_for_retry(&payload).await;
         Ok(())
     }
 
@@ -7491,6 +7525,76 @@ mod tests {
             .expect("snapshot after retry");
         assert!(snapshot.failed.records.is_empty());
         assert_eq!(snapshot.enqueued.total, 1);
+
+        clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn local_admin_retry_resets_tracked_record_off_its_stale_terminal_status() {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let store: Arc<dyn crate::job_tracking::JobTrackingStore> =
+            Arc::new(crate::job_tracking::InMemoryJobTrackingStore::new(60));
+        let state = AppState::for_test().with_profile("dev");
+        crate::job_tracking::install_tracking_store(&state, store.clone());
+
+        let key = "retry-reset-key";
+        store
+            .create(key, crate::job_tracking::TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
+        // The original attempt ran to completion and settled the record
+        // terminally, exactly as `run_job_handler` would on a final-attempt
+        // failure.
+        store
+            .fail(key, "smtp refused recipient".to_string())
+            .await
+            .unwrap();
+        let payload = crate::job_tracking::wrap_tracked_payload(key, &serde_json::json!({}));
+
+        let backend = JobAdminMemoryBackend::new_for_test(32);
+        let (tx, mut rx) = mpsc::channel(1);
+        init_global_job_client(JobClient {
+            local_sender: Some(tx),
+            local_coordination: None,
+            #[cfg(feature = "redis")]
+            redis: None,
+            #[cfg(feature = "db")]
+            pg_pool: None,
+            registry: crate::actuator::JobRegistry::new(),
+            job_admin: backend.clone(),
+            default_max_attempts: 5,
+            default_initial_backoff_ms: 250,
+            per_job_settings: HashMap::from([(
+                "send_email".to_string(),
+                JobRuntimeSettings::basic(5, 250),
+            )]),
+            interceptor: None,
+            resilience_config: None,
+        });
+
+        let failed_id = backend.record_enqueue_for_test("send_email", payload, 2, 5);
+        backend.record_start_for_test(&failed_id, 2);
+        backend.record_failure_for_test(&failed_id, "smtp refused recipient");
+
+        backend
+            .retry(&failed_id)
+            .await
+            .expect("failed job should be retried");
+        let _ = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("retry should enqueue promptly")
+            .expect("retry should enqueue a job");
+
+        let record = store.get(key).await.unwrap().expect("record");
+        assert_eq!(
+            record.status,
+            crate::job_tracking::TrackedJobStatus::Pending,
+            "an operator retry must reset the tracked record off its stale terminal status so \
+             the retried attempt's mark_running/set_progress calls surface instead of no-op'ing \
+             against a still-Failed record"
+        );
 
         clear_global_job_client();
     }
@@ -9766,6 +9870,79 @@ mod tests {
             crate::job_tracking::TrackedJobStatus::Failed,
             "an operator-cancelled enqueued tracked job must settle its status record instead \
              of staying pending until TTL expiry"
+        );
+
+        clear_global_job_client();
+    }
+
+    #[cfg(feature = "redis")]
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn redis_admin_retry_resets_tracked_record_off_its_stale_terminal_status() {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let (_container, client) = redis_test_client().await;
+        let worker_config = redis_test_worker_config("retry-tracked", "worker-1", 30_000);
+        let admin = redis_admin_test_backend(&client, &worker_config);
+        let mut connection = new_redis_connection_manager(&client, "test redis setup").unwrap();
+
+        let state = AppState::for_test().with_profile("dev");
+        let store: Arc<dyn crate::job_tracking::JobTrackingStore> =
+            Arc::new(crate::job_tracking::InMemoryJobTrackingStore::new(60));
+        crate::job_tracking::install_tracking_store(&state, store.clone());
+        let key = "retry-tracked-key";
+        store
+            .create(key, crate::job_tracking::TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
+        // The original attempt ran to completion and settled the record
+        // terminally, exactly as `run_job_handler` would on a final-attempt
+        // failure.
+        store
+            .fail(key, "smtp refused recipient".to_string())
+            .await
+            .unwrap();
+        let payload = crate::job_tracking::wrap_tracked_payload(key, &serde_json::json!({}));
+
+        let now = now_unix_ms();
+        let record = RedisJobRecord {
+            id: "job-failed-tracked".to_string(),
+            name: "send_email".to_string(),
+            queue: "default".to_string(),
+            payload,
+            attempt: 1,
+            max_attempts: 1,
+            initial_backoff_ms: 250,
+            enqueued_at_ms: Some(now),
+            started_at_ms: Some(now),
+            finished_at_ms: Some(now),
+            claimed_by: Some("worker-1".to_string()),
+            claimed_at_ms: Some(now),
+            last_error: Some("smtp refused recipient".to_string()),
+            unique_key: None,
+            unique_window: None,
+            concurrency_key: None,
+            concurrency_limit: None,
+            #[cfg(feature = "telemetry-otlp")]
+            traceparent: None,
+            #[cfg(feature = "telemetry-otlp")]
+            tracestate: None,
+        };
+        redis_store_history_admin_record(&mut connection, &worker_config, &record, true).await;
+
+        admin
+            .retry(&record.id)
+            .await
+            .expect("failed redis job should be retryable");
+
+        let tracked = store.get(key).await.unwrap().expect("record");
+        assert_eq!(
+            tracked.status,
+            crate::job_tracking::TrackedJobStatus::Pending,
+            "an operator retry must reset the tracked record off its stale terminal status so \
+             the retried attempt's mark_running/set_progress calls surface instead of no-op'ing \
+             against a still-Failed record"
         );
 
         clear_global_job_client();
@@ -12477,6 +12654,71 @@ mod tests {
                 crate::job_tracking::TrackedJobStatus::Failed,
                 "an operator-cancelled enqueued tracked job must settle its status record \
                  instead of staying pending until TTL expiry"
+            );
+
+            clear_global_job_client();
+        }
+
+        #[tokio::test]
+        #[ignore = "requires Docker (testcontainers)"]
+        async fn pg_admin_retry_resets_tracked_record_off_its_stale_terminal_status() {
+            use testcontainers::runners::AsyncRunner as _;
+            use testcontainers_modules::postgres::Postgres;
+
+            let container = Postgres::default().start().await.unwrap();
+            let port = container.get_host_port_ipv4(5432).await.unwrap();
+            let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+            let pool = pg_test_pool(&url);
+            pg_run_migration(&pool).await;
+            let backend = PgJobAdminBackend { pool: pool.clone() };
+
+            let _guard = global_job_runtime_test_lock().lock().await;
+            clear_global_job_client();
+            let store: Arc<dyn crate::job_tracking::JobTrackingStore> =
+                Arc::new(crate::job_tracking::InMemoryJobTrackingStore::new(60));
+            crate::job_tracking::install_tracking_store(&AppState::for_test(), store.clone());
+            let key = "pg-retry-tracked-key";
+            store
+                .create(key, crate::job_tracking::TrackedJobOwner::Anonymous)
+                .await
+                .unwrap();
+            // The original attempt ran to completion and settled the record
+            // terminally, exactly as `run_job_handler` would on a
+            // final-attempt failure.
+            store.fail(key, "boom".to_string()).await.unwrap();
+            let payload = crate::job_tracking::wrap_tracked_payload(key, &serde_json::json!({}));
+
+            pg_enqueue_job(
+                &pool,
+                "pg-retry-tracked".to_string(),
+                "job",
+                "default",
+                payload,
+                1,
+                1,
+                &ResolvedJobConstraints::default(),
+            )
+            .await
+            .unwrap();
+            let claimed = pg_claim_next_job(&pool, "w", false, &["default".to_string()])
+                .await
+                .unwrap();
+            pg_nack_failure(&pool, &claimed.id, "w", "boom", &claimed, None)
+                .await
+                .unwrap();
+
+            backend
+                .retry("pg-retry-tracked")
+                .await
+                .expect("retry should succeed");
+
+            let tracked = store.get(key).await.unwrap().expect("record");
+            assert_eq!(
+                tracked.status,
+                crate::job_tracking::TrackedJobStatus::Pending,
+                "an operator retry must reset the tracked record off its stale terminal status \
+                 so the retried attempt's mark_running/set_progress calls surface instead of \
+                 no-op'ing against a still-Failed record"
             );
 
             clear_global_job_client();

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -2798,6 +2798,8 @@ pub fn start_runtime(
         )))
     })?;
 
+    crate::job_tracking::ensure_tracking_store_installed_from_config(state, config);
+
     match config.backend.as_str() {
         "local" => {
             start_local_runtime(

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -4045,10 +4045,21 @@ return 1
             .query_async(&mut connection)
             .await
             .map_err(|error| redis_admin_error("cancel enqueued job", &error))?;
-        if result == 1
-            && let Some(name) = job_name
-        {
-            self.registry.record_cancel(&name);
+        if result == 1 {
+            if let Some(name) = job_name {
+                self.registry.record_cancel(&name);
+            }
+            // An operator can cancel a job before any worker ever claims it,
+            // which never reaches run_job_handler — settle the tracked
+            // record here too, or it stays pending until TTL expiry even
+            // though the durable job will never run.
+            if let Some(record) = &parsed_record {
+                crate::job_tracking::settle_tracked_payload_as_failed_globally(
+                    &record.payload,
+                    "This job was canceled.",
+                )
+                .await;
+            }
         }
         redis_admin_operation_result(result, id, "cancel enqueued job")
     }
@@ -6769,6 +6780,13 @@ struct PgJobAdminBackend {
 }
 
 #[cfg(feature = "db")]
+#[derive(diesel::QueryableByName)]
+struct PgPayloadRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    payload: String,
+}
+
+#[cfg(feature = "db")]
 impl PgJobAdminBackend {
     async fn pg_snapshot(&self, query: &JobAdminQuery) -> AutumnResult<JobAdminSnapshot> {
         let mut conn = self.pool.get().await.map_err(|e| {
@@ -6887,6 +6905,7 @@ impl PgJobAdminBackend {
     }
 
     async fn pg_cancel_enqueued(&self, id: &str) -> AutumnResult<()> {
+        use diesel::OptionalExtension as _;
         use diesel_async::RunQueryDsl as _;
 
         let mut conn = self.pool.get().await.map_err(|e| {
@@ -6895,19 +6914,31 @@ impl PgJobAdminBackend {
         let updated = diesel::sql_query(
             "UPDATE autumn_jobs \
              SET status = 'discarded', finished_at = NOW() \
-             WHERE id = $1 AND status = 'enqueued'",
+             WHERE id = $1 AND status = 'enqueued' \
+             RETURNING payload::TEXT AS payload",
         )
         .bind::<diesel::sql_types::Text, _>(id)
-        .execute(&mut *conn)
+        .get_result::<PgPayloadRow>(&mut *conn)
         .await
+        .optional()
         .map_err(|e| {
             AutumnError::internal_server_error_msg(format!("pg admin cancel failed: {e}"))
         })?;
-        if updated == 0 {
+        let Some(row) = updated else {
             return Err(AutumnError::not_found_msg(format!(
                 "job '{id}' not found or not in enqueued state"
             )));
-        }
+        };
+        // An operator can cancel a job before any worker ever claims it,
+        // which never reaches run_job_handler — settle the tracked record
+        // here too, or it stays pending until TTL expiry even though the
+        // durable job will never run.
+        let payload = serde_json::from_str::<Value>(&row.payload).unwrap_or(Value::Null);
+        crate::job_tracking::settle_tracked_payload_as_failed_globally(
+            &payload,
+            "This job was canceled.",
+        )
+        .await;
         Ok(())
     }
 }
@@ -9673,6 +9704,74 @@ mod tests {
     }
 
     #[cfg(feature = "redis")]
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn redis_admin_cancel_enqueued_settles_the_tracked_record() {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let (_container, client) = redis_test_client().await;
+        let worker_config = redis_test_worker_config("cancel-tracked", "worker-1", 30_000);
+        let admin = redis_admin_test_backend(&client, &worker_config);
+
+        let state = AppState::for_test().with_profile("dev");
+        let store: Arc<dyn crate::job_tracking::JobTrackingStore> =
+            Arc::new(crate::job_tracking::InMemoryJobTrackingStore::new(60));
+        crate::job_tracking::install_tracking_store(&state, store.clone());
+        let key = "cancel-tracked-key";
+        store
+            .create(key, crate::job_tracking::TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
+        let payload = crate::job_tracking::wrap_tracked_payload(key, &serde_json::json!({}));
+
+        let connection = new_redis_connection_manager(&client, "test redis producer").unwrap();
+        let producer = RedisClient {
+            connection,
+            key_prefix: worker_config.key_prefix.clone(),
+            delayed_key: worker_config.delayed_key.clone(),
+            record_prefix: worker_config.record_prefix.clone(),
+            unique_prefix: worker_config.unique_prefix.clone(),
+        };
+        let constraints = ResolvedJobConstraints {
+            unique_key: None,
+            unique_window: None,
+            concurrency_limit: None,
+            concurrency_scope: None,
+        };
+        assert_eq!(
+            producer
+                .enqueue(
+                    "k-tracked".to_string(),
+                    "cancel_tracked",
+                    "default",
+                    payload,
+                    3,
+                    1,
+                    None,
+                    &constraints,
+                )
+                .await
+                .unwrap(),
+            EnqueueOutcome::Queued
+        );
+
+        // Cancelling an enqueued-but-not-yet-claimed job never reaches
+        // run_job_handler.
+        admin.cancel_enqueued_redis("k-tracked").await.unwrap();
+
+        let record = store.get(key).await.unwrap().expect("record");
+        assert_eq!(
+            record.status,
+            crate::job_tracking::TrackedJobStatus::Failed,
+            "an operator-cancelled enqueued tracked job must settle its status record instead \
+             of staying pending until TTL expiry"
+        );
+
+        clear_global_job_client();
+    }
+
+    #[cfg(feature = "redis")]
     async fn redis_enqueue_with_constraints(
         client: &redis::Client,
         worker_config: &RedisWorkerConfig,
@@ -12325,6 +12424,62 @@ mod tests {
                 .expect("cancel should succeed");
             let row = pg_fetch_by_id(&pool, "cancel-c").await.unwrap();
             assert_eq!(row.status, "discarded");
+        }
+
+        #[tokio::test]
+        #[ignore = "requires Docker (testcontainers)"]
+        async fn pg_admin_cancel_enqueued_settles_the_tracked_record() {
+            use testcontainers::runners::AsyncRunner as _;
+            use testcontainers_modules::postgres::Postgres;
+
+            let container = Postgres::default().start().await.unwrap();
+            let port = container.get_host_port_ipv4(5432).await.unwrap();
+            let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+            let pool = pg_test_pool(&url);
+            pg_run_migration(&pool).await;
+            let backend = PgJobAdminBackend { pool: pool.clone() };
+
+            let _guard = global_job_runtime_test_lock().lock().await;
+            clear_global_job_client();
+            let store: Arc<dyn crate::job_tracking::JobTrackingStore> =
+                Arc::new(crate::job_tracking::InMemoryJobTrackingStore::new(60));
+            crate::job_tracking::install_tracking_store(&AppState::for_test(), store.clone());
+            let key = "pg-cancel-tracked-key";
+            store
+                .create(key, crate::job_tracking::TrackedJobOwner::Anonymous)
+                .await
+                .unwrap();
+            let payload = crate::job_tracking::wrap_tracked_payload(key, &serde_json::json!({}));
+
+            pg_enqueue_job(
+                &pool,
+                "pg-cancel-tracked".to_string(),
+                "job",
+                "default",
+                payload,
+                5,
+                1,
+                &ResolvedJobConstraints::default(),
+            )
+            .await
+            .unwrap();
+
+            // Cancelling an enqueued-but-not-yet-claimed job never reaches
+            // run_job_handler.
+            backend
+                .cancel("pg-cancel-tracked")
+                .await
+                .expect("cancel should succeed");
+
+            let record = store.get(key).await.unwrap().expect("record");
+            assert_eq!(
+                record.status,
+                crate::job_tracking::TrackedJobStatus::Failed,
+                "an operator-cancelled enqueued tracked job must settle its status record \
+                 instead of staying pending until TTL expiry"
+            );
+
+            clear_global_job_client();
         }
 
         /// Helper: fetch a single job row by id for test assertions.

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -10481,15 +10481,14 @@ mod tests {
     #[tokio::test]
     async fn run_job_handler_reports_async_panics() {
         let state = AppState::for_test().with_profile("dev");
-        let outcome =
-            run_job_handler(
-                "test_job",
-                panicking_handler,
-                state,
-                serde_json::json!({}),
-                true,
-            )
-            .await;
+        let outcome = run_job_handler(
+            "test_job",
+            panicking_handler,
+            state,
+            serde_json::json!({}),
+            true,
+        )
+        .await;
         assert_eq!(
             outcome,
             JobExecutionOutcome::Panicked("job handler panicked: forced panic".to_string())
@@ -10512,12 +10511,9 @@ mod tests {
         let state = AppState::for_test().with_profile("dev");
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
-            vec![JobInfo::new(
-                "tracked_noop",
-                1,
-                10,
-                |_state, _payload| Box::pin(async move { Ok(()) }),
-            )],
+            vec![JobInfo::new("tracked_noop", 1, 10, |_state, _payload| {
+                Box::pin(async move { Ok(()) })
+            })],
             &state,
             &shutdown,
             1,
@@ -10577,12 +10573,9 @@ mod tests {
             &crate::config::JobQueuesConfig::default(),
         );
 
-        crate::job_tracking::enqueue_tracked(
-            "capture_args",
-            serde_json::json!({"account_id": 7}),
-        )
-        .await
-        .unwrap();
+        crate::job_tracking::enqueue_tracked("capture_args", serde_json::json!({"account_id": 7}))
+            .await
+            .unwrap();
 
         let payload = timeout(Duration::from_secs(1), async {
             loop {
@@ -10800,12 +10793,9 @@ mod tests {
 
         let state = AppState::for_test().with_profile("dev");
         let shutdown = tokio_util::sync::CancellationToken::new();
-        let mut info = JobInfo::new(
-            "dedup_tracked",
-            1,
-            10,
-            |_state, _payload| Box::pin(async move { Ok(()) }),
-        );
+        let mut info = JobInfo::new("dedup_tracked", 1, 10, |_state, _payload| {
+            Box::pin(async move { Ok(()) })
+        });
         info.uniqueness = Some(JobUniqueness {
             by: Vec::new(),
             window: JobUniquenessWindow::Running,
@@ -10820,15 +10810,18 @@ mod tests {
             &crate::config::JobQueuesConfig::default(),
         );
 
-        let first = crate::job_tracking::enqueue_tracked("dedup_tracked", serde_json::json!({"x": 1}))
-            .await
-            .unwrap();
-        let second = crate::job_tracking::enqueue_tracked("dedup_tracked", serde_json::json!({"x": 1}))
-            .await
-            .unwrap();
+        let first =
+            crate::job_tracking::enqueue_tracked("dedup_tracked", serde_json::json!({"x": 1}))
+                .await
+                .unwrap();
+        let second =
+            crate::job_tracking::enqueue_tracked("dedup_tracked", serde_json::json!({"x": 1}))
+                .await
+                .unwrap();
         assert_ne!(first.token, second.token);
 
-        let store = crate::job_tracking::tracking_store_from_state(&state).expect("store installed");
+        let store =
+            crate::job_tracking::tracking_store_from_state(&state).expect("store installed");
         let key = crate::auth::hash_api_token(&second.token);
         let record = store.get(&key).await.unwrap().expect("record");
         assert_eq!(record.status, crate::job_tracking::TrackedJobStatus::Failed);
@@ -10914,7 +10907,10 @@ mod tests {
         })
         .await
         .expect("retry should succeed within 2s");
-        assert_eq!(record.status, crate::job_tracking::TrackedJobStatus::Succeeded);
+        assert_eq!(
+            record.status,
+            crate::job_tracking::TrackedJobStatus::Succeeded
+        );
 
         shutdown.cancel();
         clear_global_job_client();

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -5896,6 +5896,14 @@ fn record_pg_row_cancel_after_ack(
 const PG_WORKER_IDLE_SLEEP: std::time::Duration = std::time::Duration::from_millis(200);
 #[cfg(feature = "db")]
 const PG_MAINTENANCE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+/// How often to sweep expired rows out of `autumn_job_tracking`. Much
+/// slower than [`PG_MAINTENANCE_INTERVAL`] (which recovers stale claims —
+/// a latency-sensitive concern) since tracking-row expiry has no such
+/// urgency: the row is already invisible to reads/writes the moment it
+/// expires (`PgJobTrackingStore` filters on `expires_at` lazily), so this
+/// sweep exists only to bound table growth over time, not correctness.
+#[cfg(feature = "db")]
+const PG_TRACKING_CLEANUP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(300);
 
 /// Columns returned by every SELECT from `autumn_jobs` when OTLP is disabled.
 #[cfg(all(feature = "db", not(feature = "telemetry-otlp")))]
@@ -6767,6 +6775,8 @@ async fn pg_maintenance_loop(
 ) {
     let mut interval = tokio::time::interval(PG_MAINTENANCE_INTERVAL);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut tracking_cleanup_interval = tokio::time::interval(PG_TRACKING_CLEANUP_INTERVAL);
+    tracking_cleanup_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {
         tokio::select! {
             _ = interval.tick() => {
@@ -6775,8 +6785,34 @@ async fn pg_maintenance_loop(
                     pg_update_concurrency_blocked_gauges(&pool, &state).await;
                 }
             }
+            _ = tracking_cleanup_interval.tick() => {
+                pg_cleanup_expired_tracking_rows(&pool).await;
+            }
             () = shutdown.cancelled() => break,
         }
+    }
+}
+
+/// Delete `autumn_job_tracking` rows past their `expires_at`.
+///
+/// Expired rows are already invisible to `PgJobTrackingStore` reads/writes
+/// (it filters on `expires_at` lazily), so this exists only to bound the
+/// table's growth for high-volume tracked-job usage — every enqueue writes
+/// a row here, and without a sweep those rows would otherwise accumulate
+/// forever.
+#[cfg(feature = "db")]
+async fn pg_cleanup_expired_tracking_rows(pool: &PgPool) {
+    use diesel_async::RunQueryDsl as _;
+
+    let Ok(mut conn) = pool.get().await else {
+        tracing::warn!("job tracking cleanup could not acquire connection");
+        return;
+    };
+    if let Err(e) = diesel::sql_query("DELETE FROM autumn_job_tracking WHERE expires_at <= NOW()")
+        .execute(&mut *conn)
+        .await
+    {
+        tracing::warn!(error = %e, "job tracking cleanup failed");
     }
 }
 
@@ -12758,6 +12794,64 @@ mod tests {
             );
 
             clear_global_job_client();
+        }
+
+        #[tokio::test]
+        #[ignore = "requires Docker (testcontainers)"]
+        async fn pg_tracking_cleanup_deletes_expired_rows_and_keeps_live_ones() {
+            use testcontainers::runners::AsyncRunner as _;
+            use testcontainers_modules::postgres::Postgres;
+
+            let container = Postgres::default().start().await.unwrap();
+            let port = container.get_host_port_ipv4(5432).await.unwrap();
+            let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+            let pool = pg_test_pool(&url);
+
+            let mut conn = pool.get().await.unwrap();
+            let tracking_sql =
+                include_str!("../migrations/20260702000000_create_job_tracking/up.sql");
+            for stmt in tracking_sql.split(';') {
+                let stmt = stmt.trim();
+                if !stmt.is_empty() {
+                    diesel::sql_query(stmt).execute(&mut *conn).await.unwrap();
+                }
+            }
+            drop(conn);
+
+            // A record whose TTL puts `expires_at` far in the past — the
+            // clock only controls what timestamp gets written, not any
+            // filtering here, since `pg_cleanup_expired_tracking_rows`
+            // compares against Postgres's real `NOW()`.
+            let long_ago = chrono::DateTime::parse_from_rfc3339("2000-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc);
+            let expired_store = crate::job_tracking::PgJobTrackingStore::new(pool.clone(), 60)
+                .with_clock(std::sync::Arc::new(crate::time::FixedClock::at(long_ago)));
+            expired_store
+                .create(
+                    "expired-key",
+                    crate::job_tracking::TrackedJobOwner::Anonymous,
+                )
+                .await
+                .unwrap();
+
+            let live_store = crate::job_tracking::PgJobTrackingStore::new(pool.clone(), 86_400);
+            live_store
+                .create("live-key", crate::job_tracking::TrackedJobOwner::Anonymous)
+                .await
+                .unwrap();
+
+            pg_cleanup_expired_tracking_rows(&pool).await;
+
+            let verify_store = crate::job_tracking::PgJobTrackingStore::new(pool.clone(), 86_400);
+            assert!(
+                verify_store.get("expired-key").await.unwrap().is_none(),
+                "an expired tracking row must be swept instead of accumulating forever"
+            );
+            assert!(
+                verify_store.get("live-key").await.unwrap().is_some(),
+                "the cleanup sweep must not touch rows that haven't expired yet"
+            );
         }
 
         /// Helper: fetch a single job row by id for test assertions.

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -3404,6 +3404,16 @@ async fn execute_local_job(
                     if !coordination.try_acquire_unique(&job.name, &key, &job.id, unique.window) {
                         state.job_registry.record_deduplicated(&job.name);
                         job_admin.record_deduplicated(&job.id);
+                        // This job will never run again — it was coalesced
+                        // into the duplicate that now owns the unique lock —
+                        // so its tracked record (if any) must settle now
+                        // rather than being left non-terminal until TTL.
+                        crate::job_tracking::settle_tracked_payload_as_failed(
+                            state,
+                            &job.payload,
+                            "An equivalent job is already in progress.",
+                        )
+                        .await;
                         finish_local_slot(coordination, concurrency_group.as_ref(), tx, state);
                         return;
                     }
@@ -4832,7 +4842,7 @@ elseif ARGV[4] == 'retry' then
   if ARGV[10] == 'pending' then
     if not redis.call('SET', KEYS[7], ARGV[1], 'NX', 'PX', tonumber(ARGV[11])) then
       redis.call('DEL', key)
-      return 1
+      return 2
     end
   end
   redis.call('SET', key, ARGV[5])
@@ -4859,9 +4869,9 @@ async fn apply_claimed_redis_transition(
     mode: &str,
     encoded_record: Option<String>,
     due_at_ms: Option<u64>,
-) -> Result<bool, redis::RedisError> {
+) -> Result<i64, redis::RedisError> {
     let Some((claimed_by, claimed_at_ms)) = expected_claim_args(expected) else {
-        return Ok(false);
+        return Ok(0);
     };
 
     // The concurrency slot frees on every settle (success, retry backoff,
@@ -4877,7 +4887,7 @@ async fn apply_claimed_redis_transition(
     } else {
         "0"
     };
-    let applied: usize = redis::cmd("EVAL")
+    let applied: i64 = redis::cmd("EVAL")
         .arg(CLAIMED_REDIS_TRANSITION_SCRIPT)
         .arg(8)
         .arg(&worker_config.processing_key)
@@ -4906,7 +4916,7 @@ async fn apply_claimed_redis_transition(
         .query_async(connection)
         .await?;
 
-    Ok(applied == 1)
+    Ok(applied)
 }
 
 #[cfg(feature = "redis")]
@@ -4923,7 +4933,7 @@ async fn ack_redis_success(
         tracing::warn!(job_id = %record.id, "failed to serialize redis completed record");
         return Ok(false);
     };
-    apply_claimed_redis_transition(
+    let applied = apply_claimed_redis_transition(
         connection,
         worker_config,
         record,
@@ -4931,7 +4941,26 @@ async fn ack_redis_success(
         Some(encoded),
         None,
     )
-    .await
+    .await?;
+    Ok(applied == 1)
+}
+
+/// Outcome of [`schedule_redis_retry`], distinguishing an ordinary applied
+/// retry from a pending-window unique job whose retry was silently dropped
+/// because an equivalent job already claimed the unique slot while this one
+/// ran — the two collapse to the same Lua return code as a plain "claim
+/// changed" no-op would otherwise, but the caller needs to tell them apart:
+/// a dropped retry settles a tracked record; a claim-changed no-op doesn't.
+#[cfg(feature = "redis")]
+enum RedisRetryOutcome {
+    /// The retry record was written normally.
+    Applied,
+    /// A duplicate already held the pending-window unique lock, so the
+    /// record was deleted instead of retried (coalesced into the duplicate).
+    DroppedByDuplicate,
+    /// The claim no longer matched (another worker already settled this
+    /// job), so nothing was changed.
+    ClaimChanged,
 }
 
 #[cfg(feature = "redis")]
@@ -4940,12 +4969,12 @@ async fn schedule_redis_retry(
     worker_config: &RedisWorkerConfig,
     expected: &RedisJobRecord,
     schedule: &RedisRetrySchedule,
-) -> Result<bool, redis::RedisError> {
+) -> Result<RedisRetryOutcome, redis::RedisError> {
     let Ok(encoded) = encode_redis_record(&schedule.record) else {
         tracing::warn!(job_id = %schedule.record.id, "failed to serialize redis retry record");
-        return Ok(false);
+        return Ok(RedisRetryOutcome::ClaimChanged);
     };
-    apply_claimed_redis_transition(
+    let applied = apply_claimed_redis_transition(
         connection,
         worker_config,
         expected,
@@ -4953,7 +4982,12 @@ async fn schedule_redis_retry(
         Some(encoded),
         Some(schedule.due_at_ms),
     )
-    .await
+    .await?;
+    Ok(match applied {
+        1 => RedisRetryOutcome::Applied,
+        2 => RedisRetryOutcome::DroppedByDuplicate,
+        _ => RedisRetryOutcome::ClaimChanged,
+    })
 }
 
 #[cfg(feature = "redis")]
@@ -4967,7 +5001,7 @@ async fn dead_letter_redis_job(
         tracing::warn!(job_id = %record.id, "failed to serialize redis dead-letter record");
         return Ok(false);
     };
-    apply_claimed_redis_transition(
+    let applied = apply_claimed_redis_transition(
         connection,
         worker_config,
         expected,
@@ -4975,7 +5009,8 @@ async fn dead_letter_redis_job(
         Some(encoded),
         None,
     )
-    .await
+    .await?;
+    Ok(applied == 1)
 }
 
 #[cfg(feature = "redis")]
@@ -5312,13 +5347,30 @@ async fn settle_failed_redis_job(
     match action {
         RedisFailureAction::Retry(schedule) => {
             match schedule_redis_retry(connection, worker_config, record, &schedule).await {
-                Ok(true) => {
+                Ok(RedisRetryOutcome::Applied) => {
                     state
                         .job_registry
                         .record_retry(&schedule.record.name, &error, record.attempt);
                     job_admin.record_retrying(&schedule.record.id, &error);
                 }
-                Ok(false) => tracing::warn!(
+                Ok(RedisRetryOutcome::DroppedByDuplicate) => {
+                    // A duplicate already claimed the pending-window unique
+                    // lock while this job ran, so the retry was coalesced
+                    // into it (deleted, not requeued) — this job will never
+                    // run again, so its tracked record (if any) must settle
+                    // now rather than being left non-terminal until TTL.
+                    state
+                        .job_registry
+                        .record_deduplicated(&schedule.record.name);
+                    job_admin.record_deduplicated(&schedule.record.id);
+                    crate::job_tracking::settle_tracked_payload_as_failed(
+                        state,
+                        &record.payload,
+                        "An equivalent job is already in progress.",
+                    )
+                    .await;
+                }
+                Ok(RedisRetryOutcome::ClaimChanged) => tracing::warn!(
                     job = %record.name,
                     job_id = %record.id,
                     outcome = %outcome,
@@ -10018,6 +10070,122 @@ mod tests {
         );
 
         clear_global_job_client();
+    }
+
+    #[cfg(feature = "redis")]
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn redis_dropped_pending_window_retry_settles_the_tracked_record_instead_of_leaving_it_stuck()
+     {
+        REDIS_HANDLER_CALLS.store(0, Ordering::SeqCst);
+        let (_container, client) = redis_test_client().await;
+        let worker_config = redis_test_worker_config("dropped-pending", "worker-a", 30_000);
+        let mut connection = new_redis_connection_manager(&client, "test redis worker").unwrap();
+
+        let state = AppState::for_test().with_profile("dev");
+        let store: Arc<dyn crate::job_tracking::JobTrackingStore> =
+            Arc::new(crate::job_tracking::InMemoryJobTrackingStore::new(60));
+        crate::job_tracking::install_tracking_store(&state, store.clone());
+        let key = "dropped-pending-key";
+        store
+            .create(key, crate::job_tracking::TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
+        let payload = crate::job_tracking::wrap_tracked_payload(key, &serde_json::json!({}));
+
+        let job_admin = JobAdminMemoryBackend::new_for_test(32);
+        state.job_registry().register("send_email");
+        state.job_registry().record_enqueue("send_email");
+
+        let producer = RedisClient {
+            connection: new_redis_connection_manager(&client, "test redis producer").unwrap(),
+            key_prefix: worker_config.key_prefix.clone(),
+            delayed_key: worker_config.delayed_key.clone(),
+            record_prefix: worker_config.record_prefix.clone(),
+            unique_prefix: worker_config.unique_prefix.clone(),
+        };
+        let constraints = ResolvedJobConstraints {
+            unique_key: Some("dropped-pending-lock".to_string()),
+            unique_window: Some(JobUniquenessWindow::Pending),
+            concurrency_limit: None,
+            concurrency_scope: None,
+        };
+        assert_eq!(
+            producer
+                .enqueue(
+                    "job-original".to_string(),
+                    "send_email",
+                    "default",
+                    payload,
+                    2,
+                    1,
+                    None,
+                    &constraints,
+                )
+                .await
+                .unwrap(),
+            EnqueueOutcome::Queued
+        );
+
+        let jobs = redis_jobs_by_name(redis_counting_failure_handler, 2);
+        let claimed = claim_next_redis_job(
+            &mut connection,
+            &worker_config,
+            std::slice::from_ref(&worker_config.queue_key),
+        )
+        .await
+        .unwrap()
+        .expect("original job should be claimed");
+
+        // Claiming released the pending-window unique lock (see
+        // claim_next_redis_job); a duplicate now takes it over before the
+        // original's retry gets a chance to re-acquire it.
+        assert_eq!(
+            producer
+                .enqueue(
+                    "job-duplicate".to_string(),
+                    "send_email",
+                    "default",
+                    serde_json::json!({}),
+                    2,
+                    1,
+                    None,
+                    &constraints,
+                )
+                .await
+                .unwrap(),
+            EnqueueOutcome::Queued,
+            "the lock must be free for the duplicate to acquire it"
+        );
+
+        process_redis_job_record(
+            &mut connection,
+            claimed,
+            &jobs,
+            &state,
+            &job_admin,
+            &worker_config,
+        )
+        .await;
+
+        let tracked = store.get(key).await.unwrap().expect("record");
+        assert_eq!(
+            tracked.status,
+            crate::job_tracking::TrackedJobStatus::Failed,
+            "a tracked job whose retry was dropped because a duplicate already claimed the \
+             pending-window unique lock must settle its status record instead of staying \
+             pending/running until TTL expiry"
+        );
+        assert_eq!(
+            tracked.error.as_deref(),
+            Some("An equivalent job is already in progress.")
+        );
+
+        let status = state.job_registry().snapshot()["send_email"].clone();
+        assert_eq!(
+            status.total_deduplicated, 1,
+            "the dropped retry must be recorded as deduplicated, not as a normal retry"
+        );
     }
 
     #[cfg(feature = "redis")]
@@ -15586,6 +15754,117 @@ mod uniqueness_concurrency_tests {
             2,
             "exactly the original two attempts run; the duplicate never does"
         );
+
+        shutdown.cancel();
+        clear_global_job_client();
+    }
+
+    static DROPPED_RETRY_CALLS: AtomicUsize = AtomicUsize::new(0);
+    static DROPPED_RETRY_STARTED: OnceLock<tokio::sync::Notify> = OnceLock::new();
+    static DROPPED_RETRY_RELEASE: OnceLock<tokio::sync::Notify> = OnceLock::new();
+    fn dropped_pending_retry_handler(
+        _state: AppState,
+        _payload: Value,
+    ) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>> {
+        Box::pin(async move {
+            if DROPPED_RETRY_CALLS.fetch_add(1, Ordering::SeqCst) == 0 {
+                // First call: signal that execution has started (the
+                // pending-window key is now released) and hold until the
+                // test lets a duplicate enqueue grab it first.
+                DROPPED_RETRY_STARTED
+                    .get_or_init(tokio::sync::Notify::new)
+                    .notify_one();
+                DROPPED_RETRY_RELEASE
+                    .get_or_init(tokio::sync::Notify::new)
+                    .notified()
+                    .await;
+                Err(AutumnError::internal_server_error(std::io::Error::other(
+                    "forced failure",
+                )))
+            } else {
+                // The duplicate's own (independent) execution.
+                Ok(())
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn local_dropped_pending_window_retry_settles_the_tracked_record_instead_of_leaving_it_stuck()
+     {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+        DROPPED_RETRY_CALLS.store(0, Ordering::SeqCst);
+
+        let store: Arc<dyn crate::job_tracking::JobTrackingStore> =
+            Arc::new(crate::job_tracking::InMemoryJobTrackingStore::new(60));
+        let state = AppState::for_test().with_profile("dev");
+        crate::job_tracking::install_tracking_store(&state, store.clone());
+
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        start_local_runtime(
+            vec![JobInfo {
+                name: "dropped_pending_retry".to_string(),
+                max_attempts: 2,
+                initial_backoff_ms: 1,
+                queue: "default".to_string(),
+                uniqueness: Some(JobUniqueness {
+                    by: Vec::new(),
+                    window: JobUniquenessWindow::Pending,
+                }),
+                concurrency: None,
+                handler: dropped_pending_retry_handler,
+            }],
+            &state,
+            &shutdown,
+            2,
+            5,
+            250,
+            &crate::config::JobQueuesConfig::default(),
+        );
+
+        let payload = serde_json::json!({"invoice_id": 22});
+        let handle = enqueue_tracked("dropped_pending_retry", payload.clone())
+            .await
+            .unwrap();
+        let key = crate::auth::hash_api_token(&handle.token);
+
+        // Wait for the first attempt to start executing — the pending-window
+        // key is released at that point (see execute_queued_job).
+        DROPPED_RETRY_STARTED
+            .get_or_init(tokio::sync::Notify::new)
+            .notified()
+            .await;
+
+        // A duplicate lands while the key is free and takes it over.
+        enqueue("dropped_pending_retry", payload).await.unwrap();
+
+        // Let the original attempt fail; its retry can no longer re-acquire
+        // the pending key (the duplicate holds it), so the retry is dropped
+        // and coalesced into the duplicate instead.
+        DROPPED_RETRY_RELEASE
+            .get_or_init(tokio::sync::Notify::new)
+            .notify_one();
+
+        assert!(
+            wait_for(2_000, || deduplicated(&state, "dropped_pending_retry") == 1).await,
+            "the dropped retry must be recorded as deduplicated"
+        );
+
+        let record = store.get(&key).await.unwrap().expect("record");
+        assert_eq!(
+            record.status,
+            TrackedJobStatus::Failed,
+            "a tracked job whose retry was dropped because a duplicate already claimed the \
+             pending-window unique lock must settle its status record instead of staying \
+             pending/running until TTL expiry"
+        );
+        assert_eq!(
+            record.error.as_deref(),
+            Some("An equivalent job is already in progress.")
+        );
+
+        // The duplicate itself still runs independently.
+        assert!(wait_for(2_000, || successes(&state, "dropped_pending_retry") == 1).await);
 
         shutdown.cancel();
         clear_global_job_client();

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -320,11 +320,17 @@ impl ResolvedJobConstraints {
     }
 }
 
-/// Whether an enqueue stored a new job or coalesced into an existing one.
+/// Whether an enqueue stored a new job, coalesced into an existing one, or
+/// was never delivered at all.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum EnqueueOutcome {
     Queued,
     Deduplicated,
+    /// A `JobInterceptor::intercept_enqueue` completed without ever awaiting
+    /// the `next` future it was handed, so the job was never actually
+    /// delivered to any backend — distinct from `Queued` (which callers must
+    /// not treat as a successful delivery).
+    Skipped,
 }
 
 /// Specifies the due instant for an after-commit enqueue.
@@ -1072,6 +1078,15 @@ impl JobAdminBackend for JobAdminMemoryBackend {
                     Err(AutumnError::bad_request_msg(
                         "an equivalent unique job is already pending or running; \
                          retry after it settles",
+                    ))
+                }
+                Ok(EnqueueOutcome::Skipped) => {
+                    // A JobInterceptor declined to deliver the retry — the
+                    // record must not be left in a "retrying" state for a
+                    // job that will never actually run.
+                    self.restore_failed_retry(&id);
+                    Err(AutumnError::bad_request_msg(
+                        "the retry was intercepted and not delivered to the queue",
                     ))
                 }
                 Err(error) => {
@@ -2349,7 +2364,11 @@ impl JobClient {
                 .await
             };
             let result = match outcome {
-                Ok(EnqueueOutcome::Queued) => Ok(()),
+                // `Skipped` can never actually be produced here — it's a
+                // synthetic outcome the outer wrapper derives from whether
+                // this closure ran at all — but it's part of the enum, so
+                // the match must stay exhaustive.
+                Ok(EnqueueOutcome::Queued | EnqueueOutcome::Skipped) => Ok(()),
                 Ok(EnqueueOutcome::Deduplicated) => {
                     self.record_deduplicated_enqueue(name, &id_for_enqueue);
                     deduplicated_clone.store(true, ::std::sync::atomic::Ordering::SeqCst);
@@ -2382,13 +2401,19 @@ impl JobClient {
             actual_enqueue.await
         };
 
-        if !started.load(::std::sync::atomic::Ordering::SeqCst) {
+        let started = started.load(::std::sync::atomic::Ordering::SeqCst);
+        if !started {
             self.registry.record_cancel(name);
             self.job_admin.record_cancelled(&id);
         }
         res.map(|()| {
             if deduplicated.load(::std::sync::atomic::Ordering::SeqCst) {
                 EnqueueOutcome::Deduplicated
+            } else if !started {
+                // The interceptor completed without ever awaiting `next`, so
+                // `actual_enqueue` (and thus the real backend write) never
+                // ran — this must not be reported as Queued.
+                EnqueueOutcome::Skipped
             } else {
                 EnqueueOutcome::Queued
             }
@@ -14058,6 +14083,115 @@ mod tests {
         );
         assert_eq!(received.unwrap().unwrap().name, "test_job");
 
+        clear_global_job_client();
+    }
+
+    struct SilentlySkippingInterceptor;
+    impl crate::interceptor::JobInterceptor for SilentlySkippingInterceptor {
+        fn intercept_enqueue<'a>(
+            &'a self,
+            _name: &'a str,
+            _payload: &'a serde_json::Value,
+            _next: std::pin::Pin<
+                Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+            >,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>>
+        {
+            // Deliberately never awaits `next` — simulates an interceptor
+            // that silently decides not to deliver the job (e.g. a feature
+            // flag or rate limiter) without erroring.
+            Box::pin(async move { Ok(()) })
+        }
+
+        fn intercept_execute<'a>(
+            &'a self,
+            _name: &'a str,
+            _payload: &'a serde_json::Value,
+            next: std::pin::Pin<
+                Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+            >,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>>
+        {
+            next
+        }
+    }
+
+    #[tokio::test]
+    async fn enqueue_tracked_settles_failed_when_an_interceptor_skips_delivery() {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let state = AppState::for_test().with_profile("dev");
+        state
+            .insert_extension(Arc::new(SilentlySkippingInterceptor)
+                as Arc<dyn crate::interceptor::JobInterceptor>);
+
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        start_local_runtime(
+            vec![JobInfo::new(
+                "skipped_tracked",
+                1,
+                10,
+                |_state, _payload| Box::pin(async move { Ok(()) }),
+            )],
+            &state,
+            &shutdown,
+            1,
+            5,
+            250,
+            &crate::config::JobQueuesConfig::default(),
+        );
+
+        let handle = crate::job_tracking::enqueue_tracked("skipped_tracked", serde_json::json!({}))
+            .await
+            .expect("enqueue_tracked itself should still succeed and return a handle");
+
+        let store =
+            crate::job_tracking::tracking_store_from_state(&state).expect("store installed");
+        let key = crate::auth::hash_api_token(&handle.token);
+        let record = store.get(&key).await.unwrap().expect("record");
+        assert_eq!(
+            record.status,
+            crate::job_tracking::TrackedJobStatus::Failed,
+            "a job an interceptor silently skipped must settle its tracked status instead of \
+             staying pending forever"
+        );
+
+        shutdown.cancel();
+        clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn plain_enqueue_still_succeeds_when_an_interceptor_skips_delivery() {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let state = AppState::for_test().with_profile("dev");
+        state
+            .insert_extension(Arc::new(SilentlySkippingInterceptor)
+                as Arc<dyn crate::interceptor::JobInterceptor>);
+
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        start_local_runtime(
+            vec![JobInfo::new("skipped_plain", 1, 10, |_state, _payload| {
+                Box::pin(async move { Ok(()) })
+            })],
+            &state,
+            &shutdown,
+            1,
+            5,
+            250,
+            &crate::config::JobQueuesConfig::default(),
+        );
+
+        // Untracked enqueue's observable Ok(()) behavior is unchanged: the
+        // new EnqueueOutcome::Skipped variant only changes behavior for
+        // enqueue_tracked, which needs to distinguish it to settle status.
+        enqueue("skipped_plain", serde_json::json!({}))
+            .await
+            .expect("plain enqueue must still return Ok even when an interceptor skips delivery");
+
+        shutdown.cancel();
         clear_global_job_client();
     }
 

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -1210,6 +1210,17 @@ fn fnv1a_64(input: &str) -> u64 {
     hash
 }
 
+/// Whether `attempt` is a job's last allowed attempt.
+///
+/// The single comparison every backend's retry-vs-terminal decision is built
+/// on: shared so the `final_attempt` flag computed before execution (which
+/// decides whether a tracked job's status settles to `failed` or stays
+/// `running`) can never silently drift from that same backend's own
+/// post-execution retry/dead-letter decision.
+fn is_final_attempt<T: PartialOrd>(attempt: &T, max_attempts: &T) -> bool {
+    attempt >= max_attempts
+}
+
 /// Derive the uniqueness key for a job payload.
 ///
 /// With `unique_by` fields configured the key concatenates the canonical JSON
@@ -2133,6 +2144,7 @@ impl JobClient {
     /// or enqueueing fails in the active backend.
     #[allow(clippy::too_many_lines)]
     pub async fn enqueue(&self, name: &str, payload: Value) -> AutumnResult<()> {
+        crate::job_tracking::reject_reserved_envelope_marker(&payload)?;
         self.enqueue_with_outcome(name, payload).await.map(|_| ())
     }
 
@@ -2149,6 +2161,7 @@ impl JobClient {
         payload: Value,
         due_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> AutumnResult<()> {
+        crate::job_tracking::reject_reserved_envelope_marker(&payload)?;
         self.enqueue_with_outcome_due(name, payload, due_at)
             .await
             .map(|_| ())
@@ -2353,7 +2366,18 @@ impl JobClient {
 
         let res = if let Some(interceptor) = &self.interceptor {
             let interceptor = (*interceptor).clone();
-            run_enqueue_interceptor(interceptor, name, &payload, Box::pin(actual_enqueue)).await
+            // `payload` is the tracked-envelope-wrapped value for a tracked
+            // job (see `enqueue_tracked_for`); app-registered interceptors
+            // must see the real args, matching what `intercept_execute` sees
+            // at run time, not the internal envelope.
+            let (_, interceptor_payload) = crate::job_tracking::split_tracked_payload(&payload);
+            run_enqueue_interceptor(
+                interceptor,
+                name,
+                interceptor_payload,
+                Box::pin(actual_enqueue),
+            )
+            .await
         } else {
             actual_enqueue.await
         };
@@ -2678,6 +2702,7 @@ impl JobClient {
         conn: &mut diesel_async::AsyncPgConnection,
         due_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> AutumnResult<()> {
+        crate::job_tracking::reject_reserved_envelope_marker(&payload)?;
         let due_at = due_at.filter(|due| *due > chrono::Utc::now());
         let Some(settings) = self.per_job_settings.get(name) else {
             return Err(AutumnError::internal_server_error(std::io::Error::other(
@@ -3199,6 +3224,12 @@ async fn execute_local_job(
         if job_admin.try_record_start(&job.id, job.attempt) == JobAdminStartDecision::Canceled {
             state.job_registry.record_cancel(&job.name);
             job_admin.record_cancelled(&job.id);
+            crate::job_tracking::settle_tracked_payload_as_failed(
+                state,
+                &job.payload,
+                "This job was canceled.",
+            )
+            .await;
             return;
         }
         state.job_registry.record_start(&job.name);
@@ -3206,6 +3237,12 @@ async fn execute_local_job(
             .job_registry
             .record_failure(&job.name, format!("unknown job '{}'", job.name), true);
         job_admin.record_failure(&job.id, format!("unknown job '{}'", job.name));
+        crate::job_tracking::settle_tracked_payload_as_failed(
+            state,
+            &job.payload,
+            crate::job_tracking::GENERIC_FAILURE_MESSAGE,
+        )
+        .await;
         return;
     };
 
@@ -3242,6 +3279,12 @@ async fn execute_local_job(
             &job.id,
         );
         finish_local_slot(coordination, concurrency_group.as_ref(), tx, state);
+        crate::job_tracking::settle_tracked_payload_as_failed(
+            state,
+            &job.payload,
+            "This job was canceled.",
+        )
+        .await;
         return;
     }
     state.job_registry.record_start(&job.name);
@@ -3277,7 +3320,7 @@ async fn execute_local_job(
         use tracing_opentelemetry::OpenTelemetrySpanExt as _;
         let _ = job_span.set_parent(cx);
     }
-    let final_attempt = job.attempt >= max_attempts;
+    let final_attempt = is_final_attempt(&job.attempt, &max_attempts);
     let f = run_job_handler(
         &job.name,
         handler,
@@ -3299,7 +3342,8 @@ async fn execute_local_job(
             );
         }
         JobExecutionOutcome::Failed(error) => {
-            if job.attempt < max_attempts {
+            #[allow(clippy::if_not_else)]
+            if !is_final_attempt(&job.attempt, &max_attempts) {
                 // Running-window keys stay held across retries (the job is
                 // still in flight until it settles). A pending-window key was
                 // released when execution started, so re-acquire it now to
@@ -3501,15 +3545,15 @@ fn prepare_redis_failure_action(
     record.last_error = Some(error);
     record.finished_at_ms = Some(now_ms);
 
-    if record.attempt < record.max_attempts {
+    if is_final_attempt(&record.attempt, &record.max_attempts) {
+        RedisFailureAction::DeadLetter(record)
+    } else {
         let due_at_ms = now_ms.saturating_add(redis_retry_delay_ms(
             record.initial_backoff_ms,
             record.attempt,
         ));
         record.attempt = record.attempt.saturating_add(1);
         RedisFailureAction::Retry(RedisRetrySchedule { record, due_at_ms })
-    } else {
-        RedisFailureAction::DeadLetter(record)
     }
 }
 
@@ -3546,11 +3590,11 @@ fn recover_stale_redis_record(
     record.finished_at_ms = Some(now_ms);
     clear_redis_claim(&mut record);
 
-    if record.attempt < record.max_attempts {
+    if is_final_attempt(&record.attempt, &record.max_attempts) {
+        Some(RedisStaleRecovery::DeadLetter(record))
+    } else {
         record.attempt = record.attempt.saturating_add(1);
         Some(RedisStaleRecovery::Requeue(record))
-    } else {
-        Some(RedisStaleRecovery::DeadLetter(record))
     }
 }
 
@@ -5272,6 +5316,12 @@ async fn dead_letter_invalid_redis_job(
     clear_redis_claim(&mut dead);
     dead.last_error = Some(error.to_owned());
     let _ = dead_letter_redis_job(connection, worker_config, record, &dead).await;
+    crate::job_tracking::settle_tracked_payload_as_failed(
+        state,
+        &record.payload,
+        crate::job_tracking::GENERIC_FAILURE_MESSAGE,
+    )
+    .await;
 }
 
 #[cfg(feature = "redis")]
@@ -5288,6 +5338,12 @@ async fn process_redis_job_record(
         state.job_registry.record_cancel(&record.name);
         job_admin.record_cancelled(&record.id);
         let _ = ack_redis_success(connection, worker_config, &record).await;
+        crate::job_tracking::settle_tracked_payload_as_failed(
+            state,
+            &record.payload,
+            "This job was canceled.",
+        )
+        .await;
         return;
     }
     state.job_registry.record_start(&record.name);
@@ -5349,7 +5405,7 @@ async fn process_redis_job_record(
         use tracing_opentelemetry::OpenTelemetrySpanExt as _;
         let _ = job_span.set_parent(cx);
     }
-    let final_attempt = record.attempt >= record.max_attempts;
+    let final_attempt = is_final_attempt(&record.attempt, &record.max_attempts);
     let f = run_job_handler(
         &record.name,
         handler,
@@ -6272,6 +6328,7 @@ async fn pg_ack_success(pool: &PgPool, job_id: &str, worker_id: &str) -> AutumnR
 
 /// Handle a job failure: schedule a retry with exponential backoff or dead-letter.
 #[cfg(feature = "db")]
+#[allow(clippy::if_not_else)]
 async fn pg_nack_failure(
     pool: &PgPool,
     job_id: &str,
@@ -6287,7 +6344,7 @@ async fn pg_nack_failure(
         .await
         .map_err(|e| AutumnError::internal_server_error_msg(format!("pg pool error: {e}")))?;
 
-    if row.attempt < row.max_attempts {
+    if !is_final_attempt(&row.attempt, &row.max_attempts) {
         let delay_ms = pg_retry_delay_ms(row.initial_backoff_ms, row.attempt);
         // Re-enqueue and restore the pending-window unique key atomically in one
         // UPDATE to eliminate the window where status='enqueued' and
@@ -6476,6 +6533,19 @@ async fn pg_execute_job(
         let ack =
             pg_nack_failure(pool, &row.id, worker_id, "canceled by operator", &row, None).await;
         record_pg_row_cancel_after_ack(ack, &row, state);
+        // `pg_nack_failure` reuses the ordinary retry-vs-dead-letter decision
+        // even for a cancellation, so only settle the tracked record here
+        // when this really was the terminal attempt; otherwise the job is
+        // about to be retried and `run_job_handler` will settle it later.
+        if is_final_attempt(&attempt, &max_attempts) {
+            let payload = serde_json::from_str::<Value>(&row.payload).unwrap_or(Value::Null);
+            crate::job_tracking::settle_tracked_payload_as_failed(
+                state,
+                &payload,
+                "This job was canceled.",
+            )
+            .await;
+        }
         return;
     }
     state.job_registry.record_start(&row.name);
@@ -6501,6 +6571,12 @@ async fn pg_execute_job(
         let ack = pg_ack_dead_letter(pool, &row.id, worker_id, &error).await;
         let lifecycle = PgLifecycleRecord::Failure { error: &error };
         record_pg_row_lifecycle_ack_result(ack, &row, "unknown-type", lifecycle, state, job_admin);
+        crate::job_tracking::settle_tracked_payload_as_failed(
+            state,
+            &payload,
+            crate::job_tracking::GENERIC_FAILURE_MESSAGE,
+        )
+        .await;
         return;
     };
 
@@ -6512,7 +6588,7 @@ async fn pg_execute_job(
         use tracing_opentelemetry::OpenTelemetrySpanExt as _;
         let _ = job_span.set_parent(cx);
     }
-    let final_attempt = attempt >= max_attempts;
+    let final_attempt = is_final_attempt(&attempt, &max_attempts);
     let f = run_job_handler(&row.name, handler, state.clone(), payload, final_attempt);
     match tracing::Instrument::instrument(f, job_span).await {
         JobExecutionOutcome::Succeeded => {
@@ -6527,13 +6603,13 @@ async fn pg_execute_job(
             );
         }
         JobExecutionOutcome::Failed(error) => {
-            let lifecycle = if attempt < max_attempts {
+            let lifecycle = if is_final_attempt(&attempt, &max_attempts) {
+                PgLifecycleRecord::Failure { error: &error }
+            } else {
                 PgLifecycleRecord::Retry {
                     error: &error,
                     attempt,
                 }
-            } else {
-                PgLifecycleRecord::Failure { error: &error }
             };
             let ack = pg_nack_failure(
                 pool,
@@ -7128,6 +7204,18 @@ mod tests {
                 "forced failure",
             )))
         })
+    }
+
+    #[test]
+    fn is_final_attempt_matches_attempt_greater_or_equal_max_attempts() {
+        assert!(!is_final_attempt(&1_u32, &3));
+        assert!(!is_final_attempt(&2_u32, &3));
+        assert!(is_final_attempt(&3_u32, &3));
+        assert!(is_final_attempt(&4_u32, &3));
+        // Every backend's retry-vs-terminal branches are written as `attempt
+        // < max_attempts`, i.e. exactly `!is_final_attempt(..)`.
+        assert_eq!(is_final_attempt(&1_i32, &3), 1_i32 >= 3);
+        assert_eq!(is_final_attempt(&3_i32, &3), 3_i32 >= 3);
     }
 
     #[cfg(feature = "redis")]
@@ -7893,6 +7981,92 @@ mod tests {
             snap.scheduled.total, 0,
             "canceled scheduled job should leave the scheduled list"
         );
+
+        shutdown.cancel();
+        clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn intercept_enqueue_sees_unwrapped_args_for_a_tracked_job() {
+        static CAPTURED: std::sync::OnceLock<std::sync::Mutex<Option<Value>>> =
+            std::sync::OnceLock::new();
+        fn captured() -> &'static std::sync::Mutex<Option<Value>> {
+            CAPTURED.get_or_init(|| std::sync::Mutex::new(None))
+        }
+
+        struct CapturingInterceptor;
+        impl crate::interceptor::JobInterceptor for CapturingInterceptor {
+            fn intercept_enqueue<'a>(
+                &'a self,
+                _name: &'a str,
+                payload: &'a serde_json::Value,
+                next: std::pin::Pin<
+                    Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+                >,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+            > {
+                *captured().lock().unwrap() = Some(payload.clone());
+                next
+            }
+
+            fn intercept_execute<'a>(
+                &'a self,
+                _name: &'a str,
+                _payload: &'a serde_json::Value,
+                next: std::pin::Pin<
+                    Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+                >,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = crate::AutumnResult<()>> + Send + 'a>,
+            > {
+                next
+            }
+        }
+
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+        *captured().lock().unwrap() = None;
+
+        let state = AppState::for_test().with_profile("dev");
+        state.insert_extension(
+            Arc::new(CapturingInterceptor) as Arc<dyn crate::interceptor::JobInterceptor>
+        );
+
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        start_local_runtime(
+            vec![JobInfo::new(
+                "intercepted_tracked",
+                1,
+                10,
+                |_state, _payload| Box::pin(async move { Ok(()) }),
+            )],
+            &state,
+            &shutdown,
+            1,
+            5,
+            250,
+            &crate::config::JobQueuesConfig::default(),
+        );
+
+        crate::job_tracking::enqueue_tracked(
+            "intercepted_tracked",
+            serde_json::json!({"account_id": 9}),
+        )
+        .await
+        .unwrap();
+
+        let seen = captured()
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("intercept_enqueue should have been called");
+        assert_eq!(
+            seen,
+            serde_json::json!({"account_id": 9}),
+            "intercept_enqueue must see the real args, not the tracked envelope: {seen}"
+        );
+        assert!(seen.get("__autumn_tracked").is_none(), "{seen}");
 
         shutdown.cancel();
         clear_global_job_client();
@@ -10427,6 +10601,167 @@ mod tests {
         assert!(payload.get("args").is_none(), "{payload}");
 
         shutdown.cancel();
+        clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn enqueue_rejects_a_payload_that_collides_with_the_tracked_envelope_shape() {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let state = AppState::for_test().with_profile("dev");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        start_local_runtime(
+            vec![JobInfo::new(
+                "colliding_payload_job",
+                1,
+                10,
+                |_state, _payload| Box::pin(async move { Ok(()) }),
+            )],
+            &state,
+            &shutdown,
+            1,
+            5,
+            250,
+            &crate::config::JobQueuesConfig::default(),
+        );
+
+        // A plain (untracked) enqueue whose Args struct happens to shadow the
+        // reserved envelope marker must be rejected outright rather than
+        // silently reaching the handler with the wrong args.
+        let colliding = serde_json::json!({"__autumn_tracked": {"k": "abc"}, "other": 1});
+        let err = enqueue("colliding_payload_job", colliding)
+            .await
+            .expect_err("a colliding payload must be rejected");
+        assert!(
+            err.to_string().contains("__autumn_tracked"),
+            "unexpected error: {err}"
+        );
+
+        // enqueue_in/enqueue_at share the same guard via enqueue_due.
+        let err = enqueue_in(
+            "colliding_payload_job",
+            serde_json::json!({"__autumn_tracked": {"k": "abc"}}),
+            Duration::from_millis(1),
+        )
+        .await
+        .expect_err("a colliding payload must be rejected");
+        assert!(
+            err.to_string().contains("__autumn_tracked"),
+            "unexpected error: {err}"
+        );
+
+        shutdown.cancel();
+        clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn admin_cancel_before_local_execution_settles_the_tracked_record_instead_of_leaving_it_stuck()
+     {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let store: Arc<dyn crate::job_tracking::JobTrackingStore> =
+            Arc::new(crate::job_tracking::InMemoryJobTrackingStore::new(60));
+        let state = AppState::for_test().with_profile("dev");
+        crate::job_tracking::install_tracking_store(&state, store.clone());
+
+        let key = "cancel-test-key";
+        store
+            .create(key, crate::job_tracking::TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
+        let payload = crate::job_tracking::wrap_tracked_payload(key, &serde_json::json!({}));
+
+        let job_admin = JobAdminMemoryBackend::new_for_test(32);
+        let id = job_admin.record_enqueue_for_test("canceled_tracked", payload.clone(), 1, 3);
+        job_admin
+            .cancel_enqueued(&id)
+            .expect("enqueued job should be cancelable");
+
+        let jobs_by_name: Arc<RwLock<HashMap<String, JobInfo>>> =
+            Arc::new(RwLock::new(HashMap::from([(
+                "canceled_tracked".to_string(),
+                JobInfo::new("canceled_tracked", 3, 10, |_state, _payload| {
+                    Box::pin(async move { Ok(()) })
+                }),
+            )])));
+        let (tx, _rx) = tokio::sync::mpsc::channel::<QueuedJob>(1);
+        let coordination = Arc::new(LocalJobCoordination::default());
+
+        let job = QueuedJob {
+            id: id.clone(),
+            name: "canceled_tracked".to_string(),
+            queue: "default".to_string(),
+            payload,
+            attempt: 1,
+            max_attempts: 3,
+            initial_backoff_ms: 10,
+            #[cfg(feature = "telemetry-otlp")]
+            traceparent: None,
+            #[cfg(feature = "telemetry-otlp")]
+            tracestate: None,
+        };
+
+        // The admin already flagged this job Canceled before it ever reached
+        // a worker, so `execute_local_job` short-circuits before
+        // `run_job_handler` — the tracking record must still settle to
+        // Failed rather than being left at Pending until TTL expiry.
+        execute_local_job(job, &jobs_by_name, &tx, &state, &job_admin, &coordination).await;
+
+        let record = store.get(key).await.unwrap().expect("record");
+        assert_eq!(record.status, crate::job_tracking::TrackedJobStatus::Failed);
+
+        clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn unregistered_job_name_at_local_dispatch_settles_the_tracked_record_instead_of_leaving_it_stuck()
+     {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let store: Arc<dyn crate::job_tracking::JobTrackingStore> =
+            Arc::new(crate::job_tracking::InMemoryJobTrackingStore::new(60));
+        let state = AppState::for_test().with_profile("dev");
+        crate::job_tracking::install_tracking_store(&state, store.clone());
+
+        let key = "unregistered-test-key";
+        store
+            .create(key, crate::job_tracking::TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
+        let payload = crate::job_tracking::wrap_tracked_payload(key, &serde_json::json!({}));
+
+        let job_admin = JobAdminMemoryBackend::new_for_test(32);
+        // Never inserted into `jobs_by_name`, so the dispatcher cannot find a
+        // handler even though the tracking record was created for it.
+        let id = job_admin.record_enqueue_for_test("no_such_job", payload.clone(), 1, 3);
+
+        let jobs_by_name: Arc<RwLock<HashMap<String, JobInfo>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+        let (tx, _rx) = tokio::sync::mpsc::channel::<QueuedJob>(1);
+        let coordination = Arc::new(LocalJobCoordination::default());
+
+        let job = QueuedJob {
+            id,
+            name: "no_such_job".to_string(),
+            queue: "default".to_string(),
+            payload,
+            attempt: 1,
+            max_attempts: 3,
+            initial_backoff_ms: 10,
+            #[cfg(feature = "telemetry-otlp")]
+            traceparent: None,
+            #[cfg(feature = "telemetry-otlp")]
+            tracestate: None,
+        };
+
+        execute_local_job(job, &jobs_by_name, &tx, &state, &job_admin, &coordination).await;
+
+        let record = store.get(key).await.unwrap().expect("record");
+        assert_eq!(record.status, crate::job_tracking::TrackedJobStatus::Failed);
+
         clear_global_job_client();
     }
 

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -2499,6 +2499,11 @@ impl JobClient {
                 "enqueue_after_commit: failed to serialize payload for job '{name}': {e}"
             )))
         })?;
+        // Also validate eagerly: the deferred callback below calls
+        // enqueue_due (which re-checks this), but that runs after the
+        // transaction has already committed — by then it's too late for the
+        // caller to roll back on a rejected payload.
+        crate::job_tracking::reject_reserved_envelope_marker(&payload)?;
         let client = self.clone();
         // Keep a copy for the debug log in the eager path (name is moved into f_opt).
         let name_for_log = name.clone();
@@ -13961,6 +13966,57 @@ mod tests {
             "job should be delivered immediately for past due time outside tx"
         );
         assert_eq!(received.unwrap().unwrap().name, "test_job");
+
+        clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn enqueue_after_commit_rejects_a_colliding_payload_eagerly_not_in_the_deferred_callback()
+    {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let (tx, mut rx) = mpsc::channel(16);
+        init_global_job_client(JobClient {
+            local_sender: Some(tx),
+            local_coordination: None,
+            #[cfg(feature = "redis")]
+            redis: None,
+            #[cfg(feature = "db")]
+            pg_pool: None,
+            registry: crate::actuator::JobRegistry::new(),
+            job_admin: JobAdminMemoryBackend::new_for_test(32),
+            default_max_attempts: 3,
+            default_initial_backoff_ms: 100,
+            per_job_settings: HashMap::from([(
+                "test_job".to_string(),
+                JobRuntimeSettings::basic(3, 100),
+            )]),
+            interceptor: None,
+            resilience_config: None,
+        });
+
+        // Called outside a db.tx, so without the eager check this would
+        // enqueue immediately (see the test above) before ever reaching
+        // enqueue_due's own check — which is exactly what would let a
+        // colliding payload slip through a committed transaction when
+        // called from inside one.
+        let err = enqueue_after_commit(
+            "test_job",
+            serde_json::json!({"__autumn_tracked": {"k": "abc"}}),
+        )
+        .await
+        .expect_err("a colliding payload must be rejected before any commit/delivery");
+        assert!(
+            err.to_string().contains("__autumn_tracked"),
+            "unexpected error: {err}"
+        );
+
+        let received = tokio::time::timeout(Duration::from_millis(50), rx.recv()).await;
+        assert!(
+            received.is_err(),
+            "a rejected payload must never reach the queue"
+        );
 
         clear_global_job_client();
     }

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -1069,13 +1069,20 @@ impl JobAdminBackend for JobAdminMemoryBackend {
             })?;
             let (name, payload) = self.retry_payload(&id)?;
             let payload_for_reset = payload.clone();
+            // Snapshot the tracking record's owner/updated_at *before*
+            // re-enqueueing makes the retry visible to workers, so the
+            // reset below can detect (and skip) a retry that completes
+            // faster than this function returns.
+            let retry_snapshot =
+                crate::job_tracking::capture_retry_snapshot(&payload_for_reset).await;
             match client.enqueue_with_outcome(&name, payload).await {
                 Ok(EnqueueOutcome::Queued) => {
-                    // The record is currently `Failed` (terminal) from the
-                    // original run; reset it to `Pending` so the retried
-                    // attempt's mark_running/set_progress calls (which
-                    // otherwise no-op against a terminal record) surface.
-                    crate::job_tracking::reset_tracked_payload_for_retry(&payload_for_reset).await;
+                    // The record was `Failed` (terminal) from the original
+                    // run; reset it to `Pending` so the retried attempt's
+                    // mark_running/set_progress calls (which otherwise
+                    // no-op against a terminal record) surface.
+                    crate::job_tracking::apply_retry_reset(&payload_for_reset, retry_snapshot)
+                        .await;
                     Ok(())
                 }
                 Ok(EnqueueOutcome::Deduplicated) => {
@@ -3909,6 +3916,14 @@ impl RedisJobAdminBackend {
             .as_deref()
             .and_then(|s| serde_json::from_str::<RedisJobRecord>(s).ok())
             .map(|r| r.payload);
+        // Snapshot the tracking record's owner/updated_at *before* the EVAL
+        // script below makes the retry visible to workers, so the reset can
+        // detect (and skip) a retry that completes faster than this
+        // function returns.
+        let retry_snapshot = match &tracked_payload {
+            Some(payload) => crate::job_tracking::capture_retry_snapshot(payload).await,
+            None => None,
+        };
         // The unique lock was released when the job dead-lettered, so a
         // retried unique job must take it again under its new id — and the
         // retry must be refused when an equivalent job is already holding it,
@@ -3978,7 +3993,7 @@ return 1
         if result == 1
             && let Some(payload) = tracked_payload
         {
-            crate::job_tracking::reset_tracked_payload_for_retry(&payload).await;
+            crate::job_tracking::apply_retry_reset(&payload, retry_snapshot).await;
         }
         redis_admin_operation_result(result, id, "retry failed job")
     }
@@ -6873,6 +6888,27 @@ impl PgJobAdminBackend {
         let mut conn = self.pool.get().await.map_err(|e| {
             AutumnError::internal_server_error_msg(format!("pg admin pool error: {e}"))
         })?;
+        // Snapshot the tracking record's owner/updated_at *before* the
+        // UPDATE below makes the retry visible to workers, so the reset can
+        // detect (and skip) a retry that completes faster than this
+        // function returns.
+        let pre_retry_row = diesel::sql_query(
+            "SELECT payload::TEXT AS payload FROM autumn_jobs WHERE id = $1 AND status = 'failed'",
+        )
+        .bind::<diesel::sql_types::Text, _>(id)
+        .get_result::<PgPayloadRow>(&mut *conn)
+        .await
+        .optional()
+        .map_err(|e| {
+            AutumnError::internal_server_error_msg(format!("pg admin retry failed: {e}"))
+        })?;
+        let retry_snapshot = match &pre_retry_row {
+            Some(row) => {
+                let payload = serde_json::from_str::<Value>(&row.payload).unwrap_or(Value::Null);
+                crate::job_tracking::capture_retry_snapshot(&payload).await
+            }
+            None => None,
+        };
         let updated = diesel::sql_query(
             "UPDATE autumn_jobs \
              SET status = 'enqueued', attempt = 1, run_at = NOW(), enqueued_at = NOW(), \
@@ -6909,7 +6945,7 @@ impl PgJobAdminBackend {
         // mark_running/set_progress calls (which otherwise no-op against a
         // terminal record) surface.
         let payload = serde_json::from_str::<Value>(&row.payload).unwrap_or(Value::Null);
-        crate::job_tracking::reset_tracked_payload_for_retry(&payload).await;
+        crate::job_tracking::apply_retry_reset(&payload, retry_snapshot).await;
         Ok(())
     }
 

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -6459,13 +6459,22 @@ async fn pg_ack_dead_letter(
     .map_err(|e| AutumnError::internal_server_error_msg(format!("pg job dead-letter failed: {e}")))
 }
 
+#[cfg(feature = "db")]
+#[derive(diesel::QueryableByName)]
+struct PgStaleRecoveryRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    payload: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    status: String,
+}
+
 /// Recover jobs whose visibility timeout has expired.
 ///
 /// Uses a single `UPDATE … WHERE id IN (SELECT … FOR UPDATE SKIP LOCKED)` so
 /// concurrent maintenance tasks from multiple replicas each recover disjoint
 /// sets of stale jobs.
 #[cfg(feature = "db")]
-async fn pg_recover_stale_claims(pool: &PgPool, visibility_timeout_ms: u64) {
+async fn pg_recover_stale_claims(pool: &PgPool, visibility_timeout_ms: u64, state: &AppState) {
     use diesel_async::RunQueryDsl as _;
 
     let Ok(mut conn) = pool.get().await else {
@@ -6476,7 +6485,7 @@ async fn pg_recover_stale_claims(pool: &PgPool, visibility_timeout_ms: u64) {
     // there is no window where status='enqueued' and unique_key=NULL co-exist.
     // The CASE subquery checks for already-committed duplicates; if one exists
     // the key stays NULL (best-effort, same behaviour as pg_nack_failure).
-    let _ = diesel::sql_query(
+    let rows = diesel::sql_query(
         "UPDATE autumn_jobs \
          SET \
            status = CASE \
@@ -6523,12 +6532,32 @@ async fn pg_recover_stale_claims(pool: &PgPool, visibility_timeout_ms: u64) {
              AND claimed_at < NOW() - ($1::BIGINT * INTERVAL '1 millisecond') \
            FOR UPDATE SKIP LOCKED \
            LIMIT 100 \
-         )",
+         ) \
+         RETURNING payload::TEXT AS payload, status",
     )
     .bind::<diesel::sql_types::BigInt, _>(i64::try_from(visibility_timeout_ms).unwrap_or(i64::MAX))
-    .execute(&mut *conn)
-    .await
-    .map_err(|e| tracing::warn!(error = %e, "postgres stale claim recovery failed"));
+    .get_results::<PgStaleRecoveryRow>(&mut *conn)
+    .await;
+
+    // Rows this UPDATE flipped straight to 'failed' (the job's final
+    // attempt) are terminally dead-lettered with no further code path
+    // touching them — settle their tracked status too, or a tracked job
+    // whose worker crashed on its last attempt stays "running" until TTL
+    // expiry even though it will never run again.
+    match rows {
+        Ok(rows) => {
+            for row in rows.into_iter().filter(|row| row.status == "failed") {
+                let payload = serde_json::from_str::<Value>(&row.payload).unwrap_or(Value::Null);
+                crate::job_tracking::settle_tracked_payload_as_failed(
+                    state,
+                    &payload,
+                    crate::job_tracking::GENERIC_FAILURE_MESSAGE,
+                )
+                .await;
+            }
+        }
+        Err(e) => tracing::warn!(error = %e, "postgres stale claim recovery failed"),
+    }
 }
 
 /// Execute one claimed job and ack/nack based on the outcome.
@@ -6665,7 +6694,7 @@ async fn pg_maintenance_loop(
     loop {
         tokio::select! {
             _ = interval.tick() => {
-                pg_recover_stale_claims(&pool, visibility_timeout_ms).await;
+                pg_recover_stale_claims(&pool, visibility_timeout_ms, &state).await;
                 if survey_blocked {
                     pg_update_concurrency_blocked_gauges(&pool, &state).await;
                 }
@@ -12059,7 +12088,7 @@ mod tests {
             )).await;
 
             // Recover stale claims with a 1-second timeout
-            pg_recover_stale_claims(&pool, 1_000).await;
+            pg_recover_stale_claims(&pool, 1_000, &AppState::for_test()).await;
 
             let row = pg_fetch_by_id(&pool, &job_id).await.unwrap();
             assert_eq!(
@@ -12594,7 +12623,7 @@ mod tests {
 
             // Stale recovery dead-letters the final attempt, which must free
             // both the unique key and the concurrency slot.
-            pg_recover_stale_claims(&pool, 10).await;
+            pg_recover_stale_claims(&pool, 10, &AppState::for_test()).await;
             let recovered = pg_fetch_by_id(&pool, "crash-1").await.unwrap();
             assert_eq!(recovered.status, "failed");
 
@@ -12626,6 +12655,68 @@ mod tests {
                     .await
                     .is_some(),
                 "the concurrency slot must be free after stale recovery"
+            );
+        }
+
+        #[tokio::test]
+        #[ignore = "requires Docker (testcontainers)"]
+        async fn pg_stale_claim_recovery_dead_letter_settles_the_tracked_record() {
+            use testcontainers::runners::AsyncRunner as _;
+            use testcontainers_modules::postgres::Postgres;
+
+            let container = Postgres::default().start().await.unwrap();
+            let port = container.get_host_port_ipv4(5432).await.unwrap();
+            let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+            let pool = pg_test_pool(&url);
+            pg_run_migration(&pool).await;
+
+            let state = AppState::for_test().with_profile("dev");
+            let store: Arc<dyn crate::job_tracking::JobTrackingStore> =
+                Arc::new(crate::job_tracking::InMemoryJobTrackingStore::new(60));
+            crate::job_tracking::install_tracking_store(&state, store.clone());
+            let key = "pg-crash-tracking-key";
+            store
+                .create(key, crate::job_tracking::TrackedJobOwner::Anonymous)
+                .await
+                .unwrap();
+            let payload = crate::job_tracking::wrap_tracked_payload(key, &serde_json::json!({}));
+
+            // max_attempts = 1 so stale recovery dead-letters instead of requeueing.
+            pg_enqueue_job(
+                &pool,
+                "pg-crash-1".to_string(),
+                "crashy_tracked",
+                "default",
+                payload,
+                1,
+                10,
+                &ResolvedJobConstraints {
+                    unique_key: None,
+                    unique_window: None,
+                    concurrency_limit: None,
+                    concurrency_scope: None,
+                },
+            )
+            .await
+            .unwrap();
+
+            // Simulate a crashed worker: claim, never settle.
+            let row = pg_claim_next_job(&pool, "dead-worker", false, &["default".to_string()])
+                .await
+                .expect("claim");
+            assert_eq!(row.id, "pg-crash-1");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            pg_recover_stale_claims(&pool, 10, &state).await;
+            let recovered = pg_fetch_by_id(&pool, "pg-crash-1").await.unwrap();
+            assert_eq!(recovered.status, "failed");
+
+            let record = store.get(key).await.unwrap().expect("record");
+            assert_eq!(
+                record.status,
+                crate::job_tracking::TrackedJobStatus::Failed,
+                "a stale-recovered, terminally dead-lettered tracked job must settle its \
+                 status record instead of leaving it running until TTL expiry"
             );
         }
 

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -10322,6 +10322,333 @@ mod tests {
         );
     }
 
+    // ── Tracked-job choke-point behavior (#1373) ──────────────────────────────
+    //
+    // run_job_handler is the single point all three backends run handlers
+    // through; these tests drive it via the real local backend + the free
+    // enqueue_tracked function rather than calling it directly, so they also
+    // exercise enqueue_tracked's envelope-wrapping and the local backend's
+    // retry/dead-letter decisions end to end.
+
+    #[tokio::test]
+    async fn enqueue_tracked_token_is_a_64_char_hex_capability_distinct_from_job_ids() {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let state = AppState::for_test().with_profile("dev");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        start_local_runtime(
+            vec![JobInfo::new(
+                "tracked_noop",
+                1,
+                10,
+                |_state, _payload| Box::pin(async move { Ok(()) }),
+            )],
+            &state,
+            &shutdown,
+            1,
+            5,
+            250,
+            &crate::config::JobQueuesConfig::default(),
+        );
+
+        let handle = crate::job_tracking::enqueue_tracked("tracked_noop", serde_json::json!({}))
+            .await
+            .unwrap();
+
+        // Internal job ids are UUIDs (36 chars, hyphenated); the tracked
+        // token is a distinct 256-bit hex capability with no hyphens.
+        assert_eq!(handle.token.len(), 64, "token: {}", handle.token);
+        assert!(
+            handle.token.chars().all(|c| c.is_ascii_hexdigit()),
+            "token: {}",
+            handle.token
+        );
+        assert!(!handle.token.contains('-'), "token: {}", handle.token);
+
+        shutdown.cancel();
+        clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn tracked_envelope_is_stripped_before_handler_sees_args() {
+        static CAPTURED: std::sync::OnceLock<std::sync::Mutex<Option<Value>>> =
+            std::sync::OnceLock::new();
+        fn captured() -> &'static std::sync::Mutex<Option<Value>> {
+            CAPTURED.get_or_init(|| std::sync::Mutex::new(None))
+        }
+        fn capturing_handler(
+            _state: AppState,
+            payload: Value,
+        ) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>> {
+            Box::pin(async move {
+                *captured().lock().unwrap() = Some(payload);
+                Ok(())
+            })
+        }
+
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+        *captured().lock().unwrap() = None;
+
+        let state = AppState::for_test().with_profile("dev");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        start_local_runtime(
+            vec![JobInfo::new("capture_args", 1, 10, capturing_handler)],
+            &state,
+            &shutdown,
+            1,
+            5,
+            250,
+            &crate::config::JobQueuesConfig::default(),
+        );
+
+        crate::job_tracking::enqueue_tracked(
+            "capture_args",
+            serde_json::json!({"account_id": 7}),
+        )
+        .await
+        .unwrap();
+
+        let payload = timeout(Duration::from_secs(1), async {
+            loop {
+                let seen = captured().lock().unwrap().clone();
+                if let Some(payload) = seen {
+                    return payload;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("handler should have run within 1s");
+
+        assert_eq!(payload, serde_json::json!({"account_id": 7}));
+        assert!(payload.get("__autumn_tracked").is_none(), "{payload}");
+        assert!(payload.get("args").is_none(), "{payload}");
+
+        shutdown.cancel();
+        clear_global_job_client();
+    }
+
+    #[test]
+    fn job_unique_key_and_identity_use_inner_args_for_tracked_payloads() {
+        let inner = serde_json::json!({"account_id": 42, "principal_id": "user:7"});
+        let wrapped = crate::job_tracking::wrap_tracked_payload("somehash", &inner);
+
+        let uniqueness = JobUniqueness {
+            by: vec!["account_id".to_string()],
+            window: JobUniquenessWindow::Running,
+        };
+        assert_eq!(
+            job_unique_key(&uniqueness, &wrapped),
+            job_unique_key(&uniqueness, &inner),
+            "the tracked envelope must not change the derived unique key"
+        );
+
+        let concurrency = JobConcurrency {
+            limit: 1,
+            key: Some("account_id".to_string()),
+        };
+        assert_eq!(
+            job_concurrency_scope(&concurrency, &wrapped),
+            job_concurrency_scope(&concurrency, &inner)
+        );
+
+        let (principal, _) = job_payload_identity(&wrapped);
+        assert_eq!(principal.as_deref(), Some("user:7"));
+    }
+
+    #[tokio::test]
+    async fn deduplicated_tracked_enqueue_fails_new_token_with_duplicate_message() {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let state = AppState::for_test().with_profile("dev");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let mut info = JobInfo::new(
+            "dedup_tracked",
+            1,
+            10,
+            |_state, _payload| Box::pin(async move { Ok(()) }),
+        );
+        info.uniqueness = Some(JobUniqueness {
+            by: Vec::new(),
+            window: JobUniquenessWindow::Running,
+        });
+        start_local_runtime(
+            vec![info],
+            &state,
+            &shutdown,
+            1,
+            5,
+            250,
+            &crate::config::JobQueuesConfig::default(),
+        );
+
+        let first = crate::job_tracking::enqueue_tracked("dedup_tracked", serde_json::json!({"x": 1}))
+            .await
+            .unwrap();
+        let second = crate::job_tracking::enqueue_tracked("dedup_tracked", serde_json::json!({"x": 1}))
+            .await
+            .unwrap();
+        assert_ne!(first.token, second.token);
+
+        let store = crate::job_tracking::tracking_store_from_state(&state).expect("store installed");
+        let key = crate::auth::hash_api_token(&second.token);
+        let record = store.get(&key).await.unwrap().expect("record");
+        assert_eq!(record.status, crate::job_tracking::TrackedJobStatus::Failed);
+        assert_eq!(
+            record.error.as_deref(),
+            Some("An equivalent job is already in progress.")
+        );
+
+        shutdown.cancel();
+        clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn retryable_failure_leaves_tracked_record_running_final_attempt_settles_it() {
+        static ATTEMPTS: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        fn flaky_handler(
+            _state: AppState,
+            _payload: Value,
+        ) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>> {
+            Box::pin(async move {
+                let attempt = ATTEMPTS.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                let ctx = crate::job_tracking::JobContext::current();
+                let _ = ctx.set_progress(10, None).await;
+                if attempt < 2 {
+                    Err(AutumnError::internal_server_error(std::io::Error::other(
+                        "transient",
+                    )))
+                } else {
+                    Ok(())
+                }
+            })
+        }
+
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+        ATTEMPTS.store(0, std::sync::atomic::Ordering::SeqCst);
+
+        let state = AppState::for_test().with_profile("dev");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        start_local_runtime(
+            vec![JobInfo::new("flaky_tracked", 2, 10, flaky_handler)],
+            &state,
+            &shutdown,
+            1,
+            5,
+            250,
+            &crate::config::JobQueuesConfig::default(),
+        );
+
+        let handle = crate::job_tracking::enqueue_tracked("flaky_tracked", serde_json::json!({}))
+            .await
+            .unwrap();
+        let store = crate::job_tracking::tracking_store_from_state(&state).unwrap();
+        let key = crate::auth::hash_api_token(&handle.token);
+
+        // Wait for attempt 1 to fail and its settle logic to run.
+        timeout(Duration::from_secs(2), async {
+            while ATTEMPTS.load(std::sync::atomic::Ordering::SeqCst) < 1 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("attempt 1 should run within 2s");
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        let record = store.get(&key).await.unwrap().expect("record");
+        assert_ne!(
+            record.status,
+            crate::job_tracking::TrackedJobStatus::Failed,
+            "a retryable failure with attempts remaining must not settle the record"
+        );
+
+        // Wait for the retry (attempt 2) to succeed and settle the record.
+        let record = timeout(Duration::from_secs(2), async {
+            loop {
+                if let Some(record) = store.get(&key).await.unwrap()
+                    && record.status == crate::job_tracking::TrackedJobStatus::Succeeded
+                {
+                    return record;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("retry should succeed within 2s");
+        assert_eq!(record.status, crate::job_tracking::TrackedJobStatus::Succeeded);
+
+        shutdown.cancel();
+        clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn panic_marks_tracked_record_failed_with_generic_message_not_panic_detail() {
+        fn panicking_handler(
+            _state: AppState,
+            _payload: Value,
+        ) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>> {
+            Box::pin(async move { panic!("sensitive internal detail") })
+        }
+
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+
+        let state = AppState::for_test().with_profile("dev");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        start_local_runtime(
+            // max_attempts = 3: proves a panic dead-letters immediately
+            // regardless of remaining attempts, not just when it's the last one.
+            vec![JobInfo::new("panicking_tracked", 3, 10, panicking_handler)],
+            &state,
+            &shutdown,
+            1,
+            5,
+            250,
+            &crate::config::JobQueuesConfig::default(),
+        );
+
+        let handle =
+            crate::job_tracking::enqueue_tracked("panicking_tracked", serde_json::json!({}))
+                .await
+                .unwrap();
+        let store = crate::job_tracking::tracking_store_from_state(&state).unwrap();
+        let key = crate::auth::hash_api_token(&handle.token);
+
+        let record = timeout(Duration::from_secs(2), async {
+            loop {
+                if let Some(record) = store.get(&key).await.unwrap()
+                    && record.status == crate::job_tracking::TrackedJobStatus::Failed
+                {
+                    return record;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("a panic should settle the record to failed within 2s");
+
+        assert_eq!(
+            record.error.as_deref(),
+            Some(crate::job_tracking::GENERIC_FAILURE_MESSAGE)
+        );
+        assert!(
+            !record
+                .error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("sensitive internal detail"),
+            "the raw panic message must never reach the tracked record: {:?}",
+            record.error
+        );
+
+        shutdown.cancel();
+        clear_global_job_client();
+    }
+
     #[tokio::test]
     async fn local_unknown_job_name_records_failure_and_does_not_requeue() {
         let state = AppState::for_test().with_profile("dev");

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -16,6 +16,11 @@ use serde_json::Value;
 
 use crate::{AppState, AutumnError, AutumnResult};
 
+pub use crate::job_tracking::{
+    JobContext, JobTrackingStore, JobTrackingStoreEntry, TrackedJobHandle, TrackedJobOwner,
+    TrackedJobRecord, TrackedJobStatus, enqueue_tracked, enqueue_tracked_for,
+};
+
 /// The asynchronous function signature for a background job.
 ///
 /// Handlers receive the full `AppState` and a JSON `Value` representing the job's payload.
@@ -1211,6 +1216,7 @@ fn fnv1a_64(input: &str) -> u64 {
 /// of each selected field (missing fields read as `null`); otherwise it is a
 /// stable hash of the full canonicalized payload.
 fn job_unique_key(uniqueness: &JobUniqueness, payload: &Value) -> String {
+    let (_, payload) = crate::job_tracking::split_tracked_payload(payload);
     if uniqueness.by.is_empty() {
         let mut canonical = String::new();
         write_canonical_json(payload, &mut canonical);
@@ -1235,6 +1241,7 @@ fn job_unique_key(uniqueness: &JobUniqueness, payload: &Value) -> String {
 /// type). A configured-but-missing field reads as canonical `null` so all
 /// payloads lacking the field share one scope.
 fn job_concurrency_scope(concurrency: &JobConcurrency, payload: &Value) -> Option<String> {
+    let (_, payload) = crate::job_tracking::split_tracked_payload(payload);
     concurrency.key.as_ref().map(|field| {
         let mut scope = String::new();
         write_canonical_json(payload.get(field).unwrap_or(&Value::Null), &mut scope);
@@ -1243,6 +1250,7 @@ fn job_concurrency_scope(concurrency: &JobConcurrency, payload: &Value) -> Optio
 }
 
 fn job_payload_identity(payload: &Value) -> (Option<String>, Option<String>) {
+    let (_, payload) = crate::job_tracking::split_tracked_payload(payload);
     let principal = first_payload_string(payload, &["principal_id", "principal", "user_id"]);
     let correlation = first_payload_string(payload, &["correlation_id", "request_id"]);
     (principal, correlation)
@@ -1631,7 +1639,26 @@ async fn run_job_handler(
     handler: JobHandler,
     state: AppState,
     payload: Value,
+    final_attempt: bool,
 ) -> JobExecutionOutcome {
+    // Tracked jobs carry their args wrapped in an envelope keyed by a hash of
+    // the polling token (never the raw token). Strip it here — the single
+    // choke point all three backends run handlers through — so the handler
+    // itself only ever sees the caller's original args, and make a
+    // `JobContext` ambient for the duration of execution so `ctx.set_progress`
+    // works from anywhere inside the handler.
+    let (tracked_key, payload) = crate::job_tracking::take_tracked_payload(payload);
+    let ctx = match &tracked_key {
+        Some(key) => match crate::job_tracking::tracking_store_from_state(&state) {
+            Some(store) => {
+                let _ = store.mark_running(key).await;
+                crate::job_tracking::JobContext::tracked(key.clone(), store)
+            }
+            None => crate::job_tracking::JobContext::none(),
+        },
+        None => crate::job_tracking::JobContext::none(),
+    };
+
     // Make this job's app the ambient event context so a job (or durable event
     // listener) that calls the free `events::publish` dispatches against its own
     // app rather than the process-global bus.
@@ -1665,17 +1692,45 @@ async fn run_job_handler(
         }
     }));
 
-    let future = match interceptor_res {
-        Ok(future) => future,
-        Err(panic) => return JobExecutionOutcome::Panicked(format_job_panic(panic.as_ref())),
+    let outcome = match interceptor_res {
+        Ok(future) => {
+            let execution = std::panic::AssertUnwindSafe(future).catch_unwind();
+            match crate::job_tracking::scope(
+                ctx.clone(),
+                crate::events::scope_event_app(event_app, execution),
+            )
+            .await
+            {
+                Ok(Ok(())) => JobExecutionOutcome::Succeeded,
+                Ok(Err(error)) => JobExecutionOutcome::Failed(error.to_string()),
+                Err(panic) => JobExecutionOutcome::Panicked(format_job_panic(panic.as_ref())),
+            }
+        }
+        Err(panic) => JobExecutionOutcome::Panicked(format_job_panic(panic.as_ref())),
     };
 
-    let execution = std::panic::AssertUnwindSafe(future).catch_unwind();
-    match crate::events::scope_event_app(event_app, execution).await {
-        Ok(Ok(())) => JobExecutionOutcome::Succeeded,
-        Ok(Err(error)) => JobExecutionOutcome::Failed(error.to_string()),
-        Err(panic) => JobExecutionOutcome::Panicked(format_job_panic(panic.as_ref())),
+    if tracked_key.is_some() {
+        match &outcome {
+            JobExecutionOutcome::Succeeded => ctx.settle_success().await,
+            // Panics always dead-letter regardless of remaining attempts
+            // (matching every backend's worker loop), so they are always
+            // terminal for tracking purposes too.
+            JobExecutionOutcome::Panicked(_) => {
+                ctx.settle_failure(crate::job_tracking::GENERIC_FAILURE_MESSAGE)
+                    .await;
+            }
+            JobExecutionOutcome::Failed(_) if final_attempt => {
+                ctx.settle_failure(crate::job_tracking::GENERIC_FAILURE_MESSAGE)
+                    .await;
+            }
+            JobExecutionOutcome::Failed(_) => {
+                // A retry is pending; leave the record running so progress
+                // persists across attempts.
+            }
+        }
     }
+
+    outcome
 }
 
 fn format_job_panic(panic: &(dyn std::any::Any + Send)) -> String {
@@ -1737,6 +1792,11 @@ pub fn global_job_client() -> Option<Arc<JobClient>> {
 pub(crate) fn install_job_client(state: &AppState, client: JobClient) {
     state.insert_extension(client.clone());
     init_global_job_client(client);
+    // `enqueue_tracked` needs a tracking store the moment a job runtime is
+    // live, even for backends/tests that build a `JobClient` directly rather
+    // than going through `start_runtime` (which installs a config-driven
+    // store before the backend starter runs and gets here).
+    crate::job_tracking::ensure_tracking_store_installed(state);
 }
 
 pub(crate) fn init_global_job_client(client: JobClient) {
@@ -1757,6 +1817,7 @@ pub fn clear_global_job_client() {
     } else {
         let _ = GLOBAL_JOB_CLIENT.set(RwLock::new(None));
     }
+    crate::job_tracking::clear_global_tracking_store();
 }
 
 /// Enqueue a job payload on the configured runtime backend.
@@ -3214,7 +3275,14 @@ async fn execute_local_job(
         use tracing_opentelemetry::OpenTelemetrySpanExt as _;
         let _ = job_span.set_parent(cx);
     }
-    let f = run_job_handler(&job.name, handler, state.clone(), job.payload.clone());
+    let final_attempt = job.attempt >= max_attempts;
+    let f = run_job_handler(
+        &job.name,
+        handler,
+        state.clone(),
+        job.payload.clone(),
+        final_attempt,
+    );
     let outcome = tracing::Instrument::instrument(f, job_span).await;
     match outcome {
         JobExecutionOutcome::Succeeded => {
@@ -5279,7 +5347,14 @@ async fn process_redis_job_record(
         use tracing_opentelemetry::OpenTelemetrySpanExt as _;
         let _ = job_span.set_parent(cx);
     }
-    let f = run_job_handler(&record.name, handler, state.clone(), record.payload.clone());
+    let final_attempt = record.attempt >= record.max_attempts;
+    let f = run_job_handler(
+        &record.name,
+        handler,
+        state.clone(),
+        record.payload.clone(),
+        final_attempt,
+    );
     match tracing::Instrument::instrument(f, job_span).await {
         JobExecutionOutcome::Succeeded => {
             match ack_redis_success(connection, worker_config, &record).await {
@@ -6435,7 +6510,8 @@ async fn pg_execute_job(
         use tracing_opentelemetry::OpenTelemetrySpanExt as _;
         let _ = job_span.set_parent(cx);
     }
-    let f = run_job_handler(&row.name, handler, state.clone(), payload);
+    let final_attempt = attempt >= max_attempts;
+    let f = run_job_handler(&row.name, handler, state.clone(), payload, final_attempt);
     match tracing::Instrument::instrument(f, job_span).await {
         JobExecutionOutcome::Succeeded => {
             let ack = pg_ack_success(pool, &row.id, worker_id).await;
@@ -7366,6 +7442,7 @@ mod tests {
             instantly_panicking_handler,
             state,
             serde_json::json!({}),
+            true,
         )
         .await;
         assert_eq!(
@@ -7417,8 +7494,14 @@ mod tests {
             Arc::new(PanickingJobInterceptor) as Arc<dyn crate::interceptor::JobInterceptor>
         );
 
-        let outcome =
-            run_job_handler("test_job", success_handler, state, serde_json::json!({})).await;
+        let outcome = run_job_handler(
+            "test_job",
+            success_handler,
+            state,
+            serde_json::json!({}),
+            true,
+        )
+        .await;
 
         assert_eq!(
             outcome,
@@ -7485,6 +7568,7 @@ mod tests {
             side_effect_handler,
             state,
             serde_json::json!({}),
+            true,
         )
         .await;
 
@@ -10222,7 +10306,14 @@ mod tests {
     async fn run_job_handler_reports_async_panics() {
         let state = AppState::for_test().with_profile("dev");
         let outcome =
-            run_job_handler("test_job", panicking_handler, state, serde_json::json!({})).await;
+            run_job_handler(
+                "test_job",
+                panicking_handler,
+                state,
+                serde_json::json!({}),
+                true,
+            )
+            .await;
         assert_eq!(
             outcome,
             JobExecutionOutcome::Panicked("job handler panicked: forced panic".to_string())

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -623,6 +623,14 @@ pub async fn enqueue_tracked_for(
                 .fail(&key, "An equivalent job is already in progress.".to_owned())
                 .await?;
         }
+        Ok(crate::job::EnqueueOutcome::Skipped) => {
+            // A JobInterceptor completed without ever delivering the job to
+            // the backend — the record must not be left at Pending forever
+            // for a job that will never actually run.
+            store
+                .fail(&key, "The job could not be enqueued.".to_owned())
+                .await?;
+        }
         Err(error) => {
             // The job never entered the queue, so the `Pending` record
             // created above must not be left to linger until TTL expiry —

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -10,14 +10,14 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::AutumnResult;
 use crate::time::{ClockSource, SystemClock};
+use crate::{AppState, AutumnError, AutumnResult};
 
 /// Who is allowed to poll a tracked job's status.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -95,6 +95,341 @@ pub trait JobTrackingStore: Send + Sync + 'static {
 /// `AppState` extension carrying the installed [`JobTrackingStore`].
 #[derive(Clone)]
 pub struct JobTrackingStoreEntry(pub Arc<dyn JobTrackingStore>);
+
+// ── Job context (progress reporting from inside a handler) ───────────────────
+
+tokio::task_local! {
+    static CURRENT_JOB_CONTEXT: JobContext;
+}
+
+/// A generic, user-safe failure message persisted when a tracked job's
+/// handler fails or panics without calling
+/// [`JobContext::set_user_error`].
+pub(crate) const GENERIC_FAILURE_MESSAGE: &str = "The job failed.";
+
+struct JobContextInner {
+    key: String,
+    store: Arc<dyn JobTrackingStore>,
+    result: Mutex<Option<Value>>,
+    user_error: Mutex<Option<String>>,
+}
+
+/// Ambient handle a `#[job]` handler uses to report progress and to record a
+/// terminal result or a user-safe error for a tracked job.
+///
+/// [`JobContext::current`] always returns a value. For a job enqueued via
+/// plain [`crate::job::enqueue`] (not tracked), it is a no-op: every method is
+/// a harmless no-op and [`is_tracked`](Self::is_tracked) reports `false`.
+#[derive(Clone)]
+pub struct JobContext(Option<Arc<JobContextInner>>);
+
+impl JobContext {
+    pub(crate) fn tracked(key: String, store: Arc<dyn JobTrackingStore>) -> Self {
+        Self(Some(Arc::new(JobContextInner {
+            key,
+            store,
+            result: Mutex::new(None),
+            user_error: Mutex::new(None),
+        })))
+    }
+
+    pub(crate) const fn none() -> Self {
+        Self(None)
+    }
+
+    /// The ambient context for the currently-executing job, or a no-op
+    /// context when called outside a job or for an untracked job.
+    #[must_use]
+    pub fn current() -> Self {
+        CURRENT_JOB_CONTEXT
+            .try_with(Clone::clone)
+            .unwrap_or_else(|_| Self::none())
+    }
+
+    /// Whether this context is bound to a tracked job's status record.
+    #[must_use]
+    pub const fn is_tracked(&self) -> bool {
+        self.0.is_some()
+    }
+
+    /// Report progress. `pct` is clamped to `0..=100`. A no-op for an
+    /// untracked context.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying store write fails.
+    pub async fn set_progress(&self, pct: u8, message: Option<&str>) -> AutumnResult<()> {
+        let Some(inner) = &self.0 else {
+            return Ok(());
+        };
+        inner
+            .store
+            .set_progress(&inner.key, pct, message.map(str::to_owned))
+            .await
+    }
+
+    /// Record the JSON result to persist when the job succeeds. A no-op for
+    /// an untracked context.
+    pub fn set_result(&self, result: Value) {
+        if let Some(inner) = &self.0 {
+            *inner
+                .result
+                .lock()
+                .expect("job context result lock poisoned") = Some(result);
+        }
+    }
+
+    /// Record the user-safe error message to persist if the job ultimately
+    /// fails (its last attempt, or a panic). A no-op for an untracked
+    /// context.
+    pub fn set_user_error(&self, message: impl Into<String>) {
+        if let Some(inner) = &self.0 {
+            *inner
+                .user_error
+                .lock()
+                .expect("job context error lock poisoned") = Some(message.into());
+        }
+    }
+
+    /// Persist the terminal success result. A no-op for an untracked context.
+    pub(crate) async fn settle_success(&self) {
+        let Some(inner) = &self.0 else {
+            return;
+        };
+        let result = inner
+            .result
+            .lock()
+            .expect("job context result lock poisoned")
+            .take()
+            .unwrap_or(Value::Null);
+        let _ = inner.store.complete(&inner.key, result).await;
+    }
+
+    /// Persist the terminal failure, using `default_message` if the handler
+    /// never called [`Self::set_user_error`]. A no-op for an untracked
+    /// context.
+    pub(crate) async fn settle_failure(&self, default_message: &str) {
+        let Some(inner) = &self.0 else {
+            return;
+        };
+        let message = inner
+            .user_error
+            .lock()
+            .expect("job context error lock poisoned")
+            .take()
+            .unwrap_or_else(|| default_message.to_owned());
+        let _ = inner.store.fail(&inner.key, message).await;
+    }
+}
+
+/// Run `future` with `ctx` as the ambient [`JobContext`], so
+/// [`JobContext::current`] resolves it from anywhere inside `future`
+/// (including across `.await` points and nested async calls).
+pub(crate) async fn scope<F: Future>(ctx: JobContext, future: F) -> F::Output {
+    CURRENT_JOB_CONTEXT.scope(ctx, future).await
+}
+
+// ── Tracked-payload envelope ──────────────────────────────────────────────────
+
+const ENVELOPE_MARKER: &str = "__autumn_tracked";
+const ENVELOPE_KEY: &str = "k";
+const ENVELOPE_ARGS: &str = "args";
+
+/// Wrap `args` in the tracked-job envelope carrying the tracking key (a hash
+/// of the raw token — never the raw token itself, so a leaked payload, admin
+/// record, or queue dump never exposes the polling capability).
+pub(crate) fn wrap_tracked_payload(key: &str, args: Value) -> Value {
+    serde_json::json!({
+        ENVELOPE_MARKER: { ENVELOPE_KEY: key },
+        ENVELOPE_ARGS: args,
+    })
+}
+
+/// If `payload` is a tracked-job envelope, remove and return `(Some(key),
+/// inner_args)`; otherwise return `(None, payload)` unchanged.
+///
+/// This is the single place a job handler's payload is unwrapped before
+/// execution — called from the one choke point all three job backends run
+/// handlers through.
+pub(crate) fn take_tracked_payload(payload: Value) -> (Option<String>, Value) {
+    let Value::Object(mut obj) = payload else {
+        return (None, payload);
+    };
+    let key = obj
+        .get(ENVELOPE_MARKER)
+        .and_then(Value::as_object)
+        .and_then(|marker| marker.get(ENVELOPE_KEY))
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    match key {
+        Some(key) => {
+            let inner = obj.remove(ENVELOPE_ARGS).unwrap_or(Value::Null);
+            (Some(key), inner)
+        }
+        None => (None, Value::Object(obj)),
+    }
+}
+
+/// Borrowing counterpart of [`take_tracked_payload`], for callers (uniqueness
+/// hashing, principal/correlation extraction) that only need to read fields
+/// off the inner args without consuming the payload.
+pub(crate) fn split_tracked_payload(payload: &Value) -> (Option<&str>, &Value) {
+    let Some(obj) = payload.as_object() else {
+        return (None, payload);
+    };
+    let Some(key) = obj
+        .get(ENVELOPE_MARKER)
+        .and_then(Value::as_object)
+        .and_then(|marker| marker.get(ENVELOPE_KEY))
+        .and_then(Value::as_str)
+    else {
+        return (None, payload);
+    };
+    (Some(key), obj.get(ENVELOPE_ARGS).unwrap_or(payload))
+}
+
+// ── Global tracking-store install/resolve ─────────────────────────────────────
+
+static GLOBAL_TRACKING_STORE: OnceLock<RwLock<Option<Arc<dyn JobTrackingStore>>>> =
+    OnceLock::new();
+
+const DEFAULT_TRACKING_TTL_SECS: u64 = 86_400;
+
+/// Install `store` as this app's tracking store: both an `AppState`
+/// extension (for [`tracking_store_from_state`], used where a state is
+/// already in hand — e.g. inside the job-execution choke point) and the
+/// process-global fallback used by the free `enqueue_tracked` functions,
+/// which have no `AppState` to resolve an extension from — mirroring
+/// [`crate::job::install_job_client`].
+pub(crate) fn install_tracking_store(state: &AppState, store: Arc<dyn JobTrackingStore>) {
+    state.insert_extension(JobTrackingStoreEntry(store.clone()));
+    let lock = GLOBAL_TRACKING_STORE.get_or_init(|| RwLock::new(None));
+    if let Ok(mut guard) = lock.write() {
+        *guard = Some(store);
+    }
+}
+
+/// Install a default in-memory tracking store if this app doesn't already
+/// have one installed. Called whenever a job runtime starts so
+/// `enqueue_tracked` works even when a `JobClient` is constructed directly
+/// (as the backend starters and their tests do) rather than through
+/// `crate::job::start_runtime`, which installs a config-driven store first.
+pub(crate) fn ensure_tracking_store_installed(state: &AppState) {
+    if tracking_store_from_state(state).is_none() {
+        install_tracking_store(
+            state,
+            Arc::new(InMemoryJobTrackingStore::new(DEFAULT_TRACKING_TTL_SECS)),
+        );
+    }
+}
+
+/// Resolve the tracking store from `state`'s extensions.
+pub(crate) fn tracking_store_from_state(state: &AppState) -> Option<Arc<dyn JobTrackingStore>> {
+    state
+        .extension::<JobTrackingStoreEntry>()
+        .map(|entry| entry.0.clone())
+}
+
+/// Resolve the process-global tracking store used by the free
+/// `enqueue_tracked` functions (which have no `AppState`).
+pub(crate) fn global_tracking_store() -> Option<Arc<dyn JobTrackingStore>> {
+    GLOBAL_TRACKING_STORE.get()?.read().ok()?.clone()
+}
+
+/// Reset the process-global tracking store, mirroring
+/// [`crate::job::clear_global_job_client`].
+pub(crate) fn clear_global_tracking_store() {
+    if let Some(lock) = GLOBAL_TRACKING_STORE.get() {
+        if let Ok(mut guard) = lock.write() {
+            *guard = None;
+        }
+    } else {
+        let _ = GLOBAL_TRACKING_STORE.set(RwLock::new(None));
+    }
+}
+
+// ── enqueue_tracked ────────────────────────────────────────────────────────────
+
+/// Built-in route prefix for polling a tracked job's status: the full path is
+/// `{JOB_STATUS_PATH_PREFIX}{token}`.
+pub(crate) const JOB_STATUS_PATH_PREFIX: &str = "/_autumn/jobs/";
+
+/// A handle returned by [`enqueue_tracked`]/[`enqueue_tracked_for`] carrying
+/// the public, unguessable token used to poll the job's tracked status.
+///
+/// The token is distinct from (and never reveals) the internal job id.
+#[derive(Debug, Clone)]
+pub struct TrackedJobHandle {
+    /// The raw, unguessable polling token. Deliver this to the caller (e.g.
+    /// embed it in a redirect or JSON response) — it cannot be recovered
+    /// later; only its hash is persisted.
+    pub token: String,
+}
+
+impl TrackedJobHandle {
+    /// The path of the built-in status route for this handle's token.
+    #[must_use]
+    pub fn status_path(&self) -> String {
+        format!("{JOB_STATUS_PATH_PREFIX}{}", self.token)
+    }
+}
+
+/// Enqueue `name` with `payload`, returning a [`TrackedJobHandle`] whose
+/// token is an anonymous capability: anyone holding the token may poll the
+/// job's status. Use [`enqueue_tracked_for`] to bind status access to a
+/// session or authenticated user instead.
+///
+/// # Errors
+///
+/// Returns an internal error when the job runtime or its tracking store are
+/// not initialized, when `name` does not match a registered job, or when the
+/// active backend rejects the enqueue operation.
+pub async fn enqueue_tracked(name: &str, payload: Value) -> AutumnResult<TrackedJobHandle> {
+    enqueue_tracked_for(name, payload, TrackedJobOwner::Anonymous).await
+}
+
+/// Like [`enqueue_tracked`], binding the tracked status record to `owner` so
+/// only a request matching that session/user may poll it.
+///
+/// # Errors
+///
+/// See [`enqueue_tracked`].
+pub async fn enqueue_tracked_for(
+    name: &str,
+    payload: Value,
+    owner: TrackedJobOwner,
+) -> AutumnResult<TrackedJobHandle> {
+    let client = crate::job::global_job_client().ok_or_else(|| {
+        AutumnError::internal_server_error(std::io::Error::other(
+            "job runtime is not initialized; register jobs with AppBuilder::jobs()",
+        ))
+    })?;
+    let store = global_tracking_store().ok_or_else(|| {
+        AutumnError::internal_server_error(std::io::Error::other(
+            "job tracking store is not initialized; register jobs with AppBuilder::jobs()",
+        ))
+    })?;
+
+    let token = crate::auth::generate_raw_token();
+    let key = crate::auth::hash_api_token(&token);
+    store.create(&key, owner).await?;
+
+    let wrapped = wrap_tracked_payload(&key, payload);
+    match client.enqueue_with_outcome(name, wrapped).await {
+        Ok(crate::job::EnqueueOutcome::Queued) => {}
+        Ok(crate::job::EnqueueOutcome::Deduplicated) => {
+            store
+                .fail(
+                    &key,
+                    "An equivalent job is already in progress.".to_owned(),
+                )
+                .await?;
+        }
+        Err(error) => return Err(error),
+    }
+
+    Ok(TrackedJobHandle { token })
+}
 
 // ── In-memory store ───────────────────────────────────────────────────────────
 
@@ -398,5 +733,152 @@ mod tests {
         // Expired: reads see it as gone, and writes must not resurrect it.
         store.set_progress("k1", 50, None).await.unwrap();
         assert!(store.get("k1").await.unwrap().is_none());
+    }
+
+    // ── envelope ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn wrap_then_take_roundtrips_key_and_inner_args() {
+        let args = serde_json::json!({"account_id": 42});
+        let wrapped = wrap_tracked_payload("abc123", args.clone());
+
+        let (key, inner) = take_tracked_payload(wrapped);
+        assert_eq!(key.as_deref(), Some("abc123"));
+        assert_eq!(inner, args);
+    }
+
+    #[test]
+    fn take_tracked_payload_on_untracked_payload_is_a_passthrough() {
+        let args = serde_json::json!({"account_id": 42});
+        let (key, inner) = take_tracked_payload(args.clone());
+        assert!(key.is_none());
+        assert_eq!(inner, args);
+    }
+
+    #[test]
+    fn split_tracked_payload_borrows_inner_args_without_consuming() {
+        let args = serde_json::json!({"account_id": 42});
+        let wrapped = wrap_tracked_payload("abc123", args.clone());
+
+        let (key, inner) = split_tracked_payload(&wrapped);
+        assert_eq!(key, Some("abc123"));
+        assert_eq!(inner, &args);
+    }
+
+    #[test]
+    fn split_tracked_payload_on_untracked_payload_is_a_passthrough() {
+        let args = serde_json::json!({"account_id": 42});
+        let (key, inner) = split_tracked_payload(&args);
+        assert!(key.is_none());
+        assert_eq!(inner, &args);
+    }
+
+    // ── JobContext ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn job_context_current_outside_job_is_noop() {
+        let ctx = JobContext::current();
+        assert!(!ctx.is_tracked());
+    }
+
+    #[tokio::test]
+    async fn noop_context_methods_never_panic_or_error() {
+        let ctx = JobContext::none();
+        assert!(ctx.set_progress(50, Some("halfway")).await.is_ok());
+        ctx.set_result(serde_json::json!({"ok": true}));
+        ctx.set_user_error("should be discarded");
+        // Settling a no-op context must not panic even though nothing is stored.
+        ctx.settle_success().await;
+        ctx.settle_failure(GENERIC_FAILURE_MESSAGE).await;
+    }
+
+    #[tokio::test]
+    async fn scope_makes_context_ambient_for_current() {
+        let store: Arc<dyn JobTrackingStore> = Arc::new(InMemoryJobTrackingStore::new(60));
+        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        let ctx = JobContext::tracked("k1".to_owned(), store.clone());
+
+        let observed = scope(ctx, async { JobContext::current() }).await;
+        assert!(observed.is_tracked());
+
+        observed.set_progress(75, Some("almost done")).await.unwrap();
+        let record = store.get("k1").await.unwrap().expect("record");
+        assert_eq!(record.progress_pct, Some(75));
+    }
+
+    #[tokio::test]
+    async fn settle_success_persists_ctx_result() {
+        let store: Arc<dyn JobTrackingStore> = Arc::new(InMemoryJobTrackingStore::new(60));
+        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        let ctx = JobContext::tracked("k1".to_owned(), store.clone());
+
+        ctx.set_result(serde_json::json!({"download_url": "/blob/abc.csv"}));
+        ctx.settle_success().await;
+
+        let record = store.get("k1").await.unwrap().expect("record");
+        assert_eq!(record.status, TrackedJobStatus::Succeeded);
+        assert_eq!(
+            record.result,
+            Some(serde_json::json!({"download_url": "/blob/abc.csv"}))
+        );
+    }
+
+    #[tokio::test]
+    async fn settle_success_without_set_result_stores_null() {
+        let store: Arc<dyn JobTrackingStore> = Arc::new(InMemoryJobTrackingStore::new(60));
+        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        let ctx = JobContext::tracked("k1".to_owned(), store.clone());
+
+        ctx.settle_success().await;
+
+        let record = store.get("k1").await.unwrap().expect("record");
+        assert_eq!(record.status, TrackedJobStatus::Succeeded);
+        assert_eq!(record.result, Some(Value::Null));
+    }
+
+    #[tokio::test]
+    async fn settle_failure_uses_set_user_error_over_default() {
+        let store: Arc<dyn JobTrackingStore> = Arc::new(InMemoryJobTrackingStore::new(60));
+        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        let ctx = JobContext::tracked("k1".to_owned(), store.clone());
+
+        ctx.set_user_error("The export could not reach storage.");
+        ctx.settle_failure(GENERIC_FAILURE_MESSAGE).await;
+
+        let record = store.get("k1").await.unwrap().expect("record");
+        assert_eq!(record.status, TrackedJobStatus::Failed);
+        assert_eq!(
+            record.error.as_deref(),
+            Some("The export could not reach storage.")
+        );
+    }
+
+    #[tokio::test]
+    async fn settle_failure_without_set_user_error_uses_default_message() {
+        let store: Arc<dyn JobTrackingStore> = Arc::new(InMemoryJobTrackingStore::new(60));
+        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        let ctx = JobContext::tracked("k1".to_owned(), store.clone());
+
+        ctx.settle_failure(GENERIC_FAILURE_MESSAGE).await;
+
+        let record = store.get("k1").await.unwrap().expect("record");
+        assert_eq!(record.status, TrackedJobStatus::Failed);
+        assert_eq!(record.error.as_deref(), Some(GENERIC_FAILURE_MESSAGE));
+    }
+
+    // ── enqueue_tracked (error paths reachable without a running job runtime) ─
+
+    #[tokio::test]
+    async fn enqueue_tracked_errors_when_job_runtime_is_not_initialized() {
+        let _guard = crate::job::global_job_runtime_test_lock().lock().await;
+        crate::job::clear_global_job_client();
+
+        let err = enqueue_tracked("export_orders", serde_json::json!({}))
+            .await
+            .expect_err("no job runtime should be an error, not a panic");
+        assert!(
+            err.to_string().contains("job runtime is not initialized"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -12,6 +12,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex, OnceLock, RwLock};
 
+use axum::response::IntoResponse as _;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -429,6 +430,65 @@ pub async fn enqueue_tracked_for(
     }
 
     Ok(TrackedJobHandle { token })
+}
+
+// ── Status route ───────────────────────────────────────────────────────────────
+
+/// The built-in status route's axum path pattern (mounted at
+/// `mount_framework_routes` time when `jobs.tracking.route_enabled`).
+pub(crate) const JOB_STATUS_ROUTE_PATH: &str = "/_autumn/jobs/{token}";
+
+/// JSON representation of a tracked job's status, returned by the built-in
+/// status route to API clients (and reused as the data behind the htmx
+/// fragment for browser clients).
+#[derive(Debug, Clone, Serialize)]
+struct JobStatusDto {
+    status: TrackedJobStatus,
+    progress: Option<u8>,
+    message: Option<String>,
+    result: Option<Value>,
+    error: Option<String>,
+}
+
+impl From<&TrackedJobRecord> for JobStatusDto {
+    fn from(record: &TrackedJobRecord) -> Self {
+        Self {
+            status: record.status,
+            progress: record.progress_pct,
+            message: record.progress_message.clone(),
+            result: record.result.clone(),
+            error: record.error.clone(),
+        }
+    }
+}
+
+/// Router for the framework's built-in tracked-job status endpoint.
+///
+/// Mounted automatically unless `jobs.tracking.route_enabled = false`.
+pub(crate) fn status_router() -> axum::Router<AppState> {
+    axum::Router::new().route(JOB_STATUS_ROUTE_PATH, axum::routing::get(job_status_handler))
+}
+
+/// `GET /_autumn/jobs/{token}`: resolve the tracked-job record for `token`
+/// and return it as JSON. Unknown, expired, and (once owner binding lands)
+/// unauthorized tokens all render the identical 404 so the route is never an
+/// existence/ownership oracle.
+async fn job_status_handler(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    axum::extract::Path(token): axum::extract::Path<String>,
+) -> AutumnResult<axum::response::Response> {
+    let not_found = || AutumnError::not_found_msg("This job status page could not be found.");
+
+    let store = tracking_store_from_state(&state).ok_or_else(not_found)?;
+    let key = crate::auth::hash_api_token(&token);
+    let record = store.get(&key).await?.ok_or_else(not_found)?;
+
+    let mut response = axum::Json(JobStatusDto::from(&record)).into_response();
+    response.headers_mut().insert(
+        axum::http::header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("no-store"),
+    );
+    Ok(response)
 }
 
 // ── In-memory store ───────────────────────────────────────────────────────────

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -352,13 +352,40 @@ pub(crate) fn install_tracking_store(state: &AppState, store: Arc<dyn JobTrackin
 /// have one installed. Called whenever a job runtime starts so
 /// `enqueue_tracked` works even when a `JobClient` is constructed directly
 /// (as the backend starters and their tests do) rather than through
-/// `crate::job::start_runtime`, which installs a config-driven store first.
+/// `crate::job::start_runtime`, which installs a config-driven store first
+/// (making this a no-op fallback in that path).
 pub(crate) fn ensure_tracking_store_installed(state: &AppState) {
     if tracking_store_from_state(state).is_none() {
         install_tracking_store(
             state,
             Arc::new(InMemoryJobTrackingStore::new(DEFAULT_TRACKING_TTL_SECS)),
         );
+    }
+}
+
+/// Build the tracking store selected by `config.backend`, honoring
+/// `config.tracking.ttl_secs`.
+///
+/// Every backend gets an in-memory store today; `start_runtime` swaps in the
+/// Redis/Postgres-backed stores for those backends once they exist.
+fn store_for_config(config: &crate::config::JobConfig) -> Arc<dyn JobTrackingStore> {
+    Arc::new(InMemoryJobTrackingStore::new(config.tracking.ttl_secs))
+}
+
+/// Install a tracking store built from `config` (honoring
+/// `jobs.tracking.ttl_secs`) if this app doesn't already have one installed.
+///
+/// Called by `crate::job::start_runtime` before dispatching to a
+/// backend-specific starter, so the config-driven TTL wins over
+/// [`ensure_tracking_store_installed`]'s hardcoded default (that function
+/// runs afterward, inside `install_job_client`, and is a no-op once a store
+/// is already present).
+pub(crate) fn ensure_tracking_store_installed_from_config(
+    state: &AppState,
+    config: &crate::config::JobConfig,
+) {
+    if tracking_store_from_state(state).is_none() {
+        install_tracking_store(state, store_for_config(config));
     }
 }
 

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -539,11 +539,30 @@ pub(crate) async fn settle_tracked_payload_as_failed(
     payload: &Value,
     message: &str,
 ) {
+    settle_tracked_payload_with_store(tracking_store_from_state(state), payload, message).await;
+}
+
+/// Like [`settle_tracked_payload_as_failed`], but resolves the store from
+/// the process-global fallback instead of an `AppState` extension.
+///
+/// For use by admin backends (`RedisJobAdminBackend`/`PgJobAdminBackend`)
+/// that operate directly against a queue backend with no `AppState` in
+/// hand — an operator cancelling a job that hasn't reached a worker yet
+/// goes through these paths, not `run_job_handler`.
+pub(crate) async fn settle_tracked_payload_as_failed_globally(payload: &Value, message: &str) {
+    settle_tracked_payload_with_store(global_tracking_store(), payload, message).await;
+}
+
+async fn settle_tracked_payload_with_store(
+    store: Option<Arc<dyn JobTrackingStore>>,
+    payload: &Value,
+    message: &str,
+) {
     let (key, _) = split_tracked_payload(payload);
     let Some(key) = key else {
         return;
     };
-    if let Some(store) = tracking_store_from_state(state) {
+    if let Some(store) = store {
         let _ = store.fail(key, message.to_owned()).await;
     }
 }

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -171,6 +171,11 @@ impl JobContext {
 
     /// Record the JSON result to persist when the job succeeds. A no-op for
     /// an untracked context.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal result mutex is poisoned (only possible if a
+    /// previous holder panicked while holding it).
     pub fn set_result(&self, result: Value) {
         if let Some(inner) = &self.0 {
             *inner
@@ -183,6 +188,11 @@ impl JobContext {
     /// Record the user-safe error message to persist if the job ultimately
     /// fails (its last attempt, or a panic). A no-op for an untracked
     /// context.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal error mutex is poisoned (only possible if a
+    /// previous holder panicked while holding it).
     pub fn set_user_error(&self, message: impl Into<String>) {
         if let Some(inner) = &self.0 {
             *inner
@@ -239,7 +249,7 @@ const ENVELOPE_ARGS: &str = "args";
 /// Wrap `args` in the tracked-job envelope carrying the tracking key (a hash
 /// of the raw token — never the raw token itself, so a leaked payload, admin
 /// record, or queue dump never exposes the polling capability).
-pub(crate) fn wrap_tracked_payload(key: &str, args: Value) -> Value {
+pub(crate) fn wrap_tracked_payload(key: &str, args: &Value) -> Value {
     serde_json::json!({
         ENVELOPE_MARKER: { ENVELOPE_KEY: key },
         ENVELOPE_ARGS: args,
@@ -375,10 +385,11 @@ impl TrackedJobHandle {
     }
 }
 
-/// Enqueue `name` with `payload`, returning a [`TrackedJobHandle`] whose
-/// token is an anonymous capability: anyone holding the token may poll the
-/// job's status. Use [`enqueue_tracked_for`] to bind status access to a
-/// session or authenticated user instead.
+/// Enqueue `name` with `payload`, returning a [`TrackedJobHandle`].
+///
+/// The handle's token is an anonymous capability: anyone holding the token
+/// may poll the job's status. Use [`enqueue_tracked_for`] to bind status
+/// access to a session or authenticated user instead.
 ///
 /// # Errors
 ///
@@ -415,7 +426,7 @@ pub async fn enqueue_tracked_for(
     let key = crate::auth::hash_api_token(&token);
     store.create(&key, owner).await?;
 
-    let wrapped = wrap_tracked_payload(&key, payload);
+    let wrapped = wrap_tracked_payload(&key, &payload);
     match client.enqueue_with_outcome(name, wrapped).await {
         Ok(crate::job::EnqueueOutcome::Queued) => {}
         Ok(crate::job::EnqueueOutcome::Deduplicated) => {
@@ -470,12 +481,14 @@ pub(crate) fn status_router() -> axum::Router<AppState> {
 }
 
 /// `GET /_autumn/jobs/{token}`: resolve the tracked-job record for `token`
-/// and return it as JSON. Unknown, expired, and (once owner binding lands)
-/// unauthorized tokens all render the identical 404 so the route is never an
-/// existence/ownership oracle.
+/// and return it as JSON for API clients, or an htmx-pollable HTML fragment
+/// for browsers (content-negotiated). Unknown, expired, and (once owner
+/// binding lands) unauthorized tokens all render the identical 404 so the
+/// route is never an existence/ownership oracle.
 async fn job_status_handler(
     axum::extract::State(state): axum::extract::State<AppState>,
     axum::extract::Path(token): axum::extract::Path<String>,
+    headers: axum::http::HeaderMap,
 ) -> AutumnResult<axum::response::Response> {
     let not_found = || AutumnError::not_found_msg("This job status page could not be found.");
 
@@ -483,12 +496,103 @@ async fn job_status_handler(
     let key = crate::auth::hash_api_token(&token);
     let record = store.get(&key).await?.ok_or_else(not_found)?;
 
-    let mut response = axum::Json(JobStatusDto::from(&record)).into_response();
+    let path = format!("{JOB_STATUS_PATH_PREFIX}{token}");
+    let mut response = render_status_response(&record, &headers, &path);
     response.headers_mut().insert(
         axum::http::header::CACHE_CONTROL,
         axum::http::HeaderValue::from_static("no-store"),
     );
     Ok(response)
+}
+
+/// Whether the request prefers an htmx-pollable HTML fragment over JSON:
+/// true for an htmx request (`HX-Request: true`) or a browser `Accept`
+/// header, per [`crate::middleware::error_page_filter::accept_prefers_html`]
+/// (an absent/empty `Accept` header — the typical API client — prefers
+/// JSON). Rendering is only possible with the `maud` feature enabled.
+#[cfg(feature = "maud")]
+fn wants_html_response(headers: &axum::http::HeaderMap) -> bool {
+    let is_htmx = headers
+        .get("hx-request")
+        .is_some_and(|value| value == "true");
+    is_htmx || crate::middleware::error_page_filter::accept_prefers_html(headers)
+}
+
+#[cfg(feature = "maud")]
+fn render_status_response(
+    record: &TrackedJobRecord,
+    headers: &axum::http::HeaderMap,
+    path: &str,
+) -> axum::response::Response {
+    if wants_html_response(headers) {
+        status_fragment(record, path).into_response()
+    } else {
+        axum::Json(JobStatusDto::from(record)).into_response()
+    }
+}
+
+#[cfg(not(feature = "maud"))]
+fn render_status_response(
+    record: &TrackedJobRecord,
+    _headers: &axum::http::HeaderMap,
+    _path: &str,
+) -> axum::response::Response {
+    axum::Json(JobStatusDto::from(record)).into_response()
+}
+
+/// Render the htmx-pollable status fragment.
+///
+/// While pending/running, the wrapper `div` carries
+/// `hx-get={path} hx-trigger="every 2s" hx-swap="outerHTML"` so it re-fetches
+/// and replaces itself every 2 seconds with zero app-authored JS. Once the
+/// job reaches a terminal state the fragment carries **no** `hx-*`
+/// attributes, so htmx has nothing left to poll — it renders the download
+/// link (when the result carries a `download_url`) or the failure message.
+#[cfg(feature = "maud")]
+fn status_fragment(record: &TrackedJobRecord, path: &str) -> maud::Markup {
+    let terminal = record.status.is_terminal();
+    let (hx_get, hx_trigger, hx_swap) = if terminal {
+        (None, None, None)
+    } else {
+        (Some(path), Some("every 2s"), Some("outerHTML"))
+    };
+    let pct = record.progress_pct.unwrap_or(0);
+
+    maud::html! {
+        div id="autumn-job-status" class="autumn-job-status"
+            hx-get=[hx_get] hx-trigger=[hx_trigger] hx-swap=[hx_swap]
+        {
+            @match record.status {
+                TrackedJobStatus::Pending | TrackedJobStatus::Running => {
+                    progress class="autumn-job-status__bar" value=(pct) max="100" {}
+                    @if let Some(message) = &record.progress_message {
+                        p class="autumn-job-status__message" { (message) }
+                    } @else {
+                        p class="autumn-job-status__message" { (pct) "%" }
+                    }
+                }
+                TrackedJobStatus::Succeeded => {
+                    @if let Some(url) = record
+                        .result
+                        .as_ref()
+                        .and_then(|result| result.get("download_url"))
+                        .and_then(Value::as_str)
+                    {
+                        p class="autumn-job-status__success" {
+                            a href=(url) download="" { "Download" }
+                        }
+                    } @else {
+                        p class="autumn-job-status__success" { "Completed." }
+                    }
+                }
+                TrackedJobStatus::Failed => {
+                    p class="autumn-job-status__error" {
+                        (record.error.as_deref().unwrap_or(GENERIC_FAILURE_MESSAGE))
+                    }
+                }
+            }
+        }
+    }
 }
 
 // ── In-memory store ───────────────────────────────────────────────────────────
@@ -534,7 +638,8 @@ impl InMemoryJobTrackingStore {
         entry.expires_at > self.clock.now()
     }
 
-    fn with_record_mut<F>(&self, key: &str, f: F) -> AutumnResult<()>
+    #[allow(clippy::significant_drop_tightening)]
+    fn with_record_mut<F>(&self, key: &str, f: F)
     where
         F: FnOnce(&mut TrackedJobRecord),
     {
@@ -550,7 +655,6 @@ impl InMemoryJobTrackingStore {
             entry.record.updated_at = now;
             entry.expires_at = now + self.ttl;
         }
-        Ok(())
     }
 }
 
@@ -587,7 +691,8 @@ impl JobTrackingStore for InMemoryJobTrackingStore {
                 if !record.status.is_terminal() {
                     record.status = TrackedJobStatus::Running;
                 }
-            })
+            });
+            Ok(())
         })
     }
 
@@ -604,7 +709,8 @@ impl JobTrackingStore for InMemoryJobTrackingStore {
                     record.progress_pct = Some(pct);
                     record.progress_message = message;
                 }
-            })
+            });
+            Ok(())
         })
     }
 
@@ -614,7 +720,8 @@ impl JobTrackingStore for InMemoryJobTrackingStore {
                 record.status = TrackedJobStatus::Succeeded;
                 record.result = Some(result);
                 record.error = None;
-            })
+            });
+            Ok(())
         })
     }
 
@@ -624,7 +731,8 @@ impl JobTrackingStore for InMemoryJobTrackingStore {
                 record.status = TrackedJobStatus::Failed;
                 record.error = Some(error);
                 record.result = None;
-            })
+            });
+            Ok(())
         })
     }
 
@@ -800,7 +908,7 @@ mod tests {
     #[test]
     fn wrap_then_take_roundtrips_key_and_inner_args() {
         let args = serde_json::json!({"account_id": 42});
-        let wrapped = wrap_tracked_payload("abc123", args.clone());
+        let wrapped = wrap_tracked_payload("abc123", &args);
 
         let (key, inner) = take_tracked_payload(wrapped);
         assert_eq!(key.as_deref(), Some("abc123"));
@@ -818,7 +926,7 @@ mod tests {
     #[test]
     fn split_tracked_payload_borrows_inner_args_without_consuming() {
         let args = serde_json::json!({"account_id": 42});
-        let wrapped = wrap_tracked_payload("abc123", args.clone());
+        let wrapped = wrap_tracked_payload("abc123", &args);
 
         let (key, inner) = split_tracked_payload(&wrapped);
         assert_eq!(key, Some("abc123"));

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -21,7 +21,7 @@ use crate::time::{ClockSource, SystemClock};
 use crate::{AppState, AutumnError, AutumnResult};
 
 /// Who is allowed to poll a tracked job's status.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TrackedJobOwner {
     /// No owner bound — the token itself is the capability.
     Anonymous,
@@ -78,7 +78,7 @@ impl TrackedJobStatus {
 }
 
 /// A snapshot of a tracked job's progress and (if terminal) its result.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrackedJobRecord {
     pub status: TrackedJobStatus,
     pub progress_pct: Option<u8>,
@@ -363,12 +363,45 @@ pub(crate) fn ensure_tracking_store_installed(state: &AppState) {
     }
 }
 
-/// Build the tracking store selected by `config.backend`, honoring
-/// `config.tracking.ttl_secs`.
-///
-/// Every backend gets an in-memory store today; `start_runtime` swaps in the
-/// Redis/Postgres-backed stores for those backends once they exist.
-fn store_for_config(config: &crate::config::JobConfig) -> Arc<dyn JobTrackingStore> {
+/// Build the tracking store matching `config.backend`, honoring
+/// `config.tracking.ttl_secs`: Redis when `backend = "redis"` and a valid
+/// URL is configured, Postgres when `backend = "postgres"` and `state` has a
+/// pool, in-memory otherwise (including as a fallback if the selected
+/// backend isn't actually reachable/configured — logged, not fatal, since
+/// the job runtime itself will raise the real error for that case).
+fn store_for_config(
+    state: &AppState,
+    config: &crate::config::JobConfig,
+) -> Arc<dyn JobTrackingStore> {
+    // Only read when the `db` feature's match arm below exists; without it
+    // (e.g. `redis`-only builds) `state` would otherwise be unused.
+    let _ = state;
+    match config.backend.as_str() {
+        #[cfg(feature = "redis")]
+        "redis" => {
+            if let Some(store) = build_redis_tracking_store(config) {
+                return Arc::new(store);
+            }
+            tracing::warn!(
+                "jobs.backend=redis but jobs.redis.url is not configured; falling back to an \
+                 in-memory job tracking store (tracked job status will not survive a restart)"
+            );
+        }
+        #[cfg(feature = "db")]
+        "postgres" => {
+            if let Some(pool) = state.pool() {
+                return Arc::new(PgJobTrackingStore::new(
+                    pool.clone(),
+                    config.tracking.ttl_secs,
+                ));
+            }
+            tracing::warn!(
+                "jobs.backend=postgres but no database pool is configured; falling back to an \
+                 in-memory job tracking store (tracked job status will not survive a restart)"
+            );
+        }
+        _ => {}
+    }
     Arc::new(InMemoryJobTrackingStore::new(config.tracking.ttl_secs))
 }
 
@@ -385,7 +418,7 @@ pub(crate) fn ensure_tracking_store_installed_from_config(
     config: &crate::config::JobConfig,
 ) {
     if tracking_store_from_state(state).is_none() {
-        install_tracking_store(state, store_for_config(config));
+        install_tracking_store(state, store_for_config(state, config));
     }
 }
 
@@ -816,6 +849,435 @@ impl JobTrackingStore for InMemoryJobTrackingStore {
     }
 }
 
+// ── Redis store ───────────────────────────────────────────────────────────────
+
+/// Redis-backed [`JobTrackingStore`].
+///
+/// Each record is a single JSON blob under `SET … EX ttl_secs`, so a write
+/// both persists and refreshes the TTL in one round trip, and Redis itself
+/// expires stale records — no sweeper needed.
+#[cfg(feature = "redis")]
+#[derive(Clone)]
+pub struct RedisJobTrackingStore {
+    connection: redis::aio::ConnectionManager,
+    key_prefix: String,
+    ttl_secs: u64,
+}
+
+#[cfg(feature = "redis")]
+impl RedisJobTrackingStore {
+    /// Construct a store over an existing connection, namespacing keys under
+    /// `key_prefix` and expiring records `ttl_secs` after their last write.
+    #[must_use]
+    pub fn new(
+        connection: redis::aio::ConnectionManager,
+        key_prefix: impl Into<String>,
+        ttl_secs: u64,
+    ) -> Self {
+        Self {
+            connection,
+            key_prefix: key_prefix.into(),
+            ttl_secs,
+        }
+    }
+
+    fn key_for(&self, key: &str) -> String {
+        format!("{}:tracking:{key}", self.key_prefix)
+    }
+
+    async fn write(&self, key: &str, record: &TrackedJobRecord) -> AutumnResult<()> {
+        use redis::AsyncCommands as _;
+        let payload = serde_json::to_string(record).map_err(|error| {
+            AutumnError::internal_server_error_msg(format!(
+                "job tracking serialize failed: {error}"
+            ))
+        })?;
+        self.connection
+            .clone()
+            .set_ex::<_, _, ()>(self.key_for(key), payload, self.ttl_secs.max(1))
+            .await
+            .map_err(|error| {
+                AutumnError::internal_server_error_msg(format!(
+                    "job tracking redis write failed: {error}"
+                ))
+            })
+    }
+
+    async fn read(&self, key: &str) -> AutumnResult<Option<TrackedJobRecord>> {
+        use redis::AsyncCommands as _;
+        let payload: Option<String> = self
+            .connection
+            .clone()
+            .get(self.key_for(key))
+            .await
+            .map_err(|error| {
+                AutumnError::internal_server_error_msg(format!(
+                    "job tracking redis read failed: {error}"
+                ))
+            })?;
+        payload
+            .map(|payload| {
+                serde_json::from_str::<TrackedJobRecord>(&payload).map_err(|error| {
+                    AutumnError::internal_server_error_msg(format!(
+                        "job tracking deserialize failed: {error}"
+                    ))
+                })
+            })
+            .transpose()
+    }
+
+    /// Read-modify-write: a no-op if the key is unknown or expired.
+    async fn update(&self, key: &str, f: impl FnOnce(&mut TrackedJobRecord)) -> AutumnResult<()> {
+        let Some(mut record) = self.read(key).await? else {
+            return Ok(());
+        };
+        f(&mut record);
+        record.updated_at = chrono::Utc::now();
+        self.write(key, &record).await
+    }
+}
+
+#[cfg(feature = "redis")]
+impl JobTrackingStore for RedisJobTrackingStore {
+    fn create<'a>(&'a self, key: &'a str, owner: TrackedJobOwner) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            let record = TrackedJobRecord {
+                status: TrackedJobStatus::Pending,
+                progress_pct: None,
+                progress_message: None,
+                result: None,
+                error: None,
+                owner,
+                updated_at: chrono::Utc::now(),
+            };
+            self.write(key, &record).await
+        })
+    }
+
+    fn mark_running<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            self.update(key, |record| {
+                if !record.status.is_terminal() {
+                    record.status = TrackedJobStatus::Running;
+                }
+            })
+            .await
+        })
+    }
+
+    fn set_progress<'a>(
+        &'a self,
+        key: &'a str,
+        pct: u8,
+        message: Option<String>,
+    ) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            let pct = pct.min(100);
+            self.update(key, |record| {
+                if !record.status.is_terminal() {
+                    record.progress_pct = Some(pct);
+                    record.progress_message = message;
+                }
+            })
+            .await
+        })
+    }
+
+    fn complete<'a>(&'a self, key: &'a str, result: Value) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            self.update(key, |record| {
+                record.status = TrackedJobStatus::Succeeded;
+                record.result = Some(result);
+                record.error = None;
+            })
+            .await
+        })
+    }
+
+    fn fail<'a>(&'a self, key: &'a str, error: String) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            self.update(key, |record| {
+                record.status = TrackedJobStatus::Failed;
+                record.error = Some(error);
+                record.result = None;
+            })
+            .await
+        })
+    }
+
+    fn get<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<Option<TrackedJobRecord>>> {
+        Box::pin(async move { self.read(key).await })
+    }
+}
+
+/// Build a [`RedisJobTrackingStore`] from `[jobs.redis]` config. Returns
+/// `None` when no URL is configured or it fails to parse; the connection
+/// manager itself connects lazily, so this never blocks on Redis being up.
+#[cfg(feature = "redis")]
+fn build_redis_tracking_store(config: &crate::config::JobConfig) -> Option<RedisJobTrackingStore> {
+    let url = config
+        .redis
+        .url
+        .clone()
+        .filter(|url| !url.trim().is_empty())?;
+    let client = redis::Client::open(url).ok()?;
+    let connection = redis::aio::ConnectionManager::new_lazy_with_config(
+        client,
+        redis::aio::ConnectionManagerConfig::new(),
+    )
+    .ok()?;
+    Some(RedisJobTrackingStore::new(
+        connection,
+        config.redis.key_prefix.clone(),
+        config.tracking.ttl_secs,
+    ))
+}
+
+// ── Postgres store ───────────────────────────────────────────────────────────
+
+/// Postgres-backed [`JobTrackingStore`].
+///
+/// Each record is a single JSONB blob in `autumn_job_tracking`, keyed by the
+/// token hash, with lazy expiry (reads filter on `expires_at`; writes refresh
+/// it). See the `create_job_tracking` framework migration.
+#[cfg(feature = "db")]
+#[derive(Clone)]
+pub struct PgJobTrackingStore {
+    pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+    ttl_secs: u64,
+    clock: Arc<dyn ClockSource>,
+}
+
+#[cfg(feature = "db")]
+#[derive(diesel::QueryableByName)]
+struct PgTrackingRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    record: String,
+}
+
+#[cfg(feature = "db")]
+impl PgJobTrackingStore {
+    /// Construct a store backed by `pool`, expiring records `ttl_secs` after
+    /// their last write.
+    #[must_use]
+    pub fn new(
+        pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        ttl_secs: u64,
+    ) -> Self {
+        Self {
+            pool,
+            ttl_secs,
+            clock: Arc::new(SystemClock),
+        }
+    }
+
+    /// Replace the clock used to evaluate expiry.
+    ///
+    /// Defaults to [`SystemClock`]; tests pass a
+    /// [`crate::time::FixedClock`] to make expiry deterministic.
+    #[must_use]
+    pub fn with_clock(mut self, clock: Arc<dyn ClockSource>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    fn expires_at(&self, now: DateTime<Utc>) -> DateTime<Utc> {
+        now + chrono::TimeDelta::seconds(i64::try_from(self.ttl_secs).unwrap_or(i64::MAX))
+    }
+
+    async fn conn(
+        &self,
+    ) -> AutumnResult<
+        diesel_async::pooled_connection::deadpool::Object<diesel_async::AsyncPgConnection>,
+    > {
+        self.pool.get().await.map_err(|error| {
+            AutumnError::internal_server_error_msg(format!("job tracking pool error: {error}"))
+        })
+    }
+
+    /// Read-modify-write: a no-op if the key is unknown or expired.
+    async fn update(&self, key: &str, f: impl FnOnce(&mut TrackedJobRecord)) -> AutumnResult<()> {
+        use diesel::OptionalExtension as _;
+        use diesel_async::RunQueryDsl as _;
+
+        let now = self.clock.now();
+        let mut conn = self.conn().await?;
+        let row = diesel::sql_query(
+            "SELECT record FROM autumn_job_tracking WHERE key = $1 AND expires_at > $2",
+        )
+        .bind::<diesel::sql_types::Text, _>(key)
+        .bind::<diesel::sql_types::Timestamptz, _>(now)
+        .get_result::<PgTrackingRow>(&mut *conn)
+        .await
+        .optional()
+        .map_err(|error| {
+            AutumnError::internal_server_error_msg(format!("job tracking select failed: {error}"))
+        })?;
+
+        let Some(row) = row else {
+            return Ok(());
+        };
+        let mut record = serde_json::from_str::<TrackedJobRecord>(&row.record).map_err(
+            |error| {
+                AutumnError::internal_server_error_msg(format!(
+                    "job tracking deserialize failed: {error}"
+                ))
+            },
+        )?;
+        f(&mut record);
+        record.updated_at = now;
+        let payload = serde_json::to_string(&record).map_err(|error| {
+            AutumnError::internal_server_error_msg(format!(
+                "job tracking serialize failed: {error}"
+            ))
+        })?;
+
+        diesel::sql_query(
+            "UPDATE autumn_job_tracking SET record = $2::JSONB, updated_at = $3, expires_at = $4 \
+             WHERE key = $1",
+        )
+        .bind::<diesel::sql_types::Text, _>(key)
+        .bind::<diesel::sql_types::Text, _>(&payload)
+        .bind::<diesel::sql_types::Timestamptz, _>(now)
+        .bind::<diesel::sql_types::Timestamptz, _>(self.expires_at(now))
+        .execute(&mut *conn)
+        .await
+        .map_err(|error| {
+            AutumnError::internal_server_error_msg(format!("job tracking update failed: {error}"))
+        })?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "db")]
+impl JobTrackingStore for PgJobTrackingStore {
+    fn create<'a>(&'a self, key: &'a str, owner: TrackedJobOwner) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            use diesel_async::RunQueryDsl as _;
+
+            let now = self.clock.now();
+            let record = TrackedJobRecord {
+                status: TrackedJobStatus::Pending,
+                progress_pct: None,
+                progress_message: None,
+                result: None,
+                error: None,
+                owner,
+                updated_at: now,
+            };
+            let payload = serde_json::to_string(&record).map_err(|error| {
+                AutumnError::internal_server_error_msg(format!(
+                    "job tracking serialize failed: {error}"
+                ))
+            })?;
+            let mut conn = self.conn().await?;
+            diesel::sql_query(
+                "INSERT INTO autumn_job_tracking (key, record, updated_at, expires_at) \
+                 VALUES ($1, $2::JSONB, $3, $4) \
+                 ON CONFLICT (key) DO UPDATE SET \
+                     record = EXCLUDED.record, \
+                     updated_at = EXCLUDED.updated_at, \
+                     expires_at = EXCLUDED.expires_at",
+            )
+            .bind::<diesel::sql_types::Text, _>(key)
+            .bind::<diesel::sql_types::Text, _>(&payload)
+            .bind::<diesel::sql_types::Timestamptz, _>(now)
+            .bind::<diesel::sql_types::Timestamptz, _>(self.expires_at(now))
+            .execute(&mut *conn)
+            .await
+            .map_err(|error| {
+                AutumnError::internal_server_error_msg(format!(
+                    "job tracking insert failed: {error}"
+                ))
+            })?;
+            Ok(())
+        })
+    }
+
+    fn mark_running<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            self.update(key, |record| {
+                if !record.status.is_terminal() {
+                    record.status = TrackedJobStatus::Running;
+                }
+            })
+            .await
+        })
+    }
+
+    fn set_progress<'a>(
+        &'a self,
+        key: &'a str,
+        pct: u8,
+        message: Option<String>,
+    ) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            let pct = pct.min(100);
+            self.update(key, |record| {
+                if !record.status.is_terminal() {
+                    record.progress_pct = Some(pct);
+                    record.progress_message = message;
+                }
+            })
+            .await
+        })
+    }
+
+    fn complete<'a>(&'a self, key: &'a str, result: Value) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            self.update(key, |record| {
+                record.status = TrackedJobStatus::Succeeded;
+                record.result = Some(result);
+                record.error = None;
+            })
+            .await
+        })
+    }
+
+    fn fail<'a>(&'a self, key: &'a str, error: String) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            self.update(key, |record| {
+                record.status = TrackedJobStatus::Failed;
+                record.error = Some(error);
+                record.result = None;
+            })
+            .await
+        })
+    }
+
+    fn get<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<Option<TrackedJobRecord>>> {
+        Box::pin(async move {
+            use diesel::OptionalExtension as _;
+            use diesel_async::RunQueryDsl as _;
+
+            let now = self.clock.now();
+            let mut conn = self.conn().await?;
+            let row = diesel::sql_query(
+                "SELECT record FROM autumn_job_tracking WHERE key = $1 AND expires_at > $2",
+            )
+            .bind::<diesel::sql_types::Text, _>(key)
+            .bind::<diesel::sql_types::Timestamptz, _>(now)
+            .get_result::<PgTrackingRow>(&mut *conn)
+            .await
+            .optional()
+            .map_err(|error| {
+                AutumnError::internal_server_error_msg(format!(
+                    "job tracking select failed: {error}"
+                ))
+            })?;
+
+            row.map(|row| {
+                serde_json::from_str::<TrackedJobRecord>(&row.record).map_err(|error| {
+                    AutumnError::internal_server_error_msg(format!(
+                        "job tracking deserialize failed: {error}"
+                    ))
+                })
+            })
+            .transpose()
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1107,5 +1569,42 @@ mod tests {
             err.to_string().contains("job runtime is not initialized"),
             "unexpected error: {err}"
         );
+    }
+
+    // ── Redis/Postgres store selection (no live service needed) ──────────────
+
+    #[cfg(feature = "redis")]
+    #[test]
+    fn build_redis_tracking_store_is_none_without_a_url() {
+        let config = crate::config::JobConfig::default();
+        assert!(config.redis.url.is_none());
+        assert!(build_redis_tracking_store(&config).is_none());
+
+        let mut config = crate::config::JobConfig::default();
+        config.redis.url = Some("   ".to_owned());
+        assert!(build_redis_tracking_store(&config).is_none());
+    }
+
+    #[cfg(feature = "redis")]
+    #[tokio::test]
+    async fn build_redis_tracking_store_is_some_for_an_unreachable_but_well_formed_url() {
+        // ConnectionManager::new_lazy_with_config never dials eagerly, so
+        // construction succeeds even though nothing is listening on this port
+        // — it just needs a Tokio runtime context to spawn its background
+        // reconnect task onto.
+        let mut config = crate::config::JobConfig::default();
+        config.redis.url = Some("redis://127.0.0.1:19999".to_owned());
+        assert!(build_redis_tracking_store(&config).is_some());
+    }
+
+    #[cfg(feature = "redis")]
+    #[tokio::test]
+    async fn store_for_config_falls_back_to_memory_when_redis_backend_has_no_url() {
+        let mut config = crate::config::JobConfig::default();
+        config.backend = "redis".to_owned();
+        let state = AppState::for_test();
+        // Falling back must not panic; the resulting store is still usable.
+        let store = store_for_config(&state, &config);
+        assert!(store.get("nope").await.unwrap().is_none());
     }
 }

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -40,10 +40,20 @@ impl TrackedJobOwner {
     /// other anonymous callers, and not other sessions once the user logs in
     /// elsewhere — may poll the status.
     pub async fn from_session(session: &crate::session::Session, state: &AppState) -> Self {
-        match session.get(state.auth_session_key()).await {
-            Some(user_id) => Self::User(user_id),
-            None => Self::Session(session.id().await),
+        if let Some(user_id) = session.get(state.auth_session_key()).await {
+            return Self::User(user_id);
         }
+        // A session with no prior cookie is only persisted (and only gets a
+        // Set-Cookie on the response) if something dirties it during this
+        // request. Reading `session.id()` alone does not — so without
+        // forcing it, the id we bind to here would never actually reach the
+        // browser as a cookie, and the next poll request would present a
+        // different session entirely, getting the same 404 as an
+        // unauthorized caller.
+        if !session.is_cookie_backed().await {
+            session.touch().await;
+        }
+        Self::Session(session.id().await)
     }
 
     /// Whether a request authenticated as `session` may poll a record bound
@@ -1341,6 +1351,61 @@ mod tests {
 
     fn store() -> InMemoryJobTrackingStore {
         InMemoryJobTrackingStore::new(86_400)
+    }
+
+    // ── TrackedJobOwner::from_session ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn from_session_touches_a_fresh_non_cookie_backed_session_so_its_cookie_is_set() {
+        let session = crate::session::Session::new_for_test_without_cookie(
+            "fresh-session-id".to_owned(),
+            HashMap::new(),
+        );
+        let state = AppState::for_test();
+
+        let owner = TrackedJobOwner::from_session(&session, &state).await;
+
+        assert_eq!(
+            owner,
+            TrackedJobOwner::Session("fresh-session-id".to_owned())
+        );
+        assert!(
+            session.has_pending_changes().await,
+            "from_session must dirty a fresh, non-cookie-backed session so the browser \
+             actually receives a cookie for the id the tracked job is bound to"
+        );
+    }
+
+    #[tokio::test]
+    async fn from_session_does_not_redundantly_touch_an_already_cookie_backed_session() {
+        let session =
+            crate::session::Session::new_for_test("existing-session-id".to_owned(), HashMap::new());
+        let state = AppState::for_test();
+
+        let owner = TrackedJobOwner::from_session(&session, &state).await;
+
+        assert_eq!(
+            owner,
+            TrackedJobOwner::Session("existing-session-id".to_owned())
+        );
+        assert!(
+            !session.has_pending_changes().await,
+            "an already cookie-backed session doesn't need a forced re-save"
+        );
+    }
+
+    #[tokio::test]
+    async fn from_session_prefers_the_authenticated_user_id_over_the_session_id() {
+        let session = crate::session::Session::new_for_test_without_cookie(
+            "fresh-session-id".to_owned(),
+            HashMap::new(),
+        );
+        let state = AppState::for_test();
+        session.insert(state.auth_session_key(), "user-42").await;
+
+        let owner = TrackedJobOwner::from_session(&session, &state).await;
+
+        assert_eq!(owner, TrackedJobOwner::User("user-42".to_owned()));
     }
 
     #[tokio::test]

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -697,16 +697,36 @@ async fn job_status_handler(
 }
 
 /// Whether the request prefers an htmx-pollable HTML fragment over JSON:
-/// true for an htmx request (`HX-Request: true`) or a browser `Accept`
-/// header, per [`crate::middleware::error_page_filter::accept_prefers_html`]
-/// (an absent/empty `Accept` header — the typical API client — prefers
-/// JSON). Rendering is only possible with the `maud` feature enabled.
+/// true for an htmx request (`HX-Request: true`) or an `Accept` header that
+/// explicitly prefers `text/html` over JSON, per
+/// [`crate::middleware::error_page_filter::accept_prefers_html`]. An absent,
+/// empty, or bare-wildcard (`*/*`) `Accept` header — curl and most
+/// `fetch()`/HTTP-client defaults — prefers JSON, since this route is
+/// JSON-first for API clients and only a real browser navigation sends an
+/// explicit `text/html` preference. Rendering is only possible with the
+/// `maud` feature enabled.
 #[cfg(feature = "maud")]
 fn wants_html_response(headers: &axum::http::HeaderMap) -> bool {
     let is_htmx = headers
         .get("hx-request")
         .is_some_and(|value| value == "true");
-    is_htmx || crate::middleware::error_page_filter::accept_prefers_html(headers)
+    if is_htmx {
+        return true;
+    }
+    // `accept_prefers_html` treats a bare wildcard Accept as "probably a
+    // browser" — a reasonable default for its original use (full-page error
+    // rendering), where a real browser navigation and a bare `*/*` both
+    // reasonably get an HTML page. This status route is JSON-first for API
+    // clients, though, and a bare wildcard is exactly what curl and many
+    // `fetch()`/HTTP-client defaults send with no real preference — so only
+    // defer to it once an explicit `text/html` preference is present; an
+    // actual browser navigation always sends one.
+    let accept = headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+    accept.contains("text/html")
+        && crate::middleware::error_page_filter::accept_prefers_html(headers)
 }
 
 #[cfg(feature = "maud")]

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -31,6 +31,34 @@ pub enum TrackedJobOwner {
     User(String),
 }
 
+impl TrackedJobOwner {
+    /// Derive an owner binding from the current request's session: the
+    /// authenticated user id if logged in (per `state.auth_session_key()`),
+    /// else the raw (anonymous) session id.
+    ///
+    /// Binding to the session id means only *this* browser session — not
+    /// other anonymous callers, and not other sessions once the user logs in
+    /// elsewhere — may poll the status.
+    pub async fn from_session(session: &crate::session::Session, state: &AppState) -> Self {
+        match session.get(state.auth_session_key()).await {
+            Some(user_id) => Self::User(user_id),
+            None => Self::Session(session.id().await),
+        }
+    }
+
+    /// Whether a request authenticated as `session` may poll a record bound
+    /// to this owner.
+    async fn authorizes(&self, session: &crate::session::Session, state: &AppState) -> bool {
+        match self {
+            Self::Anonymous => true,
+            Self::User(expected) => {
+                session.get(state.auth_session_key()).await.as_deref() == Some(expected.as_str())
+            }
+            Self::Session(expected) => &session.id().await == expected,
+        }
+    }
+}
+
 /// Lifecycle status of a tracked job.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -482,12 +510,13 @@ pub(crate) fn status_router() -> axum::Router<AppState> {
 
 /// `GET /_autumn/jobs/{token}`: resolve the tracked-job record for `token`
 /// and return it as JSON for API clients, or an htmx-pollable HTML fragment
-/// for browsers (content-negotiated). Unknown, expired, and (once owner
-/// binding lands) unauthorized tokens all render the identical 404 so the
-/// route is never an existence/ownership oracle.
+/// for browsers (content-negotiated). Unknown, expired, and unauthorized
+/// tokens all render the identical 404 so the route is never an
+/// existence/ownership oracle.
 async fn job_status_handler(
     axum::extract::State(state): axum::extract::State<AppState>,
     axum::extract::Path(token): axum::extract::Path<String>,
+    session: crate::session::Session,
     headers: axum::http::HeaderMap,
 ) -> AutumnResult<axum::response::Response> {
     let not_found = || AutumnError::not_found_msg("This job status page could not be found.");
@@ -495,6 +524,9 @@ async fn job_status_handler(
     let store = tracking_store_from_state(&state).ok_or_else(not_found)?;
     let key = crate::auth::hash_api_token(&token);
     let record = store.get(&key).await?.ok_or_else(not_found)?;
+    if !record.owner.authorizes(&session, &state).await {
+        return Err(not_found());
+    }
 
     let path = format!("{JOB_STATUS_PATH_PREFIX}{token}");
     let mut response = render_status_response(&record, &headers, &path);

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -91,6 +91,39 @@ pub struct TrackedJobRecord {
 
 type BoxFut<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
+// ── Shared record-mutation logic ──────────────────────────────────────────────
+//
+// Each `JobTrackingStore` impl below applies these same transitions through
+// its own read-modify-write mechanics (in-memory mutex, Redis GET+SET,
+// Postgres SELECT+UPDATE); sharing the transition logic itself means the
+// three backends can never silently drift on what a given status change
+// actually does to a record.
+
+const fn apply_mark_running(record: &mut TrackedJobRecord) {
+    if !record.status.is_terminal() {
+        record.status = TrackedJobStatus::Running;
+    }
+}
+
+fn apply_set_progress(record: &mut TrackedJobRecord, pct: u8, message: Option<String>) {
+    if !record.status.is_terminal() {
+        record.progress_pct = Some(pct);
+        record.progress_message = message;
+    }
+}
+
+fn apply_complete(record: &mut TrackedJobRecord, result: Value) {
+    record.status = TrackedJobStatus::Succeeded;
+    record.result = Some(result);
+    record.error = None;
+}
+
+fn apply_fail(record: &mut TrackedJobRecord, error: String) {
+    record.status = TrackedJobStatus::Failed;
+    record.error = Some(error);
+    record.result = None;
+}
+
 /// Persists tracked-job progress/result, keyed by a hash of the public token.
 ///
 /// Dyn-safe (boxed-future methods) so it can be installed as an
@@ -312,7 +345,13 @@ pub(crate) fn take_tracked_payload(payload: Value) -> (Option<String>, Value) {
 /// Borrowing counterpart of [`take_tracked_payload`], for callers (uniqueness
 /// hashing, principal/correlation extraction) that only need to read fields
 /// off the inner args without consuming the payload.
+///
+/// Agrees with [`take_tracked_payload`] on the fallback for a malformed
+/// envelope (marker present, `args` missing): both report an empty
+/// (`Value::Null`) inner payload rather than one falling back to the whole
+/// wrapper while the other falls back to nothing.
 pub(crate) fn split_tracked_payload(payload: &Value) -> (Option<&str>, &Value) {
+    static NULL_ARGS: Value = Value::Null;
     let Some(obj) = payload.as_object() else {
         return (None, payload);
     };
@@ -324,7 +363,7 @@ pub(crate) fn split_tracked_payload(payload: &Value) -> (Option<&str>, &Value) {
     else {
         return (None, payload);
     };
-    (Some(key), obj.get(ENVELOPE_ARGS).unwrap_or(payload))
+    (Some(key), obj.get(ENVELOPE_ARGS).unwrap_or(&NULL_ARGS))
 }
 
 // ── Global tracking-store install/resolve ─────────────────────────────────────
@@ -354,8 +393,15 @@ pub(crate) fn install_tracking_store(state: &AppState, store: Arc<dyn JobTrackin
 /// (as the backend starters and their tests do) rather than through
 /// `crate::job::start_runtime`, which installs a config-driven store first
 /// (making this a no-op fallback in that path).
+///
+/// Also reinstalls when the process-global fallback is missing even though
+/// `state` already carries an extension: `crate::job::clear_global_job_client`
+/// resets [`GLOBAL_TRACKING_STORE`] but has no `AppState` to strip the
+/// now-stale extension from, so relying on the extension alone would leave
+/// the free `enqueue_tracked` functions permanently unable to resolve a
+/// store after a clear-and-restart cycle that reuses the same `AppState`.
 pub(crate) fn ensure_tracking_store_installed(state: &AppState) {
-    if tracking_store_from_state(state).is_none() {
+    if tracking_store_from_state(state).is_none() || global_tracking_store().is_none() {
         install_tracking_store(
             state,
             Arc::new(InMemoryJobTrackingStore::new(DEFAULT_TRACKING_TTL_SECS)),
@@ -413,11 +459,14 @@ fn store_for_config(
 /// [`ensure_tracking_store_installed`]'s hardcoded default (that function
 /// runs afterward, inside `install_job_client`, and is a no-op once a store
 /// is already present).
+///
+/// See [`ensure_tracking_store_installed`] for why this also reinstalls when
+/// the global fallback is missing, even if `state`'s extension is present.
 pub(crate) fn ensure_tracking_store_installed_from_config(
     state: &AppState,
     config: &crate::config::JobConfig,
 ) {
-    if tracking_store_from_state(state).is_none() {
+    if tracking_store_from_state(state).is_none() || global_tracking_store().is_none() {
         install_tracking_store(state, store_for_config(state, config));
     }
 }
@@ -444,6 +493,49 @@ pub(crate) fn clear_global_tracking_store() {
         }
     } else {
         let _ = GLOBAL_TRACKING_STORE.set(RwLock::new(None));
+    }
+}
+
+/// Reject a payload shaped like the tracked-job envelope: a top-level object
+/// carrying a `__autumn_tracked` field.
+///
+/// Only [`wrap_tracked_payload`] (via `enqueue_tracked`/`enqueue_tracked_for`)
+/// may construct a payload with this shape. Every other enqueue entry point
+/// must call this first so that a plain job's `Args` struct can never
+/// coincidentally collide with — and be silently misinterpreted as — a
+/// tracked job's envelope by [`take_tracked_payload`]/[`split_tracked_payload`].
+pub(crate) fn reject_reserved_envelope_marker(payload: &Value) -> AutumnResult<()> {
+    let collides = payload
+        .as_object()
+        .is_some_and(|obj| obj.contains_key(ENVELOPE_MARKER));
+    if collides {
+        return Err(AutumnError::bad_request_msg(format!(
+            "job payload must not contain a top-level '{ENVELOPE_MARKER}' field; this name is \
+             reserved for autumn_web::job::enqueue_tracked"
+        )));
+    }
+    Ok(())
+}
+
+/// If `payload` is a tracked-job envelope, settle its tracking record to
+/// `failed` with `message`.
+///
+/// Used by each backend's execute path when it short-circuits before
+/// `run_job_handler` runs (an admin-canceled job, an unregistered job name)
+/// — without this, those paths are the only way a tracked job's status
+/// record could be left stuck at `pending`/`running` until TTL expiry, even
+/// though the job itself already reached a terminal outcome.
+pub(crate) async fn settle_tracked_payload_as_failed(
+    state: &AppState,
+    payload: &Value,
+    message: &str,
+) {
+    let (key, _) = split_tracked_payload(payload);
+    let Some(key) = key else {
+        return;
+    };
+    if let Some(store) = tracking_store_from_state(state) {
+        let _ = store.fail(key, message.to_owned()).await;
     }
 }
 
@@ -525,7 +617,15 @@ pub async fn enqueue_tracked_for(
                 )
                 .await?;
         }
-        Err(error) => return Err(error),
+        Err(error) => {
+            // The job never entered the queue, so the `Pending` record
+            // created above must not be left to linger until TTL expiry —
+            // settle it the same way the `Deduplicated` outcome does.
+            let _ = store
+                .fail(&key, "The job could not be enqueued.".to_owned())
+                .await;
+            return Err(error);
+        }
     }
 
     Ok(TrackedJobHandle { token })
@@ -779,11 +879,7 @@ impl JobTrackingStore for InMemoryJobTrackingStore {
 
     fn mark_running<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<()>> {
         Box::pin(async move {
-            self.with_record_mut(key, |record| {
-                if !record.status.is_terminal() {
-                    record.status = TrackedJobStatus::Running;
-                }
-            });
+            self.with_record_mut(key, apply_mark_running);
             Ok(())
         })
     }
@@ -796,34 +892,21 @@ impl JobTrackingStore for InMemoryJobTrackingStore {
     ) -> BoxFut<'a, AutumnResult<()>> {
         Box::pin(async move {
             let pct = pct.min(100);
-            self.with_record_mut(key, |record| {
-                if !record.status.is_terminal() {
-                    record.progress_pct = Some(pct);
-                    record.progress_message = message;
-                }
-            });
+            self.with_record_mut(key, |record| apply_set_progress(record, pct, message));
             Ok(())
         })
     }
 
     fn complete<'a>(&'a self, key: &'a str, result: Value) -> BoxFut<'a, AutumnResult<()>> {
         Box::pin(async move {
-            self.with_record_mut(key, |record| {
-                record.status = TrackedJobStatus::Succeeded;
-                record.result = Some(result);
-                record.error = None;
-            });
+            self.with_record_mut(key, |record| apply_complete(record, result));
             Ok(())
         })
     }
 
     fn fail<'a>(&'a self, key: &'a str, error: String) -> BoxFut<'a, AutumnResult<()>> {
         Box::pin(async move {
-            self.with_record_mut(key, |record| {
-                record.status = TrackedJobStatus::Failed;
-                record.error = Some(error);
-                record.result = None;
-            });
+            self.with_record_mut(key, |record| apply_fail(record, error));
             Ok(())
         })
     }
@@ -955,14 +1038,7 @@ impl JobTrackingStore for RedisJobTrackingStore {
     }
 
     fn mark_running<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<()>> {
-        Box::pin(async move {
-            self.update(key, |record| {
-                if !record.status.is_terminal() {
-                    record.status = TrackedJobStatus::Running;
-                }
-            })
-            .await
-        })
+        Box::pin(async move { self.update(key, apply_mark_running).await })
     }
 
     fn set_progress<'a>(
@@ -973,36 +1049,17 @@ impl JobTrackingStore for RedisJobTrackingStore {
     ) -> BoxFut<'a, AutumnResult<()>> {
         Box::pin(async move {
             let pct = pct.min(100);
-            self.update(key, |record| {
-                if !record.status.is_terminal() {
-                    record.progress_pct = Some(pct);
-                    record.progress_message = message;
-                }
-            })
-            .await
+            self.update(key, |record| apply_set_progress(record, pct, message))
+                .await
         })
     }
 
     fn complete<'a>(&'a self, key: &'a str, result: Value) -> BoxFut<'a, AutumnResult<()>> {
-        Box::pin(async move {
-            self.update(key, |record| {
-                record.status = TrackedJobStatus::Succeeded;
-                record.result = Some(result);
-                record.error = None;
-            })
-            .await
-        })
+        Box::pin(async move { self.update(key, |record| apply_complete(record, result)).await })
     }
 
     fn fail<'a>(&'a self, key: &'a str, error: String) -> BoxFut<'a, AutumnResult<()>> {
-        Box::pin(async move {
-            self.update(key, |record| {
-                record.status = TrackedJobStatus::Failed;
-                record.error = Some(error);
-                record.result = None;
-            })
-            .await
-        })
+        Box::pin(async move { self.update(key, |record| apply_fail(record, error)).await })
     }
 
     fn get<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<Option<TrackedJobRecord>>> {
@@ -1103,7 +1160,7 @@ impl PgJobTrackingStore {
         let now = self.clock.now();
         let mut conn = self.conn().await?;
         let row = diesel::sql_query(
-            "SELECT record FROM autumn_job_tracking WHERE key = $1 AND expires_at > $2",
+            "SELECT record::TEXT AS record FROM autumn_job_tracking WHERE key = $1 AND expires_at > $2",
         )
         .bind::<diesel::sql_types::Text, _>(key)
         .bind::<diesel::sql_types::Timestamptz, _>(now)
@@ -1195,14 +1252,7 @@ impl JobTrackingStore for PgJobTrackingStore {
     }
 
     fn mark_running<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<()>> {
-        Box::pin(async move {
-            self.update(key, |record| {
-                if !record.status.is_terminal() {
-                    record.status = TrackedJobStatus::Running;
-                }
-            })
-            .await
-        })
+        Box::pin(async move { self.update(key, apply_mark_running).await })
     }
 
     fn set_progress<'a>(
@@ -1213,36 +1263,17 @@ impl JobTrackingStore for PgJobTrackingStore {
     ) -> BoxFut<'a, AutumnResult<()>> {
         Box::pin(async move {
             let pct = pct.min(100);
-            self.update(key, |record| {
-                if !record.status.is_terminal() {
-                    record.progress_pct = Some(pct);
-                    record.progress_message = message;
-                }
-            })
-            .await
+            self.update(key, |record| apply_set_progress(record, pct, message))
+                .await
         })
     }
 
     fn complete<'a>(&'a self, key: &'a str, result: Value) -> BoxFut<'a, AutumnResult<()>> {
-        Box::pin(async move {
-            self.update(key, |record| {
-                record.status = TrackedJobStatus::Succeeded;
-                record.result = Some(result);
-                record.error = None;
-            })
-            .await
-        })
+        Box::pin(async move { self.update(key, |record| apply_complete(record, result)).await })
     }
 
     fn fail<'a>(&'a self, key: &'a str, error: String) -> BoxFut<'a, AutumnResult<()>> {
-        Box::pin(async move {
-            self.update(key, |record| {
-                record.status = TrackedJobStatus::Failed;
-                record.error = Some(error);
-                record.result = None;
-            })
-            .await
-        })
+        Box::pin(async move { self.update(key, |record| apply_fail(record, error)).await })
     }
 
     fn get<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<Option<TrackedJobRecord>>> {
@@ -1253,7 +1284,7 @@ impl JobTrackingStore for PgJobTrackingStore {
             let now = self.clock.now();
             let mut conn = self.conn().await?;
             let row = diesel::sql_query(
-                "SELECT record FROM autumn_job_tracking WHERE key = $1 AND expires_at > $2",
+                "SELECT record::TEXT AS record FROM autumn_job_tracking WHERE key = $1 AND expires_at > $2",
             )
             .bind::<diesel::sql_types::Text, _>(key)
             .bind::<diesel::sql_types::Timestamptz, _>(now)
@@ -1299,6 +1330,44 @@ mod tests {
         assert_eq!(record.status, TrackedJobStatus::Pending);
         assert_eq!(record.owner, TrackedJobOwner::User("user:42".to_owned()));
         assert!(record.progress_pct.is_none());
+        assert!(record.result.is_none());
+    }
+
+    // ── shared mutation logic (single source of truth for all 3 backends) ────
+
+    #[test]
+    fn apply_functions_implement_the_documented_transitions() {
+        let mut record = TrackedJobRecord {
+            status: TrackedJobStatus::Pending,
+            progress_pct: None,
+            progress_message: None,
+            result: None,
+            error: None,
+            owner: TrackedJobOwner::Anonymous,
+            updated_at: chrono::Utc::now(),
+        };
+
+        apply_mark_running(&mut record);
+        assert_eq!(record.status, TrackedJobStatus::Running);
+
+        apply_set_progress(&mut record, 40, Some("40%".to_owned()));
+        assert_eq!(record.progress_pct, Some(40));
+        assert_eq!(record.progress_message.as_deref(), Some("40%"));
+
+        apply_complete(&mut record, serde_json::json!({"ok": true}));
+        assert_eq!(record.status, TrackedJobStatus::Succeeded);
+        assert_eq!(record.result, Some(serde_json::json!({"ok": true})));
+        assert!(record.error.is_none());
+
+        // A terminal record ignores further mark_running/set_progress calls.
+        apply_mark_running(&mut record);
+        assert_eq!(record.status, TrackedJobStatus::Succeeded);
+        apply_set_progress(&mut record, 10, None);
+        assert_eq!(record.progress_pct, Some(40));
+
+        apply_fail(&mut record, "boom".to_owned());
+        assert_eq!(record.status, TrackedJobStatus::Failed);
+        assert_eq!(record.error.as_deref(), Some("boom"));
         assert!(record.result.is_none());
     }
 
@@ -1462,6 +1531,46 @@ mod tests {
         assert_eq!(inner, &args);
     }
 
+    #[test]
+    fn reject_reserved_envelope_marker_rejects_a_colliding_top_level_field() {
+        let colliding = serde_json::json!({"__autumn_tracked": {"k": "anything"}, "other": 1});
+        let err =
+            reject_reserved_envelope_marker(&colliding).expect_err("collision must be rejected");
+        assert!(
+            err.to_string().contains("__autumn_tracked"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn reject_reserved_envelope_marker_allows_ordinary_payloads() {
+        assert!(reject_reserved_envelope_marker(&serde_json::json!({"account_id": 42})).is_ok());
+        assert!(reject_reserved_envelope_marker(&Value::Null).is_ok());
+        // A field merely containing the substring, or not exactly matching
+        // the reserved key, is not a collision.
+        assert!(
+            reject_reserved_envelope_marker(&serde_json::json!({"__autumn_tracked_at": 1}))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn take_and_split_tracked_payload_agree_on_a_malformed_envelope_missing_args() {
+        // The marker is present (so both functions detect a tracked
+        // envelope) but there is no `args` field — a state `wrap_tracked_payload`
+        // itself never produces, but the two unwrap functions must still
+        // agree on how to handle it rather than silently diverging.
+        let malformed = serde_json::json!({"__autumn_tracked": {"k": "abc123"}});
+
+        let (split_key, split_inner) = split_tracked_payload(&malformed);
+        assert_eq!(split_key, Some("abc123"));
+        assert_eq!(split_inner, &Value::Null);
+
+        let (take_key, take_inner) = take_tracked_payload(malformed);
+        assert_eq!(take_key.as_deref(), Some("abc123"));
+        assert_eq!(take_inner, Value::Null);
+    }
+
     // ── JobContext ─────────────────────────────────────────────────────────
 
     #[test]
@@ -1571,7 +1680,162 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn enqueue_failure_settles_the_orphaned_pending_record_instead_of_leaking_it() {
+        struct KeyCapturingStore {
+            inner: InMemoryJobTrackingStore,
+            last_created_key: std::sync::Mutex<Option<String>>,
+        }
+
+        impl JobTrackingStore for KeyCapturingStore {
+            fn create<'a>(
+                &'a self,
+                key: &'a str,
+                owner: TrackedJobOwner,
+            ) -> BoxFut<'a, AutumnResult<()>> {
+                *self.last_created_key.lock().unwrap() = Some(key.to_owned());
+                self.inner.create(key, owner)
+            }
+            fn mark_running<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<()>> {
+                self.inner.mark_running(key)
+            }
+            fn set_progress<'a>(
+                &'a self,
+                key: &'a str,
+                pct: u8,
+                message: Option<String>,
+            ) -> BoxFut<'a, AutumnResult<()>> {
+                self.inner.set_progress(key, pct, message)
+            }
+            fn complete<'a>(&'a self, key: &'a str, result: Value) -> BoxFut<'a, AutumnResult<()>> {
+                self.inner.complete(key, result)
+            }
+            fn fail<'a>(&'a self, key: &'a str, error: String) -> BoxFut<'a, AutumnResult<()>> {
+                self.inner.fail(key, error)
+            }
+            fn get<'a>(
+                &'a self,
+                key: &'a str,
+            ) -> BoxFut<'a, AutumnResult<Option<TrackedJobRecord>>> {
+                self.inner.get(key)
+            }
+        }
+
+        let _guard = crate::job::global_job_runtime_test_lock().lock().await;
+        crate::job::clear_global_job_client();
+
+        let store = Arc::new(KeyCapturingStore {
+            inner: InMemoryJobTrackingStore::new(60),
+            last_created_key: std::sync::Mutex::new(None),
+        });
+
+        let state = AppState::for_test().with_profile("dev");
+        install_tracking_store(&state, store.clone());
+
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        crate::job::start_local_runtime(
+            vec![crate::job::JobInfo::new(
+                "registered_job",
+                1,
+                10,
+                |_state, _payload| Box::pin(async move { Ok(()) }),
+            )],
+            &state,
+            &shutdown,
+            1,
+            5,
+            250,
+            &crate::config::JobQueuesConfig::default(),
+        );
+
+        // "unregistered_job" is never registered on this runtime, so the
+        // enqueue itself fails with an `Err` before the job ever reaches the
+        // queue — the exact scenario that used to leak the `Pending` record
+        // `store.create` had already written moments earlier.
+        let err = enqueue_tracked("unregistered_job", serde_json::json!({}))
+            .await
+            .expect_err("enqueueing an unregistered job name must error");
+        assert!(
+            err.to_string().contains("is not registered"),
+            "unexpected error: {err}"
+        );
+
+        let key = store
+            .last_created_key
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("store.create should have been called");
+        let record = store.get(&key).await.unwrap().expect("record");
+        assert_eq!(
+            record.status,
+            TrackedJobStatus::Failed,
+            "the orphaned Pending record must be settled to Failed, not left dangling"
+        );
+
+        shutdown.cancel();
+        crate::job::clear_global_job_client();
+    }
+
     // ── Redis/Postgres store selection (no live service needed) ──────────────
+
+    #[tokio::test]
+    async fn ensure_tracking_store_installed_reinstalls_after_clear_even_with_a_stale_state_extension()
+     {
+        let _guard = crate::job::global_job_runtime_test_lock().lock().await;
+        crate::job::clear_global_job_client();
+
+        let state = AppState::for_test();
+        ensure_tracking_store_installed(&state);
+        assert!(global_tracking_store().is_some(), "sanity: store installed");
+
+        // Simulate a runtime restart that clears global state without ever
+        // constructing a fresh AppState (e.g. an app's own restart helper
+        // that always calls clear_global_job_client() before reinitializing
+        // the runtime on the same, already-built AppState).
+        crate::job::clear_global_job_client();
+        assert!(
+            global_tracking_store().is_none(),
+            "sanity: clear really did reset the global"
+        );
+
+        // `state` still carries the stale JobTrackingStoreEntry extension
+        // from before the clear; without the fix this call would see that
+        // extension and skip reinstalling, leaving GLOBAL_TRACKING_STORE
+        // stuck at None and enqueue_tracked permanently broken.
+        ensure_tracking_store_installed(&state);
+        assert!(
+            global_tracking_store().is_some(),
+            "the tracking store must be reinstalled after a clear even when \
+             the same AppState (with its now-stale extension) is reused"
+        );
+
+        crate::job::clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn ensure_tracking_store_installed_from_config_reinstalls_after_clear_even_with_a_stale_state_extension()
+     {
+        let _guard = crate::job::global_job_runtime_test_lock().lock().await;
+        crate::job::clear_global_job_client();
+
+        let state = AppState::for_test();
+        let config = crate::config::JobConfig::default();
+        ensure_tracking_store_installed_from_config(&state, &config);
+        assert!(global_tracking_store().is_some(), "sanity: store installed");
+
+        crate::job::clear_global_job_client();
+        assert!(global_tracking_store().is_none(), "sanity: clear reset the global");
+
+        ensure_tracking_store_installed_from_config(&state, &config);
+        assert!(
+            global_tracking_store().is_some(),
+            "start_runtime's installer must reinstall after a clear even when \
+             the same AppState (with its now-stale extension) is reused"
+        );
+
+        crate::job::clear_global_job_client();
+    }
 
     #[cfg(feature = "redis")]
     #[test]

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -567,6 +567,32 @@ async fn settle_tracked_payload_with_store(
     }
 }
 
+/// If `payload` is a tracked-job envelope, reset its tracking record back to
+/// `pending` (preserving the existing owner), after an admin retry
+/// successfully re-enqueues it.
+///
+/// `mark_running`/`set_progress` intentionally no-op once a record is
+/// terminal, to protect against a stray write from an abandoned attempt
+/// overwriting a legitimate final result — but that guard also means a
+/// retried job's progress would never surface without this: the public
+/// status would stay at its previous `failed` state until the retry itself
+/// settles. Resolves the store from the process-global fallback since none
+/// of the three admin backends (`JobAdminMemoryBackend`,
+/// `RedisJobAdminBackend`, `PgJobAdminBackend`) carry an `AppState`.
+pub(crate) async fn reset_tracked_payload_for_retry(payload: &Value) {
+    let (key, _) = split_tracked_payload(payload);
+    let Some(key) = key else {
+        return;
+    };
+    let Some(store) = global_tracking_store() else {
+        return;
+    };
+    let Some(record) = store.get(key).await.ok().flatten() else {
+        return;
+    };
+    let _ = store.create(key, record.owner).await;
+}
+
 // ── enqueue_tracked ────────────────────────────────────────────────────────────
 
 /// Built-in route prefix for polling a tracked job's status: the full path is

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -368,8 +368,7 @@ pub(crate) fn split_tracked_payload(payload: &Value) -> (Option<&str>, &Value) {
 
 // ── Global tracking-store install/resolve ─────────────────────────────────────
 
-static GLOBAL_TRACKING_STORE: OnceLock<RwLock<Option<Arc<dyn JobTrackingStore>>>> =
-    OnceLock::new();
+static GLOBAL_TRACKING_STORE: OnceLock<RwLock<Option<Arc<dyn JobTrackingStore>>>> = OnceLock::new();
 
 const DEFAULT_TRACKING_TTL_SECS: u64 = 86_400;
 
@@ -611,10 +610,7 @@ pub async fn enqueue_tracked_for(
         Ok(crate::job::EnqueueOutcome::Queued) => {}
         Ok(crate::job::EnqueueOutcome::Deduplicated) => {
             store
-                .fail(
-                    &key,
-                    "An equivalent job is already in progress.".to_owned(),
-                )
+                .fail(&key, "An equivalent job is already in progress.".to_owned())
                 .await?;
         }
         Err(error) => {
@@ -665,7 +661,10 @@ impl From<&TrackedJobRecord> for JobStatusDto {
 ///
 /// Mounted automatically unless `jobs.tracking.route_enabled = false`.
 pub(crate) fn status_router() -> axum::Router<AppState> {
-    axum::Router::new().route(JOB_STATUS_ROUTE_PATH, axum::routing::get(job_status_handler))
+    axum::Router::new().route(
+        JOB_STATUS_ROUTE_PATH,
+        axum::routing::get(job_status_handler),
+    )
 }
 
 /// `GET /_autumn/jobs/{token}`: resolve the tracked-job record for `token`
@@ -917,8 +916,10 @@ impl JobTrackingStore for InMemoryJobTrackingStore {
                 .entries
                 .read()
                 .expect("job tracking store lock poisoned");
-            Ok(guard.get(key).filter(|entry| self.is_live(entry)).map(
-                |entry| TrackedJobRecord {
+            Ok(guard
+                .get(key)
+                .filter(|entry| self.is_live(entry))
+                .map(|entry| TrackedJobRecord {
                     status: entry.record.status,
                     progress_pct: entry.record.progress_pct,
                     progress_message: entry.record.progress_message.clone(),
@@ -926,8 +927,7 @@ impl JobTrackingStore for InMemoryJobTrackingStore {
                     error: entry.record.error.clone(),
                     owner: entry.record.owner.clone(),
                     updated_at: entry.record.updated_at,
-                },
-            ))
+                }))
         })
     }
 }
@@ -1055,7 +1055,10 @@ impl JobTrackingStore for RedisJobTrackingStore {
     }
 
     fn complete<'a>(&'a self, key: &'a str, result: Value) -> BoxFut<'a, AutumnResult<()>> {
-        Box::pin(async move { self.update(key, |record| apply_complete(record, result)).await })
+        Box::pin(async move {
+            self.update(key, |record| apply_complete(record, result))
+                .await
+        })
     }
 
     fn fail<'a>(&'a self, key: &'a str, error: String) -> BoxFut<'a, AutumnResult<()>> {
@@ -1174,13 +1177,12 @@ impl PgJobTrackingStore {
         let Some(row) = row else {
             return Ok(());
         };
-        let mut record = serde_json::from_str::<TrackedJobRecord>(&row.record).map_err(
-            |error| {
+        let mut record =
+            serde_json::from_str::<TrackedJobRecord>(&row.record).map_err(|error| {
                 AutumnError::internal_server_error_msg(format!(
                     "job tracking deserialize failed: {error}"
                 ))
-            },
-        )?;
+            })?;
         f(&mut record);
         record.updated_at = now;
         let payload = serde_json::to_string(&record).map_err(|error| {
@@ -1269,7 +1271,10 @@ impl JobTrackingStore for PgJobTrackingStore {
     }
 
     fn complete<'a>(&'a self, key: &'a str, result: Value) -> BoxFut<'a, AutumnResult<()>> {
-        Box::pin(async move { self.update(key, |record| apply_complete(record, result)).await })
+        Box::pin(async move {
+            self.update(key, |record| apply_complete(record, result))
+                .await
+        })
     }
 
     fn fail<'a>(&'a self, key: &'a str, error: String) -> BoxFut<'a, AutumnResult<()>> {
@@ -1374,7 +1379,10 @@ mod tests {
     #[tokio::test]
     async fn set_progress_clamps_above_100_and_persists_message() {
         let store = store();
-        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        store
+            .create("k1", TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
         store.mark_running("k1").await.unwrap();
 
         store
@@ -1391,7 +1399,10 @@ mod tests {
     #[tokio::test]
     async fn complete_is_terminal_and_stores_result_json() {
         let store = store();
-        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        store
+            .create("k1", TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
         store.mark_running("k1").await.unwrap();
         store.set_progress("k1", 50, None).await.unwrap();
 
@@ -1418,7 +1429,10 @@ mod tests {
     #[tokio::test]
     async fn fail_stores_user_safe_error() {
         let store = store();
-        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        store
+            .create("k1", TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
 
         store
             .fail("k1", "The export could not be completed.".to_owned())
@@ -1445,7 +1459,10 @@ mod tests {
         let start = chrono::Utc::now();
         let store = InMemoryJobTrackingStore::new(10)
             .with_clock(std::sync::Arc::new(FixedClock::at(start)));
-        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        store
+            .create("k1", TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
 
         let store = store.with_clock(std::sync::Arc::new(FixedClock::at(
             start + chrono::TimeDelta::seconds(11),
@@ -1458,7 +1475,10 @@ mod tests {
         let start = chrono::Utc::now();
         let store = InMemoryJobTrackingStore::new(10)
             .with_clock(std::sync::Arc::new(FixedClock::at(start)));
-        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        store
+            .create("k1", TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
 
         // Complete at t=8s, before the original 10s TTL expires — this must
         // push expiry out to t=18s rather than leaving it at t=10s.
@@ -1475,15 +1495,21 @@ mod tests {
             start + chrono::TimeDelta::seconds(15),
         )));
         let record = store.get("k1").await.unwrap();
-        assert!(record.is_some(), "terminal write should have refreshed the TTL");
+        assert!(
+            record.is_some(),
+            "terminal write should have refreshed the TTL"
+        );
     }
 
     #[tokio::test]
     async fn write_to_expired_key_is_a_no_op() {
         let start = chrono::Utc::now();
-        let store = InMemoryJobTrackingStore::new(5)
-            .with_clock(std::sync::Arc::new(FixedClock::at(start)));
-        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        let store =
+            InMemoryJobTrackingStore::new(5).with_clock(std::sync::Arc::new(FixedClock::at(start)));
+        store
+            .create("k1", TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
 
         let store = store.with_clock(std::sync::Arc::new(FixedClock::at(
             start + chrono::TimeDelta::seconds(6),
@@ -1549,8 +1575,7 @@ mod tests {
         // A field merely containing the substring, or not exactly matching
         // the reserved key, is not a collision.
         assert!(
-            reject_reserved_envelope_marker(&serde_json::json!({"__autumn_tracked_at": 1}))
-                .is_ok()
+            reject_reserved_envelope_marker(&serde_json::json!({"__autumn_tracked_at": 1})).is_ok()
         );
     }
 
@@ -1593,13 +1618,19 @@ mod tests {
     #[tokio::test]
     async fn scope_makes_context_ambient_for_current() {
         let store: Arc<dyn JobTrackingStore> = Arc::new(InMemoryJobTrackingStore::new(60));
-        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        store
+            .create("k1", TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
         let ctx = JobContext::tracked("k1".to_owned(), store.clone());
 
         let observed = scope(ctx, async { JobContext::current() }).await;
         assert!(observed.is_tracked());
 
-        observed.set_progress(75, Some("almost done")).await.unwrap();
+        observed
+            .set_progress(75, Some("almost done"))
+            .await
+            .unwrap();
         let record = store.get("k1").await.unwrap().expect("record");
         assert_eq!(record.progress_pct, Some(75));
     }
@@ -1607,7 +1638,10 @@ mod tests {
     #[tokio::test]
     async fn settle_success_persists_ctx_result() {
         let store: Arc<dyn JobTrackingStore> = Arc::new(InMemoryJobTrackingStore::new(60));
-        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        store
+            .create("k1", TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
         let ctx = JobContext::tracked("k1".to_owned(), store.clone());
 
         ctx.set_result(serde_json::json!({"download_url": "/blob/abc.csv"}));
@@ -1624,7 +1658,10 @@ mod tests {
     #[tokio::test]
     async fn settle_success_without_set_result_stores_null() {
         let store: Arc<dyn JobTrackingStore> = Arc::new(InMemoryJobTrackingStore::new(60));
-        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        store
+            .create("k1", TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
         let ctx = JobContext::tracked("k1".to_owned(), store.clone());
 
         ctx.settle_success().await;
@@ -1637,7 +1674,10 @@ mod tests {
     #[tokio::test]
     async fn settle_failure_uses_set_user_error_over_default() {
         let store: Arc<dyn JobTrackingStore> = Arc::new(InMemoryJobTrackingStore::new(60));
-        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        store
+            .create("k1", TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
         let ctx = JobContext::tracked("k1".to_owned(), store.clone());
 
         ctx.set_user_error("The export could not reach storage.");
@@ -1654,7 +1694,10 @@ mod tests {
     #[tokio::test]
     async fn settle_failure_without_set_user_error_uses_default_message() {
         let store: Arc<dyn JobTrackingStore> = Arc::new(InMemoryJobTrackingStore::new(60));
-        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        store
+            .create("k1", TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
         let ctx = JobContext::tracked("k1".to_owned(), store.clone());
 
         ctx.settle_failure(GENERIC_FAILURE_MESSAGE).await;
@@ -1825,7 +1868,10 @@ mod tests {
         assert!(global_tracking_store().is_some(), "sanity: store installed");
 
         crate::job::clear_global_job_client();
-        assert!(global_tracking_store().is_none(), "sanity: clear reset the global");
+        assert!(
+            global_tracking_store().is_none(),
+            "sanity: clear reset the global"
+        );
 
         ensure_tracking_store_installed_from_config(&state, &config);
         assert!(

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -1,0 +1,402 @@
+//! Tracked job handles: unguessable-token status polling for `#[job]`.
+//!
+//! [`enqueue_tracked`](crate::job::enqueue_tracked) hands the caller a
+//! [`TrackedJobHandle`] carrying a public, unguessable token distinct from the
+//! internal job id. Inside the job handler, [`JobContext::current`] exposes
+//! progress reporting (`set_progress`) and lets the handler record a terminal
+//! result or a user-safe error. A [`JobTrackingStore`] persists that state,
+//! keyed by a hash of the token, with a configurable TTL.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, RwLock};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::AutumnResult;
+use crate::time::{ClockSource, SystemClock};
+
+/// Who is allowed to poll a tracked job's status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrackedJobOwner {
+    /// No owner bound — the token itself is the capability.
+    Anonymous,
+    /// Bound to a specific (unauthenticated) session id.
+    Session(String),
+    /// Bound to an authenticated user/principal id.
+    User(String),
+}
+
+/// Lifecycle status of a tracked job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrackedJobStatus {
+    Pending,
+    Running,
+    Succeeded,
+    Failed,
+}
+
+impl TrackedJobStatus {
+    /// Terminal statuses stop htmx polling and are subject to TTL expiry.
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Succeeded | Self::Failed)
+    }
+}
+
+/// A snapshot of a tracked job's progress and (if terminal) its result.
+#[derive(Debug, Clone)]
+pub struct TrackedJobRecord {
+    pub status: TrackedJobStatus,
+    pub progress_pct: Option<u8>,
+    pub progress_message: Option<String>,
+    pub result: Option<Value>,
+    pub error: Option<String>,
+    pub owner: TrackedJobOwner,
+    pub updated_at: DateTime<Utc>,
+}
+
+type BoxFut<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Persists tracked-job progress/result, keyed by a hash of the public token.
+///
+/// Dyn-safe (boxed-future methods) so it can be installed as an
+/// `Arc<dyn JobTrackingStore>` `AppState` extension, mirroring
+/// [`crate::auth::ApiTokenStore`] and [`crate::job::JobAdminBackend`].
+pub trait JobTrackingStore: Send + Sync + 'static {
+    /// Create a new pending record for `key` (the token hash).
+    fn create<'a>(&'a self, key: &'a str, owner: TrackedJobOwner) -> BoxFut<'a, AutumnResult<()>>;
+
+    /// Transition a pending record to running.
+    fn mark_running<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<()>>;
+
+    /// Record progress. `pct` is clamped to `0..=100`.
+    fn set_progress<'a>(
+        &'a self,
+        key: &'a str,
+        pct: u8,
+        message: Option<String>,
+    ) -> BoxFut<'a, AutumnResult<()>>;
+
+    /// Mark the record succeeded with a small JSON result payload.
+    fn complete<'a>(&'a self, key: &'a str, result: Value) -> BoxFut<'a, AutumnResult<()>>;
+
+    /// Mark the record failed with a user-safe error message.
+    fn fail<'a>(&'a self, key: &'a str, error: String) -> BoxFut<'a, AutumnResult<()>>;
+
+    /// Fetch the current record, or `None` if unknown or expired.
+    fn get<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<Option<TrackedJobRecord>>>;
+}
+
+/// `AppState` extension carrying the installed [`JobTrackingStore`].
+#[derive(Clone)]
+pub struct JobTrackingStoreEntry(pub Arc<dyn JobTrackingStore>);
+
+// ── In-memory store ───────────────────────────────────────────────────────────
+
+struct MemoryEntry {
+    record: TrackedJobRecord,
+    expires_at: DateTime<Utc>,
+}
+
+/// In-memory [`JobTrackingStore`] for development, testing, and the `local`
+/// job backend. State is lost on restart and not shared across processes.
+#[derive(Clone)]
+pub struct InMemoryJobTrackingStore {
+    entries: Arc<RwLock<HashMap<String, MemoryEntry>>>,
+    ttl: chrono::TimeDelta,
+    clock: Arc<dyn ClockSource>,
+}
+
+impl InMemoryJobTrackingStore {
+    /// Construct a store whose records expire `ttl_secs` after their last
+    /// write.
+    #[must_use]
+    pub fn new(ttl_secs: u64) -> Self {
+        Self {
+            entries: Arc::new(RwLock::new(HashMap::new())),
+            ttl: chrono::TimeDelta::seconds(i64::try_from(ttl_secs).unwrap_or(i64::MAX)),
+            clock: Arc::new(SystemClock),
+        }
+    }
+
+    /// Replace the clock used to evaluate expiry.
+    ///
+    /// Defaults to [`SystemClock`]; tests pass a
+    /// [`crate::time::FixedClock`] / [`crate::time::TickingClock`] to make
+    /// expiry deterministic.
+    #[must_use]
+    pub fn with_clock(mut self, clock: Arc<dyn ClockSource>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    fn is_live(&self, entry: &MemoryEntry) -> bool {
+        entry.expires_at > self.clock.now()
+    }
+
+    fn with_record_mut<F>(&self, key: &str, f: F) -> AutumnResult<()>
+    where
+        F: FnOnce(&mut TrackedJobRecord),
+    {
+        let mut guard = self
+            .entries
+            .write()
+            .expect("job tracking store lock poisoned");
+        let now = self.clock.now();
+        if let Some(entry) = guard.get_mut(key)
+            && self.is_live(entry)
+        {
+            f(&mut entry.record);
+            entry.record.updated_at = now;
+            entry.expires_at = now + self.ttl;
+        }
+        Ok(())
+    }
+}
+
+impl JobTrackingStore for InMemoryJobTrackingStore {
+    fn create<'a>(&'a self, key: &'a str, owner: TrackedJobOwner) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            let now = self.clock.now();
+            let record = TrackedJobRecord {
+                status: TrackedJobStatus::Pending,
+                progress_pct: None,
+                progress_message: None,
+                result: None,
+                error: None,
+                owner,
+                updated_at: now,
+            };
+            self.entries
+                .write()
+                .expect("job tracking store lock poisoned")
+                .insert(
+                    key.to_owned(),
+                    MemoryEntry {
+                        record,
+                        expires_at: now + self.ttl,
+                    },
+                );
+            Ok(())
+        })
+    }
+
+    fn mark_running<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            self.with_record_mut(key, |record| {
+                if !record.status.is_terminal() {
+                    record.status = TrackedJobStatus::Running;
+                }
+            })
+        })
+    }
+
+    fn set_progress<'a>(
+        &'a self,
+        key: &'a str,
+        pct: u8,
+        message: Option<String>,
+    ) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            let pct = pct.min(100);
+            self.with_record_mut(key, |record| {
+                if !record.status.is_terminal() {
+                    record.progress_pct = Some(pct);
+                    record.progress_message = message;
+                }
+            })
+        })
+    }
+
+    fn complete<'a>(&'a self, key: &'a str, result: Value) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            self.with_record_mut(key, |record| {
+                record.status = TrackedJobStatus::Succeeded;
+                record.result = Some(result);
+                record.error = None;
+            })
+        })
+    }
+
+    fn fail<'a>(&'a self, key: &'a str, error: String) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            self.with_record_mut(key, |record| {
+                record.status = TrackedJobStatus::Failed;
+                record.error = Some(error);
+                record.result = None;
+            })
+        })
+    }
+
+    fn get<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<Option<TrackedJobRecord>>> {
+        Box::pin(async move {
+            let guard = self
+                .entries
+                .read()
+                .expect("job tracking store lock poisoned");
+            Ok(guard.get(key).filter(|entry| self.is_live(entry)).map(
+                |entry| TrackedJobRecord {
+                    status: entry.record.status,
+                    progress_pct: entry.record.progress_pct,
+                    progress_message: entry.record.progress_message.clone(),
+                    result: entry.record.result.clone(),
+                    error: entry.record.error.clone(),
+                    owner: entry.record.owner.clone(),
+                    updated_at: entry.record.updated_at,
+                },
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::time::FixedClock;
+
+    fn store() -> InMemoryJobTrackingStore {
+        InMemoryJobTrackingStore::new(86_400)
+    }
+
+    #[tokio::test]
+    async fn create_then_get_roundtrips_pending_with_owner() {
+        let store = store();
+        store
+            .create("k1", TrackedJobOwner::User("user:42".to_owned()))
+            .await
+            .unwrap();
+
+        let record = store.get("k1").await.unwrap().expect("record");
+        assert_eq!(record.status, TrackedJobStatus::Pending);
+        assert_eq!(record.owner, TrackedJobOwner::User("user:42".to_owned()));
+        assert!(record.progress_pct.is_none());
+        assert!(record.result.is_none());
+    }
+
+    #[tokio::test]
+    async fn set_progress_clamps_above_100_and_persists_message() {
+        let store = store();
+        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        store.mark_running("k1").await.unwrap();
+
+        store
+            .set_progress("k1", 250, Some("Rows 1200/5000".to_owned()))
+            .await
+            .unwrap();
+
+        let record = store.get("k1").await.unwrap().expect("record");
+        assert_eq!(record.status, TrackedJobStatus::Running);
+        assert_eq!(record.progress_pct, Some(100));
+        assert_eq!(record.progress_message.as_deref(), Some("Rows 1200/5000"));
+    }
+
+    #[tokio::test]
+    async fn complete_is_terminal_and_stores_result_json() {
+        let store = store();
+        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+        store.mark_running("k1").await.unwrap();
+        store.set_progress("k1", 50, None).await.unwrap();
+
+        store
+            .complete("k1", serde_json::json!({"download_url": "/blob/abc.csv"}))
+            .await
+            .unwrap();
+
+        let record = store.get("k1").await.unwrap().expect("record");
+        assert_eq!(record.status, TrackedJobStatus::Succeeded);
+        assert_eq!(
+            record.result,
+            Some(serde_json::json!({"download_url": "/blob/abc.csv"}))
+        );
+        assert!(record.error.is_none());
+
+        // A terminal record ignores further progress writes.
+        store.set_progress("k1", 10, None).await.unwrap();
+        let record = store.get("k1").await.unwrap().expect("record");
+        assert_eq!(record.status, TrackedJobStatus::Succeeded);
+        assert_eq!(record.progress_pct, Some(50));
+    }
+
+    #[tokio::test]
+    async fn fail_stores_user_safe_error() {
+        let store = store();
+        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+
+        store
+            .fail("k1", "The export could not be completed.".to_owned())
+            .await
+            .unwrap();
+
+        let record = store.get("k1").await.unwrap().expect("record");
+        assert_eq!(record.status, TrackedJobStatus::Failed);
+        assert_eq!(
+            record.error.as_deref(),
+            Some("The export could not be completed.")
+        );
+        assert!(record.result.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_unknown_key_returns_none() {
+        let store = store();
+        assert!(store.get("nope").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn record_expires_after_ttl() {
+        let start = chrono::Utc::now();
+        let store = InMemoryJobTrackingStore::new(10)
+            .with_clock(std::sync::Arc::new(FixedClock::at(start)));
+        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+
+        let store = store.with_clock(std::sync::Arc::new(FixedClock::at(
+            start + chrono::TimeDelta::seconds(11),
+        )));
+        assert!(store.get("k1").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn terminal_write_refreshes_expiry() {
+        let start = chrono::Utc::now();
+        let store = InMemoryJobTrackingStore::new(10)
+            .with_clock(std::sync::Arc::new(FixedClock::at(start)));
+        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+
+        // Complete at t=8s, before the original 10s TTL expires — this must
+        // push expiry out to t=18s rather than leaving it at t=10s.
+        let store = store.with_clock(std::sync::Arc::new(FixedClock::at(
+            start + chrono::TimeDelta::seconds(8),
+        )));
+        store
+            .complete("k1", serde_json::json!({"download_url": "/blob/abc.csv"}))
+            .await
+            .unwrap();
+
+        // t=15s: past the original TTL, but within the refreshed window.
+        let store = store.with_clock(std::sync::Arc::new(FixedClock::at(
+            start + chrono::TimeDelta::seconds(15),
+        )));
+        let record = store.get("k1").await.unwrap();
+        assert!(record.is_some(), "terminal write should have refreshed the TTL");
+    }
+
+    #[tokio::test]
+    async fn write_to_expired_key_is_a_no_op() {
+        let start = chrono::Utc::now();
+        let store = InMemoryJobTrackingStore::new(5)
+            .with_clock(std::sync::Arc::new(FixedClock::at(start)));
+        store.create("k1", TrackedJobOwner::Anonymous).await.unwrap();
+
+        let store = store.with_clock(std::sync::Arc::new(FixedClock::at(
+            start + chrono::TimeDelta::seconds(6),
+        )));
+        // Expired: reads see it as gone, and writes must not resurrect it.
+        store.set_progress("k1", 50, None).await.unwrap();
+        assert!(store.get("k1").await.unwrap().is_none());
+    }
+}

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -162,6 +162,20 @@ pub trait JobTrackingStore: Send + Sync + 'static {
 
     /// Fetch the current record, or `None` if unknown or expired.
     fn get<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<Option<TrackedJobRecord>>>;
+
+    /// Reset `key` back to a fresh `pending` record for a retried attempt —
+    /// but only if the stored record's `updated_at` still equals
+    /// `expected_updated_at` (the value read just before the retry decision
+    /// was made). If a worker has already re-executed and settled the
+    /// record in the meantime, `updated_at` will have moved on and this is a
+    /// no-op, so a fast retry can never clobber the fresher terminal write
+    /// with a stale `pending` reset.
+    fn reset_for_retry<'a>(
+        &'a self,
+        key: &'a str,
+        owner: TrackedJobOwner,
+        expected_updated_at: DateTime<Utc>,
+    ) -> BoxFut<'a, AutumnResult<()>>;
 }
 
 /// `AppState` extension carrying the installed [`JobTrackingStore`].
@@ -579,6 +593,13 @@ async fn settle_tracked_payload_with_store(
 /// settles. Resolves the store from the process-global fallback since none
 /// of the three admin backends (`JobAdminMemoryBackend`,
 /// `RedisJobAdminBackend`, `PgJobAdminBackend`) carry an `AppState`.
+///
+/// The reset only applies if the record is unchanged since it was read here
+/// ([`JobTrackingStore::reset_for_retry`] is a compare-and-swap on
+/// `updated_at`): the retried job is re-enqueued (and may already be
+/// claimed and executing) before this runs, so without that guard a very
+/// fast retry could settle to a terminal status and then have this call
+/// stomp it back to a stale `pending`.
 pub(crate) async fn reset_tracked_payload_for_retry(payload: &Value) {
     let (key, _) = split_tracked_payload(payload);
     let Some(key) = key else {
@@ -590,7 +611,9 @@ pub(crate) async fn reset_tracked_payload_for_retry(payload: &Value) {
     let Some(record) = store.get(key).await.ok().flatten() else {
         return;
     };
-    let _ = store.create(key, record.owner).await;
+    let _ = store
+        .reset_for_retry(key, record.owner, record.updated_at)
+        .await;
 }
 
 // ── enqueue_tracked ────────────────────────────────────────────────────────────
@@ -930,6 +953,40 @@ impl InMemoryJobTrackingStore {
             entry.expires_at = now + self.ttl;
         }
     }
+
+    #[allow(clippy::significant_drop_tightening)]
+    fn reset_for_retry_if_unchanged(
+        &self,
+        key: &str,
+        owner: TrackedJobOwner,
+        expected_updated_at: DateTime<Utc>,
+    ) {
+        let now = self.clock.now();
+        let mut guard = self
+            .entries
+            .write()
+            .expect("job tracking store lock poisoned");
+        if let Some(entry) = guard.get(key)
+            && self.is_live(entry)
+            && entry.record.updated_at == expected_updated_at
+        {
+            guard.insert(
+                key.to_owned(),
+                MemoryEntry {
+                    record: TrackedJobRecord {
+                        status: TrackedJobStatus::Pending,
+                        progress_pct: None,
+                        progress_message: None,
+                        result: None,
+                        error: None,
+                        owner,
+                        updated_at: now,
+                    },
+                    expires_at: now + self.ttl,
+                },
+            );
+        }
+    }
 }
 
 impl JobTrackingStore for InMemoryJobTrackingStore {
@@ -989,6 +1046,18 @@ impl JobTrackingStore for InMemoryJobTrackingStore {
     fn fail<'a>(&'a self, key: &'a str, error: String) -> BoxFut<'a, AutumnResult<()>> {
         Box::pin(async move {
             self.with_record_mut(key, |record| apply_fail(record, error));
+            Ok(())
+        })
+    }
+
+    fn reset_for_retry<'a>(
+        &'a self,
+        key: &'a str,
+        owner: TrackedJobOwner,
+        expected_updated_at: DateTime<Utc>,
+    ) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            self.reset_for_retry_if_unchanged(key, owner, expected_updated_at);
             Ok(())
         })
     }
@@ -1101,6 +1170,59 @@ impl RedisJobTrackingStore {
         record.updated_at = chrono::Utc::now();
         self.write(key, &record).await
     }
+
+    /// Atomically overwrite the record with `new_record`, but only if the
+    /// currently-stored record's `updated_at` still equals
+    /// `expected_updated_at` — a compare-and-swap guard evaluated inside a
+    /// single Lua script so the check-then-write cannot race against a
+    /// concurrent write landing in between.
+    async fn write_if_unchanged(
+        &self,
+        key: &str,
+        expected_updated_at: DateTime<Utc>,
+        new_record: &TrackedJobRecord,
+    ) -> AutumnResult<()> {
+        const SCRIPT: &str = r"
+local raw = redis.call('GET', KEYS[1])
+if not raw then
+  return 0
+end
+local record = cjson.decode(raw)
+if record.updated_at ~= ARGV[1] then
+  return 0
+end
+redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3])
+return 1
+";
+        let expected = serde_json::to_string(&expected_updated_at).map_err(|error| {
+            AutumnError::internal_server_error_msg(format!(
+                "job tracking serialize failed: {error}"
+            ))
+        })?;
+        // cjson.decode(raw).updated_at yields the unquoted string value, so
+        // strip the JSON string quotes serde_json wraps it in above.
+        let expected = expected.trim_matches('"').to_owned();
+        let payload = serde_json::to_string(new_record).map_err(|error| {
+            AutumnError::internal_server_error_msg(format!(
+                "job tracking serialize failed: {error}"
+            ))
+        })?;
+        redis::cmd("EVAL")
+            .arg(SCRIPT)
+            .arg(1)
+            .arg(self.key_for(key))
+            .arg(expected)
+            .arg(payload)
+            .arg(self.ttl_secs.max(1))
+            .query_async::<i64>(&mut self.connection.clone())
+            .await
+            .map_err(|error| {
+                AutumnError::internal_server_error_msg(format!(
+                    "job tracking redis reset failed: {error}"
+                ))
+            })?;
+        Ok(())
+    }
 }
 
 #[cfg(feature = "redis")]
@@ -1146,6 +1268,27 @@ impl JobTrackingStore for RedisJobTrackingStore {
 
     fn fail<'a>(&'a self, key: &'a str, error: String) -> BoxFut<'a, AutumnResult<()>> {
         Box::pin(async move { self.update(key, |record| apply_fail(record, error)).await })
+    }
+
+    fn reset_for_retry<'a>(
+        &'a self,
+        key: &'a str,
+        owner: TrackedJobOwner,
+        expected_updated_at: DateTime<Utc>,
+    ) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            let record = TrackedJobRecord {
+                status: TrackedJobStatus::Pending,
+                progress_pct: None,
+                progress_message: None,
+                result: None,
+                error: None,
+                owner,
+                updated_at: chrono::Utc::now(),
+            };
+            self.write_if_unchanged(key, expected_updated_at, &record)
+                .await
+        })
     }
 
     fn get<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<Option<TrackedJobRecord>>> {
@@ -1364,6 +1507,56 @@ impl JobTrackingStore for PgJobTrackingStore {
         Box::pin(async move { self.update(key, |record| apply_fail(record, error)).await })
     }
 
+    fn reset_for_retry<'a>(
+        &'a self,
+        key: &'a str,
+        owner: TrackedJobOwner,
+        expected_updated_at: DateTime<Utc>,
+    ) -> BoxFut<'a, AutumnResult<()>> {
+        Box::pin(async move {
+            use diesel_async::RunQueryDsl as _;
+
+            let now = self.clock.now();
+            let record = TrackedJobRecord {
+                status: TrackedJobStatus::Pending,
+                progress_pct: None,
+                progress_message: None,
+                result: None,
+                error: None,
+                owner,
+                updated_at: now,
+            };
+            let payload = serde_json::to_string(&record).map_err(|error| {
+                AutumnError::internal_server_error_msg(format!(
+                    "job tracking serialize failed: {error}"
+                ))
+            })?;
+            let mut conn = self.conn().await?;
+            // The WHERE clause is a compare-and-swap guard: it only takes
+            // effect if nothing has written to this record (e.g. the
+            // retried attempt itself already settling) since
+            // `expected_updated_at` was read, so a fast retry can never
+            // clobber a fresher terminal write with a stale reset.
+            diesel::sql_query(
+                "UPDATE autumn_job_tracking SET record = $2::JSONB, updated_at = $3, \
+                 expires_at = $4 WHERE key = $1 AND updated_at = $5",
+            )
+            .bind::<diesel::sql_types::Text, _>(key)
+            .bind::<diesel::sql_types::Text, _>(&payload)
+            .bind::<diesel::sql_types::Timestamptz, _>(now)
+            .bind::<diesel::sql_types::Timestamptz, _>(self.expires_at(now))
+            .bind::<diesel::sql_types::Timestamptz, _>(expected_updated_at)
+            .execute(&mut *conn)
+            .await
+            .map_err(|error| {
+                AutumnError::internal_server_error_msg(format!(
+                    "job tracking reset failed: {error}"
+                ))
+            })?;
+            Ok(())
+        })
+    }
+
     fn get<'a>(&'a self, key: &'a str) -> BoxFut<'a, AutumnResult<Option<TrackedJobRecord>>> {
         Box::pin(async move {
             use diesel::OptionalExtension as _;
@@ -1474,6 +1667,64 @@ mod tests {
         assert_eq!(record.owner, TrackedJobOwner::User("user:42".to_owned()));
         assert!(record.progress_pct.is_none());
         assert!(record.result.is_none());
+    }
+
+    #[tokio::test]
+    async fn reset_for_retry_applies_when_the_record_is_unchanged() {
+        let store = store();
+        store
+            .create("k1", TrackedJobOwner::User("user:42".to_owned()))
+            .await
+            .unwrap();
+        store.fail("k1", "boom".to_owned()).await.unwrap();
+        let stale = store.get("k1").await.unwrap().expect("record");
+        assert_eq!(stale.status, TrackedJobStatus::Failed);
+
+        store
+            .reset_for_retry("k1", stale.owner.clone(), stale.updated_at)
+            .await
+            .unwrap();
+
+        let record = store.get("k1").await.unwrap().expect("record");
+        assert_eq!(record.status, TrackedJobStatus::Pending);
+        assert_eq!(record.owner, TrackedJobOwner::User("user:42".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn reset_for_retry_is_a_no_op_when_a_fresher_write_already_landed() {
+        // Simulates the race Codex flagged: the retried job is re-enqueued,
+        // claimed, and settles to a terminal status before the admin retry
+        // path gets around to calling `reset_for_retry` with the
+        // `updated_at` it read *before* deciding to retry.
+        let store = store();
+        store
+            .create("k1", TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
+        store.fail("k1", "boom".to_owned()).await.unwrap();
+        let stale = store.get("k1").await.unwrap().expect("record");
+        assert_eq!(stale.status, TrackedJobStatus::Failed);
+
+        // The retried attempt runs to completion in the meantime.
+        store
+            .complete("k1", serde_json::json!({"already": "done"}))
+            .await
+            .unwrap();
+
+        // The admin retry path's reset, still holding the pre-retry
+        // snapshot, must not clobber the fresher terminal result.
+        store
+            .reset_for_retry("k1", stale.owner, stale.updated_at)
+            .await
+            .unwrap();
+
+        let record = store.get("k1").await.unwrap().expect("record");
+        assert_eq!(
+            record.status,
+            TrackedJobStatus::Succeeded,
+            "a reset computed from a stale read must not overwrite a write that landed since"
+        );
+        assert_eq!(record.result, Some(serde_json::json!({"already": "done"})));
     }
 
     // ── shared mutation logic (single source of truth for all 3 backends) ────
@@ -1893,6 +2144,14 @@ mod tests {
             }
             fn fail<'a>(&'a self, key: &'a str, error: String) -> BoxFut<'a, AutumnResult<()>> {
                 self.inner.fail(key, error)
+            }
+            fn reset_for_retry<'a>(
+                &'a self,
+                key: &'a str,
+                owner: TrackedJobOwner,
+                expected_updated_at: DateTime<Utc>,
+            ) -> BoxFut<'a, AutumnResult<()>> {
+                self.inner.reset_for_retry(key, owner, expected_updated_at)
             }
             fn get<'a>(
                 &'a self,

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -581,9 +581,34 @@ async fn settle_tracked_payload_with_store(
     }
 }
 
-/// If `payload` is a tracked-job envelope, reset its tracking record back to
-/// `pending` (preserving the existing owner), after an admin retry
-/// successfully re-enqueues it.
+/// A tracking record's owner and `updated_at`, captured *before* an admin
+/// retry makes the job visible to workers again, so
+/// [`apply_retry_reset`] can later detect whether anything wrote to the
+/// record in the meantime.
+pub(crate) type RetrySnapshot = (TrackedJobOwner, DateTime<Utc>);
+
+/// If `payload` is a tracked-job envelope, read its current tracking record.
+///
+/// Callers on the admin retry paths must call this *before* re-enqueueing —
+/// i.e. before the retried job can possibly be claimed and executed — and
+/// pass the result to [`apply_retry_reset`] once the retry is confirmed.
+/// Reading it any later (e.g. after the re-enqueue) defeats the purpose: a
+/// fast retry could already have run to completion and settled the record,
+/// and a read at that point would capture the *fresh* terminal write as the
+/// CAS baseline, making the later reset believe nothing has changed since
+/// and clobber it anyway.
+pub(crate) async fn capture_retry_snapshot(payload: &Value) -> Option<RetrySnapshot> {
+    let (key, _) = split_tracked_payload(payload);
+    let key = key?;
+    let store = global_tracking_store()?;
+    let record = store.get(key).await.ok().flatten()?;
+    Some((record.owner, record.updated_at))
+}
+
+/// If `payload` is a tracked-job envelope and `snapshot` is `Some` (i.e.
+/// [`capture_retry_snapshot`] found a record before the retry was
+/// re-enqueued), reset the tracking record back to `pending` — preserving
+/// the captured owner — now that the admin retry has succeeded.
 ///
 /// `mark_running`/`set_progress` intentionally no-op once a record is
 /// terminal, to protect against a stray write from an abandoned attempt
@@ -594,13 +619,15 @@ async fn settle_tracked_payload_with_store(
 /// of the three admin backends (`JobAdminMemoryBackend`,
 /// `RedisJobAdminBackend`, `PgJobAdminBackend`) carry an `AppState`.
 ///
-/// The reset only applies if the record is unchanged since it was read here
-/// ([`JobTrackingStore::reset_for_retry`] is a compare-and-swap on
-/// `updated_at`): the retried job is re-enqueued (and may already be
-/// claimed and executing) before this runs, so without that guard a very
-/// fast retry could settle to a terminal status and then have this call
-/// stomp it back to a stale `pending`.
-pub(crate) async fn reset_tracked_payload_for_retry(payload: &Value) {
+/// The reset only applies if the record is unchanged since `snapshot` was
+/// captured ([`JobTrackingStore::reset_for_retry`] is a compare-and-swap on
+/// `updated_at`), so a fast retry that already settled the record before
+/// this call runs is left alone rather than stomped back to a stale
+/// `pending`.
+pub(crate) async fn apply_retry_reset(payload: &Value, snapshot: Option<RetrySnapshot>) {
+    let Some((owner, expected_updated_at)) = snapshot else {
+        return;
+    };
     let (key, _) = split_tracked_payload(payload);
     let Some(key) = key else {
         return;
@@ -608,12 +635,7 @@ pub(crate) async fn reset_tracked_payload_for_retry(payload: &Value) {
     let Some(store) = global_tracking_store() else {
         return;
     };
-    let Some(record) = store.get(key).await.ok().flatten() else {
-        return;
-    };
-    let _ = store
-        .reset_for_retry(key, record.owner, record.updated_at)
-        .await;
+    let _ = store.reset_for_retry(key, owner, expected_updated_at).await;
 }
 
 // ── enqueue_tracked ────────────────────────────────────────────────────────────
@@ -1725,6 +1747,51 @@ mod tests {
             "a reset computed from a stale read must not overwrite a write that landed since"
         );
         assert_eq!(record.result, Some(serde_json::json!({"already": "done"})));
+    }
+
+    #[tokio::test]
+    async fn capture_retry_snapshot_before_enqueue_protects_a_fast_retry_from_being_reset() {
+        // A snapshot taken *after* re-enqueueing can itself already observe
+        // the retried job's terminal write (it settled faster than the
+        // admin retry path got around to reading it), which would make the
+        // CAS trivially "unchanged" and reset the fresh terminal record
+        // right back to `pending`. `capture_retry_snapshot` must be called
+        // *before* the retry is made visible so it captures the original
+        // `failed` record instead.
+        let _guard = crate::job::global_job_runtime_test_lock().lock().await;
+        crate::job::clear_global_job_client();
+
+        let store: Arc<dyn JobTrackingStore> = Arc::new(InMemoryJobTrackingStore::new(60));
+        let state = AppState::for_test().with_profile("dev");
+        install_tracking_store(&state, store.clone());
+
+        let key = "retry-snapshot-key";
+        store.create(key, TrackedJobOwner::Anonymous).await.unwrap();
+        store.fail(key, "boom".to_owned()).await.unwrap();
+        let payload = wrap_tracked_payload(key, &serde_json::json!({}));
+
+        // Captured while the record is still the original `failed` one —
+        // i.e. before the retry is re-enqueued/made visible.
+        let snapshot = capture_retry_snapshot(&payload).await;
+
+        // The retry runs to completion before `apply_retry_reset` is called.
+        store
+            .complete(key, serde_json::json!({"already": "done"}))
+            .await
+            .unwrap();
+
+        apply_retry_reset(&payload, snapshot).await;
+
+        let record = store.get(key).await.unwrap().expect("record");
+        assert_eq!(
+            record.status,
+            TrackedJobStatus::Succeeded,
+            "a snapshot captured before the retry was exposed must not let apply_retry_reset \
+             clobber a terminal write that landed since"
+        );
+        assert_eq!(record.result, Some(serde_json::json!({"already": "done"})));
+
+        crate::job::clear_global_job_client();
     }
 
     // ── shared mutation logic (single source of truth for all 3 backends) ────

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -10,6 +10,7 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, RwLock};
 
 use axum::response::IntoResponse as _;
@@ -921,6 +922,14 @@ struct MemoryEntry {
     expires_at: DateTime<Utc>,
 }
 
+/// Sweep expired entries out of an [`InMemoryJobTrackingStore`] every this
+/// many [`InMemoryJobTrackingStore::create`] calls, so long-running processes
+/// don't accumulate one dead `HashMap` entry per tracked job forever — `get`
+/// already filters expired entries out of reads, but without this they'd
+/// never actually be freed. Amortized rather than swept on every write to
+/// keep the common-case cost of `create` O(1).
+const IN_MEMORY_SWEEP_INTERVAL: u64 = 100;
+
 /// In-memory [`JobTrackingStore`] for development, testing, and the `local`
 /// job backend. State is lost on restart and not shared across processes.
 #[derive(Clone)]
@@ -928,6 +937,7 @@ pub struct InMemoryJobTrackingStore {
     entries: Arc<RwLock<HashMap<String, MemoryEntry>>>,
     ttl: chrono::TimeDelta,
     clock: Arc<dyn ClockSource>,
+    creates_since_sweep: Arc<AtomicU64>,
 }
 
 impl InMemoryJobTrackingStore {
@@ -939,6 +949,7 @@ impl InMemoryJobTrackingStore {
             entries: Arc::new(RwLock::new(HashMap::new())),
             ttl: chrono::TimeDelta::seconds(i64::try_from(ttl_secs).unwrap_or(i64::MAX)),
             clock: Arc::new(SystemClock),
+            creates_since_sweep: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -955,6 +966,36 @@ impl InMemoryJobTrackingStore {
 
     fn is_live(&self, entry: &MemoryEntry) -> bool {
         entry.expires_at > self.clock.now()
+    }
+
+    #[cfg(test)]
+    fn raw_entry_count(&self) -> usize {
+        self.entries
+            .read()
+            .expect("job tracking store lock poisoned")
+            .len()
+    }
+
+    #[allow(clippy::significant_drop_tightening)]
+    fn insert_and_maybe_sweep(&self, key: &str, record: TrackedJobRecord, now: DateTime<Utc>) {
+        let mut guard = self
+            .entries
+            .write()
+            .expect("job tracking store lock poisoned");
+        guard.insert(
+            key.to_owned(),
+            MemoryEntry {
+                record,
+                expires_at: now + self.ttl,
+            },
+        );
+        if self
+            .creates_since_sweep
+            .fetch_add(1, Ordering::Relaxed)
+            .is_multiple_of(IN_MEMORY_SWEEP_INTERVAL)
+        {
+            guard.retain(|_, entry| entry.expires_at > now);
+        }
     }
 
     #[allow(clippy::significant_drop_tightening)]
@@ -1024,16 +1065,7 @@ impl JobTrackingStore for InMemoryJobTrackingStore {
                 owner,
                 updated_at: now,
             };
-            self.entries
-                .write()
-                .expect("job tracking store lock poisoned")
-                .insert(
-                    key.to_owned(),
-                    MemoryEntry {
-                        record,
-                        expires_at: now + self.ttl,
-                    },
-                );
+            self.insert_and_maybe_sweep(key, record, now);
             Ok(())
         })
     }
@@ -1973,6 +2005,42 @@ mod tests {
         // Expired: reads see it as gone, and writes must not resurrect it.
         store.set_progress("k1", 50, None).await.unwrap();
         assert!(store.get("k1").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn expired_entries_are_evicted_not_just_filtered() {
+        let start = chrono::Utc::now();
+        let store =
+            InMemoryJobTrackingStore::new(1).with_clock(std::sync::Arc::new(FixedClock::at(start)));
+        store
+            .create("expired-key", TrackedJobOwner::Anonymous)
+            .await
+            .unwrap();
+
+        let store = store.with_clock(std::sync::Arc::new(FixedClock::at(
+            start + chrono::TimeDelta::seconds(2),
+        )));
+        assert!(
+            store.get("expired-key").await.unwrap().is_none(),
+            "reads must already treat it as gone"
+        );
+
+        // Drive enough creates to cross the amortized sweep threshold. The
+        // clock stays fixed, so every filler entry is still live when the
+        // sweep runs — only the already-expired one should be removed.
+        for i in 0..IN_MEMORY_SWEEP_INTERVAL {
+            store
+                .create(&format!("filler-{i}"), TrackedJobOwner::Anonymous)
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(
+            store.raw_entry_count(),
+            usize::try_from(IN_MEMORY_SWEEP_INTERVAL).unwrap(),
+            "the expired entry must actually be removed from the map, not just filtered on \
+             read, or a long-running process leaks one entry per expired tracked job forever"
+        );
     }
 
     // ── envelope ───────────────────────────────────────────────────────────

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -1600,8 +1600,10 @@ mod tests {
     #[cfg(feature = "redis")]
     #[tokio::test]
     async fn store_for_config_falls_back_to_memory_when_redis_backend_has_no_url() {
-        let mut config = crate::config::JobConfig::default();
-        config.backend = "redis".to_owned();
+        let config = crate::config::JobConfig {
+            backend: "redis".to_owned(),
+            ..Default::default()
+        };
         let state = AppState::for_test();
         // Falling back must not panic; the resulting store is still usable.
         let store = store_for_config(&state, &config);

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -321,6 +321,7 @@ pub mod feature_flags;
 pub mod form;
 pub mod gdpr;
 pub mod job;
+pub mod job_tracking;
 pub mod runtime_config;
 #[cfg(feature = "seed")]
 pub mod seed;

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1079,6 +1079,13 @@ fn collect_claimed_get_paths(
     if config.mail.should_mount_unsubscribe_endpoint() {
         claimed.insert(crate::mail::UNSUBSCRIBE_PATH.to_owned());
     }
+    // The tracked-job status endpoint merges a GET before the late-merged
+    // OpenAPI/MCP routers, so reserve it too (same rationale as unsubscribe
+    // above): an OpenAPI/MCP mount at this path should surface the typed
+    // collision instead of panicking in `router.merge`.
+    if config.jobs.tracking.route_enabled {
+        claimed.insert(crate::job_tracking::JOB_STATUS_ROUTE_PATH.to_owned());
+    }
     claimed
 }
 
@@ -1512,6 +1519,16 @@ fn mount_framework_routes(
         tracing::debug!(
             path = crate::mail::UNSUBSCRIBE_PATH,
             "Mounted default unsubscribe endpoint"
+        );
+    }
+
+    // Tracked-job status endpoint (enqueue_tracked / #[job] JobContext) — on
+    // by default; opt out via `jobs.tracking.route_enabled = false`.
+    if config.jobs.tracking.route_enabled {
+        router = router.merge(crate::job_tracking::status_router());
+        tracing::debug!(
+            path = crate::job_tracking::JOB_STATUS_ROUTE_PATH,
+            "Mounted tracked-job status endpoint"
         );
     }
 
@@ -4720,6 +4737,41 @@ mod tests {
                 field: "openapi_json_path",
                 ref path,
             } if path == crate::mail::UNSUBSCRIBE_PATH
+        ));
+    }
+
+    #[cfg(feature = "openapi")]
+    #[tokio::test]
+    async fn try_build_router_rejects_openapi_path_on_job_status_endpoint() {
+        // The tracked-job status endpoint merges a GET at
+        // `/_autumn/jobs/{token}` before the late-merged OpenAPI router (on by
+        // default), so the collision preflight must reserve it too.
+        let config = AutumnConfig::default();
+        assert!(config.jobs.tracking.route_enabled);
+        let openapi = crate::openapi::OpenApiConfig::new("Demo", "1.0.0")
+            .openapi_json_path(crate::job_tracking::JOB_STATUS_ROUTE_PATH);
+        let ctx = RouterContext {
+            exception_filters: Vec::new(),
+            scoped_groups: Vec::new(),
+            merge_routers: Vec::new(),
+            nest_routers: Vec::new(),
+            custom_layers: Vec::new(),
+            static_gate_layers: Vec::new(),
+            #[cfg(feature = "maud")]
+            error_page_renderer: None,
+            session_store: None,
+            openapi: Some(openapi),
+            #[cfg(feature = "mcp")]
+            mcp: None,
+        };
+        let err = super::try_build_router_inner(Vec::new(), &config, test_state(), ctx)
+            .expect_err("job status endpoint path should be reserved");
+        assert!(matches!(
+            err,
+            RouterBuildError::OpenApiPathCollision {
+                field: "openapi_json_path",
+                ref path,
+            } if path == crate::job_tracking::JOB_STATUS_ROUTE_PATH
         ));
     }
 

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -110,6 +110,15 @@ impl Session {
         Self::new_cookie_backed(id, data)
     }
 
+    /// Create a fresh, non-cookie-backed session for testing purposes (i.e.
+    /// as [`Session::is_cookie_backed`] would report for a request with no
+    /// prior session cookie).
+    #[doc(hidden)]
+    #[must_use]
+    pub fn new_for_test_without_cookie(id: String, data: HashMap<String, String>) -> Self {
+        Self::new(id, data)
+    }
+
     fn new(id: String, data: HashMap<String, String>) -> Self {
         Self::with_cookie_state(id, data, false)
     }
@@ -140,6 +149,20 @@ impl Session {
     /// than being generated for the current request.
     pub async fn is_cookie_backed(&self) -> bool {
         self.inner.read().await.cookie_backed
+    }
+
+    /// Force this session to be persisted and its cookie (re)issued on the
+    /// response, even though no session data was read or written.
+    ///
+    /// `SessionLayer` only saves the session and sends `Set-Cookie` when it
+    /// is dirty; a request that only calls [`Session::id`] never dirties it.
+    /// Call this before handing [`Session::id`]'s value to something that
+    /// will later be used to identify this session (e.g. binding an external
+    /// capability to it) — otherwise, for a session with no cookie yet, the
+    /// browser never receives the cookie needed to present that same id on a
+    /// later request.
+    pub async fn touch(&self) {
+        self.inner.write().await.dirty = true;
     }
 
     pub(crate) async fn has_pending_changes(&self) -> bool {
@@ -921,6 +944,27 @@ mod tests {
     use axum::routing::get;
     use http::Request as HttpRequest;
     use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn touch_marks_the_session_dirty_without_reading_or_writing_data() {
+        let session = Session::new_for_test_without_cookie("fresh-id".to_owned(), HashMap::new());
+        assert!(
+            !session.has_pending_changes().await,
+            "sanity: not dirty yet"
+        );
+
+        session.touch().await;
+
+        assert!(
+            session.has_pending_changes().await,
+            "touch() must dirty the session so SessionLayer persists it and sets the cookie"
+        );
+        assert_eq!(
+            session.id().await,
+            "fresh-id",
+            "touch() must not change the id"
+        );
+    }
 
     /// Sentinel store for verifying that the type-erased `BoxedSessionStore`
     /// bridge actually delegates back to the user's `SessionStore` impl

--- a/autumn/tests/compile-pass/job_tracked_three_arg.rs
+++ b/autumn/tests/compile-pass/job_tracked_three_arg.rs
@@ -1,0 +1,36 @@
+use autumn_web::job;
+use autumn_web::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ExportArgs {
+    account_id: i64,
+}
+
+#[job(name = "export_orders")]
+async fn export_orders(
+    _state: AppState,
+    args: ExportArgs,
+    ctx: job::JobContext,
+) -> AutumnResult<()> {
+    ctx.set_progress(50, Some("Rows 1200/5000")).await?;
+    ctx.set_result(serde_json::json!({ "download_url": format!("/blob/{}.csv", args.account_id) }));
+    Ok(())
+}
+
+async fn use_companion() -> AutumnResult<()> {
+    let handle = ExportOrdersJob::enqueue_tracked(ExportArgs { account_id: 42 }).await?;
+    let _path: String = handle.status_path();
+
+    let _handle = ExportOrdersJob::enqueue_tracked_for(
+        ExportArgs { account_id: 42 },
+        job::TrackedJobOwner::Anonymous,
+    )
+    .await?;
+
+    Ok(())
+}
+
+fn main() {
+    let _ = use_companion;
+}

--- a/autumn/tests/compile_fail.rs
+++ b/autumn/tests/compile_fail.rs
@@ -121,6 +121,10 @@ fn compile_pass_tests() {
     t.pass("tests/compile-pass/task_basic.rs");
     t.pass("tests/compile-pass/scheduled_coordination.rs");
 
+    // #[job] with a three-arg (AppState, Args, JobContext) signature and the
+    // generated enqueue_tracked/enqueue_tracked_for companions
+    t.pass("tests/compile-pass/job_tracked_three_arg.rs");
+
     // WebSocket macro (requires ws feature)
     #[cfg(feature = "ws")]
     t.pass("tests/compile-pass/ws_basic.rs");

--- a/autumn/tests/job_tracking_route.rs
+++ b/autumn/tests/job_tracking_route.rs
@@ -1,0 +1,190 @@
+//! Integration coverage for the built-in tracked-job status route
+//! (`GET /_autumn/jobs/{token}`, issue #1373): JSON leg, config wiring, and
+//! the OpenAPI/MCP claimed-path preflight.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use autumn_web::app::AppBuilder;
+use autumn_web::config::AutumnConfig;
+use autumn_web::job::{self, JobInfo};
+use autumn_web::plugin::Plugin;
+use autumn_web::test::{TestApp, TestClient};
+use autumn_web::{AppState, AutumnError, AutumnResult};
+use serde_json::{Value, json};
+use tokio::sync::Notify;
+
+/// Gates `tracked_gate_job` mid-execution (after it reports progress) so
+/// tests can observe the "running" state deterministically before letting it
+/// settle to a terminal state.
+static RELEASE_GATE: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+fn tracked_gate_job_handler(
+    _state: AppState,
+    payload: Value,
+) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>> {
+    Box::pin(async move {
+        let ctx = job::JobContext::current();
+        ctx.set_progress(40, Some("Rows 400/1000")).await.ok();
+        RELEASE_GATE.notified().await;
+        if payload.get("mode").and_then(Value::as_str) == Some("fail") {
+            ctx.set_user_error("The export could not reach storage.");
+            return Err(AutumnError::internal_server_error(std::io::Error::other(
+                "boom",
+            )));
+        }
+        ctx.set_result(json!({"download_url": "/blob/abc.csv"}));
+        Ok(())
+    })
+}
+
+struct TrackedGateJobPlugin;
+
+impl Plugin for TrackedGateJobPlugin {
+    fn build(self, app: AppBuilder) -> AppBuilder {
+        app.jobs(vec![JobInfo {
+            name: "tracked_gate_job".to_string(),
+            max_attempts: 1,
+            initial_backoff_ms: 1,
+            queue: "default".to_string(),
+            uniqueness: None,
+            concurrency: None,
+            handler: tracked_gate_job_handler,
+        }])
+    }
+}
+
+fn test_config() -> AutumnConfig {
+    AutumnConfig {
+        profile: Some("test".into()),
+        ..Default::default()
+    }
+}
+
+/// Poll `path` until `predicate` matches the JSON body, or panic after ~1s.
+async fn poll_until(
+    client: &TestClient,
+    path: &str,
+    predicate: impl Fn(&Value) -> bool,
+) -> Value {
+    for _ in 0..100 {
+        let response = client.get(path).send().await;
+        assert_eq!(response.header("content-type"), Some("application/json"));
+        let body: Value = response.json();
+        if predicate(&body) {
+            return body;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("condition on {path} was not met in time");
+}
+
+#[tokio::test]
+async fn status_route_tracks_progress_through_to_success_as_json() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new()
+        .config(test_config())
+        .plugin(TrackedGateJobPlugin)
+        .build();
+
+    let handle = job::enqueue_tracked("tracked_gate_job", json!({"mode": "succeed"}))
+        .await
+        .unwrap();
+
+    let running = poll_until(&client, &handle.status_path(), |body| {
+        body["status"] == "running"
+    })
+    .await;
+    assert_eq!(running["progress"], 40);
+    assert_eq!(running["message"], "Rows 400/1000");
+    assert!(running["result"].is_null());
+    assert!(running["error"].is_null());
+
+    RELEASE_GATE.notify_waiters();
+
+    let done = poll_until(&client, &handle.status_path(), |body| {
+        body["status"] == "succeeded"
+    })
+    .await;
+    assert_eq!(done["result"]["download_url"], "/blob/abc.csv");
+    assert!(done["error"].is_null());
+
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn status_route_reports_failure_as_json() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new()
+        .config(test_config())
+        .plugin(TrackedGateJobPlugin)
+        .build();
+
+    let handle = job::enqueue_tracked("tracked_gate_job", json!({"mode": "fail"}))
+        .await
+        .unwrap();
+
+    // Let it reach "running" first so we know the gate was actually hit,
+    // then release it to fail.
+    poll_until(&client, &handle.status_path(), |body| {
+        body["status"] == "running"
+    })
+    .await;
+    RELEASE_GATE.notify_waiters();
+
+    let done = poll_until(&client, &handle.status_path(), |body| {
+        body["status"] == "failed"
+    })
+    .await;
+    assert_eq!(done["error"], "The export could not reach storage.");
+    assert!(done["result"].is_null());
+
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn unknown_token_is_404() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new()
+        .config(test_config())
+        .plugin(TrackedGateJobPlugin)
+        .build();
+
+    client
+        .get("/_autumn/jobs/does-not-exist")
+        .send()
+        .await
+        .assert_status(404);
+
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn route_disabled_via_config_is_not_mounted() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let mut config = test_config();
+    config.jobs.tracking.route_enabled = false;
+
+    let client = TestApp::new()
+        .config(config)
+        .plugin(TrackedGateJobPlugin)
+        .build();
+
+    client
+        .get("/_autumn/jobs/anything")
+        .send()
+        .await
+        .assert_status(404);
+
+    job::clear_global_job_client();
+}

--- a/autumn/tests/job_tracking_route.rs
+++ b/autumn/tests/job_tracking_route.rs
@@ -65,11 +65,7 @@ fn test_config() -> AutumnConfig {
 }
 
 /// Poll `path` until `predicate` matches the JSON body, or panic after ~1s.
-async fn poll_until(
-    client: &TestClient,
-    path: &str,
-    predicate: impl Fn(&Value) -> bool,
-) -> Value {
+async fn poll_until(client: &TestClient, path: &str, predicate: impl Fn(&Value) -> bool) -> Value {
     for _ in 0..100 {
         let response = client.get(path).send().await;
         assert_eq!(response.header("content-type"), Some("application/json"));
@@ -389,7 +385,11 @@ fn build_owned_client(store: MemoryStore) -> TestClient {
         .build()
 }
 
-async fn get_status(client: &TestClient, path: &str, sid: Option<&str>) -> autumn_web::test::TestResponse {
+async fn get_status(
+    client: &TestClient,
+    path: &str,
+    sid: Option<&str>,
+) -> autumn_web::test::TestResponse {
     let mut request = client.get(path);
     if let Some(sid) = sid {
         request = request.header("Cookie", &format!("autumn.sid={sid}"));
@@ -547,7 +547,12 @@ async fn owner_mismatch_response_is_byte_identical_to_unknown_token() {
 
     seed_session(&store, "sess-stranger", None).await;
     let mismatch = get_status(&client, &handle.status_path(), Some("sess-stranger")).await;
-    let unknown = get_status(&client, "/_autumn/jobs/does-not-exist", Some("sess-stranger")).await;
+    let unknown = get_status(
+        &client,
+        "/_autumn/jobs/does-not-exist",
+        Some("sess-stranger"),
+    )
+    .await;
 
     assert_eq!(
         mismatch.header("content-type"),

--- a/autumn/tests/job_tracking_route.rs
+++ b/autumn/tests/job_tracking_route.rs
@@ -575,3 +575,45 @@ async fn owner_mismatch_response_is_byte_identical_to_unknown_token() {
 
     job::clear_global_job_client();
 }
+
+// ── TTL end-to-end via config ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn custom_ttl_from_config_expires_the_record_via_route() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let mut config = test_config();
+    config.jobs.tracking.ttl_secs = 1;
+
+    let client = TestApp::new()
+        .config(config)
+        .plugin(TrackedGateJobPlugin)
+        .build();
+
+    let handle = job::enqueue_tracked("tracked_gate_job", json!({"mode": "succeed"}))
+        .await
+        .unwrap();
+
+    poll_until(&client, &handle.status_path(), |body| {
+        body["status"] == "running"
+    })
+    .await;
+    RELEASE_GATE.notify_waiters();
+
+    poll_until(&client, &handle.status_path(), |body| {
+        body["status"] == "succeeded"
+    })
+    .await;
+
+    // The 1s TTL configured above (rather than the 86400s default) should
+    // have expired the record shortly after it settled.
+    tokio::time::sleep(Duration::from_millis(1_200)).await;
+    client
+        .get(&handle.status_path())
+        .send()
+        .await
+        .assert_status(404);
+
+    job::clear_global_job_client();
+}

--- a/autumn/tests/job_tracking_route.rs
+++ b/autumn/tests/job_tracking_route.rs
@@ -288,6 +288,39 @@ async fn accept_text_html_without_htmx_header_also_receives_fragment() {
 }
 
 #[tokio::test]
+async fn bare_wildcard_accept_still_receives_json_not_the_html_fragment() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new()
+        .config(test_config())
+        .plugin(TrackedGateJobPlugin)
+        .build();
+
+    let handle = job::enqueue_tracked("tracked_gate_job", json!({"mode": "succeed"}))
+        .await
+        .unwrap();
+
+    poll_until(&client, &handle.status_path(), |body| {
+        body["status"] == "running"
+    })
+    .await;
+
+    // A bare wildcard Accept (curl's default, and many fetch()/HTTP-client
+    // defaults) carries no real preference and must not be treated as a
+    // browser navigation — this JSON-first route should still return JSON.
+    let response = client
+        .get(&handle.status_path())
+        .header("Accept", "*/*")
+        .send()
+        .await;
+    assert_eq!(response.header("content-type"), Some("application/json"));
+
+    RELEASE_GATE.notify_waiters();
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
 async fn succeeded_fragment_renders_download_link_and_stops_polling() {
     let _guard = job::global_job_runtime_test_lock().lock().await;
     job::clear_global_job_client();

--- a/autumn/tests/job_tracking_route.rs
+++ b/autumn/tests/job_tracking_route.rs
@@ -81,6 +81,28 @@ async fn poll_until(
     panic!("condition on {path} was not met in time");
 }
 
+/// Poll `path` via an htmx request (`HX-Request: true`) until `predicate`
+/// matches the returned HTML fragment text, or panic after ~1s.
+async fn poll_until_html(
+    client: &TestClient,
+    path: &str,
+    predicate: impl Fn(&str) -> bool,
+) -> String {
+    for _ in 0..100 {
+        let response = client.get(path).header("HX-Request", "true").send().await;
+        assert_eq!(
+            response.header("content-type"),
+            Some("text/html; charset=utf-8")
+        );
+        let body = response.text();
+        if predicate(&body) {
+            return body;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("condition on {path} was not met in time");
+}
+
 #[tokio::test]
 async fn status_route_tracks_progress_through_to_success_as_json() {
     let _guard = job::global_job_runtime_test_lock().lock().await;
@@ -185,6 +207,165 @@ async fn route_disabled_via_config_is_not_mounted() {
         .send()
         .await
         .assert_status(404);
+
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn htmx_request_receives_fragment_with_every_2s_trigger_while_running() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new()
+        .config(test_config())
+        .plugin(TrackedGateJobPlugin)
+        .build();
+
+    let handle = job::enqueue_tracked("tracked_gate_job", json!({"mode": "succeed"}))
+        .await
+        .unwrap();
+
+    let running = poll_until_html(&client, &handle.status_path(), |body| {
+        // Wait for the actual progress write, not just the initial pending
+        // record (whose unset progress would also render "0%").
+        body.contains("Rows 400/1000")
+    })
+    .await;
+    assert!(
+        running.contains(r#"hx-get="/_autumn/jobs/"#),
+        "expected self hx-get while running: {running}"
+    );
+    assert!(
+        running.contains(r#"hx-trigger="every 2s""#),
+        "expected hx-trigger=\"every 2s\" while running: {running}"
+    );
+    assert!(
+        running.contains(r#"hx-swap="outerHTML""#),
+        "expected hx-swap=\"outerHTML\" while running: {running}"
+    );
+    assert!(
+        running.contains(r#"value="40""#),
+        "expected the progress bar to reflect 40%: {running}"
+    );
+
+    RELEASE_GATE.notify_waiters();
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn accept_text_html_without_htmx_header_also_receives_fragment() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new()
+        .config(test_config())
+        .plugin(TrackedGateJobPlugin)
+        .build();
+
+    let handle = job::enqueue_tracked("tracked_gate_job", json!({"mode": "succeed"}))
+        .await
+        .unwrap();
+
+    // Wait for the job to actually be running (via the JSON leg, so we don't
+    // depend on the behavior under test to observe readiness), then re-fetch
+    // with a browser-style Accept header and no HX-Request.
+    poll_until(&client, &handle.status_path(), |body| {
+        body["status"] == "running"
+    })
+    .await;
+
+    let response = client
+        .get(&handle.status_path())
+        .header("Accept", "text/html")
+        .send()
+        .await;
+    assert_eq!(
+        response.header("content-type"),
+        Some("text/html; charset=utf-8")
+    );
+    let body = response.text();
+    assert!(body.contains("autumn-job-status"), "{body}");
+
+    RELEASE_GATE.notify_waiters();
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn succeeded_fragment_renders_download_link_and_stops_polling() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new()
+        .config(test_config())
+        .plugin(TrackedGateJobPlugin)
+        .build();
+
+    let handle = job::enqueue_tracked("tracked_gate_job", json!({"mode": "succeed"}))
+        .await
+        .unwrap();
+
+    poll_until(&client, &handle.status_path(), |body| {
+        body["status"] == "running"
+    })
+    .await;
+    RELEASE_GATE.notify_waiters();
+
+    let done = poll_until_html(&client, &handle.status_path(), |body| {
+        body.contains("autumn-job-status__success")
+    })
+    .await;
+    assert!(
+        done.contains(r#"href="/blob/abc.csv""#),
+        "expected a download link: {done}"
+    );
+    assert!(
+        !done.contains("hx-get"),
+        "terminal fragment must not keep polling (no hx-get): {done}"
+    );
+    assert!(
+        !done.contains("hx-trigger"),
+        "terminal fragment must not keep polling (no hx-trigger): {done}"
+    );
+
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn failed_fragment_shows_user_safe_error_and_stops_polling() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new()
+        .config(test_config())
+        .plugin(TrackedGateJobPlugin)
+        .build();
+
+    let handle = job::enqueue_tracked("tracked_gate_job", json!({"mode": "fail"}))
+        .await
+        .unwrap();
+
+    poll_until(&client, &handle.status_path(), |body| {
+        body["status"] == "running"
+    })
+    .await;
+    RELEASE_GATE.notify_waiters();
+
+    let done = poll_until_html(&client, &handle.status_path(), |body| {
+        body.contains("autumn-job-status__error")
+    })
+    .await;
+    assert!(
+        done.contains("The export could not reach storage."),
+        "expected the user-safe error message: {done}"
+    );
+    assert!(
+        !done.contains("hx-get"),
+        "terminal fragment must not keep polling (no hx-get): {done}"
+    );
+    assert!(
+        !done.contains("hx-trigger"),
+        "terminal fragment must not keep polling (no hx-trigger): {done}"
+    );
 
     job::clear_global_job_client();
 }

--- a/autumn/tests/job_tracking_route.rs
+++ b/autumn/tests/job_tracking_route.rs
@@ -9,8 +9,9 @@ use std::time::Duration;
 
 use autumn_web::app::AppBuilder;
 use autumn_web::config::AutumnConfig;
-use autumn_web::job::{self, JobInfo};
+use autumn_web::job::{self, JobInfo, TrackedJobOwner};
 use autumn_web::plugin::Plugin;
+use autumn_web::session::{MemoryStore, SessionConfig, SessionLayer, SessionStore};
 use autumn_web::test::{TestApp, TestClient};
 use autumn_web::{AppState, AutumnError, AutumnResult};
 use serde_json::{Value, json};
@@ -366,6 +367,211 @@ async fn failed_fragment_shows_user_safe_error_and_stops_polling() {
         !done.contains("hx-trigger"),
         "terminal fragment must not keep polling (no hx-trigger): {done}"
     );
+
+    job::clear_global_job_client();
+}
+
+// ── Owner authorization ───────────────────────────────────────────────────
+
+async fn seed_session(store: &MemoryStore, sid: &str, user_id: Option<&str>) {
+    let mut data = std::collections::HashMap::new();
+    if let Some(user_id) = user_id {
+        data.insert("user_id".to_owned(), user_id.to_owned());
+    }
+    store.save(sid, data).await.unwrap();
+}
+
+fn build_owned_client(store: MemoryStore) -> TestClient {
+    TestApp::new()
+        .config(test_config())
+        .plugin(TrackedGateJobPlugin)
+        .layer(SessionLayer::new(store, SessionConfig::default()))
+        .build()
+}
+
+async fn get_status(client: &TestClient, path: &str, sid: Option<&str>) -> autumn_web::test::TestResponse {
+    let mut request = client.get(path);
+    if let Some(sid) = sid {
+        request = request.header("Cookie", &format!("autumn.sid={sid}"));
+    }
+    request.send().await
+}
+
+#[tokio::test]
+async fn anonymous_token_readable_with_token_alone() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let store = MemoryStore::new();
+    let client = build_owned_client(store.clone());
+
+    // Anonymous handle: no owner binding at all.
+    let handle = job::enqueue_tracked("tracked_gate_job", json!({"mode": "succeed"}))
+        .await
+        .unwrap();
+    RELEASE_GATE.notify_waiters();
+
+    // No cookie whatsoever still reads it.
+    get_status(&client, &handle.status_path(), None)
+        .await
+        .assert_status(200);
+    // An arbitrary session cookie also reads it — the token is the only capability.
+    seed_session(&store, "sess-anyone", None).await;
+    get_status(&client, &handle.status_path(), Some("sess-anyone"))
+        .await
+        .assert_status(200);
+
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn session_bound_token_404_for_other_session() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let store = MemoryStore::new();
+    let client = build_owned_client(store.clone());
+
+    // Seeding the session ID in the store is what makes the middleware trust
+    // the client-supplied cookie value; an unseeded ID is treated as unknown
+    // and gets a freshly minted (different) session id instead.
+    seed_session(&store, "sess-owner", None).await;
+
+    let handle = job::enqueue_tracked_for(
+        "tracked_gate_job",
+        json!({"mode": "succeed"}),
+        TrackedJobOwner::Session("sess-owner".to_owned()),
+    )
+    .await
+    .unwrap();
+    RELEASE_GATE.notify_waiters();
+
+    // The owning session reads it fine.
+    get_status(&client, &handle.status_path(), Some("sess-owner"))
+        .await
+        .assert_status(200);
+
+    // A different session — even an authenticated one — does not.
+    seed_session(&store, "sess-stranger", None).await;
+    get_status(&client, &handle.status_path(), Some("sess-stranger"))
+        .await
+        .assert_status(404);
+
+    // No cookie at all (a fresh anonymous session) does not either.
+    get_status(&client, &handle.status_path(), None)
+        .await
+        .assert_status(404);
+
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn user_bound_token_allowed_across_sessions_of_same_user() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let store = MemoryStore::new();
+    let client = build_owned_client(store.clone());
+
+    let handle = job::enqueue_tracked_for(
+        "tracked_gate_job",
+        json!({"mode": "succeed"}),
+        TrackedJobOwner::User("user-42".to_owned()),
+    )
+    .await
+    .unwrap();
+    RELEASE_GATE.notify_waiters();
+
+    // Two different (unauthenticated) session ids, both logged in as the
+    // same user, both may poll — the binding is to the user, not a session.
+    seed_session(&store, "sess-a", Some("user-42")).await;
+    seed_session(&store, "sess-b", Some("user-42")).await;
+    get_status(&client, &handle.status_path(), Some("sess-a"))
+        .await
+        .assert_status(200);
+    get_status(&client, &handle.status_path(), Some("sess-b"))
+        .await
+        .assert_status(200);
+
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn user_bound_token_404_for_other_user_and_anonymous() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let store = MemoryStore::new();
+    let client = build_owned_client(store.clone());
+
+    let handle = job::enqueue_tracked_for(
+        "tracked_gate_job",
+        json!({"mode": "succeed"}),
+        TrackedJobOwner::User("user-42".to_owned()),
+    )
+    .await
+    .unwrap();
+    RELEASE_GATE.notify_waiters();
+
+    // A different authenticated user is rejected.
+    seed_session(&store, "sess-other-user", Some("user-999")).await;
+    get_status(&client, &handle.status_path(), Some("sess-other-user"))
+        .await
+        .assert_status(404);
+
+    // An anonymous (logged-out) session is rejected.
+    seed_session(&store, "sess-anonymous", None).await;
+    get_status(&client, &handle.status_path(), Some("sess-anonymous"))
+        .await
+        .assert_status(404);
+
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn owner_mismatch_response_is_byte_identical_to_unknown_token() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let store = MemoryStore::new();
+    let client = build_owned_client(store.clone());
+
+    let handle = job::enqueue_tracked_for(
+        "tracked_gate_job",
+        json!({"mode": "succeed"}),
+        TrackedJobOwner::Session("sess-owner".to_owned()),
+    )
+    .await
+    .unwrap();
+    RELEASE_GATE.notify_waiters();
+
+    seed_session(&store, "sess-stranger", None).await;
+    let mismatch = get_status(&client, &handle.status_path(), Some("sess-stranger")).await;
+    let unknown = get_status(&client, "/_autumn/jobs/does-not-exist", Some("sess-stranger")).await;
+
+    assert_eq!(
+        mismatch.header("content-type"),
+        Some("application/problem+json")
+    );
+    assert_eq!(
+        unknown.header("content-type"),
+        Some("application/problem+json")
+    );
+    let mismatch_body: Value = mismatch.json();
+    let unknown_body: Value = unknown.json();
+    mismatch.assert_status(404);
+    unknown.assert_status(404);
+    // Compare only the fields a client actually sees as "the reason" — not
+    // `instance` (which just echoes back the requested path, and naturally
+    // differs since the two requests hit different URLs) or `request_id`
+    // (unique per request by design).
+    for field in ["type", "title", "status", "detail", "code"] {
+        assert_eq!(
+            mismatch_body[field], unknown_body[field],
+            "owner mismatch and unknown-token responses must render an \
+             identical reason for field {field:?}: {mismatch_body} vs {unknown_body}"
+        );
+    }
 
     job::clear_global_job_client();
 }

--- a/autumn/tests/job_tracking_stores_integration.rs
+++ b/autumn/tests/job_tracking_stores_integration.rs
@@ -155,7 +155,10 @@ async fn postgres_backend_persists_tracked_job_and_expires_it() {
         .expect("postgres port");
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
-    let pool = Pool::builder(manager).max_size(4).build().expect("build pool");
+    let pool = Pool::builder(manager)
+        .max_size(4)
+        .build()
+        .expect("build pool");
 
     {
         let mut conn = pool.get().await.expect("get connection");

--- a/autumn/tests/job_tracking_stores_integration.rs
+++ b/autumn/tests/job_tracking_stores_integration.rs
@@ -59,10 +59,18 @@ async fn redis_backend_persists_tracked_job_and_expires_it() {
         .expect("redis port");
     let redis_url = format!("redis://127.0.0.1:{port}");
 
-    let mut config = JobConfig::default();
-    config.backend = "redis".to_owned();
-    config.redis.url = Some(redis_url.clone());
-    config.tracking.ttl_secs = 1;
+    let config = JobConfig {
+        backend: "redis".to_owned(),
+        redis: autumn_web::config::JobRedisConfig {
+            url: Some(redis_url.clone()),
+            ..Default::default()
+        },
+        tracking: autumn_web::config::JobTrackingConfig {
+            ttl_secs: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
 
     let state = AppState::for_test().with_profile("dev");
     let shutdown = tokio_util::sync::CancellationToken::new();
@@ -163,9 +171,14 @@ async fn postgres_backend_persists_tracked_job_and_expires_it() {
             .expect("apply create_job_tracking migration");
     }
 
-    let mut config = JobConfig::default();
-    config.backend = "postgres".to_owned();
-    config.tracking.ttl_secs = 1;
+    let config = JobConfig {
+        backend: "postgres".to_owned(),
+        tracking: autumn_web::config::JobTrackingConfig {
+            ttl_secs: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
 
     let state = AppState::for_test()
         .with_profile("dev")

--- a/autumn/tests/job_tracking_stores_integration.rs
+++ b/autumn/tests/job_tracking_stores_integration.rs
@@ -1,0 +1,209 @@
+//! Docker-gated integration tests for the Redis/Postgres tracked-job stores
+//! (issue #1373): prove `enqueue_tracked` actually persists through the
+//! backend selected by `jobs.backend`, not silently through the in-memory
+//! fallback, and that the configured TTL expires records on each backend.
+//!
+//! Both tests require Docker and are marked `#[ignore]`. Run them explicitly
+//! with:
+//!
+//! ```text
+//! cargo test -p autumn-web --features redis,db --test job_tracking_stores_integration -- --ignored
+//! ```
+
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use autumn_web::config::JobConfig;
+use autumn_web::job::{self, JobInfo};
+use autumn_web::{AppState, AutumnResult};
+use serde_json::Value;
+
+fn noop_handler(
+    _state: AppState,
+    _payload: Value,
+) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>> {
+    Box::pin(async move { Ok(()) })
+}
+
+fn noop_job_info() -> JobInfo {
+    JobInfo {
+        name: "noop".to_string(),
+        max_attempts: 1,
+        initial_backoff_ms: 1,
+        queue: "default".to_string(),
+        uniqueness: None,
+        concurrency: None,
+        handler: noop_handler,
+    }
+}
+
+#[cfg(feature = "redis")]
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn redis_backend_persists_tracked_job_and_expires_it() {
+    use redis::AsyncCommands as _;
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::redis::Redis as RedisImage;
+
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let container = RedisImage::default()
+        .start()
+        .await
+        .expect("start Redis container");
+    let port = container
+        .get_host_port_ipv4(6379)
+        .await
+        .expect("redis port");
+    let redis_url = format!("redis://127.0.0.1:{port}");
+
+    let mut config = JobConfig::default();
+    config.backend = "redis".to_owned();
+    config.redis.url = Some(redis_url.clone());
+    config.tracking.ttl_secs = 1;
+
+    let state = AppState::for_test().with_profile("dev");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    job::start_runtime(vec![noop_job_info()], &state, &shutdown, &config)
+        .expect("start redis-backed job runtime");
+
+    let handle = job::enqueue_tracked("noop", serde_json::json!({}))
+        .await
+        .expect("enqueue_tracked");
+
+    // Query Redis directly, bypassing the JobTrackingStore abstraction, to
+    // prove the config-selected backend really is Redis — not the in-memory
+    // fallback, which would leave nothing here to find.
+    let client = redis::Client::open(redis_url.clone()).expect("open redis client");
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("connect to redis");
+    let key = format!(
+        "{}:tracking:{}",
+        config.redis.key_prefix,
+        autumn_web::auth::hash_api_token(&handle.token)
+    );
+
+    let payload: String = conn
+        .get(&key)
+        .await
+        .expect("tracked record should be persisted in redis");
+    let record: Value = serde_json::from_str(&payload).expect("stored record is valid JSON");
+    assert!(
+        record["status"].is_string(),
+        "expected a status field: {record}"
+    );
+
+    // The 1s TTL configured above (rather than the 86400s default) should
+    // expire the key via Redis's own EX mechanism.
+    tokio::time::sleep(Duration::from_millis(1_200)).await;
+    let exists: bool = conn.exists(&key).await.expect("check key existence");
+    assert!(!exists, "tracked record should have expired via redis TTL");
+
+    shutdown.cancel();
+    job::clear_global_job_client();
+}
+
+#[cfg(feature = "db")]
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn postgres_backend_persists_tracked_job_and_expires_it() {
+    use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+    use diesel_async::pooled_connection::deadpool::Pool;
+    use diesel_async::{AsyncPgConnection, RunQueryDsl};
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::postgres::Postgres;
+
+    const CREATE_AUTUMN_JOBS: &str =
+        include_str!("../migrations/20260513000000_create_job_queue/up.sql");
+    const CREATE_JOB_TRACKING: &str =
+        include_str!("../migrations/20260702000000_create_job_tracking/up.sql");
+
+    #[derive(diesel::QueryableByName)]
+    struct RecordRow {
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        record: String,
+    }
+
+    #[derive(diesel::QueryableByName)]
+    struct ExpiredRow {
+        #[diesel(sql_type = diesel::sql_types::Bool)]
+        expired: bool,
+    }
+
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("start Postgres container");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("postgres port");
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
+    let pool = Pool::builder(manager).max_size(4).build().expect("build pool");
+
+    {
+        let mut conn = pool.get().await.expect("get connection");
+        diesel::sql_query(CREATE_AUTUMN_JOBS)
+            .execute(&mut *conn)
+            .await
+            .expect("apply create_job_queue migration");
+        // Proves the migration in this PR actually creates the table the
+        // store depends on — not just that hand-written SQL happens to work.
+        diesel::sql_query(CREATE_JOB_TRACKING)
+            .execute(&mut *conn)
+            .await
+            .expect("apply create_job_tracking migration");
+    }
+
+    let mut config = JobConfig::default();
+    config.backend = "postgres".to_owned();
+    config.tracking.ttl_secs = 1;
+
+    let state = AppState::for_test()
+        .with_profile("dev")
+        .with_pool(pool.clone());
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    job::start_runtime(vec![noop_job_info()], &state, &shutdown, &config)
+        .expect("start postgres-backed job runtime");
+
+    let handle = job::enqueue_tracked("noop", serde_json::json!({}))
+        .await
+        .expect("enqueue_tracked");
+
+    let key = autumn_web::auth::hash_api_token(&handle.token);
+    let mut conn = pool.get().await.expect("get connection");
+    let row = diesel::sql_query("SELECT record FROM autumn_job_tracking WHERE key = $1")
+        .bind::<diesel::sql_types::Text, _>(&key)
+        .get_result::<RecordRow>(&mut *conn)
+        .await
+        .expect("tracked record should be persisted in postgres");
+    let record: Value = serde_json::from_str(&row.record).expect("stored record is valid JSON");
+    assert!(
+        record["status"].is_string(),
+        "expected a status field: {record}"
+    );
+
+    // The 1s TTL configured above should push expires_at into the past;
+    // lazy expiry means the row itself isn't deleted, only ignored on read.
+    tokio::time::sleep(Duration::from_millis(1_200)).await;
+    let expired = diesel::sql_query(
+        "SELECT (expires_at <= NOW()) AS expired FROM autumn_job_tracking WHERE key = $1",
+    )
+    .bind::<diesel::sql_types::Text, _>(&key)
+    .get_result::<ExpiredRow>(&mut *conn)
+    .await
+    .expect("row should still exist")
+    .expired;
+    assert!(expired, "record should be past its configured TTL");
+
+    shutdown.cancel();
+    job::clear_global_job_client();
+}

--- a/docs/guide/jobs.md
+++ b/docs/guide/jobs.md
@@ -499,6 +499,21 @@ The browser gets a progress bar within milliseconds and a download link the
 moment the job finishes — no hand-written status table, token, or polling
 endpoint anywhere in app code.
 
+### Known limitation: tracked status vs. the durable queue record
+
+On the Redis and Postgres backends, a job's tracked status (`succeeded`/
+`failed`) is settled *before* that backend's own success/dead-letter
+acknowledgement is written. In the rare case where that ack later fails or
+is skipped (e.g. the claim changed because another worker recovered it as
+stale in between), the tracked status can briefly report a terminal state
+the durable queue record hasn't actually reached — a poller may stop
+watching a moment before the durable backend finishes catching up, which it
+does automatically on its own retry/recovery path. This window only opens
+on an ack failure, not on ordinary success/failure/retry. Treat the tracked
+status as a progress/UX signal for the caller, not as the source of truth
+for whether a job will run again — use the admin dashboard
+([Observability](#observability)) or `JobAdminBackend` for that.
+
 ## Observability
 
 Mount `autumn-admin-plugin` to get the built-in operator dashboard at

--- a/docs/guide/jobs.md
+++ b/docs/guide/jobs.md
@@ -514,6 +514,28 @@ status as a progress/UX signal for the caller, not as the source of truth
 for whether a job will run again — use the admin dashboard
 ([Observability](#observability)) or `JobAdminBackend` for that.
 
+### Known limitation: stale progress writes on the Redis/Postgres stores
+
+`mark_running`/`set_progress` intentionally no-op once a tracked record is
+already terminal, so a stray write from an abandoned attempt can't overwrite
+a legitimate final result — but on the Redis and Postgres tracking stores
+that guard is evaluated against the value read at the *start* of that write
+(read the record, decide, write it back), not atomically at write time. If a
+worker's claim times out and it keeps running past that point while a
+replacement worker claims and completes the same job, the original worker's
+next progress write can land *after* the replacement's terminal write and
+briefly clobber it, because its in-memory guard was evaluated against the
+`running` record it read before the replacement settled. The record
+self-corrects on the next terminal write (the replacement's own retry
+path settles it, or TTL expiry clears it), so this is a transient display
+glitch, not a lost result — the queue's own durable state (visible via the
+admin dashboard) is never affected. Closing this fully means moving the
+terminal-status guard into the durable write itself (a Lua script for
+Redis, a conditional `UPDATE` for Postgres — the same compare-and-swap
+approach `JobTrackingStore::reset_for_retry` already uses to make an
+operator retry race-safe); tracked as a follow-up rather than folded into
+this change.
+
 ## Observability
 
 Mount `autumn-admin-plugin` to get the built-in operator dashboard at

--- a/docs/guide/jobs.md
+++ b/docs/guide/jobs.md
@@ -327,6 +327,171 @@ Semantics:
   adds the nullable `unique_key`/`unique_window`/`concurrency_key`/
   `concurrency_limit` columns; rows and jobs without them behave as before.
 
+## Tracked jobs and progress polling
+
+Plain `enqueue` is fire-and-forget — there's no handle, no progress, and
+nowhere for the caller to check "is it done yet?". `enqueue_tracked` fixes
+that: it returns a handle carrying a public, unguessable token, distinct
+from the internal job id, that the browser can poll at a built-in status
+route while the job reports progress from the inside.
+
+### Enqueue a tracked job
+
+```rust,ignore
+let handle = ExportOrdersJob::enqueue_tracked(ExportArgs { account_id: 42 }).await?;
+// handle.token is the raw, unguessable token — deliver it to the caller.
+// handle.status_path() is "/_autumn/jobs/{token}".
+```
+
+By default the token is an **anonymous capability**: anyone holding it can
+poll the status. To bind status access to the caller's session/user instead,
+use `enqueue_tracked_for` with an owner derived from the current session:
+
+```rust,ignore
+use autumn_web::job::TrackedJobOwner;
+
+let owner = TrackedJobOwner::from_session(&session, &state).await;
+let handle = ExportOrdersJob::enqueue_tracked_for(args, owner).await?;
+```
+
+A request whose session doesn't match the bound owner gets the identical
+`404` an unknown token would — the route is never an existence/ownership
+oracle.
+
+### Report progress from inside the handler
+
+Add a third `JobContext` argument to a `#[job]` handler to opt into
+progress reporting; the two-argument form keeps working unchanged:
+
+```rust,ignore
+#[job(name = "export_orders")]
+async fn export_orders(
+    state: AppState,
+    args: ExportArgs,
+    ctx: JobContext,
+) -> AutumnResult<()> {
+    ctx.set_progress(0, Some("Starting export")).await?;
+
+    // ... do the work, reporting progress as it goes ...
+    ctx.set_progress(50, Some("Rows 2500/5000")).await?;
+
+    // On success, the JSON result is whatever the caller wants back —
+    // e.g. a link to the finished file.
+    ctx.set_result(serde_json::json!({ "download_url": "/blob/orders-42.csv" }));
+    Ok(())
+}
+```
+
+If the handler returns `Err`, the job retries as usual (`max_attempts`,
+backoff); only the **final** failed attempt (or a panic, which always
+dead-letters) settles the tracked record to `failed`. Call
+`ctx.set_user_error("...")` before returning `Err` to control the message
+shown to the caller — otherwise a generic "The job failed." is recorded (the
+raw error is never leaked to the tracked-status response).
+
+### Poll the status
+
+`GET /_autumn/jobs/{token}` (mounted automatically; disable with
+`jobs.tracking.route_enabled = false`) is content-negotiated:
+
+- **API clients** (no `Accept: text/html`, no `HX-Request`) get JSON:
+
+  ```json
+  {"status": "running", "progress": 50, "message": "Rows 2500/5000", "result": null, "error": null}
+  ```
+
+- **htmx requests** (`HX-Request: true`) or a browser `Accept: text/html`
+  get a self-polling fragment. While the job is pending/running, the
+  fragment carries `hx-get={path} hx-trigger="every 2s" hx-swap="outerHTML"`,
+  so it keeps re-fetching and replacing itself with zero app-authored JS.
+  Once the job reaches a terminal state, the fragment drops every `hx-*`
+  attribute — htmx has nothing left to poll — and renders either a download
+  link (when the result carries a `download_url`) or the failure message.
+
+Embed the poll target directly in a page:
+
+```rust,ignore
+html! {
+    div hx-get=(handle.status_path()) hx-trigger="load" hx-swap="outerHTML" {
+        "Starting export…"
+    }
+}
+```
+
+### Result store TTL and backends
+
+Progress/result records expire `jobs.tracking.ttl_secs` after their last
+write (default `86400`, 24h). The record store follows whichever job
+backend is configured — `local` and `redis` use an in-memory or Redis-backed
+store respectively, `postgres` uses the `autumn_job_tracking` table (see
+[Migration notes](#migration-notes)) — so a tracked job's status composes
+with the backend an app already runs, with no extra setup.
+
+### Async CSV export, end to end
+
+The synchronous `GET /{plural}/export.csv` admin route runs inline on the
+request thread — fine for small tables, but a 50k-row export blocks the
+worker and risks tripping a proxy idle timeout. A tracked job moves that
+work off the request thread:
+
+```rust,ignore
+use autumn_web::data::csv::export_csv;
+use autumn_web::prelude::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExportOrdersArgs {
+    pub account_id: i64,
+}
+
+#[job(name = "export_orders")]
+async fn export_orders(
+    state: AppState,
+    args: ExportOrdersArgs,
+    ctx: JobContext,
+) -> AutumnResult<()> {
+    let repo = OrderRepository::from_state(&state);
+    let orders = repo.for_account(args.account_id).await?;
+
+    let total = orders.len();
+    let mut buffer = Vec::new();
+    for (i, chunk) in orders.chunks(500).enumerate() {
+        export_csv(chunk.iter().cloned(), &mut buffer)?;
+        let done = (i + 1) * 500.min(total);
+        ctx.set_progress(
+            u8::try_from(done * 100 / total.max(1)).unwrap_or(100),
+            Some(&format!("Rows {done}/{total}")),
+        )
+        .await?;
+    }
+
+    let url = state.storage().put("exports/orders.csv", buffer).await?;
+    ctx.set_result(serde_json::json!({ "download_url": url }));
+    Ok(())
+}
+
+// Kick it off from a request handler and hand back a poll target — the
+// initiating request returns immediately instead of blocking on the export.
+#[post("/orders/export")]
+async fn start_export(state: AppState, session: Session) -> AutumnResult<Markup> {
+    let owner = TrackedJobOwner::from_session(&session, &state).await;
+    let handle = ExportOrdersJob::enqueue_tracked_for(
+        ExportOrdersArgs { account_id: 1 },
+        owner,
+    )
+    .await?;
+
+    Ok(html! {
+        div hx-get=(handle.status_path()) hx-trigger="load" hx-swap="outerHTML" {
+            "Export starting…"
+        }
+    })
+}
+```
+
+The browser gets a progress bar within milliseconds and a download link the
+moment the job finishes — no hand-written status table, token, or polling
+endpoint anywhere in app code.
+
 ## Observability
 
 Mount `autumn-admin-plugin` to get the built-in operator dashboard at
@@ -361,11 +526,14 @@ workers start. Run your app migrations as a one-shot `autumn migrate` job before
 scaling web and worker replicas:
 
 ```bash
-autumn migrate   # creates autumn_jobs, your domain tables, etc.
+autumn migrate   # creates autumn_jobs, autumn_job_tracking, your domain tables, etc.
 ```
 
 The migration is bundled with the framework and is applied automatically by
-`autumn migrate` as long as the `db` feature is enabled.
+`autumn migrate` as long as the `db` feature is enabled. `enqueue_tracked`
+works the same way regardless of `jobs.backend` — the framework migration
+also creates `autumn_job_tracking`, the table the Postgres-backed tracking
+store uses (see [Tracked jobs and progress polling](#tracked-jobs-and-progress-polling)).
 
 ---
 

--- a/docs/guide/jobs.md
+++ b/docs/guide/jobs.md
@@ -542,6 +542,40 @@ approach `JobTrackingStore::reset_for_retry` already uses to make an
 operator retry race-safe); tracked as a follow-up rather than folded into
 this change.
 
+### Known limitation: a `JobInterceptor` erroring after `next` still settles the tracked record as failed
+
+`enqueue_tracked`/`enqueue_tracked_for` treat any `Err` from the enqueue call
+as "never delivered" and settle the tracked record to `failed`. If an app
+installs a `JobInterceptor` whose `intercept_enqueue`
+successfully awaits `next` (so the job *was* delivered to the backend) and
+then its own post-`next` logic returns an error — e.g. an audit-log call
+that fails — that error is indistinguishable, from this call site alone,
+from a delivery failure: the tracked record settles to `failed` and the
+caller sees an error even though the job will still run. A caller that
+retries on that error risks enqueueing a duplicate. Closing this requires
+`JobClient::enqueue_with_outcome` to expose whether the backend write
+actually happened on its error path too (it currently tracks this
+internally via a `started` flag but only uses it to select the `Ok`
+variant), which is a signature change shared by every enqueue path — plain
+`enqueue()` has the identical gap for the same reason — not just the
+tracked ones; tracked as a follow-up. In the meantime, avoid returning an
+error from `intercept_enqueue` after `next` has resolved successfully.
+
+### Known limitation: the built-in job-status route can collide with a user route
+
+`GET /_autumn/jobs/{token}` mounts by default (`jobs.tracking.route_enabled
+= true`) for every app that registers jobs, merged after user routes are
+already mounted. If an app happens to define its own route at that exact
+path, `try_build_router_inner` panics on the resulting Axum overlapping-route
+error at startup rather than surfacing a typed, recoverable collision error
+(the framework's other reserved-but-default-on routes — the mail
+unsubscribe endpoint, mail previews — have the same gap). `/_autumn/` is a
+framework-reserved path prefix, so this should not come up in practice;
+set `jobs.tracking.route_enabled = false` if a conflict is ever hit.
+Building a general framework-route-vs-user-route collision preflight
+(mirroring the existing OpenAPI/MCP-vs-everything check) is a broader
+router-building change than this PR's scope; tracked as a follow-up.
+
 ## Observability
 
 Mount `autumn-admin-plugin` to get the built-in operator dashboard at

--- a/docs/guide/jobs.md
+++ b/docs/guide/jobs.md
@@ -432,7 +432,12 @@ write (default `86400`, 24h). The record store follows whichever job
 backend is configured — `local` and `redis` use an in-memory or Redis-backed
 store respectively, `postgres` uses the `autumn_job_tracking` table (see
 [Migration notes](#migration-notes)) — so a tracked job's status composes
-with the backend an app already runs, with no extra setup.
+with the backend an app already runs, with no extra setup. Expired records
+are invisible to reads/writes immediately (both the Redis and Postgres
+stores filter on expiry); on Postgres, a background sweep also runs every
+5 minutes to `DELETE` expired rows so `autumn_job_tracking` doesn't grow
+unbounded (Redis expires keys natively via `EX`, so it needs no equivalent
+sweep).
 
 ### Async CSV export, end to end
 

--- a/docs/guide/jobs.md
+++ b/docs/guide/jobs.md
@@ -358,6 +358,13 @@ A request whose session doesn't match the bound owner gets the identical
 `404` an unknown token would — the route is never an existence/ownership
 oracle.
 
+`enqueue_tracked`/`enqueue_tracked_for` wrap your `Args` in an internal
+envelope under a reserved top-level field named `__autumn_tracked`. Don't
+give a job's `Args` struct a field with that exact name — `enqueue`/
+`enqueue_in`/`enqueue_at` and their `on_conn` variants reject a payload
+shaped that way with a `400` rather than risk it being misread as a tracked
+envelope.
+
 ### Report progress from inside the handler
 
 Add a third `JobContext` argument to a `#[job]` handler to opt into
@@ -456,7 +463,7 @@ async fn export_orders(
     let mut buffer = Vec::new();
     for (i, chunk) in orders.chunks(500).enumerate() {
         export_csv(chunk.iter().cloned(), &mut buffer)?;
-        let done = (i + 1) * 500.min(total);
+        let done = ((i + 1) * 500).min(total);
         ctx.set_progress(
             u8::try_from(done * 100 / total.max(1)).unwrap_or(100),
             Some(&format!("Rows {done}/{total}")),

--- a/docs/guide/jobs.md
+++ b/docs/guide/jobs.md
@@ -433,11 +433,12 @@ backend is configured — `local` and `redis` use an in-memory or Redis-backed
 store respectively, `postgres` uses the `autumn_job_tracking` table (see
 [Migration notes](#migration-notes)) — so a tracked job's status composes
 with the backend an app already runs, with no extra setup. Expired records
-are invisible to reads/writes immediately (both the Redis and Postgres
-stores filter on expiry); on Postgres, a background sweep also runs every
-5 minutes to `DELETE` expired rows so `autumn_job_tracking` doesn't grow
-unbounded (Redis expires keys natively via `EX`, so it needs no equivalent
-sweep).
+are invisible to reads/writes immediately on all three stores; each also
+actually frees the expired record so long-running processes don't
+accumulate one dead entry per tracked job forever: the in-memory store
+sweeps them out opportunistically (amortized across `create` calls), a
+Postgres background sweep runs every 5 minutes to `DELETE` expired rows,
+and Redis expires keys natively via `EX`.
 
 ### Async CSV export, end to end
 

--- a/examples/todo-app/Cargo.toml
+++ b/examples/todo-app/Cargo.toml
@@ -15,7 +15,8 @@ path = "src/bin/seed.rs"
 system-tests = ["autumn-web/system-tests"]
 
 [dependencies]
-autumn-web = { path = "../../autumn", features = ["seed", "mcp"] }
+autumn-web = { path = "../../autumn", features = ["seed", "mcp", "csv"] }
+base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 http = "1"

--- a/examples/todo-app/src/jobs.rs
+++ b/examples/todo-app/src/jobs.rs
@@ -1,0 +1,59 @@
+//! Async CSV export as a tracked background job (issue #1373).
+//!
+//! Demonstrates the enqueue → progress → download-link flow end to end: the
+//! initiating request returns immediately with a poll token instead of
+//! blocking on the export, and the browser polls `handle.status_path()` for
+//! progress and the final result.
+
+use autumn_web::data::csv::export_csv;
+use autumn_web::job::JobContext;
+use autumn_web::prelude::*;
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+
+use crate::models::Todo;
+
+/// No input needed today — the export always covers every todo. A real app
+/// might carry a filter here (e.g. a date range or `completed` flag).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExportTodosArgs {}
+
+/// Stream every todo to CSV off the request thread, reporting progress and
+/// handing back a downloadable link when done.
+///
+/// Real apps typically upload the CSV to blob storage (see the `storage`
+/// feature) and set `download_url` to a presigned link; this example embeds
+/// the CSV directly as a `data:` URL so the demo needs no extra
+/// infrastructure to run.
+#[job(name = "export_todos_csv")]
+pub async fn export_todos_csv(
+    state: AppState,
+    _args: ExportTodosArgs,
+    ctx: JobContext,
+) -> AutumnResult<()> {
+    ctx.set_progress(0, Some("Loading todos")).await?;
+
+    let pool = state
+        .pool()
+        .ok_or_else(|| AutumnError::internal_server_error_msg("database not configured"))?;
+    let mut conn = pool.get().await.map_err(|error| {
+        AutumnError::internal_server_error_msg(format!("database pool error: {error}"))
+    })?;
+    let todos = Todo::all(&mut conn).await?;
+
+    ctx.set_progress(50, Some(&format!("Encoding {} todos", todos.len())))
+        .await?;
+
+    let mut csv = Vec::new();
+    export_csv(todos, &mut csv).map_err(|error| {
+        AutumnError::internal_server_error_msg(format!("csv export failed: {error}"))
+    })?;
+    let download_url = format!(
+        "data:text/csv;base64,{}",
+        base64::engine::general_purpose::STANDARD.encode(&csv)
+    );
+
+    ctx.set_progress(100, Some("Done")).await?;
+    ctx.set_result(serde_json::json!({ "download_url": download_url }));
+    Ok(())
+}

--- a/examples/todo-app/src/main.rs
+++ b/examples/todo-app/src/main.rs
@@ -1,3 +1,4 @@
+mod jobs;
 mod models;
 mod routes;
 mod schema;
@@ -8,7 +9,7 @@ use std::sync::{Arc, OnceLock};
 
 use autumn_web::auth::{API_TOKEN_MIGRATIONS, ApiTokenStore, DbApiTokenStore, RequireApiToken};
 use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
-use autumn_web::{AutumnResult, routes};
+use autumn_web::{AutumnResult, jobs, routes};
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
@@ -95,8 +96,12 @@ async fn main() {
             routes::todos::validate_title,
             routes::todos::toggle,
             routes::todos::delete_todo,
+            routes::todos::start_export,
             routes::api::issue_token,
         ])
+        // Tracked background job powering the async CSV export (#1373):
+        // enqueue_tracked -> ctx.set_progress -> a polled download link.
+        .jobs(jobs![jobs::export_todos_csv])
         // Bearer-token-protected JSON API under `/api`. Using `.scoped(...)`
         // (rather than a merged raw router) keeps these routes in the route
         // registry, so their `#[api_doc(mcp)]` tags project them as MCP tools

--- a/examples/todo-app/src/models.rs
+++ b/examples/todo-app/src/models.rs
@@ -55,6 +55,21 @@ impl Todo {
     }
 }
 
+impl autumn_web::data::csv::CsvSchema for Todo {
+    fn csv_columns() -> &'static [&'static str] {
+        &["id", "title", "completed", "created_at"]
+    }
+
+    fn to_csv_record(&self) -> Vec<String> {
+        vec![
+            self.id.to_string(),
+            self.title.clone(),
+            self.completed.to_string(),
+            self.created_at.to_string(),
+        ]
+    }
+}
+
 /// Data needed to insert a new todo.
 ///
 /// Derives [`Validate`] so it can be used directly with

--- a/examples/todo-app/src/routes/todos.rs
+++ b/examples/todo-app/src/routes/todos.rs
@@ -264,7 +264,15 @@ fn todo_count_badge(total: i64, done: i64) -> Markup {
                     }
                 }
             }
+            button
+                hx-post=(paths::start_export())
+                hx-target="#export-status"
+                hx-swap="outerHTML"
+                class="text-xs text-amber-700 hover:text-amber-900 underline" {
+                "Export CSV"
+            }
         }
+        div id="export-status" {}
     }
 }
 
@@ -464,6 +472,31 @@ pub async fn create(db: Db, form: ChangesetForm<TodoForm>) -> AutumnResult<impl 
     }
 }
 
+/// Kick off an async CSV export (issue #1373) and hand back an htmx fragment
+/// that polls the built-in tracked-job status route for progress and the
+/// eventual download link. The request itself returns immediately — the
+/// export runs as a background job instead of blocking this thread.
+#[post("/todos/export")]
+pub async fn start_export() -> AutumnResult<Markup> {
+    let handle =
+        crate::jobs::ExportTodosCsvJob::enqueue_tracked(crate::jobs::ExportTodosArgs {}).await?;
+    Ok(export_status_fragment(&handle.status_path()))
+}
+
+/// The self-polling fragment embedded by [`start_export`] and re-rendered by
+/// the built-in `GET /_autumn/jobs/{token}` route on every 2s poll.
+fn export_status_fragment(poll_path: &str) -> Markup {
+    html! {
+        div id="export-status"
+            hx-get=(poll_path)
+            hx-trigger="load"
+            hx-swap="outerHTML"
+            class="text-xs text-stone-400 mt-1" {
+            "Preparing export…"
+        }
+    }
+}
+
 fn page_request_from_hx(hx: &HxRequest) -> PageRequest {
     if let Some(parsed_url) = hx
         .current_url
@@ -560,7 +593,8 @@ autumn_web::paths![
     create,
     validate_title,
     toggle,
-    delete_todo
+    delete_todo,
+    start_export
 ];
 
 #[cfg(test)]
@@ -576,6 +610,15 @@ mod tests {
         assert_eq!(paths::toggle(7), "/todos/7/toggle");
         assert_eq!(paths::delete_todo(3), "/todos/3");
         assert_eq!(paths::create(), "/todos");
+        assert_eq!(paths::start_export(), "/todos/export");
+    }
+
+    #[test]
+    fn export_status_fragment_polls_the_tracked_job_status_route() {
+        let html = export_status_fragment("/_autumn/jobs/abc123").into_string();
+        assert!(html.contains(r#"hx-get="/_autumn/jobs/abc123""#), "{html}");
+        assert!(html.contains(r#"hx-trigger="load""#), "{html}");
+        assert!(html.contains(r#"hx-swap="outerHTML""#), "{html}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements tracked job handles that enable progress reporting and status polling for background jobs. This allows callers to receive an unguessable token immediately upon enqueueing a job, then poll a built-in status route to monitor progress and retrieve results—without blocking on job completion.

## Key Changes

- **New `job_tracking` module** (`autumn/src/job_tracking.rs`): Core implementation of tracked job infrastructure including:
  - `TrackedJobHandle`: Public handle returned to callers with an unguessable token and status path
  - `JobContext`: Ambient context allowing handlers to report progress via `set_progress()`, record results via `set_result()`, and set user-safe errors via `set_user_error()`
  - `JobTrackingStore` trait: Pluggable backend for persisting job status (implemented for in-memory, Redis, and Postgres)
  - `TrackedJobOwner`: Access control binding (anonymous, session-bound, or user-bound)
  - Payload envelope wrapping/unwrapping to carry tracking keys through the job queue

- **Job handler signature extension**: `#[job]` macro now accepts optional third `JobContext` parameter for progress reporting, while maintaining backward compatibility with two-argument handlers

- **Job execution integration**: Modified `run_job_handler()` to:
  - Unwrap tracked job envelopes before handler execution
  - Make `JobContext` ambient via task-local storage
  - Settle tracking records to terminal states (success/failure) based on execution outcome and retry eligibility

- **Built-in status route** (`GET /_autumn/jobs/{token}`): 
  - Returns JSON status with progress percentage, message, result, and error
  - Returns HTML fragment with htmx polling directives when requested via `HX-Request` header
  - Respects `TrackedJobOwner` access control
  - Configurable via `jobs.tracking.route_enabled`

- **Configuration**: New `JobTrackingConfig` with:
  - `ttl_secs`: TTL for persisted status records (default 24 hours)
  - `route_enabled`: Toggle for built-in status route (default true)

- **Backend implementations**:
  - In-memory store with configurable TTL (default fallback)
  - Redis store with key prefixing and expiration
  - Postgres store with `autumn_job_tracking` table and TTL-based cleanup

- **API additions**:
  - `enqueue_tracked(name, args)`: Enqueue with anonymous access
  - `enqueue_tracked_for(name, args, owner)`: Enqueue with owner binding
  - `TrackedJobOwner::from_session()`: Derive owner from current session/user

- **Safety mechanisms**:
  - Reserved `__autumn_tracked` envelope marker rejected by plain `enqueue()` to prevent accidental misinterpretation
  - Token hashing ensures leaked payloads/admin records never expose raw polling capability
  - Payload unwrapping at single choke point ensures handlers always see original args
  - Uniqueness/concurrency/identity extraction operates on unwrapped payload

- **Documentation**: Updated job guide with tracked job usage patterns, progress reporting, and result retrieval

- **Tests**: 
  - Integration tests for status route JSON/HTML responses, progress tracking, and access control
  - Docker-gated tests for Redis/Postgres backend persistence and TTL expiration
  - Compile-pass test for three-argument job handler signature

## Notable Implementation Details

- Tracked job state transitions are centralized in `apply_*` functions to ensure all three backends (in-memory, Redis, Postgres) implement identical semantics
- Progress persists across retry attempts; only panics and final failures settle to terminal states
- The `final_attempt` flag is computed once before execution and shared with `run_job_handler()` to prevent drift between retry decisions and tracking state settlement
- Task-local storage (`CURRENT_JOB_CONTEXT`) makes `JobContext::current()` work transparently across `.await` points without explicit parameter threading
- Global fallback store enables `enqueue_tracked` to work without `AppState` (mirroring `enqueue` behavior)

https://claude.ai/code/session_01E1y1LNyZ4zwR4oEsZnENGX