### PR TITLE
👺 Havoc: Prevent system panics from Duration overflow during Instant addition

### DIFF
--- a/autumn-cli/src/cold_start_driver.rs
+++ b/autumn-cli/src/cold_start_driver.rs
@@ -199,7 +199,7 @@ fn measure_cold_start_once(shape: ColdStartShape) -> Result<u64, String> {
     // a server that boots fine look like a serve failure. `start` still drives the
     // measured duration recorded below.
     let url = format!("http://127.0.0.1:{port}/");
-    let deadline = Instant::now() + Duration::from_millis(budget_for(class_for(shape)).max_ms * 2);
+    let deadline = Instant::now().checked_add(Duration::from_millis(budget_for(class_for(shape)).max_ms * 2)).unwrap_or_else(Instant::now);
     let client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(2))
         .build()

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -5309,7 +5309,7 @@ async fn run_shutdown_hooks_with_timeout(
     per_hook_budget: std::time::Duration,
     total_budget: std::time::Duration,
 ) {
-    let deadline = tokio::time::Instant::now() + total_budget;
+    let deadline = tokio::time::Instant::now().checked_add(total_budget).unwrap_or_else(tokio::time::Instant::now);
     for hook in hooks.iter().rev() {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -1499,7 +1499,7 @@ mod tests {
         drop(registry_guard);
         std::thread::sleep(std::time::Duration::from_millis(25));
 
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+        let deadline = std::time::Instant::now().checked_add(std::time::Duration::from_secs(1)).unwrap_or_else(std::time::Instant::now);
         let registry_released_before_metrics = loop {
             match backend.inner.registry.try_lock() {
                 Ok(registry) => {

--- a/autumn/src/circuit_breaker.rs
+++ b/autumn/src/circuit_breaker.rs
@@ -254,7 +254,7 @@ impl CircuitBreaker {
                     let ratio = inner.failure_ratio();
                     if ratio >= failure_ratio_threshold {
                         inner.transition_to(&self.name, CircuitState::Open, ratio);
-                        inner.open_until = Some(now + open_duration);
+                        inner.open_until = Some(now.checked_add(open_duration).unwrap_or(now));
                     }
                 }
             }
@@ -273,7 +273,7 @@ impl CircuitBreaker {
                 } else {
                     inner.half_open_failures += 1;
                     inner.transition_to(&self.name, CircuitState::Open, 1.0);
-                    inner.open_until = Some(now + open_duration);
+                    inner.open_until = Some(now.checked_add(open_duration).unwrap_or(now));
                 }
             }
             CircuitState::Open => {}

--- a/autumn/src/circuit_breaker_test.rs
+++ b/autumn/src/circuit_breaker_test.rs
@@ -1,0 +1,19 @@
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    #[test]
+    fn circuit_breaker_overflow_panic() {
+        let policy = crate::circuit_breaker::CircuitBreakerPolicy {
+            failure_ratio_threshold: 0.1,
+            sample_window: Duration::from_secs(10),
+            minimum_sample_count: 1,
+            open_duration: Duration::MAX, // Massive duration!
+            half_open_trial_count: 1,
+        };
+        let breaker = crate::circuit_breaker::CircuitBreaker::new("havoc", policy);
+
+        let _ = breaker.before_call();
+        breaker.after_call(false); // Triggers open_until = Some(now + open_duration);
+    }
+}

--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -467,7 +467,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
         let entry = IdempotencyEntry {
             record,
             body_hash,
-            expires_at: Instant::now() + ttl,
+            expires_at: Instant::now().checked_add(ttl).unwrap_or_else(Instant::now),
         };
         let mut entries = self.entries.write().unwrap();
         entries.insert(key.to_owned(), entry);
@@ -504,7 +504,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
             key.to_owned(),
             MemoryInFlightLock {
                 owner: owner.to_owned(),
-                expires_at: now + ttl,
+                expires_at: now.checked_add(ttl).unwrap_or(now),
             },
         );
         true
@@ -631,7 +631,7 @@ mod redis_store {
                                     body_hash: e.body_hash,
                                     // Redis manages TTL natively. Use a fixed 24 h offset
                                     // so the in-process expiry check never fires early.
-                                    expires_at: Instant::now() + Duration::from_secs(86_400),
+                                    expires_at: Instant::now().checked_add(Duration::from_secs(86_400)).unwrap_or_else(Instant::now),
                                 }
                             })
                             .map_err(|e| {

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -1375,7 +1375,7 @@ impl RedisMaintenanceThrottle {
         if now < self.next_run_at {
             return false;
         }
-        self.next_run_at = now + self.interval;
+        self.next_run_at = now.checked_add(self.interval).unwrap_or(now);
         true
     }
 }
@@ -2853,7 +2853,7 @@ impl LocalJobCoordination {
             }
         }
         let expires_at = match window {
-            JobUniquenessWindow::TtlMs(ms) => Some(now + std::time::Duration::from_millis(ms)),
+            JobUniquenessWindow::TtlMs(ms) => Some(now.checked_add(std::time::Duration::from_millis(ms)).unwrap_or(now)),
             JobUniquenessWindow::Pending | JobUniquenessWindow::Running => None,
         };
         inner.unique_holds.insert(
@@ -13135,7 +13135,7 @@ mod uniqueness_concurrency_tests {
 
     /// Poll `cond` every few milliseconds until it holds or `deadline_ms` passes.
     async fn wait_for(deadline_ms: u64, mut cond: impl FnMut() -> bool) -> bool {
-        let deadline = std::time::Instant::now() + Duration::from_millis(deadline_ms);
+        let deadline = std::time::Instant::now().checked_add(Duration::from_millis(deadline_ms)).unwrap_or_else(std::time::Instant::now);
         while std::time::Instant::now() < deadline {
             if cond() {
                 return true;

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -1200,3 +1200,4 @@ mod tests {
         let _builder = builder.routes(vec![]);
     }
 }
+mod circuit_breaker_test;

--- a/autumn/src/runtime_config.rs
+++ b/autumn/src/runtime_config.rs
@@ -1270,7 +1270,7 @@ pub mod pg {
             store.cache_raw_until(
                 "posts_per_page",
                 Some("25".to_owned()),
-                Instant::now() + Duration::from_secs(60),
+                Instant::now().checked_add(Duration::from_secs(60)).unwrap_or_else(Instant::now),
             );
 
             assert_eq!(
@@ -1307,7 +1307,7 @@ pub mod pg {
             store.cache_raw_until(
                 "posts_per_page",
                 Some("25".to_owned()),
-                Instant::now() + Duration::from_secs(60),
+                Instant::now().checked_add(Duration::from_secs(60)).unwrap_or_else(Instant::now),
             );
             store.invalidate_cached_raw("posts_per_page");
 

--- a/autumn/src/security/rate_limit.rs
+++ b/autumn/src/security/rate_limit.rs
@@ -1235,7 +1235,7 @@ mod tests {
         }
 
         // 5 seconds later, bucket.tokens = 0.5. Deficit = 0.5. Secs = 0.5 / 0.1 = 5.0
-        let later = now + Duration::from_secs(5);
+        let later = now.checked_add(Duration::from_secs(5)).unwrap_or(now);
         match store.decide("ip1", later, 1.0, 0.1) {
             Decision::Denied {
                 retry_after_secs, ..
@@ -1244,7 +1244,7 @@ mod tests {
         }
 
         // 9.5 seconds later, bucket.tokens = 0.95. Deficit = 0.05. Secs = 0.05 / 0.1 = 0.5 -> ceil -> 1.0
-        let even_later = now + Duration::from_millis(9500);
+        let even_later = now.checked_add(Duration::from_millis(9500)).unwrap_or(now);
         match store.decide("ip1", even_later, 1.0, 0.1) {
             Decision::Denied {
                 retry_after_secs, ..

--- a/autumn/src/sharding.rs
+++ b/autumn/src/sharding.rs
@@ -499,7 +499,7 @@ impl DirectoryShardRouter {
                 key,
                 DirectoryCacheEntry {
                     shard,
-                    expires_at: std::time::Instant::now() + self.ttl,
+                    expires_at: std::time::Instant::now().checked_add(self.ttl).unwrap_or_else(std::time::Instant::now),
                 },
             );
         }

--- a/autumn/src/system_test.rs
+++ b/autumn/src/system_test.rs
@@ -830,7 +830,7 @@ impl Page {
     /// [`SystemTestError::Timeout`] or [`SystemTestError::AssertionFailed`].
     pub async fn expect_text(&self, text: &str) -> Result<&Self, SystemTestError> {
         let timeout = Duration::from_secs(5);
-        let deadline = tokio::time::Instant::now() + timeout;
+        let deadline = tokio::time::Instant::now().checked_add(timeout).unwrap_or_else(tokio::time::Instant::now);
 
         loop {
             let evaluated = self
@@ -868,7 +868,7 @@ impl Page {
     /// [`SystemTestError::Timeout`] or [`SystemTestError::AssertionFailed`].
     pub async fn expect_url(&self, pattern: &str) -> Result<&Self, SystemTestError> {
         let timeout = Duration::from_secs(5);
-        let deadline = tokio::time::Instant::now() + timeout;
+        let deadline = tokio::time::Instant::now().checked_add(timeout).unwrap_or_else(tokio::time::Instant::now);
 
         loop {
             let evaluated = self
@@ -919,7 +919,7 @@ impl Page {
         value: &str,
     ) -> Result<&Self, SystemTestError> {
         let timeout = Duration::from_secs(5);
-        let deadline = tokio::time::Instant::now() + timeout;
+        let deadline = tokio::time::Instant::now().checked_add(timeout).unwrap_or_else(tokio::time::Instant::now);
 
         loop {
             let js = format!(
@@ -1006,7 +1006,7 @@ impl Page {
     /// [`SystemTestError::AssertionFailed`] listing every captured message,
     /// with a screenshot + HTML dump written to the artifact directory.
     pub async fn expect_no_console_errors(&self) -> Result<&Self, SystemTestError> {
-        let deadline = tokio::time::Instant::now() + CONSOLE_ERROR_GRACE;
+        let deadline = tokio::time::Instant::now().checked_add(CONSOLE_ERROR_GRACE).unwrap_or_else(tokio::time::Instant::now);
         loop {
             let errors = self.console_errors();
             if !errors.is_empty() {
@@ -1045,7 +1045,7 @@ impl Page {
         predicate: impl Fn(&str) -> bool,
     ) -> Result<&Self, SystemTestError> {
         let timeout = Duration::from_secs(10);
-        let deadline = tokio::time::Instant::now() + timeout;
+        let deadline = tokio::time::Instant::now().checked_add(timeout).unwrap_or_else(tokio::time::Instant::now);
 
         loop {
             // Try getElementById(stream_id) first — this handles IDs with CSS
@@ -1120,7 +1120,7 @@ impl Page {
     // ── Internal helpers ──────────────────────────────────────────────────
 
     async fn wait_for_hx_settle(&self) -> Result<(), SystemTestError> {
-        let deadline = tokio::time::Instant::now() + self.hx_settle_timeout;
+        let deadline = tokio::time::Instant::now().checked_add(self.hx_settle_timeout).unwrap_or_else(tokio::time::Instant::now);
         loop {
             let evaluated = self
                 .inner

--- a/autumn/tests/webhook_outbound.rs
+++ b/autumn/tests/webhook_outbound.rs
@@ -16,7 +16,7 @@ where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = bool>,
 {
-    let deadline = tokio::time::Instant::now() + timeout;
+    let deadline = tokio::time::Instant::now().checked_add(timeout).unwrap_or_else(tokio::time::Instant::now);
     loop {
         if condition().await {
             return;

--- a/example-e2e/src/lib.rs
+++ b/example-e2e/src/lib.rs
@@ -319,7 +319,7 @@ async fn wait_until_healthy(
     child: &mut Child,
     timeout: Duration,
 ) -> Result<(), SpawnError> {
-    let deadline = tokio::time::Instant::now() + timeout;
+    let deadline = tokio::time::Instant::now().checked_add(timeout).unwrap_or_else(tokio::time::Instant::now);
     let url = format!("{base_url}/health");
     loop {
         if let Ok(Some(status)) = child.try_wait() {

--- a/examples/reddit-clone/src/live_events.rs
+++ b/examples/reddit-clone/src/live_events.rs
@@ -727,7 +727,7 @@ fn spawn_live_event_relay_task(
     let reconnect_interval = options.reconnect_interval;
 
     tokio::spawn(async move {
-        let mut next_reconnect_at = tokio::time::Instant::now() + reconnect_interval;
+        let mut next_reconnect_at = tokio::time::Instant::now().checked_add(reconnect_interval).unwrap_or_else(tokio::time::Instant::now);
 
         loop {
             tokio::select! {
@@ -752,7 +752,7 @@ fn spawn_live_event_relay_task(
                             );
                         }
                     }
-                    next_reconnect_at = tokio::time::Instant::now() + reconnect_interval;
+                    next_reconnect_at = tokio::time::Instant::now().checked_add(reconnect_interval).unwrap_or_else(tokio::time::Instant::now);
                 }
                 wake = wait_for_live_event_wakeup(listener.as_mut(), poll_interval) => {
                     match wake {


### PR DESCRIPTION
🧨 **The Trigger:** Directly adding unvalidated or massive `Duration` values to `tokio::time::Instant` or `std::time::Instant` using the `+` operator. Example: `Instant::now() + Duration::MAX`.
📉 **The Stack Trace:** 
```
thread 'tests::circuit_breaker_overflow_panic' panicked at library/core/src/time.rs:1072:42:
overflow when adding duration to instant
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
🧪 **Reproduction:** Call an endpoint or initialize an internal component (like the Circuit Breaker) with a massive timeout config duration, triggering the `+` evaluation.
😈 **Comment:** You assumed the duration would always be small enough to fit within an `Instant`. You were wrong. Falling back to immediate expiration via `unwrap_or_else(|| Instant::now())` gracefully degrades without crashing the process.

---
*PR created automatically by Jules for task [9242030289700679250](https://jules.google.com/task/9242030289700679250) started by @madmax983*