### PR TITLE
Add nav_bar widget for accessible top/sidebar navigation

### DIFF
--- a/autumn-admin-plugin/src/registry.rs
+++ b/autumn-admin-plugin/src/registry.rs
@@ -89,14 +89,19 @@ impl AdminRegistry {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use crate::traits::*;
     use serde_json::Value;
 
-    struct DummyModel {
-        slug: &'static str,
-        name: &'static str,
+    /// Minimal no-op [`AdminModel`] fixture shared by `registry`'s and
+    /// `templates`'s test suites — reused rather than duplicated so its
+    /// mock behavior can't silently drift between them. `pub` (not
+    /// `pub(crate)`) because `registry` itself is a private module, so
+    /// this is already crate-scoped in effect.
+    pub struct DummyModel {
+        pub slug: &'static str,
+        pub name: &'static str,
     }
 
     impl AdminModel for DummyModel {

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -129,6 +129,12 @@ const ADMIN_CSS: &str = "
         padding: 1rem 1.5rem 0.375rem;
         font-weight: 600;
     }
+    /* The sidebar hides itself entirely below 768px (see the .admin-sidebar
+       rule in the Responsive section) instead of collapsing behind nav_bar's
+       own hamburger toggle, so the toggle stays hidden at every width. */
+    .admin-sidebar .autumn-nav__toggle {
+        display: none;
+    }
 
     /* Cards */
     .card {
@@ -433,16 +439,16 @@ pub fn admin_layout(
     if registry.model_count() > 0 {
         nav_items.push(NavItem::section("Models"));
         nav_items.extend(registry.iter().map(|(slug, model)| {
-            NavItem::link(&format!("{prefix}/{slug}"), model.display_name_plural())
+            NavItem::link(format!("{prefix}/{slug}"), model.display_name_plural())
         }));
     }
     nav_items.push(NavItem::section("System"));
-    nav_items.push(NavItem::link(&jobs_href, "Jobs"));
+    nav_items.push(NavItem::link(jobs_href, "Jobs"));
     if show_config {
-        nav_items.push(NavItem::link(&config_href, "Runtime Config"));
+        nav_items.push(NavItem::link(config_href, "Runtime Config"));
     }
     nav_items.push(NavItem::plain_link(
-        &format!("{actuator_prefix}/ui"),
+        format!("{actuator_prefix}/ui"),
         "Actuator",
     ));
     let sidebar_nav = NavBarConfig::new()
@@ -467,6 +473,11 @@ pub fn admin_layout(
                 title { (title) " — Autumn Admin" }
                 script src=(HTMX_JS_PATH) {}
                 script src=(HTMX_CSRF_JS_PATH) {}
+                // Reveals/wires up nav_bar's hamburger toggle and any future
+                // dropdown menu; the sidebar itself stays fully visible/hidden
+                // via the .admin-sidebar media-query rule below, not the
+                // toggle, so its own toggle button is kept CSS-hidden always.
+                script src=(autumn_web::htmx::AUTUMN_WIDGETS_JS_PATH) defer {}
                 // External so it runs under the default CSP `script-src 'self'`.
                 script src={ (prefix) (&**ADMIN_JS_PATH) } {}
                 style {
@@ -3971,78 +3982,7 @@ mod tests {
 
     // ── admin_layout nav_bar (#1137) ──────────────────────────────────────
 
-    struct DummyModel {
-        slug: &'static str,
-        name: &'static str,
-    }
-
-    impl crate::traits::AdminModel for DummyModel {
-        fn slug(&self) -> &'static str {
-            self.slug
-        }
-        fn display_name(&self) -> &'static str {
-            self.name
-        }
-        fn display_name_plural(&self) -> &'static str {
-            self.name
-        }
-        fn fields(&self) -> Vec<AdminField> {
-            vec![]
-        }
-        fn list(
-            &self,
-            _pool: &diesel_async::pooled_connection::deadpool::Pool<
-                diesel_async::AsyncPgConnection,
-            >,
-            _params: crate::traits::ListParams,
-        ) -> crate::traits::AdminFuture<'_, ListResult> {
-            Box::pin(async {
-                Ok(ListResult {
-                    records: vec![],
-                    total: 0,
-                    page: 1,
-                    per_page: 25,
-                })
-            })
-        }
-        fn get(
-            &self,
-            _pool: &diesel_async::pooled_connection::deadpool::Pool<
-                diesel_async::AsyncPgConnection,
-            >,
-            _id: i64,
-        ) -> crate::traits::AdminFuture<'_, Option<Value>> {
-            Box::pin(async { Ok(None) })
-        }
-        fn create(
-            &self,
-            _pool: &diesel_async::pooled_connection::deadpool::Pool<
-                diesel_async::AsyncPgConnection,
-            >,
-            data: Value,
-        ) -> crate::traits::AdminFuture<'_, Value> {
-            Box::pin(async move { Ok(data) })
-        }
-        fn update(
-            &self,
-            _pool: &diesel_async::pooled_connection::deadpool::Pool<
-                diesel_async::AsyncPgConnection,
-            >,
-            _id: i64,
-            data: Value,
-        ) -> crate::traits::AdminFuture<'_, Value> {
-            Box::pin(async move { Ok(data) })
-        }
-        fn delete(
-            &self,
-            _pool: &diesel_async::pooled_connection::deadpool::Pool<
-                diesel_async::AsyncPgConnection,
-            >,
-            _id: i64,
-        ) -> crate::traits::AdminFuture<'_, ()> {
-            Box::pin(async { Ok(()) })
-        }
-    }
+    use crate::registry::tests::DummyModel;
 
     fn render_layout_with_registry(registry: &AdminRegistry, active_slug: Option<&str>) -> String {
         admin_layout(
@@ -4122,5 +4062,26 @@ mod tests {
         let html = render_layout(None);
         assert!(!html.contains(r#"class="admin-nav""#), "{html}");
         assert!(!html.contains("admin-logo"), "{html}");
+    }
+
+    #[test]
+    fn admin_layout_loads_nav_bar_widget_runtime() {
+        // nav_bar's hamburger toggle and any future dropdown depend on
+        // autumn-widgets.js to reveal/wire them up; without it the toggle
+        // stays permanently hidden and dead.
+        let html = render_layout(None);
+        assert!(
+            html.contains(autumn_web::htmx::AUTUMN_WIDGETS_JS_PATH),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn admin_sidebar_toggle_stays_hidden() {
+        // The admin sidebar hides itself entirely below 768px (see the
+        // .admin-sidebar { display: none } media rule) rather than using
+        // nav_bar's own collapse-behind-a-hamburger UX, so the toggle must
+        // never become visible even once autumn-widgets.js unhides it.
+        assert!(ADMIN_CSS.contains(".autumn-nav__toggle"), "{ADMIN_CSS}");
     }
 }

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -3972,4 +3972,156 @@ mod tests {
             "dashboard must not be active: {html}"
         );
     }
+
+    // ── admin_layout nav_bar (#1137) ──────────────────────────────────────
+
+    struct DummyModel {
+        slug: &'static str,
+        name: &'static str,
+    }
+
+    impl crate::traits::AdminModel for DummyModel {
+        fn slug(&self) -> &'static str {
+            self.slug
+        }
+        fn display_name(&self) -> &'static str {
+            self.name
+        }
+        fn display_name_plural(&self) -> &'static str {
+            self.name
+        }
+        fn fields(&self) -> Vec<AdminField> {
+            vec![]
+        }
+        fn list(
+            &self,
+            _pool: &diesel_async::pooled_connection::deadpool::Pool<
+                diesel_async::AsyncPgConnection,
+            >,
+            _params: crate::traits::ListParams,
+        ) -> crate::traits::AdminFuture<'_, ListResult> {
+            Box::pin(async {
+                Ok(ListResult {
+                    records: vec![],
+                    total: 0,
+                    page: 1,
+                    per_page: 25,
+                })
+            })
+        }
+        fn get(
+            &self,
+            _pool: &diesel_async::pooled_connection::deadpool::Pool<
+                diesel_async::AsyncPgConnection,
+            >,
+            _id: i64,
+        ) -> crate::traits::AdminFuture<'_, Option<Value>> {
+            Box::pin(async { Ok(None) })
+        }
+        fn create(
+            &self,
+            _pool: &diesel_async::pooled_connection::deadpool::Pool<
+                diesel_async::AsyncPgConnection,
+            >,
+            data: Value,
+        ) -> crate::traits::AdminFuture<'_, Value> {
+            Box::pin(async move { Ok(data) })
+        }
+        fn update(
+            &self,
+            _pool: &diesel_async::pooled_connection::deadpool::Pool<
+                diesel_async::AsyncPgConnection,
+            >,
+            _id: i64,
+            data: Value,
+        ) -> crate::traits::AdminFuture<'_, Value> {
+            Box::pin(async move { Ok(data) })
+        }
+        fn delete(
+            &self,
+            _pool: &diesel_async::pooled_connection::deadpool::Pool<
+                diesel_async::AsyncPgConnection,
+            >,
+            _id: i64,
+        ) -> crate::traits::AdminFuture<'_, ()> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    fn render_layout_with_registry(registry: &AdminRegistry, active_slug: Option<&str>) -> String {
+        admin_layout(
+            registry,
+            active_slug,
+            "Title",
+            "/admin",
+            "/actuator",
+            "tok",
+            "X-CSRF-Token",
+            &[],
+            true,
+            &html! {},
+        )
+        .into_string()
+    }
+
+    #[test]
+    fn admin_layout_renders_nav_bar_sidebar() {
+        let html = render_layout(None);
+        assert!(html.contains("autumn-nav--sidebar"), "{html}");
+        assert!(html.contains(r#"class="admin-sidebar"#), "{html}");
+        assert!(html.contains(r#"aria-label="Admin navigation""#), "{html}");
+    }
+
+    #[test]
+    fn admin_layout_brand_uses_nav_brand_class() {
+        let html = render_layout(None);
+        assert!(html.contains("autumn-nav__brand"), "{html}");
+        assert!(html.contains("🍂 Autumn Admin"), "{html}");
+        assert!(!html.contains(r#"class="admin-logo""#), "{html}");
+    }
+
+    #[test]
+    fn admin_layout_sections_render_as_nav_sections_without_models() {
+        let html = render_layout(None);
+        assert!(
+            html.contains(r#"<li class="autumn-nav__section">System</li>"#),
+            "{html}"
+        );
+        assert!(!html.contains("Models"), "{html}");
+    }
+
+    #[test]
+    fn admin_layout_sections_render_as_nav_sections_with_models() {
+        let mut registry = AdminRegistry::new();
+        registry.register(DummyModel {
+            slug: "projects",
+            name: "Projects",
+        });
+        let html = render_layout_with_registry(&registry, None);
+        assert!(
+            html.contains(r#"<li class="autumn-nav__section">Models</li>"#),
+            "{html}"
+        );
+        assert!(
+            html.contains(r#"<li class="autumn-nav__section">System</li>"#),
+            "{html}"
+        );
+        assert!(html.contains(r#"href="/admin/projects""#), "{html}");
+    }
+
+    #[test]
+    fn admin_layout_actuator_link_is_plain() {
+        let html = render_layout(None);
+        assert!(html.contains(r#"href="/actuator/ui""#), "{html}");
+        // Only one aria-current in the whole page: Dashboard's. The Actuator
+        // link must never claim active state even though it's the last item.
+        assert_eq!(html.matches(r#"aria-current="page""#).count(), 1, "{html}");
+    }
+
+    #[test]
+    fn admin_layout_has_no_hand_rolled_nav_markup() {
+        let html = render_layout(None);
+        assert!(!html.contains(r#"class="admin-nav""#), "{html}");
+        assert!(!html.contains("admin-logo"), "{html}");
+    }
 }

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -11,7 +11,9 @@ use autumn_web::job::{
 use autumn_web::pagination::Page;
 use autumn_web::runtime_config::{ConfigChangeRecord, ConfigEntry};
 use autumn_web::ui::pagination::{PagerOptions, pagination_nav};
-use autumn_web::widgets::{CardConfig, card, nav_link, stat_card};
+use autumn_web::widgets::{
+    CardConfig, NavBarConfig, NavBarLayout, NavItem, card, nav_bar, stat_card,
+};
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 use serde_json::Value;
 
@@ -90,7 +92,8 @@ const ADMIN_CSS: &str = "
         padding: 2rem;
         min-width: 0;
     }
-    .admin-logo {
+    .admin-sidebar .autumn-nav__brand {
+        display: block;
         font-size: 1.125rem;
         font-weight: 700;
         padding: 0 1.5rem 1rem;
@@ -98,8 +101,8 @@ const ADMIN_CSS: &str = "
         margin-bottom: 1rem;
         color: var(--text);
     }
-    .admin-nav { list-style: none; }
-    .admin-nav li a {
+    .admin-sidebar .autumn-nav__items { list-style: none; }
+    .admin-sidebar .autumn-nav__item a {
         display: block;
         padding: 0.5rem 1.5rem;
         color: var(--text-muted);
@@ -108,17 +111,17 @@ const ADMIN_CSS: &str = "
         border-left: 3px solid transparent;
         transition: all 0.15s;
     }
-    .admin-nav li a:hover {
+    .admin-sidebar .autumn-nav__item a:hover {
         background: var(--bg);
         color: var(--text);
         text-decoration: none;
     }
-    .admin-nav li a.active {
+    .admin-sidebar .autumn-nav__item a.active {
         background: var(--primary-light);
         color: var(--primary);
         border-left-color: var(--primary);
     }
-    .admin-nav-section {
+    .admin-sidebar .autumn-nav__section {
         font-size: 0.7rem;
         text-transform: uppercase;
         letter-spacing: 0.05em;
@@ -425,6 +428,30 @@ pub fn admin_layout(
         Some(RUNTIME_CONFIG_NAV_SLUG) => config_href.clone(),
         Some(slug) => format!("{prefix}/{slug}"),
     };
+
+    let mut nav_items = vec![NavItem::link(prefix, "Dashboard")];
+    if registry.model_count() > 0 {
+        nav_items.push(NavItem::section("Models"));
+        nav_items.extend(registry.iter().map(|(slug, model)| {
+            NavItem::link(&format!("{prefix}/{slug}"), model.display_name_plural())
+        }));
+    }
+    nav_items.push(NavItem::section("System"));
+    nav_items.push(NavItem::link(&jobs_href, "Jobs"));
+    if show_config {
+        nav_items.push(NavItem::link(&config_href, "Runtime Config"));
+    }
+    nav_items.push(NavItem::plain_link(
+        &format!("{actuator_prefix}/ui"),
+        "Actuator",
+    ));
+    let sidebar_nav = NavBarConfig::new()
+        .brand_html(html! { "🍂 Autumn Admin" }, None)
+        .items(nav_items)
+        .aria_label("Admin navigation")
+        .layout(NavBarLayout::Sidebar)
+        .class("admin-sidebar");
+
     html! {
         (DOCTYPE)
         html lang="en" {
@@ -454,38 +481,7 @@ pub fn admin_layout(
                 div class="admin-layout" {
                     // Sidebar navigation landmark
                     header role="banner" {
-                        nav class="admin-sidebar" aria-label="Admin navigation" {
-                            div class="admin-logo" { "🍂 Autumn Admin" }
-                            ul class="admin-nav" {
-                                li { (nav_link(&current_path, prefix, "Dashboard")) }
-                                @if registry.model_count() > 0 {
-                                    li { div class="admin-nav-section" { "Models" } }
-                                    @for (slug, model) in registry.iter() {
-                                        li {
-                                            (nav_link(
-                                                &current_path,
-                                                &format!("{prefix}/{slug}"),
-                                                model.display_name_plural(),
-                                            ))
-                                        }
-                                    }
-                                }
-                                li { div class="admin-nav-section" { "System" } }
-                                li {
-                                    (nav_link(&current_path, &jobs_href, "Jobs"))
-                                }
-                                @if show_config {
-                                    li {
-                                        (nav_link(
-                                            &current_path,
-                                            &config_href,
-                                            "Runtime Config",
-                                        ))
-                                    }
-                                }
-                                li { a href={ (actuator_prefix) "/ui" } { "Actuator" } }
-                            }
-                        }
+                        (nav_bar(&current_path, &sidebar_nav))
                     }
                     // Main content landmark
                     main id="admin-main" class="admin-main" {
@@ -4068,7 +4064,10 @@ mod tests {
     fn admin_layout_renders_nav_bar_sidebar() {
         let html = render_layout(None);
         assert!(html.contains("autumn-nav--sidebar"), "{html}");
-        assert!(html.contains(r#"class="admin-sidebar"#), "{html}");
+        assert!(
+            html.contains(r#"class="autumn-nav autumn-nav--sidebar admin-sidebar""#),
+            "{html}"
+        );
         assert!(html.contains(r#"aria-label="Admin navigation""#), "{html}");
     }
 

--- a/autumn-cli/src/check.rs
+++ b/autumn-cli/src/check.rs
@@ -1391,6 +1391,43 @@ mod tests {
         assert!(ids.contains(&"button-name"), "{ids:?}");
     }
 
+    // ── nav_bar full-page a11y (#1137) ──────────────────────────────
+
+    #[test]
+    fn nav_bar_full_page_passes_all_a11y_lints() {
+        use autumn_web::widgets::{NavBarConfig, NavItem, NavMenu, nav_bar};
+
+        let nav = nav_bar(
+            "/",
+            &NavBarConfig::new()
+                .brand("Acme", "/")
+                .item(NavItem::link("/", "Home"))
+                .item(NavItem::menu(
+                    NavMenu::new("Products").link("/widgets", "Widgets"),
+                ))
+                .trailing(NavItem::plain_link("/login", "Log in")),
+        )
+        .into_string();
+
+        let html = format!(
+            r##"<!DOCTYPE html>
+<html lang="en">
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  <header>{nav}</header>
+  <main id="main-content">Content</main>
+</body>
+</html>"##
+        );
+
+        let violations = analyse_html(&html);
+        assert!(
+            violations.is_empty(),
+            "nav_bar layout must pass autumn check --a11y: {:#?}",
+            violations.iter().map(|v| v.rule_id).collect::<Vec<_>>()
+        );
+    }
+
     // ── severity ordering ──────────────────────────────────────────
 
     #[test]

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -24,10 +24,33 @@ use super::{Flags, GenerateError, ensure_project_root};
 /// Compute the file actions for `autumn generate pwa`.
 ///
 /// # Errors
-/// Returns [`GenerateError::NotInProject`] when not at a project root, or
-/// [`GenerateError::Io`] if `src/main.rs` / `Cargo.toml` can't be read.
+/// Returns [`GenerateError::NotInProject`] when not at a project root,
+/// [`GenerateError::Io`] if `src/main.rs` / `Cargo.toml` can't be read, or
+/// [`GenerateError::Config`] when `src/main.rs`'s `layout()` doesn't accept
+/// `current_path` — the generated `pwa_offline` handler calls `layout()`
+/// with the current `nav_bar`-based scaffold's arity, so an app that
+/// hasn't migrated its own `layout()` needs to before running this.
 pub fn plan_pwa(project_root: &Path) -> Result<Plan, GenerateError> {
     ensure_project_root(project_root)?;
+
+    // Read src/main.rs up front (rather than where it's injected below) so
+    // the layout() shape can be validated before any plan actions are built.
+    let main_path = project_root.join("src").join("main.rs");
+    let main_existing = std::fs::read_to_string(&main_path).map_err(|_| {
+        GenerateError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("missing {}", main_path.display()),
+        ))
+    })?;
+    if layout_missing_current_path(&main_existing) {
+        return Err(GenerateError::Config(format!(
+            "{}'s layout() doesn't accept current_path — update it to \
+             layout(title: &str, current_path: &str, flash: Markup, content: Markup) \
+             (see autumn-cli/src/templates/main.rs.tmpl for the current shape) \
+             before running `autumn generate pwa`",
+            main_path.display()
+        )));
+    }
 
     let mut plan = Plan::new(project_root);
 
@@ -57,13 +80,6 @@ pub fn plan_pwa(project_root: &Path) -> Result<Plan, GenerateError> {
     );
 
     // src/main.rs: inject PWA meta tags + route handlers (idempotent)
-    let main_path = project_root.join("src").join("main.rs");
-    let main_existing = std::fs::read_to_string(&main_path).map_err(|_| {
-        GenerateError::Io(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!("missing {}", main_path.display()),
-        ))
-    })?;
     let updated_main = inject_pwa_into_main(&main_existing);
     if updated_main != main_existing {
         plan.modify(main_path, updated_main);
@@ -411,6 +427,19 @@ fn inject_pwa_meta_into_head(source: &str) -> String {
     result
 }
 
+/// True when `source` defines a `layout()` function whose signature doesn't
+/// mention `current_path` — the pre-`nav_bar` scaffold shape
+/// (`layout(title, flash, content)`) rather than the current one
+/// (`layout(title, current_path, flash, content)`). `pwa_offline`'s
+/// generated call assumes the current shape, so this gates [`plan_pwa`]
+/// with an actionable error instead of emitting code with the wrong arity.
+fn layout_missing_current_path(source: &str) -> bool {
+    source
+        .lines()
+        .find(|l| l.contains("fn layout("))
+        .is_some_and(|l| !l.contains("current_path"))
+}
+
 /// Append `pwa_manifest`, `pwa_service_worker`, `pwa_register_js`, and `pwa_offline`
 /// handler functions just before `#[autumn_web::main]`.  Idempotent — skipped when
 /// `pwa_manifest` is already defined.
@@ -575,7 +604,66 @@ async fn main() {
 }
 ";
 
+    /// The pre-`nav_bar` scaffold shape: `layout()` has no `current_path`
+    /// parameter. Apps generated before `nav_bar` shipped still look like this.
+    const OLD_SHAPE_MAIN: &str = "\
+use autumn_web::form::skip_link;
+use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};
+use autumn_web::prelude::*;
+
+const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
+
+pub fn layout(title: &str, flash: maud::Markup, content: maud::Markup) -> maud::Markup {
+    maud::html! {
+        (maud::DOCTYPE)
+        html lang=\"en\" {
+            head {
+                meta charset=\"utf-8\";
+                title { (title) }
+            }
+            body {
+                (skip_link(\"#main-content\", \"Skip to main content\"))
+                main id=\"main-content\" role=\"main\" {
+                    (flash)
+                    (content)
+                }
+            }
+        }
+    }
+}
+
+#[get(\"/\")]
+async fn index(flash: Flash) -> maud::Markup {
+    layout(\"Welcome\", flash.render().await, maud::html! {
+        h1 { \"Welcome!\" }
+    })
+}
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .routes(routes![index])
+        .migrations(MIGRATIONS)
+        .run()
+        .await;
+}
+";
+
     // ── plan_pwa: file plan tests ─────────────────────────────────────────────
+
+    #[test]
+    fn plan_pwa_rejects_layout_missing_current_path() {
+        // nav_bar's arrival made layout() take current_path as its second
+        // argument; pwa_offline's generated call now assumes that shape.
+        // Running against an app that hasn't migrated must fail loudly with
+        // an actionable message instead of silently emitting a call that
+        // won't compile.
+        let tmp = project_with_main(OLD_SHAPE_MAIN);
+        let err = plan_pwa(tmp.path()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("current_path"), "{msg}");
+        assert!(msg.contains("layout"), "{msg}");
+    }
 
     #[test]
     fn plan_pwa_requires_project_root() {

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -433,11 +433,19 @@ fn inject_pwa_meta_into_head(source: &str) -> String {
 /// (`layout(title, current_path, flash, content)`). `pwa_offline`'s
 /// generated call assumes the current shape, so this gates [`plan_pwa`]
 /// with an actionable error instead of emitting code with the wrong arity.
+///
+/// Scans the whole signature span (from `fn layout(` up to the function
+/// body's opening brace), not just the physical line `fn layout(` appears
+/// on — rustfmt wraps this signature across multiple lines at its default
+/// column width, which would otherwise put `current_path` on a line the
+/// check never looks at.
 fn layout_missing_current_path(source: &str) -> bool {
-    source
-        .lines()
-        .find(|l| l.contains("fn layout("))
-        .is_some_and(|l| !l.contains("current_path"))
+    let Some(start) = source.find("fn layout(") else {
+        return false;
+    };
+    let rest = &source[start..];
+    let signature = rest.find('{').map_or(rest, |brace| &rest[..brace]);
+    !signature.contains("current_path")
 }
 
 /// Append `pwa_manifest`, `pwa_service_worker`, `pwa_register_js`, and `pwa_offline`
@@ -663,6 +671,27 @@ async fn main() {
         let msg = err.to_string();
         assert!(msg.contains("current_path"), "{msg}");
         assert!(msg.contains("layout"), "{msg}");
+    }
+
+    #[test]
+    fn plan_pwa_accepts_rustfmt_wrapped_layout_signature() {
+        // rustfmt wraps layout()'s ~108-char signature onto separate lines
+        // (verified: `rustfmt` puts each param on its own line at the
+        // default 100-column width) — current_path then no longer shares a
+        // physical line with `fn layout(`, so a naive single-line scan would
+        // false-positive as "missing current_path" on any formatted,
+        // up-to-date project.
+        let wrapped_main = DEFAULT_MAIN.replace(
+            "pub fn layout(title: &str, current_path: &str, flash: maud::Markup, content: maud::Markup) -> maud::Markup {",
+            "pub fn layout(\n    title: &str,\n    current_path: &str,\n    flash: maud::Markup,\n    content: maud::Markup,\n) -> maud::Markup {",
+        );
+        assert_ne!(
+            wrapped_main, DEFAULT_MAIN,
+            "replacement must actually match"
+        );
+        let tmp = project_with_main(&wrapped_main);
+        plan_pwa(tmp.path())
+            .expect("rustfmt-wrapped current_path parameter must still be detected");
     }
 
     #[test]

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -44,9 +44,10 @@ pub fn plan_pwa(project_root: &Path) -> Result<Plan, GenerateError> {
     })?;
     if layout_missing_current_path(&main_existing) {
         return Err(GenerateError::Config(format!(
-            "{}'s layout() doesn't accept current_path — update it to \
-             layout(title: &str, current_path: &str, flash: Markup, content: Markup) \
-             (see autumn-cli/src/templates/main.rs.tmpl for the current shape) \
+            "{}'s layout() takes fewer than 4 parameters — the current \
+             nav_bar-based scaffold needs layout(title: &str, current_path: &str, \
+             flash: Markup, content: Markup) (see autumn-cli/src/templates/main.rs.tmpl \
+             for the current shape; the path parameter's name doesn't matter) \
              before running `autumn generate pwa`",
             main_path.display()
         )));
@@ -427,25 +428,80 @@ fn inject_pwa_meta_into_head(source: &str) -> String {
     result
 }
 
-/// True when `source` defines a `layout()` function whose signature doesn't
-/// mention `current_path` — the pre-`nav_bar` scaffold shape
-/// (`layout(title, flash, content)`) rather than the current one
-/// (`layout(title, current_path, flash, content)`). `pwa_offline`'s
-/// generated call assumes the current shape, so this gates [`plan_pwa`]
-/// with an actionable error instead of emitting code with the wrong arity.
+/// True when `source` defines a `layout()` function with fewer than 4
+/// parameters — the pre-`nav_bar` scaffold shape (`layout(title, flash,
+/// content)`) rather than the current one (`layout(title, current_path,
+/// flash, content)`). `pwa_offline`'s generated call assumes 4 positional
+/// arguments, so this gates [`plan_pwa`] with an actionable error instead
+/// of emitting code with the wrong arity.
 ///
-/// Scans the whole signature span (from `fn layout(` up to the function
-/// body's opening brace), not just the physical line `fn layout(` appears
-/// on — rustfmt wraps this signature across multiple lines at its default
-/// column width, which would otherwise put `current_path` on a line the
-/// check never looks at.
+/// Checks parameter *count*, not a specific name — Rust calls are
+/// positional, so a caller who named their path parameter `path` or
+/// `request_path` instead of `current_path` still compiles fine and must
+/// not be rejected.
 fn layout_missing_current_path(source: &str) -> bool {
     let Some(start) = source.find("fn layout(") else {
         return false;
     };
-    let rest = &source[start..];
-    let signature = rest.find('{').map_or(rest, |brace| &rest[..brace]);
-    !signature.contains("current_path")
+    let after_paren = &source[start + "fn layout(".len()..];
+    let Some(params) = balanced_prefix(after_paren) else {
+        return false;
+    };
+    count_params(params) < 4
+}
+
+/// Count comma-separated parameters in a (possibly multi-line, possibly
+/// trailing-comma) parameter list — the trailing comma rustfmt always adds
+/// when it wraps a signature onto separate lines doesn't itself count as an
+/// extra parameter.
+fn count_params(params: &str) -> usize {
+    let trimmed = params.trim();
+    if trimmed.is_empty() {
+        return 0;
+    }
+    let commas = count_top_level_commas(trimmed);
+    if trimmed.ends_with(',') {
+        commas
+    } else {
+        commas + 1
+    }
+}
+
+/// The prefix of `s` up to (not including) the `)` that closes the opening
+/// paren implicit in the caller's position — tracks `(`/`[` nesting (e.g. a
+/// closure-typed parameter like `Fn(i32) -> bool`) so an inner `)` doesn't
+/// end the scan early. Returns `None` if unbalanced.
+fn balanced_prefix(s: &str) -> Option<&str> {
+    let mut depth = 0i32;
+    for (i, c) in s.char_indices() {
+        match c {
+            '(' | '[' => depth += 1,
+            ')' if depth == 0 => return Some(&s[..i]),
+            ')' | ']' => depth -= 1,
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Count commas in `s` that aren't nested inside `(...)`/`[...]` — a cheap
+/// proxy for "how many parameters does this signature have" without a real
+/// parser. Doesn't track `<...>` generic nesting, so a parameter type with a
+/// top-level comma inside angle brackets (e.g. `HashMap<K, V>`) would
+/// over-count — harmless here since over-counting only makes this check
+/// *more* permissive, never a false rejection.
+fn count_top_level_commas(s: &str) -> usize {
+    let mut depth = 0i32;
+    let mut count = 0;
+    for c in s.chars() {
+        match c {
+            '(' | '[' => depth += 1,
+            ')' | ']' => depth -= 1,
+            ',' if depth == 0 => count += 1,
+            _ => {}
+        }
+    }
+    count
 }
 
 /// Append `pwa_manifest`, `pwa_service_worker`, `pwa_register_js`, and `pwa_offline`
@@ -692,6 +748,26 @@ async fn main() {
         let tmp = project_with_main(&wrapped_main);
         plan_pwa(tmp.path())
             .expect("rustfmt-wrapped current_path parameter must still be detected");
+    }
+
+    #[test]
+    fn plan_pwa_accepts_layout_with_renamed_path_parameter() {
+        // Rust calls are positional — a layout() with 4 parameters compiles
+        // fine against pwa_offline's 4-arg call regardless of what the
+        // second parameter is named. Requiring the literal name
+        // "current_path" would reject valid, already-migrated apps that
+        // simply chose a different name (e.g. `path`, `request_path`).
+        let renamed_main = DEFAULT_MAIN.replace(
+            "pub fn layout(title: &str, current_path: &str, flash: maud::Markup, content: maud::Markup) -> maud::Markup {",
+            "pub fn layout(title: &str, request_path: &str, flash: maud::Markup, content: maud::Markup) -> maud::Markup {",
+        );
+        assert_ne!(
+            renamed_main, DEFAULT_MAIN,
+            "replacement must actually match"
+        );
+        let tmp = project_with_main(&renamed_main);
+        plan_pwa(tmp.path())
+            .expect("a differently-named 4th parameter must still be accepted (arity, not name)");
     }
 
     #[test]

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -455,9 +455,10 @@ async fn pwa_register_js() -> impl IntoResponse {\n\
 }\n\
 \n\
 #[get(\"/offline\")]\n\
-async fn pwa_offline(flash: Flash) -> maud::Markup {\n\
+async fn pwa_offline(flash: Flash, path: CurrentPath) -> maud::Markup {\n\
     layout(\n\
         \"Offline\",\n\
+        path.as_str(),\n\
         flash.render().await,\n\
         maud::html! {\n\
             h1 { \"You are offline\" }\n\
@@ -524,7 +525,11 @@ use autumn_web::prelude::*;
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
-pub fn layout(title: &str, flash: maud::Markup, content: maud::Markup) -> maud::Markup {
+pub fn layout(title: &str, current_path: &str, flash: maud::Markup, content: maud::Markup) -> maud::Markup {
+    let nav = NavBarConfig::new()
+        .brand(\"My App\", \"/\")
+        .aria_label(\"Main navigation\")
+        .item(NavItem::link(\"/\", \"Home\"));
     maud::html! {
         (maud::DOCTYPE)
         html lang=\"en\" {
@@ -534,13 +539,12 @@ pub fn layout(title: &str, flash: maud::Markup, content: maud::Markup) -> maud::
                 title { (title) }
                 link rel=\"stylesheet\" href=(autumn_web::flash::FLASH_CSS_PATH);
                 link rel=\"stylesheet\" href=\"/static/css/app.css\";
+                script src=(autumn_web::htmx::AUTUMN_WIDGETS_JS_PATH) defer {}
             }
             body {
                 (skip_link(\"#main-content\", \"Skip to main content\"))
                 header role=\"banner\" {
-                    nav aria-label=\"Main navigation\" {
-                        a href=\"/\" { \"My App\" }
-                    }
+                    (nav_bar(current_path, &nav))
                 }
                 main id=\"main-content\" role=\"main\" {
                     (flash)
@@ -555,8 +559,8 @@ pub fn layout(title: &str, flash: maud::Markup, content: maud::Markup) -> maud::
 }
 
 #[get(\"/\")]
-async fn index(flash: Flash) -> maud::Markup {
-    layout(\"Welcome\", flash.render().await, maud::html! {
+async fn index(flash: Flash, path: CurrentPath) -> maud::Markup {
+    layout(\"Welcome\", path.as_str(), flash.render().await, maud::html! {
         h1 { \"Welcome!\" }
     })
 }
@@ -922,6 +926,26 @@ async fn main() {
         let twice = inject_pwa_into_main(&once);
         let handler_count = twice.matches("async fn pwa_manifest()").count();
         assert_eq!(handler_count, 1, "must not duplicate pwa_manifest handler");
+    }
+
+    #[test]
+    fn pwa_offline_handler_matches_current_layout_arity() {
+        // The scaffold's layout() takes (title, current_path, flash, content) —
+        // pwa_offline must extract CurrentPath and pass it through, or the
+        // generated src/main.rs fails to compile with an arity mismatch.
+        let updated = inject_pwa_into_main(DEFAULT_MAIN);
+        assert!(
+            updated.contains("async fn pwa_offline(flash: Flash, path: CurrentPath)"),
+            "pwa_offline must extract CurrentPath alongside Flash: {updated}"
+        );
+        let offline_fn_start = updated
+            .find("async fn pwa_offline")
+            .expect("pwa_offline handler must be present");
+        let offline_fn = &updated[offline_fn_start..offline_fn_start + 200];
+        assert!(
+            offline_fn.contains("\"Offline\"") && offline_fn.contains("path.as_str()"),
+            "pwa_offline must pass path.as_str() as layout()'s second argument: {offline_fn}"
+        );
     }
 
     // ── plan execution ────────────────────────────────────────────────────────

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -839,6 +839,19 @@ mod tests {
     }
 
     #[test]
+    fn main_template_nav_keeps_descriptive_aria_label() {
+        // The old hand-rolled <nav> had aria-label="Main navigation"; nav_bar's
+        // own default is just "Main", so the template must call .aria_label(...)
+        // explicitly or the landmark's accessible name silently degrades.
+        assert!(
+            templates::MAIN_RS.contains(r#".aria_label("Main navigation")"#),
+            "layout()'s NavBarConfig should keep the descriptive \"Main navigation\" \
+             aria-label instead of nav_bar's generic \"Main\" default, got:\n{}",
+            templates::MAIN_RS
+        );
+    }
+
+    #[test]
     fn autumn_toml_has_defaults() {
         let tmp = TempDir::new().unwrap();
         generate("cfg-check", tmp.path()).unwrap();

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -858,8 +858,21 @@ mod tests {
         // to a new row if the row itself is allowed to wrap. Without flex-wrap
         // on the enhanced root, the opened mobile menu squeezes/overflows onto
         // the same row as the brand and toggle instead of appearing below them.
+        //
+        // Bare-selector match (not a literal multi-line blob) so this doesn't
+        // depend on the file's line-ending style — this repo checks out
+        // `*.tmpl` as `text=auto`, which normalizes to CRLF on Windows, and
+        // an embedded `\n` here would never match the CRLF-containing string
+        // `include_str!` reads back on that platform.
+        let css = templates::INPUT_CSS;
+        let rule_start = css
+            .find(".autumn-nav--enhanced {")
+            .expect("no bare .autumn-nav--enhanced rule found in input.css.tmpl");
+        let rule_body = &css[rule_start..][..css[rule_start..]
+            .find('}')
+            .expect("unterminated .autumn-nav--enhanced rule")];
         assert!(
-            templates::INPUT_CSS.contains(".autumn-nav--enhanced {\n      @apply flex-wrap;"),
+            rule_body.contains("flex-wrap"),
             "the mobile media query must set flex-wrap on .autumn-nav--enhanced itself \
              so .autumn-nav__collapse's basis-full can actually start a new row, got:\n{}",
             templates::INPUT_CSS

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -858,23 +858,48 @@ mod tests {
         // to a new row if the row itself is allowed to wrap. Without flex-wrap
         // on the enhanced root, the opened mobile menu squeezes/overflows onto
         // the same row as the brand and toggle instead of appearing below them.
-        //
-        // Bare-selector match (not a literal multi-line blob) so this doesn't
-        // depend on the file's line-ending style — this repo checks out
-        // `*.tmpl` as `text=auto`, which normalizes to CRLF on Windows, and
-        // an embedded `\n` here would never match the CRLF-containing string
-        // `include_str!` reads back on that platform.
-        let css = templates::INPUT_CSS;
-        let rule_start = css
-            .find(".autumn-nav--enhanced {")
-            .expect("no bare .autumn-nav--enhanced rule found in input.css.tmpl");
-        let rule_body = &css[rule_start..][..css[rule_start..]
-            .find('}')
-            .expect("unterminated .autumn-nav--enhanced rule")];
+        let rule_body = css_rule_body(templates::INPUT_CSS, ".autumn-nav--enhanced {");
         assert!(
             rule_body.contains("flex-wrap"),
             "the mobile media query must set flex-wrap on .autumn-nav--enhanced itself \
              so .autumn-nav__collapse's basis-full can actually start a new row, got:\n{}",
+            templates::INPUT_CSS
+        );
+    }
+
+    /// Extract the declaration block (without the braces) of the first CSS
+    /// rule whose selector text starts with `selector_prefix` (which must
+    /// include the trailing ` {`). Scans by byte position rather than
+    /// matching a literal multi-line blob, so it doesn't depend on the
+    /// source file's line-ending style — this repo checks out `*.tmpl` as
+    /// `text=auto`, which normalizes to CRLF on Windows, and a pattern with
+    /// an embedded `\n` would never match the CRLF-containing string
+    /// `include_str!` reads back on that platform.
+    fn css_rule_body<'a>(css: &'a str, selector_prefix: &str) -> &'a str {
+        let rule_start = css
+            .find(selector_prefix)
+            .unwrap_or_else(|| panic!("no bare `{selector_prefix}` rule found in input.css.tmpl"));
+        let rest = &css[rule_start..];
+        &rest[..rest
+            .find('}')
+            .unwrap_or_else(|| panic!("unterminated `{selector_prefix}` rule"))]
+    }
+
+    #[test]
+    fn input_css_nav_collapse_is_flex_row_so_trailing_items_align_right() {
+        // .autumn-nav__collapse wraps both the primary .autumn-nav__items
+        // list and the .autumn-nav__items--trailing list; without collapse
+        // itself being a flex row (and growing to fill the nav's remaining
+        // width), the trailing list's ml-auto has no flex row to push
+        // against — the two lists just stack vertically as ordinary block
+        // children instead of sitting side by side with trailing pinned to
+        // the far right, as nav_bar's trailing-slot design intends.
+        let rule_body = css_rule_body(templates::INPUT_CSS, ".autumn-nav__collapse {");
+        assert!(
+            rule_body.contains("flex") && !rule_body.contains("flex-col"),
+            "the base (non-mobile) .autumn-nav__collapse rule must be a flex row \
+             so .autumn-nav__items--trailing's ml-auto can push it to the right \
+             edge of the nav, got:\n{}",
             templates::INPUT_CSS
         );
     }

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -803,6 +803,41 @@ mod tests {
         assert!(content.contains("autumn_web::app()"));
     }
 
+    // ── nav_bar scaffold layout (#1137) ─────────────────────────────
+
+    #[test]
+    fn main_template_uses_nav_bar_widget() {
+        assert!(
+            templates::MAIN_RS.contains("nav_bar("),
+            "main.rs.tmpl should render its nav via nav_bar(), got:\n{}",
+            templates::MAIN_RS
+        );
+        assert!(
+            templates::MAIN_RS.contains("NavBarConfig::new()"),
+            "main.rs.tmpl should build a NavBarConfig, got:\n{}",
+            templates::MAIN_RS
+        );
+        assert!(
+            !templates::MAIN_RS.contains(r#"nav aria-label="Main navigation""#),
+            "main.rs.tmpl should no longer hand-roll its <nav>, got:\n{}",
+            templates::MAIN_RS
+        );
+    }
+
+    #[test]
+    fn main_template_layout_takes_current_path() {
+        assert!(
+            templates::MAIN_RS.contains("current_path: &str"),
+            "layout() should take current_path so nav_bar can mark the active link, got:\n{}",
+            templates::MAIN_RS
+        );
+        assert!(
+            templates::MAIN_RS.contains("CurrentPath"),
+            "index() should extract CurrentPath to pass to layout(), got:\n{}",
+            templates::MAIN_RS
+        );
+    }
+
     #[test]
     fn autumn_toml_has_defaults() {
         let tmp = TempDir::new().unwrap();

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -852,6 +852,21 @@ mod tests {
     }
 
     #[test]
+    fn input_css_mobile_nav_collapse_wraps_below_header() {
+        // .autumn-nav is a flex row (nowrap by default) and .autumn-nav__collapse
+        // is one of its flex items; giving that item `basis-full` only drops it
+        // to a new row if the row itself is allowed to wrap. Without flex-wrap
+        // on the enhanced root, the opened mobile menu squeezes/overflows onto
+        // the same row as the brand and toggle instead of appearing below them.
+        assert!(
+            templates::INPUT_CSS.contains(".autumn-nav--enhanced {\n      @apply flex-wrap;"),
+            "the mobile media query must set flex-wrap on .autumn-nav--enhanced itself \
+             so .autumn-nav__collapse's basis-full can actually start a new row, got:\n{}",
+            templates::INPUT_CSS
+        );
+    }
+
+    #[test]
     fn autumn_toml_has_defaults() {
         let tmp = TempDir::new().unwrap();
         generate("cfg-check", tmp.path()).unwrap();

--- a/autumn-cli/src/templates/input.css.tmpl
+++ b/autumn-cli/src/templates/input.css.tmpl
@@ -41,6 +41,12 @@
   }
 
   @media (max-width: 768px) {
+    /* .autumn-nav is a nowrap flex row; .autumn-nav__collapse's basis-full
+       below only starts a new row (dropping the menu under the brand/toggle
+       instead of squeezing onto the same row) once the row itself can wrap. */
+    .autumn-nav--enhanced {
+      @apply flex-wrap;
+    }
     .autumn-nav--enhanced .autumn-nav__toggle {
       @apply flex;
     }

--- a/autumn-cli/src/templates/input.css.tmpl
+++ b/autumn-cli/src/templates/input.css.tmpl
@@ -10,3 +10,48 @@
     @apply top-0 outline-none ring-2 ring-offset-2 ring-blue-500;
   }
 }
+
+@layer components {
+  /* Hooks for autumn_web::widgets::nav_bar() — see its rustdoc for the full
+     class list. nav_bar itself emits no inline styles; only the responsive
+     collapse/dropdown behavior below needs app CSS. */
+  .autumn-nav {
+    @apply flex items-center gap-4 px-4 py-3;
+  }
+  .autumn-nav__brand {
+    @apply font-semibold text-gray-900 no-underline;
+  }
+  .autumn-nav__toggle {
+    @apply hidden;
+  }
+  .autumn-nav__items {
+    @apply flex items-center gap-4 list-none;
+  }
+  .autumn-nav__items--trailing {
+    @apply ml-auto;
+  }
+  .autumn-nav__item--menu {
+    @apply relative;
+  }
+  .autumn-nav__menu {
+    @apply list-none;
+  }
+  .autumn-nav__menu[hidden] {
+    @apply hidden;
+  }
+
+  @media (max-width: 768px) {
+    .autumn-nav--enhanced .autumn-nav__toggle {
+      @apply flex;
+    }
+    .autumn-nav--enhanced .autumn-nav__collapse {
+      @apply hidden w-full basis-full;
+    }
+    .autumn-nav--enhanced .autumn-nav__collapse--open {
+      @apply block;
+    }
+    .autumn-nav--enhanced .autumn-nav__items {
+      @apply flex-col items-start;
+    }
+  }
+}

--- a/autumn-cli/src/templates/input.css.tmpl
+++ b/autumn-cli/src/templates/input.css.tmpl
@@ -24,6 +24,14 @@
   .autumn-nav__toggle {
     @apply hidden;
   }
+  /* Wraps the primary and trailing item lists. Must be a flex row itself
+     (and grow to fill the space brand/toggle don't use) or the two lists
+     just stack as ordinary block children instead of sitting side by side —
+     which would leave .autumn-nav__items--trailing's ml-auto below with
+     nothing to push against. */
+  .autumn-nav__collapse {
+    @apply flex items-center gap-4 flex-1;
+  }
   .autumn-nav__items {
     @apply flex items-center gap-4 list-none;
   }
@@ -51,10 +59,10 @@
       @apply flex;
     }
     .autumn-nav--enhanced .autumn-nav__collapse {
-      @apply hidden w-full basis-full;
+      @apply hidden w-full basis-full flex-col items-start;
     }
     .autumn-nav--enhanced .autumn-nav__collapse--open {
-      @apply block;
+      @apply flex;
     }
     .autumn-nav--enhanced .autumn-nav__items {
       @apply flex-col items-start;

--- a/autumn-cli/src/templates/main.rs.tmpl
+++ b/autumn-cli/src/templates/main.rs.tmpl
@@ -13,7 +13,13 @@ static EMBEDDED_STATIC: autumn_web::include_dir::Dir = autumn_web::embed_static!
 // `flash` carries one-shot notices set with `flash.success(...)` before a
 // redirect. Pass `flash.render().await` from your handlers; it renders any
 // pending messages (and clears them) and is harmless when empty.
-pub fn layout(title: &str, flash: maud::Markup, content: maud::Markup) -> maud::Markup {
+//
+// `current_path` (from the `CurrentPath` extractor) lets nav_bar mark the
+// link matching the current page with `aria-current="page"`.
+pub fn layout(title: &str, current_path: &str, flash: maud::Markup, content: maud::Markup) -> maud::Markup {
+    let nav = NavBarConfig::new()
+        .brand("{{project_name}}", "/")
+        .item(NavItem::link("/", "Home"));
     maud::html! {
         (maud::DOCTYPE)
         html lang="en" {
@@ -24,13 +30,12 @@ pub fn layout(title: &str, flash: maud::Markup, content: maud::Markup) -> maud::
                 link rel="stylesheet" href=(autumn_web::flash::FLASH_CSS_PATH);
                 link rel="stylesheet" href="/static/css/app.css";
                 (javascript_include_tag("htmx"))
+                script src=(autumn_web::htmx::AUTUMN_WIDGETS_JS_PATH) defer {}
             }
             body {
                 (skip_link("#main-content", "Skip to main content"))
                 header role="banner" {
-                    nav aria-label="Main navigation" {
-                        a href="/" { "{{project_name}}" }
-                    }
+                    (nav_bar(current_path, &nav))
                 }
                 main id="main-content" role="main" {
                     (flash)
@@ -45,8 +50,8 @@ pub fn layout(title: &str, flash: maud::Markup, content: maud::Markup) -> maud::
 }
 
 #[get("/")]
-async fn index(flash: Flash) -> maud::Markup {
-    layout("Welcome", flash.render().await, maud::html! {
+async fn index(flash: Flash, path: CurrentPath) -> maud::Markup {
+    layout("Welcome", path.as_str(), flash.render().await, maud::html! {
         h1 { "Welcome to {{project_name}}!" }
         p { "Edit " code { "src/main.rs" } " to get started." }
     })

--- a/autumn-cli/src/templates/main.rs.tmpl
+++ b/autumn-cli/src/templates/main.rs.tmpl
@@ -19,6 +19,7 @@ static EMBEDDED_STATIC: autumn_web::include_dir::Dir = autumn_web::embed_static!
 pub fn layout(title: &str, current_path: &str, flash: maud::Markup, content: maud::Markup) -> maud::Markup {
     let nav = NavBarConfig::new()
         .brand("{{project_name}}", "/")
+        .aria_label("Main navigation")
         .item(NavItem::link("/", "Home"));
     maud::html! {
         (maud::DOCTYPE)

--- a/autumn/src/htmx.rs
+++ b/autumn/src/htmx.rs
@@ -666,6 +666,17 @@ mod tests {
         assert!(!HTMX_CSRF_JS.contains("<script"));
     }
 
+    #[test]
+    fn widgets_js_wires_nav_bar() {
+        let js = std::str::from_utf8(AUTUMN_WIDGETS_JS)
+            .expect("autumn-widgets.js should be valid UTF-8");
+        assert!(js.contains("data-autumn-nav"), "{js}");
+        assert!(js.contains("data-nav-toggle"), "{js}");
+        assert!(js.contains("data-nav-menu-toggle"), "{js}");
+        assert!(js.contains("aria-expanded"), "{js}");
+        assert!(js.contains("Escape"), "{js}");
+    }
+
     #[tokio::test]
     async fn hx_request_extractor_parses_headers() -> Result<(), axum::http::Error> {
         let req = Request::builder()

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -179,10 +179,10 @@ pub use crate::form::{Changeset, ChangesetForm, IntoChangeset};
 pub use crate::widgets::{
     ActiveSearchConfig, AutocompleteConfig, CardConfig, Column, Crumb, Cta, CtaStyle,
     DataTableConfig, HeadingLevel, HeroConfig, NavBarConfig, NavBarLayout, NavItem, NavLinkMatch,
-    NavMenu, SearchMethod, SortDir, active_search, active_search_empty_state,
-    active_search_input, active_search_results, autocomplete_empty_state, autocomplete_input,
-    autocomplete_option, breadcrumb, card, data_table, hero, nav_bar, nav_link, nav_link_matched,
-    property_list, stat_card,
+    NavMenu, SearchMethod, SortDir, active_search, active_search_empty_state, active_search_input,
+    active_search_results, autocomplete_empty_state, autocomplete_input, autocomplete_option,
+    breadcrumb, card, data_table, hero, nav_bar, nav_link, nav_link_matched, property_list,
+    stat_card,
 };
 
 // ── Hooks ───────────────────────────────────────────────────────

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -178,10 +178,11 @@ pub use crate::form::{Changeset, ChangesetForm, IntoChangeset};
 #[cfg(feature = "maud")]
 pub use crate::widgets::{
     ActiveSearchConfig, AutocompleteConfig, CardConfig, Column, Crumb, Cta, CtaStyle,
-    DataTableConfig, HeadingLevel, HeroConfig, NavLinkMatch, SearchMethod, SortDir, active_search,
-    active_search_empty_state, active_search_input, active_search_results,
-    autocomplete_empty_state, autocomplete_input, autocomplete_option, breadcrumb, card,
-    data_table, hero, nav_link, nav_link_matched, property_list, stat_card,
+    DataTableConfig, HeadingLevel, HeroConfig, NavBarConfig, NavBarLayout, NavItem, NavLinkMatch,
+    NavMenu, SearchMethod, SortDir, active_search, active_search_empty_state,
+    active_search_input, active_search_results, autocomplete_empty_state, autocomplete_input,
+    autocomplete_option, breadcrumb, card, data_table, hero, nav_bar, nav_link, nav_link_matched,
+    property_list, stat_card,
 };
 
 // ── Hooks ───────────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1329,7 +1329,7 @@ impl NavItem {
 
     /// A dropdown menu item.
     #[must_use]
-    pub fn menu(menu: NavMenu) -> Self {
+    pub const fn menu(menu: NavMenu) -> Self {
         Self::Menu(menu)
     }
 
@@ -1460,10 +1460,11 @@ impl NavBarConfig {
     }
 }
 
-/// Render an accessible top navigation bar (or sidebar, via
-/// [`NavBarLayout::Sidebar`]): a labelled `<nav>` landmark containing an
-/// optional brand, primary items, a hidden-until-enhanced hamburger toggle,
-/// and an optional right-aligned trailing item list.
+/// Render an accessible top navigation bar (or sidebar, via [`NavBarLayout::Sidebar`]).
+///
+/// Emits a labelled `<nav>` landmark containing an optional brand, primary
+/// items, a hidden-until-enhanced hamburger toggle, and an optional
+/// right-aligned trailing item list.
 ///
 /// Every [`NavItem::Link`] built with [`NavItem::link`] / `link_matched`
 /// renders through [`nav_link_matched`], so it carries `class="active"` and
@@ -1594,10 +1595,10 @@ fn render_nav_items(
 /// [`NavLinkMatch`] mode, or as a plain never-active anchor otherwise.
 #[cfg(feature = "maud")]
 fn render_nav_link_item(current_path: &str, link: &NavLinkItem) -> maud::Markup {
-    match link.match_mode {
-        Some(mode) => nav_link_matched(current_path, &link.href, &link.label, mode),
-        None => maud::html! { a href=(link.href) { (link.label) } },
+    if let Some(mode) = link.match_mode {
+        return nav_link_matched(current_path, &link.href, &link.label, mode);
     }
+    maud::html! { a href=(link.href) { (link.label) } }
 }
 
 /// Render a dropdown menu `<li>`: a trigger `<button>` plus its `<ul>` of
@@ -3133,10 +3134,7 @@ mod tests {
     fn nav_bar_escapes_labels() {
         let config = NavBarConfig::new()
             .brand("<script>alert(1)</script>", "/")
-            .item(NavItem::link(
-                "/posts",
-                "<script>alert(2)</script>",
-            ))
+            .item(NavItem::link("/posts", "<script>alert(2)</script>"))
             .item(NavItem::menu(
                 NavMenu::new("<script>alert(3)</script>").link("/x", "<script>alert(4)</script>"),
             ));

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -15,6 +15,7 @@
 //! | `breadcrumb` | Accessible `<nav>` breadcrumb trail |
 //! | `hero` | Landing-page banner: headline, optional subtitle, and CTAs |
 //! | `nav_link` | Navigation anchor, auto-marked active + `aria-current` |
+//! | `nav_bar` | Top-bar/sidebar `<nav>` landmark: brand, links, dropdowns, responsive toggle |
 //!
 //! # Interactive / search widgets
 //!
@@ -1459,11 +1460,170 @@ impl NavBarConfig {
     }
 }
 
-/// Render a navigation bar (STUB — not yet implemented).
+/// Render an accessible top navigation bar (or sidebar, via
+/// [`NavBarLayout::Sidebar`]): a labelled `<nav>` landmark containing an
+/// optional brand, primary items, a hidden-until-enhanced hamburger toggle,
+/// and an optional right-aligned trailing item list.
+///
+/// Every [`NavItem::Link`] built with [`NavItem::link`] / `link_matched`
+/// renders through [`nav_link_matched`], so it carries `class="active"` and
+/// `aria-current="page"` when its `href` matches `current_path` — pair with
+/// the [`CurrentPath`](crate::extract::CurrentPath) extractor to get
+/// `current_path` from the incoming request. [`NavItem::plain_link`] never
+/// becomes active, for links to unrelated tools that shouldn't claim
+/// "you are here" (e.g. an external or admin-actuator link).
+///
+/// [`NavItem::menu`] renders a `<button>` trigger plus a `<ul>` of sub-links.
+/// Before JavaScript enhances the page, the hamburger toggle is hidden (a
+/// horizontal bar with no toggle has nothing to hide) and every dropdown is
+/// rendered open (`aria-expanded="true"`, no `hidden` attribute) so **all
+/// links stay visible with JavaScript off** — the framework's
+/// `/static/js/autumn-widgets.js` runtime (same-origin, CSP-safe under the
+/// default `script-src 'self'`) then reveals the hamburger and wires the
+/// toggle/dropdown/Escape-to-close behavior. No app-authored JavaScript, and
+/// no inline `<script>` or `style=` attributes, are ever required.
+///
+/// # CSS hooks
+///
+/// | Selector | Element |
+/// |---|---|
+/// | `.autumn-nav` | Root `<nav>` landmark |
+/// | `.autumn-nav--sidebar` | Modifier added by [`NavBarLayout::Sidebar`] |
+/// | `.autumn-nav--enhanced` | Added by the JS runtime once initialized |
+/// | `.autumn-nav__brand` | Brand link (`<a>`) or wordmark (`<span>`) |
+/// | `.autumn-nav__toggle` | Hamburger `<button>` |
+/// | `.autumn-nav__collapse` | Collapsible container wrapping the item lists |
+/// | `.autumn-nav__collapse--open` | Added by the JS runtime while expanded |
+/// | `.autumn-nav__items` | Primary or trailing `<ul>` |
+/// | `.autumn-nav__items--trailing` | Added to the trailing `<ul>` only |
+/// | `.autumn-nav__item` | Every `<li>` wrapping a link |
+/// | `.autumn-nav__item--menu` | `<li>` wrapping a dropdown menu |
+/// | `.autumn-nav__section` | Non-interactive group-label `<li>` |
+/// | `.autumn-nav__menu-toggle` | Dropdown trigger `<button>` |
+/// | `.autumn-nav__menu` | Dropdown sub-item `<ul>` |
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::widgets::{NavBarConfig, NavItem, NavLinkMatch, NavMenu, nav_bar};
+///
+/// let config = NavBarConfig::new()
+///     .brand("Acme", "/")
+///     .item(NavItem::link("/", "Home"))
+///     .item(NavItem::link_matched("/posts", "Posts", NavLinkMatch::Prefix))
+///     .item(NavItem::link("/about", "About"))
+///     .item(NavItem::menu(
+///         NavMenu::new("Products")
+///             .link("/widgets", "Widgets")
+///             .link("/gadgets", "Gadgets"),
+///     ))
+///     .trailing(NavItem::plain_link("/login", "Log in"));
+///
+/// let html = nav_bar("/posts/3", &config).into_string();
+/// assert!(html.contains(r#"aria-current="page""#));
+/// assert!(!html.contains("style="));
+/// ```
 #[cfg(feature = "maud")]
 #[must_use]
-pub fn nav_bar(_current_path: &str, _config: &NavBarConfig) -> maud::Markup {
-    maud::html! { nav {} }
+pub fn nav_bar(current_path: &str, config: &NavBarConfig) -> maud::Markup {
+    let root_class = merge_class(
+        match config.layout {
+            NavBarLayout::Horizontal => "autumn-nav",
+            NavBarLayout::Sidebar => "autumn-nav autumn-nav--sidebar",
+        },
+        config.class.as_deref(),
+    );
+    let collapse_id = format!("{}-collapse", config.id);
+    let mut menu_counter = 0usize;
+
+    maud::html! {
+        nav id=(config.id) class=(root_class) aria-label=(config.aria_label) data-autumn-nav {
+            @if let Some((brand, href)) = &config.brand {
+                @if let Some(href) = href {
+                    a class="autumn-nav__brand" href=(href) { (brand) }
+                } @else {
+                    span class="autumn-nav__brand" { (brand) }
+                }
+            }
+            button type="button" class="autumn-nav__toggle" aria-expanded="false"
+                aria-controls=(collapse_id) hidden data-nav-toggle {
+                (config.toggle_label)
+            }
+            div id=(collapse_id) class="autumn-nav__collapse" {
+                @if !config.items.is_empty() {
+                    ul class="autumn-nav__items" {
+                        (render_nav_items(current_path, &config.items, &config.id, &mut menu_counter))
+                    }
+                }
+                @if !config.trailing.is_empty() {
+                    ul class="autumn-nav__items autumn-nav__items--trailing" {
+                        (render_nav_items(current_path, &config.trailing, &config.id, &mut menu_counter))
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Render the `<li>` items for one [`nav_bar`] item list (primary or trailing).
+#[cfg(feature = "maud")]
+fn render_nav_items(
+    current_path: &str,
+    items: &[NavItem],
+    id: &str,
+    menu_counter: &mut usize,
+) -> maud::Markup {
+    maud::html! {
+        @for item in items {
+            @match item {
+                NavItem::Link(link) => {
+                    li class="autumn-nav__item" { (render_nav_link_item(current_path, link)) }
+                }
+                NavItem::Section(label) => {
+                    li class="autumn-nav__section" { (label) }
+                }
+                NavItem::Menu(menu) => {
+                    (render_nav_menu(current_path, menu, id, menu_counter))
+                }
+            }
+        }
+    }
+}
+
+/// Render a single nav link: through [`nav_link_matched`] when it has a
+/// [`NavLinkMatch`] mode, or as a plain never-active anchor otherwise.
+#[cfg(feature = "maud")]
+fn render_nav_link_item(current_path: &str, link: &NavLinkItem) -> maud::Markup {
+    match link.match_mode {
+        Some(mode) => nav_link_matched(current_path, &link.href, &link.label, mode),
+        None => maud::html! { a href=(link.href) { (link.label) } },
+    }
+}
+
+/// Render a dropdown menu `<li>`: a trigger `<button>` plus its `<ul>` of
+/// sub-links, using and incrementing `menu_counter` to derive a unique id.
+#[cfg(feature = "maud")]
+fn render_nav_menu(
+    current_path: &str,
+    menu: &NavMenu,
+    id: &str,
+    menu_counter: &mut usize,
+) -> maud::Markup {
+    *menu_counter += 1;
+    let menu_id = format!("{id}-menu-{menu_counter}");
+    maud::html! {
+        li class="autumn-nav__item autumn-nav__item--menu" {
+            button type="button" class="autumn-nav__menu-toggle" aria-expanded="true"
+                aria-controls=(menu_id) data-nav-menu-toggle {
+                (menu.label)
+            }
+            ul id=(menu_id) class="autumn-nav__menu" {
+                @for link in &menu.links {
+                    li class="autumn-nav__item" { (render_nav_link_item(current_path, link)) }
+                }
+            }
+        }
+    }
 }
 
 // ── card ──────────────────────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1211,6 +1211,261 @@ fn nav_link_is_active(current_path: &str, href: &str, mode: NavLinkMatch) -> boo
     }
 }
 
+// ── nav_bar ──────────────────────────────────────────────────────────────────
+
+/// Layout variant for [`nav_bar`] — selects a modifier class on the root
+/// `<nav>` element.
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NavBarLayout {
+    /// Horizontal top navigation bar (default).
+    #[default]
+    Horizontal,
+    /// Vertical sidebar / dashboard nav — adds `.autumn-nav--sidebar`.
+    Sidebar,
+}
+
+/// A single navigation link, as rendered inside a [`nav_bar`] or [`NavMenu`].
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone)]
+pub struct NavLinkItem {
+    href: String,
+    label: String,
+    match_mode: Option<NavLinkMatch>,
+}
+
+/// A dropdown navigation item: a `<button>` trigger plus a `<ul>` of
+/// sub-links. Build with [`NavMenu::new`] and chain `.link()` / `.link_matched()`
+/// / `.plain_link()` for each sub-item.
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone)]
+pub struct NavMenu {
+    label: String,
+    links: Vec<NavLinkItem>,
+}
+
+#[cfg(feature = "maud")]
+impl NavMenu {
+    /// Create a new dropdown menu with the given trigger label and no sub-items.
+    #[must_use]
+    pub fn new(label: &str) -> Self {
+        Self {
+            label: label.to_string(),
+            links: Vec::new(),
+        }
+    }
+
+    /// Append a sub-link using [`NavLinkMatch::Exact`] matching.
+    #[must_use]
+    pub fn link(self, href: &str, label: &str) -> Self {
+        self.link_matched(href, label, NavLinkMatch::Exact)
+    }
+
+    /// Append a sub-link with an explicit [`NavLinkMatch`] mode.
+    #[must_use]
+    pub fn link_matched(mut self, href: &str, label: &str, mode: NavLinkMatch) -> Self {
+        self.links.push(NavLinkItem {
+            href: href.to_string(),
+            label: label.to_string(),
+            match_mode: Some(mode),
+        });
+        self
+    }
+
+    /// Append a sub-link that never becomes active (e.g. an external link).
+    #[must_use]
+    pub fn plain_link(mut self, href: &str, label: &str) -> Self {
+        self.links.push(NavLinkItem {
+            href: href.to_string(),
+            label: label.to_string(),
+            match_mode: None,
+        });
+        self
+    }
+}
+
+/// One item in a [`nav_bar`]'s primary or trailing item list.
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone)]
+pub enum NavItem {
+    /// A single navigation link.
+    Link(NavLinkItem),
+    /// A dropdown menu of sub-links.
+    Menu(NavMenu),
+    /// A non-interactive group label (e.g. `"Models"` in a sidebar nav).
+    Section(String),
+}
+
+#[cfg(feature = "maud")]
+impl NavItem {
+    /// A link using [`NavLinkMatch::Exact`] matching against the current path.
+    #[must_use]
+    pub fn link(href: &str, label: &str) -> Self {
+        Self::link_matched(href, label, NavLinkMatch::Exact)
+    }
+
+    /// A link with an explicit [`NavLinkMatch`] mode.
+    #[must_use]
+    pub fn link_matched(href: &str, label: &str, mode: NavLinkMatch) -> Self {
+        Self::Link(NavLinkItem {
+            href: href.to_string(),
+            label: label.to_string(),
+            match_mode: Some(mode),
+        })
+    }
+
+    /// A link that never becomes active regardless of the current path —
+    /// e.g. a link to an unrelated tool (an admin actuator page) that should
+    /// never claim `aria-current`.
+    #[must_use]
+    pub fn plain_link(href: &str, label: &str) -> Self {
+        Self::Link(NavLinkItem {
+            href: href.to_string(),
+            label: label.to_string(),
+            match_mode: None,
+        })
+    }
+
+    /// A dropdown menu item.
+    #[must_use]
+    pub fn menu(menu: NavMenu) -> Self {
+        Self::Menu(menu)
+    }
+
+    /// A non-interactive group label.
+    #[must_use]
+    pub fn section(label: &str) -> Self {
+        Self::Section(label.to_string())
+    }
+}
+
+/// Configuration for [`nav_bar`]. Build with [`NavBarConfig::new`].
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone)]
+pub struct NavBarConfig {
+    id: String,
+    aria_label: String,
+    brand: Option<(maud::Markup, Option<String>)>,
+    items: Vec<NavItem>,
+    trailing: Vec<NavItem>,
+    layout: NavBarLayout,
+    toggle_label: String,
+    class: Option<String>,
+}
+
+#[cfg(feature = "maud")]
+impl Default for NavBarConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "maud")]
+impl NavBarConfig {
+    /// Create a new nav bar configuration: no brand or items, `aria-label`
+    /// `"Main"`, id `"autumn-nav"`, toggle label `"Menu"`, horizontal layout.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            id: "autumn-nav".to_string(),
+            aria_label: "Main".to_string(),
+            brand: None,
+            items: Vec::new(),
+            trailing: Vec::new(),
+            layout: NavBarLayout::Horizontal,
+            toggle_label: "Menu".to_string(),
+            class: None,
+        }
+    }
+
+    /// Set the brand/logo slot from plain text linking to `href`. The text is
+    /// HTML-escaped by Maud.
+    #[must_use]
+    pub fn brand(self, label: &str, href: &str) -> Self {
+        self.brand_html(maud::html! { (label) }, Some(href))
+    }
+
+    /// Set the brand/logo slot from pre-built [`maud::Markup`]. When `href`
+    /// is `Some`, the brand renders as an anchor; when `None`, it renders as
+    /// a `<span>` (e.g. for a plain wordmark with no link).
+    ///
+    /// Callers are responsible for escaping any user-supplied content inside `brand`.
+    #[must_use]
+    pub fn brand_html(mut self, brand: maud::Markup, href: Option<&str>) -> Self {
+        self.brand = Some((brand, href.map(str::to_string)));
+        self
+    }
+
+    /// Append a primary navigation item.
+    #[must_use]
+    pub fn item(mut self, item: NavItem) -> Self {
+        self.items.push(item);
+        self
+    }
+
+    /// Append multiple primary navigation items at once — convenient when
+    /// building the list from a dynamic source (e.g. a loop over registered models).
+    #[must_use]
+    pub fn items(mut self, items: impl IntoIterator<Item = NavItem>) -> Self {
+        self.items.extend(items);
+        self
+    }
+
+    /// Append an item to the right-aligned trailing slot (account menu, CTA, etc.).
+    #[must_use]
+    pub fn trailing(mut self, item: NavItem) -> Self {
+        self.trailing.push(item);
+        self
+    }
+
+    /// Set the `aria-label` on the `<nav>` landmark (default `"Main"`). Give
+    /// each `nav_bar` on a page a distinct label so screen-reader users can
+    /// tell them apart.
+    #[must_use]
+    pub fn aria_label(mut self, label: &str) -> Self {
+        self.aria_label = label.to_string();
+        self
+    }
+
+    /// Set the layout variant (default [`NavBarLayout::Horizontal`]).
+    #[must_use]
+    pub const fn layout(mut self, layout: NavBarLayout) -> Self {
+        self.layout = layout;
+        self
+    }
+
+    /// Set the element `id` used to derive `aria-controls` target ids
+    /// (default `"autumn-nav"`). Give a second `nav_bar` on the same page a
+    /// distinct id so their collapse/menu ids don't collide.
+    #[must_use]
+    pub fn id(mut self, id: &str) -> Self {
+        self.id = id.to_string();
+        self
+    }
+
+    /// Set the visible/accessible text of the hamburger toggle button
+    /// (default `"Menu"`).
+    #[must_use]
+    pub fn toggle_label(mut self, label: &str) -> Self {
+        self.toggle_label = label.to_string();
+        self
+    }
+
+    /// Add extra CSS class(es) to the root `autumn-nav` element.
+    #[must_use]
+    pub fn class(mut self, class: impl Into<String>) -> Self {
+        self.class = Some(class.into());
+        self
+    }
+}
+
+/// Render a navigation bar (STUB — not yet implemented).
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn nav_bar(_current_path: &str, _config: &NavBarConfig) -> maud::Markup {
+    maud::html! { nav {} }
+}
+
 // ── card ──────────────────────────────────────────────────────────────────
 
 /// Heading level for the title element inside a [`card`].
@@ -2534,6 +2789,214 @@ mod tests {
         let html = nav_link("/somewhere/else", "/admin/posts", "Posts").into_string();
         assert!(html.contains(r#"href="/admin/posts""#), "{html}");
         assert!(html.contains(">Posts<"), "{html}");
+    }
+
+    // ── nav_bar ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn nav_bar_renders_single_nav_landmark_with_default_label() {
+        let config = NavBarConfig::new();
+        let html = nav_bar("/", &config).into_string();
+        assert_eq!(html.matches("<nav").count(), 1, "{html}");
+        assert!(html.contains(r#"aria-label="Main""#), "{html}");
+        assert!(html.contains(r#"class="autumn-nav""#), "{html}");
+        assert!(html.contains("data-autumn-nav"), "{html}");
+    }
+
+    #[test]
+    fn nav_bar_custom_aria_label() {
+        let config = NavBarConfig::new().aria_label("Admin navigation");
+        let html = nav_bar("/", &config).into_string();
+        assert!(html.contains(r#"aria-label="Admin navigation""#), "{html}");
+    }
+
+    #[test]
+    fn nav_bar_brand_text_renders_brand_link() {
+        let config = NavBarConfig::new().brand("Acme", "/");
+        let html = nav_bar("/", &config).into_string();
+        assert!(
+            html.contains(r#"<a class="autumn-nav__brand" href="/">Acme</a>"#),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn nav_bar_brand_html_without_href_renders_span() {
+        let config = NavBarConfig::new().brand_html(maud::html! { "Acme" }, None);
+        let html = nav_bar("/", &config).into_string();
+        assert!(
+            html.contains(r#"<span class="autumn-nav__brand">Acme</span>"#),
+            "{html}"
+        );
+        assert!(!html.contains("<a class=\"autumn-nav__brand\""), "{html}");
+    }
+
+    #[test]
+    fn nav_bar_without_brand_omits_brand_element() {
+        let config = NavBarConfig::new();
+        let html = nav_bar("/", &config).into_string();
+        assert!(!html.contains("autumn-nav__brand"), "{html}");
+    }
+
+    #[test]
+    fn nav_bar_active_link_gets_aria_current() {
+        let config = NavBarConfig::new().item(NavItem::link("/posts", "Posts"));
+        let html = nav_bar("/posts", &config).into_string();
+        assert_eq!(html.matches(r#"aria-current="page""#).count(), 1, "{html}");
+        assert!(html.contains(r#"class="active""#), "{html}");
+    }
+
+    #[test]
+    fn nav_bar_prefix_match_mode_activates_on_subpath() {
+        let config = NavBarConfig::new().item(NavItem::link_matched(
+            "/posts",
+            "Posts",
+            NavLinkMatch::Prefix,
+        ));
+        let html = nav_bar("/posts/3/edit", &config).into_string();
+        assert!(html.contains(r#"aria-current="page""#), "{html}");
+    }
+
+    #[test]
+    fn nav_bar_plain_link_never_active() {
+        let config = NavBarConfig::new().item(NavItem::plain_link("/actuator/ui", "Actuator"));
+        let html = nav_bar("/actuator/ui", &config).into_string();
+        assert!(!html.contains("aria-current"), "{html}");
+        assert!(!html.contains(r#"class="active""#), "{html}");
+        assert!(html.contains(r#"href="/actuator/ui""#), "{html}");
+    }
+
+    #[test]
+    fn nav_bar_section_renders_label_li() {
+        let config = NavBarConfig::new().item(NavItem::section("System"));
+        let html = nav_bar("/", &config).into_string();
+        assert!(
+            html.contains(r#"<li class="autumn-nav__section">System</li>"#),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn nav_bar_menu_renders_button_controlling_ul() {
+        let config = NavBarConfig::new().item(NavItem::menu(
+            NavMenu::new("Products").link("/widgets", "Widgets"),
+        ));
+        let html = nav_bar("/", &config).into_string();
+        assert!(html.contains(r#"type="button""#), "{html}");
+        assert!(html.contains("data-nav-menu-toggle"), "{html}");
+        assert!(html.contains(r#"aria-expanded="true""#), "{html}");
+        assert!(
+            html.contains(r#"aria-controls="autumn-nav-menu-1""#),
+            "{html}"
+        );
+        assert!(
+            html.contains(r#"<ul id="autumn-nav-menu-1" class="autumn-nav__menu""#),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn nav_bar_menu_sub_link_active_gets_aria_current() {
+        let config = NavBarConfig::new().item(NavItem::menu(
+            NavMenu::new("Products").link("/widgets", "Widgets"),
+        ));
+        let html = nav_bar("/widgets", &config).into_string();
+        assert!(html.contains(r#"aria-current="page""#), "{html}");
+    }
+
+    #[test]
+    fn nav_bar_menu_ids_unique_and_respect_custom_id() {
+        let config = NavBarConfig::new()
+            .item(NavItem::menu(NavMenu::new("A").link("/a", "A")))
+            .item(NavItem::menu(NavMenu::new("B").link("/b", "B")))
+            .id("top");
+        let html = nav_bar("/", &config).into_string();
+        assert!(html.contains(r#"aria-controls="top-menu-1""#), "{html}");
+        assert!(html.contains(r#"id="top-menu-1""#), "{html}");
+        assert!(html.contains(r#"aria-controls="top-menu-2""#), "{html}");
+        assert!(html.contains(r#"id="top-menu-2""#), "{html}");
+        assert!(html.contains(r#"id="top-collapse""#), "{html}");
+    }
+
+    #[test]
+    fn nav_bar_toggle_button_is_hidden_with_accessible_name() {
+        let config = NavBarConfig::new();
+        let html = nav_bar("/", &config).into_string();
+        assert!(html.contains("data-nav-toggle"), "{html}");
+        assert!(html.contains("hidden"), "{html}");
+        assert!(html.contains(r#"aria-expanded="false""#), "{html}");
+        assert!(
+            html.contains(r#"aria-controls="autumn-nav-collapse""#),
+            "{html}"
+        );
+        assert!(html.contains(">Menu<"), "{html}");
+
+        let config = NavBarConfig::new().toggle_label("Navigation");
+        let html = nav_bar("/", &config).into_string();
+        assert!(html.contains(">Navigation<"), "{html}");
+    }
+
+    #[test]
+    fn nav_bar_trailing_slot_renders_separate_list() {
+        let config = NavBarConfig::new().trailing(NavItem::plain_link("/login", "Log in"));
+        let html = nav_bar("/", &config).into_string();
+        assert!(html.contains("autumn-nav__items--trailing"), "{html}");
+        assert!(html.contains(r#"href="/login""#), "{html}");
+
+        let config = NavBarConfig::new();
+        let html = nav_bar("/", &config).into_string();
+        assert!(!html.contains("autumn-nav__items--trailing"), "{html}");
+    }
+
+    #[test]
+    fn nav_bar_sidebar_layout_adds_modifier() {
+        let config = NavBarConfig::new().layout(NavBarLayout::Sidebar);
+        let html = nav_bar("/", &config).into_string();
+        assert!(html.contains("autumn-nav--sidebar"), "{html}");
+
+        let config = NavBarConfig::new();
+        let html = nav_bar("/", &config).into_string();
+        assert!(!html.contains("autumn-nav--sidebar"), "{html}");
+    }
+
+    #[test]
+    fn nav_bar_class_merges_extra() {
+        let config = NavBarConfig::new().class("admin-sidebar");
+        let html = nav_bar("/", &config).into_string();
+        assert!(
+            html.contains(r#"class="autumn-nav admin-sidebar""#),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn nav_bar_escapes_labels() {
+        let config = NavBarConfig::new()
+            .brand("<script>alert(1)</script>", "/")
+            .item(NavItem::link(
+                "/posts",
+                "<script>alert(2)</script>",
+            ))
+            .item(NavItem::menu(
+                NavMenu::new("<script>alert(3)</script>").link("/x", "<script>alert(4)</script>"),
+            ));
+        let html = nav_bar("/", &config).into_string();
+        assert!(!html.contains("<script>"), "{html}");
+        assert!(html.contains("&lt;script&gt;"), "{html}");
+    }
+
+    #[test]
+    fn nav_bar_emits_no_inline_style_or_script() {
+        let config = NavBarConfig::new()
+            .brand("Acme", "/")
+            .item(NavItem::link("/", "Home"))
+            .item(NavItem::menu(
+                NavMenu::new("Products").link("/widgets", "Widgets"),
+            ))
+            .trailing(NavItem::plain_link("/login", "Log in"));
+        let html = nav_bar("/", &config).into_string();
+        assert!(!html.contains("style="), "{html}");
+        assert!(!html.contains("<script"), "{html}");
     }
 
     // ── property_list ──────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -1235,6 +1235,24 @@ pub struct NavLinkItem {
     match_mode: Option<NavLinkMatch>,
 }
 
+#[cfg(feature = "maud")]
+impl NavLinkItem {
+    /// Build from anything convertible to `String` — an owned `String`
+    /// (e.g. a `format!()` result) moves in for free via `.into()`, while a
+    /// `&str` literal still works ergonomically.
+    fn new(
+        href: impl Into<String>,
+        label: impl Into<String>,
+        match_mode: Option<NavLinkMatch>,
+    ) -> Self {
+        Self {
+            href: href.into(),
+            label: label.into(),
+            match_mode,
+        }
+    }
+}
+
 /// A dropdown navigation item: a `<button>` trigger plus a `<ul>` of
 /// sub-links. Build with [`NavMenu::new`] and chain `.link()` / `.link_matched()`
 /// / `.plain_link()` for each sub-item.
@@ -1249,38 +1267,35 @@ pub struct NavMenu {
 impl NavMenu {
     /// Create a new dropdown menu with the given trigger label and no sub-items.
     #[must_use]
-    pub fn new(label: &str) -> Self {
+    pub fn new(label: impl Into<String>) -> Self {
         Self {
-            label: label.to_string(),
+            label: label.into(),
             links: Vec::new(),
         }
     }
 
     /// Append a sub-link using [`NavLinkMatch::Exact`] matching.
     #[must_use]
-    pub fn link(self, href: &str, label: &str) -> Self {
+    pub fn link(self, href: impl Into<String>, label: impl Into<String>) -> Self {
         self.link_matched(href, label, NavLinkMatch::Exact)
     }
 
     /// Append a sub-link with an explicit [`NavLinkMatch`] mode.
     #[must_use]
-    pub fn link_matched(mut self, href: &str, label: &str, mode: NavLinkMatch) -> Self {
-        self.links.push(NavLinkItem {
-            href: href.to_string(),
-            label: label.to_string(),
-            match_mode: Some(mode),
-        });
+    pub fn link_matched(
+        mut self,
+        href: impl Into<String>,
+        label: impl Into<String>,
+        mode: NavLinkMatch,
+    ) -> Self {
+        self.links.push(NavLinkItem::new(href, label, Some(mode)));
         self
     }
 
     /// Append a sub-link that never becomes active (e.g. an external link).
     #[must_use]
-    pub fn plain_link(mut self, href: &str, label: &str) -> Self {
-        self.links.push(NavLinkItem {
-            href: href.to_string(),
-            label: label.to_string(),
-            match_mode: None,
-        });
+    pub fn plain_link(mut self, href: impl Into<String>, label: impl Into<String>) -> Self {
+        self.links.push(NavLinkItem::new(href, label, None));
         self
     }
 }
@@ -1301,30 +1316,26 @@ pub enum NavItem {
 impl NavItem {
     /// A link using [`NavLinkMatch::Exact`] matching against the current path.
     #[must_use]
-    pub fn link(href: &str, label: &str) -> Self {
+    pub fn link(href: impl Into<String>, label: impl Into<String>) -> Self {
         Self::link_matched(href, label, NavLinkMatch::Exact)
     }
 
     /// A link with an explicit [`NavLinkMatch`] mode.
     #[must_use]
-    pub fn link_matched(href: &str, label: &str, mode: NavLinkMatch) -> Self {
-        Self::Link(NavLinkItem {
-            href: href.to_string(),
-            label: label.to_string(),
-            match_mode: Some(mode),
-        })
+    pub fn link_matched(
+        href: impl Into<String>,
+        label: impl Into<String>,
+        mode: NavLinkMatch,
+    ) -> Self {
+        Self::Link(NavLinkItem::new(href, label, Some(mode)))
     }
 
     /// A link that never becomes active regardless of the current path —
     /// e.g. a link to an unrelated tool (an admin actuator page) that should
     /// never claim `aria-current`.
     #[must_use]
-    pub fn plain_link(href: &str, label: &str) -> Self {
-        Self::Link(NavLinkItem {
-            href: href.to_string(),
-            label: label.to_string(),
-            match_mode: None,
-        })
+    pub fn plain_link(href: impl Into<String>, label: impl Into<String>) -> Self {
+        Self::Link(NavLinkItem::new(href, label, None))
     }
 
     /// A dropdown menu item.
@@ -1335,8 +1346,8 @@ impl NavItem {
 
     /// A non-interactive group label.
     #[must_use]
-    pub fn section(label: &str) -> Self {
-        Self::Section(label.to_string())
+    pub fn section(label: impl Into<String>) -> Self {
+        Self::Section(label.into())
     }
 }
 
@@ -3128,6 +3139,28 @@ mod tests {
             html.contains(r#"class="autumn-nav admin-sidebar""#),
             "{html}"
         );
+    }
+
+    #[test]
+    fn nav_item_constructors_accept_owned_strings_without_extra_copy() {
+        // href/label should accept `impl Into<String>` (like Cta::primary),
+        // not force callers with an already-owned String (e.g. from
+        // format!()) through an extra borrow-then-reallocate round trip.
+        let post_id = 3;
+        let href: String = format!("/posts/{post_id}");
+        let label: String = "Posts".to_string();
+        let config = NavBarConfig::new()
+            .item(NavItem::link(href, label))
+            .item(NavItem::plain_link("/x".to_string(), "X".to_string()))
+            .item(NavItem::section("System".to_string()))
+            .item(NavItem::menu(
+                NavMenu::new("Products".to_string())
+                    .link(format!("/widgets/{post_id}"), "Widgets".to_string())
+                    .plain_link("/external".to_string(), "External".to_string()),
+            ));
+        let html = nav_bar("/posts/3", &config).into_string();
+        assert!(html.contains(r#"href="/posts/3""#), "{html}");
+        assert!(html.contains(r#"aria-current="page""#), "{html}");
     }
 
     #[test]

--- a/autumn/vendor/autumn-widgets.js
+++ b/autumn/vendor/autumn-widgets.js
@@ -102,9 +102,15 @@
   // so all links stay visible with JS off. Once it runs, the hamburger is
   // revealed and dropdowns collapse into working disclosure widgets.
 
+  // Total open dropdown menus across every nav_bar on the page, so the
+  // document-level click-outside handler below can skip its DOM query
+  // entirely on the common case where nothing is open.
+  var openNavMenuCount = 0;
+
   function closeNavMenu(toggle) {
     var menu = document.getElementById(toggle.getAttribute('aria-controls'));
     if (!menu) return;
+    if (toggle.getAttribute('aria-expanded') === 'true') openNavMenuCount--;
     toggle.setAttribute('aria-expanded', 'false');
     menu.hidden = true;
   }
@@ -112,6 +118,7 @@
   function openNavMenu(toggle) {
     var menu = document.getElementById(toggle.getAttribute('aria-controls'));
     if (!menu) return;
+    if (toggle.getAttribute('aria-expanded') !== 'true') openNavMenuCount++;
     toggle.setAttribute('aria-expanded', 'true');
     menu.hidden = false;
   }
@@ -152,8 +159,10 @@
     });
   }
 
-  // Clicking outside a nav_bar closes any of its open dropdowns.
+  // Clicking outside a nav_bar closes any of its open dropdowns. Skips the
+  // DOM query entirely when no dropdown is open anywhere on the page.
   document.addEventListener('click', function (e) {
+    if (openNavMenuCount === 0) return;
     document.querySelectorAll('[data-nav-menu-toggle][aria-expanded="true"]').forEach(function (menuToggle) {
       var nav = menuToggle.closest('[data-autumn-nav]');
       if (nav && !nav.contains(e.target)) closeNavMenu(menuToggle);

--- a/autumn/vendor/autumn-widgets.js
+++ b/autumn/vendor/autumn-widgets.js
@@ -96,8 +96,73 @@
     });
   }
 
+  // ── nav_bar widget ──────────────────────────────────────────────────────
+  // Progressive enhancement for autumn_web::widgets::nav_bar: before this
+  // runs, the hamburger toggle is hidden and every dropdown is rendered open
+  // so all links stay visible with JS off. Once it runs, the hamburger is
+  // revealed and dropdowns collapse into working disclosure widgets.
+
+  function closeNavMenu(toggle) {
+    var menu = document.getElementById(toggle.getAttribute('aria-controls'));
+    if (!menu) return;
+    toggle.setAttribute('aria-expanded', 'false');
+    menu.hidden = true;
+  }
+
+  function openNavMenu(toggle) {
+    var menu = document.getElementById(toggle.getAttribute('aria-controls'));
+    if (!menu) return;
+    toggle.setAttribute('aria-expanded', 'true');
+    menu.hidden = false;
+  }
+
+  function initNav(nav) {
+    if (nav.dataset.navInit) return;
+    nav.dataset.navInit = '1';
+    nav.classList.add('autumn-nav--enhanced');
+
+    var toggle = nav.querySelector('[data-nav-toggle]');
+    var collapse = toggle && document.getElementById(toggle.getAttribute('aria-controls'));
+    if (toggle && collapse) {
+      toggle.hidden = false;
+      toggle.addEventListener('click', function () {
+        var open = toggle.getAttribute('aria-expanded') === 'true';
+        toggle.setAttribute('aria-expanded', open ? 'false' : 'true');
+        collapse.classList.toggle('autumn-nav__collapse--open', !open);
+      });
+    }
+
+    var menuToggles = nav.querySelectorAll('[data-nav-menu-toggle]');
+    menuToggles.forEach(function (menuToggle) {
+      closeNavMenu(menuToggle);
+      menuToggle.addEventListener('click', function () {
+        var open = menuToggle.getAttribute('aria-expanded') === 'true';
+        menuToggles.forEach(closeNavMenu);
+        if (!open) openNavMenu(menuToggle);
+      });
+    });
+
+    // Escape closes the open dropdown (if any) and refocuses its trigger.
+    nav.addEventListener('keydown', function (e) {
+      if (e.key !== 'Escape') return;
+      var openToggle = nav.querySelector('[data-nav-menu-toggle][aria-expanded="true"]');
+      if (!openToggle) return;
+      closeNavMenu(openToggle);
+      openToggle.focus();
+    });
+  }
+
+  // Clicking outside a nav_bar closes any of its open dropdowns.
+  document.addEventListener('click', function (e) {
+    document.querySelectorAll('[data-nav-menu-toggle][aria-expanded="true"]').forEach(function (menuToggle) {
+      var nav = menuToggle.closest('[data-autumn-nav]');
+      if (nav && !nav.contains(e.target)) closeNavMenu(menuToggle);
+    });
+  });
+
   function initAll() {
     document.querySelectorAll('[data-ac-value-id]').forEach(initAutocomplete);
+    document.querySelectorAll('[data-autumn-nav]').forEach(initNav);
   }
 
   if (document.readyState === 'loading') {
@@ -106,7 +171,7 @@
     initAll();
   }
 
-  // Re-initialize after htmx swaps in new autocomplete widgets.
+  // Re-initialize after htmx swaps in new widgets.
   // Also check the swapped-in target itself in case it IS the wrapper
   // (e.g. hx-swap="outerHTML" on the wrapper element).
   document.addEventListener('htmx:afterSwap', function (e) {
@@ -116,5 +181,9 @@
       initAutocomplete(t);
     }
     t.querySelectorAll('[data-ac-value-id]').forEach(initAutocomplete);
+    if (t.dataset && 'autumnNav' in t.dataset) {
+      initNav(t);
+    }
+    t.querySelectorAll('[data-autumn-nav]').forEach(initNav);
   });
 })();

--- a/autumn/vendor/autumn-widgets.js
+++ b/autumn/vendor/autumn-widgets.js
@@ -128,14 +128,21 @@
     setNavMenuExpanded(toggle, true);
   }
 
+  // initNav is guarded per-CONTROL (toggle / menu toggle), not once per nav
+  // element: when htmx swaps a <nav data-autumn-nav>'s innerHTML (the nav
+  // itself stays in the DOM, only its children are replaced), the swapped-in
+  // hamburger/dropdown buttons are brand-new nodes with no dataset flags of
+  // their own, so they need wiring again even though the nav was already
+  // initialized once. The keydown listener is the one nav-level exception —
+  // it always queries for the *current* open toggle at Escape-press time, so
+  // it never needs re-registering and must only ever be added once.
   function initNav(nav) {
-    if (nav.dataset.navInit) return;
-    nav.dataset.navInit = '1';
     nav.classList.add('autumn-nav--enhanced');
 
     var toggle = nav.querySelector('[data-nav-toggle]');
     var collapse = toggle && document.getElementById(toggle.getAttribute('aria-controls'));
-    if (toggle && collapse) {
+    if (toggle && collapse && !toggle.dataset.navToggleInit) {
+      toggle.dataset.navToggleInit = '1';
       toggle.hidden = false;
       toggle.addEventListener('click', function () {
         var open = toggle.getAttribute('aria-expanded') === 'true';
@@ -144,19 +151,24 @@
       });
     }
 
-    var menuToggles = nav.querySelectorAll('[data-nav-menu-toggle]');
-    menuToggles.forEach(function (menuToggle) {
+    nav.querySelectorAll('[data-nav-menu-toggle]').forEach(function (menuToggle) {
+      if (menuToggle.dataset.navMenuToggleInit) return;
+      menuToggle.dataset.navMenuToggleInit = '1';
       // Collapse the server-rendered "open" default without decrementing
       // openNavMenuCount — it was never incremented for these, so treating
       // this as a close would drive the counter negative.
       setNavMenuExpanded(menuToggle, false);
       menuToggle.addEventListener('click', function () {
         var open = menuToggle.getAttribute('aria-expanded') === 'true';
-        menuToggles.forEach(closeNavMenu);
+        // Re-query rather than close over the toggle list captured at wiring
+        // time, so a later swap's newly-wired toggles are included too.
+        nav.querySelectorAll('[data-nav-menu-toggle]').forEach(closeNavMenu);
         if (!open) openNavMenu(menuToggle);
       });
     });
 
+    if (nav.dataset.navKeydownInit) return;
+    nav.dataset.navKeydownInit = '1';
     // Escape closes the open dropdown (if any) and refocuses its trigger.
     nav.addEventListener('keydown', function (e) {
       if (e.key !== 'Escape') return;

--- a/autumn/vendor/autumn-widgets.js
+++ b/autumn/vendor/autumn-widgets.js
@@ -107,20 +107,25 @@
   // entirely on the common case where nothing is open.
   var openNavMenuCount = 0;
 
-  function closeNavMenu(toggle) {
+  // Set expanded/collapsed DOM state without touching openNavMenuCount —
+  // used for the init-time normalization below, which collapses the
+  // server-rendered "all open" default rather than reacting to a real
+  // user-driven open/close transition the counter should track.
+  function setNavMenuExpanded(toggle, expanded) {
     var menu = document.getElementById(toggle.getAttribute('aria-controls'));
     if (!menu) return;
+    toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    menu.hidden = !expanded;
+  }
+
+  function closeNavMenu(toggle) {
     if (toggle.getAttribute('aria-expanded') === 'true') openNavMenuCount--;
-    toggle.setAttribute('aria-expanded', 'false');
-    menu.hidden = true;
+    setNavMenuExpanded(toggle, false);
   }
 
   function openNavMenu(toggle) {
-    var menu = document.getElementById(toggle.getAttribute('aria-controls'));
-    if (!menu) return;
     if (toggle.getAttribute('aria-expanded') !== 'true') openNavMenuCount++;
-    toggle.setAttribute('aria-expanded', 'true');
-    menu.hidden = false;
+    setNavMenuExpanded(toggle, true);
   }
 
   function initNav(nav) {
@@ -141,7 +146,10 @@
 
     var menuToggles = nav.querySelectorAll('[data-nav-menu-toggle]');
     menuToggles.forEach(function (menuToggle) {
-      closeNavMenu(menuToggle);
+      // Collapse the server-rendered "open" default without decrementing
+      // openNavMenuCount — it was never incremented for these, so treating
+      // this as a close would drive the counter negative.
+      setNavMenuExpanded(menuToggle, false);
       menuToggle.addEventListener('click', function () {
         var open = menuToggle.getAttribute('aria-expanded') === 'true';
         menuToggles.forEach(closeNavMenu);


### PR DESCRIPTION
## Summary

Introduces a new `nav_bar` widget that renders an accessible, progressively-enhanced navigation landmark supporting horizontal top bars and vertical sidebars. The widget handles active link detection, dropdown menus, responsive collapse behavior, and full keyboard/screen-reader support without requiring inline styles or scripts.

## Key Changes

- **New `nav_bar` widget** (`autumn/src/widgets.rs`):
  - `NavBarConfig` builder for configuring brand, items, layout, and accessibility attributes
  - `NavItem` enum supporting links (with active-state matching), dropdown menus, and section labels
  - `NavMenu` builder for dropdown sub-items with independent active-state matching
  - `NavBarLayout` enum for horizontal (default) vs. sidebar layouts
  - Renders semantic `<nav>` landmark with `aria-label`, optional brand, primary/trailing item lists, and hidden-until-enhanced hamburger toggle
  - All links render through existing `nav_link_matched()` for consistent active-state behavior
  - Zero inline styles/scripts; progressive enhancement via `/static/js/autumn-widgets.js`

- **JavaScript enhancement** (`autumn/vendor/autumn-widgets.js`):
  - Reveals hamburger toggle and wires click handlers for collapse/expand
  - Implements dropdown menu disclosure widgets with Escape-to-close and click-outside behavior
  - Adds `.autumn-nav--enhanced` class once initialized
  - Tracks open menu count to optimize document-level click handler

- **Admin plugin integration** (`autumn-admin-plugin/src/templates.rs`):
  - Replaces hand-rolled sidebar nav with `nav_bar` widget
  - Maintains existing visual styling via CSS hooks (`.autumn-nav__brand`, `.autumn-nav__item`, etc.)
  - Sidebar layout hides its own toggle button (sidebar stays visible via media query, not collapse)
  - Includes "Models" and "System" section labels via `NavItem::section()`

- **Scaffold templates** (`autumn-cli/src/templates/main.rs.tmpl`, `pwa.rs`):
  - Updated to use `nav_bar` instead of hand-rolled `<nav>`
  - Layout functions now accept `current_path: &str` parameter for active-link detection
  - Handlers extract `CurrentPath` and pass it to layout
  - Includes `aria_label("Main navigation")` to preserve descriptive landmark name

- **CSS scaffolding** (`autumn-cli/src/templates/input.css.tmpl`):
  - Added Tailwind component layer styles for all `nav_bar` CSS hooks
  - Responsive behavior: hamburger toggle hidden on desktop, collapse hidden on mobile until toggled
  - Dropdown menus use `[hidden]` attribute for progressive enhancement

- **Tests**:
  - Comprehensive test suite in `autumn/src/widgets.rs` covering brand rendering, active-link detection, menu IDs, accessibility attributes, XSS escaping, and no inline styles/scripts
  - Admin layout tests verify sidebar rendering and nav section labels
  - Scaffold template tests confirm `nav_bar()` usage and `CurrentPath` extraction
  - Full-page a11y lint test in `autumn-cli/src/check.rs` validates nav_bar passes all accessibility rules

## Notable Implementation Details

- **Active-state matching**: Reuses existing `NavLinkMatch` enum (Exact/Prefix) for consistent behavior across primary items, trailing items, and dropdown sub-links
- **Menu ID generation**: Counter-based unique IDs (`{id}-menu-1`, `{id}-menu-2`, etc.) prevent collisions when multiple dropdowns exist
- **Progressive enhancement**: Before JS runs, hamburger is hidden and dropdowns are open (`aria-expanded="true"`, no `hidden` attribute) so all links remain visible with JavaScript disabled
- **No inline styles**: All responsive behavior (collapse/dropdown visibility, layout shifts) handled via CSS classes and `[hidden]` attribute; framework provides Tailwind hooks
- **Accessibility**: Proper `aria-label`, `aria-expanded`, `aria-controls`, `aria-current="page"` attributes; keyboard support (Escape closes dropdowns); semantic `<nav>` landmark with distinct labels per page

https://claude.ai/code/session_01B4kqgFLZoLCTnhzx2FqYDL