### PR TITLE
Add `autumn generate channel` command for real-time broadcast channels

### DIFF
--- a/.github/workflows/generator-conformance.yml
+++ b/.github/workflows/generator-conformance.yml
@@ -67,6 +67,9 @@ jobs:
   #   generated_scaffold_config_cargo_checks      (generate.rs)
   #   generated_auth_totp_cargo_checks            (generate.rs)
   #   generated_job_cargo_checks                  (generate.rs)
+  #   generated_channel_cargo_checks              (generate.rs)
+  #   generated_channel_ws_cargo_checks           (generate.rs)
+  #   generated_channel_smoke_test_passes         (generate.rs)
   #
   # Each test scaffolds a project, patches Cargo.toml to point at the local
   # autumn-web crate, and runs `cargo build` / `cargo check`. Failures include
@@ -137,6 +140,21 @@ jobs:
         run: |
           cargo test -p autumn-cli --test generate \
             generated_job_cargo_checks -- --ignored --exact
+
+      - name: generated_channel_cargo_checks
+        run: |
+          cargo test -p autumn-cli --test generate \
+            generated_channel_cargo_checks -- --ignored --exact
+
+      - name: generated_channel_ws_cargo_checks
+        run: |
+          cargo test -p autumn-cli --test generate \
+            generated_channel_ws_cargo_checks -- --ignored --exact
+
+      - name: generated_channel_smoke_test_passes
+        run: |
+          cargo test -p autumn-cli --test generate \
+            generated_channel_smoke_test_passes -- --ignored --exact
 
   # ── Postgres e2e gate ────────────────────────────────────────────────────────
   #

--- a/autumn-cli/src/generate/channel.rs
+++ b/autumn-cli/src/generate/channel.rs
@@ -23,7 +23,7 @@ use super::model::{ensure_cargo_dependencies, validate_resource_name};
 use super::naming::{pascal, snake};
 use super::schema_edit::{
     add_mod_declaration, ensure_autumn_web_feature, ensure_dev_dependency_tokio_test_features,
-    update_main_rs,
+    remove_routes_entries_with_prefix, update_main_rs,
 };
 use super::{Flags, GenerateError, ensure_project_root, read_or_empty};
 
@@ -84,6 +84,13 @@ pub fn plan_channel(
             format!("{}: {e}", main_path.display()),
         ))
     })?;
+    // Drop any route entries a prior generation of this channel left behind
+    // under a different transport (e.g. `--ws --force` after a plain SSE
+    // run) before splicing in the current transport's entries — otherwise
+    // main.rs would keep referencing functions the just-overwritten
+    // src/channels/<snake>.rs no longer defines.
+    let main_existing =
+        remove_routes_entries_with_prefix(&main_existing, &format!("channels::{snake_name}::"));
     let route_entries = route_entries(&snake_name, transport);
     let updated_main = update_main_rs(&main_existing, &["channels"], &route_entries);
     plan.modify(main_path, updated_main);
@@ -96,10 +103,23 @@ pub fn plan_channel(
         render_smoke_test(&snake_name, transport),
     );
 
-    // ── Cargo.toml: "ws" feature + deps + tokio dev-dep test features ──────
+    // ── Cargo.toml: autumn-web feature(s) + deps + tokio dev-dep test features ──
     let cargo_path = project_root.join("Cargo.toml");
     let cargo_existing = read_or_empty(&cargo_path);
-    let mut updated_cargo = ensure_autumn_web_feature(&cargo_existing, "ws");
+    let mut updated_cargo = cargo_existing.clone();
+    // `channels`/`sse::stream`/`#[ws]` are all gated behind "ws". The SSE
+    // transport's generated view additionally uses `Markup`/`html!` and the
+    // `HTMX_JS_PATH`/`HTMX_SSE_JS_PATH` constants, which are gated behind
+    // "maud"/"htmx" — both are in autumn-web's default feature set, but a
+    // project that opts out with `default-features = false` needs them
+    // enabled explicitly too (mirrors `generate scaffold --live`).
+    let autumn_web_features: &[&str] = match transport {
+        Transport::Sse => &["ws", "htmx", "maud"],
+        Transport::Ws => &["ws"],
+    };
+    for feature in autumn_web_features {
+        updated_cargo = ensure_autumn_web_feature(&updated_cargo, feature);
+    }
     let mut deps = CHANNEL_DEPS_BASE.to_vec();
     if matches!(transport, Transport::Sse) {
         deps.push(CHANNEL_DEPS_MAUD);
@@ -200,17 +220,21 @@ pub async fn {snake_name}_events(State(state): State<AppState>) -> impl IntoResp
 }}
 
 /// `POST /{snake_name}/messages` — publish a message to every subscriber.
+///
+/// Returns a minimal acknowledgement rather than the rendered fragment: the
+/// live update comes from the SSE broadcast above, and the view's form uses
+/// `hx-swap="none"` so the response body is never used by the browser.
 #[post("/{snake_name}/messages")]
 pub async fn {snake_name}_publish(
     State(state): State<AppState>,
     Form(form): Form<{struct_name}Form>,
-) -> AutumnResult<Markup> {{
-    let fragment = message_fragment(&form.message);
+) -> AutumnResult<&'static str> {{
+    let fragment = message_fragment(&form.message).into_string();
     state
         .broadcast()
-        .publish(TOPIC, fragment.clone().into_string())
+        .publish(TOPIC, fragment)
         .map_err(AutumnError::internal_server_error)?;
-    Ok(fragment)
+    Ok("published")
 }}
 
 #[cfg(test)]
@@ -240,7 +264,7 @@ fn render_ws_channel_file(snake_name: &str) -> String {
 //! connected socket.
 
 use autumn_web::prelude::*;
-use autumn_web::reexports::tokio;
+use autumn_web::reexports::{{tokio, tracing}};
 use autumn_web::ws::{{CancellationToken, Message, WebSocket, WithShutdown, WsHandler}};
 use serde::Deserialize;
 
@@ -264,8 +288,11 @@ pub async fn {snake_name}_ws(state: AppState) -> impl WsHandler {{
                 tokio::select! {{
                     incoming = socket.recv() => match incoming {{
                         Some(Ok(Message::Text(text))) => {{
-                            channels.publish(TOPIC, text.as_str()).ok();
+                            if let Err(err) = channels.publish(TOPIC, text.as_str()) {{
+                                tracing::warn!("{{TOPIC}} channel publish failed: {{err}}");
+                            }}
                         }}
+                        Some(Ok(Message::Close(_))) => break,
                         Some(Ok(_)) => {{}}
                         _ => break,
                     }},
@@ -309,15 +336,24 @@ pub async fn {snake_name}_publish(
 ///
 /// `tests/*.rs` integration binaries cannot import the app's own binary
 /// crate (there is no `src/lib.rs`), so the generated test re-declares the
-/// publish handler under test locally — the same contract `generate
-/// scaffold`'s smoke tests use.
+/// publish handler (and, for SSE, its `message_fragment` helper) under test
+/// locally, kept byte-for-byte in sync with the real handler in
+/// `src/channels/<snake>.rs` — the same contract `generate scaffold`'s
+/// smoke tests use.
 fn render_smoke_test(snake_name: &str, transport: Transport) -> String {
     let struct_name = pascal(snake_name);
+    let extra_helper = match transport {
+        Transport::Sse => format!(
+            "\nfn message_fragment(text: &str) -> Markup {{\n    html! {{ li .\"{snake_name}-message\" {{ (text) }} }}\n}}"
+        ),
+        Transport::Ws => String::new(),
+    };
     let publish_body = match transport {
         Transport::Sse => {
-            r#"    state
+            r#"    let fragment = message_fragment(&form.message).into_string();
+    state
         .broadcast()
-        .publish(TOPIC, form.message.as_str())
+        .publish(TOPIC, fragment)
         .map_err(AutumnError::internal_server_error)?;
     Ok("published")"#
         }
@@ -344,7 +380,7 @@ use serde::Deserialize;
 use std::time::Duration;
 
 const TOPIC: &str = "{snake_name}";
-
+{extra_helper}
 #[derive(Deserialize)]
 struct {struct_name}Form {{
     message: String,
@@ -555,6 +591,22 @@ async fn main() {
         assert!(src.contains("broadcast()"), "{src}");
     }
 
+    #[test]
+    fn sse_publish_handler_does_not_clone_fragment_for_a_discarded_response() {
+        // The view's form uses hx-swap="none", so the POST response body is
+        // never used by the browser — publishing must not clone the
+        // rendered fragment just to also return it.
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let src = fs::read_to_string(tmp.path().join("src/channels/chat.rs")).unwrap();
+        assert!(!src.contains(".clone()"), "{src}");
+        assert!(src.contains(r"AutumnResult<&'static str>"), "{src}");
+    }
+
     // ── GREEN: WS transport content assertions ────────────────────────────
 
     #[test]
@@ -585,6 +637,39 @@ async fn main() {
 
         let src = fs::read_to_string(tmp.path().join("src/channels/chat.rs")).unwrap();
         assert!(src.contains(r#"#[post("/chat/messages")]"#), "{src}");
+    }
+
+    #[test]
+    fn ws_handler_explicitly_breaks_on_close_message() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Ws)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let src = fs::read_to_string(tmp.path().join("src/channels/chat.rs")).unwrap();
+        assert!(
+            src.contains("Message::Close(_))) => break"),
+            "a client close handshake must terminate the relay loop instead \
+             of falling into the Some(Ok(_)) catch-all: {src}"
+        );
+    }
+
+    #[test]
+    fn ws_handler_logs_instead_of_silently_dropping_publish_failures() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Ws)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let src = fs::read_to_string(tmp.path().join("src/channels/chat.rs")).unwrap();
+        assert!(
+            !src.contains("channels.publish(TOPIC, text.as_str()).ok();"),
+            "a client-sent message's publish failure must not be silently \
+             swallowed: {src}"
+        );
+        assert!(src.contains("tracing::warn!"), "{src}");
     }
 
     // ── GREEN: main.rs / mod.rs wiring ─────────────────────────────────────
@@ -680,6 +765,62 @@ async fn main() {
         );
     }
 
+    #[test]
+    fn force_regenerating_with_different_transport_does_not_strand_stale_routes() {
+        // Regression test: switching transports via `--force` must not leave
+        // main.rs referencing functions the regenerated channel file no
+        // longer defines (previously left `chat_page`/`chat_events` behind
+        // after switching to `--ws`, which failed to compile).
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        plan_channel(tmp.path(), "Chat", Transport::Ws)
+            .unwrap()
+            .execute(Flags {
+                force: true,
+                dry_run: false,
+            })
+            .unwrap();
+
+        let main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(
+            !main.contains("chat_page"),
+            "stale SSE page route must be removed after switching to --ws: {main}"
+        );
+        assert!(
+            !main.contains("chat_events"),
+            "stale SSE events route must be removed after switching to --ws: {main}"
+        );
+        assert!(main.contains("channels::chat::chat_ws"), "{main}");
+        assert!(main.contains("channels::chat::chat_publish"), "{main}");
+    }
+
+    #[test]
+    fn force_regenerating_back_to_sse_does_not_strand_stale_ws_route() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Ws)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags {
+                force: true,
+                dry_run: false,
+            })
+            .unwrap();
+
+        let main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(
+            !main.contains("chat_ws"),
+            "stale WS route must be removed after switching to SSE: {main}"
+        );
+        assert!(main.contains("channels::chat::chat_page"), "{main}");
+        assert!(main.contains("channels::chat::chat_events"), "{main}");
+    }
+
     // ── GREEN: smoke test content ───────────────────────────────────────────
 
     #[test]
@@ -715,6 +856,62 @@ async fn main() {
         let test_src = fs::read_to_string(tmp.path().join("tests/chat_channel.rs")).unwrap();
         assert!(test_src.contains("TestApp"), "{test_src}");
         assert!(test_src.contains(".subscribe("), "{test_src}");
+    }
+
+    #[test]
+    fn sse_smoke_test_publish_handler_matches_production_handler() {
+        // Regression test: the test's re-declared publish handler must
+        // actually exercise message_fragment/maud rendering, the same as
+        // the real src/channels/chat.rs handler — not a simplified copy
+        // that only proves the pub/sub transport works.
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let production_src = fs::read_to_string(tmp.path().join("src/channels/chat.rs")).unwrap();
+        let test_src = fs::read_to_string(tmp.path().join("tests/chat_channel.rs")).unwrap();
+
+        assert!(
+            test_src.contains("fn message_fragment("),
+            "SSE smoke test must render through message_fragment, the same \
+             as production: {test_src}"
+        );
+        assert!(test_src.contains("Markup"), "{test_src}");
+
+        // Extract each file's chat_publish body (brace-balanced, so trailing
+        // content like an inline #[cfg(test)] module or the smoke test's own
+        // #[tokio::test] fn is never swept in) and confirm they match — the
+        // doc comment promises this is "a re-declaration of the same
+        // handler", so it must actually be one.
+        let extract_publish_body = |src: &str| {
+            let name_start = src.find("chat_publish(").expect("chat_publish present");
+            let brace_start = src[name_start..].find('{').unwrap() + name_start;
+            let bytes = src.as_bytes();
+            let mut depth = 0usize;
+            let mut end = brace_start;
+            for (offset, &b) in bytes[brace_start..].iter().enumerate() {
+                match b {
+                    b'{' => depth += 1,
+                    b'}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            end = brace_start + offset;
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            src[brace_start..=end].to_owned()
+        };
+        assert_eq!(
+            extract_publish_body(&production_src),
+            extract_publish_body(&test_src),
+            "the test's re-declared chat_publish must be byte-identical to \
+             the production handler for SSE mode"
+        );
     }
 
     // ── Flag behaviour ────────────────────────────────────────────────────
@@ -779,6 +976,38 @@ async fn main() {
 
         let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
         assert!(cargo.contains("\"ws\""), "{cargo}");
+    }
+
+    #[test]
+    fn sse_transport_ensures_htmx_and_maud_autumn_web_features() {
+        // Regression test: SSE-mode generated code uses Markup/html!/
+        // HTMX_JS_PATH/HTMX_SSE_JS_PATH, which are gated behind the
+        // "maud"/"htmx" autumn-web features. Those are on by default, but a
+        // project with `default-features = false` needs them ensured
+        // explicitly — the same fix `generate scaffold --live` already
+        // applies.
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert!(cargo.contains("\"htmx\""), "{cargo}");
+        assert!(cargo.contains("\"maud\""), "{cargo}");
+    }
+
+    #[test]
+    fn ws_transport_does_not_ensure_htmx_or_maud_features() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Ws)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert!(!cargo.contains("\"htmx\""), "{cargo}");
+        assert!(!cargo.contains("\"maud\""), "{cargo}");
     }
 
     #[test]

--- a/autumn-cli/src/generate/channel.rs
+++ b/autumn-cli/src/generate/channel.rs
@@ -1,0 +1,844 @@
+//! `autumn generate channel` — scaffold a real-time broadcast channel.
+//!
+//! For a name like `Chat`, the generator produces:
+//! - `src/channels/chat.rs` — channel handler(s) that subscribe/publish
+//!   through the existing `Channels` API. SSE transport (the default) emits
+//!   a live view wired to htmx's `sse-connect`/`sse-swap` (zero client JS
+//!   authored by the user); `--ws` emits a raw `#[ws]` socket handler instead.
+//! - `src/channels/mod.rs` — created or updated with `pub mod chat;`.
+//! - `src/main.rs` — `mod channels;` declaration and the generated route(s)
+//!   registered in `routes![...]`.
+//! - `tests/chat_channel.rs` — a smoke test that publishes a message through
+//!   the in-process `TestApp`/`TestClient` and asserts a subscriber receives
+//!   it (not a stub).
+//! - `Cargo.toml` — the `"ws"` feature added to `autumn-web` (channels, SSE,
+//!   and `#[ws]` are all gated behind it), plus `serde` (and `maud` for the
+//!   SSE transport) and the `tokio` dev-dependency features the smoke test
+//!   needs for `#[tokio::test]`.
+
+use std::path::Path;
+
+use super::emit::Plan;
+use super::model::{ensure_cargo_dependencies, validate_resource_name};
+use super::naming::{pascal, snake};
+use super::schema_edit::{
+    add_mod_declaration, ensure_autumn_web_feature, ensure_dev_dependency_tokio_test_features,
+    update_main_rs,
+};
+use super::{Flags, GenerateError, ensure_project_root, read_or_empty};
+
+/// Which transport a generated channel uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transport {
+    /// SSE-over-htmx: `sse-connect`/`sse-swap`, zero client JS authored by the user.
+    Sse,
+    /// A raw `#[ws]` WebSocket handler.
+    Ws,
+}
+
+/// Cargo dependencies always required by generated channel files (the
+/// publish handler and smoke test both derive `Deserialize`/use `Form`).
+const CHANNEL_DEPS_BASE: &[(&str, &str)] =
+    &[("serde", "{ version = \"1\", features = [\"derive\"] }")];
+
+/// Extra dependency needed by the SSE transport's Maud-rendered view.
+const CHANNEL_DEPS_MAUD: (&str, &str) = ("maud", "{ version = \"0.27\", features = [\"axum\"] }");
+
+/// Compute the file actions for `autumn generate channel`.
+///
+/// # Errors
+/// Project layout and name validation errors surface here.
+pub fn plan_channel(
+    project_root: &Path,
+    name: &str,
+    transport: Transport,
+) -> Result<Plan, GenerateError> {
+    ensure_project_root(project_root)?;
+    validate_resource_name(name)?;
+
+    let snake_name = snake(name);
+
+    let mut plan = Plan::new(project_root);
+
+    // ── src/channels/<snake>.rs ─────────────────────────────────────────────
+    plan.create(
+        project_root
+            .join("src")
+            .join("channels")
+            .join(format!("{snake_name}.rs")),
+        render_channel_file(&snake_name, transport),
+    );
+
+    // ── src/channels/mod.rs (create or update) ──────────────────────────────
+    let mod_path = project_root.join("src").join("channels").join("mod.rs");
+    plan.modify(
+        mod_path.clone(),
+        add_mod_declaration(&read_or_empty(&mod_path), &snake_name),
+    );
+
+    // ── src/main.rs: add mod channels; and route entries ────────────────────
+    let main_path = project_root.join("src").join("main.rs");
+    let main_existing = std::fs::read_to_string(&main_path).map_err(|e| {
+        GenerateError::Io(std::io::Error::new(
+            e.kind(),
+            format!("{}: {e}", main_path.display()),
+        ))
+    })?;
+    let route_entries = route_entries(&snake_name, transport);
+    let updated_main = update_main_rs(&main_existing, &["channels"], &route_entries);
+    plan.modify(main_path, updated_main);
+
+    // ── tests/<snake>_channel.rs ──────────────────────────────────────────
+    plan.create(
+        project_root
+            .join("tests")
+            .join(format!("{snake_name}_channel.rs")),
+        render_smoke_test(&snake_name, transport),
+    );
+
+    // ── Cargo.toml: "ws" feature + deps + tokio dev-dep test features ──────
+    let cargo_path = project_root.join("Cargo.toml");
+    let cargo_existing = read_or_empty(&cargo_path);
+    let mut updated_cargo = ensure_autumn_web_feature(&cargo_existing, "ws");
+    let mut deps = CHANNEL_DEPS_BASE.to_vec();
+    if matches!(transport, Transport::Sse) {
+        deps.push(CHANNEL_DEPS_MAUD);
+    }
+    updated_cargo = ensure_cargo_dependencies(&updated_cargo, &deps);
+    updated_cargo = ensure_dev_dependency_tokio_test_features(&updated_cargo);
+    if updated_cargo != cargo_existing {
+        plan.modify(cargo_path, updated_cargo);
+    }
+
+    Ok(plan)
+}
+
+/// Fully-qualified route entries for `routes![...]` wiring in `main.rs`.
+fn route_entries(snake_name: &str, transport: Transport) -> Vec<String> {
+    match transport {
+        Transport::Sse => vec![
+            format!("channels::{snake_name}::{snake_name}_page"),
+            format!("channels::{snake_name}::{snake_name}_events"),
+            format!("channels::{snake_name}::{snake_name}_publish"),
+        ],
+        Transport::Ws => vec![
+            format!("channels::{snake_name}::{snake_name}_ws"),
+            format!("channels::{snake_name}::{snake_name}_publish"),
+        ],
+    }
+}
+
+/// Render `src/channels/<snake>.rs`.
+fn render_channel_file(snake_name: &str, transport: Transport) -> String {
+    match transport {
+        Transport::Sse => render_sse_channel_file(snake_name),
+        Transport::Ws => render_ws_channel_file(snake_name),
+    }
+}
+
+fn render_sse_channel_file(snake_name: &str) -> String {
+    format!(
+        r#"//! Generated by `autumn generate channel`. Edit freely.
+//!
+//! Round trip: `POST /{snake_name}/messages` publishes on the `"{snake_name}"`
+//! topic via the `Channels` API; `GET /{snake_name}/events` is an SSE
+//! subscription on that topic; the `GET /{snake_name}` view wires htmx's
+//! `sse-connect`/`sse-swap` to append each published fragment — zero client
+//! JS authored by the user.
+
+use autumn_web::prelude::*;
+use serde::Deserialize;
+
+/// Topic this channel publishes and subscribes on.
+pub const TOPIC: &str = "{snake_name}";
+
+/// Server-rendered fragment for one message. Shared by the publish handler
+/// (rendered once, broadcast verbatim) so every SSE subscriber sees exactly
+/// what the publisher saw.
+fn message_fragment(text: &str) -> Markup {{
+    html! {{ li ."{snake_name}-message" {{ (text) }} }}
+}}
+
+#[derive(Deserialize)]
+pub struct {struct_name}Form {{
+    pub message: String,
+}}
+
+/// `GET /{snake_name}` — live view. Zero client JS: htmx and its SSE
+/// extension (loaded below) drive the `sse-connect`/`sse-swap` wiring
+/// declaratively.
+#[get("/{snake_name}")]
+pub async fn {snake_name}_page() -> Markup {{
+    html! {{
+        html {{
+            head {{
+                title {{ "{struct_name}" }}
+                script src=(HTMX_JS_PATH) {{}}
+                script src=(HTMX_SSE_JS_PATH) {{}}
+            }}
+            body {{
+                h1 {{ "{struct_name}" }}
+                ul id="{snake_name}-messages" hx-ext="sse" sse-connect="/{snake_name}/events" sse-swap="message" hx-swap="beforeend" {{}}
+                form hx-post="/{snake_name}/messages" hx-swap="none" {{
+                    input type="text" name="message" required;
+                    button type="submit" {{ "Send" }}
+                }}
+            }}
+        }}
+    }}
+}}
+
+/// `GET /{snake_name}/events` — SSE subscription on [`TOPIC`].
+///
+/// Optional: to show live viewer counts on this channel, add a `Presence`
+/// param here (requires the `presence` feature on autumn-web) and publish
+/// join/leave events on a `presence:{{TOPIC}}` topic — see
+/// `autumn_web::presence::Presence::track`.
+#[get("/{snake_name}/events")]
+pub async fn {snake_name}_events(State(state): State<AppState>) -> impl IntoResponse {{
+    autumn_web::sse::stream(&state, TOPIC)
+}}
+
+/// `POST /{snake_name}/messages` — publish a message to every subscriber.
+#[post("/{snake_name}/messages")]
+pub async fn {snake_name}_publish(
+    State(state): State<AppState>,
+    Form(form): Form<{struct_name}Form>,
+) -> AutumnResult<Markup> {{
+    let fragment = message_fragment(&form.message);
+    state
+        .broadcast()
+        .publish(TOPIC, fragment.clone().into_string())
+        .map_err(AutumnError::internal_server_error)?;
+    Ok(fragment)
+}}
+
+#[cfg(test)]
+mod {snake_name}_channel_tests {{
+    use super::*;
+
+    #[test]
+    fn message_fragment_renders_text() {{
+        let html = message_fragment("hello").into_string();
+        assert!(html.contains("hello"));
+        assert!(html.contains("{snake_name}-message"));
+    }}
+}}
+"#,
+        struct_name = pascal(snake_name),
+    )
+}
+
+fn render_ws_channel_file(snake_name: &str) -> String {
+    format!(
+        r#"//! Generated by `autumn generate channel`. Edit freely.
+//!
+//! `WS /{snake_name}/ws` bridges a WebSocket connection onto the
+//! `"{snake_name}"` topic via the `Channels` API: inbound text frames are
+//! published, and every published message (including ones sent through the
+//! `POST /{snake_name}/messages` route below) is relayed back out to every
+//! connected socket.
+
+use autumn_web::prelude::*;
+use autumn_web::reexports::tokio;
+use autumn_web::ws::{{CancellationToken, Message, WebSocket, WithShutdown, WsHandler}};
+use serde::Deserialize;
+
+/// Topic this channel publishes and subscribes on.
+pub const TOPIC: &str = "{snake_name}";
+
+#[derive(Deserialize)]
+pub struct {struct_name}Form {{
+    pub message: String,
+}}
+
+/// `WS /{snake_name}/ws` — bidirectional relay over [`TOPIC`].
+#[ws("/{snake_name}/ws")]
+pub async fn {snake_name}_ws(state: AppState) -> impl WsHandler {{
+    let channels = state.channels().clone();
+    let mut rx = channels.subscribe(TOPIC);
+
+    WithShutdown(
+        move |mut socket: WebSocket, shutdown: CancellationToken| async move {{
+            loop {{
+                tokio::select! {{
+                    incoming = socket.recv() => match incoming {{
+                        Some(Ok(Message::Text(text))) => {{
+                            channels.publish(TOPIC, text.as_str()).ok();
+                        }}
+                        Some(Ok(_)) => {{}}
+                        _ => break,
+                    }},
+                    published = rx.recv() => match published {{
+                        Ok(msg) => {{
+                            if socket.send(Message::Text(msg.into_string().into())).await.is_err() {{
+                                break;
+                            }}
+                        }}
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {{}}
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    }},
+                    () = shutdown.cancelled() => {{
+                        socket.send(Message::Close(None)).await.ok();
+                        break;
+                    }}
+                }}
+            }}
+        }},
+    )
+}}
+
+/// `POST /{snake_name}/messages` — publish a message to every connected client.
+#[post("/{snake_name}/messages")]
+pub async fn {snake_name}_publish(
+    State(state): State<AppState>,
+    Form(form): Form<{struct_name}Form>,
+) -> AutumnResult<&'static str> {{
+    state
+        .channels()
+        .publish(TOPIC, form.message.as_str())
+        .map_err(AutumnError::internal_server_error)?;
+    Ok("published")
+}}
+"#,
+        struct_name = pascal(snake_name),
+    )
+}
+
+/// Render `tests/<snake>_channel.rs` — a real pub/sub round-trip smoke test.
+///
+/// `tests/*.rs` integration binaries cannot import the app's own binary
+/// crate (there is no `src/lib.rs`), so the generated test re-declares the
+/// publish handler under test locally — the same contract `generate
+/// scaffold`'s smoke tests use.
+fn render_smoke_test(snake_name: &str, transport: Transport) -> String {
+    let struct_name = pascal(snake_name);
+    let publish_body = match transport {
+        Transport::Sse => {
+            r#"    state
+        .broadcast()
+        .publish(TOPIC, form.message.as_str())
+        .map_err(AutumnError::internal_server_error)?;
+    Ok("published")"#
+        }
+        Transport::Ws => {
+            r#"    state
+        .channels()
+        .publish(TOPIC, form.message.as_str())
+        .map_err(AutumnError::internal_server_error)?;
+    Ok("published")"#
+        }
+    };
+    format!(
+        r#"//! Smoke test generated by `autumn generate channel`.
+//!
+//! Publishes through the real `Channels` registry inside an in-process
+//! `TestApp` and asserts a subscriber receives the message. `{snake_name}_publish`
+//! below is a re-declaration of `src/channels/{snake_name}.rs`'s handler of the
+//! same name — `tests/` integration binaries cannot import the app's own
+//! binary crate (there is no `src/lib.rs`).
+
+use autumn_web::prelude::*;
+use autumn_web::test::TestApp;
+use serde::Deserialize;
+use std::time::Duration;
+
+const TOPIC: &str = "{snake_name}";
+
+#[derive(Deserialize)]
+struct {struct_name}Form {{
+    message: String,
+}}
+
+#[post("/{snake_name}/messages")]
+async fn {snake_name}_publish(
+    State(state): State<AppState>,
+    Form(form): Form<{struct_name}Form>,
+) -> AutumnResult<&'static str> {{
+{publish_body}
+}}
+
+#[tokio::test]
+async fn {snake_name}_channel_delivers_published_message_to_subscriber() {{
+    let client = TestApp::new().routes(routes![{snake_name}_publish]).build();
+
+    // Subscribe BEFORE publishing — broadcast channels drop messages sent
+    // when there is no receiver.
+    let mut rx = client.state().channels().subscribe(TOPIC);
+
+    client
+        .post("/{snake_name}/messages")
+        .form("message=hello+from+the+smoke+test")
+        .send()
+        .await
+        .assert_ok();
+
+    let msg = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out waiting for channel message")
+        .expect("channel closed before delivering");
+    assert!(msg.into_string().contains("hello from the smoke test"));
+}}
+"#,
+    )
+}
+
+/// CLI entry point.
+pub fn run(name: &str, transport: Transport, flags: Flags) {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: cannot determine current directory: {e}");
+            std::process::exit(1);
+        }
+    };
+    match plan_channel(&cwd, name, transport).and_then(|p| p.execute(flags)) {
+        Ok(()) => {}
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn project_with_main(main_content: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"x\"\n\n[dependencies]\nautumn-web = \"0.6\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/main.rs"), main_content).unwrap();
+        tmp
+    }
+
+    fn default_main() -> &'static str {
+        r#"use autumn_web::prelude::*;
+
+#[get("/")]
+async fn index() -> &'static str { "ok" }
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .routes(routes![index])
+        .run()
+        .await;
+}
+"#
+    }
+
+    // ── RED: file plan assertions ─────────────────────────────────────────
+
+    #[test]
+    fn plan_creates_channel_file() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_channel(tmp.path(), "Chat", Transport::Sse).unwrap();
+        assert!(
+            plan.actions
+                .iter()
+                .any(|a| a.path().ends_with("src/channels/chat.rs")),
+            "plan must include src/channels/chat.rs"
+        );
+    }
+
+    #[test]
+    fn plan_creates_channel_mod_rs() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_channel(tmp.path(), "Chat", Transport::Sse).unwrap();
+        assert!(
+            plan.actions
+                .iter()
+                .any(|a| a.path().ends_with("src/channels/mod.rs")),
+            "plan must include src/channels/mod.rs"
+        );
+    }
+
+    #[test]
+    fn plan_modifies_main_rs() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_channel(tmp.path(), "Chat", Transport::Sse).unwrap();
+        assert!(
+            plan.actions
+                .iter()
+                .any(|a| a.path().ends_with("src/main.rs")),
+            "plan must modify src/main.rs"
+        );
+    }
+
+    #[test]
+    fn plan_creates_smoke_test() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_channel(tmp.path(), "Chat", Transport::Sse).unwrap();
+        assert!(
+            plan.actions
+                .iter()
+                .any(|a| a.path().ends_with("tests/chat_channel.rs")),
+            "plan must include tests/chat_channel.rs"
+        );
+    }
+
+    #[test]
+    fn plan_errors_when_not_in_project() {
+        let tmp = TempDir::new().unwrap();
+        let err = plan_channel(tmp.path(), "Chat", Transport::Sse).unwrap_err();
+        assert!(matches!(err, GenerateError::NotInProject));
+    }
+
+    #[test]
+    fn plan_errors_when_main_rs_missing() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[package]\nname=\"x\"\n").unwrap();
+        let err = plan_channel(tmp.path(), "Chat", Transport::Sse).unwrap_err();
+        assert!(matches!(err, GenerateError::Io(_)));
+    }
+
+    #[test]
+    fn plan_rejects_invalid_name() {
+        let tmp = project_with_main(default_main());
+        let err = plan_channel(tmp.path(), "9bad", Transport::Sse).unwrap_err();
+        assert!(matches!(err, GenerateError::InvalidName(_, _)));
+    }
+
+    // ── GREEN: SSE transport content assertions ───────────────────────────
+
+    #[test]
+    fn sse_execute_writes_page_with_htmx_wiring() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let src = fs::read_to_string(tmp.path().join("src/channels/chat.rs")).unwrap();
+        assert!(src.contains(r#"sse-connect="/chat/events""#), "{src}");
+        assert!(src.contains(r#"sse-swap="message""#), "{src}");
+        assert!(src.contains(r#"hx-ext="sse""#), "{src}");
+        assert!(src.contains("HTMX_JS_PATH"), "{src}");
+        assert!(src.contains("HTMX_SSE_JS_PATH"), "{src}");
+        assert!(
+            !src.contains("#[ws("),
+            "SSE mode must not emit a #[ws] handler: {src}"
+        );
+    }
+
+    #[test]
+    fn sse_execute_writes_events_route_using_sse_stream() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let src = fs::read_to_string(tmp.path().join("src/channels/chat.rs")).unwrap();
+        assert!(src.contains(r#"#[get("/chat/events")]"#), "{src}");
+        assert!(src.contains("autumn_web::sse::stream"), "{src}");
+    }
+
+    #[test]
+    fn sse_execute_writes_publish_route() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let src = fs::read_to_string(tmp.path().join("src/channels/chat.rs")).unwrap();
+        assert!(src.contains(r#"#[post("/chat/messages")]"#), "{src}");
+        assert!(src.contains("broadcast()"), "{src}");
+    }
+
+    // ── GREEN: WS transport content assertions ────────────────────────────
+
+    #[test]
+    fn ws_execute_writes_handler_with_ws_macro() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Ws)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let src = fs::read_to_string(tmp.path().join("src/channels/chat.rs")).unwrap();
+        assert!(src.contains(r#"#[ws("/chat/ws")]"#), "{src}");
+        assert!(src.contains("WithShutdown"), "{src}");
+        assert!(src.contains("WsHandler"), "{src}");
+        assert!(
+            !src.contains("sse-connect"),
+            "WS mode must not emit SSE htmx wiring: {src}"
+        );
+    }
+
+    #[test]
+    fn ws_execute_writes_publish_route() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Ws)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let src = fs::read_to_string(tmp.path().join("src/channels/chat.rs")).unwrap();
+        assert!(src.contains(r#"#[post("/chat/messages")]"#), "{src}");
+    }
+
+    // ── GREEN: main.rs / mod.rs wiring ─────────────────────────────────────
+
+    #[test]
+    fn execute_updates_main_rs_with_mod_declaration() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(
+            main.contains("mod channels;"),
+            "main.rs must declare mod channels"
+        );
+    }
+
+    #[test]
+    fn execute_updates_main_rs_with_sse_route_entries() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(main.contains("channels::chat::chat_page"), "{main}");
+        assert!(main.contains("channels::chat::chat_events"), "{main}");
+        assert!(main.contains("channels::chat::chat_publish"), "{main}");
+    }
+
+    #[test]
+    fn execute_updates_main_rs_with_ws_route_entries() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Ws)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(main.contains("channels::chat::chat_ws"), "{main}");
+        assert!(main.contains("channels::chat::chat_publish"), "{main}");
+    }
+
+    #[test]
+    fn execute_writes_mod_rs_with_pub_mod() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let mod_rs = fs::read_to_string(tmp.path().join("src/channels/mod.rs")).unwrap();
+        assert!(mod_rs.contains("pub mod chat;"));
+    }
+
+    #[test]
+    fn second_channel_augments_mod_rs_without_duplication() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        plan_channel(tmp.path(), "Notifications", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let mod_rs = fs::read_to_string(tmp.path().join("src/channels/mod.rs")).unwrap();
+        assert!(mod_rs.contains("pub mod chat;"));
+        assert!(mod_rs.contains("pub mod notifications;"));
+    }
+
+    #[test]
+    fn second_channel_does_not_duplicate_main_rs_mod_declaration() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        plan_channel(tmp.path(), "Notifications", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert_eq!(
+            main.matches("mod channels;").count(),
+            1,
+            "mod channels; must appear exactly once in main.rs"
+        );
+    }
+
+    // ── GREEN: smoke test content ───────────────────────────────────────────
+
+    #[test]
+    fn execute_writes_smoke_test_with_testapp_and_subscriber_assertion() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let test_src = fs::read_to_string(tmp.path().join("tests/chat_channel.rs")).unwrap();
+        assert!(test_src.contains("TestApp"), "{test_src}");
+        assert!(test_src.contains(".subscribe("), "{test_src}");
+        assert!(test_src.contains("timeout"), "{test_src}");
+        assert!(
+            !test_src.contains("todo!"),
+            "must not be a stub: {test_src}"
+        );
+        assert!(
+            !test_src.contains("#[ignore"),
+            "smoke test must actually run (no DB/Docker needed): {test_src}"
+        );
+    }
+
+    #[test]
+    fn ws_smoke_test_also_asserts_delivery() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Ws)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let test_src = fs::read_to_string(tmp.path().join("tests/chat_channel.rs")).unwrap();
+        assert!(test_src.contains("TestApp"), "{test_src}");
+        assert!(test_src.contains(".subscribe("), "{test_src}");
+    }
+
+    // ── Flag behaviour ────────────────────────────────────────────────────
+
+    #[test]
+    fn dry_run_writes_no_new_files() {
+        let tmp = project_with_main(default_main());
+        let original_main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags {
+                dry_run: true,
+                force: false,
+            })
+            .unwrap();
+
+        assert!(!tmp.path().join("src/channels/chat.rs").exists());
+        assert!(!tmp.path().join("src/channels/mod.rs").exists());
+        assert!(!tmp.path().join("tests/chat_channel.rs").exists());
+        let main_after = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert_eq!(original_main, main_after, "dry run must not modify main.rs");
+    }
+
+    #[test]
+    fn collision_without_force_returns_error() {
+        let tmp = project_with_main(default_main());
+        fs::create_dir_all(tmp.path().join("src/channels")).unwrap();
+        fs::write(tmp.path().join("src/channels/chat.rs"), "// existing").unwrap();
+        let err = plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap_err();
+        assert!(matches!(err, GenerateError::Collisions(_)));
+    }
+
+    #[test]
+    fn force_overwrites_existing_channel() {
+        let tmp = project_with_main(default_main());
+        fs::create_dir_all(tmp.path().join("src/channels")).unwrap();
+        fs::write(tmp.path().join("src/channels/chat.rs"), "// old").unwrap();
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags {
+                force: true,
+                dry_run: false,
+            })
+            .unwrap();
+
+        let src = fs::read_to_string(tmp.path().join("src/channels/chat.rs")).unwrap();
+        assert!(src.contains("TOPIC"));
+    }
+
+    // ── Cargo.toml ────────────────────────────────────────────────────────
+
+    #[test]
+    fn execute_adds_ws_feature_to_cargo_toml() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert!(cargo.contains("\"ws\""), "{cargo}");
+    }
+
+    #[test]
+    fn sse_transport_adds_maud_and_serde_deps() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert!(cargo.contains("maud"), "{cargo}");
+        assert!(cargo.contains("serde"), "{cargo}");
+    }
+
+    #[test]
+    fn ws_transport_adds_serde_dep_but_not_maud() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Ws)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert!(cargo.contains("serde"), "{cargo}");
+        assert!(!cargo.contains("maud"), "{cargo}");
+    }
+
+    #[test]
+    fn execute_adds_tokio_dev_dependency_for_smoke_test() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "Chat", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert!(cargo.contains("[dev-dependencies]"), "{cargo}");
+        assert!(cargo.contains("tokio"), "{cargo}");
+    }
+
+    // ── Name normalisation ────────────────────────────────────────────────
+
+    #[test]
+    fn snake_case_input_is_normalised() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "chat_room", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(tmp.path().join("src/channels/chat_room.rs").exists());
+    }
+
+    #[test]
+    fn pascal_case_input_is_normalised() {
+        let tmp = project_with_main(default_main());
+        plan_channel(tmp.path(), "ChatRoom", Transport::Sse)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(tmp.path().join("src/channels/chat_room.rs").exists());
+    }
+}

--- a/autumn-cli/src/generate/mod.rs
+++ b/autumn-cli/src/generate/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod admin;
 pub mod auth;
+pub mod channel;
 pub mod config;
 pub mod dsl;
 pub mod emit;

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -602,12 +602,13 @@ fn has_mod_declaration(existing: &str, name: &str) -> bool {
         .any(|line| needles.iter().any(|n| line == n))
 }
 
-/// Insert each entry into the body of the *first* `routes![ ... ]` macro
-/// invocation. Skips entries already present.
-fn ensure_routes_entries(existing: &str, entries: &[String]) -> String {
-    let Some(start) = existing.find("routes![") else {
-        return existing.to_owned();
-    };
+/// Locate the body span (byte offsets, exclusive of the enclosing
+/// `routes![`/`]`) of the *first* `routes![ ... ]` macro invocation in
+/// `existing`. Returns `None` if there is no `routes![` or its brackets are
+/// unmatched. Shared by every function that reads or rewrites the
+/// `routes![...]` body so the bracket-scan logic lives in exactly one place.
+fn find_routes_body_range(existing: &str) -> Option<(usize, usize)> {
+    let start = existing.find("routes![")?;
     let body_start = start + "routes![".len();
     // Find the matching closing bracket. The macro body cannot contain a
     // raw `]` outside of nested `[ ... ]`, so we just track depth.
@@ -628,15 +629,66 @@ fn ensure_routes_entries(existing: &str, entries: &[String]) -> String {
         i += 1;
     }
     if depth != 0 {
-        // Unmatched bracket — leave the file untouched.
-        return existing.to_owned();
+        // Unmatched bracket.
+        return None;
     }
-    let body = &existing[body_start..i];
+    Some((body_start, i))
+}
+
+/// Insert each entry into the body of the *first* `routes![ ... ]` macro
+/// invocation. Skips entries already present.
+fn ensure_routes_entries(existing: &str, entries: &[String]) -> String {
+    let Some((body_start, body_end)) = find_routes_body_range(existing) else {
+        return existing.to_owned();
+    };
+    let body = &existing[body_start..body_end];
     let new_body = augment_routes_body(body, entries);
     let mut out = String::with_capacity(existing.len() + new_body.len());
     out.push_str(&existing[..body_start]);
     out.push_str(&new_body);
-    out.push_str(&existing[i..]);
+    out.push_str(&existing[body_end..]);
+    out
+}
+
+/// Remove every entry in the *first* `routes![ ... ]` macro invocation whose
+/// identifier starts with `prefix`. A no-op (returns `existing` unchanged)
+/// if there is no `routes![...]` or no entry matches.
+///
+/// Used by generators that regenerate a resource whose route set can change
+/// between runs (e.g. `autumn generate channel <Name> --force` switching
+/// from the SSE transport's routes to the WS transport's) — call this
+/// before [`update_main_rs`] so stale entries referencing functions the
+/// regenerated file no longer defines are not left dangling in `main.rs`.
+#[must_use]
+pub fn remove_routes_entries_with_prefix(existing: &str, prefix: &str) -> String {
+    let Some((body_start, body_end)) = find_routes_body_range(existing) else {
+        return existing.to_owned();
+    };
+    let body = &existing[body_start..body_end];
+    let original_entries: Vec<&str> = body
+        .split([',', '\n'])
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    let kept: Vec<&str> = original_entries
+        .iter()
+        .copied()
+        .filter(|s| !s.starts_with(prefix))
+        .collect();
+    if kept.len() == original_entries.len() {
+        return existing.to_owned();
+    }
+    let indent = leading_indent(body);
+    let mut new_body = String::with_capacity(body.len());
+    for entry in &kept {
+        new_body.push_str(&indent);
+        new_body.push_str(entry);
+        new_body.push_str(",\n");
+    }
+    let mut out = String::with_capacity(existing.len());
+    out.push_str(&existing[..body_start]);
+    out.push_str(&new_body);
+    out.push_str(&existing[body_end..]);
     out
 }
 
@@ -3422,6 +3474,60 @@ async fn main() {\n\
         let original = "fn main() {\n    routes![]\n}\n";
         let updated = ensure_routes_entries(original, &["foo".into()]);
         assert!(updated.contains("foo"));
+    }
+
+    // ── remove_routes_entries_with_prefix ──────────────────────────────────
+
+    #[test]
+    fn remove_routes_entries_with_prefix_drops_matching_entries() {
+        let original = "fn main() {\n    routes![\n        index,\n        channels::chat::chat_page,\n        channels::chat::chat_events,\n        channels::chat::chat_publish,\n    ]\n}\n";
+        let updated = remove_routes_entries_with_prefix(original, "channels::chat::");
+        assert!(updated.contains("index,"));
+        assert!(!updated.contains("channels::chat::chat_page"));
+        assert!(!updated.contains("channels::chat::chat_events"));
+        assert!(!updated.contains("channels::chat::chat_publish"));
+    }
+
+    #[test]
+    fn remove_routes_entries_with_prefix_leaves_other_prefixes_untouched() {
+        let original = "fn main() {\n    routes![\n        channels::chat::chat_page,\n        channels::notifications::notifications_page,\n    ]\n}\n";
+        let updated = remove_routes_entries_with_prefix(original, "channels::chat::");
+        assert!(!updated.contains("channels::chat::chat_page"));
+        assert!(updated.contains("channels::notifications::notifications_page"));
+    }
+
+    #[test]
+    fn remove_routes_entries_with_prefix_is_noop_when_nothing_matches() {
+        let original = "fn main() {\n    routes![index, hello]\n}\n";
+        let updated = remove_routes_entries_with_prefix(original, "channels::chat::");
+        assert_eq!(updated, original);
+    }
+
+    #[test]
+    fn remove_routes_entries_with_prefix_no_routes_macro_leaves_file_alone() {
+        let original = "fn main() {}\n";
+        let updated = remove_routes_entries_with_prefix(original, "channels::chat::");
+        assert_eq!(updated, original);
+    }
+
+    #[test]
+    fn remove_then_ensure_routes_entries_composes_for_transport_switch() {
+        // Regression test for the `--force` transport-switch scenario: a
+        // channel generated with SSE routes, then regenerated with the WS
+        // route set, must not leave the stale SSE entries behind.
+        let original = "fn main() {\n    routes![\n        channels::chat::chat_page,\n        channels::chat::chat_events,\n        channels::chat::chat_publish,\n    ]\n}\n";
+        let stripped = remove_routes_entries_with_prefix(original, "channels::chat::");
+        let updated = ensure_routes_entries(
+            &stripped,
+            &[
+                "channels::chat::chat_ws".to_owned(),
+                "channels::chat::chat_publish".to_owned(),
+            ],
+        );
+        assert!(!updated.contains("chat_page"));
+        assert!(!updated.contains("chat_events"));
+        assert!(updated.contains("channels::chat::chat_ws"));
+        assert!(updated.contains("channels::chat::chat_publish"));
     }
 
     // ── add_mail_preview_to_app ───────────────────────────────────────────

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1497,6 +1497,44 @@ enum GenerateCommands {
         #[arg(long)]
         force: bool,
     },
+    /// Scaffold a real-time channel: a pub/sub handler over the built-in
+    /// `Channels` API, an htmx SSE live view (default) or a raw `#[ws]`
+    /// socket handler, `main.rs` route wiring, and an in-process smoke test.
+    ///
+    /// Creates:
+    ///
+    /// - `src/channels/<snake>.rs` — channel handler(s) subscribing/
+    ///   publishing through the existing `Channels` API
+    /// - `src/channels/mod.rs`     — created/updated with `pub mod`
+    /// - `src/main.rs`             — `mod channels;` + route registration
+    /// - `tests/<snake>_channel.rs` — smoke test that publishes a message
+    ///   and asserts a subscriber receives it
+    /// - `Cargo.toml`              — `"ws"` feature added to autumn-web
+    ///   (+ transport-specific deps and dev-deps)
+    ///
+    /// SSE-over-htmx is the default transport (zero client JS authored by
+    /// the user). Pass `--ws` for a raw `#[ws]` WebSocket handler instead.
+    ///
+    /// Example:
+    ///
+    ///   autumn generate channel Chat
+    #[command(verbatim_doc_comment)]
+    Channel {
+        /// Channel name (`PascalCase` or `snake_case`, e.g. `Chat`).
+        name: String,
+        /// Use SSE-over-htmx transport (default when neither flag is given).
+        #[arg(long, conflicts_with = "ws")]
+        sse: bool,
+        /// Emit a raw `#[ws]` WebSocket handler instead of the SSE view.
+        #[arg(long)]
+        ws: bool,
+        /// Print the file plan and exit without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Overwrite existing files instead of erroring on collision.
+        #[arg(long)]
+        force: bool,
+    },
     /// Generate a complete browser authentication flow: signup, login, logout,
     /// account/profile, forgot-password, and reset-password.
     ///
@@ -2583,6 +2621,20 @@ fn run_generate_command(cmd: GenerateCommands) {
             no_layout,
             generate::Flags { dry_run, force },
         ),
+        GenerateCommands::Channel {
+            name,
+            sse: _,
+            ws,
+            dry_run,
+            force,
+        } => {
+            let transport = if ws {
+                generate::channel::Transport::Ws
+            } else {
+                generate::channel::Transport::Sse
+            };
+            generate::channel::run(&name, transport, generate::Flags { dry_run, force });
+        }
         GenerateCommands::InboundMail {
             name,
             dry_run,
@@ -4732,6 +4784,93 @@ mod tests {
             panic!("expected generate mailer");
         };
         assert!(!no_layout, "no_layout must default to false");
+    }
+
+    // ── autumn generate channel tests ──────────────────────────────────────
+
+    #[test]
+    fn parse_generate_channel_with_pascal_name() {
+        let cli = Cli::try_parse_from(["autumn", "generate", "channel", "Chat"]).unwrap();
+        let Commands::Generate(GenerateCommands::Channel {
+            name,
+            sse,
+            ws,
+            dry_run,
+            force,
+        }) = cli.command
+        else {
+            panic!("expected generate channel");
+        };
+        assert_eq!(name, "Chat");
+        assert!(
+            !sse,
+            "--sse must default to false (SSE is the implicit default)"
+        );
+        assert!(!ws, "--ws must default to false");
+        assert!(!dry_run);
+        assert!(!force);
+    }
+
+    #[test]
+    fn parse_generate_channel_with_ws_flag() {
+        let cli = Cli::try_parse_from(["autumn", "generate", "channel", "Chat", "--ws"]).unwrap();
+        let Commands::Generate(GenerateCommands::Channel { ws, sse, .. }) = cli.command else {
+            panic!("expected generate channel");
+        };
+        assert!(ws, "--ws flag must set ws = true");
+        assert!(!sse);
+    }
+
+    #[test]
+    fn parse_generate_channel_with_explicit_sse_flag() {
+        let cli = Cli::try_parse_from(["autumn", "generate", "channel", "Chat", "--sse"]).unwrap();
+        let Commands::Generate(GenerateCommands::Channel { ws, sse, .. }) = cli.command else {
+            panic!("expected generate channel");
+        };
+        assert!(sse, "--sse flag must set sse = true");
+        assert!(!ws);
+    }
+
+    #[test]
+    fn parse_generate_channel_sse_and_ws_conflict_is_error() {
+        assert!(
+            Cli::try_parse_from(["autumn", "generate", "channel", "Chat", "--sse", "--ws"])
+                .is_err(),
+            "--sse and --ws are mutually exclusive"
+        );
+    }
+
+    #[test]
+    fn parse_generate_channel_with_dry_run_and_force() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "generate",
+            "channel",
+            "Chat",
+            "--dry-run",
+            "--force",
+        ])
+        .unwrap();
+        let Commands::Generate(GenerateCommands::Channel { dry_run, force, .. }) = cli.command
+        else {
+            panic!("expected generate channel");
+        };
+        assert!(dry_run);
+        assert!(force);
+    }
+
+    #[test]
+    fn parse_generate_channel_snake_case_name() {
+        let cli = Cli::try_parse_from(["autumn", "generate", "channel", "chat_room"]).unwrap();
+        let Commands::Generate(GenerateCommands::Channel { name, .. }) = cli.command else {
+            panic!("expected generate channel");
+        };
+        assert_eq!(name, "chat_room");
+    }
+
+    #[test]
+    fn parse_generate_channel_without_name_is_error() {
+        assert!(Cli::try_parse_from(["autumn", "generate", "channel"]).is_err());
     }
 
     // ── autumn maintenance tests ───────────────────────────────────────────────

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -1120,7 +1120,10 @@ fn generate_channel_ws_emits_ws_handler() {
 fn generate_channel_force_transport_switch_does_not_strand_stale_routes() {
     let (_tmp, project) = fresh_project("channel-switch-app");
     run_autumn(&project, &["generate", "channel", "Chat"]);
-    run_autumn(&project, &["generate", "channel", "Chat", "--ws", "--force"]);
+    run_autumn(
+        &project,
+        &["generate", "channel", "Chat", "--ws", "--force"],
+    );
 
     let main = fs::read_to_string(project.join("src/main.rs")).unwrap();
     assert!(

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -1049,6 +1049,203 @@ fn generated_job_cargo_checks() {
     );
 }
 
+// ── autumn generate channel integration tests ─────────────────────────────────
+
+#[test]
+fn generate_channel_creates_all_expected_files() {
+    let (_tmp, project) = fresh_project("channel-app");
+    let (stdout, _stderr) = run_autumn(&project, &["generate", "channel", "Chat"]);
+    assert!(
+        stdout.contains("chat.rs") || stdout.contains("Created"),
+        "output should mention created files: {stdout}"
+    );
+
+    assert!(project.join("src/channels/chat.rs").is_file());
+    let channel = fs::read_to_string(project.join("src/channels/chat.rs")).unwrap();
+    assert!(channel.contains(r#"#[get("/chat")]"#));
+    assert!(channel.contains(r#"#[get("/chat/events")]"#));
+    assert!(channel.contains(r#"#[post("/chat/messages")]"#));
+    assert!(channel.contains(r#"sse-connect="/chat/events""#));
+    assert!(channel.contains(r#"sse-swap="message""#));
+    assert!(channel.contains("autumn_web::sse::stream"));
+
+    assert!(project.join("src/channels/mod.rs").is_file());
+    let mod_rs = fs::read_to_string(project.join("src/channels/mod.rs")).unwrap();
+    assert!(mod_rs.contains("pub mod chat;"));
+
+    let main = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert!(main.contains("mod channels;"));
+    assert!(main.contains("channels::chat::chat_page"));
+    assert!(main.contains("channels::chat::chat_events"));
+    assert!(main.contains("channels::chat::chat_publish"));
+
+    assert!(project.join("tests/chat_channel.rs").is_file());
+    let test_src = fs::read_to_string(project.join("tests/chat_channel.rs")).unwrap();
+    assert!(test_src.contains("TestApp"));
+    assert!(test_src.contains(".subscribe("));
+    assert!(!test_src.contains("#[ignore"));
+
+    let cargo = fs::read_to_string(project.join("Cargo.toml")).unwrap();
+    assert!(
+        cargo.contains("\"ws\""),
+        "Cargo.toml must enable the ws feature: {cargo}"
+    );
+    assert!(cargo.contains("maud"));
+    assert!(cargo.contains("serde"));
+}
+
+#[test]
+fn generate_channel_ws_emits_ws_handler() {
+    let (_tmp, project) = fresh_project("channel-ws-app");
+    run_autumn(&project, &["generate", "channel", "Chat", "--ws"]);
+
+    let channel = fs::read_to_string(project.join("src/channels/chat.rs")).unwrap();
+    assert!(channel.contains(r#"#[ws("/chat/ws")]"#));
+    assert!(channel.contains("WithShutdown"));
+    assert!(!channel.contains("sse-connect"));
+
+    let main = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert!(main.contains("channels::chat::chat_ws"));
+    assert!(main.contains("channels::chat::chat_publish"));
+
+    let cargo = fs::read_to_string(project.join("Cargo.toml")).unwrap();
+    assert!(cargo.contains("\"ws\""));
+}
+
+#[test]
+fn generate_channel_dry_run_writes_nothing() {
+    let (_tmp, project) = fresh_project("channel-dry-app");
+    let (stdout, _) = run_autumn(&project, &["generate", "channel", "Chat", "--dry-run"]);
+    assert!(
+        stdout.contains("Dry run"),
+        "dry run must print Dry run header: {stdout}"
+    );
+    assert!(!project.join("src/channels/chat.rs").exists());
+    assert!(!project.join("tests/chat_channel.rs").exists());
+}
+
+#[test]
+fn generate_channel_collision_without_force_fails() {
+    let (_tmp, project) = fresh_project("channel-collide-app");
+    run_autumn(&project, &["generate", "channel", "Chat"]);
+    let (_, stderr, code) = run_autumn_failing(&project, &["generate", "channel", "Chat"]);
+    assert_eq!(code, Some(1), "second run without --force must exit 1");
+    assert!(
+        stderr.contains("would overwrite") || stderr.contains("chat.rs"),
+        "must report collision: {stderr}"
+    );
+}
+
+#[test]
+fn generate_channel_force_overwrites_existing() {
+    let (_tmp, project) = fresh_project("channel-force-app");
+    run_autumn(&project, &["generate", "channel", "Chat"]);
+    let path = project.join("src/channels/chat.rs");
+    fs::write(&path, "// corrupted").unwrap();
+    run_autumn(&project, &["generate", "channel", "Chat", "--force"]);
+    let content = fs::read_to_string(&path).unwrap();
+    assert!(
+        content.contains("TOPIC"),
+        "--force must regenerate the channel file"
+    );
+}
+
+#[test]
+fn generate_channel_sse_ws_conflict_fails() {
+    let (_tmp, project) = fresh_project("channel-conflict-app");
+    let (_, stderr, code) =
+        run_autumn_failing(&project, &["generate", "channel", "Chat", "--sse", "--ws"]);
+    assert_ne!(code, Some(0), "--sse and --ws together must fail");
+    assert!(
+        stderr.contains("cannot be used with") || stderr.contains("conflict"),
+        "clap should report the conflicting flags: {stderr}"
+    );
+}
+
+/// Slow end-to-end check: scaffold a fresh project, run `autumn generate
+/// channel` (default SSE transport), and `cargo check --tests` the result
+/// against the local `autumn-web` crate. Verifies the generator adds every
+/// dep its emitted code needs and that the generated application and smoke
+/// test actually type-check.
+///
+/// Ignored by default; run with `cargo test -p autumn-cli -- --ignored`.
+#[test]
+#[ignore = "slow: cargo-checks a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn generated_channel_cargo_checks() {
+    let (_tmp, project) = fresh_project("channel-build");
+    patch_generated_cargo_toml(&project);
+
+    run_autumn(&project, &["generate", "channel", "Chat"]);
+
+    let check = Command::new("cargo")
+        .args(["check", "--tests"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "cargo check on generated channel (SSE) failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}
+
+/// Same as [`generated_channel_cargo_checks`] but for the `--ws` transport.
+///
+/// Ignored by default; run with `cargo test -p autumn-cli -- --ignored`.
+#[test]
+#[ignore = "slow: cargo-checks a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn generated_channel_ws_cargo_checks() {
+    let (_tmp, project) = fresh_project("channel-ws-build");
+    patch_generated_cargo_toml(&project);
+
+    run_autumn(&project, &["generate", "channel", "Chat", "--ws"]);
+
+    let check = Command::new("cargo")
+        .args(["check", "--tests"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "cargo check on generated channel (--ws) failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}
+
+/// Slow end-to-end check: scaffold a fresh project, run `autumn generate
+/// channel`, and actually run the generated smoke test with `cargo test`.
+/// This is the acceptance-criterion proof that the smoke test does not just
+/// compile but passes on first run with no manual edits — it publishes a
+/// message and asserts a live subscriber receives it.
+///
+/// Ignored by default; run with `cargo test -p autumn-cli -- --ignored`.
+#[test]
+#[ignore = "slow: builds and runs a fresh project's test suite — run with `cargo test -p autumn-cli -- --ignored`"]
+fn generated_channel_smoke_test_passes() {
+    let (_tmp, project) = fresh_project("channel-smoke-build");
+    patch_generated_cargo_toml(&project);
+
+    run_autumn(&project, &["generate", "channel", "Chat"]);
+
+    let test_run = Command::new("cargo")
+        .args(["test", "--test", "chat_channel"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        test_run.status.success(),
+        "generated chat_channel smoke test failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&test_run.stdout),
+        String::from_utf8_lossy(&test_run.stderr),
+    );
+    assert!(
+        String::from_utf8_lossy(&test_run.stdout).contains("test result: ok"),
+        "expected the smoke test to report success"
+    );
+}
+
 // ── autumn generate auth integration tests ────────────────────────────────────
 
 #[allow(clippy::too_many_lines)]

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -1112,6 +1112,32 @@ fn generate_channel_ws_emits_ws_handler() {
     assert!(cargo.contains("\"ws\""));
 }
 
+/// Regression test: `autumn generate channel Chat --ws --force` after a
+/// plain SSE run must not leave `main.rs` referencing `chat_page`/
+/// `chat_events`, which `src/channels/chat.rs` no longer defines once
+/// `--ws` overwrites it.
+#[test]
+fn generate_channel_force_transport_switch_does_not_strand_stale_routes() {
+    let (_tmp, project) = fresh_project("channel-switch-app");
+    run_autumn(&project, &["generate", "channel", "Chat"]);
+    run_autumn(&project, &["generate", "channel", "Chat", "--ws", "--force"]);
+
+    let main = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert!(
+        !main.contains("chat_page"),
+        "stale SSE page route must be removed: {main}"
+    );
+    assert!(
+        !main.contains("chat_events"),
+        "stale SSE events route must be removed: {main}"
+    );
+    assert!(main.contains("channels::chat::chat_ws"));
+    assert!(main.contains("channels::chat::chat_publish"));
+
+    let channel = fs::read_to_string(project.join("src/channels/chat.rs")).unwrap();
+    assert!(channel.contains(r#"#[ws("/chat/ws")]"#));
+}
+
 #[test]
 fn generate_channel_dry_run_writes_nothing() {
     let (_tmp, project) = fresh_project("channel-dry-app");

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -9,6 +9,7 @@ single command. Four subcommands cover the cases you actually hit:
 | `autumn generate migration`          | A Diesel migration directory; columns are inferred when the name matches a verb |
 | `autumn generate task`               | A one-off operational `#[task]` skeleton under `tasks/`                         |
 | `autumn generate job`                | A `#[job]` background-job handler with args struct, `registered_jobs()` aggregator, and `.jobs(…)` wiring in `src/main.rs` |
+| `autumn generate channel`            | A real-time broadcast channel over the `Channels` API — an htmx SSE live view by default, or a raw `#[ws]` handler with `--ws` |
 | `autumn generate scaffold`           | Everything `model` does plus `#[repository]`, HTML routes, smoke test, `routes![]` registration |
 | `autumn generate wizard`             | A session-backed multi-step form wizard with per-step validation and a confirm/commit/cancel flow |
 | `autumn generate admin`              | An `AdminModel` adapter for an existing model, wired to `autumn-admin-plugin`   |
@@ -405,6 +406,75 @@ cargo test -p autumn-cli --test generate generated_job_cargo_checks -- --ignored
 ```
 
 This scaffolds a fresh project, runs `autumn generate job`, and asserts that `cargo check --tests` passes with no hand-editing required.
+
+## `autumn generate channel`
+
+For a live feature (chat, notifications, a live-updating list) built entirely
+on Autumn's existing realtime stack — the `Channels` pub/sub API, SSE, and
+`#[ws]` upgrade routes. No new transport is invented; the generator only
+wires up what already ships.
+
+```bash
+autumn generate channel Chat
+```
+
+Produces:
+
+```
+src/channels/chat.rs      # GET /chat (live view), GET /chat/events (SSE), POST /chat/messages
+src/channels/mod.rs       # pub mod chat; (created or appended)
+src/main.rs               # mod channels; + routes![...] entries added in place
+tests/chat_channel.rs     # smoke test: publishes a message, asserts a subscriber receives it
+```
+
+SSE-over-htmx is the default transport — `GET /chat` renders a view wired to
+htmx's `sse-connect`/`sse-swap`, so browser tabs update live with **zero
+client JS authored by the user**:
+
+```rust
+#[get("/chat/events")]
+pub async fn chat_events(State(state): State<AppState>) -> impl IntoResponse {
+    autumn_web::sse::stream(&state, TOPIC)
+}
+
+#[post("/chat/messages")]
+pub async fn chat_publish(
+    State(state): State<AppState>,
+    Form(form): Form<ChatForm>,
+) -> AutumnResult<Markup> {
+    let fragment = message_fragment(&form.message);
+    state.broadcast().publish(TOPIC, fragment.clone().into_string())?;
+    Ok(fragment)
+}
+```
+
+Pass `--ws` to emit a raw `#[ws]` WebSocket handler instead, for clients that
+need a bidirectional socket rather than SSE + form posts:
+
+```bash
+autumn generate channel Chat --ws
+```
+
+Either transport adds the `"ws"` feature to the `autumn-web` dependency in
+`Cargo.toml` — channels, SSE, and `#[ws]` are all gated behind it.
+
+The generated smoke test is a real assertion, not a stub: it publishes
+through the in-process `TestApp`, subscribes to the same topic, and asserts
+the message arrives — no Postgres/Docker required, so it runs on every
+`cargo test`.
+
+### Slow live channel verification
+
+```bash
+cargo test -p autumn-cli --test generate generated_channel_cargo_checks -- --ignored --exact
+cargo test -p autumn-cli --test generate generated_channel_ws_cargo_checks -- --ignored --exact
+cargo test -p autumn-cli --test generate generated_channel_smoke_test_passes -- --ignored --exact
+```
+
+These scaffold a fresh project, run `autumn generate channel` (both
+transports), and assert `cargo check --tests` passes with no hand-editing —
+plus one gate that actually runs the generated smoke test with `cargo test`
+to confirm it passes on first run.
 
 ## `autumn generate scaffold`
 

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -441,10 +441,10 @@ pub async fn chat_events(State(state): State<AppState>) -> impl IntoResponse {
 pub async fn chat_publish(
     State(state): State<AppState>,
     Form(form): Form<ChatForm>,
-) -> AutumnResult<Markup> {
-    let fragment = message_fragment(&form.message);
-    state.broadcast().publish(TOPIC, fragment.clone().into_string())?;
-    Ok(fragment)
+) -> AutumnResult<&'static str> {
+    let fragment = message_fragment(&form.message).into_string();
+    state.broadcast().publish(TOPIC, fragment)?;
+    Ok("published")
 }
 ```
 


### PR DESCRIPTION
Implements a new generator subcommand that scaffolds real-time broadcast channels using Autumn's existing `Channels` API, with support for both SSE-over-htmx (default) and raw WebSocket transports.

## Summary

This adds `autumn generate channel <Name>` to scaffold a complete real-time channel implementation, including:
- Channel handler(s) that publish/subscribe through the `Channels` API
- An htmx SSE live view by default (zero client JS required) or a raw `#[ws]` WebSocket handler with `--ws`
- Automatic `main.rs` route registration and module wiring
- An in-process smoke test that verifies pub/sub delivery
- Cargo.toml dependency and feature management

## Key Changes

- **New module `autumn-cli/src/generate/channel.rs`** (~1073 lines): Core generator logic
  - `plan_channel()`: Computes file actions (create/modify) for the channel scaffold
  - `Transport` enum: Distinguishes between SSE and WebSocket transports
  - `render_sse_channel_file()`: Generates SSE handler with htmx `sse-connect`/`sse-swap` wiring
  - `render_ws_channel_file()`: Generates `#[ws]` handler with bidirectional relay logic
  - `render_smoke_test()`: Creates transport-agnostic integration test using `TestApp`
  - Comprehensive unit tests covering both transports, file plan validation, and edge cases

- **Updated `autumn-cli/src/main.rs`**: 
  - Added `Channel` variant to `GenerateCommands` enum with `--sse`, `--ws`, `--dry-run`, `--force` flags
  - Wired command parsing to `generate::channel::run()`
  - Added CLI parsing tests for the new command

- **Enhanced `autumn-cli/src/generate/schema_edit.rs`**:
  - Extracted `find_routes_body_range()` helper to locate `routes![...]` macro body
  - Added `remove_routes_entries_with_prefix()` to clean stale route entries when regenerating with a different transport (e.g., switching from SSE to WebSocket via `--force`)

- **Integration tests in `autumn-cli/tests/generate.rs`**:
  - `generate_channel_creates_all_expected_files()`: Verifies SSE scaffold completeness
  - `generate_channel_ws_emits_ws_handler()`: Validates WebSocket transport output
  - `generate_channel_force_transport_switch_does_not_strand_stale_routes()`: Regression test for transport switching
  - `generated_channel_cargo_checks()`: End-to-end cargo check (ignored by default, slow)

- **Documentation in `docs/guide/generators.md`**: Added channel generator to the generators table and detailed usage guide

- **CI workflow update in `.github/workflows/generator-conformance.yml`**: Added channel generator tests to conformance checks

## Notable Implementation Details

- **Transport switching safety**: When regenerating a channel with a different transport via `--force`, the generator removes stale route entries (e.g., `chat_page`/`chat_events` when switching from SSE to WebSocket) before adding new ones, preventing dangling references in `main.rs`

- **Smoke test design**: The test re-declares the publish handler locally (since `tests/` cannot import the binary crate) and uses `TestApp` with real `Channels` pub/sub to verify message delivery, not a stub

- **Dependency management**: Automatically enables the `"ws"` feature on `autumn-web` (required for channels, SSE, and `#[ws]`), adds `serde` for form deserialization, and conditionally adds `maud` for SSE's Markup rendering

- **SSE view**: Uses htmx's SSE extension with declarative `sse-connect`/`sse-swap` attributes — zero client JavaScript authored by the user

- **WebSocket handler**: Implements a bidirectional relay with proper shutdown handling, lagged message recovery, and logging of publish failures

https://claude.ai/code/session_019V7c1Q5gvEsix2cWQJ9m79